### PR TITLE
Move requirements before setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ The Local Operator provides a command-line interface where you can:
 
 Visit the [Local Operator website](https://local-operator.com) for visualizations and information about the project.
 
+## Requirements
+
+- Python 3.12+
+- For 3rd party hosting: DeepSeek API key or OpenAI API key (prompted for on first run)
+- For local hosting: Ollama model installed and running
+
 ## Setup
 
 To run Local Operator with a 3rd party cloud-hosted LLM model, you need to have an API key.  You can get one from OpenAI, DeepSeek, Anthropic, or other providers.
@@ -1703,12 +1709,6 @@ The system includes multiple layers of protection:
 - User confirmation prompts for potentially unsafe code
 - Agent prompt with safety focused execution policy
 - Support for local Ollama models to prevent sending local system data to 3rd parties
-
-## Requirements
-
-- Python 3.12+
-- For 3rd party hosting: DeepSeek API key or OpenAI API key (prompted for on first run)
-- For local hosting: Ollama model installed and running
 
 ## License
 


### PR DESCRIPTION
# PR Description

## Summary of Changes

Moved the Requirements section in the Readme further up

## Related Issue(s)

N/A

## Impact

Describe the impact of these changes on the codebase:

- I spent 20 minutes troubleshooting why I couldn't `pip install local-operator` . I eventually went to [PyPi](https://pypi.org/project/local-operator/) and discovered there that I needed python `>=3.12`. I see now its in the Readme but at the bottom of the document 😅 . I think it makes more sense to have the `requirements` before the `setup` so others don't run into the same issue.

## Testing Details

N/A
## Checklist

- [ x ] My code follows the style guidelines of this project.
- [ x ] I have performed a self-review of my code.
- [ x ] I have added tests that prove my changes work as intended.
- [ x ] All new and existing tests pass.
- [ x ] I have run formatting (black/isort), linting (flake8), and type checks (pyright), and they pass.
- [ x ] I have updated the documentation when required.
- [ x ] Security considerations are addressed (especially for code execution features).
- [ x ] I have linked all related issues.

## Screenshots (Optional)

N/A