### PR TITLE
feat: Add environment context

### DIFF
--- a/local_operator/executor.py
+++ b/local_operator/executor.py
@@ -173,16 +173,12 @@ def get_context_vars_str(context_vars: Dict[str, Any]) -> str:
 
             formatted_value_str = f"{async_prefix}{key}({', '.join(args)}) -> {return_type}: {doc}"
 
-        value_lines = formatted_value_str.splitlines()
-        truncated_value = "\n".join(value_lines[:1000])
+        if len(formatted_value_str) > 100000:
+            formatted_value_str = (
+                f"{formatted_value_str[:100000]} ... (truncated due to length limits)"
+            )
 
-        if len(value_lines) > 1000:
-            truncated_value += "\n... (truncated to 1000 lines)"
-
-        if len(truncated_value) > 50000:
-            truncated_value = f"{truncated_value[:50000]} ... (truncated due to length limits)"
-
-        entry = f"{key}: {truncated_value}\n"
+        entry = f"{key}: {formatted_value_str}\n"
         context_vars_str += entry
 
     return context_vars_str

--- a/local_operator/executor.py
+++ b/local_operator/executor.py
@@ -1,4 +1,5 @@
 import asyncio
+import inspect
 import io
 import os
 import sys
@@ -118,6 +119,73 @@ def process_json_response(response_str: str) -> ResponseJsonSchema:
     response_json = ResponseJsonSchema.model_validate_json(response_content)
 
     return response_json
+
+
+def get_context_vars_str(context_vars: Dict[str, Any]) -> str:
+    """Get the context variables as a string, limiting each value to 1000 lines.
+
+    This function converts a dictionary of context variables into a string
+    representation, limiting the output to a maximum of 1000 lines per value
+    to prevent excessive output.  It also ignores built-in variables and other
+    common uninteresting variables.
+
+    Args:
+        context_vars (Dict[str, Any]): A dictionary of context variables.
+
+    Returns:
+        str: A string representation of the context variables, with each value
+              limited to a maximum of 1000 lines.
+    """
+    context_vars_str = ""
+    ignored_keys = {"__builtins__", "__doc__", "__file__", "__name__", "__package__"}
+
+    for key, value in context_vars.items():
+        if key in ignored_keys:
+            continue
+
+        value_str = str(value)
+        formatted_value_str = value_str
+
+        if callable(value):
+            doc = value.__doc__ or "No description available"
+            # Get first line of docstring
+            doc = doc.split("\n")[0].strip()
+
+            sig = inspect.signature(value)
+            args = []
+            for p in sig.parameters.values():
+                arg_type = (
+                    p.annotation.__name__
+                    if hasattr(p.annotation, "__name__")
+                    else str(p.annotation)
+                )
+                args.append(f"{p.name}: {arg_type}")
+
+            return_type = (
+                sig.return_annotation.__name__
+                if hasattr(sig.return_annotation, "__name__")
+                else str(sig.return_annotation)
+            )
+
+            # Check if function is async
+            is_async = inspect.iscoroutinefunction(value)
+            async_prefix = "async " if is_async else ""
+
+            formatted_value_str = f"{async_prefix}{key}({', '.join(args)}) -> {return_type}: {doc}"
+
+        value_lines = formatted_value_str.splitlines()
+        truncated_value = "\n".join(value_lines[:1000])
+
+        if len(value_lines) > 1000:
+            truncated_value += "\n... (truncated to 1000 lines)"
+
+        if len(truncated_value) > 50000:
+            truncated_value = f"{truncated_value[:50000]} ... (truncated due to length limits)"
+
+        entry = f"{key}: {truncated_value}\n"
+        context_vars_str += entry
+
+    return context_vars_str
 
 
 class ExecutorTokenMetrics(BaseModel):

--- a/local_operator/operator.py
+++ b/local_operator/operator.py
@@ -6,7 +6,7 @@ import subprocess
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
-from typing import Any, Dict, List, Tuple
+from typing import Dict, List, Tuple
 
 from langchain_core.messages import BaseMessage
 from pydantic import ValidationError
@@ -18,6 +18,7 @@ from local_operator.credentials import CredentialManager
 from local_operator.executor import (
     ExecutorInitError,
     LocalCodeExecutor,
+    get_context_vars_str,
     process_json_response,
 )
 from local_operator.model.configure import ModelConfiguration
@@ -256,46 +257,6 @@ class Operator:
 
         return directory_tree_str
 
-    def _get_context_vars_str(self, context_vars: Dict[str, Any]) -> str:
-        """Get the context variables as a string, limiting each value to 1000 lines.
-
-        This function converts a dictionary of context variables into a string
-        representation, limiting the output to a maximum of 1000 lines per value
-        to prevent excessive output.  It also ignores built-in variables and other
-        common uninteresting variables.
-
-        Args:
-            context_vars (Dict[str, Any]): A dictionary of context variables.
-
-        Returns:
-            str: A string representation of the context variables, with each value
-                 limited to a maximum of 1000 lines.
-        """
-        context_vars_str = ""
-        ignored_keys = {"__builtins__", "__doc__", "__file__", "__name__", "__package__"}
-        total_length = 0
-
-        for key, value in context_vars.items():
-            if key in ignored_keys:
-                continue
-
-            value_str = str(value)
-            value_lines = value_str.splitlines()
-            truncated_value = "\n".join(value_lines[:1000])
-
-            if len(value_lines) > 1000:
-                truncated_value += "\n... (truncated to 1000 lines)"
-
-            entry = f"{key}: {truncated_value}\n"
-
-            if total_length + len(entry) < 50000:
-                context_vars_str += entry
-                total_length += len(entry)
-            else:
-                context_vars_str += f"{key}: ... (truncated due to length limits)\n"
-
-        return context_vars_str
-
     def get_environment_details(self) -> str:
         """Get environment details."""
         directory_index = index_current_directory()
@@ -323,7 +284,7 @@ class Operator:
         {directory_tree_str}
         </directory tree>
         <context variables>
-        {self._get_context_vars_str(self.executor.context)}
+        {get_context_vars_str(self.executor.context)}
         </context variables>"""
 
         print(details_str)

--- a/local_operator/operator.py
+++ b/local_operator/operator.py
@@ -287,8 +287,6 @@ class Operator:
         {get_context_vars_str(self.executor.context)}
         </context variables>"""
 
-        print(details_str)
-
         return details_str
 
     def add_ephemeral_messages(self) -> None:

--- a/local_operator/operator.py
+++ b/local_operator/operator.py
@@ -283,9 +283,9 @@ class Operator:
         <directory tree>
         {directory_tree_str}
         </directory tree>
-        <context variables>
+        <execution context variables>
         {get_context_vars_str(self.executor.context)}
-        </context variables>"""
+        </execution context variables>"""
 
         return details_str
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.2.17"
+version = "0.2.18"
 description = "A Python-based agent for local command execution"
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damianvtran@gmail.com" }]


### PR DESCRIPTION
# PR Description

## Summary of Changes

Adds environment context to the operator with the python variables of the execution context, allowing the agent to use this information on each step

- Modifies the operator to include environment details in the prompt.
- Adds a function to get the context variables as a string.
- Updates documentation to reflect the new environment context.


## Related Issue(s)

None

## Impact

- No breaking changes.
- No new dependencies.
- No known performance or security implications.


## Testing Details

- Manually tested the environment context through the CLI.
- Added new unit tests for the get_context_vars_str function.


## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my changes work as intended.
- [x] All new and existing tests pass.
- [x] I have run formatting (black/isort), linting (flake8), and type checks (pyright), and they pass.
- [x] I have updated the documentation when required.
- [x] Security considerations are addressed (especially for code execution features).
- [ ] I have linked all related issues.


## Screenshots (Optional)

If applicable, please attach screenshots that illustrate the changes or new features.
