### PR TITLE
Agents skip planning according to complexity

### DIFF
--- a/examples/notebooks/business_pricing_margin.ipynb
+++ b/examples/notebooks/business_pricing_margin.ipynb
@@ -1,0 +1,1621 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\n",
+    "# 🤖 Local Operator Conversation Notebook 📓\n",
+    "\n",
+    "This notebook contains the exported conversation and code execution history from a\n",
+    "<a href='https://local-operator.com'>Local Operator</a> agent session.\n",
+    "\n",
+    "## 📊 Session Information\n",
+    "\n",
+    "<table style='width: 80%; border-collapse: collapse;'>\n",
+    "  <tr><td style='padding: 8px; font-weight: bold;'>📅 Date and Time</td>\n",
+    "  <td>2025-03-01 10:48:58</td></tr>\n",
+    "  <tr><td style='padding: 8px; font-weight: bold;'>🔢 Local Operator Version</td>\n",
+    "  <td>0.3.4</td></tr>\n",
+    "  <tr><td style='padding: 8px; font-weight: bold;'>🧠 Model</td>\n",
+    "  <td>google/gemini-2.0-flash-001</td></tr>\n",
+    "  <tr><td style='padding: 8px; font-weight: bold;'>☁️ Hosting</td>\n",
+    "  <td>openrouter</td></tr>\n",
+    "  <tr><td style='padding: 8px; font-weight: bold;'>💬 Max Conversation History</td>\n",
+    "  <td>100</td></tr>\n",
+    "  <tr><td style='padding: 8px; font-weight: bold;'>📜 Detailed Conversation Length</td>\n",
+    "  <td>35</td></tr>\n",
+    "  <tr><td style='padding: 8px; font-weight: bold;'>📚 Learning History Length</td>\n",
+    "  <td>50</td></tr>\n",
+    "</table>\n",
+    "\n",
+    "💡 **Tip:** To reproduce this conversation, you can run Local Operator with the\n",
+    "same configuration settings listed above.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "👤 **User**: My API costs the business 0.1 cents USD per request, and I want to offer a few tiers of usage at 100, 500, and 2000 requests per day.  What should the monthly subscription costs be for these tiers to achieve a 70% margin?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "🤖 **Assistant**: Here's my plan to calculate the monthly subscription costs for the API tiers:\n",
+    "\n",
+    "1. **Calculate the monthly cost per tier:** Determine the total cost per month for each tier based on the number of requests per day and the cost per request.\n",
+    "2. **Calculate the revenue per tier:** Calculate the revenue needed per month for each tier to achieve a 70% margin.\n",
+    "3. **Calculate the monthly subscription price per tier:** Determine the monthly subscription price for each tier based on the required revenue.\n",
+    "4. **Present the results:** Display the calculated monthly subscription prices for each tier.\n",
+    "5. **Verification:** Double-check the calculations to ensure accuracy and that the 70% margin is achieved.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "🤖 **Assistant**: I will now calculate the monthly cost for each tier. The tiers are 100, 500, and 2000 requests per day, and the cost per request is 0.1 cents USD."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Output:\n",
+      "{100: 3.0, 500: 15.0, 2000: 60.0}\n",
+      "Errors:\n",
+      "[No error output]\n",
+      "Logging:\n",
+      "[No logger output]\n"
+     ]
+    }
+   ],
+   "source": [
+    "tiers = [100, 500, 2000]\n",
+    "cost_per_request = 0.001  # USD\n",
+    "days_in_month = 30\n",
+    "\n",
+    "monthly_costs = {}\n",
+    "for tier in tiers:\n",
+    "    monthly_requests = tier * days_in_month\n",
+    "    monthly_cost = monthly_requests * cost_per_request\n",
+    "    monthly_costs[tier] = monthly_cost\n",
+    "\n",
+    "print(monthly_costs)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "🤖 **Assistant**: I will now calculate the revenue needed per month for each tier to achieve a 70% margin."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Output:\n",
+      "{100: 9.999999999999998, 500: 49.99999999999999, 2000: 199.99999999999997}\n",
+      "Errors:\n",
+      "[No error output]\n",
+      "Logging:\n",
+      "[No logger output]\n"
+     ]
+    }
+   ],
+   "source": [
+    "monthly_costs = {100: 3.0, 500: 15.0, 2000: 60.0}\n",
+    "margin = 0.70\n",
+    "\n",
+    "monthly_revenues = {}\n",
+    "for tier, cost in monthly_costs.items():\n",
+    "    monthly_revenue = cost / (1 - margin)\n",
+    "    monthly_revenues[tier] = monthly_revenue\n",
+    "\n",
+    "print(monthly_revenues)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "🤖 **Assistant**: The monthly revenue needed is already calculated in the previous step. The monthly subscription price per tier will be set to the calculated monthly revenue for each tier."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Output:\n",
+      "{100: 9.999999999999998, 500: 49.99999999999999, 2000: 199.99999999999997}\n",
+      "Errors:\n",
+      "[No error output]\n",
+      "Logging:\n",
+      "[No logger output]\n"
+     ]
+    }
+   ],
+   "source": [
+    "monthly_revenues = {100: 9.999999999999998, 500: 49.99999999999999, 2000: 199.99999999999997}\n",
+    "\n",
+    "monthly_subscription_prices = monthly_revenues\n",
+    "\n",
+    "print(monthly_subscription_prices)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "🤖 **Assistant**: I will now present the calculated monthly subscription prices for each tier."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Output:\n",
+      "Monthly Subscription Prices (USD):\n",
+      "Tier 100: $10.00\n",
+      "Tier 500: $50.00\n",
+      "Tier 2000: $200.00\n",
+      "Errors:\n",
+      "[No error output]\n",
+      "Logging:\n",
+      "[No logger output]\n"
+     ]
+    }
+   ],
+   "source": [
+    "monthly_subscription_prices = {100: 9.999999999999998, 500: 49.99999999999999, 2000: 199.99999999999997}\n",
+    "\n",
+    "print(\"Monthly Subscription Prices (USD):\")\n",
+    "for tier, price in monthly_subscription_prices.items():\n",
+    "    print(f\"Tier {tier}: ${price:.2f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "🤖 **Assistant**: I will now verify the calculations to ensure accuracy and that the 70% margin is achieved."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Output:\n",
+      "Tier 100: Price = $10.00, Cost = $3.00, Margin = 0.70\n",
+      "Tier 500: Price = $50.00, Cost = $15.00, Margin = 0.70\n",
+      "Tier 2000: Price = $200.00, Cost = $60.00, Margin = 0.70\n",
+      "Errors:\n",
+      "[No error output]\n",
+      "Logging:\n",
+      "[No logger output]\n"
+     ]
+    }
+   ],
+   "source": [
+    "monthly_costs = {100: 3.0, 500: 15.0, 2000: 60.0}\n",
+    "monthly_subscription_prices = {100: 9.999999999999998, 500: 49.99999999999999, 2000: 199.99999999999997}\n",
+    "margin = 0.70\n",
+    "\n",
+    "for tier, price in monthly_subscription_prices.items():\n",
+    "    cost = monthly_costs[tier]\n",
+    "    calculated_margin = (price - cost) / price\n",
+    "    print(f\"Tier {tier}: Price = ${price:.2f}, Cost = ${cost:.2f}, Margin = {calculated_margin:.2f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "👤 **User**: What should I be charging assuming that the 0.1 cent cost of goods has a 7% annual increase in cost?  I'd like to bake this into the ongoing contract costs and account for the next two years in cost of good increase.  Provide the first and second years worth of increased price"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "🤖 **Assistant**: Here's my plan to calculate the monthly subscription costs for the API tiers, accounting for a 7% annual increase in the cost of goods for the next two years:\n",
+    "\n",
+    "1. **Calculate the cost per request for year 1:** Increase the current cost per request by 7% to determine the cost per request for the first year.\n",
+    "2. **Calculate the cost per request for year 2:** Increase the cost per request for year 1 by 7% to determine the cost per request for the second year.\n",
+    "3. **Calculate the monthly cost per tier for year 1:** Determine the total cost per month for each tier based on the number of requests per day and the cost per request for year 1.\n",
+    "4. **Calculate the monthly cost per tier for year 2:** Determine the total cost per month for each tier based on the number of requests per day and the cost per request for year 2.\n",
+    "5. **Calculate the revenue per tier for year 1:** Calculate the revenue needed per month for each tier to achieve a 70% margin, using the monthly cost for year 1.\n",
+    "6. **Calculate the revenue per tier for year 2:** Calculate the revenue needed per month for each tier to achieve a 70% margin, using the monthly cost for year 2.\n",
+    "7. **Calculate the monthly subscription price per tier for year 1:** Determine the monthly subscription price for each tier based on the required revenue for year 1.\n",
+    "8. **Calculate the monthly subscription price per tier for year 2:** Determine the monthly subscription price for each tier based on the required revenue for year 2.\n",
+    "9. **Present the results:** Display the calculated monthly subscription prices for each tier for both year 1 and year 2.\n",
+    "10. **Verification:** Double-check the calculations to ensure accuracy and that the 70% margin is achieved for both years.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "🤖 **Assistant**: I will now calculate the cost per request for year 1, increasing the current cost per request by 7%."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Output:\n",
+      "cost_per_request_year1=0.00107\n",
+      "Errors:\n",
+      "[No error output]\n",
+      "Logging:\n",
+      "[No logger output]\n"
+     ]
+    }
+   ],
+   "source": [
+    "cost_per_request = 0.001  # USD\n",
+    "annual_increase = 0.07\n",
+    "\n",
+    "cost_per_request_year1 = cost_per_request * (1 + annual_increase)\n",
+    "\n",
+    "print(f\"{cost_per_request_year1=}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "🤖 **Assistant**: I will now calculate the cost per request for year 2, increasing the cost per request for year 1 by 7%."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Output:\n",
+      "cost_per_request_year2=0.0011449000000000001\n",
+      "Errors:\n",
+      "[No error output]\n",
+      "Logging:\n",
+      "[No logger output]\n"
+     ]
+    }
+   ],
+   "source": [
+    "cost_per_request_year1 = 0.00107\n",
+    "annual_increase = 0.07\n",
+    "\n",
+    "cost_per_request_year2 = cost_per_request_year1 * (1 + annual_increase)\n",
+    "\n",
+    "print(f\"{cost_per_request_year2=}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "🤖 **Assistant**: I will now calculate the monthly cost per tier for year 1, using the cost per request for year 1."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Output:\n",
+      "monthly_costs_year1={100: 3.21, 500: 16.05, 2000: 64.2}\n",
+      "Errors:\n",
+      "[No error output]\n",
+      "Logging:\n",
+      "[No logger output]\n"
+     ]
+    }
+   ],
+   "source": [
+    "tiers = [100, 500, 2000]\n",
+    "cost_per_request_year1 = 0.00107\n",
+    "days_in_month = 30\n",
+    "\n",
+    "monthly_costs_year1 = {}\n",
+    "for tier in tiers:\n",
+    "    monthly_requests = tier * days_in_month\n",
+    "    monthly_cost = monthly_requests * cost_per_request_year1\n",
+    "    monthly_costs_year1[tier] = monthly_cost\n",
+    "\n",
+    "print(f\"{monthly_costs_year1=}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "🤖 **Assistant**: I will now calculate the monthly cost per tier for year 2, using the cost per request for year 2."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Output:\n",
+      "monthly_costs_year2={100: 3.4347000000000003, 500: 17.1735, 2000: 68.694}\n",
+      "Errors:\n",
+      "[No error output]\n",
+      "Logging:\n",
+      "[No logger output]\n"
+     ]
+    }
+   ],
+   "source": [
+    "tiers = [100, 500, 2000]\n",
+    "cost_per_request_year2 = 0.0011449000000000001\n",
+    "days_in_month = 30\n",
+    "\n",
+    "monthly_costs_year2 = {}\n",
+    "for tier in tiers:\n",
+    "    monthly_requests = tier * days_in_month\n",
+    "    monthly_cost = monthly_requests * cost_per_request_year2\n",
+    "    monthly_costs_year2[tier] = monthly_cost\n",
+    "\n",
+    "print(f\"{monthly_costs_year2=}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "🤖 **Assistant**: I will now calculate the revenue per tier for year 1, using the monthly cost for year 1 and a 70% margin."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Output:\n",
+      "monthly_revenues_year1={100: 10.699999999999998, 500: 53.49999999999999, 2000: 213.99999999999997}\n",
+      "Errors:\n",
+      "[No error output]\n",
+      "Logging:\n",
+      "[No logger output]\n"
+     ]
+    }
+   ],
+   "source": [
+    "monthly_costs_year1 = {100: 3.21, 500: 16.05, 2000: 64.2}\n",
+    "margin = 0.70\n",
+    "\n",
+    "monthly_revenues_year1 = {}\n",
+    "for tier, cost in monthly_costs_year1.items():\n",
+    "    monthly_revenue = cost / (1 - margin)\n",
+    "    monthly_revenues_year1[tier] = monthly_revenue\n",
+    "\n",
+    "print(f\"{monthly_revenues_year1=}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "🤖 **Assistant**: I will now calculate the revenue per tier for year 2, using the monthly cost for year 2 and a 70% margin."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Output:\n",
+      "monthly_revenues_year2={100: 11.449, 500: 57.24499999999999, 2000: 228.97999999999996}\n",
+      "Errors:\n",
+      "[No error output]\n",
+      "Logging:\n",
+      "[No logger output]\n"
+     ]
+    }
+   ],
+   "source": [
+    "monthly_costs_year2 = {100: 3.4347000000000003, 500: 17.1735, 2000: 68.694}\n",
+    "margin = 0.70\n",
+    "\n",
+    "monthly_revenues_year2 = {}\n",
+    "for tier, cost in monthly_costs_year2.items():\n",
+    "    monthly_revenue = cost / (1 - margin)\n",
+    "    monthly_revenues_year2[tier] = monthly_revenue\n",
+    "\n",
+    "print(f\"{monthly_revenues_year2=}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "🤖 **Assistant**: I will now calculate the monthly subscription price per tier for year 1, which is equal to the revenue per tier for year 1."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Output:\n",
+      "monthly_subscription_prices_year1={100: 10.699999999999998, 500: 53.49999999999999, 2000: 213.99999999999997}\n",
+      "Errors:\n",
+      "[No error output]\n",
+      "Logging:\n",
+      "[No logger output]\n"
+     ]
+    }
+   ],
+   "source": [
+    "monthly_revenues_year1 = {100: 10.699999999999998, 500: 53.49999999999999, 2000: 213.99999999999997}\n",
+    "\n",
+    "monthly_subscription_prices_year1 = monthly_revenues_year1\n",
+    "\n",
+    "print(f\"{monthly_subscription_prices_year1=}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "🤖 **Assistant**: I will now calculate the monthly subscription price per tier for year 2, which is equal to the revenue per tier for year 2."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Output:\n",
+      "monthly_subscription_prices_year2={100: 11.449, 500: 57.24499999999999, 2000: 228.97999999999996}\n",
+      "Errors:\n",
+      "[No error output]\n",
+      "Logging:\n",
+      "[No logger output]\n"
+     ]
+    }
+   ],
+   "source": [
+    "monthly_revenues_year2 = {100: 11.449, 500: 57.24499999999999, 2000: 228.97999999999996}\n",
+    "\n",
+    "monthly_subscription_prices_year2 = monthly_revenues_year2\n",
+    "\n",
+    "print(f\"{monthly_subscription_prices_year2=}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "🤖 **Assistant**: I will now present the calculated monthly subscription prices for each tier for both year 1 and year 2."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Output:\n",
+      "Monthly Subscription Prices (USD):\n",
+      "Year 1:\n",
+      "  Tier 100: $10.70\n",
+      "  Tier 500: $53.50\n",
+      "  Tier 2000: $214.00\n",
+      "Year 2:\n",
+      "  Tier 100: $11.45\n",
+      "  Tier 500: $57.24\n",
+      "  Tier 2000: $228.98\n",
+      "Errors:\n",
+      "[No error output]\n",
+      "Logging:\n",
+      "[No logger output]\n"
+     ]
+    }
+   ],
+   "source": [
+    "monthly_subscription_prices_year1 = {100: 10.699999999999998, 500: 53.49999999999999, 2000: 213.99999999999997}\n",
+    "monthly_subscription_prices_year2 = {100: 11.449, 500: 57.24499999999999, 2000: 228.97999999999996}\n",
+    "\n",
+    "print(\"Monthly Subscription Prices (USD):\")\n",
+    "print(\"Year 1:\")\n",
+    "for tier, price in monthly_subscription_prices_year1.items():\n",
+    "    print(f\"  Tier {tier}: ${price:.2f}\")\n",
+    "print(\"Year 2:\")\n",
+    "for tier, price in monthly_subscription_prices_year2.items():\n",
+    "    print(f\"  Tier {tier}: ${price:.2f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "🤖 **Assistant**: I will now verify the calculations to ensure accuracy and that the 70% margin is achieved for both years."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Output:\n",
+      "Year 1 Verification:\n",
+      "  Tier 100: Price = $10.70, Cost = $3.21, Margin = 0.70\n",
+      "  Tier 500: Price = $53.50, Cost = $16.05, Margin = 0.70\n",
+      "  Tier 2000: Price = $214.00, Cost = $64.20, Margin = 0.70\n",
+      "Year 2 Verification:\n",
+      "  Tier 100: Price = $11.45, Cost = $3.43, Margin = 0.70\n",
+      "  Tier 500: Price = $57.24, Cost = $17.17, Margin = 0.70\n",
+      "  Tier 2000: Price = $228.98, Cost = $68.69, Margin = 0.70\n",
+      "Errors:\n",
+      "[No error output]\n",
+      "Logging:\n",
+      "[No logger output]\n"
+     ]
+    }
+   ],
+   "source": [
+    "monthly_costs_year1 = {100: 3.21, 500: 16.05, 2000: 64.2}\n",
+    "monthly_subscription_prices_year1 = {100: 10.699999999999998, 500: 53.49999999999999, 2000: 213.99999999999997}\n",
+    "monthly_costs_year2 = {100: 3.4347000000000003, 500: 17.1735, 2000: 68.694}\n",
+    "monthly_subscription_prices_year2 = {100: 11.449, 500: 57.24499999999999, 2000: 228.97999999999996}\n",
+    "margin = 0.70\n",
+    "\n",
+    "print(\"Year 1 Verification:\")\n",
+    "for tier, price in monthly_subscription_prices_year1.items():\n",
+    "    cost = monthly_costs_year1[tier]\n",
+    "    calculated_margin = (price - cost) / price\n",
+    "    print(f\"  Tier {tier}: Price = ${price:.2f}, Cost = ${cost:.2f}, Margin = {calculated_margin:.2f}\")\n",
+    "\n",
+    "print(\"Year 2 Verification:\")\n",
+    "for tier, price in monthly_subscription_prices_year2.items():\n",
+    "    cost = monthly_costs_year2[tier]\n",
+    "    calculated_margin = (price - cost) / price\n",
+    "    print(f\"  Tier {tier}: Price = ${price:.2f}, Cost = ${cost:.2f}, Margin = {calculated_margin:.2f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "👤 **User**: let's go with the year 2 pricing as our new baseline today so that we ensure the margin.  Now, assume that each customer makes on average 3 support requests a year and each support request costs around $0.30 USD. What should I be charging for the subscription to maintain that 70% margin per subscription?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "🤖 **Assistant**: Here's my plan to calculate the new monthly subscription costs for the API tiers, incorporating the support request costs and maintaining a 70% margin:\n",
+    "\n",
+    "1. **Calculate the annual support cost per customer:** Determine the total annual cost of support requests per customer (3 requests * $0.30/request).\n",
+    "2. **Calculate the monthly support cost per customer:** Divide the annual support cost by 12 to get the monthly support cost per customer.\n",
+    "3. **Retrieve the year 2 monthly subscription prices:** Access the previously calculated year 2 monthly subscription prices for each tier.\n",
+    "4. **Calculate the new monthly cost per tier:** Add the monthly support cost to the year 2 monthly cost for each tier.\n",
+    "5. **Calculate the new revenue per tier:** Calculate the new revenue needed per month for each tier to achieve a 70% margin, using the new monthly cost.\n",
+    "6. **Calculate the new monthly subscription price per tier:** Determine the new monthly subscription price for each tier based on the required new revenue.\n",
+    "7. **Present the results:** Display the calculated new monthly subscription prices for each tier.\n",
+    "8. **Verification:** Double-check the calculations to ensure accuracy and that the 70% margin is achieved.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "🤖 **Assistant**: I will now calculate the annual support cost per customer."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Output:\n",
+      "annual_support_cost=0.8999999999999999\n",
+      "Errors:\n",
+      "[No error output]\n",
+      "Logging:\n",
+      "[No logger output]\n"
+     ]
+    }
+   ],
+   "source": [
+    "support_requests_per_year = 3\n",
+    "cost_per_support_request = 0.30  # USD\n",
+    "\n",
+    "annual_support_cost = support_requests_per_year * cost_per_support_request\n",
+    "\n",
+    "print(f\"{annual_support_cost=}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "🤖 **Assistant**: I will now calculate the monthly support cost per customer."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Output:\n",
+      "monthly_support_cost=0.075\n",
+      "Errors:\n",
+      "[No error output]\n",
+      "Logging:\n",
+      "[No logger output]\n"
+     ]
+    }
+   ],
+   "source": [
+    "annual_support_cost = 0.8999999999999999\n",
+    "\n",
+    "monthly_support_cost = annual_support_cost / 12\n",
+    "\n",
+    "print(f\"{monthly_support_cost=}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "🤖 **Assistant**: I will now retrieve the year 2 monthly subscription prices."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Output:\n",
+      "monthly_subscription_prices_year2={100: 11.449, 500: 57.24499999999999, 2000: 228.97999999999996}\n",
+      "Errors:\n",
+      "[No error output]\n",
+      "Logging:\n",
+      "[No logger output]\n"
+     ]
+    }
+   ],
+   "source": [
+    "monthly_subscription_prices_year2 = {100: 11.449, 500: 57.24499999999999, 2000: 228.97999999999996}\n",
+    "\n",
+    "print(f\"{monthly_subscription_prices_year2=}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "🤖 **Assistant**: I will now calculate the new monthly cost per tier by adding the monthly support cost to the year 2 monthly cost for each tier."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Output:\n",
+      "new_monthly_costs={100: 3.5097000000000005, 500: 17.2485, 2000: 68.769}\n",
+      "Errors:\n",
+      "[No error output]\n",
+      "Logging:\n",
+      "[No logger output]\n"
+     ]
+    }
+   ],
+   "source": [
+    "monthly_costs_year2 = {100: 3.4347000000000003, 500: 17.1735, 2000: 68.694}\n",
+    "monthly_support_cost = 0.075\n",
+    "\n",
+    "new_monthly_costs = {}\n",
+    "for tier, cost in monthly_costs_year2.items():\n",
+    "    new_monthly_cost = cost + monthly_support_cost\n",
+    "    new_monthly_costs[tier] = new_monthly_cost\n",
+    "\n",
+    "print(f\"{new_monthly_costs=}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "🤖 **Assistant**: I will now calculate the new revenue per tier to achieve a 70% margin, using the new monthly cost."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Output:\n",
+      "new_monthly_revenues={100: 11.699, 500: 57.49499999999999, 2000: 229.23}\n",
+      "Errors:\n",
+      "[No error output]\n",
+      "Logging:\n",
+      "[No logger output]\n"
+     ]
+    }
+   ],
+   "source": [
+    "new_monthly_costs = {100: 3.5097000000000005, 500: 17.2485, 2000: 68.769}\n",
+    "margin = 0.70\n",
+    "\n",
+    "new_monthly_revenues = {}\n",
+    "for tier, cost in new_monthly_costs.items():\n",
+    "    new_monthly_revenue = cost / (1 - margin)\n",
+    "    new_monthly_revenues[tier] = new_monthly_revenue\n",
+    "\n",
+    "print(f\"{new_monthly_revenues=}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "🤖 **Assistant**: I will now calculate the new monthly subscription price per tier, which is equal to the new revenue per tier."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Output:\n",
+      "new_monthly_subscription_prices={100: 11.699, 500: 57.49499999999999, 2000: 229.23}\n",
+      "Errors:\n",
+      "[No error output]\n",
+      "Logging:\n",
+      "[No logger output]\n"
+     ]
+    }
+   ],
+   "source": [
+    "new_monthly_revenues = {100: 11.699, 500: 57.49499999999999, 2000: 229.23}\n",
+    "\n",
+    "new_monthly_subscription_prices = new_monthly_revenues\n",
+    "\n",
+    "print(f\"{new_monthly_subscription_prices=}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "🤖 **Assistant**: I will now present the calculated new monthly subscription prices for each tier."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Output:\n",
+      "New Monthly Subscription Prices (USD):\n",
+      "  Tier 100: $11.70\n",
+      "  Tier 500: $57.49\n",
+      "  Tier 2000: $229.23\n",
+      "Errors:\n",
+      "[No error output]\n",
+      "Logging:\n",
+      "[No logger output]\n"
+     ]
+    }
+   ],
+   "source": [
+    "new_monthly_subscription_prices = {100: 11.699, 500: 57.49499999999999, 2000: 229.23}\n",
+    "\n",
+    "print(\"New Monthly Subscription Prices (USD):\")\n",
+    "for tier, price in new_monthly_subscription_prices.items():\n",
+    "    print(f\"  Tier {tier}: ${price:.2f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "🤖 **Assistant**: I will now verify the calculations to ensure accuracy and that the 70% margin is achieved."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Output:\n",
+      "Verification:\n",
+      "  Tier 100: Price = $11.70, Cost = $3.51, Margin = 0.70\n",
+      "  Tier 500: Price = $57.49, Cost = $17.25, Margin = 0.70\n",
+      "  Tier 2000: Price = $229.23, Cost = $68.77, Margin = 0.70\n",
+      "Errors:\n",
+      "[No error output]\n",
+      "Logging:\n",
+      "[No logger output]\n"
+     ]
+    }
+   ],
+   "source": [
+    "new_monthly_costs = {100: 3.5097000000000005, 500: 17.2485, 2000: 68.769}\n",
+    "new_monthly_subscription_prices = {100: 11.699, 500: 57.49499999999999, 2000: 229.23}\n",
+    "margin = 0.70\n",
+    "\n",
+    "print(\"Verification:\")\n",
+    "for tier, price in new_monthly_subscription_prices.items():\n",
+    "    cost = new_monthly_costs[tier]\n",
+    "    calculated_margin = (price - cost) / price\n",
+    "    print(f\"  Tier {tier}: Price = ${price:.2f}, Cost = ${cost:.2f}, Margin = {calculated_margin:.2f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "👤 **User**: Taking the above prices, what should I charge if each lead takes about $0.25 to generate and I have a conversion rate of 10%?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "🤖 **Assistant**: Here's my plan to calculate the new monthly subscription costs for the API tiers, incorporating the lead generation costs and conversion rate, while maintaining a 70% margin:\n",
+    "\n",
+    "1. **Calculate the cost per acquired customer:** Determine the cost to acquire a single customer, considering the lead generation cost and conversion rate.\n",
+    "2. **Calculate the monthly cost per acquired customer:** Divide the cost per acquired customer by the average customer lifetime in months (assume 12 months for now, but this could be adjusted).\n",
+    "3. **Retrieve the current monthly costs per tier:** Access the previously calculated `new_monthly_costs` for each tier.\n",
+    "4. **Add the monthly acquisition cost to the monthly costs:** Add the monthly acquisition cost per customer to the existing monthly cost for each tier.\n",
+    "5. **Calculate the new revenue per tier:** Calculate the new revenue needed per month for each tier to achieve a 70% margin, using the updated monthly costs.\n",
+    "6. **Calculate the new monthly subscription price per tier:** Determine the new monthly subscription price for each tier based on the required new revenue.\n",
+    "7. **Present the results:** Display the calculated new monthly subscription prices for each tier.\n",
+    "8. **Verification:** Double-check the calculations to ensure accuracy and that the 70% margin is achieved.\n",
+    "9. **Consider adjusting customer lifetime:** If the resulting prices seem unreasonable, consider adjusting the assumed customer lifetime and recalculating.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "🤖 **Assistant**: I will now calculate the cost per acquired customer."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Output:\n",
+      "cost_per_acquired_customer=2.5\n",
+      "Errors:\n",
+      "[No error output]\n",
+      "Logging:\n",
+      "[No logger output]\n"
+     ]
+    }
+   ],
+   "source": [
+    "lead_generation_cost = 0.25  # USD\n",
+    "conversion_rate = 0.10\n",
+    "\n",
+    "cost_per_acquired_customer = lead_generation_cost / conversion_rate\n",
+    "\n",
+    "print(f\"{cost_per_acquired_customer=}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "🤖 **Assistant**: I will now calculate the monthly cost per acquired customer, assuming a 12-month customer lifetime."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Output:\n",
+      "monthly_acquisition_cost=0.20833333333333334\n",
+      "Errors:\n",
+      "[No error output]\n",
+      "Logging:\n",
+      "[No logger output]\n"
+     ]
+    }
+   ],
+   "source": [
+    "cost_per_acquired_customer = 2.5  # USD\n",
+    "average_customer_lifetime_months = 12\n",
+    "\n",
+    "monthly_acquisition_cost = cost_per_acquired_customer / average_customer_lifetime_months\n",
+    "\n",
+    "print(f\"{monthly_acquisition_cost=}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "🤖 **Assistant**: I will now retrieve the current monthly costs per tier."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Output:\n",
+      "new_monthly_costs={100: 3.5097000000000005, 500: 17.2485, 2000: 68.769}\n",
+      "Errors:\n",
+      "[No error output]\n",
+      "Logging:\n",
+      "[No logger output]\n"
+     ]
+    }
+   ],
+   "source": [
+    "new_monthly_costs = {100: 3.5097000000000005, 500: 17.2485, 2000: 68.769}\n",
+    "\n",
+    "print(f\"{new_monthly_costs=}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "🤖 **Assistant**: I will now add the monthly acquisition cost to the existing monthly costs for each tier."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Output:\n",
+      "updated_monthly_costs={100: 3.718033333333334, 500: 17.456833333333332, 2000: 68.97733333333333}\n",
+      "Errors:\n",
+      "[No error output]\n",
+      "Logging:\n",
+      "[No logger output]\n"
+     ]
+    }
+   ],
+   "source": [
+    "new_monthly_costs = {100: 3.5097000000000005, 500: 17.2485, 2000: 68.769}\n",
+    "monthly_acquisition_cost = 0.20833333333333334\n",
+    "\n",
+    "updated_monthly_costs = {}\n",
+    "for tier, cost in new_monthly_costs.items():\n",
+    "    updated_cost = cost + monthly_acquisition_cost\n",
+    "    updated_monthly_costs[tier] = updated_cost\n",
+    "\n",
+    "print(f\"{updated_monthly_costs=}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "🤖 **Assistant**: I will now calculate the new revenue per tier to achieve a 70% margin, using the updated monthly costs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Output:\n",
+      "new_monthly_revenues={100: 12.393444444444444, 500: 58.18944444444443, 2000: 229.92444444444442}\n",
+      "Errors:\n",
+      "[No error output]\n",
+      "Logging:\n",
+      "[No logger output]\n"
+     ]
+    }
+   ],
+   "source": [
+    "updated_monthly_costs = {100: 3.718033333333334, 500: 17.456833333333332, 2000: 68.97733333333333}\n",
+    "margin = 0.70\n",
+    "\n",
+    "new_monthly_revenues = {}\n",
+    "for tier, cost in updated_monthly_costs.items():\n",
+    "    new_monthly_revenue = cost / (1 - margin)\n",
+    "    new_monthly_revenues[tier] = new_monthly_revenue\n",
+    "\n",
+    "print(f\"{new_monthly_revenues=}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "🤖 **Assistant**: I will now calculate the new monthly subscription price per tier, which is equal to the new revenue per tier."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Output:\n",
+      "new_monthly_subscription_prices={100: 12.393444444444444, 500: 58.18944444444443, 2000: 229.92444444444442}\n",
+      "Errors:\n",
+      "[No error output]\n",
+      "Logging:\n",
+      "[No logger output]\n"
+     ]
+    }
+   ],
+   "source": [
+    "new_monthly_revenues = {100: 12.393444444444444, 500: 58.18944444444443, 2000: 229.92444444444442}\n",
+    "\n",
+    "new_monthly_subscription_prices = new_monthly_revenues\n",
+    "\n",
+    "print(f\"{new_monthly_subscription_prices=}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "🤖 **Assistant**: I will now present the calculated new monthly subscription prices for each tier."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Output:\n",
+      "New Monthly Subscription Prices (USD):\n",
+      "  Tier 100: $12.39\n",
+      "  Tier 500: $58.19\n",
+      "  Tier 2000: $229.92\n",
+      "Errors:\n",
+      "[No error output]\n",
+      "Logging:\n",
+      "[No logger output]\n"
+     ]
+    }
+   ],
+   "source": [
+    "new_monthly_subscription_prices = {100: 12.393444444444444, 500: 58.18944444444443, 2000: 229.92444444444442}\n",
+    "\n",
+    "print(\"New Monthly Subscription Prices (USD):\")\n",
+    "for tier, price in new_monthly_subscription_prices.items():\n",
+    "    print(f\"  Tier {tier}: ${price:.2f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "🤖 **Assistant**: I will now verify the calculations to ensure accuracy and that the 70% margin is achieved."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Output:\n",
+      "Verification:\n",
+      "  Tier 100: Price = $12.39, Cost = $3.72, Margin = 0.70\n",
+      "  Tier 500: Price = $58.19, Cost = $17.46, Margin = 0.70\n",
+      "  Tier 2000: Price = $229.92, Cost = $68.98, Margin = 0.70\n",
+      "Errors:\n",
+      "[No error output]\n",
+      "Logging:\n",
+      "[No logger output]\n"
+     ]
+    }
+   ],
+   "source": [
+    "updated_monthly_costs = {100: 3.718033333333334, 500: 17.456833333333332, 2000: 68.97733333333333}\n",
+    "new_monthly_subscription_prices = {100: 12.393444444444444, 500: 58.18944444444443, 2000: 229.92444444444442}\n",
+    "margin = 0.70\n",
+    "\n",
+    "print(\"Verification:\")\n",
+    "for tier, price in new_monthly_subscription_prices.items():\n",
+    "    cost = updated_monthly_costs[tier]\n",
+    "    calculated_margin = (price - cost) / price\n",
+    "    print(f\"  Tier {tier}: Price = ${price:.2f}, Cost = ${cost:.2f}, Margin = {calculated_margin:.2f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "👤 **User**: can you please now redo the calculations that you did to get pricing for the 3 tiers at 50, 60, 70, and 80 percent margins?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "🤖 **Assistant**: Here's my plan to calculate the monthly subscription costs for the API tiers at 50%, 60%, 70%, and 80% margins:\n",
+    "\n",
+    "1. **Define the tiers:** Use the existing tiers of 100, 500, and 2000 requests per day.\n",
+    "2. **Define the margins:** Use the requested margins of 50%, 60%, 70%, and 80%.\n",
+    "3. **Retrieve the updated monthly costs:** Access the previously calculated `updated_monthly_costs` for each tier, which includes the cost of goods, support, and lead generation.\n",
+    "4. **Calculate the revenue per tier for each margin:** For each tier and each margin, calculate the revenue needed per month to achieve the specified margin, using the `updated_monthly_costs`.\n",
+    "5. **Calculate the monthly subscription price per tier for each margin:** Set the monthly subscription price equal to the calculated revenue.\n",
+    "6. **Present the results:** Display the calculated monthly subscription prices for each tier and each margin in a clear table format.\n",
+    "7. **Verification:** Double-check the calculations to ensure accuracy and that the specified margins are achieved.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "🤖 **Assistant**: I will now define the tiers to be used in the calculations."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Output:\n",
+      "tiers=[100, 500, 2000]\n",
+      "Errors:\n",
+      "[No error output]\n",
+      "Logging:\n",
+      "[No logger output]\n"
+     ]
+    }
+   ],
+   "source": [
+    "tiers = [100, 500, 2000]\n",
+    "\n",
+    "print(f\"{tiers=}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "🤖 **Assistant**: I will now define the margins to be used in the calculations."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Output:\n",
+      "margins=[0.5, 0.6, 0.7, 0.8]\n",
+      "Errors:\n",
+      "[No error output]\n",
+      "Logging:\n",
+      "[No logger output]\n"
+     ]
+    }
+   ],
+   "source": [
+    "margins = [0.50, 0.60, 0.70, 0.80]\n",
+    "\n",
+    "print(f\"{margins=}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "🤖 **Assistant**: I will now retrieve the updated monthly costs for each tier."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Output:\n",
+      "updated_monthly_costs={100: 3.718033333333334, 500: 17.456833333333332, 2000: 68.97733333333333}\n",
+      "Errors:\n",
+      "[No error output]\n",
+      "Logging:\n",
+      "[No logger output]\n"
+     ]
+    }
+   ],
+   "source": [
+    "updated_monthly_costs = {100: 3.718033333333334, 500: 17.456833333333332, 2000: 68.97733333333333}\n",
+    "\n",
+    "print(f\"{updated_monthly_costs=}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "🤖 **Assistant**: I will now calculate the revenue per tier for each margin."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Output:\n",
+      "revenue_per_tier={100: {0.5: 7.436066666666668, 0.6: 9.295083333333334, 0.7: 12.393444444444444, 0.8: 18.590166666666676}, 500: {0.5: 34.913666666666664, 0.6: 43.642083333333325, 0.7: 58.18944444444443, 0.8: 87.28416666666668}, 2000: {0.5: 137.95466666666667, 0.6: 172.44333333333333, 0.7: 229.92444444444442, 0.8: 344.88666666666677}}\n",
+      "Errors:\n",
+      "[No error output]\n",
+      "Logging:\n",
+      "[No logger output]\n"
+     ]
+    }
+   ],
+   "source": [
+    "tiers = [100, 500, 2000]\n",
+    "margins = [0.50, 0.60, 0.70, 0.80]\n",
+    "updated_monthly_costs = {100: 3.718033333333334, 500: 17.456833333333332, 2000: 68.97733333333333}\n",
+    "\n",
+    "revenue_per_tier = {}\n",
+    "for tier in tiers:\n",
+    "    revenue_per_tier[tier] = {}\n",
+    "    for margin in margins:\n",
+    "        cost = updated_monthly_costs[tier]\n",
+    "        revenue = cost / (1 - margin)\n",
+    "        revenue_per_tier[tier][margin] = revenue\n",
+    "\n",
+    "print(f\"{revenue_per_tier=}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "🤖 **Assistant**: I will now calculate the monthly subscription price per tier for each margin, setting it equal to the calculated revenue."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Output:\n",
+      "monthly_subscription_prices={100: {0.5: 7.436066666666668, 0.6: 9.295083333333334, 0.7: 12.393444444444444, 0.8: 18.590166666666676}, 500: {0.5: 34.913666666666664, 0.6: 43.642083333333325, 0.7: 58.18944444444443, 0.8: 87.28416666666668}, 2000: {0.5: 137.95466666666667, 0.6: 172.44333333333333, 0.7: 229.92444444444442, 0.8: 344.88666666666677}}\n",
+      "Errors:\n",
+      "[No error output]\n",
+      "Logging:\n",
+      "[No logger output]\n"
+     ]
+    }
+   ],
+   "source": [
+    "tiers = [100, 500, 2000]\n",
+    "margins = [0.50, 0.60, 0.70, 0.80]\n",
+    "updated_monthly_costs = {100: 3.718033333333334, 500: 17.456833333333332, 2000: 68.97733333333333}\n",
+    "\n",
+    "revenue_per_tier = {100: {0.5: 7.436066666666668, 0.6: 9.295083333333334, 0.7: 12.393444444444444, 0.8: 18.590166666666676}, 500: {0.5: 34.913666666666664, 0.6: 43.642083333333325, 0.7: 58.18944444444443, 0.8: 87.28416666666668}, 2000: {0.5: 137.95466666666667, 0.6: 172.44333333333333, 0.7: 229.92444444444442, 0.8: 344.88666666666677}}\n",
+    "\n",
+    "monthly_subscription_prices = revenue_per_tier\n",
+    "\n",
+    "print(f\"{monthly_subscription_prices=}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "🤖 **Assistant**: I will now present the calculated monthly subscription prices for each tier and each margin in a clear table format."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Output:\n",
+      "Monthly Subscription Prices (USD):\n",
+      "-------------------------------------------------------------------\n",
+      "| Tier  | 50% Margin | 60% Margin | 70% Margin | 80% Margin |\n",
+      "-------------------------------------------------------------------\n",
+      "| 100   | $7.44       | $9.30       | $12.39      | $18.59      |\n",
+      "| 500   | $34.91      | $43.64      | $58.19      | $87.28      |\n",
+      "| 2000  | $137.95     | $172.44     | $229.92     | $344.89     |\n",
+      "-------------------------------------------------------------------\n",
+      "Errors:\n",
+      "[No error output]\n",
+      "Logging:\n",
+      "[No logger output]\n"
+     ]
+    }
+   ],
+   "source": [
+    "tiers = [100, 500, 2000]\n",
+    "margins = [0.50, 0.60, 0.70, 0.80]\n",
+    "updated_monthly_costs = {100: 3.718033333333334, 500: 17.456833333333332, 2000: 68.97733333333333}\n",
+    "revenue_per_tier = {100: {0.5: 7.436066666666668, 0.6: 9.295083333333334, 0.7: 12.393444444444444, 0.8: 18.590166666666676}, 500: {0.5: 34.913666666666664, 0.6: 43.642083333333325, 0.7: 58.18944444444443, 0.8: 87.28416666666668}, 2000: {0.5: 137.95466666666667, 0.6: 172.44333333333333, 0.7: 229.92444444444442, 0.8: 344.88666666666677}}\n",
+    "\n",
+    "print(\"Monthly Subscription Prices (USD):\")\n",
+    "print(\"-------------------------------------------------------------------\")\n",
+    "print(\"| Tier  | 50% Margin | 60% Margin | 70% Margin | 80% Margin |\")\n",
+    "print(\"-------------------------------------------------------------------\")\n",
+    "for tier in tiers:\n",
+    "    print(f\"| {tier:<5} | ${revenue_per_tier[tier][0.50]:<10.2f} | ${revenue_per_tier[tier][0.60]:<10.2f} | ${revenue_per_tier[tier][0.70]:<10.2f} | ${revenue_per_tier[tier][0.80]:<10.2f} |\")\n",
+    "print(\"-------------------------------------------------------------------\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "🤖 **Assistant**: I will now verify the calculations to ensure accuracy and that the specified margins are achieved."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Output:\n",
+      "Verification:\n",
+      "Tier 100:\n",
+      "  50% Margin: Price = $7.44, Cost = $3.72, Calculated Margin = 0.50\n",
+      "  60% Margin: Price = $9.30, Cost = $3.72, Calculated Margin = 0.60\n",
+      "  70% Margin: Price = $12.39, Cost = $3.72, Calculated Margin = 0.70\n",
+      "  80% Margin: Price = $18.59, Cost = $3.72, Calculated Margin = 0.80\n",
+      "Tier 500:\n",
+      "  50% Margin: Price = $34.91, Cost = $17.46, Calculated Margin = 0.50\n",
+      "  60% Margin: Price = $43.64, Cost = $17.46, Calculated Margin = 0.60\n",
+      "  70% Margin: Price = $58.19, Cost = $17.46, Calculated Margin = 0.70\n",
+      "  80% Margin: Price = $87.28, Cost = $17.46, Calculated Margin = 0.80\n",
+      "Tier 2000:\n",
+      "  50% Margin: Price = $137.95, Cost = $68.98, Calculated Margin = 0.50\n",
+      "  60% Margin: Price = $172.44, Cost = $68.98, Calculated Margin = 0.60\n",
+      "  70% Margin: Price = $229.92, Cost = $68.98, Calculated Margin = 0.70\n",
+      "  80% Margin: Price = $344.89, Cost = $68.98, Calculated Margin = 0.80\n",
+      "Errors:\n",
+      "[No error output]\n",
+      "Logging:\n",
+      "[No logger output]\n"
+     ]
+    }
+   ],
+   "source": [
+    "tiers = [100, 500, 2000]\n",
+    "margins = [0.50, 0.60, 0.70, 0.80]\n",
+    "updated_monthly_costs = {100: 3.718033333333334, 500: 17.456833333333332, 2000: 68.97733333333333}\n",
+    "revenue_per_tier = {100: {0.5: 7.436066666666668, 0.6: 9.295083333333334, 0.7: 12.393444444444444, 0.8: 18.590166666666676}, 500: {0.5: 34.913666666666664, 0.6: 43.642083333333325, 0.7: 58.18944444444443, 0.8: 87.28416666666668}, 2000: {0.5: 137.95466666666667, 0.6: 172.44333333333333, 0.7: 229.92444444444442, 0.8: 344.88666666666677}}\n",
+    "\n",
+    "print(\"Verification:\")\n",
+    "for tier in tiers:\n",
+    "    print(f\"Tier {tier}:\")\n",
+    "    for margin in margins:\n",
+    "        price = revenue_per_tier[tier][margin]\n",
+    "        cost = updated_monthly_costs[tier]\n",
+    "        calculated_margin = (price - cost) / price\n",
+    "        print(f\"  {int(margin*100)}% Margin: Price = ${price:.2f}, Cost = ${cost:.2f}, Calculated Margin = {calculated_margin:.2f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8e5d7439",
+   "metadata": {},
+   "source": [
+    "👤 **User**: save this conversation to a new agent called marginbot"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "🤖 **Assistant**: I will now save this conversation to a new agent called marginbot."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Output:\n",
+      "[No output]\n",
+      "Errors:\n",
+      "[No error output]\n",
+      "Logging:\n",
+      "[No logger output]\n"
+     ]
+    }
+   ],
+   "source": [
+    "agent_name = \"marginbot\"\n",
+    "tools.create_agent_from_conversation(name=agent_name)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "👤 **User**: please save a notebook from this conversation"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.x"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/local_operator/cli.py
+++ b/local_operator/cli.py
@@ -477,7 +477,7 @@ def main() -> int:
 
         executor = LocalCodeExecutor(
             model_configuration=model_configuration,
-            detail_conversation_length=config_manager.get_config_value("detail_length", 10),
+            detail_conversation_length=config_manager.get_config_value("detail_length", 35),
             max_conversation_history=config_manager.get_config_value(
                 "max_conversation_history", 100
             ),

--- a/local_operator/config.py
+++ b/local_operator/config.py
@@ -91,8 +91,8 @@ DEFAULT_CONFIG = Config(
         },
         "values": {
             "conversation_length": 100,
-            "detail_length": 25,
-            "max_learnings_history": 100,
+            "detail_length": 35,
+            "max_learnings_history": 50,
             "hosting": "",
             "model_name": "",
         },

--- a/local_operator/prompts.py
+++ b/local_operator/prompts.py
@@ -374,7 +374,7 @@ and </response_format> tags.
   "if applicable.  Be specific and include information that will prevent you from "
   "repeating errors.  Empty for the first step.",
   "previous_goal": "Your goal from the previous step.  Empty for the first step.",
-  "learnings": "Aggregated information learned so far from previous steps.  Include
+  "learnings": "Important information learned from the previous step.  Include
   detailed information that will help you in future steps.  Ensure that this
   contains useful insights as opposed to simply being anccounting of actions.
   Empty for the first step.",
@@ -391,7 +391,7 @@ and </response_format> tags.
       "find": "Required for EDIT: the string to find",
       "replace": "Required for EDIT: the string to replace it with"
     }
-  ], // Only include if the action is EDIT
+  ], // Empty array unless the action is EDIT
   "action": "RESEARCH | CODE | READ | WRITE | EDIT | DONE | ASK | BYE"
 }
 </response_format>

--- a/local_operator/prompts.py
+++ b/local_operator/prompts.py
@@ -131,6 +131,10 @@ Core Principles:
 - 🐍 Write Python code for code actions in the style of Jupyter Notebook cells.  Use
   print() to the console to output the results of the code.  Ensure that the output
   can be captured when the system runs exec() on your code.
+- 📦 Write modular code with well-defined, reusable components. Break complex calculations
+  into smaller, named variables that can be easily modified and reassembled if the user
+  requests changes or recalculations. Focus on making your code replicable, maintainable,
+  and easy to understand.
 - 🖥️ You are in a Python interpreter environment similar to a Jupyter Notebook. You will
   be shown the variables in your context, the files in your working directory, and other
   relevant context at each step.  Use variables from previous steps and don't repeat work
@@ -432,7 +436,11 @@ code:
 - Create a validation plan for how you will check that each step is successful
   and that the overall goal is achieved at the end.  This should be a list of
   checks that you will perform to verify that the goal is achieved once you
-  complete the initial execution plan.
+  complete the initial execution plan.  Always double-check your work and verify
+- Plan to make your code modular, reusable, and replicable.  You should be able to
+  reanalyze and use parts of your completed work if the user asks you to change
+  something later
+- Plan contingencies for if the user asks for you to re-do the work
 
 Present the plan in a clear and detailed manner.  Be specific and include all the
 details and data you will need to verify that the goal is achieved.

--- a/local_operator/prompts.py
+++ b/local_operator/prompts.py
@@ -402,7 +402,13 @@ Given the above information about how you will need to operate in execution mode
 brainstorm, think, and respond with a detailed plan of actions to achieve the
 user's most recent request in the conversation.
 
-The plan should be a detailed list of steps that are logical and will achieve the goal.
+First, determine if you need to plan at all.  Some tasks that require a single step
+or a simple console command can be performed without planning.  If you determine
+that planning is not needed, respond with "[SKIP_PLANNING]" and we will continue to
+execution.
+
+If planning is needed, respond with a detailed list of steps that are logical and will
+achieve the goal.
 Pay close attention to the user's request and the information provided to you.
 Only include steps that are necessary to achieve the goal to its fullest extent.
 Be specific, and include any files, queries, and other details that will be needed
@@ -427,6 +433,16 @@ details and data you will need to verify that the goal is achieved.
 
 Only respond with natural language, and do not include any JSON or code.  You will be
 asked to generate code and perform actions in subsequent steps.
+"""
+
+PlanUserPrompt: str = """
+Determine if planning is required.  If not required, then respond with "[SKIP_PLANNING]".
+
+If planning is required, then please come up with a detailed writeup for a plan of actions
+to achieve the goal for the user's recent request before proceeding with the execution phase.
+Your plan will be used to perform actions in the next steps. Respond in natural language
+format, not JSON or code. Keep in mind that the user might change directions with their
+request, so determine if you need to be planning for the same goal or a new one.
 """
 
 SafetyCheckSystemPrompt: str = """

--- a/local_operator/prompts.py
+++ b/local_operator/prompts.py
@@ -341,6 +341,9 @@ Critical Constraints:
   meaningfully better improvement over the last with new techniques and approaches.
 - Use await for async functions.  Never call `asyncio.run()`, as this is already handled
   for you in the runtime and the code executor.
+- You cannot "see" plots and figures, do not attempt to use them in your own analysis.
+  Create them for the user's benefit to help them understand your thinking, but your
+  analysis must be based on text and data alone.
 
 Response Format:
 {response_format}
@@ -374,13 +377,16 @@ and </response_format> tags.
   "if applicable.  Be specific and include information that will prevent you from "
   "repeating errors.  Empty for the first step.",
   "previous_goal": "Your goal from the previous step.  Empty for the first step.",
-  "learnings": "Aggregated information learned so far from previous steps.  Include
+  "learnings": "Important new information learned from the previous step.  Include
   detailed information that will help you in future steps.  Ensure that this
   contains useful insights as opposed to simply being anccounting of actions.
   Empty for the first step.",
   "current_goal": "Your goal for the current step.",
-  "next_goal": "Your goal for the next step",
-  "response": "Natural language response to the user's goal",
+  "next_goal": "Your goal for the next step.  This should move you forward in the plan,
+  address an error, or otherwise be an improvement over the last action.",
+  "response": "Natural language response to the user's goal.  Explain what you are
+  doing, and summarize the results of the previous step.  Include a detailed summary of
+  the final results and/or response to the user for DONE actions.",
   "code": "Required for CODE: code to achieve the user's goal, must be
   valid Python code.  Do not provide for WRITE or EDIT",
   "content": "Required for WRITE: content to write to a file, if applicable.

--- a/local_operator/prompts.py
+++ b/local_operator/prompts.py
@@ -374,7 +374,7 @@ and </response_format> tags.
   "if applicable.  Be specific and include information that will prevent you from "
   "repeating errors.  Empty for the first step.",
   "previous_goal": "Your goal from the previous step.  Empty for the first step.",
-  "learnings": "Important information learned from the previous step.  Include
+  "learnings": "Aggregated information learned so far from previous steps.  Include
   detailed information that will help you in future steps.  Ensure that this
   contains useful insights as opposed to simply being anccounting of actions.
   Empty for the first step.",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.3.4"
+version = "0.3.5"
 description = "A Python-based agent for local command execution"
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damianvtran@gmail.com" }]


### PR DESCRIPTION
# PR Description

## Summary of Changes

The key change is the capability of agents to skip planning for simple tasks and save time.

- This PR introduces a new example notebook `business_pricing_margin.ipynb` that demonstrates how to use Local Operator to calculate business pricing and margins. 
- Updates the `detail_length` and `max_learnings_history` in `local_operator/config.py` and `local_operator/cli.py` to improve the agent's planning and learning capabilities
- Modifies `local_operator/operator.py` and `local_operator/prompts.py` to skip planning when appropriate.

## Related Issue(s)

- NA

## Impact

- Improves the agent's planning and learning capabilities to not waste tokens planning for simple tasks
- Improvements to agent behaviour by updating instructions for code modularity in the main system prompt
- There are no breaking changes.
- There are no dependency updates.
- There are no performance or security implications.

## Testing Details

- The new notebook was tested by running it and verifying the results.
- The changes to the agent's planning and learning capabilities were tested by running several conversations and verifying that the agent is able to plan and learn effectively.

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my changes work as intended.
- [x] All new and existing tests pass.
- [x] I have run formatting (black/isort), linting (flake8), and type checks (pyright), and they pass.
- [x] I have updated the documentation when required.
- [x] Security considerations are addressed (especially for code execution features).
- [x] I have linked all related issues.

## Screenshots (Optional)
If applicable, please attach screenshots that illustrate the changes or new features.