### PR TITLE
fix: improve agent context serialization, reduce detail length, and bump version to 0.11.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,7 @@ jobs:
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
         run: |
           # Run CLI to create test file
-          local-operator --hosting openrouter --model google/gemini-2.0-flash-001 exec "create a file called test.txt with the text 'hello world' in it" || exit 1
+          local-operator --hosting openrouter --model google/gemini-2.5-flash-preview exec "create a file called test.txt with the text 'hello world' in it" || exit 1
 
           # Check if file exists and contains correct text
           if [ ! -f test.txt ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,7 +186,7 @@ jobs:
             -d '{
               "prompt": "create a file called test.txt with the text '\''hello world'\'' in it",
               "hosting": "openrouter",
-              "model": "google/gemini-2.0-flash-001",
+              "model": "google/gemini-2.5-flash-preview",
               "context": [],
               "options": {
                 "temperature": 0.7,

--- a/local_operator/agents.py
+++ b/local_operator/agents.py
@@ -840,7 +840,8 @@ class AgentRegistry:
 
         This method serializes the agent's context using dill and saves it to a file
         named "context.pkl" in the agent's directory. It handles unpicklable objects
-        by converting them to a serializable format, including Pydantic models and modules.
+        by converting them to a serializable format, including Pydantic
+        models, modules, and builtins.
 
         Args:
             agent_id (str): The unique identifier of the agent.
@@ -858,26 +859,39 @@ class AgentRegistry:
             agent_dir.mkdir(parents=True, exist_ok=True)
 
         context_file = agent_dir / "context.pkl"
+        tmp_context_file = agent_dir / "context.pkl.tmp"
 
         def convert_unpicklable(obj: Any) -> Any:
+            # Handle Pydantic models
             if isinstance(obj, BaseModel):
-                # Convert Pydantic models to dictionaries
                 return {
                     "__pydantic_model__": obj.__class__.__module__ + "." + obj.__class__.__name__,
                     "data": convert_unpicklable(obj.model_dump()),
                 }
+            # Skip builtins (enumerate, range, etc.)
+            elif (
+                type(obj).__module__ == "builtins"
+                and isinstance(obj, object)
+                and not isinstance(obj, (int, float, str, bool, type(None), list, tuple, dict))
+            ):
+                # Do not store builtins in context
+                return None
             elif isinstance(obj, dict):
                 result = {}
                 for k, v in obj.items():
                     try:
-                        # Skip keys that can't be pickled instead of converting to strings
                         dill.dumps(k)
-                        result[k] = convert_unpicklable(v)
+                        v_converted = convert_unpicklable(v)
+                        if v_converted is not None:
+                            result[k] = v_converted
                     except Exception:
                         pass
                 return result
             elif isinstance(obj, (list, tuple)):
-                return type(obj)(convert_unpicklable(x) for x in obj)
+                # Omit None values (skipped builtins)
+                items = [convert_unpicklable(x) for x in obj]
+                items = [x for x in items if x is not None]
+                return type(obj)(items)
             elif isinstance(obj, (int, float, str, bool, type(None))):
                 return obj
             elif hasattr(obj, "__iter__") and hasattr(obj, "__next__"):
@@ -897,8 +911,11 @@ class AgentRegistry:
                     logging.warning(f"Failed to pickle function {obj.__name__}: {str(e)}")
                     return str(obj)
             else:
-                dill.dumps(obj)
-                return obj
+                try:
+                    dill.dumps(obj)
+                    return obj
+                except Exception:
+                    return str(obj)
 
         try:
             # Make a copy to avoid modifying the original
@@ -913,8 +930,10 @@ class AgentRegistry:
 
             serializable_context = convert_unpicklable(context_copy)
 
-            with context_file.open("wb") as f:
+            # Write atomically: write to temp file, then move
+            with tmp_context_file.open("wb") as f:
                 dill.dump(serializable_context, f)
+            tmp_context_file.replace(context_file)
         except Exception as e:
             logging.error(f"Failed to save agent context: {str(e)}")
 
@@ -923,7 +942,7 @@ class AgentRegistry:
 
         This method deserializes the agent's context using dill from a file
         named "context.pkl" in the agent's directory. It handles the reconstruction
-        of serialized Pydantic models, modules, and other transformed objects.
+        of serialized Pydantic models, modules, builtins, and other transformed objects.
 
         Args:
             agent_id (str): The unique identifier of the agent.
@@ -971,11 +990,19 @@ class AgentRegistry:
                     logging.error(f"Failed to reconstruct callable function: {str(e)}")
                     return None
             elif isinstance(obj, dict):
-                return {k: reconstruct_objects(v) for k, v in obj.items()}
+                # Remove any keys whose value is None (i.e., skipped builtins)
+                return {
+                    k: v
+                    for k, v in ((k, reconstruct_objects(v)) for k, v in obj.items())
+                    if v is not None
+                }
             elif isinstance(obj, list):
-                return [reconstruct_objects(item) for item in obj]
+                # Remove None values (skipped builtins)
+                return [item for item in (reconstruct_objects(i) for i in obj) if item is not None]
             elif isinstance(obj, tuple):
-                return tuple(reconstruct_objects(item) for item in obj)
+                return tuple(
+                    item for item in (reconstruct_objects(i) for i in obj) if item is not None
+                )
             else:
                 try:
                     return dill.loads(obj)

--- a/local_operator/agents.py
+++ b/local_operator/agents.py
@@ -869,10 +869,16 @@ class AgentRegistry:
             elif isinstance(obj, dict):
                 result = {}
                 for k, v in obj.items():
+                    # skip any built-in function or built-in class (always available in context)
+                    if (
+                        inspect.isbuiltin(v) or inspect.isroutine(v) or inspect.isclass(v)
+                    ) and getattr(v, "__module__", None) == "builtins":
+                        continue
                     try:
-                        # Skip keys that can't be pickled instead of converting to strings
                         dill.dumps(k)
-                        result[k] = convert_unpicklable(v)
+                        converted = convert_unpicklable(v)
+                        if converted is not None:
+                            result[k] = converted
                     except Exception:
                         pass
                 return result

--- a/local_operator/bootstrap.py
+++ b/local_operator/bootstrap.py
@@ -233,7 +233,7 @@ def initialize_operator(
     executor = LocalCodeExecutor(
         model_configuration=model_configuration,
         max_conversation_history=config_manager.get_config_value("max_conversation_history", 100),
-        detail_conversation_length=config_manager.get_config_value("detail_length", 35),
+        detail_conversation_length=config_manager.get_config_value("detail_length", 20),
         max_learnings_history=config_manager.get_config_value("max_learnings_history", 50),
         can_prompt_user=(operator_type == OperatorType.CLI),  # Only CLI can prompt
         agent=current_agent,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.11.0"
+version = "0.11.1"
 description = "A Python-based agent for local command execution"
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@local-operator.com" }]

--- a/tests/unit/test_agents.py
+++ b/tests/unit/test_agents.py
@@ -1119,8 +1119,9 @@ def test_save_and_load_agent_context(temp_agents_dir: Path):
         "nested": {"tools": {"should_be_saved": True}},  # This should be saved (nested)
         "os": os,
         "requests": requests,
-        # "builtin_enumerate": enumerate,
-        # "builtin_range": range,
+        "builtin_enumerate": enumerate,
+        "builtin_range": range,
+        "builtin_zip": zip,
     }
 
     # Save the context
@@ -1156,6 +1157,7 @@ def test_save_and_load_agent_context(temp_agents_dir: Path):
     assert "ssl_context" not in loaded_context
     assert "builtin_enumerate" not in loaded_context
     assert "builtin_range" not in loaded_context
+    assert "builtin_zip" not in loaded_context
 
     # Verify top-level "tools" key is not saved
     assert "tools" not in loaded_context

--- a/tests/unit/test_agents.py
+++ b/tests/unit/test_agents.py
@@ -1122,6 +1122,7 @@ def test_save_and_load_agent_context(temp_agents_dir: Path):
         "builtin_enumerate": enumerate,
         "builtin_range": range,
         "builtin_zip": zip,
+        "empty_value": None,
     }
 
     # Save the context
@@ -1158,6 +1159,7 @@ def test_save_and_load_agent_context(temp_agents_dir: Path):
     assert "builtin_enumerate" not in loaded_context
     assert "builtin_range" not in loaded_context
     assert "builtin_zip" not in loaded_context
+    assert "empty_value" not in loaded_context
 
     # Verify top-level "tools" key is not saved
     assert "tools" not in loaded_context

--- a/tests/unit/test_agents.py
+++ b/tests/unit/test_agents.py
@@ -1119,6 +1119,8 @@ def test_save_and_load_agent_context(temp_agents_dir: Path):
         "nested": {"tools": {"should_be_saved": True}},  # This should be saved (nested)
         "os": os,
         "requests": requests,
+        # "builtin_enumerate": enumerate,
+        # "builtin_range": range,
     }
 
     # Save the context
@@ -1152,6 +1154,8 @@ def test_save_and_load_agent_context(temp_agents_dir: Path):
     assert loaded_context["generator"] == [0, 1, 2, 3, 4]
 
     assert "ssl_context" not in loaded_context
+    assert "builtin_enumerate" not in loaded_context
+    assert "builtin_range" not in loaded_context
 
     # Verify top-level "tools" key is not saved
     assert "tools" not in loaded_context


### PR DESCRIPTION
# PR Description

## Summary of Changes

This PR introduces the following changes:
- Improves agent context serialization by skipping built-in functions/classes and empty values in `local_operator/agents.py`.
- Changes the default `detail_conversation_length` from 35 to 20 in `local_operator/bootstrap.py`.
- Bumps the project version from 0.11.0 to 0.11.1 in `pyproject.toml`.
- Updates unit tests in `tests/unit/test_agents.py` to cover new context handling logic.

## Related Issue(s)

- Related: #... _(Please link if applicable)_

## Impact

- No breaking changes.
- Improves reliability of agent context persistence.
- Minor configuration and version update.
- No dependency updates beyond version bump.
- No known security or performance regressions.

## Testing Details

- Updated and ran unit tests for agent context serialization.
- Manual verification of agent context save/load and conversation detail length.

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my changes work as intended.
- [x] All new and existing tests pass.
- [x] I have run formatting (black/isort), linting (flake8), and type checks (pyright), and they pass.
- [x] I have updated the documentation when required.
- [x] Security considerations are addressed (especially for code execution features).
- [x] I have linked all related issues.

## Screenshots (Optional)

If applicable, please attach screenshots that illustrate the changes or new features.
