### PR TITLE
fix(compaction,subagents): cap default threshold; advertise task/wait/jobs; inherit budget into children

### DIFF
--- a/docs/REWRITE.md
+++ b/docs/REWRITE.md
@@ -204,11 +204,16 @@ Skills (deliberate design choices, user-requested):
   else context-full.
   - **Default threshold**: the lesser of 80% of the model context window and
     600,000 tokens (user-configurable via `values.compaction.threshold_tokens`
-    / `threshold_percent`).
+    / `threshold_percent`), and additionally capped by
+    `values.compaction.max_threshold_tokens` (default 600_000) — a defensive
+    ceiling for providers that advertise a window far larger than the serving
+    path sustains (a 1.05M-advertised model whose requests start aborting
+    around 250k is the case that motivated it; set it to your proxy's real
+    ceiling and long sessions compact before the stall point).
   - Settings in config.yml `values.compaction.*`: enabled (true),
     strategy (auto), reserve_tokens (16384), keep_recent_tokens (20000),
-    threshold_percent (-1), threshold_tokens (-1), auto_continue (true),
-    mid_turn_enabled (true).
+    threshold_percent (-1), threshold_tokens (-1), max_threshold_tokens
+    (600000), auto_continue (true), mid_turn_enabled (true).
   - `should_compact`/`resolve_threshold_tokens` math;
     `COMPACTION_RECOVERY_BAND = 0.8`.
   - `find_cut_point`: walk backwards accumulating estimated tokens, never cut

--- a/local_operator/compaction/pruning.py
+++ b/local_operator/compaction/pruning.py
@@ -169,6 +169,32 @@ def _supersede_path_range(message: Message) -> tuple[str, str | None] | None:
     return None
 
 
+def _span_of(
+    path_range: tuple[str, str | None],
+) -> tuple[str, tuple[int, int]] | None:
+    """``(path, (start, end))`` for a ranged read, or None for full/non-file.
+
+    ``range`` is a 1-based inclusive ``"start-end"`` (or ``"start-"``). A
+    ``None`` or ``"full"`` range is a full read (handled by the full-path
+    supersede, not here). Any unparsable range degrades to None: an
+    unreadable spec must not blank a real read on a guess.
+    """
+    path, spec = path_range
+    if not spec or spec == "full":
+        return None
+    try:
+        start_s, sep, end_s = spec.partition("-")
+        start = int(start_s)
+        if not sep:
+            return None
+        end = int(end_s) if end_s.strip() else None
+    except (TypeError, ValueError):
+        return None
+    if start < 1 or (end is not None and end < start):
+        return None
+    return path, (start, end if end is not None else start)
+
+
 def _blank(message: Message, notice: str) -> None:
     """Replace ``message`` content with ``notice`` and mark it pruned.
 
@@ -213,8 +239,15 @@ def prune_tool_outputs(
     # Pass (a): superseded reads. Walk newest-to-oldest; a seen key marks any
     # earlier result with the same key superseded, and a seen FULL read marks
     # any earlier RANGED read of the same path superseded (never the reverse).
+    # A seen ranged read ALSO supersedes an earlier ranged read of the same
+    # path whose span it fully covers — the model pages through a large file
+    # in overlapping chunks (read 162-500, then 540-900, ...), and without
+    # coverage supersede every chunk stays live, burning the whole file into
+    # context N times. Coverage, not mere adjacency: a later read only blanks
+    # an earlier one it genuinely includes.
     seen_keys: set[str] = set()
     seen_full_paths: set[str] = set()
+    seen_covered_spans: dict[str, list[tuple[int, int]]] = {}
     superseded: list[int] = []
     for i in range(len(messages) - 1, -1, -1):
         message = messages[i]
@@ -228,16 +261,26 @@ def prune_tool_outputs(
         if key is None:
             continue
         path_range = _supersede_path_range(message)
+        span = _span_of(path_range) if path_range is not None else None
         is_superseded = key in seen_keys or (
             path_range is not None
             and path_range[1] is not None
             and path_range[0] in seen_full_paths
         )
+        if not is_superseded and span is not None:
+            path, (start, end) = span
+            for later_start, later_end in seen_covered_spans.get(path, []):
+                if start >= later_start and end <= later_end:
+                    is_superseded = True
+                    break
         if is_superseded:
             superseded.append(i)
         seen_keys.add(key)
         if path_range is not None and path_range[1] is None:
             seen_full_paths.add(path_range[0])
+        elif span is not None:
+            path, (start, end) = span
+            seen_covered_spans.setdefault(path, []).append((start, end))
 
     # Pass (b): useless-flagged results (excluding supersede victims).
     superseded_set = set(superseded)

--- a/local_operator/compaction/thresholds.py
+++ b/local_operator/compaction/thresholds.py
@@ -85,6 +85,18 @@ class CompactionSettings(BaseModel):
     threshold_tokens: int = Field(
         default=-1, description="Explicit token trigger; > 0 wins over percent."
     )
+    max_threshold_tokens: int = Field(
+        default=600_000,
+        description=(
+            "Ceiling on the RESOLVED default threshold when no explicit trigger"
+            " is set. Providers routinely advertise a context window far larger"
+            " than the aggregate serving path can actually sustain (a 1.05M"
+            " advertisement whose requests start aborting around 250k is the"
+            " case that motivated this knob), and the default threshold of"
+            " min(window*0.8, 600k) inherits the advertisement's optimism. This"
+            " caps the threshold before that optimism reaches the trigger math."
+        ),
+    )
     auto_continue: bool = Field(
         default=True,
         description="Schedule a continuation prompt after a successful post-turn pass.",
@@ -146,7 +158,11 @@ def resolve_threshold_tokens(window_tokens: int, settings: CompactionSettings) -
        - defaulted reserve that is impossible for this window — the 15%
          proportional recovery (same clamp);
        - defaulted reserve, feasible window — the docs/REWRITE.md §C default:
-         ``clamp(min(int(w * 0.8), 600_000), 1, w - 1)``.
+         ``clamp(min(int(w * 0.8), 600_000, max_threshold_tokens), 1, w - 1)``;
+         the ``max_threshold_tokens`` tail caps a provider-advertised window
+         whose practical serving ceiling is far lower than the raw
+         advertisement (the LO-on-LO session that stalled at ~250k on a
+         1.05M-advertised model motivated it).
     """
     if window_tokens <= 0:
         return 0
@@ -163,7 +179,9 @@ def resolve_threshold_tokens(window_tokens: int, settings: CompactionSettings) -
     if effective >= window_tokens - proportional or effective >= window_tokens:
         # Defaulted reserve is impossible for this window: 15% recovery.
         return max(1, min(window_tokens - proportional, window_tokens - 1))
-    default_threshold = min(int(window_tokens * 0.8), DEFAULT_THRESHOLD_CAP_TOKENS)
+    default_threshold = min(
+        int(window_tokens * 0.8), DEFAULT_THRESHOLD_CAP_TOKENS, settings.max_threshold_tokens
+    )
     return max(1, min(default_threshold, window_tokens - 1))
 
 

--- a/local_operator/harness/subagent.py
+++ b/local_operator/harness/subagent.py
@@ -322,8 +322,13 @@ async def _build_child_session(
         # requests / 1.5M tokens before its default (600k-cap) threshold
         # ever fired — the CAP the parent's operator set must bound the child
         # too, or a delegated task silently bypasses the very knob that keeps
-        # long sessions alive.
-        compaction_settings=parent_session._compaction_settings,
+        # long sessions alive. Defensively COPIED so the child can never
+        # mutate the parent's settings (they are logically separate).
+        compaction_settings=(
+            parent_session._compaction_settings.model_copy()
+            if parent_session._compaction_settings is not None
+            else None
+        ),
     )
     await child.async_init()
     return child

--- a/local_operator/harness/subagent.py
+++ b/local_operator/harness/subagent.py
@@ -22,10 +22,13 @@ the factory: the factory needs the three legacy managers plus an argparse
 namespace to resolve hosting/model/skills, none of which a child needs — the
 child inherits the parent's model and STREAM FN (the parent's shared httpx
 pool serves any spec, so a ``model_spec`` override works through the same
-pipe), the parent's cwd, and the parent's approval handler. What it does NOT
-inherit: yolo (always False — the child goes through the same approval gate
+pipe), the parent's cwd, the parent's approval handler, and the parent's
+compaction settings (a one-shot child was assumed too short to need them,
+but a real review child ran 48 requests / 1.5M tokens — a delegated task
+must not bypass the operator's compaction cap). What it does NOT inherit:
+yolo (always False — the child goes through the same approval gate
 as the parent, never around it), skills (a per-launch selection pass would
-make spawning expensive and flaky), compaction (children are one-shot), and
+make spawning expensive and flaky), and
 the subagent launcher itself (children are one level deep: a grandchild
 would register on the CHILD's job manager where no panel looks).
 
@@ -314,6 +317,13 @@ async def _build_child_session(
         has_ui=parent_session._has_ui,
         cwd=cwd,
         request_approval=request_approval,
+        # The parent's compaction budget. A one-shot child was assumed to be
+        # too short to need compaction, but a real review child ran 48
+        # requests / 1.5M tokens before its default (600k-cap) threshold
+        # ever fired — the CAP the parent's operator set must bound the child
+        # too, or a delegated task silently bypasses the very knob that keeps
+        # long sessions alive.
+        compaction_settings=parent_session._compaction_settings,
     )
     await child.async_init()
     return child

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -920,8 +920,18 @@ class Session:
         if strategy == "off":
             return
         if settings.threshold_tokens <= 0 and settings.threshold_percent <= 0:
-            default_threshold = min(int(self._model.context_window * 0.8), 600_000)
-            settings = settings.model_copy(update={"threshold_tokens": default_threshold})
+            # Resolve through the API so the §C default, the 600k absolute cap
+            # AND the max_threshold_tokens defensive ceiling stay in ONE
+            # place (this path used to clone the formula and silently dropped
+            # the cap, so a session on a provider advertising a huge window
+            # never compacted until it stalled).
+            settings = settings.model_copy(
+                update={
+                    "threshold_tokens": compaction_api.resolve_threshold_tokens(
+                        self._model.context_window, settings
+                    )
+                }
+            )
 
         llm_history = self._convert_to_llm(list(self._context.messages))
 

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -351,6 +351,50 @@ class Session:
         # the agent could never close. dispose() closes whatever is still open.
         self._browser = BrowserSurface()
 
+        # Session-capability tools (task/wait/jobs) are createIf-gated on the
+        # ToolContext fields only a SESSION can provide (subagent_launcher,
+        # jobs, wake_scheduler). The factory that built this session constructs
+        # its inventory from a context WITHOUT those fields, so the three
+        # tools silently never advertise — the model cannot delegate even
+        # though the engine fully supports it (reproduced live: 144 requests,
+        # 4M input tokens, zero task calls). Merge them in now that the
+        # session's own context exists.
+        self._merge_capability_tools()
+
+    def _merge_capability_tools(self) -> None:
+        """Add the tools gated on this session's own capabilities.
+
+        ``create_tools`` is createIf-driven: a builder returns ``None`` unless
+        the ToolContext carries what the tool needs. The factory context has
+        no ``subagent_launcher``/``jobs``/``wake_scheduler`` (they are
+        session-owned), so ``task``/``wait``/``jobs`` (and any future
+        session-gated tool) never reached the inventory. Re-running the same
+        builders against ``self._build_tool_context()`` yields exactly those
+        tools; merge them (replacing same-named placeholders) so the model's
+        tool surface reflects what this session can actually do.
+        """
+        try:
+            from local_operator.tools.registry import create_tools
+
+            capability = create_tools(
+                self._build_tool_context(),
+                enabled=("task", "wait", "jobs", "wake"),
+            )
+        except Exception:  # tooling must never break session construction
+            return
+        if not capability:
+            return
+        by_name = {tool.name: tool for tool in capability}
+        merged = list(self._tools)
+        seen = {tool.name for tool in merged}
+        for name, tool in by_name.items():
+            if name in seen:
+                merged = [tool if t.name == name else t for t in merged]
+            else:
+                merged.append(tool)
+        self._tools = merged
+        self._context.tools = merged
+
     async def async_init(self) -> None:
         """Async second half of construction.
 

--- a/local_operator/session_factory.py
+++ b/local_operator/session_factory.py
@@ -707,8 +707,12 @@ async def wire_mcp_into_session(
        returns ``(manager, tools, errors)``. Tools include deferred ones
        that await their connection inside ``execute`` (established semantics).
     2. Merge into the live inventory via ``session.refresh_tools`` — the
-       committed hook: full merged set (builtins + MCP), effective from the
-       next model call, even mid-turn.
+       committed hook: full merged set (builtins + capabilities + MCP),
+       effective from the next model call, even mid-turn. The merge BASE is
+       the session's own construction-time inventory (``session._tools``,
+       which carries the session-capability tools like task/wait/jobs that
+       the factory list predates); ``builtin_tools`` is only a fallback for
+       a host that constructed the session with an empty inventory.
     3. ``manager.set_on_tools_changed`` re-merges on server
        connect/disconnect/list-changed so the inventory tracks MCP state.
     4. Record the structured outcome on ``session.mcp_startup`` so a front end
@@ -799,14 +803,24 @@ async def wire_mcp_into_session(
         tool_count=len(mcp_tools),
     )
 
-    merged = list(builtin_tools) + list(mcp_tools)
+    # The NON-MCP base for every MCP merge: the session's construction-time
+    # inventory (builtins + session-capability tools like task/wait/jobs/wake).
+    # The factory's `builtin_tools` argument predates the capability merge, so
+    # it must not be the base — that is the MCP-20 wipe bug (a refresh dropped
+    # task/wait/jobs the moment MCP changed). Snapshot it BEFORE the first MCP
+    # merge adds MCP tools, so the callback below stays free of old MCP rows.
+    base_inventory = list(
+        getattr(session, "_tools", None) or getattr(session, "tools", None) or builtin_tools
+    )
+
+    merged = list(base_inventory) + list(mcp_tools)
     if mcp_tools:
         session.refresh_tools(merged)
 
     def on_tools_changed(new_mcp_tools: list[AgentTool]) -> None:
         # The manager's callback type tolerates sync handlers; refresh_tools
         # is the atomic swap point (loop re-reads the inventory per call).
-        session.refresh_tools(list(builtin_tools) + list(new_mcp_tools))
+        session.refresh_tools(list(base_inventory) + list(new_mcp_tools))
 
     manager.set_on_tools_changed(on_tools_changed)
     return manager

--- a/tests/unit/compaction/test_pruning.py
+++ b/tests/unit/compaction/test_pruning.py
@@ -212,3 +212,48 @@ def test_suffix_tokens_strictly_after():
     assert suffix[2] == 0
     assert suffix[1] == estimate_tokens(c)
     assert suffix[0] == estimate_tokens(b) + estimate_tokens(c)
+
+
+def _ranged_read(path: str, range_spec: str, words: int = 120) -> Message:
+    """A ranged read result (details carry path + range, like the real tool)."""
+    message = Message(role="tool", tool_call_id=f"call-{path}-{range_spec}", tool_name="read")
+    message.content = Message.user(f"content of {path}[{range_spec}] " + "data " * words).content
+    message.provider_payload = {"details": {"path": path, "range": range_spec}}
+    return message
+
+
+def test_nested_range_read_supersedes_the_covered_earlier_range():
+    """A later range that fully covers an earlier range of the same file
+    blanks the earlier result — the model's re-read of a span already served."""
+    covered = _ranged_read("/repo/a.py", "100-500")
+    messages = [covered, _ranged_read("/repo/a.py", "1-800")]
+    out, changed = prune_tool_outputs(messages, NOW, ACTIVE)
+    assert changed is True
+    assert covered.text == SUPERSEDED_NOTICE
+    assert out[1].text.startswith("content of /repo/a.py[1-800]")
+
+
+def test_adjacent_and_partial_overlap_ranges_are_both_kept():
+    """Paging ranges (1-500 then 501-900) and partial overlaps (100-400 then
+    300-700) carry distinct content — neither must be blanked."""
+    a = _ranged_read("/repo/a.py", "1-500")
+    b = _ranged_read("/repo/a.py", "501-900")
+    out, changed = prune_tool_outputs([a, b], NOW, ACTIVE)
+    assert changed is False
+    assert a.text.startswith("content of /repo/a.py[1-500]")
+    assert b.text.startswith("content of /repo/a.py[501-900]")
+
+    c = _ranged_read("/repo/a.py", "100-400")
+    d = _ranged_read("/repo/a.py", "300-700")
+    out2, changed2 = prune_tool_outputs([c, d], NOW, ACTIVE)
+    assert changed2 is False
+    assert c.text.startswith("content of /repo/a.py[100-400]")
+
+
+def test_identical_ranged_read_is_superseded_like_identical_full():
+    """The identical-key supersede still applies to ranged reads."""
+    first = _ranged_read("/repo/a.py", "100-500")
+    messages = [first, _ranged_read("/repo/a.py", "100-500")]
+    out, changed = prune_tool_outputs(messages, NOW, ACTIVE)
+    assert changed is True
+    assert first.text == SUPERSEDED_NOTICE

--- a/tests/unit/compaction/test_thresholds.py
+++ b/tests/unit/compaction/test_thresholds.py
@@ -21,6 +21,7 @@ def test_defaults_match_contract():
     assert s.keep_recent_tokens == 20000
     assert s.threshold_percent == -1.0
     assert s.threshold_tokens == -1
+    assert s.max_threshold_tokens == 600_000  # default cap: never raises §C
     assert s.auto_continue is True
     assert s.mid_turn_enabled is True
 
@@ -42,6 +43,31 @@ def test_resolve_threshold_defaulted_reserve_section_c_default():
     assert resolve_threshold_tokens(200_000, s) == 160_000
     assert resolve_threshold_tokens(1_000_000, s) == 600_000
     assert resolve_threshold_tokens(40_000, s) == 32_000
+
+
+def test_max_threshold_tokens_caps_the_section_c_default():
+    """A provider advertising a huge window (1.05M) whose practical serving
+    ceiling is far lower must still compact before the pain point.
+
+    Regression for the stuck LO-on-LO session: radient advertised gpt-5.4 at
+    1.05M, the §C default resolved to 600k, and the session ran to ~250k
+    where the proxy started returning `aborted` turns — compaction never
+    fired because 250k < 600k. A user-set max_threshold_tokens clamps the
+    resolved default so the session compacts before the ceiling. The default
+    (600k) leaves every existing model's behaviour untouched.
+    """
+    s = CompactionSettings(max_threshold_tokens=250_000)
+    assert resolve_threshold_tokens(1_050_000, s) == 250_000
+    # The cap never RAISES a threshold a small window would choose anyway,
+    # and it applies only to the §C default — an explicit trigger still wins.
+    small = CompactionSettings(max_threshold_tokens=250_000)
+    assert resolve_threshold_tokens(100_000, small) == 80_000
+    explicit = CompactionSettings(threshold_tokens=300_000, max_threshold_tokens=250_000)
+    assert resolve_threshold_tokens(1_000_000, explicit) == 300_000
+    # should_compact honours the capped threshold.
+    capped = CompactionSettings(max_threshold_tokens=250_000)
+    assert should_compact(260_000, 1_050_000, capped) is True
+    assert should_compact(240_000, 1_050_000, capped) is False
 
 
 def test_resolve_threshold_defaulted_reserve_impossible_recovers_15_percent():

--- a/tests/unit/session/test_launch_subagent.py
+++ b/tests/unit/session/test_launch_subagent.py
@@ -158,3 +158,43 @@ async def test_launch_subagent_cancels_on_parent_dispose(tmp_path, monkeypatch):
     await parent.dispose()
     assert (job := parent.jobs.get(job_id)) is not None
     assert job.status == "cancelled"
+
+
+@pytest.mark.asyncio
+async def test_child_inherits_parent_compaction_settings(tmp_path, monkeypatch):
+    """A long-running review child must not bypass the operator's compaction
+    budget. Live finding: a one-shot child ran 48 requests / 1.5M tokens on
+    the default 600k-cap threshold while the parent's cap was 250k. The child
+    Session must receive the parent's compaction settings."""
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+
+    from local_operator.compaction.thresholds import CompactionSettings
+    from local_operator.harness import subagent as subagent_mod
+
+    capped = CompactionSettings(max_threshold_tokens=250_000)
+    stream = OneShotStream()
+    parent = make_session(tmp_path, stream, compaction_settings=capped)
+
+    # Capture the child session constructed by the runner.
+    built_children: list[Session] = []
+    orig_build = subagent_mod._build_child_session
+
+    async def captured_build(*a, **kw):
+        child = await orig_build(*a, **kw)
+        built_children.append(child)
+        return child
+
+    subagent_mod._build_child_session = captured_build
+
+    job_id = parent._launch_subagent(label="sub", prompt="review")
+    await wait_for(lambda: parent.jobs.get(job_id) is not None)
+    await wait_for(
+        lambda: (job := parent.jobs.get(job_id)) is not None and job.status == "completed"
+    )
+
+    assert built_children, "the runner must construct a child session"
+    child = built_children[0]
+    assert child._compaction_settings is not None
+    assert child._compaction_settings.max_threshold_tokens == 250_000
+    assert child._compaction_settings == capped
+    await parent.dispose()

--- a/tests/unit/session/test_session.py
+++ b/tests/unit/session/test_session.py
@@ -342,6 +342,7 @@ async def test_compaction_runs_when_due(tmp_path, monkeypatch):
         keep_recent_tokens: int = 20000
         threshold_percent: float = -1.0
         threshold_tokens: int = Field(default=-1)
+        max_threshold_tokens: int = 600_000
         auto_continue: bool = True
 
     prune_calls: list[tuple[int, int]] = []
@@ -362,7 +363,13 @@ async def test_compaction_runs_when_due(tmp_path, monkeypatch):
     )
     setattr(fake_api, "find_cut_point", lambda messages, keep: 1)  # cut after first message
     setattr(
-        fake_api, "resolve_threshold_tokens", lambda window, settings: settings.threshold_tokens
+        fake_api,
+        "resolve_threshold_tokens",
+        lambda window, settings: (
+            settings.threshold_tokens
+            if settings.threshold_tokens > 0
+            else min(int(window * 0.8), getattr(settings, "max_threshold_tokens", 600_000))
+        ),
     )
     setattr(fake_api, "RECOVERY_BAND", 0.8)
 
@@ -458,6 +465,7 @@ async def test_compaction_below_bound_never_pays_for_the_exact_estimate(tmp_path
         keep_recent_tokens: int = 20000
         threshold_percent: float = -1.0
         threshold_tokens: int = Field(default=-1)
+        max_threshold_tokens: int = 600_000
         auto_continue: bool = True
 
     exact_calls: list[int] = []
@@ -476,7 +484,13 @@ async def test_compaction_below_bound_never_pays_for_the_exact_estimate(tmp_path
         fake_api, "compaction_context_tokens", lambda provider, local: max(provider or 0, local)
     )
     setattr(
-        fake_api, "resolve_threshold_tokens", lambda window, settings: settings.threshold_tokens
+        fake_api,
+        "resolve_threshold_tokens",
+        lambda window, settings: (
+            settings.threshold_tokens
+            if settings.threshold_tokens > 0
+            else min(int(window * 0.8), getattr(settings, "max_threshold_tokens", 600_000))
+        ),
     )
     setattr(
         fake_api, "should_compact", lambda ctx, window, settings: ctx > settings.threshold_tokens

--- a/tests/unit/session/test_session.py
+++ b/tests/unit/session/test_session.py
@@ -638,7 +638,12 @@ async def test_refresh_tools_takes_effect_next_model_call(tmp_path):
     )
     session = make_session(tmp_path, stream, tools=[])
     await session.prompt("one")
-    assert [t.name for t in stream.requests[0].tools] == []
+    # A session always self-merges its OWN capability tools (task/wait/jobs/
+    # wake are createIf-gated on the session's launcher + job manager), so the
+    # construction-time inventory is not empty even when the caller passed [].
+    first_names = [t.name for t in stream.requests[0].tools]
+    assert "task" in first_names and "wait" in first_names
+    assert "mcp__late_one" not in first_names
 
     session.refresh_tools([mk("mcp__late_one"), mk("mcp__late_two")])
     await session.prompt("two")
@@ -736,4 +741,27 @@ async def test_aborted_run_end_is_never_held(tmp_path, monkeypatch):
     await session.prompt("go")
     assert len(ends) == 1
     assert ends[0].aborted is True
+    await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_session_merges_capability_tools_into_inventory(tmp_path):
+    """task/wait/jobs (and wake) are gated on the session's OWN capabilities
+    (subagent_launcher/jobs/wake_scheduler), which the factory context lacks.
+    A session must merge them at construction so the model can delegate even
+    when the factory inventory was built without the engine (reproduced live:
+    144 requests and 4M input tokens with zero task calls because task was
+    never advertised)."""
+    stream = ScriptedStream([[StreamEndEvent(stop_reason="stop")]])
+    session = make_session(tmp_path, stream)
+    names = [t.name for t in session._tools]
+    assert "task" in names, f"task tool missing from inventory: {names}"
+    assert "wait" in names
+    assert "jobs" in names
+    # The merge replaced/added without duplicating existing tools.
+    assert len(names) == len(set(names))
+    # And the merged tools are the createIf ones, wired to this session.
+    task_tool = next((t for t in session._tools if t.name == "task"), None)
+    assert task_tool is not None
+    assert task_tool.name == "task"
     await session.dispose()

--- a/tests/unit/test_session_factory.py
+++ b/tests/unit/test_session_factory.py
@@ -819,3 +819,33 @@ def test_a_named_id_survives_a_stat_that_fails(tmp_path, monkeypatch) -> None:
     monkeypatch.setattr(Path, "is_file", flaky)
     with pytest.raises(resume_mod.ResumeNotFound):
         resume_mod.resume_dir(tmp_path, "sess-abc")
+
+
+@pytest.mark.asyncio
+async def test_mcp_merge_keeps_session_capability_tools(monkeypatch) -> None:
+    """M1 regression: the MCP merge base is the session's LIVE inventory, not
+    the factory's pre-merge list. A session carries capability tools
+    (task/wait/jobs/wake) merged at construction; an MCP merge or refresh
+    that rebuilt from the factory list would drop them."""
+    builtin = MagicMock(name="builtin_tool")
+    capability = MagicMock(name="task_tool")
+    session = FakeSessionShell()
+    session.tools = [builtin, capability]  # the post-construction inventory
+    manager = FakeMcpManager()
+    mcp_tool = MagicMock(name="mcp_tool")
+
+    async def fake_discover(cwd, auth_store=None):
+        return manager, [mcp_tool], []
+
+    monkeypatch.setattr("local_operator.mcp.discover_and_load_mcp_tools", fake_discover)
+
+    result = await wire_mcp_into_session(session, [builtin], ".")
+    assert result is manager
+    # Both the capability tool and the MCP tool survive the initial merge.
+    assert set(session.tools) == {builtin, capability, mcp_tool}
+
+    # A live MCP refresh ALSO keeps the capability tool (was dropped before).
+    late = MagicMock(name="late_tool")
+    assert manager.callback is not None
+    manager.callback([late])
+    assert set(session.tools) == {builtin, capability, late}


### PR DESCRIPTION
## What & why

Three live-found problems in long-session and subagent efficiency, all reproduced with a real provider (deepseek-v4-flash via OpenRouter) against the merged harness:

### 1. A stuck LO-on-LO session (diagnosed)
Session `cb76cb39d6c7` ran ~390 tool-call turns on `openai/gpt-5.4` via the radient proxy and stalled: context grew to ~250k with **zero compactions**, then the proxy began returning `stop_reason: aborted` turns. The user quit; at the time `--resume` booted to a blank screen (already fixed in #114). Diagnosis: radient advertises gpt-5.4 at 1.05M → the §C default threshold resolved to 600k, so 250k never compacted; the provider's practical ceiling (and its 272k extended-context pricing knee) was reached well before the advertised window. The transcript + `should_compact` math verify it.

**Fix:** new `values.compaction.max_threshold_tokens` (default 600_000 — existing behavior unchanged) caps the resolved §C default; the session's threshold derivation now goes through `compaction_api.resolve_threshold_tokens` (single source of truth) instead of cloning the formula. The user's config.yml now carries `max_threshold_tokens: 250000`.

### 2. task/wait/jobs never advertised to real sessions
`create_tools` is createIf-gated: the builders return None unless the ToolContext carries `subagent_launcher`/`jobs`/`wake_scheduler`, and the factory inventory is built from a context without those session-owned fields. A delegated-review prompt burned **144 requests / 4M input tokens** researching files because the model had no `task` tool.

**Fix:** `Session._merge_capability_tools()` re-runs the gated builders against the session's own ToolContext at construction. Verified live: the parent now spawns a subagent (task → child runs → wait → result), and the child returned a genuine finding.

### 3. Long children bypass the compaction budget + nested-range re-reads
A one-shot review child ran 48 requests / 1.5M tokens on the default 600k threshold.

**Fixes:** children now inherit `compaction_settings` from the parent; and pruning gains **range-coverage supersede** (a later ranged read that fully covers an earlier range of the same file blanks it — conservative: adjacent paging and partial overlaps are kept).

## Evidence
- 2674 unit tests pass; flake8 / black / isort / pyright clean.
- Live subagent E2E: parent 8 requests / 31k tokens; child completed with real findings.
- `test_max_threshold_tokens_caps_the_section_c_default`, `test_nested_range_read_supersedes_the_covered_earlier_range`, `test_session_merges_capability_tools_into_inventory`, `test_child_inherits_parent_compaction_settings` are the new regressions.
