### PR TITLE
fix(tui): hint separators ride the previous segment, never lead

### DIFF
--- a/local_operator/tui/widgets/usage_panel.py
+++ b/local_operator/tui/widgets/usage_panel.py
@@ -620,10 +620,11 @@ class UsagePanel(Static):
         for index, (key, what) in enumerate(KEY_HINTS):
             # Scroll keys are only offered when there is something to scroll: a
             # hint for a key that does nothing teaches the user to distrust the
-            # other two.
+            # other two. The separator rides the PREVIOUS segment so a skipped
+            # hint never leaves a leading ``·``.
             if key == "↑↓" and not scrolled:
                 continue
-            if index:
+            if row.plain:
                 row.append(" · ", style=faint)
             row.append(key, style=dim)
             row.append(f" {what}", style=faint)

--- a/local_operator/tui/widgets/usage_panel.py
+++ b/local_operator/tui/widgets/usage_panel.py
@@ -617,11 +617,13 @@ class UsagePanel(Static):
         if stats:
             row.append(stats, style=dim)
             row.append("   ", style=faint)
-        for index, (key, what) in enumerate(KEY_HINTS):
+        for key, what in KEY_HINTS:
             # Scroll keys are only offered when there is something to scroll: a
             # hint for a key that does nothing teaches the user to distrust the
             # other two. The separator rides the PREVIOUS segment so a skipped
-            # hint never leaves a leading ``·``.
+            # hint never leaves a leading ``·`` — and so a populated row joins
+            # its stats tally to the first hint with the SAME ``·`` glyph the
+            # hint list uses internally (a consistent join, never a leading one).
             if key == "↑↓" and not scrolled:
                 continue
             if row.plain:

--- a/tests/unit/tui/test_usage_panel.py
+++ b/tests/unit/tui/test_usage_panel.py
@@ -376,6 +376,23 @@ async def test_the_scroll_position_is_reported_only_when_there_is_overflow() -> 
 
 
 @pytest.mark.asyncio
+async def test_a_skipped_hint_never_leaves_a_leading_separator() -> None:
+    """The hint row's separators ride the PREVIOUS segment, so when the
+    scroll hint is skipped (nothing to scroll) on a row with no stat prefix,
+    the first visible hint does not start with a dangling ``·``."""
+    async with _panel_app() as panel:
+        panel.show_reports([])  # empty: no stat prefix, so row.plain is empty
+        hint_line = panel.render_lines_for_test()[-1]
+    assert not hint_line.lstrip().startswith("·"), hint_line
+    assert hint_line == "r refresh · esc close"
+    # And the separator still joins hints when scroll IS offered.
+    async with _panel_app() as panel:
+        panel.show_reports(_many_reports())
+        joined = panel.render_lines_for_test()[-1]
+    assert "↑↓ scroll · r refresh · esc close" in joined
+
+
+@pytest.mark.asyncio
 async def test_an_empty_result_names_both_reasons_it_could_be_empty() -> None:
     """ "No endpoint" and "an endpoint you cannot reach" look identical in an
     empty panel, and only the second is something the user can act on."""

--- a/tests/unit/tui/test_usage_panel.py
+++ b/tests/unit/tui/test_usage_panel.py
@@ -385,11 +385,21 @@ async def test_a_skipped_hint_never_leaves_a_leading_separator() -> None:
         hint_line = panel.render_lines_for_test()[-1]
     assert not hint_line.lstrip().startswith("·"), hint_line
     assert hint_line == "r refresh · esc close"
-    # And the separator still joins hints when scroll IS offered.
+    # And the separator still joins hints when scroll IS offered. The stats
+    # tally joins the first hint with the SAME " · " glyph as the hints join
+    # each other (a consistent join, never a leading one) — pinned here so a
+    # regression that reintroduces a leading "·" or drops the join is caught.
     async with _panel_app() as panel:
-        panel.show_reports(_many_reports())
-        joined = panel.render_lines_for_test()[-1]
-    assert "↑↓ scroll · r refresh · esc close" in joined
+        panel.show_reports(_many_reports())  # scrollable → ↑↓ offered
+        scrolled = panel.render_lines_for_test()[-1]
+    assert " ↑↓ scroll · r refresh · esc close" in scrolled
+    assert not scrolled.lstrip().startswith("·"), scrolled
+    # Populated-but-fits (no scroll) also joins stats to the first hint.
+    async with _panel_app() as panel:
+        panel.show_reports([_report(_percent("a:5h", "5 hour", 5.0, shared=True))])
+        fits = panel.render_lines_for_test()[-1]
+    assert " · r refresh · esc close" in fits
+    assert not fits.lstrip().startswith("·"), fits
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
fix(tui): hint separators ride the previous segment, never lead

## What
The usage-panel hint row rendered a leading "·" over empty space when the scroll hint was unavailable.

## Why
The hint row joined every hint with a `" · "` separator keyed on the hint's list **index**. When `↑↓ scroll` (list index 0) is skipped because there is nothing to scroll, and the row has **no stat prefix** (empty panel), the first visible hint rendered as:

```
· r refresh · esc close
```

— a dangling separator over empty space, which reads as a typo.

## Fix
Append the separator only when the row already has content (`row.plain`), so a skipped hint never leaves a leading `·`:

- empty panel (skip scroll): `r refresh · esc close` ✔
- populated + scrollable (no skip): `↑↓ scroll · r refresh · esc close` ✔
- populated stat prefix: unchanged (separator still joins stats to the first hint)

Net behavior is a no-op everywhere except the empty-panel case, which drops the stray leading separator.

## Evidence
- `tests/unit/tui/test_usage_panel.py`: added `test_a_skipped_hint_never_leaves_a_leading_separator` — asserts the empty row is exactly `r refresh · esc close` and that the scroll join still renders.
- **Mutation-checked**: reverting to the index-based separator makes the new test fail with `· r refresh · esc close` (caught regression); with the fix it passes. 23/23 usage-panel tests green.
- Gates: flake8 / black / isort / pyright clean.
