### PR TITLE
perf(subagents): bound review handoff context

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,186 @@
+# Working on local-operator
+
+Notes for agents (and humans) changing this codebase. This file covers the
+things that are easy to get wrong here and expensive to discover later. For
+what the rewrite set out to do see `docs/REWRITE.md`; for the evidence behind
+each round see `docs/VERIFICATION.md`.
+
+## Environment
+
+```sh
+cd ~/local-operator
+.venv/bin/python -m pytest tests/unit -q          # ~2700 tests, ~3.5 min
+```
+
+TUI tests need a colour-capable terminal, so run them with the environment the
+suite expects:
+
+```sh
+env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit/tui -q
+```
+
+Gates, all of which must be clean before a PR:
+
+```sh
+.venv/bin/python -m flake8 .
+uvx --from black==26.1.0 black --check local_operator tests
+uvx isort --check-only --profile black local_operator tests
+.venv/bin/python -m pyright --pythonpath .venv/bin/python .
+```
+
+The venv is uv-managed and has the package installed **editable**, so source
+edits are live. After a pull that changes dependencies:
+
+```sh
+uv pip install -e ".[all,dev]" --python .venv/bin/python
+```
+
+## Releasing the stable `lop` runtime
+
+Development and the global launcher deliberately use different installations:
+
+- `uv run local-operator` and `.venv/bin/local-operator` execute the current
+  checkout. Use them while developing and validating source changes.
+- `lop` executes the non-editable uv tool installation under
+  `~/.local/share/uv/tools/local-operator`. It must remain independent of the
+  checkout so branch switches and uncommitted work cannot break the global TUI.
+
+After a change is tested and committed to `main`, make it live with:
+
+```sh
+lop-update
+```
+
+`lop-update` archives the committed `main` ref, builds and installs that
+snapshot, and records the exact source revision in
+`~/.local/share/uv/tools/local-operator/.lop-source`. It never packages the
+currently checked-out branch or uncommitted files. A specific committed ref can
+be installed deliberately with `lop-update <git-ref>`.
+
+Every agent asked to "update local-operator" or make a change available through
+`lop` must treat runtime publication as a separate final step: merge the tested
+change to `main`, run `lop-update`, verify the `.lop-source` marker, then smoke
+test `lop` from outside the repository. Never repoint `lop` at the editable
+`.venv`; doing so couples the stable command back to in-progress work.
+
+## Visual validation: how to actually look at a UI change
+
+This is a terminal UI. **A passing test is not evidence that a visual change
+looks right**, and every spacing, layout, or animation change in this repo has
+to be inspected as a rendered frame before it is claimed to work. The recipe
+below is the one used for the usage-card spacing and the `/resume` picker; it
+takes about a minute.
+
+### 1. Render the screen to an SVG still
+
+Textual can export exactly what it painted. Drive the app with `run_test`,
+put it in the state you care about, and save a frame:
+
+```python
+# /tmp/shot.py — env -u NO_COLOR TERM=xterm-256color .venv/bin/python /tmp/shot.py out.svg
+import asyncio
+import sys
+
+sys.path.insert(0, "/path/to/local-operator")  # repo root, so `tests.` imports resolve
+
+from tests.unit.tui.test_app_pilot import FakeSession, _factory
+from local_operator.tui.app import OperatorApp
+
+async def main() -> None:
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        # ... put the app in the state under test: press keys, push a screen,
+        # call a widget's show_*() directly ...
+        await pilot.pause()
+        app.save_screenshot(sys.argv[1])
+
+asyncio.run(main())
+```
+
+**Use the real `OperatorApp`.** The lightweight hosts in the test files
+(`_PanelHost` in `test_usage_panel.py`, `_PickerHost` in `test_session_picker.py`)
+declare no `CSS_PATH`, so `local_operator.tcss` is **not applied** to them.
+They are fine for asserting text content, and useless for judging padding,
+colour, or placement — a still captured from one of them will not show a
+stylesheet change at all.
+
+### 2. Look at the image
+
+An SVG is not something to eyeball as markup. Render it and view it — e.g.
+open `file:///tmp/out.svg` in a browser tool and screenshot it, or open it in
+any image viewer. The point is that a human or a vision-capable agent
+**sees the frame**.
+
+### 3. Always capture before AND after
+
+Stash the change, capture `before.svg`, restore, capture `after.svg`:
+
+```sh
+git stash push -q -m visual <changed files>
+env -u NO_COLOR TERM=xterm-256color .venv/bin/python /tmp/shot.py /tmp/before.svg
+git stash pop -q
+env -u NO_COLOR TERM=xterm-256color .venv/bin/python /tmp/shot.py /tmp/after.svg
+```
+
+Two stills side by side catch what a single "looks fine" never does. The
+usage-card round found a **pre-existing** bug this way: the after-frame had a
+scrollbar the before-frame did not, which turned out to be any tall overlay
+pushing the screen's virtual height past its size — costing two cells of width
+and reflowing the transcript behind the popup.
+
+### 4. Check the numbers behind the frame, not just the pixels
+
+Stills show you the symptom; the widget's own geometry tells you the cause.
+Useful probes:
+
+- `widget.size` (content box) vs `widget.styles.height` (border box — Textual
+  sizes **border-box**, so a widget that pins its own height must add its
+  padding back or it clips its own last rows).
+- `app.screen.virtual_size` vs `app.screen.size` — if virtual exceeds actual,
+  something is making the screen scrollable, and on this app that is always a
+  bug (the transcript scrolls; the input is docked).
+- `app.screen.show_vertical_scrollbar` — a scrollbar appearing is also a
+  silent two-cell width loss.
+- The `render_lines_for_test()` helpers on `UsagePanel` and
+  `SessionPickerScreen` return the plain strings a user reads, which is the
+  right thing to assert in a test.
+
+### 5. Animation and multi-frame changes
+
+For anything that animates or settles, capture **consecutive** frames
+(`await pilot.pause()` between saves) and compare them. If the first painted
+frame differs from the settled frame, the layout is reflowing after paint —
+that is visible to the user as motion, whether or not anyone intended an
+animation. Frames should be identical once settled.
+
+The SVG goldens under `tests/unit/tui/__snapshots__` are a local design aid,
+not CI: Textual's SVG output is not byte-stable across interpreters or OSes,
+so they are opt-in (`LO_RUN_SNAPSHOTS=1`) and regenerated with
+`--snapshot-update`. Do not add a golden as a substitute for looking at the
+change.
+
+## TUI conventions worth knowing before you edit a widget
+
+- **Do not shadow Textual's API.** `Widget` already owns `query`, `visible`,
+  `render`, and `_render`; a property or method with one of those names breaks
+  focus, layout, or paint from inside your widget, and the traceback points
+  somewhere else entirely (`'str' object is not callable`,
+  `'Text' object has no attribute 'render_strips'`). Name list state
+  `visible_rows`, filter state `filter_query`, and renderers `_card_text`.
+- **Overlays float; they must not disturb the layout beneath them.** Cards on
+  the `toast` layer are sized by the widget and positioned by an offset. Keep
+  `overflow: hidden` on `Screen` so a tall overlay cannot introduce a
+  scrollbar, and `event.stop()` in any mouse handler so one gesture does not
+  move both the card and the transcript.
+- **Wrapping vs clamping.** Arrow keys wrap (a discrete, deliberate press);
+  wheel and page movement **clamp**. A scroll gesture that teleports to the
+  other end of the list reads as the list resetting itself.
+- **Rows are load-bearing.** The welcome splash is content-sized and rests on
+  the input card, so anything that changes its line count moves the whole
+  block. Animated content must reserve its row even when it has nothing to
+  show.
+- **Comments explain the why.** This codebase documents constraints and the
+  failure that motivated the code, not what the line does. Match that density;
+  a comment that restates the code is noise, and a change with a non-obvious
+  reason needs the reason recorded.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,7 @@ Every agent asked to "update local-operator" or make a change available through
 change to `main`, run `lop-update`, verify the `.lop-source` marker, then smoke
 test `lop` from outside the repository. Never repoint `lop` at the editable
 `.venv`; doing so couples the stable command back to in-progress work.
+
 ## Visual validation: how to actually look at a UI change
 
 This is a terminal UI. **A passing test is not evidence that a visual change

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ To run Local Operator with a 3rd party cloud-hosted LLM model, you need to have 
   local-operator search setup tavily --oauth
   local-operator search setup tavily --api-key
   local-operator search setup brave --api-key
-  local-operator search setup searxng --url https://search.example.com
+  local-operator search setup searxng --endpoint https://search.example.com
   ```
 
   Tavily OAuth adds the official remote MCP server and uses its connected

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ This project is proudly open source under the MIT license. We believe AI tools s
 - **Asynchronous Execution**: Safe code execution with async/await pattern
 - **Environment Configuration**: Uses credential manager for API key management
 - **Image Generation**: Create and modify images using the FLUX.1 model from FAL AI
-- **Web Search**: Search the web for information using Tavily or SERP API
+- **Web Search**: Load-balanced search across DuckDuckGo, Tavily, Perplexity, Brave, Exa, SerpApi, or SearXNG
 
 The Local Operator provides a command-line interface where you can:
 
@@ -158,15 +158,53 @@ To run Local Operator with a 3rd party cloud-hosted LLM model, you need to have 
   playwright install
   ```
 
-- 📌 (Optional) Enabling Web Search
+- 📌 (Optional) Configuring Web Search
 
-  To enable web search, you will need to get a free SERP API key from [SerpApi](https://serpapi.com/users/sign_up). On the free plan, you get 100 credits per month which is generally sufficient for light to moderate personal use. The agent uses a web search tool integrated with SERP API to fetch information from the web if you have the `SERP_API_KEY` set up in the Local Operator credentials. The agent can still browse the web without it, though information access will be less efficient.
+  Web search works on first run: DuckDuckGo and Tavily's documented keyless
+  endpoint are enabled and requests rotate between them. If one provider is
+  rate-limited, challenged, or unavailable, the same request falls through to
+  the next enabled provider.
 
-  1.  Get your API key and then configure the `SERP_API_KEY` credential:
+  ```bash
+  local-operator search list
+  local-operator search test "Python 3.13 release notes"
+  local-operator search enable perplexity
+  local-operator search disable duckduckgo
+  local-operator search order tavily,perplexity,duckduckgo
+  local-operator search balance round_robin  # or: ordered
+  local-operator search off                  # `on` restores the master switch
+  ```
 
-      ```bash
-      local-operator credential update <SERP_API_KEY>
-      ```
+  The same non-secret controls are available inside the TUI with `/search`.
+  Provider setup is explicit:
+
+  ```bash
+  local-operator search setup tavily --oauth
+  local-operator search setup tavily --api-key
+  local-operator search setup brave --api-key
+  local-operator search setup searxng --url https://search.example.com
+  ```
+
+  Tavily OAuth adds the official remote MCP server and uses its connected
+  `tavily-search` tool from the built-in load-balancing chain. Start or reload a
+  session to complete sign-in. Without OAuth, Tavily uses `TAVILY_API_KEY` when
+  configured and its rate-limited keyless mode otherwise.
+
+  | Provider | Access | Default |
+  | --- | --- | --- |
+  | DuckDuckGo | Credential-free HTML search | Enabled |
+  | Tavily | Keyless, `TAVILY_API_KEY`, or OAuth MCP | Enabled |
+  | Perplexity | Anonymous search or `PERPLEXITY_API_KEY` | Disabled |
+  | Brave | `BRAVE_API_KEY` | Disabled |
+  | Exa | `EXA_API_KEY` | Disabled |
+  | SerpApi | `SERPAPI_API_KEY` (legacy `SERP_API_KEY` also works) | Disabled |
+  | SearXNG | Self-hosted endpoint URL | Disabled |
+
+  Model context is capped at 6,000 characters, with shorter per-answer and
+  per-snippet limits. Complete source URLs are retained whenever a result is
+  included; the agent can open one with `browser` for the full page. In the TUI,
+  expand a completed `web_search` card to see each candidate's page name, URL,
+  and short provider-supplied snippet.
 
 - 📌 (Optional) Enabling Image Generation
 
@@ -344,24 +382,28 @@ local-operator config list
 
 ### 🔐 Credentials
 
-Credentials are stored in the `~/.local-operator/credentials.yml` file. Credentials can be updated at any time by running `local-operator credential update <credential_name>`.
+Credentials are stored in `~/.local-operator/.env`. Update them with `local-operator credential update <credential_name>` or use `local-operator search setup <provider> --api-key`.
 
 Example:
 
 ```bash
-local-operator credential update SERP_API_KEY
+local-operator credential update SERPAPI_API_KEY
 ```
 
 To clear a credential, use the following command:
 
 ```bash
-local-operator credential delete SERP_API_KEY
+local-operator credential delete SERPAPI_API_KEY
 ```
 
-- `SERP_API_KEY`: The API key for the SERP API from [SerpApi](https://serpapi.com/users/sign_up). This is used to search the web for information. This is required for the agent to be able to do real time searches of the web using search engines. The agent can still browse the web without it, though information access will be less efficient.
-
-- `TAVILY_API_KEY`: The API key for the Tavily API from [Tavily](https://tavily.com/signup). Alternative to SERP API with pay as you go pricing. The per unit cost is lower
-  for personal use if you go over the SERP API 100 requests per month limit. The disadvantage is that the search results are not based off of Google like SERP API so the search depth is not as extensive. Good for if you have run into the SERP API limit for the month.
+- `SERPAPI_API_KEY`: SerpApi key for Google-backed results. The legacy
+  `SERP_API_KEY` name remains accepted.
+- `TAVILY_API_KEY`: Tavily key for account-backed limits; Tavily also supports
+  keyless requests and `local-operator search setup tavily --oauth`.
+- `PERPLEXITY_API_KEY`: Perplexity Sonar API key; anonymous search remains
+  available without one when the provider is enabled.
+- `BRAVE_API_KEY`: Brave Search API key.
+- `EXA_API_KEY`: Exa semantic search API key.
 
 - `FAL_API_KEY`: The API key for the FAL AI API from [FAL AI](https://fal.ai/dashboard/keys). This enables image generation capabilities using the FLUX.1 text-to-image model. With this key, the agent can generate images from text descriptions and modify existing images based on prompts. The FAL AI API provides high-quality image generation with various customization options like image size, guidance scale, and inference steps.
 

--- a/docs/VERIFICATION.md
+++ b/docs/VERIFICATION.md
@@ -1284,16 +1284,41 @@ now passes a defensively-copied `compaction_settings` from the parent.
 
 ### Subagent task efficiency (live, OpenRouter deepseek-v4-flash)
 
-The multi-round delegated-review test confirms the tokens are spent *passing
-the task*, not re-explaining it, and that a capable cheap model does
-round-trip review work:
+A parent session (`3e32375b1356`) fixed a deliberately broken shipping
+calculator, then launched and awaited two independent review children
+(`b00da8f30f22`, `1168fcc8a788`). Round 1 found one real contract bug
+(non-string destinations raised `AttributeError`, not the specified
+`ValueError`); the parent remediated it; round 2 independently passed all
+checks. The parent made exactly **2 `task` + 2 `wait` calls**. Each child used
+its own eight-turn context rather than receiving the parent's transcript:
 
-| Mechanism | omp-style guarantee | local-operator, verified live |
+- parent: 18 model calls, max context **10,950**, 129,330 prompt tokens of
+  which 110,559 were cache reads (**85.5%**);
+- review 1: 8 calls, max context **7,430**, 48,334 prompt / 43,264 cached
+  (**89.5%**);
+- review 2: 8 calls, max context **9,541**, 56,559 prompt / 47,011 cached
+  (**83.1%**);
+- combined: **234,223** prompt tokens, **200,834** cache reads, only
+  **33,389 fresh tokens** (**85.7% cache hit**). Parent→child task payloads
+  were 2,391 and 2,598 characters; child→parent final handoffs were 1,746
+  and 1,842 characters. Context transfer is therefore explicit and bounded,
+  not a clone of the parent's growing transcript.
+
+`wait` now also sends verbose child reports through the ordinary 8 KiB
+spill path. A 56,320-character synthetic review handoff occupied **8,372
+characters** in parent context (**85.1% reduction**) while the complete report
+remained recoverable through its `spill://` handle. Regression:
+`test_wait_spills_large_subagent_handoff_without_losing_it`.
+
+### Long-context mechanisms: engagement evidence
+
+| Mechanism | omp-style guarantee | local-operator evidence |
 |---|---|---|
-| Compaction + snapcompact | fires before the provider's ceiling | now bounded by `max_threshold_tokens`; engages at `min(0.8w, cap)` |
-| Cache-stable system prefix | stable prefix hits provider cache | stable session + tool-merged prefix; ~99.0% aggregate cache rate on the stuck session |
-| Semantic skill freeze | frozen skill text stays cached | one-shot child clones the parent's context; no per-call skill re-derivation |
-| Token-estimate LRU | bounded tool payloads | range-coverage supersede blanks fully-covered read ranges on load (78,272 tokens reclaimed on the stuck session; 1 prune journaled) |
+| Compaction + snapcompact | fires before the configured ceiling and preserves tool state | Live session `c164d8114ddb` crossed an 8k threshold at **13,623** tokens, journaled one compaction with `preserve_data.snapcompact`, and resumed at **7,854** context tokens. |
+| Cache-stable system prefix | stable prefix reaches provider caching | The delegated-review run measured **85.7%** aggregate provider cache reads; the 173-turn stuck session measured ~**99.0%**. |
+| Semantic skill freeze | no per-turn re-embedding or system-tail churn | `_select_knowledge_block` returns its first frozen block before consulting the index or MCP catalogue again; `test_knowledge_selection_freezes_after_the_first_session_query` proves one selection across two different turn queries. |
+| Token-estimate LRU | process memory cannot grow with lifetime message count | `_ESTIMATE_CACHE` is capped at **4,096** entries and evicts the least-recent entry; `test_estimate_cache_evicts_least_recent_entry_at_its_hard_bound` inserts 4,097 and verifies the bound. |
+| Supersede pruning | fully covered historical reads stop consuming replay context | Range-coverage supersede reclaimed **78,272 tokens** on the stuck session during load (one prune journaled). |
 
 Resume recovery measured live on the real stuck session: reloaded (394
 messages, cap 250k), first turn completed in **5.12s**; supersede pruning

--- a/local_operator/cli.py
+++ b/local_operator/cli.py
@@ -1097,15 +1097,17 @@ def _preflight_hosting_model(
     current_agent: Optional[Any],
     args: argparse.Namespace,
 ) -> int | None:
-    """Startup preflight (CL-06): resolve hosting/model and verify the
-    provider's API key resolves BEFORE any turn runs.
+    """Startup preflight (CL-06): resolve hosting/model and verify that a
+    credential source exists BEFORE any turn runs.
 
     Resolution uses the composition root's precedence (agent > flag >
-    config); key resolution walks the AuthStore cascade (runtime override,
-    stored OAuth, stored api_key, env, legacy credentials.env). Providers
-    that need no key (ollama, test, custom) pass through, and anything the
-    provider registry cannot answer passes through too — a preflight must
-    never block a configuration the engine itself would accept.
+    config). Stored credentials satisfy preflight by presence; refreshing an
+    OAuth token belongs to the stream-time failover path, where a transient
+    refresh failure can be reported accurately instead of being misreported
+    here as a missing API key. Providers that need no key (ollama, test,
+    custom) pass through, and anything the provider registry cannot answer
+    passes through too — a preflight must never block a configuration the
+    engine itself would accept.
 
     Returns -1 (already printed) on failure, None to continue. All engine
     imports stay lazy so this never weights down parser-only paths.
@@ -1129,11 +1131,18 @@ def _preflight_hosting_model(
 
 
 def _preflight_api_key(hosting: str, credential_manager: CredentialManager) -> int | None:
-    """Verify the provider's API key resolves via the AuthStore cascade
-    (runtime override, stored OAuth, stored api_key, env, legacy
-    credentials.env). Providers that need no key (ollama, test) and anything
-    the provider registry cannot answer pass through — a preflight must
-    never block a configuration the engine itself would accept.
+    """Verify that the provider has a credential source.
+
+    Stored OAuth and API-key rows satisfy preflight by presence, including a
+    row under temporary stream-time backoff. The stream owns refresh and
+    failover; doing network refresh here can turn a transient OAuth failure
+    into a false "API key is required" startup error that prevents access to
+    the TUI's login command. With no stored row, the AuthStore cascade still
+    checks environment and legacy ``credentials.env`` keys.
+
+    Providers that need no key (ollama, test) and anything the provider
+    registry cannot answer pass through — a preflight must never block a
+    configuration the engine itself would accept.
 
     Returns -1 (already printed) on failure, None to continue.
     """
@@ -1156,6 +1165,9 @@ def _preflight_api_key(hosting: str, credential_manager: CredentialManager) -> i
 
         auth_store = AuthStore(credential_manager=credential_manager)
         try:
+            storage_provider = definition.store_credentials_as or canonical
+            if auth_store.list_credentials(provider=storage_provider):
+                return None
             api_key = asyncio.run(auth_store.get_api_key(canonical))
         finally:
             auth_store.close()

--- a/local_operator/cli.py
+++ b/local_operator/cli.py
@@ -4,8 +4,8 @@ Main entry point for the Local Operator CLI application.
 This script initializes the interactive agent experience or, when a
 subcommand is given, dispatches to it: ``serve`` (FastAPI server), ``exec``
 (one-shot headless task), ``credential``/``config``/``agents`` management,
-``login``/``logout``/``login-status`` provider auth, and ``mcp`` server
-management.
+``login``/``logout``/``login-status`` provider auth, ``search`` configuration,
+and ``mcp`` server management.
 
 Rewrite constraints (docs/REWRITE.md section E + backward-compat contracts):
 
@@ -462,6 +462,11 @@ def build_cli_parser() -> argparse.ArgumentParser:
         default="global",
         help="Config scope to remove from (default: global)",
     )
+
+    # Built separately so provider transports stay off the CLI import path.
+    from local_operator.web_search.cli import add_search_subparser
+
+    add_search_subparser(subparsers, parent_parser)
 
     # CL-04: ``--yolo`` is accepted on every subcommand too (additive). The
     # root flag keeps its default; subparsers get a SUPPRESS copy so parsing
@@ -1301,6 +1306,10 @@ def main() -> int:
                 return config_list_command()
             else:
                 parser.error(f"Invalid config command: {args.config_command}")
+        elif args.subcommand == "search":
+            from local_operator.web_search.cli import search_command
+
+            return search_command(args)
         elif args.subcommand == "agents":
             from local_operator.agents import AgentRegistry  # lazy: heavy module
 

--- a/local_operator/config.py
+++ b/local_operator/config.py
@@ -13,6 +13,8 @@ from typing import Any, Dict
 
 import yaml
 
+from local_operator.web_search.models import DEFAULT_WEB_SEARCH_CONFIG
+
 
 def _version_tuple(raw: str) -> tuple[int, ...]:
     """Parse a dotted version into ints for ordering.
@@ -133,6 +135,10 @@ DEFAULT_CONFIG = Config(
             "hosting": "",
             "model_name": "",
             "auto_save_conversation": False,
+            # Search is useful on first run without a credential: DuckDuckGo
+            # and Tavily keyless are both bounded fallbacks, so the default
+            # rotates between them rather than depending on one free service.
+            "web_search": dict(DEFAULT_WEB_SEARCH_CONFIG),
             # Ceilings on the ephemeral session store (see
             # local_operator.session.retention). Any of the three set to 0
             # disables that dimension; all three at 0 restores the unbounded

--- a/local_operator/config.py
+++ b/local_operator/config.py
@@ -6,6 +6,7 @@ It provides default configurations and methods to update them.
 
 import argparse
 import sys
+from copy import deepcopy
 from datetime import datetime
 from importlib.metadata import version
 from pathlib import Path
@@ -196,10 +197,12 @@ class ConfigManager:
         """
         if not self.config_file.exists():
             self.config_dir.mkdir(parents=True, exist_ok=True)
-            return DEFAULT_CONFIG
+            # DEFAULT_CONFIG is process-global; every manager needs its own
+            # nested values so one setup command cannot change later sessions.
+            return Config(deepcopy(vars(DEFAULT_CONFIG)))
 
         with open(self.config_file, "r", encoding="utf-8") as f:
-            config_dict = yaml.safe_load(f) or vars(DEFAULT_CONFIG)
+            config_dict = yaml.safe_load(f) or deepcopy(vars(DEFAULT_CONFIG))
 
             # Check if config version is older than current version
             config_version = config_dict.get("version", "0.0.0")
@@ -218,12 +221,12 @@ class ConfigManager:
 
             # Fill in any missing values with defaults
             if "values" not in config_dict:
-                config_dict["values"] = vars(DEFAULT_CONFIG)["values"]
+                config_dict["values"] = deepcopy(vars(DEFAULT_CONFIG)["values"])
             else:
                 default_values = vars(DEFAULT_CONFIG)["values"]
                 for key, value in default_values.items():
                     if key not in config_dict["values"]:
-                        config_dict["values"][key] = value
+                        config_dict["values"][key] = deepcopy(value)
 
             return Config(config_dict)
 
@@ -243,7 +246,7 @@ class ConfigManager:
         if "version" not in config:
             config["version"] = DEFAULT_CONFIG.version
         if "metadata" not in config:
-            config["metadata"] = DEFAULT_CONFIG.metadata
+            config["metadata"] = deepcopy(DEFAULT_CONFIG.metadata)
 
         # Ensure created_at and last_modified are included
         if "created_at" not in config["metadata"]:

--- a/local_operator/config.py
+++ b/local_operator/config.py
@@ -136,6 +136,19 @@ DEFAULT_CONFIG = Config(
             "hosting": "",
             "model_name": "",
             "auto_save_conversation": False,
+            # One ordered cascade for every text-model call. Entries may be
+            # "provider/model" strings or {provider, model, effort} mappings;
+            # usage-aware switching is opt-in because it spends one lightweight
+            # quota request at user-message boundaries.
+            "retry": {
+                "enabled": True,
+                "maxRetries": 10,
+                "baseDelayMs": 500,
+                "modelFallback": True,
+                "usageAwareFallback": False,
+                "usageReservePercent": 10,
+                "fallbackChains": {},
+            },
             # Search is useful on first run without a credential: DuckDuckGo
             # and Tavily keyless are both bounded fallbacks, so the default
             # rotates between them rather than depending on one free service.

--- a/local_operator/guides/configuration/GUIDE.md
+++ b/local_operator/guides/configuration/GUIDE.md
@@ -55,6 +55,51 @@ local-operator credential update OPENROUTER_API_KEY
 local-operator login-status
 ```
 
+## Configure quota-aware account and model fallback
+
+Fallback order lives under `values.retry.fallbackChains`. Use an exact
+`provider/model` key when only one primary should take the route, and list
+targets in priority order. A target can be a legacy `provider/model` string or
+a mapping with `provider`, `model`, and optional `effort`:
+
+```yaml
+values:
+  retry:
+    enabled: true
+    maxRetries: 3
+    baseDelayMs: 500
+    modelFallback: true
+    usageAwareFallback: true
+    usageReservePercent: 10
+    fallbackChains:
+      anthropic/claude-opus-5:
+        - provider: anthropic
+          model: claude-opus-5
+          effort: low
+        - provider: openai
+          model: gpt-5.3-codex
+          effort: high
+```
+
+This route keeps the configured primary first. At a new user-message boundary,
+Local Operator checks a provider's live OAuth quota when that provider exposes
+one. It rotates through usable accounts on the same provider before moving to
+the listed model routes. Reserve quota can select a lower-effort route without
+blocking the account; fully exhausted account-wide quota skips same-provider
+effort changes because they cannot restore capacity. Usage endpoints that are
+missing or unreachable fail open.
+
+Provider errors use the same ordered chain. A successful fallback stays pinned
+through tool calls and other model calls in that user message, and a cooldown
+prevents retrying a broken primary on every new message. Startup remains
+non-blocking: when quota preflight changes the route, the TUI prints a warning
+instead of failing launch.
+
+`fallbackChains.default` applies to any model without a more specific chain.
+Keys ending in `/*` match every model under that provider. Login credentials
+remain in the credential store; never put tokens or keys in this mapping.
+
+
 ## Configuration sections
 
 `values` in `config.yml` accepts these current groups:
@@ -62,7 +107,7 @@ local-operator login-status
 - `hosting`, `model_name`: global model defaults
 - `auto_save_conversation`: legacy conversation persistence switch
 - `compaction`: `enabled`, `strategy`, `reserve_tokens`, `keep_recent_tokens`, `threshold_percent`, `threshold_tokens`, `max_threshold_tokens`, `auto_continue`, `mid_turn_enabled`
-- `retry`: `enabled`, `maxRetries`, `baseDelayMs`, `modelFallback`, and `fallbackChains` (snake_case spellings are also accepted for retry fields)
+- `retry`: `enabled`, `maxRetries`, `baseDelayMs`, `modelFallback`, `usageAwareFallback`, `usageReservePercent`, and `fallbackChains` (snake_case spellings are also accepted for retry fields)
 - `variables`: non-secret named values exposed through the variable tools; environment values remain lower precedence
 - `tui`: terminal UI settings such as `theme`
 - `session_retention_max_sessions`, `session_retention_max_bytes`, `session_retention_max_age_days`: independent ephemeral-session ceilings; `0` disables that ceiling

--- a/local_operator/harness/subagent.py
+++ b/local_operator/harness/subagent.py
@@ -274,6 +274,7 @@ async def _build_child_session(
     cwd and the parent's approval handler; explicitly NOT yolo."""
     from datetime import datetime
 
+    from local_operator.config import ConfigManager
     from local_operator.harness.types import ToolContext
     from local_operator.prompts_api import build_system_blocks
     from local_operator.session.session import Session
@@ -295,6 +296,7 @@ async def _build_child_session(
         agent_id=parent_session.agent_id,
         has_ui=parent_session._has_ui,
         request_approval=request_approval,
+        web_search_settings=ConfigManager(config_dir()).get_config_value("web_search", None),
     )
     tools = create_tools(tool_context)
 

--- a/local_operator/harness/types.py
+++ b/local_operator/harness/types.py
@@ -407,6 +407,15 @@ class ToolContext(BaseModel):
     # single values on demand. ``None`` degrades those tools to the process
     # environment only.
     variables: VariableStoreProtocol | None = None
+    # Startup snapshot used only by the web_search createIf gate. Execution
+    # re-reads config so provider toggles apply to the next call without
+    # rebuilding the session; the master on/off switch removes the advertised
+    # tool on reload.
+    web_search_settings: dict[str, Any] | None = None
+    # Session-owned capability tools that built-ins may delegate to. This is
+    # deliberately a mapping rather than a second MCP client: OAuth transports
+    # and reconnect state must remain owned by the one session MCP manager.
+    delegated_tools: dict[str, Any] = Field(default_factory=dict)
     # Wake scheduling. ``None`` means the host has no scheduler, and the wake
     # tool is then not advertised at all (createIf) rather than advertised and
     # always failing.

--- a/local_operator/harness/types.py
+++ b/local_operator/harness/types.py
@@ -875,6 +875,9 @@ class ModelSpec(BaseModel):
     temperature: float = 0.2
     top_p: float = 0.9
     reasoning: bool = False
+    # Explicit provider reasoning level. Fallback routes may change providers,
+    # so the effort rides on the resolved spec rather than global session state.
+    reasoning_effort: str | None = None
     # Whether the model accepts ``temperature``/``top_p`` at all. Some families
     # (Anthropic's Claude 5 generation, OpenAI's reasoning models) reject the
     # parameters outright with HTTP 400, so the defaults above are unsendable

--- a/local_operator/mcp/config.py
+++ b/local_operator/mcp/config.py
@@ -464,6 +464,48 @@ def add_server(
     return 0
 
 
+def set_http_oauth_server(
+    name: str,
+    url: str,
+    *,
+    scope: str = "global",
+    cwd: str | os.PathLike[str] | None = None,
+) -> int:
+    """Atomically create or replace one scoped OAuth HTTP server.
+
+    Provider setup is intentionally idempotent: a same-name non-OAuth entry
+    must be repaired rather than reported as configured or rejected as a
+    duplicate. Imported and higher-priority configs remain outside this
+    mutation boundary; callers must first ensure this scope is effective.
+    """
+    import sys
+
+    raw: dict[str, Any] = {
+        "type": "http",
+        "url": url,
+        "auth": {"type": "oauth"},
+    }
+    errors = validate_server_config(name, _coerce_server_config(raw))
+    if errors:
+        for error in errors:
+            print(f"error: {error}", file=sys.stderr)
+        return 1
+
+    path = _scope_path(cwd, scope)
+    doc = _read_json(path) or {}
+    servers = doc.setdefault("mcpServers", {})
+    if not isinstance(servers, dict):
+        servers = {}
+        doc["mcpServers"] = servers
+    servers[name] = raw
+    try:
+        _write_json_atomic(path, doc)
+    except OSError as exc:
+        print(f"error: could not write {path}: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
 def remove_server(
     name: str,
     *,

--- a/local_operator/mcp/config.py
+++ b/local_operator/mcp/config.py
@@ -400,10 +400,15 @@ def add_server(
     env: dict[str, str] | None = None,
     url: str | None = None,
     headers: dict[str, str] | None = None,
+    oauth: bool = False,
     scope: str = "global",
     cwd: str | os.PathLike[str] | None = None,
 ) -> int:
     """Add one server to the scoped mcp.json (``mcp add``).
+
+    ``oauth=True`` writes the canonical HTTP auth block used by the SDK's
+    dynamic client-registration flow. It is rejected for stdio because that
+    transport owns authentication inside its child process.
 
     Returns an exit code: 0 on success, 1 on a validation or duplicate error
     (the message is printed to stderr so the CLI can report it).
@@ -415,6 +420,9 @@ def add_server(
         return 1
     if not command and not url:
         print("error: a server needs a command (stdio) or a url (http)", file=sys.stderr)
+        return 1
+    if oauth and command:
+        print("error: OAuth authentication requires an HTTP server URL", file=sys.stderr)
         return 1
 
     raw: dict[str, Any]
@@ -428,6 +436,8 @@ def add_server(
         raw = {"type": "http", "url": url}
         if headers:
             raw["headers"] = headers
+        if oauth:
+            raw["auth"] = {"type": "oauth"}
 
     cfg = _coerce_server_config(raw)
     errors = validate_server_config(name, cfg)

--- a/local_operator/model/configure.py
+++ b/local_operator/model/configure.py
@@ -19,11 +19,12 @@ from __future__ import annotations
 
 import dataclasses
 import functools
+import inspect
 import logging
 import os
 import re
 import time
-from collections.abc import AsyncIterator, Callable, Mapping
+from collections.abc import AsyncIterator, Awaitable, Callable, Mapping
 from typing import TYPE_CHECKING, Any, Optional
 
 from pydantic import BaseModel, SecretStr
@@ -252,7 +253,7 @@ def build_model_spec(hosting: str, model_name: str, info: ModelInfo | None = Non
 
     definition = get_provider_definition(canonical)
     lowered = model_name.lower()
-    reasoning = any(
+    reasoning = "gpt-5" in lowered or any(
         marker in lowered for marker in ("o1", "o3", "reasoner", "thinking", "deep-research")
     )
     # Keyed on the model, not on the provider that fronts it. `claude-opus-5`
@@ -1048,14 +1049,17 @@ def configure_model(
 
 
 class SessionStreamFn:
-    """The ``LoopConfig.stream_fn`` for one session, plus the pool it owns.
+    """One session's shared client pool and stateful failover router.
 
-    One ``httpx.AsyncClient`` per session: every wire client shares it, and
-    :meth:`close` releases the connection pool on session dispose — a fresh
-    client per LLM round trip leaked one pool per turn for the process
-    lifetime. ``close`` lives on the callable (rather than being returned
-    alongside it) because the loop config carries nothing but the callable.
+    Hard fallback stays pinned for the rest of a user message, so tool loops,
+    compaction and naming do not re-send a warm prompt to a provider that just
+    rejected it. Optional usage preflight runs once at the message boundary,
+    rotates through same-provider OAuth accounts first, then selects the first
+    configured provider/model/effort route with working auth.
     """
+
+    USAGE_CHECK_TTL_S = 60.0
+    DEFAULT_USAGE_BLOCK_MS = 5 * 60 * 1000
 
     def __init__(
         self,
@@ -1065,21 +1069,260 @@ class SessionStreamFn:
     ) -> None:
         import httpx
 
+        from local_operator.providers.failover import FailoverRouteState
+
         self._auth_store = auth_store
         self._settings = settings
         self._session_id = session_id
         self._http = httpx.AsyncClient(timeout=httpx.Timeout(600.0, connect=30.0))
+        self._notice_handler: Callable[[str, str], Awaitable[None] | None] | None = None
+        self._route_state = FailoverRouteState(on_change=self._on_route_change)
+        self._message_boundary_pending = True
+        self._primary_selector: str | None = None
+        self._usage_checked_selector: str | None = None
+        self._usage_checked_at = 0.0
 
     def _client_for(self, spec: ModelSpec) -> WireClient:
         from local_operator.providers.clients import client_for_spec
 
         return client_for_spec(spec, http_client=self._http)
 
+    def set_notice_handler(
+        self, handler: Callable[[str, str], Awaitable[None] | None] | None
+    ) -> None:
+        """Install the owning session's event bridge."""
+        self._notice_handler = handler
+
+    def begin_message(self) -> None:
+        """Mark the next model call as a user-message boundary."""
+        self._message_boundary_pending = True
+
+    async def _notice(self, text: str, kind: str = "warning") -> None:
+        if self._notice_handler is None:
+            return
+        result = self._notice_handler(text, kind)
+        if inspect.isawaitable(result):
+            await result
+
+    async def _on_route_change(self, target: Any, reason: str) -> None:
+        effort = f" ({target.effort} effort)" if target.effort else ""
+        await self._notice(f"{reason} — falling back to {target.selector}{effort}")
+
+    def _fallback_targets(self, model: ModelSpec) -> list[Any]:
+        from local_operator.providers.failover import (
+            RetrySettings,
+            expand_fallback_targets,
+            resolve_chain,
+        )
+
+        retry = RetrySettings.from_settings(self._settings)
+        if not retry.enabled or not retry.model_fallback:
+            return []
+        selector = f"{model.provider}/{model.model_id}"
+        chain = resolve_chain(selector, retry.fallback_chains)
+        return expand_fallback_targets(selector, chain or [])
+
+    async def _target_has_auth(self, target: Any) -> bool:
+        from local_operator.providers.failover import parse_selector
+        from local_operator.providers.registry import get_provider_definition
+
+        provider, _model_id = parse_selector(target.selector)
+        definition = get_provider_definition(provider)
+        if definition is not None and definition.allows_missing_api_key:
+            return True
+        try:
+            return bool(await self._auth_store.get_api_key(provider, self._session_id))
+        except Exception:
+            return False
+
+    async def _first_available_fallback(
+        self,
+        model: ModelSpec,
+        *,
+        different_provider: bool = False,
+    ) -> Any | None:
+        from local_operator.providers.failover import parse_selector
+
+        for target in self._fallback_targets(model):
+            provider, _model_id = parse_selector(target.selector)
+            if different_provider and provider == model.provider:
+                continue
+            if await self._target_has_auth(target):
+                return target
+        return None
+
+    @staticmethod
+    def _storage_provider(provider: str) -> str:
+        from local_operator.providers.registry import get_provider_definition
+
+        definition = get_provider_definition(provider)
+        return definition.store_credentials_as or provider if definition is not None else provider
+
+    async def _primary_has_auth(self, model: ModelSpec) -> bool:
+        from local_operator.providers.failover import FallbackTarget
+
+        return await self._target_has_auth(
+            FallbackTarget(f"{model.provider}/{model.model_id}", model.reasoning_effort)
+        )
+
+    async def preflight_usage(self, model: ModelSpec) -> None:
+        """Check reliable OAuth quota once per user-message boundary.
+
+        Unknown/unreachable usage fails open. A low account is suppressed only
+        when a sibling or configured fallback is ready, so preflight can never
+        turn usable reserve capacity into a dead end.
+        """
+        from local_operator.providers.failover import RetrySettings, parse_selector
+
+        selector = f"{model.provider}/{model.model_id}"
+
+        if selector != self._primary_selector:
+            self._primary_selector = selector
+            self._route_state.clear()
+            self._usage_checked_at = 0.0
+        if not self._message_boundary_pending:
+            return
+        self._message_boundary_pending = False
+
+        now = time.monotonic()
+        if (
+            selector == self._usage_checked_selector
+            and now - self._usage_checked_at < self.USAGE_CHECK_TTL_S
+        ):
+            return
+        self._usage_checked_selector = selector
+        self._usage_checked_at = now
+
+        retry = RetrySettings.from_settings(self._settings)
+        if self._route_state.active is not None and not self._route_state.primary_retry_due():
+            return
+        if not retry.usage_aware_fallback:
+            if self._route_state.active is not None and await self._primary_has_auth(model):
+                self._route_state.clear()
+            return
+
+        attempted_ids: set[int] = set()
+        while True:
+            try:
+                access = await self._auth_store.get_oauth_access(model.provider, self._session_id)
+            except Exception:
+                return
+            if access is None:
+                storage = self._storage_provider(model.provider)
+                rows = self._auth_store.list_credentials(storage)
+                if rows and all(self._auth_store.is_blocked(row.id, storage) for row in rows):
+                    fallback = await self._first_available_fallback(
+                        model,
+                        different_provider=True,
+                    )
+                    if fallback is not None:
+                        await self._route_state.activate(
+                            fallback,
+                            f"{model.provider} credentials temporarily unavailable",
+                        )
+                return
+            if access.kind != "oauth" or access.credential_id in attempted_ids:
+                return
+            attempted_ids.add(access.credential_id)
+
+            from local_operator.providers.usage import fetch_usage, usage_health
+
+            report = await fetch_usage(
+                self._http,
+                model.provider,
+                access_token=access.access_token,
+                account_id=access.account_id,
+            )
+            if report is None:
+                return
+            health = usage_health(
+                report,
+                model.model_id,
+                reserve_percent=retry.usage_reserve_percent,
+            )
+            if health.state == "healthy":
+                self._route_state.clear()
+                return
+            if health.state == "unknown":
+                return
+
+            remaining = (
+                ""
+                if health.remaining_fraction is None
+                else f" ({health.remaining_fraction * 100:.0f}% remaining)"
+            )
+            condition = "quota exhausted" if health.state == "depleted" else "quota low"
+            if health.scope != "account":
+                fallback = await self._first_available_fallback(model)
+                if fallback is None:
+                    await self._notice(
+                        f"{model.provider} {condition}{remaining} for {model.model_id}; "
+                        "no configured model fallback is available"
+                    )
+                    return
+                await self._route_state.activate(
+                    fallback,
+                    f"{model.provider} {condition}{remaining} for {model.model_id}",
+                )
+                return
+
+            storage = self._storage_provider(model.provider)
+            row = self._auth_store.get_credential(access.credential_id)
+            siblings = [
+                candidate
+                for candidate in self._auth_store.list_credentials(storage)
+                if candidate.id != access.credential_id
+                and (row is None or candidate.credential_type == row.credential_type)
+                and not self._auth_store.is_blocked(candidate.id, storage)
+            ]
+            fallback = await self._first_available_fallback(
+                model,
+                # A different effort cannot revive a fully exhausted provider,
+                # but it can preserve reserve quota by reducing token spend.
+                different_provider=health.state == "depleted",
+            )
+            if not siblings and fallback is None:
+                await self._notice(
+                    f"{model.provider} {condition}{remaining}; no configured fallback is available"
+                )
+                return
+
+            block_ms = max(
+                60_000,
+                health.reset_after_ms or self.DEFAULT_USAGE_BLOCK_MS,
+            )
+            if siblings:
+                self._auth_store.block_credential(
+                    access.credential_id,
+                    storage,
+                    block_ms=block_ms,
+                )
+                await self._notice(
+                    f"{model.provider} {condition}{remaining} — trying another "
+                    f"{model.provider} account before provider fallback"
+                )
+                continue
+
+            assert fallback is not None
+            fallback_provider, _model_id = parse_selector(fallback.selector)
+            if fallback_provider != model.provider:
+                self._auth_store.block_credential(
+                    access.credential_id,
+                    storage,
+                    block_ms=block_ms,
+                )
+            await self._route_state.activate(
+                fallback,
+                f"{model.provider} {condition}{remaining}",
+            )
+            return
+
     async def __call__(
         self, request: ChatRequest, signal: AbortSignal | None
     ) -> AsyncIterator[StreamEvent]:
         from local_operator.providers.failover import stream_with_failover
 
+        await self.preflight_usage(request.model)
         async for event in stream_with_failover(
             request,
             self._auth_store,
@@ -1087,6 +1330,7 @@ class SessionStreamFn:
             self._client_for,
             signal=signal,
             session_id=self._session_id,
+            route_state=self._route_state,
         ):
             yield event
 

--- a/local_operator/providers/clients.py
+++ b/local_operator/providers/clients.py
@@ -250,6 +250,54 @@ def _message_to_openai(message: Message) -> dict[str, Any]:
     return {"role": role, "content": parts}
 
 
+def _messages_to_openai_responses(messages: Sequence[Message]) -> list[dict[str, Any]]:
+    """Render harness history as Responses input items, including tool turns."""
+    items: list[dict[str, Any]] = []
+    for message in messages:
+        if message.role == "assistant" and message.tool_calls:
+            if message.text:
+                items.append({"role": "assistant", "content": message.text})
+            for call in message.tool_calls:
+                items.append(
+                    {
+                        "type": "function_call",
+                        "call_id": call.id,
+                        "name": call.name,
+                        "arguments": (
+                            call.raw_arguments
+                            if call.raw_arguments is not None
+                            else json.dumps(call.arguments)
+                        ),
+                    }
+                )
+            continue
+        if message.role == "tool":
+            output = _tool_content_openai(message)
+            items.append(
+                {
+                    "type": "function_call_output",
+                    "call_id": message.tool_call_id or "",
+                    "output": output if isinstance(output, str) else json.dumps(output),
+                }
+            )
+            continue
+
+        content: list[dict[str, Any]] = []
+        text_type = "output_text" if message.role == "assistant" else "input_text"
+        for block in message.content:
+            if isinstance(block, TextContent):
+                content.append({"type": text_type, "text": block.text})
+            elif isinstance(block, ImageContent):
+                content.append(
+                    {
+                        "type": "input_image",
+                        "image_url": f"data:{block.mime_type};base64,{block.data}",
+                    }
+                )
+        items.append({"role": message.role, "content": content})
+    return items
+
+
 EMPTY_TOOL_RESULT_TEXT = "[tool returned no output]"
 
 
@@ -295,6 +343,19 @@ def _tools_to_openai(tools: Sequence[AgentTool]) -> list[dict[str, Any]]:
     ]
 
 
+def _tools_to_openai_responses(tools: Sequence[AgentTool]) -> list[dict[str, Any]]:
+    """Responses tools are flat; chat-completions nests fields under ``function``."""
+    return [
+        {
+            "type": "function",
+            "name": tool.name,
+            "description": tool.description,
+            "parameters": tool.parameters or {"type": "object", "properties": {}},
+        }
+        for tool in tools
+    ]
+
+
 _FINISH_TO_STOP_REASON = {
     "stop": "stop",
     "length": "length",
@@ -314,6 +375,8 @@ _FINISH_TO_STOP_REASON = {
 #: three minutes has stalled, and treating that as patience turns a dead
 #: connection into a UI that looks frozen for the whole request timeout.
 STREAM_READ_TIMEOUT_S = 180.0
+CODEX_RESPONSES_URL = "https://chatgpt.com/backend-api/codex/responses"
+CODEX_BETA_HEADER = "responses=experimental"
 
 
 def _stream_timeout(total: float) -> httpx.Timeout:
@@ -342,10 +405,11 @@ class OpenAICompatClient:
     ``prompt_tokens_details.cached_tokens``.
 
     ChatGPT OAuth credentials (``oauth_access`` with ``kind == "oauth"`` and
-    an ``org_id``) are routed to ``{base_url}/responses`` instead — ChatGPT
-    subscription tokens are rejected by ``chat/completions`` and require the
-    Responses endpoint plus the ``chatgpt-account-id`` header
-    (mirrors ``openai-codex-responses``). Plain API keys keep ``chat/completions``.
+    an ``org_id``) are routed to ChatGPT's Codex Responses endpoint instead.
+    Subscription tokens are rejected by both ``chat/completions`` and the
+    public API's ``/responses`` endpoint; the Codex endpoint also requires its
+    account, beta, and originator headers. Plain API keys keep
+    ``chat/completions``.
     """
 
     def __init__(
@@ -375,6 +439,14 @@ class OpenAICompatClient:
             if oauth_access.org_id:
                 # ChatGPT subscription scope: which account pays for this call.
                 headers["chatgpt-account-id"] = oauth_access.org_id
+            headers.update(
+                {
+                    "Accept": "text/event-stream",
+                    "OpenAI-Beta": CODEX_BETA_HEADER,
+                    "originator": "local-operator",
+                    "User-Agent": "local-operator",
+                }
+            )
         if bearer:
             headers["Authorization"] = f"Bearer {bearer}"
         return headers
@@ -402,6 +474,8 @@ class OpenAICompatClient:
         if max_tokens and max_tokens > 0:
             body["max_tokens"] = max_tokens
         body.update(_sampling_params(request))
+        if request.model.reasoning_effort:
+            body["reasoning_effort"] = request.model.reasoning_effort
         if request.stop_sequences:
             body["stop"] = list(request.stop_sequences)
         return body
@@ -486,8 +560,23 @@ class OpenAICompatClient:
         if max_tokens and max_tokens > 0:
             body["max_output_tokens"] = max_tokens
         body.update(_sampling_params(request))
+        if request.model.reasoning_effort:
+            body["reasoning"] = {"effort": request.model.reasoning_effort}
         if request.stop_sequences:
             body["stop"] = list(request.stop_sequences)
+        return body
+
+    def _build_codex_responses_body(self, request: ChatRequest) -> dict[str, Any]:
+        """ChatGPT Codex body: Responses-shaped, with public-API-only keys removed."""
+        body = self._build_responses_body(request)
+        body["store"] = False
+        body["input"] = _messages_to_openai_responses(request.messages)
+        body.pop("max_output_tokens", None)
+        body.pop("temperature", None)
+        body.pop("top_p", None)
+        body.pop("stop", None)
+        if request.tools:
+            body["tools"] = _tools_to_openai_responses(request.tools)
         return body
 
     async def stream(
@@ -582,8 +671,8 @@ class OpenAICompatClient:
         api_key: str | None,
         oauth_access: "OAuthAccess | None",
     ) -> AsyncIterator[StreamEvent]:
-        """SSE parse for ``POST {base}/responses`` (ChatGPT OAuth route)."""
-        url = f"{self._base_url}/responses"
+        """SSE parse for ChatGPT's Codex Responses endpoint."""
+        url = CODEX_RESPONSES_URL
         usage: Usage | None = None
         provider_payload: dict[str, Any] | None = None
         tool_call_count = 0
@@ -593,7 +682,7 @@ class OpenAICompatClient:
         async with self._http.stream(
             "POST",
             url,
-            json=self._build_responses_body(request),
+            json=self._build_codex_responses_body(request),
             headers=self._headers(api_key, oauth_access),
         ) as response:
             if response.status_code >= 400:
@@ -701,7 +790,11 @@ class AnthropicClient:
         )
 
     def _headers(
-        self, api_key: str | None, oauth_access: "OAuthAccess | None" = None
+        self,
+        api_key: str | None,
+        oauth_access: "OAuthAccess | None" = None,
+        *,
+        effort: str | None = None,
     ) -> dict[str, str]:
         headers = {"anthropic-version": ANTHROPIC_VERSION, "Content-Type": "application/json"}
         if self._is_oauth(oauth_access):
@@ -712,6 +805,10 @@ class AnthropicClient:
             headers["anthropic-beta"] = "oauth-2025-04-20"
         elif api_key:
             headers["x-api-key"] = api_key
+        if effort:
+            beta = "effort-2025-11-24"
+            existing = headers.get("anthropic-beta")
+            headers["anthropic-beta"] = f"{existing},{beta}" if existing else beta
         return headers
 
     # Anthropic caps cache_control markers per request; the harness keeps the
@@ -911,6 +1008,9 @@ class AnthropicClient:
                 "required": {"type": "any"},
             }.get(request.tool_choice, {"type": "auto"})
         body.update(_sampling_params(request))
+        if request.model.reasoning_effort:
+            body["thinking"] = {"type": "adaptive"}
+            body["output_config"] = {"effort": request.model.reasoning_effort}
         if request.stop_sequences:
             body["stop_sequences"] = list(request.stop_sequences)
         return body
@@ -930,7 +1030,11 @@ class AnthropicClient:
             "POST",
             url,
             json=self._build_body(request, oauth=self._is_oauth(oauth_access)),
-            headers=self._headers(api_key, oauth_access),
+            headers=self._headers(
+                api_key,
+                oauth_access,
+                effort=request.model.reasoning_effort,
+            ),
         ) as response:
             if response.status_code >= 400:
                 await response.aread()

--- a/local_operator/providers/failover.py
+++ b/local_operator/providers/failover.py
@@ -447,13 +447,23 @@ class FailoverRouteState:
         *,
         cooldown_ms: int = 0,
     ) -> None:
+        if self.active == target:
+            # Already on this route: nothing changed, so nothing is re-armed.
+            # The cooldown MUST NOT be bumped here. `stream_with_failover`
+            # calls `activate` on every request that enters the sticky
+            # fallback route, so bumping before this return turned a fixed
+            # post-failure cooldown into a sliding window: a user sending
+            # messages more often than the cooldown never reached
+            # `primary_retry_due()`, and stayed pinned to the fallback for the
+            # whole session even after the primary recovered. The docstring
+            # above promises a retry "only after primary_retry_at_ms", which
+            # is a deadline set when the route CHANGES, not on every use.
+            return
         if cooldown_ms > 0:
             self.primary_retry_at_ms = max(
                 self.primary_retry_at_ms,
                 int(time.time() * 1000) + cooldown_ms,
             )
-        if self.active == target:
-            return
         self.active = target
         if self.on_change is None:
             return

--- a/local_operator/providers/failover.py
+++ b/local_operator/providers/failover.py
@@ -20,6 +20,7 @@ import asyncio
 import dataclasses
 import inspect
 import random
+import time
 from collections.abc import AsyncIterator, Awaitable, Callable, Mapping, Sequence
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
@@ -248,6 +249,21 @@ async def resolve_next_key(
 # ---------------------------------------------------------------------------
 
 DEFAULT_CHAIN_KEY = "default"
+SUPPORTED_EFFORTS = frozenset({"minimal", "low", "medium", "high", "xhigh", "max"})
+
+
+@dataclasses.dataclass(frozen=True)
+class FallbackTarget:
+    """One resolved cascade entry.
+
+    ``selector`` keeps routing compatible with the existing
+    ``provider/model`` chain format. ``effort`` is optional because many
+    providers either do not expose reasoning levels or should use their model
+    default.
+    """
+
+    selector: str
+    effort: str | None = None
 
 
 def _chain_specificity(key: str, selector: str) -> int | None:
@@ -261,7 +277,7 @@ def _chain_specificity(key: str, selector: str) -> int | None:
     return None
 
 
-def resolve_chain(selector: str, chains: Mapping[str, Sequence[str]]) -> list[str] | None:
+def resolve_chain(selector: str, chains: Mapping[str, Sequence[Any]]) -> list[Any] | None:
     """Pick the fallback chain for ``selector`` by specificity:
     exact ``provider/model`` → longest matching wildcard prefix → ``default``.
     """
@@ -281,24 +297,55 @@ def resolve_chain(selector: str, chains: Mapping[str, Sequence[str]]) -> list[st
     return list(chains[best_key])
 
 
-def expand_fallback_candidates(selector: str, chain: Sequence[str]) -> list[str]:
-    """Materialize chain entries into concrete selectors.
+def _fallback_target(entry: Any) -> FallbackTarget | None:
+    """Normalize a legacy selector string or a provider/model/effort mapping."""
+    effort: str | None = None
+    if isinstance(entry, str):
+        selector = entry.strip()
+    elif isinstance(entry, Mapping):
+        provider = str(entry.get("provider") or "").strip()
+        model = str(entry.get("model") or entry.get("model_id") or "").strip()
+        selector = str(entry.get("selector") or "").strip()
+        if not selector and provider and model:
+            selector = f"{provider}/{model}"
+        raw_effort = entry.get("effort")
+        if raw_effort is not None:
+            effort = str(raw_effort).strip().lower()
+            if effort not in SUPPORTED_EFFORTS:
+                return None
+    else:
+        return None
+    provider, model_id = parse_selector(selector)
+    if not provider or not model_id:
+        return None
+    return FallbackTarget(selector=selector, effort=effort)
 
-    - Plain entries are kept as-is.
-    - ``provider/*`` keeps the failing model id and swaps the provider.
-    - Id-prefixed wildcards (``openrouter/google/*``) re-prefix the bare id.
-    The current selector is never emitted as its own fallback.
+
+def expand_fallback_targets(selector: str, chain: Sequence[Any]) -> list[FallbackTarget]:
+    """Materialize configured entries into unique provider/model/effort targets.
+
+    ``provider/*`` keeps the failing model id. A mapping may explicitly repeat
+    the current selector with a different effort; that is a real fallback
+    route, while an unchanged legacy string is still suppressed.
     """
     _, _, bare_id = selector.partition("/")
-    candidates: list[str] = []
+    targets: list[FallbackTarget] = []
     for entry in chain:
-        if entry.endswith("/*"):
-            candidate = f"{entry[:-1]}{bare_id}"
-        else:
-            candidate = entry
-        if candidate and candidate != selector and candidate not in candidates:
-            candidates.append(candidate)
-    return candidates
+        target = _fallback_target(entry)
+        if target is None:
+            continue
+        if target.selector.endswith("/*"):
+            target = dataclasses.replace(target, selector=f"{target.selector[:-1]}{bare_id}")
+        if target.selector == selector and target.effort is None:
+            continue
+        if target not in targets:
+            targets.append(target)
+    return targets
+
+
+def expand_fallback_candidates(selector: str, chain: Sequence[Any]) -> list[str]:
+    """Backward-compatible selector-only view of :func:`expand_fallback_targets`."""
+    return [target.selector for target in expand_fallback_targets(selector, chain)]
 
 
 # ---------------------------------------------------------------------------
@@ -339,13 +386,15 @@ def _same_credential_retry_allowed(
 
 @dataclasses.dataclass(frozen=True)
 class RetrySettings:
-    """The ``values.retry.*`` config surface (defaults from the established harness)."""
+    """The ``values.retry.*`` config surface."""
 
     enabled: bool = True
     max_retries: int = 10
     base_delay_ms: int = 500
     model_fallback: bool = True
-    fallback_chains: Mapping[str, Sequence[str]] = dataclasses.field(default_factory=dict)
+    usage_aware_fallback: bool = False
+    usage_reserve_percent: float = 10.0
+    fallback_chains: Mapping[str, Sequence[Any]] = dataclasses.field(default_factory=dict)
 
     @staticmethod
     def from_settings(settings: Mapping[str, Any] | None) -> "RetrySettings":
@@ -355,13 +404,70 @@ class RetrySettings:
         chains = retry.get("fallbackChains", retry.get("fallback_chains", {}))
         if not isinstance(chains, Mapping):
             chains = {}
+        reserve = retry.get("usageReservePercent", retry.get("usage_reserve_percent", 10.0))
+        try:
+            reserve_percent = min(100.0, max(0.0, float(reserve)))
+        except (TypeError, ValueError):
+            reserve_percent = 10.0
         return RetrySettings(
             enabled=bool(retry.get("enabled", True)),
             max_retries=int(retry.get("maxRetries", retry.get("max_retries", 10))),
             base_delay_ms=int(retry.get("baseDelayMs", retry.get("base_delay_ms", 500))),
             model_fallback=bool(retry.get("modelFallback", retry.get("model_fallback", True))),
+            usage_aware_fallback=bool(
+                retry.get("usageAwareFallback", retry.get("usage_aware_fallback", False))
+            ),
+            usage_reserve_percent=reserve_percent,
             fallback_chains=chains,
         )
+
+
+RouteChangeHandler = Callable[[FallbackTarget, str], Awaitable[None] | None]
+
+
+@dataclasses.dataclass
+class FailoverRouteState:
+    """Session-sticky fallback route with a primary-probe cooldown.
+
+    A successful fallback stays active for later model calls in the same user
+    message. At later message boundaries, quota-aware preflight may return to
+    the primary only after ``primary_retry_at_ms``. Without that suppression a
+    healthy quota endpoint would make a transport-broken primary consume the
+    full prompt once per user message before failing over again.
+    """
+
+    active: FallbackTarget | None = None
+    on_change: RouteChangeHandler | None = None
+    primary_retry_at_ms: int = 0
+
+    async def activate(
+        self,
+        target: FallbackTarget,
+        reason: str,
+        *,
+        cooldown_ms: int = 0,
+    ) -> None:
+        if cooldown_ms > 0:
+            self.primary_retry_at_ms = max(
+                self.primary_retry_at_ms,
+                int(time.time() * 1000) + cooldown_ms,
+            )
+        if self.active == target:
+            return
+        self.active = target
+        if self.on_change is None:
+            return
+        result = self.on_change(target, reason)
+        if inspect.isawaitable(result):
+            await result
+
+    def primary_retry_due(self, now_ms: int | None = None) -> bool:
+        now = int(time.time() * 1000) if now_ms is None else now_ms
+        return now >= self.primary_retry_at_ms
+
+    def clear(self) -> None:
+        self.active = None
+        self.primary_retry_at_ms = 0
 
 
 def parse_selector(selector: str) -> tuple[str, str]:
@@ -369,10 +475,29 @@ def parse_selector(selector: str) -> tuple[str, str]:
     return provider, model_id
 
 
+def spec_for_target(base: ModelSpec, target: FallbackTarget) -> ModelSpec:
+    """Build the fallback model's OWN spec, then carry only sampling choices.
+
+    Cloning the primary spec kept its base URL, context window and capabilities;
+    a cross-provider fallback could therefore send an OpenAI model to the
+    Anthropic endpoint. Model metadata and transport identity belong to the
+    target, while temperature/top-p remain session preferences.
+    """
+    from local_operator.model.configure import build_model_spec
+
+    target_spec = build_model_spec(*parse_selector(target.selector))
+    return target_spec.model_copy(
+        update={
+            "temperature": base.temperature,
+            "top_p": base.top_p,
+            "reasoning_effort": target.effort,
+        }
+    )
+
+
 def spec_for_selector(base: ModelSpec, selector: str) -> ModelSpec:
-    """Clone ``base`` with the provider/model swapped in (knobs carry over)."""
-    provider, model_id = parse_selector(selector)
-    return base.model_copy(update={"provider": provider, "model_id": model_id})
+    """Backward-compatible selector-only wrapper."""
+    return spec_for_target(base, FallbackTarget(selector))
 
 
 # ---------------------------------------------------------------------------
@@ -453,6 +578,7 @@ async def stream_with_failover(
     *,
     session_id: str | None = None,
     signal: AbortSignal | None = None,
+    route_state: FailoverRouteState | None = None,
 ) -> AsyncIterator[StreamEvent]:
     """Stream one provider call with tier-1 + tier-2 failover.
 
@@ -473,36 +599,45 @@ async def stream_with_failover(
     """
     retry = RetrySettings.from_settings(settings)
     primary_selector = _selector_for_request(request)
+    primary_target = FallbackTarget(primary_selector, request.model.reasoning_effort)
 
-    selectors = [primary_selector]
+    targets = [primary_target]
     if retry.enabled and retry.model_fallback:
         chain = resolve_chain(primary_selector, retry.fallback_chains)
         if chain:
-            selectors.extend(expand_fallback_candidates(primary_selector, chain))
+            for candidate in expand_fallback_targets(primary_selector, chain):
+                if candidate not in targets:
+                    targets.append(candidate)
+    if route_state is not None and route_state.active in targets:
+        targets = targets[targets.index(route_state.active) :]
 
     last_error: ProviderError | None = None
-    clients: dict[str, "WireClient"] = {}
+    clients: dict[tuple[str, str | None], "WireClient"] = {}
     rng = random.Random()
 
-    for selector in selectors:
+    for target in targets:
+        selector = target.selector
         if signal is not None and signal.aborted:
             raise ProviderError(None, signal.reason or "aborted", retryable=False)
 
         provider, _model_id = parse_selector(selector)
-        spec = (
-            request.model
-            if selector == primary_selector
-            else spec_for_selector(request.model, selector)
-        )
-        client = clients.get(selector)
+        spec = request.model if target == primary_target else spec_for_target(request.model, target)
+        route_key = (selector, target.effort)
+        client = clients.get(route_key)
         if client is None:
             built = client_for(spec)
             client = await built if inspect.isawaitable(built) else built
-            clients[selector] = client
+            clients[route_key] = client
         current_request = (
-            request if selector == primary_selector else request.model_copy(update={"model": spec})
+            request if target == primary_target else request.model_copy(update={"model": spec})
         )
-
+        if route_state is not None and target != primary_target:
+            cooldown_ms = max(60_000, last_error.retry_after_ms or 0) if last_error else 60_000
+            await route_state.activate(
+                target,
+                "provider failure",
+                cooldown_ms=cooldown_ms,
+            )
         state = AuthRetryKeyState()
         error: BaseException | None = None
         access: "OAuthAccess | None" = None  # credential record for this attempt
@@ -537,6 +672,8 @@ async def stream_with_failover(
                 async for event in client.stream(current_request, key, oauth_access=access):
                     forwarded_any = True
                     yield event
+                if route_state is not None and target == primary_target:
+                    route_state.clear()
                 return  # clean completion
             except asyncio.CancelledError:
                 raise

--- a/local_operator/providers/usage.py
+++ b/local_operator/providers/usage.py
@@ -261,6 +261,80 @@ class UsageReport:
     identity: str | None = None
 
 
+@dataclass(frozen=True)
+class QuotaHealth:
+    """Whether a provider account can accept another message."""
+
+    state: Literal["healthy", "reserve", "depleted", "unknown"]
+    remaining_fraction: float | None = None
+    reset_after_ms: int | None = None
+    scope: Literal["account", "model", "unknown"] = "unknown"
+
+
+def usage_health(
+    report: UsageReport,
+    model_id: str,
+    *,
+    reserve_percent: float = 10.0,
+    now_ms: float | None = None,
+) -> QuotaHealth:
+    """Reduce a normalized report to the limits that gate ``model_id``.
+
+    Shared windows always apply; tier windows apply only when their tier name
+    appears in the model id. Anthropic's enabled extra-usage meter supersedes
+    the included-plan windows because paid headroom keeps requests runnable
+    after the plan reaches 100%.
+    """
+    lowered_model = model_id.lower()
+    extra = [
+        limit
+        for limit in report.limits
+        if limit.id.endswith(":extra") and limit.amount.fraction() is not None
+    ]
+    if extra:
+        relevant = extra
+    else:
+        relevant = [
+            limit
+            for limit in report.limits
+            if limit.shared
+            or (limit.tier and limit.tier.lower() in lowered_model)
+            or (not limit.shared and not limit.tier)
+        ]
+    measured: list[tuple[UsageLimit, float]] = []
+    for limit in relevant:
+        fraction = limit.amount.fraction()
+        if fraction is not None:
+            measured.append((limit, max(0.0, min(1.0, 1.0 - fraction))))
+    if not measured:
+        return QuotaHealth("unknown")
+
+    remaining = min(value for _limit, value in measured)
+    threshold = min(100.0, max(0.0, float(reserve_percent))) / 100.0
+    state: Literal["healthy", "reserve", "depleted", "unknown"]
+    if remaining <= 0:
+        state = "depleted"
+    elif remaining <= threshold:
+        state = "reserve"
+    else:
+        state = "healthy"
+    binding = [limit for limit, value in measured if value <= threshold]
+    binding_resets = [limit.resets_in_ms(now_ms) for limit in binding]
+    reset_after = max((value for value in binding_resets if value is not None), default=None)
+    if not binding:
+        scope: Literal["account", "model", "unknown"] = "unknown"
+    elif all(limit.tier and not limit.shared for limit in binding):
+        scope = "model"
+    else:
+        scope = "account"
+    return QuotaHealth(
+        state,
+        remaining_fraction=remaining,
+        reset_after_ms=reset_after,
+        scope=scope,
+    )
+
+
 # ---------------------------------------------------------------------------
 # Per-provider fetchers. Each returns a ``UsageReport`` or ``None``.
 # ---------------------------------------------------------------------------

--- a/local_operator/server/utils/operator.py
+++ b/local_operator/server/utils/operator.py
@@ -527,8 +527,8 @@ class ServerExecutor:
             self.config_manager.get_config().values if self.config_manager is not None else None
         )
         auth_store = AuthStore(credential_manager=self.credential_manager)
+        stream_fn = create_stream_fn(auth_store, settings=settings)
         try:
-            stream_fn = create_stream_fn(auth_store, settings=settings)
             request = ChatRequest(
                 model=self.model_configuration.spec,
                 system_blocks=system_blocks,
@@ -548,6 +548,10 @@ class ServerExecutor:
                     raise RuntimeError(event.error)
             return ModelResponse("".join(chunks))
         finally:
+            try:
+                await stream_fn.close()
+            except Exception:  # noqa: BLE001 — teardown must not mask the completion
+                logger.debug("stream client close failed", exc_info=True)
             try:
                 auth_store.close()
             except Exception:  # noqa: BLE001 — teardown must not mask errors

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -849,6 +849,9 @@ class Session:
             browser=self._browser,
             subagent_launcher=self._launch_subagent,
             jobs=self.jobs,
+            delegated_tools={
+                tool.name: tool for tool in self._tools if tool.name.startswith("mcp__")
+            },
         )
 
     def _launch_subagent(self, label: str, prompt: str) -> str:

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -35,7 +35,7 @@ import inspect
 import logging
 import time
 from collections.abc import AsyncIterator, Awaitable, Callable, Coroutine, Sequence
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 from local_operator.harness.jobs import AsyncJobManager
 from local_operator.harness.loop import AgentLoop, LoopContext
@@ -256,6 +256,12 @@ class Session:
     ) -> None:
         self._model = model
         self._stream_fn = stream_fn
+        notice_bridge = getattr(self._stream_fn, "set_notice_handler", None)
+        if callable(notice_bridge):
+            # The stream owns provider routing; the session owns ordered event
+            # delivery. Binding the two here lets every front end receive quota
+            # and fallback notices without teaching the harness loop providers.
+            notice_bridge(self._stream_notice)
         self._tools = list(tools)
         self._transcript = transcript
         self._session_id = session_id or transcript.directory.name
@@ -502,6 +508,19 @@ class Session:
         """Exposed so the wake tool can list/create/cancel schedules."""
         return self._wake
 
+    async def preflight_usage(self) -> None:
+        """Run the stream's message-boundary quota check without starting a turn.
+
+        The TUI calls this after subscribing, so an exhausted default provider
+        becomes a visible warning while startup itself remains successful.
+        """
+        preflight = getattr(self._stream_fn, "preflight_usage", None)
+        if not callable(preflight):
+            return
+        result = preflight(self._model)
+        if inspect.isawaitable(result):
+            await result
+
     # -- driving turns --------------------------------------------------------
     async def prompt(self, text: str) -> None:
         """Run one user turn to completion (awaitable) or raise.
@@ -616,6 +635,14 @@ class Session:
 
         return _unsubscribe
 
+    async def _stream_notice(
+        self,
+        text: str,
+        kind: Literal["info", "warning", "error"] = "warning",
+    ) -> None:
+        """Bridge provider-routing diagnostics onto the session event stream."""
+        await self._emit(NoticeEvent(text=text, kind=kind))
+
     async def _emit(self, event: AgentEvent) -> None:
         for handler in list(self._handlers):
             try:
@@ -648,6 +675,9 @@ class Session:
         The generation stamp on the emitted end is the one from the start that
         opened the run, so the TUI's supersede guard still pairs them.
         """
+        begin_message = getattr(self._stream_fn, "begin_message", None)
+        if callable(begin_message):
+            begin_message()
         self._turn_task = asyncio.current_task()
         try:
             await self._run_turn(initial)

--- a/local_operator/session_factory.py
+++ b/local_operator/session_factory.py
@@ -731,6 +731,7 @@ async def _prepare(
         # overrides ride above the project file and process environment, and
         # values stay out of the system prompt (read on demand, not baked).
         variables=_build_variable_store(effective_cwd, config_manager),
+        web_search_settings=config_manager.get_config_value("web_search", None),
     )
     tools = create_tools(tool_context)
 

--- a/local_operator/tools/builtin.py
+++ b/local_operator/tools/builtin.py
@@ -3648,15 +3648,17 @@ class JobsParams(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
 
-#: Formatted status text shared by ``wait``'s settled return and the machine
-#: detail payload.
-def _job_summary(job: Any) -> str:
+#: Formatted status text shared by ``wait``'s settled return and its detail
+#: payload.  A child report can dwarf an ordinary tool result, so it uses the
+#: same bounded, lossless spill path as every other verbose tool.
+def _job_summary(job: Any, context: ToolContext | None = None) -> tuple[str, dict[str, Any] | None]:
+    """Return a context-bounded handoff while keeping the full report readable."""
     text = f"job {job.id} ({job.label}) [{job.status}]"
     if job.status == "completed" and job.result_text:
         text += f"\n{job.result_text}"
     if job.status == "failed" and job.error_text:
         text += f"\n{job.error_text}"
-    return text
+    return spill_truncate(text, "wait", context)
 
 
 @_guard("task")
@@ -3760,11 +3762,15 @@ async def execute_wait(
         job = jobs.get(params.job_id)
         if job is None:
             return _error(tool_call_id, "wait", f"job {params.job_id} disappeared")
+    text, spill_details = _job_summary(job, context)
+    details = {"job_id": job.id, "status": job.status}
+    if spill_details:
+        details.update(spill_details)
     return _text(
         tool_call_id,
         "wait",
-        _job_summary(job),
-        details={"job_id": job.id, "status": job.status},
+        text,
+        details=details,
     )
 
 

--- a/local_operator/tools/registry.py
+++ b/local_operator/tools/registry.py
@@ -15,6 +15,7 @@ from collections.abc import Callable, Sequence
 
 from local_operator.harness.types import AgentTool, ToolContext
 from local_operator.tools import builtin
+from local_operator.web_search.tool import build_web_search_tool
 
 #: Factory table: tool name -> builder (createIf convention). ``wake`` takes
 #: the context and returns ``None`` when no wake scheduler is attached, so a
@@ -28,6 +29,7 @@ TOOL_BUILDERS: dict[str, Callable[[ToolContext], AgentTool | None]] = {
     "glob": lambda _context: builtin.build_glob_tool(),
     "grep": lambda _context: builtin.build_grep_tool(),
     "todo": lambda _context: builtin.build_todo_tool(),
+    "web_search": lambda context: build_web_search_tool(context),
     "wake": lambda context: builtin.build_wake_tool(context),
     "task": lambda context: builtin.build_task_tool(context),
     "wait": lambda context: builtin.build_wait_tool(context),
@@ -49,6 +51,7 @@ DEFAULT_TOOL_NAMES: list[str] = [
     "glob",
     "grep",
     "todo",
+    "web_search",
     "wake",
     "task",
     "wait",

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -1918,19 +1918,42 @@ class OperatorApp(App[None]):
         try:
             if not words:
                 settings = load_search_settings(manager)
+                statuses = provider_statuses(settings, credentials)
+                labels = {status.id: status.label for status in statuses}
+                strategy = settings.strategy.replace("_", " ").title()
+                order = " → ".join(labels[value] for value in settings.providers)
                 items: list[tuple[str, str]] = [
                     (
-                        "web search",
-                        f"{'on' if settings.enabled else 'off'} · "
-                        f"{settings.strategy} · "
-                        f"{', '.join(settings.providers) or 'no providers'}",
+                        "Web search",
+                        f"{'On' if settings.enabled else 'Off'} · {strategy} · "
+                        f"{order or 'No providers'}",
                     )
                 ]
-                for status in provider_statuses(settings, credentials):
+                for status in statuses:
                     enabled = "enabled" if status.enabled else "disabled"
-                    ready = "ready" if status.available else "setup needed"
-                    items.append((status.id, f"{enabled} · {ready} · {status.detail}"))
-                items.append(("setup", "local-operator search setup <provider>"))
+                    available = "available" if status.available else "setup needed"
+                    items.append((status.label, f"{enabled} · {available} · {status.detail}"))
+                items.extend(
+                    [
+                        ("toggle", "/search on|off · /search enable|disable <provider>"),
+                        (
+                            "balance",
+                            "/search balance round_robin|ordered · " "/search order <providers…>",
+                        ),
+                        (
+                            "setup (shell)",
+                            "local-operator search setup tavily --oauth|--api-key",
+                        ),
+                        (
+                            "API keys (shell)",
+                            "local-operator search setup <provider> --api-key",
+                        ),
+                        (
+                            "SearXNG (shell)",
+                            "local-operator search setup searxng --endpoint <url>",
+                        ),
+                    ]
+                )
                 self._append_block(RichBlock(_tree_listing(items)))
                 return
 
@@ -1979,7 +2002,19 @@ class OperatorApp(App[None]):
                 if provider not in PROVIDER_IDS:
                     notice(f"unknown search provider: {provider}", "warning")
                     return
-                notice(f"run: local-operator search setup {provider}")
+                if provider == "tavily":
+                    notice(
+                        "run in a shell: local-operator search setup tavily "
+                        "--oauth (or --api-key)"
+                    )
+                elif provider == "searxng":
+                    notice(
+                        "run in a shell: local-operator search setup searxng " "--endpoint <url>"
+                    )
+                elif provider in ("brave", "exa", "serpapi", "perplexity"):
+                    notice(f"run in a shell: local-operator search setup {provider} " "--api-key")
+                else:
+                    notice("DuckDuckGo needs no setup; use /search enable duckduckgo")
                 return
             notice(
                 "usage: /search [on|off|enable <provider>|disable <provider>|"

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -476,6 +476,16 @@ class OperatorApp(App[None]):
         session.set_approval_handler(self.request_tool_approval)
         self._controller = EventController(session, self)
         self._controller.subscribe()
+        # The app is already painted and subscribed, so quota I/O cannot delay
+        # first paint and any warning lands in the transcript. This is an
+        # optional session capability so lightweight hosts do not need to fake
+        # network preflight; failure must never become another startup gate.
+        usage_preflight = getattr(session, "preflight_usage", None)
+        if callable(usage_preflight):
+            try:
+                await cast(Callable[[], Awaitable[None]], usage_preflight)()
+            except Exception:
+                pass
         assert self._status is not None
         self._status.update(
             model_label=session.model_label,

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 
 import os
 import time
-from typing import TYPE_CHECKING, Any, Awaitable, Callable, NamedTuple, Protocol
+from typing import TYPE_CHECKING, Any, Awaitable, Callable, NamedTuple, Protocol, cast
 
 from rich.console import Group
 from rich.style import Style
@@ -122,6 +122,7 @@ SLASH_COMMANDS: list[SlashCommand] = [
     ),
     SlashCommand("model", "Show or switch model (provider/id)", aliases=("models",)),
     SlashCommand("provider", "List providers and their login/usage state"),
+    SlashCommand("search", "Configure web search providers and load balancing"),
     SlashCommand("accounts", "List stored credentials"),
     SlashCommand("usage", "Show provider usage quota"),
     SlashCommand("goal", "Show, set, or clear the session goal"),
@@ -1465,6 +1466,8 @@ class OperatorApp(App[None]):
             self._cmd_model(arg, notice)
         elif command == "/provider":
             self._cmd_providers(notice)
+        elif command == "/search":
+            self._cmd_search(arg, notice)
         elif command == "/accounts":
             self._cmd_accounts(notice)
         elif command == "/usage":
@@ -1885,6 +1888,107 @@ class OperatorApp(App[None]):
             notice(f"loop finished after {completed} iteration(s)")
 
     # -- providers / accounts / usage --------------------------------------
+    def _cmd_search(self, arg: str, notice: NoticeFn) -> None:
+        """``/search`` status plus non-secret provider toggles.
+
+        Secret entry stays in the normal terminal command. Textual's editor is
+        transcript-visible, so accepting an API key here would persist it in
+        clear text and hand it to the model on the next turn.
+        """
+        from local_operator.config import ConfigManager
+        from local_operator.credentials import CredentialManager
+        from local_operator.paths import config_dir
+        from local_operator.web_search.models import (
+            PROVIDER_IDS,
+            SearchProviderId,
+            SearchStrategy,
+        )
+        from local_operator.web_search.providers import provider_statuses
+        from local_operator.web_search.service import (
+            load_search_settings,
+            set_provider_enabled,
+            set_provider_order,
+            set_search_enabled,
+            set_search_strategy,
+        )
+
+        manager = ConfigManager(config_dir())
+        credentials = CredentialManager(config_dir())
+        words = arg.split()
+        try:
+            if not words:
+                settings = load_search_settings(manager)
+                items: list[tuple[str, str]] = [
+                    (
+                        "web search",
+                        f"{'on' if settings.enabled else 'off'} · "
+                        f"{settings.strategy} · "
+                        f"{', '.join(settings.providers) or 'no providers'}",
+                    )
+                ]
+                for status in provider_statuses(settings, credentials):
+                    enabled = "enabled" if status.enabled else "disabled"
+                    ready = "ready" if status.available else "setup needed"
+                    items.append((status.id, f"{enabled} · {ready} · {status.detail}"))
+                items.append(("setup", "local-operator search setup <provider>"))
+                self._append_block(RichBlock(_tree_listing(items)))
+                return
+
+            command = words[0].lower()
+            if command in ("on", "off") and len(words) == 1:
+                set_search_enabled(manager, command == "on")
+                notice(
+                    f"web search {command}; /reload "
+                    f"{'adds' if command == 'on' else 'removes'} the tool"
+                )
+                return
+            if command in ("enable", "disable") and len(words) == 2:
+                provider = words[1].lower()
+                if provider not in PROVIDER_IDS:
+                    notice(f"unknown search provider: {provider}", "warning")
+                    return
+                set_provider_enabled(
+                    manager,
+                    cast(SearchProviderId, provider),
+                    command == "enable",
+                )
+                notice(f"{provider} {command}d; applies to the next search")
+                return
+            if command == "balance" and len(words) == 2:
+                strategy = words[1].lower()
+                if strategy not in ("round_robin", "ordered"):
+                    notice("search balance must be round_robin or ordered", "warning")
+                    return
+                set_search_strategy(manager, cast(SearchStrategy, strategy))
+                notice(f"search balance: {strategy}")
+                return
+            if command == "order" and len(words) >= 2:
+                provider_words = [word.lower().strip(",") for word in words[1:]]
+                unknown = [word for word in provider_words if word not in PROVIDER_IDS]
+                if unknown:
+                    notice(f"unknown search provider: {unknown[0]}", "warning")
+                    return
+                providers: list[SearchProviderId] = [
+                    cast(SearchProviderId, word) for word in provider_words
+                ]
+                set_provider_order(manager, providers)
+                notice("search order: " + ", ".join(providers))
+                return
+            if command == "setup" and len(words) == 2:
+                provider = words[1].lower()
+                if provider not in PROVIDER_IDS:
+                    notice(f"unknown search provider: {provider}", "warning")
+                    return
+                notice(f"run: local-operator search setup {provider}")
+                return
+            notice(
+                "usage: /search [on|off|enable <provider>|disable <provider>|"
+                "balance <round_robin|ordered>|order <providers…>|setup <provider>]",
+                "warning",
+            )
+        except Exception as error:
+            notice(f"search configuration failed: {error}", "error")
+
     def _cmd_providers(self, notice: NoticeFn) -> None:
         """``/provider`` — list loginable providers and their state."""
         if self._providers is None:

--- a/local_operator/tui/glyphs.py
+++ b/local_operator/tui/glyphs.py
@@ -95,7 +95,7 @@ PLAIN_TOOL_ICONS: dict[str, str] = {
     "list_variables": "x",  # the algebraic unknown
     "read_variable": "x",
     "browser": "@",  # the URL sigil
-    "web_search": "⌕",  # find/search without reusing grep's /pattern/ sigil
+    "web_search": "?",  # a search query, in the verified ASCII fallback repertoire
     "task": "»",  # work passed onward
     "agent": "»",
 }

--- a/local_operator/tui/glyphs.py
+++ b/local_operator/tui/glyphs.py
@@ -69,6 +69,7 @@ NERD_TOOL_ICONS: dict[str, str] = {
     "list_variables": "\uf0ca",  # nf-fa-list_ul
     "read_variable": "\uf02b",  # nf-fa-tag
     "browser": "\uf0ac",  # nf-fa-globe
+    "web_search": "\uf0ac",  # nf-fa-globe
     "task": "\uf0c0",  # nf-fa-users — work handed to another agent
     "agent": "\uf0c0",
 }
@@ -94,6 +95,7 @@ PLAIN_TOOL_ICONS: dict[str, str] = {
     "list_variables": "x",  # the algebraic unknown
     "read_variable": "x",
     "browser": "@",  # the URL sigil
+    "web_search": "⌕",  # find/search without reusing grep's /pattern/ sigil
     "task": "»",  # work passed onward
     "agent": "»",
 }

--- a/local_operator/tui/widgets/tool_card.py
+++ b/local_operator/tui/widgets/tool_card.py
@@ -370,7 +370,7 @@ def _search_result_output(details: dict[str, Any] | None) -> list[str]:
             if len(snippet) > SEARCH_EXPANDED_SNIPPET_CHARS:
                 snippet = snippet[: SEARCH_EXPANDED_SNIPPET_CHARS - 1].rstrip() + "…"
             lines.append(f"   {snippet}")
-    lines.append("Open a result URL with browser to read the full page.")
+    lines.append("Ask Operator to open result N with browser for the full page.")
     return lines
 
 
@@ -1018,6 +1018,8 @@ class ToolCard(TranscriptBlock):
             return row
         if self._diff:
             self._append_diff_body(row, width)
+        elif self.tool_name.lower() == "web_search" and self._output:
+            self._append_search_body(row, width)
         elif self._output:
             self._append_output_body(row, width)
         return row
@@ -1040,6 +1042,33 @@ class ToolCard(TranscriptBlock):
         hidden = len(self._output) - len(shown)
         if hidden > 0:
             marker = f"… {hidden} more line{'s' if hidden != 1 else ''}"
+            row.append("\n" + indent, style=dim)
+            row.append(truncate_cells(marker, line_width), style=dim)
+
+    def _append_search_body(self, row: Text, width: int) -> None:
+        """Search expansion hierarchy: titles lead, URLs signal, snippets recede."""
+        fg = Style(color=theme_mod.semantic_color("fg"), bold=True)
+        signal = Style(color=theme_mod.semantic_color("signal"))
+        muted = Style(color=theme_mod.semantic_color("muted"))
+        dim = Style(color=theme_mod.semantic_color("dim"))
+        line_width = max(1, width - 2 - OUTPUT_INDENT)
+        indent = " " * OUTPUT_INDENT
+        shown = self._output[:EXPAND_MAX_LINES]
+        for line in shown:
+            stripped = line.strip()
+            if stripped.startswith(("http://", "https://")):
+                ink = signal
+            elif stripped[:1].isdigit() and ". " in stripped:
+                ink = fg
+            elif stripped.startswith(("Provider:", "Sources:", "Ask Operator")):
+                ink = muted
+            else:
+                ink = dim
+            row.append("\n" + indent, style=dim)
+            row.append(truncate_cells(line, line_width), style=ink)
+        hidden = len(self._output) - len(shown)
+        if hidden > 0:
+            marker = f"… {hidden} more search line{'s' if hidden != 1 else ''}"
             row.append("\n" + indent, style=dim)
             row.append(truncate_cells(marker, line_width), style=dim)
 
@@ -1170,12 +1199,10 @@ class ToolCard(TranscriptBlock):
         slot_token = "dim"
         remaining = max(0, width - prefix_cells - status_cells - 2)
         if self.can_expand():
-            # Offered under the pointer or under keyboard focus, silent at
-            # rest. A settled transcript is content, not a wall of controls:
-            # printing ⟨expand⟩ on every row costs ~9 cells of permanent
-            # chrome on the common 80-column terminal, and the row's ground
-            # already lifts on :hover and :focus to say it is a target.
-            if self._hovered or self._focused:
+            # Generic tool output stays quiet until the row is targeted. Search
+            # sources are the primary result, not diagnostics, so their
+            # disclosure remains visible at rest and in colorless terminals.
+            if self.tool_name.lower() == "web_search" or self._hovered or self._focused:
                 offer = COLLAPSE_HINT if self._expanded else EXPAND_HINT
                 if remaining - (cell_len(offer) + 1) >= _SUMMARY_FLOOR:
                     slot = offer

--- a/local_operator/tui/widgets/tool_card.py
+++ b/local_operator/tui/widgets/tool_card.py
@@ -1060,10 +1060,12 @@ class ToolCard(TranscriptBlock):
                 ink = signal
             elif stripped[:1].isdigit() and ". " in stripped:
                 ink = fg
-            elif stripped.startswith(("Provider:", "Sources:", "Ask Operator")):
-                ink = muted
-            else:
+            elif stripped.startswith(("Provider:", "Sources:")):
                 ink = dim
+            else:
+                # Snippets and the actionable footer must meet normal-text
+                # contrast; ``dim`` is reserved for structural metadata.
+                ink = muted
             row.append("\n" + indent, style=dim)
             row.append(truncate_cells(line, line_width), style=ink)
         hidden = len(self._output) - len(shown)

--- a/local_operator/tui/widgets/tool_card.py
+++ b/local_operator/tui/widgets/tool_card.py
@@ -184,6 +184,10 @@ OUTPUT_INDENT = 2
 #: transcript into a scroll trap. The head is kept (it carries the command's
 #: framing) and the remainder is announced on a dim marker row.
 EXPAND_MAX_LINES = 40
+#: Search details are persisted separately from the token-bounded model text.
+#: The expansion gets enough of each provider snippet to identify the page,
+#: while the source URL remains the path to the complete document.
+SEARCH_EXPANDED_SNIPPET_CHARS = 360
 #: Last-resort width for a card built before it has been laid out. Content
 #: rendered at this width is corrected by the first resize.
 FALLBACK_WIDTH = 80
@@ -338,6 +342,36 @@ def _diff_counts(details: dict[str, Any] | None) -> tuple[int, int]:
         return value if value > 0 else 0
 
     return (_count(details.get("added")), _count(details.get("removed")))
+
+
+def _search_result_output(details: dict[str, Any] | None) -> list[str]:
+    """Structured web-search rows: provider, page name, URL, and short snippet."""
+    if not isinstance(details, dict):
+        return []
+    sources = details.get("sources")
+    if not isinstance(sources, list) or not sources:
+        return []
+
+    provider = _strip_control_sequences(str(details.get("provider") or "search"))
+    auth_mode = _strip_control_sequences(str(details.get("auth_mode") or ""))
+    lines = [f"Provider: {provider}" + (f" ({auth_mode})" if auth_mode else ""), "Sources:"]
+    for index, source in enumerate(sources, start=1):
+        if not isinstance(source, dict):
+            continue
+        title = _strip_control_sequences(
+            " ".join(str(source.get("title") or "Untitled result").split())
+        )
+        url = _strip_control_sequences(" ".join(str(source.get("url") or "").split()))
+        snippet = _strip_control_sequences(" ".join(str(source.get("snippet") or "").split()))
+        lines.append(f"{index}. {title}")
+        if url:
+            lines.append(f"   {url}")
+        if snippet:
+            if len(snippet) > SEARCH_EXPANDED_SNIPPET_CHARS:
+                snippet = snippet[: SEARCH_EXPANDED_SNIPPET_CHARS - 1].rstrip() + "…"
+            lines.append(f"   {snippet}")
+    lines.append("Open a result URL with browser to read the full page.")
+    return lines
 
 
 def _clamp_runs(runs: list[tuple[str, Style]], limit: int) -> list[tuple[str, Style]]:
@@ -673,16 +707,19 @@ class ToolCard(TranscriptBlock):
             self._refresh_row()
 
     def _absorb_result(self, result_text: str, details: dict[str, Any] | None) -> None:
-        """Capture the payload the expansion and the diff counters read.
+        """Capture the expansion payload and diff counters.
 
-        The write/edit tools report a rendered unified diff under
-        ``details["diff"]``; when present, that diff is what the expanded card
-        reveals (coloured per line), and the raw output is not also shown —
-        one story per card. Plain-output tools (bash, read) have no diff and
-        expand to their cleaned output as before.
+        Web search is rendered from structured details, not the model-facing
+        text: the latter is deliberately token-capped, while the expansion
+        must reliably retain every candidate's page name, URL, and snippet.
+        Write/edit tools prefer their rendered diff; all other tools expand to
+        cleaned result text.
         """
         self._added, self._removed = _diff_counts(details)
-        self._output = self._clean_output(result_text)
+        search_output = (
+            _search_result_output(details) if self.tool_name.lower() == "web_search" else []
+        )
+        self._output = search_output or self._clean_output(result_text)
         diff = details.get("diff") if isinstance(details, dict) else None
         if isinstance(diff, list) and diff:
             self._diff = [str(line) for line in diff]

--- a/local_operator/web_search/__init__.py
+++ b/local_operator/web_search/__init__.py
@@ -1,0 +1,5 @@
+"""Load-balanced web search for Local Operator."""
+
+from local_operator.web_search.models import PROVIDER_IDS, SearchProviderId
+
+__all__ = ["PROVIDER_IDS", "SearchProviderId"]

--- a/local_operator/web_search/cli.py
+++ b/local_operator/web_search/cli.py
@@ -1,0 +1,236 @@
+"""CLI configuration experience for built-in web search."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import getpass
+import json
+from pathlib import Path
+
+from local_operator.config import ConfigManager
+from local_operator.credentials import CredentialManager
+from local_operator.paths import config_dir
+from local_operator.web_search.models import PROVIDER_IDS, SearchProviderId
+
+_API_KEY_NAMES: dict[SearchProviderId, str] = {
+    "tavily": "TAVILY_API_KEY",
+    "perplexity": "PERPLEXITY_API_KEY",
+    "brave": "BRAVE_API_KEY",
+    "exa": "EXA_API_KEY",
+    "serpapi": "SERPAPI_API_KEY",
+}
+TAVILY_MCP_URL = "https://mcp.tavily.com/mcp/"
+
+
+def add_search_subparser(
+    subparsers: argparse._SubParsersAction[argparse.ArgumentParser],
+    parent_parser: argparse.ArgumentParser,
+) -> None:
+    """Install ``search`` and its focused configuration subcommands."""
+    search_parser = subparsers.add_parser(
+        "search",
+        help="Configure and test load-balanced web search",
+        parents=[parent_parser],
+    )
+    commands = search_parser.add_subparsers(dest="search_command")
+    commands.add_parser("list", help="Show provider readiness and enabled state")
+    commands.add_parser("on", help="Enable the web_search tool")
+    commands.add_parser("off", help="Disable the web_search tool")
+
+    enable = commands.add_parser("enable", help="Enable a provider")
+    enable.add_argument("provider", choices=PROVIDER_IDS)
+    disable = commands.add_parser("disable", help="Disable a provider")
+    disable.add_argument("provider", choices=PROVIDER_IDS)
+
+    strategy = commands.add_parser("balance", help="Choose load-balancing strategy")
+    strategy.add_argument("strategy", choices=("round_robin", "ordered"))
+
+    order = commands.add_parser("order", help="Set enabled providers and their priority")
+    order.add_argument("providers", nargs="+", choices=PROVIDER_IDS)
+
+    setup = commands.add_parser("setup", help="Configure credentials or free access")
+    setup.add_argument("provider", choices=PROVIDER_IDS)
+    setup_mode = setup.add_mutually_exclusive_group()
+    setup_mode.add_argument(
+        "--oauth",
+        action="store_true",
+        help="Configure Tavily's remote OAuth MCP server",
+    )
+    setup_mode.add_argument(
+        "--api-key",
+        action="store_true",
+        help="Store an API key instead of using the provider's free mode",
+    )
+    setup.add_argument("--endpoint", help="SearXNG base URL")
+
+    test = commands.add_parser("test", help="Run a real search through the configured chain")
+    test.add_argument("query")
+    test.add_argument("--provider", choices=PROVIDER_IDS)
+    test.add_argument("--max-results", type=int, default=3)
+    test.add_argument("--json", action="store_true", dest="as_json")
+
+
+def _stack() -> tuple[ConfigManager, CredentialManager]:
+    base = config_dir()
+    return ConfigManager(base), CredentialManager(base)
+
+
+def format_search_status(manager: ConfigManager, credentials: CredentialManager) -> str:
+    """Plain, width-tolerant status table shared by CLI and TUI."""
+    from local_operator.web_search.providers import provider_statuses
+    from local_operator.web_search.service import load_search_settings
+
+    settings = load_search_settings(manager)
+    header = (
+        f"Web search: {'on' if settings.enabled else 'off'} | "
+        f"balance: {settings.strategy} | order: {', '.join(settings.providers) or 'none'}"
+    )
+    rows = [header]
+    for status in provider_statuses(settings, credentials):
+        enabled = "enabled" if status.enabled else "disabled"
+        ready = "ready" if status.available else "setup needed"
+        rows.append(f"{status.id:<12} {enabled:<8} {ready:<12} {status.access} | {status.detail}")
+    rows.append("Setup: local-operator search setup <provider>")
+    return "\n".join(rows)
+
+
+def _store_api_key(provider_id: SearchProviderId, credentials: CredentialManager) -> None:
+    key_name = _API_KEY_NAMES.get(provider_id)
+    if key_name is None:
+        raise ValueError(f"{provider_id} does not use an API key")
+    value = getpass.getpass(f"{key_name}: ").strip()
+    if not value:
+        raise ValueError("API key was empty; nothing changed")
+    credentials.set_credential(key_name, value)
+
+
+def _setup_tavily_oauth() -> int:
+    from local_operator.mcp import config as mcp_config
+
+    current = mcp_config.list_effective_servers(Path.cwd())
+    existing = current.get("tavily")
+    if isinstance(existing, dict) and existing.get("url") == TAVILY_MCP_URL:
+        print("Tavily OAuth MCP is already configured. It will reconnect on the next session.")
+        return 0
+    result = mcp_config.add_server(
+        "tavily",
+        url=TAVILY_MCP_URL,
+        oauth=True,
+        scope="global",
+    )
+    if result == 0:
+        print("Tavily OAuth MCP configured. Start or reload a session to sign in.")
+    return result
+
+
+def _setup_provider(args: argparse.Namespace) -> int:
+    from local_operator.web_search.providers import PROVIDERS
+    from local_operator.web_search.service import (
+        set_provider_enabled,
+        set_searxng_endpoint,
+    )
+
+    manager, credentials = _stack()
+    provider_id: SearchProviderId = args.provider
+    if args.oauth and provider_id != "tavily":
+        print("error: --oauth is supported only for Tavily")
+        return 1
+    if args.endpoint and provider_id != "searxng":
+        print("error: --endpoint is supported only for SearXNG")
+        return 1
+
+    try:
+        if provider_id == "tavily" and args.oauth:
+            result = _setup_tavily_oauth()
+            if result != 0:
+                return result
+        elif provider_id == "tavily" and args.api_key:
+            _store_api_key(provider_id, credentials)
+        elif provider_id == "perplexity" and args.api_key:
+            _store_api_key(provider_id, credentials)
+        elif provider_id in ("brave", "exa", "serpapi"):
+            _store_api_key(provider_id, credentials)
+        elif provider_id == "searxng":
+            endpoint = str(args.endpoint or input("SearXNG base URL: ")).strip().rstrip("/")
+            if not endpoint.startswith(("http://", "https://")):
+                raise ValueError("SearXNG endpoint must start with http:// or https://")
+            set_searxng_endpoint(manager, endpoint)
+        # DuckDuckGo, Tavily keyless, and Perplexity anonymous need no secret.
+        set_provider_enabled(manager, provider_id, True)
+    except (OSError, ValueError) as error:
+        print(f"error: {error}")
+        return 1
+
+    mode = PROVIDERS[provider_id].access
+    print(f"Enabled {provider_id} ({mode}).")
+    return 0
+
+
+async def _test_search(args: argparse.Namespace) -> int:
+    from local_operator.web_search.service import WebSearchService, load_search_settings
+
+    manager, credentials = _stack()
+    service = WebSearchService(load_search_settings(manager), credentials)
+    try:
+        response = await service.search(
+            args.query,
+            limit=args.max_results,
+            forced_provider=args.provider,
+        )
+    except Exception as error:
+        print(f"error: {error}")
+        return 1
+    if args.as_json:
+        print(json.dumps(response.model_dump(mode="json"), indent=2))
+        return 0
+    print(f"Provider: {response.provider} ({response.auth_mode})")
+    if response.answer:
+        print(response.answer)
+    for index, source in enumerate(response.sources, start=1):
+        print(f"{index}. {source.title}\n   {source.url}")
+    if response.failures:
+        print("Fallbacks: " + "; ".join(response.failures))
+    return 0
+
+
+def search_command(args: argparse.Namespace) -> int:
+    """Dispatch ``search`` configuration and smoke-test commands."""
+    from local_operator.web_search.service import (
+        set_provider_enabled,
+        set_provider_order,
+        set_search_enabled,
+        set_search_strategy,
+    )
+
+    command = args.search_command or "list"
+    manager, credentials = _stack()
+    if command == "list":
+        print(format_search_status(manager, credentials))
+        return 0
+    if command == "on":
+        set_search_enabled(manager, True)
+        print("Web search enabled. Reload a running session if the tool was previously off.")
+        return 0
+    if command == "off":
+        set_search_enabled(manager, False)
+        print("Web search disabled. Reload a running session to remove the tool.")
+        return 0
+    if command in ("enable", "disable"):
+        set_provider_enabled(manager, args.provider, command == "enable")
+        print(f"{args.provider} {command}d.")
+        return 0
+    if command == "balance":
+        set_search_strategy(manager, args.strategy)
+        print(f"Web search balance strategy: {args.strategy}")
+        return 0
+    if command == "order":
+        set_provider_order(manager, args.providers)
+        print("Web search order: " + ", ".join(args.providers))
+        return 0
+    if command == "setup":
+        return _setup_provider(args)
+    if command == "test":
+        return asyncio.run(_test_search(args))
+    print(f"error: unknown search command {command}")
+    return 1

--- a/local_operator/web_search/cli.py
+++ b/local_operator/web_search/cli.py
@@ -108,17 +108,25 @@ def _store_api_key(provider_id: SearchProviderId, credentials: CredentialManager
 def _setup_tavily_oauth() -> int:
     from local_operator.mcp import config as mcp_config
 
-    current = mcp_config.list_effective_servers(Path.cwd())
+    current, sources = mcp_config.load_all_mcp_configs(Path.cwd())
     existing = current.get("tavily")
-    if isinstance(existing, dict) and existing.get("url") == TAVILY_MCP_URL:
-        print("Tavily OAuth MCP is already configured. It will reconnect on the next session.")
-        return 0
-    result = mcp_config.add_server(
-        "tavily",
-        url=TAVILY_MCP_URL,
-        oauth=True,
-        scope="global",
-    )
+    if existing is not None:
+        existing_url = getattr(existing, "url", "").rstrip("/")
+        auth = getattr(existing, "auth", None)
+        if existing_url == TAVILY_MCP_URL.rstrip("/") and getattr(auth, "type", None) == "oauth":
+            print("Tavily OAuth MCP is already configured. It will reconnect on the next session.")
+            return 0
+
+        global_path = mcp_config._scope_path(None, "global")
+        source = Path(sources["tavily"])
+        if source != global_path:
+            print(
+                f"error: Tavily is configured by {source} without the required "
+                "OAuth URL/auth block; update or remove that higher-priority entry"
+            )
+            return 1
+
+    result = mcp_config.set_http_oauth_server("tavily", TAVILY_MCP_URL, scope="global")
     if result == 0:
         print("Tavily OAuth MCP configured. Start or reload a session to sign in.")
     return result

--- a/local_operator/web_search/models.py
+++ b/local_operator/web_search/models.py
@@ -1,0 +1,88 @@
+"""Shared web-search configuration and result models.
+
+The built-in providers intentionally expose one small contract.  Provider-specific
+payloads stop at this boundary so the model-facing tool, CLI status view, and TUI
+cannot drift into seven subtly different result formats.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+SearchProviderId = Literal[
+    "duckduckgo",
+    "tavily",
+    "perplexity",
+    "brave",
+    "exa",
+    "serpapi",
+    "searxng",
+]
+SearchStrategy = Literal["round_robin", "ordered"]
+
+PROVIDER_IDS: tuple[SearchProviderId, ...] = (
+    "duckduckgo",
+    "tavily",
+    "perplexity",
+    "brave",
+    "exa",
+    "serpapi",
+    "searxng",
+)
+
+
+class SearchSource(BaseModel):
+    """One normalized result from any search provider."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    title: str
+    url: str
+    snippet: str | None = None
+    published_date: str | None = None
+
+
+class SearchResponse(BaseModel):
+    """Normalized response returned by the load-balancing service."""
+
+    provider: SearchProviderId
+    auth_mode: str
+    sources: list[SearchSource] = Field(default_factory=list)
+    answer: str | None = None
+    request_id: str | None = None
+    failures: list[str] = Field(default_factory=list)
+
+
+class ProviderStatus(BaseModel):
+    """Readiness row shared by ``search list`` and the TUI's ``/search`` view."""
+
+    id: SearchProviderId
+    label: str
+    enabled: bool
+    available: bool
+    access: str
+    detail: str
+
+
+class WebSearchSettings(BaseModel):
+    """Validated view of the loose ``values.web_search`` YAML mapping."""
+
+    enabled: bool = True
+    strategy: SearchStrategy = "round_robin"
+    providers: list[SearchProviderId] = Field(default_factory=lambda: ["duckduckgo", "tavily"])
+    timeout_seconds: float = 20.0
+    searxng_endpoint: str = ""
+
+
+DEFAULT_WEB_SEARCH_CONFIG: dict[str, object] = {
+    "enabled": True,
+    "strategy": "round_robin",
+    # Two credential-free transports make load balancing useful on first run.
+    # Tavily's official keyless mode is rate-limited; DDG remains the durable
+    # no-account fallback when that budget is exhausted.
+    "providers": ["duckduckgo", "tavily"],
+    "timeout_seconds": 20.0,
+    "searxng_endpoint": "",
+}

--- a/local_operator/web_search/providers.py
+++ b/local_operator/web_search/providers.py
@@ -1,0 +1,635 @@
+"""Built-in web-search provider transports.
+
+This is deliberately a curated subset of Oh My Pi's much larger provider list:
+the credential-free defaults, the established search APIs Local Operator already
+documented, two prominent independent/AI-native APIs, and self-hosted SearXNG.
+Each transport stays dependency-free beyond the project's existing ``httpx``.
+"""
+
+from __future__ import annotations
+
+import html
+import json
+import re
+import uuid
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable
+from urllib.parse import parse_qs, unquote, urlparse
+
+import httpx
+
+from local_operator.credentials import CredentialManager
+from local_operator.web_search.models import (
+    PROVIDER_IDS,
+    ProviderStatus,
+    SearchProviderId,
+    SearchResponse,
+    SearchSource,
+    WebSearchSettings,
+)
+
+ProviderSearch = Callable[
+    [httpx.AsyncClient, CredentialManager, WebSearchSettings, str, int],
+    Awaitable[SearchResponse],
+]
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderDefinition:
+    """Static provider metadata plus its normalized transport."""
+
+    id: SearchProviderId
+    label: str
+    access: str
+    detail: str
+    credential_keys: tuple[str, ...]
+    search: ProviderSearch
+
+
+def _credential(manager: CredentialManager, *keys: str) -> str:
+    """Resolve the first non-empty stored/environment credential without logging it."""
+    for key in keys:
+        value = manager.get_credential(key).get_secret_value().strip()
+        if value:
+            return value
+    return ""
+
+
+def _http_error(provider: str, response: httpx.Response) -> RuntimeError:
+    body = response.text.strip()
+    if len(body) > 500:
+        body = body[:500] + "…"
+    suffix = f": {body}" if body else ""
+    return RuntimeError(f"{provider} returned HTTP {response.status_code}{suffix}")
+
+
+def _ensure_success(provider: str, response: httpx.Response) -> None:
+    if not response.is_success:
+        raise _http_error(provider, response)
+
+
+def _bounded_text(value: object, limit: int) -> str:
+    text = str(value or "").strip()
+    if len(text) <= limit:
+        return text
+    return text[: limit - 1].rstrip() + "…"
+
+
+def _source(
+    *,
+    title: object,
+    url: object,
+    snippet: object = None,
+    published_date: object = None,
+) -> SearchSource | None:
+    target = str(url or "").strip()
+    if len(target) > 4_096:
+        return None
+    if not target.startswith(("http://", "https://")):
+        return None
+    shown_title = _bounded_text(title or target, 500) or target
+    shown_snippet = _bounded_text(snippet, 2_000) or None
+    shown_date = _bounded_text(published_date, 100) or None
+    return SearchSource(
+        title=shown_title,
+        url=target,
+        snippet=shown_snippet,
+        published_date=shown_date,
+    )
+
+
+def _clean_html(fragment: str) -> str:
+    text = re.sub(r"<[^>]+>", " ", fragment)
+    return re.sub(r"\s+", " ", html.unescape(text)).strip()
+
+
+def _unwrap_duckduckgo_url(href: str) -> str:
+    decoded = html.unescape(href)
+    parsed = urlparse(decoded if "://" in decoded else f"https:{decoded}")
+    wrapped = parse_qs(parsed.query).get("uddg")
+    if wrapped:
+        return unquote(wrapped[0])
+    if decoded.startswith("//"):
+        return "https:" + decoded
+    return decoded
+
+
+def parse_duckduckgo_html(page: str, limit: int) -> list[SearchSource]:
+    """Parse DDG's no-JavaScript result rows without adding an HTML dependency."""
+    rows: list[SearchSource] = []
+    block_pattern = re.compile(
+        r'<div\b[^>]*class="[^"]*\bresult\b[^"]*"[^>]*>([\s\S]*?)'
+        r'(?=<div\b[^>]*class="[^"]*\bresult\b|<div\b[^>]*class="[^"]*\bnav-link\b|$)',
+        re.IGNORECASE,
+    )
+    title_pattern = re.compile(
+        r'<a\b[^>]*class="[^"]*\bresult__a\b[^"]*"[^>]*href="([^"]+)"[^>]*>' r"([\s\S]*?)</a>",
+        re.IGNORECASE,
+    )
+    snippet_pattern = re.compile(
+        r'<(?:a|div|span)\b[^>]*class="[^"]*\bresult__snippet\b[^"]*"[^>]*>'
+        r"([\s\S]*?)</(?:a|div|span)>",
+        re.IGNORECASE,
+    )
+    for block_match in block_pattern.finditer(page):
+        block = block_match.group(1)
+        title_match = title_pattern.search(block)
+        if title_match is None:
+            continue
+        snippet_match = snippet_pattern.search(block)
+        source = _source(
+            title=_clean_html(title_match.group(2)),
+            url=_unwrap_duckduckgo_url(title_match.group(1)),
+            snippet=_clean_html(snippet_match.group(1)) if snippet_match else None,
+        )
+        if source is not None:
+            rows.append(source)
+        if len(rows) >= limit:
+            break
+    return rows
+
+
+async def _search_duckduckgo(
+    client: httpx.AsyncClient,
+    _credentials: CredentialManager,
+    _settings: WebSearchSettings,
+    query: str,
+    limit: int,
+) -> SearchResponse:
+    response = await client.post(
+        "https://html.duckduckgo.com/html/",
+        data={"q": query},
+        headers={
+            "Accept": "text/html,application/xhtml+xml",
+            "User-Agent": (
+                "Mozilla/5.0 (compatible; LocalOperator/0.16; "
+                "+https://github.com/damianvtran/local-operator)"
+            ),
+        },
+    )
+    _ensure_success("DuckDuckGo", response)
+    if "anomaly-modal" in response.text or "anomaly.js" in response.text:
+        raise RuntimeError("DuckDuckGo returned a bot challenge")
+    return SearchResponse(
+        provider="duckduckgo",
+        auth_mode="credential-free",
+        sources=parse_duckduckgo_html(response.text, limit),
+    )
+
+
+def tavily_response_from_payload(
+    payload: dict[str, Any],
+    *,
+    auth_mode: str,
+    limit: int,
+) -> SearchResponse:
+    """Normalize the identical direct-API and remote-MCP Tavily schemas."""
+    sources = [
+        source
+        for item in payload.get("results", [])
+        if isinstance(item, dict)
+        and (
+            source := _source(
+                title=item.get("title"),
+                url=item.get("url"),
+                snippet=item.get("content"),
+                published_date=item.get("published_date"),
+            )
+        )
+        is not None
+    ]
+    return SearchResponse(
+        provider="tavily",
+        auth_mode=auth_mode,
+        sources=sources[:limit],
+        answer=str(payload.get("answer") or "").strip() or None,
+        request_id=str(payload.get("request_id") or "").strip() or None,
+    )
+
+
+async def _search_tavily(
+    client: httpx.AsyncClient,
+    credentials: CredentialManager,
+    _settings: WebSearchSettings,
+    query: str,
+    limit: int,
+) -> SearchResponse:
+    key = _credential(credentials, "TAVILY_API_KEY")
+    headers = {"Content-Type": "application/json"}
+    auth_mode = "api-key"
+    if key:
+        headers["Authorization"] = f"Bearer {key}"
+    else:
+        # Tavily documents this as its zero-account, rate-limited mode. Keeping
+        # the wire shape identical lets a later key upgrade change no callers.
+        headers["X-Tavily-Access-Mode"] = "keyless"
+        auth_mode = "keyless"
+    response = await client.post(
+        "https://api.tavily.com/search",
+        headers=headers,
+        json={
+            "query": query,
+            "search_depth": "basic",
+            "max_results": limit,
+            "include_answer": "basic",
+            "include_raw_content": False,
+        },
+    )
+    _ensure_success("Tavily", response)
+    payload = response.json()
+    if not isinstance(payload, dict):
+        raise RuntimeError("Tavily returned a non-object response")
+    return tavily_response_from_payload(payload, auth_mode=auth_mode, limit=limit)
+
+
+def _perplexity_sources(payload: dict[str, Any], limit: int) -> list[SearchSource]:
+    rows: list[SearchSource] = []
+    candidates = payload.get("search_results") or payload.get("sources_list") or []
+    for item in candidates:
+        if not isinstance(item, dict):
+            continue
+        source = _source(
+            title=item.get("title") or item.get("name"),
+            url=item.get("url"),
+            snippet=item.get("snippet"),
+            published_date=item.get("date") or item.get("timestamp"),
+        )
+        if source is not None:
+            rows.append(source)
+        if len(rows) >= limit:
+            break
+    if rows:
+        return rows
+    for citation in payload.get("citations", []):
+        source = _source(title=citation, url=citation)
+        if source is not None:
+            rows.append(source)
+        if len(rows) >= limit:
+            break
+    return rows
+
+
+def _perplexity_answer(payload: dict[str, Any]) -> str | None:
+    choices = payload.get("choices")
+    if isinstance(choices, list) and choices and isinstance(choices[0], dict):
+        message = choices[0].get("message")
+        if isinstance(message, dict):
+            answer = str(message.get("content") or "").strip()
+            if answer:
+                return answer
+    answer = str(payload.get("text") or "").strip()
+    return answer or None
+
+
+def _parse_perplexity_sse(body: str) -> dict[str, Any]:
+    """Fold Perplexity's partial SSE blocks without losing earlier sources.
+
+    The stream sends web results and answer markdown in different events. A
+    plain ``dict.update`` keeps whichever block arrived last, which produced a
+    cited answer with an empty source list on the live anonymous endpoint.
+    """
+    merged: dict[str, Any] = {}
+    sources_by_url: dict[str, dict[str, Any]] = {}
+    answer = ""
+    for line in body.splitlines():
+        if not line.startswith("data:"):
+            continue
+        raw = line[5:].strip()
+        if not raw or raw == "[DONE]":
+            continue
+        try:
+            event = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(event, dict):
+            continue
+        merged.update({key: value for key, value in event.items() if key != "blocks"})
+        event_sources = event.get("sources_list")
+        if isinstance(event_sources, list):
+            for item in event_sources:
+                if isinstance(item, dict) and item.get("url"):
+                    sources_by_url[str(item["url"])] = item
+        for block in event.get("blocks") or []:
+            if not isinstance(block, dict):
+                continue
+            web_results = (block.get("web_result_block") or {}).get("web_results") or []
+            for item in web_results:
+                if isinstance(item, dict) and item.get("url"):
+                    sources_by_url[str(item["url"])] = item
+            markdown = block.get("markdown_block")
+            if not isinstance(markdown, dict):
+                continue
+            chunks = markdown.get("chunks")
+            if isinstance(chunks, list) and chunks:
+                answer = "".join(str(chunk) for chunk in chunks)
+            elif markdown.get("answer"):
+                answer = str(markdown["answer"])
+        if event.get("text"):
+            answer = str(event["text"])
+    if sources_by_url:
+        merged["sources_list"] = list(sources_by_url.values())
+    if answer:
+        merged["text"] = answer
+    return merged
+
+
+async def _search_perplexity(
+    client: httpx.AsyncClient,
+    credentials: CredentialManager,
+    _settings: WebSearchSettings,
+    query: str,
+    limit: int,
+) -> SearchResponse:
+    key = _credential(credentials, "PERPLEXITY_API_KEY")
+    if key:
+        response = await client.post(
+            "https://api.perplexity.ai/chat/completions",
+            headers={"Authorization": f"Bearer {key}"},
+            json={
+                "model": "sonar",
+                "messages": [{"role": "user", "content": query}],
+                "return_citations": True,
+                "return_related_questions": False,
+            },
+        )
+        _ensure_success("Perplexity", response)
+        payload = response.json()
+        return SearchResponse(
+            provider="perplexity",
+            auth_mode="api-key",
+            sources=_perplexity_sources(payload, limit),
+            answer=_perplexity_answer(payload),
+            request_id=str(payload.get("id") or "").strip() or None,
+        )
+
+    request_id = str(uuid.uuid4())
+    response = await client.post(
+        "https://www.perplexity.ai/rest/sse/perplexity_ask",
+        headers={
+            "Accept": "text/event-stream",
+            "Content-Type": "application/json",
+            "Origin": "https://www.perplexity.ai",
+            "Referer": "https://www.perplexity.ai/",
+            "User-Agent": "Mozilla/5.0 (compatible; LocalOperator/0.16)",
+            "X-Request-ID": request_id,
+        },
+        json={
+            "query_str": query,
+            "params": {
+                "query_str": query,
+                "search_focus": "internet",
+                "mode": "copilot",
+                "sources": ["web"],
+                "attachments": [],
+                "frontend_uuid": str(uuid.uuid4()),
+                "frontend_context_uuid": str(uuid.uuid4()),
+                "language": "en-US",
+                "is_incognito": True,
+                "use_schematized_api": True,
+                "skip_search_enabled": False,
+                "always_search_override": True,
+                "send_back_text_in_streaming_api": True,
+            },
+        },
+    )
+    _ensure_success("Perplexity", response)
+    payload = _parse_perplexity_sse(response.text)
+    return SearchResponse(
+        provider="perplexity",
+        auth_mode="anonymous",
+        sources=_perplexity_sources(payload, limit),
+        answer=_perplexity_answer(payload),
+        request_id=str(payload.get("uuid") or request_id),
+    )
+
+
+async def _search_brave(
+    client: httpx.AsyncClient,
+    credentials: CredentialManager,
+    _settings: WebSearchSettings,
+    query: str,
+    limit: int,
+) -> SearchResponse:
+    key = _credential(credentials, "BRAVE_API_KEY")
+    response = await client.get(
+        "https://api.search.brave.com/res/v1/web/search",
+        headers={"Accept": "application/json", "X-Subscription-Token": key},
+        params={"q": query, "count": limit, "extra_snippets": "true"},
+    )
+    _ensure_success("Brave", response)
+    payload = response.json()
+    sources: list[SearchSource] = []
+    for item in payload.get("web", {}).get("results", []):
+        if not isinstance(item, dict):
+            continue
+        snippets = [str(item.get("description") or "").strip()]
+        snippets.extend(str(value).strip() for value in item.get("extra_snippets") or [])
+        source = _source(
+            title=item.get("title"),
+            url=item.get("url"),
+            snippet="\n".join(value for value in dict.fromkeys(snippets) if value),
+            published_date=item.get("age"),
+        )
+        if source is not None:
+            sources.append(source)
+    return SearchResponse(
+        provider="brave",
+        auth_mode="api-key",
+        sources=sources[:limit],
+        request_id=response.headers.get("x-request-id"),
+    )
+
+
+async def _search_exa(
+    client: httpx.AsyncClient,
+    credentials: CredentialManager,
+    _settings: WebSearchSettings,
+    query: str,
+    limit: int,
+) -> SearchResponse:
+    key = _credential(credentials, "EXA_API_KEY")
+    response = await client.post(
+        "https://api.exa.ai/search",
+        headers={"Content-Type": "application/json", "x-api-key": key},
+        json={"query": query, "numResults": limit, "type": "auto", "contents": {"text": True}},
+    )
+    _ensure_success("Exa", response)
+    payload = response.json()
+    sources = [
+        source
+        for item in payload.get("results", [])
+        if isinstance(item, dict)
+        and (
+            source := _source(
+                title=item.get("title"),
+                url=item.get("url"),
+                snippet=item.get("text"),
+                published_date=item.get("publishedDate"),
+            )
+        )
+        is not None
+    ]
+    return SearchResponse(provider="exa", auth_mode="api-key", sources=sources[:limit])
+
+
+async def _search_serpapi(
+    client: httpx.AsyncClient,
+    credentials: CredentialManager,
+    _settings: WebSearchSettings,
+    query: str,
+    limit: int,
+) -> SearchResponse:
+    key = _credential(credentials, "SERPAPI_API_KEY", "SERP_API_KEY")
+    response = await client.get(
+        "https://serpapi.com/search.json",
+        params={"q": query, "engine": "google", "api_key": key, "num": limit},
+    )
+    _ensure_success("SerpApi", response)
+    payload = response.json()
+    if payload.get("error"):
+        raise RuntimeError(f"SerpApi error: {payload['error']}")
+    sources = [
+        source
+        for item in payload.get("organic_results", [])
+        if isinstance(item, dict)
+        and (
+            source := _source(
+                title=item.get("title"),
+                url=item.get("link"),
+                snippet=item.get("snippet"),
+                published_date=item.get("date"),
+            )
+        )
+        is not None
+    ]
+    metadata = payload.get("search_metadata") or {}
+    return SearchResponse(
+        provider="serpapi",
+        auth_mode="api-key",
+        sources=sources[:limit],
+        request_id=str(metadata.get("id") or "").strip() or None,
+    )
+
+
+async def _search_searxng(
+    client: httpx.AsyncClient,
+    _credentials: CredentialManager,
+    settings: WebSearchSettings,
+    query: str,
+    limit: int,
+) -> SearchResponse:
+    endpoint = settings.searxng_endpoint.rstrip("/")
+    response = await client.get(
+        f"{endpoint}/search",
+        params={"q": query, "format": "json", "categories": "general"},
+    )
+    _ensure_success("SearXNG", response)
+    payload = response.json()
+    sources = [
+        source
+        for item in payload.get("results", [])
+        if isinstance(item, dict)
+        and (
+            source := _source(
+                title=item.get("title"),
+                url=item.get("url"),
+                snippet=item.get("content"),
+                published_date=item.get("publishedDate"),
+            )
+        )
+        is not None
+    ]
+    return SearchResponse(provider="searxng", auth_mode="self-hosted", sources=sources[:limit])
+
+
+PROVIDERS: dict[SearchProviderId, ProviderDefinition] = {
+    "duckduckgo": ProviderDefinition(
+        "duckduckgo",
+        "DuckDuckGo",
+        "free",
+        "Credential-free HTML search",
+        (),
+        _search_duckduckgo,
+    ),
+    "tavily": ProviderDefinition(
+        "tavily",
+        "Tavily",
+        "free / key / OAuth MCP",
+        "Official keyless access; TAVILY_API_KEY raises limits",
+        ("TAVILY_API_KEY",),
+        _search_tavily,
+    ),
+    "perplexity": ProviderDefinition(
+        "perplexity",
+        "Perplexity",
+        "anonymous / key",
+        "Best-effort anonymous search; PERPLEXITY_API_KEY uses Sonar",
+        ("PERPLEXITY_API_KEY",),
+        _search_perplexity,
+    ),
+    "brave": ProviderDefinition(
+        "brave",
+        "Brave",
+        "API key",
+        "Independent search index; requires BRAVE_API_KEY",
+        ("BRAVE_API_KEY",),
+        _search_brave,
+    ),
+    "exa": ProviderDefinition(
+        "exa",
+        "Exa",
+        "API key",
+        "AI-native semantic search; requires EXA_API_KEY",
+        ("EXA_API_KEY",),
+        _search_exa,
+    ),
+    "serpapi": ProviderDefinition(
+        "serpapi",
+        "SerpApi",
+        "API key",
+        "Google-backed results; requires SERPAPI_API_KEY",
+        ("SERPAPI_API_KEY", "SERP_API_KEY"),
+        _search_serpapi,
+    ),
+    "searxng": ProviderDefinition(
+        "searxng",
+        "SearXNG",
+        "self-hosted",
+        "Private metasearch; requires a SearXNG endpoint",
+        (),
+        _search_searxng,
+    ),
+}
+
+
+def provider_available(
+    provider_id: SearchProviderId,
+    credentials: CredentialManager,
+    settings: WebSearchSettings,
+) -> bool:
+    """Whether the provider can make a request with current local configuration."""
+    if provider_id in ("duckduckgo", "tavily", "perplexity"):
+        return True
+    if provider_id == "searxng":
+        return settings.searxng_endpoint.startswith(("http://", "https://"))
+    definition = PROVIDERS[provider_id]
+    return bool(_credential(credentials, *definition.credential_keys))
+
+
+def provider_statuses(
+    settings: WebSearchSettings,
+    credentials: CredentialManager,
+) -> list[ProviderStatus]:
+    """Return every provider in the stable, user-facing catalogue order."""
+    enabled = set(settings.providers)
+    return [
+        ProviderStatus(
+            id=provider_id,
+            label=PROVIDERS[provider_id].label,
+            enabled=provider_id in enabled,
+            available=provider_available(provider_id, credentials, settings),
+            access=PROVIDERS[provider_id].access,
+            detail=PROVIDERS[provider_id].detail,
+        )
+        for provider_id in PROVIDER_IDS
+    ]

--- a/local_operator/web_search/providers.py
+++ b/local_operator/web_search/providers.py
@@ -14,7 +14,7 @@ import re
 import uuid
 from dataclasses import dataclass
 from typing import Any, Awaitable, Callable
-from urllib.parse import parse_qs, unquote, urlparse
+from urllib.parse import parse_qs, urlparse
 
 import httpx
 
@@ -108,7 +108,7 @@ def _unwrap_duckduckgo_url(href: str) -> str:
     parsed = urlparse(decoded if "://" in decoded else f"https:{decoded}")
     wrapped = parse_qs(parsed.query).get("uddg")
     if wrapped:
-        return unquote(wrapped[0])
+        return wrapped[0]
     if decoded.startswith("//"):
         return "https:" + decoded
     return decoded
@@ -563,7 +563,7 @@ PROVIDERS: dict[SearchProviderId, ProviderDefinition] = {
         "tavily",
         "Tavily",
         "free / key / OAuth MCP",
-        "Official keyless access; TAVILY_API_KEY raises limits",
+        "Keyless by default; API key raises limits; OAuth setup available",
         ("TAVILY_API_KEY",),
         _search_tavily,
     ),

--- a/local_operator/web_search/providers.py
+++ b/local_operator/web_search/providers.py
@@ -451,7 +451,15 @@ async def _search_exa(
     response = await client.post(
         "https://api.exa.ai/search",
         headers={"Content-Type": "application/json", "x-api-key": key},
-        json={"query": query, "numResults": limit, "type": "auto", "contents": {"text": True}},
+        json={
+            "query": query,
+            "numResults": limit,
+            "type": "auto",
+            # Exa can return whole page text here, but downloading it only to
+            # truncate it wastes latency and context. Query-grounded summaries
+            # are the provider-native short snippet contract the UI needs.
+            "contents": {"summary": {"query": query}},
+        },
     )
     _ensure_success("Exa", response)
     payload = response.json()
@@ -463,7 +471,7 @@ async def _search_exa(
             source := _source(
                 title=item.get("title"),
                 url=item.get("url"),
-                snippet=item.get("text"),
+                snippet=item.get("summary"),
                 published_date=item.get("publishedDate"),
             )
         )

--- a/local_operator/web_search/service.py
+++ b/local_operator/web_search/service.py
@@ -1,0 +1,235 @@
+"""Web-search configuration, status, and load-balanced execution."""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Awaitable, Callable, Mapping
+from typing import Any
+
+import httpx
+from pydantic import ValidationError
+
+from local_operator.config import ConfigManager
+from local_operator.credentials import CredentialManager
+from local_operator.web_search.models import (
+    DEFAULT_WEB_SEARCH_CONFIG,
+    PROVIDER_IDS,
+    SearchProviderId,
+    SearchResponse,
+    SearchStrategy,
+    WebSearchSettings,
+)
+from local_operator.web_search.providers import PROVIDERS, provider_available
+
+_ROUND_ROBIN_LOCK = threading.Lock()
+_ROUND_ROBIN_OFFSET = 0
+
+
+def coerce_search_settings(raw: object) -> WebSearchSettings:
+    """Validate loose YAML while preserving safe defaults for malformed fields."""
+    merged = dict(DEFAULT_WEB_SEARCH_CONFIG)
+    if isinstance(raw, Mapping):
+        merged.update(raw)
+
+    providers = merged.get("providers")
+    if not isinstance(providers, list):
+        merged["providers"] = list(DEFAULT_WEB_SEARCH_CONFIG["providers"])  # type: ignore[arg-type]
+    else:
+        # Stable de-duplication also drops stale provider ids from older/future
+        # configs. One typo must not prevent every other provider from loading.
+        merged["providers"] = list(
+            dict.fromkeys(value for value in providers if value in PROVIDER_IDS)
+        )
+
+    try:
+        settings = WebSearchSettings.model_validate(merged)
+    except ValidationError:
+        settings = WebSearchSettings.model_validate(DEFAULT_WEB_SEARCH_CONFIG)
+    settings.timeout_seconds = min(max(settings.timeout_seconds, 1.0), 120.0)
+    return settings
+
+
+def load_search_settings(manager: ConfigManager) -> WebSearchSettings:
+    """Read the current search mapping from a configuration manager."""
+    return coerce_search_settings(manager.get_config_value("web_search", None))
+
+
+def save_search_settings(manager: ConfigManager, settings: WebSearchSettings) -> None:
+    """Persist only the stable public search fields under ``values.web_search``."""
+    manager.set_config_value("web_search", settings.model_dump(mode="json"))
+
+
+def set_search_enabled(manager: ConfigManager, enabled: bool) -> WebSearchSettings:
+    settings = load_search_settings(manager)
+    settings.enabled = enabled
+    save_search_settings(manager, settings)
+    return settings
+
+
+def set_provider_enabled(
+    manager: ConfigManager,
+    provider_id: SearchProviderId,
+    enabled: bool,
+) -> WebSearchSettings:
+    """Enable/disable a provider without disturbing the chosen priority order."""
+    settings = load_search_settings(manager)
+    if enabled and provider_id not in settings.providers:
+        settings.providers.append(provider_id)
+    elif not enabled:
+        settings.providers = [value for value in settings.providers if value != provider_id]
+    save_search_settings(manager, settings)
+    return settings
+
+
+def set_search_strategy(
+    manager: ConfigManager,
+    strategy: SearchStrategy,
+) -> WebSearchSettings:
+    settings = load_search_settings(manager)
+    settings.strategy = strategy
+    save_search_settings(manager, settings)
+    return settings
+
+
+def set_provider_order(
+    manager: ConfigManager,
+    providers: list[SearchProviderId],
+) -> WebSearchSettings:
+    """Replace the enabled provider order; callers validate ids before this point."""
+    settings = load_search_settings(manager)
+    settings.providers = list(dict.fromkeys(providers))
+    save_search_settings(manager, settings)
+    return settings
+
+
+def set_searxng_endpoint(manager: ConfigManager, endpoint: str) -> WebSearchSettings:
+    settings = load_search_settings(manager)
+    settings.searxng_endpoint = endpoint.rstrip("/")
+    save_search_settings(manager, settings)
+    return settings
+
+
+def _next_offset(size: int) -> int:
+    """Return one process-wide fair starting offset for a provider set."""
+    global _ROUND_ROBIN_OFFSET
+    if size <= 1:
+        return 0
+    with _ROUND_ROBIN_LOCK:
+        offset = _ROUND_ROBIN_OFFSET % size
+        _ROUND_ROBIN_OFFSET += 1
+    return offset
+
+
+def reset_round_robin_for_tests() -> None:
+    """Reset deterministic state. Kept explicit so tests never reach into globals."""
+    global _ROUND_ROBIN_OFFSET
+    with _ROUND_ROBIN_LOCK:
+        _ROUND_ROBIN_OFFSET = 0
+
+
+TavilyOAuthSearch = Callable[[str, int], Awaitable[SearchResponse]]
+
+
+class WebSearchService:
+    """Resolve configured providers and execute one search with fallback.
+
+    ``round_robin`` rotates the first attempt per call, then walks the remaining
+    providers as a fallback chain. This spreads successful traffic without
+    sacrificing availability when a free tier is rate-limited or a scraper is
+    challenged. ``ordered`` always starts from the configured first provider.
+    """
+
+    def __init__(
+        self,
+        settings: WebSearchSettings,
+        credentials: CredentialManager,
+        *,
+        transport: httpx.AsyncBaseTransport | None = None,
+        tavily_oauth_search: TavilyOAuthSearch | None = None,
+    ) -> None:
+        self.settings = settings
+        self.credentials = credentials
+        self.transport = transport
+        self.tavily_oauth_search = tavily_oauth_search
+
+    def candidates(self, forced_provider: SearchProviderId | None = None) -> list[SearchProviderId]:
+        if not self.settings.enabled:
+            raise RuntimeError("Web search is disabled. Run `local-operator search on`.")
+        configured = list(self.settings.providers)
+        if forced_provider is not None:
+            if forced_provider not in configured:
+                raise RuntimeError(
+                    f"Search provider {forced_provider!r} is disabled. "
+                    f"Run `local-operator search enable {forced_provider}`."
+                )
+            return [forced_provider]
+        if self.settings.strategy == "round_robin" and len(configured) > 1:
+            offset = _next_offset(len(configured))
+            configured = configured[offset:] + configured[:offset]
+        return configured
+
+    async def search(
+        self,
+        query: str,
+        *,
+        limit: int = 5,
+        forced_provider: SearchProviderId | None = None,
+    ) -> SearchResponse:
+        clean_query = query.strip()
+        if not clean_query:
+            raise ValueError("Search query must not be empty")
+        limit = min(max(limit, 1), 20)
+        failures: list[str] = []
+        candidates = self.candidates(forced_provider)
+        if not candidates:
+            raise RuntimeError(
+                "No web search providers are enabled. Run "
+                "`local-operator search enable duckduckgo`."
+            )
+
+        timeout = httpx.Timeout(self.settings.timeout_seconds)
+        async with httpx.AsyncClient(
+            timeout=timeout,
+            follow_redirects=True,
+            transport=self.transport,
+        ) as client:
+            for provider_id in candidates:
+                if provider_id == "tavily" and self.tavily_oauth_search is not None:
+                    try:
+                        oauth_response = await self.tavily_oauth_search(clean_query, limit)
+                    except Exception as error:
+                        # OAuth MCP is an optional higher-trust transport. Its
+                        # failure must not suppress Tavily's keyless/API path.
+                        failures.append(f"tavily OAuth MCP: {error}")
+                    else:
+                        if oauth_response.sources or (oauth_response.answer or "").strip():
+                            oauth_response.failures = list(failures)
+                            return oauth_response
+                        failures.append("tavily OAuth MCP: returned no results")
+                if not provider_available(provider_id, self.credentials, self.settings):
+                    failures.append(f"{provider_id}: not configured")
+                    continue
+                try:
+                    response = await PROVIDERS[provider_id].search(
+                        client,
+                        self.credentials,
+                        self.settings,
+                        clean_query,
+                        limit,
+                    )
+                except Exception as error:  # one provider failure is the fallback trigger
+                    failures.append(f"{provider_id}: {error}")
+                    continue
+                if not response.sources and not (response.answer or "").strip():
+                    failures.append(f"{provider_id}: returned no results")
+                    continue
+                response.failures = list(failures)
+                return response
+
+        summary = "; ".join(failures) or "no candidates"
+        raise RuntimeError(f"All configured web search providers failed: {summary}")
+
+
+def search_settings_dict(settings: WebSearchSettings) -> dict[str, Any]:
+    """JSON-friendly settings view for server/CLI callers."""
+    return settings.model_dump(mode="json")

--- a/local_operator/web_search/tool.py
+++ b/local_operator/web_search/tool.py
@@ -1,0 +1,251 @@
+"""Model-facing ``web_search`` tool backed by the load-balancing service."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import uuid
+from contextlib import suppress
+from typing import Any, Callable
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+from local_operator.config import ConfigManager
+from local_operator.credentials import CredentialManager
+from local_operator.harness.types import (
+    AbortSignal,
+    AgentTool,
+    AgentToolUpdate,
+    TextContent,
+    ToolContext,
+    ToolResult,
+)
+from local_operator.paths import config_dir
+from local_operator.web_search.models import SearchProviderId, SearchResponse
+from local_operator.web_search.providers import tavily_response_from_payload
+from local_operator.web_search.service import (
+    WebSearchService,
+    coerce_search_settings,
+    load_search_settings,
+)
+
+MODEL_CONTEXT_MAX_CHARS = 6_000
+MODEL_ANSWER_MAX_CHARS = 1_200
+MODEL_SNIPPET_MAX_CHARS = 320
+MODEL_TITLE_MAX_CHARS = 240
+MODEL_URL_MAX_CHARS = 2_048
+_SOURCE_FOOTER = (
+    "Snippets are intentionally capped. To read one result in full, call " "`browser` with its URL."
+)
+
+
+class WebSearchParams(BaseModel):
+    """Arguments accepted by the built-in search tool."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    query: str = Field(description="Search query.", min_length=1)
+    max_results: int = Field(default=5, ge=1, le=20, description="Maximum results to return.")
+    provider: SearchProviderId | None = Field(
+        default=None,
+        description="Optional enabled provider to use instead of load balancing.",
+    )
+
+
+def _result(
+    tool_call_id: str,
+    text: str,
+    *,
+    error: bool = False,
+    details: dict[str, Any] | None = None,
+) -> ToolResult:
+    return ToolResult(
+        tool_call_id=tool_call_id,
+        tool_name="web_search",
+        content=[TextContent(text=text)],
+        details=details,
+        is_error=error,
+    )
+
+
+def _clip(text: str, limit: int) -> str:
+    compact = " ".join(text.split())
+    if len(compact) <= limit:
+        return compact
+    return compact[: limit - 1].rstrip() + "…"
+
+
+def _hard_clip(text: str, limit: int) -> str:
+    if len(text) <= limit:
+        return text
+    return text[: limit - 1].rstrip() + "…"
+
+
+def _render_response(response: SearchResponse) -> str:
+    """Render bounded model context while preserving complete usable result blocks."""
+    sections = [f"Provider: {response.provider} ({response.auth_mode})"]
+    if response.answer:
+        sections.append(_clip(response.answer, MODEL_ANSWER_MAX_CHARS))
+
+    failures = ""
+    if response.failures:
+        failures = "Fallbacks: " + _clip("; ".join(response.failures), 600)
+
+    source_blocks: list[str] = []
+    omitted = 0
+    for source_position, source in enumerate(response.sources):
+        # A clipped URL is not actionable. Omit the whole candidate instead so
+        # every URL that reaches model context can be passed to browser verbatim.
+        if len(source.url) > MODEL_URL_MAX_CHARS:
+            omitted += 1
+            continue
+        index = len(source_blocks) + 1
+        title = _clip(source.title, MODEL_TITLE_MAX_CHARS)
+        lines = [f"{index}. {title}", f"   {source.url}"]
+        if source.snippet:
+            lines.append(f"   {_clip(source.snippet, MODEL_SNIPPET_MAX_CHARS)}")
+        block = "\n".join(lines)
+        trial_sources = "Sources:\n" + "\n".join([*source_blocks, block])
+        tail = "\n\n".join(part for part in (failures, _SOURCE_FOOTER) if part)
+        trial = "\n\n".join([*sections, trial_sources, tail])
+        # Reserve enough room for the explicit omission marker so the hard cap
+        # never silently cuts a URL or leaves a half-result in model context.
+        if len(trial) + 80 > MODEL_CONTEXT_MAX_CHARS:
+            omitted += len(response.sources) - source_position
+            break
+        source_blocks.append(block)
+
+    if source_blocks:
+        sources = "Sources:\n" + "\n".join(source_blocks)
+        if omitted:
+            sources += f"\n… {omitted} more result{'s' if omitted != 1 else ''} omitted"
+        sections.append(sources)
+    elif response.sources:
+        sections.append(f"… {len(response.sources)} results omitted by the context limit")
+    if failures:
+        sections.append(failures)
+    sections.append(_SOURCE_FOOTER)
+    rendered = "\n\n".join(sections)
+    # The source-block budget above should make this unreachable, but the cap is
+    # an invariant at the model boundary even if future sections are added.
+    return _hard_clip(rendered, MODEL_CONTEXT_MAX_CHARS)
+
+
+async def _search_or_abort(service_call, signal: AbortSignal | None):
+    if signal is None:
+        return await service_call
+    if signal.aborted:
+        raise asyncio.CancelledError(signal.reason or "aborted")
+    search_task = asyncio.create_task(service_call)
+    abort_task = asyncio.create_task(signal.wait())
+    try:
+        done, _pending = await asyncio.wait(
+            {search_task, abort_task}, return_when=asyncio.FIRST_COMPLETED
+        )
+        if abort_task in done:
+            search_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await search_task
+            raise asyncio.CancelledError(signal.reason or "aborted")
+        return await search_task
+    finally:
+        abort_task.cancel()
+        with suppress(asyncio.CancelledError):
+            await abort_task
+
+
+def _tavily_oauth_delegate(
+    context: ToolContext | None,
+    signal: AbortSignal | None,
+    on_update: Callable[[AgentToolUpdate], None] | None,
+):
+    """Reuse the session's connected Tavily MCP tool when OAuth is configured."""
+    if context is None:
+        return None
+    tool = context.delegated_tools.get("mcp__tavily_search")
+    if not isinstance(tool, AgentTool):
+        return None
+
+    async def search(query: str, limit: int) -> SearchResponse:
+        result = await tool.execute(
+            f"web-search-tavily-{uuid.uuid4().hex}",
+            {"query": query, "max_results": limit, "search_depth": "basic"},
+            signal,
+            on_update,
+            context,
+        )
+        if result.is_error:
+            raise RuntimeError(result.text or "Tavily OAuth MCP search failed")
+        try:
+            payload = json.loads(result.text)
+        except json.JSONDecodeError as error:
+            raise RuntimeError("Tavily OAuth MCP returned non-JSON output") from error
+        if not isinstance(payload, dict):
+            raise RuntimeError("Tavily OAuth MCP returned a non-object response")
+        return tavily_response_from_payload(payload, auth_mode="oauth-mcp", limit=limit)
+
+    return search
+
+
+async def execute_web_search(
+    tool_call_id: str,
+    args: dict[str, Any],
+    signal: AbortSignal | None = None,
+    on_update: Callable[[AgentToolUpdate], None] | None = None,
+    context: ToolContext | None = None,
+) -> ToolResult:
+    """Execute one configured search, respecting abort and provider fallback."""
+    try:
+        params = WebSearchParams.model_validate(args)
+    except ValidationError as error:
+        return _result(tool_call_id, f"Invalid web_search arguments: {error}", error=True)
+
+    manager = ConfigManager(config_dir())
+    settings = load_search_settings(manager)
+    credentials = CredentialManager(config_dir())
+    service = WebSearchService(
+        settings,
+        credentials,
+        tavily_oauth_search=_tavily_oauth_delegate(context, signal, on_update),
+    )
+    try:
+        response = await _search_or_abort(
+            service.search(
+                params.query,
+                limit=params.max_results,
+                forced_provider=params.provider,
+            ),
+            signal,
+        )
+    except asyncio.CancelledError:
+        return _result(tool_call_id, "Web search aborted.", error=True)
+    except Exception as error:
+        return _result(tool_call_id, str(error), error=True)
+
+    text = _render_response(response)
+    details = response.model_dump(mode="json")
+    details["context_chars"] = len(text)
+    details["context_max_chars"] = MODEL_CONTEXT_MAX_CHARS
+    details["context_truncated"] = " omitted" in text
+    return _result(tool_call_id, text, details=details)
+
+
+def build_web_search_tool(context: ToolContext | None = None) -> AgentTool | None:
+    """Create the tool unless the startup configuration disables web search."""
+    raw_settings = context.web_search_settings if context is not None else None
+    if not coerce_search_settings(raw_settings).enabled:
+        return None
+    return AgentTool(
+        name="web_search",
+        label="Web Search",
+        description=(
+            "Search the public web with load balancing and automatic fallback. "
+            "Results include bounded snippets and source URLs; call browser on a URL "
+            "when the full page is needed. Use provider only for a specific enabled source."
+        ),
+        parameters=WebSearchParams.model_json_schema(),
+        approval_tier="read",
+        concurrency="shared",
+        interruptible=True,
+        execute=execute_web_search,
+    )

--- a/local_operator/web_search/tool.py
+++ b/local_operator/web_search/tool.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 import asyncio
+import inspect
 import json
 import uuid
-from contextlib import suppress
 from typing import Any, Callable
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
@@ -135,6 +135,10 @@ async def _search_or_abort(service_call, signal: AbortSignal | None):
     if signal is None:
         return await service_call
     if signal.aborted:
+        # The caller constructs the provider coroutine before handing it over.
+        # Close an unscheduled coroutine or Python will warn at collection time.
+        if inspect.iscoroutine(service_call):
+            service_call.close()
         raise asyncio.CancelledError(signal.reason or "aborted")
     search_task = asyncio.create_task(service_call)
     abort_task = asyncio.create_task(signal.wait())
@@ -143,15 +147,76 @@ async def _search_or_abort(service_call, signal: AbortSignal | None):
             {search_task, abort_task}, return_when=asyncio.FIRST_COMPLETED
         )
         if abort_task in done:
-            search_task.cancel()
-            with suppress(asyncio.CancelledError):
-                await search_task
             raise asyncio.CancelledError(signal.reason or "aborted")
         return await search_task
     finally:
-        abort_task.cancel()
-        with suppress(asyncio.CancelledError):
-            await abort_task
+        # Immediate steering cancels this coroutine itself rather than setting
+        # AbortSignal. Own and reap both children on every exit so provider or
+        # delegated MCP I/O can never continue detached from its tool call.
+        for task in (search_task, abort_task):
+            if not task.done():
+                task.cancel()
+        await asyncio.gather(search_task, abort_task, return_exceptions=True)
+
+
+def _parse_tavily_mcp_text(text: str) -> dict[str, Any]:
+    """Parse the official Tavily MCP's ``formatResults`` text contract."""
+    answer: list[str] = []
+    results: list[dict[str, str]] = []
+    current: dict[str, str] = {}
+    collecting: str | None = None
+
+    def finish() -> None:
+        nonlocal current
+        if current.get("url"):
+            results.append(current)
+        current = {}
+
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if line == "Detailed Results:":
+            collecting = None
+        elif line.startswith("Answer:"):
+            answer.append(line.removeprefix("Answer:").strip())
+            collecting = "answer"
+        elif line.startswith("Title:"):
+            finish()
+            current["title"] = line.removeprefix("Title:").strip()
+            collecting = None
+        elif line.startswith("URL:"):
+            current["url"] = line.removeprefix("URL:").strip()
+            collecting = None
+        elif line.startswith("Content:"):
+            current["content"] = line.removeprefix("Content:").strip()
+            collecting = "content"
+        elif line.startswith(("ID:", "Score:", "Raw Content:")):
+            collecting = None
+        elif line and collecting == "answer":
+            answer.append(line)
+        elif line and collecting == "content":
+            current["content"] = " ".join(part for part in (current.get("content"), line) if part)
+    finish()
+    if not results:
+        raise RuntimeError("Tavily OAuth MCP returned no parseable results")
+    return {"answer": " ".join(answer).strip() or None, "results": results}
+
+
+def _tavily_mcp_payload(result: ToolResult) -> dict[str, Any]:
+    """Normalize official prose plus structured payloads from other servers."""
+    server_result = (result.details or {}).get("server_result")
+    if isinstance(server_result, dict):
+        structured = server_result.get("structuredContent")
+        if not isinstance(structured, dict):
+            structured = server_result.get("structured_content")
+        if isinstance(structured, dict):
+            return structured
+    try:
+        payload = json.loads(result.text)
+    except json.JSONDecodeError:
+        return _parse_tavily_mcp_text(result.text)
+    if not isinstance(payload, dict):
+        raise RuntimeError("Tavily OAuth MCP returned a non-object response")
+    return payload
 
 
 def _tavily_oauth_delegate(
@@ -176,12 +241,7 @@ def _tavily_oauth_delegate(
         )
         if result.is_error:
             raise RuntimeError(result.text or "Tavily OAuth MCP search failed")
-        try:
-            payload = json.loads(result.text)
-        except json.JSONDecodeError as error:
-            raise RuntimeError("Tavily OAuth MCP returned non-JSON output") from error
-        if not isinstance(payload, dict):
-            raise RuntimeError("Tavily OAuth MCP returned a non-object response")
+        payload = _tavily_mcp_payload(result)
         return tavily_response_from_payload(payload, auth_mode="oauth-mcp", limit=limit)
 
     return search

--- a/local_operator/web_search/tool.py
+++ b/local_operator/web_search/tool.py
@@ -81,8 +81,14 @@ def _hard_clip(text: str, limit: int) -> str:
     return text[: limit - 1].rstrip() + "…"
 
 
-def _render_response(response: SearchResponse) -> str:
-    """Render bounded model context while preserving complete usable result blocks."""
+def _render_response(response: SearchResponse) -> tuple[str, int]:
+    """Bounded model context, and HOW MANY sources it left out.
+
+    The count is returned rather than re-derived by the caller: it is known
+    exactly here, and the only other way to recover it was scanning the
+    rendered text for the word "omitted" — which a result snippet containing
+    that word would have flipped on an untruncated response.
+    """
     sections = [f"Provider: {response.provider} ({response.auth_mode})"]
     if response.answer:
         sections.append(_clip(response.answer, MODEL_ANSWER_MAX_CHARS))
@@ -121,14 +127,19 @@ def _render_response(response: SearchResponse) -> str:
             sources += f"\n… {omitted} more result{'s' if omitted != 1 else ''} omitted"
         sections.append(sources)
     elif response.sources:
-        sections.append(f"… {len(response.sources)} results omitted by the context limit")
+        # Same plural guard as the sibling branch above. "by the context limit"
+        # is deliberately NOT claimed here: a source is also omitted when its
+        # URL exceeds MODEL_URL_MAX_CHARS, which reaches this branch too, so
+        # naming one of the two causes would be wrong half the time.
+        omitted = len(response.sources)
+        sections.append(f"… {omitted} result{'s' if omitted != 1 else ''} omitted")
     if failures:
         sections.append(failures)
     sections.append(_SOURCE_FOOTER)
     rendered = "\n\n".join(sections)
     # The source-block budget above should make this unreachable, but the cap is
     # an invariant at the model boundary even if future sections are added.
-    return _hard_clip(rendered, MODEL_CONTEXT_MAX_CHARS)
+    return _hard_clip(rendered, MODEL_CONTEXT_MAX_CHARS), omitted
 
 
 async def _search_or_abort(service_call, signal: AbortSignal | None):
@@ -296,11 +307,11 @@ async def execute_web_search(
     except Exception as error:
         return _result(tool_call_id, str(error), error=True)
 
-    text = _render_response(response)
+    text, omitted = _render_response(response)
     details = response.model_dump(mode="json")
     details["context_chars"] = len(text)
     details["context_max_chars"] = MODEL_CONTEXT_MAX_CHARS
-    details["context_truncated"] = " omitted" in text
+    details["context_truncated"] = omitted > 0
     return _result(tool_call_id, text, details=details)
 
 

--- a/local_operator/web_search/tool.py
+++ b/local_operator/web_search/tool.py
@@ -160,41 +160,55 @@ async def _search_or_abort(service_call, signal: AbortSignal | None):
 
 
 def _parse_tavily_mcp_text(text: str) -> dict[str, Any]:
-    """Parse the official Tavily MCP's ``formatResults`` text contract."""
+    """Parse the official Tavily MCP's unescaped ``formatResults`` text."""
     answer: list[str] = []
     results: list[dict[str, str]] = []
     current: dict[str, str] = {}
-    collecting: str | None = None
+    in_results = False
+    phase: str | None = None
+    previous_blank = False
 
     def finish() -> None:
         nonlocal current
         if current.get("url"):
+            content = current.get("content")
+            if content is not None:
+                current["content"] = content.strip()
             results.append(current)
         current = {}
 
-    for raw_line in text.splitlines():
+    for raw_line in text.replace("\r\n", "\n").splitlines():
         line = raw_line.strip()
+        if not line:
+            if phase == "content" and current.get("content"):
+                current["content"] += "\n"
+            previous_blank = True
+            continue
         if line == "Detailed Results:":
-            collecting = None
-        elif line.startswith("Answer:"):
+            in_results = True
+            phase = None
+        elif not in_results and line.startswith("Answer:"):
             answer.append(line.removeprefix("Answer:").strip())
-            collecting = "answer"
-        elif line.startswith("Title:"):
+            phase = "answer"
+        elif not in_results and phase == "answer":
+            answer.append(line)
+        elif in_results and previous_blank and line.startswith("Title:"):
+            # Official records begin with a blank line before Title. Content is
+            # unescaped, so Title:/URL: text inside an ordinary snippet must
+            # remain content rather than becoming a forged source record.
             finish()
             current["title"] = line.removeprefix("Title:").strip()
-            collecting = None
-        elif line.startswith("URL:"):
+            phase = "metadata"
+        elif phase == "metadata" and line.startswith("ID:"):
+            pass
+        elif phase == "metadata" and line.startswith("URL:"):
             current["url"] = line.removeprefix("URL:").strip()
-            collecting = None
-        elif line.startswith("Content:"):
+        elif phase == "metadata" and line.startswith("Content:"):
             current["content"] = line.removeprefix("Content:").strip()
-            collecting = "content"
-        elif line.startswith(("ID:", "Score:", "Raw Content:")):
-            collecting = None
-        elif line and collecting == "answer":
-            answer.append(line)
-        elif line and collecting == "content":
+            phase = "content"
+        elif phase == "content":
             current["content"] = " ".join(part for part in (current.get("content"), line) if part)
+        previous_blank = False
     finish()
     if not results:
         raise RuntimeError("Tavily OAuth MCP returned no parseable results")

--- a/local_operator/web_search/tool.py
+++ b/local_operator/web_search/tool.py
@@ -81,6 +81,28 @@ def _hard_clip(text: str, limit: int) -> str:
     return text[: limit - 1].rstrip() + "…"
 
 
+def _omission_note(url_omitted: int, budget_omitted: int, *, more: bool) -> str:
+    """One line saying how many sources were dropped AND why.
+
+    The two causes are reported separately when both fired, because they point
+    the model at different next actions and it cannot tell them apart from a
+    bare count. ``more`` distinguishes "some results are shown, these are
+    additional" from "nothing is shown at all".
+
+    Previously this was one number with the cause hardcoded to the context
+    limit, which was simply wrong for a URL omission; dropping the cause
+    entirely fixed the inaccuracy and lost the actionability with it.
+    """
+    parts: list[str] = []
+    if budget_omitted:
+        parts.append(f"{budget_omitted} by the context limit")
+    if url_omitted:
+        parts.append(f"{url_omitted} for an unusable URL")
+    total = url_omitted + budget_omitted
+    lead = f"{total} {'more ' if more else ''}result{'s' if total != 1 else ''} omitted"
+    return f"{lead} ({', '.join(parts)})" if parts else lead
+
+
 def _render_response(response: SearchResponse) -> tuple[str, int]:
     """Bounded model context, and HOW MANY sources it left out.
 
@@ -98,12 +120,19 @@ def _render_response(response: SearchResponse) -> tuple[str, int]:
         failures = "Fallbacks: " + _clip("; ".join(response.failures), 600)
 
     source_blocks: list[str] = []
-    omitted = 0
+    # The two causes are counted apart because they imply OPPOSITE next moves
+    # for the model: a budget omission means "your query matched too much,
+    # narrow it", an unusable-URL omission means "that one result cannot be
+    # fetched, the query was fine". Collapsing them into one number threw that
+    # away, and the footer below tells the model to call `browser` with a URL
+    # the response may have just declined to supply.
+    omitted_url = 0
+    omitted_budget = 0
     for source_position, source in enumerate(response.sources):
         # A clipped URL is not actionable. Omit the whole candidate instead so
         # every URL that reaches model context can be passed to browser verbatim.
         if len(source.url) > MODEL_URL_MAX_CHARS:
-            omitted += 1
+            omitted_url += 1
             continue
         index = len(source_blocks) + 1
         title = _clip(source.title, MODEL_TITLE_MAX_CHARS)
@@ -117,22 +146,18 @@ def _render_response(response: SearchResponse) -> tuple[str, int]:
         # Reserve enough room for the explicit omission marker so the hard cap
         # never silently cuts a URL or leaves a half-result in model context.
         if len(trial) + 80 > MODEL_CONTEXT_MAX_CHARS:
-            omitted += len(response.sources) - source_position
+            omitted_budget += len(response.sources) - source_position
             break
         source_blocks.append(block)
 
+    omitted = omitted_url + omitted_budget
     if source_blocks:
         sources = "Sources:\n" + "\n".join(source_blocks)
         if omitted:
-            sources += f"\n… {omitted} more result{'s' if omitted != 1 else ''} omitted"
+            sources += f"\n… {_omission_note(omitted_url, omitted_budget, more=True)}"
         sections.append(sources)
     elif response.sources:
-        # Same plural guard as the sibling branch above. "by the context limit"
-        # is deliberately NOT claimed here: a source is also omitted when its
-        # URL exceeds MODEL_URL_MAX_CHARS, which reaches this branch too, so
-        # naming one of the two causes would be wrong half the time.
-        omitted = len(response.sources)
-        sections.append(f"… {omitted} result{'s' if omitted != 1 else ''} omitted")
+        sections.append(f"… {_omission_note(omitted_url, omitted_budget, more=False)}")
     if failures:
         sections.append(failures)
     sections.append(_SOURCE_FOOTER)

--- a/tests/unit/compaction/test_tokens.py
+++ b/tests/unit/compaction/test_tokens.py
@@ -86,6 +86,19 @@ def test_memoization_hits_cache_and_invalidation_recomputes():
     assert after > before
 
 
+def test_estimate_cache_evicts_least_recent_entry_at_its_hard_bound():
+    """Long-lived servers must retain one turn's working set, not every session."""
+    messages = [
+        Message.user(f"message {index}") for index in range(tokens_mod._ESTIMATE_CACHE_MAX + 1)
+    ]
+    for message in messages:
+        estimate_tokens(message)
+
+    assert len(tokens_mod._ESTIMATE_CACHE) == tokens_mod._ESTIMATE_CACHE_MAX
+    assert messages[0].id not in tokens_mod._ESTIMATE_CACHE
+    assert messages[-1].id in tokens_mod._ESTIMATE_CACHE
+
+
 def test_invalidation_notifies_subscribers_and_unsubscribe():
     """register_invalidator subscribers fire on invalidation; unsubscribe stops them."""
     seen: list[str] = []

--- a/tests/unit/model/test_configure.py
+++ b/tests/unit/model/test_configure.py
@@ -14,6 +14,7 @@ import requests
 from pydantic import SecretStr
 
 from local_operator.credentials import CredentialManager
+from local_operator.harness.types import ModelSpec
 from local_operator.model.configure import (
     DEFAULT_TEMPERATURE,
     calculate_cost,
@@ -23,6 +24,9 @@ from local_operator.model.configure import (
     validate_model,
 )
 from local_operator.model.registry import ModelInfo
+from local_operator.providers.auth_store import AuthStore
+from local_operator.providers.failover import FallbackTarget
+from local_operator.providers.usage import UsageAmount, UsageLimit, UsageReport
 
 
 @pytest.fixture
@@ -235,6 +239,220 @@ def test_configure_model_openrouter_via_client(mock_openrouter_client):
 def test_create_stream_fn_returns_callable():
     stream_fn = create_stream_fn(MagicMock(), None)
     assert callable(stream_fn)
+
+
+def _oauth(access: str, account_id: str) -> dict[str, Any]:
+    return {
+        "access": access,
+        "refresh": f"refresh-{access}",
+        "expires": 10**15,
+        "account_id": account_id,
+    }
+
+
+def _anthropic_usage(used_percent: float) -> UsageReport:
+    return UsageReport(
+        provider="anthropic",
+        limits=[
+            UsageLimit(
+                id="anthropic:5h",
+                label="5 hour",
+                amount=UsageAmount(used=used_percent, limit=100.0, unit="percent"),
+                window="5h",
+                shared=True,
+                resets_at_ms=10**15,
+            )
+        ],
+    )
+
+
+@pytest.mark.asyncio
+async def test_usage_preflight_rotates_accounts_before_providers(tmp_path) -> None:
+    store = AuthStore(tmp_path / "auth.db")
+    first = store.upsert_credential("anthropic", _oauth("oauth-a", "account-a"))
+    second = store.upsert_credential("anthropic", _oauth("oauth-b", "account-b"))
+    store.upsert_credential("openai", {"key": "sk-openai", "source": "login"})
+    stream = create_stream_fn(
+        store,
+        {
+            "retry": {
+                "usageAwareFallback": True,
+                "usageReservePercent": 10,
+                "fallbackChains": {"default": ["openai/gpt-5.3-codex"]},
+            }
+        },
+        session_id="session-a",
+    )
+    notices: list[str] = []
+    stream.set_notice_handler(lambda text, kind: notices.append(f"{kind}:{text}"))
+    model = ModelSpec(provider="anthropic", model_id="claude-opus-5")
+
+    async def usage_for_access(_client, _provider, *, access_token=None, **_kwargs):
+        return _anthropic_usage(100.0 if access_token == "oauth-a" else 25.0)
+
+    try:
+        with patch("local_operator.providers.usage.fetch_usage", side_effect=usage_for_access):
+            await stream.preflight_usage(model)
+
+        assert store.is_blocked(first.id, "anthropic")
+        assert not store.is_blocked(second.id, "anthropic")
+        selected = await store.get_oauth_access("anthropic", "session-a")
+        assert selected is not None and selected.credential_id == second.id
+        assert stream._route_state.active is None
+        assert any("trying another anthropic account" in notice for notice in notices)
+    finally:
+        await stream.close()
+        store.close()
+
+
+@pytest.mark.asyncio
+async def test_usage_preflight_exhausts_accounts_then_uses_provider_fallback(tmp_path) -> None:
+    store = AuthStore(tmp_path / "auth.db")
+    first = store.upsert_credential("anthropic", _oauth("oauth-a", "account-a"))
+    second = store.upsert_credential("anthropic", _oauth("oauth-b", "account-b"))
+    store.upsert_credential("openai", {"key": "sk-openai", "source": "login"})
+    stream = create_stream_fn(
+        store,
+        {
+            "retry": {
+                "usageAwareFallback": True,
+                "fallbackChains": {
+                    "default": [
+                        {
+                            "provider": "anthropic",
+                            "model": "claude-opus-5",
+                            "effort": "low",
+                        },
+                        {
+                            "provider": "openai",
+                            "model": "gpt-5.3-codex",
+                            "effort": "high",
+                        },
+                    ]
+                },
+            }
+        },
+        session_id="session-a",
+    )
+    model = ModelSpec(provider="anthropic", model_id="claude-opus-5")
+
+    try:
+        with patch(
+            "local_operator.providers.usage.fetch_usage",
+            side_effect=lambda *_args, **_kwargs: _anthropic_usage(100.0),
+        ):
+            await stream.preflight_usage(model)
+
+        assert store.is_blocked(first.id, "anthropic")
+        assert store.is_blocked(second.id, "anthropic")
+        assert stream._route_state.active == FallbackTarget("openai/gpt-5.3-codex", "high")
+    finally:
+        await stream.close()
+        store.close()
+
+
+@pytest.mark.asyncio
+async def test_usage_reserve_can_reduce_effort_without_blocking_account(tmp_path) -> None:
+    store = AuthStore(tmp_path / "auth.db")
+    account = store.upsert_credential("anthropic", _oauth("oauth-a", "account-a"))
+    stream = create_stream_fn(
+        store,
+        {
+            "retry": {
+                "usageAwareFallback": True,
+                "usageReservePercent": 10,
+                "fallbackChains": {
+                    "default": [
+                        {
+                            "provider": "anthropic",
+                            "model": "claude-opus-5",
+                            "effort": "low",
+                        }
+                    ]
+                },
+            }
+        },
+        session_id="session-a",
+    )
+    model = ModelSpec(
+        provider="anthropic",
+        model_id="claude-opus-5",
+        reasoning=True,
+        reasoning_effort="high",
+    )
+
+    try:
+        with patch(
+            "local_operator.providers.usage.fetch_usage",
+            side_effect=lambda *_args, **_kwargs: _anthropic_usage(95.0),
+        ):
+            await stream.preflight_usage(model)
+
+        assert not store.is_blocked(account.id, "anthropic")
+        assert stream._route_state.active == FallbackTarget("anthropic/claude-opus-5", "low")
+    finally:
+        await stream.close()
+        store.close()
+
+
+@pytest.mark.asyncio
+async def test_transport_fallback_cooldown_skips_quota_probe(tmp_path) -> None:
+    store = AuthStore(tmp_path / "auth.db")
+    store.upsert_credential("anthropic", _oauth("oauth-a", "account-a"))
+    stream = create_stream_fn(
+        store,
+        {"retry": {"usageAwareFallback": True}},
+        session_id="session-a",
+    )
+    stream._primary_selector = "anthropic/claude-opus-5"
+    await stream._route_state.activate(
+        FallbackTarget("openai/gpt-5.3-codex"),
+        "provider failure",
+        cooldown_ms=60_000,
+    )
+    model = ModelSpec(provider="anthropic", model_id="claude-opus-5")
+
+    try:
+        with patch("local_operator.providers.usage.fetch_usage") as fetch:
+            await stream.preflight_usage(model)
+        fetch.assert_not_called()
+        assert stream._route_state.active == FallbackTarget("openai/gpt-5.3-codex")
+    finally:
+        await stream.close()
+        store.close()
+
+
+@pytest.mark.asyncio
+async def test_startup_preflight_warns_when_primary_credentials_are_blocked(tmp_path) -> None:
+    store = AuthStore(tmp_path / "auth.db")
+    account = store.upsert_credential("anthropic", _oauth("oauth-a", "account-a"))
+    store.block_credential(account.id, "anthropic", block_ms=60_000)
+    store.upsert_credential("openai", {"key": "sk-openai", "source": "login"})
+    stream = create_stream_fn(
+        store,
+        {
+            "retry": {
+                "usageAwareFallback": True,
+                "fallbackChains": {"default": ["openai/gpt-5.3-codex"]},
+            }
+        },
+        session_id="session-a",
+    )
+    notices: list[str] = []
+    stream.set_notice_handler(lambda text, kind: notices.append(text))
+
+    try:
+        with patch("local_operator.providers.usage.fetch_usage") as fetch:
+            await stream.preflight_usage(ModelSpec(provider="anthropic", model_id="claude-opus-5"))
+        fetch.assert_not_called()
+        assert stream._route_state.active == FallbackTarget("openai/gpt-5.3-codex")
+        assert notices == [
+            "anthropic credentials temporarily unavailable — "
+            "falling back to openai/gpt-5.3-codex"
+        ]
+    finally:
+        await stream.close()
+        store.close()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/providers/test_clients.py
+++ b/tests/unit/providers/test_clients.py
@@ -493,8 +493,8 @@ def _responses_sse() -> bytes:
     return _sse(events)
 
 
-async def test_openai_oauth_routes_to_responses_with_account_header() -> None:
-    """ChatGPT OAuth: /responses endpoint + chatgpt-account-id header."""
+async def test_openai_oauth_routes_to_codex_responses_with_required_headers() -> None:
+    """ChatGPT OAuth uses the Codex endpoint rather than the public API."""
     captured: dict[str, Any] = {}
 
     def handler(request: httpx.Request) -> httpx.Response:
@@ -519,10 +519,14 @@ async def test_openai_oauth_routes_to_responses_with_account_header() -> None:
             oauth_access=access,
         )
     )
-    assert captured["url"] == "https://api.openai.com/v1/responses"
+    assert captured["url"] == "https://chatgpt.com/backend-api/codex/responses"
     assert captured["headers"]["chatgpt-account-id"] == "acct-42"
     assert captured["headers"]["authorization"] == "Bearer chatgpt-token"
+    assert captured["headers"]["openai-beta"] == "responses=experimental"
+    assert captured["headers"]["originator"] == "local-operator"
+    assert captured["body"]["store"] is False
     assert "input" in captured["body"] and "messages" not in captured["body"]
+    assert "max_output_tokens" not in captured["body"]
     texts = [e.delta for e in events if isinstance(e, StreamTextDelta)]
     assert texts == ["Hello", " ChatGPT"]
     usage = events[-1].usage
@@ -739,6 +743,33 @@ def test_openai_compat_markers_gate_on_cache_support():
         ChatRequest(model=spec_nocache, messages=[Message.user("a"), Message.user("b")])
     )
     assert "cache_control" not in str(plain["messages"])
+
+
+def test_reasoning_effort_reaches_openai_and_anthropic_wires() -> None:
+    openai_spec = ModelSpec(
+        provider="openai",
+        model_id="gpt-5.3-codex",
+        reasoning=True,
+        reasoning_effort="high",
+        supports_sampling_params=False,
+    )
+    request = ChatRequest(model=openai_spec, messages=[Message.user("hi")])
+    openai = OpenAICompatClient("https://api.openai.com/v1")
+    assert openai._build_body(request)["reasoning_effort"] == "high"
+    assert openai._build_responses_body(request)["reasoning"] == {"effort": "high"}
+
+    anthropic_spec = ModelSpec(
+        provider="anthropic",
+        model_id="claude-opus-5",
+        reasoning=True,
+        reasoning_effort="max",
+        supports_sampling_params=False,
+    )
+    anthropic = AnthropicClient()
+    body = anthropic._build_body(ChatRequest(model=anthropic_spec, messages=[Message.user("hi")]))
+    assert body["thinking"] == {"type": "adaptive"}
+    assert body["output_config"] == {"effort": "max"}
+    assert "effort-2025-11-24" in anthropic._headers("key", effort="max")["anthropic-beta"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/providers/test_failover.py
+++ b/tests/unit/providers/test_failover.py
@@ -19,13 +19,17 @@ from local_operator.harness.types import (
 from local_operator.providers.failover import (
     AUTH_RETRY_MAX_ATTEMPTS,
     AuthRetryKeyState,
+    FailoverRouteState,
+    FallbackTarget,
     ProviderError,
     RetrySettings,
     backoff_delay_ms,
     expand_fallback_candidates,
+    expand_fallback_targets,
     is_direct_credential_rotation_error,
     resolve_chain,
     resolve_next_key,
+    spec_for_target,
     stream_with_failover,
 )
 
@@ -175,6 +179,35 @@ def test_expand_candidates_never_emits_current_selector() -> None:
     assert candidates == ["anthropic/claude"]
 
 
+def test_structured_fallback_entry_carries_effort() -> None:
+    targets = expand_fallback_targets(
+        "anthropic/claude-opus-5",
+        [{"provider": "openai", "model": "gpt-5.3-codex", "effort": "high"}],
+    )
+    assert targets == [FallbackTarget("openai/gpt-5.3-codex", "high")]
+    spec = spec_for_target(
+        ModelSpec(
+            provider="anthropic",
+            model_id="claude-opus-5",
+            base_url="https://api.anthropic.com",
+        ),
+        targets[0],
+    )
+    assert spec.provider == "openai"
+    assert spec.base_url == "https://api.openai.com/v1"
+    assert spec.reasoning_effort == "high"
+
+
+def test_invalid_structured_effort_is_not_silently_dropped() -> None:
+    assert (
+        expand_fallback_targets(
+            "anthropic/claude",
+            [{"provider": "openai", "model": "gpt-5", "effort": "turbo"}],
+        )
+        == []
+    )
+
+
 def test_retry_settings_from_config() -> None:
     settings = RetrySettings.from_settings(
         {
@@ -191,6 +224,8 @@ def test_retry_settings_from_config() -> None:
     assert settings.base_delay_ms == 250
     assert settings.model_fallback is False
     assert settings.fallback_chains == {"default": ["a/b"]}
+    assert settings.usage_aware_fallback is False
+    assert settings.usage_reserve_percent == 10
     empty = RetrySettings.from_settings(None)
     assert empty.enabled and empty.max_retries == 10 and empty.base_delay_ms == 500
 
@@ -329,6 +364,78 @@ async def test_stream_fallback_chain_walks_to_next_model() -> None:
     got = [event async for event in stream_with_failover(_request(), auth, settings, client_for)]
     assert [s.model_id for s in specs_seen] == ["gpt-4o", "claude-x"]
     assert any(isinstance(e, StreamTextDelta) and e.delta == "fallback" for e in got)
+
+
+async def test_fallback_chain_deduplicates_current_model_and_effort() -> None:
+    specs_seen: list[str] = []
+
+    async def client_for(spec: ModelSpec) -> Any:
+        specs_seen.append(f"{spec.provider}/{spec.model_id}/{spec.reasoning_effort}")
+        if spec.provider == "openai":
+            return ScriptedClient(ProviderError(400, "unavailable"))
+        return ScriptedClient([StreamEndEvent(stop_reason="stop")])
+
+    request = _request()
+    request = request.model_copy(
+        update={"model": request.model.model_copy(update={"reasoning_effort": "low"})}
+    )
+    settings = {
+        "retry": {
+            "fallbackChains": {
+                "default": [
+                    {"provider": "openai", "model": "gpt-4o", "effort": "low"},
+                    {"provider": "anthropic", "model": "claude-x", "effort": "high"},
+                ]
+            }
+        }
+    }
+
+    _ = [
+        event
+        async for event in stream_with_failover(
+            request,
+            FakeAuth({"openai": ["k1"], "anthropic": ["k2"]}),
+            settings,
+            client_for,
+        )
+    ]
+    assert specs_seen == ["openai/gpt-4o/low", "anthropic/claude-x/high"]
+
+
+async def test_successful_fallback_stays_pinned_for_same_message() -> None:
+    """A tool loop must not probe the exhausted primary before every model call."""
+    specs_seen: list[str] = []
+
+    async def client_for(spec: ModelSpec) -> Any:
+        specs_seen.append(f"{spec.provider}/{spec.model_id}")
+        if spec.provider == "openai":
+            return ScriptedClient(ProviderError(400, "model unavailable"))
+        return ScriptedClient([StreamEndEvent(stop_reason="stop")])
+
+    settings = {
+        "retry": {
+            "fallbackChains": {
+                "default": [{"provider": "anthropic", "model": "claude-opus-5", "effort": "high"}]
+            }
+        }
+    }
+    state = FailoverRouteState()
+    auth = FakeAuth({"openai": ["k1"], "anthropic": ["k2"]})
+
+    for _ in range(2):
+        _ = [
+            event
+            async for event in stream_with_failover(
+                _request(), auth, settings, client_for, route_state=state
+            )
+        ]
+
+    assert specs_seen == [
+        "openai/gpt-4o",
+        "anthropic/claude-opus-5",
+        "anthropic/claude-opus-5",
+    ]
+    assert state.active == FallbackTarget("anthropic/claude-opus-5", "high")
 
 
 async def test_stream_exhaustion_raises_last_error() -> None:

--- a/tests/unit/providers/test_failover.py
+++ b/tests/unit/providers/test_failover.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import asyncio
 import random
 from collections.abc import AsyncIterator
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -16,6 +17,7 @@ from local_operator.harness.types import (
     StreamEndEvent,
     StreamTextDelta,
 )
+from local_operator.providers import failover as failover_module
 from local_operator.providers.failover import (
     AUTH_RETRY_MAX_ATTEMPTS,
     AuthRetryKeyState,
@@ -436,6 +438,53 @@ async def test_successful_fallback_stays_pinned_for_same_message() -> None:
         "anthropic/claude-opus-5",
     ]
     assert state.active == FallbackTarget("anthropic/claude-opus-5", "high")
+
+
+@pytest.mark.asyncio
+async def test_the_primary_cooldown_is_a_deadline_not_a_sliding_window(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Re-entering the SAME fallback route must not push the retry deadline out.
+
+    ``stream_with_failover`` calls ``activate`` on every request that lands on
+    the sticky fallback, so arming the cooldown before the "already on this
+    route" early return made it slide forward on each use. A user sending
+    messages more often than the cooldown never reached ``primary_retry_due``
+    and stayed pinned to the fallback for the whole session, even after the
+    primary recovered — the opposite of the fixed post-failure probe the class
+    docstring promises.
+
+    The clock MUST advance between calls or this test cannot discriminate:
+    the arming is ``max(existing, now + cooldown)``, so six re-entries inside
+    one millisecond compute the same deadline whether the bug is present or
+    not. Verified by mutation — with a frozen clock the buggy order passes.
+    """
+    now_ms = 1_000_000
+
+    def fake_time() -> float:
+        return now_ms / 1000
+
+    # `failover.py` does `import time` and calls `time.time()`, so the patch
+    # goes on the module's own `time` binding — swapping a stand-in rather
+    # than mutating the real `time` module, which every other test shares.
+    monkeypatch.setattr(failover_module, "time", SimpleNamespace(time=fake_time), raising=True)
+
+    target = FallbackTarget("anthropic/claude-opus-5", "high")
+    state = FailoverRouteState()
+
+    await state.activate(target, "quota", cooldown_ms=60_000)
+    armed = state.primary_retry_at_ms
+    assert armed == now_ms + 60_000, "the route CHANGED, so the cooldown must arm"
+
+    # Five more requests on the route that is already active, ten seconds
+    # apart — the real shape of a user who keeps typing.
+    for _ in range(5):
+        now_ms += 10_000
+        await state.activate(target, "quota", cooldown_ms=60_000)
+
+    assert state.primary_retry_at_ms == armed, "re-entry re-armed the cooldown"
+    # 50s of use later the deadline has arrived, so the primary gets probed.
+    assert state.primary_retry_due(now_ms=now_ms + 10_001)
 
 
 async def test_stream_exhaustion_raises_last_error() -> None:

--- a/tests/unit/providers/test_usage.py
+++ b/tests/unit/providers/test_usage.py
@@ -16,7 +16,9 @@ import pytest
 from local_operator.providers.usage import (
     UsageAmount,
     UsageLimit,
+    UsageReport,
     fetch_usage,
+    usage_health,
     usage_supported,
 )
 
@@ -43,6 +45,69 @@ def _recording_client(payload, status: int = 200) -> tuple[httpx.AsyncClient, li
         return httpx.Response(status, json=payload)
 
     return httpx.AsyncClient(transport=httpx.MockTransport(handler)), urls
+
+
+def test_usage_health_shared_window_reaches_reserve() -> None:
+    report = UsageReport(
+        provider="anthropic",
+        limits=[
+            UsageLimit(
+                id="anthropic:7d",
+                label="7 day",
+                amount=UsageAmount(used_fraction=0.95),
+                shared=True,
+                resets_at_ms=20_000,
+            )
+        ],
+    )
+    health = usage_health(report, "claude-opus-5", reserve_percent=10, now_ms=10_000)
+    assert health.state == "reserve"
+    assert health.scope == "account"
+    assert health.remaining_fraction == pytest.approx(0.05)
+    assert health.reset_after_ms == 10_000
+
+
+def test_usage_health_ignores_unrelated_model_tier() -> None:
+    report = UsageReport(
+        provider="anthropic",
+        limits=[
+            UsageLimit(
+                id="anthropic:sonnet",
+                label="Sonnet",
+                amount=UsageAmount(used_fraction=1.0),
+                tier="sonnet",
+            ),
+            UsageLimit(
+                id="anthropic:shared",
+                label="Shared",
+                amount=UsageAmount(used_fraction=0.2),
+                shared=True,
+            ),
+        ],
+    )
+    assert usage_health(report, "claude-opus-5").state == "healthy"
+
+
+def test_usage_health_enabled_extra_credit_supersedes_included_plan() -> None:
+    report = UsageReport(
+        provider="anthropic",
+        limits=[
+            UsageLimit(
+                id="anthropic:7d",
+                label="7 day",
+                amount=UsageAmount(used_fraction=1.0),
+                shared=True,
+            ),
+            UsageLimit(
+                id="anthropic:extra",
+                label="Extra usage",
+                amount=UsageAmount(used=25, limit=100),
+            ),
+        ],
+    )
+    health = usage_health(report, "claude-opus-5")
+    assert health.state == "healthy"
+    assert health.remaining_fraction == pytest.approx(0.75)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/session/test_session.py
+++ b/tests/unit/session/test_session.py
@@ -22,6 +22,7 @@ from local_operator.harness.types import (
     CustomMessage,
     Message,
     ModelSpec,
+    NoticeEvent,
     StreamEndEvent,
     StreamEvent,
     StreamTextDelta,
@@ -60,6 +61,21 @@ class ScriptedStream:
                 yield event
 
         return gen()
+
+
+class PreflightStream(ScriptedStream):
+    def __init__(self) -> None:
+        super().__init__([[StreamEndEvent(stop_reason="stop")]])
+        self.notice_handler = None
+        self.preflight_models: list[ModelSpec] = []
+
+    def set_notice_handler(self, handler) -> None:
+        self.notice_handler = handler
+
+    async def preflight_usage(self, model: ModelSpec) -> None:
+        self.preflight_models.append(model)
+        assert self.notice_handler is not None
+        await self.notice_handler("anthropic quota low — falling back to openai", "warning")
 
 
 def echo_tool(executed: list[str], delay: float = 0.0, name: str = "echo") -> AgentTool:
@@ -129,6 +145,22 @@ async def test_prompt_full_turn_events_and_persistence(tmp_path):
     # System blocks reached the provider.
     assert stream.requests[0].system_blocks == ["stable", "env"]
     await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_usage_preflight_warns_without_starting_model_turn(tmp_path):
+    stream = PreflightStream()
+    session = make_session(tmp_path, stream)
+    events: list[AgentEvent] = []
+    session.subscribe(events.append)
+
+    await session.preflight_usage()
+
+    assert stream.preflight_models == [MODEL]
+    assert stream.requests == []
+    assert [event.type for event in events] == ["notice"]
+    assert isinstance(events[0], NoticeEvent)
+    assert events[0].text == "anthropic quota low — falling back to openai"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_cli_new.py
+++ b/tests/unit/test_cli_new.py
@@ -767,6 +767,38 @@ def test_main_preflight_missing_api_key(
     assert called["factory"] is False
 
 
+def test_preflight_accepts_stored_oauth_under_temporary_backoff(
+    tmp_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys,
+) -> None:
+    """A transient refresh failure must not become a false missing-key error.
+
+    Stream-time failover owns the temporary block and the next refresh. Startup
+    only needs to know that the OAuth credential exists, so the user can still
+    reach the TUI and `/login` if the provider ultimately rejects it.
+    """
+    from local_operator.providers.auth_store import AuthStore
+
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_OAUTH_TOKEN", raising=False)
+    store = AuthStore()
+    credential = store.upsert_credential(
+        "anthropic",
+        {
+            "access": "expired-access",
+            "refresh": "refresh-token",
+            "expires": 0,
+            "account_id": "account-id",
+        },
+    )
+    store.block_credential(credential.id, "anthropic")
+    store.close()
+
+    assert cli._preflight_api_key("anthropic", _bare_credential_manager()) is None
+    assert capsys.readouterr().err == ""
+
+
 def test_main_preflight_env_key_passes(
     tmp_home: Path, quiet_env: None, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -61,6 +61,19 @@ def test_config_manager_initialization(temp_config_dir):
     )
 
 
+def test_config_managers_do_not_share_nested_defaults(temp_config_dir):
+    """A provider setup in one fresh config must not alter another."""
+    first = ConfigManager(temp_config_dir / "first")
+    first_search = dict(first.get_config_value("web_search"))
+    first_search["providers"] = ["searxng"]
+    first_search["searxng_endpoint"] = "https://search.example.test"
+    first.config.set_value("web_search", first_search)
+
+    second = ConfigManager(temp_config_dir / "second")
+
+    assert second.get_config_value("web_search") == DEFAULT_CONFIG.get_value("web_search")
+
+
 @patch("local_operator.config.version")
 def test_config_manager_version_warning(mock_version, temp_config_dir, capsys):
     """Test ConfigManager warns about old config versions."""

--- a/tests/unit/test_session_factory.py
+++ b/tests/unit/test_session_factory.py
@@ -399,6 +399,33 @@ async def test_knowledge_backend_failure_falls_back_to_local_routing(
     assert any("using local routing" in warning for warning in warnings)
 
 
+@pytest.mark.asyncio
+async def test_knowledge_selection_freezes_after_the_first_session_query() -> None:
+    """Later turns must not re-embed skills or churn the cacheable system tail."""
+
+    class CountingIndex:
+        def __init__(self) -> None:
+            self.queries: list[str] = []
+
+        async def select(self, query: str):
+            self.queries.append(query)
+            return []
+
+    index = CountingIndex()
+    catalogue = ["first catalogue"]
+    hooks = session_factory._KnowledgeHooks(
+        index=index,  # type: ignore[arg-type]
+        mcp_catalogue=lambda: catalogue[0],
+    )
+
+    first = await session_factory._select_knowledge_block(hooks, "first task")
+    catalogue[0] = "changed catalogue"
+    second = await session_factory._select_knowledge_block(hooks, "unrelated later task")
+
+    assert first == second == "first catalogue"
+    assert index.queries == ["first task"]
+
+
 # --- MCP merge + dispose folding ------------------------------------------------------
 
 

--- a/tests/unit/tools/test_task_wait_jobs.py
+++ b/tests/unit/tools/test_task_wait_jobs.py
@@ -112,6 +112,37 @@ async def test_wait_returns_final_output_when_job_completes(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_wait_spills_large_subagent_handoff_without_losing_it(tmp_path, monkeypatch):
+    """One verbose child must not consume an unbounded slice of parent context."""
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    report = "\n".join(f"review finding {index}: {'x' * 120}" for index in range(400))
+
+    async def verbose_runner(job_id: str, signal: Any, report_progress) -> str:
+        return report
+
+    manager = AsyncJobManager()
+    job_id = manager.register("task", "verbose review", verbose_runner)
+    context = ToolContext(cwd=str(tmp_path), session_id="parent", jobs=manager)
+    tools = _tools(context)
+
+    waited = await _call(tools, "wait", {"job_id": job_id, "wait_ms": 1000}, context)
+
+    assert waited.is_error is False
+    assert waited.details is not None
+    spill = waited.details["spill"]
+    assert spill["complete"] is True
+    assert spill["handle"] in waited.text
+    assert len(waited.text) < builtin.TOOL_OUTPUT_LIMIT_CHARS + 1_000
+    stored = builtin.get_store().read_lines(spill["handle"])
+    assert stored is not None
+    lines, _total = stored
+    recovered = "\n".join(lines)
+    assert "review finding 0:" in recovered
+    assert "review finding 399:" in recovered
+    await manager.dispose()
+
+
+@pytest.mark.asyncio
 async def test_wait_bounded_by_wait_ms_times_out(tmp_path):
     manager = AsyncJobManager()
     context = ToolContext(cwd=str(tmp_path), session_id="s", jobs=manager, subagent_launcher=None)

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -36,6 +36,8 @@ class FakeSession:
         self.disposed = False
         self._handlers: list[Any] = []
         self._history: list[Any] = []
+        self.preflight_calls = 0
+        self.preflight_notice: str | None = None
 
     @property
     def session_id(self) -> str:
@@ -70,6 +72,11 @@ class FakeSession:
 
     async def seed_history(self, messages: list[Any]) -> None:
         pass
+
+    async def preflight_usage(self) -> None:
+        self.preflight_calls += 1
+        if self.preflight_notice is not None:
+            self.emit(NoticeEvent(text=self.preflight_notice, kind="warning"))
 
     async def prompt(self, text: str, attachments: list[Any] | None = None) -> None:
         self.prompts.append(text)
@@ -164,10 +171,29 @@ async def test_boot_typing_sends_prompt() -> None:
         await pilot.pause()
         await pilot.pause()
         assert session.prompts == ["hi"]
+        assert session.preflight_calls == 1
         # A user block was appended for the submitted prompt (the boot hint
         # is lifted by the first real block, D9).
         transcript = app.query_one(TranscriptView)
         assert len(transcript.blocks()) == 1
+
+
+@pytest.mark.asyncio
+async def test_boot_renders_non_blocking_quota_warning() -> None:
+    session = FakeSession()
+    session.preflight_notice = (
+        "anthropic quota exhausted — falling back to openai/gpt-5.3-codex (high effort)"
+    )
+    app = OperatorApp(lambda: _factory(session))
+
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.pause()
+
+        text = _transcript_text(app)
+        assert "anthropic quota exhausted" in text
+        assert "falling back to openai/gpt-5.3-codex (high effort)" in text
+        assert session.prompts == []
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tui/test_command_picker.py
+++ b/tests/unit/tui/test_command_picker.py
@@ -541,7 +541,7 @@ async def test_click_on_the_overflow_row_does_nothing() -> None:
     [
         ("u", ["usage"]),
         ("g", ["goal"]),
-        ("s", ["skills"]),
+        ("s", ["search", "skills"]),
         ("c", ["clear", "compact"]),
         ("lo", ["loop", "login", "logout"]),
         ("mo", ["model"]),

--- a/tests/unit/tui/test_search_command.py
+++ b/tests/unit/tui/test_search_command.py
@@ -14,21 +14,26 @@ async def test_search_command_shows_status_and_applies_provider_toggle(
     session = FakeSession()
     app = OperatorApp(lambda: _factory(session))
 
-    async with app.run_test(size=(100, 30)) as pilot:
+    async with app.run_test(size=(120, 40)) as pilot:
         await pilot.pause()
         app._run_slash_command("/search")
         await pilot.pause()
         first = _transcript_text(app)
-        assert "web search" in first
-        assert "round_robin" in first
-        assert "duckduckgo" in first and "enabled · ready" in first
-        assert "local-operator search setup <provider>" in first
+        assert "Web search" in first
+        assert "Round Robin" in first
+        assert "DuckDuckGo" in first and "enabled · available" in first
+        assert "/search enable|disable <provider>" in first
+        assert "/search balance round_robin|ordered" in first
+        assert "search setup tavily --oauth|--api-key" in first
+        assert "search setup searxng --endpoint <url>" in first
 
+        app._run_slash_command("/search setup tavily")
         app._run_slash_command("/search disable tavily")
         app._run_slash_command("/search")
         await pilot.pause()
         after = _transcript_text(app)
+        assert "run in a shell: local-operator search setup tavily --oauth" in after
         assert "tavily disabled; applies to the next search" in after
-        assert "tavily" in after and "disabled · ready" in after
+        assert "Tavily" in after and "disabled · available" in after
 
     assert session.prompts == []

--- a/tests/unit/tui/test_search_command.py
+++ b/tests/unit/tui/test_search_command.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import pytest
+
+from local_operator.tui.app import OperatorApp
+from tests.unit.tui.test_app_pilot import FakeSession, _factory, _transcript_text
+
+
+@pytest.mark.asyncio
+async def test_search_command_shows_status_and_applies_provider_toggle(
+    monkeypatch, tmp_path
+) -> None:
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    session = FakeSession()
+    app = OperatorApp(lambda: _factory(session))
+
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        app._run_slash_command("/search")
+        await pilot.pause()
+        first = _transcript_text(app)
+        assert "web search" in first
+        assert "round_robin" in first
+        assert "duckduckgo" in first and "enabled · ready" in first
+        assert "local-operator search setup <provider>" in first
+
+        app._run_slash_command("/search disable tavily")
+        app._run_slash_command("/search")
+        await pilot.pause()
+        after = _transcript_text(app)
+        assert "tavily disabled; applies to the next search" in after
+        assert "tavily" in after and "disabled · ready" in after
+
+    assert session.prompts == []

--- a/tests/unit/tui/test_tool_card.py
+++ b/tests/unit/tui/test_tool_card.py
@@ -300,13 +300,20 @@ def test_web_search_expansion_uses_structured_page_metadata() -> None:
         },
     )
 
+    # Search sources are primary content, so their disclosure stays visible
+    # without requiring hover or prior knowledge of generic card controls.
+    assert EXPAND_HINT in card._build_row(120).plain
     card.toggle_expanded()
-    content = card._build_content(120).plain
+    content = card._build_content(120)
 
-    assert "Python 3.13 release" in content
-    assert "https://python.org/downloads/release/python-3130/" in content
-    assert "Release notes and downloads for Python 3.13." in content
-    assert "Open a result URL with browser" in content
+    assert "Python 3.13 release" in content.plain
+    assert "https://python.org/downloads/release/python-3130/" in content.plain
+    assert "Release notes and downloads for Python 3.13." in content.plain
+    assert "Ask Operator to open result N with browser" in content.plain
+    assert _style_at(content, "Python 3.13 release").bold is True
+    assert (
+        _style_at(content, "https://python.org").color != _style_at(content, "Release notes").color
+    )
 
 
 # --- the one-line guarantee ------------------------------------------------

--- a/tests/unit/tui/test_tool_card.py
+++ b/tests/unit/tui/test_tool_card.py
@@ -282,6 +282,33 @@ def test_a_tool_without_a_diff_expands_to_its_raw_output() -> None:
     assert "one" in content and "three" in content
 
 
+def test_web_search_expansion_uses_structured_page_metadata() -> None:
+    """The model's bounded text must not impoverish the human expansion."""
+    card = ToolCard("t", "web_search", {"query": "python release"})
+    card.mark_done(
+        "Provider: duckduckgo (credential-free)",
+        {
+            "provider": "duckduckgo",
+            "auth_mode": "credential-free",
+            "sources": [
+                {
+                    "title": "Python 3.13 release",
+                    "url": "https://python.org/downloads/release/python-3130/",
+                    "snippet": "Release notes and downloads for Python 3.13.",
+                }
+            ],
+        },
+    )
+
+    card.toggle_expanded()
+    content = card._build_content(120).plain
+
+    assert "Python 3.13 release" in content
+    assert "https://python.org/downloads/release/python-3130/" in content
+    assert "Release notes and downloads for Python 3.13." in content
+    assert "Open a result URL with browser" in content
+
+
 # --- the one-line guarantee ------------------------------------------------
 
 

--- a/tests/unit/web_search/test_cli.py
+++ b/tests/unit/web_search/test_cli.py
@@ -43,6 +43,65 @@ def test_setup_tavily_oauth_writes_http_oauth_server(monkeypatch, tmp_path) -> N
     assert "tavily" in load_search_settings(ConfigManager(config_dir())).providers
 
 
+def test_setup_tavily_oauth_repairs_global_non_oauth_entry(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    workdir = tmp_path / "work"
+    workdir.mkdir()
+    monkeypatch.chdir(workdir)
+    mcp_path = tmp_path / ".local-operator" / "mcp.json"
+    mcp_path.parent.mkdir()
+    mcp_path.write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "tavily": {
+                        "type": "http",
+                        "url": "https://mcp.tavily.com/mcp",
+                        "headers": {"X-Test": "not-oauth"},
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert search_command(_args("setup", "tavily", "--oauth")) == 0
+    assert search_command(_args("setup", "tavily", "--oauth")) == 0
+
+    payload = json.loads(mcp_path.read_text(encoding="utf-8"))
+    assert payload["mcpServers"]["tavily"] == {
+        "type": "http",
+        "url": "https://mcp.tavily.com/mcp/",
+        "auth": {"type": "oauth"},
+    }
+
+
+def test_setup_tavily_oauth_rejects_shadowed_non_oauth_entry(monkeypatch, tmp_path, capsys) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    project = tmp_path / "project"
+    project_config = project / ".local-operator" / "mcp.json"
+    project_config.parent.mkdir(parents=True)
+    project_config.write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "tavily": {
+                        "type": "http",
+                        "url": "https://mcp.tavily.com/mcp/",
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(project)
+
+    assert search_command(_args("setup", "tavily", "--oauth")) == 1
+    assert "higher-priority entry" in capsys.readouterr().out
+
+
 def test_setup_searxng_validates_and_stores_endpoint(monkeypatch, tmp_path) -> None:
     monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
 

--- a/tests/unit/web_search/test_cli.py
+++ b/tests/unit/web_search/test_cli.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import json
+
+from local_operator.cli import build_cli_parser
+from local_operator.config import ConfigManager
+from local_operator.mcp import config as mcp_config
+from local_operator.paths import config_dir
+from local_operator.web_search.cli import search_command
+from local_operator.web_search.service import load_search_settings
+
+
+def _args(*parts: str):
+    return build_cli_parser().parse_args(["search", *parts])
+
+
+def test_search_enable_disable_and_order_persist(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+
+    assert search_command(_args("disable", "tavily")) == 0
+    assert search_command(_args("enable", "brave")) == 0
+    assert search_command(_args("balance", "ordered")) == 0
+    assert search_command(_args("order", "brave", "duckduckgo")) == 0
+
+    settings = load_search_settings(ConfigManager(config_dir()))
+    assert settings.strategy == "ordered"
+    assert settings.providers == ["brave", "duckduckgo"]
+
+
+def test_setup_tavily_oauth_writes_http_oauth_server(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    mcp_path = tmp_path / "mcp.json"
+    monkeypatch.setattr(mcp_config, "_scope_path", lambda _cwd, _scope: mcp_path)
+
+    assert search_command(_args("setup", "tavily", "--oauth")) == 0
+
+    payload = json.loads(mcp_path.read_text(encoding="utf-8"))
+    assert payload["mcpServers"]["tavily"] == {
+        "type": "http",
+        "url": "https://mcp.tavily.com/mcp/",
+        "auth": {"type": "oauth"},
+    }
+    assert "tavily" in load_search_settings(ConfigManager(config_dir())).providers
+
+
+def test_setup_searxng_validates_and_stores_endpoint(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+
+    assert (
+        search_command(_args("setup", "searxng", "--endpoint", "https://search.example.test/")) == 0
+    )
+
+    settings = load_search_settings(ConfigManager(config_dir()))
+    assert settings.searxng_endpoint == "https://search.example.test"
+    assert "searxng" in settings.providers
+
+
+def test_setup_rejects_oauth_for_non_tavily(monkeypatch, tmp_path, capsys) -> None:
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+
+    assert search_command(_args("setup", "brave", "--oauth")) == 1
+
+    assert "--oauth is supported only for Tavily" in capsys.readouterr().out

--- a/tests/unit/web_search/test_providers.py
+++ b/tests/unit/web_search/test_providers.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from local_operator.credentials import CredentialManager
+from local_operator.web_search.models import WebSearchSettings
+from local_operator.web_search.providers import PROVIDERS, parse_duckduckgo_html
+
+
+def _credentials(tmp_path) -> CredentialManager:
+    return CredentialManager(tmp_path / "config")
+
+
+def test_duckduckgo_parser_unwraps_links_and_inline_markup() -> None:
+    page = (
+        '<div class="result results_links">\n'
+        '  <h2><a class="result__a" href="//duckduckgo.com/l/?uddg='
+        'https%3A%2F%2Fexample.com%2Fdoc">Example <b>Doc</b></a></h2>\n'
+        '  <a class="result__snippet">Useful &amp; current.</a>\n'
+        "</div>\n"
+        '<div class="nav-link"></div>'
+    )
+
+    rows = parse_duckduckgo_html(page, 5)
+
+    assert len(rows) == 1
+    assert rows[0].title == "Example Doc"
+    assert rows[0].url == "https://example.com/doc"
+    assert rows[0].snippet == "Useful & current."
+
+
+@pytest.mark.asyncio
+async def test_tavily_uses_official_keyless_header_when_no_key_exists(tmp_path) -> None:
+    seen: httpx.Request | None = None
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal seen
+        seen = request
+        return httpx.Response(
+            200,
+            json={
+                "answer": "Current answer",
+                "request_id": "req-1",
+                "results": [
+                    {"title": "Result", "url": "https://example.com", "content": "Snippet"}
+                ],
+            },
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        response = await PROVIDERS["tavily"].search(
+            client,
+            _credentials(tmp_path),
+            WebSearchSettings(),
+            "current fact",
+            3,
+        )
+
+    assert seen is not None
+    assert seen.headers["X-Tavily-Access-Mode"] == "keyless"
+    assert "Authorization" not in seen.headers
+    assert json.loads(seen.content)["max_results"] == 3
+    assert response.auth_mode == "keyless"
+    assert response.sources[0].url == "https://example.com"
+
+
+@pytest.mark.asyncio
+async def test_tavily_prefers_stored_key_over_keyless_mode(tmp_path) -> None:
+    credentials = _credentials(tmp_path)
+    credentials.set_credential("TAVILY_API_KEY", "secret-key")
+    seen: httpx.Request | None = None
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal seen
+        seen = request
+        return httpx.Response(200, json={"results": [{"url": "https://example.com"}]})
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        response = await PROVIDERS["tavily"].search(
+            client, credentials, WebSearchSettings(), "query", 1
+        )
+
+    assert seen is not None
+    assert seen.headers["Authorization"] == "Bearer secret-key"
+    assert "X-Tavily-Access-Mode" not in seen.headers
+    assert response.auth_mode == "api-key"
+
+
+@pytest.mark.asyncio
+async def test_serpapi_accepts_legacy_serp_api_key_name(tmp_path) -> None:
+    credentials = _credentials(tmp_path)
+    credentials.set_credential("SERP_API_KEY", "legacy-key")
+    seen: httpx.Request | None = None
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal seen
+        seen = request
+        return httpx.Response(
+            200,
+            json={
+                "search_metadata": {"id": "search-1"},
+                "organic_results": [
+                    {"title": "Result", "link": "https://example.com", "snippet": "Body"}
+                ],
+            },
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        response = await PROVIDERS["serpapi"].search(
+            client, credentials, WebSearchSettings(), "query", 2
+        )
+
+    assert seen is not None
+    assert seen.url.params["api_key"] == "legacy-key"
+    assert response.request_id == "search-1"
+    assert response.sources[0].title == "Result"
+
+
+@pytest.mark.asyncio
+async def test_perplexity_anonymous_sse_yields_answer_and_sources(tmp_path) -> None:
+    source_event = {
+        "uuid": "pplx-1",
+        "blocks": [
+            {
+                "intended_usage": "web_results",
+                "web_result_block": {
+                    "web_results": [
+                        {
+                            "name": "Source",
+                            "url": "https://example.com",
+                            "snippet": "Evidence",
+                        }
+                    ]
+                },
+            }
+        ],
+    }
+    answer_event = {
+        "uuid": "pplx-1",
+        "blocks": [
+            {
+                "intended_usage": "ask_text",
+                "markdown_block": {"answer": "Grounded answer"},
+            }
+        ],
+        "final": True,
+    }
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        body = (
+            "data: "
+            + json.dumps(source_event)
+            + "\n\ndata: "
+            + json.dumps(answer_event)
+            + "\n\ndata: [DONE]\n"
+        )
+        return httpx.Response(200, text=body)
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        response = await PROVIDERS["perplexity"].search(
+            client,
+            _credentials(tmp_path),
+            WebSearchSettings(),
+            "query",
+            3,
+        )
+
+    assert response.auth_mode == "anonymous"
+    assert response.answer == "Grounded answer"
+    assert response.sources[0].url == "https://example.com"

--- a/tests/unit/web_search/test_providers.py
+++ b/tests/unit/web_search/test_providers.py
@@ -18,7 +18,7 @@ def test_duckduckgo_parser_unwraps_links_and_inline_markup() -> None:
     page = (
         '<div class="result results_links">\n'
         '  <h2><a class="result__a" href="//duckduckgo.com/l/?uddg='
-        'https%3A%2F%2Fexample.com%2Fdoc">Example <b>Doc</b></a></h2>\n'
+        'https%3A%2F%2Fexample.com%2Fdocument%252Fversion">Example <b>Doc</b></a></h2>\n'
         '  <a class="result__snippet">Useful &amp; current.</a>\n'
         "</div>\n"
         '<div class="nav-link"></div>'
@@ -28,7 +28,7 @@ def test_duckduckgo_parser_unwraps_links_and_inline_markup() -> None:
 
     assert len(rows) == 1
     assert rows[0].title == "Example Doc"
-    assert rows[0].url == "https://example.com/doc"
+    assert rows[0].url == "https://example.com/document%2Fversion"
     assert rows[0].snippet == "Useful & current."
 
 

--- a/tests/unit/web_search/test_providers.py
+++ b/tests/unit/web_search/test_providers.py
@@ -120,6 +120,108 @@ async def test_serpapi_accepts_legacy_serp_api_key_name(tmp_path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_brave_uses_subscription_token_and_maps_extra_snippets(tmp_path) -> None:
+    credentials = _credentials(tmp_path)
+    credentials.set_credential("BRAVE_API_KEY", "brave-key")
+    seen: httpx.Request | None = None
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal seen
+        seen = request
+        return httpx.Response(
+            200,
+            json={
+                "web": {
+                    "results": [
+                        {
+                            "title": "Brave result",
+                            "url": "https://example.com/brave",
+                            "description": "Primary",
+                            "extra_snippets": ["Extra"],
+                        }
+                    ]
+                }
+            },
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        response = await PROVIDERS["brave"].search(
+            client, credentials, WebSearchSettings(), "query", 2
+        )
+
+    assert seen is not None
+    assert seen.headers["X-Subscription-Token"] == "brave-key"
+    assert seen.url.params["count"] == "2"
+    assert response.sources[0].snippet == "Primary\nExtra"
+
+
+@pytest.mark.asyncio
+async def test_exa_requests_query_summary_instead_of_full_page_text(tmp_path) -> None:
+    credentials = _credentials(tmp_path)
+    credentials.set_credential("EXA_API_KEY", "exa-key")
+    seen: httpx.Request | None = None
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal seen
+        seen = request
+        return httpx.Response(
+            200,
+            json={
+                "results": [
+                    {
+                        "title": "Exa result",
+                        "url": "https://example.com/exa",
+                        "summary": "Query-grounded summary",
+                    }
+                ]
+            },
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        response = await PROVIDERS["exa"].search(
+            client, credentials, WebSearchSettings(), "semantic query", 4
+        )
+
+    assert seen is not None
+    payload = json.loads(seen.content)
+    assert payload["contents"] == {"summary": {"query": "semantic query"}}
+    assert "text" not in payload["contents"]
+    assert response.sources[0].snippet == "Query-grounded summary"
+
+
+@pytest.mark.asyncio
+async def test_searxng_uses_configured_endpoint_and_json_contract(tmp_path) -> None:
+    seen: httpx.Request | None = None
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal seen
+        seen = request
+        return httpx.Response(
+            200,
+            json={
+                "results": [
+                    {
+                        "title": "Private result",
+                        "url": "https://example.com/private",
+                        "content": "Private snippet",
+                    }
+                ]
+            },
+        )
+
+    settings = WebSearchSettings(searxng_endpoint="https://search.example.com")
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        response = await PROVIDERS["searxng"].search(
+            client, _credentials(tmp_path), settings, "query", 3
+        )
+
+    assert seen is not None
+    assert str(seen.url).startswith("https://search.example.com/search?")
+    assert seen.url.params["format"] == "json"
+    assert response.sources[0].snippet == "Private snippet"
+
+
+@pytest.mark.asyncio
 async def test_perplexity_anonymous_sse_yields_answer_and_sources(tmp_path) -> None:
     source_event = {
         "uuid": "pplx-1",

--- a/tests/unit/web_search/test_service.py
+++ b/tests/unit/web_search/test_service.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from local_operator.credentials import CredentialManager
+from local_operator.web_search.models import (
+    SearchProviderId,
+    SearchResponse,
+    SearchSource,
+    WebSearchSettings,
+)
+from local_operator.web_search.providers import PROVIDERS
+from local_operator.web_search.service import (
+    WebSearchService,
+    coerce_search_settings,
+    reset_round_robin_for_tests,
+)
+
+
+def _credentials(tmp_path) -> CredentialManager:
+    return CredentialManager(tmp_path / "config")
+
+
+def _response(provider: SearchProviderId) -> SearchResponse:
+    return SearchResponse(
+        provider=provider,
+        auth_mode="test",
+        sources=[SearchSource(title=provider, url=f"https://{provider}.example")],
+    )
+
+
+@pytest.fixture(autouse=True)
+def _reset_rotation() -> None:
+    reset_round_robin_for_tests()
+
+
+@pytest.mark.asyncio
+async def test_round_robin_rotates_first_success_across_enabled_providers(
+    tmp_path, monkeypatch
+) -> None:
+    async def duck(*_args):
+        return _response("duckduckgo")
+
+    async def tavily(*_args):
+        return _response("tavily")
+
+    monkeypatch.setitem(PROVIDERS, "duckduckgo", replace(PROVIDERS["duckduckgo"], search=duck))
+    monkeypatch.setitem(PROVIDERS, "tavily", replace(PROVIDERS["tavily"], search=tavily))
+    service = WebSearchService(
+        WebSearchSettings(providers=["duckduckgo", "tavily"], strategy="round_robin"),
+        _credentials(tmp_path),
+    )
+
+    first = await service.search("first")
+    second = await service.search("second")
+
+    assert first.provider == "duckduckgo"
+    assert second.provider == "tavily"
+
+
+@pytest.mark.asyncio
+async def test_tavily_oauth_delegate_precedes_direct_transport(tmp_path, monkeypatch) -> None:
+    direct_called = False
+
+    async def direct(*_args):
+        nonlocal direct_called
+        direct_called = True
+        return _response("tavily")
+
+    async def oauth(_query: str, _limit: int) -> SearchResponse:
+        response = _response("tavily")
+        response.auth_mode = "oauth-mcp"
+        return response
+
+    monkeypatch.setitem(PROVIDERS, "tavily", replace(PROVIDERS["tavily"], search=direct))
+    service = WebSearchService(
+        WebSearchSettings(providers=["tavily"]),
+        _credentials(tmp_path),
+        tavily_oauth_search=oauth,
+    )
+
+    response = await service.search("query")
+
+    assert response.auth_mode == "oauth-mcp"
+    assert direct_called is False
+
+
+@pytest.mark.asyncio
+async def test_failure_falls_through_and_is_reported(tmp_path, monkeypatch) -> None:
+    async def duck(*_args):
+        raise RuntimeError("challenged")
+
+    async def tavily(*_args):
+        return _response("tavily")
+
+    monkeypatch.setitem(PROVIDERS, "duckduckgo", replace(PROVIDERS["duckduckgo"], search=duck))
+    monkeypatch.setitem(PROVIDERS, "tavily", replace(PROVIDERS["tavily"], search=tavily))
+    service = WebSearchService(
+        WebSearchSettings(providers=["duckduckgo", "tavily"], strategy="ordered"),
+        _credentials(tmp_path),
+    )
+
+    response = await service.search("fallback")
+
+    assert response.provider == "tavily"
+    assert response.failures == ["duckduckgo: challenged"]
+
+
+@pytest.mark.asyncio
+async def test_unconfigured_key_provider_is_skipped(tmp_path, monkeypatch) -> None:
+    async def duck(*_args):
+        return _response("duckduckgo")
+
+    monkeypatch.setitem(PROVIDERS, "duckduckgo", replace(PROVIDERS["duckduckgo"], search=duck))
+    service = WebSearchService(
+        WebSearchSettings(providers=["brave", "duckduckgo"], strategy="ordered"),
+        _credentials(tmp_path),
+    )
+
+    response = await service.search("fallback")
+
+    assert response.provider == "duckduckgo"
+    assert response.failures == ["brave: not configured"]
+
+
+@pytest.mark.asyncio
+async def test_forced_provider_must_be_enabled(tmp_path) -> None:
+    service = WebSearchService(
+        WebSearchSettings(providers=["duckduckgo"]),
+        _credentials(tmp_path),
+    )
+
+    with pytest.raises(RuntimeError, match="is disabled"):
+        await service.search("query", forced_provider="brave")
+
+
+@pytest.mark.asyncio
+async def test_master_switch_blocks_execution(tmp_path) -> None:
+    service = WebSearchService(
+        WebSearchSettings(enabled=False),
+        _credentials(tmp_path),
+    )
+
+    with pytest.raises(RuntimeError, match="Web search is disabled"):
+        await service.search("query")
+
+
+def test_malformed_config_preserves_valid_provider_subset() -> None:
+    settings = coerce_search_settings(
+        {
+            "strategy": "round_robin",
+            "providers": ["tavily", "unknown", "tavily", "duckduckgo"],
+            "timeout_seconds": 500,
+        }
+    )
+
+    assert settings.providers == ["tavily", "duckduckgo"]
+    assert settings.timeout_seconds == 120

--- a/tests/unit/web_search/test_tool.py
+++ b/tests/unit/web_search/test_tool.py
@@ -1,16 +1,23 @@
 from __future__ import annotations
 
-import json
+import asyncio
 
 import pytest
 
-from local_operator.harness.types import AgentTool, TextContent, ToolContext, ToolResult
+from local_operator.harness.types import (
+    AbortSignal,
+    AgentTool,
+    TextContent,
+    ToolContext,
+    ToolResult,
+)
 from local_operator.tools.registry import create_tools
 from local_operator.web_search.models import SearchResponse, SearchSource
 from local_operator.web_search.tool import (
     MODEL_CONTEXT_MAX_CHARS,
     WebSearchParams,
     _render_response,
+    _search_or_abort,
     _tavily_oauth_delegate,
     build_web_search_tool,
 )
@@ -79,17 +86,13 @@ async def test_tavily_oauth_delegate_normalizes_mcp_result() -> None:
             tool_name="mcp__tavily_search",
             content=[
                 TextContent(
-                    text=json.dumps(
-                        {
-                            "answer": "Answer",
-                            "results": [
-                                {
-                                    "title": "Source",
-                                    "url": "https://example.com",
-                                    "content": "Evidence",
-                                }
-                            ],
-                        }
+                    text=(
+                        "Answer: Answer\n\n"
+                        "Detailed Results:\n\n"
+                        "Title: Source\n"
+                        "ID: source-1\n"
+                        "URL: https://example.com\n"
+                        "Content: Evidence"
                     )
                 )
             ],
@@ -111,3 +114,77 @@ async def test_tavily_oauth_delegate_normalizes_mcp_result() -> None:
     assert response.auth_mode == "oauth-mcp"
     assert response.answer == "Answer"
     assert response.sources[0].url == "https://example.com"
+
+
+@pytest.mark.asyncio
+async def test_tavily_oauth_delegate_accepts_structured_mcp_result() -> None:
+    async def execute(tool_call_id, _args, _signal, _on_update, _context):
+        payload = {
+            "answer": "Structured answer",
+            "results": [
+                {
+                    "title": "Structured source",
+                    "url": "https://structured.example.com",
+                    "content": "Structured evidence",
+                }
+            ],
+        }
+        return ToolResult(
+            tool_call_id=tool_call_id,
+            tool_name="mcp__tavily_search",
+            content=[TextContent(text="Human-readable fallback")],
+            details={"server_result": {"structuredContent": payload}},
+        )
+
+    context = ToolContext(
+        delegated_tools={
+            "mcp__tavily_search": AgentTool(
+                name="mcp__tavily_search",
+                execute=execute,
+            )
+        }
+    )
+    delegate = _tavily_oauth_delegate(context, None, None)
+
+    assert delegate is not None
+    response = await delegate("query", 2)
+
+    assert response.answer == "Structured answer"
+    assert response.sources[0].url == "https://structured.example.com"
+
+
+@pytest.mark.asyncio
+async def test_search_wrapper_reaps_provider_task_when_parent_is_cancelled() -> None:
+    started = asyncio.Event()
+    cancelled = asyncio.Event()
+    never = asyncio.Event()
+
+    async def provider_call() -> None:
+        started.set()
+        try:
+            await never.wait()
+        except asyncio.CancelledError:
+            cancelled.set()
+            raise
+
+    task = asyncio.create_task(_search_or_abort(provider_call(), AbortSignal()))
+    await started.wait()
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert cancelled.is_set()
+
+
+@pytest.mark.asyncio
+async def test_search_wrapper_closes_call_when_signal_is_already_aborted() -> None:
+    async def provider_call() -> None:
+        await asyncio.sleep(0)
+
+    call = provider_call()
+    signal = AbortSignal()
+    signal.abort("stopped before dispatch")
+
+    with pytest.raises(asyncio.CancelledError):
+        await _search_or_abort(call, signal)
+    assert call.cr_frame is None

--- a/tests/unit/web_search/test_tool.py
+++ b/tests/unit/web_search/test_tool.py
@@ -82,33 +82,53 @@ def test_model_search_context_is_bounded_and_points_to_full_page_fetch() -> None
     assert omitted > 0
 
 
-def test_a_single_omitted_source_is_not_reported_in_the_plural() -> None:
-    """One over-long URL is "1 result omitted", and no cause is claimed.
+def test_an_omission_says_how_many_and_why() -> None:
+    """The two causes imply opposite next moves, so they are reported apart.
 
-    The all-omitted branch is reached by BOTH the context budget and the
-    per-URL cap, so naming either one would be wrong half the time. It
-    previously said "1 results omitted by the context limit" — plural, and
-    attributing a cause that this case does not have.
+    A budget omission means "the query matched too much, narrow it"; an
+    unusable-URL omission means "that result cannot be fetched, the query was
+    fine". The message went from a hardcoded "by the context limit" (wrong for
+    a URL omission) to a bare count (accurate but unactionable) to naming the
+    cause it actually knows. The footer tells the model to call `browser` with
+    a URL, so "we dropped one because its URL was unusable" is the difference
+    between a sensible next call and a confused one.
     """
-    response = SearchResponse(
-        provider="duckduckgo",
-        auth_mode="credential-free",
-        answer="",
-        sources=[
-            SearchSource(
-                title="t",
-                url="https://example.com/" + "x" * MODEL_URL_MAX_CHARS,
-                snippet="s",
-            )
-        ],
+    long_url = "https://example.com/" + "x" * MODEL_URL_MAX_CHARS
+
+    def _response(sources: list[SearchSource]) -> SearchResponse:
+        return SearchResponse(
+            provider="duckduckgo",
+            auth_mode="credential-free",
+            answer="",
+            sources=sources,
+        )
+
+    # Sole source, unusable URL: singular, and the cause is the URL.
+    rendered, omitted = _render_response(
+        _response([SearchSource(title="t", url=long_url, snippet="s")])
     )
-
-    rendered, omitted = _render_response(response)
-
     assert omitted == 1
-    assert "1 result omitted" in rendered
-    assert "1 results" not in rendered
-    assert "context limit" not in rendered
+    assert "1 result omitted (1 for an unusable URL)" in rendered
+    assert "1 results" not in rendered, "plural for one result"
+    assert "context limit" not in rendered, "a URL omission is not a budget omission"
+
+    # Both causes at once: each is named with its own count.
+    rendered, omitted = _render_response(
+        _response(
+            [SearchSource(title="t", url=long_url, snippet="s")]
+            + [
+                SearchSource(
+                    title=f"t{i}",
+                    url=f"https://example.com/{i}",
+                    snippet="snippet " * 400,
+                )
+                for i in range(20)
+            ]
+        )
+    )
+    assert omitted > 1
+    assert "by the context limit" in rendered
+    assert "1 for an unusable URL" in rendered
 
 
 @pytest.mark.asyncio

--- a/tests/unit/web_search/test_tool.py
+++ b/tests/unit/web_search/test_tool.py
@@ -92,7 +92,12 @@ async def test_tavily_oauth_delegate_normalizes_mcp_result() -> None:
                         "Title: Source\n"
                         "ID: source-1\n"
                         "URL: https://example.com\n"
-                        "Content: Evidence"
+                        "Content: Evidence\n"
+                        "Title: not a record\n"
+                        "URL: https://untrusted-content.example\n\n"
+                        "Title: Second source\n"
+                        "URL: https://second.example.com\n"
+                        "Content: More evidence"
                     )
                 )
             ],
@@ -114,6 +119,9 @@ async def test_tavily_oauth_delegate_normalizes_mcp_result() -> None:
     assert response.auth_mode == "oauth-mcp"
     assert response.answer == "Answer"
     assert response.sources[0].url == "https://example.com"
+    assert len(response.sources) == 2
+    assert response.sources[1].url == "https://second.example.com"
+    assert "untrusted-content.example" in (response.sources[0].snippet or "")
 
 
 @pytest.mark.asyncio

--- a/tests/unit/web_search/test_tool.py
+++ b/tests/unit/web_search/test_tool.py
@@ -15,6 +15,7 @@ from local_operator.tools.registry import create_tools
 from local_operator.web_search.models import SearchResponse, SearchSource
 from local_operator.web_search.tool import (
     MODEL_CONTEXT_MAX_CHARS,
+    MODEL_URL_MAX_CHARS,
     WebSearchParams,
     _render_response,
     _search_or_abort,
@@ -69,12 +70,45 @@ def test_model_search_context_is_bounded_and_points_to_full_page_fetch() -> None
         ],
     )
 
-    rendered = _render_response(response)
+    rendered, omitted = _render_response(response)
 
     assert len(rendered) <= MODEL_CONTEXT_MAX_CHARS
     assert "https://example.com/result/0" in rendered
     assert "more results omitted" in rendered
     assert "call `browser` with its URL" in rendered
+    # The count is returned, not re-derived from the prose: `details`
+    # ["context_truncated"] used to be a `" omitted" in text` scan, which a
+    # result snippet containing the word would have flipped on a full response.
+    assert omitted > 0
+
+
+def test_a_single_omitted_source_is_not_reported_in_the_plural() -> None:
+    """One over-long URL is "1 result omitted", and no cause is claimed.
+
+    The all-omitted branch is reached by BOTH the context budget and the
+    per-URL cap, so naming either one would be wrong half the time. It
+    previously said "1 results omitted by the context limit" — plural, and
+    attributing a cause that this case does not have.
+    """
+    response = SearchResponse(
+        provider="duckduckgo",
+        auth_mode="credential-free",
+        answer="",
+        sources=[
+            SearchSource(
+                title="t",
+                url="https://example.com/" + "x" * MODEL_URL_MAX_CHARS,
+                snippet="s",
+            )
+        ],
+    )
+
+    rendered, omitted = _render_response(response)
+
+    assert omitted == 1
+    assert "1 result omitted" in rendered
+    assert "1 results" not in rendered
+    assert "context limit" not in rendered
 
 
 @pytest.mark.asyncio

--- a/tests/unit/web_search/test_tool.py
+++ b/tests/unit/web_search/test_tool.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from local_operator.harness.types import AgentTool, TextContent, ToolContext, ToolResult
+from local_operator.tools.registry import create_tools
+from local_operator.web_search.models import SearchResponse, SearchSource
+from local_operator.web_search.tool import (
+    MODEL_CONTEXT_MAX_CHARS,
+    WebSearchParams,
+    _render_response,
+    _tavily_oauth_delegate,
+    build_web_search_tool,
+)
+
+
+def test_web_search_is_in_default_tool_inventory() -> None:
+    tools = {tool.name: tool for tool in create_tools(ToolContext(cwd="."))}
+
+    assert "web_search" in tools
+    assert tools["web_search"].approval_tier == "read"
+    assert tools["web_search"].concurrency == "shared"
+    assert tools["web_search"].interruptible is True
+
+
+def test_master_switch_removes_tool_at_session_creation() -> None:
+    context = ToolContext(cwd=".", web_search_settings={"enabled": False})
+
+    assert build_web_search_tool(context) is None
+    assert "web_search" not in {tool.name for tool in create_tools(context)}
+
+
+def test_provider_argument_is_closed_to_supported_catalogue() -> None:
+    schema = WebSearchParams.model_json_schema()
+    provider = schema["properties"]["provider"]
+
+    assert set(provider["anyOf"][0]["enum"]) == {
+        "duckduckgo",
+        "tavily",
+        "perplexity",
+        "brave",
+        "exa",
+        "serpapi",
+        "searxng",
+    }
+
+
+def test_model_search_context_is_bounded_and_points_to_full_page_fetch() -> None:
+    response = SearchResponse(
+        provider="duckduckgo",
+        auth_mode="credential-free",
+        answer="answer " * 1_000,
+        sources=[
+            SearchSource(
+                title=f"Result {index} " + "title " * 100,
+                url=f"https://example.com/result/{index}",
+                snippet="snippet " * 400,
+            )
+            for index in range(20)
+        ],
+    )
+
+    rendered = _render_response(response)
+
+    assert len(rendered) <= MODEL_CONTEXT_MAX_CHARS
+    assert "https://example.com/result/0" in rendered
+    assert "more results omitted" in rendered
+    assert "call `browser` with its URL" in rendered
+
+
+@pytest.mark.asyncio
+async def test_tavily_oauth_delegate_normalizes_mcp_result() -> None:
+    async def execute(tool_call_id, args, _signal, _on_update, _context):
+        assert args == {"query": "query", "max_results": 2, "search_depth": "basic"}
+        return ToolResult(
+            tool_call_id=tool_call_id,
+            tool_name="mcp__tavily_search",
+            content=[
+                TextContent(
+                    text=json.dumps(
+                        {
+                            "answer": "Answer",
+                            "results": [
+                                {
+                                    "title": "Source",
+                                    "url": "https://example.com",
+                                    "content": "Evidence",
+                                }
+                            ],
+                        }
+                    )
+                )
+            ],
+        )
+
+    context = ToolContext(
+        delegated_tools={
+            "mcp__tavily_search": AgentTool(
+                name="mcp__tavily_search",
+                execute=execute,
+            )
+        }
+    )
+    delegate = _tavily_oauth_delegate(context, None, None)
+
+    assert delegate is not None
+    response = await delegate("query", 2)
+
+    assert response.auth_mode == "oauth-mcp"
+    assert response.answer == "Answer"
+    assert response.sources[0].url == "https://example.com"


### PR DESCRIPTION
## What

- Route completed `wait` handoffs through the existing 8 KiB spill path so verbose subagent reports cannot consume an unbounded parent-context slice; full output remains recoverable through `spill://`.
- Add hard-bound regressions for the 4,096-entry token-estimate LRU and one-shot semantic knowledge selection.
- Record the live two-round delegated-review and snapcompact measurements in `docs/VERIFICATION.md`.

## Why

The live review probe proved task isolation and provider-cache reuse, but `wait` still copied a child's final report into the parent verbatim. A pathological reviewer could therefore erase the context savings of the isolated child in one handoff. This uses the same bounded/lossless output contract already applied to other verbose tools rather than inventing a subagent-specific transport.

## Runtime evidence

### Real delegated review

OpenRouter `deepseek/deepseek-v4-flash-0731`, parent session `3e32375b1356`, child sessions `b00da8f30f22` and `1168fcc8a788`:

- Parent launched and awaited exactly two review rounds (`task` ×2, `wait` ×2).
- Round 1 found a real contract bug (non-string destination raised `AttributeError` instead of `ValueError`); parent remediated it; round 2 passed independently.
- 34 model calls total; 234,223 prompt tokens, 200,834 provider cache-read tokens, 33,389 fresh tokens: **85.7% cache hit**.
- Max context: parent 10,950; children 7,430 and 9,541. Parent→child payloads were 2,391 / 2,598 chars, proving children received explicit task context rather than the parent transcript.

### Bounded handoff reproduction

A 56,320-character completed-child report passed through `_job_summary` produced an 8,372-character parent result (**85.1% reduction**) with `spill.complete=true`; first and last findings were recovered from the stored handle.

### Live snapcompact

Session `c164d8114ddb` crossed an 8k configured threshold at 13,623 tokens, journaled one compaction with `preserve_data.snapcompact`, and resumed at 7,854 context tokens.

## Validation

- `pytest tests/unit/tools/test_task_wait_jobs.py tests/unit/compaction/test_tokens.py tests/unit/test_session_factory.py -q` → **73 passed**
- `pytest tests/unit -q` → **2759 passed, 7 skipped**
- `flake8 local_operator tests` → clean
- `black --check local_operator tests` → clean
- `isort --check-only local_operator tests` → clean
- `pyright` → **0 errors, 0 warnings, 0 informations**

No user-visible UI delta; no design review required.