### PR TITLE
fix(models): stop Unknown labels and list ChatGPT Codex models

### DIFF
--- a/local_operator/model/configure.py
+++ b/local_operator/model/configure.py
@@ -287,6 +287,13 @@ def build_model_spec(hosting: str, model_name: str, info: ModelInfo | None = Non
     resolved_name = getattr(info, "name", "") if info is not None else ""
     if not isinstance(resolved_name, str):
         resolved_name = ""
+    # The shared unknown-model singleton is named "Unknown". That word is a
+    # STATUS, not a model: a live listing that fills the window but not the
+    # name used to paint the status band ``Unknown`` for every unshipped id
+    # (Grok 4.6 was the reported case). Treat it as no name so the band falls
+    # back to the selector the operator typed.
+    if resolved_name.casefold() == "unknown":
+        resolved_name = ""
     resolved_id = getattr(info, "id", None)
     describes_this_model = isinstance(resolved_id, str) and _normalised_id(
         resolved_id
@@ -754,12 +761,12 @@ def _env_secret_is_oauth(secret: str) -> bool:
     return any(value == secret and "OAUTH" in name.upper() for name, value in os.environ.items())
 
 
-def _catalogue_credential(provider: str) -> tuple[str, bool]:
-    """``(secret, is_oauth)`` for a listing call, preferring an explicit key.
+def _catalogue_credential(provider: str) -> tuple[str, bool, str | None]:
+    """``(secret, is_oauth, account_id)`` for a listing call.
 
-    The flag matters and is not cosmetic: Anthropic authenticates an API key with
-    ``x-api-key`` and an OAuth token with ``Authorization: Bearer``, so sending the
-    wrong header shape is a 401 and therefore a model that cannot be described.
+    The OAuth flag selects provider-specific auth, while OpenAI additionally
+    requires the stored ChatGPT account id to authorize its current Codex
+    catalogue. Explicit keys keep precedence and are not account-scoped.
 
     Order is env, then the credential file, then the OAuth store — an explicit
     variable is the operator overriding config for one run, which is the same
@@ -769,12 +776,12 @@ def _catalogue_credential(provider: str) -> tuple[str, bool]:
     """
     key = _catalogue_api_key(provider)
     if key:
-        return key, _env_secret_is_oauth(key)
+        return key, _env_secret_is_oauth(key), None
     return _oauth_listing_token(provider)
 
 
-def _oauth_listing_token(provider: str) -> tuple[str, bool]:
-    """The newest stored token for ``provider``, or ``("", False)``.
+def _oauth_listing_token(provider: str) -> tuple[str, bool, str | None]:
+    """The newest stored token and account scope, or ``("", False, None)``.
 
     Best-effort by construction: an unreadable store, a missing table or a row
     without a token all mean "no listing", never an exception. Opened and closed
@@ -793,7 +800,12 @@ def _oauth_listing_token(provider: str) -> tuple[str, bool]:
         for row in reversed(rows):
             token = str(row.data.get("access") or "")
             if token:
-                return token, row.credential_type == "oauth"
+                account_id = row.data.get("account_id") or row.data.get("org_id")
+                return (
+                    token,
+                    row.credential_type == "oauth",
+                    (str(account_id) if account_id else None),
+                )
     except Exception as exc:  # noqa: BLE001 - metadata is never worth a failed start
         logger.debug("could not read a stored %s token for the listing: %s", provider, exc)
     finally:
@@ -802,7 +814,7 @@ def _oauth_listing_token(provider: str) -> tuple[str, bool]:
                 store.close()
             except Exception:  # noqa: BLE001 - closing a broken handle is not fatal
                 pass
-    return "", False
+    return "", False, None
 
 
 def _normalised_id(model_id: str) -> str:
@@ -854,11 +866,12 @@ def _info_from_discovery(
     try:
         from local_operator.model.discovery import DEFAULT_TIMEOUT_S, available_models
 
-        secret, is_oauth = _catalogue_credential(provider)
+        secret, is_oauth, account_id = _catalogue_credential(provider)
         rows, status = available_models(
             provider,
             api_key=secret or None,
             is_oauth=is_oauth,
+            account_id=account_id,
             timeout=DEFAULT_TIMEOUT_S if timeout is None else timeout,
         )
     except Exception as exc:  # noqa: BLE001 — metadata is never worth a failed start
@@ -1144,6 +1157,13 @@ def _registry_fallback(provider: str, model_id: str) -> ModelInfo:
     owns those two fields itself, because only it knows whether the match was the
     same model under another spelling (keep the real name) or a newer generation
     inheriting limits (the name would be a lie).
+
+    The same overwrite applies to the global ``unknown_model_info`` singleton.
+    Returning it as-is is how a live xAI listing that carries a 500k window and
+    no display name painted the status band ``Unknown``: discovery copies the
+    fallback, fills the window, and keeps the placeholder's name because an
+    empty listing name is treated as "no name" rather than "this model is
+    called Unknown". The id is this model's; the name must be too.
     """
     try:
         info = get_model_info(provider, model_id)
@@ -1161,7 +1181,7 @@ def _registry_fallback(provider: str, model_id: str) -> ModelInfo:
     if template is not None:
         return template.model_copy(deep=True, update={"id": model_id, "name": model_id})
     if info is not None:
-        return info
+        return info.model_copy(deep=True, update={"id": model_id, "name": model_id})
     return ModelInfo(id=model_id, name=model_id, description="Unknown model")
 
 

--- a/local_operator/model/configure.py
+++ b/local_operator/model/configure.py
@@ -745,7 +745,7 @@ def _catalogue_api_key(provider: str) -> str:
 
 
 def _env_secret_is_oauth(secret: str) -> bool:
-    """True when ``secret`` was picked up out of an OAuth-named env variable.
+    """True when ``secret`` came ONLY out of OAuth-named env variables.
 
     The callable ``env_keys`` resolvers can hand back either kind of credential —
     ``_anthropic_env_key`` prefers ``ANTHROPIC_OAUTH_TOKEN`` over
@@ -757,8 +757,19 @@ def _env_secret_is_oauth(secret: str) -> bool:
     Matching on the variable NAME keeps this a general rule instead of a second
     place that knows about Anthropic specifically, and it runs at most once per
     model id per TTL bucket.
+
+    ``all`` and not ``any``, because the two misclassifications do not cost the
+    same. A plain ``OPENAI_API_KEY`` whose value happens to equal that of any
+    other variable with OAUTH in its name was reported as an OAuth token, and
+    OpenAI's OAuth route needs a ChatGPT account id that an env key cannot
+    supply — so the provider became unlistable outright, silently and for as
+    long as the variables stayed set. An OAuth token misread as a key costs one
+    401 on one provider and falls back to the bundled registry. When a value
+    appears under both kinds of name it is genuinely ambiguous, and this resolves
+    the ambiguity toward the cheaper mistake.
     """
-    return any(value == secret and "OAUTH" in name.upper() for name, value in os.environ.items())
+    names = [name.upper() for name, value in os.environ.items() if value == secret]
+    return bool(names) and all("OAUTH" in name for name in names)
 
 
 def _catalogue_credential(provider: str) -> tuple[str, bool, str | None]:

--- a/local_operator/model/discovery.py
+++ b/local_operator/model/discovery.py
@@ -9,15 +9,13 @@ answer into the registry.
 Three properties are load-bearing, and each exists because the obvious version
 of this feature broke in exactly that way:
 
-- **The listing never subtracts.** Ids are UNIONed and every numeric field falls
-  back to the registry, because a listing is only as rich as the provider chose
-  to make it and several are far poorer than the bundled data. A lean
-  OpenAI-compatible gateway returns nothing but an id; replacing a registry row
-  with that is how a session ends up with ``context_window = -1`` and auto
-  compaction that never fires. Where a listing IS rich it wins outright, which is
-  the other half of the same rule: Anthropic's ``/v1/models`` reports
-  ``max_input_tokens``, and that is the only place a model released after this
-  package can state its real 1M window.
+- **List authority matches the endpoint.** ChatGPT's account-scoped Codex
+  catalogue is the user's actual selectable set, so it replaces OpenAI's stale
+  static ids when available. Generic compatibility endpoints are often partial
+  entitlement snapshots, so those ids are UNIONed instead. In both cases fields
+  fall back individually: a lean listing that returns only an id must not erase
+  the registry's context window and stop compaction from firing, while a rich
+  listing such as Anthropic's ``/v1/models`` supplies the real current limit.
 - **Failure and emptiness are different answers.** A transport error yields
   ``None`` ("keep what we had") and a successful listing with no models yields
   ``[]`` ("this provider really has nothing"). Collapsing them turns a flaky
@@ -34,6 +32,7 @@ disk speed and a listing outage is invisible for as long as the cache holds.
 from __future__ import annotations
 
 import dataclasses
+import hashlib
 import logging
 import math
 import time
@@ -59,6 +58,17 @@ logger = logging.getLogger("local_operator.model.discovery")
 #: timeout. ``_fetch_gemini`` spends it as a deadline across its pages rather than
 #: per request, because 25 pages x this value is not "seconds".
 DEFAULT_TIMEOUT_S = 10.0
+#: ChatGPT OAuth tokens are subscription credentials, not OpenAI API keys:
+#: ``api.openai.com/v1/models`` rejects them. The account-scoped Codex endpoint
+#: is the catalogue used by OpenAI's own client and reports the currently
+#: available slugs plus their display metadata and context windows.
+OPENAI_CHATGPT_MODELS_URL = "https://chatgpt.com/backend-api/codex/models"
+#: The endpoint requires a compatibility version and rejects a versionless
+#: request. This describes the catalogue schema parsed below, not this package's
+#: release number; using local-operator's current 0.x version would incorrectly
+#: hide models whose minimum Codex client version is numerically newer.
+OPENAI_MODELS_CLIENT_VERSION = "1.0.0"
+OPENAI_OAUTH_PROVIDERS = frozenset({"openai", "openai-device"})
 
 #: Anthropic pins its wire format with a dated header and rejects requests that
 #: omit it. Duplicated from the wire client rather than imported, so listing a
@@ -184,6 +194,7 @@ class _FetchContext:
     base_url: str
     api_key: str | None
     is_oauth: bool
+    account_id: str | None
     client: httpx.Client
     timeout: float
 
@@ -421,8 +432,64 @@ def _row_from_openai_entry(entry: Mapping[str, object]) -> DiscoveredModel | Non
     )
 
 
+def _row_from_openai_codex_entry(entry: Mapping[str, object]) -> DiscoveredModel | None:
+    """One selectable model from ChatGPT's account-scoped Codex catalogue.
+
+    This is deliberately separate from the public OpenAI-compatible shape:
+    Codex addresses a model by ``slug`` and places modalities at the top level.
+    Explicitly hidden rows are internal helpers, not user-selectable models.
+    """
+    visibility = _first_str(entry.get("visibility"))
+    if visibility and visibility != "list":
+        return None
+    model_id = _first_str(entry.get("slug"))
+    if not model_id:
+        return None
+    return DiscoveredModel(
+        id=model_id,
+        name=_first_str(entry.get("display_name")),
+        context_window=_first_positive_int(
+            entry.get("context_window"),
+            entry.get("max_context_window"),
+        ),
+        max_tokens=_first_positive_int(
+            entry.get("max_tokens"),
+            entry.get("max_output_tokens"),
+        ),
+        supports_images=_has_image_input({"input_modalities": entry.get("input_modalities")}),
+    )
+
+
+def _fetch_openai_oauth(ctx: _FetchContext) -> list[DiscoveredModel] | None:
+    """The current ChatGPT/Codex models available to one logged-in account."""
+    if not ctx.api_key or not ctx.account_id:
+        # The account header is part of the authorization boundary. A token
+        # without it cannot safely ask which workspace's models are available.
+        return None
+    body = _get_json(
+        ctx,
+        OPENAI_CHATGPT_MODELS_URL,
+        headers={
+            "Accept": "application/json",
+            "Authorization": f"Bearer {ctx.api_key}",
+            "ChatGPT-Account-ID": ctx.account_id,
+        },
+        params={"client_version": OPENAI_MODELS_CLIENT_VERSION},
+    )
+    if body is None:
+        return None
+    entries = _entry_list(body, "models")
+    if entries is None:
+        return None
+    rows = (_row_from_openai_codex_entry(entry) for entry in entries)
+    return [row for row in rows if row is not None]
+
+
 def _fetch_openai_compat(ctx: _FetchContext) -> list[DiscoveredModel] | None:
-    """``GET {base_url}/models`` for every OpenAI-shaped gateway."""
+    """The provider's model catalogue, including ChatGPT's OAuth-only route."""
+    if ctx.is_oauth and ctx.provider_id in OPENAI_OAUTH_PROVIDERS:
+        return _fetch_openai_oauth(ctx)
+
     headers = {"Accept": "application/json"}
     if ctx.api_key:
         # Bearer serves both API keys and OAuth access tokens on this wire, so
@@ -698,6 +765,7 @@ def fetch_models(
     *,
     api_key: str | None,
     is_oauth: bool = False,
+    account_id: str | None = None,
     base_url: str | None = None,
     client: httpx.Client | None = None,
     timeout: float = DEFAULT_TIMEOUT_S,
@@ -715,7 +783,10 @@ def fetch_models(
         provider_id: Registry provider id, or a legacy alias.
         api_key: API key or OAuth access token; ``None`` for keyless hosts.
         is_oauth: ``api_key`` is an OAuth access token, which changes the header
-            scheme on the Anthropic wire.
+            scheme on the Anthropic wire and selects ChatGPT's Codex catalogue
+            for OpenAI instead of ``api.openai.com/v1/models``.
+        account_id: ChatGPT account scope required by the Codex listing. Other
+            providers ignore it.
         base_url: Overrides the registry base (proxies, local gateways).
         client: Reused HTTP client. When omitted, one is created and closed here;
             a caller listing several providers should pass one so the connection
@@ -744,6 +815,7 @@ def fetch_models(
                 base_url=resolved_base,
                 api_key=api_key,
                 is_oauth=is_oauth,
+                account_id=account_id,
                 client=active,
                 timeout=timeout,
             )
@@ -765,12 +837,16 @@ def fetch_models(
 def merge_models(
     static_rows: Mapping[str, ModelInfo],
     live: list[DiscoveredModel] | None,
+    *,
+    include_static_only: bool = True,
 ) -> list[DiscoveredModel]:
-    """Fold a listing into the registry so the result is never the poorer of the two.
+    """Fold a listing into the registry without losing known per-model metadata.
 
-    Live rows come first because providers list newest-first, which puts a model
-    released this week where the user will actually see it -- the entire point of
-    discovery. Registry-only ids follow, in the registry's curated order.
+    Most provider listings are incomplete entitlement snapshots, so their static
+    ids remain reachable by default. A caller with an authoritative account-scoped
+    catalogue can set ``include_static_only=False``: listed ids still inherit
+    missing specs, but obsolete registry-only ids are not presented as available.
+    Live rows always come first because providers list newest-first.
     """
     merged: list[DiscoveredModel] = []
     seen: set[str] = set()
@@ -783,14 +859,14 @@ def merge_models(
         seen.add(row.id)
         merged.append(_merge_one(row, static_rows.get(row.id)))
 
-    for model_id, info in static_rows.items():
-        if model_id in seen:
-            continue
-        seen.add(model_id)
-        # Static ids are never pruned: a listing that omits an id we know works
-        # -- a gateway filtering by entitlement, a page we failed to fetch --
-        # would otherwise make a model the user is running today unreachable.
-        merged.append(_from_static(model_id, info))
+    if include_static_only:
+        for model_id, info in static_rows.items():
+            if model_id in seen:
+                continue
+            seen.add(model_id)
+            # Static ids are retained for non-authoritative listings: gateways
+            # filter by entitlement and may omit a model the user runs today.
+            merged.append(_from_static(model_id, info))
 
     return merged
 
@@ -894,17 +970,23 @@ def _merge_name(live_name: str, static_name: str, model_id: str) -> str:
     return candidate
 
 
-def _cache_key(provider_id: str) -> str:
-    """Cache document name for a provider's listing.
+def _cache_key(
+    provider_id: str,
+    *,
+    is_oauth: bool = False,
+    account_id: str | None = None,
+) -> str:
+    """Cache document name, isolated by credential scope where required.
 
-    ``.listing`` rather than the bare provider id because an earlier release
-    cached a differently-shaped document -- the provider client's raw
-    ``list_models()`` payload -- under ``<provider>.models.json``. Reusing that
-    name would hand this reader a document it cannot interpret and, since the
-    payload is written before anything maps it, serve the failure as a fresh cache
-    hit for a full day. The old documents are unreachable by name and
-    ``catalogue.purge_legacy_documents`` deletes them.
+    ``.listing`` avoids the incompatible legacy ``<provider>.models.json``
+    layout. OpenAI's OAuth catalogue is account-scoped and has a different
+    schema from its API-key catalogue, so it gets a hashed account suffix: an
+    API-key cache or another workspace must never decide which models this
+    account can select. The raw account id is intentionally absent from disk.
     """
+    if provider_id == "openai" and is_oauth and account_id:
+        account_scope = hashlib.sha256(account_id.encode("utf-8")).hexdigest()[:12]
+        return f"{provider_id}.oauth.{account_scope}.listing"
     return f"{provider_id}.listing"
 
 
@@ -974,6 +1056,7 @@ def available_models(
     *,
     api_key: str | None,
     is_oauth: bool = False,
+    account_id: str | None = None,
     base_url: str | None = None,
     ttl_s: float = DEFAULT_TTL_S,
     cache_dir: Path | None = None,
@@ -982,11 +1065,10 @@ def available_models(
 ) -> tuple[list[DiscoveredModel], ListingStatus]:
     """Every model a UI should offer for ``provider_id``, plus how it was obtained.
 
-    The result is always at least the registry, so a provider outage costs the
-    user discovery of new models and nothing else. This never raises and never
-    blocks longer than ``timeout``: it is called from the model picker and from
-    session start while the user waits, and a fresh cache skips the request
-    entirely.
+    A provider outage falls back to the registry, so failed discovery never
+    prevents selection. A successful authoritative catalogue may intentionally
+    replace registry-only ids. This never raises and never blocks longer than
+    ``timeout``; a fresh cache skips the request entirely.
 
     Returns:
         ``(models, status)``, where status is ``"ok"`` (fetched live just now),
@@ -1003,6 +1085,7 @@ def available_models(
             rows,
             api_key=api_key,
             is_oauth=is_oauth,
+            account_id=account_id,
             base_url=base_url,
             ttl_s=ttl_s,
             cache_dir=cache_dir,
@@ -1023,6 +1106,7 @@ def _available_models(
     *,
     api_key: str | None,
     is_oauth: bool,
+    account_id: str | None,
     base_url: str | None,
     ttl_s: float,
     cache_dir: Path | None,
@@ -1060,6 +1144,7 @@ def _available_models(
             definition.id,
             api_key=api_key,
             is_oauth=is_oauth,
+            account_id=account_id,
             base_url=resolved_base,
             client=client,
             timeout=timeout,
@@ -1072,8 +1157,8 @@ def _available_models(
             "models": [dataclasses.asdict(row) for row in live],
         }
 
-    capture = listing_capture_version(definition.id)
-    key = _cache_key(definition.id)
+    storage_id = definition.store_credentials_as or definition.id
+    key = _cache_key(storage_id, is_oauth=is_oauth, account_id=account_id)
     payload = cached_listing(key, fetch, ttl_s=ttl_s, cache_dir=cache_dir)
     live_rows = _rows_from_payload(payload, capture)
     if live_rows is None:
@@ -1100,7 +1185,12 @@ def _available_models(
             # Neither a listing nor a cache: the registry is all there is.
             return merge_models(rows, None), "static"
 
-    merged = merge_models(rows, live_rows)
+    authoritative_live = is_oauth and storage_id == "openai"
+    merged = merge_models(
+        rows,
+        live_rows,
+        include_static_only=not authoritative_live,
+    )
     if not fetched:
         return merged, "cached"
     return merged, ("empty" if not live_rows else "ok")

--- a/local_operator/model/discovery.py
+++ b/local_operator/model/discovery.py
@@ -69,6 +69,11 @@ OPENAI_CHATGPT_MODELS_URL = "https://chatgpt.com/backend-api/codex/models"
 #: hide models whose minimum Codex client version is numerically newer.
 OPENAI_MODELS_CLIENT_VERSION = "1.0.0"
 OPENAI_OAUTH_PROVIDERS = frozenset({"openai", "openai-device"})
+#: Visibility values this catalogue uses for rows that are internal helpers
+#: rather than models an operator may select. A DENYLIST rather than the
+#: inverse test: this listing may prune the registry, so an unrecognised or
+#: renamed value must not be read as "hide every row" and empty the picker.
+_OPENAI_CODEX_HIDDEN_VISIBILITY = frozenset({"hide", "hidden", "internal", "none"})
 
 #: Anthropic pins its wire format with a dated header and rejects requests that
 #: omit it. Duplicated from the wire client rather than imported, so listing a
@@ -432,17 +437,56 @@ def _row_from_openai_entry(entry: Mapping[str, object]) -> DiscoveredModel | Non
     )
 
 
+def _serves_account_scoped_catalogue(
+    provider_id: str,
+    *,
+    is_oauth: bool,
+    api_key: str | None,
+    account_id: str | None,
+) -> bool:
+    """Whether a listing for ``provider_id`` is ChatGPT's account-scoped one.
+
+    ONE predicate, read by all three places that need the answer: the
+    transport that chooses the endpoint, the cache key that isolates the
+    document, and the merge that decides whether the listing may prune
+    registry ids. They used to be spelled separately and disagreed — the
+    prune test omitted ``account_id`` and keyed off the credential-storage id
+    rather than the provider actually fetched, so the weakest of the three
+    was the only destructive one. An OAuth run with no account scope then
+    read the shared API-KEY cache document (``_cache_key`` degrades to the
+    unscoped name without an account id) and pruned the registry against a
+    listing written under a different credential, taking 11 shipped OpenAI
+    ids down to 1 with no request issued. A pre-change document parses
+    cleanly too, so an upgrade hit the same path.
+
+    Authority is therefore defined once, by the conditions under which the
+    account-scoped request is actually issuable, and every site derives from
+    it instead of restating it.
+    """
+    return bool(
+        is_oauth and provider_id in OPENAI_OAUTH_PROVIDERS and api_key and account_id,
+    )
+
+
 def _row_from_openai_codex_entry(entry: Mapping[str, object]) -> DiscoveredModel | None:
     """One selectable model from ChatGPT's account-scoped Codex catalogue.
 
     This is deliberately separate from the public OpenAI-compatible shape:
     Codex addresses a model by ``slug`` and places modalities at the top level.
-    Explicitly hidden rows are internal helpers, not user-selectable models.
+
+    Both the id and the visibility test are deliberately permissive, because
+    this listing is now allowed to PRUNE the registry: a schema change at an
+    endpoint nobody here controls used to cost "no new models" and would
+    otherwise cost the whole OpenAI picker. So ``id`` is accepted as a
+    fallback spelling of ``slug`` (as in the public shape), and a row is
+    dropped only for a visibility value KNOWN to mean hidden. An unrecognised
+    value leaves the row listed: showing one internal helper model is a far
+    smaller harm than dropping every row and emptying the picker.
     """
-    visibility = _first_str(entry.get("visibility"))
-    if visibility and visibility != "list":
+    visibility = _first_str(entry.get("visibility")).casefold()
+    if visibility in _OPENAI_CODEX_HIDDEN_VISIBILITY:
         return None
-    model_id = _first_str(entry.get("slug"))
+    model_id = _first_str(entry.get("slug")) or _first_str(entry.get("id"))
     if not model_id:
         return None
     return DiscoveredModel(
@@ -481,14 +525,40 @@ def _fetch_openai_oauth(ctx: _FetchContext) -> list[DiscoveredModel] | None:
     entries = _entry_list(body, "models")
     if entries is None:
         return None
-    rows = (_row_from_openai_codex_entry(entry) for entry in entries)
-    return [row for row in rows if row is not None]
+    rows = [row for row in (_row_from_openai_codex_entry(e) for e in entries) if row is not None]
+    if not rows:
+        # A 200 that yields nothing selectable is indistinguishable from "this
+        # account has no models" at the call site, and the two have very
+        # different remedies. The pinned client version is the likeliest cause
+        # of a filtered catalogue, so it is named here: without it, a listing
+        # filtered by a version this package pins is invisible in the logs.
+        logger.warning(
+            "openai model listing at %s returned %d entries but no selectable "
+            "models (client_version=%s); keeping the bundled catalogue",
+            OPENAI_CHATGPT_MODELS_URL,
+            len(entries),
+            OPENAI_MODELS_CLIENT_VERSION,
+        )
+    return rows
 
 
 def _fetch_openai_compat(ctx: _FetchContext) -> list[DiscoveredModel] | None:
     """The provider's model catalogue, including ChatGPT's OAuth-only route."""
-    if ctx.is_oauth and ctx.provider_id in OPENAI_OAUTH_PROVIDERS:
+    if _serves_account_scoped_catalogue(
+        ctx.provider_id,
+        is_oauth=ctx.is_oauth,
+        api_key=ctx.api_key,
+        account_id=ctx.account_id,
+    ):
         return _fetch_openai_oauth(ctx)
+    if ctx.is_oauth and ctx.provider_id in OPENAI_OAUTH_PROVIDERS:
+        # An OAuth token for these providers cannot be spent on
+        # ``api.openai.com/v1/models`` (it rejects subscription credentials),
+        # and without an account scope the Codex catalogue is not askable
+        # either. Falling through to the generic wire would spend the token on
+        # a request that answers 401 and read as a listing outage; saying "no
+        # listing" keeps the bundled catalogue and issues no request.
+        return None
 
     headers = {"Accept": "application/json"}
     if ctx.api_key:
@@ -971,9 +1041,9 @@ def _merge_name(live_name: str, static_name: str, model_id: str) -> str:
 
 
 def _cache_key(
-    provider_id: str,
+    storage_id: str,
     *,
-    is_oauth: bool = False,
+    account_scoped: bool = False,
     account_id: str | None = None,
 ) -> str:
     """Cache document name, isolated by credential scope where required.
@@ -983,11 +1053,19 @@ def _cache_key(
     schema from its API-key catalogue, so it gets a hashed account suffix: an
     API-key cache or another workspace must never decide which models this
     account can select. The raw account id is intentionally absent from disk.
+
+    ``storage_id`` is the credential-storage identity rather than the provider
+    id, so ``openai-device`` shares one document with ``openai`` — they are one
+    logged-in account and listing twice under two names would ask the same
+    endpoint for the same answer. ``account_scoped`` is passed in rather than
+    re-derived here: :func:`_serves_account_scoped_catalogue` is the single
+    place that decides it, and a second spelling of the same test is how the
+    scoping and the pruning came to disagree.
     """
-    if provider_id == "openai" and is_oauth and account_id:
+    if account_scoped and account_id:
         account_scope = hashlib.sha256(account_id.encode("utf-8")).hexdigest()[:12]
-        return f"{provider_id}.oauth.{account_scope}.listing"
-    return f"{provider_id}.listing"
+        return f"{storage_id}.oauth.{account_scope}.listing"
+    return f"{storage_id}.listing"
 
 
 def _rows_from_payload(
@@ -1158,7 +1236,16 @@ def _available_models(
         }
 
     storage_id = definition.store_credentials_as or definition.id
-    key = _cache_key(storage_id, is_oauth=is_oauth, account_id=account_id)
+    # Derived ONCE and reused for both the document name and the pruning
+    # decision, so the two cannot disagree about whether this listing is the
+    # account's authoritative catalogue.
+    account_scoped = _serves_account_scoped_catalogue(
+        definition.id,
+        is_oauth=is_oauth,
+        api_key=api_key,
+        account_id=account_id,
+    )
+    key = _cache_key(storage_id, account_scoped=account_scoped, account_id=account_id)
     payload = cached_listing(key, fetch, ttl_s=ttl_s, cache_dir=cache_dir)
     live_rows = _rows_from_payload(payload, capture)
     if live_rows is None:
@@ -1185,7 +1272,15 @@ def _available_models(
             # Neither a listing nor a cache: the registry is all there is.
             return merge_models(rows, None), "static"
 
-    authoritative_live = is_oauth and storage_id == "openai"
+    # An authoritative listing may replace the bundled ids -- but only when it
+    # actually listed something. A 200 that parses to nothing (a renamed field,
+    # an unrecognised visibility value, a catalogue filtered by the pinned
+    # client version) would otherwise prune the registry to EMPTY and cache the
+    # emptiness for the 24h TTL, leaving the picker with no OpenAI models at
+    # all and no request issued to recover. Before this path existed the same
+    # answer still offered every bundled id, which is the behaviour to keep:
+    # upstream schema drift should cost "no new models", never "no models".
+    authoritative_live = account_scoped and bool(live_rows)
     merged = merge_models(
         rows,
         live_rows,

--- a/local_operator/model/naming.py
+++ b/local_operator/model/naming.py
@@ -221,6 +221,11 @@ def _unambiguous_name(provider: str, model_id: str, selector: str, name: str) ->
     for candidate in (name, (curated.name if curated else "").strip()):
         if not candidate or _echoes_id(candidate, model_id):
             continue
+        # "Unknown" is the shipped placeholder's identity, not a model. A
+        # listing that leaves the name blank used to keep that word and paint
+        # it on the band for every unshipped id.
+        if candidate.casefold() == "unknown":
+            continue
         if _names_one(_full_index(), candidate, selector):
             return candidate
     return ""

--- a/local_operator/providers/controller.py
+++ b/local_operator/providers/controller.py
@@ -400,37 +400,61 @@ class ProviderController:
                 )
         return entries
 
-    def entry_for(self, provider: str, model_id: str) -> CatalogueEntry | None:
+    def entry_for(
+        self,
+        provider: str,
+        model_id: str,
+        *,
+        spec: ModelSpec | None = None,
+    ) -> CatalogueEntry | None:
         """One entry for ``provider``/``model_id``, or ``None`` if unknown here.
 
         Exists for the model a session is ALREADY RUNNING. A picker must offer
-        it whatever the catalogue says, and after an authoritative listing it may
-        not be in the catalogue at all: the account's live list is allowed to
-        prune bundled ids, so a session started on one of those ids had its own
-        model disappear from the list while the status band still named it, and
-        typing the id answered "no matching models".
+        it whatever the catalogue says, and after an authoritative listing it
+        may not be in the catalogue at all: the account's live list is allowed
+        to prune bundled ids, so a session started on one of those ids had its
+        own model disappear from the list while the status band still named it,
+        and typing the id answered "no matching models".
+
+        ``spec`` is the session's already-resolved active model. It matters for
+        aggregators: they deliberately have no ENUMERABLE static catalogue, so
+        ``static_models("openrouter")`` is empty even for a model the session
+        is running. Re-listing here would put synchronous network/cache work
+        back on the TUI thread; the spec already carries the name and context
+        that session startup resolved. Prices are unknown on ``ModelSpec`` and
+        stay unknown rather than being invented.
 
         Built here rather than in the caller because the normalization is this
         module's job (see :class:`CatalogueEntry`): a caller reaching into the
         registry itself would have to know that a context window of ``-1`` and
         ``0`` both mean unknown, and would spell the price rules a second time.
-        ``None`` means the registry does not describe this pair, which is a real
-        answer for a model the operator configured by hand.
+        ``None`` means neither the registry nor the active spec describes this
+        pair, which is a real answer for a model an operator configured by hand.
         """
         definition = get_provider_definition(provider)
         if definition is None:
             return None
         info = static_models(definition.id).get(model_id)
-        if info is None:
+        if info is not None:
+            name = info.name or ""
+            context_window = max(0, info.context_window or 0)
+            input_price = _price(info.input_price, definition)
+            output_price = _price(info.output_price, definition)
+        elif spec is not None and spec.provider == definition.id and spec.model_id == model_id:
+            name = spec.display_name
+            context_window = max(0, spec.context_window)
+            input_price = -1.0
+            output_price = -1.0
+        else:
             return None
         usable = self.usable_providers()
         return CatalogueEntry(
             provider=definition.id,
             model_id=model_id,
-            label=model_label(definition.id, model_id, info.name or "").full,
-            context_window=max(0, info.context_window or 0),
-            input_price=_price(info.input_price, definition),
-            output_price=_price(info.output_price, definition),
+            label=model_label(definition.id, model_id, name).full,
+            context_window=context_window,
+            input_price=input_price,
+            output_price=output_price,
             connected=usable is None or definition.id in usable,
             aggregated=definition.id in AGGREGATOR_PROVIDERS,
         )

--- a/local_operator/providers/controller.py
+++ b/local_operator/providers/controller.py
@@ -425,12 +425,17 @@ class ProviderController:
             connected = usable is None or definition.id in usable
             api_key: str | None = None
             is_oauth = False
+            account_id: str | None = None
             if connected:
                 try:
-                    api_key, is_oauth = await self._listing_credential(definition.id)
+                    api_key, is_oauth, account_id = await self._listing_credential(definition.id)
                 except Exception:  # noqa: BLE001 — one provider's auth is not fatal
-                    api_key, is_oauth = None, False
-            kwargs: dict[str, Any] = {"api_key": api_key, "is_oauth": is_oauth}
+                    api_key, is_oauth, account_id = None, False, None
+            kwargs: dict[str, Any] = {
+                "api_key": api_key,
+                "is_oauth": is_oauth,
+                "account_id": account_id,
+            }
             if ttl_s is not None:
                 kwargs["ttl_s"] = ttl_s
             # Off the event loop: discovery is synchronous httpx by design (it is
@@ -453,21 +458,19 @@ class ProviderController:
                 )
         return entries, statuses
 
-    async def _listing_credential(self, provider: str) -> tuple[str | None, bool]:
-        """``(secret, is_oauth)`` for a model LISTING call.
+    async def _listing_credential(self, provider: str) -> tuple[str | None, bool, str | None]:
+        """``(secret, is_oauth, account_id)`` for a model listing call.
 
-        Separate from the usage path because the two want different things from the
-        same store: usage needs a billing key and gives up without one, while a
-        listing is happy with either an OAuth access token or an API key and is
-        worth attempting with whichever exists. The OAuth branch is reported as
-        such because Anthropic switches header shape on it — `x-api-key` for keys,
-        `Authorization: Bearer` for tokens — and sending the wrong one is a 401.
+        The account id is part of OpenAI's ChatGPT authorization boundary; the
+        current Codex catalogue rejects a subscription token without it. Other
+        providers ignore the value, while ``is_oauth`` still selects Anthropic's
+        bearer header instead of its API-key header.
         """
         access = await self.auth_store.get_oauth_access(provider)
         if access is not None and access.kind == "oauth" and access.access_token:
-            return access.access_token, True
+            return access.access_token, True, access.account_id or access.org_id
         if access is not None and access.access_token:
-            return access.access_token, False
+            return access.access_token, False, None
         try:
             stored = await self.auth_store.get_api_key(provider)
         except Exception:  # noqa: BLE001 — a refresh failure just means no listing
@@ -475,7 +478,7 @@ class ProviderController:
         # The environment is the last tier of the same cascade the stream uses, so
         # a key set there has to reach the listing too: otherwise the provider a
         # session is ACTUALLY RUNNING ON is the one whose catalogue stays empty.
-        return stored or resolve_env_key(provider), False
+        return stored or resolve_env_key(provider), False, None
 
     async def _fetch_one(
         self,

--- a/local_operator/providers/controller.py
+++ b/local_operator/providers/controller.py
@@ -400,6 +400,41 @@ class ProviderController:
                 )
         return entries
 
+    def entry_for(self, provider: str, model_id: str) -> CatalogueEntry | None:
+        """One entry for ``provider``/``model_id``, or ``None`` if unknown here.
+
+        Exists for the model a session is ALREADY RUNNING. A picker must offer
+        it whatever the catalogue says, and after an authoritative listing it may
+        not be in the catalogue at all: the account's live list is allowed to
+        prune bundled ids, so a session started on one of those ids had its own
+        model disappear from the list while the status band still named it, and
+        typing the id answered "no matching models".
+
+        Built here rather than in the caller because the normalization is this
+        module's job (see :class:`CatalogueEntry`): a caller reaching into the
+        registry itself would have to know that a context window of ``-1`` and
+        ``0`` both mean unknown, and would spell the price rules a second time.
+        ``None`` means the registry does not describe this pair, which is a real
+        answer for a model the operator configured by hand.
+        """
+        definition = get_provider_definition(provider)
+        if definition is None:
+            return None
+        info = static_models(definition.id).get(model_id)
+        if info is None:
+            return None
+        usable = self.usable_providers()
+        return CatalogueEntry(
+            provider=definition.id,
+            model_id=model_id,
+            label=model_label(definition.id, model_id, info.name or "").full,
+            context_window=max(0, info.context_window or 0),
+            input_price=_price(info.input_price, definition),
+            output_price=_price(info.output_price, definition),
+            connected=usable is None or definition.id in usable,
+            aggregated=definition.id in AGGREGATOR_PROVIDERS,
+        )
+
     async def live_catalogue(
         self, *, ttl_s: float | None = None
     ) -> tuple[list[CatalogueEntry], dict[str, str]]:

--- a/local_operator/providers/controller.py
+++ b/local_operator/providers/controller.py
@@ -465,20 +465,35 @@ class ProviderController:
         current Codex catalogue rejects a subscription token without it. Other
         providers ignore the value, while ``is_oauth`` still selects Anthropic's
         bearer header instead of its API-key header.
+
+        The lookup follows ``store_credentials_as``, because the credential a
+        login flavour needs is not stored under its own id. ``openai-device``
+        and ``xai-oauth`` are login flavours of ``openai`` and ``xai`` -- the
+        registry says so, and ``discovery._static_rows`` already follows it for
+        the bundled rows -- and the login writes ONE row, under the aliased
+        name. Asking ``AuthStore`` for the literal id (its ``WHERE provider = ?``
+        is exact) therefore found nothing, so the flavour listed anonymously:
+        for ``openai-device`` that meant no OAuth, no account scope, no
+        account-scoped catalogue, and the picker offering that logged-in
+        ChatGPT account the bundled ``gpt-4o``/``o3`` rows under a second
+        prefix -- the very ids this listing exists to stop presenting as
+        current.
         """
-        access = await self.auth_store.get_oauth_access(provider)
+        definition = get_provider_definition(provider)
+        credential_id = (definition.store_credentials_as or provider) if definition else provider
+        access = await self.auth_store.get_oauth_access(credential_id)
         if access is not None and access.kind == "oauth" and access.access_token:
             return access.access_token, True, access.account_id or access.org_id
         if access is not None and access.access_token:
             return access.access_token, False, None
         try:
-            stored = await self.auth_store.get_api_key(provider)
+            stored = await self.auth_store.get_api_key(credential_id)
         except Exception:  # noqa: BLE001 — a refresh failure just means no listing
             stored = None
         # The environment is the last tier of the same cascade the stream uses, so
         # a key set there has to reach the listing too: otherwise the provider a
         # session is ACTUALLY RUNNING ON is the one whose catalogue stays empty.
-        return stored or resolve_env_key(provider), False, None
+        return stored or resolve_env_key(credential_id), False, None
 
     async def _fetch_one(
         self,

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -4120,13 +4120,14 @@ class OperatorApp(App[None]):
             for entry in entries
             if usable is None or entry.provider in usable or entry.selector == current
         ]
+        # Count what the catalogue FILTER dropped before appending a current
+        # row that was never in ``entries``. Subtracting the rescued row made
+        # one real hidden catalogue entry disappear from the footer; flooring
+        # at zero prevented ``-1`` but did not preserve what "hidden" means.
+        hidden = len(entries) - len(rows)
         rows = self._with_current_row(rows, current)
         if usable is None:
             return rows, "credential check unavailable — showing every model"
-        # ``max(0, …)``: a rebuilt current row is not in ``entries``, so a
-        # catalogue that pruned the running model would otherwise report a
-        # NEGATIVE hidden count.
-        hidden = max(0, len(entries) - len(rows))
         return rows, (f"{hidden} hidden — /login <provider>" if hidden else "")
 
     def _with_current_row(self, rows: list[ModelRow], current: str | None) -> list[ModelRow]:
@@ -4149,12 +4150,20 @@ class OperatorApp(App[None]):
         provider, _, model_id = current.partition("/")
         if not provider or not model_id:
             return rows
+        spec = self._session.model if self._session is not None else None
         try:
-            entry = providers.entry_for(provider, model_id)
+            try:
+                entry = providers.entry_for(provider, model_id, spec=spec)
+            except TypeError:
+                # Backward-compatible with a duck-typed embedding facade that
+                # implemented the old two-argument courtesy. The real
+                # controller's method is synchronous and side-effect-free, so a
+                # retry cannot duplicate work; a rescue row must never be the
+                # reason an older host's picker fails to paint.
+                entry = providers.entry_for(provider, model_id)
         # ``AttributeError`` included deliberately: this facade is duck-typed
         # (``provider_controller: Any``) and an embedding host may not implement
-        # ``entry_for`` at all. A rescue row is a courtesy; never the reason a
-        # picker fails to paint.
+        # ``entry_for`` at all.
         except Exception:  # noqa: BLE001 — a rescue row never costs the list
             return rows
         if entry is None:

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -4095,6 +4095,14 @@ class OperatorApp(App[None]):
         broken configuration invisible rather than obvious. And when the credential
         store cannot be read at all, EVERY row stays: an empty picker claims the
         user owns no models, which is precisely what the app failed to find out.
+
+        Exempting the current row from the filter is not enough on its own: an
+        authoritative live listing may PRUNE bundled ids, so a session running one
+        of them gets no entry to exempt. The band went on naming the model while
+        the list showed no `●` and typing the id answered "no matching models" —
+        the list and the set `/model` accepts disagreeing, with the list being the
+        discovery surface. So a missing current row is rebuilt from the registry
+        rather than merely spared.
         """
         usable = self._usable_providers()
         current = self._current_selector()
@@ -4112,10 +4120,57 @@ class OperatorApp(App[None]):
             for entry in entries
             if usable is None or entry.provider in usable or entry.selector == current
         ]
+        rows = self._with_current_row(rows, current)
         if usable is None:
             return rows, "credential check unavailable — showing every model"
-        hidden = len(entries) - len(rows)
+        # ``max(0, …)``: a rebuilt current row is not in ``entries``, so a
+        # catalogue that pruned the running model would otherwise report a
+        # NEGATIVE hidden count.
+        hidden = max(0, len(entries) - len(rows))
         return rows, (f"{hidden} hidden — /login <provider>" if hidden else "")
+
+    def _with_current_row(self, rows: list[ModelRow], current: str | None) -> list[ModelRow]:
+        """``rows`` guaranteed to contain the session's own model.
+
+        A no-op in the ordinary case, which is every case where the catalogue
+        listed the running model. It earns its place when an authoritative live
+        listing withdrew a bundled id the session is running: the registry still
+        describes that model, the session is still on it, and ``/model`` still
+        accepts it, so the one surface that must not deny it is the list.
+
+        Appended rather than inserted at the head: the picker owns its own
+        ranking and marks the current row itself.
+        """
+        if not current or any(row.selector == current for row in rows):
+            return rows
+        providers = self._providers
+        if providers is None:
+            return rows
+        provider, _, model_id = current.partition("/")
+        if not provider or not model_id:
+            return rows
+        try:
+            entry = providers.entry_for(provider, model_id)
+        # ``AttributeError`` included deliberately: this facade is duck-typed
+        # (``provider_controller: Any``) and an embedding host may not implement
+        # ``entry_for`` at all. A rescue row is a courtesy; never the reason a
+        # picker fails to paint.
+        except Exception:  # noqa: BLE001 — a rescue row never costs the list
+            return rows
+        if entry is None:
+            return rows
+        return rows + [
+            ModelRow(
+                provider=entry.provider,
+                model_id=entry.model_id,
+                label=entry.label,
+                context_window=entry.context_window,
+                input_price=entry.input_price,
+                output_price=entry.output_price,
+                connected=entry.connected,
+                aggregated=entry.aggregated,
+            )
+        ]
 
     def _usable_providers(self) -> set[str] | None:
         """Providers a turn could run on, or ``None`` when that cannot be read.

--- a/local_operator/tui/widgets/model_picker.py
+++ b/local_operator/tui/widgets/model_picker.py
@@ -535,8 +535,16 @@ class ModelPicker(Static):
         # Suppressed when it carries nothing the selector already said, which is
         # every model whose name resolution declined to shorten it — those rows
         # would otherwise print their own id twice.
+        #
+        # Compared case-INSENSITIVELY, which is what the rule above always
+        # meant. ChatGPT's Codex catalogue titles its display names off the slug
+        # (``gpt-5.6-luna`` -> ``GPT-5.6-Luna``), so an exact comparison let
+        # every row in that family print `openai/gpt-5.6-luna  (GPT-5.6-Luna)`
+        # and spend ~16 cells restating its own id. Names that genuinely differ
+        # keep their parenthetical: `Claude Opus 5` and `GPT-4.1 mini` still
+        # differ from their selectors once folded.
         name = row.label.strip()
-        if name and name not in (row.model_id, row.selector):
+        if name and name.casefold() not in (row.model_id.casefold(), row.selector.casefold()):
             # Measured against a layout that ALWAYS reserves the numbers run,
             # even at the widths where it is not painted. Sized against the
             # painted layout instead, the annotation GREW as the window shrank:

--- a/tests/unit/model/test_catalogue.py
+++ b/tests/unit/model/test_catalogue.py
@@ -678,6 +678,31 @@ def test_an_oauth_token_from_the_environment_is_not_sent_as_an_api_key(monkeypat
     )
 
 
+def test_a_plain_api_key_is_not_read_as_oauth_because_a_value_collides(monkeypatch) -> None:
+    """The kind is inferred from variable NAMES, and a value can sit under several.
+
+    Any variable with OAUTH in its name holding the same string flipped the flag,
+    and for OpenAI that is not a cosmetic misread: the OAuth route needs a ChatGPT
+    account id an env key cannot supply, so the provider became unlistable
+    outright — silently, and for as long as both variables stayed set. An OAuth
+    token misread the other way costs one 401 and falls back to the registry, so
+    an ambiguous value resolves to the cheaper mistake.
+    """
+    from local_operator.model import configure as configure_mod
+
+    monkeypatch.setattr(configure_mod, "_oauth_listing_token", lambda _provider: ("", False, None))
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-proj-shared")
+    monkeypatch.setenv("SOME_TOOL_OAUTH_TOKEN", "sk-proj-shared")
+
+    assert configure_mod._catalogue_credential("openai") == ("sk-proj-shared", False, None)
+
+    # And a value that appears ONLY under an OAuth-named variable is still OAuth,
+    # which is the case the name test exists for.
+    monkeypatch.delenv("OPENAI_API_KEY")
+    monkeypatch.setenv("ANTHROPIC_OAUTH_TOKEN", "sk-ant-oat-only")
+    assert configure_mod._catalogue_credential("anthropic") == ("sk-ant-oat-only", True, None)
+
+
 def test_stored_openai_oauth_account_scope_reaches_model_discovery(tmp_path, monkeypatch) -> None:
     from local_operator.model import configure as configure_mod
     from local_operator.providers.auth_store import AuthStore

--- a/tests/unit/model/test_catalogue.py
+++ b/tests/unit/model/test_catalogue.py
@@ -644,12 +644,22 @@ def test_an_env_api_key_beats_a_stored_oauth_row_and_keeps_its_kind(monkeypatch)
     from local_operator.model import configure as configure_mod
 
     monkeypatch.setattr(
-        configure_mod, "_oauth_listing_token", lambda _provider: ("oauth-access-token", True)
+        configure_mod,
+        "_oauth_listing_token",
+        lambda _provider: ("oauth-access-token", True, None),
     )
-    assert configure_mod._catalogue_credential("anthropic") == ("oauth-access-token", True)
+    assert configure_mod._catalogue_credential("anthropic") == (
+        "oauth-access-token",
+        True,
+        None,
+    )
 
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-explicit")
-    assert configure_mod._catalogue_credential("anthropic") == ("sk-ant-explicit", False)
+    assert configure_mod._catalogue_credential("anthropic") == (
+        "sk-ant-explicit",
+        False,
+        None,
+    )
 
 
 def test_an_oauth_token_from_the_environment_is_not_sent_as_an_api_key(monkeypatch) -> None:
@@ -661,7 +671,35 @@ def test_an_oauth_token_from_the_environment_is_not_sent_as_an_api_key(monkeypat
     monkeypatch.setenv("ANTHROPIC_OAUTH_TOKEN", "sk-ant-oat-token")
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-key")
 
-    assert configure_mod._catalogue_credential("anthropic") == ("sk-ant-oat-token", True)
+    assert configure_mod._catalogue_credential("anthropic") == (
+        "sk-ant-oat-token",
+        True,
+        None,
+    )
+
+
+def test_stored_openai_oauth_account_scope_reaches_model_discovery(tmp_path, monkeypatch) -> None:
+    from local_operator.model import configure as configure_mod
+    from local_operator.providers.auth_store import AuthStore
+
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    store = AuthStore()
+    store.upsert_credential(
+        "openai",
+        {
+            "access": "chatgpt-token",
+            "refresh": "refresh-token",
+            "account_id": "acct-42",
+        },
+    )
+    store.close()
+
+    assert configure_mod._catalogue_credential("openai") == (
+        "chatgpt-token",
+        True,
+        "acct-42",
+    )
 
 
 def test_no_key_anywhere_still_resolves(tmp_path, monkeypatch) -> None:
@@ -1141,6 +1179,43 @@ def test_the_memo_can_be_dropped_when_the_cause_of_a_bad_answer_is_fixed(monkeyp
 
     configure_mod.invalidate_model_info_cache()
     assert configure_mod.resolve_model_info("anthropic", future).name == "Claude Opus 9"
+
+
+def test_an_unshipped_xai_id_does_not_keep_the_unknown_placeholder_name(monkeypatch) -> None:
+    """The reported Grok 4.6 band.
+
+    xAI's listing quotes a 500k window and no display name. Resolution used to
+    start from the shared ``unknown_model_info`` singleton (``name="Unknown"``)
+    and keep that word when the listing had nothing to overwrite it with, so
+    the status band painted ``Unknown`` for a model that was running fine.
+    The fallback must describe THIS id, and a nameless listing must not invent
+    one.
+    """
+    from local_operator.model import configure as configure_mod
+    from local_operator.model.discovery import DiscoveredModel
+    from local_operator.model.registry import unknown_model_info, xai_models
+
+    model_id = "grok-4.6"
+    assert model_id not in xai_models, "the id this test treats as unshipped now ships"
+
+    _stub_discovery(
+        monkeypatch,
+        [DiscoveredModel(id=model_id, name="", context_window=500_000)],
+    )
+    configure_mod.invalidate_model_info_cache()
+    info = configure_mod.resolve_model_info("xai", model_id)
+    spec = configure_mod.build_model_spec("xai", model_id, info)
+
+    assert info is not unknown_model_info
+    assert info.id == model_id
+    assert info.name == model_id
+    assert info.name != "Unknown"
+    assert info.context_window == 500_000
+    # The id wearing a name's clothes is refused by the band (see naming.py),
+    # so the operator sees ``grok-4.6`` rather than the placeholder word.
+    assert spec.display_name in ("", model_id)
+    assert spec.display_name != "Unknown"
+    assert spec.context_window == 500_000
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/model/test_discovery.py
+++ b/tests/unit/model/test_discovery.py
@@ -259,6 +259,46 @@ def test_openai_oauth_without_an_account_scope_falls_back_without_a_request() ->
     assert client.calls == []
 
 
+def test_an_unrecognised_visibility_value_does_not_hide_every_model() -> None:
+    """This listing may PRUNE the registry, so the visibility test is a denylist.
+
+    Testing ``!= "list"`` dropped every row the moment the endpoint renamed or
+    added a value, and a listing that parses to nothing then emptied the whole
+    OpenAI picker. Showing one internal helper is the far smaller harm.
+    """
+    body = {
+        "models": [
+            {"slug": "gpt-5.6-sol", "display_name": "GPT-5.6-Sol", "visibility": "visible"},
+            {"slug": "codex-auto-review", "visibility": "HIDE"},
+        ]
+    }
+    rows = fetch_models(
+        "openai",
+        api_key="chatgpt-token",
+        is_oauth=True,
+        account_id="acct-42",
+        client=_StubClient([_Response(200, body)]),
+    )
+
+    assert rows is not None
+    assert [row.id for row in rows] == ["gpt-5.6-sol"], "unknown value hid a real model"
+
+
+def test_a_codex_row_may_spell_its_id_the_public_way() -> None:
+    """``slug`` with no fallback made one renamed key cost every row."""
+    body = {"models": [{"id": "gpt-5.6-luna", "display_name": "GPT-5.6-Luna"}]}
+    rows = fetch_models(
+        "openai",
+        api_key="chatgpt-token",
+        is_oauth=True,
+        account_id="acct-42",
+        client=_StubClient([_Response(200, body)]),
+    )
+
+    assert rows is not None
+    assert [row.id for row in rows] == ["gpt-5.6-luna"]
+
+
 # -- Anthropic transport ------------------------------------------------------
 
 
@@ -1048,6 +1088,132 @@ def test_openai_api_key_and_oauth_catalogues_do_not_share_a_cache(tmp_path) -> N
         "https://api.openai.com/v1/models",
         discovery.OPENAI_CHATGPT_MODELS_URL,
     ]
+
+
+def test_an_unscoped_oauth_run_never_prunes_from_the_api_key_document(tmp_path) -> None:
+    """The pruning decision must require the SAME account scope the cache key
+    and the transport require.
+
+    Without the account id ``_cache_key`` degrades to the shared unscoped
+    document, so an OAuth run read the listing an API KEY wrote and then used
+    it to prune the registry -- 11 bundled ids down to 1, with no HTTP request
+    issued and a reassuring ``cached`` status. The same path accepted a
+    document written before the account-scoped catalogue existed, so an upgrade
+    hit it too.
+    """
+    client = _StubClient([_Response(200, {"data": [{"id": "api-only"}]})])
+
+    available_models("openai", api_key="sk-api", client=client, cache_dir=tmp_path)
+    models, status = available_models(
+        "openai",
+        api_key="chatgpt-token",
+        is_oauth=True,
+        account_id=None,
+        client=client,
+        cache_dir=tmp_path,
+    )
+
+    assert status == "cached"
+    listed = {model.id for model in models}
+    assert set(static_models("openai")) <= listed, "an unscoped run pruned the registry"
+    assert len(client.calls) == 1, "the second run must not issue a request"
+
+
+def test_a_codex_listing_that_parses_to_nothing_keeps_the_bundled_models(tmp_path) -> None:
+    """Upstream schema drift must cost "no new models", never "no models".
+
+    A 200 whose rows all drop (a renamed key, an unknown visibility value, a
+    catalogue filtered by the pinned client version) pruned the registry to
+    EMPTY and cached the emptiness for the 24h TTL, so the picker offered no
+    OpenAI model at all and issued no request that could recover it.
+    """
+    client = _StubClient([_Response(200, {"models": []})])
+
+    models, status = available_models(
+        "openai",
+        api_key="chatgpt-token",
+        is_oauth=True,
+        account_id="acct-42",
+        client=client,
+        cache_dir=tmp_path,
+    )
+
+    assert status == "empty"
+    assert {model.id for model in models} == set(static_models("openai"))
+
+
+def test_a_subscription_token_is_never_spent_on_the_generic_endpoint() -> None:
+    """One predicate drives the endpoint choice, the cache scope AND the prune.
+
+    They were spelled three separate ways and disagreed: the prune test omitted
+    the account id and keyed off the credential-storage id rather than the
+    provider actually fetched. Denying the predicate must therefore stop the
+    request too, not fall through to ``api.openai.com/v1/models`` -- that wire
+    rejects a subscription credential, so trying it would burn a request and
+    report a listing outage for a token that was simply asked the wrong thing.
+    """
+    client = _StubClient([_Response(200, {"data": [{"id": "gpt-4.1"}]})])
+
+    rows = fetch_models(
+        "openai",
+        api_key="chatgpt-token",
+        is_oauth=True,
+        account_id=None,
+        client=client,
+    )
+
+    assert rows is None
+    assert client.calls == [], "an unscoped OAuth listing must issue no request"
+
+
+def test_listing_authority_requires_every_condition_the_request_needs() -> None:
+    """The prune predicate is the only destructive one, so it may not be
+    weaker than the predicate that decides the request is issuable.
+
+    ``openai-device`` shares OpenAI's credential row and IS on the
+    account-scoped route. A sibling that shared the row WITHOUT being on that
+    route would receive a generic ``/v1/models`` snapshot -- explicitly a
+    partial entitlement list -- and, under the old ``storage_id == "openai"``
+    test, prune the bundled catalogue from it.
+    """
+    scoped = discovery._serves_account_scoped_catalogue
+    kw = {"is_oauth": True, "api_key": "tok", "account_id": "acct-42"}
+
+    assert scoped("openai", **kw) is True
+    assert scoped("openai-device", **kw) is True
+    # Not on the account-scoped route, whatever credential row it shares.
+    assert scoped("openai-enterprise", **kw) is False
+    assert scoped("openrouter", **kw) is False
+    # Every condition the request itself needs is required here too.
+    assert scoped("openai", is_oauth=False, api_key="tok", account_id="acct-42") is False
+    assert scoped("openai", is_oauth=True, api_key=None, account_id="acct-42") is False
+    assert scoped("openai", is_oauth=True, api_key="tok", account_id=None) is False
+
+
+def test_openai_device_shares_the_account_scoped_document(tmp_path) -> None:
+    """``store_credentials_as`` is what puts ``openai-device`` on the same
+    account-scoped route and the same cache document as ``openai``.
+
+    It has no bundled models of its own, so reading it off the provider id
+    instead would list a device-flow login against an empty registry and cache
+    the answer under a second name for the same account.
+    """
+    client = _StubClient([_Response(200, _OPENAI_CODEX_BODY)])
+
+    models, status = available_models(
+        "openai-device",
+        api_key="chatgpt-token",
+        is_oauth=True,
+        account_id="acct-42",
+        client=client,
+        cache_dir=tmp_path,
+    )
+
+    assert status == "ok"
+    assert [model.id for model in models] == ["gpt-5.6-sol"]
+    assert client.calls[0][0] == discovery.OPENAI_CHATGPT_MODELS_URL
+    written = sorted(path.name for path in tmp_path.glob("*.json"))
+    assert written == ["openai.oauth.931c7c164da4.listing.json"], written
 
 
 def test_available_models_serves_a_fresh_cache_without_a_request(tmp_path) -> None:

--- a/tests/unit/model/test_discovery.py
+++ b/tests/unit/model/test_discovery.py
@@ -104,6 +104,28 @@ def _info(model_id: str = "m", **overrides: object) -> ModelInfo:
 # -- OpenAI-compatible transport ---------------------------------------------
 
 
+#: Captured from ChatGPT's account-scoped Codex catalogue on 2026-08-09,
+#: trimmed to one selectable row and one internal hidden row.
+_OPENAI_CODEX_BODY = {
+    "models": [
+        {
+            "slug": "gpt-5.6-sol",
+            "display_name": "GPT-5.6-Sol",
+            "visibility": "list",
+            "context_window": 272_000,
+            "max_context_window": 272_000,
+            "input_modalities": ["text", "image"],
+        },
+        {
+            "slug": "codex-auto-review",
+            "display_name": "Codex Auto Review",
+            "visibility": "hide",
+            "context_window": 272_000,
+            "input_modalities": ["text", "image"],
+        },
+    ]
+}
+
 _OPENROUTER_BODY = {
     "data": [
         {
@@ -192,6 +214,49 @@ def test_openai_compat_sends_a_bearer_key_and_omits_it_when_keyless() -> None:
     # provider must send no Authorization at all rather than "Bearer None".
     assert "Authorization" not in keyless.calls[0][1]
     assert keyless.calls[0][0] == "http://localhost:11434/v1/models"
+
+
+def test_openai_oauth_uses_the_account_scoped_codex_catalogue() -> None:
+    """ChatGPT subscription tokens receive 403 from ``api.openai.com/v1/models``.
+
+    The Codex catalogue is the endpoint OpenAI's own client uses for those
+    tokens. It requires the account header and returns ``slug`` rows rather than
+    the public API's ``id`` rows.
+    """
+    client = _StubClient([_Response(200, _OPENAI_CODEX_BODY)])
+    rows = fetch_models(
+        "openai",
+        api_key="chatgpt-token",
+        is_oauth=True,
+        account_id="acct-42",
+        client=client,
+    )
+
+    assert rows is not None
+    assert [(row.id, row.name) for row in rows] == [("gpt-5.6-sol", "GPT-5.6-Sol")]
+    assert rows[0].context_window == 272_000
+    assert rows[0].supports_images is True
+    url, headers, params, _timeout = client.calls[0]
+    assert url == discovery.OPENAI_CHATGPT_MODELS_URL
+    assert headers["Authorization"] == "Bearer chatgpt-token"
+    assert headers["ChatGPT-Account-ID"] == "acct-42"
+    assert params == {"client_version": discovery.OPENAI_MODELS_CLIENT_VERSION}
+
+
+def test_openai_oauth_without_an_account_scope_falls_back_without_a_request() -> None:
+    client = _StubClient([])
+
+    assert (
+        fetch_models(
+            "openai",
+            api_key="chatgpt-token",
+            is_oauth=True,
+            account_id=None,
+            client=client,
+        )
+        is None
+    )
+    assert client.calls == []
 
 
 # -- Anthropic transport ------------------------------------------------------
@@ -917,6 +982,72 @@ def test_available_models_reports_ok_and_merges_the_registry(tmp_path) -> None:
     # Registry-only: the listing did not mention it, and a model the user can run
     # today must not vanish from the picker because of that.
     assert by_id["claude-3-5-sonnet-20241022"].context_window == 200_000
+
+
+def test_openai_oauth_catalogue_is_authoritative_when_available(tmp_path) -> None:
+    """A successful account-scoped response replaces the stale static id list."""
+    client = _StubClient([_Response(200, _OPENAI_CODEX_BODY)])
+
+    models, status = available_models(
+        "openai",
+        api_key="chatgpt-token",
+        is_oauth=True,
+        account_id="acct-42",
+        client=client,
+        cache_dir=tmp_path,
+    )
+
+    assert status == "ok"
+    assert [model.id for model in models] == ["gpt-5.6-sol"]
+    assert "gpt-4o" in static_models("openai"), "fixture no longer proves static ids were pruned"
+
+
+def test_openai_oauth_falls_back_to_static_when_the_endpoint_is_unavailable(tmp_path) -> None:
+    client = _StubClient([_Response(403, {"detail": "forbidden"})])
+
+    models, status = available_models(
+        "openai",
+        api_key="chatgpt-token",
+        is_oauth=True,
+        account_id="acct-42",
+        client=client,
+        cache_dir=tmp_path,
+    )
+
+    assert status == "static"
+    assert {model.id for model in models} == set(static_models("openai"))
+
+
+def test_openai_api_key_and_oauth_catalogues_do_not_share_a_cache(tmp_path) -> None:
+    """An API-key cache must not mask an account's newer OAuth-only models."""
+    client = _StubClient(
+        [
+            _Response(200, {"data": [{"id": "api-only"}]}),
+            _Response(200, _OPENAI_CODEX_BODY),
+        ]
+    )
+
+    available_models(
+        "openai",
+        api_key="sk-api",
+        client=client,
+        cache_dir=tmp_path,
+    )
+    oauth_models, oauth_status = available_models(
+        "openai",
+        api_key="chatgpt-token",
+        is_oauth=True,
+        account_id="acct-42",
+        client=client,
+        cache_dir=tmp_path,
+    )
+
+    assert oauth_status == "ok"
+    assert [model.id for model in oauth_models] == ["gpt-5.6-sol"]
+    assert [call[0] for call in client.calls] == [
+        "https://api.openai.com/v1/models",
+        discovery.OPENAI_CHATGPT_MODELS_URL,
+    ]
 
 
 def test_available_models_serves_a_fresh_cache_without_a_request(tmp_path) -> None:

--- a/tests/unit/model/test_naming.py
+++ b/tests/unit/model/test_naming.py
@@ -286,6 +286,16 @@ def test_a_placeholder_row_supplies_no_name() -> None:
     assert model_label("ollama", "qwen3:32b").full == "ollama/qwen3:32b"
 
 
+def test_the_unknown_placeholder_name_is_not_a_display_name() -> None:
+    """``Unknown`` is the shipped fallback's identity, not a model. Promoting it
+    is how a nameless xAI listing painted the status band ``Unknown`` for a
+    running Grok 4.6 session."""
+    info = ModelInfo(id="grok-4.6", name="Unknown", description="Unknown model")
+    assert build_model_spec("xai", "grok-4.6", info).display_name == ""
+    assert model_label("xai", "grok-4.6", "Unknown").full == "xai/grok-4.6"
+    assert model_label("xai", "grok-4.6", "Unknown").compact == "grok-4.6"
+
+
 def test_a_normalised_id_still_supplies_its_name() -> None:
     """The placeholder guard compares ids under ``_normalised_id``, not by
     equality, and this is why. ``_info_from_discovery`` matches rows on the

--- a/tests/unit/providers/test_controller.py
+++ b/tests/unit/providers/test_controller.py
@@ -253,6 +253,31 @@ async def test_openai_listing_credential_carries_the_chatgpt_account_scope(
     )
 
 
+@pytest.mark.asyncio
+async def test_a_login_flavour_finds_the_row_its_login_actually_wrote(controller, store) -> None:
+    """``openai-device`` is a login flavour of ``openai``, not a second account.
+
+    The ChatGPT device-code login writes ONE credential row, under the aliased
+    name (``store_credentials_as``). Asking ``AuthStore`` for the literal id
+    found nothing — its ``WHERE provider = ?`` is exact — so the flavour listed
+    anonymously: no OAuth, no account scope, no account-scoped catalogue, and a
+    logged-in account was offered the bundled ``gpt-4o``/``o3`` rows under that
+    second prefix. Exactly the ids an authoritative listing exists to withdraw.
+    """
+    store.oauth["openai"] = types.SimpleNamespace(
+        kind="oauth",
+        access_token="chatgpt-token",
+        account_id="acct-42",
+        org_id=None,
+    )
+
+    assert await controller._listing_credential("openai-device") == (
+        "chatgpt-token",
+        True,
+        "acct-42",
+    )
+
+
 def test_usage_enabled_provider_ids(controller) -> None:
     ids = controller.usage_enabled_providers()
     assert "openrouter" in ids

--- a/tests/unit/providers/test_controller.py
+++ b/tests/unit/providers/test_controller.py
@@ -373,6 +373,26 @@ def test_the_static_catalogue_needs_no_network_and_carries_real_models(controlle
     assert all(entry.provider and entry.model_id for entry in entries)
 
 
+def test_one_entry_can_be_rebuilt_for_the_model_a_session_is_running(controller) -> None:
+    """A picker must offer the running model even when the catalogue withdrew it.
+
+    An authoritative account-scoped listing is allowed to prune bundled ids, so
+    the session's own model can be absent from the catalogue entirely. This is
+    how the picker gets it back, with the same normalization every other entry
+    goes through rather than a caller reaching into the registry itself.
+    """
+    entry = controller.entry_for("anthropic", "claude-opus-4-20250514")
+
+    assert entry is not None
+    assert entry.selector == "anthropic/claude-opus-4-20250514"
+    assert entry.context_window > 0
+    assert entry.input_price > 0
+    # An id the registry does not describe is a real answer, not an error: an
+    # operator may have configured a model by hand.
+    assert controller.entry_for("anthropic", "claude-not-a-model") is None
+    assert controller.entry_for("not-a-provider", "whatever") is None
+
+
 def test_an_unknown_price_is_not_reported_as_free(controller, monkeypatch) -> None:
     """The picker renders a genuine pair of zeroes as `free`, so an unknown price
     passed through as zero would advertise a paid model as costing nothing.

--- a/tests/unit/providers/test_controller.py
+++ b/tests/unit/providers/test_controller.py
@@ -13,6 +13,7 @@ from typing import Any
 import httpx
 import pytest
 
+from local_operator.harness.types import ModelSpec
 from local_operator.providers.controller import ProviderController
 from local_operator.providers.usage import UsageReport
 
@@ -416,6 +417,45 @@ def test_one_entry_can_be_rebuilt_for_the_model_a_session_is_running(controller)
     # operator may have configured a model by hand.
     assert controller.entry_for("anthropic", "claude-not-a-model") is None
     assert controller.entry_for("not-a-provider", "whatever") is None
+
+
+def test_an_aggregator_current_model_is_rebuilt_from_the_resolved_spec(controller) -> None:
+    """Aggregators deliberately have no enumerable static catalogue.
+
+    ``static_models('openrouter')`` is empty even for a model the session is
+    running, so a rescue that only reads static rows cannot restore the current
+    marker when the live listing is unavailable. Session startup already
+    resolved the exact model; the single-row rescue spends that spec rather than
+    doing synchronous network/cache work on the TUI thread.
+    """
+    spec = ModelSpec(
+        provider="openrouter",
+        model_id="deepseek/deepseek-chat",
+        display_name="DeepSeek Chat",
+        context_window=64_000,
+    )
+
+    entry = controller.entry_for(
+        "openrouter",
+        "deepseek/deepseek-chat",
+        spec=spec,
+    )
+
+    assert entry is not None
+    assert entry.selector == "openrouter/deepseek/deepseek-chat"
+    # Naming's honesty rule declines an ambiguous family name and spends the
+    # selector instead — the rescue must use the SAME display decision as the
+    # band, not force the raw metadata name through.
+    assert entry.label == "openrouter/deepseek/deepseek-chat"
+    assert entry.context_window == 64_000
+    assert entry.input_price == -1.0
+    assert entry.output_price == -1.0
+    assert entry.aggregated is True
+
+    # The supplied spec is only evidence for itself, never a generic bypass for
+    # another selector or provider.
+    assert controller.entry_for("openrouter", "other/model", spec=spec) is None
+    assert controller.entry_for("radient", spec.model_id, spec=spec) is None
 
 
 def test_an_unknown_price_is_not_reported_as_free(controller, monkeypatch) -> None:

--- a/tests/unit/providers/test_controller.py
+++ b/tests/unit/providers/test_controller.py
@@ -235,6 +235,24 @@ class TestUsageIsPerAccount:
         assert calls == 1
 
 
+@pytest.mark.asyncio
+async def test_openai_listing_credential_carries_the_chatgpt_account_scope(
+    controller, store
+) -> None:
+    store.oauth["openai"] = types.SimpleNamespace(
+        kind="oauth",
+        access_token="chatgpt-token",
+        account_id="acct-42",
+        org_id=None,
+    )
+
+    assert await controller._listing_credential("openai") == (
+        "chatgpt-token",
+        True,
+        "acct-42",
+    )
+
+
 def test_usage_enabled_provider_ids(controller) -> None:
     ids = controller.usage_enabled_providers()
     assert "openrouter" in ids

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import re
 from collections.abc import Callable, Sequence
 from pathlib import Path
 from types import SimpleNamespace
@@ -2138,6 +2139,89 @@ async def test_the_model_list_offers_what_the_user_can_actually_run() -> None:
         offered = {row.selector for row in picker.rows()}
     # openrouter has a credential; ollama needs none by definition; anthropic has
     # neither and is the one the user cannot act on.
+    assert offered == {"openrouter/deepseek/deepseek-chat", "ollama/qwen3:8b"}, offered
+
+
+class _PruningController(_AccessController):
+    """A catalogue that withdrew the model the session is running.
+
+    This is what an authoritative account-scoped listing does: the account's own
+    catalogue replaces the bundled ids, so a session started on a bundled id has
+    no entry in the list at all. The registry still describes it and ``/model``
+    still accepts it, which is exactly the disagreement the rescue exists to
+    close.
+    """
+
+    def static_catalogue(self):
+        from local_operator.providers.controller import CatalogueEntry
+
+        return [
+            CatalogueEntry(
+                provider="openrouter",
+                model_id="deepseek/deepseek-chat",
+                label="DeepSeek Chat",
+                context_window=64_000,
+                input_price=0.14,
+                output_price=0.28,
+                connected=True,
+                aggregated=True,
+            )
+        ]
+
+    def entry_for(self, provider, model_id):
+        from local_operator.providers.controller import CatalogueEntry
+
+        if (provider, model_id) != ("test", "model"):
+            return None
+        return CatalogueEntry(
+            provider=provider,
+            model_id=model_id,
+            label="Test Model",
+            context_window=128_000,
+            input_price=1.0,
+            output_price=2.0,
+            connected=True,
+        )
+
+
+@pytest.mark.asyncio
+async def test_the_running_model_is_offered_even_when_the_listing_withdrew_it() -> None:
+    """The band names the model; the list must not deny it.
+
+    An authoritative listing may prune bundled ids, and exempting the current row
+    from the credential filter does not help when no entry arrives to exempt. The
+    session read `test/model` on the band while the picker showed no current row
+    and typing the id answered "no matching models" — the list disagreeing with
+    the set `/model` accepts, with the list being the discovery surface.
+    """
+    ctrl = _PruningController()
+    app = OperatorApp(lambda: _factory(FakeSession()), provider_controller=ctrl)
+    async with app.run_test(size=(90, 24)) as pilot:
+        await pilot.pause()
+        picker = await _open_model_picker(app, pilot)
+        offered = {row.selector for row in picker.rows()}
+        chrome = picker.render_text(90).plain
+
+    assert "test/model" in offered, offered
+    # The `●` is the whole point: it is what answers "what am I on", and a row
+    # without it would leave the band and the list contradicting each other.
+    assert "test/model" in chrome and "●" in chrome, chrome
+    # And the count stays honest: the rescued row is not one of the catalogue's
+    # entries, so a naive subtraction reports a NEGATIVE number of hidden rows.
+    assert not re.search(r"-\d+\s+hidden", chrome), chrome
+
+
+@pytest.mark.asyncio
+async def test_a_host_facade_without_the_rescue_still_paints_the_list() -> None:
+    """The provider facade is duck-typed, so an embedding host need not implement
+    ``entry_for``. A missing courtesy must never cost the picker."""
+    ctrl = _AccessController()  # no entry_for at all
+    app = OperatorApp(lambda: _factory(FakeSession()), provider_controller=ctrl)
+    async with app.run_test(size=(90, 24)) as pilot:
+        await pilot.pause()
+        picker = await _open_model_picker(app, pilot)
+        offered = {row.selector for row in picker.rows()}
+
     assert offered == {"openrouter/deepseek/deepseek-chat", "ollama/qwen3:8b"}, offered
 
 

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -2263,6 +2263,77 @@ async def test_a_hidden_model_is_still_reachable_by_typing_its_selector() -> Non
     assert "anthropic needs login — /login anthropic" in text, text
 
 
+class _OpenAILiveController(_AccessController):
+    """Logged into OpenAI with the account-scoped Codex catalogue, not the
+    shipped gpt-4o/o3 registry. That is the ChatGPT OAuth path: the public
+    ``/v1/models`` 403s a subscription token, so gpt-5.6 only exists here."""
+
+    def __init__(self) -> None:
+        super().__init__(stored=("openai",))
+
+    def login_providers(self):
+        return [
+            _FakeDef("openai", "OpenAI", None, ("gpt",)),
+            _FakeDef("anthropic", "Anthropic", None, ("claude",)),
+        ]
+
+    def static_catalogue(self):
+        from local_operator.providers.controller import CatalogueEntry
+
+        return [
+            CatalogueEntry(
+                provider="openai",
+                model_id="gpt-4o",
+                label="GPT-4o",
+                context_window=128_000,
+                input_price=2.5,
+                output_price=10.0,
+                connected=True,
+            )
+        ]
+
+    async def live_catalogue(self, *, ttl_s=None):
+        from local_operator.providers.controller import CatalogueEntry
+
+        return [
+            CatalogueEntry(
+                provider="openai",
+                model_id=model_id,
+                label=label,
+                context_window=272_000,
+                input_price=0.0,
+                output_price=0.0,
+                connected=True,
+            )
+            for model_id, label in (
+                ("gpt-5.6-sol", "GPT-5.6-Sol"),
+                ("gpt-5.6-terra", "GPT-5.6-Terra"),
+                ("gpt-5.6-luna", "GPT-5.6-Luna"),
+                ("gpt-5.5", "GPT-5.5"),
+            )
+        ], {"openai": "ok"}
+
+
+@pytest.mark.asyncio
+async def test_chatgpt_oauth_offers_the_live_gpt_5_family() -> None:
+    """The reported `/model gpt-5.6` miss. A ChatGPT login whose live
+    catalogue is the Codex list must surface those slugs, not the shipped
+    gpt-4o/o3 registry that the public API would have left behind."""
+    ctrl = _OpenAILiveController()
+    app = OperatorApp(lambda: _factory(FakeSession()), provider_controller=ctrl)
+    async with app.run_test(size=(90, 24)) as pilot:
+        await pilot.pause()
+        picker = await _open_model_picker(app, pilot)
+        editor = app.query_one(Editor)
+        editor.text = "/model gpt-5.6"
+        await pilot.pause()
+        offered = {row.model_id for row in picker.suggestions()}
+        chrome = picker.render_text(90).plain
+    assert {"gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"} <= offered, offered
+    assert "gpt-4o" not in offered
+    assert "no matching models" not in chrome
+
+
 @pytest.mark.asyncio
 async def test_a_failed_credential_check_is_reported_as_itself() -> None:
     """Neither a confirmation the app cannot make nor the old blanket warning: the

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -2184,6 +2184,55 @@ class _PruningController(_AccessController):
         )
 
 
+class _PruningWithHiddenController(_PruningController):
+    """One usable row, one filtered row, and one rescued row not in either."""
+
+    def static_catalogue(self):
+        from local_operator.providers.controller import CatalogueEntry
+
+        return [
+            CatalogueEntry(
+                provider="openrouter",
+                model_id="deepseek/deepseek-chat",
+                label="DeepSeek Chat",
+                context_window=64_000,
+                input_price=0.14,
+                output_price=0.28,
+                connected=True,
+                aggregated=True,
+            ),
+            CatalogueEntry(
+                provider="anthropic",
+                model_id="claude-opus-5",
+                label="Claude Opus 5",
+                context_window=1_000_000,
+                input_price=15.0,
+                output_price=75.0,
+                connected=False,
+            ),
+        ]
+
+
+@pytest.mark.asyncio
+async def test_a_rescued_row_does_not_hide_a_real_hidden_catalogue_entry() -> None:
+    """``hidden`` counts catalogue rows filtered out, not final rows painted.
+
+    A rescued current row was never in ``entries``. Subtracting it anyway made
+    one real filtered catalogue entry disappear from the footer; flooring at
+    zero prevented ``-1`` but did not preserve what the count means.
+    """
+    ctrl = _PruningWithHiddenController()
+    app = OperatorApp(lambda: _factory(FakeSession()), provider_controller=ctrl)
+    async with app.run_test(size=(90, 24)) as pilot:
+        await pilot.pause()
+        picker = await _open_model_picker(app, pilot)
+        offered = {row.selector for row in picker.rows()}
+        chrome = picker.render_text(90).plain
+
+    assert offered == {"openrouter/deepseek/deepseek-chat", "test/model"}, offered
+    assert "1 hidden — /login <provider>" in chrome, chrome
+
+
 @pytest.mark.asyncio
 async def test_the_running_model_is_offered_even_when_the_listing_withdrew_it() -> None:
     """The band names the model; the list must not deny it.

--- a/tests/unit/tui/test_model_picker.py
+++ b/tests/unit/tui/test_model_picker.py
@@ -52,6 +52,30 @@ def test_window_is_abbreviated_and_unknown_is_blank() -> None:
     assert format_window(-1) == ""
 
 
+def test_a_name_that_only_recases_the_id_is_not_printed_beside_it() -> None:
+    """The parenthetical exists to add what the selector did not say.
+
+    ChatGPT's Codex catalogue titles its display names off the slug
+    (``gpt-5.6-luna`` -> ``GPT-5.6-Luna``), so an exact comparison let every row
+    in that family spend ~16 cells restating its own id. A name that genuinely
+    differs keeps its parenthetical: that is the half a case-insensitive test
+    could break, so both are pinned here.
+    """
+    picker = ModelPicker(lambda row: None)
+    picker.set_rows(
+        [
+            ModelRow("openai", "gpt-5.6-luna", "GPT-5.6-Luna", 272_000, 1.25, 10.0, True),
+            ModelRow("openai", "gpt-4.1-mini", "GPT-4.1 mini", 128_000, 0.4, 1.6, True),
+        ],
+        current=None,
+    )
+    picker.open("")
+    painted = picker.render_text(100).plain
+
+    assert "(GPT-5.6-Luna)" not in painted, painted
+    assert "(GPT-4.1 mini)" in painted, painted
+
+
 def test_a_large_price_keeps_its_decimal() -> None:
     """Rounding is not free in a price column: `$18.75` rendered as `$19` reads as
     a real quoted rate the provider does not charge."""

--- a/tests/unit/tui/test_status_line.py
+++ b/tests/unit/tui/test_status_line.py
@@ -235,6 +235,13 @@ def test_a_listing_name_reaches_the_band_for_a_model_no_registry_row_covers() ->
     )
 
 
+def test_the_unknown_placeholder_does_not_reach_the_band() -> None:
+    """The word the shared fallback is named, not a model. A nameless listing
+    used to keep it and paint it on the band for every unshipped id."""
+    assert format_model_label("xai/grok-4.6", short=False, name="Unknown") == "xai/grok-4.6"
+    assert format_model_label("xai/grok-4.6", short=True, name="Unknown") == "grok-4.6"
+
+
 def test_a_resold_model_keeps_its_selector_however_the_reseller_names_it() -> None:
     """Both shipped aggregators list the same models under the same names — 398 of
     ~400 in their real cached catalogues — so a reseller's name cannot say which


### PR DESCRIPTION
## What changed

- stop the shared `unknown_model_info` placeholder (`name="Unknown"`) leaking into the status band for an unshipped model
- refuse `"Unknown"` as a display name in both `build_model_spec` and `model/naming.py`
- list ChatGPT OAuth models from the account-scoped Codex catalogue (`chatgpt.com/backend-api/codex/models`) instead of `api.openai.com/v1/models`
- isolate that catalogue on disk by hashed account id so an API-key cache cannot hide OAuth-only slugs
- treat a successful Codex listing as authoritative, so stale shipped ids (`gpt-4o`, `o3`) do not crowd out `gpt-5.6-*`

## Why

Two user-visible misses, same root class: metadata that does not describe *this* model.

1. Switching to xAI Grok 4.6 ran the model (500k window, real turns) but the band painted **Unknown**. xAI's listing quotes a window and no display name. Resolution started from the process-wide `unknown_model_info` singleton and kept its name when the listing had nothing to overwrite it with.
2. `/model gpt-5.6` said **no matching models** on a logged-in ChatGPT account. ChatGPT subscription tokens are rejected by `api.openai.com/v1/models` (403). The models that account can actually run live on the Codex catalogue, which this tree already talks to for inference.

A leftover rescue commit (`ea6ae0c`) already had the Codex listing path; it never landed on `main`. This ports that work onto current `main` and adds the name-leak fix the Grok 4.6 band needed.

## Impact

- No breaking API change.
- ChatGPT OAuth `/model` now offers the account's current slugs (`gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`, …). The shipped gpt-4o/o3 registry is no longer offered to that account under either the `openai` or the `openai-device` prefix. The four live rows are still listed once per prefix; collapsing login-flavour aliases to a single section is deferred (design round D1).
- An unshipped direct-provider id with no listing name falls back to the selector (`xai/grok-4.6` / `grok-4.6`), never the word Unknown.
- If the Codex endpoint is down, the picker still falls back to the static OpenAI registry.

## Testing Details

### Automated

- `env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit/model tests/unit/providers/test_controller.py tests/unit/tui/test_status_line.py tests/unit/tui/test_app_pilot.py tests/unit/tui/test_model_picker.py tests/unit/tui/test_welcome.py -q`
  - result: **605 passed**
- flake8 / black / isort / pyright on the changed files: clean

New coverage:

- unshipped xAI id no longer keeps the Unknown placeholder
- `"Unknown"` is refused as a band / spec display name
- Codex OAuth listing parse, account-header requirement, authoritative merge, and isolated cache
- controller listing credential carries the ChatGPT account id
- `/model gpt-5.6` offers the live Codex family

### Visual (real OperatorApp, stylesheet loaded)

Before/after stills from `OperatorApp.run_test` + `save_screenshot`, then rendered and viewed:

| | before | after |
|---|---|---|
| Grok 4.6 band | `◆ Unknown` | `◆ xai/grok-4.6` |
| `/model gpt-5.6` | `no matching models` | `openai/gpt-5.6-luna`, `sol`, `terra` |

Resolved numbers for Grok 4.6 after the fix: `id=grok-4.6`, `name=grok-4.6` (not Unknown), `window=500000`, band short=`grok-4.6`, band full=`xai/grok-4.6`.

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my changes work as intended.
- [x] All new and existing tests pass (focused suites above).
- [x] I have run formatting (black/isort), linting (flake8), and type checks (pyright), and they pass on the changed files.
- [x] Security considerations are addressed (account id is hashed in the cache key, never written raw).
- [x] Screenshots captured and viewed for both user-visible surfaces.

### Review rounds

- Two code rounds and two design rounds are recorded on this PR with per-finding remediation replies. Round 2 of each is clean on the merged head.
- **Note for a bisect:** an OAuth token for `openai`/`openai-device` with no account scope yields "no listing" rather than falling through to `api.openai.com/v1/models`. Round 2's remediation comment described this as a change; it is not. The first commit on this branch already had that outcome (`_fetch_openai_oauth` returned `None` on a missing account id) and the remediation only relocated the decision into `_serves_account_scoped_catalogue` and made it explicit.

- Code review round 1 (`ReviewModelLabel`, approved-with-changes: 2 majors) and design review round 1 (`DesignModelLabel`, 1 major) are recorded on this PR with per-finding remediation replies.
- The two code majors were one root cause: three predicates described "this is the account's authoritative Codex catalogue" — the transport, the cache key, and the prune — and disagreed. Authority is now derived once, in `_serves_account_scoped_catalogue`, from the conditions under which the account-scoped request is issuable, and pruning additionally requires that the listing actually listed something.
- Remediation mutation matrix: 6 of 6 mutations killed (`N1`–`N6`), unmutated baseline 345 passed. Full table in the remediation comment.
- Post-remediation frames re-captured with the design reviewer's own harness and viewed: `/tmp/design125/fixed/e2e-picker-bare.svg` shows 8 rows, zero stale ids, no id-restating parentheticals.

## Change class

C2 — standard product fix, pre-authorized. No RFC.

