### PR TITLE
fix(harness): report subagent job state honestly

### DIFF
--- a/local_operator/harness/comms.py
+++ b/local_operator/harness/comms.py
@@ -469,23 +469,39 @@ class SubagentComms:
 
         Two states reach here and the caller acts on them differently. A job
         the manager PARKED is waiting for a slot and may not start for
-        minutes, so the honest advice is to stop waiting on it. A job that is
-        running but has not reached ``attach`` yet is mid-construction (the
-        child session is being built: config, tools, MCP wiring) and will take
-        the message the moment it is up.
+        minutes, so the honest advice is to stop waiting on it. An ADMITTED
+        job is only waiting on this event loop: ``register`` calls
+        ``ensure_future``, which schedules the runner without entering it, so
+        a parent that registers a child and then does non-yielding work leaves
+        it scheduled-but-unstarted for the whole stretch. One loop yield — the
+        caller's next await, including its next tool call — is enough to start
+        it, so the honest advice there is to retry.
+
+        Neither string promises a session is being BUILT. In the state this
+        branch was written for, the runner coroutine has not been entered at
+        all, so nothing is under construction yet; "scheduled" covers that and
+        the build that follows it, and both resolve on the same advice.
 
         Both used to report the capacity gate. That is a false statement about
         an admitted job, and it is the one an operator acts on: it says
         "nothing is happening" about a child that is already spending tokens,
         so a stuck-looking run gets cancelled instead of waited out.
+
+        Neither string names ``record.label``: the only render site
+        (``builtin.py``'s hub result) already prefixes ``{label} ({job_id}): ``,
+        and the card truncates the reason as content — so a stuttered label
+        spends the exact cells that would otherwise have carried the state.
         """
         jobs = self._jobs()
         job = jobs.get(record.job_id) if jobs is not None else None
         if job is not None and getattr(job, "queued", False):
-            return "subagent has not started yet (parked behind the job capacity gate)"
+            return (
+                "subagent has not started yet (parked behind the job capacity gate); "
+                "it starts when a slot frees, so do not wait on it"
+            )
         return (
-            f"subagent {record.label} is still starting up (its session is being built); "
-            "retry in a moment"
+            "subagent has not started yet (it is scheduled, and starts when this "
+            "session next yields); retry in a moment"
         )
 
     def _gone_reason(self, record: _ChildRecord) -> str:

--- a/local_operator/harness/comms.py
+++ b/local_operator/harness/comms.py
@@ -286,7 +286,8 @@ class SubagentComms:
         if record.child is None:
             if record.settled or not self._is_running(record):
                 return Delivery(job_id, record.label, "failed", self._gone_reason(record))
-            # Parked behind the capacity gate: a course change has to reach a
+            # Not started yet — parked behind the capacity gate, or still
+            # building its session. Either way a course change has to reach a
             # child that has not read its prompt yet, so buffer it as a note.
             # It arrives before any work is done, which is the point.
             record.pending.append(self._to_child_message(text, expects_reply=False, steer=True))
@@ -303,7 +304,7 @@ class SubagentComms:
             reason = (
                 self._gone_reason(record)
                 if record.settled or not self._is_running(record)
-                else "subagent has not started yet (parked behind the job capacity gate)"
+                else self._not_started_reason(record)
             )
             return Reply(job_id, record.label, error=reason)
         if record.ask is not None and not record.ask.done():
@@ -462,6 +463,30 @@ class SubagentComms:
             return False
         job = jobs.get(record.job_id)
         return job is not None and job.status == "running"
+
+    def _not_started_reason(self, record: _ChildRecord) -> str:
+        """Why a running job has no live child yet — and they are not the same.
+
+        Two states reach here and the caller acts on them differently. A job
+        the manager PARKED is waiting for a slot and may not start for
+        minutes, so the honest advice is to stop waiting on it. A job that is
+        running but has not reached ``attach`` yet is mid-construction (the
+        child session is being built: config, tools, MCP wiring) and will take
+        the message the moment it is up.
+
+        Both used to report the capacity gate. That is a false statement about
+        an admitted job, and it is the one an operator acts on: it says
+        "nothing is happening" about a child that is already spending tokens,
+        so a stuck-looking run gets cancelled instead of waited out.
+        """
+        jobs = self._jobs()
+        job = jobs.get(record.job_id) if jobs is not None else None
+        if job is not None and getattr(job, "queued", False):
+            return "subagent has not started yet (parked behind the job capacity gate)"
+        return (
+            f"subagent {record.label} is still starting up (its session is being built); "
+            "retry in a moment"
+        )
 
     def _gone_reason(self, record: _ChildRecord) -> str:
         # ``record.settled`` (set by detach, as the child's runner tears it

--- a/local_operator/harness/jobs.py
+++ b/local_operator/harness/jobs.py
@@ -36,6 +36,14 @@ logger = logging.getLogger(__name__)
 DEFAULT_MAX_RUNNING_JOBS = 15
 DEFAULT_RETENTION_MS = 5 * 60_000
 
+#: ``result_text`` stamped by :meth:`AsyncJobManager.cancel` on a job that was
+#: cancelled while still PARKED, so the one fact the cancellation destroys —
+#: that the job never ran — survives on the row every settled surface already
+#: reads. Named rather than inlined because two renderers match on it: the
+#: panel row prints it as the outcome, and the full-page view's title spends it
+#: instead of the bare word ``cancelled`` beside a duration that is parked time.
+CANCELLED_BEFORE_START = "cancelled before it started"
+
 JobStatus = Literal["running", "completed", "failed", "cancelled"]
 JobType = Literal["bash", "task"]
 
@@ -267,6 +275,18 @@ class AsyncJobManager:
         # is dropped for the same reason: ``start_queued`` refuses a non-running
         # job, so the entry could never run again and only kept the closure
         # (prompt, parent session, model spec) alive for the life of the manager.
+        #
+        # Clearing the flag also erases the ONLY record that the job never ran,
+        # and every surface then presents its PARKED time as work time: the
+        # panel row and the page title both measure ``settled_at - start_time``,
+        # which for a parked job is how long it waited, printed in the column
+        # where every other row's number is time a child spent working. So the
+        # fact moves to the carrier the settled-row paths already read, before
+        # the flag that carried it is dropped. Only a parked job can be stamped
+        # (a running one may be mid-``_run_job`` and owns this field), and only
+        # when nothing else claimed it.
+        if job.queued and job.result_text is None:
+            job.result_text = CANCELLED_BEFORE_START
         job.queued = False
         self._queued_runners.pop(job_id, None)
         signal = self._signals.get(job_id)

--- a/local_operator/harness/jobs.py
+++ b/local_operator/harness/jobs.py
@@ -259,6 +259,16 @@ class AsyncJobManager:
         if job.status != "running":
             return False
         job.status = "cancelled"
+        # A job cancelled while still parked stops being queued: ``queued`` is
+        # "waiting for a slot", and a cancelled job is waiting for nothing. Left
+        # set, every reader that branches on it reported the job as still
+        # pending — the panel painted ``⏳ queued`` on a row whose status was
+        # ``cancelled``, which reads as work that is about to start. Its runner
+        # is dropped for the same reason: ``start_queued`` refuses a non-running
+        # job, so the entry could never run again and only kept the closure
+        # (prompt, parent session, model spec) alive for the life of the manager.
+        job.queued = False
+        self._queued_runners.pop(job_id, None)
         signal = self._signals.get(job_id)
         if signal is not None:
             signal.abort("cancelled")

--- a/local_operator/harness/jobs.py
+++ b/local_operator/harness/jobs.py
@@ -36,12 +36,12 @@ logger = logging.getLogger(__name__)
 DEFAULT_MAX_RUNNING_JOBS = 15
 DEFAULT_RETENTION_MS = 5 * 60_000
 
-#: ``result_text`` stamped by :meth:`AsyncJobManager.cancel` on a job that was
-#: cancelled while still PARKED, so the one fact the cancellation destroys —
-#: that the job never ran — survives on the row every settled surface already
-#: reads. Named rather than inlined because two renderers match on it: the
-#: panel row prints it as the outcome, and the full-page view's title spends it
-#: instead of the bare word ``cancelled`` beside a duration that is parked time.
+#: ``result_text`` stamped by :meth:`AsyncJobManager.cancel` on a job whose
+#: runner was never entered, so the one fact the cancellation destroys — that
+#: the job never ran — survives on the row every settled surface already reads.
+#: Named rather than inlined because two renderers match on it: the panel row
+#: prints it as the outcome, and the full-page view's title spends it instead of
+#: the bare word ``cancelled`` beside a duration that was spent waiting.
 CANCELLED_BEFORE_START = "cancelled before it started"
 
 JobStatus = Literal["running", "completed", "failed", "cancelled"]
@@ -63,6 +63,15 @@ class AsyncJob(BaseModel):
     type: JobType
     status: JobStatus = "running"
     start_time: float
+    # Epoch seconds when the job's runner actually BEGAN, or ``None`` if it
+    # never did. Distinct from ``start_time``, which is stamped at
+    # REGISTRATION: ``register`` calls ``ensure_future``, which schedules the
+    # runner without entering it, so between the two a job is admitted, counted
+    # against capacity, and has not run a line. ``queued`` does not answer this
+    # — it means "parked behind the gate", and the admitted-but-not-yet-entered
+    # state is not parked — so anything that needs to know whether work
+    # happened must read this and not that.
+    started_at: float | None = None
     # Epoch seconds when the job SETTLED (completed/failed/cancelled).
     # Retention sweeps against this, not start_time, so a long-running job
     # stays observable for the full window after it finishes.
@@ -276,16 +285,28 @@ class AsyncJobManager:
         # job, so the entry could never run again and only kept the closure
         # (prompt, parent session, model spec) alive for the life of the manager.
         #
-        # Clearing the flag also erases the ONLY record that the job never ran,
-        # and every surface then presents its PARKED time as work time: the
-        # panel row and the page title both measure ``settled_at - start_time``,
-        # which for a parked job is how long it waited, printed in the column
-        # where every other row's number is time a child spent working. So the
-        # fact moves to the carrier the settled-row paths already read, before
-        # the flag that carried it is dropped. Only a parked job can be stamped
-        # (a running one may be mid-``_run_job`` and owns this field), and only
-        # when nothing else claimed it.
-        if job.queued and job.result_text is None:
+        # Cancelling also erases the record that the job never ran, and every
+        # surface then presents its WAITING time as work time: the panel row and
+        # the page title both measure ``settled_at - start_time``, which for a
+        # job that never began is how long it sat, printed in the column where
+        # every other row's number is time a child spent working. So the fact
+        # moves to the carrier the settled-row paths already read.
+        #
+        # Keyed on ``started_at``, NOT on ``queued``. ``queued`` means "parked
+        # at the capacity gate", which is only one of three ways a job reaches
+        # here without its runner ever being entered: a job admitted with
+        # ``queued=False`` is merely SCHEDULED (``register`` calls
+        # ``ensure_future``, which does not enter the coroutine), and a job
+        # promoted by ``start_queued`` has ``queued`` cleared before its runner
+        # runs. Both did no work, and the first is the state this fix was
+        # written for — the ledger that motivated it recorded
+        # ``at_capacity: False`` with nothing parked, so keying on ``queued``
+        # would have stamped none of the rows in that incident.
+        #
+        # A genuinely running job is left alone for a different reason: it may
+        # be mid-``_run_job`` and owns ``result_text``. ``started_at is None``
+        # excludes it by construction.
+        if job.started_at is None and job.result_text is None:
             job.result_text = CANCELLED_BEFORE_START
         job.queued = False
         self._queued_runners.pop(job_id, None)
@@ -342,6 +363,11 @@ class AsyncJobManager:
         return report
 
     async def _run_job(self, job: AsyncJob, coro: Awaitable[str | None]) -> None:
+        # FIRST statement, before any await: this is the fact "the runner
+        # actually began", and everything that asks whether a job did work
+        # reads it. Stamping it later would leave a window where the coroutine
+        # is running and the row still says it never started.
+        job.started_at = time.time()
         try:
             result = await coro
             if job.status == "cancelled":

--- a/local_operator/tools/builtin.py
+++ b/local_operator/tools/builtin.py
@@ -4165,7 +4165,7 @@ async def execute_jobs(
         # was fixed to stop printing. Both branches are nine cells, so the
         # grid holds either way.
         age = f"{max(now - reference, 0.0):8.1f}s" if reference else f"{'unknown':>9}"
-        lines.append(f"{job.id}  {job.status:<9}  {age} {sense:<3}  {job.label}")
+        lines.append(f"{job.id}  {job.status:<9}  {age} {sense:<4}  {job.label}")
     return _text(
         tool_call_id,
         "jobs",

--- a/local_operator/tools/builtin.py
+++ b/local_operator/tools/builtin.py
@@ -4137,10 +4137,18 @@ async def execute_jobs(
         # duck-typed row without one. The guard covers ONLY that attribute:
         # ``id``/``status``/``settled_at``/``label`` are read unguarded on the
         # same row, so a row missing any of those still raises.
-        if job.status != "running" and job.settled_at:
-            reference, sense = job.settled_at, "ago"
-        else:
-            reference, sense = getattr(job, "start_time", None), "up"
+        # The SENSE follows the status, never the clock. Sharing one test let
+        # a settled row with no ``settled_at`` print ``up`` beside a
+        # ``completed`` or ``cancelled`` — a contradiction a reader cannot
+        # reconcile, reachable through the real manager in the window inside
+        # ``cancel()``'s await where the status is set and the settle stamp is
+        # not yet. A settled row with no clock says ``old``: settled, and when
+        # is not known.
+        running = job.status == "running"
+        reference = (
+            job.settled_at if not running and job.settled_at else getattr(job, "start_time", None)
+        )
+        sense = "up" if running else ("ago" if job.settled_at else "old")
         # A row with no clock says so. Printing 0.0s made it byte-identical to
         # a job launched this instant — the exact unreadable number this tool
         # was fixed to stop printing. Both branches are nine cells, so the

--- a/local_operator/tools/builtin.py
+++ b/local_operator/tools/builtin.py
@@ -4120,16 +4120,33 @@ async def execute_jobs(
         # job, whatever its real age — the one number this tool exists to
         # report, and the reading a caller uses to decide whether a subagent is
         # progressing or wedged. A six-minute child and one launched a second
-        # ago were indistinguishable. ``start_time`` is the age's only source;
-        # it is guarded because a replayed or embedder-supplied row may carry
-        # none, and a missing clock is worth 0.0s rather than a traceback.
-        reference = (
-            job.settled_at
-            if job.status != "running" and job.settled_at
-            else getattr(job, "start_time", None)
-        )
-        elapsed = max(now - reference, 0.0) if reference else 0.0
-        lines.append(f"{job.id}  {job.status:<9}  {elapsed:6.1f}s  {job.label}")
+        # ago were indistinguishable.
+        #
+        # Two quantities in one column, so each row says WHICH with a sense
+        # word: ``up`` is "has been running this long", ``ago`` is "settled
+        # this long ago". Without it the two readings are identical in shape
+        # and a reader comparing a settled row against the subagent panel
+        # (which reports the job's own duration) gets two numbers and no way
+        # to reconcile them.
+        #
+        # Eight cells, not six: a running bash job in a long session reaches
+        # 2h46m40s, at which point ``6.1f`` overflows its field and shears the
+        # label column one cell for that row alone. Eight covers 11.5 days.
+        # ``start_time`` is guarded because ``JobManagerProtocol.list()`` is
+        # typed ``list[Any]``, so a third-party embedder may hand this loop a
+        # duck-typed row without one. The guard covers ONLY that attribute:
+        # ``id``/``status``/``settled_at``/``label`` are read unguarded on the
+        # same row, so a row missing any of those still raises.
+        if job.status != "running" and job.settled_at:
+            reference, sense = job.settled_at, "ago"
+        else:
+            reference, sense = getattr(job, "start_time", None), "up"
+        # A row with no clock says so. Printing 0.0s made it byte-identical to
+        # a job launched this instant — the exact unreadable number this tool
+        # was fixed to stop printing. Both branches are nine cells, so the
+        # grid holds either way.
+        age = f"{max(now - reference, 0.0):8.1f}s" if reference else f"{'unknown':>9}"
+        lines.append(f"{job.id}  {job.status:<9}  {age} {sense:<3}  {job.label}")
     return _text(
         tool_call_id,
         "jobs",
@@ -4146,7 +4163,8 @@ def build_jobs_tool(context: ToolContext) -> AgentTool | None:
         label="List jobs",
         description=(
             "List running and recently-settled background jobs (task/bash) "
-            "with their id, status and elapsed time."
+            "with their id, status and age — 'up' is how long a running job "
+            "has been going, 'ago' is how long since a settled one finished."
         ),
         parameters=JobsParams.model_json_schema(),
         approval_tier="read",

--- a/local_operator/tools/builtin.py
+++ b/local_operator/tools/builtin.py
@@ -4148,7 +4148,18 @@ async def execute_jobs(
         reference = (
             job.settled_at if not running and job.settled_at else getattr(job, "start_time", None)
         )
-        sense = "up" if running else ("ago" if job.settled_at else "old")
+        # A PARKED job is ``running`` with ``queued=True`` and a runner that
+        # has never been entered, so ``up`` would present its wait as uptime —
+        # the same misreport this PR was filed to stop, on the third surface.
+        # ``waiting`` names what the number is: time spent at the gate. The
+        # check is guarded like ``start_time`` because this row may be
+        # duck-typed by an embedder.
+        if running and getattr(job, "queued", False):
+            sense = "wait"
+        elif running:
+            sense = "up"
+        else:
+            sense = "ago" if job.settled_at else "old"
         # A row with no clock says so. Printing 0.0s made it byte-identical to
         # a job launched this instant — the exact unreadable number this tool
         # was fixed to stop printing. Both branches are nine cells, so the
@@ -4172,7 +4183,9 @@ def build_jobs_tool(context: ToolContext) -> AgentTool | None:
         description=(
             "List running and recently-settled background jobs (task/bash) "
             "with their id, status and age — 'up' is how long a running job "
-            "has been going, 'ago' is how long since a settled one finished."
+            "has been going, 'wait' is how long a parked one has been waiting "
+            "for a slot, 'ago' is how long since a settled one finished, and "
+            "'old' is a settled job whose finish time was not recorded."
         ),
         parameters=JobsParams.model_json_schema(),
         approval_tier="read",

--- a/local_operator/tools/builtin.py
+++ b/local_operator/tools/builtin.py
@@ -4115,8 +4115,21 @@ async def execute_jobs(
     for job in rows:
         # A settled job is reported by when it SETTLED (the useful fact: "it
         # finished N seconds ago"); a running one by how long it has been going.
-        elapsed = job.settled_at if job.status != "running" and job.settled_at else now
-        lines.append(f"{job.id}  {job.status:<9}  {now - elapsed:6.1f}s  {job.label}")
+        #
+        # The running case read ``now - now`` and printed 0.0s for EVERY live
+        # job, whatever its real age — the one number this tool exists to
+        # report, and the reading a caller uses to decide whether a subagent is
+        # progressing or wedged. A six-minute child and one launched a second
+        # ago were indistinguishable. ``start_time`` is the age's only source;
+        # it is guarded because a replayed or embedder-supplied row may carry
+        # none, and a missing clock is worth 0.0s rather than a traceback.
+        reference = (
+            job.settled_at
+            if job.status != "running" and job.settled_at
+            else getattr(job, "start_time", None)
+        )
+        elapsed = max(now - reference, 0.0) if reference else 0.0
+        lines.append(f"{job.id}  {job.status:<9}  {elapsed:6.1f}s  {job.label}")
     return _text(
         tool_call_id,
         "jobs",

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -3121,6 +3121,12 @@ class OperatorApp(App[None]):
             status=str(getattr(job, "status", "") or "gone") if job is not None else "gone",
             queued=bool(getattr(job, "queued", False)),
             elapsed=job_elapsed(job) if job is not None else "0s",
+            # The settled outcome, for the one fact the page's own fields
+            # cannot carry: a job cancelled while still PARKED never ran, so
+            # its `elapsed` is parked time, and the title says so instead of
+            # pairing the bare word `cancelled` with a duration that reads as
+            # a run (`harness/jobs.CANCELLED_BEFORE_START`).
+            outcome=str(getattr(job, "result_text", "") or ""),
             # The instruction the parent delegated. Recorded on the job at
             # REGISTRATION (`AsyncJob.prompt`), which is the only place it
             # survives: `Session.prompt` feeds the user message straight into

--- a/local_operator/tui/widgets/subagent_panel.py
+++ b/local_operator/tui/widgets/subagent_panel.py
@@ -317,6 +317,15 @@ def _read_row(job: Any, *, fallback_id: str, current: bool) -> RowFacts:
         activity = " ".join(
             strip_control_sequences(str(getattr(job, "result_text", "") or "")).split()
         )
+        if not activity and status == "cancelled":
+            # ``cancelled`` was the only state that painted no word: a job
+            # cancelled mid-run records no ``result_text``, so the row's whole
+            # state rested on a 1-cell ``⊘`` while the page it opens prints
+            # ``⊘ cancelled`` and the sibling ``queued`` branch already spells
+            # itself. Cancelled-while-PARKED does not reach here empty — the
+            # manager stamps ``CANCELLED_BEFORE_START`` on it, which is the
+            # more specific sentence and wins on its own.
+            activity = status_glyph(status)[1]
     if current and not running:
         # The page IS this row's detail, three rows above it. Repeating a
         # SETTLED outcome here printed a failed child's error string twice in
@@ -412,26 +421,34 @@ def _row_rung(facts: RowFacts, stats: JobStats, width: int, column: int, clock: 
 
 #: Everything on a row that is not the label, the glyph, the numbers or the
 #: activity: ``• `` + the two spaces after the label + the space after the
-#: glyph. The elapsed reading and the GLYPH are added by the caller, being the
-#: two chrome fields whose width varies — ``⏳`` is two cells where every other
-#: state mark is one, so a constant here measured a queued row one cell
-#: narrower than it drew and ``compose_row``'s own truncate then ate the last
-#: cell of a dollar figure. A money value clipped mid-digit is a worse answer
-#: than the ``$0.0000`` this module refuses to print.
+#: glyph. The elapsed reading and the GLYPH COLUMN are added by the caller,
+#: being the two chrome fields whose width varies with the row.
 _CHROME_CELLS = 2 + 2 + 1
+
+#: Cells the state mark is padded out to, so the clock, the numbers and the
+#: activity start in the same column on every row. ``⏳`` (U+23F3) is
+#: ``East_Asian_Width=W`` and draws two cells where every other mark draws
+#: one, so an unpadded queued row pushed everything after it one cell right —
+#: its clock alone out of the column the other rows right-align into.
+_GLYPH_COL = 2
 
 
 def _glyph_cells(facts: RowFacts) -> int:
-    """Cells the state mark occupies — measured, never assumed.
+    """Cells the state mark's COLUMN occupies — measured, never assumed.
 
     A running row's spinner frame and ``✓``/``✗``/``⊘`` are one cell each and
     ``⏳`` is two, and the set is shared with the full-page view's title, so
     this widget does not get to pick. Any frame will do for the measurement:
     the spinner glyphs are the same width as each other by construction (the
     band's arithmetic already depends on that).
+
+    The answer is the padded column rather than the raw glyph, because that is
+    what :func:`compose_row` spends — a budget measured one cell short of what
+    the row draws is what lets ``compose_row``'s own truncate eat the last
+    cell of a dollar figure.
     """
     glyph, _word, _token = status_glyph(facts.status, queued=facts.queued)
-    return cell_len(glyph)
+    return max(_GLYPH_COL, cell_len(glyph))
 
 
 def _lay_out(
@@ -590,6 +607,12 @@ def compose_row(
     # different states on two surfaces. A running row's glyph advances on the
     # panel's timer, so a stopped timer means a frozen row — visible at once.
     row.append(glyph, style=Style(color=theme_mod.semantic_color(token)))
+    # Padded to one shared column so what follows starts in the same cell on
+    # every row. Without it a `⏳` row — two cells where every other mark is
+    # one — carried its clock, numbers and activity one cell right of the
+    # column the rest of the list right-aligns into, which is visible as a
+    # single stepped row in a list whose whole job is comparison.
+    row.append(" " * max(0, _GLYPH_COL - cell_len(glyph)), style=dim)
     # RIGHT-aligned into the panel's clock column, which is the one field D2's
     # label column did not settle: `22s` is two cells narrower than `7m49s`,
     # and that row's context and cost then sat two cells left of everybody

--- a/local_operator/tui/widgets/subagent_view.py
+++ b/local_operator/tui/widgets/subagent_view.py
@@ -61,6 +61,7 @@ from textual.message import Message
 from textual.widgets import Static
 
 from local_operator.ansi import strip_control_sequences
+from local_operator.harness.jobs import CANCELLED_BEFORE_START
 from local_operator.tui import theme as theme_mod
 from local_operator.tui.widgets import tool_card
 from local_operator.tui.widgets.assistant import AssistantBlock
@@ -778,6 +779,11 @@ class SubagentView(Vertical):
         self._status = "running"
         self._queued = False
         self._elapsed = "0s"
+        #: The job's settled ``result_text``, verbatim. Read for ONE fact the
+        #: page cannot otherwise know: a job cancelled while still parked never
+        #: ran, so its duration is parked time and the bare word ``cancelled``
+        #: beside it reads as a run that burned that long.
+        self._outcome = ""
 
     @property
     def job_id(self) -> str:
@@ -833,6 +839,7 @@ class SubagentView(Vertical):
         status: str,
         queued: bool,
         elapsed: str,
+        outcome: str = "",
         events: Sequence[Any],
         prompt: str = "",
         progress: str = "",
@@ -860,6 +867,7 @@ class SubagentView(Vertical):
         self._status = status
         self._queued = queued
         self._elapsed = elapsed
+        self._outcome = strip_control_sequences(outcome or "").strip()
         self._running = status == "running" and not queued
         gone = status == "gone"
 
@@ -1078,6 +1086,16 @@ class SubagentView(Vertical):
             return row
 
         glyph, word, token = status_glyph(self._status, queued=self._queued, spinner_glyph=spinner)
+        if self._status == "cancelled" and self._outcome == CANCELLED_BEFORE_START:
+            # `⊘ cancelled · 1m36s` beside rows reading `⣷ running · 7m53s`
+            # presents a PARKED wait as a run: an operator concludes the child
+            # burned a minute and a half of tokens before they killed it, when
+            # it burned none. The duration is right — it is the age of the job
+            # — so what the title owes is the sense of it, and the manager
+            # stamps exactly that phrase on the row for both surfaces to spend
+            # (`harness/jobs.py`). Matched rather than sniffed: `cancel` is the
+            # only writer of `result_text` on a cancelled job.
+            word = CANCELLED_BEFORE_START
         glyph_style = Style(color=theme_mod.semantic_color(token))
         # Most disposable first. The glyph is never dropped: it is the one
         # field that survives a colourless frame and the only one that still

--- a/local_operator/tui/widgets/subagent_view.py
+++ b/local_operator/tui/widgets/subagent_view.py
@@ -1095,32 +1095,52 @@ class SubagentView(Vertical):
             # stamps exactly that phrase on the row for both surfaces to spend
             # (`harness/jobs.py`). Matched rather than sniffed: `cancel` is the
             # only writer of `result_text` on a cancelled job.
-            word = CANCELLED_BEFORE_START
+            # Two rungs, not one: the phrase is 27 cells where the bare word
+            # is 9, and a single-rung ladder dropped the STATE entirely at
+            # widths where the bare word still fit — the page then showed a
+            # glyph and a duration with no word on screen. The ladder below
+            # tries every rung with the phrase first, then every rung with the
+            # bare word, so the state is the last thing to go after it has
+            # already been shortened once.
+            word_choices = [CANCELLED_BEFORE_START, "cancelled"]
+        else:
+            word_choices = [word]
         glyph_style = Style(color=theme_mod.semantic_color(token))
         # Most disposable first. The glyph is never dropped: it is the one
         # field that survives a colourless frame and the only one that still
         # answers "is this running" at a width where nothing else fits.
-        tail: list[tuple[str, Style]] = []
-        if tools:
-            tail.append((f" · {tools} tool{'' if tools == 1 else 's'}", dim))
-        tail.append((f" · {self._elapsed}", dim))
-        tail.append((f" {word}", dim))
-        for dropped in range(len(tail) + 1):
-            fields = tail[dropped:]
-            # The label gets whatever the fields do not want, floored at eight
-            # cells so it never vanishes entirely — it is the page's subject.
-            spend = sum(cell_len(text) for text, _ in fields) + 13
-            label = truncate_cells(self._label, max(8, width - spend))
-            row = Text(no_wrap=True, overflow="ellipsis")
-            row.append("Subagent", style=dim)
-            row.append(" · ", style=faint)
-            row.append(label, style=fg)
-            row.append("  ", style=dim)
-            row.append(glyph, style=glyph_style)
-            for text, style in reversed(fields):
-                row.append(text, style=style)
-            if cell_len(row.plain) <= width:
-                return row
+        # Most disposable first, and the state word is shortened before it is
+        # dropped, never the reverse: dropping the word inside one pass would
+        # end the ladder before the shorter variant was ever tried — the exact
+        # widths between the phrase and the bare word then showed a glyph and
+        # a duration with no state on screen. So each pass keeps at least the
+        # word field (``len(tail)`` rungs, not ``len(tail) + 1``), every word
+        # variant is tried in turn, and the wordless rung comes last.
+        for keep_word in (True, False):
+            for word_choice in word_choices if keep_word else [word_choices[-1]]:
+                tail: list[tuple[str, Style]] = []
+                if tools:
+                    tail.append((f" · {tools} tool{'' if tools == 1 else 's'}", dim))
+                tail.append((f" · {self._elapsed}", dim))
+                tail.append((f" {word_choice}", dim))
+                rungs = len(tail) if keep_word else len(tail) + 1
+                for dropped in range(rungs):
+                    fields = tail[dropped:]
+                    # The label gets whatever the fields do not want, floored
+                    # at eight cells so it never vanishes entirely — it is the
+                    # page's subject.
+                    spend = sum(cell_len(text) for text, _ in fields) + 13
+                    label = truncate_cells(self._label, max(8, width - spend))
+                    row = Text(no_wrap=True, overflow="ellipsis")
+                    row.append("Subagent", style=dim)
+                    row.append(" · ", style=faint)
+                    row.append(label, style=fg)
+                    row.append("  ", style=dim)
+                    row.append(glyph, style=glyph_style)
+                    for text, style in reversed(fields):
+                        row.append(text, style=style)
+                    if cell_len(row.plain) <= width:
+                        return row
         # Narrower than the breadcrumb itself: keep the two things that
         # identify the page, and let the label take the ellipsis.
         row = Text(no_wrap=True, overflow="ellipsis")

--- a/local_operator/tui/widgets/subagent_view.py
+++ b/local_operator/tui/widgets/subagent_view.py
@@ -1128,8 +1128,13 @@ class SubagentView(Vertical):
                     fields = tail[dropped:]
                     # The label gets whatever the fields do not want, floored
                     # at eight cells so it never vanishes entirely — it is the
-                    # page's subject.
-                    spend = sum(cell_len(text) for text, _ in fields) + 13
+                    # page's subject. The fixed chrome is the breadcrumb AND
+                    # the glyph: counting only the 13 breadcrumb cells left
+                    # the budget one short, so a rung whose label consumed it
+                    # exactly was rejected and the ladder fell through —
+                    # non-monotone in width, with the state word visible at
+                    # 35 cells and gone again at 36-40 where it still fit.
+                    spend = sum(cell_len(text) for text, _ in fields) + 13 + cell_len(glyph)
                     label = truncate_cells(self._label, max(8, width - spend))
                     row = Text(no_wrap=True, overflow="ellipsis")
                     row.append("Subagent", style=dim)

--- a/tests/unit/harness/test_comms.py
+++ b/tests/unit/harness/test_comms.py
@@ -62,9 +62,14 @@ async def wait_for(predicate, timeout: float = 10.0) -> None:
 
 
 class FakeJob:
-    def __init__(self, job_id: str, status: str = "running") -> None:
+    def __init__(self, job_id: str, status: str = "running", queued: bool = False) -> None:
         self.id = job_id
         self.status = status
+        #: Mirrors ``AsyncJob.queued``: admitted to the ledger but holding no
+        #: execution slot. Distinct from "running but still building its
+        #: session", which is what a job carries between registration and
+        #: ``attach``.
+        self.queued = queued
 
 
 class FakeJobs:
@@ -236,6 +241,37 @@ def test_send_to_an_unstarted_child_buffers_until_it_attaches():
     comms.attach("job-1", child, tmp_dir())
     [aside] = child.materialize()
     assert "skip the migration" in hub_aside(aside).details["text"]
+
+
+@pytest.mark.asyncio
+async def test_a_starting_child_is_not_reported_as_parked_behind_the_gate():
+    """Two states reach the no-live-child branch and an operator acts on them
+    differently.
+
+    A PARKED job is waiting for a slot and may not start for minutes. A job
+    that is running but has not reached ``attach`` yet is mid-construction —
+    its session is being built — and takes the message moments later. Both
+    used to report the capacity gate, which is a false statement about an
+    admitted job: it says "nothing is happening" about a child that is
+    already spending tokens, so a healthy run reads as stuck and gets
+    cancelled instead of waited out.
+    """
+    jobs = FakeJobs()
+    comms = SubagentComms(FakeParent(jobs))  # type: ignore[arg-type]
+
+    jobs.add("job-starting")  # running, not queued, no child attached yet
+    comms.record_launch("job-starting", "reviewer")
+    starting = await comms.ask("job-starting", "status?", timeout_ms=50)
+
+    jobs.add("job-parked").queued = True
+    comms.record_launch("job-parked", "designer")
+    parked = await comms.ask("job-parked", "status?", timeout_ms=50)
+
+    assert "still starting up" in (starting.error or "")
+    assert "capacity gate" not in (starting.error or "")
+    # The genuinely parked job keeps the message that names its real cause.
+    assert "capacity gate" in (parked.error or "")
+    assert starting.error != parked.error
 
 
 def test_send_to_an_unknown_job_fails_without_raising():

--- a/tests/unit/harness/test_comms.py
+++ b/tests/unit/harness/test_comms.py
@@ -248,13 +248,19 @@ async def test_a_starting_child_is_not_reported_as_parked_behind_the_gate():
     """Two states reach the no-live-child branch and an operator acts on them
     differently.
 
-    A PARKED job is waiting for a slot and may not start for minutes. A job
-    that is running but has not reached ``attach`` yet is mid-construction —
-    its session is being built — and takes the message moments later. Both
-    used to report the capacity gate, which is a false statement about an
-    admitted job: it says "nothing is happening" about a child that is
-    already spending tokens, so a healthy run reads as stuck and gets
-    cancelled instead of waited out.
+    A PARKED job is waiting for a slot and may not start for minutes. An
+    ADMITTED job is waiting only on this event loop — ``register`` schedules
+    the runner without entering it, so one yield starts it. Both used to
+    report the capacity gate, which is a false statement about an admitted
+    job: it says "nothing is happening" about a child that is already
+    spending tokens, so a healthy run reads as stuck and gets cancelled
+    instead of waited out.
+
+    Neither string may claim a session is being BUILT (in the state this
+    branch was written for the runner has not been entered at all), neither
+    may stutter the label the render site already prints, and both owe the
+    caller a next step — the parked one most of all, because that is the
+    state where a caller most needs to be told to stop waiting.
     """
     jobs = FakeJobs()
     comms = SubagentComms(FakeParent(jobs))  # type: ignore[arg-type]
@@ -267,11 +273,19 @@ async def test_a_starting_child_is_not_reported_as_parked_behind_the_gate():
     comms.record_launch("job-parked", "designer")
     parked = await comms.ask("job-parked", "status?", timeout_ms=50)
 
-    assert "still starting up" in (starting.error or "")
+    assert "scheduled" in (starting.error or "")
     assert "capacity gate" not in (starting.error or "")
-    # The genuinely parked job keeps the message that names its real cause.
+    assert "being built" not in (starting.error or "")
+    # The genuinely parked job keeps the message that names its real cause,
+    # and now carries the advice its sibling always had.
     assert "capacity gate" in (parked.error or "")
+    assert "do not wait on it" in (parked.error or "")
     assert starting.error != parked.error
+    # The only render site prefixes `{label} ({job_id}): `, and the card
+    # truncates the reason as content — a stuttered label spends the cells
+    # that would otherwise have carried the state word.
+    assert "reviewer" not in (starting.error or "")
+    assert "designer" not in (parked.error or "")
 
 
 def test_send_to_an_unknown_job_fails_without_raising():

--- a/tests/unit/harness/test_jobs.py
+++ b/tests/unit/harness/test_jobs.py
@@ -104,6 +104,43 @@ async def test_start_queued_promotes_and_runs():
 
 
 @pytest.mark.asyncio
+async def test_cancelling_a_parked_job_clears_its_queued_flag_and_runner():
+    """``queued`` means "waiting for a slot", and a cancelled job waits for
+    nothing.
+
+    Left set, every reader that branches on the flag reported the job as
+    pending: the subagent panel painted ``⏳ queued`` on a row whose status was
+    ``cancelled``, which reads as work about to start rather than work that
+    was stopped. The parked runner is dropped with it — ``start_queued``
+    refuses a non-running job, so the entry could never run again and only
+    pinned its closure (prompt, parent session, model spec) for the life of
+    the manager.
+    """
+    manager = AsyncJobManager(max_running=1)
+    gate = asyncio.Event()
+
+    async def blocked(job_id, signal, report_progress):
+        await gate.wait()
+        return "ok"
+
+    running = manager.register("task", "running", blocked)
+    parked = manager.register("task", "parked", blocked, queued=manager.at_capacity())
+    assert require_job(manager, parked).queued is True
+
+    assert await manager.cancel(parked) is True
+    job = require_job(manager, parked)
+    assert job.status == "cancelled"
+    assert job.queued is False, "a cancelled job is not waiting for a slot"
+    # The runner is gone, so nothing can promote it and nothing pins its closure.
+    assert parked not in manager._queued_runners
+    assert manager.queued_ids() == []
+
+    gate.set()
+    await wait_for(lambda: require_job(manager, running).status == "completed")
+    await manager.dispose()
+
+
+@pytest.mark.asyncio
 async def test_cancel_aborts_signal_and_sets_status():
     manager = AsyncJobManager()
     gate = asyncio.Event()

--- a/tests/unit/harness/test_jobs.py
+++ b/tests/unit/harness/test_jobs.py
@@ -146,16 +146,21 @@ async def test_cancelling_a_parked_job_clears_its_queued_flag_and_runner():
 
 
 @pytest.mark.asyncio
-async def test_cancelling_a_parked_job_records_that_it_never_ran():
-    """Clearing ``queued`` erases the only record that the job never started,
-    and every surface then presents its PARKED time as work time.
+async def test_cancelling_a_job_that_never_ran_records_that_it_never_ran():
+    """Cancelling erases the record that the job never started, and every
+    surface then presents its WAITING time as work time.
 
     Both the panel row and the full-page view measure ``settled_at -
-    start_time``, which for a job cancelled at the gate is how long it waited
-    — printed in the column where every other row's number is time a child
-    spent working. A child that ran 0 s and spent $0 rendered ``⊘ 1m36s`` with
-    no word beside it, which reads as a run somebody killed a minute and a
-    half in. So the fact moves to the carrier the settled paths already read.
+    start_time``, which for a job that never began is how long it sat — printed
+    in the column where every other row's number is time a child spent working.
+    A child that ran 0 s and spent $0 rendered ``⊘ 1m36s`` with no word beside
+    it, which reads as a run somebody killed a minute and a half in.
+
+    Three states reach ``cancel`` without the runner ever being entered, and
+    ``queued`` only identifies one of them. The ADMITTED-but-not-yet-entered
+    job is the state that motivated this fix at all: the observed ledger had
+    ``at_capacity: False`` with nothing parked, so a stamp keyed on ``queued``
+    would have labelled none of those rows.
     """
     manager = AsyncJobManager(max_running=1)
     gate = asyncio.Event()
@@ -170,16 +175,46 @@ async def test_cancelling_a_parked_job_records_that_it_never_ran():
     # `running` a job that genuinely started — and what stops its coroutine
     # being abandoned un-awaited when `cancel` kills the task.
     await asyncio.sleep(0)
+    assert require_job(manager, running).started_at is not None
+    assert require_job(manager, parked).started_at is None
 
     assert await manager.cancel(parked) is True
     assert require_job(manager, parked).result_text == CANCELLED_BEFORE_START
 
-    # A job cancelled while genuinely RUNNING owns this field — the runner may
-    # be mid-flight in it — so only the parked case is stamped.
+    # A job whose runner DID begin owns this field — it may be mid-flight in it
+    # — so a genuinely running job is never stamped.
     assert await manager.cancel(running) is True
     assert require_job(manager, running).result_text is None
 
     gate.set()
+    await manager.dispose()
+
+
+@pytest.mark.asyncio
+async def test_an_admitted_job_cancelled_before_it_ran_is_not_called_a_run():
+    """The state this fix exists for, and the one ``queued`` does not identify.
+
+    ``register`` calls ``ensure_future``, which SCHEDULES the runner without
+    entering it, so between registration and the parent's next await the job is
+    admitted, counted against capacity, ``queued=False``, and has not executed a
+    line. Cancelled there it did no work, and a stamp keyed on ``queued`` left
+    it reading ``⊘ cancelled · 1m36s`` — the exact failure the parked case was
+    fixed for, on the row the original incident actually produced.
+    """
+    manager = AsyncJobManager(max_running=15)
+
+    async def never_reached(job_id, signal, report_progress):
+        return "ok"
+
+    admitted = manager.register("task", "admitted", never_reached)
+    job = require_job(manager, admitted)
+    # No yield: the runner is scheduled and has not been entered.
+    assert job.queued is False, "premise: this job is admitted, not parked"
+    assert job.started_at is None, "premise: its runner has not begun"
+
+    assert await manager.cancel(admitted) is True
+    assert job.result_text == CANCELLED_BEFORE_START
+
     await manager.dispose()
 
 

--- a/tests/unit/harness/test_jobs.py
+++ b/tests/unit/harness/test_jobs.py
@@ -8,6 +8,7 @@ import asyncio
 import pytest
 
 from local_operator.harness.jobs import (
+    CANCELLED_BEFORE_START,
     DEFAULT_MAX_RUNNING_JOBS,
     AsyncJob,
     AsyncJobManager,
@@ -133,10 +134,52 @@ async def test_cancelling_a_parked_job_clears_its_queued_flag_and_runner():
     assert job.queued is False, "a cancelled job is not waiting for a slot"
     # The runner is gone, so nothing can promote it and nothing pins its closure.
     assert parked not in manager._queued_runners
-    assert manager.queued_ids() == []
+    # The surviving running job still holds the manager's only slot: clearing
+    # a cancelled row's ``queued`` must not free or double-count one.
+    # (``queued_ids() == []`` was asserted here and could not fail — it filters
+    # on ``status == "running"``, which a cancelled row never is.)
+    assert manager.at_capacity() is True
 
     gate.set()
     await wait_for(lambda: require_job(manager, running).status == "completed")
+    await manager.dispose()
+
+
+@pytest.mark.asyncio
+async def test_cancelling_a_parked_job_records_that_it_never_ran():
+    """Clearing ``queued`` erases the only record that the job never started,
+    and every surface then presents its PARKED time as work time.
+
+    Both the panel row and the full-page view measure ``settled_at -
+    start_time``, which for a job cancelled at the gate is how long it waited
+    — printed in the column where every other row's number is time a child
+    spent working. A child that ran 0 s and spent $0 rendered ``⊘ 1m36s`` with
+    no word beside it, which reads as a run somebody killed a minute and a
+    half in. So the fact moves to the carrier the settled paths already read.
+    """
+    manager = AsyncJobManager(max_running=1)
+    gate = asyncio.Event()
+
+    async def blocked(job_id, signal, report_progress):
+        await gate.wait()
+        return "ok"
+
+    running = manager.register("task", "running", blocked)
+    parked = manager.register("task", "parked", blocked, queued=manager.at_capacity())
+    # `register` only SCHEDULES the runner, so the yield is what makes
+    # `running` a job that genuinely started — and what stops its coroutine
+    # being abandoned un-awaited when `cancel` kills the task.
+    await asyncio.sleep(0)
+
+    assert await manager.cancel(parked) is True
+    assert require_job(manager, parked).result_text == CANCELLED_BEFORE_START
+
+    # A job cancelled while genuinely RUNNING owns this field — the runner may
+    # be mid-flight in it — so only the parked case is stamped.
+    assert await manager.cancel(running) is True
+    assert require_job(manager, running).result_text is None
+
+    gate.set()
     await manager.dispose()
 
 

--- a/tests/unit/tools/test_task_wait_jobs.py
+++ b/tests/unit/tools/test_task_wait_jobs.py
@@ -206,6 +206,11 @@ async def test_jobs_reports_how_long_a_running_job_has_been_going(tmp_path):
     assert job is not None
     job.start_time -= 373.0  # a child that has been running 6m13s
 
+    # Let the runner actually start before dispose cancels it; registration
+    # only SCHEDULES it (``ensure_future``), so without a yield its coroutine
+    # is never awaited and the test leaves a RuntimeWarning behind.
+    await asyncio.sleep(0)
+
     context = ToolContext(cwd=str(tmp_path), session_id="s", jobs=manager)
     tools = _tools(context)
     result = await _call(tools, "jobs", {}, context)
@@ -213,7 +218,108 @@ async def test_jobs_reports_how_long_a_running_job_has_been_going(tmp_path):
     row = next(line for line in result.text.splitlines() if running_id in line)
     seconds = float(row.split()[2].rstrip("s"))
     assert seconds >= 373.0, f"a long-running job reported {seconds}s: {row!r}"
+    # The number is useless without which quantity it is: this column also
+    # carries "settled N seconds ago" for a settled row, in the same shape.
+    assert row.split()[3] == "up", f"a running job's age is not marked as uptime: {row!r}"
 
+    await manager.dispose()
+
+
+@pytest.mark.asyncio
+async def test_jobs_says_which_quantity_each_age_is(tmp_path):
+    """One column, two facts: a running row's age is uptime, a settled row's
+    is time since it settled.
+
+    Adjacent rows were identical in presentation — ``running  373.0s`` and
+    ``failed  287.5s`` — while the first counts up from launch and the second
+    counts up from the end. A reader comparing a settled row against the
+    subagent panel (which reports the job's own DURATION) got two numbers with
+    no way to reconcile them.
+    """
+    manager = AsyncJobManager()
+    running_id = manager.register("task", "alpha", _slow_runner)
+    settled_id = manager.register("task", "beta", _quick_runner)
+
+    def _settled() -> bool:
+        job = manager.get(settled_id)
+        return job is not None and job.status != "running"
+
+    await wait_for(_settled)
+    settled = manager.get(settled_id)
+    assert settled is not None and settled.settled_at is not None
+    settled.settled_at -= 287.5  # finished nearly five minutes ago
+
+    context = ToolContext(cwd=str(tmp_path), session_id="s", jobs=manager)
+    result = await _call(_tools(context), "jobs", {}, context)
+    rows = {line.split()[0]: line for line in result.text.splitlines()}
+
+    assert rows[running_id].split()[3] == "up"
+    assert rows[settled_id].split()[3] == "ago"
+    assert float(rows[settled_id].split()[2].rstrip("s")) >= 287.5
+
+    await manager.dispose()
+
+
+@pytest.mark.asyncio
+async def test_jobs_keeps_its_columns_aligned_at_any_age(tmp_path):
+    """A day-old running job must not shear the grid.
+
+    ``6.1f`` fits through ``9999.9s`` and overflows at 2h46m40s, pushing that
+    row's label one cell right of every other row's and its decimal point out
+    of the column. An overnight ``bash`` watcher reaches that in an ordinary
+    session — retention only sweeps SETTLED rows — and before the age column
+    carried a real number for running jobs it was unreachable.
+    """
+    manager = AsyncJobManager()
+    ages = (0.0, 12.3, 373.0, 3600.0, 86400.0)
+    ids = [manager.register("task", f"job {age}", _slow_runner) for age in ages]
+    await asyncio.sleep(0)
+    for job_id, age in zip(ids, ages):
+        job = manager.get(job_id)
+        assert job is not None
+        job.start_time -= age
+
+    context = ToolContext(cwd=str(tmp_path), session_id="s", jobs=manager)
+    result = await _call(_tools(context), "jobs", {}, context)
+    lines = result.text.splitlines()
+
+    label_columns = {line.index("job ") for line in lines}
+    assert len(label_columns) == 1, f"the label column sheared: {lines!r}"
+    decimals = {line.index(".", 12) for line in lines}
+    assert len(decimals) == 1, f"the decimal point sheared: {lines!r}"
+
+    await manager.dispose()
+
+
+@pytest.mark.asyncio
+async def test_jobs_says_unknown_rather_than_zero_for_a_row_with_no_clock(tmp_path):
+    """``JobManagerProtocol.list()`` is typed ``list[Any]``, so an embedder may
+    hand this tool a row with no ``start_time``.
+
+    Rendering that as ``0.0s`` is byte-identical to a job launched this
+    instant — the exact unreadable reading this column was fixed to stop
+    printing, and worse for being a number a caller will act on.
+    """
+
+    class NoClock:
+        id = "aaaaaaaaaaaa"
+        type = "task"
+        status = "running"
+        settled_at = None
+        label = "embedder row"
+
+    class OneRow(AsyncJobManager):
+        def list(self, *, owner_id: str | None = None) -> list[Any]:
+            return [NoClock()]
+
+    manager = OneRow()
+    context = ToolContext(cwd=str(tmp_path), session_id="s", jobs=manager)
+    result = await _call(_tools(context), "jobs", {}, context)
+
+    row = result.text.splitlines()[0]
+    assert result.is_error is False
+    assert "unknown" in row, f"a row with no clock reported a number: {row!r}"
+    assert "0.0s" not in row
     await manager.dispose()
 
 

--- a/tests/unit/tools/test_task_wait_jobs.py
+++ b/tests/unit/tools/test_task_wait_jobs.py
@@ -261,6 +261,36 @@ async def test_jobs_says_which_quantity_each_age_is(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_jobs_never_says_up_beside_a_settled_status(tmp_path):
+    """The sense follows the STATUS, not the clock.
+
+    Sharing one test let a settled row with no ``settled_at`` print ``up``
+    beside a ``completed`` or ``cancelled`` — a contradiction no reader can
+    reconcile. It is reachable through the real manager, in the window inside
+    ``cancel()``'s await where the status is set and the settle stamp is not
+    yet, so this drives exactly that: a cancelled row with the stamp withheld.
+    """
+    manager = AsyncJobManager()
+    job_id = manager.register("task", "probe", _slow_runner)
+    # Let the runner begin, then cancel; the row is settled the moment cancel
+    # returns, and the settle stamp arrives from the runner's own teardown.
+    await asyncio.sleep(0)
+    await manager.cancel(job_id)
+    job = manager.get(job_id)
+    assert job is not None and job.status == "cancelled"
+    job.settled_at = None  # the window, held open
+
+    context = ToolContext(cwd=str(tmp_path), session_id="s", jobs=manager)
+    result = await _call(_tools(context), "jobs", {}, context)
+    row = next(line for line in result.text.splitlines() if line.startswith(job_id))
+
+    assert "cancelled" in row
+    assert row.split()[3] != "up", row
+
+    await manager.dispose()
+
+
+@pytest.mark.asyncio
 async def test_jobs_keeps_its_columns_aligned_at_any_age(tmp_path):
     """A day-old running job must not shear the grid.
 

--- a/tests/unit/tools/test_task_wait_jobs.py
+++ b/tests/unit/tools/test_task_wait_jobs.py
@@ -291,6 +291,36 @@ async def test_jobs_never_says_up_beside_a_settled_status(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_jobs_says_wait_for_a_job_that_has_not_been_admitted(tmp_path):
+    """A parked job is ``running`` with ``queued=True`` and a runner that has
+    never been entered, so ``up`` presented its wait as uptime — the same
+    misreport this PR was filed to stop, on the third surface."""
+    manager = AsyncJobManager(max_running=1)
+    gate = asyncio.Event()
+
+    async def blocked(job_id, signal, report_progress):
+        await gate.wait()
+        return "ok"
+
+    manager.register("task", "alpha", blocked)
+    parked_id = manager.register("task", "parked", blocked, queued=True)
+    await asyncio.sleep(0)
+    parked = manager.get(parked_id)
+    assert parked is not None and parked.queued and parked.started_at is None
+    parked.start_time -= 215.0
+
+    context = ToolContext(cwd=str(tmp_path), session_id="s", jobs=manager)
+    result = await _call(_tools(context), "jobs", {}, context)
+    row = next(line for line in result.text.splitlines() if line.startswith(parked_id))
+
+    assert "215.0s" in row, row
+    assert row.split()[3] == "wait", row
+
+    gate.set()
+    await manager.dispose()
+
+
+@pytest.mark.asyncio
 async def test_jobs_keeps_its_columns_aligned_at_any_age(tmp_path):
     """A day-old running job must not shear the grid.
 

--- a/tests/unit/tools/test_task_wait_jobs.py
+++ b/tests/unit/tools/test_task_wait_jobs.py
@@ -302,7 +302,7 @@ async def test_jobs_says_wait_for_a_job_that_has_not_been_admitted(tmp_path):
         await gate.wait()
         return "ok"
 
-    manager.register("task", "alpha", blocked)
+    running_id = manager.register("task", "alpha", blocked)
     parked_id = manager.register("task", "parked", blocked, queued=True)
     await asyncio.sleep(0)
     parked = manager.get(parked_id)
@@ -311,10 +311,15 @@ async def test_jobs_says_wait_for_a_job_that_has_not_been_admitted(tmp_path):
 
     context = ToolContext(cwd=str(tmp_path), session_id="s", jobs=manager)
     result = await _call(_tools(context), "jobs", {}, context)
-    row = next(line for line in result.text.splitlines() if line.startswith(parked_id))
+    rows = {line.split()[0]: line for line in result.text.splitlines()}
+    row = rows[parked_id]
 
     assert "215.0s" in row, row
     assert row.split()[3] == "wait", row
+    # ``wait`` is four cells where every other sense is at most three. The
+    # field must budget for the widest vocabulary entry or the one parked row
+    # shears its label one cell right of the entire table.
+    assert row.index("parked") == rows[running_id].index("alpha"), rows
 
     gate.set()
     await manager.dispose()

--- a/tests/unit/tools/test_task_wait_jobs.py
+++ b/tests/unit/tools/test_task_wait_jobs.py
@@ -190,6 +190,34 @@ async def test_jobs_lists_ids_labels_and_statuses(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_jobs_reports_how_long_a_running_job_has_been_going(tmp_path):
+    """The elapsed column read ``now - now`` and printed 0.0s for every live
+    job, whatever its real age.
+
+    That is the one number this tool exists to report: a caller polling
+    ``jobs`` uses it to tell a subagent that is progressing from one that is
+    wedged, and a six-minute child was indistinguishable from one launched a
+    second ago. Asserted against a job whose ``start_time`` is backdated,
+    because a fresh job is genuinely ~0s and cannot tell the two apart.
+    """
+    manager = AsyncJobManager()
+    running_id = manager.register("task", "beta", _slow_runner)
+    job = manager.get(running_id)
+    assert job is not None
+    job.start_time -= 373.0  # a child that has been running 6m13s
+
+    context = ToolContext(cwd=str(tmp_path), session_id="s", jobs=manager)
+    tools = _tools(context)
+    result = await _call(tools, "jobs", {}, context)
+
+    row = next(line for line in result.text.splitlines() if running_id in line)
+    seconds = float(row.split()[2].rstrip("s"))
+    assert seconds >= 373.0, f"a long-running job reported {seconds}s: {row!r}"
+
+    await manager.dispose()
+
+
+@pytest.mark.asyncio
 async def test_jobs_empty_manager(tmp_path):
     manager = AsyncJobManager()
     context = ToolContext(cwd=str(tmp_path), session_id="s", jobs=manager)

--- a/tests/unit/tui/test_band_panels.py
+++ b/tests/unit/tui/test_band_panels.py
@@ -165,6 +165,11 @@ class _Job:
         self.status = status
         self.label = label
         self.start_time = 1_700_000_000.0
+        # Mirrors ``AsyncJob.started_at``: when the runner actually began, or
+        # ``None`` if it never did. Defaulted to ``None`` so a fixture that
+        # does not think about it says "never ran" — the same default the real
+        # model carries, and the discriminator ``cancel()`` stamps on.
+        self.started_at: float | None = None
         self.result_text: str | None = None
         self.error_text: str | None = None
         self.settled_at: float | None = None

--- a/tests/unit/tui/test_subagent_stats.py
+++ b/tests/unit/tui/test_subagent_stats.py
@@ -25,6 +25,7 @@ from rich.cells import cell_len
 from textual.geometry import Size
 from textual.widgets import Static
 
+from local_operator.harness.jobs import CANCELLED_BEFORE_START
 from local_operator.harness.types import Usage
 from local_operator.tui.app import OperatorApp
 from local_operator.tui.widgets.status_line import StatusLine, SubagentBand
@@ -35,6 +36,7 @@ from local_operator.tui.widgets.subagent_panel import (
     SubagentPanel,
     SubagentRow,
     compose_row,
+    job_elapsed,
     job_stats,
     panel_layout,
     row_facts,
@@ -347,6 +349,68 @@ def test_a_row_never_overruns_the_width_it_was_given() -> None:
     for width in range(20, 141):
         for row in _column(jobs, width):
             assert cell_len(row) <= width, f"{width}: {row!r}"
+
+
+def test_every_state_paints_a_word_beside_its_mark() -> None:
+    """``cancelled`` was the only row state carried by a glyph alone.
+
+    A job cancelled mid-run records no ``result_text``, so its row spent its
+    activity column on nothing and the whole state rested on a 1-cell ``⊘`` —
+    in a list where running rows say what they are doing, failed rows say how
+    they failed, and the sibling ``queued`` branch already spells itself. The
+    page the row opens prints ``⊘ cancelled``; the row it opens from did not.
+    """
+    jobs = [
+        Job("j1", "docs sweep", progress="auditing merged MRs"),
+        Job("j2", "queued crawler", queued=True),
+        Job("j3", "flaky test bisect", status="cancelled", settled=True),
+        Job("j4", "pip-audit", status="failed", settled=True, error_text="exited 1"),
+        Job("j5", "changelog", status="completed", settled=True, result_text="wrote 41 entries"),
+    ]
+    rows = _column(jobs, 120)
+    words = [row_facts(job, fallback_id=job.id, current=False).activity for job in jobs]
+    assert all(words), dict(zip([job.label for job in jobs], words))
+    assert "cancelled" in rows[2], rows[2]
+
+
+def test_a_cancelled_row_prints_its_state_once() -> None:
+    """The manager stamps the parked case, so the row must not add a second
+    word beside it — and the running case must not be left silent."""
+    stamped = Job(
+        "j1",
+        "flaky test bisect",
+        status="cancelled",
+        settled=True,
+        result_text=CANCELLED_BEFORE_START,
+    )
+    mid_run = Job("j2", "flaky test bisect", status="cancelled", settled=True)
+    assert _plain(stamped, 120).count("cancelled") == 1
+    assert _plain(mid_run, 120).count("cancelled") == 1
+    assert CANCELLED_BEFORE_START in _plain(stamped, 120)
+
+
+def test_the_clock_column_starts_in_the_same_cell_on_every_row() -> None:
+    """``⏳`` is two cells where every other state mark is one.
+
+    Appended raw it pushed a queued row's clock, numbers and activity one cell
+    right of the column the rest of the list right-aligns into — one stepped
+    row in a list whose whole job is comparison.
+    """
+    jobs = [
+        Job("j1", "docs sweep", progress="auditing merged MRs", age=469.0),
+        Job("j2", "queued crawler", queued=True, age=215.0),
+        Job("j3", "flaky test bisect", status="cancelled", settled=True, age=96.0),
+        Job("j4", "pip-audit", status="failed", settled=True, error_text="exited 1", age=58.0),
+    ]
+    rows = _column(jobs, 120)
+    # Durations right-align into one column, so every row's clock has to END
+    # in the same CELL — measured in cells, because `⏳` is one character and
+    # two of them.
+    ends = set()
+    for job, row in zip(jobs, rows):
+        elapsed = job_elapsed(job)
+        ends.add(cell_len(row[: row.index(elapsed) + len(elapsed)]))
+    assert len(ends) == 1, f"the clock column sheared: {rows!r}"
 
 
 def test_the_whole_column_sheds_together_so_a_blank_cell_means_one_thing() -> None:

--- a/tests/unit/tui/test_subagent_stats.py
+++ b/tests/unit/tui/test_subagent_stats.py
@@ -35,6 +35,7 @@ from local_operator.tui.widgets.subagent_panel import (
     JobStats,
     SubagentPanel,
     SubagentRow,
+    _glyph_cells,
     compose_row,
     job_elapsed,
     job_stats,
@@ -411,6 +412,25 @@ def test_the_clock_column_starts_in_the_same_cell_on_every_row() -> None:
         elapsed = job_elapsed(job)
         ends.add(cell_len(row[: row.index(elapsed) + len(elapsed)]))
     assert len(ends) == 1, f"the clock column sheared: {rows!r}"
+
+
+def test_the_glyph_budget_is_the_column_the_row_actually_draws() -> None:
+    """The pad and the BUDGET are two halves of one fix, and each can regress
+    alone.
+
+    ``compose_row`` spends ``_glyph_cells`` when it decides what to truncate. A
+    budget measured at the raw glyph width while the row draws a padded column
+    is short by one cell, which is what let the truncate eat the last cell of a
+    dollar figure — and a money value clipped mid-digit is a worse answer than
+    the ``$0.0000`` this module refuses to print. So the budget must report the
+    padded column for a one-cell mark, not the mark.
+    """
+    facts = {"fallback_id": "j0", "current": False}
+    one_cell = row_facts(Job("j1", "docs sweep", progress="auditing merged MRs"), **facts)
+    two_cell = row_facts(Job("j2", "queued crawler", queued=True), **facts)
+
+    assert _glyph_cells(one_cell) == 2, "a one-cell mark still occupies the shared column"
+    assert _glyph_cells(two_cell) == 2, "and a two-cell mark is already that wide"
 
 
 def test_the_whole_column_sheds_together_so_a_blank_cell_means_one_thing() -> None:

--- a/tests/unit/tui/test_subagent_view.py
+++ b/tests/unit/tui/test_subagent_view.py
@@ -21,6 +21,7 @@ from typing import Any
 import pytest
 from rich.cells import cell_len
 
+from local_operator.harness.jobs import CANCELLED_BEFORE_START
 from local_operator.tui.app import SUBAGENT_LAYOUT_CLASS, OperatorApp
 from local_operator.tui.widgets.assistant import AssistantBlock
 from local_operator.tui.widgets.editor import Editor
@@ -379,6 +380,40 @@ async def test_a_swept_job_says_so_instead_of_claiming_to_be_running() -> None:
         assert rows[0] == "Subagent · sub-gone  no longer on the ledger"
         assert GLYPH_DONE not in rows[0]
         assert LEDGER_GONE_NOTE in " ".join(rows)
+
+
+@pytest.mark.asyncio
+async def test_the_title_says_a_cancelled_child_never_ran() -> None:
+    """``⊘ cancelled · 1m36s`` presents parked time as work time.
+
+    A job cancelled at the capacity gate ran for zero seconds and spent
+    nothing; its duration is how long it WAITED. Beside a page whose sibling
+    rows read ``⣷ running · 7m53s``, the bare word paired with that number
+    says an operator killed a child a minute and a half into its work. The
+    manager records the distinction on the row (``CANCELLED_BEFORE_START``)
+    and the title spends it.
+    """
+    parked = _Job("sub-parked", "flaky test bisect", status="cancelled")
+    parked.settled_at = parked.start_time + 96.0
+    parked.result_text = CANCELLED_BEFORE_START
+    mid_run = _Job("sub-midrun", "docs sweep agent", status="cancelled")
+    mid_run.settled_at = mid_run.start_time + 96.0
+    session = FakeSession()
+    session.jobs = _fake_jobs(parked, mid_run)
+    app = OperatorApp(_async_factory(session))
+    async with app.run_test(size=(120, 40)) as pilot:
+        view = await _open(pilot, app, parked)
+        title = view.rendered_rows()[0]
+        assert CANCELLED_BEFORE_START in title, title
+        assert "1m36s" in title  # the number stays; what it MEANS is now said
+
+        # A child cancelled while genuinely running keeps the bare word: it
+        # did work, and that duration is work time.
+        app._open_subagent_view("sub-midrun")
+        await pilot.pause()
+        title = view.rendered_rows()[0]
+        assert "cancelled" in title
+        assert CANCELLED_BEFORE_START not in title, title
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tui/test_subagent_view.py
+++ b/tests/unit/tui/test_subagent_view.py
@@ -420,6 +420,30 @@ async def test_the_title_says_a_cancelled_child_never_ran() -> None:
 
 
 @pytest.mark.asyncio
+async def test_a_narrow_title_shortens_the_state_word_before_losing_it() -> None:
+    """The phrase is 27 cells where the bare word is 9, and a single-rung
+    ladder dropped the state ENTIRELY at the widths between the two.
+
+    At those widths the page showed a glyph and a duration with no word on
+    screen — for the one state whose whole point is being said. The state is
+    shortened before it is dropped, so it is the last thing to go, not the
+    first.
+    """
+    parked = _Job("sub-parked", "flaky test bisect", status="cancelled")
+    parked.settled_at = parked.start_time + 96.0
+    parked.result_text = CANCELLED_BEFORE_START
+    session = FakeSession()
+    session.jobs = _fake_jobs(parked)
+    app = OperatorApp(_async_factory(session))
+    async with app.run_test(size=(48, 24)) as pilot:
+        view = await _open(pilot, app, parked)
+        title = view.rendered_rows()[0]
+
+    assert "cancelled" in title, title
+    assert CANCELLED_BEFORE_START not in title, "premise: too narrow for the phrase"
+
+
+@pytest.mark.asyncio
 async def test_opening_another_subagent_retargets_the_same_page() -> None:
     """The band stays live under the page precisely so a reader can hop
     between children; hopping must not stack two pages or leave the previous

--- a/tests/unit/tui/test_subagent_view.py
+++ b/tests/unit/tui/test_subagent_view.py
@@ -384,14 +384,15 @@ async def test_a_swept_job_says_so_instead_of_claiming_to_be_running() -> None:
 
 @pytest.mark.asyncio
 async def test_the_title_says_a_cancelled_child_never_ran() -> None:
-    """``⊘ cancelled · 1m36s`` presents parked time as work time.
+    """``⊘ cancelled · 1m36s`` presents waiting time as work time.
 
-    A job cancelled at the capacity gate ran for zero seconds and spent
-    nothing; its duration is how long it WAITED. Beside a page whose sibling
-    rows read ``⣷ running · 7m53s``, the bare word paired with that number
-    says an operator killed a child a minute and a half into its work. The
-    manager records the distinction on the row (``CANCELLED_BEFORE_START``)
-    and the title spends it.
+    A job cancelled before its runner was entered ran for zero seconds and
+    spent nothing; its duration is how long it WAITED. Beside a page whose
+    sibling rows read ``⣷ running · 7m53s``, the bare word paired with that
+    number says an operator killed a child a minute and a half into its work.
+    The manager records the distinction on the row
+    (``CANCELLED_BEFORE_START``, keyed on ``started_at``) and the title spends
+    it.
     """
     parked = _Job("sub-parked", "flaky test bisect", status="cancelled")
     parked.settled_at = parked.start_time + 96.0
@@ -407,8 +408,10 @@ async def test_the_title_says_a_cancelled_child_never_ran() -> None:
         assert CANCELLED_BEFORE_START in title, title
         assert "1m36s" in title  # the number stays; what it MEANS is now said
 
-        # A child cancelled while genuinely running keeps the bare word: it
-        # did work, and that duration is work time.
+        # A child whose runner DID begin keeps the bare word: it worked, and
+        # that duration is work time. ``started_at`` is what separates the two,
+        # and it is set on this fixture to say so — ``queued`` would not, since
+        # an admitted-but-never-entered job is not parked either.
         app._open_subagent_view("sub-midrun")
         await pilot.pause()
         title = view.rendered_rows()[0]

--- a/tests/unit/tui/test_subagent_view.py
+++ b/tests/unit/tui/test_subagent_view.py
@@ -446,14 +446,14 @@ async def test_a_narrow_title_shortens_the_state_word_before_losing_it() -> None
 
 
 @pytest.mark.asyncio
-async def test_the_title_gains_fields_monotonically_as_it_widens() -> None:
-    """The ladder's arithmetic must not make the title sawtooth.
+async def test_the_title_never_loses_its_state_as_it_widens() -> None:
+    """A wider title must never lose a state word a narrower one carried.
 
     The label budget omitted the glyph cell, so a rung whose label consumed its
-    budget exactly was rejected and the ladder fell through: the state word
-    visible at 35 cells and gone again at 36-40, where it still fit. A title
-    that loses a field as the page WIDENS tells a reader their window shrank,
-    and a reader who saw both widths would believe it.
+    budget exactly was rejected and the ladder fell through: the state visible
+    at 35 cells and gone again at 36-40, where it still fit. The assertion is
+    deliberately about STATE preservation, not every field: the ladder may
+    trade a duration for the longer, more precise phrase as it widens.
     """
     parked = _Job("sub-parked", "flaky test bisect", status="cancelled")
     parked.settled_at = parked.start_time + 96.0
@@ -464,15 +464,15 @@ async def test_the_title_gains_fields_monotonically_as_it_widens() -> None:
     async with app.run_test(size=(120, 24)) as pilot:
         view = await _open(pilot, app, parked)
 
-        prev = None
+        state_seen = False
         for width in range(20, 110):
             row = view._title_row(width, "⠋", 0).plain
-            present = tuple(part for part in (CANCELLED_BEFORE_START, "1m36s") if part in row)
-            if prev is not None:
-                assert len(present) >= len(
-                    prev
-                ), f"width {width} lost a field its narrower neighbour kept: {row!r}"
-            prev = present
+            has_state = "cancelled" in row
+            if state_seen:
+                assert (
+                    has_state
+                ), f"width {width} lost the state its narrower neighbour kept: {row!r}"
+            state_seen = state_seen or has_state
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tui/test_subagent_view.py
+++ b/tests/unit/tui/test_subagent_view.py
@@ -399,6 +399,10 @@ async def test_the_title_says_a_cancelled_child_never_ran() -> None:
     parked.result_text = CANCELLED_BEFORE_START
     mid_run = _Job("sub-midrun", "docs sweep agent", status="cancelled")
     mid_run.settled_at = mid_run.start_time + 96.0
+    # Representational, not load-bearing: the view reads ``result_text``, but
+    # this row's premise is "its runner began", and ``started_at`` is the fact
+    # that says so on a real job — left unset, the row encodes the OPPOSITE.
+    mid_run.started_at = mid_run.start_time
     session = FakeSession()
     session.jobs = _fake_jobs(parked, mid_run)
     app = OperatorApp(_async_factory(session))
@@ -406,12 +410,10 @@ async def test_the_title_says_a_cancelled_child_never_ran() -> None:
         view = await _open(pilot, app, parked)
         title = view.rendered_rows()[0]
         assert CANCELLED_BEFORE_START in title, title
-        assert "1m36s" in title  # the number stays; what it MEANS is now said
-
         # A child whose runner DID begin keeps the bare word: it worked, and
-        # that duration is work time. ``started_at`` is what separates the two,
-        # and it is set on this fixture to say so — ``queued`` would not, since
-        # an admitted-but-never-entered job is not parked either.
+        # that duration is work time. ``started_at`` (set above) is what
+        # separates it from the parked row — ``queued`` would not, since an
+        # admitted-but-never-entered job is not parked either.
         app._open_subagent_view("sub-midrun")
         await pilot.pause()
         title = view.rendered_rows()[0]
@@ -441,6 +443,36 @@ async def test_a_narrow_title_shortens_the_state_word_before_losing_it() -> None
 
     assert "cancelled" in title, title
     assert CANCELLED_BEFORE_START not in title, "premise: too narrow for the phrase"
+
+
+@pytest.mark.asyncio
+async def test_the_title_gains_fields_monotonically_as_it_widens() -> None:
+    """The ladder's arithmetic must not make the title sawtooth.
+
+    The label budget omitted the glyph cell, so a rung whose label consumed its
+    budget exactly was rejected and the ladder fell through: the state word
+    visible at 35 cells and gone again at 36-40, where it still fit. A title
+    that loses a field as the page WIDENS tells a reader their window shrank,
+    and a reader who saw both widths would believe it.
+    """
+    parked = _Job("sub-parked", "flaky test bisect", status="cancelled")
+    parked.settled_at = parked.start_time + 96.0
+    parked.result_text = CANCELLED_BEFORE_START
+    session = FakeSession()
+    session.jobs = _fake_jobs(parked)
+    app = OperatorApp(_async_factory(session))
+    async with app.run_test(size=(120, 24)) as pilot:
+        view = await _open(pilot, app, parked)
+
+        prev = None
+        for width in range(20, 110):
+            row = view._title_row(width, "⠋", 0).plain
+            present = tuple(part for part in (CANCELLED_BEFORE_START, "1m36s") if part in row)
+            if prev is not None:
+                assert len(present) >= len(
+                    prev
+                ), f"width {width} lost a field its narrower neighbour kept: {row!r}"
+            prev = present
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What changed

Three fixes to how background subagent jobs report their own state.

- **`jobs` elapsed time.** A running job's age was computed as `now - now`, so every live job printed `0.0s` regardless of its real age. Now measured from `start_time`.
- **`hub` "not started" reason.** Any child with no live session was reported as *"parked behind the job capacity gate"*, including one already admitted and mid-construction. Parked and starting-up are now distinct messages.
- **Cancelling a parked job.** `queued` stayed `True` after cancellation, so the subagent panel painted `⏳ queued` on a row whose status was `cancelled`, and the manager kept the parked runner closure alive for its own lifetime. Both are now cleared on cancel.

## Why

All three make a healthy subagent look dead, and "looks dead" is what a caller acts on when deciding whether to cancel it.

Observed live: three review subagents showed `⊘` with `6m13s · 14.9%/500k` in the panel — they had been running for six minutes and had spent real tokens — while `hub op=ask` answered *"subagent has not started yet (parked behind the job capacity gate)"* and `jobs` reported `0.0s`. Two of the three instruments said nothing was happening about children that were working, so they were cancelled.

The panel's `⊘` was correct (they were cancelled, by me, on that false evidence). The bugs are in what the other two instruments reported.

### Why `jobs` could not be right

```
elapsed = job.settled_at if job.status != "running" and job.settled_at else now
lines.append(f"... {now - elapsed:6.1f}s ...")
```

For a running job `elapsed` **is** `now`, so the printed value is `now - now == 0.0` by construction — it never read `start_time` at all. The settled branch was fine, which is why this survived: a completed job reported a plausible "finished N seconds ago".

## Impact

- No API or schema change; three reporting paths and one cancellation path.
- `hub`'s parked-message wording changes for the mid-construction case only. A genuinely parked job keeps the original message naming the capacity gate.
- Cancelled parked jobs now render `⊘ cancelled` instead of `⏳ queued`.
- Minor memory win: a cancelled parked job no longer pins its runner closure.

## Testing Details

### Automated

- `env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit/harness tests/unit/tools tests/unit/session tests/unit/tui/test_subagent_stats.py tests/unit/tui/test_subagent_view.py -q` → **633 passed**
- flake8 / black / isort / pyright on changed files: clean

### Mutation-tested

Each new test was run against the reverted fix and observed to fail, so none is decoration:

| Test | Failure on reverted code |
|---|---|
| `test_jobs_reports_how_long_a_running_job_has_been_going` | `a long-running job reported 0.0s: 'd62a0e246cd6  running  0.0s  beta'` |
| `test_a_starting_child_is_not_reported_as_parked_behind_the_gate` | `assert 'still starting up' in 'subagent has not started yet (parked behind the job capacity gate)'` |
| `test_cancelling_a_parked_job_clears_its_queued_flag_and_runner` | `AssertionError: a cancelled job is not waiting for a slot` |

### Behavioural, before/after

Driving the real `AsyncJobManager` and `SubagentComms`:

```
# before
RUNNING, not yet attached -> 'subagent has not started yet (parked behind the job capacity gate)'
GENUINELY QUEUED          -> 'subagent has not started yet (parked behind the job capacity gate)'
same message for both states: True
after cancel: queued=True  status=cancelled  glyph=('⏳','queued')  leaked runner=True

# after
RUNNING, not yet attached -> 'subagent reviewer is still starting up (its session is being built); retry in a moment'
GENUINELY QUEUED          -> 'subagent has not started yet (parked behind the job capacity gate)'
same message for both states: False
after cancel: queued=False status=cancelled  glyph=('⊘','cancelled')  leaked runner=False
```

Elapsed-time arithmetic, against a job backdated to a 373s age: `0.0s` before, `373.0s` after.

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my changes work as intended, each verified to fail on the unfixed code.
- [x] All new and existing tests pass.
- [x] I have run formatting (black/isort), linting (flake8), and type checks (pyright).
- [x] Durable comments record why each path exists and the failure that motivated it.

## Change class

C2 — standard bug fix, pre-authorized. No RFC.
