### PR TITLE
chore(release): 0.17.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.17.0"
+version = "0.17.1"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@radienthq.com" }]


### PR DESCRIPTION
## What changed

Bumps the package version from `0.17.0` to `0.17.1` for the reviewed fixes now on `main`:

- #121 — bound and harden the custom-instructions loader
- #125 — stop `Unknown` model labels and list account-scoped ChatGPT Codex models
- #126 — report subagent lifecycle state and job ages honestly

Also includes the QwenCloud Token Plan provider merged independently before this release cut.

## Validation

No runtime behavior changes in this PR; release metadata only.

- Combined `origin/main` unit suite: **3923 passed, 7 skipped**
- `python -m build`: wheel + sdist built successfully
- Built artifacts:
  - `local_operator-0.17.1-py3-none-any.whl`
  - `local_operator-0.17.1.tar.gz`
- Wheel `METADATA`: `Version: 0.17.1`
- Source `pyproject.toml`: `version = "0.17.1"`

## Release

After merge, publish GitHub release `v0.17.1`. `.github/workflows/publish.yml` builds and publishes to PyPI on `release: published` using trusted publishing.

## Change class

C0 — release metadata for already-reviewed C2 changes. Pre-authorized; no RFC.
