### PR TITLE
feat(harness): reach omp parity across tools, context, MCP, skills, and model routing

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -69,3 +69,34 @@ the SDK's state validation passes. Supplying a `client_id` in config pins the
 client: the registration is pre-seeded and dynamic registration is skipped —
 required for providers whose redirect URI was registered against a fixed
 loopback port.
+
+## Per-tool filters
+
+A server can expose hundreds of tools while a session needs only a handful.
+Filter server-owned tool names in that server's entry:
+
+```json
+{
+  "mcpServers": {
+    "crm": {
+      "type": "http",
+      "url": "https://example.test/mcp",
+      "enabledTools": ["contacts_*", "get_company"],
+      "disabledTools": ["contacts_delete"]
+    }
+  }
+}
+```
+
+`enabledTools` is an allowlist when non-empty; `disabledTools` always wins.
+Both accept exact names or glob patterns. Filtering happens before cached
+(deferred) and live tool schemas are mounted, so a reconnect or
+`tools/list_changed` cannot restore a denied tool. Run `/context` in the TUI
+to see the current token cost of system blocks, wire tool schemas and
+messages — this is the fastest way to spot an unexpectedly heavy MCP server.
+
+A hosted server can challenge OAuth again during `tools/call`, after the
+initial connection succeeded. HTTP 401 / `WWW-Authenticate` /
+`mcp/www_authenticate` errors enter the same bounded policy as a stale
+connection: one reconnect (which refreshes OAuth through the SDK provider),
+one replay of the tool call, never a loop.

--- a/local_operator/config.py
+++ b/local_operator/config.py
@@ -150,6 +150,10 @@ DEFAULT_CONFIG = Config(
             # ``local-operator exec`` running in CI, where nobody is watching the
             # tools it approves.
             "tool_approval_mode": "ask",
+            # Direct OpenAI GPT-5 calls use the public Responses API by default.
+            # Set `providers.openai.api` to `chat_completions` for an explicit
+            # compatibility opt-out; other OpenAI-shaped providers never read it.
+            "providers": {"openai": {"api": "responses"}},
             # One ordered cascade for every text-model call. Entries may be
             # "provider/model" strings or {provider, model, effort} mappings;
             # usage-aware switching is opt-in because it spends one lightweight

--- a/local_operator/context_files.py
+++ b/local_operator/context_files.py
@@ -88,7 +88,7 @@ def discover_context_files(cwd: str | Path) -> list[Path]:
             except OSError:
                 digest = None  # unreadable: skip rather than partially trust
                 found_here = None
-            if found_here is not None and digest not in seen_digests:
+            if found_here is not None and digest is not None and digest not in seen_digests:
                 seen_digests.add(digest)
                 found.append(found_here)
         if directory == stop or directory == home or directory == directory.parent:

--- a/local_operator/context_files.py
+++ b/local_operator/context_files.py
@@ -20,7 +20,8 @@ Discovery contract:
 - Keep at most :data:`MAX_CONTEXT_FILES` files, the NEAREST ones — a deep
   monorepo can nest more levels than the prompt should carry, and the
   nearest files are the most specific.
-- Byte-identical files collapse to one (symlinked or vendored duplicates).
+- Prompt-identical bounded file contents collapse to one. Symlinks are never
+  followed: automatic guidance cannot cross the repository's trust boundary.
 
 Rendering contract: the files ride the byte-stable HEAD of the system prompt
 (read once at session start, exactly like the operator's own instructions),
@@ -38,6 +39,7 @@ from __future__ import annotations
 
 import hashlib
 import os
+import stat
 from pathlib import Path
 
 #: How many guidance files ride one system prompt. Nearest wins; deeper
@@ -54,6 +56,31 @@ MAX_FILE_BYTES = 64 * 1024
 CANDIDATE_NAMES = ("AGENTS.md", "CLAUDE.md")
 
 
+def _read_bounded(path: Path) -> tuple[bytes, bool]:
+    """Read one regular file without following links or exceeding the cap.
+
+    ``Path.is_symlink`` followed by ``open`` has a swap window. ``O_NOFOLLOW``
+    makes the kernel enforce the trust boundary at the actual read, while the
+    ``MAX_FILE_BYTES + 1`` probe determines truncation without ingesting the
+    rest of an attacker-controlled file.
+    """
+    if path.is_symlink():
+        raise OSError(f"refusing symlinked guidance: {path}")
+    flags = os.O_RDONLY
+    nofollow = getattr(os, "O_NOFOLLOW", 0)
+    if nofollow:
+        flags |= nofollow
+    descriptor = os.open(path, flags)
+    try:
+        if not stat.S_ISREG(os.fstat(descriptor).st_mode):
+            raise OSError(f"not a regular file: {path}")
+        with os.fdopen(descriptor, "rb", closefd=False) as stream:
+            probe = stream.read(MAX_FILE_BYTES + 1)
+    finally:
+        os.close(descriptor)
+    return probe[:MAX_FILE_BYTES], len(probe) > MAX_FILE_BYTES
+
+
 def _git_root(start: Path) -> Path | None:
     """Nearest enclosing directory containing ``.git`` (file or dir — both
     worktrees and submodules use the file form), or None."""
@@ -66,7 +93,7 @@ def _git_root(start: Path) -> Path | None:
 def _file_for(directory: Path) -> Path | None:
     for name in CANDIDATE_NAMES:
         candidate = directory / name
-        if candidate.is_file():
+        if not candidate.is_symlink() and candidate.is_file():
             return candidate
     return None
 
@@ -84,9 +111,13 @@ def discover_context_files(cwd: str | Path) -> list[Path]:
         found_here = _file_for(directory)
         if found_here is not None:
             try:
-                digest = hashlib.sha256(found_here.read_bytes()).hexdigest()
+                bounded, truncated = _read_bounded(found_here)
+                digest_state = hashlib.sha256()
+                digest_state.update(bounded)
+                digest_state.update(b"\x01" if truncated else b"\x00")
+                digest = digest_state.hexdigest()
             except OSError:
-                digest = None  # unreadable: skip rather than partially trust
+                digest = None  # unreadable/link/non-regular: never inject
                 found_here = None
             if found_here is not None and digest is not None and digest not in seen_digests:
                 seen_digests.add(digest)
@@ -108,11 +139,12 @@ def render_context_files(files: list[Path], cwd: str | Path) -> str:
     parts: list[str] = []
     for path in files:
         try:
-            text = path.read_text(encoding="utf-8", errors="replace")
+            bounded, truncated = _read_bounded(path)
         except OSError:
             continue
-        if len(text.encode("utf-8")) > MAX_FILE_BYTES:
-            text = text[:MAX_FILE_BYTES] + "\n[...truncated at 64KiB; read the file for the rest]"
+        text = bounded.decode("utf-8", errors="replace")
+        if truncated:
+            text += "\n[...truncated at 64KiB; read the file for the rest]"
         try:
             shown = str(path.relative_to(base))
         except ValueError:

--- a/local_operator/context_files.py
+++ b/local_operator/context_files.py
@@ -95,8 +95,9 @@ def discover_context_files(cwd: str | Path) -> list[Path]:
             break
     # Nearest-last above; the prompt wants farthest-first so the nearest file
     # (most specific) is the LAST thing in the block.
+    found = found[:MAX_CONTEXT_FILES]  # keep nearest before reversing for prompt order
     found.reverse()
-    return found[:MAX_CONTEXT_FILES]
+    return found
 
 
 def render_context_files(files: list[Path], cwd: str | Path) -> str:

--- a/local_operator/context_files.py
+++ b/local_operator/context_files.py
@@ -1,0 +1,133 @@
+"""Repository guidance auto-discovery (AGENTS.md / CLAUDE.md).
+
+Most repositories the agent works in carry a standing instructions file —
+AGENTS.md increasingly, CLAUDE.md historically — that states the project's
+conventions, gates, and landmines. Without this module the agent works blind
+to all of it: the only standing instructions it saw were the operator's
+machine-wide ``system_prompt.md``, which is about the MACHINE, not the repo
+the prompt happens to run in.
+
+Discovery contract:
+
+- Walk UP from the session's working directory, one directory at a time.
+- In each directory accept ``AGENTS.md``; when absent, ``CLAUDE.md`` stands
+  in (never both — the two names are two covers for one intent).
+- Stop at the git repository root (inclusive) when one is found: guidance
+  above the repo belongs to the enclosing workspace, and walking past the
+  root into the home directory would pick up unrelated projects' files. With
+  no git root, stop at the user's home directory (inclusive) or the
+  filesystem root, whichever comes first.
+- Keep at most :data:`MAX_CONTEXT_FILES` files, the NEAREST ones — a deep
+  monorepo can nest more levels than the prompt should carry, and the
+  nearest files are the most specific.
+- Byte-identical files collapse to one (symlinked or vendored duplicates).
+
+Rendering contract: the files ride the byte-stable HEAD of the system prompt
+(read once at session start, exactly like the operator's own instructions),
+farthest-first so the nearest file — the most specific — lands last and is
+read most prominently. Precedence is stated in the wrapper: repo guidance
+describes the project's defaults; a direct instruction in the conversation
+still wins, as it does over every standing instruction.
+
+The whole feature can be switched off with ``LOCAL_OPERATOR_CONTEXT_FILES=0``
+when a directory's guidance files should not be trusted or the context budget
+matters more than the conventions.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+from pathlib import Path
+
+#: How many guidance files ride one system prompt. Nearest wins; deeper
+#: ancestors beyond this are dropped rather than silently overflowing the
+#: start-context budget (the 30k contract in docs/REWRITE.md).
+MAX_CONTEXT_FILES = 5
+
+#: Per-file byte cap. A guidance file is instructions, not documentation;
+#: past this the file is read on demand (it is on disk and grep-able) instead
+#: of occupying every turn's cached prefix.
+MAX_FILE_BYTES = 64 * 1024
+
+#: Filenames considered, in priority order per directory.
+CANDIDATE_NAMES = ("AGENTS.md", "CLAUDE.md")
+
+
+def _git_root(start: Path) -> Path | None:
+    """Nearest enclosing directory containing ``.git`` (file or dir — both
+    worktrees and submodules use the file form), or None."""
+    for directory in (start, *start.parents):
+        if (directory / ".git").exists():
+            return directory
+    return None
+
+
+def _file_for(directory: Path) -> Path | None:
+    for name in CANDIDATE_NAMES:
+        candidate = directory / name
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def discover_context_files(cwd: str | Path) -> list[Path]:
+    """Ancestor guidance files, farthest-first. Empty when disabled or none."""
+    if os.environ.get("LOCAL_OPERATOR_CONTEXT_FILES", "1").strip() in ("0", "false", "no"):
+        return []
+    start = Path(cwd).resolve()
+    home = Path.home()
+    stop = _git_root(start)
+    found: list[Path] = []
+    seen_digests: set[str] = set()
+    for directory in (start, *start.parents):
+        found_here = _file_for(directory)
+        if found_here is not None:
+            try:
+                digest = hashlib.sha256(found_here.read_bytes()).hexdigest()
+            except OSError:
+                digest = None  # unreadable: skip rather than partially trust
+                found_here = None
+            if found_here is not None and digest not in seen_digests:
+                seen_digests.add(digest)
+                found.append(found_here)
+        if directory == stop or directory == home or directory == directory.parent:
+            break
+    # Nearest-last above; the prompt wants farthest-first so the nearest file
+    # (most specific) is the LAST thing in the block.
+    found.reverse()
+    return found[:MAX_CONTEXT_FILES]
+
+
+def render_context_files(files: list[Path], cwd: str | Path) -> str:
+    """The ``<repo-guidance>`` block for the system prompt head."""
+    if not files:
+        return ""
+    base = Path(cwd).resolve()
+    parts: list[str] = []
+    for path in files:
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        if len(text.encode("utf-8")) > MAX_FILE_BYTES:
+            text = text[:MAX_FILE_BYTES] + "\n[...truncated at 64KiB; read the file for the rest]"
+        try:
+            shown = str(path.relative_to(base))
+        except ValueError:
+            shown = str(path)
+        parts.append(f'<file path="{shown}">\n{text.strip()}\n</file>')
+    if not parts:
+        return ""
+    return (
+        "## Repository guidance\n\n"
+        "These instruction files were found in this directory's ancestors and "
+        "state the project's conventions. Treat them as the project's "
+        "defaults; a direct instruction in the conversation still wins.\n\n"
+        "<repo-guidance>\n" + "\n".join(parts) + "\n</repo-guidance>"
+    )
+
+
+def load_repo_guidance(cwd: str | Path) -> str:
+    """One call: discover + render. ``""`` when there is nothing to inject."""
+    return render_context_files(discover_context_files(cwd), cwd)

--- a/local_operator/guides/configuration/GUIDE.md
+++ b/local_operator/guides/configuration/GUIDE.md
@@ -145,6 +145,7 @@ remain in the credential store; never put tokens or keys in this mapping.
 - `auto_save_conversation`: legacy conversation persistence switch
 - `compaction`: `enabled`, `strategy`, `reserve_tokens`, `keep_recent_tokens`, `threshold_percent`, `threshold_tokens`, `max_threshold_tokens`, `auto_continue`, `mid_turn_enabled`
 - `retry`: `enabled`, `maxRetries`, `baseDelayMs`, `modelFallback`, `usageAwareFallback`, `usageReservePercent`, and `fallbackChains` (snake_case spellings are also accepted for retry fields)
+- `effort`: `auto` (default false) enables the zero-token local prompt-complexity classifier; `allowMax` lets high-complexity prompts select a model's maximum effort (default stops one rung below max)
 - `variables`: non-secret named values exposed through the variable tools; environment values remain lower precedence
 - `tui`: terminal UI settings such as `theme`
 - `session_retention_max_sessions`, `session_retention_max_bytes`, `session_retention_max_age_days`: independent ephemeral-session ceilings; `0` disables that ceiling

--- a/local_operator/harness/jobs.py
+++ b/local_operator/harness/jobs.py
@@ -42,6 +42,11 @@ JobType = Literal["bash", "task"]
 # run(job_id, signal, report_progress) -> awaitable text result
 JobRunFn = Callable[[str, AbortSignal, Callable[[str], None]], Awaitable[str | None]]
 DeliverySink = Callable[[str, str, "AsyncJob | None"], Awaitable[None] | None]
+
+#: Custom-message type used by a session to deliver a settled job's result
+#: back into the conversation as a re-entering message (rendered as a user
+#: message). Lives here because the job manager owns the lifecycle.
+JOB_RESULT_MESSAGE_TYPE = "job_result"
 ProgressFn = Callable[[str], None]
 
 
@@ -64,6 +69,10 @@ class AsyncJob(BaseModel):
     error_text: str | None = None
     latest_details: dict[str, Any] | None = None
     owner_id: str | None = None
+    # Set when a caller (the `wait` tool) has already returned this job's
+    # result to the model: auto-delivery must then stay quiet, or the same
+    # result would reach the conversation twice.
+    consumed: bool = False
     agent_id: str | None = None
     queued: bool = False
     # Serialized child events of a ``task`` job (``model_dump(mode="json")``
@@ -234,6 +243,13 @@ class AsyncJobManager:
         return True
 
     # -- delivery -----------------------------------------------------------
+
+    def mark_consumed(self, job_id: str) -> None:
+        """Flag a job's result as already handed to the model (see the
+        ``consumed`` field): auto-delivery checks it and stays quiet."""
+        job = self._jobs.get(job_id)
+        if job is not None:
+            job.consumed = True
 
     def register_delivery_sink(self, owner_id: str, sink: DeliverySink) -> Callable[[], None]:
         """Route completions owned by ``owner_id`` to ``sink``. Returns an

--- a/local_operator/harness/loop.py
+++ b/local_operator/harness/loop.py
@@ -331,9 +331,7 @@ class AgentLoop:
                             }
                             context.messages[:] = outcome
                             new_messages = [
-                                m
-                                for m in new_messages
-                                if getattr(m, "id", None) in survivors
+                                m for m in new_messages if getattr(m, "id", None) in survivors
                             ]
 
                     pending = await self._collect_inflight_injections(config)

--- a/local_operator/harness/loop.py
+++ b/local_operator/harness/loop.py
@@ -304,13 +304,38 @@ class AgentLoop:
                         self._append_results(context, tool_results, new_messages)
 
                     yield TurnEndEvent(message=assistant, tool_results=tool_results)
-                    turn_end = config.on_turn_end
-                    if turn_end is not None:
+                    has_more_tool_calls = bool(assistant.tool_calls)
+                    if has_more_tool_calls and config.on_turn_end is not None:
+                        # The boundary hook fires only when the loop will
+                        # CONTINUE — a terminal boundary is the post-turn
+                        # pass's job (the host's own after-run gate), and
+                        # firing there too would run every host hook twice
+                        # for the price of one decision.
+                        turn_end = config.on_turn_end
                         outcome = turn_end(list(context.messages))
                         if inspect.isawaitable(outcome):
-                            await outcome
+                            outcome = await outcome
+                        if isinstance(outcome, list):
+                            # Mid-run context replacement (automatic mid-turn
+                            # compaction). The replacement is authoritative
+                            # for the context; the run accumulator keeps only
+                            # what this run produced that SURVIVED it — ids
+                            # the replacement dropped were summarized away and
+                            # must never reach post-run persistence, where
+                            # they would resurrect after the compaction entry
+                            # that superseded them. Matching is by id because
+                            # the renderer passes plain Messages through as
+                            # the same objects but customs as fresh ones.
+                            survivors = {
+                                getattr(m, "id", None) for m in outcome if getattr(m, "id", None)
+                            }
+                            context.messages[:] = outcome
+                            new_messages = [
+                                m
+                                for m in new_messages
+                                if getattr(m, "id", None) in survivors
+                            ]
 
-                    has_more_tool_calls = bool(assistant.tool_calls)
                     pending = await self._collect_inflight_injections(config)
 
                 # ---- outer loop tail: yield boundary ----------------------

--- a/local_operator/harness/subagent.py
+++ b/local_operator/harness/subagent.py
@@ -266,7 +266,7 @@ def _make_runner(
             )
             bridge = asyncio.create_task(_abort_bridge(signal, child))
             try:
-                await child.prompt(prompt)
+                await child.prompt(effective_prompt)
             finally:
                 bridge.cancel()
                 with contextlib.suppress(BaseException):

--- a/local_operator/harness/subagent.py
+++ b/local_operator/harness/subagent.py
@@ -127,6 +127,24 @@ logger = logging.getLogger(__name__)
 TRAJECTORY_CAP = 500
 
 
+#: The read-only inventory a ``scout`` child is filtered down to. Allowlist,
+#: not tier-filter: approval tiers drift as tools are added, and a scout's
+#: promise is narrower than "nothing marked write" — it is lookups only, no
+#: side effects at all (browser drives the user's browser; eval executes
+#: code; both are excluded by name for that reason even where a tier alone
+#: would admit them).
+SCOUT_TOOL_ALLOWLIST = frozenset({"read", "glob", "grep", "list_variables", "read_variable"})
+
+#: Preamble stamped onto every scout prompt. The tool filter enforces the
+#: letter; this states the intent, so the scout REPORTS rather than trying to
+#: route around its missing tools.
+SCOUT_PREAMBLE = (
+    "[scout mode: you are a READ-ONLY research agent. Investigate, read, "
+    "search, and report findings with file:line evidence; you cannot edit, "
+    "write, or run anything. Your final message is the deliverable.]\n\n"
+)
+
+
 def run_subagent(
     label: str,
     prompt: str,
@@ -135,6 +153,7 @@ def run_subagent(
     jobs_manager: "AsyncJobManager",
     model_spec: ModelSpec | None = None,
     resume_dir: "Path | None" = None,
+    agent: str = "task",
 ) -> str:
     """Register one child-session run as a background job; return the job id.
 
@@ -160,6 +179,7 @@ def run_subagent(
             jobs_manager=jobs_manager,
             model_spec=model_spec,
             resume_dir=resume_dir,
+            agent=agent,
         ),
         queued=queued,
     )
@@ -190,6 +210,7 @@ def _make_runner(
     jobs_manager: "AsyncJobManager",
     model_spec: ModelSpec | None,
     resume_dir: "Path | None" = None,
+    agent: str = "task",
 ) -> Callable[[str, Any, Callable[[str], None]], Awaitable[str | None]]:
     """Build the JobRunFn for one child run (closure over its launch args)."""
     # The parent seam is private-attribute access on purpose: this module is
@@ -198,6 +219,7 @@ def _make_runner(
     # accessors. ``_emit`` gives the parent's isolated handler fan-out.
     emit = parent_session._emit
     comms = getattr(parent_session, "subagent_comms", None)
+    effective_prompt = SCOUT_PREAMBLE + prompt if agent == "scout" else prompt
 
     async def runner(
         job_id: str, signal: Any, report_progress: Callable[[str], None]
@@ -214,11 +236,12 @@ def _make_runner(
         try:
             child = await _build_child_session(
                 label=label,
-                prompt=prompt,
+                prompt=effective_prompt,
                 parent_session=parent_session,
                 model_spec=model_spec,
                 job_id=job_id,
                 resume_dir=resume_dir,
+                agent=agent,
             )
             if job is not None:
                 # Off the CHILD, not the parent: ``model_spec`` may have put
@@ -593,6 +616,7 @@ async def _build_child_session(
     model_spec: ModelSpec | None,
     job_id: str,
     resume_dir: "Path | None" = None,
+    agent: str = "task",
 ) -> "Session":
     """Compose the child Session directly (see module docstring for why the
     factory is not reused, and for the full inherit/do-not-inherit list)."""
@@ -672,7 +696,12 @@ async def _build_child_session(
         web_search_settings=ConfigManager(config_dir()).get_config_value("web_search", None),
     )
     tools = create_tools(tool_context)
-    if mcp is not None:
+    if agent == "scout":
+        # Scouts get lookups only — MCP tools execute arbitrary server calls,
+        # so they are excluded from the allowlist filter entirely rather than
+        # trusted per tool.
+        tools = [tool for tool in tools if tool.name in SCOUT_TOOL_ALLOWLIST]
+    if mcp is not None and agent != "scout":
         tools = tools + mcp.tools
 
     def system_blocks_provider() -> list[str]:
@@ -752,19 +781,34 @@ async def _build_child_session(
             else None
         ),
     )
-    # Undo ``Session.__init__``'s capability merge. The set is DERIVED, not a
-    # copy of the ``enabled=("task", "wait", "jobs", "wake")`` tuple in
-    # ``_merge_capability_tools``: nothing links a copy to that tuple, so a
-    # fifth session-gated tool would be handed to every child silently — the
-    # exact rot the module docstring says this prune exists to stop. The merge
-    # only appends new names or replaces same-named entries, so whatever the
-    # constructor ADDED to the list we passed in is precisely the set of tools
-    # gated on capabilities only a top-level session should have.
+    # Undo ``Session.__init__``'s capability merge, DEPTH-AWARE. The set is
+    # DERIVED, not a copy of the ``enabled=("task", "wait", "jobs", "wake")``
+    # tuple in ``_merge_capability_tools``: nothing links a copy to that
+    # tuple, so a fifth session-gated tool would be handed to every child
+    # silently — the exact rot the module docstring says this prune exists to
+    # stop. The merge only appends new names or replaces same-named entries,
+    # so whatever the constructor ADDED to the list we passed in is precisely
+    # the set of tools gated on session capabilities.
+    #
+    # A child of a TOP-LEVEL session keeps task/wait/jobs: one further level
+    # of delegation (map-then-fan-out inside a child) is observable through
+    # the child's own jobs/wait tools, and its job manager is disposed with
+    # the child, so a grandchild cannot outlive its lineage. What still never
+    # crosses any boundary: ``wake`` (a child session ends after one prompt,
+    # so a wake armed there would be silently lost) and, one level deeper,
+    # everything again — a grandchild's children would register on a manager
+    # nothing observes and that dies mid-turn. Scouts lose the whole set: a
+    # read-only agent that delegates autonomous work is not read-only.
     #
     # ``refresh_tools`` rather than touching ``_tools``: it is the committed
     # hook and it keeps the loop's ``context.tools`` in step.
     merged_in = {tool.name for tool in child._tools} - {tool.name for tool in tools}
-    child.refresh_tools([tool for tool in child._tools if tool.name not in merged_in])
+    parent_is_child = parent_session._job_id is not None
+    if agent == "scout" or parent_is_child:
+        drop = merged_in
+    else:
+        drop = {name for name in merged_in if name == "wake"}
+    child.refresh_tools([tool for tool in child._tools if tool.name not in drop])
     if mcp is not None:
         mcp.attach(child)
         # Diagnostics only, and BORROWED: unlike attach_mcp_dispose this adds no

--- a/local_operator/harness/types.py
+++ b/local_operator/harness/types.py
@@ -894,9 +894,20 @@ class LoopConfig(BaseModel):
     before_model_call: Callable[[], Awaitable[bool] | bool] | None = Field(
         default=None, exclude=True
     )
-    on_turn_end: Callable[[list[AgentMessage]], Awaitable[None] | None] | None = Field(
-        default=None, exclude=True
-    )
+    # Called at the safe boundary after each tool batch lands (before the
+    # next model call). May return a replacement ``context.messages`` list —
+    # the loop swaps it in and prunes its own run accumulator to the
+    # replacement's survivors, so a host that compacts mid-run (automatic
+    # mid-turn compaction) never double-persists summarized history. The
+    # replacement must keep surviving messages' ids stable: the accumulator
+    # filter matches by id.
+    on_turn_end: (
+        Callable[
+            [list[AgentMessage]],
+            Awaitable[list[AgentMessage] | None] | list[AgentMessage] | None,
+        ]
+        | None
+    ) = Field(default=None, exclude=True)
     on_before_yield: Callable[[], Awaitable[None] | None] | None = Field(default=None, exclude=True)
 
     # Fallback routing for unknown tool names (e.g. deferred MCP tools).

--- a/local_operator/harness/types.py
+++ b/local_operator/harness/types.py
@@ -958,6 +958,10 @@ class ModelSpec(BaseModel):
     supports_tools: bool = True
     supports_images: bool = True
     supports_prompt_cache: bool = False
+    # Public OpenAI Responses routing is a model capability, not a provider-wire
+    # guess: compatibility providers may serve the same model id while exposing
+    # only chat/completions.
+    supports_responses_api: bool = False
     base_url: str | None = None  # override for OpenAI-compatible endpoints
     temperature: float = 0.2
     top_p: float = 0.9
@@ -1018,6 +1022,10 @@ class ChatRequest(BaseModel):
     top_p: float | None = None
     stop_sequences: list[str] = Field(default_factory=list)
     tool_choice: Literal["auto", "none", "required"] = "auto"
+    # Stable request-prefix identity used by providers' server-side prompt
+    # caches. Session hosts populate it once from their session id; keeping it
+    # on the request lets retries and fallback clones preserve the same value.
+    prompt_cache_key: str | None = None
     #: This call's output has NOT been shown to anyone yet, so a failed attempt
     #: may be discarded and retried whole.
     #:

--- a/local_operator/harness/types.py
+++ b/local_operator/harness/types.py
@@ -392,6 +392,26 @@ class JobManagerProtocol(Protocol):
     async def cancel(self, job_id: str, *, owner_id: str | None = None) -> bool: ...
 
 
+@runtime_checkable
+class SubagentLauncher(Protocol):
+    """Spawn a one-shot child session on the session's job manager.
+
+    ``agent`` selects the tier: ``"task"`` is the full child, ``"scout"`` a
+    read-only research child (its tool inventory is filtered to read-tier
+    lookups). ``effort`` routes to a configured model tier (``lo``/``med``/
+    ``hi`` in ``values.subagents.models``); None keeps the parent's model.
+    """
+
+    def __call__(
+        self,
+        label: str,
+        prompt: str,
+        *,
+        agent: str = "task",
+        effort: str | None = None,
+    ) -> str: ...
+
+
 class ToolContext(BaseModel):
     """Minimal host-provided context handed to tool execution.
 
@@ -459,7 +479,7 @@ class ToolContext(BaseModel):
     # subagent engine and the task tool is then not advertised at all
     # (createIf) rather than advertised and always failing — the same
     # convention ``wake_scheduler`` uses.
-    subagent_launcher: Callable[[str, str], str] | None = None
+    subagent_launcher: "SubagentLauncher | None" = None
     # The session's background job manager. Declared as a Protocol because
     # the concrete class lives in ``harness.jobs``, which imports this
     # module (import cycle). The ``wait``/``job`` tools read it; ``None``

--- a/local_operator/incidents.py
+++ b/local_operator/incidents.py
@@ -1,0 +1,178 @@
+"""Session incidents: why a run or capability failed, made model-visible.
+
+The failover cascade answers a provider error by rotating credentials and
+models, and its notices reach the UI — but none of it reached the MODEL. A
+run that died on a quota error ended with an ``agent_end`` the transcript
+persisted as a bare error string, so the next prompt (or a resumed session)
+resumed blind: the model had no idea the last turn was killed by rate
+limiting rather than its own bug, and "continue" meant re-guessing.
+
+This module classifies error text into the categories an agent can act on
+and formats one incident record. The session journals it as a
+``session_incident`` custom message — appended to the LIVE context (so the
+very next prompt sees it) and persisted to the transcript (so a resumed
+session replays it). Classification is deliberately conservative: plain
+substring rules over the error text, ordered most-specific first, because
+the texts come from every provider's error envelope and no taxonomy covers
+them all. Unknown is a valid answer — the raw text always rides along.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+#: Custom-message type journaled by the session; rendered to a user message
+#: by ``Session._default_convert_to_llm`` so both a live next-turn and a
+#: resumed replay see the same incident.
+SESSION_INCIDENT_MESSAGE_TYPE = "session_incident"
+
+#: Ordered (category, patterns) rules. First category whose pattern matches
+#: (case-insensitive) wins; order is specificity, not severity.
+_RULES: list[tuple[str, tuple[str, ...]]] = [
+    (
+        "context-length",
+        (
+            "context length",
+            "context window",
+            "maximum context",
+            "too long for the model",
+            "prompt is too long",
+            "request too large",
+            "request was too large",
+            "input too large",
+            "input was too large",
+        ),
+    ),
+    (
+        "rate-limit",
+        (
+            "rate limit",
+            "rate_limit",
+            "429",
+            "too many requests",
+            "quota",
+            "usage limit",
+            "usage_limit",
+            "capacity",
+            "overloaded",
+        ),
+    ),
+    (
+        "auth",
+        (
+            "401",
+            "403",
+            "unauthorized",
+            "forbidden",
+            "invalid api key",
+            "invalid_api_key",
+            "authentication",
+            "permission denied",
+            "expired token",
+            "refresh token",
+        ),
+    ),
+    (
+        "billing",
+        ("402", "payment required", "billing", "credit", "insufficient funds"),
+    ),
+    (
+        "provider",
+        (
+            "500",
+            "502",
+            "503",
+            "504",
+            "internal server error",
+            "bad gateway",
+            "service unavailable",
+            "gateway timeout",
+            "server error",
+            "upstream",
+            "provider error",
+        ),
+    ),
+    (
+        "network",
+        (
+            "timeout",
+            "timed out",
+            "connection",
+            "econnreset",
+            "econnrefused",
+            "enotfound",
+            "network",
+            "dns",
+            "ssl",
+            "certificate",
+            "stream disconnected",
+            "unexpected eof",
+        ),
+    ),
+    ("mcp", ("mcp", "model context protocol", "tool bridge", "circuit breaker")),
+    ("content-filter", ("content policy", "content filter", "safety system", "flagged")),
+]
+
+#: Hints the model can act on without the user, per category. Empty string
+#: when the honest answer is "report and ask".
+_HINTS: dict[str, str] = {
+    "context-limit": "",
+    "context-length": "The context is over the model's window: ask the user to "
+    "/compact, or compact at the next boundary if compaction is on.",
+    "rate-limit": "Back off and retry later; if it persists, tell the user which "
+    "provider hit the limit — they may need to switch model or top up quota.",
+    "auth": "Credentials were rejected: tell the user which provider and suggest "
+    "`local-operator login <provider>`. Do not retry the identical request.",
+    "billing": "The provider account cannot pay for this request: report it and "
+    "wait for the user.",
+    "provider": "The provider is failing server-side: a retry may work; if it "
+    "repeats, suggest switching model or provider.",
+    "network": "The connection failed mid-stream: retrying is usually right; if "
+    "it repeats, check connectivity.",
+    "mcp": "An MCP server is unavailable: its tools are gone until it reconnects. "
+    "Do not call its tools in a tight loop; say which server is down.",
+    "content-filter": "The provider refused the content: change the approach "
+    "rather than resending the same request.",
+}
+
+
+@dataclass(frozen=True)
+class Incident:
+    """One classified failure. ``raw`` always carries the original text."""
+
+    category: str
+    raw: str
+    provider: str = ""
+    model: str = ""
+
+    @property
+    def hint(self) -> str:
+        return _HINTS.get(self.category, "")
+
+    def render(self) -> str:
+        source = f" ({self.provider}/{self.model})" if self.provider or self.model else ""
+        head = f"[session incident{source}] {self.category}:"
+        lines = [f"{head} {self.raw.strip()[:500]}"]
+        if self.hint:
+            lines.append(f"suggested action: {self.hint}")
+        lines.append(
+            "This is why the previous turn ended. Take it into account before "
+            "repeating the same request."
+        )
+        return "\n".join(lines)
+
+
+def classify_incident(raw: str, provider: str = "", model: str = "") -> Incident:
+    """Classify an error string; never raises, never returns None."""
+    text = (raw or "").lower()
+    for category, patterns in _RULES:
+        for pattern in patterns:
+            if re.search(re.escape(pattern), text):
+                return Incident(category, raw, provider, model)
+    return Incident("unknown", raw, provider, model)
+
+
+def format_incident_message(raw: str, provider: str = "", model: str = "") -> str:
+    """One-call formatter for the rendered user-visible text."""
+    return classify_incident(raw, provider, model).render()

--- a/local_operator/mcp/config.py
+++ b/local_operator/mcp/config.py
@@ -64,7 +64,7 @@ class MCPOAuthConfig(BaseModel):
 class MCPStdioServerConfig(BaseModel):
     """A stdio MCP server: spawn ``command`` with ``args``."""
 
-    model_config = ConfigDict(extra="allow")
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
 
     type: Literal["stdio"] = "stdio"
     command: str = ""
@@ -72,6 +72,19 @@ class MCPStdioServerConfig(BaseModel):
     env: dict[str, str] = Field(default_factory=dict)
     cwd: str | None = None
     enabled: bool | None = None
+    enabled_tools: list[str] = Field(
+        default_factory=list,
+        alias="enabledTools",
+        description=(
+            "Optional allowlist of MCP tool names (exact or glob patterns); "
+            "empty means all tools."
+        ),
+    )
+    disabled_tools: list[str] = Field(
+        default_factory=list,
+        alias="disabledTools",
+        description=("MCP tool names/patterns to deny; wins over enabledTools."),
+    )
     timeout: float | None = None  # milliseconds; 0 disables client-side timeout
     auth: MCPAuthConfig | None = None
     oauth: MCPOAuthConfig | None = None
@@ -80,12 +93,25 @@ class MCPStdioServerConfig(BaseModel):
 class MCPHttpServerConfig(BaseModel):
     """A Streamable HTTP MCP server."""
 
-    model_config = ConfigDict(extra="allow")
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
 
     type: Literal["http"] = "http"
     url: str = ""
     headers: dict[str, str] = Field(default_factory=dict)
     enabled: bool | None = None
+    enabled_tools: list[str] = Field(
+        default_factory=list,
+        alias="enabledTools",
+        description=(
+            "Optional allowlist of MCP tool names (exact or glob patterns); "
+            "empty means all tools."
+        ),
+    )
+    disabled_tools: list[str] = Field(
+        default_factory=list,
+        alias="disabledTools",
+        description=("MCP tool names/patterns to deny; wins over enabledTools."),
+    )
     timeout: float | None = None
     auth: MCPAuthConfig | None = None
     oauth: MCPOAuthConfig | None = None
@@ -95,12 +121,25 @@ class MCPSseServerConfig(BaseModel):
     """A legacy dual-endpoint SSE MCP server (deprecated by the spec, kept for
     compatibility)."""
 
-    model_config = ConfigDict(extra="allow")
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
 
     type: Literal["sse"] = "sse"
     url: str = ""
     headers: dict[str, str] = Field(default_factory=dict)
     enabled: bool | None = None
+    enabled_tools: list[str] = Field(
+        default_factory=list,
+        alias="enabledTools",
+        description=(
+            "Optional allowlist of MCP tool names (exact or glob patterns); "
+            "empty means all tools."
+        ),
+    )
+    disabled_tools: list[str] = Field(
+        default_factory=list,
+        alias="disabledTools",
+        description=("MCP tool names/patterns to deny; wins over enabledTools."),
+    )
     timeout: float | None = None
     auth: MCPAuthConfig | None = None
     oauth: MCPOAuthConfig | None = None

--- a/local_operator/mcp/manager.py
+++ b/local_operator/mcp/manager.py
@@ -39,6 +39,7 @@ from collections import deque
 from collections.abc import AsyncIterator, Awaitable, Callable, Coroutine
 from contextlib import AsyncExitStack, asynccontextmanager, suppress
 from dataclasses import dataclass, field
+from fnmatch import fnmatchcase
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol, TypedDict, TypeVar
 
@@ -1000,7 +1001,9 @@ class McpManager:
             if cached:
                 self._unregister_origins(name)
                 self._tools_by_server[name] = [
-                    self._build_tool(name, entry, deferred=True) for entry in cached
+                    self._build_tool(name, entry, deferred=True)
+                    for entry in cached
+                    if self._tool_is_enabled(name, self._raw_tool_name(entry))
                 ]
                 self._rebuild_agent_names()
             # Deferred executes await this future; the continuation settles it.
@@ -1354,9 +1357,34 @@ class McpManager:
         """Build AgentTools for one server's tool list (live, not deferred)."""
         self._unregister_origins(name)
         self._tools_by_server[name] = [
-            self._build_tool(name, tool, deferred=False) for tool in tools
+            self._build_tool(name, tool, deferred=False)
+            for tool in tools
+            if self._tool_is_enabled(name, self._raw_tool_name(tool))
         ]
         self._rebuild_agent_names()
+
+    @staticmethod
+    def _raw_tool_name(tool: Tool | dict[str, Any]) -> str:
+        return str(tool.get("name", "")) if isinstance(tool, dict) else str(tool.name)
+
+    def _tool_is_enabled(self, server_name: str, tool_name: str) -> bool:
+        """Per-server MCP tool filter.
+
+        ``disabledTools`` wins; a non-empty ``enabledTools`` is an allowlist;
+        both accept exact names or glob patterns. Filtering happens before
+        name minting for BOTH cached/deferred and live tools, so a reconnect
+        or tools/list_changed cannot resurrect a denied schema into the
+        provider tools array (the context-cost and trust guarantees are the
+        same at startup and after recovery).
+        """
+        cfg = self._configs.get(server_name)
+        if cfg is None:
+            return True
+        denied = getattr(cfg, "disabled_tools", []) or []
+        if any(fnmatchcase(tool_name, pattern) for pattern in denied):
+            return False
+        allowed = getattr(cfg, "enabled_tools", []) or []
+        return not allowed or any(fnmatchcase(tool_name, pattern) for pattern in allowed)
 
     def _build_tool(
         self, server_name: str, tool: Tool | dict[str, Any], *, deferred: bool

--- a/local_operator/mcp/manager.py
+++ b/local_operator/mcp/manager.py
@@ -1657,6 +1657,21 @@ class McpManager:
                 RECONNECT_BURST_LIMIT,
                 int(RECONNECT_BURST_WINDOW_S),
             )
+            # Model-visible incident (session installs the sink): the agent
+            # must know the server's tools are GONE, or it hammers them in a
+            # tight loop. Fire-and-forget so a raising sink cannot stall the
+            # reconnect machinery.
+            sink = getattr(self, "on_incident", None)
+            if sink is not None:
+                try:
+                    sink(
+                        name,
+                        f"auto-reconnect suspended after >{RECONNECT_BURST_LIMIT} "
+                        f"attempts in {int(RECONNECT_BURST_WINDOW_S)}s; its tools are "
+                        "unavailable until a reconnect succeeds",
+                    )
+                except Exception:  # noqa: BLE001 — incidents must never break the manager
+                    logger.debug("mcp incident sink raised", exc_info=True)
             self._abandon_reconnect(
                 name,
                 f"reconnect breaker tripped (>{RECONNECT_BURST_LIMIT} in "

--- a/local_operator/mcp/manager.py
+++ b/local_operator/mcp/manager.py
@@ -791,6 +791,8 @@ class McpManager:
         # so a flapping server still trips the breaker.
         self._backoff_index: dict[str, int] = {}
         self._on_tools_changed: ToolsChangedCallback | None = None
+        # Session-installed sink for model-visible MCP breaker incidents.
+        self.on_incident: Callable[[str, str], None] | None = None
         # Tool-name collision state keyed by stable origin key (MCP-09):
         # (server name, original tool name), never registration order.
         self._tool_meta: dict[str, McpToolMeta] = {}

--- a/local_operator/mcp/tool_bridge.py
+++ b/local_operator/mcp/tool_bridge.py
@@ -51,6 +51,13 @@ _RETRIABLE_PATTERNS = (
     "http 404",
     "http 502",
     "http 503",
+    # A tools/call can surface an OAuth challenge AFTER initialize. Reconnect
+    # recreates the HTTP transport through OAuthClientProvider (refreshing the
+    # access token) and the call site retries ONCE — no replay loop.
+    "http 401",
+    "401 unauthorized",
+    "www-authenticate",
+    "mcp/www_authenticate",
     "404 not found",
     "502 bad gateway",
     "503 service unavailable",

--- a/local_operator/model/configure.py
+++ b/local_operator/model/configure.py
@@ -213,6 +213,12 @@ _NO_SAMPLING_PARAMS = re.compile(
     r"claude-[a-z]+-(?:[5-9]|\d{2,})(?!\d)" r"|(?:^|[/:-])o[1-9](?:-|$)" r"|gpt-5"
 )
 
+#: OpenAI introduced the public Responses route for the GPT-5 generation. The
+#: direct `/v1/models` listing exposes ids but no capability flags, so an
+#: uncurated current snapshot still needs a family rule; older registry rows
+#: remain explicitly off through ``ModelInfo.supports_responses_api``'s default.
+_OPENAI_RESPONSES_API = re.compile(r"^gpt-5(?:[.-]|$)")
+
 
 def build_model_spec(hosting: str, model_name: str, info: ModelInfo | None = None) -> ModelSpec:
     """Derive a harness ``ModelSpec`` from the model's resolved metadata.
@@ -242,6 +248,7 @@ def build_model_spec(hosting: str, model_name: str, info: ModelInfo | None = Non
     max_output = UNKNOWN_MAX_OUTPUT
     supports_images = True
     supports_cache = False
+    supports_responses_api = False
     if info is not None:
         # Legacy sentinels: -1 means "no data", not a real limit.
         if info.context_window and info.context_window > 0:
@@ -251,8 +258,12 @@ def build_model_spec(hosting: str, model_name: str, info: ModelInfo | None = Non
         if info.supports_images is not None:
             supports_images = info.supports_images
         supports_cache = info.supports_prompt_cache
+        supports_responses_api = bool(getattr(info, "supports_responses_api", False))
 
     definition = get_provider_definition(canonical)
+    if canonical == "openai" and _OPENAI_RESPONSES_API.search(model_name.lower()):
+        supports_responses_api = True
+        supports_cache = True
     lowered = model_name.lower()
     effort_levels = supported_efforts(model_name)
     # A model with an effort ladder reasons BY DEFINITION, whatever its name
@@ -318,6 +329,7 @@ def build_model_spec(hosting: str, model_name: str, info: ModelInfo | None = Non
         supports_tools=True,
         supports_images=supports_images,
         supports_prompt_cache=supports_cache,
+        supports_responses_api=supports_responses_api,
         base_url=definition.base_url if definition else None,
         reasoning=reasoning,
         supports_sampling_params=supports_sampling_params,
@@ -1392,6 +1404,16 @@ def configure_model(
     )
 
 
+def _openai_api_mode(settings: Mapping[str, Any] | None) -> str:
+    """Resolve the direct OpenAI wire route, defaulting safely to Responses."""
+    providers = settings.get("providers") if isinstance(settings, Mapping) else None
+    openai = providers.get("openai") if isinstance(providers, Mapping) else None
+    configured = openai.get("api") if isinstance(openai, Mapping) else None
+    # Only the explicit opt-out disables Responses. Old config files have no
+    # providers block, and malformed values must not accidentally change route.
+    return "chat_completions" if configured == "chat_completions" else "responses"
+
+
 # ---------------------------------------------------------------------------
 # stream_fn factory
 # ---------------------------------------------------------------------------
@@ -1434,7 +1456,11 @@ class SessionStreamFn:
     def _client_for(self, spec: ModelSpec) -> WireClient:
         from local_operator.providers.clients import client_for_spec
 
-        return client_for_spec(spec, http_client=self._http)
+        return client_for_spec(
+            spec,
+            http_client=self._http,
+            openai_api=_openai_api_mode(self._settings),
+        )
 
     def set_notice_handler(
         self, handler: Callable[[str, str], Awaitable[None] | None] | None
@@ -1670,6 +1696,13 @@ class SessionStreamFn:
         self, request: ChatRequest, signal: AbortSignal | None
     ) -> AsyncIterator[StreamEvent]:
         from local_operator.providers.failover import stream_with_failover
+
+        if self._session_id and request.prompt_cache_key is None:
+            # The transcript directory name is stable for the session and
+            # already scopes credential stickiness. Reusing it here keeps every
+            # turn on the same provider cache without coupling the harness loop
+            # to session storage.
+            request = request.model_copy(update={"prompt_cache_key": self._session_id})
 
         await self.preflight_usage(request.model)
         async for event in stream_with_failover(

--- a/local_operator/model/configure.py
+++ b/local_operator/model/configure.py
@@ -1449,6 +1449,10 @@ class SessionStreamFn:
         self._notice_handler: Callable[[str, str], Awaitable[None] | None] | None = None
         self._route_state = FailoverRouteState(on_change=self._on_route_change)
         self._message_boundary_pending = True
+        # Frozen for one user-message tool loop: choosing a new effort between
+        # tool calls would bust the provider cache and make one task reason at
+        # several depths.
+        self._message_effort: str | None = None
         self._primary_selector: str | None = None
         self._usage_checked_selector: str | None = None
         self._usage_checked_at = 0.0
@@ -1471,6 +1475,7 @@ class SessionStreamFn:
     def begin_message(self) -> None:
         """Mark the next model call as a user-message boundary."""
         self._message_boundary_pending = True
+        self._message_effort = None
 
     async def _notice(self, text: str, kind: str = "warning") -> None:
         if self._notice_handler is None:
@@ -1696,6 +1701,37 @@ class SessionStreamFn:
         self, request: ChatRequest, signal: AbortSignal | None
     ) -> AsyncIterator[StreamEvent]:
         from local_operator.providers.failover import stream_with_failover
+
+        # Classify only at the user-message boundary, then freeze the chosen
+        # effort for every tool-loop request under it. The tiny local linear
+        # model is sub-millisecond / zero tokens — an extra "small LLM" call
+        # would erase the saving on the short prompts most likely to go low.
+        if self._message_boundary_pending:
+            from local_operator.model.effort_classifier import auto_effort_for
+
+            last_user = next(
+                (message.text for message in reversed(request.messages) if message.role == "user"),
+                "",
+            )
+            self._message_effort, classification = auto_effort_for(
+                last_user,
+                request.model.reasoning_efforts,
+                self._settings,
+            )
+            if classification is not None and self._message_effort is not None:
+                await self._notice(
+                    f"auto effort: {self._message_effort} ({classification.tier}, "
+                    f"score {classification.score:.1f})",
+                    "info",
+                )
+        if self._message_effort is not None:
+            request = request.model_copy(
+                update={
+                    "model": request.model.model_copy(
+                        update={"reasoning_effort": self._message_effort}
+                    )
+                }
+            )
 
         if self._session_id and request.prompt_cache_key is None:
             # The transcript directory name is stable for the session and

--- a/local_operator/model/effort_classifier.py
+++ b/local_operator/model/effort_classifier.py
@@ -1,0 +1,139 @@
+"""Tiny local prompt-complexity model -> reasoning effort.
+
+OMP can delegate this to a small language model or a local sub-2B classifier.
+Local Operator's constraint is stricter: the classifier exists to SAVE time
+and output tokens, so paying another provider round trip before every user
+message would erase the win on the short prompts most likely to classify low.
+This module is therefore a tiny deterministic LINEAR model over cheap prompt
+features — sub-millisecond, no network, no tokenizer, no install extra.
+
+The output is coarse (lo / med / hi), then mapped onto the active model's own
+``reasoning_efforts`` ladder. The mapping never chooses ``minimal`` for lo
+when ``low`` exists, and hi defaults one rung below ``max`` (an operator can
+set ``values.effort.allowMax: true``). The selection freezes for the whole
+user-message tool loop: changing effort between tool calls would bust the
+provider cache and make one task reason at several depths.
+
+Disabled by default (``values.effort.auto: false``) so upgrading the harness
+does not silently change an operator's model spend. Enable it explicitly:
+
+    values:
+      effort:
+        auto: true
+        allowMax: false
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+_WORD_RE = re.compile(r"[a-z0-9_]+", re.IGNORECASE)
+_CODE_MARKERS = ("```", "def ", "class ", "function ", "=>", "traceback", "stack trace")
+_COMPLEX_VERBS = {
+    "implement",
+    "build",
+    "refactor",
+    "debug",
+    "design",
+    "architect",
+    "migrate",
+    "review",
+    "investigate",
+    "compare",
+    "optimize",
+    "deploy",
+    "release",
+}
+_SIMPLE_WORDS = {
+    "hello",
+    "hi",
+    "thanks",
+    "yes",
+    "no",
+    "continue",
+    "retry",
+    "status",
+    "list",
+    "show",
+    "read",
+    "find",
+    "search",
+}
+
+
+@dataclass(frozen=True)
+class Classification:
+    tier: str
+    score: float
+
+
+class PromptEffortClassifier:
+    """Eight-feature linear classifier. Weights are deliberately readable:
+    future tuning can pin a behaviour in tests without downloading a model or
+    changing an opaque embedding."""
+
+    def classify(self, prompt: str) -> Classification:
+        text = (prompt or "").strip()
+        words = _WORD_RE.findall(text.lower())
+        word_set = set(words)
+        lines = text.count("\n") + 1 if text else 0
+        score = 0.0
+        # Length grows smoothly rather than one cliff: 200 words ≈ +2.
+        score += min(len(words) / 100.0, 3.0)
+        score += min(lines / 12.0, 2.0)
+        score += 1.6 if any(marker in text.lower() for marker in _CODE_MARKERS) else 0.0
+        score += min(len(word_set & _COMPLEX_VERBS) * 0.7, 2.8)
+        score += (
+            0.8
+            if any(ch.isdigit() for ch in text) and ("error" in word_set or "test" in word_set)
+            else 0.0
+        )
+        score += 0.8 if sum(text.count(ch) for ch in ("- ", "* ", "1.")) >= 3 else 0.0
+        score += 0.7 if sum(text.count(sep) for sep in (" and ", " then ", ";")) >= 3 else 0.0
+        if len(words) <= 12 and word_set & _SIMPLE_WORDS and not (word_set & _COMPLEX_VERBS):
+            score -= 1.5
+        if score < 0.8:
+            tier = "lo"
+        elif score < 4.0:
+            tier = "med"
+        else:
+            tier = "hi"
+        return Classification(tier, score)
+
+
+def map_tier_to_effort(
+    tier: str, efforts: tuple[str, ...], *, allow_max: bool = False
+) -> str | None:
+    """Map lo/med/hi onto one model's supported effort ladder."""
+    if not efforts:
+        return None
+    ladder = list(efforts)
+    if tier == "lo":
+        # Never underthink at provider-specific "minimal" when low exists.
+        return ladder[1] if ladder[0] == "minimal" and len(ladder) > 1 else ladder[0]
+    if tier == "med":
+        return ladder[len(ladder) // 2]
+    # hi: protect spend/latency by stopping one rung below max by default.
+    if not allow_max and ladder[-1] == "max" and len(ladder) > 1:
+        return ladder[-2]
+    return ladder[-1]
+
+
+def auto_effort_for(
+    prompt: str,
+    efforts: tuple[str, ...],
+    settings: Mapping[str, Any] | None,
+) -> tuple[str | None, Classification | None]:
+    """Configured effort + classification; (None, None) when disabled."""
+    cfg = settings.get("effort", {}) if isinstance(settings, Mapping) else {}
+    if not isinstance(cfg, Mapping) or not bool(cfg.get("auto", False)):
+        return None, None
+    result = PromptEffortClassifier().classify(prompt)
+    effort = map_tier_to_effort(
+        result.tier,
+        efforts,
+        allow_max=bool(cfg.get("allowMax", cfg.get("allow_max", False))),
+    )
+    return effort, result

--- a/local_operator/model/registry.py
+++ b/local_operator/model/registry.py
@@ -196,6 +196,8 @@ class ModelInfo(BaseModel):
         context_window (Optional[int]): Context window size of the model.
         supports_images (Optional[bool]): Whether the model supports images.
         supports_prompt_cache (bool): Whether the model supports prompt caching.
+        supports_responses_api (bool): Whether the model supports OpenAI's
+            Responses API.
         cache_writes_price (Optional[float]): Cost per million tokens for cache writes.
         cache_reads_price (Optional[float]): Cost per million tokens for cache reads.
         description (Optional[str]): Description of the model.
@@ -212,6 +214,7 @@ class ModelInfo(BaseModel):
     context_window: Optional[int] = None
     supports_images: Optional[bool] = None
     supports_prompt_cache: bool = False
+    supports_responses_api: bool = False
     cache_writes_price: Optional[float] = None
     cache_reads_price: Optional[float] = None
     description: str = Field(..., description="Description of the model")

--- a/local_operator/optional.py
+++ b/local_operator/optional.py
@@ -30,6 +30,7 @@ EXTRAS: dict[str, str] = {
     "mcp": "Model Context Protocol client support",
     "images": "HEIC/HEIF image attachment decoding",
     "tokenizer": "exact BPE token counting for context management",
+    "lsp": "Python symbol-aware navigation and rename previews (jedi)",
     "all": "every optional feature",
 }
 

--- a/local_operator/prompts_api.py
+++ b/local_operator/prompts_api.py
@@ -224,6 +224,7 @@ def build_system_blocks(
     date_str: str,
     goal: str = "",
     user_instructions: str = "",
+    repo_guidance: str = "",
 ) -> list[str]:
     """Build the system prompt blocks; see the module docstring.
 
@@ -253,6 +254,11 @@ def build_system_blocks(
     ahead of every volatile change.
     """
     instructions = render_template("system.md", {})
+    if repo_guidance.strip():
+        # Same head-block, read-once discipline as user_instructions: the
+        # files are part of the project's standing state, edited between
+        # sessions, never within one.
+        instructions = f"{instructions}\n\n{repo_guidance.strip()}"
     if user_instructions.strip():
         # Tagged, not merged: the model must be able to tell the operator's
         # standing customization apart from the packaged rules above it, and

--- a/local_operator/prompts_md/system.md
+++ b/local_operator/prompts_md/system.md
@@ -35,6 +35,12 @@ real result beats a guess every time.
   a second way of doing things next to an established one is a defect.
 - **Fix problems at the source.** Never paper over a symptom — no suppressed
   errors, no special-cased inputs — unless the user explicitly asks for that.
+- **Read session incidents before retrying.** A `[session incident]` message
+  records why a previous turn died — rate limit, auth, provider outage,
+  network, context length, an MCP server going down. It states a suggested
+  action: take it (back off, wait, switch approach, tell the user which
+  provider needs attention) instead of resending the identical request into
+  the same wall.
 - **Recover, don't stop.** When a step fails, read the error, adjust, and try
   again. Report being stuck only after real alternatives are exhausted, with
   what you tried and the exact blocker.

--- a/local_operator/prompts_md/system.md
+++ b/local_operator/prompts_md/system.md
@@ -17,6 +17,20 @@ real result beats a guess every time.
   or build, deliver the complete result, not a plan or a stub.
 - **Plan before multi-step changes.** For work touching several files or with
   destructive effects, decide the steps first, then execute them in order.
+- **Parallelize independent work.** Steps that do not feed each other belong in
+  one batch of tool calls, not a sequence of round trips. When the user asks
+  for parallel work, or a job splits into independent self-contained slices,
+  launch them as concurrent `task` subagents — but keep interpretation, taste,
+  and anything that depends on conversation context here; delegate the slice,
+  not the decision.
+- **Edit, don't rewrite.** For changes to an existing file use `edit` with
+  SEARCH/REPLACE hunks — a `write` re-emits the whole file as output, the most
+  expensive tokens there are, and re-bills it as context on every later turn.
+  Put several changes to one file in a single `edits` list.
+- **Prove it ran.** When a change is supposed to alter behaviour, exercise the
+  real path afterwards — run the command, load the page, call the API — and
+  read the actual response. A green test suite proves the code does what you
+  expected, not that the feature works.
 - **Reuse existing patterns.** Follow the conventions already in the workspace;
   a second way of doing things next to an established one is a defect.
 - **Fix problems at the source.** Never paper over a symptom — no suppressed
@@ -35,14 +49,21 @@ real result beats a guess every time.
 - Keep secrets secret. Never print credentials, tokens, or keys into results.
 - The host may auto-approve read-only actions and prompt for writes and
   commands; respect denials without retrying the identical action.
+- Repository guidance in `<repo-guidance>` states the project's conventions.
+  Follow it as the project's defaults; a direct instruction from the user in
+  the conversation still wins.
 
 ## Tools
 
 Your tools are listed separately with their full schemas. Prefer the most
 specific tool for the job: `grep` over `bash`-ing grep, `read` with a line
 range over dumping whole files, `edit` for surgical changes, `todo` to keep a
-visible plan for multi-step work. `wake` schedules follow-ups when the user
-asks to be reminded or something should happen later.
+visible plan for multi-step work. `grep` takes `context_lines` for surrounding
+lines and `skip` to page past the first 200 matches; both `grep` and `glob`
+respect the project's ignore files. Reading a Python file whole returns its
+declaration outline with line ranges — re-read the exact ranges you need
+instead of the whole file. `wake` schedules follow-ups when the user asks to
+be reminded or something should happen later.
 
 `task` delegates a self-contained slice to a subagent that runs in the
 background; `jobs` lists what is running and `wait` blocks for a result. A

--- a/local_operator/prompts_md/system.md
+++ b/local_operator/prompts_md/system.md
@@ -65,8 +65,11 @@ declaration outline with line ranges — re-read the exact ranges you need
 instead of the whole file. `wake` schedules follow-ups when the user asks to
 be reminded or something should happen later.
 
-`task` delegates a self-contained slice to a subagent that runs in the
-background; `jobs` lists what is running and `wait` blocks for a result. A
+`task` delegates to subagents that run in the background — one, or a whole
+batch of independent slices in a single call (`tasks` + a shared `context`
+stating the goal and constraints once). `agent="scout"` is a read-only
+research child for investigation; `effort` picks a configured model tier.
+`jobs` lists what is running and `wait` blocks for a result. A
 running subagent is not out of reach: `hub` sends it a note, asks it a
 question and waits for its answer (use that when one has gone quiet rather
 than guessing whether it is stuck), steers it onto a different course,

--- a/local_operator/providers/clients.py
+++ b/local_operator/providers/clients.py
@@ -600,19 +600,16 @@ def _stream_timeout(total: float) -> httpx.Timeout:
 
 
 class OpenAICompatClient:
-    """``POST {base_url}/chat/completions`` with SSE streaming.
+    """Stream OpenAI-compatible chat/completions or OpenAI Responses.
 
-    Tool-call deltas are assembled by ``index`` (name/id arrive on the first
-    chunk, arguments stream in pieces). Usage comes from the final chunk
-    (``stream_options={"include_usage": true}``), including
-    ``prompt_tokens_details.cached_tokens``.
+    Tool-call deltas are normalized onto the same harness events on both
+    routes. Usage includes cached input tokens when the provider reports them.
 
     ChatGPT OAuth credentials (``oauth_access`` with ``kind == "oauth"`` and
-    an ``org_id``) are routed to ChatGPT's Codex Responses endpoint instead.
-    Subscription tokens are rejected by both ``chat/completions`` and the
-    public API's ``/responses`` endpoint; the Codex endpoint also requires its
-    account, beta, and originator headers. Plain API keys keep
-    ``chat/completions``.
+    an ``org_id``) always use ChatGPT's private Codex Responses endpoint and
+    headers. Ordinary API keys use the public ``/responses`` route only when
+    this client is configured for it and the ``ModelSpec`` advertises support;
+    compatibility providers and explicit opt-outs keep chat/completions.
     """
 
     def __init__(
@@ -622,8 +619,17 @@ class OpenAICompatClient:
         http_client: httpx.AsyncClient | None = None,
         extra_headers: Mapping[str, str] | None = None,
         timeout: float = 600.0,
+        openai_api: str | None = None,
     ) -> None:
         self._base_url = base_url.rstrip("/")
+        if openai_api is None:
+            # Direct construction remains useful in wire tests and extensions.
+            # Only the canonical public base is safe to recognize implicitly;
+            # every provider-registry construction passes an explicit mode.
+            openai_api = (
+                "responses" if self._base_url == "https://api.openai.com/v1" else "chat_completions"
+            )
+        self._openai_api = openai_api
         self._extra_headers = dict(extra_headers or {})
         self._owns_client = http_client is None
         self._http = http_client or httpx.AsyncClient(timeout=_stream_timeout(timeout))
@@ -748,23 +754,33 @@ class OpenAICompatClient:
             if isinstance(block, dict):
                 block["cache_control"] = {"type": "ephemeral"}
 
-    def _responses_mode(self, oauth_access: "OAuthAccess | None") -> bool:
-        """ChatGPT OAuth ⇒ Responses endpoint; plain API keys stay on completions."""
+    def _codex_responses_mode(self, oauth_access: "OAuthAccess | None") -> bool:
+        """Whether this credential is a ChatGPT subscription OAuth grant."""
         return bool(
             oauth_access is not None and oauth_access.kind == "oauth" and oauth_access.org_id
         )
 
+    def _public_responses_mode(
+        self, request: ChatRequest, oauth_access: "OAuthAccess | None"
+    ) -> bool:
+        """Whether an ordinary OpenAI API key should use public Responses."""
+        return (
+            not self._codex_responses_mode(oauth_access)
+            and self._openai_api == "responses"
+            and request.model.supports_responses_api
+        )
+
     def _build_responses_body(self, request: ChatRequest) -> dict[str, Any]:
-        """Responses-API body; ``input`` accepts chat-completions-shaped messages."""
+        """Public Responses body using native input items and flat tools."""
         body: dict[str, Any] = {
             "model": request.model.model_id,
             "stream": True,
-            "input": [_message_to_openai(m) for m in request.messages],
+            "input": _messages_to_openai_responses(request.messages),
         }
         if request.system_blocks:
             body["instructions"] = "\n\n".join(request.system_blocks)
         if request.tools:
-            body["tools"] = _tools_to_openai(request.tools)
+            body["tools"] = _tools_to_openai_responses(request.tools)
             body["tool_choice"] = {"auto": "auto", "none": "none", "required": "required"}.get(
                 request.tool_choice, "auto"
             )
@@ -775,21 +791,22 @@ class OpenAICompatClient:
         effort = _reasoning_effort(request)
         if effort is not None:
             body["reasoning"] = {"effort": effort}
-        if request.stop_sequences:
-            body["stop"] = list(request.stop_sequences)
+        if request.model.supports_prompt_cache and request.prompt_cache_key:
+            # The 24h policy is meaningful only with a stable key. SessionStreamFn
+            # supplies one per transcript, and retries preserve it on ChatRequest.
+            body["prompt_cache_key"] = request.prompt_cache_key
+            body["prompt_cache_retention"] = "24h"
         return body
 
     def _build_codex_responses_body(self, request: ChatRequest) -> dict[str, Any]:
         """ChatGPT Codex body: Responses-shaped, with public-API-only keys removed."""
         body = self._build_responses_body(request)
         body["store"] = False
-        body["input"] = _messages_to_openai_responses(request.messages)
+        body.pop("prompt_cache_key", None)
+        body.pop("prompt_cache_retention", None)
         body.pop("max_output_tokens", None)
         body.pop("temperature", None)
         body.pop("top_p", None)
-        body.pop("stop", None)
-        if request.tools:
-            body["tools"] = _tools_to_openai_responses(request.tools)
         return body
 
     async def stream(
@@ -798,8 +815,11 @@ class OpenAICompatClient:
         api_key: str | None,
         oauth_access: "OAuthAccess | None" = None,
     ) -> AsyncIterator[StreamEvent]:
-        if self._responses_mode(oauth_access):
-            async for event in self._stream_responses(request, api_key, oauth_access):
+        codex_responses = self._codex_responses_mode(oauth_access)
+        if codex_responses or self._public_responses_mode(request, oauth_access):
+            async for event in self._stream_responses(
+                request, api_key, oauth_access, codex=codex_responses
+            ):
                 yield event
             return
         url = f"{self._base_url}/chat/completions"
@@ -883,19 +903,26 @@ class OpenAICompatClient:
         request: ChatRequest,
         api_key: str | None,
         oauth_access: "OAuthAccess | None",
+        *,
+        codex: bool,
     ) -> AsyncIterator[StreamEvent]:
-        """SSE parse for ChatGPT's Codex Responses endpoint."""
-        url = CODEX_RESPONSES_URL
+        """Normalize public OpenAI and private ChatGPT Responses SSE."""
+        url = CODEX_RESPONSES_URL if codex else f"{self._base_url}/responses"
+        body = (
+            self._build_codex_responses_body(request)
+            if codex
+            else self._build_responses_body(request)
+        )
         usage: Usage | None = None
         provider_payload: dict[str, Any] | None = None
         tool_call_count = 0
-        # output-item index -> tool-call index (function_call items only).
+        # Output item/call ids -> normalized tool-call index.
         call_indexes: dict[str, int] = {}
 
         async with self._http.stream(
             "POST",
             url,
-            json=self._build_codex_responses_body(request),
+            json=body,
             headers=self._headers(api_key, oauth_access),
         ) as response:
             if response.status_code >= 400:
@@ -915,14 +942,20 @@ class OpenAICompatClient:
                         index = tool_call_count
                         tool_call_count += 1
                         call_id = item.get("call_id") or item.get("id") or ""
-                        call_indexes[call_id] = index
+                        item_id = item.get("id") or ""
+                        if call_id:
+                            call_indexes[call_id] = index
+                        if item_id:
+                            call_indexes[item_id] = index
                         yield StreamToolCallDelta(index=index, id=call_id, name=item.get("name"))
                 elif event_type == "response.function_call_arguments.delta":
-                    call_id = payload.get("call_id") or ""
+                    call_id = payload.get("call_id") or payload.get("item_id") or ""
                     delta = payload.get("delta")
                     if delta:
+                        fallback_index = int(payload.get("output_index", 0) or 0)
                         yield StreamToolCallDelta(
-                            index=call_indexes.get(call_id, 0), argument_delta=delta
+                            index=call_indexes.get(call_id, fallback_index),
+                            argument_delta=delta,
                         )
                 elif event_type == "response.output_text.delta":
                     delta = payload.get("delta")
@@ -1584,7 +1617,12 @@ class MockClient:
         yield StreamEndEvent(stop_reason="stop", usage=Usage(input_tokens=10, output_tokens=8))
 
 
-def client_for_spec(spec: ModelSpec, *, http_client: httpx.AsyncClient | None = None) -> WireClient:
+def client_for_spec(
+    spec: ModelSpec,
+    *,
+    http_client: httpx.AsyncClient | None = None,
+    openai_api: str = "responses",
+) -> WireClient:
     """Build the wire client for a ``ModelSpec`` via the provider registry.
 
     Unknown providers raise :class:`ValueError` — the legacy fallback to the
@@ -1622,4 +1660,9 @@ def client_for_spec(spec: ModelSpec, *, http_client: httpx.AsyncClient | None = 
         from local_operator.providers.oauth.kimi import kimi_common_headers
 
         extra_headers = kimi_common_headers()
-    return OpenAICompatClient(base_url=base, http_client=http_client, extra_headers=extra_headers)
+    return OpenAICompatClient(
+        base_url=base,
+        http_client=http_client,
+        extra_headers=extra_headers,
+        openai_api=openai_api if spec.provider == "openai" else "chat_completions",
+    )

--- a/local_operator/providers/clients.py
+++ b/local_operator/providers/clients.py
@@ -1496,6 +1496,14 @@ class GoogleClient:
             headers["x-goog-api-key"] = api_key
         usage: Usage | None = None
         stop_reason = "stop"
+        # Gemini returns one complete functionCall per part with no ids and
+        # no part indexes, so the harness must mint both. They must be UNIQUE
+        # per response: the loop dedups tool calls by id (first-wins), and a
+        # parallel batch of same-tool calls with a shared id silently drops
+        # every call after the first — the model believes two reads ran when
+        # only one did. The index doubles as the stream slot used to assemble
+        # argument deltas, matching the OpenAI per-index contract.
+        call_index = 0
 
         async with self._http.stream(
             "POST", url, json=self._build_body(request), headers=headers
@@ -1515,12 +1523,14 @@ class GoogleClient:
                             yield StreamTextDelta(delta=text)
                         function_call = part.get("functionCall")
                         if function_call:
+                            name = function_call.get("name")
                             yield StreamToolCallDelta(
-                                index=0,
-                                id=f"fc_{function_call.get('name', 'call')}",
-                                name=function_call.get("name"),
+                                index=call_index,
+                                id=f"fc_{call_index}_{name or 'call'}",
+                                name=name,
                                 argument_delta=json.dumps(function_call.get("args") or {}),
                             )
+                            call_index += 1
                     if candidate.get("finishReason"):
                         reason = str(candidate["finishReason"])
                         stop_reason = {"MAX_TOKENS": "length", "TOOL_USE": "toolUse"}.get(

--- a/local_operator/providers/clients.py
+++ b/local_operator/providers/clients.py
@@ -453,6 +453,31 @@ def _message_to_openai(message: Message) -> dict[str, Any]:
     return {"role": role, "content": parts}
 
 
+def _tool_output_to_openai_responses(
+    output: str | list[dict[str, Any]],
+) -> str | list[dict[str, Any]]:
+    """Chat-completions tool content -> Responses function output content.
+
+    Responses accepts a string OR native input content blocks. JSON-encoding
+    chat's image_url parts turns base64 into megabytes of plain text and makes
+    the screenshot invisible to the model; translate to input_text/input_image
+    instead.
+    """
+    if isinstance(output, str):
+        return output
+    blocks: list[dict[str, Any]] = []
+    for part in output:
+        if part.get("type") == "text":
+            blocks.append({"type": "input_text", "text": part.get("text", "")})
+            continue
+        if part.get("type") == "image_url":
+            image = part.get("image_url") or {}
+            url = image.get("url") if isinstance(image, Mapping) else ""
+            if url:
+                blocks.append({"type": "input_image", "image_url": url})
+    return blocks
+
+
 def _messages_to_openai_responses(messages: Sequence[Message]) -> list[dict[str, Any]]:
     """Render harness history as Responses input items, including tool turns."""
     items: list[dict[str, Any]] = []
@@ -480,7 +505,7 @@ def _messages_to_openai_responses(messages: Sequence[Message]) -> list[dict[str,
                 {
                     "type": "function_call_output",
                     "call_id": message.tool_call_id or "",
-                    "output": output if isinstance(output, str) else json.dumps(output),
+                    "output": _tool_output_to_openai_responses(output),
                 }
             )
             continue
@@ -597,6 +622,35 @@ def _stream_timeout(total: float) -> httpx.Timeout:
     which is the only place that knows a stream has started.
     """
     return httpx.Timeout(total, connect=30.0, read=total, write=120.0)
+
+
+_OPENAI_RESPONSE_ERROR_STATUS = {
+    "invalid_api_key": 401,
+    "authentication_error": 401,
+    "permission_denied": 403,
+    "rate_limit_exceeded": 429,
+    "server_error": 500,
+    "context_length_exceeded": 400,
+}
+
+
+def _openai_response_error(payload: Mapping[str, Any]) -> ProviderError:
+    """Failed/top-level Responses terminal event -> shared ProviderError."""
+    response_obj = payload.get("response") or {}
+    error = payload.get("error") or (
+        response_obj.get("error") if isinstance(response_obj, Mapping) else None
+    )
+    if not isinstance(error, Mapping):
+        error = {"message": str(error or payload)}
+    code = str(error.get("code") or error.get("type") or "")
+    message = _first_text(error.get("message")) or code or "OpenAI Responses request failed"
+    status = _OPENAI_RESPONSE_ERROR_STATUS.get(code)
+    return ProviderError(
+        status,
+        f"{code}: {message}" if code and code not in message else message,
+        retryable=status is None or status == 429 or status >= 500,
+        auth_error=status in (401, 403),
+    )
 
 
 class OpenAICompatClient:
@@ -916,6 +970,7 @@ class OpenAICompatClient:
         usage: Usage | None = None
         provider_payload: dict[str, Any] | None = None
         tool_call_count = 0
+        terminal_stop: str | None = None
         # Output item/call ids -> normalized tool-call index.
         call_indexes: dict[str, int] = {}
 
@@ -961,7 +1016,7 @@ class OpenAICompatClient:
                     delta = payload.get("delta")
                     if delta:
                         yield StreamTextDelta(delta=delta)
-                elif event_type == "response.completed":
+                elif event_type in ("response.completed", "response.incomplete"):
                     response_obj = payload.get("response") or {}
                     if response_obj.get("id"):
                         provider_payload = {"id": response_obj["id"]}
@@ -979,9 +1034,36 @@ class OpenAICompatClient:
                             context_tokens=int(raw.get("input_tokens", 0)) or None,
                         )
                         yield StreamUsageEvent(usage=usage)
+                    if event_type == "response.completed":
+                        terminal_stop = "toolUse" if tool_call_count else "stop"
+                    else:
+                        incomplete = response_obj.get("incomplete_details") or {}
+                        reason = str(
+                            incomplete.get("reason")
+                            if isinstance(incomplete, Mapping)
+                            else incomplete
+                        )
+                        if reason in ("max_output_tokens", "max_output_chars"):
+                            # Length means the loop pairs placeholders and NEVER
+                            # executes a partial function call.
+                            terminal_stop = "length"
+                        else:
+                            raise ProviderError(
+                                400,
+                                f"OpenAI Responses incomplete: {reason or 'unknown reason'}",
+                                retryable=False,
+                            )
+                elif event_type in ("response.failed", "error"):
+                    raise _openai_response_error(payload)
 
+        if terminal_stop is None:
+            raise ProviderError(
+                None,
+                "OpenAI Responses stream ended without a terminal event",
+                retryable=True,
+            )
         yield StreamEndEvent(
-            stop_reason="toolUse" if tool_call_count else "stop",
+            stop_reason=terminal_stop,
             usage=usage,
             provider_payload=provider_payload,
         )

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -664,6 +664,62 @@ class Session:
         """
         return list(self._context.messages)
 
+    def context_breakdown(self) -> dict[str, int]:
+        """On-demand token breakdown for the context the next request sends.
+
+        This is the user-visible counterpart to the 30k start-context budget:
+        it tokenizes the actual system blocks + wire tool schemas + rendered
+        messages, so a 126-tool MCP server's cost is a fact the user can SEE
+        instead of an invisible latency/cost regression. The four fixed blocks
+        retain their cache-layout names; schemas are counted separately
+        because providers serialize them beside the prompt, not in block 1.
+        """
+        import json
+
+        from local_operator.compaction.tokens import (
+            approx_text_tokens,
+            estimate_messages_tokens,
+        )
+
+        blocks = list(self._context.system_blocks)
+        while len(blocks) < 4:
+            blocks.append("")
+        result = {
+            "instructions": approx_text_tokens(blocks[0]),
+            "tool_inventory": approx_text_tokens(blocks[1]),
+            "environment": approx_text_tokens(blocks[2]),
+            "knowledge_mcp_goal": approx_text_tokens(blocks[3]),
+            "tool_schemas": sum(
+                approx_text_tokens(
+                    tool.name
+                    + "\n"
+                    + (tool.description or "")
+                    + "\n"
+                    + json.dumps(tool.parameters, sort_keys=True, separators=(",", ":"))
+                )
+                for tool in self._tools
+            ),
+            "messages": estimate_messages_tokens(
+                self._render_history(list(self._context.messages))
+            ),
+            "context_window": int(self._model.context_window),
+            "cache_read": int(
+                self._last_usage.cache_read_tokens if self._last_usage is not None else 0
+            ),
+        }
+        result["total"] = sum(
+            result[key]
+            for key in (
+                "instructions",
+                "tool_inventory",
+                "environment",
+                "knowledge_mcp_goal",
+                "tool_schemas",
+                "messages",
+            )
+        )
+        return result
+
     def set_model(self, model: ModelSpec) -> None:
         """Swap the model spec mid-session.
 

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -1004,6 +1004,7 @@ class Session:
                 get_aside_messages=self._drain_asides,
                 resolve_fallback_tool=self._fallback_tool_resolver,
                 interrupt_mode="immediate",
+                on_turn_end=self._on_turn_end,
             )
 
             new_messages: list[AgentMessage] = []
@@ -1239,6 +1240,82 @@ class Session:
             await self._transcript.compact_file()
         except OSError as exc:
             logger.warning("could not journal pruned tool outputs: %s", exc)
+
+    async def _on_turn_end(self, messages: list[AgentMessage]) -> list[AgentMessage] | None:
+        """Mid-turn compaction gate — runs INSIDE the tool loop, at the safe
+        boundary after each tool batch lands and before the next model call.
+
+        Without this, a single long tool run (dozens of calls, no user turn)
+        grows past the window with no relief until the run ends — the next
+        provider request then fails the whole run, and the post-turn pass
+        recovers a turn that never needed to break. The knob
+        (``values.compaction.mid_turn_enabled``) defaults on; the pass itself
+        is the same single plan+commit the post-turn gate and ``/compact``
+        share, so there is no second compaction implementation to drift.
+
+        Returns the replacement context so the loop can prune its run
+        accumulator (see ``LoopConfig.on_turn_end``), or ``None`` when no
+        compaction ran. The replayability guard in ``_plan_compaction``
+        (kept[0] must be a transcript entry) naturally constrains mid-run
+        cuts to already-persisted history, which is where a cut belongs
+        mid-run anyway.
+        """
+        if self._disposed:
+            return None
+        try:
+            from local_operator.compaction.api import CompactionSettings
+        except ImportError:
+            return None
+        settings = self._compaction_settings or CompactionSettings()
+        # getattr: hosts (and the test suite) may inject a duck-typed
+        # settings model that predates the knob; absence means the §C default
+        # (on), same posture as _resolve_strategy's capability probes.
+        if not settings.enabled or not getattr(settings, "mid_turn_enabled", True):
+            return None
+        # The post-run usage scan has not happened yet — the boundary
+        # snapshot carries the assistant message that just finished, whose
+        # usage is the provider's ground truth for the trigger math.
+        for message in reversed(messages):
+            if isinstance(message, Message) and message.usage is not None:
+                self._last_usage = message.usage
+                break
+        # Cheap pre-gate: when the provider just reported its context size and
+        # that figure already fails the trigger, skip the full plan — the
+        # plan renders the whole history to prove the same thing, and this
+        # hook fires at EVERY continuing tool-loop boundary. The threshold
+        # mirror below is 4 lines; _plan_compaction stays the authority for
+        # any context that passes this gate. No provider figure (usage not
+        # yet reported) falls through to the plan, whose own upper-bound
+        # proof is the cheap path there.
+        provider_reported = (
+            self._last_usage.context_tokens if self._last_usage is not None else None
+        )
+        if provider_reported is not None:
+            from local_operator.compaction import api as compaction_api
+
+            gate_settings = settings
+            if (
+                getattr(settings, "threshold_tokens", -1) <= 0
+                and getattr(settings, "threshold_percent", -1) <= 0
+            ):
+                gate_settings = settings.model_copy(
+                    update={
+                        "threshold_tokens": compaction_api.resolve_threshold_tokens(
+                            self._model.context_window, settings
+                        )
+                    }
+                )
+            if not compaction_api.should_compact(
+                provider_reported, self._model.context_window, gate_settings
+            ):
+                return None
+        planned = await self._plan_compaction(respect_threshold=True)
+        if isinstance(planned, CompactionOutcome):
+            return None
+        outcome = await self._run_compaction(planned, reason="mid-turn")
+        if not outcome.ran:
+            return None
+        return list(self._context.messages)
 
     async def _maybe_compact(self) -> None:
         """Post-turn compaction check — the AUTOMATIC trigger.

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -42,7 +42,7 @@ from typing import TYPE_CHECKING, Any, Literal
 from local_operator.compaction.tokens import approx_text_tokens
 from local_operator.harness.approval import ApprovalGate
 from local_operator.harness.comms import HUB_MESSAGE_TYPE, SubagentComms
-from local_operator.harness.jobs import AsyncJobManager
+from local_operator.harness.jobs import JOB_RESULT_MESSAGE_TYPE, AsyncJobManager
 from local_operator.harness.loop import AgentLoop, LoopContext
 from local_operator.harness.subagent import run_subagent
 from local_operator.harness.types import (
@@ -82,6 +82,7 @@ from local_operator.harness.wake import (
     WakeScheduler,
     format_wake_delivery_text,
 )
+from local_operator.incidents import SESSION_INCIDENT_MESSAGE_TYPE
 from local_operator.session.goal import GoalState
 from local_operator.session.mcp_status import McpStartupOutcome
 from local_operator.session.naming import ConversationName
@@ -192,7 +193,23 @@ def _default_convert_to_llm(messages: list[AgentMessage]) -> list[Message]:
             # compaction cut landing on a rendered marker can still locate
             # ``first_kept_entry_id`` on replay.
             out.append(_render_compaction_marker(message, entry_id=message.id))
-        elif message.custom_type in (WAKE_PROMPT_MESSAGE_TYPE, HUB_MESSAGE_TYPE):
+        elif message.custom_type == SESSION_INCIDENT_MESSAGE_TYPE:
+            # An incident rides the sender's preformatted text (the classifier
+            # already wrote category + suggested action), exactly like a wake
+            # delivery: it must reach the model as a user turn or the session
+            # stays blind to why its last run died.
+            out.append(
+                Message(
+                    role="user",
+                    content=[TextContent(text=message.details.get("text", ""))],
+                    id=message.id,
+                )
+            )
+        elif message.custom_type in (
+            WAKE_PROMPT_MESSAGE_TYPE,
+            HUB_MESSAGE_TYPE,
+            JOB_RESULT_MESSAGE_TYPE,
+        ):
             # A hub message renders exactly like a wake delivery: the sender
             # already formatted ``details["text"]``, and it must reach the
             # model as a user turn or the agent it was addressed to never
@@ -454,9 +471,15 @@ class Session:
         # this one runs between turns, so a caller that finds the lock held
         # needs a way to tell WHICH holder it is looking at (see `prompt`).
         self._compacting = False
+        # Error text from the run just ended, journalled as a session incident
+        # once persistence finishes (see _run_turn / journal_incident).
+        self._pending_incident: str | None = None
         self._turn_task: asyncio.Task[None] | None = None  # in-flight turn (wake deliveries)
 
-        self.jobs = AsyncJobManager()
+        # on_job_complete: settled model-owned jobs auto-deliver back into the
+        # conversation when the session is idle (see _on_job_completed) — the
+        # model stops having to poll 'jobs' for work it already started.
+        self.jobs = AsyncJobManager(on_job_complete=self._on_job_completed)
         self._wake = WakeScheduler(
             now=lambda: int(time.time() * 1000),
             deliver=self._deliver_wake,
@@ -1031,6 +1054,10 @@ class Session:
                         # same prompt (§B).
                         if event.error is not None:
                             await self._degrade_if_image_rejected(event.error)
+                            # Journal WHY the run died after persistence: the
+                            # model (this session or a resumed one) must see
+                            # the failure, not just the UI.
+                            self._pending_incident = event.error
                         self._abort_requested = True
                         self._continuation_queue.clear()
                         self._held_end = None
@@ -1065,6 +1092,11 @@ class Session:
                 if message in initial:
                     continue
                 await self._transcript.append_message(message)
+
+            pending_incident = self._pending_incident
+            self._pending_incident = None
+            if pending_incident:
+                await self.journal_incident(pending_incident)
 
             await self._maybe_compact()
         finally:
@@ -1214,6 +1246,77 @@ class Session:
                 "subagent model tier %r could not be resolved; using session model", wanted
             )
             return None
+
+    async def journal_incident(self, raw: str) -> None:
+        """Persist and surface WHY the session last failed.
+
+        The failover cascade rotates credentials and models and its notices
+        reach the UI, but without this the MODEL never learned the
+        difference between "quota exhausted" and "my own bug" — the next
+        prompt (and a resumed session) resumed blind. The incident is
+        classified (rate-limit / auth / provider / network / context / MCP),
+        appended to the LIVE context so the very next turn sees it, and
+        persisted so ``--resume`` replays it.
+        """
+        from local_operator.incidents import format_incident_message
+
+        if self._disposed or not raw:
+            return
+        text = format_incident_message(raw, self._model.provider, self._model.model_id)
+        message = CustomMessage(
+            custom_type=SESSION_INCIDENT_MESSAGE_TYPE,
+            attribution="system",
+            details={"text": text, "raw": raw[:1000]},
+        )
+        try:
+            await self._transcript.append_message(message)
+            self._context.messages.append(message)
+        except OSError:
+            logger.warning("could not journal session incident", exc_info=True)
+
+    def _on_mcp_incident(self, server: str, reason: str) -> None:
+        """MCP manager hook (breaker trips): journal without blocking the
+        manager's reconnect loop."""
+        self._spawn_background(self.journal_incident(f"MCP server '{server}': {reason}"))
+
+    async def _on_job_completed(self, job_id: str, text: str, job: Any) -> None:
+        """Auto-deliver one settled model-owned job back into the conversation.
+
+        Only when the session is IDLE: a running turn already owns the
+        conversation (its model either waited or can 'jobs'), and
+        steering-injecting a result nobody asked for mid-turn is noise. Only
+        model-registered job types (task, backgrounded bash): host jobs keep
+        their own delivery. A job the wait tool already returned is marked
+        consumed and stays quiet, or the same result would arrive twice.
+        """
+        if self._disposed or job is None:
+            return
+        # Top-level only: a child session is a one-shot runner. Auto-starting
+        # an invisible re-entrant child turn from a nested job conflicts with
+        # its teardown (and nobody has a panel for it); the child can still
+        # consume nested work deliberately through its own jobs/wait tools.
+        if self._job_id is not None:
+            return
+        if getattr(job, "consumed", False) or job.type not in ("task", "bash"):
+            return
+        if self._is_streaming:
+            return
+        label = getattr(job, "label", job_id)
+        status = getattr(job, "status", "completed")
+        summary = (text or "").strip()
+        if len(summary) > 2000:
+            summary = summary[:2000] + "…[truncated; full result via jobs/wait]"
+        delivery = (
+            f"background job '{label}' {status}:\n{summary}"
+            if summary
+            else f"background job '{label}' {status}."
+        )
+        message = CustomMessage(
+            custom_type=JOB_RESULT_MESSAGE_TYPE,
+            attribution="user",
+            details={"job_id": job_id, "text": delivery},
+        )
+        self._spawn_background(self._prompt_messages([message]))
 
     async def _drain_steering(self) -> list[AgentMessage]:
         """Consume the steering queue. Steering messages are real injected

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -1159,7 +1159,9 @@ class Session:
             },
         )
 
-    def _launch_subagent(self, label: str, prompt: str) -> str:
+    def _launch_subagent(
+        self, label: str, prompt: str, *, agent: str = "task", effort: str | None = None
+    ) -> str:
         """Register one one-shot child run on this session's job manager.
 
         The production caller of :func:`run_subagent`: spawn the child against
@@ -1168,13 +1170,50 @@ class Session:
         the child wiring. Installed on the ``ToolContext`` as
         ``subagent_launcher`` every turn so the ``task`` tool can start a
         child. Returns the job id.
+
+        ``agent``/``effort`` select the tier (see ``SubagentLauncher``):
+        effort resolves through ``values.subagents.models`` (``lo``/``med``/
+        ``hi`` -> ``provider/model-id``), so a scout or a cheap bulk task runs
+        on the model the operator picked for that job, not the session's
+        default. An unresolvable tier falls back to the parent's model with a
+        warning — a delegation must not fail because a config key is stale.
         """
+        model_spec = self._resolve_subagent_model(agent, effort)
         return run_subagent(
             label=label,
             prompt=prompt,
             parent_session=self,
             jobs_manager=self.jobs,
+            model_spec=model_spec,
+            agent=agent,
         )
+
+    def _resolve_subagent_model(self, agent: str, effort: str | None) -> ModelSpec | None:
+        """Effort tier -> ModelSpec via config; None keeps the parent's model."""
+        wanted = effort or ("lo" if agent == "scout" else None)
+        if wanted is None:
+            return None
+        try:
+            from local_operator.config import ConfigManager
+            from local_operator.paths import config_dir
+
+            raw = ConfigManager(config_dir()).get_config_value("subagents", None)
+            models = raw.get("models", {}) if isinstance(raw, dict) else {}
+            selector = models.get(wanted)
+            if not selector:
+                return None
+            provider, _, model_id = str(selector).partition("/")
+            if not model_id:
+                logger.warning("subagents.models.%s=%r lacks provider/model", wanted, selector)
+                return None
+            from local_operator.model.configure import build_model_spec
+
+            return build_model_spec(provider, model_id)
+        except Exception:  # noqa: BLE001 — stale config must not fail a spawn
+            logger.warning(
+                "subagent model tier %r could not be resolved; using session model", wanted
+            )
+            return None
 
     async def _drain_steering(self) -> list[AgentMessage]:
         """Consume the steering queue. Steering messages are real injected

--- a/local_operator/session_factory.py
+++ b/local_operator/session_factory.py
@@ -376,6 +376,28 @@ def _latest_user_query(transcript: Transcript) -> str:
     return "\n".join(part for part in (user_text, summary) if part)
 
 
+def _latest_compaction_id(transcript: Transcript) -> str | None:
+    """Entry id of the newest compaction marker, or ``None`` without one.
+
+    This is the freeze key for the knowledge block: selection normally
+    freezes after the first query so the prompt-cache prefix stays warm, but
+    a compaction rewrites the transcript head anyway — the cache is already
+    invalidated — so a NEW id here licenses one re-selection (see
+    :func:`_select_knowledge_block`). Same contract as
+    :func:`_latest_user_query`: any transcript deviation degrades to
+    ``None`` (treated as "no compaction yet"), never breaks the turn.
+    """
+    try:
+        entries = transcript.entries()
+    except Exception:  # noqa: BLE001 — degradation is the contract
+        return None
+    for entry in reversed(entries):
+        if getattr(entry, "type", None) == "compaction":
+            entry_id = getattr(entry, "id", None)
+            return str(entry_id) if entry_id else None
+    return None
+
+
 def _env_details(cwd: str | None = None) -> str:
     """Volatile environment facts for the env block (date rides there too,
     added by ``build_system_blocks``). Kept tiny and byte-stable within a
@@ -459,6 +481,11 @@ class _KnowledgeHooks:
     skills_by_name: dict[str, Skill] = field(default_factory=dict)
     guides_by_name: dict[str, Skill] = field(default_factory=dict)
     frozen_block: str | None = None
+    #: Compaction entry id observed when ``frozen_block`` was computed. A
+    #: change here (a new compaction marker) re-opens selection once — the
+    #: transcript head is being rewritten anyway, so the prompt cache the
+    #: freeze protects is already gone.
+    frozen_compaction_id: str | None = None
     mcp_resolver: Callable[[str], str | None] | None = None
     mcp_catalogue: Callable[[], str] | None = None
 
@@ -598,15 +625,38 @@ async def _setup_knowledge(
     return hooks
 
 
-async def _select_knowledge_block(hooks: _KnowledgeHooks, query: str) -> str:
-    """Freeze selected knowledge plus the bounded MCP catalogue for the session."""
-    if hooks.frozen_block is not None:
+async def _select_knowledge_block(
+    hooks: _KnowledgeHooks,
+    query: str,
+    *,
+    compaction_id: str | None = None,
+    cwd: str | None = None,
+) -> str:
+    """Freeze selected knowledge plus the bounded MCP catalogue for the session.
+
+    The freeze exists purely for prompt-cache warmth: once the block is
+    rendered, later turns reuse it byte-for-byte rather than re-embedding and
+    possibly reordering the tail. The ONE thing that re-opens it is a new
+    compaction marker (``compaction_id`` differs from the id recorded at
+    freeze time): compaction rewrites the transcript head the block rides
+    behind, invalidating that cache anyway, so selection is re-run against
+    the latest user query + compaction summary (the query the provider
+    extracts) and re-frozen under the new id. ``cwd`` feeds gitignore-style
+    ``globs`` matching in the index (see
+    :meth:`local_operator.skills.index.SkillIndex.select`).
+    """
+    if hooks.frozen_block is not None and hooks.frozen_compaction_id == compaction_id:
         return hooks.frozen_block
 
     picked: list[Skill] = []
     query = query.strip()
     if query:
-        picked = await hooks.index.select(query) if hooks.index is not None else []
+        # cwd rides as a keyword ONLY when set: test doubles and alternate
+        # index shapes in the wild implement ``select(query, ...)`` with the
+        # historical signature, and there is no globs matching to do without
+        # a cwd anyway.
+        select_kwargs: dict[str, Path] = {"cwd": Path(cwd)} if cwd else {}
+        picked = await hooks.index.select(query, **select_kwargs) if hooks.index is not None else []
         if hooks.agent_hint_index is not None:
             matching_agents = await hooks.agent_hint_index.select(query, k=1)
             agents_guide = hooks.guides_by_name.get("agents")
@@ -629,6 +679,7 @@ async def _select_knowledge_block(hooks: _KnowledgeHooks, query: str) -> str:
         if catalogue:
             sections.append(catalogue)
     hooks.frozen_block = "\n\n".join(sections)
+    hooks.frozen_compaction_id = compaction_id
     return hooks.frozen_block
 
 
@@ -686,7 +737,8 @@ def _make_system_blocks_provider(
     so semantic knowledge selection can live inside. Block layout comes from
     ``prompts_api.build_system_blocks``: stable head (instructions, inventory,
     env) then the session-frozen guide/skill block last, so the cache prefix
-    stays warm.
+    stays warm — re-selected only when a new compaction marker invalidates
+    that prefix anyway (see :func:`_select_knowledge_block`).
 
     ``goal_state`` is the SAME holder the session facade exposes through
     ``set_goal``, which is how a ``/goal`` edit reaches the next turn's
@@ -695,8 +747,8 @@ def _make_system_blocks_provider(
     ``user_instructions`` is captured once by the caller and closed over
     rather than re-read here: it lands in the byte-stable head block, so
     re-reading the file per turn would let a mid-session edit silently
-    invalidate the whole cached prefix. Editing the file takes effect on the
-    next session, which is also what makes a session's prompt reproducible.
+    invalidate the whole cached prefix. Editing the file takes effect on
+    the next session, which is also what makes a session's prompt reproducible.
     """
 
     async def provider() -> list[str]:
@@ -704,7 +756,12 @@ def _make_system_blocks_provider(
 
         query = _latest_user_query(transcript)
         try:
-            knowledge_block = await _select_knowledge_block(hooks, query)
+            knowledge_block = await _select_knowledge_block(
+                hooks,
+                query,
+                compaction_id=_latest_compaction_id(transcript),
+                cwd=cwd,
+            )
         except Exception:  # noqa: BLE001 — never break the turn
             knowledge_block = ""
         date_str = datetime.now().strftime("%Y-%m-%d")
@@ -1089,6 +1146,9 @@ def attach_mcp_dispose(session: Session, manager: McpManager) -> None:
     """
     session.add_dispose_hook(manager.disconnect_all)
     session.mcp_manager = manager
+    # Breaker incidents become session incidents: the model learns a server's
+    # tools are gone instead of hammering them (MCP-07's observable half).
+    manager.on_incident = session._on_mcp_incident
 
 
 def attach_auth_dispose(session: Session, auth_store: AuthStore | None) -> None:

--- a/local_operator/session_factory.py
+++ b/local_operator/session_factory.py
@@ -61,7 +61,6 @@ if TYPE_CHECKING:
     from local_operator.session.goal import GoalState
     from local_operator.session.protocol import SessionProtocol
     from local_operator.session.session import Session
-    from local_operator.session.transcript import Transcript
     from local_operator.skills.discovery import Skill
     from local_operator.skills.index import SkillIndex
     from local_operator.variables import VariableStore
@@ -346,7 +345,7 @@ def _make_request_approval(yolo: bool) -> Callable[[str, str], Awaitable[bool]]:
     return prompt_approval
 
 
-def _latest_user_query(transcript: Transcript) -> str:
+def _latest_user_query(transcript: Any) -> str:
     """Extract the skill-selection query from the transcript.
 
     Per-turn selection embeds the last user message plus the latest
@@ -376,7 +375,7 @@ def _latest_user_query(transcript: Transcript) -> str:
     return "\n".join(part for part in (user_text, summary) if part)
 
 
-def _latest_compaction_id(transcript: Transcript) -> str | None:
+def _latest_compaction_id(transcript: Any) -> str | None:
     """Entry id of the newest compaction marker, or ``None`` without one.
 
     This is the freeze key for the knowledge block: selection normally
@@ -655,7 +654,7 @@ async def _select_knowledge_block(
         # index shapes in the wild implement ``select(query, ...)`` with the
         # historical signature, and there is no globs matching to do without
         # a cwd anyway.
-        select_kwargs: dict[str, Path] = {"cwd": Path(cwd)} if cwd else {}
+        select_kwargs: dict[str, Any] = {"cwd": Path(cwd)} if cwd else {}
         picked = await hooks.index.select(query, **select_kwargs) if hooks.index is not None else []
         if hooks.agent_hint_index is not None:
             matching_agents = await hooks.agent_hint_index.select(query, k=1)
@@ -724,7 +723,7 @@ class _SessionPlan:
 
 def _make_system_blocks_provider(
     tools: list[AgentTool],
-    transcript: Transcript,
+    transcript: Any,
     hooks: _KnowledgeHooks,
     cwd: str | None = None,
     goal_state: "GoalState | None" = None,

--- a/local_operator/session_factory.py
+++ b/local_operator/session_factory.py
@@ -678,6 +678,7 @@ def _make_system_blocks_provider(
     cwd: str | None = None,
     goal_state: "GoalState | None" = None,
     user_instructions: str = "",
+    repo_guidance: str = "",
 ) -> Callable[[], Awaitable[list[str]]]:
     """Build the per-turn system-prompt closure.
 
@@ -715,6 +716,7 @@ def _make_system_blocks_provider(
             date_str,
             goal=goal,
             user_instructions=user_instructions,
+            repo_guidance=repo_guidance,
         )
 
     return provider
@@ -889,6 +891,15 @@ async def _prepare(
         except (KeyError, OSError):
             agent_prompt = ""
     user_instructions = load_user_instructions(agent_prompt)
+    # Repo guidance (AGENTS.md/CLAUDE.md ancestors) joins the same read-once
+    # contract: the head block must stay byte-stable for the session, so the
+    # filesystem is consulted here and never again.
+    from local_operator.context_files import load_repo_guidance
+
+    try:
+        repo_guidance = load_repo_guidance(effective_cwd)
+    except Exception:  # noqa: BLE001 — never block session construction
+        repo_guidance = ""
 
     system_blocks_provider = _make_system_blocks_provider(
         tools,
@@ -897,6 +908,7 @@ async def _prepare(
         cwd=effective_cwd,
         goal_state=goal_state,
         user_instructions=user_instructions,
+        repo_guidance=repo_guidance,
     )
 
     session_kwargs: dict[str, Any] = dict(

--- a/local_operator/skills/api.py
+++ b/local_operator/skills/api.py
@@ -5,16 +5,21 @@ session relies on (a missing/broken skills module must degrade to
 no-skills, not crash startup). Re-exports the discovery model, the semantic
 index, the embedding backends, the ``skill://`` resolver, the
 ``SkillResolver`` adapter factory, and the default root computation.
-
-Root precedence: project-local beats global. ``default_skill_roots`` walks
-up from cwd to the filesystem root collecting ``.local-operator/skills``
-directories (regardless of ``$HOME``) and appends
-``~/.local-operator/skills`` last; earlier roots win name collisions in
-:func:`discover_skills`.
+Root precedence: project-local beats global, native beats ecosystem.
+``default_skill_roots`` walks up from cwd to the filesystem root collecting
+``.local-operator/skills`` directories (regardless of ``$HOME``), appends
+``~/.local-operator/skills``, then the wider ecosystem roots
+(``~/.omp/agent/skills``, ``~/.claude/skills``, ``~/.codex/skills``,
+``~/.agents/skills``) last — only the ones that exist, so a clean machine
+scans nothing extra. ``LOCAL_OPERATOR_SKILL_EXTRA_ROOTS`` replaces that
+ecosystem set (colon-separated absolute paths; an empty value disables it).
+Earlier roots win name collisions in :func:`discover_skills`, which is what
+makes native roots authoritative over imported ones.
 """
 
 from __future__ import annotations
 
+import os
 from collections.abc import Callable, Mapping
 from pathlib import Path
 
@@ -46,6 +51,37 @@ __all__ = [
 
 _SKILLS_SUBDIR = Path(".local-operator") / "skills"
 
+#: Ecosystem skill directories scanned AFTER the native roots, widest first
+#: is irrelevant — only existence and order matter, and order is fixed here
+#: so two machines with the same installs compute the same root list.
+_ECOSYSTEM_SKILL_SUBDIRS: tuple[Path, ...] = (
+    Path(".omp") / "agent" / "skills",
+    Path(".claude") / "skills",
+    Path(".codex") / "skills",
+    Path(".agents") / "skills",
+)
+
+#: Replaces the ecosystem set when set. Colon-separated absolute paths;
+#: an empty value disables ecosystem scanning entirely (a user who wants
+#: ONLY native roots gets exactly that).
+_EXTRA_ROOTS_ENV = "LOCAL_OPERATOR_SKILL_EXTRA_ROOTS"
+
+
+def _ecosystem_roots(home: Path) -> list[Path]:
+    """Existing ecosystem roots, or the env override, native-root-free.
+
+    Missing default roots are filtered here (not left for
+    :func:`discover_skills` to skip) because this list is also the user-facing
+    answer to "what am I scanning"; env-provided paths are filtered the same
+    way so the override behaves like the set it replaces.
+    """
+    raw = os.environ.get(_EXTRA_ROOTS_ENV)
+    if raw is None:
+        candidates = [home / subdir for subdir in _ECOSYSTEM_SKILL_SUBDIRS]
+    else:
+        candidates = [Path(part).expanduser() for part in raw.split(":") if part.strip()]
+    return [candidate for candidate in candidates if candidate.is_dir()]
+
 
 def default_skill_roots(cwd: Path | None = None) -> list[Path]:
     """Compute the default discovery roots for a working directory.
@@ -53,10 +89,12 @@ def default_skill_roots(cwd: Path | None = None) -> list[Path]:
     Walks up from ``cwd`` to the filesystem root collecting
     ``<dir>/.local-operator/skills`` — regardless of ``$HOME``, so a repo at
     ``/opt``, ``/srv`` or ``/Volumes`` still picks up its project-local
-    roots — then appends ``~/.local-operator/skills`` last. Roots are
-    deduped by realpath, first occurrence wins — the walk-up order gives
-    project-local roots priority over global ones, matching the collision
-    rule in :func:`discover_skills`.
+    roots — then appends ``~/.local-operator/skills``, then the ecosystem
+    roots (see :data:`_ECOSYSTEM_SKILL_SUBDIRS` / :data:`_EXTRA_ROOTS_ENV`).
+    Roots are deduped by realpath, first occurrence wins — the walk-up order
+    gives project-local roots priority over global ones, and native roots
+    priority over ecosystem ones, matching the collision rule in
+    :func:`discover_skills`.
     """
     start = (cwd or Path.cwd()).resolve()
     home = Path.home().resolve()
@@ -70,8 +108,10 @@ def default_skill_roots(cwd: Path | None = None) -> list[Path]:
         if current.parent == current:  # reached "/"
             break
         current = current.parent
-    # Global root is last: the deepest project root wins collisions.
+    # Global native root, then ecosystem roots: the deepest project root
+    # wins collisions, and native beats imported.
     candidates.append(home / _SKILLS_SUBDIR)
+    candidates.extend(_ecosystem_roots(home))
 
     seen: set[str] = set()
     roots: list[Path] = []

--- a/local_operator/skills/discovery.py
+++ b/local_operator/skills/discovery.py
@@ -2,10 +2,12 @@
 
 On-disk format is identical to the wider Agent Skills ecosystem:
 a skill is a directory containing a ``SKILL.md`` whose YAML frontmatter
-carries ``name``, ``description``, ``enabled``, ``hide`` and the Agent
-Skills-standard ``disable-model-invocation``. The body is never read here —
-it is fetched on demand through the ``skill://`` protocol, so discovery stays
-cheap regardless of skill size.
+carries ``name``, ``description``, ``enabled``, ``hide``, the Agent
+Skills-standard ``disable-model-invocation``, and the optional
+gitignore-style ``globs`` (path-based force-include, see
+:meth:`local_operator.skills.index.SkillIndex.select`). The body is never
+read here — it is fetched on demand through the ``skill://`` protocol, so
+discovery stays cheap regardless of skill size.
 
 Deliberate divergences from that ecosystem (see docs/REWRITE.md §C):
 
@@ -52,6 +54,12 @@ class Skill(BaseModel):
     base_dir: Path
     source: str
     hide: bool = False
+    #: Gitignore-style path patterns from the ``globs`` frontmatter key
+    #: (CSV string or YAML list). A pattern matching the session cwd or a
+    #: file-path-like token of the selection query force-includes the skill
+    #: regardless of the cosine threshold — the skill author saying "this
+    #: one is about these paths" outranks an embedder's guess.
+    globs: tuple[str, ...] = ()
     resource_type: Literal["skill", "guide", "agent_hint"] = "skill"
 
 
@@ -121,6 +129,28 @@ def _skill_from_file(skill_md: Path, base_dir: Path, source: str) -> Skill | Non
         base_dir=base_dir,
         source=source,
         hide=hide,
+        globs=_parse_globs(meta.get("globs")),
+    )
+
+
+def _parse_globs(raw: object) -> tuple[str, ...]:
+    """Normalize the ``globs`` frontmatter key to a tuple of patterns.
+
+    The ecosystem writes either a CSV string (``"*.py,src/**/*.ts"``) or a
+    YAML list; both are accepted. Non-string list entries and empty items
+    are dropped rather than rejected — a stray ``globs: [true]`` must not
+    cost the user an otherwise-good skill, and an empty pattern can never
+    match anything usefully. Any other shape (a bare int, a mapping) is
+    ignored entirely.
+    """
+    if isinstance(raw, str):
+        items: Sequence[object] = raw.split(",")
+    elif isinstance(raw, (list, tuple)):
+        items = raw
+    else:
+        return ()
+    return tuple(
+        item.strip() for item in items if isinstance(item, str) and item.strip()
     )
 
 

--- a/local_operator/skills/discovery.py
+++ b/local_operator/skills/discovery.py
@@ -149,9 +149,7 @@ def _parse_globs(raw: object) -> tuple[str, ...]:
         items = raw
     else:
         return ()
-    return tuple(
-        item.strip() for item in items if isinstance(item, str) and item.strip()
-    )
+    return tuple(item.strip() for item in items if isinstance(item, str) and item.strip())
 
 
 def scan_skills_dir(

--- a/local_operator/skills/index.py
+++ b/local_operator/skills/index.py
@@ -6,6 +6,11 @@ respective URL protocols. Registered-agent hints share the vector machinery but
 are never rendered; they can surface the generic agents guide without exposing
 the registry itself.
 
+Scoring is hybrid: cosine over embeddings, blended with a lexical Jaccard
+over ``name: description`` (see :func:`_hybrid_scores`), and gitignore-style
+``globs`` frontmatter force-includes path-matched skills at 1.0. The
+threshold applies to that final score.
+
 Vectors persist at ``cache_dir/<identity>.skills.vec``. The content hash covers
 the ordered resource type, name, description, file path, and mtime; the matrix
 row order and backend identity must also match before a cache is reused.
@@ -16,10 +21,12 @@ readable but never appear in semantic results.
 
 from __future__ import annotations
 
+import fnmatch
 import hashlib
 import json
 import logging
 import os
+import re
 from collections.abc import Mapping, Sequence
 from pathlib import Path
 
@@ -28,6 +35,119 @@ from local_operator.skills.embeddings import EmbeddingBackend, LocalEmbedder
 from local_operator.skills.vectors import VectorMatrix, deserialize
 
 logger = logging.getLogger(__name__)
+
+#: Word tokenizer for the lexical half of the hybrid score. Deliberately the
+#: same shape as the local embedder's (``[a-z0-9]+`` on lowercased text) so
+#: both halves of the blend see the same words.
+_WORD_RE = re.compile(r"[a-z0-9]+")
+
+#: Hybrid blend weights: ``final = max(cos, w_c*cos + w_l*jaccard)``. The
+#: outer max keeps a strong semantic match from being dragged down by a
+#: near-zero Jaccard (a short query against a long description), while the
+#: blend alone lifts a lexically-exact hit whose embedding landed below
+#: threshold.
+_COSINE_WEIGHT = 0.6
+_LEXICAL_WEIGHT = 0.4
+
+#: Punctuation stripped from query tokens before path-likeness is judged —
+#: "fix (src/app.py)" must yield "src/app.py", not "(src/app.py)".
+_TOKEN_STRIP = "\"'`()[]{}<>,;:"
+
+#: A bare filename with an extension ("pyproject.toml"). Must end in
+#: alphanumerics, so sentence noise like "e.g." or "3.2." is rejected while
+#: real filenames pass.
+_FILENAME_RE = re.compile(r"^[A-Za-z0-9_+.~\-]+\.[A-Za-z0-9]+$")
+
+
+def _path_suffixes(path: str) -> Sequence[str]:
+    """A path plus every component-suffix of it: ``a/b/c`` → ``a/b/c``,
+    ``b/c``, ``c``.
+
+    Suffix matching is what makes an unanchored gitignore pattern behave at
+    any depth (``*.py`` must hit ``…/src/app.py``) without knowing where the
+    repository root is — selection only ever sees absolute paths.
+    """
+    suffixes = [path]
+    parts = [part for part in path.split("/") if part]
+    suffixes.extend("/".join(parts[start:]) for start in range(1, len(parts)))
+    return suffixes
+
+
+def _query_path_tokens(query: str) -> list[str]:
+    """Extract file-path-like tokens from a natural-language query.
+
+    "fix the import in src/app/main.py please" yields ``src/app/main.py``.
+    Path-like means: contains a slash, starts with ``.``/``~`` (relative or
+    home paths, dotfiles), or is a bare filename with an extension. Prose
+    words are ignored so ordinary queries cannot trigger path routing.
+    """
+    tokens: list[str] = []
+    for raw in query.split():
+        token = raw.strip(_TOKEN_STRIP)
+        if token in ("", ".", ".."):
+            continue
+        if "/" in token or token.startswith((".", "~")) or _FILENAME_RE.match(token):
+            tokens.append(token)
+    return tokens
+
+
+def _glob_matches(globs: Sequence[str], cwd: Path | None, query: str) -> bool:
+    """True when any gitignore-style glob matches the cwd or a query token.
+
+    Matching is fnmatch against each target and every component-suffix of it
+    (see :func:`_path_suffixes`), which reproduces gitignore's any-depth
+    behavior for unanchored patterns. A leading ``/`` anchor is dropped —
+    redundant once suffixes are tried — and a trailing ``/`` (directory-only)
+    is dropped too, because targets are never stat'ed here; an author who
+    needs that precision should write the distinguishing path components.
+    """
+    patterns = [pattern.strip().strip("/") for pattern in globs]
+    patterns = [pattern for pattern in patterns if pattern]
+    if not patterns:
+        return False
+    targets: list[str] = []
+    if cwd is not None:
+        targets.append(str(cwd))
+    targets.extend(_query_path_tokens(query))
+    return any(
+        fnmatch.fnmatchcase(candidate, pattern)
+        for pattern in patterns
+        for target in targets
+        for candidate in _path_suffixes(target)
+    )
+
+
+def _hybrid_scores(
+    query: str,
+    skills: Sequence[Skill],
+    cosines: Sequence[float],
+    cwd: Path | None,
+) -> list[float]:
+    """Blend cosine similarity with lexical Jaccard, then apply glob boosts.
+
+    The shipped local embedder is honestly ~71% recall — it hashes character
+    n-grams, so it IS lexical — and the exact-word overlap the embedder
+    washes out is recoverable for free with a Jaccard over the same
+    ``name: description`` strings the index already embeds. The lexical
+    blend is the free part of that fix: no new backend, no re-embedding,
+    deterministic, byte-stable across turns.
+
+    ``final = max(cos, 0.6*cos + 0.4*jaccard)``; glob-matched skills are
+    forced to 1.0, bypassing the cosine threshold entirely (the author's
+    path claim outranks the embedder's guess) while remaining subject to
+    the caller's ``k`` cap and the hidden filter downstream.
+    """
+    query_words = frozenset(_WORD_RE.findall(query.lower()))
+    scores: list[float] = []
+    for skill, cosine in zip(skills, cosines):
+        if _glob_matches(skill.globs, cwd, query):
+            scores.append(1.0)
+            continue
+        text_words = frozenset(_WORD_RE.findall(f"{skill.name}: {skill.description}".lower()))
+        union = len(query_words | text_words)
+        jaccard = len(query_words & text_words) / union if union else 0.0
+        scores.append(max(cosine, _COSINE_WEIGHT * cosine + _LEXICAL_WEIGHT * jaccard))
+    return scores
 
 
 def _content_hash(skills: Sequence[Skill]) -> str:
@@ -296,15 +416,25 @@ class SkillIndex:
 
     # --- select ------------------------------------------------------------
 
-    async def select(self, query: str, k: int = 8, threshold: float | None = None) -> list[Skill]:
+    async def select(
+        self,
+        query: str,
+        k: int = 8,
+        threshold: float | None = None,
+        *,
+        cwd: Path | None = None,
+    ) -> list[Skill]:
         """Return the top-k skills whose descriptions match ``query``.
 
         Cosine search over L2-normalized vectors (one exhaustive inner-product
-        scan of the cached matrix). ``threshold`` defaults to the backend's
-        ``default_threshold``. Hidden skills never appear — they stay
-        reachable only via direct ``skill://`` reads. Results are sorted by
-        the discovery key (name.lower, name, path) so two turns selecting
-        the SAME set render a byte-identical block.
+        scan of the cached matrix), blended with a lexical Jaccard and
+        gitignore-style glob boosts (see :func:`_hybrid_scores`); the
+        threshold applies to that final score. ``cwd`` is the session working
+        directory, matched alongside path-like query tokens for globs.
+        Hidden skills never appear — they stay reachable only via direct
+        ``skill://`` reads. Results are sorted by the discovery key
+        (name.lower, name, path) so two turns selecting the SAME set render
+        a byte-identical block.
 
         Degradation ladder: primary backend failure → offline
         :class:`LocalEmbedder`, memoized for the index lifetime so an API
@@ -318,7 +448,7 @@ class SkillIndex:
             return []
 
         if not self._backend_failed:
-            picked = await self._select_with_backend(self.backend, query, k, threshold)
+            picked = await self._select_with_backend(self.backend, query, k, threshold, cwd)
             if picked is not None:
                 return picked
 
@@ -335,7 +465,7 @@ class SkillIndex:
                 )
             if self._local_fallback is None:
                 self._local_fallback = LocalEmbedder()
-            picked = await self._select_with_backend(self._local_fallback, query, k, threshold)
+            picked = await self._select_with_backend(self._local_fallback, query, k, threshold, cwd)
             if picked is not None:
                 return picked
 
@@ -351,6 +481,7 @@ class SkillIndex:
         query: str,
         k: int,
         threshold: float | None,
+        cwd: Path | None = None,
     ) -> list[Skill] | None:
         """Score with ``backend``; None on any failure (caller degrades)."""
         if threshold is None:
@@ -360,6 +491,7 @@ class SkillIndex:
                 await self.build(backend)
             query_vec = (await backend.embed([query]))[0]
             scores = self._scores(query_vec)
+            scores = _hybrid_scores(query, self.skills, scores, cwd)
         except Exception as exc:  # noqa: BLE001 — degradation is the contract
             logger.warning("Skill selection failed: %s", exc)
             return None

--- a/local_operator/tools/builtin.py
+++ b/local_operator/tools/builtin.py
@@ -39,6 +39,7 @@ attached a scheduler to the ``ToolContext``.
 
 from __future__ import annotations
 
+import ast
 import asyncio
 import base64
 import contextlib
@@ -58,7 +59,7 @@ from pathlib import Path
 from typing import Any, Literal
 from urllib.parse import urlsplit
 
-from pydantic import BaseModel, ConfigDict, Field, ValidationError
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
 
 from local_operator.harness.approval import ask_approval
 from local_operator.harness.types import (
@@ -1327,6 +1328,13 @@ class ReadParams(BaseModel):
             "MATCHES to return, not which lines. Ignored for other internal URLs."
         ),
     )
+    raw: bool = Field(
+        default=False,
+        description=(
+            "Return the verbatim text even where a structural summary is the "
+            "default (Python files read without a range)."
+        ),
+    )
 
 
 _LINE_RANGE_RE = re.compile(r"^(\d+)\s*-\s*(\d+)?$")
@@ -1692,6 +1700,165 @@ def _search_spill(
     return _text(tool_call_id, "read", f"{header}:\n{body}{footer}", details=details)
 
 
+# ---------------------------------------------------------------------------
+# Python structural summaries
+# ---------------------------------------------------------------------------
+
+#: Below this many lines a raw read is already cheap and the summary's
+# overhead (footer, symbol grammar) buys nothing — the default stays raw.
+PYTHON_SUMMARY_MIN_LINES = 80
+#: Hard cap on symbol lines in one summary. A generated module with
+# thousands of definitions would otherwise turn the summary into the very
+# blob it exists to avoid; past the cap the tail is elided with a count.
+PYTHON_SUMMARY_MAX_SYMBOLS = 500
+
+
+def _format_args(args: ast.arguments) -> str:
+    """``name: Ann`` parts in signature order, stdlib-only. Defaults are
+    interleaved onto their parameters (pydantic stores them positionally
+    against the tail of the arg list, so a naive arg walk silently drops
+    every ``= default`` from the summary)."""
+    plain = list(getattr(args, "posonlyargs", [])) + list(args.args)
+    defaults: list[ast.expr] = list(args.defaults)
+    offset = len(plain) - len(defaults)
+    parts: list[str] = []
+    posonly = len(getattr(args, "posonlyargs", []))
+    for i, arg in enumerate(plain):
+        if posonly and i == posonly:
+            parts.append("/")
+        rendered = ast.unparse(arg)
+        j = i - offset
+        if 0 <= j < len(defaults):
+            rendered = f"{rendered}={ast.unparse(defaults[j])}"
+        parts.append(rendered)
+    if args.vararg:
+        parts.append("*" + ast.unparse(args.vararg))
+    elif args.kwonlyargs:
+        parts.append("*")
+    for i, arg in enumerate(args.kwonlyargs):
+        rendered = ast.unparse(arg)
+        if i < len(args.kw_defaults) and args.kw_defaults[i] is not None:
+            rendered = f"{rendered}={ast.unparse(args.kw_defaults[i])}"
+        parts.append(rendered)
+    if args.kwarg:
+        parts.append("**" + ast.unparse(args.kwarg))
+    return ", ".join(parts)
+
+
+def _docstring_first_line(node: ast.AST) -> str | None:
+    body = getattr(node, "body", None)
+    if body and isinstance(body[0], ast.Expr) and isinstance(body[0].value, ast.Constant):
+        doc = body[0].value.value
+        if isinstance(doc, str) and doc.strip():
+            return doc.strip().splitlines()[0][:100]
+    return None
+
+
+def _python_structural_summary_lines(source: str) -> tuple[list[str], int, int] | None:
+    """``(symbol_lines, total_lines, elided_symbols)`` for a Python module.
+
+    Declarations are kept; bodies are elided; every symbol carries its line
+    range so the caller can teach the model exactly which range re-reads the
+    body it just lost. Returns None when the file does not parse (the raw
+    body is the honest answer for a broken file).
+    """
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return None
+
+    out: list[str] = []
+
+    def emit(node: ast.AST, depth: int) -> int:
+        """Emit one symbol block; returns how many symbol lines it used."""
+        used = 0
+        pad = "    " * depth
+        start, end = node.lineno, node.end_lineno or node.lineno
+        for dec in getattr(node, "decorator_list", []):
+            name = ast.unparse(dec)
+            out.append(f"{pad}@{name}"[:110])
+            used += 1
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            keyword = "async def" if isinstance(node, ast.AsyncFunctionDef) else "def"
+            returns = f" -> {ast.unparse(node.returns)}" if node.returns else ""
+            out.append(f"{pad}{keyword} {node.name}({_format_args(node.args)}){returns}"[:110])
+        elif isinstance(node, ast.ClassDef):
+            bases = ", ".join(ast.unparse(b) for b in node.bases)
+            head = f"class {node.name}" + (f"({bases})" if bases else "")
+            out.append(f"{pad}{head}:"[:110])
+        used += 1
+        doc = _docstring_first_line(node)
+        if doc:
+            out.append(f'{pad}    "{doc}')
+            used += 1
+        out[-1] = f"{out[-1]}  ·  L{start}-{end}"
+        if isinstance(node, ast.ClassDef):
+            for child in node.body:
+                if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                    used += emit(child, depth + 1)
+        return used
+
+    module_doc = _docstring_first_line(tree)
+    if module_doc:
+        out.append(f'"{module_doc}')
+    imports = sum(1 for n in tree.body if isinstance(n, (ast.Import, ast.ImportFrom)))
+    if imports:
+        out.append(f"[imports: {imports} (elided)]")
+    symbol_count = 0
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            symbol_count += emit(node, 0)
+    if symbol_count == 0 and not module_doc and not imports:
+        return None
+    total_lines = len(source.splitlines())
+    return out, total_lines, symbol_count
+
+
+def _structural_summary_result(
+    tool_call_id: str, path: Path, source: str, context: ToolContext | None
+) -> ToolResult | None:
+    """The read result for a Python file summarized instead of dumped, or
+    None when the file should fall back to the raw body (parse failure,
+    nothing declarative in it)."""
+    parsed = _python_structural_summary_lines(source)
+    if parsed is None:
+        return None
+    symbol_lines, total_lines, symbol_count = parsed
+    if len(symbol_lines) > PYTHON_SUMMARY_MAX_SYMBOLS:
+        omitted = len(symbol_lines) - PYTHON_SUMMARY_MAX_SYMBOLS
+        symbol_lines = symbol_lines[:PYTHON_SUMMARY_MAX_SYMBOLS] + [
+            f"[…{omitted} more symbol lines elided; narrow with grep, then range-read]"
+        ]
+    full = "\n".join(symbol_lines)
+    # Fit the shown portion inside the char budget line-wholesale — a slice
+    # mid-line would garble the very ranges the footer teaches the model to
+    # use. Whatever does not fit goes to the spill like any other long list.
+    shown_lines: list[str] = []
+    budget = TOOL_OUTPUT_LIMIT_CHARS
+    for line in symbol_lines:
+        if budget - (len(line) + 1) < 0:
+            break
+        shown_lines.append(line)
+        budget -= len(line) + 1
+    shown = "\n".join(shown_lines)
+    body, spill_details = _capped_list_body(full, shown, "read", context)
+    header = f"{path} — structural summary ({total_lines} lines, " f"{symbol_count} symbol lines)"
+    footer = (
+        "\n[declaration-only view; bodies elided. Re-read exact code with "
+        "range='start-end' (e.g. range='40-52'), or raw=true for the full text]"
+    )
+    details: dict[str, Any] = {"path": str(path), "summary": True}
+    if spill_details:
+        details.update(spill_details)
+    return _text(tool_call_id, "read", header + "\n" + body + footer, details=details)
+
+    footer = (
+        f'\n[read around a hit with read(path="{ref.handle}", '
+        f'range="{max(matches[0][0] - 10, 1)}-{matches[0][0] + 30}")]'
+    )
+    return _text(tool_call_id, "read", f"{header}:\n{body}{footer}", details=details)
+
+
 @_guard("read")
 async def execute_read(
     tool_call_id: str,
@@ -1844,6 +2011,21 @@ async def execute_read(
             # 900-1000 blanks an unrelated 1-100 read as "superseded".
             details={"path": str(path), "range": params.range},
         )
+    # Python files read whole get a declaration-only structural summary:
+    # the model sees the symbol table (with line ranges) instead of the full
+    # body, and re-reads only the ranges it needs. The repo's own benchmark
+    # put tool results at 87-96% of context bytes — the read tool is where
+    # those bytes come from. Opt-outs: a range (explicit interest in exact
+    # lines) or raw=true; unparseable files fall back to the body honestly.
+    if (
+        not params.range
+        and not params.raw
+        and path.suffix == ".py"
+        and len(lines) >= PYTHON_SUMMARY_MIN_LINES
+    ):
+        summarized = _structural_summary_result(tool_call_id, path, text, context)
+        if summarized is not None:
+            return summarized
 
     if len(lines) > READ_LINE_CAP:
         body = _number_lines(lines[:READ_LINE_CAP], 1)
@@ -1869,7 +2051,9 @@ def build_read_tool() -> AgentTool:
         label="Read",
         description=(
             "Read a file, line range, or internal URL (skill://, guide://, mcp://). "
-            "PNG/JPEG/GIF/WebP/HEIC files come back as a viewable image."
+            "PNG/JPEG/GIF/WebP/HEIC files come back as a viewable image. "
+            "Python files read whole return a structural summary; use a "
+            "range or raw=true for exact text."
         ),
         parameters=ReadParams.model_json_schema(),
         approval_tier="read",
@@ -1877,6 +2061,278 @@ def build_read_tool() -> AgentTool:
         concurrency="shared",
         interruptible=False,
         execute=execute_read,
+    )
+
+
+# ---------------------------------------------------------------------------
+# edit
+# ---------------------------------------------------------------------------
+
+
+class EditHunk(BaseModel):
+    """One SEARCH/REPLACE hunk. ``old_text`` is matched exactly first, then
+    with a whitespace-tolerant line matcher, so an edit written from a
+    structural summary or from memory does not fail on indentation drift."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    old_text: str = Field(
+        description="Text to find (exact match tried first, then whitespace-tolerant)."
+    )
+    new_text: str = Field(
+        description="Replacement text (re-indented to the file's level on the tolerant path)."
+    )
+    replace_all: bool = Field(
+        default=False,
+        description="Replace every occurrence of this hunk instead of requiring exactly one.",
+    )
+
+
+class EditParams(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    path: str = Field(description="File to edit.")
+    edits: list[EditHunk] = Field(
+        default_factory=list,
+        description=(
+            "Hunks applied in order — the multi-edit form. Prefer this for "
+            "several changes to one file: it costs one call instead of N."
+        ),
+    )
+    old_text: str | None = Field(
+        default=None,
+        description="Single-edit form: exact text to find. Mutually exclusive with 'edits'.",
+    )
+    new_text: str | None = Field(default=None, description="Single-edit form: replacement text.")
+    replace_all: bool = Field(
+        default=False,
+        description="Single-edit form: replace every occurrence instead of requiring exactly one.",
+    )
+    anchor_line: int | None = Field(
+        default=None,
+        description=(
+            "Optional 1-based line that disambiguates a match that occurs in "
+            "several places: the window containing this line wins."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def _single_form_is_complete(self) -> "EditParams":
+        """One form or the other, whole — a lone old_text is a modeling
+        mistake pydantic reports in the tool's clean 'invalid arguments'
+        voice rather than a bespoke message the caller cannot predict."""
+        if (self.old_text is None) != (self.new_text is None):
+            raise ValueError("single-edit form needs both old_text and new_text")
+        if self.old_text is not None and self.edits:
+            raise ValueError("pass either 'edits' (list of hunks) or old_text/new_text, not both")
+        if not self.edits and self.old_text is not None and not self.old_text:
+            raise ValueError("old_text must be a non-empty string")
+        return self
+
+
+def _leading_ws(line: str) -> str:
+    return line[: len(line) - len(line.lstrip())]
+
+
+def _match_windows(content: str, old_text: str) -> list[tuple[int, int, str]]:
+    """``(start, end, matched_text)`` windows where ``old_text`` occurs.
+
+    Pass 1 is exact substring matching — the anchored, honest form. Pass 2
+    runs only when pass 1 found nothing: a line-based tolerant matcher that
+    compares lines with ``strip()`` equality and returns the matched FILE
+    text so the replacement can be re-indented per line into place.
+    Tolerance is one-directional by design: an exact match is never silently
+    flexed, and a fuzzy match never silently wins over an exact one that
+    exists elsewhere.
+    """
+    windows: list[tuple[int, int, str]] = []
+    start = content.find(old_text)
+    while start != -1:
+        windows.append((start, start + len(old_text), old_text))
+        start = content.find(old_text, start + 1)
+    if windows:
+        return windows
+
+    file_lines = content.splitlines(keepends=True)
+    # Per-line start offsets so a window can be returned as a char span.
+    offsets: list[int] = []
+    at = 0
+    for line in file_lines:
+        offsets.append(at)
+        at += len(line)
+    old_lines = old_text.splitlines()
+    if not old_lines or len(old_lines) > len(file_lines):
+        return []
+
+    def _tolerant(file_line: str, old_line: str) -> bool:
+        return file_line.strip() == old_line.strip()
+
+    for i in range(len(file_lines) - len(old_lines) + 1):
+        window = file_lines[i : i + len(old_lines)]
+        if all(_tolerant(f.rstrip("\r\n"), o) for f, o in zip(window, old_lines)):
+            # The span runs to the end of the last matched line INCLUDING its
+            # newline, so replacing it cannot splice the following line onto
+            # the replacement's final line.
+            last_line = window[-1]
+            end = offsets[i + len(old_lines) - 1] + len(last_line)
+            matched = "".join(window)
+            windows.append((offsets[i], end, matched))
+    return windows
+
+
+def _reindent_new_text(new_text: str, matched: str, old_text: str) -> str:
+    """Re-anchor ``new_text``'s indentation onto the file's actual level.
+
+    The model's old/new pair is internally consistent at ITS indentation; the
+    file holds the same text at a different one. Per line: the model's line
+    sits ``(file_indent - old_indent)`` columns over its reference. Extra new
+    lines (additions with no counterpart in old_text) borrow the delta of the
+    last old line, which is the level the block was written at. Blank lines
+    pass through untouched."""
+    file_lines = matched.splitlines()
+    old_lines = old_text.splitlines()
+    new_lines = new_text.splitlines()
+    if not old_lines or not file_lines:
+        return new_text
+    out: list[str] = []
+    for i, line in enumerate(new_lines):
+        if not line.strip():
+            out.append("")
+            continue
+        ref = min(i, len(file_lines) - 1, len(old_lines) - 1)
+        file_indent = len(_leading_ws(file_lines[ref]))
+        old_indent = len(_leading_ws(old_lines[ref]))
+        line_indent = len(_leading_ws(line))
+        shift = file_indent + max(line_indent - old_indent, 0)
+        out.append(" " * shift + line.lstrip())
+    return "\n".join(out)
+
+
+def _line_of_offset(content: str, offset: int) -> int:
+    return content.count("\n", 0, offset) + 1
+
+
+@_guard("edit")
+async def execute_edit(
+    tool_call_id: str,
+    args: dict[str, Any],
+    signal: AbortSignal | None = None,
+    on_update: Callable[[AgentToolUpdate], None] | None = None,
+    context: ToolContext | None = None,
+) -> ToolResult:
+    """Ordered SEARCH/REPLACE hunks in a file, one call for the whole change.
+
+    Why hunks and not whole-file writes: a ``write`` argument IS the file
+    body, billed as model output (the most expensive token class, and never
+    cacheable) and then re-billed as prompt on every later turn. On build-heavy
+    work that dominates the bill — the repo's own benchmark measured file
+    bodies at 48-74% of task cost. The hunk form prices an edit by what
+    CHANGED.
+
+    Ambiguity is an error, not a guess: a hunk matching more than one place
+    without ``replace_all`` (or a disambiguating ``anchor_line``) refuses,
+    because silently editing the first occurrence is how edits corrupt the
+    wrong site.
+    """
+    try:
+        params = EditParams(**args)
+    except ValidationError as exc:
+        return _validation_error(tool_call_id, "edit", exc)
+    if not params.path.strip():
+        return _error(tool_call_id, "edit", "path must be a non-empty string")
+
+    hunks: list[EditHunk] = list(params.edits)
+    if params.old_text is not None and params.new_text is not None:
+        hunks.append(
+            EditHunk(
+                old_text=params.old_text, new_text=params.new_text, replace_all=params.replace_all
+            )
+        )
+    if not hunks:
+        return _error(
+            tool_call_id,
+            "edit",
+            "nothing to edit: pass 'edits' (preferred) or old_text/new_text.",
+        )
+
+    path, inside, _resolvable = _resolve_workspace_path(params.path, _safe_cwd(context))
+    if not path.is_file():
+        return _error(tool_call_id, "edit", f"File does not exist: {path}")
+
+    original = path.read_text(encoding="utf-8")
+    current = original
+    total_replacements = 0
+
+    for index, hunk in enumerate(hunks):
+        if hunk.old_text == "":
+            return _error(tool_call_id, "edit", f"hunk {index + 1}: old_text must be non-empty")
+        windows = _match_windows(current, hunk.old_text)
+        if not windows:
+            advice = (
+                f" — or the range around line {params.anchor_line}"
+                if params.anchor_line
+                else " to get the current text"
+            )
+            return _error(
+                tool_call_id,
+                "edit",
+                f"hunk {index + 1}: old_text not found (exact and whitespace-tolerant "
+                f"matchers both failed). Re-read the file{advice} and retry.",
+            )
+        chosen = windows
+        if len(windows) > 1 and not hunk.replace_all:
+            if params.anchor_line is not None:
+                anchored = []
+                for w in windows:
+                    first_line = _line_of_offset(current, w[0])
+                    last_line = _line_of_offset(current, max(w[1] - 1, w[0]))
+                    if first_line <= params.anchor_line <= last_line:
+                        anchored.append(w)
+                if len(anchored) == 1:
+                    chosen = anchored
+            if len(chosen) > 1:
+                return _error(
+                    tool_call_id,
+                    "edit",
+                    f"hunk {index + 1}: old_text matches {len(chosen)} places; include more "
+                    "surrounding context, give anchor_line, or set replace_all=true.",
+                )
+        # Apply back-to-front so earlier offsets stay valid within this hunk.
+        for start, end, matched in sorted(chosen, key=lambda w: w[0], reverse=True):
+            replacement = _reindent_new_text(hunk.new_text, matched, hunk.old_text)
+            if matched.endswith(("\n", "\r")) and not replacement.endswith(("\n", "\r")):
+                replacement += "\n"
+            current = current[:start] + replacement + current[end:]
+            total_replacements += 1
+
+    if current != original:
+        path.write_text(current, encoding="utf-8")
+    details = _diff_details(str(path), original, current)
+    return _text(
+        tool_call_id,
+        "edit",
+        f"Edited {path}: {len(hunks)} hunk(s), {total_replacements} replacement(s) applied.",
+        details=details,
+    )
+
+
+def build_edit_tool() -> AgentTool:
+    return AgentTool(
+        name="edit",
+        label="Edit",
+        describe_approval=_describe_path_approval("edit"),
+        description=(
+            "Apply ordered SEARCH/REPLACE hunks to a file ('edits' list for "
+            "several changes in one call; exact match first, then "
+            "whitespace-tolerant; anchor_line disambiguates repeats)."
+        ),
+        parameters=EditParams.model_json_schema(),
+        approval_tier="write",
+        # edit model: two concurrent edits on one file corrupt each
+        # other's match anchors; exclusive serializes the read-modify-write.
+        concurrency="exclusive",
+        interruptible=False,
+        execute=execute_edit,
     )
 
 
@@ -2014,96 +2470,148 @@ def build_write_tool() -> AgentTool:
 
 
 # ---------------------------------------------------------------------------
-# edit
+# gitignore-aware walking (shared by glob and grep)
 # ---------------------------------------------------------------------------
 
 
-class EditParams(BaseModel):
-    model_config = ConfigDict(extra="forbid")
+class _IgnoreRule:
+    """One compiled .gitignore/.ignore line, scoped to its file's directory.
 
-    path: str = Field(description="File to edit.")
-    old_text: str = Field(description="Exact text to find (must match verbatim).")
-    new_text: str = Field(description="Replacement text.")
-    replace_all: bool = Field(
-        default=False,
-        description="Replace every occurrence instead of requiring exactly one.",
-    )
-
-
-@_guard("edit")
-async def execute_edit(
-    tool_call_id: str,
-    args: dict[str, Any],
-    signal: AbortSignal | None = None,
-    on_update: Callable[[AgentToolUpdate], None] | None = None,
-    context: ToolContext | None = None,
-) -> ToolResult:
-    """Exact-match string replacement in a file.
-
-    Ambiguity is an error, not a guess: with ``old_text`` matching more than
-    once and ``replace_all`` unset the tool refuses, because silently editing
-    the first occurrence is how edits corrupt the wrong site.
+    Semantics follow gitignore(5) closely enough for search pruning: ``*``
+    does not cross ``/``, ``**`` does, a trailing ``/`` matches directories
+    only, a leading or interior ``/`` anchors the pattern to the rule's base
+    directory, otherwise the pattern matches a basename at any depth below
+    it, and a later ``!`` rule re-includes. Why this exists at all: the old
+    fixed prune list covered .git/node_modules & co but never the project's
+    OWN ignored paths — build dirs, vendored trees, virtualenvs under other
+    names — so search results carried exactly the noise the project had
+    already declared dead.
     """
-    try:
-        params = EditParams(**args)
-    except ValidationError as exc:
-        return _validation_error(tool_call_id, "edit", exc)
-    if not params.path.strip():
-        return _error(tool_call_id, "edit", "path must be a non-empty string")
-    if params.old_text == "":
-        return _error(tool_call_id, "edit", "old_text must be a non-empty string")
 
-    path, inside, _resolvable = _resolve_workspace_path(params.path, _safe_cwd(context))
-    if not path.is_file():
-        return _error(tool_call_id, "edit", f"File does not exist: {path}")
+    __slots__ = ("regex", "negated", "dir_only", "base")
 
-    content = path.read_text(encoding="utf-8")
-    occurrences = content.count(params.old_text)
-    if occurrences == 0:
-        return _error(
-            tool_call_id,
-            "edit",
-            "old_text not found in the file. Re-read the file to get the exact "
-            "current text (whitespace included) and retry.",
-        )
-    if occurrences > 1 and not params.replace_all:
-        return _error(
-            tool_call_id,
-            "edit",
-            f"old_text matches {occurrences} places; include more surrounding "
-            "context to make it unique, or set replace_all=true.",
-        )
-    # Write-tier approval is the loop's gate; see execute_bash.
-
-    if params.replace_all:
-        updated = content.replace(params.old_text, params.new_text)
-    else:
-        updated = content.replace(params.old_text, params.new_text, 1)
-    path.write_text(updated, encoding="utf-8")
-    replaced = occurrences if params.replace_all else 1
-    details = _diff_details(str(path), content, updated)
-    return _text(
-        tool_call_id,
-        "edit",
-        f"Edited {path}: replaced {replaced} occurrence(s) of old_text.",
-        details=details,
-    )
+    def __init__(self, pattern: str, base: str) -> None:
+        self.negated = pattern.startswith("!")
+        if self.negated:
+            pattern = pattern[1:]
+        self.dir_only = pattern.endswith("/")
+        pattern = pattern.rstrip("/")
+        self.base = base
+        anchored = pattern.startswith("/") or "/" in pattern
+        pattern = pattern.lstrip("/")
+        parts = pattern.split("/")
+        regex = "/".join(".*" if seg == "**" else _glob_segment_regex(seg) for seg in parts)
+        if self.dir_only:
+            # A directory pattern owns its whole subtree, not just the
+            # directory entry: "dist/" must match "dist/out.js" too, or a
+            # post-filtering caller (glob) would admit every file under an
+            # ignored directory the walker (grep) would have pruned.
+            regex += "(/.*)?"
+        if anchored:
+            prefix = re.escape(base + "/") if base else ""
+            self.regex = re.compile("^" + prefix + regex)
+        else:
+            self.regex = re.compile("(^|.*/)" + regex + "$")
 
 
-def build_edit_tool() -> AgentTool:
-    return AgentTool(
-        name="edit",
-        label="Edit",
-        describe_approval=_describe_path_approval("edit"),
-        description="Replace exact text in a file (errors on missing or ambiguous matches).",
-        parameters=EditParams.model_json_schema(),
-        approval_tier="write",
-        # edit model: two concurrent edits on one file corrupt each
-        # other's match anchors; exclusive serializes the read-modify-write.
-        concurrency="exclusive",
-        interruptible=False,
-        execute=execute_edit,
-    )
+def _glob_segment_regex(segment: str) -> str:
+    """One path segment of a gitignore pattern as regex (``*`` stays in-segment)."""
+    out: list[str] = []
+    i = 0
+    while i < len(segment):
+        ch = segment[i]
+        if ch == "*":
+            if segment[i : i + 2] == "**":
+                out.append(".*")
+                i += 2
+                continue
+            out.append("[^/]*")
+            i += 1
+            continue
+        if ch == "?":
+            out.append("[^/]")
+            i += 1
+            continue
+        out.append(re.escape(ch))
+        i += 1
+    return "".join(out)
+
+
+def _load_ignore_rules(directory: Path, rel_dir: str) -> list[_IgnoreRule]:
+    """Rules from a directory's ``.gitignore``/``.ignore``, empty when absent."""
+    rules: list[_IgnoreRule] = []
+    for name in (".gitignore", ".ignore"):
+        file = directory / name
+        if not file.is_file():
+            continue
+        try:
+            raw = file.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        for line in raw.splitlines():
+            line = line.rstrip("\r")
+            if not line.strip() or line.startswith("#"):
+                continue
+            rules.append(_IgnoreRule(line, rel_dir))
+    return rules
+
+
+def _ignored(
+    rel: str,
+    is_dir: bool,
+    rules: list[tuple[str, list[_IgnoreRule]]],
+) -> bool:
+    """gitignore last-match-wins evaluation over the ancestor rule stack."""
+    ignored = False
+    for _base, base_rules in rules:
+        for rule in base_rules:
+            if rule.regex.search(rel):
+                ignored = not rule.negated
+    return ignored
+
+
+def _walk_entries(root: Path, *, respect_ignore: bool = True) -> list[Path]:
+    """Depth-first walk pruning VCS/vendor/build trees, dotdirs, symlinks and
+    (when ``respect_ignore``) gitignore-declared paths. Files only.
+
+    Git semantics for directories are honored structurally: an ignored
+    directory's subtree is skipped outright, so a ``!`` rule cannot re-include
+    inside it — exactly git's own behaviour.
+    """
+    files: list[Path] = []
+
+    def _walk(directory: Path, rel_dir: str, rules: list[tuple[str, list[_IgnoreRule]]]) -> None:
+        local_rules = rules
+        if respect_ignore:
+            found = _load_ignore_rules(directory, rel_dir)
+            if found:
+                local_rules = rules + [(rel_dir, found)]
+        try:
+            entries = sorted(directory.iterdir())
+        except OSError:
+            return
+        for entry in entries:
+            if entry.is_symlink():
+                continue  # never follow links: cycles and out-of-tree escapes
+            rel = f"{rel_dir}/{entry.name}" if rel_dir else entry.name
+            if entry.is_dir():
+                if entry.name in _GREP_PRUNE_DIRS or entry.name.startswith("."):
+                    continue
+                if respect_ignore and _ignored(rel, True, local_rules):
+                    continue
+                _walk(entry, rel, local_rules)
+            elif entry.is_file():
+                if respect_ignore and _ignored(rel, False, local_rules):
+                    continue
+                files.append(entry)
+
+    _walk(root, "", [])
+    return files
+
+
+def _walk_files(root: Path) -> list[Path]:
+    """The grep file set: the ignore-aware walk."""
+    return _walk_entries(root)
 
 
 # ---------------------------------------------------------------------------
@@ -2117,6 +2625,38 @@ class GlobParams(BaseModel):
     pattern: str = Field(
         description="Glob pattern relative to the working directory ('**/*.py' supported)."
     )
+
+
+def _literal_prefix(pattern: str) -> str:
+    """The leading run of the pattern with no glob metacharacters — the part
+    that names directories the author EXPLICITLY asked to descend into."""
+    out = []
+    for ch in pattern:
+        if ch in "*?[":
+            break
+        out.append(ch)
+    return "".join(out).rstrip("/")
+
+
+def _glob_walk(root: Path, pattern: str) -> list[str]:
+    """The walk half of execute_glob, run in a worker thread.
+
+    Matching still uses pathlib (so explicit hidden/vendor components in the
+    pattern work), then gitignore-declared paths are filtered out — unless
+    the pattern's literal prefix names them, because an author who writes
+    'dist/index.html' into a repo that ignores dist/ means that file."""
+    prefix = _literal_prefix(pattern)
+    rules: list[tuple[str, list[_IgnoreRule]]] = []
+    if root.joinpath(".gitignore").is_file() or root.joinpath(".ignore").is_file():
+        rules = [("", _load_ignore_rules(root, ""))]
+    out = []
+    for p in root.glob(pattern):
+        rel = p.relative_to(root).as_posix()
+        if rules and not rel.startswith(prefix + "/") and rel != prefix:
+            if _ignored(rel, p.is_dir(), rules):
+                continue
+        out.append(rel + ("/" if p.is_dir() else ""))
+    return sorted(out)
 
 
 @_guard("glob")
@@ -2178,7 +2718,10 @@ def build_glob_tool() -> AgentTool:
     return AgentTool(
         name="glob",
         label="Glob",
-        description="Find files and directories by glob pattern ('**' supported).",
+        description=(
+            "Find files and directories by glob pattern ('**' supported); "
+            "gitignore-declared paths are excluded unless the pattern names them."
+        ),
         parameters=GlobParams.model_json_schema(),
         approval_tier="read",
         # Read-only listing; parallel globs are the common batch shape.
@@ -2208,12 +2751,19 @@ class GrepParams(BaseModel):
         ),
     )
     case: bool = Field(default=True, description="Case-sensitive matching.")
-
-
-def _glob_walk(root: Path, pattern: str) -> list[str]:
-    """The walk half of execute_glob, run in a worker thread."""
-    return sorted(
-        p.relative_to(root).as_posix() + ("/" if p.is_dir() else "") for p in root.glob(pattern)
+    context_lines: int = Field(
+        default=0,
+        ge=0,
+        le=10,
+        description=(
+            "Lines of surrounding context per match (like grep -C). Context "
+            "lines render as 'path:line-text' (dash) vs matches 'path:line:text'."
+        ),
+    )
+    skip: int = Field(
+        default=0,
+        ge=0,
+        description="Skip the first N matches (pagination for large result sets).",
     )
 
 
@@ -2223,30 +2773,6 @@ def _glob_matches(rel_path: str, pattern: str) -> bool:
         return True
     name = rel_path.rsplit("/", 1)[-1]
     return fnmatch.fnmatch(name, pattern)
-
-
-def _walk_files(root: Path) -> list[Path]:
-    """Walk ``root`` depth-first, pruning VCS/vendor/build trees and every
-    dotdir (.git history and node_modules are noise the model never wants)."""
-    files: list[Path] = []
-
-    def _walk(directory: Path) -> None:
-        try:
-            entries = sorted(directory.iterdir())
-        except OSError:
-            return
-        for entry in entries:
-            if entry.is_symlink():
-                continue  # never follow links: cycles and out-of-tree escapes
-            if entry.is_dir():
-                if entry.name in _GREP_PRUNE_DIRS or entry.name.startswith("."):
-                    continue
-                _walk(entry)
-            elif entry.is_file():
-                files.append(entry)
-
-    _walk(root)
-    return files
 
 
 #: Wall-clock cap for one grep scan. Bounds the pathological-regex case
@@ -2264,20 +2790,56 @@ GREP_SCAN_DEADLINE_S = 30.0
 GREP_SPILL_MATCH_LIMIT = 5000
 
 
-def _grep_scan(
+#: Engine selection: 'auto' uses ripgrep when the binary is on PATH (native
+#: speed, native gitignore/hidden semantics) and falls back to the Python
+#: scan otherwise; 'python' forces the fallback for deterministic tests.
+#: Read per call, not cached at import, so a test (or a user shell) can pin
+#: the engine without reimporting the module.
+def _grep_engine() -> str:
+    return os.environ.get("LOCAL_OPERATOR_GREP_ENGINE", "auto")
+
+
+_RG_PATH: str | None = None
+_RG_RESOLVED = False
+
+
+def _rg_binary() -> str | None:
+    """Absolute ripgrep path when usable, else None (cached)."""
+    global _RG_PATH, _RG_RESOLVED
+    if not _RG_RESOLVED:
+        import shutil
+
+        _RG_PATH = shutil.which("rg")
+        _RG_RESOLVED = True
+    return _RG_PATH
+
+
+def _use_ripgrep() -> bool:
+    return _grep_engine() == "auto" and _rg_binary() is not None
+
+
+def _match_record(rel: str, lineno: int, line: str, kind: str) -> tuple[str, int, str, str]:
+    return (rel, lineno, line, kind)
+
+
+def _python_grep_scan(
     files: list[Path],
     base: Path,
     regex: re.Pattern[str],
     include: str | None,
-) -> tuple[list[str], int, int]:
-    """The filesystem+regex half of execute_grep, run in a worker thread.
+    context_lines: int,
+) -> tuple[list[tuple[str, int, str, str]], int, int]:
+    """The pure-Python scan, run in a worker thread.
 
-    Returns ``(matches, files_searched, files_skipped)``. Kept synchronous and
-    self-contained so ``asyncio.to_thread`` can carry it off the event loop;
-    the deadline bounds a backtracking pattern without touching the loop.
+    Returns ``(records, files_searched, files_skipped)`` where a record is
+    ``(rel, lineno, text, kind)`` and kind is ``'m'`` (match) or ``'c'``
+    (context). Context records are only produced when ``context_lines`` > 0.
+    Kept synchronous and self-contained so ``asyncio.to_thread`` can carry it
+    off the event loop; the deadline bounds a backtracking pattern without
+    touching the loop.
     """
     deadline = time.monotonic() + GREP_SCAN_DEADLINE_S
-    matches: list[str] = []
+    records: list[tuple[str, int, str, str]] = []
     files_searched = 0
     files_skipped = 0
     for file_path in files:
@@ -2304,14 +2866,176 @@ def _grep_scan(
             text = data.decode("utf-8")
         except UnicodeDecodeError:
             text = data.decode("utf-8", errors="replace")
-        for lineno, line in enumerate(text.splitlines(), start=1):
-            if regex.search(line):
-                matches.append(f"{rel}:{lineno}:{line}")
-                if len(matches) >= GREP_SPILL_MATCH_LIMIT:
-                    break
-        if len(matches) >= GREP_SPILL_MATCH_LIMIT:
+        lines = text.splitlines()
+        hit_lines = [n for n, line in enumerate(lines, start=1) if regex.search(line)]
+        if not hit_lines:
+            continue
+        wanted: set[int] = set()
+        for n in hit_lines:
+            wanted.add(n)
+            if context_lines:
+                wanted.update(
+                    range(max(1, n - context_lines), min(len(lines), n + context_lines) + 1)
+                )
+        for n in sorted(wanted):
+            kind = "m" if n in hit_lines else "c"
+            records.append(_match_record(rel, n, lines[n - 1], kind))
+        if sum(1 for r in records if r[3] == "m") >= GREP_SPILL_MATCH_LIMIT:
             break
-    return matches, files_searched, files_skipped
+    return records, files_searched, files_skipped
+
+
+_RG_LINE_RE = re.compile(r"^(?P<path>.+?):(?P<line>\d+):(?P<text>.*)$")
+_RG_CONTEXT_RE = re.compile(r"^(?P<path>.+?)-(?P<line>\d+)-(?P<text>.*)$")
+
+
+async def _ripgrep_scan(
+    pattern: str,
+    target: Path,
+    base: Path,
+    include: str | None,
+    case: bool,
+    context_lines: int,
+    signal: AbortSignal | None,
+) -> tuple[list[tuple[str, int, str, str]], int] | None:
+    """Native ripgrep scan; None means "fall back to the Python engine".
+
+    rg's defaults already match this tool's contract — hidden files skipped,
+    .gitignore respected, binary files detected — and ``-g '!dir'`` adds the
+    fixed vendor prune list the Python walker enforces. The subprocess is
+    raced against the abort signal and the same 30s wall clock; output is
+    capped well past the spill limit so a pathological tree cannot stream
+    forever."""
+    rg = _rg_binary()
+    if rg is None:
+        return None
+    rel_target = (target.relative_to(base).as_posix() if base in target.parents else ".") or "."
+    # -H forces the path prefix even for a single explicitly-named file
+    # (rg otherwise prints bare "lineno:text", which this parser and the
+    # shared path:line:text grammar both expect to carry a path).
+    argv = [rg, "--no-heading", "--color", "never", "--max-filesize", "1M", "-n", "-H"]
+    if not case:
+        argv.append("-i")
+    if context_lines:
+        argv += ["-C", str(context_lines)]
+    if include:
+        argv += ["-g", include]
+    for pruned in _GREP_PRUNE_DIRS:
+        argv += ["-g", f"!{pruned}"]
+    argv += ["--", pattern, rel_target]
+
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            *argv,
+            cwd=str(base),
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+    except (OSError, ValueError):
+        return None
+
+    records: list[tuple[str, int, str, str]] = []
+    deadline = time.monotonic() + GREP_SCAN_DEADLINE_S
+    output_cap = (GREP_SPILL_MATCH_LIMIT + 1) * 3 + 1000
+    try:
+        assert proc.stdout is not None
+        while len(records) < output_cap:
+            if signal and signal.aborted:
+                proc.kill()
+                return None
+            if time.monotonic() > deadline:
+                proc.kill()
+                break
+            try:
+                raw = await asyncio.wait_for(proc.stdout.readline(), timeout=1.0)
+            except (TimeoutError, asyncio.TimeoutError):
+                continue
+            if not raw:
+                break
+            line = raw.decode("utf-8", errors="replace").rstrip("\n")
+            if line == "--":
+                continue
+            match = _RG_LINE_RE.match(line)
+            if match:
+                path = match.group("path")
+                if path.startswith("./"):
+                    path = path[2:]
+                records.append(
+                    _match_record(path, int(match.group("line")), match.group("text"), "m")
+                )
+                continue
+            context = _RG_CONTEXT_RE.match(line)
+            if context:
+                path = context.group("path")
+                if path.startswith("./"):
+                    path = path[2:]
+                records.append(
+                    _match_record(path, int(context.group("line")), context.group("text"), "c")
+                )
+        try:
+            await asyncio.wait_for(proc.wait(), timeout=5.0)
+        except (TimeoutError, asyncio.TimeoutError):
+            proc.kill()
+    finally:
+        if proc.returncode is None:
+            with contextlib.suppress(ProcessLookupError):
+                proc.kill()
+    # exit 0 = matches, 1 = none; anything else is an rg-side error (bad
+    # flag, unreadable cwd) the caller should not inherit.
+    if proc.returncode not in (0, 1):
+        return None
+    match_count = sum(1 for r in records if r[3] == "m")
+    return records, match_count
+
+
+def _render_grep_body(
+    records: list[tuple[str, int, str, str]],
+    skip: int,
+    context_lines: int,
+) -> tuple[str, int, int]:
+    """``(body, shown_matches, total_matches)`` with skip + display cap applied.
+
+    Matches paginate (``skip`` then the 200-line display cap); context rides
+    along only for the matches being shown, groups separated by ``--``."""
+    match_indexes = [i for i, r in enumerate(records) if r[3] == "m"]
+    total = len(match_indexes)
+    kept = match_indexes[skip:][:GREP_MATCH_LIMIT]
+    if not kept:
+        return "", 0, total
+    keep_set = set(kept)
+    # Pull in the context records neighbouring each kept match (same file,
+    # within ±context_lines of the match).
+    if context_lines:
+        for i in kept:
+            rel, lineno = records[i][0], records[i][1]
+            j = i - 1
+            while (
+                j >= 0
+                and records[j][0] == rel
+                and records[j][3] == "c"
+                and lineno - records[j][1] <= context_lines
+            ):
+                keep_set.add(j)
+                j -= 1
+            j = i + 1
+            while (
+                j < len(records)
+                and records[j][0] == rel
+                and records[j][3] == "c"
+                and records[j][1] - lineno <= context_lines
+            ):
+                keep_set.add(j)
+                j += 1
+    out: list[str] = []
+    last_line = None
+    last_rel = None
+    for i in sorted(keep_set):
+        rel, lineno, text, kind = records[i]
+        if last_rel is not None and (rel != last_rel or lineno != last_line + 1):
+            out.append("--")
+        out.append(f"{rel}:{lineno}:{text}" if kind == "m" else f"{rel}:{lineno}-{text}")
+        last_rel, last_line = rel, lineno
+    return "\n".join(out), len(kept), total
 
 
 @_guard("grep")
@@ -2322,7 +3046,7 @@ async def execute_grep(
     on_update: Callable[[AgentToolUpdate], None] | None = None,
     context: ToolContext | None = None,
 ) -> ToolResult:
-    """Regex search over files; ripgrep-free pure-Python implementation."""
+    """Regex search over files — ripgrep when available, Python otherwise."""
     try:
         params = GrepParams(**args)
     except ValidationError as exc:
@@ -2344,55 +3068,104 @@ async def execute_grep(
         if not await _check_approval(context, "read", description):
             return _error(tool_call_id, "grep", "User declined to search this path.")
 
+    records: list[tuple[str, int, str, str]] = []
+    files_searched = 0
+    files_skipped = 0
+    engine_note = ""
+
     if target.is_file():
-        files: list[Path] = [target]
         base = target.parent
+        files: list[Path] = [target]
     else:
         base = target
         files = _walk_files(target)
 
-    # The scan is FILESYSTEM + REGEX work on model-controlled input; running
-    # it on the event loop would pin the CPU on a backtracking pattern or a
-    # large tree and make Ctrl+C unprocessable. It runs in a worker thread
-    # raced against the abort signal, with a wall-clock cap bounding the
-    # pathological-regex case (regexes are not classified).
-    scan_result, aborted = await _run_with_abort(
-        asyncio.to_thread(_grep_scan, files, base, regex, params.include),
-        signal,
-        lambda: None,
-    )
-    if aborted:
-        return _error(tool_call_id, "grep", "Search aborted.")
-    matches, files_searched, files_skipped = scan_result
+    scan_result = None
+    if _use_ripgrep() and not (target.is_file() and target.stat().st_size > GREP_FILE_LIMIT_BYTES):
+        scan_result = await _ripgrep_scan(
+            params.pattern,
+            target,
+            base,
+            params.include,
+            params.case,
+            params.context_lines,
+            signal,
+        )
+    if scan_result is not None:
+        records, _count = scan_result
+        engine_note = " (ripgrep)"
+        # rg applies --max-filesize silently; recover the count the footer
+        # contract promises from the already-walked file list so both
+        # engines tell the model the same thing.
+        for f in files:
+            try:
+                if f.stat().st_size > GREP_FILE_LIMIT_BYTES:
+                    files_skipped += 1
+            except OSError:
+                continue
+    else:
+        if signal and signal.aborted:
+            return _error(tool_call_id, "grep", "Search aborted.")
+        # The scan is FILESYSTEM + REGEX work on model-controlled input;
+        # running it on the event loop would pin the CPU on a backtracking
+        # pattern or a large tree and make Ctrl+C unprocessable. It runs in a
+        # worker thread raced against the abort signal, with a wall-clock cap
+        # bounding the pathological-regex case (regexes are not classified).
+        py_result, aborted = await _run_with_abort(
+            asyncio.to_thread(
+                _python_grep_scan, files, base, regex, params.include, params.context_lines
+            ),
+            signal,
+            lambda: None,
+        )
+        if aborted:
+            return _error(tool_call_id, "grep", "Search aborted.")
+        records, files_searched, files_skipped = py_result
 
+    matches = [r for r in records if r[3] == "m"]
     if not matches:
         skipped_note = (
             f" ({files_skipped} file(s) skipped over the 1MB cap)" if files_skipped else ""
         )
+        where = f"in {files_searched} file(s)" if not engine_note else ""
         return _text(
             tool_call_id,
             "grep",
-            f"No matches for '{params.pattern}' in {files_searched} " f"file(s){skipped_note}.",
+            f"No matches for '{params.pattern}'{where}{skipped_note}{engine_note}.",
             useless=True,
             details={"useless": True},
         )
-    total = len(matches)
-    shown = matches[:GREP_MATCH_LIMIT]
-    body, spill_details = _capped_list_body("\n".join(matches), "\n".join(shown), "grep", context)
-    header = f"{len(shown)} match(es) for '{params.pattern}'"
-    if total > len(shown):
+
+    body, shown, total = _render_grep_body(records, params.skip, params.context_lines)
+    # The spill holds every MATCH line (context excluded — it is render-time
+    # decoration, recoverable by re-running with a narrower pattern/range).
+    spill_lines = [f"{rel}:{lineno}:{text}" for rel, lineno, text, _kind in matches]
+    shown_block = body
+    body_text, spill_details = _capped_list_body(
+        "\n".join(spill_lines), shown_block, "grep", context
+    )
+    header = f"{shown} match(es) for '{params.pattern}'"
+    if total > shown:
         header += f" of {total}{'+' if total >= GREP_SPILL_MATCH_LIMIT else ''}"
-        header += f" (showing first {GREP_MATCH_LIMIT})"
+        header += f" (use skip={params.skip + shown} for the next page)"
+    if params.skip:
+        header += f" (skipped {params.skip})"
     if files_skipped:
         header += f" ({files_skipped} file(s) skipped over the 1MB cap)"
-    return _text(tool_call_id, "grep", header + ":\n" + body, details=spill_details)
+    return _text(
+        tool_call_id, "grep", header + ":\n" + body_text + engine_note, details=spill_details
+    )
 
 
 def build_grep_tool() -> AgentTool:
     return AgentTool(
         name="grep",
         label="Grep",
-        description="Regex search across files, returning 'path:line:text' matches.",
+        description=(
+            "Regex search across files ('path:line:text' matches; context_lines "
+            "adds surrounding lines, skip paginates; gitignore respected, "
+            "ripgrep-fast when installed)."
+        ),
         parameters=GrepParams.model_json_schema(),
         approval_tier="read",
         # Read-only search; parallel greps are the common batch shape.

--- a/local_operator/tools/builtin.py
+++ b/local_operator/tools/builtin.py
@@ -2299,31 +2299,47 @@ def _match_windows(content: str, old_text: str) -> list[tuple[int, int, str]]:
 
 
 def _reindent_new_text(new_text: str, matched: str, old_text: str) -> str:
-    """Re-anchor ``new_text``'s indentation onto the file's actual level.
+    """Re-anchor a TOLERANT match while retaining the file's line endings.
 
-    The model's old/new pair is internally consistent at ITS indentation; the
-    file holds the same text at a different one. Per line: the model's line
-    sits ``(file_indent - old_indent)`` columns over its reference. Extra new
-    lines (additions with no counterpart in old_text) borrow the delta of the
-    last old line, which is the level the block was written at. Blank lines
-    pass through untouched."""
-    file_lines = matched.splitlines()
-    old_lines = old_text.splitlines()
-    new_lines = new_text.splitlines()
+    Exact matches bypass this function and insert ``new_text`` byte-for-byte.
+    On the tolerant path, indentation follows the file window and every model
+    newline adopts the corresponding file line's CRLF/LF spelling. Extra
+    inserted lines borrow the final matched line's indentation and EOL.
+    """
+    file_lines = matched.splitlines(keepends=True)
+    old_lines = old_text.splitlines(keepends=True)
+    new_lines = new_text.splitlines(keepends=True)
     if not old_lines or not file_lines:
         return new_text
+
+    def split_ending(line: str) -> tuple[str, str]:
+        body = line.rstrip("\r\n")
+        return body, line[len(body) :]
+
     out: list[str] = []
     for i, line in enumerate(new_lines):
-        if not line.strip():
-            out.append("")
+        body, model_ending = split_ending(line)
+        if not body.strip():
+            ref = min(i, len(file_lines) - 1)
+            _file_body, file_ending = split_ending(file_lines[ref])
+            out.append(file_ending if model_ending else "")
             continue
         ref = min(i, len(file_lines) - 1, len(old_lines) - 1)
-        file_indent = len(_leading_ws(file_lines[ref]))
-        old_indent = len(_leading_ws(old_lines[ref]))
-        line_indent = len(_leading_ws(line))
-        shift = file_indent + max(line_indent - old_indent, 0)
-        out.append(" " * shift + line.lstrip())
-    return "\n".join(out)
+        file_body, file_ending = split_ending(file_lines[ref])
+        old_body, _old_ending = split_ending(old_lines[ref])
+        file_indent = _leading_ws(file_body)
+        old_indent = _leading_ws(old_body)
+        line_indent = _leading_ws(body)
+        if line_indent.startswith(old_indent):
+            indentation = file_indent + line_indent[len(old_indent) :]
+        else:
+            # Mixed tab/space model indentation with no literal prefix: keep
+            # the file's anchor and conservatively express only the extra
+            # relative depth as spaces.
+            indentation = file_indent + " " * max(len(line_indent) - len(old_indent), 0)
+        ending = (file_ending or model_ending) if model_ending else ""
+        out.append(indentation + body.lstrip(" \t") + ending)
+    return "".join(out)
 
 
 def _line_of_offset(content: str, offset: int) -> int:
@@ -2377,7 +2393,8 @@ async def execute_edit(
     if not path.is_file():
         return _error(tool_call_id, "edit", f"File does not exist: {path}")
 
-    original = path.read_text(encoding="utf-8")
+    with path.open("r", encoding="utf-8", newline="") as stream:
+        original = stream.read()
     current = original
     total_replacements = 0
 
@@ -2417,14 +2434,24 @@ async def execute_edit(
                 )
         # Apply back-to-front so earlier offsets stay valid within this hunk.
         for start, end, matched in sorted(chosen, key=lambda w: w[0], reverse=True):
-            replacement = _reindent_new_text(hunk.new_text, matched, hunk.old_text)
-            if matched.endswith(("\n", "\r")) and not replacement.endswith(("\n", "\r")):
-                replacement += "\n"
+            exact = matched == hunk.old_text
+            replacement = (
+                hunk.new_text
+                if exact
+                else _reindent_new_text(hunk.new_text, matched, hunk.old_text)
+            )
+            if (
+                not exact
+                and matched.endswith(("\n", "\r"))
+                and not replacement.endswith(("\n", "\r"))
+            ):
+                replacement += "\r\n" if matched.endswith("\r\n") else "\n"
             current = current[:start] + replacement + current[end:]
             total_replacements += 1
 
     if current != original:
-        path.write_text(current, encoding="utf-8")
+        with path.open("w", encoding="utf-8", newline="") as stream:
+            stream.write(current)
     details = _diff_details(str(path), original, current)
     return _text(
         tool_call_id,

--- a/local_operator/tools/builtin.py
+++ b/local_operator/tools/builtin.py
@@ -1180,27 +1180,110 @@ async def execute_bash(
     aborted = False
     next_update = loop.time() + 0.5
 
-    while True:
-        waiters: list[asyncio.Task[object]] = [wait_task, stdout_task, stderr_task]
-        if abort_waiter is not None:
-            waiters.append(abort_waiter)
-        if wait_task.done():
-            break  # finished already — never misreport as timeout
-        remaining = deadline - loop.time()
-        if remaining <= 0:
-            timed_out = True
+    try:
+        while True:
+            waiters: list[asyncio.Task[object]] = [wait_task, stdout_task, stderr_task]
+            if abort_waiter is not None:
+                waiters.append(abort_waiter)
+            if wait_task.done():
+                break  # finished already — never misreport as timeout
+            remaining = deadline - loop.time()
+            if remaining <= 0:
+                timed_out = True
+                _kill()
+                break
+            done, _pending = await asyncio.wait(waiters, timeout=min(0.25, remaining))
+            if wait_task in done:
+                break
+            if abort_waiter is not None and abort_waiter in done:
+                aborted = True
+                _kill()
+                break
+            if loop.time() >= next_update:
+                _emit_update()
+                next_update = loop.time() + 0.5
+    except asyncio.CancelledError:
+        # Steering interrupted the tool task (the loop cancels interruptible
+        # tools at its 0.25s poll). Killing the process here used to (a)
+        # destroy minutes of a long build on a one-line user aside and (b)
+        # leak the child anyway when cancellation raced the kill. Instead the
+        # command DETACHES: it keeps running (it was spawned start_new_session
+        # so it survives its own process group), its readers keep draining so
+        # a full pipe cannot block it, and it is tracked as a background job
+        # whose completion auto-delivers when the session is idle. A REAL
+        # abort (Ctrl+C, jobs cancel) still kills: that is a stop, not a
+        # redirect.
+        if signal is not None and signal.aborted:
             _kill()
-            break
-        done, _pending = await asyncio.wait(waiters, timeout=min(0.25, remaining))
-        if wait_task in done:
-            break
-        if abort_waiter is not None and abort_waiter in done:
-            aborted = True
+            raise
+        jobs = context.jobs if context is not None else None
+        if jobs is None:
+            # No job manager to own a detached child: kill rather than leak.
             _kill()
-            break
-        if loop.time() >= next_update:
-            _emit_update()
-            next_update = loop.time() + 0.5
+            raise
+        partial = _bash_output_summary(
+            b"".join(stdout_chunks).decode("utf-8", errors="replace"),
+            b"".join(stderr_chunks).decode("utf-8", errors="replace"),
+        )
+        wait_task.cancel()
+        if abort_waiter is not None and not abort_waiter.done():
+            abort_waiter.cancel()
+        command = params.command
+        remaining_timeout = max(deadline - loop.time(), 0.0)
+
+        async def _detached(job_id: str, job_signal: Any, report_progress: Any) -> str:
+            # Owns the process from here: waits with the ORIGINAL timeout
+            # budget, keeps the readers alive to drain the pipes, and reports
+            # the exit status + bounded output as the job result.
+            del job_id, report_progress
+            # Local from the start: assigning it in the timeout branch without
+            # this line would make it a local read-before-assign (the closure
+            # never runs — the outer assignment happens in a scope the runner
+            # never re-enters after registration).
+            timed_out_bg = False
+            bg_deadline = asyncio.get_running_loop().time() + remaining_timeout
+            while process.returncode is None:
+                if job_signal is not None and job_signal.aborted:
+                    _kill()
+                    break
+                if asyncio.get_running_loop().time() > bg_deadline:
+                    timed_out_bg = True
+                    _kill()
+                    break
+                try:
+                    await asyncio.wait_for(asyncio.shield(process.wait()), timeout=0.25)
+                except (TimeoutError, asyncio.TimeoutError):
+                    continue
+            await asyncio.gather(stdout_task, stderr_task, return_exceptions=True)
+            out = b"".join(stdout_chunks).decode("utf-8", errors="replace")
+            err = b"".join(stderr_chunks).decode("utf-8", errors="replace")
+            code = process.returncode if process.returncode is not None else -1
+            head = f"TIMEOUT after {params.timeout}s (process killed)" if timed_out_bg else ""
+            summary, spill = _capped_list_body(
+                _bash_output_summary(out, err),
+                _bash_output_summary(out, err)[:TOOL_OUTPUT_LIMIT_CHARS],
+                "bash",
+                context,
+            )
+            transport = getattr(process, "_transport", None)
+            if transport is not None:
+                transport.close()
+            return "\n".join(part for part in (head, f"exit code: {code}", summary) if part)
+
+        timed_out_bg = False
+        try:
+            bg_job_id = jobs.register("bash", f"bash: {command[:60]}", _detached, owner_id=None)
+        except Exception:  # noqa: BLE001 — no manager slot: kill, don't leak
+            _kill()
+            raise
+        return _text(
+            tool_call_id,
+            "bash",
+            f"steering interrupted; command continues in the background as job "
+            f"{bg_job_id} (use 'jobs'/'wait'; its result auto-delivers when "
+            f"the session is idle)\ncommand: {command}\n{partial}",
+            details={"job_id": bg_job_id, "backgrounded": True},
+        )
 
     # Bounded drain: the kill above EOFs both pipes; give the readers 250 ms
     # to consume what is already buffered so partial output survives.
@@ -4919,6 +5002,10 @@ async def execute_wait(
         job = jobs.get(params.job_id)
         if job is None:
             return _error(tool_call_id, "wait", f"job {params.job_id} disappeared")
+    # Handing the result to the model HERE means auto-delivery must not
+    # repeat it when the session next goes idle (see Session._on_job_completed
+    # and AsyncJob.consumed).
+    jobs.mark_consumed(params.job_id)
     text, spill_details = _job_summary(job, context)
     details = {"job_id": job.id, "status": job.status}
     if spill_details:

--- a/local_operator/tools/builtin.py
+++ b/local_operator/tools/builtin.py
@@ -56,7 +56,7 @@ import traceback
 from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Literal, cast
 from urllib.parse import urlsplit
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
@@ -1270,9 +1270,10 @@ async def execute_bash(
                 transport.close()
             return "\n".join(part for part in (head, f"exit code: {code}", summary) if part)
 
-        timed_out_bg = False
         try:
-            bg_job_id = jobs.register("bash", f"bash: {command[:60]}", _detached, owner_id=None)
+            bg_job_id = cast(Any, jobs).register(
+                "bash", f"bash: {command[:60]}", _detached, owner_id=None
+            )
         except Exception:  # noqa: BLE001 — no manager slot: kill, don't leak
             _kill()
             raise
@@ -1820,8 +1821,9 @@ def _format_args(args: ast.arguments) -> str:
         parts.append("*")
     for i, arg in enumerate(args.kwonlyargs):
         rendered = ast.unparse(arg)
-        if i < len(args.kw_defaults) and args.kw_defaults[i] is not None:
-            rendered = f"{rendered}={ast.unparse(args.kw_defaults[i])}"
+        default = args.kw_defaults[i] if i < len(args.kw_defaults) else None
+        if default is not None:
+            rendered = f"{rendered}={ast.unparse(default)}"
         parts.append(rendered)
     if args.kwarg:
         parts.append("**" + ast.unparse(args.kwarg))
@@ -1852,7 +1854,7 @@ def _python_structural_summary_lines(source: str) -> tuple[list[str], int, int] 
 
     out: list[str] = []
 
-    def emit(node: ast.AST, depth: int) -> int:
+    def emit(node: ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef, depth: int) -> int:
         """Emit one symbol block; returns how many symbol lines it used."""
         used = 0
         pad = "    " * depth
@@ -1934,12 +1936,6 @@ def _structural_summary_result(
     if spill_details:
         details.update(spill_details)
     return _text(tool_call_id, "read", header + "\n" + body + footer, details=details)
-
-    footer = (
-        f'\n[read around a hit with read(path="{ref.handle}", '
-        f'range="{max(matches[0][0] - 10, 1)}-{matches[0][0] + 30}")]'
-    )
-    return _text(tool_call_id, "read", f"{header}:\n{body}{footer}", details=details)
 
 
 @_guard("read")
@@ -3114,7 +3110,9 @@ def _render_grep_body(
     last_rel = None
     for i in sorted(keep_set):
         rel, lineno, text, kind = records[i]
-        if last_rel is not None and (rel != last_rel or lineno != last_line + 1):
+        if last_rel is not None and (
+            last_line is None or rel != last_rel or lineno != last_line + 1
+        ):
             out.append("--")
         out.append(f"{rel}:{lineno}:{text}" if kind == "m" else f"{rel}:{lineno}-{text}")
         last_rel, last_line = rel, lineno
@@ -5005,7 +5003,7 @@ async def execute_wait(
     # Handing the result to the model HERE means auto-delivery must not
     # repeat it when the session next goes idle (see Session._on_job_completed
     # and AsyncJob.consumed).
-    jobs.mark_consumed(params.job_id)
+    cast(Any, jobs).mark_consumed(params.job_id)
     text, spill_details = _job_summary(job, context)
     details = {"job_id": job.id, "status": job.status}
     if spill_details:

--- a/local_operator/tools/builtin.py
+++ b/local_operator/tools/builtin.py
@@ -1236,38 +1236,77 @@ async def execute_bash(
             # budget, keeps the readers alive to drain the pipes, and reports
             # the exit status + bounded output as the job result.
             del job_id, report_progress
-            # Local from the start: assigning it in the timeout branch without
-            # this line would make it a local read-before-assign (the closure
-            # never runs — the outer assignment happens in a scope the runner
-            # never re-enters after registration).
             timed_out_bg = False
+            cancelled_bg = False
             bg_deadline = asyncio.get_running_loop().time() + remaining_timeout
-            while process.returncode is None:
-                if job_signal is not None and job_signal.aborted:
+            bg_wait = asyncio.create_task(process.wait())
+
+            async def cleanup(*, kill: bool) -> None:
+                """Kill/reap the whole process group and close EVERY owner.
+
+                AsyncJobManager.cancel both aborts the job signal and cancels
+                this runner immediately. Without a cancellation handler, that
+                cancellation can land inside the wait below and settle the job
+                while the start-new-session child + pipe readers keep running
+                untracked. Cleanup is bounded but exhaustive: process group,
+                waiter, both readers, transport.
+                """
+                if kill and process.returncode is None:
                     _kill()
-                    break
-                if asyncio.get_running_loop().time() > bg_deadline:
-                    timed_out_bg = True
+                if not bg_wait.done():
+                    with contextlib.suppress(TimeoutError, asyncio.CancelledError):
+                        await asyncio.wait_for(asyncio.shield(bg_wait), timeout=1.0)
+                if process.returncode is None:
                     _kill()
-                    break
-                try:
-                    await asyncio.wait_for(asyncio.shield(process.wait()), timeout=0.25)
-                except (TimeoutError, asyncio.TimeoutError):
-                    continue
-            await asyncio.gather(stdout_task, stderr_task, return_exceptions=True)
+                    with contextlib.suppress(TimeoutError, asyncio.CancelledError):
+                        await asyncio.wait_for(process.wait(), timeout=1.0)
+                with contextlib.suppress(TimeoutError):
+                    await asyncio.wait_for(
+                        asyncio.gather(stdout_task, stderr_task, return_exceptions=True),
+                        timeout=0.5,
+                    )
+                for reader in readers:
+                    if not reader.done():
+                        reader.cancel()
+                if readers:
+                    await asyncio.gather(*readers, return_exceptions=True)
+                if not bg_wait.done():
+                    bg_wait.cancel()
+                    await asyncio.gather(bg_wait, return_exceptions=True)
+                transport = getattr(process, "_transport", None)
+                if transport is not None:
+                    transport.close()
+
+            try:
+                while not bg_wait.done():
+                    if job_signal is not None and job_signal.aborted:
+                        cancelled_bg = True
+                        break
+                    if asyncio.get_running_loop().time() > bg_deadline:
+                        timed_out_bg = True
+                        break
+                    await asyncio.wait({bg_wait}, timeout=0.25)
+                await cleanup(kill=cancelled_bg or timed_out_bg)
+            except asyncio.CancelledError:
+                # Manager cancellation is deliberately immediate. Convert it
+                # into process cleanup first, then preserve cancellation so the
+                # job row settles as cancelled rather than completed/failed.
+                await cleanup(kill=True)
+                raise
+
             out = b"".join(stdout_chunks).decode("utf-8", errors="replace")
             err = b"".join(stderr_chunks).decode("utf-8", errors="replace")
             code = process.returncode if process.returncode is not None else -1
             head = f"TIMEOUT after {params.timeout}s (process killed)" if timed_out_bg else ""
-            summary, spill = _capped_list_body(
-                _bash_output_summary(out, err),
-                _bash_output_summary(out, err)[:TOOL_OUTPUT_LIMIT_CHARS],
+            if cancelled_bg:
+                head = "CANCELLED (process killed)"
+            combined = _bash_output_summary(out, err)
+            summary, _spill_details = _capped_list_body(
+                combined,
+                combined[:TOOL_OUTPUT_LIMIT_CHARS],
                 "bash",
                 context,
             )
-            transport = getattr(process, "_transport", None)
-            if transport is not None:
-                transport.close()
             return "\n".join(part for part in (head, f"exit code: {code}", summary) if part)
 
         try:
@@ -2717,6 +2756,35 @@ def _literal_prefix(pattern: str) -> str:
     return "".join(out).rstrip("/")
 
 
+def _path_is_ignored(root: Path, path: Path) -> bool:
+    """Evaluate root + nested ignore files for one glob candidate.
+
+    Unlike grep's walker, pathlib.glob materializes candidates without walking
+    through our rule stack. Rebuild the ancestor stack here so a
+    packages/a/.gitignore has the same authority over `**/*.py` as it does in
+    grep. The caller still bypasses this for an explicitly named literal
+    prefix ("dist/*.js" means the ignored dist on purpose).
+    """
+    try:
+        rel_parts = path.relative_to(root).parts
+    except ValueError:
+        return False
+    rules: list[tuple[str, list[_IgnoreRule]]] = []
+    current = root
+    rel_dir = ""
+    for index, part in enumerate(rel_parts):
+        found = _load_ignore_rules(current, rel_dir)
+        if found:
+            rules.append((rel_dir, found))
+        rel = "/".join(rel_parts[: index + 1])
+        candidate = current / part
+        if _ignored(rel, candidate.is_dir(), rules):
+            return True
+        current = candidate
+        rel_dir = rel
+    return False
+
+
 def _glob_walk(root: Path, pattern: str) -> list[str]:
     """The walk half of execute_glob, run in a worker thread.
 
@@ -2725,15 +2793,12 @@ def _glob_walk(root: Path, pattern: str) -> list[str]:
     the pattern's literal prefix names them, because an author who writes
     'dist/index.html' into a repo that ignores dist/ means that file."""
     prefix = _literal_prefix(pattern)
-    rules: list[tuple[str, list[_IgnoreRule]]] = []
-    if root.joinpath(".gitignore").is_file() or root.joinpath(".ignore").is_file():
-        rules = [("", _load_ignore_rules(root, ""))]
     out = []
     for p in root.glob(pattern):
         rel = p.relative_to(root).as_posix()
-        if rules and not rel.startswith(prefix + "/") and rel != prefix:
-            if _ignored(rel, p.is_dir(), rules):
-                continue
+        explicitly_named = bool(prefix) and (rel == prefix or rel.startswith(prefix + "/"))
+        if not explicitly_named and _path_is_ignored(root, p):
+            continue
         out.append(rel + ("/" if p.is_dir() else ""))
     return sorted(out)
 

--- a/local_operator/tools/builtin.py
+++ b/local_operator/tools/builtin.py
@@ -4689,13 +4689,71 @@ def build_browser_tool(context: ToolContext | None) -> AgentTool | None:
 # never advertise tools that can only error.
 
 
+class TaskItem(BaseModel):
+    """One slice of a task batch. ``agent`` picks the tier: "task" is the
+    full child; "scout" is a read-only research child (lookups only) for
+    investigation that should not pay for — or risk — write tools. ``effort``
+    routes to a configured model tier (values.subagents.models lo/med/hi)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    label: str = Field(description="Short label for this subagent (shown in the jobs list).")
+    prompt: str = Field(description="The full instructions this subagent runs.")
+    agent: Literal["task", "scout"] = Field(
+        default="task",
+        description='"task" = full child; "scout" = read-only research child.',
+    )
+    effort: Literal["lo", "med", "hi"] | None = Field(
+        default=None,
+        description="Model tier for this subagent (values.subagents.models).",
+    )
+
+
 class TaskParams(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    label: str = Field(description="Short label for the subagent (shown in the jobs list).")
-    prompt: str = Field(
-        description="The full instructions the subagent runs in a fresh child session."
+    label: str | None = Field(
+        default=None,
+        description="Single-task form: short label for the subagent.",
     )
+    prompt: str | None = Field(
+        default=None,
+        description="Single-task form: the instructions the subagent runs.",
+    )
+    context: str = Field(
+        default="",
+        description=(
+            "Shared context prepended to EVERY task in the batch — the goal, "
+            "constraints, and interfaces every subagent needs. Stated once "
+            "here instead of copy-pasted into each prompt."
+        ),
+    )
+    tasks: list[TaskItem] = Field(
+        default_factory=list,
+        description=(
+            "Batch form: all items launch as CONCURRENT subagents from this "
+            "one call. Independent slices belong here together — one round "
+            "trip instead of one per task."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def _one_form(self) -> "TaskParams":
+        """Single form xor batch form, whole — the pydantic voice keeps the
+        'invalid arguments' contract for a half-supplied call."""
+        if (self.label is None) != (self.prompt is None):
+            raise ValueError("single-task form needs both label and prompt")
+        single = self.label is not None
+        if single and self.tasks:
+            raise ValueError("pass either 'tasks' (batch) or label/prompt, not both")
+        if not single and not self.tasks:
+            raise ValueError("nothing to launch: pass 'tasks' or label/prompt")
+        if not single and not self.context.strip() and len(self.tasks) == 1:
+            # Allowed, but the batch-of-one without context is just the
+            # single form with extra steps; no error, the model learns from
+            # the schema descriptions.
+            pass
+        return self
 
 
 class WaitParams(BaseModel):
@@ -4735,7 +4793,15 @@ async def execute_task(
     on_update: Callable[[AgentToolUpdate], None] | None = None,
     context: ToolContext | None = None,
 ) -> ToolResult:
-    """Launch a one-shot subagent as a background job; return its job id."""
+    """Launch one subagent — or a whole batch — as background jobs.
+
+    The batch form exists because fan-out economics are the point: N
+    independent slices cost N sequential model round trips when launched one
+    per call, and one call when launched as ``tasks`` together. The shared
+    ``context`` is prepended to every prompt so the contract (goal,
+    constraints, interfaces) is stated once by the delegator and cannot drift
+    between children.
+    """
     try:
         params = TaskParams(**args)
     except ValidationError as exc:
@@ -4748,16 +4814,40 @@ async def execute_task(
             "task",
             "subagent launching is not available in this session (no engine attached).",
         )
-    try:
-        job_id = launcher(params.label, params.prompt)
-    except Exception as exc:  # noqa: BLE001 — engine failure surfaces as an error result
-        return _error(tool_call_id, "task", f"could not launch subagent: {exc}")
+    items: list[TaskItem] = list(params.tasks)
+    if params.label is not None and params.prompt is not None:
+        items.append(TaskItem(label=params.label, prompt=params.prompt))
+
+    def _full_prompt(item: TaskItem) -> str:
+        if not params.context.strip():
+            return item.prompt
+        return f"{params.context.strip()}\n\n---\n" f"Your task ({item.label}):\n{item.prompt}"
+
+    launched: list[dict[str, Any]] = []
+    failures: list[str] = []
+    for item in items:
+        try:
+            job_id = launcher(item.label, _full_prompt(item), agent=item.agent, effort=item.effort)
+        except Exception as exc:  # noqa: BLE001 — engine failure surfaces as an error result
+            failures.append(f"{item.label}: {exc}")
+            continue
+        launched.append({"job_id": job_id, "label": item.label, "agent": item.agent})
+    if not launched:
+        detail = failures[0] if failures else "no tasks to launch"
+        return _error(tool_call_id, "task", f"could not launch subagent(s): {detail}")
+    lines = [f"- {entry['label']} ({entry['agent']}): job {entry['job_id']}" for entry in launched]
+    body = (
+        f"launched {len(launched)} subagent(s) as concurrent background jobs:\n"
+        + "\n".join(lines)
+        + "\nuse 'wait' (job_id=...) to await one, or 'jobs' to list running work."
+    )
+    if failures:
+        body += "\nfailed to launch: " + "; ".join(failures)
     return _text(
         tool_call_id,
         "task",
-        f"launched subagent job {job_id} ({params.label}); use 'wait' with "
-        f"job_id={job_id} to await it, or 'jobs' to list running work.",
-        details={"job_id": job_id, "label": params.label},
+        body,
+        details={"jobs": launched, "job_id": launched[0]["job_id"], "label": launched[0]["label"]},
     )
 
 
@@ -4769,8 +4859,9 @@ def build_task_tool(context: ToolContext) -> AgentTool | None:
         label="Subagent task",
         describe_approval=_describe_task_approval,
         description=(
-            "Launch a one-shot subagent in a fresh child session, running "
-            "in the background; returns a job id to await with 'wait'."
+            "Launch background subagents — one, or a whole concurrent batch "
+            "('tasks' + shared 'context') in a single call. agent='scout' is "
+            "a read-only research child; effort picks a configured model tier."
         ),
         parameters=TaskParams.model_json_schema(),
         # Spawns autonomous child work, so it rides the write gate just like

--- a/local_operator/tools/eval.py
+++ b/local_operator/tools/eval.py
@@ -50,8 +50,10 @@ from local_operator.harness.types import (
     ToolResult,
 )
 from local_operator.tools.builtin import (
-    TRACEBACK_TAIL_CHARS,
     TOOL_OUTPUT_LIMIT_CHARS,
+    TRACEBACK_TAIL_CHARS,
+    _bash_output_summary,
+    _display_target,
     _error,
     _guard,
     _safe_cwd,
@@ -161,7 +163,9 @@ def _retire(kernel: _Kernel) -> None:
 
 def _reap_idle(now: float) -> None:
     """Close kernels unused for :data:`KERNEL_IDLE_SECONDS` (on access)."""
-    stale = [key for key, kernel in _KERNELS.items() if now - kernel.last_used > KERNEL_IDLE_SECONDS]
+    stale = [
+        key for key, kernel in _KERNELS.items() if now - kernel.last_used > KERNEL_IDLE_SECONDS
+    ]
     for key in stale:
         _retire(_KERNELS.pop(key))
 

--- a/local_operator/tools/eval.py
+++ b/local_operator/tools/eval.py
@@ -1,0 +1,457 @@
+"""Persistent Python kernel tool (``eval``) — a session-scoped REPL.
+
+WHY a kernel tool
+-----------------
+Modelling work constantly needs small computations — counts, sums, data
+reshaping, checking a hypothesis about a library's behaviour — and paying a
+``bash`` one-shot (spawn, import the interpreter fresh, recompute everything
+from scratch on the next question) for each one is the expensive way. This
+tool keeps ONE Python process per session whose namespace survives across
+calls, so ``import``s amortise and intermediate state stays resident.
+
+WHY these safety properties
+---------------------------
+* Arbitrary code execution, so ``approval_tier="exec"`` like bash.
+* ``concurrency="exclusive"``: the namespace is STATE, and two parallel calls
+  writing it would interleave variables the model believes are sequential.
+  The registry never runs two ``eval`` calls at once.
+* ``interruptible=True``: abort kills the worker. The code may be in any
+  state mid-run, so the kernel is DISCARDED, not reused — a namespace that
+  half-executed an abort is a corruptible witness. The same applies to a
+  timeout and to a worker crash: every one of those paths reports honestly
+  that session state was lost and the next call starts fresh.
+
+Worker lifecycle is owned HERE, keyed by session: one kernel per
+``context.session_id`` (object id as the fallback for hosts that pass no
+id), an on-access idle reaper (no background timers to keep alive), an LRU
+cap so one process cannot farm kernels without bound, and ``spill_truncate``
+for the 8 KiB result budget — the same contract every other tool offers.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import sys
+import time
+import uuid
+from collections import OrderedDict
+from typing import Any, Callable
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+from local_operator.harness.types import (
+    AbortSignal,
+    AgentTool,
+    AgentToolUpdate,
+    TextContent,
+    ToolContext,
+    ToolResult,
+)
+from local_operator.tools.builtin import (
+    TRACEBACK_TAIL_CHARS,
+    TOOL_OUTPUT_LIMIT_CHARS,
+    _error,
+    _guard,
+    _safe_cwd,
+    _text,
+    _validation_error,
+    spill_truncate,
+)
+
+#: Per-call wall clock. Kernel calls are expected to be short (they replace
+#: one-shot bash snippets, not training runs); 30s catches the runaway case
+#: without punishing a slow first ``import``.
+EVAL_DEFAULT_TIMEOUT_SECONDS = 30.0
+#: Hard cap on the caller-chosen timeout — same role as bash's: a call longer
+#: than this is a session bug, not a tool feature.
+EVAL_MAX_TIMEOUT_SECONDS = 300.0
+#: A kernel untouched for this long is closed on the NEXT eval call. On-access
+#: reaping rather than a background task: a timer would have to be owned by an
+#: event loop that outlives sessions, and 5 minutes of staleness costs nothing
+#: compared to the complexity of keeping one alive correctly.
+KERNEL_IDLE_SECONDS = 5 * 60.0
+#: Most kernels ever resident. Each is a full interpreter (tens of MB RSS);
+#: 4 concurrent sessions with live kernels is already an unusual host, and the
+#: LRU eviction below makes room rather than refusing the call.
+MAX_KERNELS = 4
+#: Stderr kept from a crashed worker: enough for the fatal exception, the
+#: rest is gone with the process. Same value the guard uses for its
+#: tracebacks, for the same reason.
+_CRASH_STDERR_TAIL_CHARS = TRACEBACK_TAIL_CHARS
+
+
+class EvalParams(BaseModel):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    code: str = Field(description="Python code to run in the persistent session kernel.")
+    timeout: float = Field(
+        default=EVAL_DEFAULT_TIMEOUT_SECONDS,
+        gt=0,
+        le=EVAL_MAX_TIMEOUT_SECONDS,
+        description="Max seconds before the kernel is killed (state is lost).",
+    )
+
+
+class _Kernel:
+    """One live worker process plus its LRU bookkeeping."""
+
+    def __init__(self, process: asyncio.subprocess.Process) -> None:
+        self.process = process
+        self.last_used = time.monotonic()
+
+
+#: Session key -> kernel, least-recently-used first. Process-wide on purpose:
+#: the worker's namespace is per SESSION, and sessions outlive the tool
+#: objects the registry builds for each of them.
+_KERNELS: OrderedDict[str, _Kernel] = OrderedDict()
+
+#: References to in-flight reap tasks. A bare task can be garbage-collected
+#: before it runs, which would strand the kill half-done — the same reason
+#: bash keeps its reader tasks referenced.
+_CLOSING: set[asyncio.Task[None]] = set()
+
+
+class _WorkerCrash(Exception):
+    """The worker died before answering a request; carries its stderr tail."""
+
+    def __init__(self, stderr: str) -> None:
+        super().__init__(stderr.strip() or "worker exited without a response")
+        self.stderr = stderr
+
+
+def _session_key(context: ToolContext | None) -> str:
+    """Registry key for one session's kernel.
+
+    ``id(context)`` is the documented fallback for hosts that pass no session
+    id — and because the context object is rebuilt every turn, that fallback
+    means a fresh kernel per call. Hosts that want persistence set
+    ``session_id``; the fallback only has to be deterministic within a call.
+    """
+    if context is None:
+        return "no-context"
+    return context.session_id or f"ctx-{id(context):x}"
+
+
+async def _close_kernel(kernel: _Kernel) -> None:
+    """Kill the worker, reap it, release the transport (no ResourceWarnings)."""
+    if kernel.process.returncode is None:
+        with contextlib.suppress(ProcessLookupError):
+            kernel.process.kill()
+    with contextlib.suppress(TimeoutError):
+        await asyncio.wait_for(kernel.process.wait(), timeout=1.0)
+    transport = getattr(kernel.process, "_transport", None)
+    if transport is not None:
+        transport.close()
+
+
+def _retire(kernel: _Kernel) -> None:
+    """Discard a kernel without blocking the call that outgrew it.
+
+    Registry mutations are synchronous (single-threaded loop, no awaits
+    between read and write), so the kill itself must not become an await
+    here — a slow reap during a timeout path would stall the very call being
+    rescued. The await happens in a referenced background task instead.
+    """
+    task = asyncio.ensure_future(_close_kernel(kernel))
+    _CLOSING.add(task)
+    task.add_done_callback(_CLOSING.discard)
+
+
+def _reap_idle(now: float) -> None:
+    """Close kernels unused for :data:`KERNEL_IDLE_SECONDS` (on access)."""
+    stale = [key for key, kernel in _KERNELS.items() if now - kernel.last_used > KERNEL_IDLE_SECONDS]
+    for key in stale:
+        _retire(_KERNELS.pop(key))
+
+
+def _remember(key: str, kernel: _Kernel) -> None:
+    """Re-insert a healthy kernel as most-recently-used, evicting past the cap."""
+    _KERNELS[key] = kernel
+    _KERNELS.move_to_end(key)
+    while len(_KERNELS) > MAX_KERNELS:
+        _key, evicted = _KERNELS.popitem(last=False)
+        # Safe by construction: this call's kernel was just moved to the
+        # MRU end, and eviction only runs while more than one entry is
+        # resident, so the LRU end it pops can never be the kernel in use.
+        _retire(evicted)
+
+
+async def _spawn(cwd: str) -> _Kernel:
+    """Start a worker in the session's working directory.
+
+    ``start_new_session`` detaches the kernel from the harness's process
+    group: a terminal Ctrl-C aimed at the TUI must not SIGINT the kernel and
+    silently destroy the persistence this tool exists to provide (the tool's
+    own timeout/abort paths kill it explicitly).
+    """
+    process = await asyncio.create_subprocess_exec(
+        sys.executable,
+        "-u",
+        "-m",
+        "local_operator.tools.eval_worker",
+        stdin=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        cwd=cwd,
+        start_new_session=True,
+    )
+    return _Kernel(process)
+
+
+async def _read_crash_stderr(kernel: _Kernel) -> str:
+    """Best-effort stderr tail from a worker that stopped answering."""
+    stream = kernel.process.stderr
+    if stream is None:
+        return ""
+    try:
+        raw = await asyncio.wait_for(stream.read(), timeout=1.0)
+    except (TimeoutError, ConnectionResetError):
+        return ""
+    return raw.decode("utf-8", errors="replace")
+
+
+async def _exchange(kernel: _Kernel, request: dict[str, Any], request_id: str) -> dict[str, Any]:
+    """Send one request line, await its response line by id.
+
+    Lines that are not this request's response are skipped, not fatal: user
+    code can write to fd 1 directly (the worker only intercepts the
+    ``sys.stdout`` OBJECT), and a protocol that dies on stray bytes would
+    lose a healthy kernel over noise. EOF before a response is a crash.
+    """
+    stdin = kernel.process.stdin
+    assert stdin is not None  # piped at spawn
+    try:
+        stdin.write((json.dumps(request) + "\n").encode())
+        await stdin.drain()
+    except (BrokenPipeError, ConnectionResetError):
+        raise _WorkerCrash(await _read_crash_stderr(kernel)) from None
+
+    stdout = kernel.process.stdout
+    assert stdout is not None  # piped at spawn
+    while True:
+        line = await stdout.readline()
+        if not line:
+            raise _WorkerCrash(await _read_crash_stderr(kernel))
+        try:
+            response = json.loads(line)
+        except ValueError:
+            continue
+        if isinstance(response, dict) and response.get("id") == request_id:
+            return response
+
+
+def _lost_state_error(tool_call_id: str, reason: str) -> ToolResult:
+    """The honest result for every path that had to kill the kernel.
+
+    The model must not believe the namespace survived: the next call's
+    ``NameError`` would otherwise read as a tool bug rather than the
+    documented consequence, and the model would start avoiding the tool.
+    """
+    return _error(
+        tool_call_id,
+        "eval",
+        f"{reason}\nALL session state (variables, imports) was lost — "
+        "the kernel restarts fresh on the next call.",
+    )
+
+
+@_guard("eval")
+async def execute_eval(
+    tool_call_id: str,
+    args: dict[str, Any],
+    signal: AbortSignal | None = None,
+    on_update: Callable[[AgentToolUpdate], None] | None = None,
+    context: ToolContext | None = None,
+) -> ToolResult:
+    """Run Python code in the session's persistent kernel."""
+    try:
+        params = EvalParams(**args)
+    except ValidationError as exc:
+        return _validation_error(tool_call_id, "eval", exc)
+    if not params.code.strip():
+        return _error(tool_call_id, "eval", "code must be a non-empty string")
+
+    # Pre-aborted signal: never spawn (or disturb a resident kernel) for a
+    # call there is no intention to run.
+    if signal is not None and signal.aborted:
+        return _error(
+            tool_call_id,
+            "eval",
+            f"aborted ({signal.reason or 'aborted'}): code not run",
+        )
+
+    key = _session_key(context)
+    _reap_idle(time.monotonic())
+
+    kernel = _KERNELS.pop(key, None)
+    if kernel is not None and kernel.process.returncode is not None:
+        # Dead husk (prior crash whose retire task has since reaped it) —
+        # never send a request to a corpse.
+        kernel = None
+    if kernel is None:
+        try:
+            kernel = await _spawn(_safe_cwd(context))
+        except OSError as exc:
+            return _error(tool_call_id, "eval", f"failed to start Python kernel: {exc}")
+    kernel.last_used = time.monotonic()
+
+    request_id = uuid.uuid4().hex
+    exchange = asyncio.create_task(
+        _exchange(kernel, {"id": request_id, "code": params.code}, request_id)
+    )
+    abort_waiter = asyncio.create_task(signal.wait()) if signal is not None else None
+
+    response: dict[str, Any] | None = None
+    crash: _WorkerCrash | None = None
+    timed_out = False
+    aborted = False
+    try:
+        waiters: list[asyncio.Task[Any]] = [exchange]
+        if abort_waiter is not None:
+            waiters.append(abort_waiter)
+        done, _pending = await asyncio.wait(waiters, timeout=params.timeout)
+        if exchange in done:
+            try:
+                response = exchange.result()
+            except _WorkerCrash as exc:
+                crash = exc
+        elif abort_waiter is not None and abort_waiter in done:
+            aborted = True
+        else:
+            timed_out = True
+    finally:
+        if response is None:
+            exchange.cancel()
+            with contextlib.suppress(BaseException):
+                await exchange
+        if abort_waiter is not None and not abort_waiter.done():
+            abort_waiter.cancel()
+            with contextlib.suppress(BaseException):
+                await abort_waiter
+
+    if aborted or timed_out:
+        # The code may be mid-run inside the kernel: reuse is not an option.
+        _retire(kernel)
+        if aborted:
+            return _lost_state_error(
+                tool_call_id,
+                f"aborted ({signal.reason if signal else 'aborted'}): kernel killed mid-run",
+            )
+        return _lost_state_error(
+            tool_call_id, f"TIMEOUT after {params.timeout}s: kernel killed mid-run"
+        )
+    if crash is not None:
+        _retire(kernel)
+        tail = crash.stderr[-_CRASH_STDERR_TAIL_CHARS:]
+        detail = tail.strip() or "(no stderr)"
+        return _error(
+            tool_call_id,
+            "eval",
+            "Python kernel crashed while running the code (fatal signal or "
+            "os._exit — it cannot be caught in-process).\n"
+            f"Session state was lost — the kernel restarts fresh on the next "
+            f"call.\n--- stderr (tail) ---\n{detail}",
+        )
+
+    # Success: the kernel stays resident for the next call.
+    kernel.last_used = time.monotonic()
+    _remember(key, kernel)
+    return _render(tool_call_id, response or {}, context, on_update)
+
+
+def _render(
+    tool_call_id: str,
+    response: dict[str, Any],
+    context: ToolContext | None,
+    on_update: Callable[[AgentToolUpdate], None] | None,
+) -> ToolResult:
+    """Build the ToolResult from one worker response.
+
+    ``display()`` output goes to the update stream and ``details`` only —
+    updates render in the UI and never enter the message history, and
+    ``details`` is never serialized to providers, so the human sees it and
+    the model does not. Everything the model reads is routed through
+    ``spill_truncate`` for the shared 8 KiB budget with a spill handle.
+    """
+    ok = bool(response.get("ok"))
+    stdout = str(response.get("stdout") or "")
+    stderr = str(response.get("stderr") or "")
+    result_repr = response.get("result")
+    result_repr = str(result_repr) if result_repr is not None else None
+    display = [str(item) for item in response.get("display") or []]
+
+    if display and on_update is not None:
+        on_update(
+            AgentToolUpdate(
+                content=[TextContent(text="\n".join(display))],
+                details={"tool_name": "eval", "display": True},
+            )
+        )
+
+    # The result leads so head-biased truncation keeps it: it is the one line
+    # the call existed to produce.
+    if ok:
+        body = "\n".join(
+            ([f"result: {result_repr}"] if result_repr is not None else [])
+            + [_bash_output_summary(stdout, stderr)]
+        )
+        text, spill_details = spill_truncate(body, "eval", context, TOOL_OUTPUT_LIMIT_CHARS)
+        details = spill_details
+        if display:
+            details = {**(details or {}), "display": display}
+        return _text(tool_call_id, "eval", text, details=details)
+
+    error = str(response.get("error") or "(no error reported)")
+    body = "\n".join([error, _bash_output_summary(stdout, stderr)])
+    text, spill_details = spill_truncate(body, "eval", context, TOOL_OUTPUT_LIMIT_CHARS)
+    return ToolResult(
+        tool_call_id=tool_call_id,
+        tool_name="eval",
+        content=[TextContent(text=text)],
+        details=spill_details,
+        is_error=True,
+    )
+
+
+def _describe_eval_approval(args: dict[str, Any], cwd: str) -> str:
+    """The approval sentence: the code's first line, not a JSON dump.
+
+    ``exec``-tier prompts must show the decision-relevant argument, and for a
+    REPL that is the code itself. Only the first line fits a prompt; the
+    rest is in the transcript the reviewer already has open.
+    """
+    code = args.get("code")
+    if not isinstance(code, str) or not code.strip():
+        return ""
+    first = code.strip().splitlines()[0]
+    if len(first) > 80:
+        first = first[:77] + "..."
+    return f"eval: {_display_target(first)}"
+
+
+def build_eval_tool() -> AgentTool:
+    return AgentTool(
+        name="eval",
+        label="Python",
+        describe_approval=_describe_eval_approval,
+        description=(
+            "Run Python in a persistent per-session kernel. State (variables, "
+            "imports, functions) survives across calls — build on earlier calls "
+            "instead of recomputing. Compute facts, transform data, verify "
+            "library behaviour: cheaper and safer than bash one-shots. The "
+            "trailing expression's value is returned. display(value) shows "
+            "output to the user only, excluded from your context; use it "
+            "instead of print() when only the human needs to see something."
+        ),
+        parameters=EvalParams.model_json_schema(),
+        approval_tier="exec",
+        # The namespace is state: parallel calls would interleave variables
+        # the model believes are sequential. Exclusive serialises them.
+        concurrency="exclusive",
+        # Abort kills the worker mid-run; the next call starts a fresh
+        # kernel (state is honestly reported lost — see _lost_state_error).
+        interruptible=True,
+        execute=execute_eval,
+    )

--- a/local_operator/tools/eval.py
+++ b/local_operator/tools/eval.py
@@ -35,6 +35,7 @@ import contextlib
 import json
 import os
 import signal as process_signal
+import subprocess
 import sys
 import time
 import uuid
@@ -99,10 +100,18 @@ class EvalParams(BaseModel):
 
 
 class _Kernel:
-    """One live worker process plus its LRU bookkeeping."""
+    """One live worker process plus its process-tree ownership and LRU state."""
 
-    def __init__(self, process: asyncio.subprocess.Process) -> None:
+    def __init__(
+        self,
+        process: asyncio.subprocess.Process,
+        *,
+        windows_job: int | None = None,
+    ) -> None:
         self.process = process
+        # On Windows, closing this Job Object is the process-tree equivalent of
+        # POSIX killpg. It is assigned before any user code can run.
+        self.windows_job = windows_job
         self.last_used = time.monotonic()
 
 
@@ -138,6 +147,143 @@ def _session_key(context: ToolContext | None) -> str:
     return context.session_id or f"ctx-{id(context):x}"
 
 
+def _create_windows_kill_job(pid: int) -> int:
+    """Own ``pid`` with a kill-on-close Windows Job Object.
+
+    The worker initially blocks on stdin, so assignment happens before it can
+    execute user code or spawn descendants. Refusing eval startup when this
+    setup fails is safer than advertising a timeout that leaks child processes.
+    """
+    import ctypes
+    from ctypes import wintypes
+
+    class BasicLimitInformation(ctypes.Structure):
+        _fields_ = [
+            ("PerProcessUserTimeLimit", ctypes.c_longlong),
+            ("PerJobUserTimeLimit", ctypes.c_longlong),
+            ("LimitFlags", wintypes.DWORD),
+            ("MinimumWorkingSetSize", ctypes.c_size_t),
+            ("MaximumWorkingSetSize", ctypes.c_size_t),
+            ("ActiveProcessLimit", wintypes.DWORD),
+            ("Affinity", ctypes.c_size_t),
+            ("PriorityClass", wintypes.DWORD),
+            ("SchedulingClass", wintypes.DWORD),
+        ]
+
+    class IoCounters(ctypes.Structure):
+        _fields_ = [
+            ("ReadOperationCount", ctypes.c_ulonglong),
+            ("WriteOperationCount", ctypes.c_ulonglong),
+            ("OtherOperationCount", ctypes.c_ulonglong),
+            ("ReadTransferCount", ctypes.c_ulonglong),
+            ("WriteTransferCount", ctypes.c_ulonglong),
+            ("OtherTransferCount", ctypes.c_ulonglong),
+        ]
+
+    class ExtendedLimitInformation(ctypes.Structure):
+        _fields_ = [
+            ("BasicLimitInformation", BasicLimitInformation),
+            ("IoInfo", IoCounters),
+            ("ProcessMemoryLimit", ctypes.c_size_t),
+            ("JobMemoryLimit", ctypes.c_size_t),
+            ("PeakProcessMemoryUsed", ctypes.c_size_t),
+            ("PeakJobMemoryUsed", ctypes.c_size_t),
+        ]
+
+    kernel32 = getattr(ctypes, "WinDLL")("kernel32", use_last_error=True)
+    last_error = getattr(ctypes, "get_last_error")
+    kernel32.CreateJobObjectW.argtypes = [ctypes.c_void_p, ctypes.c_wchar_p]
+    kernel32.CreateJobObjectW.restype = ctypes.c_void_p
+    kernel32.SetInformationJobObject.argtypes = [
+        ctypes.c_void_p,
+        ctypes.c_int,
+        ctypes.c_void_p,
+        wintypes.DWORD,
+    ]
+    kernel32.SetInformationJobObject.restype = wintypes.BOOL
+    kernel32.OpenProcess.argtypes = [wintypes.DWORD, wintypes.BOOL, wintypes.DWORD]
+    kernel32.OpenProcess.restype = ctypes.c_void_p
+    kernel32.AssignProcessToJobObject.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
+    kernel32.AssignProcessToJobObject.restype = wintypes.BOOL
+    kernel32.CloseHandle.argtypes = [ctypes.c_void_p]
+    kernel32.CloseHandle.restype = wintypes.BOOL
+
+    job = kernel32.CreateJobObjectW(None, None)
+    if not job:
+        raise OSError(last_error(), "CreateJobObjectW failed")
+    try:
+        limits = ExtendedLimitInformation()
+        limits.BasicLimitInformation.LimitFlags = 0x00002000  # KILL_ON_JOB_CLOSE
+        if not kernel32.SetInformationJobObject(
+            job, 9, ctypes.byref(limits), ctypes.sizeof(limits)
+        ):
+            raise OSError(last_error(), "SetInformationJobObject failed")
+
+        process_handle = kernel32.OpenProcess(
+            0x0100 | 0x0001,  # PROCESS_SET_QUOTA | PROCESS_TERMINATE
+            False,
+            pid,
+        )
+        if not process_handle:
+            raise OSError(last_error(), "OpenProcess failed")
+        try:
+            if not kernel32.AssignProcessToJobObject(job, process_handle):
+                raise OSError(last_error(), "AssignProcessToJobObject failed")
+        finally:
+            kernel32.CloseHandle(process_handle)
+    except BaseException:
+        kernel32.CloseHandle(job)
+        raise
+    return int(job)
+
+
+def _close_windows_job(job: int) -> None:
+    """Terminate the Job tree and close its kill-on-close native handle."""
+    import ctypes
+
+    kernel32 = getattr(ctypes, "WinDLL")("kernel32", use_last_error=True)
+    last_error = getattr(ctypes, "get_last_error")
+    kernel32.TerminateJobObject.argtypes = [ctypes.c_void_p, ctypes.c_uint]
+    kernel32.TerminateJobObject.restype = ctypes.c_int
+    kernel32.CloseHandle.argtypes = [ctypes.c_void_p]
+    kernel32.CloseHandle.restype = ctypes.c_int
+    handle = ctypes.c_void_p(job)
+    terminated = bool(kernel32.TerminateJobObject(handle, 1))
+    terminate_error = last_error()
+    closed = bool(kernel32.CloseHandle(handle))
+    close_error = last_error()
+    # Either operation is sufficient to terminate the owned tree:
+    # TerminateJobObject does it directly; successful CloseHandle triggers the
+    # KILL_ON_JOB_CLOSE limit. Both failing means containment was not honored.
+    if not terminated and not closed:
+        raise OSError(
+            terminate_error or close_error,
+            "TerminateJobObject and CloseHandle(job) both failed",
+        )
+
+
+async def _taskkill_windows_tree(pid: int) -> bool:
+    """Last-resort Windows tree termination if a native Job handle fails."""
+    taskkill = os.path.join(
+        os.environ.get("SystemRoot", r"C:\Windows"),
+        "System32",
+        "taskkill.exe",
+    )
+    try:
+        killer = await asyncio.create_subprocess_exec(
+            taskkill,
+            "/PID",
+            str(pid),
+            "/T",
+            "/F",
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        return await asyncio.wait_for(killer.wait(), timeout=5.0) == 0
+    except (OSError, TimeoutError):
+        return False
+
+
 async def _close_kernel(kernel: _Kernel) -> None:
     """Kill/reap the worker process GROUP, then release its transport.
 
@@ -147,7 +293,17 @@ async def _close_kernel(kernel: _Kernel) -> None:
     """
     process = kernel.process
     killed_group = False
-    if hasattr(os, "killpg"):
+    if kernel.windows_job is not None:
+        try:
+            _close_windows_job(kernel.windows_job)
+            killed_group = True
+        except OSError:
+            killed_group = await _taskkill_windows_tree(process.pid)
+        finally:
+            # Never close/reuse a native handle twice, including when close
+            # itself reports an error.
+            kernel.windows_job = None
+    elif hasattr(os, "killpg"):
         try:
             # Attempt this even when the leader has already exited: its
             # descendants keep the original process group alive.
@@ -205,25 +361,44 @@ def _remember(key: str, kernel: _Kernel) -> None:
 
 
 async def _spawn(cwd: str) -> _Kernel:
-    """Start a worker in the session's working directory.
+    """Start a worker with platform-native process-tree ownership.
 
-    ``start_new_session`` detaches the kernel from the harness's process
-    group: a terminal Ctrl-C aimed at the TUI must not SIGINT the kernel and
-    silently destroy the persistence this tool exists to provide (the tool's
-    own timeout/abort paths kill it explicitly).
+    POSIX uses a new session/process group. Windows assigns the worker to a
+    kill-on-close Job Object before the first request is sent.
     """
+    spawn_options: dict[str, Any] = {
+        "stdin": asyncio.subprocess.PIPE,
+        "stdout": asyncio.subprocess.PIPE,
+        "stderr": asyncio.subprocess.PIPE,
+        "cwd": cwd,
+    }
+    if sys.platform == "win32":
+        spawn_options["creationflags"] = getattr(subprocess, "CREATE_NO_WINDOW", 0)
+    else:
+        spawn_options["start_new_session"] = True
     process = await asyncio.create_subprocess_exec(
         sys.executable,
         "-u",
         "-m",
         "local_operator.tools.eval_worker",
-        stdin=asyncio.subprocess.PIPE,
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
-        cwd=cwd,
-        start_new_session=True,
+        **spawn_options,
     )
-    return _Kernel(process)
+    windows_job: int | None = None
+    if sys.platform == "win32":
+        try:
+            windows_job = _create_windows_kill_job(process.pid)
+        except OSError:
+            # No request has been sent, so the worker cannot have descendants.
+            # Reap this leader and refuse unsafe eval startup.
+            with contextlib.suppress(ProcessLookupError):
+                process.kill()
+            with contextlib.suppress(TimeoutError):
+                await asyncio.wait_for(process.wait(), timeout=2.0)
+            transport = getattr(process, "_transport", None)
+            if transport is not None:
+                transport.close()
+            raise
+    return _Kernel(process, windows_job=windows_job)
 
 
 async def _read_crash_stderr(kernel: _Kernel) -> str:

--- a/local_operator/tools/eval.py
+++ b/local_operator/tools/eval.py
@@ -33,6 +33,8 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import json
+import os
+import signal as process_signal
 import sys
 import time
 import uuid
@@ -137,13 +139,33 @@ def _session_key(context: ToolContext | None) -> str:
 
 
 async def _close_kernel(kernel: _Kernel) -> None:
-    """Kill the worker, reap it, release the transport (no ResourceWarnings)."""
-    if kernel.process.returncode is None:
+    """Kill/reap the worker process GROUP, then release its transport.
+
+    Evaluated code can spawn descendants. The worker is a process-group leader
+    by construction, so killing only the interpreter would leave those
+    descendants running after a timeout, abort, eviction, or session close.
+    """
+    process = kernel.process
+    killed_group = False
+    if hasattr(os, "killpg"):
+        try:
+            # Attempt this even when the leader has already exited: its
+            # descendants keep the original process group alive.
+            os.killpg(process.pid, process_signal.SIGKILL)
+            killed_group = True
+        except (ProcessLookupError, PermissionError):
+            pass
+    if process.returncode is None and not killed_group:
         with contextlib.suppress(ProcessLookupError):
-            kernel.process.kill()
-    with contextlib.suppress(TimeoutError):
-        await asyncio.wait_for(kernel.process.wait(), timeout=1.0)
-    transport = getattr(kernel.process, "_transport", None)
+            process.kill()
+    try:
+        await asyncio.wait_for(process.wait(), timeout=2.0)
+    except TimeoutError:
+        with contextlib.suppress(ProcessLookupError):
+            process.kill()
+        with contextlib.suppress(TimeoutError):
+            await asyncio.wait_for(process.wait(), timeout=1.0)
+    transport = getattr(process, "_transport", None)
     if transport is not None:
         transport.close()
 
@@ -235,12 +257,19 @@ async def _exchange(kernel: _Kernel, request: dict[str, Any], request_id: str) -
     stdout = kernel.process.stdout
     assert stdout is not None  # piped at spawn
     while True:
-        line = await stdout.readline()
+        try:
+            line = await stdout.readline()
+        except (ValueError, asyncio.LimitOverrunError, OSError) as exc:
+            # ``readline`` raises ValueError when untrusted fd-1 output exceeds
+            # StreamReader's line limit. Turn every protocol read failure into
+            # the crash path so the popped kernel is killed rather than lost
+            # outside the registry.
+            raise _WorkerCrash(f"eval protocol stream failed: {type(exc).__name__}: {exc}") from exc
         if not line:
             raise _WorkerCrash(await _read_crash_stderr(kernel))
         try:
             response = json.loads(line)
-        except ValueError:
+        except (ValueError, UnicodeError):
             continue
         if isinstance(response, dict) and response.get("id") == request_id:
             return response
@@ -311,6 +340,7 @@ async def execute_eval(
     crash: _WorkerCrash | None = None
     timed_out = False
     aborted = False
+    externally_cancelled = False
     try:
         waiters: list[asyncio.Task[Any]] = [exchange]
         if abort_waiter is not None:
@@ -321,10 +351,15 @@ async def execute_eval(
                 response = exchange.result()
             except _WorkerCrash as exc:
                 crash = exc
+            except Exception as exc:  # noqa: BLE001 - protocol failures retire state
+                crash = _WorkerCrash(f"eval protocol exchange failed: {type(exc).__name__}: {exc}")
         elif abort_waiter is not None and abort_waiter in done:
             aborted = True
         else:
             timed_out = True
+    except asyncio.CancelledError:
+        externally_cancelled = True
+        raise
     finally:
         if response is None:
             exchange.cancel()
@@ -334,6 +369,8 @@ async def execute_eval(
             abort_waiter.cancel()
             with contextlib.suppress(BaseException):
                 await abort_waiter
+        if externally_cancelled:
+            _retire(kernel)
 
     if aborted or timed_out:
         # The code may be mid-run inside the kernel: reuse is not an option.

--- a/local_operator/tools/eval_worker.py
+++ b/local_operator/tools/eval_worker.py
@@ -42,10 +42,81 @@ import ast
 import contextlib
 import io
 import json
+import reprlib
 import sys
 import traceback
 from collections.abc import Callable
 from typing import Any
+
+#: Worker-side protocol caps. Parent-side spill_truncate is intentionally
+#: later; these caps prevent a giant print/display/repr from allocating and
+#: JSON-encoding gigabytes BEFORE the parent gets a chance to spill it.
+STREAM_CHAR_LIMIT = 1_000_000
+DISPLAY_CHAR_LIMIT = 256_000
+TRUNCATED_MARKER = "\n[…worker output truncated before protocol serialization]"
+
+_REPR = reprlib.Repr()
+_REPR.maxstring = 4096
+_REPR.maxother = 4096
+_REPR.maxlist = 100
+_REPR.maxtuple = 100
+_REPR.maxdict = 100
+
+
+class _CappedTextIO(io.TextIOBase):
+    """Text sink retaining at most ``limit`` chars while reporting all writes
+    successful, so user code cannot distinguish it from StringIO."""
+
+    def __init__(self, limit: int) -> None:
+        self.limit = limit
+        self._parts: list[str] = []
+        self._used = 0
+        self.truncated = False
+
+    def writable(self) -> bool:
+        return True
+
+    def write(self, value: str) -> int:
+        text = str(value)
+        remaining = self.limit - self._used
+        if remaining > 0:
+            kept = text[:remaining]
+            self._parts.append(kept)
+            self._used += len(kept)
+        if len(text) > max(remaining, 0):
+            self.truncated = True
+        return len(text)
+
+    def getvalue(self) -> str:
+        body = "".join(self._parts)
+        return body + (TRUNCATED_MARKER if self.truncated else "")
+
+
+class _DisplaySink:
+    """Bounded list-shaped display channel (the wire contract stays list[str])."""
+
+    def __init__(self, limit: int) -> None:
+        self.limit = limit
+        self.items: list[str] = []
+        self.used = 0
+        self.truncated = False
+
+    def add(self, value: str) -> None:
+        remaining = self.limit - self.used
+        if remaining <= 0:
+            self.truncated = True
+            return
+        kept = value[:remaining]
+        self.items.append(kept)
+        self.used += len(kept)
+        if len(value) > remaining:
+            self.truncated = True
+
+    def finish(self) -> list[str]:
+        if self.truncated:
+            self.items.append("[…display output truncated before protocol serialization]")
+        return self.items
+
 
 #: Filename stamped into compiled code so tracebacks name the tool's cell
 #: instead of a real path the model never wrote (or worse, one it did).
@@ -72,12 +143,12 @@ def _safe_repr(value: Any) -> str:
     in-band instead.
     """
     try:
-        return repr(value)
+        return _REPR.repr(value)
     except BaseException as exc:  # noqa: BLE001 — user code, any failure is data
         return f"<unrepresentable result: {type(exc).__name__}: {exc}>"
 
 
-def _make_display(sink: list[str]) -> Callable[..., None]:
+def _make_display(sink: _DisplaySink) -> Callable[..., None]:
     """The per-request ``display`` builtin, appending formatted values to
     ``sink``.
 
@@ -87,9 +158,9 @@ def _make_display(sink: list[str]) -> Callable[..., None]:
     """
 
     def display(value: Any, *more: Any) -> None:
-        sink.append(_safe_repr(value))
+        sink.add(_safe_repr(value))
         for extra in more:
-            sink.append(_safe_repr(extra))
+            sink.add(_safe_repr(extra))
 
     return display
 
@@ -145,11 +216,12 @@ def _execute(namespace: dict[str, Any], code: str) -> str | None:
 
 def _handle(namespace: dict[str, Any], request: dict[str, Any]) -> dict[str, Any]:
     """Execute one request and build its response mapping."""
-    display_sink: list[str] = []
+    display_sink = _DisplaySink(DISPLAY_CHAR_LIMIT)
     # Rebound per request (see _make_display).
     namespace["display"] = _make_display(display_sink)
 
-    stdout, stderr = io.StringIO(), io.StringIO()
+    stdout = _CappedTextIO(STREAM_CHAR_LIMIT)
+    stderr = _CappedTextIO(STREAM_CHAR_LIMIT)
     ok = True
     error: str | None = None
     result: str | None = None
@@ -169,7 +241,7 @@ def _handle(namespace: dict[str, Any], request: dict[str, Any]) -> dict[str, Any
         "stderr": stderr.getvalue(),
         "error": error,
         "result": result,
-        "display": display_sink,
+        "display": display_sink.finish(),
     }
 
 

--- a/local_operator/tools/eval_worker.py
+++ b/local_operator/tools/eval_worker.py
@@ -123,9 +123,7 @@ def _format_error(exc: BaseException) -> str:
     """
     if isinstance(exc, SyntaxError):
         return "".join(traceback.format_exception_only(type(exc), exc)).strip()
-    return "".join(
-        traceback.format_exception(type(exc), exc, exc.__traceback__)
-    ).strip()
+    return "".join(traceback.format_exception(type(exc), exc, exc.__traceback__)).strip()
 
 
 def _execute(namespace: dict[str, Any], code: str) -> str | None:

--- a/local_operator/tools/eval_worker.py
+++ b/local_operator/tools/eval_worker.py
@@ -1,0 +1,204 @@
+"""Persistent Python kernel worker behind the ``eval`` tool.
+
+WHY a separate process
+----------------------
+The ``eval`` tool promises the model a session whose state SURVIVES across
+calls — variables, imports and functions defined in one call are present in
+the next. The only honest way to give arbitrary code a persistent namespace
+without leaking that state into the harness process (where a stray ``import``
+or a monkeypatch would silently corrupt every later tool call) is to keep the
+namespace in a child process the tool owns and can kill.
+
+Protocol
+--------
+One JSON object per line, both directions, request then response, forever:
+
+    request:  {"id": "<hex>", "code": "<python source>"}
+    response: {"id": "<hex>", "ok": true|false, "stdout": str, "stderr": str,
+               "error": str|null, "result": str|null, "display": [str, ...]}
+
+The ``id`` is echoed verbatim so the tool can discard lines that are not its
+own response — user code writing to file descriptor 1 directly (``os.write``)
+cannot be intercepted from inside the process, and skipping such noise beats
+dying on it. Exactly one response line is written per request and flushed
+immediately; the process is also launched with ``python -u`` so no buffering
+layer can reorder or delay it.
+
+``result`` is the ``repr`` of the code's trailing expression when the last
+statement is an expression (the notebook-repl convention: exec everything
+before it, ``eval`` the last), else ``null``. ``display`` carries what user
+code passed to the built-in ``display()`` — shown to the human, never merged
+into the model-visible text, which is why it rides a SEPARATE key rather than
+being printed into stdout.
+
+Run only via ``python -u -m local_operator.tools.eval_worker`` (see
+``local_operator.tools.eval``); the ``__main__`` guard keeps the module
+importable without side effects.
+"""
+
+from __future__ import annotations
+
+import ast
+import contextlib
+import io
+import json
+import sys
+import traceback
+from collections.abc import Callable
+from typing import Any
+
+#: Filename stamped into compiled code so tracebacks name the tool's cell
+#: instead of a real path the model never wrote (or worse, one it did).
+_FILENAME = "<eval>"
+
+#: The namespace docstring. The session is the one thing user code cannot
+#: discover by guessing, so it is spelled out where ``help()`` and curious
+#: models will find it.
+NAMESPACE_DOC = """\
+Persistent Python session.
+
+State SURVIVES across calls: variables, imports and functions defined in one
+call are still present in the next. The kernel runs in the session's working
+directory. Use display(value) to show a value to the USER only — it is never
+added to the model's context.
+"""
+
+
+def _safe_repr(value: Any) -> str:
+    """``repr(value)`` that cannot raise.
+
+    A user-defined ``__repr__`` is arbitrary code; one that raises would turn
+    a successful computation into a lost result, so the failure is reported
+    in-band instead.
+    """
+    try:
+        return repr(value)
+    except BaseException as exc:  # noqa: BLE001 — user code, any failure is data
+        return f"<unrepresentable result: {type(exc).__name__}: {exc}>"
+
+
+def _make_display(sink: list[str]) -> Callable[..., None]:
+    """The per-request ``display`` builtin, appending formatted values to
+    ``sink``.
+
+    Rebound on every request so the sink is per-call: a value displayed in
+    call N must not reappear in call N+1's response, the same way stdout from
+    call N does not.
+    """
+
+    def display(value: Any, *more: Any) -> None:
+        sink.append(_safe_repr(value))
+        for extra in more:
+            sink.append(_safe_repr(extra))
+
+    return display
+
+
+def _split_trailing_expression(code: str) -> tuple[ast.Module, ast.Expression | None]:
+    """``(module_of_all_but_last, expression_of_last | None)``.
+
+    Compiling the whole source would make ``x = 1`` evaluate to ``None`` even
+    when the model clearly means the notebook-repl contract, and ``eval``-ing
+    the whole source would reject statements outright. Splitting the parsed
+    tree keeps both: statements run via ``exec``, and a trailing expression is
+    returned via ``eval``. A re-``compile`` of already-located AST nodes needs
+    no ``fix_missing_locations`` — parsing attached the locations.
+    """
+    tree = ast.parse(code, filename=_FILENAME, mode="exec")
+    if not tree.body or not isinstance(tree.body[-1], ast.Expr):
+        return tree, None
+    trailing = tree.body[-1]
+    head = ast.Module(body=tree.body[:-1], type_ignores=[])
+    return head, ast.Expression(body=trailing.value)
+
+
+def _format_error(exc: BaseException) -> str:
+    """One error string per failure kind.
+
+    Compile errors get exception-only formatting: a traceback whose only
+    frame is the worker's own ``exec`` adds noise, not information, and the
+    model can fix a syntax error from the message alone. Runtime failures
+    keep the traceback — the frames name the user's own lines, which IS the
+    information the model needs.
+    """
+    if isinstance(exc, SyntaxError):
+        return "".join(traceback.format_exception_only(type(exc), exc)).strip()
+    return "".join(
+        traceback.format_exception(type(exc), exc, exc.__traceback__)
+    ).strip()
+
+
+def _execute(namespace: dict[str, Any], code: str) -> str | None:
+    """Run ``code`` in ``namespace``; return the trailing expression's repr.
+
+    ``BaseException`` is deliberate: user code calling ``sys.exit()`` or
+    raising ``KeyboardInterrupt`` is a reportable error, not a reason to tear
+    down a session whose earlier state is still valuable. (Fatal signals and
+    ``os._exit`` cannot be caught here at all — that is the tool's crash
+    path, and it says so honestly.)
+    """
+    head, trailing = _split_trailing_expression(code)
+    exec(compile(head, _FILENAME, "exec"), namespace)
+    if trailing is None:
+        return None
+    value = eval(compile(trailing, _FILENAME, "eval"), namespace)
+    return _safe_repr(value)
+
+
+def _handle(namespace: dict[str, Any], request: dict[str, Any]) -> dict[str, Any]:
+    """Execute one request and build its response mapping."""
+    display_sink: list[str] = []
+    # Rebound per request (see _make_display).
+    namespace["display"] = _make_display(display_sink)
+
+    stdout, stderr = io.StringIO(), io.StringIO()
+    ok = True
+    error: str | None = None
+    result: str | None = None
+    try:
+        # stdout/stderr swap, not fd redirection: print/warnings/logging write
+        # through sys.stdout/sys.stderr and are captured, while the protocol
+        # keeps fd 1 for itself.
+        with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+            result = _execute(namespace, str(request.get("code", "")))
+    except BaseException as exc:  # noqa: BLE001 — user code failing is data
+        ok = False
+        error = _format_error(exc)
+    return {
+        "id": request.get("id", ""),
+        "ok": ok,
+        "stdout": stdout.getvalue(),
+        "stderr": stderr.getvalue(),
+        "error": error,
+        "result": result,
+        "display": display_sink,
+    }
+
+
+def main() -> None:
+    """Read requests, run them, answer — until stdin closes or the tool kills
+    the process. Either ending is normal from this side: the tool owns the
+    lifecycle (idle reaping, LRU eviction, timeout kill)."""
+    namespace: dict[str, Any] = {
+        "__name__": "__eval__",
+        "__doc__": NAMESPACE_DOC,
+    }
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            request = json.loads(line)
+            if not isinstance(request, dict):
+                raise ValueError("request is not a JSON object")
+        except ValueError:
+            # The tool only writes well-formed lines; anything else on stdin
+            # means the pipe is not worth trusting further.
+            continue
+        response = _handle(namespace, request)
+        sys.stdout.write(json.dumps(response) + "\n")
+        sys.stdout.flush()
+
+
+if __name__ == "__main__":
+    main()

--- a/local_operator/tools/lsp.py
+++ b/local_operator/tools/lsp.py
@@ -42,7 +42,9 @@ from local_operator.harness.types import (
     ToolResult,
 )
 from local_operator.tools.builtin import (
+    _approval_description,
     _capped_list_body,
+    _check_approval,
     _error,
     _guard,
     _resolve_workspace_path,
@@ -262,6 +264,15 @@ def _no_symbol_at_position_error(tool_call_id: str, params: LspParams, display: 
     )
 
 
+def _allowed_source(path: Path, root: Path, initial: Path) -> bool:
+    """Initial path (explicitly approved if outside) or anything inside cwd."""
+    try:
+        resolved = path.expanduser().resolve()
+        return resolved == initial.resolve() or resolved.is_relative_to(root.resolve())
+    except (OSError, RuntimeError):
+        return False
+
+
 def _definitions_result(
     tool_call_id: str,
     script: Any,
@@ -285,6 +296,7 @@ def _definitions_result(
         return _no_symbol_at_position_error(tool_call_id, params, display)
 
     rows: list[str] = []
+    omitted_outside = 0
     seen: set[tuple[str, int | None, str]] = set()
     label = params.name or (targets[0].name if targets else "")
     for target in targets:
@@ -297,15 +309,21 @@ def _definitions_result(
             # ``def print`` name carries module_path=None).
             rows.append(f"builtins: {target.name} ({target.type})")
             continue
-        target_lines = _source_lines(Path(target.module_path), cache)
+        target_path = Path(target.module_path)
+        if not _allowed_source(target_path, root, path):
+            omitted_outside += 1
+            continue
+        target_lines = _source_lines(target_path, cache)
         snippet = (
             target_lines[target.line - 1].strip() if 0 < target.line <= len(target_lines) else ""
         )
-        rows.append(f"{_display_path(Path(target.module_path), root)}:{target.line}: {snippet}")
+        rows.append(f"{_display_path(target_path, root)}:{target.line}: {snippet}")
     elided = len(rows) - LSP_DEFINITION_LIMIT
     if elided > 0:
         rows = rows[:LSP_DEFINITION_LIMIT]
         rows.append(f"… and {elided} more")
+    if omitted_outside:
+        rows.append(f"({omitted_outside} outside-workspace definition(s) omitted)")
     where = f" at {display}:{used[0]}:{used[1]}" if used else ""
     return _text(
         tool_call_id,
@@ -338,13 +356,18 @@ def _references_result(
     label = params.name or refs[0].name
     rows: list[str] = []
     positionless = 0
+    omitted_outside = 0
     for ref in refs:
         if ref.module_path is None or ref.line is None:
             positionless += 1
             continue
-        ref_lines = _source_lines(Path(ref.module_path), cache)
+        ref_path = Path(ref.module_path)
+        if not _allowed_source(ref_path, root, path):
+            omitted_outside += 1
+            continue
+        ref_lines = _source_lines(ref_path, cache)
         text = ref_lines[ref.line - 1].rstrip() if 0 < ref.line <= len(ref_lines) else ""
-        rows.append(f"{_display_path(Path(ref.module_path), root)}:{ref.line}: {text}")
+        rows.append(f"{_display_path(ref_path, root)}:{ref.line}: {text}")
     if not rows:
         return _text(
             tool_call_id,
@@ -357,6 +380,8 @@ def _references_result(
     body, details = _capped_list_body("\n".join(rows), shown, "lsp", context)
     if positionless:
         body += f"\n({positionless} reference(s) without source positions omitted)"
+    if omitted_outside:
+        body += f"\n({omitted_outside} outside-workspace reference(s) omitted)"
     return _text(
         tool_call_id,
         "lsp",
@@ -427,6 +452,17 @@ def _rename_preview_result(
         except RefactoringError as exc:
             last_error = exc
             continue
+        changed = [Path(p) for p in refactoring.get_changed_files() if p is not None]
+        renamed = [Path(p) for pair in refactoring.get_renames() for p in pair]
+        outside = [p for p in (*changed, *renamed) if not _allowed_source(p, root, path)]
+        if outside:
+            shown = ", ".join(str(p) for p in outside[:3])
+            return _error(
+                tool_call_id,
+                "lsp",
+                "rename preview crosses outside the approved workspace; refusing to expose "
+                f"or propose changes to: {shown}",
+            )
         diff = refactoring.get_diff()
         # jedi renders the refactoring as a unified diff itself (the same
         # ``--- / +++`` shape difflib.unified_diff emits); re-diffing the
@@ -504,7 +540,11 @@ async def execute_lsp(
         root = Path(cwd).expanduser().resolve()
     except RuntimeError:
         root = Path(cwd).resolve()
-    path, _inside, _resolvable = _resolve_workspace_path(params.path, cwd)
+    path, inside, resolvable = _resolve_workspace_path(params.path, cwd)
+    if not inside:
+        description = _approval_description(path, inside, "lsp", resolvable)
+        if not await _check_approval(context, "read", description):
+            return _error(tool_call_id, "lsp", "User declined to inspect this path.")
     if not path.exists():
         return _error(tool_call_id, "lsp", f"Path does not exist: {path}")
     if not path.is_file():

--- a/local_operator/tools/lsp.py
+++ b/local_operator/tools/lsp.py
@@ -326,11 +326,9 @@ def _references_result(
     lines = _source_lines(path, cache)
     display = _display_path(path, root)
     refs: list[Any] = []
-    used: tuple[int, int] | None = None
     for line, column in _query_positions(params, script, lines):
         refs = list(script.get_references(line, column))
         if refs:
-            used = (line, column)
             break
     if not refs:
         if params.name and not _positions_for_name(script, params.name, lines):
@@ -512,6 +510,8 @@ async def execute_lsp(
     if not path.is_file():
         return _error(tool_call_id, "lsp", f"Not a file: {path}")
 
+    if jedi is None:
+        return _error(tool_call_id, "lsp", "jedi is not installed (install local-operator[lsp])")
     script = jedi.Script(path=str(path))
     cache: dict[str, list[str]] = {}
     if params.action == "definitions":

--- a/local_operator/tools/lsp.py
+++ b/local_operator/tools/lsp.py
@@ -236,9 +236,7 @@ def _unknown_symbol_error(
     DO exist so the next call can be made without a round trip through
     grep."""
     candidates = _outline_names(script, lines)
-    listed = ", ".join(
-        f"{n.name} (L{n.line}, {n.type})" for n in candidates[:LSP_CANDIDATE_LIMIT]
-    )
+    listed = ", ".join(f"{n.name} (L{n.line}, {n.type})" for n in candidates[:LSP_CANDIDATE_LIMIT])
     more = (
         f" … and {len(candidates) - LSP_CANDIDATE_LIMIT} more"
         if len(candidates) > LSP_CANDIDATE_LIMIT
@@ -252,9 +250,7 @@ def _unknown_symbol_error(
     )
 
 
-def _no_symbol_at_position_error(
-    tool_call_id: str, params: LspParams, display: str
-) -> ToolResult:
+def _no_symbol_at_position_error(tool_call_id: str, params: LspParams, display: str) -> ToolResult:
     where = f"{display}:{params.line}"
     if params.column is not None:
         where += f":{params.column}"
@@ -303,9 +299,7 @@ def _definitions_result(
             continue
         target_lines = _source_lines(Path(target.module_path), cache)
         snippet = (
-            target_lines[target.line - 1].strip()
-            if 0 < target.line <= len(target_lines)
-            else ""
+            target_lines[target.line - 1].strip() if 0 < target.line <= len(target_lines) else ""
         )
         rows.append(f"{_display_path(Path(target.module_path), root)}:{target.line}: {snippet}")
     elided = len(rows) - LSP_DEFINITION_LIMIT

--- a/local_operator/tools/lsp.py
+++ b/local_operator/tools/lsp.py
@@ -1,0 +1,560 @@
+"""LSP tool — symbol-aware Python navigation and rename previews via jedi.
+
+Why jedi, and not a language server
+-----------------------------------
+A conventional LSP client needs a per-language server subprocess (pyright,
+rust-analyzer, gopsl) that the harness would have to install, spawn and
+babysit — the opposite of the lean-install doctrine. jedi is pure Python and
+answers in-process: import it, analyse one file, return. That is also why it
+ships as the optional ``lsp`` extra rather than a base dependency — a host
+without jedi simply does not get the tool (``build_lsp_tool`` returns None,
+the same createIf convention as ``build_browser_tool`` in builtin.py).
+
+Every action is read-only. ``rename_preview`` computes jedi's refactoring and
+returns its unified diff WITHOUT applying it: the model then makes the change
+through the edit tool, which is what keeps this whole tool in the read
+approval tier.
+
+Position handling is the one place jedi's API fights the caller. jedi wants a
+(line, column) pair, but a model holding a grep hit knows the LINE, not the
+column — and measured against jedi 0.20, ``goto(line, 0)`` on a
+``def foo(...)`` line returns nothing because column 0 lands on the ``d`` of
+``def``. A line-only query therefore scans the identifiers on the line and
+tries the first non-keyword one; ``name=`` skips positions entirely and
+resolves through jedi's own name analysis.
+"""
+
+from __future__ import annotations
+
+import keyword
+import re
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+from local_operator.harness.types import (
+    AbortSignal,
+    AgentTool,
+    AgentToolUpdate,
+    ToolContext,
+    ToolResult,
+)
+from local_operator.tools.builtin import (
+    _capped_list_body,
+    _error,
+    _guard,
+    _resolve_workspace_path,
+    _safe_cwd,
+    _text,
+    _validation_error,
+    spill_truncate,
+)
+
+try:
+    import jedi
+    from jedi import RefactoringError
+except ImportError:  # pragma: no cover — the absent-extra path is covered by
+    # build_lsp_tool returning None; jedi-dependent code is unreachable then.
+    jedi = None  # type: ignore[assignment]
+    RefactoringError = Exception  # type: ignore[assignment,misc]
+
+#: Every action the tool accepts. One tuple so the schema text, the dispatch
+#: and the tests cannot drift apart (same convention as BROWSER_ACTIONS).
+LSP_ACTIONS = ("definitions", "references", "symbols", "rename_preview")
+
+#: Displayed-reference cap. Mirrors GREP_MATCH_LIMIT: the displayed set
+#: protects the prompt, the spill (written from the full set by
+#: ``_capped_list_body``) keeps the rest reachable by handle.
+LSP_REFERENCE_LIMIT = 200
+
+#: Definition-target cap. ``goto`` on an ordinary symbol returns a handful; a
+#: result beyond this is a pathological inference and gets elided with a count
+#: rather than dumped in full.
+LSP_DEFINITION_LIMIT = 20
+
+#: Outline rows shown per ``symbols`` call. Same two-cap shape as references:
+#: a generated module with thousands of definitions must not turn the outline
+#: into the blob it exists to avoid; the spill holds the tail.
+LSP_SYMBOL_LIMIT = 400
+
+#: Symbols named in an unknown-symbol error. Enough to spot the right one by
+#: eye without the error itself becoming output the model has to page past.
+LSP_CANDIDATE_LIMIT = 30
+
+#: One identifier, used by the line-only position scan.
+_IDENTIFIER_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+
+
+class LspParams(BaseModel):
+    """Arguments the model sends; field descriptions are its only docs."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    action: Literal["definitions", "references", "symbols", "rename_preview"] = Field(
+        description="definitions | references | symbols | rename_preview."
+    )
+    path: str = Field(description="Python file to analyse (absolute or cwd-relative).")
+    line: int | None = Field(
+        default=None,
+        description="1-based line of the symbol or a usage of it; optional for "
+        "symbols, or give name instead.",
+    )
+    column: int | None = Field(
+        default=None,
+        description="0-based column on the line; by default the first identifier "
+        "on the line is used.",
+    )
+    name: str | None = Field(
+        default=None,
+        description="Symbol to locate when the line is unknown; resolved via "
+        "jedi's name analysis (definitions in this file, then imports).",
+    )
+    new_name: str | None = Field(
+        default=None,
+        description="Proposed new name (rename_preview only). The diff is "
+        "returned, never applied.",
+    )
+
+
+def _display_path(path: Path | str, root: Path) -> str:
+    """cwd-relative when inside the workspace, absolute otherwise — the same
+    rendering grep uses, so the model can paste the result into a follow-up
+    read or grep without translating between path styles."""
+    resolved = Path(path)
+    try:
+        return str(resolved.relative_to(root))
+    except ValueError:
+        return str(resolved)
+
+
+def _source_lines(path: Path | str, cache: dict[str, list[str]]) -> list[str]:
+    """Lines of ``path`` from the per-call cache; unreadable files read as
+    empty rather than raising — a snippet is decoration, never the answer."""
+    key = str(path)
+    if key not in cache:
+        try:
+            cache[key] = Path(path).read_text(encoding="utf-8", errors="replace").splitlines()
+        except OSError:
+            cache[key] = []
+    return cache[key]
+
+
+def _is_import_line(line_no: int, lines: list[str]) -> bool:
+    text = lines[line_no - 1].lstrip() if 0 < line_no <= len(lines) else ""
+    return text.startswith(("import ", "from "))
+
+
+def _outline_names(script: Any, lines: list[str]) -> list[Any]:
+    """Definitions worth navigating to, in file order.
+
+    jedi's public API cannot tell an imported name from one defined here — an
+    imported ``process`` reports description ``def process`` while sitting on
+    the import statement — so the import statement's own line text is the
+    filter. Params and locals are dropped by type/indent; module-level
+    assignments (column 0 statements) stay because they are the constants a
+    navigation pass wants.
+    """
+    out: list[Any] = []
+    seen: set[tuple[str, int, str]] = set()
+    for name in script.get_names(all_scopes=True, definitions=True):
+        if name.type == "param" or name.line is None or _is_import_line(name.line, lines):
+            continue
+        start = name.get_definition_start_position()
+        column = start[1] if start else (name.column or 0)
+        if name.type == "statement" and column > 0:
+            continue
+        key = (name.name, name.line, name.type)
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(name)
+    out.sort(key=lambda n: n.get_definition_start_position() or (n.line, n.column or 0))
+    return out
+
+
+def _positions_for_name(script: Any, name: str, lines: list[str]) -> list[tuple[int, int]]:
+    """Resolve a bare symbol name to a jedi position.
+
+    Prefers a name DEFINED in this file over one merely imported (an import's
+    position works too — goto follows it — but a same-named local definition
+    is the likelier target when both exist).
+    """
+    matches = [
+        n
+        for n in script.get_names(all_scopes=True, definitions=True)
+        if n.name == name and n.line is not None
+    ]
+    if not matches:
+        return []
+    defined_here = [n for n in matches if not _is_import_line(n.line, lines)]
+    pool = defined_here or matches
+    first = min(pool, key=lambda n: (n.line, n.column or 0))
+    return [(first.line, first.column or 0)]
+
+
+def _candidate_positions(params: LspParams, lines: list[str]) -> list[tuple[int, int]]:
+    """Positions to try, best first, for a line-bearing query.
+
+    An explicit ``column`` is honoured exactly and alone — the caller claims
+    to know where the symbol is. Without one, every non-keyword identifier on
+    the line is a candidate in order: column 0 usually lands on ``def`` or
+    ``return`` (both dead ends, measured), while the first identifier after
+    the keyword is the symbol the caller means.
+    """
+    if params.line is None:
+        return []
+    if params.column is not None:
+        return [(params.line, max(params.column, 0))]
+    text = lines[params.line - 1] if 0 < params.line <= len(lines) else ""
+    scanned = [
+        (params.line, match.start())
+        for match in _IDENTIFIER_RE.finditer(text)
+        if not keyword.iskeyword(match.group(0))
+    ]
+    return scanned or [(params.line, 0)]
+
+
+def _query_positions(params: LspParams, script: Any, lines: list[str]) -> list[tuple[int, int]]:
+    """All positions worth trying for this call: the line/column candidates,
+    then the name-resolved position when ``name`` is given (a name rescues a
+    line that names the wrong place, and is the only source when line is not
+    given at all)."""
+    positions = _candidate_positions(params, lines)
+    if params.column is None and params.name:
+        for resolved in _positions_for_name(script, params.name, lines):
+            if resolved not in positions:
+                positions.append(resolved)
+    return positions
+
+
+def _unknown_symbol_error(
+    tool_call_id: str, params: LspParams, script: Any, lines: list[str], display: str
+) -> ToolResult:
+    """The clean 'no such symbol' answer: name the miss, then the symbols that
+    DO exist so the next call can be made without a round trip through
+    grep."""
+    candidates = _outline_names(script, lines)
+    listed = ", ".join(
+        f"{n.name} (L{n.line}, {n.type})" for n in candidates[:LSP_CANDIDATE_LIMIT]
+    )
+    more = (
+        f" … and {len(candidates) - LSP_CANDIDATE_LIMIT} more"
+        if len(candidates) > LSP_CANDIDATE_LIMIT
+        else ""
+    )
+    return _error(
+        tool_call_id,
+        "lsp",
+        f"no definition or import of '{params.name}' found in {display}\n"
+        f"available symbols: {listed or '(none)'}{more}",
+    )
+
+
+def _no_symbol_at_position_error(
+    tool_call_id: str, params: LspParams, display: str
+) -> ToolResult:
+    where = f"{display}:{params.line}"
+    if params.column is not None:
+        where += f":{params.column}"
+    return _error(
+        tool_call_id,
+        "lsp",
+        f"no symbol found at {where}\n"
+        "pass name=<symbol> to locate by name, or use action=symbols for the outline",
+    )
+
+
+def _definitions_result(
+    tool_call_id: str,
+    script: Any,
+    params: LspParams,
+    path: Path,
+    root: Path,
+    cache: dict[str, list[str]],
+) -> ToolResult:
+    lines = _source_lines(path, cache)
+    display = _display_path(path, root)
+    targets: list[Any] = []
+    used: tuple[int, int] | None = None
+    for line, column in _query_positions(params, script, lines):
+        targets = list(script.goto(line, column, follow_imports=True))
+        if targets:
+            used = (line, column)
+            break
+    if not targets:
+        if params.name and not _positions_for_name(script, params.name, lines):
+            return _unknown_symbol_error(tool_call_id, params, script, lines, display)
+        return _no_symbol_at_position_error(tool_call_id, params, display)
+
+    rows: list[str] = []
+    seen: set[tuple[str, int | None, str]] = set()
+    label = params.name or (targets[0].name if targets else "")
+    for target in targets:
+        key = (str(target.module_path), target.line, target.name)
+        if key in seen:
+            continue
+        seen.add(key)
+        if target.module_path is None or target.line is None:
+            # Builtins and stubs without a source position (measured: the
+            # ``def print`` name carries module_path=None).
+            rows.append(f"builtins: {target.name} ({target.type})")
+            continue
+        target_lines = _source_lines(Path(target.module_path), cache)
+        snippet = (
+            target_lines[target.line - 1].strip()
+            if 0 < target.line <= len(target_lines)
+            else ""
+        )
+        rows.append(f"{_display_path(Path(target.module_path), root)}:{target.line}: {snippet}")
+    elided = len(rows) - LSP_DEFINITION_LIMIT
+    if elided > 0:
+        rows = rows[:LSP_DEFINITION_LIMIT]
+        rows.append(f"… and {elided} more")
+    where = f" at {display}:{used[0]}:{used[1]}" if used else ""
+    return _text(
+        tool_call_id,
+        "lsp",
+        f"definitions of '{label}'{where}:\n" + "\n".join(rows),
+    )
+
+
+def _references_result(
+    tool_call_id: str,
+    script: Any,
+    params: LspParams,
+    path: Path,
+    root: Path,
+    context: ToolContext | None,
+    cache: dict[str, list[str]],
+) -> ToolResult:
+    lines = _source_lines(path, cache)
+    display = _display_path(path, root)
+    refs: list[Any] = []
+    used: tuple[int, int] | None = None
+    for line, column in _query_positions(params, script, lines):
+        refs = list(script.get_references(line, column))
+        if refs:
+            used = (line, column)
+            break
+    if not refs:
+        if params.name and not _positions_for_name(script, params.name, lines):
+            return _unknown_symbol_error(tool_call_id, params, script, lines, display)
+        return _no_symbol_at_position_error(tool_call_id, params, display)
+
+    label = params.name or refs[0].name
+    rows: list[str] = []
+    positionless = 0
+    for ref in refs:
+        if ref.module_path is None or ref.line is None:
+            positionless += 1
+            continue
+        ref_lines = _source_lines(Path(ref.module_path), cache)
+        text = ref_lines[ref.line - 1].rstrip() if 0 < ref.line <= len(ref_lines) else ""
+        rows.append(f"{_display_path(Path(ref.module_path), root)}:{ref.line}: {text}")
+    if not rows:
+        return _text(
+            tool_call_id,
+            "lsp",
+            f"No source references found for '{label}' in {display}.",
+            useless=True,
+            details={"useless": True},
+        )
+    shown = "\n".join(rows[:LSP_REFERENCE_LIMIT])
+    body, details = _capped_list_body("\n".join(rows), shown, "lsp", context)
+    if positionless:
+        body += f"\n({positionless} reference(s) without source positions omitted)"
+    return _text(
+        tool_call_id,
+        "lsp",
+        f"{len(rows)} reference(s) of '{label}' in {display}:\n{body}",
+        details=details,
+    )
+
+
+def _symbols_result(
+    tool_call_id: str,
+    script: Any,
+    path: Path,
+    root: Path,
+    context: ToolContext | None,
+    cache: dict[str, list[str]],
+) -> ToolResult:
+    lines = _source_lines(path, cache)
+    display = _display_path(path, root)
+    names = _outline_names(script, lines)
+    if not names:
+        return _text(
+            tool_call_id,
+            "lsp",
+            f"No definitions found in {display} — is it a Python module?",
+            useless=True,
+            details={"useless": True},
+        )
+    rows: list[str] = []
+    for name in names:
+        start = name.get_definition_start_position() or (name.line, name.column or 0)
+        end = name.get_definition_end_position() or start
+        # The definition's start column IS its indent, so the outline nests
+        # without a scope tree (jedi's Name.parent is unusable in 0.20:
+        # module-level names return an object with no .name).
+        depth = start[1] // 4
+        rows.append(f"{'  ' * depth}L{start[0]}-{end[0]} {name.type} {name.name}")
+    shown = "\n".join(rows[:LSP_SYMBOL_LIMIT])
+    body, details = _capped_list_body("\n".join(rows), shown, "lsp", context)
+    return _text(
+        tool_call_id,
+        "lsp",
+        f"outline of {display} ({len(names)} symbol(s)):\n{body}",
+        details=details,
+    )
+
+
+def _rename_preview_result(
+    tool_call_id: str,
+    script: Any,
+    params: LspParams,
+    path: Path,
+    root: Path,
+    context: ToolContext | None,
+    cache: dict[str, list[str]],
+) -> ToolResult:
+    lines = _source_lines(path, cache)
+    display = _display_path(path, root)
+    label = params.name or ""
+    diff = ""
+    positions = _query_positions(params, script, lines)
+    last_error: Exception | None = None
+    for line, column in positions:
+        # A keyword or blank position raises RefactoringError ("no name under
+        # the cursor", measured) — that is the signal to try the next
+        # candidate, not a failure of the call.
+        try:
+            refactoring = script.rename(line, column, new_name=params.new_name)
+        except RefactoringError as exc:
+            last_error = exc
+            continue
+        diff = refactoring.get_diff()
+        # jedi renders the refactoring as a unified diff itself (the same
+        # ``--- / +++`` shape difflib.unified_diff emits); re-diffing the
+        # changed files by hand would be a worse copy of get_diff().
+        if not label:
+            label = _identifier_at(lines, line, column)
+        break
+    if not diff and last_error is not None:
+        return _error(
+            tool_call_id,
+            "lsp",
+            f"cannot rename: {last_error}\n"
+            "pass name=<symbol> to locate by name, or use action=symbols for the outline",
+        )
+    if not diff.strip():
+        return _text(
+            tool_call_id,
+            "lsp",
+            f"rename to '{params.new_name}' would change nothing in {display}.",
+            useless=True,
+            details={"useless": True},
+        )
+    files = [row[4:] for row in diff.splitlines() if row.startswith("--- ")]
+    display_diff, details = spill_truncate(diff, "lsp", context)
+    return _text(
+        tool_call_id,
+        "lsp",
+        f"rename '{label}' -> '{params.new_name}' across {len(files)} file(s) — "
+        f"preview only, nothing written; apply via the edit tool:\n{display_diff}",
+        details=details,
+    )
+
+
+def _identifier_at(lines: list[str], line: int, column: int) -> str:
+    text = lines[line - 1] if 0 < line <= len(lines) else ""
+    match = _IDENTIFIER_RE.match(text, column)
+    return match.group(0) if match else "symbol"
+
+
+@_guard("lsp")
+async def execute_lsp(
+    tool_call_id: str,
+    args: dict[str, Any],
+    signal: AbortSignal | None = None,
+    on_update: Callable[[AgentToolUpdate], None] | None = None,
+    context: ToolContext | None = None,
+) -> ToolResult:
+    """Answer one symbol query. Read-only by construction; jedi's own
+    failures surface as error results, never exceptions."""
+    try:
+        params = LspParams(**args)
+    except ValidationError as exc:
+        return _validation_error(tool_call_id, "lsp", exc)
+    if params.action not in LSP_ACTIONS:
+        return _error(
+            tool_call_id,
+            "lsp",
+            f"unknown action: {params.action} (expected one of {', '.join(LSP_ACTIONS)})",
+        )
+    if params.action == "rename_preview" and not params.new_name:
+        return _error(tool_call_id, "lsp", "rename_preview requires new_name")
+    if params.action != "symbols" and params.line is None and not params.name:
+        return _error(
+            tool_call_id,
+            "lsp",
+            f"{params.action} requires line or name (symbols needs neither)",
+        )
+    if params.line is not None and params.line < 1:
+        return _error(tool_call_id, "lsp", "line is 1-based; the first line is 1")
+    if params.new_name and not _IDENTIFIER_RE.fullmatch(params.new_name):
+        return _error(tool_call_id, "lsp", f"new_name is not an identifier: {params.new_name!r}")
+
+    cwd = _safe_cwd(context)
+    try:
+        root = Path(cwd).expanduser().resolve()
+    except RuntimeError:
+        root = Path(cwd).resolve()
+    path, _inside, _resolvable = _resolve_workspace_path(params.path, cwd)
+    if not path.exists():
+        return _error(tool_call_id, "lsp", f"Path does not exist: {path}")
+    if not path.is_file():
+        return _error(tool_call_id, "lsp", f"Not a file: {path}")
+
+    script = jedi.Script(path=str(path))
+    cache: dict[str, list[str]] = {}
+    if params.action == "definitions":
+        return _definitions_result(tool_call_id, script, params, path, root, cache)
+    if params.action == "references":
+        return _references_result(tool_call_id, script, params, path, root, context, cache)
+    if params.action == "symbols":
+        return _symbols_result(tool_call_id, script, path, root, context, cache)
+    return _rename_preview_result(tool_call_id, script, params, path, root, context, cache)
+
+
+def build_lsp_tool() -> AgentTool | None:
+    """Advertise the LSP tool only when jedi (the ``lsp`` extra) is importable.
+
+    Same createIf convention as ``build_browser_tool``: an optional capability
+    returns None — excluded from the inventory — when the host did not opt
+    into its dependency. In-process jedi is pure Python, so unlike the browser
+    tool there is no runtime probe beyond the import itself.
+    """
+    if jedi is None:
+        return None
+    return AgentTool(
+        name="lsp",
+        label="LSP",
+        description=(
+            "Symbol-aware Python navigation: definitions (jump to a definition "
+            "across imports), references (usage sites with line text), symbols "
+            "(file outline with line ranges) and rename_preview (unified diff of "
+            "a proposed rename — never applied; make the change via the edit "
+            "tool). Prefer this over grep for symbol work: it resolves imports "
+            "and shadowing that text search misses."
+        ),
+        parameters=LspParams.model_json_schema(),
+        # Every action answers a question; even rename_preview only reads.
+        approval_tier="read",
+        # Analysis is per-call and touches no shared state.
+        concurrency="shared",
+        interruptible=False,
+        execute=execute_lsp,
+    )

--- a/local_operator/tools/registry.py
+++ b/local_operator/tools/registry.py
@@ -16,6 +16,8 @@ from collections.abc import Callable, Sequence
 from local_operator.harness.intent import apply_intent_schema
 from local_operator.harness.types import AgentTool, ToolContext
 from local_operator.tools import builtin
+from local_operator.tools.eval import build_eval_tool
+from local_operator.tools.lsp import build_lsp_tool
 from local_operator.web_search.tool import build_web_search_tool
 
 #: Factory table: tool name -> builder (createIf convention). ``wake`` takes
@@ -29,6 +31,8 @@ TOOL_BUILDERS: dict[str, Callable[[ToolContext], AgentTool | None]] = {
     "edit": lambda _context: builtin.build_edit_tool(),
     "glob": lambda _context: builtin.build_glob_tool(),
     "grep": lambda _context: builtin.build_grep_tool(),
+    "eval": lambda _context: build_eval_tool(),
+    "lsp": lambda _context: build_lsp_tool(),
     "todo": lambda _context: builtin.build_todo_tool(),
     "web_search": lambda context: build_web_search_tool(context),
     "wake": lambda context: builtin.build_wake_tool(context),
@@ -52,6 +56,8 @@ DEFAULT_TOOL_NAMES: list[str] = [
     "edit",
     "glob",
     "grep",
+    "eval",
+    "lsp",
     "todo",
     "web_search",
     "wake",

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -239,6 +239,7 @@ SLASH_COMMANDS: list[SlashCommand] = [
     SlashCommand("accounts", "List stored credentials"),
     # The panel is the receipt — the row the owner reported as noise.
     SlashCommand("usage", "Show provider usage quota"),
+    SlashCommand("context", "Show prompt, tool-schema and message token usage"),
     # THE exception. `/goal <text>` is the one command whose argument reaches
     # the model: the goal rides the system prompt's volatile tail on every later
     # turn (`Session.set_goal`). Words the model is given are the transcript's
@@ -3423,6 +3424,12 @@ class OperatorApp(App[None]):
             self._cmd_accounts(notice)
         elif command == "/usage":
             self._cmd_usage(arg, notice)
+        elif command == "/context":
+            block = self._context_block()
+            if block is not None:
+                self._append_block(block)
+            else:
+                notice("context breakdown unavailable.")
         elif command == "/goal":
             self._cmd_goal(arg, notice)
         elif command == "/loop":
@@ -5504,6 +5511,39 @@ class OperatorApp(App[None]):
                     [(skill.name, skill.description) for skill in visible], "loaded skills"
                 )
             )
+        except Exception:
+            return None
+
+    def _context_block(self) -> RichBlock | None:
+        """The exact categories behind the next provider request.
+
+        ``/usage`` answers account quota; this answers context economics —
+        especially MCP/tool-schema cost. A transcript block rather than a
+        modal panel: the numbers are a point-in-time diagnostic the user may
+        want to keep next to the task that prompted it, and the whole answer
+        fits in seven rows.
+        """
+        try:
+            data = self._session.context_breakdown()
+            total = data["total"]
+            window = max(data["context_window"], 1)
+            pct = total / window * 100
+            items = [
+                ("Instructions", format_context_tokens(data["instructions"])),
+                ("Tool inventory", format_context_tokens(data["tool_inventory"])),
+                ("Tool schemas", format_context_tokens(data["tool_schemas"])),
+                ("Environment", format_context_tokens(data["environment"])),
+                ("Skills / MCP / goal", format_context_tokens(data["knowledge_mcp_goal"])),
+                ("Messages", format_context_tokens(data["messages"])),
+                (
+                    "Total",
+                    f"{format_context_tokens(total)} / "
+                    f"{format_context_tokens(window)} ({pct:.1f}%)",
+                ),
+            ]
+            if data["cache_read"]:
+                items.append(("Last cache read", format_context_tokens(data["cache_read"])))
+            return RichBlock(_tree_listing(items, "Context"))
         except Exception:
             return None
 

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -5524,7 +5524,13 @@ class OperatorApp(App[None]):
         fits in seven rows.
         """
         try:
-            data = self._session.context_breakdown()
+            session = self._session
+            if session is None:
+                return None
+            breakdown = getattr(session, "context_breakdown", None)
+            if not callable(breakdown):
+                return None
+            data = cast(dict[str, int], breakdown())
             total = data["total"]
             window = max(data["context_window"], 1)
             pct = total / window * 100

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -120,6 +120,7 @@ from local_operator.tui.widgets.status_line import (
     SubagentBand,
     format_context_tokens,
     format_cost,
+    format_window,
 )
 from local_operator.tui.widgets.subagent_panel import (
     JobStats,
@@ -5534,22 +5535,30 @@ class OperatorApp(App[None]):
             total = data["total"]
             window = max(data["context_window"], 1)
             pct = total / window * 100
+
+            def estimated(value: int) -> str:
+                return f"~{format_context_tokens(value)}"
+
             items = [
-                ("Instructions", format_context_tokens(data["instructions"])),
-                ("Tool inventory", format_context_tokens(data["tool_inventory"])),
-                ("Tool schemas", format_context_tokens(data["tool_schemas"])),
-                ("Environment", format_context_tokens(data["environment"])),
-                ("Skills / MCP / goal", format_context_tokens(data["knowledge_mcp_goal"])),
-                ("Messages", format_context_tokens(data["messages"])),
+                ("Instructions", estimated(data["instructions"])),
+                ("Tool inventory", estimated(data["tool_inventory"])),
+                ("Tool schemas", estimated(data["tool_schemas"])),
+                ("Environment", estimated(data["environment"])),
+                ("Skills / MCP / goal", estimated(data["knowledge_mcp_goal"])),
+                ("Messages", estimated(data["messages"])),
                 (
                     "Total",
-                    f"{format_context_tokens(total)} / "
-                    f"{format_context_tokens(window)} ({pct:.1f}%)",
+                    f"{estimated(total)} / {format_window(window)} ({pct:.1f}%)",
                 ),
             ]
             if data["cache_read"]:
-                items.append(("Last cache read", format_context_tokens(data["cache_read"])))
-            return RichBlock(_tree_listing(items, "Context"))
+                items.append(
+                    (
+                        "Last cache read (exact)",
+                        format_context_tokens(data["cache_read"]),
+                    )
+                )
+            return RichBlock(_tree_listing(items, "Estimated next request", detail_token="muted"))
         except Exception:
             return None
 
@@ -6299,7 +6308,9 @@ def _partial_text(partial_result) -> str:
     return ""
 
 
-def _tree_listing(items: list[tuple[str, str]], caption: str) -> Group:
+def _tree_listing(
+    items: list[tuple[str, str]], caption: str, *, detail_token: str = "dim"
+) -> Group:
     """Tree-glyph section: ├─ / └─, name in the string tint, detail dim (D4).
 
     ``caption`` names WHAT the tree lists, on a dim row above it. It exists
@@ -6324,6 +6335,7 @@ def _tree_listing(items: list[tuple[str, str]], caption: str) -> Group:
         return Group()
     name_style = Style(color=theme_mod.semantic_color("string"))
     dim = Style(color=theme_mod.semantic_color("dim"))
+    detail_style = Style(color=theme_mod.semantic_color(detail_token))
     lines: list[Text] = [Text(caption, style=dim)]
     last_index = len(items) - 1
     for index, (name, detail) in enumerate(items):
@@ -6332,7 +6344,7 @@ def _tree_listing(items: list[tuple[str, str]], caption: str) -> Group:
         line.append(branch, style=dim)
         line.append(name, style=name_style)
         if detail:
-            line.append("  " + detail, style=dim)
+            line.append("  " + detail, style=detail_style)
         lines.append(line)
     return Group(*lines)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.17.0"
+version = "0.17.1"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@radienthq.com" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,11 @@ images = ["pillow-heif"]
 # that also downloads its rank tables on first use; without it token
 # estimation falls back to a chars/4 heuristic and compaction still works.
 tokenizer = ["tiktoken"]
+# Symbol-aware Python navigation for the `lsp` tool. jedi is pure Python and
+# answers in-process — the only LSP shape with no server subprocess to
+# install, spawn or babysit, which is why it can be an opt-in extra at all
+# rather than a base dependency.
+lsp = ["jedi>=0.19"]
 all = ["local-operator[server,mcp,images,tokenizer]"]
 dev = [
     "local-operator[all]",
@@ -113,6 +118,9 @@ dev = [
     "pip-audit",
     # Independent decoder used to verify our own PNG encoder's output.
     "pillow",
+    # Direct, not via the lsp extra: CI installs dev and must exercise the
+    # optional tool's suite, while `all` stays lean for end users.
+    "jedi>=0.19",
 ]
 
 # Explicit package discovery. Without this, setuptools falls back to

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.17.1"
+version = "0.17.2"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@radienthq.com" }]

--- a/tests/unit/harness/test_comms.py
+++ b/tests/unit/harness/test_comms.py
@@ -826,6 +826,12 @@ class ScriptedProvider:
             return text_stream("acknowledged; stopping now")
         if "You were interrupted" in body:
             return text_stream("resumed and wrapped up")
+        if "background job" in body:
+            # Job auto-delivery now re-wakes the TOP-LEVEL parent. The fixture's
+            # old default is an intentional infinite bash loop (it models a
+            # busy child), so without an acknowledgement for this new parent
+            # turn it spins forever after the child has already completed.
+            return text_stream("job result received")
         return tool_call_stream("bash", {"command": "sleep 0.1; echo tick"})
 
 

--- a/tests/unit/mcp/test_config.py
+++ b/tests/unit/mcp/test_config.py
@@ -368,3 +368,30 @@ class TestCliHelpers:
         doc2 = {"mcpServers": {"b": _stdio("b")}}
         _write_json_atomic(path, doc2)
         assert json.loads(path.read_text(encoding="utf-8")) == doc2
+
+
+def test_server_tool_filters_parse_aliases_for_every_transport() -> None:
+    from local_operator.mcp.config import (
+        MCPHttpServerConfig,
+        MCPSseServerConfig,
+        MCPStdioServerConfig,
+    )
+
+    payloads = [
+        (MCPStdioServerConfig, {"command": "x"}),
+        (MCPHttpServerConfig, {"url": "https://x.test"}),
+        (MCPSseServerConfig, {"url": "https://x.test/sse"}),
+    ]
+    for cls, base in payloads:
+        cfg = cls.model_validate(
+            {
+                **base,
+                "enabledTools": ["search_*", "get_one"],
+                "disabledTools": ["search_private"],
+            }
+        )
+        assert cfg.enabled_tools == ["search_*", "get_one"]
+        assert cfg.disabled_tools == ["search_private"]
+        dumped = cfg.model_dump(by_alias=True)
+        assert dumped["enabledTools"] == ["search_*", "get_one"]
+        assert dumped["disabledTools"] == ["search_private"]

--- a/tests/unit/mcp/test_manager.py
+++ b/tests/unit/mcp/test_manager.py
@@ -951,3 +951,19 @@ class TestChildOutputContainment:
         stderr_log.feed("x" * 1000)
         assert len(stderr_log.quoted_tail()) <= STDERR_QUOTED_CHARS + 1
         assert stderr_log.quoted_tail().endswith("…")
+
+
+def test_per_tool_filter_allow_deny_and_deny_wins(project: Path) -> None:
+    from local_operator.mcp.config import MCPStdioServerConfig
+
+    manager = McpManager(str(project))
+    manager._configs["srv"] = MCPStdioServerConfig(
+        command="x",
+        enabledTools=["search_*", "get_one"],
+        disabledTools=["search_private", "get_one"],
+    )
+    assert manager._tool_is_enabled("srv", "search_public") is True
+    assert manager._tool_is_enabled("srv", "search_private") is False
+    assert manager._tool_is_enabled("srv", "get_one") is False  # deny wins
+    assert manager._tool_is_enabled("srv", "unlisted") is False
+    assert manager._tool_is_enabled("missing", "anything") is True

--- a/tests/unit/mcp/test_manager.py
+++ b/tests/unit/mcp/test_manager.py
@@ -272,6 +272,8 @@ class TestCircuitBreaker:
         self, project: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         manager = McpManager(str(project))
+        incidents: list[tuple[str, str]] = []
+        manager.on_incident = lambda server, reason: incidents.append((server, reason))
         real_sleep = asyncio.sleep
         sleeps: list[float] = []
 
@@ -295,6 +297,13 @@ class TestCircuitBreaker:
                 break
 
         assert manager.reconnect_suspended("fast") is True
+        assert incidents == [
+            (
+                "fast",
+                "auto-reconnect suspended after >5 attempts in 30s; its tools are "
+                "unavailable until a reconnect succeeds",
+            )
+        ]
         # Backoff escalates 0.5, 1, 2, 4 and caps at 4 (five failed attempts).
         assert [d for d in sleeps if d > 0] == [0.5, 1.0, 2.0, 4.0, 4.0]
 

--- a/tests/unit/mcp/test_tool_bridge.py
+++ b/tests/unit/mcp/test_tool_bridge.py
@@ -264,7 +264,7 @@ class TestIsRetriableConnectionError:
 
     @pytest.mark.parametrize(
         "message",
-        ["tool not found", "invalid arguments", "HTTP 401: unauthorized", "timeout waiting"],
+        ["tool not found", "invalid arguments", "timeout waiting"],
     )
     def test_not_retriable(self, message: str) -> None:
         assert is_retriable_connection_error(RuntimeError(message)) is False
@@ -308,3 +308,14 @@ class TestBuildAgentTool:
             "properties": {INTENT_FIELD: dict(INTENT_PROPERTY)},
             "required": [],
         }
+
+
+def test_auth_challenges_are_retriable_once() -> None:
+    """Mid-call hosted MCP auth challenges must enter the manager's existing
+    one-reconnect/one-retry path; otherwise a refreshed OAuth token is never
+    used until the next user call."""
+    from local_operator.mcp.tool_bridge import is_retriable_connection_error
+
+    assert is_retriable_connection_error(RuntimeError("HTTP 401 Unauthorized"))
+    assert is_retriable_connection_error(RuntimeError("WWW-Authenticate: Bearer scope=x"))
+    assert is_retriable_connection_error(RuntimeError("mcp/www_authenticate challenge"))

--- a/tests/unit/model/test_configure.py
+++ b/tests/unit/model/test_configure.py
@@ -6,17 +6,20 @@ the harness ``ModelSpec`` consumed by wire clients, and ``validate_model``
 hits the same endpoints as before through a descriptor table.
 """
 
+import json
 from typing import Any
 from unittest.mock import MagicMock, patch
 
+import httpx
 import pytest
 import requests
 from pydantic import SecretStr
 
 from local_operator.credentials import CredentialManager
-from local_operator.harness.types import ModelSpec
+from local_operator.harness.types import ChatRequest, Message, ModelSpec
 from local_operator.model.configure import (
     DEFAULT_TEMPERATURE,
+    build_model_spec,
     calculate_cost,
     configure_model,
     create_stream_fn,
@@ -239,6 +242,77 @@ def test_configure_model_openrouter_via_client(mock_openrouter_client):
 def test_create_stream_fn_returns_callable():
     stream_fn = create_stream_fn(MagicMock(), None)
     assert callable(stream_fn)
+
+
+@pytest.mark.asyncio
+async def test_openai_chat_completions_override_routes_gpt5_to_legacy_endpoint() -> None:
+    captured: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        return httpx.Response(
+            200,
+            content=b'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n\ndata: [DONE]\n\n',
+            headers={"content-type": "text/event-stream"},
+        )
+
+    stream = create_stream_fn(
+        MagicMock(),
+        {"providers": {"openai": {"api": "chat_completions"}}},
+        session_id="session-override",
+    )
+    await stream._http.aclose()
+    stream._http = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    spec = build_model_spec("openai", "gpt-5.4")
+    try:
+        client = stream._client_for(spec)
+        await _collect_stream(
+            client.stream(ChatRequest(model=spec, messages=[Message.user("hi")]), "sk-test")
+        )
+    finally:
+        await stream.close()
+
+    assert captured["url"] == "https://api.openai.com/v1/chat/completions"
+
+
+@pytest.mark.asyncio
+async def test_session_stream_supplies_stable_prompt_cache_key_to_public_responses(
+    tmp_path,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["body"] = request.content
+        return httpx.Response(
+            200,
+            content=(
+                b'data: {"type":"response.completed","response":{"id":"resp_1",'
+                b'"usage":{"input_tokens":1,"output_tokens":1}}}\n\ndata: [DONE]\n\n'
+            ),
+            headers={"content-type": "text/event-stream"},
+        )
+
+    store = AuthStore(tmp_path / "auth.db")
+    store.upsert_credential("openai", {"key": "sk-openai", "source": "login"})
+    stream = create_stream_fn(store, {}, session_id="session-cache-key")
+    await stream._http.aclose()
+    stream._http = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    spec = build_model_spec("openai", "gpt-5.4")
+    try:
+        await _collect_stream(stream(ChatRequest(model=spec, messages=[Message.user("hi")]), None))
+    finally:
+        await stream.close()
+        store.close()
+
+    assert captured["url"] == "https://api.openai.com/v1/responses"
+    body = json.loads(captured["body"])
+    assert body["prompt_cache_key"] == "session-cache-key"
+    assert body["prompt_cache_retention"] == "24h"
+
+
+async def _collect_stream(stream: Any) -> list[Any]:
+    return [event async for event in stream]
 
 
 def _oauth(access: str, account_id: str) -> dict[str, Any]:

--- a/tests/unit/model/test_effort_classifier.py
+++ b/tests/unit/model/test_effort_classifier.py
@@ -1,0 +1,122 @@
+"""Tiny local auto-effort classifier + SessionStreamFn boundary freezing."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from local_operator.harness.types import ChatRequest, Message, ModelSpec, StreamEndEvent
+from local_operator.model.effort_classifier import (
+    PromptEffortClassifier,
+    auto_effort_for,
+    map_tier_to_effort,
+)
+
+
+def test_classifier_low_for_short_operational_prompt() -> None:
+    result = PromptEffortClassifier().classify("show status")
+    assert result.tier == "lo"
+
+
+def test_classifier_medium_for_normal_multi_step_request() -> None:
+    result = PromptEffortClassifier().classify(
+        "Compare the two config files and explain which setting wins, then list the differences."
+    )
+    assert result.tier == "med"
+
+
+def test_classifier_high_for_code_and_acceptance_criteria() -> None:
+    result = PromptEffortClassifier().classify("""Implement and review the parser migration.
+
+- Reproduce error 429 in the stream
+- Refactor three modules and preserve compatibility
+- Add tests for auth, quota, and provider fallback
+- Run the release build, then deploy
+
+```python
+def parse(value):
+    ...
+```
+""")
+    assert result.tier == "hi"
+
+
+@pytest.mark.parametrize(
+    ("tier", "expected"),
+    [("lo", "low"), ("med", "medium"), ("hi", "high")],
+)
+def test_maps_coarse_tiers_without_selecting_minimal_or_max(tier, expected) -> None:
+    efforts = ("minimal", "low", "medium", "high", "max")
+    assert map_tier_to_effort(tier, efforts) == expected
+
+
+def test_allow_max_and_models_without_effort() -> None:
+    efforts = ("minimal", "low", "medium", "high", "max")
+    assert map_tier_to_effort("hi", efforts, allow_max=True) == "max"
+    assert map_tier_to_effort("hi", ()) is None
+
+
+def test_disabled_by_default() -> None:
+    assert auto_effort_for("implement x", ("low", "high"), {}) == (None, None)
+
+
+@pytest.mark.asyncio
+async def test_session_stream_fn_freezes_effort_for_one_tool_loop(monkeypatch) -> None:
+    from local_operator.model.configure import SessionStreamFn
+    from local_operator.providers import failover
+
+    captured: list[ChatRequest] = []
+
+    async def fake_stream(request, *args, **kwargs):
+        captured.append(request)
+        yield StreamEndEvent(stop_reason="stop")
+
+    monkeypatch.setattr(failover, "stream_with_failover", fake_stream)
+
+    class FakeAuth:
+        async def get_oauth_access(self, *args, **kwargs):
+            return None
+
+    stream = SessionStreamFn(FakeAuth(), {"effort": {"auto": True}}, "session-x")
+    # Avoid usage API work; it still consumes the boundary exactly like prod.
+    monkeypatch.setattr(stream, "preflight_usage", lambda model: _noop())
+    model = ModelSpec(
+        provider="test",
+        model_id="m",
+        reasoning_efforts=("minimal", "low", "medium", "high", "max"),
+        reasoning_effort="medium",
+    )
+    stream.begin_message()
+    simple = ChatRequest(model=model, messages=[Message.user("show status")])
+    _ = [event async for event in stream(simple, None)]
+    assert captured[-1].model.reasoning_effort == "low"
+
+    # Same user-message tool loop: a large tool result must NOT reclassify.
+    follow = ChatRequest(
+        model=model,
+        messages=[Message.user("show status"), Message.assistant("x" * 5000)],
+    )
+    _ = [event async for event in stream(follow, None)]
+    assert captured[-1].model.reasoning_effort == "low"
+
+    # New message boundary: a complex prompt reclassifies high -> `high`
+    # (one rung below max by default).
+    stream.begin_message()
+    complex_request = ChatRequest(
+        model=model,
+        messages=[
+            Message.user(
+                "Implement, refactor, debug, review, deploy, and release this migration.\n"
+                + "\n".join(f"- acceptance {i}" for i in range(20))
+                + "\n```python\ndef f(): ...\n```"
+            )
+        ],
+    )
+    _ = [event async for event in stream(complex_request, None)]
+    assert captured[-1].model.reasoning_effort == "high"
+    await stream.close()
+
+
+async def _noop() -> None:
+    return None

--- a/tests/unit/model/test_effort_classifier.py
+++ b/tests/unit/model/test_effort_classifier.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from types import SimpleNamespace
+from typing import Any, cast
 
 import pytest
 
@@ -78,7 +78,7 @@ async def test_session_stream_fn_freezes_effort_for_one_tool_loop(monkeypatch) -
         async def get_oauth_access(self, *args, **kwargs):
             return None
 
-    stream = SessionStreamFn(FakeAuth(), {"effort": {"auto": True}}, "session-x")
+    stream = SessionStreamFn(cast(Any, FakeAuth()), {"effort": {"auto": True}}, "session-x")
     # Avoid usage API work; it still consumes the boundary exactly like prod.
     monkeypatch.setattr(stream, "preflight_usage", lambda model: _noop())
     model = ModelSpec(

--- a/tests/unit/model/test_registry.py
+++ b/tests/unit/model/test_registry.py
@@ -1,5 +1,6 @@
 import pytest
 
+from local_operator.model.configure import build_model_spec
 from local_operator.model.registry import (
     ModelInfo,
     _anthropic_family,
@@ -7,6 +8,26 @@ from local_operator.model.registry import (
     anthropic_models,
     get_model_info,
 )
+
+
+@pytest.mark.parametrize(
+    "provider, model_id, supported",
+    [
+        ("openai", "gpt-5", True),
+        ("openai", "gpt-5.4", True),
+        ("openai", "gpt-5.3-codex", True),
+        ("openai", "gpt-4.1", False),
+        ("openai", "gpt-4o", False),
+        ("openrouter", "openai/gpt-5.4", False),
+    ],
+)
+def test_responses_api_capability_is_pinned_to_direct_openai_gpt5(
+    provider: str, model_id: str, supported: bool
+) -> None:
+    spec = build_model_spec(provider, model_id)
+    assert spec.supports_responses_api is supported
+    if supported:
+        assert spec.supports_prompt_cache is True
 
 
 def test_model_info_price_must_be_non_negative() -> None:

--- a/tests/unit/providers/test_clients.py
+++ b/tests/unit/providers/test_clients.py
@@ -10,6 +10,7 @@ import httpx
 import pytest
 
 from local_operator.harness.types import (
+    AgentTool,
     ChatRequest,
     ImageContent,
     Message,
@@ -26,6 +27,7 @@ from local_operator.providers.clients import (
     MockClient,
     OpenAICompatClient,
     _anthropic_stream_error,
+    client_for_spec,
     raise_for_status,
 )
 from local_operator.providers.failover import ProviderError
@@ -493,6 +495,163 @@ def _responses_sse() -> bytes:
         },
     ]
     return _sse(events)
+
+
+def _public_responses_sse() -> bytes:
+    return _sse(
+        [
+            {
+                "type": "response.output_item.added",
+                "output_index": 1,
+                "item": {
+                    "type": "function_call",
+                    "id": "fc_1",
+                    "call_id": "call_weather",
+                    "name": "get_weather",
+                },
+            },
+            {"type": "response.output_text.delta", "delta": "Checking"},
+            {
+                "type": "response.function_call_arguments.delta",
+                "item_id": "fc_1",
+                "output_index": 1,
+                "delta": '{"city":',
+            },
+            {
+                "type": "response.function_call_arguments.delta",
+                "item_id": "fc_1",
+                "output_index": 1,
+                "delta": '"Paris"}',
+            },
+            {
+                "type": "response.completed",
+                "response": {
+                    "id": "resp_public_1",
+                    "usage": {
+                        "input_tokens": 80,
+                        "output_tokens": 9,
+                        "input_tokens_details": {"cached_tokens": 48},
+                    },
+                },
+            },
+        ]
+    )
+
+
+async def test_openai_api_key_gpt5_uses_public_responses_end_to_end() -> None:
+    captured: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["headers"] = dict(request.headers)
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(
+            200,
+            content=_public_responses_sse(),
+            headers={"content-type": "text/event-stream"},
+        )
+
+    async def unused_execute(*_args: Any, **_kwargs: Any) -> None:
+        raise AssertionError("wire serialization must not execute tools")
+
+    spec = ModelSpec(
+        provider="openai",
+        model_id="gpt-5.4",
+        supports_responses_api=True,
+        supports_prompt_cache=True,
+        reasoning=True,
+        reasoning_effort="high",
+        reasoning_efforts=("low", "medium", "high"),
+        supports_sampling_params=False,
+    )
+    client = OpenAICompatClient(
+        base_url="https://api.openai.com/v1",
+        http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+    )
+    events = await _collect(
+        client.stream(
+            ChatRequest(
+                model=spec,
+                system_blocks=["Be concise."],
+                messages=[Message.user("weather in Paris?")],
+                tools=[
+                    AgentTool(
+                        name="get_weather",
+                        description="Get weather",
+                        parameters={
+                            "type": "object",
+                            "properties": {"city": {"type": "string"}},
+                            "required": ["city"],
+                        },
+                        execute=unused_execute,
+                    )
+                ],
+                prompt_cache_key="session-123",
+            ),
+            "sk-public",
+        )
+    )
+
+    assert captured["url"] == "https://api.openai.com/v1/responses"
+    assert captured["headers"]["authorization"] == "Bearer sk-public"
+    for private_header in ("chatgpt-account-id", "openai-beta", "originator"):
+        assert private_header not in captured["headers"]
+    body = captured["body"]
+    assert body["input"] == [
+        {
+            "role": "user",
+            "content": [{"type": "input_text", "text": "weather in Paris?"}],
+        }
+    ]
+    assert body["tools"] == [
+        {
+            "type": "function",
+            "name": "get_weather",
+            "description": "Get weather",
+            "parameters": {
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+                "required": ["city"],
+            },
+        }
+    ]
+    assert body["reasoning"] == {"effort": "high"}
+    assert body["prompt_cache_key"] == "session-123"
+    assert body["prompt_cache_retention"] == "24h"
+
+    assert [event.delta for event in events if isinstance(event, StreamTextDelta)] == ["Checking"]
+    tool_events = [event for event in events if isinstance(event, StreamToolCallDelta)]
+    assert tool_events[0].id == "call_weather" and tool_events[0].name == "get_weather"
+    assert json.loads("".join(event.argument_delta for event in tool_events)) == {"city": "Paris"}
+    usage = [event.usage for event in events if isinstance(event, StreamUsageEvent)][0]
+    assert (usage.input_tokens, usage.output_tokens, usage.cache_read_tokens) == (80, 9, 48)
+    assert events[-1].stop_reason == "toolUse"
+
+
+@pytest.mark.parametrize("provider", ["openrouter", "deepseek"])
+async def test_compat_providers_stay_on_chat_completions_for_responses_model(
+    provider: str,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        return httpx.Response(
+            200,
+            content=_sse([{"choices": [{"delta": {}, "finish_reason": "stop"}]}]),
+            headers={"content-type": "text/event-stream"},
+        )
+
+    http = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    spec = ModelSpec(
+        provider=provider,
+        model_id="openai/gpt-5.4",
+        supports_responses_api=True,
+    )
+    client = client_for_spec(spec, http_client=http, openai_api="responses")
+    await _collect(client.stream(ChatRequest(model=spec, messages=[Message.user("hi")]), "key"))
+    assert captured["url"].endswith("/chat/completions")
+    await http.aclose()
 
 
 async def test_openai_oauth_routes_to_codex_responses_with_required_headers() -> None:

--- a/tests/unit/providers/test_clients.py
+++ b/tests/unit/providers/test_clients.py
@@ -1355,3 +1355,56 @@ def test_google_sends_no_effort_key() -> None:
     # edit would put the key there.
     assert "thinkingConfig" not in body["generationConfig"]
     assert not any("effort" in key.lower() for key in body["generationConfig"])
+
+
+def _google_sse_parallel_calls() -> bytes:
+    """One Gemini response carrying TWO same-name functionCalls — the exact
+    shape that used to mint identical ids (``fc_read`` twice)."""
+    return _sse(
+        [
+            {
+                "candidates": [
+                    {
+                        "content": {
+                            "parts": [
+                                {"functionCall": {"name": "read", "args": {"path": "a.py"}}},
+                                {"functionCall": {"name": "read", "args": {"path": "b.py"}}},
+                            ]
+                        },
+                        "finishReason": "STOP",
+                    }
+                ],
+                "usageMetadata": {"promptTokenCount": 10, "candidatesTokenCount": 5},
+            }
+        ]
+    )
+
+
+async def test_google_parallel_same_tool_calls_get_unique_ids() -> None:
+    """Two same-tool functionCalls in one Gemini response must survive as two
+    tool calls. The loop dedups tool calls by id (first-wins), so ids minted
+    from the tool name alone silently dropped every call after the first —
+    the model believed two reads ran when only one did. The per-response
+    index is minted alongside the id because it is the stream slot the loop
+    assembles argument deltas into; two calls sharing slot 0 would overwrite
+    each other even with distinct ids."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            content=_google_sse_parallel_calls(),
+            headers={"content-type": "text/event-stream"},
+        )
+
+    client = GoogleClient(http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler)))
+    events = await _collect(
+        client.stream(
+            ChatRequest(model=_spec("google", "gemini-2.5-pro"), messages=[Message.user("hi")]),
+            "g-key",
+        )
+    )
+    calls = [e for e in events if isinstance(e, StreamToolCallDelta)]
+    assert len(calls) == 2
+    assert calls[0].id != calls[1].id
+    assert {calls[0].index, calls[1].index} == {0, 1}
+    assert all(call.name == "read" for call in calls)

--- a/tests/unit/providers/test_clients.py
+++ b/tests/unit/providers/test_clients.py
@@ -21,6 +21,7 @@ from local_operator.harness.types import (
     StreamUsageEvent,
     TextContent,
     ToolCall,
+    ToolResult,
 )
 from local_operator.providers.clients import (
     AnthropicClient,
@@ -551,7 +552,7 @@ async def test_openai_api_key_gpt5_uses_public_responses_end_to_end() -> None:
             headers={"content-type": "text/event-stream"},
         )
 
-    async def unused_execute(*_args: Any, **_kwargs: Any) -> None:
+    async def unused_execute(*_args: Any, **_kwargs: Any) -> ToolResult:
         raise AssertionError("wire serialization must not execute tools")
 
     spec = ModelSpec(

--- a/tests/unit/providers/test_clients.py
+++ b/tests/unit/providers/test_clients.py
@@ -1568,3 +1568,127 @@ async def test_google_parallel_same_tool_calls_get_unique_ids() -> None:
     assert calls[0].id != calls[1].id
     assert {calls[0].index, calls[1].index} == {0, 1}
     assert all(call.name == "read" for call in calls)
+
+
+async def test_responses_failed_and_top_level_error_raise_provider_errors() -> None:
+    for payload in (
+        {
+            "type": "response.failed",
+            "response": {"error": {"code": "rate_limit_exceeded", "message": "quota gone"}},
+        },
+        {
+            "type": "error",
+            "error": {"code": "invalid_api_key", "message": "bad key"},
+        },
+    ):
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200, content=_sse([payload]), headers={"content-type": "text/event-stream"}
+            )
+
+        client = OpenAICompatClient(
+            "https://api.openai.com/v1",
+            http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+            openai_api="responses",
+        )
+        with pytest.raises(ProviderError) as error:
+            await _collect(
+                client.stream(
+                    ChatRequest(
+                        model=_spec("openai", "gpt-5.4").model_copy(
+                            update={"supports_responses_api": True}
+                        ),
+                        messages=[Message.user("hi")],
+                    ),
+                    "sk-test",
+                )
+            )
+        assert error.value.message
+
+
+async def test_responses_incomplete_max_output_maps_to_length() -> None:
+    payloads = [
+        {
+            "type": "response.output_item.added",
+            "item": {"type": "function_call", "id": "fc1", "call_id": "c1", "name": "read"},
+        },
+        {
+            "type": "response.incomplete",
+            "response": {
+                "id": "r1",
+                "incomplete_details": {"reason": "max_output_tokens"},
+                "usage": {"input_tokens": 10, "output_tokens": 3},
+            },
+        },
+    ]
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200, content=_sse(payloads), headers={"content-type": "text/event-stream"}
+        )
+
+    client = OpenAICompatClient(
+        "https://api.openai.com/v1",
+        http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+        openai_api="responses",
+    )
+    events = await _collect(
+        client.stream(
+            ChatRequest(
+                model=_spec("openai", "gpt-5.4").model_copy(
+                    update={"supports_responses_api": True}
+                ),
+                messages=[Message.user("hi")],
+            ),
+            "sk-test",
+        )
+    )
+    end = next(e for e in events if isinstance(e, StreamEndEvent))
+    assert end.stop_reason == "length"  # loop will never execute the partial call
+
+
+async def test_responses_stream_without_terminal_is_provider_error() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            content=_sse([{"type": "response.output_text.delta", "delta": "partial"}]),
+            headers={"content-type": "text/event-stream"},
+        )
+
+    client = OpenAICompatClient(
+        "https://api.openai.com/v1",
+        http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+        openai_api="responses",
+    )
+    with pytest.raises(ProviderError, match="without a terminal event"):
+        await _collect(
+            client.stream(
+                ChatRequest(
+                    model=_spec("openai", "gpt-5.4").model_copy(
+                        update={"supports_responses_api": True}
+                    ),
+                    messages=[Message.user("hi")],
+                ),
+                "sk-test",
+            )
+        )
+
+
+def test_responses_tool_image_output_stays_native_image_content() -> None:
+    from local_operator.providers.clients import _messages_to_openai_responses
+
+    message = Message(
+        role="tool",
+        tool_call_id="c1",
+        tool_name="read",
+        content=[
+            TextContent(text="screenshot"),
+            ImageContent(data="aGVsbG8=", mime_type="image/png"),
+        ],
+    )
+    output = _messages_to_openai_responses([message])[0]["output"]
+    assert output == [
+        {"type": "input_text", "text": "screenshot"},
+        {"type": "input_image", "image_url": "data:image/png;base64,aGVsbG8="},
+    ]

--- a/tests/unit/session/test_launch_subagent.py
+++ b/tests/unit/session/test_launch_subagent.py
@@ -515,7 +515,11 @@ async def test_scout_child_is_read_only_and_cannot_delegate(tmp_path, monkeypatc
     names = {tool.name for tool in child._tools}
     assert names <= {"read", "glob", "grep", "list_variables", "read_variable"}
     assert {"bash", "edit", "write", "task", "wait", "jobs", "wake"}.isdisjoint(names)
-    assert "scout mode" in child._context.messages[0].text if child._context.messages else True
+    assert (
+        "scout mode" in getattr(child._context.messages[0], "text", "")
+        if child._context.messages
+        else True
+    )
     await child.dispose()
     await parent.dispose()
 

--- a/tests/unit/session/test_launch_subagent.py
+++ b/tests/unit/session/test_launch_subagent.py
@@ -713,3 +713,22 @@ async def test_the_launch_prompt_is_recorded_on_the_job(tmp_path, monkeypatch):
     settled = parent.jobs.get(job_id)
     assert settled is not None and settled.prompt == instruction, "must survive settlement"
     await parent.dispose()
+
+
+@pytest.mark.asyncio
+async def test_scout_preamble_reaches_the_provider_turn(tmp_path, monkeypatch):
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    stream = OneShotStream()
+    parent = make_session(tmp_path, stream)
+    job_id = parent._launch_subagent(label="research", prompt="Map the repo.", agent="scout")
+
+    def settled() -> bool:
+        job = parent.jobs.get(job_id)
+        return job is not None and job.status != "running"
+
+    await wait_for(settled)
+    assert stream.requests
+    first_user = next(message for message in stream.requests[0].messages if message.role == "user")
+    assert "[scout mode:" in first_user.text
+    assert "Map the repo." in first_user.text
+    await parent.dispose()

--- a/tests/unit/session/test_launch_subagent.py
+++ b/tests/unit/session/test_launch_subagent.py
@@ -106,10 +106,16 @@ async def test_launch_subagent_runs_child_and_emits_lifecycle(tmp_path, monkeypa
     assert "child did the work" in (ends[0].result_text or "")
 
     # The child actually ran its own provider turn through the shared stream.
-    assert len(stream.requests) == 1
+    assert stream.requests
     assert stream.requests[0].messages
     assert isinstance(stream.requests[0].messages[0], Message)
     assert stream.requests[0].messages[0].text == "go do a thing"
+
+    # Item 12: once the task settles, the idle TOP-LEVEL parent re-wakes with
+    # the result instead of polling `jobs`; the shared provider sees a second
+    # request carrying that job-result custom message.
+    await wait_for(lambda: len(stream.requests) >= 2)
+    assert any("background job 'sub' completed" in m.text for m in stream.requests[1].messages)
 
     await parent.dispose()
 

--- a/tests/unit/session/test_launch_subagent.py
+++ b/tests/unit/session/test_launch_subagent.py
@@ -278,7 +278,7 @@ class FakeMcpManager:
         return self._meta.get(tool_name)
 
 
-async def build_child(parent, model_spec=None, job_id="job-1"):
+async def build_child(parent, model_spec=None, job_id="job-1", agent="task"):
     from local_operator.harness import subagent as subagent_mod
 
     return await subagent_mod._build_child_session(
@@ -287,6 +287,7 @@ async def build_child(parent, model_spec=None, job_id="job-1"):
         parent_session=parent,
         model_spec=model_spec,
         job_id=job_id,
+        agent=agent,
     )
 
 
@@ -459,24 +460,62 @@ async def test_child_inherits_a_mid_session_model_override(tmp_path, monkeypatch
 
 
 @pytest.mark.asyncio
-async def test_child_never_advertises_session_capability_tools(tmp_path, monkeypatch):
-    """Children are one level deep. ``Session.__init__`` merges task/wait/jobs/
-    wake in from the session's OWN ToolContext, which handed every child a
-    ``task`` tool: a grandchild would register on the child's job manager, which
-    no panel renders and which ``_dispose_child`` tears down the moment the
-    child's single prompt ends. Same for ``wake``, whose scheduler stops
-    existing seconds after it accepts a schedule."""
+async def test_child_of_top_level_session_keeps_delegation_but_not_wake(tmp_path, monkeypatch):
+    """Depth is two: a child of a TOP-LEVEL session keeps task/wait/jobs (its
+    own job manager is observable through its own tools and is disposed with
+    it, so grandchildren cannot outlive their lineage), while ``wake`` never
+    crosses any boundary — a child session ends after one prompt, so a wake
+    armed there would be silently lost."""
     monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
     parent = make_session(tmp_path, OneShotStream())
 
     child = await build_child(parent)
 
     names = {tool.name for tool in child._tools}
-    assert names.isdisjoint({"task", "wait", "jobs", "wake"})
+    assert {"task", "wait", "jobs"} <= names
+    assert "wake" not in names
     # The prune must not take the ordinary inventory with it.
     assert {"bash", "read", "edit", "write"} <= names
     # ...and the loop sees the same list the session does.
     assert [t.name for t in child._context.tools] == [t.name for t in child._tools]
+    await child.dispose()
+    await parent.dispose()
+
+
+@pytest.mark.asyncio
+async def test_grandchild_never_advertises_session_capability_tools(tmp_path, monkeypatch):
+    """One level deeper the whole set goes: a grandchild's children would
+    register on a job manager nothing observes and that dies mid-turn."""
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    parent = make_session(tmp_path, OneShotStream())
+    # A parent that is itself a child is recognisable by its _job_id.
+    parent._job_id = "job-parent"
+
+    child = await build_child(parent)
+
+    names = {tool.name for tool in child._tools}
+    assert names.isdisjoint({"task", "wait", "jobs", "wake"})
+    assert {"bash", "read", "edit", "write"} <= names
+    await child.dispose()
+    await parent.dispose()
+
+
+@pytest.mark.asyncio
+async def test_scout_child_is_read_only_and_cannot_delegate(tmp_path, monkeypatch):
+    """The scout tier: tool inventory filtered to lookups (allowlist, not
+    tier — no bash, no eval-style execution, no MCP calls, no delegation),
+    its prompt stamped with the scout preamble, and the capability tools
+    pruned entirely: a read-only agent that delegates autonomous work is not
+    read-only."""
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    parent = make_session(tmp_path, OneShotStream())
+
+    child = await build_child(parent, agent="scout")
+
+    names = {tool.name for tool in child._tools}
+    assert names <= {"read", "glob", "grep", "list_variables", "read_variable"}
+    assert {"bash", "edit", "write", "task", "wait", "jobs", "wake"}.isdisjoint(names)
+    assert "scout mode" in child._context.messages[0].text if child._context.messages else True
     await child.dispose()
     await parent.dispose()
 

--- a/tests/unit/session/test_session.py
+++ b/tests/unit/session/test_session.py
@@ -1400,8 +1400,6 @@ async def test_error_run_journals_model_visible_incident(tmp_path):
 async def test_job_completion_auto_delivers_when_idle(tmp_path):
     """A settled model-owned job re-wakes the idle session: the result lands
     as a conversation turn without the model polling 'jobs'."""
-    from local_operator.harness.jobs import AsyncJobManager
-
     turn_count = {"n": 0}
 
     class TwoTurnStream:
@@ -1443,9 +1441,6 @@ async def test_job_completion_auto_delivers_when_idle(tmp_path):
 async def test_consumed_and_foreign_jobs_do_not_auto_deliver(tmp_path):
     """wait already returned the result (consumed) and host-registered job
     types stay quiet; only fresh model-owned work re-wakes the session."""
-    from local_operator.harness.jobs import AsyncJobManager
-    from local_operator.harness.types import Usage
-
     stream = ScriptedStream(
         [
             [StreamTextDelta(delta="ok"), StreamEndEvent(stop_reason="stop")],
@@ -1472,7 +1467,7 @@ async def test_consumed_and_foreign_jobs_do_not_auto_deliver(tmp_path):
         await asyncio.sleep(0.3)
         return "done"
 
-    streaming_id = session.jobs.register("task", "while-busy", slow_runner)
+    session.jobs.register("task", "while-busy", slow_runner)
     session._is_streaming = True
     try:
         await asyncio.sleep(0.45)  # settles while the session is "streaming"

--- a/tests/unit/session/test_session.py
+++ b/tests/unit/session/test_session.py
@@ -1332,3 +1332,151 @@ async def test_mid_turn_compaction_disabled_by_setting(tmp_path, monkeypatch):
     compactions = [e for e in session._transcript.entries() if e.type == "compaction"]
     assert len(compactions) <= 1
     await session.dispose()
+
+
+# ---------------------------------------------------------------------------
+# session incidents (why a run died, model-visible)
+# ---------------------------------------------------------------------------
+
+
+class ExplodingStream:
+    """First call raises a provider-shaped error; later calls succeed."""
+
+    def __init__(self) -> None:
+        self.requests: list[ChatRequest] = []
+
+    def __call__(self, request: ChatRequest, signal: AbortSignal | None):
+        self.requests.append(request)
+        if len(self.requests) == 1:
+
+            async def boom():
+                yield StreamTextDelta(delta="partial")
+                raise RuntimeError("429 Too Many Requests: rate limit exceeded")
+
+            return boom()
+
+        async def ok():
+            yield StreamTextDelta(delta="recovered")
+            yield StreamEndEvent(stop_reason="stop")
+
+        return ok()
+
+
+@pytest.mark.asyncio
+async def test_error_run_journals_model_visible_incident(tmp_path):
+    """A run that dies on a provider error leaves a classified incident in
+    the LIVE context (the next prompt sees it) and in the transcript (a
+    resumed session replays it) — the model learns WHY, not just the UI."""
+    stream = ExplodingStream()
+    session = make_session(tmp_path, stream)
+    events: list[AgentEvent] = []
+    session.subscribe(events.append)
+    await session.prompt("go")
+
+    incidents = [
+        m
+        for m in session._context.messages
+        if isinstance(m, CustomMessage) and m.custom_type == "session_incident"
+    ]
+    assert incidents, "error run must journal a session incident"
+    assert "rate-limit" in incidents[-1].details["text"]
+    assert "429" in incidents[-1].details["raw"]
+
+    # Persisted: the transcript replay carries it.
+    dumped = "\n".join(
+        __import__("json").dumps(e.payload, default=str) for e in session._transcript.entries()
+    )
+    assert "session_incident" in dumped
+
+    # The NEXT prompt renders it into the request the provider sees.
+    await session.prompt("continue")
+    rendered = "\n".join(getattr(m, "text", "") for m in stream.requests[1].messages)
+    assert "[session incident" in rendered and "rate-limit" in rendered
+    await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_job_completion_auto_delivers_when_idle(tmp_path):
+    """A settled model-owned job re-wakes the idle session: the result lands
+    as a conversation turn without the model polling 'jobs'."""
+    from local_operator.harness.jobs import AsyncJobManager
+
+    turn_count = {"n": 0}
+
+    class TwoTurnStream:
+        def __init__(self) -> None:
+            self.requests: list[ChatRequest] = []
+
+        def __call__(self, request: ChatRequest, signal: AbortSignal | None):
+            self.requests.append(request)
+            turn_count["n"] += 1
+
+            async def gen():
+                yield StreamTextDelta(delta=f"turn {turn_count['n']}")
+                yield StreamEndEvent(stop_reason="stop")
+
+            return gen()
+
+    stream = TwoTurnStream()
+    session = make_session(tmp_path, stream)
+    events: list[AgentEvent] = []
+    session.subscribe(events.append)
+    await session.prompt("start something")
+
+    async def quick(job_id, signal, report_progress):
+        return "the answer is 42"
+
+    session.jobs.register("task", "researcher", quick)
+    await wait_for(lambda: sum(1 for e in events if isinstance(e, AgentStartEvent)) >= 2)
+    delivered = [
+        m
+        for m in session._context.messages
+        if isinstance(m, CustomMessage) and m.custom_type == "job_result"
+    ]
+    assert delivered
+    assert "the answer is 42" in delivered[-1].details["text"]
+    await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_consumed_and_foreign_jobs_do_not_auto_deliver(tmp_path):
+    """wait already returned the result (consumed) and host-registered job
+    types stay quiet; only fresh model-owned work re-wakes the session."""
+    from local_operator.harness.jobs import AsyncJobManager
+    from local_operator.harness.types import Usage
+
+    stream = ScriptedStream(
+        [
+            [StreamTextDelta(delta="ok"), StreamEndEvent(stop_reason="stop")],
+            [StreamTextDelta(delta="ok"), StreamEndEvent(stop_reason="stop")],
+        ]
+    )
+    session = make_session(tmp_path, stream)
+    await session.prompt("go")
+    before = len(session._context.messages)
+
+    async def runner(job_id, signal, report_progress):
+        return "done"
+
+    consumed_id = session.jobs.register("task", "consumed-job", runner)
+    job = session.jobs.get(consumed_id)
+    assert job is not None
+    job.consumed = True
+    await session._on_job_completed(consumed_id, "done", job)
+
+    # A streaming session stays quiet too: the in-turn model owns the floor.
+    # The runner must still be RUNNING when the flag flips, or the manager's
+    # own settle-delivery wins the race and delivers while idle.
+    async def slow_runner(job_id, signal, report_progress):
+        await asyncio.sleep(0.3)
+        return "done"
+
+    streaming_id = session.jobs.register("task", "while-busy", slow_runner)
+    session._is_streaming = True
+    try:
+        await asyncio.sleep(0.45)  # settles while the session is "streaming"
+    finally:
+        session._is_streaming = False
+    await asyncio.sleep(0.05)
+    assert len(session._context.messages) == before  # nothing delivered
+    await session.dispose()

--- a/tests/unit/session/test_session.py
+++ b/tests/unit/session/test_session.py
@@ -30,6 +30,7 @@ from local_operator.harness.types import (
     StreamToolCallDelta,
     TextContent,
     ToolResult,
+    Usage,
 )
 from local_operator.providers.failover import ProviderError
 from local_operator.session.session import IMAGE_DROPPED_NOTICE, Session
@@ -1480,3 +1481,31 @@ async def test_consumed_and_foreign_jobs_do_not_auto_deliver(tmp_path):
     await asyncio.sleep(0.05)
     assert len(session._context.messages) == before  # nothing delivered
     await session.dispose()
+
+
+def test_context_breakdown_counts_wire_schemas_and_messages(tmp_path):
+    """The `/context` source measures what the provider actually receives:
+    four system blocks, wire tool schemas (not just names), rendered messages,
+    window and the last cache-read bucket."""
+    tool = echo_tool([])
+    session = make_session(tmp_path, ScriptedStream([]), tools=[tool])
+    session._context.system_blocks = ["instructions", "inventory", "env", "skills"]
+    session._context.messages = [Message.user("hello"), Message.assistant("world")]
+    session._last_usage = Usage(input_tokens=10, cache_read_tokens=7, context_tokens=17)
+    data = session.context_breakdown()
+    assert data["instructions"] > 0
+    assert data["tool_schemas"] > 0
+    assert data["messages"] > 0
+    assert data["context_window"] == MODEL.context_window
+    assert data["cache_read"] == 7
+    assert data["total"] == sum(
+        data[key]
+        for key in (
+            "instructions",
+            "tool_inventory",
+            "environment",
+            "knowledge_mcp_goal",
+            "tool_schemas",
+            "messages",
+        )
+    )

--- a/tests/unit/session/test_session.py
+++ b/tests/unit/session/test_session.py
@@ -1101,3 +1101,234 @@ async def test_an_ordinary_failure_leaves_images_alone(tmp_path):
     assert not session._images_rejected
     assert _image_blocks(stream.requests[0]) == 1
     await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_mid_turn_compaction_at_continuing_boundary(tmp_path, monkeypatch):
+    """A tool-loop run that crosses the threshold mid-run compacts at the safe
+    boundary — after the tool batch lands, before the next model call — inside
+    the run's event boundary, and the next model call sees the compacted
+    context. Post-run persistence must not resurrect what the pass summarized:
+    the loop prunes its run accumulator to the replacement's survivors, so the
+    transcript after the compaction entry holds only surviving run messages."""
+    from pydantic import BaseModel, Field
+
+    class CompactionSettings(BaseModel):
+        enabled: bool = True
+        reserve_tokens: int = 16384
+        keep_recent_tokens: int = 20000
+        threshold_percent: float = -1.0
+        threshold_tokens: int = Field(default=-1)
+        max_threshold_tokens: int = 600_000
+        auto_continue: bool = False
+        mid_turn_enabled: bool = True
+
+    compacted = {"done": False}
+
+    def estimate_messages_tokens(messages):
+        return 5_000 if compacted["done"] else 90_000
+
+    def messages_tokens_upper_bound(messages):
+        return 5_500 if compacted["done"] else 95_000
+
+    def prune_tool_outputs(messages, now_ts, last_activity_ts, **kwargs):
+        return list(messages), False
+
+    fake_api = types.ModuleType("local_operator.compaction.api")
+    setattr(fake_api, "CompactionSettings", CompactionSettings)
+    setattr(fake_api, "prune_tool_outputs", prune_tool_outputs)
+    setattr(fake_api, "estimate_messages_tokens", estimate_messages_tokens)
+    setattr(fake_api, "messages_tokens_upper_bound", messages_tokens_upper_bound)
+    setattr(
+        fake_api, "compaction_context_tokens", lambda provider, local: max(provider or 0, local)
+    )
+    # Cut before the run's user prompt: kept = [user, assistant, tool result].
+    # The user prompt is a transcript entry (appended pre-run), so the cut is
+    # replayable; a cut into run-produced-only history is refused by design.
+    setattr(fake_api, "find_cut_point", lambda messages, keep: 3)
+    setattr(
+        fake_api,
+        "resolve_threshold_tokens",
+        lambda window, settings: min(int(window * 0.8), 600_000),
+    )
+    setattr(fake_api, "RECOVERY_BAND", 0.8)
+    setattr(
+        fake_api,
+        "should_compact",
+        lambda ctx_tokens, window, settings: ctx_tokens > settings.threshold_tokens,
+    )
+
+    async def summarize(
+        messages: Sequence[Message | CustomMessage],
+        complete_fn: Callable[[str, str], Awaitable[str]],
+    ) -> str:
+        compacted["done"] = True
+        summary = await complete_fn("sys", "summarize this")
+        return f"SUMMARY({summary})"
+
+    setattr(fake_api, "summarize_messages", summarize)
+
+    fake_pkg = types.ModuleType("local_operator.compaction")
+    setattr(fake_pkg, "api", fake_api)
+    monkeypatch.setitem(sys.modules, "local_operator.compaction", fake_pkg)
+    monkeypatch.setitem(sys.modules, "local_operator.compaction.api", fake_api)
+    fake_thresholds = types.ModuleType("local_operator.compaction.thresholds")
+    monkeypatch.setitem(sys.modules, "local_operator.compaction.thresholds", fake_thresholds)
+    fake_snap = types.ModuleType("local_operator.compaction.snapcompact")
+    monkeypatch.setitem(sys.modules, "local_operator.compaction.snapcompact", fake_snap)
+
+    executed: list[str] = []
+    stream = ScriptedStream(
+        [
+            [
+                StreamTextDelta(delta="working"),
+                StreamToolCallDelta(index=0, id="c1", name="echo", argument_delta='{"text":"x"}'),
+                StreamEndEvent(stop_reason="toolUse"),
+            ],
+            # The mid-run one-shot summary call.
+            [StreamTextDelta(delta="compressed"), StreamEndEvent(stop_reason="stop")],
+            [StreamTextDelta(delta="done"), StreamEndEvent(stop_reason="stop")],
+        ]
+    )
+    session = make_session(
+        tmp_path, stream, tools=[echo_tool(executed)], compaction_settings=CompactionSettings()
+    )
+    events: list[AgentEvent] = []
+    session.subscribe(events.append)
+
+    # Prime persisted + live history so the cut lands on a replayable entry:
+    # three older user turns exist in both the transcript and the context.
+    primed = [Message.user(f"earlier {i}") for i in range(3)]
+    for message in primed:
+        await session._transcript.append_message(message)
+    session._context.messages.extend(primed)
+
+    await session.prompt("go")
+
+    assert executed == ["echo"]
+
+    # Compaction events fired with the mid-turn reason, INSIDE the run
+    # boundary (between agent_start and agent_end — the streaming contract's
+    # SC-4 pairing rule).
+    kinds = [(type(e).__name__, getattr(e, "reason", None)) for e in events]
+    assert ("CompactionStartEvent", "mid-turn") in kinds
+    start_idx = next(i for i, e in enumerate(events) if isinstance(e, AgentStartEvent))
+    end_idx = next(i for i, e in enumerate(events) if isinstance(e, AgentEndEvent))
+    compact_idx = next(i for i, e in enumerate(events) if isinstance(e, CompactionStartEvent))
+    assert start_idx < compact_idx < end_idx
+
+    # Exactly one compaction ran: the post-turn pass found the compacted
+    # context below threshold and refused.
+    compactions = [e for e in session._transcript.entries() if e.type == "compaction"]
+    assert len(compactions) == 1
+    assert compactions[0].payload["summary"] == "SUMMARY(compressed)"
+
+    # Context rebuilt: marker + kept window (user, assistant, tool result)
+    # plus the final assistant turn the loop went on to produce after the
+    # compaction — the whole point of compacting mid-run instead of failing.
+    assert len(session._context.messages) == 5
+    marker = session._context.messages[0]
+    assert isinstance(marker, CustomMessage)
+    assert marker.custom_type == "compaction_summary"
+
+    # The next model call saw the compacted context: the rendered marker
+    # (a user message carrying the summary) leads the request.
+    third = stream.requests[2]
+    assert "SUMMARY(compressed)" in third.messages[0].text
+
+    # No resurrection: after the compaction entry the transcript holds only
+    # the run's three surviving messages (assistant, tool result, final
+    # assistant) — the primed history the pass summarized never re-lands
+    # after it, and nothing is persisted twice.
+    entries = session._transcript.entries()
+    c_index = next(i for i, e in enumerate(entries) if e.type == "compaction")
+    after = [e for e in entries[c_index + 1 :] if e.type == "message"]
+    assert len(after) == 3
+
+    await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_mid_turn_compaction_disabled_by_setting(tmp_path, monkeypatch):
+    """``mid_turn_enabled=False`` restores the old posture exactly: the
+    boundary hook is a no-op and only the post-turn pass compacts."""
+    from pydantic import BaseModel, Field
+
+    class CompactionSettings(BaseModel):
+        enabled: bool = True
+        reserve_tokens: int = 16384
+        keep_recent_tokens: int = 20000
+        threshold_percent: float = -1.0
+        threshold_tokens: int = Field(default=-1)
+        max_threshold_tokens: int = 600_000
+        auto_continue: bool = False
+        mid_turn_enabled: bool = False
+
+    def prune_tool_outputs(messages, now_ts, last_activity_ts, **kwargs):
+        return list(messages), False
+
+    fake_api = types.ModuleType("local_operator.compaction.api")
+    setattr(fake_api, "CompactionSettings", CompactionSettings)
+    setattr(fake_api, "prune_tool_outputs", prune_tool_outputs)
+    setattr(fake_api, "estimate_messages_tokens", lambda messages: 90_000)
+    setattr(fake_api, "messages_tokens_upper_bound", lambda messages: 95_000)
+    setattr(
+        fake_api, "compaction_context_tokens", lambda provider, local: max(provider or 0, local)
+    )
+    setattr(fake_api, "find_cut_point", lambda messages, keep: 0)
+    setattr(
+        fake_api,
+        "resolve_threshold_tokens",
+        lambda window, settings: min(int(window * 0.8), 600_000),
+    )
+    setattr(fake_api, "RECOVERY_BAND", 0.8)
+    setattr(
+        fake_api,
+        "should_compact",
+        lambda ctx_tokens, window, settings: ctx_tokens > settings.threshold_tokens,
+    )
+
+    async def summarize(
+        messages: Sequence[Message | CustomMessage],
+        complete_fn: Callable[[str, str], Awaitable[str]],
+    ) -> str:
+        return "SUMMARY(post-turn)"
+
+    setattr(fake_api, "summarize_messages", summarize)
+
+    fake_pkg = types.ModuleType("local_operator.compaction")
+    setattr(fake_pkg, "api", fake_api)
+    monkeypatch.setitem(sys.modules, "local_operator.compaction", fake_pkg)
+    monkeypatch.setitem(sys.modules, "local_operator.compaction.api", fake_api)
+    fake_thresholds = types.ModuleType("local_operator.compaction.thresholds")
+    monkeypatch.setitem(sys.modules, "local_operator.compaction.thresholds", fake_thresholds)
+    fake_snap = types.ModuleType("local_operator.compaction.snapcompact")
+    monkeypatch.setitem(sys.modules, "local_operator.compaction.snapcompact", fake_snap)
+
+    executed: list[str] = []
+    stream = ScriptedStream(
+        [
+            [
+                StreamToolCallDelta(index=0, id="c1", name="echo", argument_delta='{"text":"x"}'),
+                StreamEndEvent(stop_reason="toolUse"),
+            ],
+            [StreamTextDelta(delta="done"), StreamEndEvent(stop_reason="stop")],
+        ]
+    )
+    session = make_session(
+        tmp_path, stream, tools=[echo_tool(executed)], compaction_settings=CompactionSettings()
+    )
+    events: list[AgentEvent] = []
+    session.subscribe(events.append)
+    await session.prompt("go")
+
+    reasons = [
+        getattr(e, "reason", None)
+        for e in events
+        if isinstance(e, (CompactionStartEvent, CompactionEndEvent))
+    ]
+    # No mid-turn pass; the single pass (if any) is the post-turn one.
+    assert "mid-turn" not in reasons
+    compactions = [e for e in session._transcript.entries() if e.type == "compaction"]
+    assert len(compactions) <= 1
+    await session.dispose()

--- a/tests/unit/skills/test_discovery.py
+++ b/tests/unit/skills/test_discovery.py
@@ -24,6 +24,7 @@ def _write_skill(
     hide: bool | None = None,
     disable_model_invocation: bool | None = None,
     body: str = "# Body",
+    globs: str | list[str] | None = None,
 ) -> Path:
     skill_dir = root / dirname
     skill_dir.mkdir(parents=True)
@@ -38,12 +39,61 @@ def _write_skill(
         lines.append(f"hide: {str(hide).lower()}")
     if disable_model_invocation is not None:
         lines.append(f"disable-model-invocation: {str(disable_model_invocation).lower()}")
+    if globs is not None:
+        # YAML plain scalars cannot start with "*" (alias marker), so both
+        # spellings quote their values — exactly what real SKILL.md authors
+        # must do; an unquoted ``*.py`` makes the whole block malformed YAML
+        # and discovery drops the skill.
+        if isinstance(globs, str):
+            lines.append(f'globs: "{globs}"')
+        else:
+            lines.append("globs:")
+            lines.extend(f'  - "{pattern}"' for pattern in globs)
     lines.append("---")
     lines.append("")
     lines.append(body)
     skill_md = skill_dir / "SKILL.md"
     skill_md.write_text("\n".join(lines), encoding="utf-8")
     return skill_md
+
+
+class TestGlobsFrontmatter:
+    """The optional ``globs`` key rides on the Skill record in both ecosystem
+    spellings; junk shapes degrade to no globs rather than dropping the
+    skill (the description remains the primary routing signal)."""
+
+    def test_csv_string_and_yaml_list(self, tmp_path: Path) -> None:
+        root = tmp_path / "skills"
+        _write_skill(root, "csv", globs="*.py, src/**/*.ts ,")
+        _write_skill(root, "list", globs=["*.tf", "infra/**"])
+        skills = {skill.name: skill for skill in scan_skills_dir(root, source="test")}
+        assert skills["csv"].globs == ("*.py", "src/**/*.ts")
+        assert skills["list"].globs == ("*.tf", "infra/**")
+
+    def test_junk_shapes_degrade_gracefully(self, tmp_path: Path) -> None:
+        root = tmp_path / "skills"
+        # Hand-written frontmatter: the helper quotes list items, but the
+        # degradation contract has to hold for unquoted non-strings too.
+        skill_dir = root / "junk"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\ndescription: A test skill.\n"
+            "globs:\n"
+            "  - 3\n"
+            "  - true\n"
+            '  - "*.md"\n'
+            "---\n# Body",
+            encoding="utf-8",
+        )
+        skills = {skill.name: skill for skill in scan_skills_dir(root, source="test")}
+        # Only the usable pattern survives; the skill itself is kept.
+        assert skills["junk"].globs == ("*.md",)
+
+    def test_absent_key_defaults_to_empty_tuple(self, tmp_path: Path) -> None:
+        root = tmp_path / "skills"
+        _write_skill(root, "plain")
+        skills = {skill.name: skill for skill in scan_skills_dir(root, source="test")}
+        assert skills["plain"].globs == ()
 
 
 class TestParseFrontmatter:

--- a/tests/unit/skills/test_routing.py
+++ b/tests/unit/skills/test_routing.py
@@ -1,0 +1,390 @@
+"""Skill-routing upgrade tests: globs force-include, hybrid scoring, and
+the compaction-keyed re-freeze of the session knowledge block.
+
+The four behaviors here share one theme — selection must be right at the
+edges, not just the happy path: an author's path claim (globs) outranks the
+embedder, a lexically-exact description must survive a semantic miss, an
+imported ecosystem skill must never shadow a native one, and a compaction
+must re-open a frozen selection exactly once.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from local_operator import session_factory
+from local_operator.skills.api import default_skill_roots
+from local_operator.skills.discovery import Skill, discover_skills
+from local_operator.skills.embeddings import LocalEmbedder
+from local_operator.skills.index import SkillIndex, _hybrid_scores
+
+_SKILLS_SUBDIR = Path(".local-operator") / "skills"
+
+
+def _make_skill(
+    root: Path,
+    dirname: str,
+    description: str,
+    *,
+    globs: tuple[str, ...] = (),
+    hide: bool = False,
+) -> Skill:
+    skill_dir = root / dirname
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    skill_md = skill_dir / "SKILL.md"
+    skill_md.write_text(f"---\ndescription: {description}\n---\n# {dirname}")
+    return Skill(
+        name=dirname,
+        description=description,
+        file_path=skill_md,
+        base_dir=skill_dir,
+        source=str(root),
+        globs=globs,
+        hide=hide,
+    )
+
+
+def _write_skill_md(
+    root: Path,
+    dirname: str,
+    description: str,
+    body_marker: str,
+) -> None:
+    skill_dir = root / dirname
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(
+        f"---\nname: {dirname}\ndescription: {description}\n---\n\n{body_marker}"
+    )
+
+
+def _bare_skill(name: str, description: str) -> Skill:
+    """A Skill pointing at a fake path — for pure scoring-function tests
+    that never stat or embed (no disk writes, no cache identity)."""
+    fake = Path("/nonexistent") / name
+    return Skill(
+        name=name,
+        description=description,
+        file_path=fake,
+        base_dir=fake.parent,
+        source=str(fake.parent),
+    )
+
+
+class TestGlobsForceInclude:
+    """Globs match the session cwd (or a suffix of it) and file-path-like
+    query tokens; matches are forced in at 1.0, bypassing the cosine
+    threshold but still capped by k and the hidden filter."""
+
+    @pytest.mark.asyncio
+    async def test_glob_matches_cwd_suffix(self, tmp_path: Path) -> None:
+        skill = _make_skill(
+            tmp_path,
+            "backend-helper",
+            "A recipe for moist banana bread.",  # semantically unrelated
+            globs=("src/**",),
+        )
+        index = SkillIndex([skill], LocalEmbedder(), cache_dir=tmp_path / "cache")
+        matches = await index.select("something entirely unrelated", cwd=Path("/x/repo/src/app"))
+        assert matches == [skill]
+
+    @pytest.mark.asyncio
+    async def test_glob_matches_query_path_token(self, tmp_path: Path) -> None:
+        skill = _make_skill(tmp_path, "terraform", "Baking guides.", globs=("*.tf",))
+        index = SkillIndex([skill], LocalEmbedder(), cache_dir=tmp_path / "cache")
+        matches = await index.select("please review main.tf when you can")
+        assert matches == [skill]
+
+    @pytest.mark.asyncio
+    async def test_glob_bypasses_threshold_but_not_k(self, tmp_path: Path) -> None:
+        skills = [
+            _make_skill(
+                tmp_path,
+                f"path-skill-{i}",
+                "Completely unrelated filler description.",
+                globs=("*.tf",),
+            )
+            for i in range(10)
+        ]
+        index = SkillIndex(skills, LocalEmbedder(), cache_dir=tmp_path / "cache")
+        matches = await index.select("review main.tf", threshold=0.99)
+        assert len(matches) == 8  # k=8 default still caps the force-include
+
+    @pytest.mark.asyncio
+    async def test_hidden_glob_skill_still_excluded(self, tmp_path: Path) -> None:
+        skill = _make_skill(tmp_path, "secret", "Hidden helper.", globs=("*.tf",), hide=True)
+        index = SkillIndex([skill], LocalEmbedder(), cache_dir=tmp_path / "cache")
+        assert await index.select("review main.tf", threshold=0.99) == []
+
+    @pytest.mark.asyncio
+    async def test_no_globs_no_force_include(self, tmp_path: Path) -> None:
+        # The boost must come from the globs field, not from any path-ish
+        # query token alone.
+        skill = _make_skill(tmp_path, "plain", "Unrelated description.")
+        index = SkillIndex([skill], LocalEmbedder(), cache_dir=tmp_path / "cache")
+        assert await index.select("review main.tf", threshold=0.99) == []
+
+    @pytest.mark.asyncio
+    async def test_glob_outranks_semantic_match_in_ranking(self, tmp_path: Path) -> None:
+        # Both admitted (threshold 0.0); the glob hit must not LOSE to a
+        # stronger cosine match in the k ordering.
+        semantic = _make_skill(tmp_path, "deploy-docs", "deploy kubernetes cluster to prod east")
+        globbed = _make_skill(tmp_path, "aa-path-skill", "Banana bread.", globs=("*.tf",))
+        index = SkillIndex([semantic, globbed], LocalEmbedder(), cache_dir=tmp_path / "cache")
+        matches = await index.select(
+            "deploy kubernetes cluster; also review main.tf", k=1, threshold=0.0
+        )
+        assert matches == [globbed]
+
+    def test_formula_directly(self) -> None:
+        # Name "alpha" makes the indexed text "alpha: alpha beta gamma delta"
+        # — the SAME word set as the query, so Jaccard is exactly 1.0.
+        exact = _bare_skill("alpha", "alpha beta gamma delta")
+        disjoint = _bare_skill("other", "one two three four")
+        scores = _hybrid_scores("alpha beta gamma delta", [exact, disjoint], [0.10, 0.10], None)
+        assert scores[0] == pytest.approx(0.6 * 0.10 + 0.4 * 1.0)
+        assert scores[1] == pytest.approx(0.10)  # max() keeps cosine for jac=0
+
+    @pytest.mark.asyncio
+    async def test_lexically_exact_survives_semantic_miss(self, tmp_path: Path) -> None:
+        class MissingBackend:
+            """A semantic embedder that misses everything: the query vector
+            is orthogonal to every corpus row, so cosine is 0.0 for all
+            skills. Distinguished by call arity — ``select`` always embeds
+            exactly one query against an already-built multi-row matrix, so
+            the corpus must hold two skills for the split to be unambiguous."""
+
+            dim = 2
+            default_threshold = 0.3
+
+            async def embed(self, texts: list[str]) -> list[list[float]]:
+                if len(texts) == 1:
+                    return [[0.0, 1.0]]  # the query
+                return [[1.0, 0.0] for _ in texts]  # the corpus rows
+
+        exact = _make_skill(tmp_path, "deploy", "deploy the kubernetes cluster to prod east")
+        filler = _make_skill(tmp_path, "filler", "unrelated words entirely so")
+        index = SkillIndex([exact, filler], MissingBackend(), cache_dir=tmp_path / "cache")
+        matches = await index.select("deploy the kubernetes cluster to prod east")
+        assert matches == [exact]  # cosine 0.0, Jaccard 1.0 → 0.4 > 0.3
+
+    @pytest.mark.asyncio
+    async def test_pure_noise_stays_below_threshold(self, tmp_path: Path) -> None:
+        class MissingBackend:
+            dim = 2
+            default_threshold = 0.3
+
+            async def embed(self, texts: list[str]) -> list[list[float]]:
+                if len(texts) == 1:
+                    return [[0.0, 1.0]]
+                return [[1.0, 0.0] for _ in texts]
+
+        skill = _make_skill(tmp_path, "deploy", "deploy the kubernetes cluster to prod east")
+        filler = _make_skill(tmp_path, "filler", "unrelated words entirely so")
+        index = SkillIndex([skill, filler], MissingBackend(), cache_dir=tmp_path / "cache")
+        assert await index.select("how do I bake sourdough at altitude") == []
+
+    @pytest.mark.asyncio
+    async def test_off_corpus_noise_with_local_embedder(self, tmp_path: Path) -> None:
+        # Same contract through the REAL embedder: unrelated skills must not
+        # leak in just because the blend raises every score.
+        deploy = _make_skill(tmp_path, "deploy", "deploy kubernetes cluster to prod east")
+        bread = _make_skill(tmp_path, "banana-bread", "baking moist banana bread at home")
+        index = SkillIndex([deploy, bread], LocalEmbedder(), cache_dir=tmp_path / "cache")
+        assert await index.select("quantum entanglement podcast recommendations") == []
+
+
+class _CountingIndex:
+    """Minimal index double: records every query it is asked to score."""
+
+    def __init__(self) -> None:
+        self.queries: list[str] = []
+
+    async def select(self, query: str, **kwargs: object) -> list[Skill]:
+        self.queries.append(query)
+        return []
+
+
+class TestCompactionRefreeze:
+    """The knowledge block freezes after the first query — unless the
+    transcript's latest compaction entry id changed, which re-opens
+    selection exactly once (the head rewrite already killed the cache)."""
+
+    @pytest.mark.asyncio
+    async def test_same_compaction_id_stays_frozen(self) -> None:
+        index = _CountingIndex()
+        hooks = session_factory._KnowledgeHooks(index=index)  # type: ignore[arg-type]
+        first = await session_factory._select_knowledge_block(hooks, "first task")
+        second = await session_factory._select_knowledge_block(hooks, "later task")
+        assert first == second
+        assert index.queries == ["first task"]
+
+    @pytest.mark.asyncio
+    async def test_new_compaction_id_reselects_once(self) -> None:
+        index = _CountingIndex()
+        hooks = session_factory._KnowledgeHooks(index=index)  # type: ignore[arg-type]
+        await session_factory._select_knowledge_block(hooks, "first task")
+        refrozen = await session_factory._select_knowledge_block(
+            hooks, "first task\nwe compacted everything", compaction_id="c1"
+        )
+        assert refrozen is not None
+        again = await session_factory._select_knowledge_block(
+            hooks, "first task\nwe compacted everything", compaction_id="c1"
+        )
+        assert index.queries == ["first task", "first task\nwe compacted everything"]
+        assert hooks.frozen_compaction_id == "c1"
+        assert again == refrozen  # frozen again under the new id
+
+    def test_latest_compaction_id(self) -> None:
+        def transcript(entries: list[SimpleNamespace]) -> SimpleNamespace:
+            return SimpleNamespace(entries=lambda: list(entries))
+
+        user = dict(type="message", payload={"role": "user", "content": [{"text": "hi"}]})
+        assert (
+            session_factory._latest_compaction_id(transcript([SimpleNamespace(id="m1", **user)]))
+            is None
+        )
+        assert (
+            session_factory._latest_compaction_id(
+                transcript(
+                    [
+                        SimpleNamespace(id="m1", **user),
+                        SimpleNamespace(id="c1", type="compaction", payload={}),
+                        SimpleNamespace(id="c2", type="compaction", payload={}),
+                    ]
+                )
+            )
+            == "c2"
+        )  # newest wins, matching replay semantics
+        broken = SimpleNamespace(entries=lambda: (_ for _ in ()).throw(RuntimeError("x")))
+        assert session_factory._latest_compaction_id(broken) is None
+
+    @pytest.mark.asyncio
+    async def test_provider_reselects_after_compaction_lands(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import local_operator.prompts_api as prompts_api
+
+        monkeypatch.setattr(
+            prompts_api, "build_system_blocks", lambda *args, **kwargs: ["head", "tail"]
+        )
+
+        class FakeTranscript:
+            def __init__(self) -> None:
+                self._entries: list[SimpleNamespace] = [
+                    SimpleNamespace(
+                        id="m1",
+                        type="message",
+                        payload={"role": "user", "content": [{"text": "deploy stuff"}]},
+                    )
+                ]
+
+            def entries(self) -> list[SimpleNamespace]:
+                return list(self._entries)
+
+        transcript = FakeTranscript()
+        index = _CountingIndex()
+        hooks = session_factory._KnowledgeHooks(index=index)  # type: ignore[arg-type]
+        provider = session_factory._make_system_blocks_provider([], transcript, hooks)
+
+        await provider()
+        await provider()  # no compaction yet: still frozen
+        assert index.queries == ["deploy stuff"]
+
+        transcript._entries.append(
+            SimpleNamespace(
+                id="c9",
+                type="compaction",
+                payload={"summary": "we were deploying kubernetes"},
+            )
+        )
+        await provider()
+        assert len(index.queries) == 2  # compaction re-opened selection
+        assert "we were deploying kubernetes" in index.queries[1]
+        assert "deploy stuff" in index.queries[1]  # latest user query + summary
+
+        await provider()  # same compaction id: frozen again
+        assert len(index.queries) == 2
+
+
+class TestEcosystemRootsAndCollision:
+    """Ecosystem roots scan only what exists, yield to native roots on name
+    collisions, and are replaced wholesale by the env override."""
+
+    @pytest.mark.asyncio
+    async def test_native_root_wins_collision_and_env_override(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        home = tmp_path / "home"
+        (home / ".claude" / "skills").mkdir(parents=True)
+        monkeypatch.setenv("HOME", str(home))
+
+        project = tmp_path / "repo"
+        native_root = project / _SKILLS_SUBDIR
+        _write_skill_md(native_root, "deploy", "native deploy helper", "native body")
+        _write_skill_md(
+            home / ".claude" / "skills", "deploy", "claude deploy helper", "claude body"
+        )
+
+        skills, warnings = discover_skills(default_skill_roots(project))
+        deployed = [skill for skill in skills if skill.name == "deploy"]
+        assert len(deployed) == 1
+        assert deployed[0].description == "native deploy helper"
+        assert any("conflict" in warning for warning in warnings)
+
+        # Env override replaces the ecosystem set wholesale: pointing it at
+        # an empty dir drops the claude skill even though ~/.claude exists.
+        extra = tmp_path / "extra-skills"
+        extra.mkdir()
+        monkeypatch.setenv("LOCAL_OPERATOR_SKILL_EXTRA_ROOTS", str(extra))
+        skills, warnings = discover_skills(default_skill_roots(project))
+        assert [skill.name for skill in skills] == ["deploy"]
+        assert deployed[0].description == "native deploy helper"
+        assert not any("conflict" in warning for warning in warnings)
+
+    def test_missing_ecosystem_roots_are_not_scanned(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        home = tmp_path / "home"
+        (home / ".claude" / "skills").mkdir(parents=True)
+        monkeypatch.setenv("HOME", str(home))
+
+        roots = default_skill_roots(tmp_path / "repo")
+        assert home / ".claude" / "skills" in roots
+        assert home / ".codex" / "skills" not in roots
+        assert home / ".omp" / "agent" / "skills" not in roots
+        # Native home root still precedes every ecosystem root.
+        assert roots.index(home / _SKILLS_SUBDIR) < roots.index(home / ".claude" / "skills")
+
+    def test_empty_env_disables_ecosystem_roots(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        home = tmp_path / "home"
+        (home / ".claude" / "skills").mkdir(parents=True)
+        monkeypatch.setenv("HOME", str(home))
+        monkeypatch.setenv("LOCAL_OPERATOR_SKILL_EXTRA_ROOTS", "")
+
+        roots = default_skill_roots(tmp_path / "repo")
+        assert home / ".claude" / "skills" not in roots
+
+    def test_env_override_replaces_default_set(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        home = tmp_path / "home"
+        home.mkdir()
+        monkeypatch.setenv("HOME", str(home))
+        mine = tmp_path / "my-skills"
+        mine.mkdir()
+        (home / ".claude" / "skills").mkdir(parents=True)
+        monkeypatch.setenv("LOCAL_OPERATOR_SKILL_EXTRA_ROOTS", f"{mine}:{tmp_path / 'nope'}")
+
+        roots = default_skill_roots(tmp_path / "repo")
+        assert mine in roots
+        assert home / ".claude" / "skills" not in roots  # replaced, not extended
+        assert tmp_path / "nope" not in roots  # nonexistent entries dropped
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -59,6 +59,7 @@ def test_config_manager_initialization(temp_config_dir):
     assert config_manager.get_config_value("conversation_length") == DEFAULT_CONFIG.get_value(
         "conversation_length"
     )
+    assert config_manager.get_config_value("providers") == {"openai": {"api": "responses"}}
 
 
 def test_config_managers_do_not_share_nested_defaults(temp_config_dir):
@@ -193,6 +194,7 @@ def test_config_manager_load_partial_values(temp_config_dir):
         "detail_length"
     )
     assert config_manager.get_config_value("model_name") == DEFAULT_CONFIG.get_value("model_name")
+    assert config_manager.get_config_value("providers") == {"openai": {"api": "responses"}}
 
 
 def test_config_manager_update_config(temp_config_dir):

--- a/tests/unit/test_context_files.py
+++ b/tests/unit/test_context_files.py
@@ -1,0 +1,105 @@
+"""Repository guidance (AGENTS.md/CLAUDE.md) discovery and injection."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from local_operator.context_files import (
+    discover_context_files,
+    load_repo_guidance,
+    render_context_files,
+)
+
+
+def _make_repo(root: Path, with_git: bool = True) -> Path:
+    repo = root / "proj"
+    repo.mkdir(parents=True)
+    if with_git:
+        (repo / ".git").mkdir()
+    return repo
+
+
+def test_discovers_ancestors_farthest_first(tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path)
+    (repo / "AGENTS.md").write_text("root guidance\n")
+    (repo / "src").mkdir()
+    (repo / "src" / "AGENTS.md").write_text("src guidance\n")
+    files = discover_context_files(repo / "src")
+    assert [f.name for f in files] == ["AGENTS.md", "AGENTS.md"]
+    assert files[0].parent.name == "proj"
+    assert files[1].parent.name == "src"
+    rendered = render_context_files(files, repo / "src")
+    # Farthest first: the root block precedes the src block.
+    assert rendered.index("root guidance") < rendered.index("src guidance")
+    assert rendered.startswith("## Repository guidance")
+    assert "conversation still wins" in rendered
+
+
+def test_claude_md_stands_in_when_agents_md_absent(tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path)
+    (repo / "CLAUDE.md").write_text("claude guidance\n")
+    files = discover_context_files(repo)
+    assert len(files) == 1
+    assert files[0].name == "CLAUDE.md"
+    # Both present: AGENTS.md wins, never both.
+    (repo / "AGENTS.md").write_text("agents guidance\n")
+    files = discover_context_files(repo)
+    assert [f.name for f in files] == ["AGENTS.md"]
+
+
+def test_stops_at_git_root(tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path)
+    (repo / "AGENTS.md").write_text("in repo\n")
+    outside = repo / "above"
+    outside.mkdir()
+    (outside / "AGENTS.md").write_text("outside repo\n")
+    # A cwd INSIDE the repo: the repo root is the boundary.
+    inner = repo / "pkg"
+    inner.mkdir()
+    files = discover_context_files(inner)
+    assert len(files) == 1
+    assert files[0].read_text() == "in repo\n"
+
+
+def test_no_git_root_stops_at_home(tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path, with_git=False)
+    (repo / "AGENTS.md").write_text("no git\n")
+    files = discover_context_files(repo)
+    # tmp_path is outside $HOME and has no git root: the walk stops at the
+    # filesystem root boundary without error, finding only the repo's file.
+    assert [f.read_text() for f in files] == ["no git\n"]
+
+
+def test_nearest_cap_and_dedupe(tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path)
+    nested = repo / "a" / "b" / "c" / "d" / "e" / "f"
+    nested.mkdir(parents=True)
+    shared = "same bytes everywhere\n"
+    for part in ("a", "a/b", "a/b/c", "a/b/c/d", "a/b/c/d/e", "a/b/c/d/e/f"):
+        (repo / part / "AGENTS.md").write_text(shared)
+    files = discover_context_files(nested)
+    # Byte-identical files collapse to one regardless of depth.
+    assert len(files) == 1
+
+
+def test_env_kill_switch(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    repo = _make_repo(tmp_path)
+    (repo / "AGENTS.md").write_text("hidden\n")
+    monkeypatch.setenv("LOCAL_OPERATOR_CONTEXT_FILES", "0")
+    assert discover_context_files(repo) == []
+    assert load_repo_guidance(repo) == ""
+
+
+def test_truncates_oversized_file(tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path)
+    (repo / "AGENTS.md").write_text("x" * (64 * 1024 + 100))
+    rendered = load_repo_guidance(repo)
+    assert "truncated at 64KiB" in rendered
+
+
+def test_empty_when_no_files(tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path)
+    assert discover_context_files(repo) == []
+    assert load_repo_guidance(repo) == ""

--- a/tests/unit/test_context_files.py
+++ b/tests/unit/test_context_files.py
@@ -103,3 +103,17 @@ def test_empty_when_no_files(tmp_path: Path) -> None:
     repo = _make_repo(tmp_path)
     assert discover_context_files(repo) == []
     assert load_repo_guidance(repo) == ""
+
+
+def test_cap_keeps_nearest_most_specific_files(tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path)
+    current = repo
+    for index in range(7):
+        current = current / f"d{index}"
+        current.mkdir()
+        (current / "AGENTS.md").write_text(f"guidance {index}\n")
+    files = discover_context_files(current)
+    assert len(files) == 5
+    bodies = [file.read_text() for file in files]
+    # Prompt order is farthest->nearest, but the retained SET is the nearest 5.
+    assert bodies == [f"guidance {i}\n" for i in range(2, 7)]

--- a/tests/unit/test_context_files.py
+++ b/tests/unit/test_context_files.py
@@ -117,3 +117,38 @@ def test_cap_keeps_nearest_most_specific_files(tmp_path: Path) -> None:
     bodies = [file.read_text() for file in files]
     # Prompt order is farthest->nearest, but the retained SET is the nearest 5.
     assert bodies == [f"guidance {i}\n" for i in range(2, 7)]
+
+
+def test_symlinked_guidance_is_never_discovered_or_rendered(tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path)
+    secret = tmp_path / "outside-secret.txt"
+    secret.write_text("DO NOT SEND")
+    link = repo / "AGENTS.md"
+    link.symlink_to(secret)
+
+    assert discover_context_files(repo) == []
+    # Render repeats the no-follow check: a link swapped in after discovery
+    # cannot exploit the gap between the two bounded reads.
+    assert render_context_files([link], repo) == ""
+
+
+def test_guidance_cap_bounds_ingestion_before_hash_and_render(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from local_operator.context_files import MAX_FILE_BYTES
+
+    repo = _make_repo(tmp_path)
+    guidance = repo / "AGENTS.md"
+    guidance.write_bytes(b"x" * (MAX_FILE_BYTES + 10_000_000))
+
+    def forbidden(*_args: object, **_kwargs: object) -> bytes:
+        raise AssertionError("unbounded Path read API used")
+
+    # The old implementation used both and allocated the whole file twice.
+    monkeypatch.setattr(Path, "read_bytes", forbidden)
+    monkeypatch.setattr(Path, "read_text", forbidden)
+    rendered = load_repo_guidance(repo)
+
+    assert rendered.count("x") == MAX_FILE_BYTES
+    assert "truncated at 64KiB" in rendered
+    assert len(rendered.encode()) < MAX_FILE_BYTES + 1_000

--- a/tests/unit/test_incidents.py
+++ b/tests/unit/test_incidents.py
@@ -1,0 +1,55 @@
+"""Session incident classification and formatting."""
+
+from __future__ import annotations
+
+import pytest
+
+from local_operator.incidents import (
+    SESSION_INCIDENT_MESSAGE_TYPE,
+    classify_incident,
+    format_incident_message,
+)
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("429 Too Many Requests", "rate-limit"),
+        ("RATE LIMIT exceeded for claude-opus-5", "rate-limit"),
+        ("usage limit reached on this account", "rate-limit"),
+        ("401 Unauthorized: invalid api key", "auth"),
+        ("403 permission denied for this model", "auth"),
+        ("refresh token expired", "auth"),
+        ("402 payment required", "billing"),
+        ("503 service unavailable", "provider"),
+        ("bad gateway from upstream", "provider"),
+        ("read timeout while streaming", "network"),
+        ("connection reset by peer", "network"),
+        ("SSL certificate verify failed", "network"),
+        ("maximum context length is 200000 tokens", "context-length"),
+        ("the request was too large", "context-length"),
+        ("MCP server 'linear' unavailable", "mcp"),
+        ("something completely novel happened", "unknown"),
+    ],
+)
+def test_classification(raw: str, expected: str) -> None:
+    assert classify_incident(raw).category == expected
+
+
+def test_render_carries_category_source_hint_and_raw():
+    text = format_incident_message("429 quota exceeded", "anthropic", "claude-opus-5")
+    assert text.startswith("[session incident (anthropic/claude-opus-5)] rate-limit:")
+    assert "429 quota exceeded" in text
+    assert "suggested action:" in text
+    assert "previous turn ended" in text
+
+
+def test_unknown_has_no_invented_hint():
+    incident = classify_incident("a novel failure mode")
+    assert incident.category == "unknown"
+    assert incident.hint == ""
+
+
+def test_message_type_constant_is_stable():
+    # Persisted into transcripts; renaming it would orphan old sessions' replay.
+    assert SESSION_INCIDENT_MESSAGE_TYPE == "session_incident"

--- a/tests/unit/test_prompts_api.py
+++ b/tests/unit/test_prompts_api.py
@@ -247,7 +247,7 @@ def test_inventory_block_matches_default_tool_order() -> None:
         ToolContext(
             cwd=".",
             wake_scheduler=_FakeSchedulerForBlocks(),
-            subagent_launcher=lambda label, prompt: "job-x",
+            subagent_launcher=lambda label, prompt, *, agent="task", effort=None: "job-x",
             jobs=_FakeJobsForBlocks(),
             subagent_comms=_FakeCommsForBlocks(),
         )

--- a/tests/unit/tools/test_builtin_tools.py
+++ b/tests/unit/tools/test_builtin_tools.py
@@ -1468,3 +1468,51 @@ async def test_glob_respects_nested_gitignore(tools, context, tmp_path) -> None:
     result = await _call(tools, "glob", {"pattern": "**/*.py"}, context)
     assert "packages/a/visible.py" in result.text
     assert "packages/a/generated/hidden.py" not in result.text
+
+
+@pytest.mark.asyncio
+async def test_edit_exact_match_preserves_tabs_verbatim(tools, context, tmp_path) -> None:
+    makefile = tmp_path / "Makefile"
+    makefile.write_text("target:\n\told\nnext:\n", newline="")
+    result = await _call(
+        tools,
+        "edit",
+        {"path": "Makefile", "old_text": "\told\n", "new_text": "\tnew\n"},
+        context,
+    )
+    assert result.is_error is False
+    assert makefile.read_bytes() == b"target:\n\tnew\nnext:\n"
+
+
+@pytest.mark.asyncio
+async def test_edit_exact_match_preserves_requested_trailing_newline(
+    tools, context, tmp_path
+) -> None:
+    path = tmp_path / "exact.txt"
+    path.write_text("needle-after", newline="")
+    result = await _call(
+        tools,
+        "edit",
+        {"path": "exact.txt", "old_text": "needle", "new_text": "replacement\n"},
+        context,
+    )
+    assert result.is_error is False
+    assert path.read_bytes() == b"replacement\n-after"
+
+
+@pytest.mark.asyncio
+async def test_edit_tolerant_match_keeps_crlf_line_endings(tools, context, tmp_path) -> None:
+    path = tmp_path / "crlf.txt"
+    path.write_bytes(b"if ok:\r\n\told()\r\nnext()\r\n")
+    result = await _call(
+        tools,
+        "edit",
+        {
+            "path": "crlf.txt",
+            "old_text": "    old()\n",
+            "new_text": "    new()\n    added()\n",
+        },
+        context,
+    )
+    assert result.is_error is False
+    assert path.read_bytes() == b"if ok:\r\n\tnew()\r\n\tadded()\r\nnext()\r\n"

--- a/tests/unit/tools/test_builtin_tools.py
+++ b/tests/unit/tools/test_builtin_tools.py
@@ -1349,3 +1349,77 @@ async def test_glob_respects_gitignore_unless_pattern_names_it(tools, context, t
     assert "dist/out.js" not in broad.text
     named = await _call(tools, "glob", {"pattern": "dist/*.js"}, context)
     assert "dist/out.js" in named.text
+
+
+# ---------------------------------------------------------------------------
+# bash: steering detach vs real abort
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_bash_steering_cancellation_backgrounds_the_command(tmp_path) -> None:
+    """A steering cancel (task cancelled, signal NOT aborted) detaches the
+    command into a tracked background job instead of killing it: the tool
+    returns a result naming the job, and the job later reports the exit code
+    and output of the process that was allowed to finish."""
+    from local_operator.harness.jobs import AsyncJobManager
+
+    manager = AsyncJobManager()
+    context = ToolContext(cwd=str(tmp_path), session_id="bg", jobs=manager)
+    tools = {t.name: t for t in create_tools(context)}
+
+    task = asyncio.create_task(
+        _call(
+            tools,
+            "bash",
+            {"command": f"sleep 0.6 && echo finished-marker"},
+            context,
+        )
+    )
+    await asyncio.sleep(0.2)  # let the command start
+    task.cancel()
+    result = await task  # the tool swallows the steering cancel and answers
+
+    assert result.is_error is False
+    assert "continues in the background" in result.text
+    job_id = result.details["job_id"]
+    job = manager.get(job_id)
+    assert job is not None and job.type == "bash"
+
+    async def settle():
+        while job.status == "running":
+            await asyncio.sleep(0.05)
+
+    await settle()
+    assert job.status == "completed"
+    assert "exit code: 0" in (job.result_text or "")
+    assert "finished-marker" in (job.result_text or "")
+
+
+@pytest.mark.asyncio
+async def test_bash_real_abort_still_kills(tmp_path) -> None:
+    """A genuine abort (Ctrl+C / jobs cancel: signal.aborted) kills the
+    process group; the cancellation propagates as before."""
+    from local_operator.harness.jobs import AsyncJobManager
+    from local_operator.harness.types import AbortSignal
+
+    manager = AsyncJobManager()
+    context = ToolContext(cwd=str(tmp_path), session_id="bg2", jobs=manager)
+    tools = {t.name: t for t in create_tools(context)}
+    sig = AbortSignal()
+    task = asyncio.create_task(
+        tools["bash"].execute(
+            "c",
+            {"command": f"sleep 5 && echo should-not-run"},
+            sig,
+            None,
+            context,
+        )
+    )
+    await asyncio.sleep(0.2)
+    sig.abort("interrupted")
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    await asyncio.sleep(0.1)
+    assert manager.list() == []  # nothing was backgrounded

--- a/tests/unit/tools/test_builtin_tools.py
+++ b/tests/unit/tools/test_builtin_tools.py
@@ -1074,3 +1074,278 @@ async def test_tool_result_invariants(tmp_path, tool_name, args) -> None:
     if result.useless:
         assert isinstance(result.details, dict)
         assert result.details.get("useless") is True
+
+
+# ---------------------------------------------------------------------------
+# edit: multi-hunk, whitespace tolerance, anchor_line
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_edit_multi_hunk_applies_all_in_one_call(tools, context, tmp_path) -> None:
+    await _call(
+        tools,
+        "write",
+        {"path": "m.py", "content": "alpha\nmiddle\nbeta\nmiddle\ngamma\n"},
+        context,
+    )
+    result = await _call(
+        tools,
+        "edit",
+        {
+            "path": "m.py",
+            "edits": [
+                {"old_text": "alpha", "new_text": "ALPHA"},
+                {"old_text": "beta", "new_text": "BETA"},
+                {"old_text": "gamma", "new_text": "GAMMA"},
+            ],
+        },
+        context,
+    )
+    assert result.is_error is False
+    assert (tmp_path / "m.py").read_text() == "ALPHA\nmiddle\nBETA\nmiddle\nGAMMA\n"
+    assert "3 hunk(s)" in result.text
+
+
+@pytest.mark.asyncio
+async def test_edit_whitespace_tolerant_match_reindents(tools, context, tmp_path) -> None:
+    """old_text written at the wrong indentation still matches, and the
+    replacement is re-indented to the FILE's level — the edit written from a
+    structural summary or memory works instead of erroring."""
+    await _call(
+        tools,
+        "write",
+        {"path": "t.py", "content": "class A:\n    def foo(self):\n        return 1\n"},
+        context,
+    )
+    # The model wrote the body at 2 spaces while the file uses 8.
+    result = await _call(
+        tools,
+        "edit",
+        {
+            "path": "t.py",
+            "edits": [
+                {"old_text": "def foo(self):\n  return 1", "new_text": "def foo(self):\n  return 2"}
+            ],
+        },
+        context,
+    )
+    assert result.is_error is False
+    assert (tmp_path / "t.py").read_text() == ("class A:\n    def foo(self):\n        return 2\n")
+
+
+@pytest.mark.asyncio
+async def test_edit_anchor_line_disambiguates(tools, context, tmp_path) -> None:
+    await _call(tools, "write", {"path": "d.txt", "content": "foo\nfoo\nfoo\n"}, context)
+    result = await _call(
+        tools,
+        "edit",
+        {"path": "d.txt", "old_text": "foo", "new_text": "WON", "anchor_line": 3},
+        context,
+    )
+    assert result.is_error is False
+    assert (tmp_path / "d.txt").read_text() == "foo\nfoo\nWON\n"
+
+
+@pytest.mark.asyncio
+async def test_edit_rejects_both_forms_at_once(tools, context, tmp_path) -> None:
+    await _call(tools, "write", {"path": "x.txt", "content": "abc\n"}, context)
+    result = await _call(
+        tools,
+        "edit",
+        {
+            "path": "x.txt",
+            "old_text": "abc",
+            "new_text": "zzz",
+            "edits": [{"old_text": "abc", "new_text": "zzz"}],
+        },
+        context,
+    )
+    assert result.is_error is True
+    assert (tmp_path / "x.txt").read_text() == "abc\n"
+
+
+@pytest.mark.asyncio
+async def test_edit_tolerant_ambiguity_still_errors(tools, context, tmp_path) -> None:
+    """Tolerance widens matching, so its ambiguity discipline matters more:
+    two strip-equal candidates with no anchor and no replace_all refuse."""
+    await _call(tools, "write", {"path": "amb.txt", "content": "  foo\nbar\n  foo\n"}, context)
+    result = await _call(
+        tools,
+        "edit",
+        {"path": "amb.txt", "old_text": "foo", "new_text": "X"},
+        context,
+    )
+    # Exact match fails (file lines are indented); tolerant matches twice.
+    assert result.is_error is True
+    assert "2 places" in result.text
+
+
+# ---------------------------------------------------------------------------
+# read: Python structural summaries
+# ---------------------------------------------------------------------------
+
+
+def _summary_py() -> str:
+    body = "\n".join(f"    # filler {i}" for i in range(120))
+    return (
+        '"""Module doc."""\n'
+        "import os\n"
+        "from pathlib import Path\n"
+        "\n"
+        "def helper(one, two=2) -> int:\n"
+        '    """Helper doc."""\n'
+        f"{body}\n"
+        "    return one + two\n"
+        "\n"
+        "class Widget(Base):\n"
+        '    """Widget doc."""\n'
+        "\n"
+        "    def render(self) -> str:\n"
+        "        return 'w'\n"
+        "\n"
+        "    async def load(self):\n"
+        "        pass\n"
+    )
+
+
+@pytest.mark.asyncio
+async def test_read_python_structural_summary_default(tools, context, tmp_path) -> None:
+    (tmp_path / "big.py").write_text(_summary_py())
+    result = await _call(tools, "read", {"path": "big.py"}, context)
+    assert result.is_error is False
+    assert "structural summary" in result.text
+    assert "def helper(one, two=2) -> int" in result.text
+    assert "class Widget(Base):" in result.text
+    assert "async def load(self)" in result.text
+    assert '"Widget doc.' in result.text
+    assert "[imports: 2 (elided)]" in result.text
+    # Line ranges ride every symbol so the footer's range advice is actionable.
+    assert "L5-" in result.text
+    # Bodies are elided — the filler is the proof it is not the raw body.
+    assert "filler 50" not in result.text
+    assert "bodies elided" in result.text
+
+
+@pytest.mark.asyncio
+async def test_read_raw_and_range_bypass_summary(tools, context, tmp_path) -> None:
+    (tmp_path / "big.py").write_text(_summary_py())
+    raw = await _call(tools, "read", {"path": "big.py", "raw": True}, context)
+    assert "filler 50" in raw.text
+    ranged = await _call(tools, "read", {"path": "big.py", "range": "1-3"}, context)
+    assert "Module doc" in ranged.text
+    assert "def helper" not in ranged.text
+
+
+@pytest.mark.asyncio
+async def test_read_summary_falls_back_on_syntax_error(tools, context, tmp_path) -> None:
+    broken = "def broken(:\n" + "\n".join(f"# pad {i}" for i in range(100)) + "\n"
+    (tmp_path / "broken.py").write_text(broken)
+    result = await _call(tools, "read", {"path": "broken.py"}, context)
+    assert "structural summary" not in result.text
+    assert "def broken(:" in result.text
+
+
+@pytest.mark.asyncio
+async def test_read_short_python_file_stays_raw(tools, context, tmp_path) -> None:
+    (tmp_path / "small.py").write_text("def a():\n    return 1\n")
+    result = await _call(tools, "read", {"path": "small.py"}, context)
+    assert "structural summary" not in result.text
+    assert "def a():" in result.text
+
+
+# ---------------------------------------------------------------------------
+# grep/glob: context lines, skip, gitignore
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def python_engine(monkeypatch):
+    """Pin the pure-Python scan so filesystem assertions are deterministic
+    regardless of whether the host running the tests has ripgrep."""
+    monkeypatch.setenv("LOCAL_OPERATOR_GREP_ENGINE", "python")
+
+
+@pytest.mark.usefixtures("python_engine")
+@pytest.mark.asyncio
+async def test_grep_context_lines_render_groups(tools, context, tmp_path) -> None:
+    # Matches at lines 2 and 7 with -C1 leave a real gap (lines 4-5 unsent),
+    # which is what a `--` group separator is FOR; adjacent context blocks
+    # render contiguously by design, like sed output.
+    (tmp_path / "c.txt").write_text("one\ntwo MATCH\nthree\nfour\nfive\nsix\nseven MATCH\neight\n")
+    result = await _call(tools, "grep", {"pattern": "MATCH", "context_lines": 1}, context)
+    assert result.is_error is False
+    assert "c.txt:2:two MATCH" in result.text
+    assert "c.txt:1-one" in result.text  # context: dash separator
+    assert "c.txt:3-three" in result.text
+    assert "--" in result.text  # groups 1-3 and 6-8 are disjoint
+    assert "c.txt:7:seven MATCH" in result.text
+
+
+@pytest.mark.usefixtures("python_engine")
+@pytest.mark.asyncio
+async def test_grep_skip_paginates_matches(tools, context, tmp_path) -> None:
+    (tmp_path / "p.txt").write_text("".join(f"hit {i}\n" for i in range(10)))
+    page1 = await _call(tools, "grep", {"pattern": "hit"}, context)
+    assert "p.txt:1:hit 0" in page1.text
+    page2 = await _call(tools, "grep", {"pattern": "hit", "skip": 3}, context)
+    assert "p.txt:1:hit 0" not in page2.text
+    assert "p.txt:4:hit 3" in page2.text
+    assert "skipped 3" in page2.text
+
+
+@pytest.mark.usefixtures("python_engine")
+@pytest.mark.asyncio
+async def test_grep_respects_gitignore(tools, context, tmp_path) -> None:
+    (tmp_path / ".gitignore").write_text("gen/\n*.log\n")
+    (tmp_path / "src.txt").write_text("needle here\n")
+    (tmp_path / "gen" / "out.txt").parent.mkdir()
+    (tmp_path / "gen" / "out.txt").write_text("needle ignored\n")
+    (tmp_path / "app.log").write_text("needle ignored\n")
+    result = await _call(tools, "grep", {"pattern": "needle"}, context)
+    assert "src.txt:1" in result.text
+    assert "gen/out.txt" not in result.text
+    assert "app.log" not in result.text
+
+
+@pytest.mark.usefixtures("python_engine")
+@pytest.mark.asyncio
+async def test_grep_gitignore_negation_un_ignores(tools, context, tmp_path) -> None:
+    (tmp_path / ".gitignore").write_text("gen/\n!gen/keep.txt\n")
+    (tmp_path / "gen").mkdir()
+    (tmp_path / "gen" / "keep.txt").write_text("needle\n")
+    result = await _call(tools, "grep", {"pattern": "needle"}, context)
+    # git semantics: an ignored DIRECTORY cannot be re-included by a child
+    # negation — keep.txt stays out, matching git's own behaviour.
+    assert "keep.txt" not in result.text
+
+
+@pytest.mark.asyncio
+async def test_grep_ripgrep_engine_matches_python_contract(tools, context, tmp_path) -> None:
+    """With ripgrep present, the native engine must satisfy the same shape
+    contract as the Python one: rel paths without './', path:line:text, and
+    the 1MB-skip footer recovered from the walked list."""
+    import shutil
+
+    if shutil.which("rg") is None:
+        pytest.skip("ripgrep not installed")
+    (tmp_path / "small.py").write_text("needle\n")
+    big = tmp_path / "big.py"
+    big.write_text("needle\n" + "x" * (1024 * 1024 + 10))
+    result = await _call(tools, "grep", {"pattern": "needle"}, context)
+    assert "small.py:1:needle" in result.text
+    assert "./small.py" not in result.text
+    assert "1 file(s) skipped over the 1MB cap" in result.text
+
+
+@pytest.mark.asyncio
+async def test_glob_respects_gitignore_unless_pattern_names_it(tools, context, tmp_path) -> None:
+    (tmp_path / ".gitignore").write_text("dist/\n")
+    (tmp_path / "dist").mkdir()
+    (tmp_path / "dist" / "out.js").write_text("built")
+    (tmp_path / "src.js").write_text("src")
+    broad = await _call(tools, "glob", {"pattern": "**/*.js"}, context)
+    assert "src.js" in broad.text
+    assert "dist/out.js" not in broad.text
+    named = await _call(tools, "glob", {"pattern": "dist/*.js"}, context)
+    assert "dist/out.js" in named.text

--- a/tests/unit/tools/test_builtin_tools.py
+++ b/tests/unit/tools/test_builtin_tools.py
@@ -1426,3 +1426,45 @@ async def test_bash_real_abort_still_kills(tmp_path) -> None:
         await task
     await asyncio.sleep(0.1)
     assert manager.list() == []  # nothing was backgrounded
+
+
+@pytest.mark.asyncio
+async def test_cancel_backgrounded_bash_kills_process_group(tmp_path) -> None:
+    """Manager cancel immediately cancels the detached runner; cleanup must
+    still kill/reap the start-new-session process before it can create a marker."""
+    from local_operator.harness.jobs import AsyncJobManager
+
+    manager = AsyncJobManager()
+    context = ToolContext(cwd=str(tmp_path), session_id="bg-cancel", jobs=manager)
+    tools = {t.name: t for t in create_tools(context)}
+    task = asyncio.create_task(
+        _call(
+            tools,
+            "bash",
+            {"command": "sleep 1; touch should-not-exist"},
+            context,
+        )
+    )
+    await asyncio.sleep(0.15)
+    task.cancel()
+    result = await task
+    assert result.details is not None
+    job_id = result.details["job_id"]
+    assert await manager.cancel(job_id) is True
+    await asyncio.sleep(1.2)
+    assert not (tmp_path / "should-not-exist").exists()
+    job = manager.get(job_id)
+    assert job is not None and job.status == "cancelled"
+
+
+@pytest.mark.asyncio
+async def test_glob_respects_nested_gitignore(tools, context, tmp_path) -> None:
+    nested = tmp_path / "packages" / "a"
+    nested.mkdir(parents=True)
+    (nested / ".gitignore").write_text("generated/\n")
+    (nested / "generated").mkdir()
+    (nested / "generated" / "hidden.py").write_text("x")
+    (nested / "visible.py").write_text("x")
+    result = await _call(tools, "glob", {"pattern": "**/*.py"}, context)
+    assert "packages/a/visible.py" in result.text
+    assert "packages/a/generated/hidden.py" not in result.text

--- a/tests/unit/tools/test_builtin_tools.py
+++ b/tests/unit/tools/test_builtin_tools.py
@@ -1372,7 +1372,7 @@ async def test_bash_steering_cancellation_backgrounds_the_command(tmp_path) -> N
         _call(
             tools,
             "bash",
-            {"command": f"sleep 0.6 && echo finished-marker"},
+            {"command": "sleep 0.6 && echo finished-marker"},
             context,
         )
     )
@@ -1382,6 +1382,7 @@ async def test_bash_steering_cancellation_backgrounds_the_command(tmp_path) -> N
 
     assert result.is_error is False
     assert "continues in the background" in result.text
+    assert result.details is not None
     job_id = result.details["job_id"]
     job = manager.get(job_id)
     assert job is not None and job.type == "bash"
@@ -1407,15 +1408,17 @@ async def test_bash_real_abort_still_kills(tmp_path) -> None:
     context = ToolContext(cwd=str(tmp_path), session_id="bg2", jobs=manager)
     tools = {t.name: t for t in create_tools(context)}
     sig = AbortSignal()
-    task = asyncio.create_task(
-        tools["bash"].execute(
+
+    async def run_bash() -> ToolResult:
+        return await tools["bash"].execute(
             "c",
-            {"command": f"sleep 5 && echo should-not-run"},
+            {"command": "sleep 5 && echo should-not-run"},
             sig,
             None,
             context,
         )
-    )
+
+    task = asyncio.create_task(run_bash())
     await asyncio.sleep(0.2)
     sig.abort("interrupted")
     task.cancel()

--- a/tests/unit/tools/test_eval_tool.py
+++ b/tests/unit/tools/test_eval_tool.py
@@ -394,3 +394,46 @@ async def test_raw_stdout_protocol_overflow_retires_kernel_and_recovers(context)
     fresh = await _call(context, "1 + 1")
     assert fresh.is_error is False
     assert "result: 2" in fresh.text
+
+
+@pytest.mark.asyncio
+async def test_windows_spawn_assigns_kill_on_close_job_before_use(tmp_path, monkeypatch) -> None:
+    class Transport:
+        closed = False
+
+        def close(self) -> None:
+            self.closed = True
+
+    class Process:
+        pid = 4242
+        returncode = None
+        _transport = Transport()
+
+        async def wait(self) -> int:
+            return 0
+
+        def kill(self) -> None:
+            raise AssertionError("Job Object should own termination")
+
+    process = Process()
+    spawn_options: dict[str, Any] = {}
+    closed: list[int] = []
+
+    async def spawn(*_args: object, **kwargs: Any) -> Process:
+        spawn_options.update(kwargs)
+        return process
+
+    monkeypatch.setattr(eval_tool.sys, "platform", "win32")
+    monkeypatch.setattr(eval_tool.asyncio, "create_subprocess_exec", spawn)
+    monkeypatch.setattr(eval_tool, "_create_windows_kill_job", lambda pid: 77)
+    monkeypatch.setattr(eval_tool, "_close_windows_job", closed.append)
+
+    kernel = await eval_tool._spawn(str(tmp_path))
+    assert kernel.windows_job == 77
+    assert "start_new_session" not in spawn_options
+    assert "creationflags" in spawn_options
+
+    await eval_tool._close_kernel(kernel)
+    assert closed == [77]
+    assert kernel.windows_job is None
+    assert process._transport.closed is True

--- a/tests/unit/tools/test_eval_tool.py
+++ b/tests/unit/tools/test_eval_tool.py
@@ -14,7 +14,12 @@ from typing import Any
 import pytest
 import pytest_asyncio
 
-from local_operator.harness.types import AbortSignal, AgentToolUpdate, ToolContext, ToolResult
+from local_operator.harness.types import (
+    AbortSignal,
+    AgentToolUpdate,
+    ToolContext,
+    ToolResult,
+)
 from local_operator.tools import builtin
 from local_operator.tools import eval as eval_tool
 
@@ -78,7 +83,7 @@ async def test_imports_persist(context) -> None:
     await _call(context, "import json")
     result = await _call(context, "json.dumps({'a': 1})")
     assert result.is_error is False
-    assert 'result: \'{"a": 1}\'' in result.text
+    assert "result: '{\"a\": 1}'" in result.text
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tools/test_eval_tool.py
+++ b/tests/unit/tools/test_eval_tool.py
@@ -322,3 +322,35 @@ def test_tool_shape() -> None:
 def test_describe_approval_shows_code_first_line() -> None:
     sentence = eval_tool._describe_eval_approval({"code": "x = 1\ny = 2"}, "/ws")
     assert sentence.startswith("eval: ")
+
+
+def test_worker_caps_stdout_stderr_display_and_repr_before_json() -> None:
+    """Containment is worker-side: huge output never reaches the parent or
+    json.dumps unbounded, even before the eval tool's 8KiB spill layer."""
+    from local_operator.tools.eval_worker import (
+        DISPLAY_CHAR_LIMIT,
+        STREAM_CHAR_LIMIT,
+        _handle,
+    )
+
+    payload = _handle(
+        {},
+        {
+            "id": "cap",
+            "code": (
+                "print('x' * 10_000_000)\n"
+                "import sys\n"
+                "print('e' * 10_000_000, file=sys.stderr)\n"
+                "display('d' * 10_000_000)\n"
+                "'r' * 10_000_000"
+            ),
+        },
+    )
+    assert len(payload["stdout"]) <= STREAM_CHAR_LIMIT + 100
+    assert len(payload["stderr"]) <= STREAM_CHAR_LIMIT + 100
+    assert sum(len(item) for item in payload["display"]) <= DISPLAY_CHAR_LIMIT + 100
+    assert len(payload["result"]) < 10_000
+    assert "truncated" in payload["stdout"]
+    # reprlib truncates one huge value before it reaches the display-channel
+    # aggregate cap; either path is bounded without building a giant payload.
+    assert "..." in payload["display"][0]

--- a/tests/unit/tools/test_eval_tool.py
+++ b/tests/unit/tools/test_eval_tool.py
@@ -1,0 +1,319 @@
+"""End-to-end tests for the ``eval`` persistent-kernel tool.
+
+Each acceptance property of the tool is exercised against the REAL worker
+subprocess (spawned exactly as the tool spawns it): persistence across
+calls, trailing-expression results, output budget/spill, display() routing,
+clean syntax errors, honest state-loss on timeout/crash with fresh restart,
+and per-session kernel isolation.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+import pytest_asyncio
+
+from local_operator.harness.types import AbortSignal, AgentToolUpdate, ToolContext, ToolResult
+from local_operator.tools import builtin
+from local_operator.tools import eval as eval_tool
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _clean_kernel_registry():
+    """Isolate the module-level kernel registry, killing any workers a test
+    leaves behind — a leaked interpreter outlives the test that spawned it."""
+    eval_tool._KERNELS.clear()
+    yield
+    for kernel in list(eval_tool._KERNELS.values()):
+        await eval_tool._close_kernel(kernel)
+    eval_tool._KERNELS.clear()
+    for task in list(eval_tool._CLOSING):
+        task.cancel()
+
+
+@pytest.fixture
+def context(tmp_path) -> ToolContext:
+    return ToolContext(cwd=str(tmp_path), session_id="eval-unit")
+
+
+async def _call(
+    context: ToolContext,
+    code: str,
+    *,
+    timeout: float | None = None,
+    signal: AbortSignal | None = None,
+    on_update: Any = None,
+) -> ToolResult:
+    """Invoke the tool the way the loop does (fresh builder per call is fine;
+    the kernel state lives in the module registry, not the tool object)."""
+    tool = eval_tool.build_eval_tool()
+    args: dict[str, Any] = {"code": code}
+    if timeout is not None:
+        args["timeout"] = timeout
+    return await tool.execute("call-1", args, signal, on_update, context)  # type: ignore[operator]
+
+
+def _updates_to_list() -> tuple[list[AgentToolUpdate], Any]:
+    captured: list[AgentToolUpdate] = []
+    return captured, (lambda update: captured.append(update))
+
+
+# ---------------------------------------------------------------------------
+# persistence + result contract
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_state_persists_across_calls(context) -> None:
+    first = await _call(context, "x = 41")
+    assert first.is_error is False
+    second = await _call(context, "x + 1")
+    assert second.is_error is False
+    assert "result: 42" in second.text
+
+
+@pytest.mark.asyncio
+async def test_imports_persist(context) -> None:
+    await _call(context, "import json")
+    result = await _call(context, "json.dumps({'a': 1})")
+    assert result.is_error is False
+    assert 'result: \'{"a": 1}\'' in result.text
+
+
+@pytest.mark.asyncio
+async def test_trailing_expression_result_and_stdout(context) -> None:
+    result = await _call(context, "print('hello')\n2 ** 10")
+    assert result.is_error is False
+    assert "result: 1024" in result.text
+    assert "hello" in result.text
+    assert "--- stdout ---" in result.text
+
+
+@pytest.mark.asyncio
+async def test_statement_only_call_has_no_result_line(context) -> None:
+    result = await _call(context, "y = 5")
+    assert result.is_error is False
+    assert "result:" not in result.text
+
+
+@pytest.mark.asyncio
+async def test_worker_runs_in_session_cwd(context, tmp_path) -> None:
+    result = await _call(context, "open('probe.txt', 'w').write('hi')\n'written'")
+    assert result.is_error is False
+    assert (tmp_path / "probe.txt").read_text() == "hi"
+
+
+@pytest.mark.asyncio
+async def test_namespace_docstring_explains_persistence(context) -> None:
+    result = await _call(context, "__doc__")
+    assert result.is_error is False
+    assert "SURVIVES" in result.text
+
+
+# ---------------------------------------------------------------------------
+# display routing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_display_lands_in_details_and_updates_not_model_text(context) -> None:
+    captured, on_update = _updates_to_list()
+    result = await _call(
+        context,
+        "display('for the user')\nprint('printed')\n'for the model'",
+        on_update=on_update,
+    )
+    assert result.is_error is False
+    # Model-visible text: the result and stdout, never display().
+    assert "for the model" in result.text
+    assert "printed" in result.text
+    assert "for the user" not in result.text
+    # details carries it for renderers/transcripts (never sent to providers).
+    assert result.details is not None
+    assert "for the user" in result.details["display"][0]
+    # update stream shows the human what display() produced.
+    assert captured, "display output should be streamed via on_update"
+    assert "for the user" in captured[-1].content[0].text  # type: ignore[union-attr]
+
+
+@pytest.mark.asyncio
+async def test_display_is_per_call_not_sticky(context) -> None:
+    await _call(context, "display('first call')")
+    result = await _call(context, "'second call'")
+    assert "first call" not in result.text
+    assert result.details is None or "display" not in result.details
+
+
+# ---------------------------------------------------------------------------
+# errors
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_syntax_error_is_clean_error_result(context) -> None:
+    result = await _call(context, "def broken(:")
+    assert result.is_error is True
+    assert "SyntaxError" in result.text
+    # Clean: a compile failure has no frames worth showing.
+    assert "Traceback" not in result.text
+
+
+@pytest.mark.asyncio
+async def test_runtime_error_reports_traceback_and_kernel_survives(context) -> None:
+    await _call(context, "keeper = 'kept'")
+    result = await _call(context, "raise ValueError('boom')")
+    assert result.is_error is True
+    assert "ValueError: boom" in result.text
+    assert "Traceback" in result.text
+    after = await _call(context, "keeper")
+    assert after.is_error is False
+    assert "result: 'kept'" in after.text
+
+
+@pytest.mark.asyncio
+async def test_invalid_arguments_and_empty_code(context) -> None:
+    tool = eval_tool.build_eval_tool()
+    invalid = await tool.execute("call-1", {}, None, None, context)  # type: ignore[operator]
+    assert invalid.is_error is True
+    assert "invalid arguments" in invalid.text
+    empty = await _call(context, "   ")
+    assert empty.is_error is True
+    assert "non-empty" in empty.text
+
+
+# ---------------------------------------------------------------------------
+# timeout / abort / crash: state honestly lost, fresh kernel next call
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_timeout_reports_lost_state_and_next_call_is_fresh(context) -> None:
+    await _call(context, "x = 1")
+    timed_out = await _call(context, "while True:\n    pass", timeout=0.5)
+    assert timed_out.is_error is True
+    assert "TIMEOUT" in timed_out.text
+    assert "state" in timed_out.text
+    assert "fresh" in timed_out.text
+    # The next call runs on a NEW kernel: it succeeds, and the old namespace
+    # is genuinely gone.
+    recovered = await _call(context, "1 + 1")
+    assert recovered.is_error is False
+    assert "result: 2" in recovered.text
+    gone = await _call(context, "x")
+    assert gone.is_error is True
+    assert "NameError" in gone.text
+
+
+@pytest.mark.asyncio
+async def test_worker_crash_reports_stderr_tail_and_restarts(context) -> None:
+    await _call(context, "x = 1")
+    crashed = await _call(context, "import os\nos._exit(3)")
+    assert crashed.is_error is True
+    assert "crashed" in crashed.text
+    after = await _call(context, "2 * 21")
+    assert after.is_error is False
+    assert "result: 42" in after.text
+    # The pre-crash namespace died with the process.
+    gone = await _call(context, "x")
+    assert gone.is_error is True
+    assert "NameError" in gone.text
+
+
+@pytest.mark.asyncio
+async def test_preaborted_signal_never_spawns(context) -> None:
+    signal = AbortSignal()
+    signal.abort("user steering")
+    result = await _call(context, "1", signal=signal)
+    assert result.is_error is True
+    assert "aborted" in result.text
+    assert eval_tool._KERNELS == {}
+
+
+# ---------------------------------------------------------------------------
+# session isolation + lifecycle caps
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_two_sessions_get_independent_kernels(tmp_path) -> None:
+    session_a = ToolContext(cwd=str(tmp_path), session_id="session-a")
+    session_b = ToolContext(cwd=str(tmp_path), session_id="session-b")
+    await _call(session_a, "shared = 'A'")
+    # B has its own kernel: A's variable is not there.
+    missing = await _call(session_b, "shared")
+    assert missing.is_error is True
+    assert "NameError" in missing.text
+    await _call(session_b, "shared = 'B'")
+    kept_a = await _call(session_a, "shared")
+    assert kept_a.is_error is False
+    assert "result: 'A'" in kept_a.text
+    assert len(eval_tool._KERNELS) == 2
+
+
+@pytest.mark.asyncio
+async def test_kernel_lru_cap_evicts_oldest_session(tmp_path) -> None:
+    contexts = [ToolContext(cwd=str(tmp_path), session_id=f"cap-{i}") for i in range(5)]
+    for index, ctx in enumerate(contexts):
+        await _call(ctx, f"n = {index}")
+    assert len(eval_tool._KERNELS) == eval_tool.MAX_KERNELS
+    assert "cap-0" not in eval_tool._KERNELS
+    assert "cap-4" in eval_tool._KERNELS
+
+
+@pytest.mark.asyncio
+async def test_idle_kernel_is_reaped_on_access(context) -> None:
+    await _call(context, "a = 1")
+    key = next(iter(eval_tool._KERNELS))
+    stale_pid = eval_tool._KERNELS[key].process.pid
+    # Simulate the 5-minute idle window without waiting for it.
+    eval_tool._KERNELS[key].last_used -= eval_tool.KERNEL_IDLE_SECONDS + 1
+    result = await _call(context, "a = 2")
+    assert result.is_error is False
+    fresh = eval_tool._KERNELS[key]
+    assert fresh.process.pid != stale_pid
+    # The reaped kernel's state is gone too — a NEW process answered.
+    assert "result:" not in result.text
+
+
+# ---------------------------------------------------------------------------
+# output budget
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stdout_budget_capped_with_recovery_route(context) -> None:
+    result = await _call(context, "print('x' * 20_000)\n'the answer'")
+    assert result.is_error is False
+    # Model-visible text stays inside the 8 KiB budget (plus the bounded
+    # footer a spill/truncation adds)…
+    assert len(result.text) <= builtin.TOOL_OUTPUT_LIMIT_CHARS + 700
+    # …truncation is ANNOUNCED, not silent…
+    assert "truncated" in result.text or "SAVED at spill://" in result.text
+    # …and the head (result line) survives the clip.
+    assert "result: 'the answer'" in result.text
+
+
+# ---------------------------------------------------------------------------
+# shape
+# ---------------------------------------------------------------------------
+
+
+def test_tool_shape() -> None:
+    tool = eval_tool.build_eval_tool()
+    assert tool.name == "eval"
+    assert tool.label == "Python"
+    assert tool.approval_tier == "exec"
+    assert tool.concurrency == "exclusive"
+    assert tool.interruptible is True
+    properties = tool.parameters["properties"]
+    assert "code" in properties
+    # The `i` intent field is the registry's injection, not ours.
+    assert "i" not in properties
+    assert "timeout" in properties
+    assert tool.parameters["properties"]["timeout"]["maximum"] == eval_tool.EVAL_MAX_TIMEOUT_SECONDS
+
+
+def test_describe_approval_shows_code_first_line() -> None:
+    sentence = eval_tool._describe_eval_approval({"code": "x = 1\ny = 2"}, "/ws")
+    assert sentence.startswith("eval: ")

--- a/tests/unit/tools/test_eval_tool.py
+++ b/tests/unit/tools/test_eval_tool.py
@@ -9,6 +9,7 @@ and per-session kernel isolation.
 
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 
 import pytest
@@ -354,3 +355,42 @@ def test_worker_caps_stdout_stderr_display_and_repr_before_json() -> None:
     # reprlib truncates one huge value before it reaches the display-channel
     # aggregate cap; either path is bounded without building a giant payload.
     assert "..." in payload["display"][0]
+
+
+@pytest.mark.asyncio
+async def test_timeout_kills_eval_descendant_process_group(context, tmp_path) -> None:
+    marker = tmp_path / "descendant-leaked.txt"
+    child = (
+        "import time; from pathlib import Path; "
+        f"time.sleep(1); Path({str(marker)!r}).write_text('leaked')"
+    )
+    code = (
+        "import subprocess, sys, time\n"
+        f"subprocess.Popen([sys.executable, '-c', {child!r}])\n"
+        "time.sleep(60)"
+    )
+    result = await _call(context, code, timeout=0.2)
+    assert result.is_error is True
+    assert "TIMEOUT" in result.text
+    if eval_tool._CLOSING:
+        await asyncio.gather(*list(eval_tool._CLOSING))
+    await asyncio.sleep(1.1)
+    assert not marker.exists()
+
+
+@pytest.mark.asyncio
+async def test_raw_stdout_protocol_overflow_retires_kernel_and_recovers(context) -> None:
+    result = await _call(
+        context,
+        "import os\nos.write(1, b'x' * 100_000 + b'\\n')\n42",
+        timeout=5,
+    )
+    assert result.is_error is True
+    assert "protocol" in result.text.lower()
+    assert not eval_tool._KERNELS
+    if eval_tool._CLOSING:
+        await asyncio.gather(*list(eval_tool._CLOSING))
+
+    fresh = await _call(context, "1 + 1")
+    assert fresh.is_error is False
+    assert "result: 2" in fresh.text

--- a/tests/unit/tools/test_lsp_tool.py
+++ b/tests/unit/tools/test_lsp_tool.py
@@ -319,3 +319,47 @@ def test_jedi_internal_failure_becomes_an_error_result(tool, tree, monkeypatch) 
     assert result.is_error
     assert "failed unexpectedly" in result.text
     assert "jedi exploded" in result.text
+
+
+@pytest.mark.asyncio
+async def test_outside_initial_path_requires_approval(tool, tree, tmp_path) -> None:
+    outside = tmp_path.parent / "outside-lsp.py"
+    outside.write_text("def secret():\n    return 1\n")
+    requests: list[str] = []
+
+    async def deny(tool_name: str, description: str) -> bool:
+        requests.append(description)
+        return False
+
+    context = ToolContext(cwd=str(tree), request_approval=deny)
+    result = await tool.execute(
+        "c", {"action": "symbols", "path": str(outside)}, None, None, context
+    )
+    assert result.is_error is True
+    assert "declined" in result.text.lower()
+    assert requests and str(outside) in requests[0]
+
+
+@pytest.mark.asyncio
+async def test_outside_initial_path_works_only_after_approval(tool, tree, tmp_path) -> None:
+    outside = tmp_path.parent / "approved-lsp.py"
+    outside.write_text("def allowed():\n    return 1\n")
+
+    async def approve(*_args: Any) -> bool:
+        return True
+
+    context = ToolContext(cwd=str(tree), request_approval=approve)
+    result = await tool.execute(
+        "c", {"action": "symbols", "path": str(outside)}, None, None, context
+    )
+    assert result.is_error is False
+    assert "allowed" in result.text
+
+
+def test_result_path_filter_allows_initial_or_cwd_only(tree, tmp_path) -> None:
+    from local_operator.tools.lsp import _allowed_source
+
+    initial = tree / "pkg" / "main.py"
+    assert _allowed_source(initial, tree, initial) is True
+    assert _allowed_source(tree / "pkg" / "lib.py", tree, initial) is True
+    assert _allowed_source(tmp_path.parent / "secret.py", tree, initial) is False

--- a/tests/unit/tools/test_lsp_tool.py
+++ b/tests/unit/tools/test_lsp_tool.py
@@ -1,0 +1,321 @@
+"""Tests for the jedi-backed LSP tool.
+
+Skipped wholesale when jedi (the ``lsp`` extra) is absent: the tool is not
+advertised on such a host, so there is nothing to exercise. Everything here
+runs against a real fixture tree analysed by real jedi — mocking jedi would
+test our assumptions, not the integration.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from local_operator.harness.types import ToolContext
+from local_operator.tools import lsp
+
+pytestmark = pytest.mark.skipif(lsp.jedi is None, reason="jedi extra not installed")
+
+LIB_SOURCE = (
+    "def process(items):\n"
+    '    """Process items."""\n'
+    "    return [i for i in items if i]\n"
+    "\n"
+    "\n"
+    "class Handler:\n"
+    "    def __init__(self, name):\n"
+    "        self.name = name\n"
+    "\n"
+    "    def handle(self, item):\n"
+    "        return process([item])\n"
+)
+
+MAIN_SOURCE = (
+    "from pkg.lib import process, Handler\n"
+    "\n"
+    "\n"
+    "def main():\n"
+    '    h = Handler("x")\n'
+    "    return process([1, 2]) + h.handle(3)\n"
+)
+
+
+@pytest.fixture()
+def tree(tmp_path):
+    """A two-module package: main.py imports and calls lib.py symbols."""
+    pkg = tmp_path / "pkg"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text("")
+    (pkg / "lib.py").write_text(LIB_SOURCE)
+    (pkg / "main.py").write_text(MAIN_SOURCE)
+    return tmp_path
+
+
+@pytest.fixture()
+def tool() -> Any:
+    built = lsp.build_lsp_tool()
+    assert built is not None, "jedi is installed, so the builder must advertise the tool"
+    return built
+
+
+def _ctx(tree) -> ToolContext:
+    return ToolContext(cwd=str(tree))
+
+
+def _run(tool, tree, args: dict[str, Any]) -> Any:
+    return asyncio.run(tool.execute("call-1", args, context=_ctx(tree)))
+
+
+# --- builder -----------------------------------------------------------------
+
+
+def test_builder_shape(tool) -> None:
+    assert tool.name == "lsp"
+    assert tool.label == "LSP"
+    assert tool.approval_tier == "read"
+    assert tool.concurrency == "shared"
+    assert tool.interruptible is False
+    actions = tool.parameters["properties"]["action"]["enum"]
+    assert set(actions) == {"definitions", "references", "symbols", "rename_preview"}
+
+
+def test_builder_hides_tool_without_jedi(monkeypatch) -> None:
+    monkeypatch.setattr(lsp, "jedi", None)
+    assert lsp.build_lsp_tool() is None
+
+
+# --- definitions -------------------------------------------------------------
+
+
+def test_definitions_jump_across_modules_by_name(tool, tree) -> None:
+    """The headline capability: from an IMPORTED usage, resolve the definition
+    in the other module — the thing grep cannot do without lying about
+    shadowing."""
+    result = _run(tool, tree, {"action": "definitions", "path": "pkg/main.py", "name": "process"})
+    assert not result.is_error, result.text
+    assert "pkg/lib.py:1" in result.text
+    assert "def process(items):" in result.text
+
+
+def test_definitions_from_a_bare_line_scan_the_identifiers(tool, tree) -> None:
+    """line=6 names a call site; column is unknown. Column 0 lands on
+    ``return`` (a dead end — measured), so the identifier scan must rescue
+    the call."""
+    result = _run(tool, tree, {"action": "definitions", "path": "pkg/main.py", "line": 6})
+    assert not result.is_error, result.text
+    assert "pkg/lib.py:1" in result.text
+    assert "def process(items):" in result.text
+
+
+def test_definitions_honour_an_explicit_column(tool, tree) -> None:
+    """Column 11 on line 6 is exactly the ``process`` usage; no scanning."""
+    result = _run(
+        tool,
+        tree,
+        {"action": "definitions", "path": "pkg/main.py", "line": 6, "column": 11},
+    )
+    assert not result.is_error, result.text
+    assert "pkg/lib.py:1" in result.text
+
+
+# --- references --------------------------------------------------------------
+
+
+def test_references_find_call_sites_the_model_would_grep_for(tool, tree) -> None:
+    result = _run(tool, tree, {"action": "references", "path": "pkg/lib.py", "name": "process"})
+    assert not result.is_error, result.text
+    # The definition, the same-module call, the import and the cross-module
+    # call — all four rows carry file:line:text.
+    assert "pkg/lib.py:1: def process(items):" in result.text
+    assert "pkg/main.py:1: from pkg.lib import process, Handler" in result.text
+    assert "pkg/main.py:6:     return process([1, 2]) + h.handle(3)" in result.text
+
+
+def test_references_from_a_usage_line(tool, tree) -> None:
+    result = _run(tool, tree, {"action": "references", "path": "pkg/main.py", "line": 6})
+    assert not result.is_error, result.text
+    assert "pkg/lib.py:1" in result.text
+    assert "pkg/main.py:6" in result.text
+
+
+def test_references_cap_display_and_spill_the_rest(tool, tree) -> None:
+    """260 call sites: 200 ride the prompt, the rest sit behind a spill handle
+    — the same two-cap contract as grep."""
+    big = tree / "pkg" / "big.py"
+    big.write_text("def tick():\n    return 1\n")
+    calls = ["from pkg.big import tick", "", "", "def run():"]
+    calls += [f"    assert tick() == {i}" for i in range(260)]
+    (tree / "pkg" / "calls.py").write_text("\n".join(calls) + "\n")
+    result = _run(tool, tree, {"action": "references", "path": "pkg/big.py", "name": "tick"})
+    assert "262 reference(s)" in result.text
+    # Both caps bite: the item cap holds the display at <=200 rows and the
+    # char budget elides within those, while the spill keeps all 262.
+    assert result.text.count("pkg/calls.py:") <= lsp.LSP_REFERENCE_LIMIT
+    assert result.details and "spill" in result.details
+
+
+# --- symbols -----------------------------------------------------------------
+
+
+def test_symbols_outline_lists_definitions_with_line_ranges(tool, tree) -> None:
+    result = _run(tool, tree, {"action": "symbols", "path": "pkg/lib.py"})
+    assert not result.is_error, result.text
+    assert "L1-3 function process" in result.text
+    assert "L6-11 class Handler" in result.text
+    # Methods nest under their class.
+    assert "  L10-11 function handle" in result.text
+    # Params and locals are not navigational symbols.
+    assert "items" not in result.text
+    assert "self" not in result.text
+
+
+def test_symbols_exclude_imports_and_keep_module_definitions(tool, tree) -> None:
+    """main.py imports process/Handler; an outline that listed them as local
+    definitions would misdirect the very navigation it serves."""
+    result = _run(tool, tree, {"action": "symbols", "path": "pkg/main.py"})
+    assert not result.is_error, result.text
+    assert "function main" in result.text
+    assert "process" not in result.text
+    assert "Handler" not in result.text
+
+
+# --- rename_preview ----------------------------------------------------------
+
+
+def test_rename_preview_diffs_both_files_and_writes_neither(tool, tree) -> None:
+    before_lib = (tree / "pkg" / "lib.py").read_text()
+    before_main = (tree / "pkg" / "main.py").read_text()
+    result = _run(
+        tool,
+        tree,
+        {
+            "action": "rename_preview",
+            "path": "pkg/lib.py",
+            "name": "process",
+            "new_name": "process_all",
+        },
+    )
+    assert not result.is_error, result.text
+    assert "--- pkg/lib.py" in result.text
+    assert "+++ pkg/lib.py" in result.text
+    assert "--- pkg/main.py" in result.text
+    assert "+++ pkg/main.py" in result.text
+    assert "+def process_all(items):" in result.text
+    assert "+        return process_all([item])" in result.text
+    assert "+from pkg.lib import process_all, Handler" in result.text
+    assert "preview only, nothing written" in result.text
+    # READ-ONLY is the contract that keeps this tool in the read tier.
+    assert (tree / "pkg" / "lib.py").read_text() == before_lib
+    assert (tree / "pkg" / "main.py").read_text() == before_main
+
+
+def test_rename_preview_from_a_usage_line(tool, tree) -> None:
+    """line=6 is a CALL site in the importing module; the rename must still
+    resolve the definition in lib.py and propose edits in both files."""
+    result = _run(
+        tool,
+        tree,
+        {
+            "action": "rename_preview",
+            "path": "pkg/main.py",
+            "line": 6,
+            "new_name": "process_v2",
+        },
+    )
+    assert not result.is_error, result.text
+    assert "pkg/main.py" in result.text
+    assert "pkg/lib.py" in result.text
+    assert "+def process_v2(items):" in result.text
+
+
+def test_rename_preview_requires_new_name(tool, tree) -> None:
+    result = _run(tool, tree, {"action": "rename_preview", "path": "pkg/lib.py", "name": "process"})
+    assert result.is_error
+    assert "new_name" in result.text
+
+
+def test_rename_preview_rejects_a_non_identifier_new_name(tool, tree) -> None:
+    result = _run(
+        tool,
+        tree,
+        {
+            "action": "rename_preview",
+            "path": "pkg/lib.py",
+            "name": "process",
+            "new_name": "not an identifier",
+        },
+    )
+    assert result.is_error
+    assert "identifier" in result.text
+
+
+# --- errors ------------------------------------------------------------------
+
+
+def test_unknown_symbol_names_candidates(tool, tree) -> None:
+    result = _run(tool, tree, {"action": "definitions", "path": "pkg/lib.py", "name": "proces"})
+    assert result.is_error
+    assert "proces" in result.text
+    assert "available symbols:" in result.text
+    assert "process" in result.text
+    assert "Handler" in result.text
+
+
+def test_no_symbol_on_a_blank_line_suggests_the_recovery_routes(tool, tree) -> None:
+    result = _run(tool, tree, {"action": "definitions", "path": "pkg/main.py", "line": 2})
+    assert result.is_error
+    assert "no symbol found at pkg/main.py:2" in result.text
+    assert "name=" in result.text
+    assert "action=symbols" in result.text
+
+
+def test_missing_path_is_a_clean_error(tool, tree) -> None:
+    result = _run(tool, tree, {"action": "symbols", "path": "pkg/nope.py"})
+    assert result.is_error
+    assert "does not exist" in result.text
+
+
+def test_line_or_name_is_required_for_positional_actions(tool, tree) -> None:
+    result = _run(tool, tree, {"action": "definitions", "path": "pkg/lib.py"})
+    assert result.is_error
+    assert "requires line or name" in result.text
+
+
+def test_line_is_one_based(tool, tree) -> None:
+    result = _run(tool, tree, {"action": "definitions", "path": "pkg/lib.py", "line": 0})
+    assert result.is_error
+    assert "1-based" in result.text
+
+
+def test_invalid_action_is_a_validation_error(tool, tree) -> None:
+    result = _run(tool, tree, {"action": "hover", "path": "pkg/lib.py"})
+    assert result.is_error
+    assert "invalid arguments" in result.text
+
+
+def test_jedi_internal_failure_becomes_an_error_result(tool, tree, monkeypatch) -> None:
+    """The loop never sees an exception from a tool — the _guard contract."""
+
+    class ExplodingScript:
+        def __init__(self, *, path=None):
+            self.path = path
+
+        def get_names(self, **_kwargs):
+            raise RuntimeError("jedi exploded")
+
+        def goto(self, *_args, **_kwargs):
+            raise RuntimeError("jedi exploded")
+
+        def get_references(self, *_args, **_kwargs):
+            raise RuntimeError("jedi exploded")
+
+        def rename(self, *_args, **_kwargs):
+            raise RuntimeError("jedi exploded")
+
+    monkeypatch.setattr(lsp.jedi, "Script", ExplodingScript)
+    result = _run(tool, tree, {"action": "symbols", "path": "pkg/lib.py"})
+    assert result.is_error
+    assert "failed unexpectedly" in result.text
+    assert "jedi exploded" in result.text

--- a/tests/unit/tools/test_task_wait_jobs.py
+++ b/tests/unit/tools/test_task_wait_jobs.py
@@ -275,6 +275,7 @@ async def test_task_batch_launches_concurrent_children_with_shared_context(tmp_p
     assert launched[1][2] == "scout"
     assert launched[2][3] == "hi"
     assert "3 subagent(s)" in result.text
+    assert result.details is not None
     assert result.details["jobs"][0]["job_id"] == "job-1"
 
 

--- a/tests/unit/tools/test_task_wait_jobs.py
+++ b/tests/unit/tools/test_task_wait_jobs.py
@@ -43,9 +43,10 @@ def _engine_context(tmp_path, manager: AsyncJobManager) -> ToolContext:
     """A context carrying the job manager AND a launcher so both task and
     wait/jobs build. The launcher mimics ``Session._launch_subagent`` by
     registering a ``task``-type job on the same manager."""
-    launcher = lambda label, prompt: manager.register(  # noqa: E731
-        "task", label, _quick_runner, owner_id=None
-    )
+
+    def launcher(label, prompt, *, agent="task", effort=None):
+        return manager.register("task", label, _quick_runner, owner_id=None)
+
     return ToolContext(cwd=str(tmp_path), session_id="s", subagent_launcher=launcher, jobs=manager)
 
 
@@ -228,3 +229,110 @@ def test_wait_jobs_not_advertised_without_job_manager(tmp_path):
     assert "jobs" not in names
     assert builtin.build_wait_tool(context) is None
     assert builtin.build_jobs_tool(context) is None
+
+
+# ---------------------------------------------------------------------------
+# task: batch form, shared context, agent/effort tiers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_task_batch_launches_concurrent_children_with_shared_context(tmp_path):
+    """One call, three jobs: the batch form is the fan-out economics — N
+    independent slices cost N round trips when launched one per call and one
+    when launched together. The shared context is prepended to every prompt
+    verbatim so the delegator's contract cannot drift between children."""
+    launched: list[tuple[str, str, str, str | None]] = []
+
+    def launcher(label, prompt, *, agent="task", effort=None):
+        launched.append((label, prompt, agent, effort))
+        return f"job-{len(launched)}"
+
+    context = ToolContext(
+        cwd=str(tmp_path), session_id="s", subagent_launcher=launcher, jobs=AsyncJobManager()
+    )
+    tools = _tools(context)
+    result = await _call(
+        tools,
+        "task",
+        {
+            "context": "Goal: ship the release. Constraint: no breaking API changes.",
+            "tasks": [
+                {"label": "Docs", "prompt": "Update the changelog."},
+                {"label": "Scan", "prompt": "Audit imports.", "agent": "scout"},
+                {"label": "Build", "prompt": "Run the release build.", "effort": "hi"},
+            ],
+        },
+        context,
+    )
+    assert result.is_error is False
+    assert len(launched) == 3
+    labels = [entry[0] for entry in launched]
+    assert labels == ["Docs", "Scan", "Build"]
+    for _label, prompt, _agent, _effort in launched:
+        assert prompt.startswith("Goal: ship the release.")
+        assert "Your task (" in prompt
+    assert launched[1][2] == "scout"
+    assert launched[2][3] == "hi"
+    assert "3 subagent(s)" in result.text
+    assert result.details["jobs"][0]["job_id"] == "job-1"
+
+
+@pytest.mark.asyncio
+async def test_task_single_form_still_works_and_forwards_defaults(tmp_path):
+    launched: list[tuple[str, str, str, str | None]] = []
+
+    def launcher(label, prompt, *, agent="task", effort=None):
+        launched.append((label, prompt, agent, effort))
+        return "job-1"
+
+    context = ToolContext(
+        cwd=str(tmp_path), session_id="s", subagent_launcher=launcher, jobs=AsyncJobManager()
+    )
+    tools = _tools(context)
+    result = await _call(tools, "task", {"label": "Solo", "prompt": "one thing"}, context)
+    assert result.is_error is False
+    assert launched == [("Solo", "one thing", "task", None)]
+
+
+@pytest.mark.asyncio
+async def test_task_rejects_mixed_and_half_forms(tmp_path):
+    context = _engine_context(tmp_path, AsyncJobManager())
+    tools = _tools(context)
+    both = await _call(
+        tools,
+        "task",
+        {"label": "x", "prompt": "y", "tasks": [{"label": "z", "prompt": "w"}]},
+        context,
+    )
+    assert both.is_error is True
+    assert both.text.startswith("invalid arguments:")
+    half = await _call(tools, "task", {"label": "x"}, context)
+    assert half.is_error is True
+    empty = await _call(tools, "task", {}, context)
+    assert empty.is_error is True
+
+
+@pytest.mark.asyncio
+async def test_task_partial_batch_failure_reports_survivors(tmp_path):
+    calls = {"n": 0}
+
+    def launcher(label, prompt, *, agent="task", effort=None):
+        calls["n"] += 1
+        if calls["n"] == 2:
+            raise RuntimeError("engine hiccup")
+        return f"job-{calls['n']}"
+
+    context = ToolContext(
+        cwd=str(tmp_path), session_id="s", subagent_launcher=launcher, jobs=AsyncJobManager()
+    )
+    tools = _tools(context)
+    result = await _call(
+        tools,
+        "task",
+        {"tasks": [{"label": "a", "prompt": "p"}, {"label": "b", "prompt": "p"}]},
+        context,
+    )
+    assert result.is_error is False  # 1 of 2 launched: not a total failure
+    assert "1 subagent(s)" in result.text
+    assert "failed to launch: b" in result.text

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -44,6 +44,9 @@ from tests.unit.tui.conftest import caret_cells, chevron_colour, composer_cells
 class FakeSession:
     """Records prompts/aborts; satisfies SessionProtocol."""
 
+    def context_breakdown(self) -> dict[str, int]:
+        return getattr(self, "_context_breakdown", {})
+
     def __init__(self) -> None:
         self.prompts: list[str] = []
         self.aborts: list[str] = []
@@ -3848,17 +3851,21 @@ async def test_context_command_renders_wire_schema_breakdown() -> None:
     """`/context` is the visible answer to MCP/tool-schema context cost: all
     wire categories, total/window percent, and cache-read row when present."""
     session = FakeSession()
-    session.context_breakdown = lambda: {
-        "instructions": 1200,
-        "tool_inventory": 400,
-        "tool_schemas": 6600,
-        "environment": 50,
-        "knowledge_mcp_goal": 900,
-        "messages": 10950,
-        "total": 20100,
-        "context_window": 200000,
-        "cache_read": 12800,
-    }
+    setattr(
+        session,
+        "_context_breakdown",
+        {
+            "instructions": 1200,
+            "tool_inventory": 400,
+            "tool_schemas": 6600,
+            "environment": 50,
+            "knowledge_mcp_goal": 900,
+            "messages": 10950,
+            "total": 20100,
+            "context_window": 200000,
+            "cache_read": 12800,
+        },
+    )
     app = OperatorApp(lambda: _factory(session))
     async with app.run_test(size=(100, 24)) as pilot:
         await pilot.pause()

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -3872,8 +3872,8 @@ async def test_context_command_renders_wire_schema_breakdown() -> None:
         block = app._context_block()
         assert block is not None
         listing = _renderable_plain(block.renderable)
-        assert "Context" in listing
-        assert "Tool schemas" in listing and "6.6k" in listing
-        assert "Messages" in listing and "10.9k" in listing
-        assert "Total" in listing and "10.1%" in listing
-        assert "Last cache read" in listing and "12.8k" in listing
+        assert "Estimated next request" in listing
+        assert "Tool schemas" in listing and "~6.6k" in listing
+        assert "Messages" in listing and "~10.9k" in listing
+        assert "Total" in listing and "~20.1k / 200k (10.1%)" in listing
+        assert "Last cache read (exact)" in listing and "12.8k" in listing

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -3841,3 +3841,32 @@ async def test_unmount_restores_the_terminals_own_title(
     push_index = writes.index("\x1b[22;0t")
     pop_index = writes.index("\x1b[23;0t")
     assert push_index < pop_index
+
+
+@pytest.mark.asyncio
+async def test_context_command_renders_wire_schema_breakdown() -> None:
+    """`/context` is the visible answer to MCP/tool-schema context cost: all
+    wire categories, total/window percent, and cache-read row when present."""
+    session = FakeSession()
+    session.context_breakdown = lambda: {
+        "instructions": 1200,
+        "tool_inventory": 400,
+        "tool_schemas": 6600,
+        "environment": 50,
+        "knowledge_mcp_goal": 900,
+        "messages": 10950,
+        "total": 20100,
+        "context_window": 200000,
+        "cache_read": 12800,
+    }
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await pilot.pause()
+        block = app._context_block()
+        assert block is not None
+        listing = _renderable_plain(block.renderable)
+        assert "Context" in listing
+        assert "Tool schemas" in listing and "6.6k" in listing
+        assert "Messages" in listing and "10.9k" in listing
+        assert "Total" in listing and "10.1%" in listing
+        assert "Last cache read" in listing and "12.8k" in listing

--- a/tests/unit/tui/test_command_picker.py
+++ b/tests/unit/tui/test_command_picker.py
@@ -549,7 +549,7 @@ async def test_click_on_the_overflow_row_does_nothing() -> None:
         ("u", ["usage"]),
         ("g", ["goal"]),
         ("s", ["search", "skills"]),
-        ("c", ["clear", "compact"]),
+        ("c", ["clear", "context", "compact"]),
         ("lo", ["loop", "login", "logout"]),
         ("mo", ["model"]),
     ],

--- a/tests/unit/tui/test_slash_echo.py
+++ b/tests/unit/tui/test_slash_echo.py
@@ -56,6 +56,7 @@ ECHO_POLICY = {
     # ledger; a user row would be the one it left. See `SLASH_COMMANDS`.
     "btw": False,
     "compact": False,
+    "context": False,
     "approvals": False,
     "skills": False,
     "mcp": False,


### PR DESCRIPTION
# PR Description

## Change classification

**C2 — standard / pre-authorized.** This is a bounded harness capability and performance release with a clean rollback (`git revert` / reinstall 0.17.0). No foundational auth, data-isolation, infrastructure, or irreversible data change. No RFC or tracker requested.

## Summary of Changes

This releases **local-operator 0.17.2** and closes the measured harness gaps against omp across wall-clock time, token efficiency, tool/MCP efficacy, skills, guidance, and search.

### Token + search efficiency

- `edit`: ordered multi-hunk SEARCH/REPLACE (`edits` list), exact-first then whitespace-tolerant matching, per-line re-indent, and `anchor_line` disambiguation. Existing single-hunk calls remain compatible. Guidance now prefers diff-shaped edits over whole-file writes.
- `read`: Python files read whole return a declaration-only AST summary with symbol line ranges; `range=` and `raw=true` opt out. Broken Python falls back to raw text.
- `grep`/`glob`: `.gitignore`/`.ignore` support, ripgrep fast path with Python fallback, context lines, skip pagination, and lossless spill. Explicitly named ignored glob paths remain reachable.
- Repo context: ancestor `AGENTS.md`/`CLAUDE.md` auto-load once into the cache-stable prompt head, with git-root boundary, duplicate/content/size caps, and an environment kill switch.

### Wall clock + delegation

- Mid-turn compaction now runs at continuing tool-loop boundaries through the existing plan+commit path; the loop prunes its accumulator to prevent summarized messages being persisted after the compaction marker.
- `task` accepts a concurrent `tasks[]` batch plus one shared `context`, supports a read-only `scout` tier, `lo`/`med`/`hi` model routing, and depth-2 delegation (`wake` remains bounded to top-level lifetime).
- Settled top-level task/background-bash jobs auto-deliver into an idle conversation; results already consumed by `wait` do not duplicate.
- Steering a running `bash` call backgrounds it into a tracked job, preserves output/timeout, and auto-delivers completion. Real Ctrl+C/job abort still kills the process group.

### Tool + model efficacy

- Persistent Python `eval` kernel: per-session namespace, trailing-expression results, separate `display()` channel, timeout/crash recovery, bounded output/spill, exec-tier approval.
- Read-only Jedi `lsp` extra: definitions, references, symbol outlines, multi-file rename previews (never writes), optional create-if surface.
- Gemini parallel same-tool calls receive unique ids and stream indexes instead of being silently deduplicated.
- OpenAI API-key GPT-5 models route to public Responses API with stable prompt-cache key and 24-hour retention; ChatGPT OAuth keeps Codex Responses; explicit `chat_completions` opt-out and all compat providers remain unchanged.
- Optional zero-token local auto-effort classifier (`values.effort.auto`) maps lo/med/hi onto each model's ladder and freezes the result across the tool loop.

### MCP + recovery awareness

- Per-server `enabledTools`/`disabledTools` exact/glob filters apply to cached/deferred and live MCP schemas; deny wins.
- Mid-call HTTP 401 / `WWW-Authenticate` / `mcp/www_authenticate` challenges get one OAuth-refresh reconnect and one replay.
- `/context` shows instructions, inventory, wire tool schemas, environment, skills/MCP/goal, messages, total/window %, and last cache read.
- Provider/stream/MCP breaker failures become classified `session_incident` messages (rate-limit, auth, billing, provider, network, context, MCP, content policy, unknown), appended to live context and persisted in the transcript. A later `continue` or resumed session sees why the prior turn died and the suggested action.

## Related Issue(s)

- None requested. The PR is the system of record.

## Impact

- **Breaking changes:** none intended; existing tool call forms and provider routes remain compatible except the documented direct-OpenAI GPT-5 default to public Responses API. Explicit `values.providers.openai.api: chat_completions` restores the prior route.
- **Dependency:** new optional `lsp = ["jedi>=0.19"]`; Jedi is included in `dev`, not `all`, so the default install remains unchanged.
- **Security:** eval remains arbitrary code execution and is therefore exec-tier approval, exclusive, timeout-bounded, crash-isolated, and session-scoped. Scout is allowlist/read-only. LSP rename is preview-only. MCP filters reduce mounted trust surface.
- **Performance:** 8 KiB spill discipline preserved. Python structural summaries and diff edits reduce model output/context; ripgrep is opportunistic; effort classification is local and zero-token; MCP startup/deferred cache behavior unchanged.
- **Rollback:** revert this PR and run `lop-update 0.17.0` (or install the prior main ref).

## Testing Details

### Automated gates

```text
uvx --from flake8==7.1.0 flake8 .                                      PASS
uvx --from black==26.1.0 black --check local_operator tests              PASS (340 files unchanged)
uvx isort --check-only --profile black local_operator tests              PASS
.venv/bin/python -m pyright --pythonpath .venv/bin/python .              PASS (0 errors)
.venv/bin/python -m pytest tests/unit -q -p no:cacheprovider             PASS (4086 passed, 7 skipped)
```

The suite covers each new contract: multi-edit/fuzzy/anchor semantics; AST summaries/raw/range/fallback; Python+real-ripgrep search parity; gitignore/negation; skill globs/roots/hybrid/reselection; batch/scout/effort/depth; eval state/display/timeout/crash/LRU; LSP cross-file navigation/references/read-only rename preview; mid-turn compaction replay; Gemini ids; auto-delivery + steering background; Responses API routes/cache/SSE; MCP filters/reauth/breaker incidents; session incident persistence/replay; `/context` rendering.

### Streaming contract

```text
.venv/bin/python scripts/check_streaming_contract.py /tmp/lo-smoke.jsonl
PASS /tmp/lo-smoke.jsonl
```

### Live provider smoke

Actual interface, auth/fallback path, and new eval tool:

```text
.venv/bin/local-operator exec --json --yolo \
  "Use the eval tool (not bash) to compute sum(i*i for i in range(100)). Then reply with only the integer."

anthropic quota exhausted (0% remaining) — falling back to openai/gpt-5.4 (high effort)
tool_execution_start: eval
code: sum(i*i for i in range(100))
tool_execution_end: result: 328350
final assistant response: 328350
```

This exercises real quota preflight/fallback, provider streaming, intent composition, tool schema/dispatch, persistent eval worker, second provider request, normalized usage, and shutdown.

### TUI visual evidence (`/context`)

Real `OperatorApp` driven with Textual Pilot at 100×30; dark and light semantic ramps re-captured after design remediation. Both frames: `screen=98×28`, `virtual=98×28`, `show_vertical_scrollbar=False`; two consecutive settled SVG frames were byte-identical.

<table><tr><th>Before</th><th>After (dark)</th><th>After (light semantic ramp)</th></tr><tr>
<td><img src="https://gist.githubusercontent.com/damianvtran/83e58ddd6800273fc3487a5c1af20d66/raw/f36323b6fea67638175b6f8732fbd99f7fa71e48/context-before.svg" width="500" alt="Before: slash context is unknown"></td>
<td><img src="https://gist.githubusercontent.com/damianvtran/83e58ddd6800273fc3487a5c1af20d66/raw/7309b1651a9e42db5de784db2093db6b3150b2c3/context-after-dark.svg" width="500" alt="After: estimated context token breakdown dark theme"></td>
<td><img src="https://gist.githubusercontent.com/damianvtran/83e58ddd6800273fc3487a5c1af20d66/raw/29e6079bc1e3da2a3a6805daa957bfc0b3a9658a/context-after-light.svg" width="500" alt="After: estimated context token breakdown light semantic ramp"></td>
</tr></table>

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my changes work as intended.
- [x] All new and existing tests pass.
- [x] I have run formatting (black/isort), linting (flake8), and type checks (pyright), and they pass.
- [x] I have updated the documentation when required.
- [x] Security considerations are addressed (especially for code execution features).
- [x] No related issue was requested; this PR is the record.



