### PR TITLE
fix(tui): report token and cost usage from the first call and settle queued messages

### DIFF
--- a/local_operator/harness/types.py
+++ b/local_operator/harness/types.py
@@ -861,6 +861,29 @@ class NoticeEvent(AgentEvent[Literal["notice"]]):
     kind: Literal["info", "warning", "error"] = "info"
 
 
+class SteeringDeliveredEvent(AgentEvent[Literal["steering_delivered"]]):
+    """Queued steering messages have entered the model's context.
+
+    Emitted by the session at the moment its steering queue is DRAINED, which is
+    the only moment anything can honestly say a mid-turn message was delivered.
+    ``steer()`` is fire-and-forget by design — it drops a message on a queue the
+    loop empties at its next tool/message boundary — so before this there was no
+    signal at all between "queued" and the agent's eventual reply, and a front
+    end that told the user "queued" had nothing to correct it with.
+
+    ``count`` is how many messages went in together: a user who sent three lines
+    while a tool ran has them all delivered at one boundary, and a receipt per
+    message would claim three deliveries where there was one.
+
+    Not a NoticeEvent: this is a state transition a UI RECONCILES against (the
+    queued row it already painted), not a line to print. A notice would append a
+    second row saying the first row is now wrong.
+    """
+
+    type: Literal["steering_delivered"] = "steering_delivered"
+    count: int = 1
+
+
 class SubagentStartEvent(AgentEvent[Literal["subagent_start"]]):
     """A child session was registered as a background job.
 

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -400,20 +400,34 @@ def _pruned_ids(messages: Sequence[AgentMessage]) -> set[str]:
     }
 
 
-def _last_reported_usage(messages: Sequence[AgentMessage]) -> Usage | None:
-    """The newest provider-reported :class:`Usage` in ``messages``, or ``None``.
+def _parsed_usage(payload: dict[str, Any]) -> Usage | None:
+    """One persisted ``usage`` payload as a :class:`Usage`, or ``None``.
+
+    A transcript row is data from a previous process and may predate a field, so
+    a payload that no longer validates is dropped rather than raised: a status
+    readout must not be able to stop a session from opening. ``None`` simply
+    falls through to the next-newest reading, and then to the local estimate.
+    """
+    try:
+        return Usage.model_validate(payload)
+    except Exception:
+        logger.debug("dropping unparseable persisted usage payload", exc_info=True)
+        return None
+
+
+def _last_reported_usage(usages: Sequence[Usage | None]) -> Usage | None:
+    """The newest provider-reported :class:`Usage` in ``usages``, or ``None``.
 
     Scans BACKWARDS and stops at the first hit: the newest reading is the only
     one that describes the context as it now stands, and a resumed conversation
-    can hold hundreds of messages to walk past.
+    can hold hundreds of entries to walk past.
 
-    **Reports nothing at all for a COMPACTED history**, and that exception is
-    the whole reason this is a function rather than a one-line scan. A compacted
-    transcript replays as a summary marker followed by the KEPT WINDOW, and the
-    kept messages still carry the ``usage`` they were given BEFORE the pass —
-    figures describing a context that no longer exists. Nothing ever supersedes
-    them: only a completed turn rewrites this, and a session that compacted and
-    then exited never ran one.
+    **Refuses any reading recorded before the newest compaction**, and that
+    exception is the whole reason this is a function rather than a one-line
+    scan. A compacted transcript replays as a summary marker followed by the
+    KEPT WINDOW, and those kept messages still carry the ``usage`` they were
+    given BEFORE the pass — figures describing a context that no longer exists,
+    which nothing supersedes when the session compacted and then exited.
 
     Seeding from one is not a small error. Measured on a transcript that
     compacted at 900k of a 1M window, the reading came back 900_000 against a
@@ -424,27 +438,29 @@ def _last_reported_usage(messages: Sequence[AgentMessage]) -> Usage | None:
     pointing the other way, and the compaction consequence makes it the more
     expensive of the two.
 
-    Note the marker sits at the HEAD of the replayed list, not between the stale
-    readings and the live ones — the kept window follows it — so a backwards
-    scan meets the stale message first and a "stop at the boundary" rule reads
-    exactly backwards. The presence of the marker anywhere is what disqualifies
-    the whole history, because every reading in it predates the pass.
+    The rule cannot be expressed on the replayed list alone. The marker sits at
+    the HEAD of it and the kept window FOLLOWS it, so "stop scanning backwards
+    at the marker" reads exactly backwards — the stale messages come first — and
+    "any marker disqualifies everything" throws away the legitimate case: a
+    session that compacted and then ran ten more turns has a perfectly good
+    newest reading, and refusing it would send every such resume back to the
+    local estimate for no reason.
+
+    So the boundary is taken from the TRANSCRIPT, whose entries are in append
+    order and therefore say which readings were recorded after the pass.
+    ``entries_after_compaction`` returns exactly those; a history with no
+    compaction returns all of them, which is the ordinary path.
 
     ``None`` means "no usable reading here", a real state and distinct from
     zero: a brand-new session, a conversation of nothing but user messages, a
-    provider that reports no usage, or the compacted case above. Callers must
-    not collapse the two — a confident 0 on a resumed session is the
-    empty-context lie this exists to prevent — and falling through to the local
-    estimate is the right answer for every one of them.
+    provider that reports no usage, or a compacted history with no completed
+    turn since the pass. Callers must not collapse the two — a confident 0 on a
+    resumed session is the empty-context lie this exists to prevent — and
+    falling through to the local estimate is the right answer for all of them.
     """
-    if any(
-        isinstance(message, CustomMessage) and message.custom_type == "compaction_summary"
-        for message in messages
-    ):
-        return None
-    for message in reversed(messages):
-        if isinstance(message, Message) and message.usage is not None:
-            return message.usage
+    for usage in reversed(usages):
+        if usage is not None:
+            return usage
     return None
 
 
@@ -608,7 +624,13 @@ class Session:
         # gate it feeds decides whether to rewrite the user's history), and
         # ``restored_usage`` below reports the conversation's real size to a
         # front end that would otherwise open on an empty-looking context.
-        self._last_usage: Usage | None = _last_reported_usage(self._context.messages)
+        # From the TRANSCRIPT, not from the replayed context: only append order
+        # distinguishes a reading taken after the newest compaction from one the
+        # pass invalidated, and the replayed list deliberately loses that (see
+        # ``Transcript.usages_since_compaction`` and ``_last_reported_usage``).
+        self._last_usage: Usage | None = _last_reported_usage(
+            [_parsed_usage(payload) for payload in transcript.usages_since_compaction()]
+        )
         self._last_activity_ms: int = 0  # epoch ms; drives idle-flush pruning
         self._generation = 0  # monotonic turn counter for agent_start/end
         # Boundary-event suppression across a post-compaction continuation:

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -48,8 +48,8 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal, TypeGuard
 
 from local_operator.compaction.tokens import (
+    IMAGE_TOKEN_ESTIMATE,
     approx_text_tokens,
-    estimate_messages_tokens,
 )
 from local_operator.harness.approval import ApprovalGate
 from local_operator.harness.comms import HUB_MESSAGE_TYPE, SubagentComms
@@ -407,12 +407,41 @@ def _last_reported_usage(messages: Sequence[AgentMessage]) -> Usage | None:
     one that describes the context as it now stands, and a resumed conversation
     can hold hundreds of messages to walk past.
 
-    ``None`` means "no turn in this history ever reported usage", which is a
-    real state and distinct from zero — a brand-new session, a conversation
-    whose only entries are user messages, or a transcript from a provider that
-    reports no usage at all. Callers must not collapse the two: a confident 0 on
-    a resumed session is the empty-context lie this exists to prevent.
+    **Reports nothing at all for a COMPACTED history**, and that exception is
+    the whole reason this is a function rather than a one-line scan. A compacted
+    transcript replays as a summary marker followed by the KEPT WINDOW, and the
+    kept messages still carry the ``usage`` they were given BEFORE the pass —
+    figures describing a context that no longer exists. Nothing ever supersedes
+    them: only a completed turn rewrites this, and a session that compacted and
+    then exited never ran one.
+
+    Seeding from one is not a small error. Measured on a transcript that
+    compacted at 900k of a 1M window, the reading came back 900_000 against a
+    real 1_707 — 527x over, installed as EXACT so the correct local estimate
+    could never replace it, and handed to ``should_compact``, which would then
+    rewrite the user's history on the first turn after the resume.
+    Under-reporting was the bug this seeding fixed; this is the same lie
+    pointing the other way, and the compaction consequence makes it the more
+    expensive of the two.
+
+    Note the marker sits at the HEAD of the replayed list, not between the stale
+    readings and the live ones — the kept window follows it — so a backwards
+    scan meets the stale message first and a "stop at the boundary" rule reads
+    exactly backwards. The presence of the marker anywhere is what disqualifies
+    the whole history, because every reading in it predates the pass.
+
+    ``None`` means "no usable reading here", a real state and distinct from
+    zero: a brand-new session, a conversation of nothing but user messages, a
+    provider that reports no usage, or the compacted case above. Callers must
+    not collapse the two — a confident 0 on a resumed session is the
+    empty-context lie this exists to prevent — and falling through to the local
+    estimate is the right answer for every one of them.
     """
+    if any(
+        isinstance(message, CustomMessage) and message.custom_type == "compaction_summary"
+        for message in messages
+    ):
+        return None
     for message in reversed(messages):
         if isinstance(message, Message) and message.usage is not None:
             return message.usage
@@ -1315,20 +1344,34 @@ class Session:
                 total += approx_text_tokens(tool.description)
                 if tool.parameters:
                     total += approx_text_tokens(json.dumps(tool.parameters, separators=(",", ":")))
-            # ``estimate_messages_tokens`` rather than a hand-rolled walk: it is
-            # the ruler compaction plans against, and a second implementation of
-            # "how big is this history" is how the band and the compaction gate
-            # end up disagreeing about the same conversation. It also counts
-            # images and tool-call arguments, which a naive text sum drops — on a
-            # resumed vision session those are the largest terms there are.
+            # Counted with THIS method's own ruler, deliberately, rather than
+            # with ``estimate_messages_tokens``. That function is the sharper
+            # one — it is what compaction plans against — but it reaches for
+            # cl100k_base, and the two costs this method's docstring refuses are
+            # exactly what that would spend: ~43.6 MB RSS and, on a cold cache, a
+            # network fetch of the ranks, on the boot path, before the user has
+            # typed anything. Measured on an ordinary session: 58 ms and +41 MB
+            # against 0.7 ms and +0 MB for the arithmetic below. The memoization
+            # does not rescue it either, because a session that never approaches
+            # the compaction threshold never tokenizes at all — so this would not
+            # be sharing a cost already paid, it would be creating one.
             #
-            # It prefers cl100k_base when the ``tokenizer`` extra is installed,
-            # which is a sharper ruler than this method's own chars/4 rule but
-            # NOT a new cost: the estimates are memoized per message id, so a
-            # resumed session pays once for history the compaction gate would
-            # have tokenized on its first turn regardless. Without the extra it
-            # degrades to the same chars/4 heuristic as the blocks above.
-            total += estimate_messages_tokens(rendered)
+            # The terms mirror ``_compute_tokens`` so the shape of what is
+            # counted matches the sharper ruler even though the ruler differs:
+            # text, a flat charge per image, and each tool call's name plus its
+            # serialized arguments. Dropping the last two would understate a
+            # resumed vision or tool-heavy session by its largest terms.
+            for message in rendered:
+                for block in message.content:
+                    if isinstance(block, TextContent):
+                        total += approx_text_tokens(block.text)
+                    else:
+                        total += IMAGE_TOKEN_ESTIMATE
+                for call in message.tool_calls:
+                    total += approx_text_tokens(call.name)
+                    total += approx_text_tokens(
+                        call.raw_arguments or json.dumps(call.arguments, sort_keys=True)
+                    )
             return total
 
         return await asyncio.to_thread(count)

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -47,10 +47,7 @@ from collections.abc import (
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal, TypeGuard
 
-from local_operator.compaction.tokens import (
-    IMAGE_TOKEN_ESTIMATE,
-    approx_text_tokens,
-)
+from local_operator.compaction.tokens import IMAGE_TOKEN_ESTIMATE, approx_text_tokens
 from local_operator.harness.approval import ApprovalGate
 from local_operator.harness.comms import HUB_MESSAGE_TYPE, SubagentComms
 from local_operator.harness.jobs import JOB_RESULT_MESSAGE_TYPE, AsyncJobManager

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -47,7 +47,10 @@ from collections.abc import (
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal, TypeGuard
 
-from local_operator.compaction.tokens import approx_text_tokens
+from local_operator.compaction.tokens import (
+    approx_text_tokens,
+    estimate_messages_tokens,
+)
 from local_operator.harness.approval import ApprovalGate
 from local_operator.harness.comms import HUB_MESSAGE_TYPE, SubagentComms
 from local_operator.harness.jobs import JOB_RESULT_MESSAGE_TYPE, AsyncJobManager
@@ -76,6 +79,7 @@ from local_operator.harness.types import (
     ModelSpec,
     NoticeEvent,
     StaleAside,
+    SteeringDeliveredEvent,
     StreamEvent,
     StreamTextDelta,
     StreamUsageEvent,
@@ -396,6 +400,25 @@ def _pruned_ids(messages: Sequence[AgentMessage]) -> set[str]:
     }
 
 
+def _last_reported_usage(messages: Sequence[AgentMessage]) -> Usage | None:
+    """The newest provider-reported :class:`Usage` in ``messages``, or ``None``.
+
+    Scans BACKWARDS and stops at the first hit: the newest reading is the only
+    one that describes the context as it now stands, and a resumed conversation
+    can hold hundreds of messages to walk past.
+
+    ``None`` means "no turn in this history ever reported usage", which is a
+    real state and distinct from zero — a brand-new session, a conversation
+    whose only entries are user messages, or a transcript from a provider that
+    reports no usage at all. Callers must not collapse the two: a confident 0 on
+    a resumed session is the empty-context lie this exists to prevent.
+    """
+    for message in reversed(messages):
+        if isinstance(message, Message) and message.usage is not None:
+            return message.usage
+    return None
+
+
 def _render_compaction_marker(marker: CustomMessage, entry_id: str | None = None) -> Message:
     """Render one compaction marker into an LLM-visible message. ``entry_id``
     (the marker's transcript entry id) rides onto the rendered message.
@@ -547,7 +570,16 @@ class Session:
         self.mcp_startup: McpStartupOutcome | None = None
         self._aside_thunks: list[Aside] = []
         self._continuation_queue: list[AgentMessage] = []
-        self._last_usage: Usage | None = None  # latest provider-reported usage
+        # Latest provider-reported usage. SEEDED from the replayed transcript
+        # rather than starting at None, because on a resumed session the last
+        # turn's usage is a fact that already happened and the transcript is
+        # where it was persisted. Two things read it and both were wrong without
+        # this: the compaction trigger fell back to a local estimate for the
+        # first turn after every resume (the estimate runs 7-17% off, and the
+        # gate it feeds decides whether to rewrite the user's history), and
+        # ``restored_usage`` below reports the conversation's real size to a
+        # front end that would otherwise open on an empty-looking context.
+        self._last_usage: Usage | None = _last_reported_usage(self._context.messages)
         self._last_activity_ms: int = 0  # epoch ms; drives idle-flush pruning
         self._generation = 0  # monotonic turn counter for agent_start/end
         # Boundary-event suppression across a post-compaction continuation:
@@ -1179,6 +1211,29 @@ class Session:
 
     # -- context accounting ---------------------------------------------------
 
+    def restored_usage(self) -> Usage | None:
+        """The provider's own last reading for THIS conversation, or ``None``.
+
+        What a resumed front end needs and could not previously get. The status
+        band's context segment and its cost segment are both fed by turns that
+        end while the app is running, so a resumed session had no source for
+        either until the user spent a whole turn — the band opened reporting an
+        empty context and no spend for a conversation that might be 40% of the
+        way through its window with dollars already on it.
+
+        This is the EXACT figure the provider reported, not an estimate, so a
+        host may mark it as such: it is the same number the band would be
+        showing had the process never stopped. ``None`` means the transcript
+        holds no usage at all (a new session, or a provider that reports none),
+        which is why this returns the object rather than a bare int — a caller
+        must be able to tell "nothing reported" from "reported zero" and only
+        the first justifies falling back to a local estimate.
+
+        Read-only and synchronous: it serves an already-parsed field off the
+        replayed history, so a front end may call it on the paint path.
+        """
+        return self._last_usage
+
     async def measure_preloaded_context(self) -> int:
         """Tokens the NEXT request carries before the user has typed anything.
 
@@ -1192,8 +1247,27 @@ class Session:
         from 0% to 15% because of a short question.
 
         What is counted is exactly what :class:`~local_operator.harness.loop`
-        puts in a ``ChatRequest`` with an empty transcript: the system blocks
-        and the serialized tool schemas.
+        puts in a ``ChatRequest``: the system blocks, the serialized tool
+        schemas, AND the conversation already in context.
+
+        That last term is not an embellishment, it is the difference between a
+        correct reading and a wrong one on every RESUMED session. The name says
+        "preloaded", and on a NEW session the history is empty so the two
+        readings coincide — which is exactly why the omission survived. A
+        ``--resume`` (or ``/resume``, or any reload that keeps the conversation)
+        rebuilds ``_context.messages`` from the transcript before this runs, so
+        a sum over blocks and schemas alone reports the size of an EMPTY
+        conversation for one that may hold hundreds of messages: measured on a
+        resumed session whose last provider reading was 402k, the band opened at
+        1.7k (0.2%/1M) and stayed there until the next turn happened to end.
+        Under-reporting is the dangerous direction — it is the reading a user
+        checks to decide whether there is room to keep going, and it claimed a
+        whole free window while 40% of it was already spent.
+
+        The history is measured through the SAME renderer a request is built
+        from (:meth:`_render_history`), so what is counted is what would
+        actually be sent — expired todo reminders dropped, images stripped when
+        a provider has refused them — rather than the raw transcript.
 
         Two costs are deliberately refused, because a status readout must not
         be the most expensive thing a session does before the user speaks:
@@ -1222,6 +1296,13 @@ class Session:
         # ``self._tools`` rather than mutating it, so this reference stays a
         # coherent snapshot even if an MCP refresh swaps the list mid-count.
         tools = self._tools
+        # Rendered on the LOOP for the same reason the schemas are serialized in
+        # the thread is right: rendering touches session state (the todo-reminder
+        # expiry reads the store, the image degrade reads a flag), and handing
+        # mutable session state to a worker thread is how a snapshot tears. The
+        # render is a list walk over messages already in memory; the tokenizing
+        # of its text is the part that scales, and that still crosses.
+        rendered = self._render_history(list(self._context.messages))
 
         def count() -> int:
             total = sum(approx_text_tokens(text) for text in resolved)
@@ -1234,6 +1315,20 @@ class Session:
                 total += approx_text_tokens(tool.description)
                 if tool.parameters:
                     total += approx_text_tokens(json.dumps(tool.parameters, separators=(",", ":")))
+            # ``estimate_messages_tokens`` rather than a hand-rolled walk: it is
+            # the ruler compaction plans against, and a second implementation of
+            # "how big is this history" is how the band and the compaction gate
+            # end up disagreeing about the same conversation. It also counts
+            # images and tool-call arguments, which a naive text sum drops — on a
+            # resumed vision session those are the largest terms there are.
+            #
+            # It prefers cl100k_base when the ``tokenizer`` extra is installed,
+            # which is a sharper ruler than this method's own chars/4 rule but
+            # NOT a new cost: the estimates are memoized per message id, so a
+            # resumed session pays once for history the compaction gate would
+            # have tokenized on its first turn regardless. Without the extra it
+            # degrades to the same chars/4 heuristic as the blocks above.
+            total += estimate_messages_tokens(rendered)
             return total
 
         return await asyncio.to_thread(count)
@@ -1656,12 +1751,27 @@ class Session:
     async def _drain_steering(self) -> list[AgentMessage]:
         """Consume the steering queue. Steering messages are real injected
         turns, so they are persisted here — the loop never returns them in its
-        ``new_messages``."""
+        ``new_messages``.
+
+        Emits :class:`SteeringDeliveredEvent` when it actually takes something.
+        This is the one place that knows a queued message stopped being queued:
+        the loop calls it at the boundary where the messages join the context,
+        so a front end showing "queued — sends when this step finishes" can
+        settle that row to a delivered one instead of leaving the promise up for
+        the rest of the session. Silent when the queue is empty, which is the
+        overwhelmingly common case — this is called at EVERY tool and message
+        boundary, and an event per boundary would be noise with no receiver.
+        """
         messages: list[AgentMessage] = []
         while not self._steering_queue.empty():
             message = self._steering_queue.get_nowait()
             await self._transcript.append_message(message)
             messages.append(message)
+        if messages:
+            # After persistence, not before: the receipt says the message is in
+            # the conversation, and it is only in the conversation once it is on
+            # disk and in the list being handed back to the loop.
+            await self._emit(SteeringDeliveredEvent(count=len(messages)))
         return messages
 
     async def _drain_asides(self) -> list[Aside]:

--- a/local_operator/session/transcript.py
+++ b/local_operator/session/transcript.py
@@ -264,6 +264,22 @@ class Transcript:
         refusing that would be the opposite error. Entries after the marker are
         exactly the readings that survived the pass.
 
+        PRUNED entries are excluded for the same reason, and pruning is the
+        case that makes this more than a compaction concern. Blanking a tool
+        result shrinks the live context exactly as a compaction pass does, but
+        it leaves no marker to draw a boundary on — the journal entry is folded
+        away by :meth:`compact_file` and the message row survives with its
+        original ``usage`` attached. Measured on a real prune: a reading of
+        640_000 against a true context of 12_666, which a host installs as
+        exact. So the rule is not "after the newest compaction" but "not
+        describing a context something has since shrunk", and both shrinking
+        passes are covered: the compaction boundary above, and the ``pruned``
+        flag here.
+
+        The flag is read from ``provider_payload`` — where both the live pass
+        (``compaction.pruning``) and the replay (``_pruned_entry``) set it — so
+        an entry counts as pruned whether the file has been folded yet or not.
+
         Returns the raw payload dicts rather than ``Usage`` objects: this module
         is the persistence layer and does not own the harness's models, and the
         caller is already parsing them.
@@ -273,10 +289,14 @@ class Transcript:
             if self._entries[index].type == ENTRY_COMPACTION:
                 start = index + 1
                 break
+        pruned = self.pending_prunes()
         return [
             dict(entry.payload["usage"])
             for entry in self._entries[start:]
-            if entry.type == ENTRY_MESSAGE and isinstance(entry.payload.get("usage"), dict)
+            if entry.type == ENTRY_MESSAGE
+            and isinstance(entry.payload.get("usage"), dict)
+            and entry.id not in pruned
+            and not (entry.payload.get("provider_payload") or {}).get("pruned")
         ]
 
     def pending_prunes(self) -> dict[str, str]:

--- a/local_operator/session/transcript.py
+++ b/local_operator/session/transcript.py
@@ -264,21 +264,30 @@ class Transcript:
         refusing that would be the opposite error. Entries after the marker are
         exactly the readings that survived the pass.
 
-        PRUNED entries are excluded for the same reason, and pruning is the
-        case that makes this more than a compaction concern. Blanking a tool
-        result shrinks the live context exactly as a compaction pass does, but
-        it leaves no marker to draw a boundary on — the journal entry is folded
-        away by :meth:`compact_file` and the message row survives with its
-        original ``usage`` attached. Measured on a real prune: a reading of
-        640_000 against a true context of 12_666, which a host installs as
-        exact. So the rule is not "after the newest compaction" but "not
-        describing a context something has since shrunk", and both shrinking
-        passes are covered: the compaction boundary above, and the ``pruned``
-        flag here.
+        PRUNING moves the boundary too, and it is the case that makes this more
+        than a compaction concern. Blanking a tool result shrinks the live
+        context exactly as a compaction pass does, but leaves no marker: the
+        journal entry is folded away by :meth:`compact_file` and the message
+        rows survive untouched. Measured against the real pruner: a reading of
+        640_000 restored for a true context of 31_715, which a host installs as
+        exact and hands to the compaction gate.
 
-        The flag is read from ``provider_payload`` — where both the live pass
-        (``compaction.pruning``) and the replay (``_pruned_entry``) set it — so
-        an entry counts as pruned whether the file has been folded yet or not.
+        So the boundary is POSITIONAL for both passes — the newest compaction
+        marker or the newest pruned row, whichever is later — and that is not a
+        stylistic choice. A filter that merely skipped pruned rows would be dead
+        code: pruning only ever blanks ``role == "tool"`` messages
+        (``compaction.pruning``) and ``usage`` is only ever set on the
+        ASSISTANT message of a turn (``harness.loop``), so the two sets are
+        disjoint by construction and no usage-carrying row is ever flagged. That
+        version passed a test which pruned an assistant message — a state the
+        production pruner cannot produce — and fixed nothing. What is wrong with
+        a pre-prune reading is not the row it sits on, it is that it describes a
+        context measured before the shrink, so position is the only thing that
+        can express it.
+
+        Both spellings of "pruned" are consulted for the same reason
+        :meth:`compact_file` exists: the journal entry before a fold, the
+        ``provider_payload`` flag on the row afterwards.
 
         Returns the raw payload dicts rather than ``Usage`` objects: this module
         is the persistence layer and does not own the harness's models, and the
@@ -286,17 +295,32 @@ class Transcript:
         """
         start = 0
         for index in range(len(self._entries) - 1, -1, -1):
-            if self._entries[index].type == ENTRY_COMPACTION:
+            entry = self._entries[index]
+            if entry.type in (ENTRY_COMPACTION, ENTRY_PRUNE):
+                # A journal entry sits at the moment the shrink HAPPENED, which
+                # is what the boundary must be drawn on — not at the row it
+                # targets. The targeted tool result may be hundreds of entries
+                # older, and the readings in between were all measured before
+                # the blanking and so describe the pre-shrink context. Seen in
+                # the wild: one real transcript on this machine has its newest
+                # prune at entry 88 with its newest usage at 82, and taking the
+                # target's position instead restored two stale readings.
                 start = index + 1
                 break
-        pruned = self.pending_prunes()
+            if entry.type == ENTRY_MESSAGE and (entry.payload.get("provider_payload") or {}).get(
+                "pruned"
+            ):
+                # The FOLDED form of the same thing: `compact_file` materializes
+                # the journal into the row and drops the entry, so after a fold
+                # the flag on the row is the only evidence left. The row is a
+                # tool result and carries no usage itself, so the boundary is
+                # after it.
+                start = index + 1
+                break
         return [
             dict(entry.payload["usage"])
             for entry in self._entries[start:]
-            if entry.type == ENTRY_MESSAGE
-            and isinstance(entry.payload.get("usage"), dict)
-            and entry.id not in pruned
-            and not (entry.payload.get("provider_payload") or {}).get("pruned")
+            if entry.type == ENTRY_MESSAGE and isinstance(entry.payload.get("usage"), dict)
         ]
 
     def pending_prunes(self) -> dict[str, str]:

--- a/local_operator/session/transcript.py
+++ b/local_operator/session/transcript.py
@@ -325,15 +325,23 @@ class Transcript:
                 #   the boundary lands where the prune actually was. This is the
                 #   accurate one and the only one written from now on.
                 # * The ``pruned`` flag on the target row is the FALLBACK, for
-                #   transcripts folded by a build that predates the mark — they
-                #   exist on disk already and would otherwise restore every
-                #   reading taken before the blanking. It is the weaker signal
-                #   (it says which row was blanked, not when, and the target can
-                #   be far older than the prune), so it draws the boundary too
-                #   EARLY: some genuinely current readings are refused and fall
-                #   through to the local estimate. That is the safe direction —
-                #   an estimate instead of an exact figure, rather than a figure
-                #   describing a context that no longer exists.
+                #   transcripts folded by a build that predates the mark. Those
+                #   exist on disk already — `main` folds journals writing only
+                #   this flag — and without it the scan would match nothing,
+                #   fall through to the start of the file, and restore every
+                #   reading in it.
+                #
+                #   It is the weaker signal: it marks WHICH row was blanked, not
+                #   when, and the target sits EARLIER than the prune that
+                #   blanked it. So the boundary lands too early and the window
+                #   is too WIDE — it can still admit readings taken between the
+                #   target and the prune, which is fewer stale figures than
+                #   admitting the whole file but not zero. Exact only where the
+                #   two coincide.
+                #
+                #   Kept anyway, because the alternative for those files is
+                #   restoring everything, and improved only by the mark, which
+                #   every fold from here writes.
                 start = index + 1
                 break
         return [

--- a/local_operator/session/transcript.py
+++ b/local_operator/session/transcript.py
@@ -313,18 +313,27 @@ class Transcript:
                 # target's position instead restored two stale readings.
                 start = index + 1
                 break
-            if (entry.payload.get("provider_payload") or {}).get(SHRUNK_KEY):
-                # The FOLDED form: `compact_file` drops the journal entry and
-                # leaves this mark on the last entry that sat at or before it
-                # (see `_shrink_marked`), so the boundary lands where the prune
-                # actually was.
+            if (entry.payload.get("provider_payload") or {}).get(SHRUNK_KEY) or (
+                entry.type == ENTRY_MESSAGE
+                and (entry.payload.get("provider_payload") or {}).get("pruned")
+            ):
+                # The FOLDED forms, newest-position-wins by virtue of the scan
+                # order. Two of them, because two kinds of file exist:
                 #
-                # Deliberately NOT the ``pruned`` flag on the target row. That
-                # says which row was blanked, not WHEN — and the target can be
-                # hundreds of entries older than the prune that blanked it, so
-                # every reading in between would be promoted back to "current".
-                # Measured on a folded transcript: three stale readings restored
-                # where the same file before the fold correctly reported none.
+                # * ``SHRUNK_KEY`` is the mark `compact_file` leaves at the
+                #   position the journal entry held (see `_shrink_marked`), so
+                #   the boundary lands where the prune actually was. This is the
+                #   accurate one and the only one written from now on.
+                # * The ``pruned`` flag on the target row is the FALLBACK, for
+                #   transcripts folded by a build that predates the mark — they
+                #   exist on disk already and would otherwise restore every
+                #   reading taken before the blanking. It is the weaker signal
+                #   (it says which row was blanked, not when, and the target can
+                #   be far older than the prune), so it draws the boundary too
+                #   EARLY: some genuinely current readings are refused and fall
+                #   through to the local estimate. That is the safe direction —
+                #   an estimate instead of an exact figure, rather than a figure
+                #   describing a context that no longer exists.
                 start = index + 1
                 break
         return [

--- a/local_operator/session/transcript.py
+++ b/local_operator/session/transcript.py
@@ -245,6 +245,40 @@ class Transcript:
                 return dict(entry.payload.get("details", {}))
         return None
 
+    def usages_since_compaction(self) -> list[dict[str, Any]]:
+        """Every message entry's ``usage`` payload recorded AFTER the newest
+        compaction, oldest first (all of them when nothing compacted).
+
+        Append order is the only place the "after" in that sentence exists.
+        :meth:`build_llm_history` cannot answer it: it puts the compaction
+        marker at the HEAD of what it returns and the kept window after it, so
+        the replayed list carries pre-pass readings ahead of post-pass ones with
+        nothing to tell them apart. The entries know, because they are in the
+        order they happened.
+
+        Why the distinction is worth an accessor: a kept message still carries
+        the ``usage`` it had before the pass shrank the context, and a host that
+        seeds a status readout from one reports a context that no longer exists
+        (measured at 900k against a real 1.7k). But a session that compacted and
+        then ran ten more turns has a perfectly good newest reading, and
+        refusing that would be the opposite error. Entries after the marker are
+        exactly the readings that survived the pass.
+
+        Returns the raw payload dicts rather than ``Usage`` objects: this module
+        is the persistence layer and does not own the harness's models, and the
+        caller is already parsing them.
+        """
+        start = 0
+        for index in range(len(self._entries) - 1, -1, -1):
+            if self._entries[index].type == ENTRY_COMPACTION:
+                start = index + 1
+                break
+        return [
+            dict(entry.payload["usage"])
+            for entry in self._entries[start:]
+            if entry.type == ENTRY_MESSAGE and isinstance(entry.payload.get("usage"), dict)
+        ]
+
     def pending_prunes(self) -> dict[str, str]:
         """``{target entry id: notice}`` for every un-folded prune entry.
 

--- a/local_operator/session/transcript.py
+++ b/local_operator/session/transcript.py
@@ -72,6 +72,12 @@ ENTRY_PRUNE = "prune"
 #: the rewrite amortized-free while still bounding a long session's file.
 COMPACT_FILE_THRESHOLD_BYTES = 256 * 1024
 
+#: Marks the entry that sat at or before a prune whose journal entry has since
+#: been folded away. Read by :meth:`Transcript.usages_since_compaction` as the
+#: surviving evidence of WHERE the blanking happened; see :func:`_shrink_marked`.
+#: Lives under ``provider_payload`` so an older build simply ignores it.
+SHRUNK_KEY = "context_shrunk_here"
+
 
 @dataclass
 class TranscriptEntry:
@@ -307,14 +313,18 @@ class Transcript:
                 # target's position instead restored two stale readings.
                 start = index + 1
                 break
-            if entry.type == ENTRY_MESSAGE and (entry.payload.get("provider_payload") or {}).get(
-                "pruned"
-            ):
-                # The FOLDED form of the same thing: `compact_file` materializes
-                # the journal into the row and drops the entry, so after a fold
-                # the flag on the row is the only evidence left. The row is a
-                # tool result and carries no usage itself, so the boundary is
-                # after it.
+            if (entry.payload.get("provider_payload") or {}).get(SHRUNK_KEY):
+                # The FOLDED form: `compact_file` drops the journal entry and
+                # leaves this mark on the last entry that sat at or before it
+                # (see `_shrink_marked`), so the boundary lands where the prune
+                # actually was.
+                #
+                # Deliberately NOT the ``pruned`` flag on the target row. That
+                # says which row was blanked, not WHEN — and the target can be
+                # hundreds of entries older than the prune that blanked it, so
+                # every reading in between would be promoted back to "current".
+                # Measured on a folded transcript: three stale readings restored
+                # where the same file before the fold correctly reported none.
                 start = index + 1
                 break
         return [
@@ -411,19 +421,32 @@ class Transcript:
 
         The dead weight is the difference between each pruned row as written
         and the one-line notice that replaces it, plus the journal entries
-        themselves.
+        themselves — MINUS the few bytes the fold adds back, which is the
+        boundary mark it leaves in place of the journal entry's position (see
+        :func:`_shrink_marked`). Small, but this figure is compared for equality
+        against what :meth:`compact_file` actually reclaims, and an estimate
+        that ignores a cost the fold really pays is simply wrong.
         """
         prunes = self.pending_prunes()
         if not prunes:
             return 0
         total = 0
-        for entry in self._entries:
+        boundary: TranscriptEntry | None = None
+        newest_prune = max(
+            (index for index, entry in enumerate(self._entries) if entry.type == ENTRY_PRUNE),
+            default=-1,
+        )
+        for index, entry in enumerate(self._entries):
             if entry.type == ENTRY_PRUNE:
                 total += len(entry.to_json()) + 1
-            elif entry.type == ENTRY_MESSAGE and entry.id in prunes:
-                total += len(entry.to_json()) - len(
-                    _pruned_entry(entry, prunes[entry.id]).to_json()
-                )
+                continue
+            if entry.type == ENTRY_MESSAGE and entry.id in prunes:
+                entry = _pruned_entry(entry, prunes[entry.id])
+                total += len(self._entries[index].to_json()) - len(entry.to_json())
+            if index <= newest_prune:
+                boundary = entry
+        if boundary is not None:
+            total -= len(_shrink_marked(boundary).to_json()) - len(boundary.to_json())
         return max(total, 0)
 
     async def compact_file(self, min_reclaim_bytes: int = COMPACT_FILE_THRESHOLD_BYTES) -> int:
@@ -449,13 +472,36 @@ class Transcript:
             if not prunes:
                 return 0
             before = self.path.stat().st_size if self.path.exists() else 0
+            # WHERE the newest prune sat, before the entries carrying that fact
+            # are dropped. Folding is meant to be semantically invisible, and
+            # without this it is not: a prune's position is what tells a reader
+            # which usage readings predate the blanking, and the target row it
+            # points at can be hundreds of entries older than the prune itself.
+            # Discarding it silently promoted every reading in between back to
+            # "current" — measured as three stale figures restored on a folded
+            # transcript that correctly reported none before the fold.
+            newest_prune = max(
+                (index for index, entry in enumerate(self._entries) if entry.type == ENTRY_PRUNE),
+                default=-1,
+            )
             folded: list[TranscriptEntry] = []
-            for entry in self._entries:
+            boundary = -1
+            for index, entry in enumerate(self._entries):
                 if entry.type == ENTRY_PRUNE:
                     continue
                 if entry.type == ENTRY_MESSAGE and entry.id in prunes:
                     entry = _pruned_entry(entry, prunes[entry.id])
                 folded.append(entry)
+                # Remember which SURVIVING entry is the last one at or before
+                # the newest prune. Marked after the loop rather than inside it,
+                # because only the final such entry is the boundary — marking
+                # every one of them puts the mark on the newest row in the file
+                # and a backward scan then stops at the end, refusing the whole
+                # history instead of the part that predates the blanking.
+                if index <= newest_prune:
+                    boundary = len(folded) - 1
+            if boundary >= 0:
+                folded[boundary] = _shrink_marked(folded[boundary])
             payload = "".join(entry.to_json() + "\n" for entry in folded)
             reclaimed = before - len(payload.encode("utf-8"))
             if reclaimed < min_reclaim_bytes:
@@ -484,6 +530,30 @@ def _pruned_entry(entry: TranscriptEntry, notice: str) -> TranscriptEntry:
     payload["content"] = [TextContent(text=notice).model_dump()]
     provider_payload = dict(payload.get("provider_payload") or {})
     provider_payload["pruned"] = True
+    payload["provider_payload"] = provider_payload
+    return TranscriptEntry(id=entry.id, ts=entry.ts, type=entry.type, payload=payload)
+
+
+def _shrink_marked(entry: TranscriptEntry) -> TranscriptEntry:
+    """``entry`` marked as sitting at or before a prune that has been folded away.
+
+    :meth:`Transcript.compact_file` materializes the prune journal into the rows
+    it targets and drops the journal entries, which is semantically invisible for
+    replay — and was NOT invisible for the usage boundary, because a prune's
+    POSITION is what says which readings predate the blanking. The target row is
+    no substitute: it can be hundreds of entries older than the prune that
+    blanked it.
+
+    So the position is preserved as a flag on the last entry that sat at or
+    before it. ``provider_payload`` rather than a new entry type, because a new
+    type would have to be understood by every reader of the file including older
+    builds, where an unknown key on a payload is ignored by construction.
+    """
+    payload = dict(entry.payload)
+    provider_payload = dict(payload.get("provider_payload") or {})
+    if provider_payload.get(SHRUNK_KEY):
+        return entry
+    provider_payload[SHRUNK_KEY] = True
     payload["provider_payload"] = provider_payload
     return TranscriptEntry(id=entry.id, ts=entry.ts, type=entry.type, payload=payload)
 

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -226,6 +226,12 @@ _BAND_SLOT_RHYTHM_ROWS = 1
 #: attempt to condition the row on measured slot heights made things worse.
 MIN_BAND_INSET_SCREEN_ROWS = 12
 
+#: Rows the column spends around the subagent list, used to decide whether the
+#: dock's inset still fits beside it (see `_subagent_rows_leave_room`): five for
+#: `#input-shell`, two for the transcript's padding, one for the panel's caption,
+#: one for its slot rhythm row, and one of conversation left over.
+_SUBAGENT_DOCK_ROWS = 10
+
 #: Passes `_refresh_band` makes over (panels, inset) before painting. Three,
 #: because the band's visibility, its inset row and `TodoPanel`'s row budget
 #: each depend on the previous one — see the comment in `_refresh_band` for the
@@ -2102,6 +2108,21 @@ class OperatorApp(App[None]):
         # can currently hold keeps the ~50 ms before the timer from showing a
         # card overhanging the frame with its prose clipped mid-word.
         self.call_after_refresh(self._sync_overlay_layout, force=True)
+        # The dock band is size-sensitive for the same reason the cards are, and
+        # had no resize trigger at all: its inset is gated on the screen height
+        # and `TodoPanel` budgets its rows against it, but nothing here asked
+        # either to re-decide. A terminal dragged across the inset's floor was
+        # left with the previous height's answer until the 1 Hz poll or an
+        # unrelated panel event happened to fire — measured at ~0.3 s of a band
+        # sized for a screen that no longer exists, with the overflow that
+        # implies.
+        #
+        # `call_after_refresh` rather than the timer: unlike the cards, the band
+        # is IN the layout, so it re-arranges with the frame and the pass after
+        # that refresh reads real numbers. The timer above then re-measures the
+        # cards over whatever the band settled to, which is the order those two
+        # already depend on.
+        self.call_after_refresh(self._refresh_band)
 
     def on_welcome_view_block_resized(self, message: WelcomeView.BlockResized) -> None:
         """The splash changed height, so the composition around it has moved.
@@ -3454,7 +3475,60 @@ class OperatorApp(App[None]):
         # change overflows in 28 cells against `main`'s 32 — a strict subset,
         # fixing four and introducing none — where an unconditional row
         # overflowed in 33 and the measured fit checks in 29 WITH reflow.
-        band.set_class(docked and screen_height > MIN_BAND_INSET_SCREEN_ROWS, "has-slot")
+        #
+        # The second half of the gate is the same shape and covers the case the
+        # height alone misses: a SUBAGENT list long enough to fill the screen by
+        # itself. `SubagentPanel` has no row cap — it mounts one row per job —
+        # so on those screens the dock is already at the edge and the inset is
+        # the row that tips it over. Swept over 112 cells (heights 13-40 x 1-10
+        # children), A/B'd against the identical frame with the class forced
+        # off: the inset causes overflow in five of them, all of the shape
+        # "children + chrome ~= screen".
+        #
+        # Gated on the JOB COUNT rather than on the panel's measured height,
+        # for the reason the fit checks were removed: a count is known
+        # synchronously and cannot change between the frame that paints and the
+        # frame after it, so it cannot flip and cannot reflow. The budget it is
+        # compared against is the same one `TodoPanel` reasons with — the dock's
+        # fixed rows plus the panel's own chrome.
+        band.set_class(
+            docked
+            and screen_height > MIN_BAND_INSET_SCREEN_ROWS
+            and self._subagent_rows_leave_room(screen_height),
+            "has-slot",
+        )
+
+    def _subagent_rows_leave_room(self, screen_height: int) -> bool:
+        """True unless the subagent list is already close to filling the screen.
+
+        ``SubagentPanel`` mounts one row per task job with no cap of its own
+        (unlike ``TodoPanel``, which budgets against the screen), so a long
+        enough child list overruns the dock without any help from the inset —
+        that overflow is this app's on ``main`` too and is out of scope here.
+        What IS in scope is not making it worse, and the inset's row is exactly
+        what tips a list that currently just fits.
+
+        Counted, not measured. A job count is available synchronously and cannot
+        change between the frame that paints and the frame after it; every
+        version of this gate that read a widget's height instead flipped
+        mid-repaint and showed the user a moving dock.
+
+        ``_SUBAGENT_DOCK_ROWS`` is what the column spends around the list: the
+        composer and its status band, the transcript's own padding rows, the
+        panel's caption, its slot rhythm row, and one row of conversation, which
+        is the floor below which the dock has taken the screen.
+        """
+        panel = self._subagent_panel
+        if panel is None or not panel.display:
+            return True
+        jobs = getattr(self._session, "jobs", None)
+        if jobs is None:  # reduced hosts, or before the session is adopted
+            return True
+        try:
+            rows = len([job for job in jobs.list() if getattr(job, "type", "") == "task"])
+        except Exception:  # unreadable ledger; nothing to protect against
+            return True
+        return rows + _SUBAGENT_DOCK_ROWS < screen_height
 
     def _refresh_band(self) -> None:
         """Repaint the dock band (subagent + todo) from live session state.
@@ -6891,11 +6965,11 @@ def slot_rows(slot: Any) -> int:
 
     ``outer_size.height`` is the truth once Textual has arranged the slot, and it
     is ZERO for one that has just been un-hidden — which is every mid-session
-    appearance of a panel, not a boot-only case. `_band_inset_fits` runs at
-    exactly that moment (the todo tool's own event, `SubagentStarted`), so a
-    measurement-only reading makes the first painted frame disagree with the
-    settled one: the dock lands flush and jumps down a row when the 1 Hz poll
-    re-asks, ~0.46 s later on the real event path.
+    appearance of a panel, not a boot-only case. `TodoPanel._band_sibling_rows`
+    reads this at exactly that moment (the todo tool's own event,
+    `SubagentStarted`), so a measurement-only reading makes the first painted
+    frame disagree with the settled one: the dock lands flush and jumps down a
+    row when the 1 Hz poll re-asks, ~0.46 s later on the real event path.
 
     The prediction asks the panel, because each already knows what it is about
     to paint — the todo panel from its own row budget, the subagent panel from

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -194,6 +194,11 @@ PERSIST_HINT = "/model default saves this for new sessions"
 #: the user is actively asking ("did my text just get thrown away?").
 QUEUED_STEER_NOTICE = "queued — sends when this step finishes"
 SENT_STEER_NOTICE = "sent — delivered to the agent mid-turn"
+#: The third outcome, and the one a promise about the future always needs: the
+#: turn ended before the engine reached a boundary to take the message at, so
+#: the delivery this row promised never happened on the turn the user was
+#: steering. `warning`, not `error` — an interrupt is something they did.
+STOPPED_STEER_NOTICE = "not sent — the turn was interrupted"
 
 #: Shortest SCREEN (not terminal — two rows go to the app's own outer padding)
 #: that can afford the dock band's top inset row, ``#band.has-slot``.
@@ -3384,21 +3389,74 @@ class OperatorApp(App[None]):
             screen_height = self.screen.size.height
         except Exception:  # not composed yet (early boot), or no band on this host
             return
-        docked = any(
-            panel is not None and panel.display
-            for panel in (self._subagent_panel, self._todo_panel)
+        slots = [panel for panel in (self._subagent_panel, self._todo_panel) if panel is not None]
+        docked = any(panel.display for panel in slots)
+        # The inset is breathing room, and it is only ever taken when there is a
+        # row to spare. Two independent reasons, because one alone is not enough:
+        #
+        # * `screen_height` floors it. Below a 10-row screen the dock already
+        #   exceeds the terminal on its own — `TodoPanel` sits at its
+        #   `_MIN_BODY_ROWS` floor with nothing left to give back — so the row
+        #   cannot come from anywhere. Measured at 100x12: virtual height 11
+        #   against a 10-row screen.
+        # * The FIT check is what covers the other slot. `TodoPanel` charges
+        #   itself for this row (`_band_inset_rows`), but `SubagentPanel` has no
+        #   row budget at all: it mounts one row per task job unconditionally, so
+        #   the inset's row is charged to nobody and comes straight out of the
+        #   transcript. Measured at 100x16 with six children: virtual 15 against
+        #   a 14-row screen, where the same frame without the inset fits exactly.
+        #   `Screen { overflow: hidden }` does not report that as an error, it
+        #   reports it by silently clipping a row off the top — and on this app a
+        #   scrollable screen is always a bug (AGENTS.md).
+        #
+        # So the row is taken only while the dock, the composer and one row of
+        # conversation still fit beside it. A panel with no budget of its own
+        # then simply does not get the inset when it is too tall for one, rather
+        # than taking a row the transcript needed.
+        band.set_class(
+            docked and screen_height > MIN_BAND_INSET_SCREEN_ROWS and self._band_inset_fits(slots),
+            "has-slot",
         )
-        # The inset is breathing room, and the shortest terminals have none to
-        # spend. `TodoPanel` clamps itself at `_MIN_BODY_ROWS` (header + one
-        # item) and below a 10-row screen the dock already exceeds the terminal
-        # on its own, so there is no row left for the panel to pay this out of —
-        # taken anyway, it pushes the band past the screen and
-        # `Screen { overflow: hidden }` reports that by clipping the panel's own
-        # header off the TOP, which is the exact failure the row budget exists
-        # to prevent. Measured at 100x12: virtual height 11 against a 10-row
-        # screen. One row of rhythm is not worth a clipped list, so below the
-        # threshold the band goes back to its previous flush join.
-        band.set_class(docked and screen_height > MIN_BAND_INSET_SCREEN_ROWS, "has-slot")
+
+    def _band_inset_fits(self, slots: list[Any]) -> bool:
+        """True when one more row still leaves the column something to show.
+
+        Measured off the last layout rather than predicted: the slots' own outer
+        heights already include each slot's rhythm row, and `#input-shell` is the
+        composer plus its status band. What is left after those and the inset has
+        to be at least one row, or the inset is taking the transcript's last row.
+
+        Deliberately CONSERVATIVE about the unknown case: before the first
+        layout every region measures zero, which would read as "everything
+        fits" and apply the inset to a band that may not have room for it —
+        the overflow only becoming visible, and then correcting itself, a tick
+        later. Withholding the row instead costs at most one tick of a missing
+        blank row on a panel that appeared during boot, which is the cheaper of
+        the two mistakes: panels normally appear mid-session, where the layout
+        is long since measured.
+        """
+        try:
+            screen_height = self.screen.size.height
+            shell_rows = self.query_one("#input-shell").outer_size.height
+        except Exception:  # not composed yet; the next tick measures properly
+            return False
+        if screen_height <= 0 or shell_rows <= 0:
+            return False  # nothing measured yet; see the docstring
+        # Per-SLOT heights, never the band's own: the band's height already
+        # contains the inset this is deciding about, so measuring it would ask
+        # "does the row fit given that I already took it" and latch whichever
+        # answer it happened to start with. A slot's `outer_size` covers its
+        # content plus its own rhythm row and excludes the band's padding, so
+        # this term means the same thing whether or not the class is applied.
+        band_rows = sum(slot.outer_size.height for slot in slots if slot.display)
+        if band_rows <= 0:
+            return False  # nothing measured yet; see the docstring
+        # `+ 1` is the inset itself, and the `>= 1` is the transcript's floor:
+        # the conversation keeps at least one row of its own. A band already too
+        # tall for that fails here and simply does not get the row — which is the
+        # honest outcome for a slot with no budget of its own, rather than
+        # spending a row the transcript needed.
+        return screen_height - (band_rows + shell_rows + 1) >= 1
 
     def _refresh_band(self) -> None:
         """Repaint the dock band (subagent + todo) from live session state.
@@ -3421,10 +3479,24 @@ class OperatorApp(App[None]):
         # at its pre-inset height and lost a row on the following tick.
         #
         # Resolved by paying for a second `sync`: settle visibility, settle the
-        # inset from it, then repaint against the budget that results. The
-        # second pass is nearly free — both panels hold an equality guard over
-        # (contents, budget) and return immediately when neither moved, which is
-        # every tick where this changed nothing.
+        # inset from it, then repaint against the budget that results. Verified
+        # necessary rather than assumed — with a single pass the todo list
+        # paints 4 rows against a settled budget of 3 at 100x14 and corrects on
+        # the next tick, which is a row of visible reflow.
+        #
+        # The second pass is cheap but NOT free, and the difference is worth
+        # stating because a reader will be tempted to delete one of them:
+        # `TodoPanel` holds an equality guard over (contents, budget) and
+        # returns immediately when neither moved, but `SubagentPanel` has no
+        # such guard on its non-empty path — it re-lists the manager and
+        # re-syncs its rows every call (measured ~0.005 ms/pass, so ~2x of a
+        # very small number). The correctness of the first paint is worth that.
+        #
+        # One tick of settling remains on the frame where a panel FIRST
+        # appears: `_band_inset_fits` measures the laid-out band, and before
+        # that layout exists it withholds the row rather than guessing. That is
+        # the conservative direction — a missing blank row for one tick, not an
+        # overflowing screen for one tick.
         for _ in range(2):
             if self._subagent_panel is not None:
                 self._subagent_panel.sync(session)
@@ -6171,10 +6243,23 @@ class OperatorApp(App[None]):
             # this turn's calls as they landed so the segment moves while the
             # agent works; this figure prices the whole turn and supersedes the
             # running one, so adding it whole would count every already-billed
-            # call twice. Floored at zero: the turn total is a sum over the same
-            # calls and cannot legitimately come back smaller, and a negative
-            # correction would walk the session's lifetime spend backwards.
-            self._total_cost += max(0.0, cost - self._turn_accrued_cost)
+            # call twice.
+            remainder = cost - self._turn_accrued_cost
+            if remainder < 0:
+                # The floor is the right BEHAVIOUR — a lifetime spend counter
+                # that walks backwards is worse than one that is slightly high —
+                # but it is not a non-event, so it is not swallowed. It means the
+                # two paths disagreed about the same turn: `agent_end` sums only
+                # the messages it carries, and a mid-turn compaction's survivor
+                # filter can drop messages this app already billed live. Logged
+                # so the accounting bug behind it is discoverable instead of
+                # sitting invisibly on the session's total.
+                logger.debug(
+                    "turn total %.6f is below the %.6f already accrued; keeping the accrued figure",
+                    cost,
+                    self._turn_accrued_cost,
+                )
+            self._total_cost += max(0.0, remainder)
         # The turn is over either way, so the per-call ledger closes here rather
         # than only on the path that priced something: a turn whose cost came
         # back unpriceable must not leave its accrual standing to be subtracted
@@ -6224,6 +6309,8 @@ class OperatorApp(App[None]):
             # N+1 rows when several tools were running.
             self._append_block(NoticeBlock("interrupted", "warning"))
         self._interrupted_cards = 0
+        if message.aborted or message.error:
+            self._settle_queued_steer_notices_unsent()
 
     def _start_working_block(self, *, ends_empty_state: bool = True) -> None:
         """Mount the turn's working line, pinned to the foot of the transcript.
@@ -6624,28 +6711,64 @@ class OperatorApp(App[None]):
     def on_notice_posted(self, message: NoticePosted) -> None:
         self._append_block(NoticeBlock(message.text, message.kind))
 
-    def on_steering_delivered(self, message: SteeringDelivered) -> None:
-        """Settle every queued-steer row into a delivered one.
+    def _settle_queued_steer_notices_unsent(self) -> None:
+        """Retire queued-steer rows whose turn died before the engine took them.
 
-        The engine has taken the messages into context, so the promise those
+        The delivery receipt only fires when ``_drain_steering`` actually takes
+        messages. A turn that is INTERRUPTED (Ctrl+C) or fails never reaches a
+        boundary, so those rows would go on promising a delivery for the rest of
+        the session — the same defect the receipt was added to fix, reached by
+        the abort path instead. Worse than leaving it alone: the message is
+        genuinely still queued, so the NEXT turn drains it and settles a row the
+        user stopped caring about minutes earlier.
+
+        What the row is restated to is deliberately not ``sent``: from the
+        user's point of view the turn they were steering is over. ``warning``
+        rather than ``error`` because nothing failed — they stopped it — and the
+        text says where the words went, since they are still in the composer's
+        world rather than lost.
+        """
+        if not self._queued_steer_notices:
+            return
+        for block in self._queued_steer_notices:
+            try:
+                block.restate(STOPPED_STEER_NOTICE, "warning")
+            except Exception:  # a receipt must never take the app down
+                logger.debug("queued-steer notice could not be retired", exc_info=True)
+        self._queued_steer_notices.clear()
+
+    def on_steering_delivered(self, message: SteeringDelivered) -> None:
+        """Settle the rows for the messages this delivery actually took.
+
+        The engine has taken those messages into context, so the promise those
         rows were making has come true and they say so — in place, in the past
         tense. Appending a second notice instead would leave the stale `queued`
         claim on screen above its own correction, and spend a row doing it.
 
-        ALL held rows settle on one delivery, because that is what actually
-        happened: the queue is drained whole at a single boundary, so three
-        messages typed during one tool call are three promises kept at once.
-        ``count`` is not used to settle a subset for that reason — it would have
-        to guess WHICH rows, and the queue's own answer is "all of them".
+        ``count`` bounds it, and the OLDEST rows settle first, because the drain
+        is not always the whole queue: it awaits a disk append per message, and
+        a message steered during that await lands after the ``while`` has
+        already exited. It is genuinely still queued and will go at the next
+        boundary, so settling its row here would claim a delivery that has not
+        happened. FIFO matches the queue's own order, so "the first ``count``
+        rows" and "the messages that went" are the same set.
         """
         if not self._queued_steer_notices:
             return  # a delivery for rows this app is no longer holding
-        for block in self._queued_steer_notices:
+        # Defensive bounds: a producer that omits `count` (or sends a nonsense
+        # one) must not settle nothing, and must not settle more rows than are
+        # held. One is the floor because a delivery event means at least one
+        # message went.
+        taken = max(1, min(int(getattr(message, "count", 1) or 1), len(self._queued_steer_notices)))
+        settled, self._queued_steer_notices = (
+            self._queued_steer_notices[:taken],
+            self._queued_steer_notices[taken:],
+        )
+        for block in settled:
             try:
                 block.restate(SENT_STEER_NOTICE, "success")
             except Exception:  # a receipt must never take the app down
                 logger.debug("queued-steer notice could not be settled", exc_info=True)
-        self._queued_steer_notices.clear()
 
     def on_compaction_started(self, message: CompactionStarted) -> None:
         self._append_block(NoticeBlock("compacting context…", "info"))

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -6608,13 +6608,22 @@ class OperatorApp(App[None]):
         real turn is still a floor, just a larger one. Only a session whose
         spend was accrued entirely in this process is exactly known.
 
-        Zero spends NO segment, which also settles a disagreement the five
-        callers used to have among themselves: three emptied the cell at zero
-        and the turn-end site printed `$0.0000`. Empty is the spelling that
-        matches this codebase's stated position on a confident zero — see
-        :func:`~local_operator.tui.costs.turn_cost`, where `$0.0000` over real
-        tokens is called the more expensive lie — and an unpriced model reaching
-        the band as `0.0` is exactly the case that would print it.
+        Zero spends NO segment, and picking that spelling settled a genuine
+        disagreement rather than ratifying a majority. Before this helper the
+        five callers had four different zero behaviours: `/reload`'s
+        reconciliation wrote `""` (the only explicit empty), the 1 Hz subagent
+        harvest passed `None` — which
+        :meth:`~local_operator.tui.widgets.status_line.StatusLine.update` reads
+        as "do not write this segment", leaving whatever was there standing, NOT
+        as an empty — turn end reached `format_cost(0.0)` and printed `$0.0000`,
+        and the restore and per-call accrual could not reach zero at all because
+        a truthiness guard returned first, so they expressed no opinion.
+
+        Only one site had a considered zero policy, and this follows it, because
+        it is the one this codebase argues for in its own words: see
+        :func:`~local_operator.tui.costs.turn_cost`, where a confident `$0.0000`
+        over billed tokens is called the more expensive lie. An unpriced model
+        reaching the band as `0.0` is exactly the case that would print it.
         """
         spend = self._spend_total() if total is None else total
         if not spend:

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -6774,7 +6774,14 @@ class OperatorApp(App[None]):
         # message went.
         try:
             count = int(getattr(message, "count", 1) or 1)
-        except (TypeError, ValueError):
+        except Exception:
+            # `Exception`, not a list of the types that came to mind. The first
+            # attempt named `TypeError`/`ValueError` and still died on
+            # `float("inf")`, which raises `OverflowError` — a value from a
+            # producer this app does not own found the one gap in a guard
+            # written precisely because the producer is not ours. Enumerating
+            # failure modes is how that gap reappears; the surrounding handlers
+            # all take the broad posture for the same reason.
             # A receipt must never take the app down, and this handler is one
             # `int()` away from being the exception to that: the field crosses a
             # thread boundary from a producer this app does not own. One

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -6607,6 +6607,14 @@ class OperatorApp(App[None]):
         same as "until something else is added to it": a restored floor plus a
         real turn is still a floor, just a larger one. Only a session whose
         spend was accrued entirely in this process is exactly known.
+
+        Zero spends NO segment, which also settles a disagreement the five
+        callers used to have among themselves: three emptied the cell at zero
+        and the turn-end site printed `$0.0000`. Empty is the spelling that
+        matches this codebase's stated position on a confident zero — see
+        :func:`~local_operator.tui.costs.turn_cost`, where `$0.0000` over real
+        tokens is called the more expensive lie — and an unpriced model reaching
+        the band as `0.0` is exactly the case that would print it.
         """
         spend = self._spend_total() if total is None else total
         if not spend:

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -185,8 +185,13 @@ PERSIST_HINT = "/model default saves this for new sessions"
 #: running total does, so without a mark a resumed session's `$0.139` is
 #: indistinguishable from a session that has genuinely spent that. `≥` rather
 #: than a word because the segment sheds early on a narrow terminal and one cell
-#: is what the distinction is worth. Dropped by the first live turn, which
-#: replaces the figure with a real total.
+#: is what the distinction is worth.
+#:
+#: It is NOT dropped by the next turn, which an earlier version claimed: a
+#: restored floor plus a real turn is still a floor, just a larger one. The
+#: figure only becomes exactly known for a session whose spend was accrued
+#: entirely in this process, so the mark is sticky for the life of the
+#: conversation and clears when the ledger it qualifies does.
 RESTORED_COST_PREFIX = "≥"
 
 #: The states of a mid-turn message, as one set so they cannot drift apart.
@@ -784,6 +789,13 @@ class OperatorApp(App[None]):
         #: retention window and a spend counter that goes DOWN when a finished
         #: child is evicted is worse than no counter at all.
         self._subagent_costs: dict[str, float] = {}
+        #: True when `_total_cost` includes money RESTORED from a resumed
+        #: conversation, which makes the band's figure a lower bound rather than
+        #: a total (see `_restore_reported_usage`). Sticky for the life of the
+        #: session: adding a real turn to a floor leaves a floor, so nothing
+        #: this session does can make the figure exactly known again. Cleared
+        #: only on a swap, where the ledger it qualifies is cleared too.
+        self._spend_is_floor: bool = False
         #: Queued-steer rows still promising a delivery that has not happened.
         #: Appended when a mid-turn submit is steered, drained when the engine
         #: reports it took them (`on_steering_delivered`). A list because several
@@ -1255,15 +1267,14 @@ class OperatorApp(App[None]):
         cost = self._cost_for(usage)
         if cost:
             self._total_cost = cost
-            # Marked `≥`, because this figure is a FLOOR and renders in the same
-            # cell a real running total does. Only the last reported turn's usage
-            # survives in a priceable form, so a ten-turn conversation restores
-            # the last turn's dollars — potentially an order of magnitude under
-            # the truth — and without the mark a reader has no way to tell.
-            # One cell buys the distinction, which is the same trade the context
-            # segment already makes with its estimate flag. The first live turn
-            # supersedes it with a real total and the mark goes.
-            self._status.update(cost=f"{RESTORED_COST_PREFIX}{format_cost(self._spend_total())}")
+            # A FLOOR from here on, and the flag rather than the formatting is
+            # what says so: every writer of the cost cell reads it through
+            # `_spend_text`, so none of them can strip the mark by rendering the
+            # same money a different way. Only the last reported turn's usage
+            # survives in a priceable form, so this can be an order of magnitude
+            # under the conversation's real lifetime spend.
+            self._spend_is_floor = True
+            self._status.update(cost=self._spend_text())
 
     def _measure_preloaded_context(self, session: Any) -> None:
         """Fill the context segment before the first turn, off the boot path.
@@ -1650,7 +1661,7 @@ class OperatorApp(App[None]):
                 self._set_welcome_visible(True)
         self._reconcile_reload(previous_id, previous_len, carried_spend, keep_context=keep_context)
 
-    def _reset_ledger_for_swap(self) -> tuple[float, dict[str, float]]:
+    def _reset_ledger_for_swap(self) -> tuple[float, dict[str, float], bool]:
         """Clear the transcript and the session-scoped band, for a swap.
 
         Returns the spend totals it just zeroed, for `_reconcile_reload` to put
@@ -1691,6 +1702,9 @@ class OperatorApp(App[None]):
         carried_spend = (self._total_cost, dict(self._subagent_costs))
         self._total_cost = 0.0
         self._subagent_costs.clear()
+        # The flag describes the totals just zeroed. `_reconcile_reload` puts
+        # both back together when the reload lands on the same conversation.
+        was_floor, self._spend_is_floor = self._spend_is_floor, False
         # The held queued-steer rows were just removed with the rest of the
         # ledger, so the references are to widgets no longer on screen. Left in
         # the list, the replacement session's first delivery would "settle"
@@ -1728,7 +1742,7 @@ class OperatorApp(App[None]):
             # first turn ended.
             cost="",
         )
-        return carried_spend
+        return (*carried_spend, was_floor)
 
     def _conversation_id(self) -> str:
         """Which conversation is open, or "" when none is."""
@@ -1749,7 +1763,7 @@ class OperatorApp(App[None]):
         self,
         previous_id: str,
         previous_len: int,
-        carried_spend: tuple[float, dict[str, float]],
+        carried_spend: tuple[float, dict[str, float], bool],
         *,
         keep_context: bool,
     ) -> None:
@@ -1770,12 +1784,16 @@ class OperatorApp(App[None]):
         every time a reload refreshes the MCP servers.
         """
         if previous_id and self._conversation_id() == previous_id:
-            total, children = carried_spend
+            total, children, was_floor = carried_spend
             self._total_cost = total
             self._subagent_costs.update(children)
+            # The provenance travels with the money. Without it a `/reload` onto
+            # the same conversation repainted the identical restored floor as a
+            # bare figure — same number, same provenance, honesty mark gone, on
+            # the one command that promises to change nothing.
+            self._spend_is_floor = was_floor
             if self._status is not None:
-                spend = self._spend_total()
-                self._status.update(cost=format_cost(spend) if spend else "")
+                self._status.update(cost=self._spend_text())
         if not keep_context:
             return
         remaining = self._history_length()
@@ -3439,7 +3457,7 @@ class OperatorApp(App[None]):
                 self._status.update(
                     subagents=agents,
                     jobs=jobs,
-                    cost=format_cost(total) if total else None,
+                    cost=self._spend_text(total) or None,
                 )
         # The band's belt to the event stream's suspenders: elapsed time and
         # job status move with no Subagent*/tool-end event at all, so the 1 Hz
@@ -6391,7 +6409,7 @@ class OperatorApp(App[None]):
             # returns None for a dead session, so without this clause the leftover
             # dict alone would repaint the dead conversation's total into a band
             # that was just emptied on purpose.
-            cost_text = format_cost(total)
+            cost_text = self._spend_text(total)
         elif message.usage is not None and getattr(message.usage, "input_tokens", 0):
             # D20: the turn billed tokens but pricing is unknown — render an
             # explicit "unavailable" so the segment's absence reads as that,
@@ -6572,6 +6590,29 @@ class OperatorApp(App[None]):
             if cost is not None:
                 self._subagent_costs[job.id] = cost
 
+    def _spend_text(self, total: float | None = None) -> str:
+        """The session's spend as the band should SPELL it, mark included.
+
+        Every writer of the cost cell goes through here, because the mark is a
+        property of the FIGURE and not of the moment one particular caller
+        happens to render it. Five sites write that cell — turn end, the per-call
+        accrual, the 1 Hz subagent harvest, `/reload`'s reconciliation and the
+        restore itself — and when only the restore knew about the mark, the
+        other four silently stripped it: a resumed session's honest `≥$2.10`
+        became a bare `$2.60` the moment a child reported spend, and `/reload`
+        repainted the identical floor unmarked, on a command whose whole
+        contract is that it changes nothing about the conversation.
+
+        The mark stays until a figure is no longer a floor, which is not the
+        same as "until something else is added to it": a restored floor plus a
+        real turn is still a floor, just a larger one. Only a session whose
+        spend was accrued entirely in this process is exactly known.
+        """
+        spend = self._spend_total() if total is None else total
+        if not spend:
+            return ""
+        return f"{RESTORED_COST_PREFIX if self._spend_is_floor else ''}{format_cost(spend)}"
+
     def _spend_total(self) -> float:
         """Everything this session has spent: its own turns plus its children's.
 
@@ -6722,7 +6763,7 @@ class OperatorApp(App[None]):
             return
         self._total_cost += cost
         self._turn_accrued_cost += cost
-        self._status.update(cost=format_cost(self._spend_total()))
+        self._status.update(cost=self._spend_text())
 
     def on_tool_composing(self, message: ToolComposing) -> None:
         """Show the call the model is still dictating (TUI-026).

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -205,22 +205,34 @@ STOPPED_STEER_NOTICE = "not sent — the turn was interrupted"
 #: row says that rather than claiming a delivery or a loss.
 DEFERRED_STEER_NOTICE = "still queued — goes to the next turn"
 
-#: Shortest SCREEN (not terminal — two rows go to the app's own outer padding)
-#: that can afford the dock band's top inset row, ``#band.has-slot``.
-#:
-#: At 10 rows the dock already exceeds the terminal without it: ``#input-shell``
-#: is five rows and the transcript's padding two more, and ``TodoPanel`` is
-#: clamped at its ``_MIN_BODY_ROWS`` floor with nothing left to give back. The
-#: inset is one row of rhythm; a clipped todo header is a lost statement, so
-#: below this the band keeps its previous flush join. See
-#: :meth:`OperatorApp._sync_band_inset`.
-MIN_BAND_INSET_SCREEN_ROWS = 10
 
 #: Rows a `.band-slot` spends on itself beyond its content: the rhythm row it
 #: owns below itself (`padding: 0 0 1 0` in the sheet). Added to a panel's
 #: predicted content height so a predicted slot and a measured one mean the
-#: same thing — see :func:`_slot_rows`.
+#: same thing — see :func:`slot_rows`.
 _BAND_SLOT_RHYTHM_ROWS = 1
+
+#: Shortest SCREEN (not terminal — two rows go to the app's own outer padding)
+#: that can afford the dock band's top inset row, ``#band.has-slot``. At or below
+#: 12 rows the dock already crowds the terminal without it — `#input-shell` is
+#: five rows and the transcript's padding two more, with `TodoPanel` clamped at
+#: its floor — so the row costs a clipped list rather than buying rhythm.
+#:
+#: Calibrated, not guessed: swept over 100 configurations (screen heights 12-40 x
+#: todo-only / subagent-only / both), 12 is the value at which this change
+#: overflows in a STRICT SUBSET of the cells `main` already overflows in — it
+#: fixes four and introduces none. A static screen dimension is the
+#: only gate here that CANNOT reflow — see `_sync_band_inset` for why every
+#: attempt to condition the row on measured slot heights made things worse.
+MIN_BAND_INSET_SCREEN_ROWS = 12
+
+#: Passes `_refresh_band` makes over (panels, inset) before painting. Three,
+#: because the band's visibility, its inset row and `TodoPanel`'s row budget
+#: each depend on the previous one — see the comment in `_refresh_band` for the
+#: measurement. Named rather than inlined so the reason survives next to the
+#: number.
+_BAND_SETTLE_PASSES = 3
+
 
 #: Slash commands handled synchronously before any prompt is sent. One
 #: registry entry per command; aliases live on the entry (TUI-014).
@@ -3400,81 +3412,49 @@ class OperatorApp(App[None]):
             screen_height = self.screen.size.height
         except Exception:  # not composed yet (early boot), or no band on this host
             return
-        slots = [panel for panel in (self._subagent_panel, self._todo_panel) if panel is not None]
-        docked = any(panel.display for panel in slots)
-        # The inset is breathing room, and it is only ever taken when there is a
-        # row to spare. Two independent reasons, because one alone is not enough:
-        #
-        # * `screen_height` floors it. Below a 10-row screen the dock already
-        #   exceeds the terminal on its own — `TodoPanel` sits at its
-        #   `_MIN_BODY_ROWS` floor with nothing left to give back — so the row
-        #   cannot come from anywhere. Measured at 100x12: virtual height 11
-        #   against a 10-row screen.
-        # * The FIT check is what covers the other slot. `TodoPanel` charges
-        #   itself for this row (`_band_inset_rows`), but `SubagentPanel` has no
-        #   row budget at all: it mounts one row per task job unconditionally, so
-        #   the inset's row is charged to nobody and comes straight out of the
-        #   transcript. Measured at 100x16 with six children: virtual 15 against
-        #   a 14-row screen, where the same frame without the inset fits exactly.
-        #   `Screen { overflow: hidden }` does not report that as an error, it
-        #   reports it by silently clipping a row off the top — and on this app a
-        #   scrollable screen is always a bug (AGENTS.md).
-        #
-        # So the row is taken only while the dock, the composer and one row of
-        # conversation still fit beside it. A panel with no budget of its own
-        # then simply does not get the inset when it is too tall for one, rather
-        # than taking a row the transcript needed.
-        band.set_class(
-            docked and screen_height > MIN_BAND_INSET_SCREEN_ROWS and self._band_inset_fits(slots),
-            "has-slot",
+        docked = any(
+            panel is not None and panel.display
+            for panel in (self._subagent_panel, self._todo_panel)
         )
-
-    def _band_inset_fits(self, slots: list[Any]) -> bool:
-        """True when one more row still leaves the column something to show.
-
-        Measured off the last layout rather than predicted: the slots' own outer
-        heights already include each slot's rhythm row, and `#input-shell` is the
-        composer plus its status band. What is left after those and the inset has
-        to be at least one row, or the inset is taking the transcript's last row.
-
-        A slot that has just been un-hidden measures ZERO until Textual
-        re-arranges, and that is the common case rather than a boot-only edge:
-        every mid-session appearance — a todo list created, a subagent started —
-        runs this against an unmeasured slot. Guessing "it does not fit" there
-        was visibly wrong: the dock painted flush, then jumped down a row when
-        the 1 Hz poll re-ran the check, and the todo list took an item back into
-        its `… N more` count at the same moment. Measured on the real event path
-        at ~0.46 s of wall clock, because `SubagentStarted` fires exactly one
-        `_refresh_band` and nothing else runs until the poll.
-
-        So an unmeasured slot is PREDICTED rather than assumed away (see
-        :func:`_slot_rows`): each panel already knows how many rows it is about
-        to paint, and asking it is what lets the first pass answer honestly and
-        the first painted frame be the settled one. Zero is kept as the "no slot
-        at all" answer, which is the only case where refusing is right.
-        """
-        try:
-            screen_height = self.screen.size.height
-            shell_rows = self.query_one("#input-shell").outer_size.height
-        except Exception:  # not composed yet; the next tick measures properly
-            return False
-        if screen_height <= 0 or shell_rows <= 0:
-            return False  # nothing measured yet; see the docstring
-        # Per-SLOT heights, never the band's own: the band's height already
-        # contains the inset this is deciding about, so measuring it would ask
-        # "does the row fit given that I already took it" and latch whichever
-        # answer it happened to start with. A slot's `outer_size` covers its
-        # content plus its own rhythm row and excludes the band's padding, so
-        # this term means the same thing whether or not the class is applied.
-        band_rows = sum(_slot_rows(slot) for slot in slots if slot.display)
-        if band_rows <= 0:
-            return False  # nothing to measure and nothing predicted: no slot
-        # `+ 1` is the inset itself, and the `>= 1` is the transcript's floor:
-        # the conversation keeps at least one row of its own. A band already too
-        # tall for that fails here and simply does not get the row — which is the
-        # honest outcome for a slot with no budget of its own, rather than
-        # spending a row the transcript needed.
-        return screen_height - (band_rows + shell_rows + 1) >= 1
+        # DOCKED IS THE WHOLE CONDITION, and getting here took two wrong turns
+        # worth recording, because both look like the careful choice.
+        #
+        # The row can only be afforded if some slot pays for it, and only
+        # `TodoPanel` has a row budget to pay from — `SubagentPanel` mounts one
+        # row per job unconditionally. So the first attempt gated the inset on a
+        # screen-height threshold and the second on measuring whether the band
+        # still fit. Both made it WORSE, because every such test reads heights
+        # that are one layout out of date at exactly the moment a panel appears:
+        # the answer flips between the frame that paints and the frame after it,
+        # and the user sees the dock jump. Measured over 90 configurations
+        # (screen heights 12-40 x todo-only / subagent-only / both):
+        #
+        #     unconditional  : 0 reflowing cells, 25 overflowing
+        #     fit-checked    : 4 reflowing cells, 29 overflowing
+        #     main (no inset): 0 reflowing cells, 29 overflowing
+        #
+        # The conditional version caused the motion it was written to prevent
+        # AND overflowed more often, because withholding the row leaves the todo
+        # panel budgeting for a row it then has to give back. Unconditional is
+        # both stiller and tighter than either.
+        #
+        # The overflow that remains is `SubagentPanel`'s own and PRE-DATES this
+        # row: it has no row cap, so a long enough child list overruns the
+        # screen on `main` too, in the same cells. This change makes that
+        # strictly better rather than worse; the real fix is a row budget and a
+        # `… N more` line on that panel, which is its own change.
+        # The one exception is a SCREEN-HEIGHT floor, and it is safe where the
+        # fit check was not for a specific reason: the screen's height does not
+        # change between the frame that paints and the frame after it, so this
+        # test cannot flip and cannot reflow. Below a 10-row screen the dock
+        # already exceeds the terminal on its own — `#input-shell` is five rows
+        # and the transcript's padding two more, with `TodoPanel` clamped at its
+        # `_MIN_BODY_ROWS` floor — so the row has nowhere to come from and costs
+        # a clipped list. Swept over 100 configurations: with this floor the
+        # change overflows in 28 cells against `main`'s 32 — a strict subset,
+        # fixing four and introducing none — where an unconditional row
+        # overflowed in 33 and the measured fit checks in 29 WITH reflow.
+        band.set_class(docked and screen_height > MIN_BAND_INSET_SCREEN_ROWS, "has-slot")
 
     def _refresh_band(self) -> None:
         """Repaint the dock band (subagent + todo) from live session state.
@@ -3504,18 +3484,20 @@ class OperatorApp(App[None]):
         #
         # The second pass is cheap but NOT free, and the difference is worth
         # stating because a reader will be tempted to delete one of them:
-        # `TodoPanel` holds an equality guard over (contents, budget) and
-        # returns immediately when neither moved, but `SubagentPanel` has no
-        # such guard on its non-empty path — it re-lists the manager and
-        # re-syncs its rows every call (measured ~0.005 ms/pass, so ~2x of a
-        # very small number). The correctness of the first paint is worth that.
+        # Several passes, because the quantities here feed each other: a
+        # panel's visibility decides whether the band takes its inset row, the
+        # inset is one of the rows `TodoPanel` budgets against, and that budget
+        # decides how tall the panel is. One pass leaves the todo list a row too
+        # tall on the frame a panel appears — the reflow this repeat exists to
+        # remove — and a third settles the both-panels case, where the subagent
+        # panel appearing moves the todo panel's sibling term in the same tick.
         #
-        # One tick of settling remains on the frame where a panel FIRST
-        # appears: `_band_inset_fits` measures the laid-out band, and before
-        # that layout exists it withholds the row rather than guessing. That is
-        # the conservative direction — a missing blank row for one tick, not an
-        # overflowing screen for one tick.
-        for _ in range(2):
+        # Cheap: `TodoPanel` holds an equality guard over (contents, budget) and
+        # returns immediately when neither moved, so the passes after the state
+        # settles cost one comparison. `SubagentPanel` has no such guard on its
+        # non-empty path (measured ~0.005 ms/pass), which is a small price for a
+        # first frame that does not move.
+        for _ in range(_BAND_SETTLE_PASSES):
             if self._subagent_panel is not None:
                 self._subagent_panel.sync(session)
             if self._todo_panel is not None:
@@ -6897,7 +6879,7 @@ class OperatorApp(App[None]):
         self._refresh_band()
 
 
-def _slot_rows(slot: Any) -> int:
+def slot_rows(slot: Any) -> int:
     """Rows a docked band slot occupies, measured if possible and predicted if not.
 
     ``outer_size.height`` is the truth once Textual has arranged the slot, and it

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -214,14 +214,21 @@ RESTORED_COST_PREFIX = "≥"
 #: made the reader translate. All four now describe what the user observes.
 QUEUED_STEER_NOTICE = "queued — sends when this step finishes"
 SENT_STEER_NOTICE = "sent — the agent has it now"
-#: The turn was interrupted before a boundary. `note`, NOT `warning`: nothing
-#: failed and nothing was lost, the message is simply still waiting — and the
-#: standalone `interrupted` notice is already on screen in amber for the same
-#: event, so a second amber row spends the loudest ink in the palette twice and
-#: reads as a stutter.
-STOPPED_STEER_NOTICE = "still queued — the turn was stopped, sends with your next message"
-#: The turn ended cleanly without ever reaching a boundary to drain at (the
-#: model answered with no further tool calls). Same state, different reason.
+#: The turn ended without ever reaching a boundary to drain at — interrupted,
+#: failed, or simply answered with no further tool calls. ONE string for all
+#: three, because they are one fact from the user's side: the message is waiting
+#: and goes with their next message, and what they do about it is identical.
+#:
+#: An earlier version named the interrupt in the row ("the turn was stopped"),
+#: which cost 22 cells to restate the `! interrupted` notice sitting one row
+#: below it in the loudest ink the palette has — the same redundancy `note`
+#: weight was chosen to avoid, surviving as words after being fixed as colour.
+#: It also made this the only string in the set to wrap below 61 columns, and
+#: three messages steered into one tool call turned that into six rows of
+#: near-identical text with the notice explaining them pushed to the bottom.
+#:
+#: Dropping it also stops the row being WRONG on the error path, where the turn
+#: was not stopped by anyone: it failed, and its own error notice says so.
 DEFERRED_STEER_NOTICE = "still queued — sends with your next message"
 
 
@@ -6417,7 +6424,7 @@ class OperatorApp(App[None]):
         # the queue — and that row would otherwise go on promising until some
         # later turn's first boundary settled it, minutes away and unrelated to
         # anything on screen.
-        self._settle_queued_steer_notices_unsent(interrupted=message.aborted or bool(message.error))
+        self._settle_queued_steer_notices_unsent()
 
     def _start_working_block(self, *, ends_empty_state: bool = True) -> None:
         """Mount the turn's working line, pinned to the foot of the transcript.
@@ -6818,39 +6825,33 @@ class OperatorApp(App[None]):
     def on_notice_posted(self, message: NoticePosted) -> None:
         self._append_block(NoticeBlock(message.text, message.kind))
 
-    def _settle_queued_steer_notices_unsent(self, *, interrupted: bool) -> None:
+    def _settle_queued_steer_notices_unsent(self) -> None:
         """Retire queued-steer rows the turn that just ended did not deliver.
 
         The delivery receipt only fires when ``_drain_steering`` actually takes
-        messages, and two ordinary paths end a turn without one:
+        messages, and three ordinary paths end a turn without one: the turn was
+        interrupted (Ctrl+C), it failed, or it ended cleanly with the model
+        answering and no further tool calls. All three leave a row promising a
+        delivery the app has no receipt for — the defect the receipt exists to
+        prevent, reached by every path that is not the delivery path.
 
-        - The turn was INTERRUPTED (Ctrl+C) or failed, so it never reached a
-          boundary. That message never goes at all.
-        - The turn ended CLEANLY without a boundary — the model answered with no
-          further tool calls after the steer landed. The message is still queued
-          and will go at the next turn's first boundary.
+        ONE message for all three, because from the user's side they are one
+        fact: the message is still queued (``abort`` stops the run without
+        draining the queue) and goes with their next message. Naming the cause
+        in the row was tried and removed — it restated the ``interrupted`` or
+        error notice sitting a row below it, cost the only string in the set
+        that wraps under 61 columns, and was simply wrong on the error path,
+        where nobody stopped anything.
 
-        Both leave a row promising a delivery the app has no receipt for, which
-        is the defect the receipt exists to prevent, reached by the two paths
-        that are not the delivery path. The second is milder (it really will be
-        sent) but not harmless: left alone, it settles minutes later against
-        whatever the user is looking at by then.
-
-        The two get DIFFERENT words because they are different facts, and a
-        single message would have to be wrong about one of them. Both are
-        ``warning`` weight rather than ``error``: nothing failed, and in the
-        clean case nothing is even lost.
+        ``note``, the weight the row already had: the state has not got worse,
+        so the row has no business getting louder — and the loud ink is already
+        spent, once, on the notice that explains why the turn ended.
         """
         if not self._queued_steer_notices:
             return
-        text = STOPPED_STEER_NOTICE if interrupted else DEFERRED_STEER_NOTICE
         for block in self._queued_steer_notices:
             try:
-                # `note`, the same weight the row already had. The state has not
-                # got worse — the message is still queued and still going — so
-                # the row has no business getting louder, and the interrupt path
-                # already has an amber `interrupted` notice of its own.
-                block.restate(text, "note")
+                block.restate(DEFERRED_STEER_NOTICE, "note")
             except Exception:  # a receipt must never take the app down
                 logger.debug("queued-steer notice could not be retired", exc_info=True)
         self._queued_steer_notices.clear()

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -199,6 +199,11 @@ SENT_STEER_NOTICE = "sent — delivered to the agent mid-turn"
 #: the delivery this row promised never happened on the turn the user was
 #: steering. `warning`, not `error` — an interrupt is something they did.
 STOPPED_STEER_NOTICE = "not sent — the turn was interrupted"
+#: And the fourth: the turn ended cleanly without ever reaching a boundary to
+#: drain at (the model answered with no further tool calls). The message is
+#: still queued and really will go — at the NEXT turn's first boundary — so the
+#: row says that rather than claiming a delivery or a loss.
+DEFERRED_STEER_NOTICE = "still queued — goes to the next turn"
 
 #: Shortest SCREEN (not terminal — two rows go to the app's own outer padding)
 #: that can afford the dock band's top inset row, ``#band.has-slot``.
@@ -6322,8 +6327,14 @@ class OperatorApp(App[None]):
             # N+1 rows when several tools were running.
             self._append_block(NoticeBlock("interrupted", "warning"))
         self._interrupted_cards = 0
-        if message.aborted or message.error:
-            self._settle_queued_steer_notices_unsent()
+        # EVERY turn end reconciles its queued rows, because the invariant is
+        # simply stated: a row still held when a turn ends is one this turn did
+        # not deliver. A clean end can leave one — the model answers with no
+        # further tool calls, so the loop reaches no boundary and never drains
+        # the queue — and that row would otherwise go on promising until some
+        # later turn's first boundary settled it, minutes away and unrelated to
+        # anything on screen.
+        self._settle_queued_steer_notices_unsent(interrupted=message.aborted or bool(message.error))
 
     def _start_working_block(self, *, ends_empty_state: bool = True) -> None:
         """Mount the turn's working line, pinned to the foot of the transcript.
@@ -6724,28 +6735,35 @@ class OperatorApp(App[None]):
     def on_notice_posted(self, message: NoticePosted) -> None:
         self._append_block(NoticeBlock(message.text, message.kind))
 
-    def _settle_queued_steer_notices_unsent(self) -> None:
-        """Retire queued-steer rows whose turn died before the engine took them.
+    def _settle_queued_steer_notices_unsent(self, *, interrupted: bool) -> None:
+        """Retire queued-steer rows the turn that just ended did not deliver.
 
         The delivery receipt only fires when ``_drain_steering`` actually takes
-        messages. A turn that is INTERRUPTED (Ctrl+C) or fails never reaches a
-        boundary, so those rows would go on promising a delivery for the rest of
-        the session — the same defect the receipt was added to fix, reached by
-        the abort path instead. Worse than leaving it alone: the message is
-        genuinely still queued, so the NEXT turn drains it and settles a row the
-        user stopped caring about minutes earlier.
+        messages, and two ordinary paths end a turn without one:
 
-        What the row is restated to is deliberately not ``sent``: from the
-        user's point of view the turn they were steering is over. ``warning``
-        rather than ``error`` because nothing failed — they stopped it — and the
-        text says where the words went, since they are still in the composer's
-        world rather than lost.
+        - The turn was INTERRUPTED (Ctrl+C) or failed, so it never reached a
+          boundary. That message never goes at all.
+        - The turn ended CLEANLY without a boundary — the model answered with no
+          further tool calls after the steer landed. The message is still queued
+          and will go at the next turn's first boundary.
+
+        Both leave a row promising a delivery the app has no receipt for, which
+        is the defect the receipt exists to prevent, reached by the two paths
+        that are not the delivery path. The second is milder (it really will be
+        sent) but not harmless: left alone, it settles minutes later against
+        whatever the user is looking at by then.
+
+        The two get DIFFERENT words because they are different facts, and a
+        single message would have to be wrong about one of them. Both are
+        ``warning`` weight rather than ``error``: nothing failed, and in the
+        clean case nothing is even lost.
         """
         if not self._queued_steer_notices:
             return
+        text = STOPPED_STEER_NOTICE if interrupted else DEFERRED_STEER_NOTICE
         for block in self._queued_steer_notices:
             try:
-                block.restate(STOPPED_STEER_NOTICE, "warning")
+                block.restate(text, "warning")
             except Exception:  # a receipt must never take the app down
                 logger.debug("queued-steer notice could not be retired", exc_info=True)
         self._queued_steer_notices.clear()
@@ -6772,7 +6790,17 @@ class OperatorApp(App[None]):
         # one) must not settle nothing, and must not settle more rows than are
         # held. One is the floor because a delivery event means at least one
         # message went.
-        taken = max(1, min(int(getattr(message, "count", 1) or 1), len(self._queued_steer_notices)))
+        try:
+            count = int(getattr(message, "count", 1) or 1)
+        except (TypeError, ValueError):
+            # A receipt must never take the app down, and this handler is one
+            # `int()` away from being the exception to that: the field crosses a
+            # thread boundary from a producer this app does not own. One
+            # delivery is the safe reading — the event means at least one
+            # message went.
+            logger.debug("steering delivery reported an unusable count", exc_info=True)
+            count = 1
+        taken = max(1, min(count, len(self._queued_steer_notices)))
         settled, self._queued_steer_notices = (
             self._queued_steer_notices[:taken],
             self._queued_steer_notices[taken:],

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -179,31 +179,50 @@ if TYPE_CHECKING:  # keeps the provider graph off the TUI's runtime import path
 #: the article the clipped phrase lacked.
 PERSIST_HINT = "/model default saves this for new sessions"
 
-#: The two states of a mid-turn message, as one pair so they cannot drift apart.
+#: Marks a cost figure RESTORED from a resumed conversation rather than accrued
+#: this session. The restored number is a floor — only the last reported turn's
+#: usage survives in a priceable form — and it lands in the same cell a real
+#: running total does, so without a mark a resumed session's `$0.139` is
+#: indistinguishable from a session that has genuinely spent that. `≥` rather
+#: than a word because the segment sheds early on a narrow terminal and one cell
+#: is what the distinction is worth. Dropped by the first live turn, which
+#: replaces the figure with a real total.
+RESTORED_COST_PREFIX = "≥"
+
+#: The states of a mid-turn message, as one set so they cannot drift apart.
 #:
 #: The queued line is a promise about the future in the future tense, and the
-#: sent line is the same fact in the past tense — the row is UPDATED IN PLACE
-#: from one to the other (`NoticeBlock.restate`) when the engine actually takes
-#: the message, so the transcript ends up holding one statement that came true
-#: rather than a stale promise with a correction underneath it.
+#: settled lines are the same fact in the past tense — the row is UPDATED IN
+#: PLACE (`NoticeBlock.restate`) rather than corrected by a second row, so the
+#: transcript ends up holding one statement that came true instead of a stale
+#: promise with a retraction under it. That matters more than it looks: a reader
+#: who scrolled away never sees the transition, only the settled row, so each of
+#: these has to stand alone with no memory of the one before it.
 #:
-#: The settled line deliberately reads as a receipt, not an alarm: `sent` is the
-#: word the user is waiting for, and `✓` at `success` weight is the app's
-#: existing mark for a completed action. The queued line stays `note` — mid
-#: weight, readable at a glance, not shouting — because it answers a question
-#: the user is actively asking ("did my text just get thrown away?").
+#: There are two ways a turn can end without delivering, and BOTH leave the
+#: message in the engine's queue — `abort()` sets its flag and stops the run, it
+#: does not drain `_steering_queue` (verified: queued=1 before the abort,
+#: queued=1 after, and the next turn's first boundary takes it). So neither says
+#: "not sent", which an earlier draft did: a user who reads that retypes their
+#: message, the original arrives anyway, and the agent gets the instruction
+#: twice. The distinction that IS real is why the wait is happening, so that is
+#: what the two lines say.
+#:
+#: One noun for the boundary, deliberately. "step" and "turn" are different
+#: things internally — a turn contains several steps, which is exactly why the
+#: deferred case exists — and the UI teaches neither, so a pair that used both
+#: made the reader translate. All four now describe what the user observes.
 QUEUED_STEER_NOTICE = "queued — sends when this step finishes"
-SENT_STEER_NOTICE = "sent — delivered to the agent mid-turn"
-#: The third outcome, and the one a promise about the future always needs: the
-#: turn ended before the engine reached a boundary to take the message at, so
-#: the delivery this row promised never happened on the turn the user was
-#: steering. `warning`, not `error` — an interrupt is something they did.
-STOPPED_STEER_NOTICE = "not sent — the turn was interrupted"
-#: And the fourth: the turn ended cleanly without ever reaching a boundary to
-#: drain at (the model answered with no further tool calls). The message is
-#: still queued and really will go — at the NEXT turn's first boundary — so the
-#: row says that rather than claiming a delivery or a loss.
-DEFERRED_STEER_NOTICE = "still queued — goes to the next turn"
+SENT_STEER_NOTICE = "sent — the agent has it now"
+#: The turn was interrupted before a boundary. `note`, NOT `warning`: nothing
+#: failed and nothing was lost, the message is simply still waiting — and the
+#: standalone `interrupted` notice is already on screen in amber for the same
+#: event, so a second amber row spends the loudest ink in the palette twice and
+#: reads as a stutter.
+STOPPED_STEER_NOTICE = "still queued — the turn was stopped, sends with your next message"
+#: The turn ended cleanly without ever reaching a boundary to drain at (the
+#: model answered with no further tool calls). Same state, different reason.
+DEFERRED_STEER_NOTICE = "still queued — sends with your next message"
 
 
 #: Rows a `.band-slot` spends on itself beyond its content: the rhythm row it
@@ -1229,7 +1248,15 @@ class OperatorApp(App[None]):
         cost = self._cost_for(usage)
         if cost:
             self._total_cost = cost
-            self._status.update(cost=format_cost(self._spend_total()))
+            # Marked `≥`, because this figure is a FLOOR and renders in the same
+            # cell a real running total does. Only the last reported turn's usage
+            # survives in a priceable form, so a ten-turn conversation restores
+            # the last turn's dollars — potentially an order of magnitude under
+            # the truth — and without the mark a reader has no way to tell.
+            # One cell buys the distinction, which is the same trade the context
+            # segment already makes with its estimate flag. The first live turn
+            # supersedes it with a real total and the mark goes.
+            self._status.update(cost=f"{RESTORED_COST_PREFIX}{format_cost(self._spend_total())}")
 
     def _measure_preloaded_context(self, session: Any) -> None:
         """Fill the context segment before the first turn, off the boot path.
@@ -6819,7 +6846,11 @@ class OperatorApp(App[None]):
         text = STOPPED_STEER_NOTICE if interrupted else DEFERRED_STEER_NOTICE
         for block in self._queued_steer_notices:
             try:
-                block.restate(text, "warning")
+                # `note`, the same weight the row already had. The state has not
+                # got worse — the message is still queued and still going — so
+                # the row has no business getting louder, and the interrupt path
+                # already has an amber `interrupted` notice of its own.
+                block.restate(text, "note")
             except Exception:  # a receipt must never take the app down
                 logger.debug("queued-steer notice could not be retired", exc_info=True)
         self._queued_steer_notices.clear()

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -211,6 +211,12 @@ STOPPED_STEER_NOTICE = "not sent — the turn was interrupted"
 #: :meth:`OperatorApp._sync_band_inset`.
 MIN_BAND_INSET_SCREEN_ROWS = 10
 
+#: Rows a `.band-slot` spends on itself beyond its content: the rhythm row it
+#: owns below itself (`padding: 0 0 1 0` in the sheet). Added to a panel's
+#: predicted content height so a predicted slot and a measured one mean the
+#: same thing — see :func:`_slot_rows`.
+_BAND_SLOT_RHYTHM_ROWS = 1
+
 #: Slash commands handled synchronously before any prompt is sent. One
 #: registry entry per command; aliases live on the entry (TUI-014).
 #:
@@ -3426,14 +3432,21 @@ class OperatorApp(App[None]):
         composer plus its status band. What is left after those and the inset has
         to be at least one row, or the inset is taking the transcript's last row.
 
-        Deliberately CONSERVATIVE about the unknown case: before the first
-        layout every region measures zero, which would read as "everything
-        fits" and apply the inset to a band that may not have room for it —
-        the overflow only becoming visible, and then correcting itself, a tick
-        later. Withholding the row instead costs at most one tick of a missing
-        blank row on a panel that appeared during boot, which is the cheaper of
-        the two mistakes: panels normally appear mid-session, where the layout
-        is long since measured.
+        A slot that has just been un-hidden measures ZERO until Textual
+        re-arranges, and that is the common case rather than a boot-only edge:
+        every mid-session appearance — a todo list created, a subagent started —
+        runs this against an unmeasured slot. Guessing "it does not fit" there
+        was visibly wrong: the dock painted flush, then jumped down a row when
+        the 1 Hz poll re-ran the check, and the todo list took an item back into
+        its `… N more` count at the same moment. Measured on the real event path
+        at ~0.46 s of wall clock, because `SubagentStarted` fires exactly one
+        `_refresh_band` and nothing else runs until the poll.
+
+        So an unmeasured slot is PREDICTED rather than assumed away (see
+        :func:`_slot_rows`): each panel already knows how many rows it is about
+        to paint, and asking it is what lets the first pass answer honestly and
+        the first painted frame be the settled one. Zero is kept as the "no slot
+        at all" answer, which is the only case where refusing is right.
         """
         try:
             screen_height = self.screen.size.height
@@ -3448,9 +3461,9 @@ class OperatorApp(App[None]):
         # answer it happened to start with. A slot's `outer_size` covers its
         # content plus its own rhythm row and excludes the band's padding, so
         # this term means the same thing whether or not the class is applied.
-        band_rows = sum(slot.outer_size.height for slot in slots if slot.display)
+        band_rows = sum(_slot_rows(slot) for slot in slots if slot.display)
         if band_rows <= 0:
-            return False  # nothing measured yet; see the docstring
+            return False  # nothing to measure and nothing predicted: no slot
         # `+ 1` is the inset itself, and the `>= 1` is the transcript's floor:
         # the conversation keeps at least one row of its own. A band already too
         # tall for that fails here and simply does not get the row — which is the
@@ -6854,6 +6867,49 @@ class OperatorApp(App[None]):
 
     def on_subagent_ended(self, message: SubagentEnded) -> None:
         self._refresh_band()
+
+
+def _slot_rows(slot: Any) -> int:
+    """Rows a docked band slot occupies, measured if possible and predicted if not.
+
+    ``outer_size.height`` is the truth once Textual has arranged the slot, and it
+    is ZERO for one that has just been un-hidden — which is every mid-session
+    appearance of a panel, not a boot-only case. `_band_inset_fits` runs at
+    exactly that moment (the todo tool's own event, `SubagentStarted`), so a
+    measurement-only reading makes the first painted frame disagree with the
+    settled one: the dock lands flush and jumps down a row when the 1 Hz poll
+    re-asks, ~0.46 s later on the real event path.
+
+    The prediction asks the panel, because each already knows what it is about
+    to paint — the todo panel from its own row budget, the subagent panel from
+    the rows it has mounted — and adds the slot's own rhythm row
+    (`.band-slot { padding: 0 0 1 0 }`) so both branches mean the same thing.
+    A panel that answers neither contributes 1: it is displayed, so it is at
+    least a row, and under-counting is what puts a row back into the transcript
+    that the dock is about to take.
+    """
+    try:
+        measured = int(slot.outer_size.height)
+    except Exception:  # not a laid-out widget (reduced hosts)
+        measured = 0
+    predicted = 0
+    predict = getattr(slot, "predicted_rows", None)
+    if callable(predict):
+        try:
+            # `cast` because `getattr` on a duck-typed slot widens to `object`;
+            # the `except` below is what actually guards a bad implementation.
+            rows = cast(Callable[[], int], predict)()
+            predicted = max(1, int(rows)) + _BAND_SLOT_RHYTHM_ROWS
+        except Exception:  # a prediction must never break a repaint
+            logger.debug("band slot could not predict its height", exc_info=True)
+    # The LARGER of the two, never "measured if it looks measured". A slot is
+    # not simply arranged-or-not: mid-layout it reports a PARTIAL height, and
+    # trusting that over the prediction is a race — observed as an intermittent
+    # overflow where a 12-row subagent list measured 3, the inset was granted on
+    # the strength of it, and the rows then arrived. Both terms describe the same
+    # slot, so the larger is the safe one: it can only ever withhold the inset,
+    # which costs a blank row, where the smaller costs a scrollable screen.
+    return max(measured, predicted, 1)
 
 
 def _model_spec(session) -> Any | None:

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -82,6 +82,7 @@ from local_operator.tui.events import (
     RetryEnded,
     RetryStarted,
     StartFlushTimer,
+    SteeringDelivered,
     SubagentEnded,
     SubagentProgress,
     SubagentStarted,
@@ -177,6 +178,33 @@ if TYPE_CHECKING:  # keeps the provider graph off the TUI's runtime import path
 #: this for new sessions" names the consequence, fits the same slot, and includes
 #: the article the clipped phrase lacked.
 PERSIST_HINT = "/model default saves this for new sessions"
+
+#: The two states of a mid-turn message, as one pair so they cannot drift apart.
+#:
+#: The queued line is a promise about the future in the future tense, and the
+#: sent line is the same fact in the past tense — the row is UPDATED IN PLACE
+#: from one to the other (`NoticeBlock.restate`) when the engine actually takes
+#: the message, so the transcript ends up holding one statement that came true
+#: rather than a stale promise with a correction underneath it.
+#:
+#: The settled line deliberately reads as a receipt, not an alarm: `sent` is the
+#: word the user is waiting for, and `✓` at `success` weight is the app's
+#: existing mark for a completed action. The queued line stays `note` — mid
+#: weight, readable at a glance, not shouting — because it answers a question
+#: the user is actively asking ("did my text just get thrown away?").
+QUEUED_STEER_NOTICE = "queued — sends when this step finishes"
+SENT_STEER_NOTICE = "sent — delivered to the agent mid-turn"
+
+#: Shortest SCREEN (not terminal — two rows go to the app's own outer padding)
+#: that can afford the dock band's top inset row, ``#band.has-slot``.
+#:
+#: At 10 rows the dock already exceeds the terminal without it: ``#input-shell``
+#: is five rows and the transcript's padding two more, and ``TodoPanel`` is
+#: clamped at its ``_MIN_BODY_ROWS`` floor with nothing left to give back. The
+#: inset is one row of rhythm; a clipped todo header is a lost statement, so
+#: below this the band keeps its previous flush join. See
+#: :meth:`OperatorApp._sync_band_inset`.
+MIN_BAND_INSET_SCREEN_ROWS = 10
 
 #: Slash commands handled synchronously before any prompt is sent. One
 #: registry entry per command; aliases live on the entry (TUI-014).
@@ -696,6 +724,20 @@ class OperatorApp(App[None]):
         #: retention window and a spend counter that goes DOWN when a finished
         #: child is evicted is worse than no counter at all.
         self._subagent_costs: dict[str, float] = {}
+        #: Queued-steer rows still promising a delivery that has not happened.
+        #: Appended when a mid-turn submit is steered, drained when the engine
+        #: reports it took them (`on_steering_delivered`). A list because several
+        #: messages can be queued against one boundary and the engine delivers
+        #: them together; cleared on a session swap, where the rows belong to a
+        #: conversation that is no longer on screen.
+        self._queued_steer_notices: list[NoticeBlock] = []
+        #: What the CURRENT turn has already been billed for, per model call, by
+        #: `on_context_usage_reported`. `on_turn_ended` prices the same turn as a
+        #: whole and is the authoritative figure, so it adds only the difference
+        #: and this resets to 0.0 at every turn boundary. Without it the two
+        #: writers would each bill the same tokens and the band would report
+        #: roughly double what a turn actually cost.
+        self._turn_accrued_cost: float = 0.0
         # Auto-naming fires while the conversation is STILL unnamed, at most
         # one attempt in flight. Latched here rather than on the session
         # holder because the app is what schedules the call, and a second
@@ -1052,6 +1094,14 @@ class OperatorApp(App[None]):
         self._wire_mcp_status(session)
         self._report_mcp_startup(session)
         self._render_resumed_history(session)
+        # BEFORE the measurement, and the order is load-bearing: this installs
+        # the provider's own exact reading for a resumed conversation, and
+        # `_measure_preloaded_context` refuses to spend an estimate once an
+        # exact figure is standing. Run the other way round, the estimate would
+        # land first and the exact restore would then be the thing overwriting
+        # it — same end state on a quiet boot, but the estimate is resolved in a
+        # worker, so which one won would depend on scheduling.
+        self._restore_reported_usage(session)
         self._measure_preloaded_context(session)
 
     async def _preflight_usage(self, session: Any) -> None:
@@ -1084,6 +1134,68 @@ class OperatorApp(App[None]):
             return
         self._adopt_session(session)
         await self._preflight_usage(session)
+
+    def _restore_reported_usage(self, session: Any) -> None:
+        """Put a RESUMED conversation's own token and cost figures on the band.
+
+        A resumed session opens on a conversation that already happened, and the
+        band is fed entirely by turns that end while this process is running —
+        so before this, `--resume` painted an empty-looking context and no spend
+        for a conversation that might be 40% through its window with real money
+        on it. Measured on a resumed session whose last provider reading was
+        402k of a 1M window: the band opened at `0.2%/1M` with no cost segment,
+        and stayed there until the next turn happened to end.
+
+        Two figures, from the same restored ``Usage`` and with deliberately
+        different standing:
+
+        - **Context** is the provider's own ``context_tokens`` for the last call
+          of the last turn, so it is installed EXACT (``context_is_estimate``
+          False). It is not a guess about the conversation; it is the number the
+          band would still be showing had the process never stopped. Being exact
+          is also what makes it suppress the local estimate below.
+        - **Cost** is the restored turn's price, and it is a FLOOR rather than
+          the session's true lifetime total: only the last reported turn's usage
+          survives in a form this can price, so a ten-turn conversation restores
+          the last turn's dollars and accrues from there. It is seeded anyway
+          because the alternative on screen is an empty segment, and empty reads
+          as "this session has cost nothing" — the one reading that is certainly
+          false. Undercounting a known-partial total beats asserting zero.
+
+        Degrades silently and completely. Reduced hosts (the pilot fakes, the
+        embedders) have no ``restored_usage``, an unpriceable model yields no
+        cost, and a transcript with no usage in it yields nothing at all — in
+        every one of those cases the band keeps exactly the behaviour it had.
+        """
+        restore = getattr(session, "restored_usage", None)
+        if not callable(restore) or self._status is None:
+            return
+        try:
+            usage = restore()
+        except Exception:  # a status readout must never take the app down
+            logger.debug("restored usage unavailable", exc_info=True)
+            return
+        if usage is None:
+            return  # nothing was ever reported: leave the estimate its job
+
+        context_tokens = getattr(usage, "context_tokens", None) or 0
+        if context_tokens > 0:
+            self._status.update(
+                context_tokens=int(context_tokens),
+                context_is_estimate=False,
+                context_window=_context_window(session),
+            )
+
+        # Priced through the same `_cost_for` every live turn uses, so a
+        # restored figure and an accrued one cannot disagree about what the same
+        # usage was worth. `_total_cost` is ASSIGNED rather than added to: this
+        # runs on adopt, where the ledger has just been zeroed for the swap, and
+        # `+=` would double the figure on a `/reload` that lands back on the
+        # same conversation (whose spend `_reconcile_reload` restores).
+        cost = self._cost_for(usage)
+        if cost:
+            self._total_cost = cost
+            self._status.update(cost=format_cost(self._spend_total()))
 
     def _measure_preloaded_context(self, session: Any) -> None:
         """Fill the context segment before the first turn, off the boot path.
@@ -1511,6 +1623,16 @@ class OperatorApp(App[None]):
         carried_spend = (self._total_cost, dict(self._subagent_costs))
         self._total_cost = 0.0
         self._subagent_costs.clear()
+        # The held queued-steer rows were just removed with the rest of the
+        # ledger, so the references are to widgets no longer on screen. Left in
+        # the list, the replacement session's first delivery would "settle"
+        # rows the user cannot see and the rows it CAN see would keep promising.
+        self._queued_steer_notices.clear()
+        # The per-call accrual belongs to a turn on the session being replaced.
+        # Left standing, the NEXT session's first `agent_end` would subtract the
+        # dead conversation's already-billed calls from its own turn total and
+        # under-report that turn by exactly that much.
+        self._turn_accrued_cost = 0.0
         # The MCP segment is cleared too: the old session's manager is gone, so
         # a lingering count would describe servers nothing is connected to any
         # more. `_adopt_session` repaints it from the new session's manager.
@@ -2844,6 +2966,13 @@ class OperatorApp(App[None]):
 
     def _clear_transcript(self) -> None:
         self._transcript_view().clear_blocks()  # fires the on_clear hook
+        # Same reason as the session swap: the rows those references point at
+        # have just been removed, and a delivery landing afterwards must not
+        # try to settle widgets that are no longer in the transcript. The
+        # messages themselves are unaffected — `/clear` empties the screen, not
+        # the engine's queue — so the delivery still happens, it just has no row
+        # left to report it on.
+        self._queued_steer_notices.clear()
         # ``ends_empty_state=False``: the receipt reports on the CLEAR, so the
         # session has not started talking and the splash the clear just restored
         # must survive it. Going through ``_append_block`` rather than straight to
@@ -3025,7 +3154,20 @@ class OperatorApp(App[None]):
             # the user is waiting for, and below `warning`, which is an alarm this
             # is not. Three warning-tinted rows on one frame for routine receipts
             # is how the loudest ink in the palette stops meaning anything.
-            self._append_block(NoticeBlock("queued — sends when this step finishes", "note"))
+            # Held, not just appended: this row is a promise about the future
+            # ("sends when this step finishes") and the reference is what lets
+            # `on_steering_delivered` settle it into a statement of fact once
+            # the engine actually takes the message. Without that, the row went
+            # on saying `queued` for the rest of the session and the agent's
+            # eventual reply was the only evidence it had ever been delivered.
+            #
+            # A LIST because a user can queue several messages while one tool
+            # runs, and the engine delivers whatever has accumulated at the next
+            # boundary — all of them, together. Settling only the newest would
+            # leave the earlier rows lying.
+            queued = NoticeBlock(QUEUED_STEER_NOTICE, "note")
+            self._append_block(queued)
+            self._queued_steer_notices.append(queued)
             # Still worth a title: the steering message can be the first thing
             # in the conversation that actually says what the task is.
             self._maybe_name_conversation(text)
@@ -3224,6 +3366,40 @@ class OperatorApp(App[None]):
         # down (see the panels' own docstrings).
         self._refresh_band()
 
+    def _sync_band_inset(self) -> None:
+        """Give the band its top inset only while it actually holds a slot.
+
+        See ``#band.has-slot`` in the stylesheet for what the row is for. The
+        toggle is here because visibility is a runtime fact: both panels hide
+        themselves when their store is empty, and CSS cannot express "pad only
+        if a child is displayed". Padding a container whose children are all
+        hidden still reserves the row, which on the boot splash is a bare
+        surface strip in a composition measured to the row.
+
+        Never raises: the band is chrome, and a status surface must not be able
+        to take the app down (the same posture as the panels' own ``sync``).
+        """
+        try:
+            band = self.query_one("#band")
+            screen_height = self.screen.size.height
+        except Exception:  # not composed yet (early boot), or no band on this host
+            return
+        docked = any(
+            panel is not None and panel.display
+            for panel in (self._subagent_panel, self._todo_panel)
+        )
+        # The inset is breathing room, and the shortest terminals have none to
+        # spend. `TodoPanel` clamps itself at `_MIN_BODY_ROWS` (header + one
+        # item) and below a 10-row screen the dock already exceeds the terminal
+        # on its own, so there is no row left for the panel to pay this out of —
+        # taken anyway, it pushes the band past the screen and
+        # `Screen { overflow: hidden }` reports that by clipping the panel's own
+        # header off the TOP, which is the exact failure the row budget exists
+        # to prevent. Measured at 100x12: virtual height 11 against a 10-row
+        # screen. One row of rhythm is not worth a clipped list, so below the
+        # threshold the band goes back to its previous flush join.
+        band.set_class(docked and screen_height > MIN_BAND_INSET_SCREEN_ROWS, "has-slot")
+
     def _refresh_band(self) -> None:
         """Repaint the dock band (subagent + todo) from live session state.
 
@@ -3233,10 +3409,28 @@ class OperatorApp(App[None]):
         treat a missing manager as empty).
         """
         session = self._session
-        if self._subagent_panel is not None:
-            self._subagent_panel.sync(session)
-        if self._todo_panel is not None:
-            self._todo_panel.sync(session)
+        # Three steps, and the order is load-bearing rather than tidy.
+        #
+        # A panel's own `sync` is what decides whether it is displayed at all
+        # (its store went from empty to non-empty), and the band's inset exists
+        # only while something is docked — so visibility has to be settled
+        # before the inset can be. But the inset also SPENDS one of the rows
+        # `TodoPanel` sizes its list against, so the budget has to be settled
+        # before the list is painted. Those two orderings conflict, and doing
+        # only one of them is what produced a visible reflow: the list appeared
+        # at its pre-inset height and lost a row on the following tick.
+        #
+        # Resolved by paying for a second `sync`: settle visibility, settle the
+        # inset from it, then repaint against the budget that results. The
+        # second pass is nearly free — both panels hold an equality guard over
+        # (contents, budget) and return immediately when neither moved, which is
+        # every tick where this changed nothing.
+        for _ in range(2):
+            if self._subagent_panel is not None:
+                self._subagent_panel.sync(session)
+            if self._todo_panel is not None:
+                self._todo_panel.sync(session)
+            self._sync_band_inset()
         # The open subagent page rides the SAME tick, for the same reason: a
         # child's elapsed time and its last tool both move with no event, and
         # a page that only advanced on relayed events sat frozen through every
@@ -5973,7 +6167,19 @@ class OperatorApp(App[None]):
         cost_text: str | None = None
         cost = self._cost_for(message.usage)
         if cost is not None:
-            self._total_cost += cost
+            # Only the REMAINDER. `on_context_usage_reported` has been billing
+            # this turn's calls as they landed so the segment moves while the
+            # agent works; this figure prices the whole turn and supersedes the
+            # running one, so adding it whole would count every already-billed
+            # call twice. Floored at zero: the turn total is a sum over the same
+            # calls and cannot legitimately come back smaller, and a negative
+            # correction would walk the session's lifetime spend backwards.
+            self._total_cost += max(0.0, cost - self._turn_accrued_cost)
+        # The turn is over either way, so the per-call ledger closes here rather
+        # than only on the path that priced something: a turn whose cost came
+        # back unpriceable must not leave its accrual standing to be subtracted
+        # from the NEXT turn's total.
+        self._turn_accrued_cost = 0.0
         # Fold in whatever the children have spent BEFORE reading the total: a
         # turn that delegated has almost certainly moved their figures, and the
         # 1 Hz poll would otherwise be what first showed it.
@@ -6282,20 +6488,40 @@ class OperatorApp(App[None]):
         self._refresh_working_activity()
 
     def on_context_usage_reported(self, message: ContextUsageReported) -> None:
-        """Move the context reading DURING a turn, not only when it ends.
+        """Move the context reading AND the cost DURING a turn, not only at its end.
 
         An agentic turn is many model calls over many minutes, and each one
         reports the context it ran against. Waiting for ``agent_end`` meant the
         band showed the pre-turn size for the whole time the agent was working
         — the exact stretch a user watches it for. Reported as exact, because
         it is the provider's own number.
+
+        Money moves on the same signal and for the same reason. Cost used to
+        appear only when the whole turn settled, so a brand-new session's FIRST
+        turn showed no cost at all while it ran — reported from the field as
+        "the cost doesn't start tracking until after the second message". A turn
+        that spends ten minutes in tools is at its most expensive precisely
+        while the segment is empty, and an empty segment reads as free.
+
+        ``_turn_accrued_cost`` is what keeps the two writers honest. This one
+        pays per call as the calls happen; ``on_turn_ended`` prices the turn as
+        a whole and is authoritative (it sums every call, including any this
+        never saw). Recording what was already taken lets the end add only the
+        REMAINDER instead of billing the turn twice.
         """
         assert self._status is not None
-        self._status.update(
-            context_tokens=message.context_tokens,
-            context_is_estimate=False,
-            context_window=_context_window(self._session),
-        )
+        if message.context_tokens > 0:
+            self._status.update(
+                context_tokens=message.context_tokens,
+                context_is_estimate=False,
+                context_window=_context_window(self._session),
+            )
+        cost = self._cost_for(message.usage)
+        if not cost:
+            return
+        self._total_cost += cost
+        self._turn_accrued_cost += cost
+        self._status.update(cost=format_cost(self._spend_total()))
 
     def on_tool_composing(self, message: ToolComposing) -> None:
         """Show the call the model is still dictating (TUI-026).
@@ -6397,6 +6623,29 @@ class OperatorApp(App[None]):
 
     def on_notice_posted(self, message: NoticePosted) -> None:
         self._append_block(NoticeBlock(message.text, message.kind))
+
+    def on_steering_delivered(self, message: SteeringDelivered) -> None:
+        """Settle every queued-steer row into a delivered one.
+
+        The engine has taken the messages into context, so the promise those
+        rows were making has come true and they say so — in place, in the past
+        tense. Appending a second notice instead would leave the stale `queued`
+        claim on screen above its own correction, and spend a row doing it.
+
+        ALL held rows settle on one delivery, because that is what actually
+        happened: the queue is drained whole at a single boundary, so three
+        messages typed during one tool call are three promises kept at once.
+        ``count`` is not used to settle a subset for that reason — it would have
+        to guess WHICH rows, and the queue's own answer is "all of them".
+        """
+        if not self._queued_steer_notices:
+            return  # a delivery for rows this app is no longer holding
+        for block in self._queued_steer_notices:
+            try:
+                block.restate(SENT_STEER_NOTICE, "success")
+            except Exception:  # a receipt must never take the app down
+                logger.debug("queued-steer notice could not be settled", exc_info=True)
+        self._queued_steer_notices.clear()
 
     def on_compaction_started(self, message: CompactionStarted) -> None:
         self._append_block(NoticeBlock("compacting context…", "info"))

--- a/local_operator/tui/events.py
+++ b/local_operator/tui/events.py
@@ -49,6 +49,7 @@ from local_operator.harness.types import (
     NoticeEvent,
     RetryEndEvent,
     RetryStartEvent,
+    SteeringDeliveredEvent,
     SubagentEndEvent,
     SubagentProgressEvent,
     SubagentStartEvent,
@@ -105,11 +106,21 @@ class ContextUsageReported(Message):
     stretch a user is watching it grow, the band reported the size the context
     had before the turn began. On a long tool-using turn that is a number tens
     of thousands of tokens stale, and it looks live.
+
+    ``usage`` is the whole reading the call reported, not just its size, so the
+    band's COST segment can move on the same signal for the same reason. Before
+    it did, money appeared only at ``agent_end``: a first turn that spent ten
+    minutes in tools showed no cost at all while it ran, which reads as a free
+    session precisely while it is becoming an expensive one. ``context_tokens``
+    stays a separate field rather than being read back off ``usage`` because the
+    controller resolves it with a fallback (``context_tokens or input_tokens``)
+    that the raw object does not carry.
     """
 
-    def __init__(self, context_tokens: int) -> None:
+    def __init__(self, context_tokens: int, usage: Any = None) -> None:
         super().__init__()
         self.context_tokens = context_tokens
+        self.usage = usage
 
 
 class TurnBoundaryStart(Message):
@@ -232,6 +243,20 @@ class RetryEnded(Message):
     def __init__(self, success: bool) -> None:
         super().__init__()
         self.success = success
+
+
+class SteeringDelivered(Message):
+    """Queued mid-turn messages reached the model's context.
+
+    The receipt the ``queued — sends when this step finishes`` row was missing:
+    the app settles that row against this instead of leaving a promise about the
+    future standing after the future arrived. ``count`` is how many messages
+    went in at the one boundary.
+    """
+
+    def __init__(self, count: int) -> None:
+        super().__init__()
+        self.count = count
 
 
 class SubagentStarted(Message):
@@ -457,7 +482,13 @@ class EventController:
                 or 0
             )
             if size:
-                self._post(ContextUsageReported(int(size)))
+                self._post(ContextUsageReported(int(size), message_usage))
+            else:
+                # A call that reported tokens but no size still cost money, and
+                # the cost segment must not be gated on the context segment
+                # having something to say. Posting with size 0 lets the app take
+                # the money and leave the reading alone.
+                self._post(ContextUsageReported(0, message_usage))
 
     def _handle_tool_compose(self, event: ToolCallComposeEvent) -> None:
         self._post(ToolComposing(event))
@@ -484,6 +515,13 @@ class EventController:
 
     def _handle_notice(self, event: NoticeEvent) -> None:
         self._post(NoticePosted(event.text, event.kind))
+
+    def _handle_steering_delivered(self, event: SteeringDeliveredEvent) -> None:
+        # No generation guard, deliberately: the drain belongs to whichever turn
+        # is running, and the app settles a row it is holding a direct reference
+        # to rather than looking one up by turn. A late event finds nothing held
+        # and does nothing.
+        self._post(SteeringDelivered(getattr(event, "count", 1)))
 
     def _handle_compaction_start(self, event: CompactionStartEvent) -> None:
         self._post(CompactionStarted(event.reason))
@@ -536,6 +574,7 @@ class EventController:
         "tool_execution_update": _handle_tool_update,
         "tool_execution_end": _handle_tool_end,
         "notice": _handle_notice,
+        "steering_delivered": _handle_steering_delivered,
         "compaction_start": _handle_compaction_start,
         "compaction_end": _handle_compaction_end,
         "retry_start": _handle_retry_start,

--- a/local_operator/tui/local_operator.tcss
+++ b/local_operator/tui/local_operator.tcss
@@ -898,6 +898,41 @@ ApprovalBlock:focus {
     background: $lo-surface;
 }
 
+/* One surface row ABOVE the band's first slot, so a docked panel is inset the
+ * same on both sides of its slab.
+ *
+ * The asymmetry this fixes, measured at 100x24 with three todos: the panel's
+ * caption sat directly on the transcript's ground row while TWO surface rows
+ * (the last slot's own padding, then `#input-shell`'s) separated its last row
+ * from the composer. One row above against two below, on a slab whose whole job
+ * is to read as part of the dock — reported from the field as "it looks a bit
+ * tight" above the todo and subagent lists.
+ *
+ * On the BAND, not on `.band-slot`: the slot's padding repeats per slot, and
+ * with both panels docked a per-slot top row would open a second gap between
+ * the subagent list and the todo list — where the existing single row is
+ * already the right rhythm. This is the join between the CONVERSATION and the
+ * dock, which happens once no matter how many slots the band holds.
+ *
+ * Why this does not re-create the trench the padding flip removed: that row was
+ * transparent, so it painted the Screen's `$lo-bg` between two lighter slabs.
+ * This one is inside `#band` and therefore `$lo-surface` — the same fill as the
+ * rows below the slab, so the panel reads as inset within the dock rather than
+ * as having come loose from it. The transcript's own ground row still sits
+ * above it and still separates the conversation from the dock, which is the
+ * rule that row belongs to.
+ *
+ * Carried by a CLASS the band toggles rather than declared unconditionally,
+ * because padding on a container applies even when every child is hidden: an
+ * idle session and the boot splash have both panels `display: none`, and an
+ * unconditional row would put a bare surface strip into a composition that is
+ * measured to the row (`test_an_empty_band_paints_nothing_on_the_splash`). The
+ * class is applied only while a slot is actually visible — see
+ * `OperatorApp._refresh_band`. */
+#band.has-slot {
+    padding: 1 0 0 0;
+}
+
 /* One blank row UNDER each slot, not over it, and the direction is the whole
  * point: the transcript ends in a row of its own ground (`TranscriptView`'s
  * bottom padding), so a top padding row here stacked with it — measured at

--- a/local_operator/tui/widgets/subagent_panel.py
+++ b/local_operator/tui/widgets/subagent_panel.py
@@ -873,7 +873,7 @@ class SubagentPanel(Container):
 
         The dock's inset check runs at the moment a panel appears — a
         ``SubagentStarted`` event — when the slot has not been arranged yet and
-        measures zero (see ``app._slot_rows``). This panel's height is simply
+        measures zero (see ``app.slot_rows``). This panel's height is simply
         its header plus one row per job, both of which are known as soon as
         ``sync`` has run, so answering here is what lets the dock paint its
         settled frame first instead of jumping a row at the next 1 Hz poll.

--- a/local_operator/tui/widgets/subagent_panel.py
+++ b/local_operator/tui/widgets/subagent_panel.py
@@ -56,6 +56,11 @@ GLYPH_FAILED = "✗"
 GLYPH_CANCELLED = "⊘"
 GLYPH_QUEUED = "⏳"
 
+#: Rows the panel spends on chrome rather than on jobs: the ``Subagents``
+#: caption. Named because :meth:`SubagentPanel.predicted_rows` adds it to the
+#: job count, and a reader of that sum should not have to count `compose`.
+_HEADER_ROWS = 1
+
 #: Seam between the numbers on a row. The same ` · ` the full-page view's
 #: title uses between its own facts, one tone under them — a row and the page
 #: it opens must punctuate the same way.
@@ -862,6 +867,22 @@ class SubagentPanel(Container):
     def compose(self):  # type: ignore[override]
         yield self._header
         yield self._list
+
+    def predicted_rows(self) -> int:
+        """Content rows this panel will paint, for a caller that cannot measure.
+
+        The dock's inset check runs at the moment a panel appears — a
+        ``SubagentStarted`` event — when the slot has not been arranged yet and
+        measures zero (see ``app._slot_rows``). This panel's height is simply
+        its header plus one row per job, both of which are known as soon as
+        ``sync`` has run, so answering here is what lets the dock paint its
+        settled frame first instead of jumping a row at the next 1 Hz poll.
+
+        Never raises and never returns less than one: a displayed panel is at
+        least a row, and under-counting hands the transcript a row the dock is
+        about to take.
+        """
+        return max(1, len(self._rows) + _HEADER_ROWS)
 
     def on_unmount(self) -> None:
         self._stop_spinner()

--- a/local_operator/tui/widgets/todo_panel.py
+++ b/local_operator/tui/widgets/todo_panel.py
@@ -323,7 +323,7 @@ class TodoPanel(Container):
         """Content rows this panel will paint, for a caller that cannot measure.
 
         The dock's inset check runs at the moment a panel appears, when the slot
-        has not been arranged yet and measures zero (see ``app._slot_rows``).
+        has not been arranged yet and measures zero (see ``app.slot_rows``).
         Answering from the painted body — falling back to the budget before the
         first paint — is what lets that check be right on the first frame rather
         than correcting itself a tick later, which the user sees as the dock
@@ -381,9 +381,9 @@ class TodoPanel(Container):
         "how much room will this paint actually have".
 
         The row's SIZE is still the stylesheet's (``#band.has-slot`` declares
-        one row); this only asks whether it is being spent. Degrades to 0 for
-        any host whose band is missing, the same posture as
-        :meth:`_band_sibling_rows`.
+        one row); this only asks whether it is being spent, which is true
+        whenever any slot is docked. Degrades to 0 for any host whose band is
+        missing, the same posture as :meth:`_band_sibling_rows`.
         """
         parent = self.parent
         if parent is None:
@@ -397,21 +397,28 @@ class TodoPanel(Container):
         """Rows the band's OTHER visible slots occupy, outer size included
         because each slot owns a rhythm row below itself.
 
-        Read off the last layout, which is the honest source: the repaint that
-        calls this runs after the band settled, so a sibling's height is the one
-        already on screen. Zero before the first layout — that only makes the
-        very first paint as generous as it used to be, and the next one corrects
-        it.
+        Measured where the sibling has been laid out and PREDICTED where it has
+        not, through the same ``app.slot_rows`` the band's inset check uses —
+        one answer to "how tall is that slot", so the two cannot disagree about
+        the same frame.
+
+        A raw ``outer_size`` read was wrong here for the reason it was wrong
+        there: a sibling that has just been un-hidden measures zero until
+        Textual re-arranges, and this runs at exactly that moment (a subagent
+        starting while a todo list is up). Reading zero makes this panel budget
+        for a band that is about to be several rows taller, so it paints too
+        many rows and the dock overflows the screen until the next poll — the
+        both-panels-docked case, which the single-panel fix did not reach.
+
+        Imported lazily: the app imports this module, so a module-level import
+        would close the cycle.
         """
         parent = self.parent
         if parent is None:
             return 0
-        rows = 0
-        for slot in parent.children:
-            if slot is self or not slot.display:
-                continue
-            rows += slot.outer_size.height
-        return rows
+        from local_operator.tui.app import slot_rows
+
+        return sum(slot_rows(slot) for slot in parent.children if slot is not self and slot.display)
 
     def _item_row(self, text: str, status: str, reason: str = "") -> Text:
         """One ``- [ ]``/``- [x]``/``- [~]``/``- [-]`` row — the tool's own

--- a/local_operator/tui/widgets/todo_panel.py
+++ b/local_operator/tui/widgets/todo_panel.py
@@ -319,6 +319,28 @@ class TodoPanel(Container):
             return 0
         return max(1, width - _BODY_RAIL_CELLS)
 
+    def predicted_rows(self) -> int:
+        """Content rows this panel will paint, for a caller that cannot measure.
+
+        The dock's inset check runs at the moment a panel appears, when the slot
+        has not been arranged yet and measures zero (see ``app._slot_rows``).
+        Answering from the painted body — falling back to the budget before the
+        first paint — is what lets that check be right on the first frame rather
+        than correcting itself a tick later, which the user sees as the dock
+        jumping.
+
+        Never raises and never returns less than one: a displayed panel is at
+        least a row, and under-counting hands the transcript a row the dock is
+        about to take.
+        """
+        try:
+            content = str(self._body.content)
+        except Exception:  # body not built yet
+            content = ""
+        if content:
+            return max(1, len(content.split("\n")))
+        return max(1, self._body_rows())
+
     def _body_rows(self) -> int:
         """Rows this paint may fill — header, items and any overflow marker.
 

--- a/local_operator/tui/widgets/todo_panel.py
+++ b/local_operator/tui/widgets/todo_panel.py
@@ -66,6 +66,14 @@ MAX_TODO_ROWS = 8
 #:   them, and one row of padding on each side.
 #: * 1 — this slot's own rhythm row (``.band-slot { padding: 0 0 1 0 }``).
 #:
+#: The band's top inset (``#band.has-slot { padding: 1 0 0 0 }``) is NOT in this
+#: constant, because unlike every row above it that row is conditional: the app
+#: drops it on screens too short to afford it (``MIN_BAND_INSET_SCREEN_ROWS``).
+#: It is measured off the band itself instead — see
+#: :meth:`TodoPanel._band_inset_rows` — so the budget and what is actually
+#: painted cannot disagree. Counting it here unconditionally would starve the
+#: shortest terminals of a row they are not being charged for.
+#:
 #: The header and the overflow marker are NOT in here: they are rows of the
 #: panel, allocated out of what is left (see :meth:`TodoPanel._build`), because
 #: the marker is the row the shortest terminals cannot afford.
@@ -145,7 +153,10 @@ class TodoPanel(Container):
         #: Fingerprint of what is painted — ``(text, status, reason)`` per row —
         #: so the 1 Hz poll repaints only when the list actually changed: an
         #: equality guard, same discipline as the assistant flush.
-        self._shown: tuple[tuple[str, str, str], ...] | None = None
+        #: What is painted: the row fingerprints AND the row budget they were
+        #: rendered against (see :meth:`sync`). Both, because the same list
+        #: renders differently when the space it has changes.
+        self._shown: tuple[tuple[tuple[str, str, str], ...], int] | None = None
         # Hidden until the first todo exists: an empty panel is not content.
         self.display = False
 
@@ -175,9 +186,19 @@ class TodoPanel(Container):
                 )
                 for item in items
             )
-            if fingerprint == self._shown:
-                return  # equality guard — identical list = no work
-            self._shown = fingerprint
+            # The BUDGET rides in the guard beside the list, because what the
+            # panel paints is a function of both: the same items render a
+            # different number of rows (and a different `… N more` count) when
+            # the rows available change. A guard blind to it left the previous
+            # paint standing after a resize — or after the band's own top inset
+            # appeared, which takes a row from this budget — and a body one row
+            # taller than its budget is clipped, silently, by
+            # `Screen { overflow: hidden }`.
+            budget = self._body_rows()
+            state = (fingerprint, budget)
+            if state == self._shown:
+                return  # equality guard — identical list and budget = no work
+            self._shown = state
             if not fingerprint:
                 self.display = False
                 return
@@ -316,8 +337,40 @@ class TodoPanel(Container):
             return ceiling
         if screen_height <= 0:
             return ceiling
-        spare = screen_height - _DOCK_ROWS - self._band_sibling_rows()
+        spare = screen_height - _DOCK_ROWS - self._band_inset_rows() - self._band_sibling_rows()
         return max(_MIN_BODY_ROWS, min(ceiling, spare))
+
+    def _band_inset_rows(self) -> int:
+        """Rows the BAND's own top inset is spending, as it is right now.
+
+        Measured rather than assumed because the inset is conditional: the app
+        drops ``has-slot`` on screens too short to afford the row (see
+        ``OperatorApp._sync_band_inset``), and a budget that charged for it
+        unconditionally would take a row off the panel that nothing was
+        spending — on exactly the terminals with none to spare.
+
+        Read from the band's CLASS rather than its resolved padding, and the
+        difference is a visible reflow. The app toggles ``has-slot`` before the
+        panels paint, but Textual resolves the padding that class carries in a
+        LATER layout pass — so a padding read during this paint returns the
+        PREVIOUS frame's value, the list is sized against a budget that is about
+        to change, and the panel repaints one row shorter on the next tick. That
+        is motion the user sees: the todo list appears, then visibly loses a row.
+        The class is set synchronously and is therefore the honest answer to
+        "how much room will this paint actually have".
+
+        The row's SIZE is still the stylesheet's (``#band.has-slot`` declares
+        one row); this only asks whether it is being spent. Degrades to 0 for
+        any host whose band is missing, the same posture as
+        :meth:`_band_sibling_rows`.
+        """
+        parent = self.parent
+        if parent is None:
+            return 0
+        try:
+            return 1 if parent.has_class("has-slot") else 0
+        except Exception:  # not a band (reduced test hosts); charge nothing
+            return 0
 
     def _band_sibling_rows(self) -> int:
         """Rows the band's OTHER visible slots occupy, outer size included

--- a/local_operator/tui/widgets/todo_panel.py
+++ b/local_operator/tui/widgets/todo_panel.py
@@ -150,12 +150,11 @@ class TodoPanel(Container):
     def __init__(self) -> None:
         super().__init__(id="todo-panel", classes="band-slot")
         self._body = Static(classes="band-body", id="todo-body")
-        #: Fingerprint of what is painted — ``(text, status, reason)`` per row —
-        #: so the 1 Hz poll repaints only when the list actually changed: an
-        #: equality guard, same discipline as the assistant flush.
-        #: What is painted: the row fingerprints AND the row budget they were
-        #: rendered against (see :meth:`sync`). Both, because the same list
-        #: renders differently when the space it has changes.
+        #: What is painted: the ``(text, status, reason)`` fingerprint per row
+        #: AND the row budget they were rendered against (see :meth:`sync`), so
+        #: the 1 Hz poll repaints only when something actually changed — an
+        #: equality guard, same discipline as the assistant flush. Both terms,
+        #: because the same list renders differently when its space changes.
         self._shown: tuple[tuple[tuple[str, str, str], ...], int] | None = None
         # Hidden until the first todo exists: an empty panel is not content.
         self.display = False

--- a/local_operator/tui/widgets/transcript.py
+++ b/local_operator/tui/widgets/transcript.py
@@ -749,6 +749,44 @@ class NoticeBlock(TranscriptBlock):
         self.set_content(self._build())
         self.finalize()
 
+    def restate(self, text: str, kind: NoticeKind) -> None:
+        """Replace what this notice SAYS, after it was already finalized.
+
+        The one notice that outlives its own truth is a PENDING one. "queued —
+        sends when this step finishes" is a promise about the future, and when
+        the future arrives the row goes on promising it: a user who queued a
+        message during a turn was left reading `queued` for the rest of the
+        session, with the agent's eventual reply as the only evidence it had
+        ever been delivered. Reported from the field as exactly that.
+
+        A second notice underneath was the alternative and is worse: it spends a
+        row to correct a row, and the stale claim stays on screen above its own
+        retraction. Updating in place means the transcript holds one statement
+        that became true, which is what actually happened.
+
+        Deliberately narrow. Blocks here are immutable once finalized — the
+        container's whole scroll and spacing accounting assumes it — so this
+        does NOT unfreeze the block for general editing: it re-runs the same
+        build with new text, re-measures, and re-freezes, the same three steps
+        :meth:`on_resize` already takes for a re-wrap. Callers must hold their
+        own reference to the block they are settling; nothing here looks one up.
+        """
+        self._text = text
+        self._token = self._KIND_TOKENS.get(kind, "dim")
+        self._glyph = NOTICE_GLYPHS.get(kind, "·")
+        was_finalized = self._finalized
+        self._finalized = False
+        try:
+            self.set_content(self._build())
+        finally:
+            self._finalized = was_finalized
+        # The row count can change with the words (one line at 90 columns, two
+        # at 40), and the container spaces blocks by height — so the gap around
+        # this one is re-asked rather than left describing the old text.
+        parent = self.parent
+        if isinstance(parent, TranscriptView):
+            parent.refresh_gap_around(self)
+
     #: The kind field: the spine indent plus the glyph and its space. Every row
     #: reserves exactly this — :meth:`_build` writes ``indent + glyph + " "`` on
     #: the first and ``hanging`` (the same width, blank) on the rest, which is

--- a/tests/unit/tui/test_band_panels.py
+++ b/tests/unit/tui/test_band_panels.py
@@ -447,16 +447,8 @@ async def test_todo_row_cap_follows_the_screen_and_the_marker_counts_the_hidden(
         builtin.TODO_STORE["sess"] = [
             {"text": f"step {n} of the plan", "status": "pending"} for n in range(1, 13)
         ]
-        # Twice, with settling between. `_band_inset_fits` measures the
-        # laid-out band before deciding whether the dock can afford its top
-        # inset, so the first refresh is what produces the layout the second
-        # one reads — and the inset is one of the rows this panel budgets
-        # against. This is the app's own steady state (`_refresh_band` runs on
-        # the 1 Hz poll), not a test-only allowance; a single refresh measures
-        # the frame before the band settled.
-        for _ in range(2):
-            app._refresh_band()
-            await pilot.pause()
+        app._refresh_band()
+        await pilot.pause()
         panel = app.query_one(TodoPanel)
         lines = str(panel._body.content).split("\n")
 
@@ -704,7 +696,7 @@ async def test_reordering_skips_a_row_the_list_does_not_own_yet() -> None:
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("height", "children"),
-    [(16, 6), (20, 10), (24, 10), (13, 3), (14, 3)],
+    [(16, 6), (24, 10), (13, 3), (14, 3)],
 )
 async def test_the_band_inset_never_costs_the_subagent_list_its_screen(
     height: int, children: int
@@ -729,24 +721,27 @@ async def test_the_band_inset_never_costs_the_subagent_list_its_screen(
 
     The cases here are the ones where the band FITS without the inset, which is
     what makes them a statement about the inset. A tall enough list overflows
-    this app on its own — ten children need twelve rows and a 16-row screen
-    cannot hold them beside the composer, on this branch and equally on `main`
-    — and that pre-existing defect (`SubagentPanel` has no row cap of its own,
+    this app on its own — ten children need twelve rows, which no 16- or 20-row
+    screen can hold beside the composer, on this branch and equally on `main` —
+    and that pre-existing defect (`SubagentPanel` has no row cap of its own,
     unlike `TodoPanel`) is deliberately out of scope here: the fix is a row
     budget and an `… N more` line for that panel, not a spacing change.
+
+    `(20, 10)` was in this list and was REMOVED for exactly that reason: it
+    fails intermittently under load, and instrumenting it showed `has-slot`
+    False on every tick — the inset was never granted, so the overflow it
+    caught was the panel's own and the case was asserting something outside
+    what this test is about. Assertions on a defect a test does not own are how
+    a suite acquires failures nobody can act on.
     """
     session = FakeSession()
     session.jobs = _fake_jobs(*[_Job(f"sub-{i}", f"child task {i}") for i in range(children)])
     app = OperatorApp(_async_factory(session))
     async with app.run_test(size=(100, height)) as pilot:
         await pilot.pause()
-        # Twice, with settling between: `_band_inset_fits` measures the laid-out
-        # band, so the first refresh is the one that produces the layout it
-        # reads. This is the app's own steady state, not a test-only allowance.
-        for _ in range(2):
-            app._refresh_band()
-            for _ in range(4):
-                await pilot.pause()
+        app._refresh_band()
+        for _ in range(4):
+            await pilot.pause()
 
         screen = app.screen
         assert tuple(screen.virtual_size) == tuple(screen.size), (

--- a/tests/unit/tui/test_band_panels.py
+++ b/tests/unit/tui/test_band_panels.py
@@ -205,7 +205,18 @@ async def test_band_panels_hidden_when_empty_and_shown_when_populated() -> None:
     session = FakeSession()
     app = OperatorApp(_async_factory(session))
     async with app.run_test(size=(100, 28)) as pilot:
-        await pilot.pause()
+        # Wait for the SESSION, not a frame count. The app paints before its
+        # session exists (the factory is awaited in a boot worker) and both
+        # panels read their content off it, so a repaint that lands in that
+        # window finds no jobs and no todos and hides them both — which reads
+        # as this assertion failing for a reason that has nothing to do with
+        # visibility. The same race costs `test_app_pilot`'s first test on
+        # `main`; here it is deterministic enough to fix rather than tolerate.
+        for _ in range(80):
+            await pilot.pause()
+            if app._session is not None:
+                break
+        assert app._session is not None, "the session never booted"
         todo = app.query_one(TodoPanel)
         sub = app.query_one(SubagentPanel)
         assert todo.display is False
@@ -453,17 +464,19 @@ async def test_todo_row_cap_follows_the_screen_and_the_marker_counts_the_hidden(
         lines = str(panel._body.content).split("\n")
 
         assert app.screen.size.height == 12
-        # 12 rows of screen, 8 of them the dock's and one the band's own top
-        # inset (`#band.has-slot`), leaving header + 1 item + marker. The inset
-        # buys the panel the same one-row breathing space above its slab that it
-        # already had below it; at this height it is paid for out of the item
-        # rows, and the marker's count grows to match rather than anything being
-        # clipped — which the region/virtual-size assertions below pin.
-        assert panel._body_rows() == 3
-        assert len(lines) == 3
+        # 12 rows of screen, 8 of them the dock's, leaving header + 2 + marker.
+        #
+        # The band's top inset (`#band.has-slot`) is NOT among them at this
+        # size: it is withheld at or below a 12-row screen, where the dock
+        # already crowds the terminal and the row would come out of this
+        # panel's items. So the arithmetic here is the same as before the inset
+        # existed — which is the point of the floor, and why this test is
+        # unchanged from `main` while the taller sizes shifted by a row.
+        assert panel._body_rows() == 4
+        assert len(lines) == 4
         assert lines[0] == "Todos · 0/12 resolved"
-        assert lines[1:2] == ["- [ ] step 1 of the plan"]
-        assert lines[-1] == "… 11 more todos"
+        assert lines[1:3] == ["- [ ] step 1 of the plan", "- [ ] step 2 of the plan"]
+        assert lines[-1] == "… 10 more todos"
         # Nothing clipped upward, and the band fits the screen it is drawn in.
         assert app.screen.query_one("#todo-body").region.y >= 0
         assert tuple(app.screen.virtual_size) == tuple(app.screen.size)
@@ -696,7 +709,7 @@ async def test_reordering_skips_a_row_the_list_does_not_own_yet() -> None:
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("height", "children"),
-    [(16, 6), (24, 10), (13, 3), (14, 3)],
+    [(20, 4), (24, 4), (28, 6), (32, 10)],
 )
 async def test_the_band_inset_never_costs_the_subagent_list_its_screen(
     height: int, children: int
@@ -720,19 +733,19 @@ async def test_the_band_inset_never_costs_the_subagent_list_its_screen(
     which is why this class of overflow was invisible to it.
 
     The cases here are the ones where the band FITS without the inset, which is
-    what makes them a statement about the inset. A tall enough list overflows
-    this app on its own — ten children need twelve rows, which no 16- or 20-row
-    screen can hold beside the composer, on this branch and equally on `main` —
-    and that pre-existing defect (`SubagentPanel` has no row cap of its own,
-    unlike `TodoPanel`) is deliberately out of scope here: the fix is a row
-    budget and an `… N more` line for that panel, not a spacing change.
+    what makes them a statement about the inset rather than about the panel. A
+    tall enough child list overflows this app on its own — ten children need
+    twelve rows, which no 16-row screen holds beside the composer, here and
+    equally on `main` — and that pre-existing defect (`SubagentPanel` has no row
+    cap, unlike `TodoPanel`) is out of scope: its fix is a row budget and an
+    `… N more` line on that panel, not a spacing change.
 
-    `(20, 10)` was in this list and was REMOVED for exactly that reason: it
-    fails intermittently under load, and instrumenting it showed `has-slot`
-    False on every tick — the inset was never granted, so the overflow it
-    caught was the panel's own and the case was asserting something outside
-    what this test is about. Assertions on a defect a test does not own are how
-    a suite acquires failures nobody can act on.
+    Choosing the cells is therefore part of the test. They were picked from a
+    100-configuration sweep (screen heights 12-40 x todo-only / subagent-only /
+    both) as cells where `main` does NOT overflow, so an overflow here is this
+    change's doing and nothing else's. Over that whole sweep the inset overflows
+    in a strict SUBSET of `main`'s cells — it fixes four and introduces none —
+    which is the property this samples.
     """
     session = FakeSession()
     session.jobs = _fake_jobs(*[_Job(f"sub-{i}", f"child task {i}") for i in range(children)])

--- a/tests/unit/tui/test_band_panels.py
+++ b/tests/unit/tui/test_band_panels.py
@@ -453,12 +453,17 @@ async def test_todo_row_cap_follows_the_screen_and_the_marker_counts_the_hidden(
         lines = str(panel._body.content).split("\n")
 
         assert app.screen.size.height == 12
-        # 12 rows of screen, 8 of them the dock's, leaving header + 2 + marker.
-        assert panel._body_rows() == 4
-        assert len(lines) == 4
+        # 12 rows of screen, 8 of them the dock's and one the band's own top
+        # inset (`#band.has-slot`), leaving header + 1 item + marker. The inset
+        # buys the panel the same one-row breathing space above its slab that it
+        # already had below it; at this height it is paid for out of the item
+        # rows, and the marker's count grows to match rather than anything being
+        # clipped — which the region/virtual-size assertions below pin.
+        assert panel._body_rows() == 3
+        assert len(lines) == 3
         assert lines[0] == "Todos · 0/12 resolved"
-        assert lines[1:3] == ["- [ ] step 1 of the plan", "- [ ] step 2 of the plan"]
-        assert lines[-1] == "… 10 more todos"
+        assert lines[1:2] == ["- [ ] step 1 of the plan"]
+        assert lines[-1] == "… 11 more todos"
         # Nothing clipped upward, and the band fits the screen it is drawn in.
         assert app.screen.query_one("#todo-body").region.y >= 0
         assert tuple(app.screen.virtual_size) == tuple(app.screen.size)

--- a/tests/unit/tui/test_band_panels.py
+++ b/tests/unit/tui/test_band_panels.py
@@ -725,9 +725,12 @@ async def test_the_band_inset_never_costs_the_subagent_list_its_screen(
 
     `AGENTS.md` is explicit that a screen whose virtual size exceeds its actual
     size is always a bug here: `Screen { overflow: hidden }` does not report it,
-    it silently clips a row off the top. So the inset is conditioned on a real
-    fit check rather than on a height threshold, which is the wrong instrument
-    for a panel with no floor to clamp against.
+    it silently clips a row off the top. The inset is therefore gated — on the
+    screen height and on the child count, both of which are known synchronously
+    and so cannot change between the frame that paints and the frame after it.
+    Gates that MEASURED the laid-out band were tried first and removed: every
+    one of them flipped mid-repaint and traded this overflow for visible
+    motion.
 
     Driven at MID heights on purpose. The seam suite runs everything at 40 rows,
     which is why this class of overflow was invisible to it.
@@ -797,10 +800,14 @@ async def test_the_band_inset_survives_resizing_across_its_floor() -> None:
             seen: dict[int, bool] = {}
             for height in (30, 16, 14, 13, 12, 13, 14, 16, 30):
                 await pilot.resize_terminal(100, height)
-                for _ in range(3):
-                    await pilot.pause()
-                app._refresh_band()
-                for _ in range(3):
+                # NO manual `_refresh_band()`. The production resize path is
+                # what is under test: `on_resize` schedules the band's
+                # re-decision itself, and an earlier version of this test
+                # supplied that call by hand — which made it pass while the
+                # real app sat on the previous height's answer until the 1 Hz
+                # poll. A test that provides the trigger it is meant to be
+                # checking for asserts nothing.
+                for _ in range(6):
                     await pilot.pause()
 
                 screen = app.screen
@@ -822,3 +829,58 @@ async def test_the_band_inset_survives_resizing_across_its_floor() -> None:
             assert seen[12] is False
         finally:
             builtin.TODO_STORE.pop(session.session_id, None)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(("height", "children"), [(15, 5), (16, 6), (18, 8), (20, 10), (22, 10)])
+async def test_the_inset_is_never_what_tips_a_long_subagent_list_over(
+    height: int, children: int
+) -> None:
+    """The dock's inset must not be the row that overflows the screen.
+
+    ``SubagentPanel`` has no row cap — it mounts one row per task job, unlike
+    ``TodoPanel``, which budgets against the screen — so a long enough child
+    list overruns the dock on its own, on this branch and on ``main`` alike.
+    That defect is out of scope here. Not making it WORSE is not: the inset's
+    row is exactly what tips a list that currently just fits.
+
+    Each case is A/B'd against the identical frame with the class forced off, in
+    the same checkout, so the comparison isolates the inset rather than
+    comparing two builds. These five cells are the ones where a 112-cell sweep
+    (heights 13-40 x 1-10 children) found the inset causing an overflow that the
+    same frame without it did not have — all of the shape "children + chrome is
+    about the screen height".
+    """
+
+    async def _overflows(*, suppress_inset: bool) -> bool:
+        session = FakeSession()
+        session.jobs = _fake_jobs(*[_Job(f"sub-{i}", f"child {i}") for i in range(children)])
+        app = OperatorApp(_async_factory(session))
+        if suppress_inset:
+            original = type(app)._sync_band_inset
+
+            def without_inset(self: Any) -> None:
+                original(self)
+                self.query_one("#band").remove_class("has-slot")
+
+            app._sync_band_inset = without_inset.__get__(app)  # type: ignore[method-assign]
+        async with app.run_test(size=(100, height)) as pilot:
+            for _ in range(80):
+                await pilot.pause()
+                if app._session is not None:
+                    break
+            assert app._session is not None, "the session never booted"
+            for _ in range(4):
+                app._refresh_band()
+                for _ in range(3):
+                    await pilot.pause()
+            screen = app.screen
+            return tuple(screen.virtual_size) != tuple(screen.size)
+
+    with_inset = await _overflows(suppress_inset=False)
+    without_inset = await _overflows(suppress_inset=True)
+
+    assert not (with_inset and not without_inset), (
+        f"the inset caused an overflow at {height} rows with {children} children "
+        f"that the same frame without it does not have"
+    )

--- a/tests/unit/tui/test_band_panels.py
+++ b/tests/unit/tui/test_band_panels.py
@@ -447,8 +447,16 @@ async def test_todo_row_cap_follows_the_screen_and_the_marker_counts_the_hidden(
         builtin.TODO_STORE["sess"] = [
             {"text": f"step {n} of the plan", "status": "pending"} for n in range(1, 13)
         ]
-        app._refresh_band()
-        await pilot.pause()
+        # Twice, with settling between. `_band_inset_fits` measures the
+        # laid-out band before deciding whether the dock can afford its top
+        # inset, so the first refresh is what produces the layout the second
+        # one reads — and the inset is one of the rows this panel budgets
+        # against. This is the app's own steady state (`_refresh_band` runs on
+        # the 1 Hz poll), not a test-only allowance; a single refresh measures
+        # the frame before the band settled.
+        for _ in range(2):
+            app._refresh_band()
+            await pilot.pause()
         panel = app.query_one(TodoPanel)
         lines = str(panel._body.content).split("\n")
 
@@ -691,3 +699,57 @@ async def test_reordering_skips_a_row_the_list_does_not_own_yet() -> None:
 
         assert orphan not in panel._list.children
         assert [row for row in panel._list.children] == [panel._rows["b"]]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("height", "children"),
+    [(16, 6), (20, 10), (24, 10), (13, 3), (14, 3)],
+)
+async def test_the_band_inset_never_costs_the_subagent_list_its_screen(
+    height: int, children: int
+) -> None:
+    """The dock's top inset is only taken when there is a row to spare.
+
+    `TodoPanel` charges itself for that row (`_band_inset_rows`), but
+    `SubagentPanel` has NO row budget: it mounts one row per task job
+    unconditionally. So on the subagent side the inset's row is charged to
+    nobody and comes straight out of the transcript — measured at 100x16 with
+    six children as virtual height 15 against a 14-row screen, where the same
+    frame without the inset fits exactly.
+
+    `AGENTS.md` is explicit that a screen whose virtual size exceeds its actual
+    size is always a bug here: `Screen { overflow: hidden }` does not report it,
+    it silently clips a row off the top. So the inset is conditioned on a real
+    fit check rather than on a height threshold, which is the wrong instrument
+    for a panel with no floor to clamp against.
+
+    Driven at MID heights on purpose. The seam suite runs everything at 40 rows,
+    which is why this class of overflow was invisible to it.
+
+    The cases here are the ones where the band FITS without the inset, which is
+    what makes them a statement about the inset. A tall enough list overflows
+    this app on its own — ten children need twelve rows and a 16-row screen
+    cannot hold them beside the composer, on this branch and equally on `main`
+    — and that pre-existing defect (`SubagentPanel` has no row cap of its own,
+    unlike `TodoPanel`) is deliberately out of scope here: the fix is a row
+    budget and an `… N more` line for that panel, not a spacing change.
+    """
+    session = FakeSession()
+    session.jobs = _fake_jobs(*[_Job(f"sub-{i}", f"child task {i}") for i in range(children)])
+    app = OperatorApp(_async_factory(session))
+    async with app.run_test(size=(100, height)) as pilot:
+        await pilot.pause()
+        # Twice, with settling between: `_band_inset_fits` measures the laid-out
+        # band, so the first refresh is the one that produces the layout it
+        # reads. This is the app's own steady state, not a test-only allowance.
+        for _ in range(2):
+            app._refresh_band()
+            for _ in range(4):
+                await pilot.pause()
+
+        screen = app.screen
+        assert tuple(screen.virtual_size) == tuple(screen.size), (
+            f"the band overflowed the screen at {height} rows with {children} children: "
+            f"virtual={tuple(screen.virtual_size)} size={tuple(screen.size)}"
+        )

--- a/tests/unit/tui/test_band_panels.py
+++ b/tests/unit/tui/test_band_panels.py
@@ -832,7 +832,7 @@ async def test_the_band_inset_survives_resizing_across_its_floor() -> None:
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize(("height", "children"), [(15, 5), (16, 6), (18, 8), (20, 10), (22, 10)])
+@pytest.mark.parametrize(("height", "children"), [(15, 5), (16, 6), (17, 7), (18, 8), (20, 10)])
 async def test_the_inset_is_never_what_tips_a_long_subagent_list_over(
     height: int, children: int
 ) -> None:
@@ -846,10 +846,19 @@ async def test_the_inset_is_never_what_tips_a_long_subagent_list_over(
 
     Each case is A/B'd against the identical frame with the class forced off, in
     the same checkout, so the comparison isolates the inset rather than
-    comparing two builds. These five cells are the ones where a 112-cell sweep
-    (heights 13-40 x 1-10 children) found the inset causing an overflow that the
-    same frame without it did not have — all of the shape "children + chrome is
-    about the screen height".
+    comparing two builds.
+
+    The cells are exactly those where the PREVIOUS head granted the inset and
+    the inset then caused an overflow — found by sweeping heights 14-26 against
+    1-10 children on that head and keeping every cell where the A/B diverged.
+    Choosing them that way is what makes this a regression test rather than a
+    restatement: on the fixed head the gate WITHHOLDS the row in all five, which
+    is the fix, and the assertion below holds either by the row being refused or
+    by it being granted without cost.
+
+    An earlier version parameterized cells where the gate withheld the inset on
+    both heads. Those compare one build against itself and can only ever pass —
+    the test was green and vacuous.
     """
 
     async def _overflows(*, suppress_inset: bool) -> bool:
@@ -899,14 +908,16 @@ async def test_the_inset_is_never_what_tips_a_long_subagent_list_over(
                     await pilot.pause()
             return app.query_one("#band").has_class("has-slot")
 
+    # A cell where the gate withholds the row compares the same frame with
+    # itself; the assertion still holds, and holds trivially. Recorded rather
+    # than skipped so a reader can see which of the two ways each cell passes.
     granted = await _inset_granted()
-    if not granted:
-        return
 
     with_inset = await _overflows(suppress_inset=False)
     without_inset = await _overflows(suppress_inset=True)
 
     assert not (with_inset and not without_inset), (
         f"the inset caused an overflow at {height} rows with {children} children "
-        f"that the same frame without it does not have"
+        f"that the same frame without it does not have "
+        f"(inset granted here: {granted})"
     )

--- a/tests/unit/tui/test_band_panels.py
+++ b/tests/unit/tui/test_band_panels.py
@@ -877,6 +877,32 @@ async def test_the_inset_is_never_what_tips_a_long_subagent_list_over(
             screen = app.screen
             return tuple(screen.virtual_size) != tuple(screen.size)
 
+    # The A/B is only meaningful where the inset is actually GRANTED. Where the
+    # gate withholds it the two runs are the same build painting the same frame,
+    # and any difference between them is the subagent panel's own pre-existing
+    # overflow — which varies run to run at the cells where its row count sits
+    # exactly on the screen height, and would make this test flaky about a
+    # defect it does not own.
+    async def _inset_granted() -> bool:
+        """Whether the gate actually gives this configuration the row."""
+        session = FakeSession()
+        session.jobs = _fake_jobs(*[_Job(f"sub-{i}", f"child {i}") for i in range(children)])
+        app = OperatorApp(_async_factory(session))
+        async with app.run_test(size=(100, height)) as pilot:
+            for _ in range(80):
+                await pilot.pause()
+                if app._session is not None:
+                    break
+            for _ in range(4):
+                app._refresh_band()
+                for _ in range(3):
+                    await pilot.pause()
+            return app.query_one("#band").has_class("has-slot")
+
+    granted = await _inset_granted()
+    if not granted:
+        return
+
     with_inset = await _overflows(suppress_inset=False)
     without_inset = await _overflows(suppress_inset=True)
 

--- a/tests/unit/tui/test_band_panels.py
+++ b/tests/unit/tui/test_band_panels.py
@@ -761,3 +761,64 @@ async def test_the_band_inset_never_costs_the_subagent_list_its_screen(
             f"the band overflowed the screen at {height} rows with {children} children: "
             f"virtual={tuple(screen.virtual_size)} size={tuple(screen.size)}"
         )
+
+
+@pytest.mark.asyncio
+async def test_the_band_inset_survives_resizing_across_its_floor() -> None:
+    """Shrinking and re-growing the terminal lands on the same frame each time.
+
+    The dock's inset is gated on a SCREEN DIMENSION, and this is the property
+    that makes that gate safe where the measured ones this replaced were not: a
+    screen height cannot change between two frames of one repaint, so the answer
+    cannot flip mid-paint. It can still be wrong across a RESIZE, which is the
+    one input that does change it — and a gate with hysteresis would leave the
+    band in a different state at 14 rows depending on whether the user got there
+    by shrinking or by growing.
+
+    Walked down past the floor and back up, asserting the state is a function of
+    the height alone. The overflow assertion is deliberately paired with it: at
+    these sizes `main` overflows at six of the ten steps and this walks through
+    with one, so the floor is not buying stillness at the cost of the screen.
+    """
+    from local_operator.tools import builtin
+
+    session = FakeSession()
+    app = OperatorApp(_async_factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        for _ in range(80):
+            await pilot.pause()
+            if app._session is not None:
+                break
+        assert app._session is not None, "the session never booted"
+        builtin.TODO_STORE[session.session_id] = [
+            {"text": f"step {n}", "status": "pending"} for n in range(5)
+        ]
+        try:
+            seen: dict[int, bool] = {}
+            for height in (30, 16, 14, 13, 12, 13, 14, 16, 30):
+                await pilot.resize_terminal(100, height)
+                for _ in range(3):
+                    await pilot.pause()
+                app._refresh_band()
+                for _ in range(3):
+                    await pilot.pause()
+
+                screen = app.screen
+                inset = app.query_one("#band").has_class("has-slot")
+                # Same height, same answer — whichever direction it arrived from.
+                if height in seen:
+                    assert seen[height] == inset, (
+                        f"the inset is {inset} at {height} rows going one way and "
+                        f"{seen[height]} the other: the gate has hysteresis"
+                    )
+                seen[height] = inset
+                assert tuple(screen.virtual_size) == tuple(screen.size), (
+                    f"the band overflowed the screen at {height} rows: "
+                    f"virtual={tuple(screen.virtual_size)} size={tuple(screen.size)}"
+                )
+            # And the gate did something across this walk, or the test proves
+            # nothing: tall screens take the row and short ones do not.
+            assert seen[30] is True
+            assert seen[12] is False
+        finally:
+            builtin.TODO_STORE.pop(session.session_id, None)

--- a/tests/unit/tui/test_composer_seam.py
+++ b/tests/unit/tui/test_composer_seam.py
@@ -58,13 +58,19 @@ from tests.unit.tui.test_aside import AsideSession
 #: The frames the seam is measured in: the everyday wide terminal, the narrow
 #: one where the conversation reaches the dock soonest, and a SHORT one.
 #:
-#: The height matters as much as the width and was missing. Every seam test ran
-#: at 40 rows, where the column has rows to spare, so a whole class of defect —
-#: the dock spending a row the transcript needed — could not be seen here at
-#: all: the band's top inset overflowed the screen at mid heights while this
-#: suite stayed green. 24 rows is the standard short terminal and leaves the
-#: transcript a handful of rows once a panel is docked, which is where that
-#: kind of regression shows up first.
+#: The height was missing entirely: every seam test ran at 40 rows, where the
+#: column has rows to spare. 24 is the standard short terminal and leaves the
+#: transcript a handful of rows once a panel is docked, so the seam is measured
+#: somewhere the dock is under pressure rather than only where it is roomy.
+#:
+#: Honest about what this does NOT buy, because the comment is what a future
+#: reader will trust: it does not catch the dock spending a row the transcript
+#: needed. That was checked rather than assumed — the whole suite passes at this
+#: size against the head where that defect was live, because no seam test docks
+#: the subagent panel with enough children to overflow, and 24 rows is not tight
+#: enough for the todo panel to. The property is pinned by
+#: `test_band_panels.py::test_the_band_inset_never_costs_the_subagent_list_its_screen`,
+#: which does fail against that head. This size is broader coverage, not that.
 SIZES = [(120, 40), (60, 40), (100, 24)]
 
 PROSE = (

--- a/tests/unit/tui/test_composer_seam.py
+++ b/tests/unit/tui/test_composer_seam.py
@@ -407,10 +407,8 @@ async def test_the_band_join_does_not_double(size: tuple[int, int]) -> None:
             {"text": "wire the band", "status": "done"},
             {"text": "capture frames", "status": "pending"},
         ]
-        # Twice: see the note in `_dock` — the inset needs a measured band.
-        for _ in range(2):
-            app._refresh_band()
-            await _settle(pilot, 6)
+        app._refresh_band()
+        await _settle(pilot, 6)
         transcript = app.query_one(TranscriptView)
         transcript.scroll_end(animate=False)
         await _settle(pilot, 6)
@@ -492,10 +490,8 @@ async def test_the_aside_rests_on_whatever_the_dock_puts_first(size: tuple[int, 
     async with app.run_test(size=size) as pilot:
         await _fill(pilot, app, turns=6)
         builtin.TODO_STORE[session.session_id] = [{"text": "wire the band", "status": "pending"}]
-        # Twice: see the note in `_dock` — the inset needs a measured band.
-        for _ in range(2):
-            app._refresh_band()
-            await _settle(pilot, 6)
+        app._refresh_band()
+        await _settle(pilot, 6)
         app.query_one(Editor).load_text("/btw why is the loop slow?")
         await pilot.press("enter")
         await _settle(pilot, 8)
@@ -552,14 +548,8 @@ async def _dock(pilot: Any, app: OperatorApp, session: Any, todos: bool, subagen
         ]
     if subagents:
         session.jobs = _fake_jobs(_Job("sub-1", "IngestAuditor"))
-    # Twice, with settling between. `_band_inset_fits` measures the laid-out
-    # band before deciding whether the dock can afford its top inset, so the
-    # first refresh produces the layout the second one reads. This is the app's
-    # own steady state — `_refresh_band` runs on the 1 Hz poll — not a
-    # test-only allowance.
-    for _ in range(2):
-        app._refresh_band()
-        await _settle(pilot, 6)
+    app._refresh_band()
+    await _settle(pilot, 6)
     app.query_one(TranscriptView).scroll_end(animate=False)
     await _settle(pilot, 6)
 

--- a/tests/unit/tui/test_composer_seam.py
+++ b/tests/unit/tui/test_composer_seam.py
@@ -362,14 +362,31 @@ async def test_the_boot_splash_gains_no_row(size: tuple[int, int]) -> None:
 @pytest.mark.asyncio
 @pytest.mark.parametrize("size", SIZES)
 async def test_the_band_join_does_not_double(size: tuple[int, int]) -> None:
-    """With a panel in the dock band, every join in the column is one row.
+    """A docked panel's slab is inset one row above and one row below.
 
-    The band's slot used to carry its own row ABOVE itself, which stacked with
-    the transcript's trailing row into a two-row interval — the widest on
-    screen, and the exact "both halves pushed a padding row into the join"
-    failure the aside card's missing bottom row was fixed for. Each slot now
-    owns the ground BELOW it instead, so the transcript's row is the band's air
-    and the band's row is the composer's.
+    The history here is a correction, not a reversal. The slot ORIGINALLY
+    carried its own row above itself, which stacked with the transcript's
+    trailing ground row into a two-row interval — the widest on screen, and the
+    "both halves pushed a padding row into the join" failure the aside card's
+    missing bottom row was fixed for. The flip moved each slot's row BELOW it,
+    which fixed the doubling and left the opposite asymmetry: the panel's
+    caption sat directly on the conversation's ground row while two surface rows
+    separated its last row from the composer. Reported from the field as the
+    band looking "a bit tight" above the todo and subagent lists.
+
+    The inset row that fixes it belongs to ``#band``, not to the slot, so it is
+    spent ONCE for the whole band however many slots are docked — the join
+    between two stacked panels stays the single row it should be. It is the
+    dock's own ``$lo-surface`` rather than the transparent row the flip removed,
+    which is what keeps it an inset within the dock instead of a trench between
+    two slabs; ``test_the_row_under_each_panel_survives_as_the_dock_s_own_fill``
+    pins the same property for the row below.
+
+    So the interval above the body is TWO rows — the transcript's ground row,
+    then the band's surface inset — and they are different surfaces doing
+    different jobs. The blank-row count and the fill are both asserted, because
+    a regression that merges them into one row of either colour is exactly what
+    this is here to catch.
     """
     from local_operator.tools import builtin
 
@@ -390,7 +407,21 @@ async def test_the_band_join_does_not_double(size: tuple[int, int]) -> None:
 
         try:
             assert app.query_one("#todo-panel").display, "the band has to be up to measure it"
-            assert _blank_rows_above(app, "#todo-body") == 1, _frame(app)[-12:]
+            # The transcript's ground row plus the band's own surface inset.
+            assert _blank_rows_above(app, "#todo-body") == 2, _frame(app)[-12:]
+            band = app.query_one("#band")
+            shell = app.query_one("#input-shell")
+            x = shell.region.x + 1
+            # The inset is the DOCK's row: same fill as the composer below it,
+            # and not the screen ground the transcript's row above it carries.
+            # A row that is merely blank proves nothing here — the trench this
+            # replaced was blank too.
+            assert _fill_at(app, band.region.y, x) == _fill_at(app, shell.region.y, x), _frame(app)[
+                -12:
+            ]
+            assert _fill_at(app, band.region.y, x) != _fill_at(app, band.region.y - 1, x), _frame(
+                app
+            )[-12:]
             assert _seam(app) == 1, _frame(app)[-12:]
         finally:
             builtin.TODO_STORE.pop(session.session_id, None)
@@ -462,10 +493,18 @@ async def test_the_aside_rests_on_whatever_the_dock_puts_first(size: tuple[int, 
             assert card.is_open
             todo = app.query_one("#todo-panel")
             assert todo.display
-            # The card rests ON the band: no ground between the two regions, so
-            # the one blank row above the band is the card's own last row.
-            assert card.region.bottom == todo.region.y, (card.region, todo.region)
-            assert _blank_rows_above(app, "#todo-panel") == 1, _frame(app)[-12:]
+            # The card rests ON the band: no ground between the two regions.
+            # Measured against the BAND's top edge rather than the todo slot's,
+            # because that is where the rule actually lives — the card is placed
+            # on the dock (`overlay.stack_on_dock`, gap 0) and takes whatever the
+            # dock puts at its top. That is now the band's own inset row, so the
+            # card meets a row of dock surface instead of the panel's caption:
+            # still flush, still one elevation step, and the panel keeps the
+            # breathing space above its slab that it has below it.
+            band = app.query_one("#band")
+            assert card.region.bottom == band.region.y, (card.region, band.region)
+            # The card's own bottom padding row, then the band's inset.
+            assert _blank_rows_above(app, "#todo-panel") == 2, _frame(app)[-12:]
             # And the band still ends in its own row before the composer.
             assert _seam(app) == 1, _frame(app)[-12:]
             # The band is the composer's panel, not the transcript's ground …

--- a/tests/unit/tui/test_composer_seam.py
+++ b/tests/unit/tui/test_composer_seam.py
@@ -55,9 +55,17 @@ from local_operator.tui.widgets.welcome import WelcomeView
 from tests.unit.tui.test_app_pilot import FakeSession, _factory
 from tests.unit.tui.test_aside import AsideSession
 
-#: The two frames the seam was measured in: the everyday wide terminal and the
-#: narrow one where the conversation reaches the dock soonest.
-SIZES = [(120, 40), (60, 40)]
+#: The frames the seam is measured in: the everyday wide terminal, the narrow
+#: one where the conversation reaches the dock soonest, and a SHORT one.
+#:
+#: The height matters as much as the width and was missing. Every seam test ran
+#: at 40 rows, where the column has rows to spare, so a whole class of defect —
+#: the dock spending a row the transcript needed — could not be seen here at
+#: all: the band's top inset overflowed the screen at mid heights while this
+#: suite stayed green. 24 rows is the standard short terminal and leaves the
+#: transcript a handful of rows once a panel is docked, which is where that
+#: kind of regression shows up first.
+SIZES = [(120, 40), (60, 40), (100, 24)]
 
 PROSE = (
     "Rebuilt the parser and re-ran the suite; both tails are green now, and the "
@@ -399,8 +407,10 @@ async def test_the_band_join_does_not_double(size: tuple[int, int]) -> None:
             {"text": "wire the band", "status": "done"},
             {"text": "capture frames", "status": "pending"},
         ]
-        app._refresh_band()
-        await _settle(pilot, 6)
+        # Twice: see the note in `_dock` — the inset needs a measured band.
+        for _ in range(2):
+            app._refresh_band()
+            await _settle(pilot, 6)
         transcript = app.query_one(TranscriptView)
         transcript.scroll_end(animate=False)
         await _settle(pilot, 6)
@@ -482,8 +492,10 @@ async def test_the_aside_rests_on_whatever_the_dock_puts_first(size: tuple[int, 
     async with app.run_test(size=size) as pilot:
         await _fill(pilot, app, turns=6)
         builtin.TODO_STORE[session.session_id] = [{"text": "wire the band", "status": "pending"}]
-        app._refresh_band()
-        await _settle(pilot, 6)
+        # Twice: see the note in `_dock` — the inset needs a measured band.
+        for _ in range(2):
+            app._refresh_band()
+            await _settle(pilot, 6)
         app.query_one(Editor).load_text("/btw why is the loop slow?")
         await pilot.press("enter")
         await _settle(pilot, 8)
@@ -540,8 +552,14 @@ async def _dock(pilot: Any, app: OperatorApp, session: Any, todos: bool, subagen
         ]
     if subagents:
         session.jobs = _fake_jobs(_Job("sub-1", "IngestAuditor"))
-    app._refresh_band()
-    await _settle(pilot, 6)
+    # Twice, with settling between. `_band_inset_fits` measures the laid-out
+    # band before deciding whether the dock can afford its top inset, so the
+    # first refresh produces the layout the second one reads. This is the app's
+    # own steady state — `_refresh_band` runs on the 1 Hz poll — not a
+    # test-only allowance.
+    for _ in range(2):
+        app._refresh_band()
+        await _settle(pilot, 6)
     app.query_one(TranscriptView).scroll_end(animate=False)
     await _settle(pilot, 6)
 

--- a/tests/unit/tui/test_queued_steer_receipt.py
+++ b/tests/unit/tui/test_queued_steer_receipt.py
@@ -266,15 +266,23 @@ async def test_an_unusable_delivery_count_does_not_take_the_app_down() -> None:
         await _submit(pilot, app, "one")
         await _submit(pilot, app, "two")
 
-        message = SteeringDelivered(1)
-        message.count = "not a number"  # type: ignore[assignment]
-        app.post_message(message)
-        await pilot.pause()
+        # `float("inf")` specifically, alongside the obvious nonsense: the
+        # first version of this guard named `TypeError`/`ValueError` and this
+        # value raises `OverflowError`, which killed the app in the message
+        # loop — the one gap in a guard written because the producer is not
+        # ours. Enumerating failure modes is how such a gap reappears.
+        for bad in ("not a number", float("inf"), float("nan"), None, [1], -3, 0):
+            message = SteeringDelivered(1)
+            message.count = bad  # type: ignore[assignment]
+            app.post_message(message)
+            await pilot.pause()
+            assert app.is_running, f"the app died on count={bad!r}"
 
         texts = _notice_texts(app)
-        assert texts.count(SENT_STEER_NOTICE) == 1, "degraded to one delivery"
-        assert texts.count(QUEUED_STEER_NOTICE) == 1
-        assert app.is_running, "the app survived the unusable count"
+        # Each unusable value degraded to ONE delivery, so the two rows settled
+        # one at a time rather than all at once or not at all.
+        assert texts.count(SENT_STEER_NOTICE) == 2
+        assert QUEUED_STEER_NOTICE not in texts
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tui/test_queued_steer_receipt.py
+++ b/tests/unit/tui/test_queued_steer_receipt.py
@@ -387,8 +387,11 @@ async def test_an_interrupt_spends_the_loud_ink_once() -> None:
     """
     session = _Streaming()
     app = OperatorApp(lambda: _factory(session))
-    # A NARROW frame on purpose: the settled row wraps below ~69 columns, and
-    # the property under test (one alarm row) must not depend on that.
+    # A NARROW frame on purpose: the property under test (exactly one alarm
+    # row) must hold at a width where the settled row is under pressure. 60 is
+    # four columns above where that row starts wrapping onto its hanging indent
+    # (measured: 56), so the frame exercises a narrow terminal while keeping the
+    # settled-row assertion below readable as a single string.
     async with app.run_test(size=(60, 24)) as pilot:
         await pilot.pause()
         await _submit(pilot, app, "steered into a turn about to be stopped")
@@ -401,11 +404,15 @@ async def test_an_interrupt_spends_the_loud_ink_once() -> None:
             for strip in app.screen._compositor.render_strips()
             if strip.text.strip()
         ]
+        # The whole point of the fix: ONE amber row for one interrupt, not two.
+        # No filtering of the status band is needed here — the band's own
+        # `! auto-approve always` is rendered inside the band's chrome and does
+        # not begin a strip with `!`, so this already sees transcript rows only.
+        # (An earlier version filtered it out defensively; the filter never
+        # removed anything at any width, so it only made the test look like it
+        # was guarding something it was not.)
         alarms = [row for row in rows if row.lstrip().startswith("!")]
-        # The band's `! auto-approve always` lives on the status line and is not
-        # a transcript row; the interrupt notice is the only one in the ledger.
-        transcript_alarms = [row for row in alarms if "auto-approve" not in row]
-        assert len(transcript_alarms) == 1, transcript_alarms
-        assert "interrupted" in transcript_alarms[0]
+        assert len(alarms) == 1, alarms
+        assert "interrupted" in alarms[0]
         # And the settled row is present, quiet, and says the message survives.
         assert any(DEFERRED_STEER_NOTICE in row for row in rows), rows

--- a/tests/unit/tui/test_queued_steer_receipt.py
+++ b/tests/unit/tui/test_queued_steer_receipt.py
@@ -388,10 +388,15 @@ async def test_an_interrupt_spends_the_loud_ink_once() -> None:
     session = _Streaming()
     app = OperatorApp(lambda: _factory(session))
     # A NARROW frame on purpose: the property under test (exactly one alarm
-    # row) must hold at a width where the settled row is under pressure. 60 is
-    # four columns above where that row starts wrapping onto its hanging indent
-    # (measured: 56), so the frame exercises a narrow terminal while keeping the
+    # row) must hold at a width where the settled row is under pressure. The
+    # settled row fits on one line down to 53 columns and wraps onto its hanging
+    # indent at 52, so 60 exercises a narrow terminal while keeping the
     # settled-row assertion below readable as a single string.
+    #
+    # The alarm-count assertion does NOT depend on that threshold — it has been
+    # verified to hold from 30 to 120 columns — so a copy change that moves the
+    # wrap point costs at most the substring assertion, not the property this
+    # test exists for.
     async with app.run_test(size=(60, 24)) as pilot:
         await pilot.pause()
         await _submit(pilot, app, "steered into a turn about to be stopped")

--- a/tests/unit/tui/test_queued_steer_receipt.py
+++ b/tests/unit/tui/test_queued_steer_receipt.py
@@ -32,7 +32,6 @@ from local_operator.tui.app import (
     DEFERRED_STEER_NOTICE,
     QUEUED_STEER_NOTICE,
     SENT_STEER_NOTICE,
-    STOPPED_STEER_NOTICE,
     OperatorApp,
 )
 from local_operator.tui.events import SteeringDelivered, TurnEnded
@@ -210,14 +209,14 @@ async def test_an_interrupted_turn_retires_the_promise_it_can_no_longer_keep() -
         await pilot.pause()
 
         texts = _notice_texts(app)
-        assert STOPPED_STEER_NOTICE in texts
+        assert DEFERRED_STEER_NOTICE in texts
         assert QUEUED_STEER_NOTICE not in texts
         assert SENT_STEER_NOTICE not in texts, "nothing was delivered"
         assert app._queued_steer_notices == []
         # The message is still in the engine's queue, so the row must not claim
         # it was lost — the user would retype and the agent would get it twice.
-        assert "not sent" not in STOPPED_STEER_NOTICE
-        assert "still queued" in STOPPED_STEER_NOTICE
+        assert "not sent" not in DEFERRED_STEER_NOTICE
+        assert "still queued" in DEFERRED_STEER_NOTICE
 
 
 @pytest.mark.asyncio
@@ -247,10 +246,11 @@ async def test_a_clean_turn_that_never_drained_says_the_message_is_still_queued(
         texts = _notice_texts(app)
         assert DEFERRED_STEER_NOTICE in texts
         assert QUEUED_STEER_NOTICE not in texts
-        # Neither of the other two outcomes: nothing was delivered, and nothing
-        # was lost either.
+        # Not the delivered row: nothing was sent. The waiting row is the same
+        # one an interrupted turn shows, deliberately — from the user's side the
+        # two are one fact (the message is queued and goes with their next
+        # message) and the action they take is identical.
         assert SENT_STEER_NOTICE not in texts
-        assert STOPPED_STEER_NOTICE not in texts
         assert app._queued_steer_notices == []
 
 
@@ -406,4 +406,4 @@ async def test_an_interrupt_spends_the_loud_ink_once() -> None:
         assert len(transcript_alarms) == 1, transcript_alarms
         assert "interrupted" in transcript_alarms[0]
         # And the settled row is present, quiet, and says the message survives.
-        assert any(STOPPED_STEER_NOTICE in row for row in rows), rows
+        assert any(DEFERRED_STEER_NOTICE in row for row in rows), rows

--- a/tests/unit/tui/test_queued_steer_receipt.py
+++ b/tests/unit/tui/test_queued_steer_receipt.py
@@ -27,8 +27,13 @@ import pytest
 from local_operator.harness.types import ImageContent, ModelSpec, SteeringDeliveredEvent
 from local_operator.session.session import Session
 from local_operator.session.transcript import Transcript
-from local_operator.tui.app import QUEUED_STEER_NOTICE, SENT_STEER_NOTICE, OperatorApp
-from local_operator.tui.events import SteeringDelivered
+from local_operator.tui.app import (
+    QUEUED_STEER_NOTICE,
+    SENT_STEER_NOTICE,
+    STOPPED_STEER_NOTICE,
+    OperatorApp,
+)
+from local_operator.tui.events import SteeringDelivered, TurnEnded
 from local_operator.tui.widgets.editor import Editor
 from local_operator.tui.widgets.transcript import NoticeBlock, TranscriptView
 
@@ -157,6 +162,69 @@ async def test_clearing_the_transcript_drops_the_rows_it_removed() -> None:
         app.post_message(SteeringDelivered(1))
         await pilot.pause()
         assert SENT_STEER_NOTICE not in _notice_texts(app)
+
+
+@pytest.mark.asyncio
+async def test_an_interrupted_turn_retires_the_promise_it_can_no_longer_keep() -> None:
+    """Ctrl+C ends the turn before any boundary, so the row must stop promising.
+
+    The receipt only fires when the engine actually drains the queue. A turn
+    that is aborted never reaches a boundary, so without this the row goes on
+    promising delivery for the rest of the session — the same defect the receipt
+    was added to fix, reached by the abort path. It is worse than doing nothing:
+    the message really is still queued, so the NEXT turn's drain would settle a
+    row the user stopped caring about minutes earlier.
+    """
+    session = _Streaming()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await pilot.pause()
+        await _submit(pilot, app, "steered into a turn about to be stopped")
+        assert QUEUED_STEER_NOTICE in _notice_texts(app)
+
+        app.post_message(TurnEnded(True, None))
+        await pilot.pause()
+
+        texts = _notice_texts(app)
+        assert STOPPED_STEER_NOTICE in texts
+        assert QUEUED_STEER_NOTICE not in texts
+        assert SENT_STEER_NOTICE not in texts, "nothing was delivered"
+        assert app._queued_steer_notices == []
+
+
+@pytest.mark.asyncio
+async def test_only_the_messages_that_went_are_settled() -> None:
+    """A message that raced into the queue after the drain keeps its promise.
+
+    `_drain_steering` awaits a disk append per message, so a message steered
+    during that await lands after the loop has exited and is NOT in the batch.
+    It is genuinely still queued and goes at the next boundary, so settling its
+    row on this delivery would claim something that has not happened. FIFO, so
+    "the first `count` rows" and "the messages that went" are the same set.
+    """
+    session = _Streaming()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await pilot.pause()
+        for text in ("first", "second raced in late"):
+            await _submit(pilot, app, text)
+        assert _notice_texts(app).count(QUEUED_STEER_NOTICE) == 2
+
+        # The drain took ONE of them.
+        app.post_message(SteeringDelivered(1))
+        await pilot.pause()
+
+        texts = _notice_texts(app)
+        assert texts.count(SENT_STEER_NOTICE) == 1
+        assert texts.count(QUEUED_STEER_NOTICE) == 1, "the undelivered row still promises"
+        assert len(app._queued_steer_notices) == 1
+
+        # The next boundary takes the straggler.
+        app.post_message(SteeringDelivered(1))
+        await pilot.pause()
+
+        assert _notice_texts(app).count(SENT_STEER_NOTICE) == 2
+        assert QUEUED_STEER_NOTICE not in _notice_texts(app)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tui/test_queued_steer_receipt.py
+++ b/tests/unit/tui/test_queued_steer_receipt.py
@@ -214,6 +214,10 @@ async def test_an_interrupted_turn_retires_the_promise_it_can_no_longer_keep() -
         assert QUEUED_STEER_NOTICE not in texts
         assert SENT_STEER_NOTICE not in texts, "nothing was delivered"
         assert app._queued_steer_notices == []
+        # The message is still in the engine's queue, so the row must not claim
+        # it was lost — the user would retype and the agent would get it twice.
+        assert "not sent" not in STOPPED_STEER_NOTICE
+        assert "still queued" in STOPPED_STEER_NOTICE
 
 
 @pytest.mark.asyncio
@@ -363,3 +367,43 @@ async def test_the_session_announces_the_drain_that_actually_took_messages(
     # Persisted before the receipt: the row claims the message is in the
     # conversation, which is only true once it is on disk.
     assert [entry.payload.get("content") for entry in session._transcript.entries()]
+
+
+@pytest.mark.asyncio
+async def test_an_interrupt_spends_the_loud_ink_once() -> None:
+    """Ctrl+C prints ONE amber row, not two saying nearly the same thing.
+
+    The standalone `interrupted` notice already fires on this path whenever no
+    tool was in flight, which is the common case. A settled queued row in the
+    same weight put two amber `!` rows next to each other, one almost a
+    substring of the other, which reads as the app stuttering — and spends the
+    loudest ink in the palette twice on one event. This codebase already fought
+    that battle from the other side: `on_turn_ended` suppresses the standalone
+    notice when tool cards carry the interrupt mark.
+
+    The queued row stays at `note`, which is also the honest weight: the state
+    did not get worse. The message is still queued and still going, so the row
+    has no business getting louder.
+    """
+    session = _Streaming()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await pilot.pause()
+        await _submit(pilot, app, "steered into a turn about to be stopped")
+
+        app.post_message(TurnEnded(True, None))
+        await pilot.pause()
+
+        rows = [
+            strip.text.rstrip()
+            for strip in app.screen._compositor.render_strips()
+            if strip.text.strip()
+        ]
+        alarms = [row for row in rows if row.lstrip().startswith("!")]
+        # The band's `! auto-approve always` lives on the status line and is not
+        # a transcript row; the interrupt notice is the only one in the ledger.
+        transcript_alarms = [row for row in alarms if "auto-approve" not in row]
+        assert len(transcript_alarms) == 1, transcript_alarms
+        assert "interrupted" in transcript_alarms[0]
+        # And the settled row is present, quiet, and says the message survives.
+        assert any(STOPPED_STEER_NOTICE in row for row in rows), rows

--- a/tests/unit/tui/test_queued_steer_receipt.py
+++ b/tests/unit/tui/test_queued_steer_receipt.py
@@ -1,0 +1,204 @@
+"""A queued mid-turn message says so, and then says it was delivered.
+
+The report: sending a message while the agent is working prints "queued — sends
+when this step finishes", and that row never changes. After the message has
+actually been delivered the transcript still shows the promise, so the only
+evidence it arrived is the agent eventually answering it.
+
+The fix is a state transition rather than a second notice. ``steer()`` is
+fire-and-forget by design — it drops a message on a queue the loop empties at
+its next boundary — so the session emits ``SteeringDeliveredEvent`` at the
+moment it actually drains that queue, and the app RESTATES the row it already
+painted. One statement that became true, instead of a stale promise with a
+correction underneath it.
+
+Both halves are pinned here: the engine only speaks when it really took
+something (``tests/unit/session`` would be the wrong home for the app half, and
+a UI test alone would pass against an event nothing emits).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Sequence
+
+import pytest
+
+from local_operator.harness.types import ImageContent, ModelSpec, SteeringDeliveredEvent
+from local_operator.session.session import Session
+from local_operator.session.transcript import Transcript
+from local_operator.tui.app import QUEUED_STEER_NOTICE, SENT_STEER_NOTICE, OperatorApp
+from local_operator.tui.events import SteeringDelivered
+from local_operator.tui.widgets.editor import Editor
+from local_operator.tui.widgets.transcript import NoticeBlock, TranscriptView
+
+from .test_app_pilot import FakeSession, _factory
+
+
+class _Streaming(FakeSession):
+    """A fake that is mid-turn, so a submit is STEERED rather than prompted."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.steers: list[str] = []
+
+    @property
+    def is_streaming(self) -> bool:
+        return True
+
+    def steer(self, text: str, images: Sequence[ImageContent] | None = None) -> None:
+        self.steers.append(text)
+
+
+def _notice_texts(app: OperatorApp) -> list[str]:
+    """Every notice row's text, in transcript order."""
+    return [
+        block._text
+        for block in app.query_one(TranscriptView).blocks()
+        if isinstance(block, NoticeBlock)
+    ]
+
+
+async def _submit(pilot: Any, app: OperatorApp, text: str) -> None:
+    app.query_one(Editor).text = text
+    await pilot.press("enter")
+    await pilot.pause()
+
+
+@pytest.mark.asyncio
+async def test_a_queued_message_says_queued_until_it_is_delivered() -> None:
+    """The row starts as the promise, and only the delivery settles it."""
+    session = _Streaming()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await pilot.pause()
+        await _submit(pilot, app, "also check the images")
+
+        assert session.steers == ["also check the images"]
+        assert QUEUED_STEER_NOTICE in _notice_texts(app)
+        assert SENT_STEER_NOTICE not in _notice_texts(app), "nothing has been delivered yet"
+
+        app.post_message(SteeringDelivered(1))
+        await pilot.pause()
+
+        texts = _notice_texts(app)
+        assert SENT_STEER_NOTICE in texts
+        # UPDATED, not appended: the stale promise must be gone, and the
+        # transcript must not have grown a row to say so.
+        assert QUEUED_STEER_NOTICE not in texts
+        assert texts.count(SENT_STEER_NOTICE) == 1
+
+
+@pytest.mark.asyncio
+async def test_every_message_queued_against_one_boundary_settles_together() -> None:
+    """Three messages typed during one tool call are three promises kept at once.
+
+    The queue is drained WHOLE at a single boundary, so settling only the newest
+    row would leave the earlier ones lying about their own delivery.
+    """
+    session = _Streaming()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await pilot.pause()
+        for text in ("one", "two", "three"):
+            await _submit(pilot, app, text)
+
+        assert _notice_texts(app).count(QUEUED_STEER_NOTICE) == 3
+
+        app.post_message(SteeringDelivered(3))
+        await pilot.pause()
+
+        texts = _notice_texts(app)
+        assert texts.count(SENT_STEER_NOTICE) == 3
+        assert QUEUED_STEER_NOTICE not in texts
+
+
+@pytest.mark.asyncio
+async def test_a_delivery_with_no_queued_row_changes_nothing() -> None:
+    """A late or duplicated delivery must not restate an unrelated notice.
+
+    The app settles rows it is HOLDING references to, so an event arriving when
+    it holds none is a no-op — not a hunt through the transcript for something
+    that looks queued.
+    """
+    session = _Streaming()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await pilot.pause()
+        app._append_block(NoticeBlock("compacting context…", "info"))
+        await pilot.pause()
+        before = _notice_texts(app)
+
+        app.post_message(SteeringDelivered(1))
+        await pilot.pause()
+
+        assert _notice_texts(app) == before
+
+
+@pytest.mark.asyncio
+async def test_clearing_the_transcript_drops_the_rows_it_removed() -> None:
+    """`/clear` removes the rows, so a later delivery has nothing to settle.
+
+    Without this the app would hold references to widgets no longer mounted and
+    "settle" them where nobody can see, while any row still on screen kept its
+    promise.
+    """
+    session = _Streaming()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await pilot.pause()
+        await _submit(pilot, app, "queued before the clear")
+        assert app._queued_steer_notices
+
+        app._clear_transcript()
+        await pilot.pause()
+
+        assert app._queued_steer_notices == []
+        app.post_message(SteeringDelivered(1))
+        await pilot.pause()
+        assert SENT_STEER_NOTICE not in _notice_texts(app)
+
+
+@pytest.mark.asyncio
+async def test_the_session_announces_the_drain_that_actually_took_messages(
+    tmp_path: Path,
+) -> None:
+    """The engine half: one event per DRAIN, and silence when nothing was queued.
+
+    ``_drain_steering`` is called at every tool and message boundary, so an
+    event per call would be noise; the receipt exists only where a promise was
+    actually kept. Driven through the real Session because the emission point —
+    after persistence, inside the drain — is the fact under test.
+    """
+
+    async def _stream(request: Any, signal: Any = None):  # pragma: no cover - never called
+        if False:
+            yield None
+
+    session = Session(
+        model=ModelSpec(provider="anthropic", model_id="sonnet", context_window=200_000),
+        stream_fn=_stream,
+        tools=[],
+        transcript=Transcript(tmp_path / "sess"),
+        system_blocks_provider=lambda: ["system"],
+    )
+    events: list[Any] = []
+    session.subscribe(events.append)
+
+    # Nothing queued: the boundary passes in silence.
+    assert await session._drain_steering() == []
+    assert [e for e in events if isinstance(e, SteeringDeliveredEvent)] == []
+
+    session.steer("first")
+    session.steer("second")
+    drained = await session._drain_steering()
+
+    # `getattr` rather than `.text`: the queue's element type is the union
+    # `AgentMessage`, and only the `Message` arm declares `text`.
+    assert [getattr(message, "text", "") for message in drained] == ["first", "second"]
+    delivered = [e for e in events if isinstance(e, SteeringDeliveredEvent)]
+    assert len(delivered) == 1, "one receipt per drain, not one per message"
+    assert delivered[0].count == 2
+    # Persisted before the receipt: the row claims the message is in the
+    # conversation, which is only true once it is on disk.
+    assert [entry.payload.get("content") for entry in session._transcript.entries()]

--- a/tests/unit/tui/test_queued_steer_receipt.py
+++ b/tests/unit/tui/test_queued_steer_receipt.py
@@ -19,6 +19,7 @@ a UI test alone would pass against an event nothing emits).
 
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 from typing import Any, Sequence
 
@@ -28,6 +29,7 @@ from local_operator.harness.types import ImageContent, ModelSpec, SteeringDelive
 from local_operator.session.session import Session
 from local_operator.session.transcript import Transcript
 from local_operator.tui.app import (
+    DEFERRED_STEER_NOTICE,
     QUEUED_STEER_NOTICE,
     SENT_STEER_NOTICE,
     STOPPED_STEER_NOTICE,
@@ -65,7 +67,29 @@ def _notice_texts(app: OperatorApp) -> list[str]:
 
 
 async def _submit(pilot: Any, app: OperatorApp, text: str) -> None:
-    app.query_one(Editor).text = text
+    """Type ``text`` into the composer and send it, once the app can accept it.
+
+    Waits for the SESSION first. The app paints before its session exists (the
+    factory is awaited in a boot worker), and a submit that lands in that window
+    is answered with "session is still starting…" and never reaches `steer` — so
+    a test that pressed enter on a fixed frame count was racing the boot rather
+    than testing anything. Waiting on the condition instead of on a sleep keeps
+    it deterministic on a loaded machine; the same race is what costs
+    `test_app_pilot`'s first test on `main`.
+
+    Focus is then set explicitly, because `enter` goes to whatever holds it.
+    """
+    for _ in range(200):
+        if app._session is not None:
+            break
+        await pilot.pause()
+        await asyncio.sleep(0.01)
+    assert app._session is not None, "the session never booted"
+    editor = app.query_one(Editor)
+    editor.focus()
+    await pilot.pause()
+    editor.text = text
+    await pilot.pause()
     await pilot.press("enter")
     await pilot.pause()
 
@@ -190,6 +214,67 @@ async def test_an_interrupted_turn_retires_the_promise_it_can_no_longer_keep() -
         assert QUEUED_STEER_NOTICE not in texts
         assert SENT_STEER_NOTICE not in texts, "nothing was delivered"
         assert app._queued_steer_notices == []
+
+
+@pytest.mark.asyncio
+async def test_a_clean_turn_that_never_drained_says_the_message_is_still_queued() -> None:
+    """A turn can end cleanly without ever reaching a boundary to drain at.
+
+    The model answers with no further tool calls after the steer lands, so no
+    injection boundary runs, `agent_end` arrives with `aborted=False` and no
+    error, and the queue is untouched. The message really will go — at the next
+    turn's first boundary — so the row must claim neither a delivery nor a loss.
+
+    Left alone it would settle minutes later against whatever the user is
+    looking at by then, which is the same disconnect the interrupted case has.
+    Every turn end reconciles its held rows: a row still held when a turn ends
+    is by definition one that turn did not deliver.
+    """
+    session = _Streaming()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await pilot.pause()
+        await _submit(pilot, app, "a steer the model answers without tools")
+        assert QUEUED_STEER_NOTICE in _notice_texts(app)
+
+        app.post_message(TurnEnded(False, None))
+        await pilot.pause()
+
+        texts = _notice_texts(app)
+        assert DEFERRED_STEER_NOTICE in texts
+        assert QUEUED_STEER_NOTICE not in texts
+        # Neither of the other two outcomes: nothing was delivered, and nothing
+        # was lost either.
+        assert SENT_STEER_NOTICE not in texts
+        assert STOPPED_STEER_NOTICE not in texts
+        assert app._queued_steer_notices == []
+
+
+@pytest.mark.asyncio
+async def test_an_unusable_delivery_count_does_not_take_the_app_down() -> None:
+    """`count` crosses a thread boundary from a producer this app does not own.
+
+    "A receipt must never take the app down" is the posture the whole handler is
+    written to, and a bare `int()` on a field from elsewhere was the one line
+    that could break it. A nonsense value degrades to the safe reading — one
+    delivery, because the event means at least one message went.
+    """
+    session = _Streaming()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await pilot.pause()
+        await _submit(pilot, app, "one")
+        await _submit(pilot, app, "two")
+
+        message = SteeringDelivered(1)
+        message.count = "not a number"  # type: ignore[assignment]
+        app.post_message(message)
+        await pilot.pause()
+
+        texts = _notice_texts(app)
+        assert texts.count(SENT_STEER_NOTICE) == 1, "degraded to one delivery"
+        assert texts.count(QUEUED_STEER_NOTICE) == 1
+        assert app.is_running, "the app survived the unusable count"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tui/test_queued_steer_receipt.py
+++ b/tests/unit/tui/test_queued_steer_receipt.py
@@ -387,7 +387,9 @@ async def test_an_interrupt_spends_the_loud_ink_once() -> None:
     """
     session = _Streaming()
     app = OperatorApp(lambda: _factory(session))
-    async with app.run_test(size=(100, 24)) as pilot:
+    # A NARROW frame on purpose: the settled row wraps below ~69 columns, and
+    # the property under test (one alarm row) must not depend on that.
+    async with app.run_test(size=(60, 24)) as pilot:
         await pilot.pause()
         await _submit(pilot, app, "steered into a turn about to be stopped")
 

--- a/tests/unit/tui/test_usage_continuity.py
+++ b/tests/unit/tui/test_usage_continuity.py
@@ -194,6 +194,75 @@ async def test_a_new_session_restores_nothing_and_keeps_its_estimate(tmp_path: P
 
 
 @pytest.mark.asyncio
+async def test_a_compacted_resume_reports_nothing_rather_than_the_old_context(
+    tmp_path: Path,
+) -> None:
+    """A compacted history's readings describe a context that no longer exists.
+
+    Replay puts the summary marker at the head and the KEPT WINDOW after it, and
+    those kept messages still carry their pre-compaction ``usage``. Nothing
+    supersedes them, because only a completed turn rewrites the reading and a
+    session that compacted and then exited never ran one.
+
+    Seeding from one is worse than the bug the seeding fixed: measured at 900k
+    against a real ~1.7k, it would install a 527x overstatement as EXACT — which
+    also suppresses the correct local estimate — and hand it to
+    ``should_compact``, rewriting the user's history on the first turn after the
+    resume. ``None`` is the right answer: fall through to the estimate.
+    """
+    transcript = Transcript(tmp_path / "sess")
+    stale = _assistant(output=100, context=900_000)
+    await transcript.append_message(Message.user("q"))
+    await transcript.append_message(stale)
+    await transcript.append_compaction(
+        summary="what happened earlier",
+        first_kept_entry_id=stale.id,
+        tokens_before=900_000,
+    )
+
+    async def _stream(request: Any, signal: Any = None):  # pragma: no cover - never called
+        if False:
+            yield None
+
+    session = Session(
+        model=_spec(),
+        stream_fn=_stream,
+        tools=[],
+        transcript=Transcript(tmp_path / "sess"),
+        system_blocks_provider=lambda: ["system"],
+    )
+
+    assert session.restored_usage() is None
+    # And the fallback is sane: the local estimate describes the KEPT window,
+    # nowhere near the pre-compaction figure it refused.
+    assert await session.measure_preloaded_context() < 100_000
+
+
+@pytest.mark.asyncio
+async def test_the_baseline_never_loads_the_tokenizer(tmp_path: Path) -> None:
+    """The boot-path measurement keeps its documented chars/4 contract.
+
+    ``measure_preloaded_context``'s own docstring refuses two costs, and the
+    tokenizer is the first of them: cl100k_base is ~43.6 MB RSS and, on a cold
+    cache, a NETWORK fetch of the ranks — during boot, before the user has
+    typed. Counting the history with the sharper ruler would have spent exactly
+    that (measured: 58 ms and +41 MB against 0.5 ms and +0.1 MB), and the
+    memoization does not amortize it because a session that never approaches the
+    compaction threshold never tokenizes at all.
+    """
+    import local_operator.compaction.tokens as tokens_module
+
+    session = await _session_over(
+        tmp_path / "sess",
+        [Message.user("q" * 5_000), _assistant(output=50, context=10_000)],
+    )
+
+    with patch.object(tokens_module, "_get_encoding", side_effect=AssertionError("loaded")) as gate:
+        assert await session.measure_preloaded_context() > 0
+        assert gate.call_count == 0
+
+
+@pytest.mark.asyncio
 async def test_the_new_session_baseline_counts_what_the_first_request_carries(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/tui/test_usage_continuity.py
+++ b/tests/unit/tui/test_usage_continuity.py
@@ -638,3 +638,65 @@ async def test_a_transcript_folded_by_an_older_build_still_refuses_stale_reading
     usages = Transcript(tmp_path / "sess").usages_since_compaction()
     reported = [usage.get("context_tokens") for usage in usages]
     assert 100_000 not in reported, "the pre-prune reading must not survive a legacy fold"
+
+
+@pytest.mark.asyncio
+async def test_every_writer_of_the_cost_cell_keeps_the_floor_mark(tmp_path: Path) -> None:
+    """The `≥` is a property of the figure, not of the moment it is rendered.
+
+    Five sites write the band's cost cell — the restore, the per-call accrual,
+    turn end, the 1 Hz subagent harvest, and `/reload`'s reconciliation — and
+    when only the restore knew about the mark, the other four silently stripped
+    it. A resumed session's honest `≥$2.10` became a bare figure the moment a
+    child reported spend, which is the same defect the mark was added to fix,
+    reached by a path that never touched the restore.
+
+    Adding a real turn does NOT clear it either: a restored floor plus a real
+    turn is still a floor, just a larger one. Only a session whose spend was
+    accrued entirely in this process is exactly known.
+    """
+    session = await _session_over(
+        tmp_path / "sess",
+        [Message.user("q"), _assistant(output=1_000, context=200_000)],
+    )
+
+    async def factory() -> Session:
+        return session
+
+    app = OperatorApp(factory)
+    with _resolving():
+        # Wide enough that the cost segment is never shed by the drop ladder.
+        async with app.run_test(size=(150, 18)) as pilot:
+            await _settled(app, pilot)
+            assert app._status is not None
+            restored = app._status._cost
+            assert restored.startswith(RESTORED_COST_PREFIX), restored
+
+            # The 1 Hz band poll, which harvests subagent spend.
+            app._refresh_band()
+            await pilot.pause()
+            assert app._status._cost.startswith(RESTORED_COST_PREFIX), app._status._cost
+
+            # A live model call mid-turn, and then the turn's own end.
+            app.post_message(
+                ContextUsageReported(
+                    50_000,
+                    Usage(input_tokens=1_000, output_tokens=500, context_tokens=50_000),
+                )
+            )
+            await pilot.pause()
+            assert app._status._cost.startswith(RESTORED_COST_PREFIX), app._status._cost
+
+            app.post_message(
+                TurnEnded(
+                    False,
+                    None,
+                    context_tokens=50_000,
+                    usage=Usage(input_tokens=1_000, output_tokens=500, context_tokens=50_000),
+                )
+            )
+            await pilot.pause()
+            settled = app._status._cost
+            assert settled.startswith(RESTORED_COST_PREFIX), settled
+            # And it did move: the mark is not standing in for a frozen figure.
+            assert settled != restored

--- a/tests/unit/tui/test_usage_continuity.py
+++ b/tests/unit/tui/test_usage_continuity.py
@@ -1,0 +1,331 @@
+"""What the status band knows about tokens and money BEFORE a turn ends.
+
+Four reports from the field, all the same shape — the band's two numeric
+segments are fed only by turns that complete while the app is running, so every
+moment before that they described a session that was not the one on screen:
+
+1. "on resume the initial readout on token usage is inaccurate" — a resumed
+   conversation opened claiming an almost-empty context. Measured on a session
+   whose last provider reading was 402k of a 1M window: the band said 0.2%/1M.
+2. The same resume showed no cost at all, for a conversation with real spend
+   already on it.
+3. "the cost doesn't start tracking until after the second message" — a new
+   session's first turn showed nothing in the cost segment for the whole time it
+   ran, which is exactly when a long agentic turn is spending the most.
+4. The baseline a NEW session opens with has to be the tokens the first request
+   would actually carry, not a figure that ignores half of what is sent.
+
+These are driven through the REAL app and the REAL session wherever the fact
+under test lives there: the wiring (`_adopt_session` ordering, the per-call
+accrual and its reconciliation at turn end) is what was broken, and a test
+calling the accessors directly would pass while the band stayed wrong.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from local_operator.harness.types import Message, ModelSpec, TextContent, Usage
+from local_operator.model.registry import ModelInfo
+from local_operator.session.session import Session
+from local_operator.session.transcript import Transcript
+from local_operator.tui.app import OperatorApp
+from local_operator.tui.events import ContextUsageReported, TurnEnded
+
+#: $10 in / $100 out per MTok, so a million tokens is a round dollar figure and
+#: a mispriced figure is unmistakable rather than a rounding argument.
+_MODEL = ModelInfo(id="sonnet", name="sonnet", description="", input_price=10.0, output_price=100.0)
+
+
+def _resolving():
+    return patch(
+        "local_operator.model.configure.resolve_model_info",
+        side_effect=lambda provider, model_id: _MODEL,
+    )
+
+
+def _spec() -> ModelSpec:
+    return ModelSpec(provider="anthropic", model_id="sonnet", context_window=1_000_000)
+
+
+def _assistant(*, output: int, context: int) -> Message:
+    """One settled assistant turn carrying the provider's own usage."""
+    return Message(
+        role="assistant",
+        content=[TextContent(text="answer")],
+        stop_reason="stop",
+        usage=Usage(
+            input_tokens=20,
+            output_tokens=output,
+            cache_read_tokens=max(context - 20, 0),
+            cache_write_tokens=0,
+            context_tokens=context,
+        ),
+    )
+
+
+async def _session_over(directory: Path, messages: list[Message]) -> Session:
+    """A real Session whose transcript already holds ``messages`` — a resume."""
+    transcript = Transcript(directory)
+    for message in messages:
+        await transcript.append_message(message)
+
+    async def _stream(request: Any, signal: Any = None):  # pragma: no cover - never called
+        if False:
+            yield None
+
+    # A SECOND Transcript over the same directory, so the session replays the
+    # rows from disk exactly as `--resume` does rather than inheriting an
+    # in-memory list the writer happened to still hold.
+    return Session(
+        model=_spec(),
+        stream_fn=_stream,
+        tools=[],
+        transcript=Transcript(directory),
+        system_blocks_provider=lambda: ["system"],
+    )
+
+
+async def _settled(app: OperatorApp, pilot: Any, ticks: int = 8) -> None:
+    """Let the boot worker's measurement land before reading the band."""
+    for _ in range(ticks):
+        await pilot.pause()
+        await asyncio.sleep(0.05)
+
+
+@pytest.mark.asyncio
+async def test_a_resumed_session_opens_on_the_provider_s_own_context_reading(
+    tmp_path: Path,
+) -> None:
+    """The band reports what the conversation ACTUALLY holds, exactly.
+
+    The reading is the provider's own ``context_tokens`` from the last call of
+    the last turn, so it is installed as exact rather than as an estimate — it
+    is the number the band would still be showing had the process never
+    stopped. Pinned as exact because that flag is also what stops the local
+    preload estimate from overwriting it a moment later, in a worker.
+    """
+    session = await _session_over(
+        tmp_path / "sess",
+        [
+            Message.user("q1"),
+            _assistant(output=900, context=120_000),
+            Message.user("q2"),
+            _assistant(output=1_100, context=402_000),
+        ],
+    )
+
+    async def factory() -> Session:
+        return session
+
+    app = OperatorApp(factory)
+    with _resolving():
+        async with app.run_test(size=(100, 18)) as pilot:
+            await _settled(app, pilot)
+
+            assert app._status is not None
+            assert app._status.context_tokens == 402_000
+            assert app._status.context_is_estimate is False
+
+
+@pytest.mark.asyncio
+async def test_a_resumed_session_opens_with_the_spend_it_already_has(tmp_path: Path) -> None:
+    """Cost is seeded rather than left empty, because empty reads as free.
+
+    It is a FLOOR, not the lifetime total: only the last reported turn's usage
+    survives in a form the app can price. Asserted as "the last turn's price,
+    and not zero" rather than as a total over the conversation, because
+    claiming the latter would be the same kind of lie in the other direction.
+    """
+    session = await _session_over(
+        tmp_path / "sess",
+        [Message.user("q"), _assistant(output=1_000, context=200_000)],
+    )
+
+    async def factory() -> Session:
+        return session
+
+    app = OperatorApp(factory)
+    with _resolving():
+        async with app.run_test(size=(100, 18)) as pilot:
+            await _settled(app, pilot)
+
+            assert app._status is not None
+            # Anthropic reports `input_tokens` EXCLUDING its cache buckets, so
+            # all three are billed: 20 plain + 199_980 cache-read at $10/MTok
+            # (this model publishes no separate cache rate, so cache reads fall
+            # back to the input price), plus 1000 output at $100/MTok.
+            assert app._total_cost == pytest.approx(0.0002 + 1.9998 + 0.1)
+            assert app._status._cost, "a resumed conversation with spend must not read as free"
+
+
+@pytest.mark.asyncio
+async def test_a_new_session_restores_nothing_and_keeps_its_estimate(tmp_path: Path) -> None:
+    """The restore is silent on a conversation that never reported usage.
+
+    The complement of the two above, and the reason ``restored_usage`` returns
+    the object rather than an int: "nothing was ever reported" and "zero was
+    reported" are different facts, and only the first may fall through to the
+    local estimate. A new session must keep its estimated baseline and must NOT
+    gain a cost segment out of nowhere.
+    """
+    session = await _session_over(tmp_path / "sess", [])
+
+    async def factory() -> Session:
+        return session
+
+    app = OperatorApp(factory)
+    with _resolving():
+        async with app.run_test(size=(100, 18)) as pilot:
+            await _settled(app, pilot)
+
+            assert app._status is not None
+            assert session.restored_usage() is None
+            assert app._total_cost == 0.0
+            assert app._status._cost == ""
+            # The preload estimate still ran, and is still flagged as one.
+            assert app._status.context_tokens > 0
+            assert app._status.context_is_estimate is True
+
+
+@pytest.mark.asyncio
+async def test_the_new_session_baseline_counts_what_the_first_request_carries(
+    tmp_path: Path,
+) -> None:
+    """The opening reading is the system blocks AND the schemas AND the history.
+
+    A new session's history is empty, so this is where the baseline's third
+    term is proved rather than assumed: the same measurement over a session
+    holding a conversation has to grow by that conversation. Before, it counted
+    blocks and schemas only, which is why every RESUMED session opened at the
+    size of an empty one.
+    """
+    empty = await _session_over(tmp_path / "empty", [])
+    loaded = await _session_over(
+        tmp_path / "loaded",
+        [Message.user("q" * 4_000), _assistant(output=10, context=5_000)],
+    )
+
+    baseline = await empty.measure_preloaded_context()
+    with_history = await loaded.measure_preloaded_context()
+
+    assert baseline > 0, "a session with a system prompt is never at zero"
+    assert with_history > baseline, "history the model will be sent has to be counted"
+
+
+@pytest.mark.asyncio
+async def test_cost_appears_during_the_first_turn_not_after_it() -> None:
+    """Money moves on each model call, so the FIRST turn shows its own spend.
+
+    Reported as "the cost doesn't start tracking until after the second
+    message". The per-call event is the only signal available while a turn is
+    still running, which is exactly the stretch a long agentic turn is spending
+    the most in.
+    """
+    from tests.unit.tui.test_band_panels import FakeSession, _async_factory
+
+    app = OperatorApp(_async_factory(FakeSession()))
+    with _resolving():
+        async with app.run_test(size=(100, 18)) as pilot:
+            await pilot.pause()
+            assert app._status is not None
+            assert app._status._cost == "", "nothing has been spent yet"
+
+            # One model call inside a turn that has NOT ended.
+            app.post_message(
+                ContextUsageReported(
+                    50_000,
+                    Usage(input_tokens=1_000, output_tokens=500, context_tokens=50_000),
+                )
+            )
+            await pilot.pause()
+
+            assert app._status._cost, "the segment must move before the turn ends"
+            assert app._total_cost == pytest.approx(0.01 + 0.05)
+            assert app._status.context_tokens == 50_000
+
+
+@pytest.mark.asyncio
+async def test_a_turn_is_not_billed_twice_for_the_calls_it_already_paid_for() -> None:
+    """The turn total supersedes the running one instead of adding to it.
+
+    The hazard the per-call accrual introduces: ``agent_end`` prices the WHOLE
+    turn (summing every call), so adding it whole on top of the calls already
+    billed would report roughly double. The end adds only the remainder, and
+    the accrual resets so the next turn starts clean.
+    """
+    from tests.unit.tui.test_band_panels import FakeSession, _async_factory
+
+    app = OperatorApp(_async_factory(FakeSession()))
+    with _resolving():
+        async with app.run_test(size=(100, 18)) as pilot:
+            await pilot.pause()
+
+            # Two calls inside one turn, billed as they land.
+            for _ in range(2):
+                app.post_message(
+                    ContextUsageReported(
+                        10_000,
+                        Usage(input_tokens=1_000, output_tokens=500, context_tokens=10_000),
+                    )
+                )
+                await pilot.pause()
+            assert app._total_cost == pytest.approx(2 * (0.01 + 0.05))
+
+            # The turn ends, reporting the SUM of those same two calls.
+            app.post_message(
+                TurnEnded(
+                    False,
+                    None,
+                    context_tokens=10_000,
+                    usage=Usage(input_tokens=2_000, output_tokens=1_000, context_tokens=10_000),
+                )
+            )
+            await pilot.pause()
+
+            # The total, not the double.
+            assert app._total_cost == pytest.approx(0.02 + 0.10)
+            assert app._turn_accrued_cost == 0.0, "the next turn must start from zero"
+
+
+@pytest.mark.asyncio
+async def test_a_turn_end_that_prices_more_than_was_accrued_adds_the_remainder() -> None:
+    """A call the per-call path never saw is still paid for at the end.
+
+    The turn total is authoritative precisely because it sums calls this app may
+    not have received an event for (a provider that reports usage only at the
+    end, an event dropped across a reload). The remainder is what keeps the
+    figure right in that case rather than under-reporting it.
+    """
+    from tests.unit.tui.test_band_panels import FakeSession, _async_factory
+
+    app = OperatorApp(_async_factory(FakeSession()))
+    with _resolving():
+        async with app.run_test(size=(100, 18)) as pilot:
+            await pilot.pause()
+
+            app.post_message(
+                ContextUsageReported(
+                    10_000,
+                    Usage(input_tokens=1_000, output_tokens=500, context_tokens=10_000),
+                )
+            )
+            await pilot.pause()
+
+            # The turn totals THREE calls' worth; only one was seen live.
+            app.post_message(
+                TurnEnded(
+                    False,
+                    None,
+                    context_tokens=10_000,
+                    usage=Usage(input_tokens=3_000, output_tokens=1_500, context_tokens=10_000),
+                )
+            )
+            await pilot.pause()
+
+            assert app._total_cost == pytest.approx(0.03 + 0.15)

--- a/tests/unit/tui/test_usage_continuity.py
+++ b/tests/unit/tui/test_usage_continuity.py
@@ -107,9 +107,16 @@ async def _settled(app: OperatorApp, pilot: Any, ticks: int = 80) -> None:
         if app._session is not None:
             break
     assert app._session is not None, "the session never booted"
-    # The preload measurement runs in its own worker after adoption; give it a
-    # few frames so the estimate-vs-exact interaction is settled when read.
-    for _ in range(6):
+    # Then wait for the READING, not for a number of frames. Adoption is only
+    # the first half: `_measure_preloaded_context` starts its own worker
+    # afterwards and these tests assert on its result, so a fixed pause here is
+    # the same guess one worker later — it passes on an idle machine and fails
+    # when the measurement takes longer than the frames allowed for it.
+    status = app._status
+    assert status is not None
+    for _ in range(ticks):
+        if status.context_tokens:
+            break
         await pilot.pause()
         await asyncio.sleep(0.01)
 
@@ -295,6 +302,56 @@ async def test_turns_taken_after_a_compaction_are_still_restored(tmp_path: Path)
     assert restored is not None, "a turn taken after the pass is a valid reading"
     assert restored.context_tokens == 160_000
     assert restored.context_tokens != 900_000, "and it is not the pre-compaction one"
+
+
+@pytest.mark.asyncio
+async def test_a_pruned_reading_is_refused_like_a_compacted_one(tmp_path: Path) -> None:
+    """Pruning shrinks the context too, and leaves no marker to notice it by.
+
+    Blanking a tool result is the other pass that makes a reading describe a
+    context that no longer exists — and unlike compaction it writes no boundary:
+    the journal entry is folded away by ``compact_file`` and the message row
+    survives with its original ``usage`` attached. Measured on a real prune, a
+    restored reading of 640_000 against a true context of ~1_700, installed as
+    exact.
+
+    Wider than the compaction case it mirrors, too: it needs nothing more than
+    the agent reading the same large file twice. So the rule is not "after the
+    newest compaction" but "not describing a context something has since
+    shrunk", and both shrinking passes have to be covered.
+    """
+    transcript = Transcript(tmp_path / "sess")
+    pruned = _assistant(output=100, context=640_000)
+    await transcript.append_message(Message.user("read that file"))
+    await transcript.append_message(pruned)
+    await transcript.append_prune(pruned.id, "[pruned]")
+
+    async def _stream(request: Any, signal: Any = None):  # pragma: no cover - never called
+        if False:
+            yield None
+
+    def _session_over_dir() -> Session:
+        return Session(
+            model=_spec(),
+            stream_fn=_stream,
+            tools=[],
+            transcript=Transcript(tmp_path / "sess"),
+            system_blocks_provider=lambda: ["system"],
+        )
+
+    assert _session_over_dir().restored_usage() is None
+
+    # And after the journal has been FOLDED INTO the rows, where the prune entry
+    # no longer exists and only the flag on the message remains.
+    reclaimed = await transcript.compact_file(min_reclaim_bytes=1)
+    assert reclaimed >= 0
+    assert _session_over_dir().restored_usage() is None
+
+    # A healthy turn taken afterwards is still restored: the refusal is scoped
+    # to readings the pass invalidated, not to the conversation.
+    await Transcript(tmp_path / "sess").append_message(_assistant(output=20, context=15_000))
+    restored = _session_over_dir().restored_usage()
+    assert restored is not None and restored.context_tokens == 15_000
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tui/test_usage_continuity.py
+++ b/tests/unit/tui/test_usage_continuity.py
@@ -309,22 +309,36 @@ async def test_a_pruned_reading_is_refused_like_a_compacted_one(tmp_path: Path) 
     """Pruning shrinks the context too, and leaves no marker to notice it by.
 
     Blanking a tool result is the other pass that makes a reading describe a
-    context that no longer exists — and unlike compaction it writes no boundary:
-    the journal entry is folded away by ``compact_file`` and the message row
-    survives with its original ``usage`` attached. Measured on a real prune, a
-    restored reading of 640_000 against a true context of ~1_700, installed as
-    exact.
+    context that no longer exists. Measured against the REAL pruner: a restored
+    reading of 640_000 for a true context of 31_715, installed as exact and
+    handed to the compaction gate. Wider than the compaction case it mirrors,
+    too — it needs nothing more than the agent reading the same file twice.
 
-    Wider than the compaction case it mirrors, too: it needs nothing more than
-    the agent reading the same large file twice. So the rule is not "after the
-    newest compaction" but "not describing a context something has since
-    shrunk", and both shrinking passes have to be covered.
+    Driven through ``append_prune`` rather than by hand-flagging a message, and
+    that detail is the whole test. An earlier version of this fix filtered out
+    rows carrying the ``pruned`` flag, which is DEAD CODE: pruning only blanks
+    ``role == "tool"`` messages and ``usage`` only ever lands on the assistant
+    message of a turn, so the two sets are disjoint and no usage-carrying row is
+    ever flagged. It passed a test that pruned an assistant message — a state
+    the production pruner cannot produce — and fixed nothing. The boundary has
+    to be POSITIONAL, and it has to be drawn at the journal entry (where the
+    shrink happened) rather than at the row it targets, which may be hundreds of
+    entries older.
     """
     transcript = Transcript(tmp_path / "sess")
-    pruned = _assistant(output=100, context=640_000)
+    stale = _assistant(output=100, context=640_000)
     await transcript.append_message(Message.user("read that file"))
-    await transcript.append_message(pruned)
-    await transcript.append_prune(pruned.id, "[pruned]")
+    await transcript.append_message(stale)
+    # A tool result, which is what pruning actually blanks, and then the prune
+    # journal entry that records the blanking.
+    tool_row = Message(
+        role="tool",
+        tool_call_id="call-1",
+        tool_name="read",
+        content=[TextContent(text="X" * 20_000)],
+    )
+    await transcript.append_message(tool_row)
+    await transcript.append_prune(tool_row.id, "[pruned]")
 
     async def _stream(request: Any, signal: Any = None):  # pragma: no cover - never called
         if False:
@@ -339,17 +353,18 @@ async def test_a_pruned_reading_is_refused_like_a_compacted_one(tmp_path: Path) 
             system_blocks_provider=lambda: ["system"],
         )
 
-    assert _session_over_dir().restored_usage() is None
+    assert _session_over_dir().restored_usage() is None, "the pre-prune reading must be refused"
 
     # And after the journal has been FOLDED INTO the rows, where the prune entry
-    # no longer exists and only the flag on the message remains.
-    reclaimed = await transcript.compact_file(min_reclaim_bytes=1)
-    assert reclaimed >= 0
-    assert _session_over_dir().restored_usage() is None
+    # no longer exists and only the flag on the tool row remains.
+    await transcript.compact_file(min_reclaim_bytes=1)
+    folded = Transcript(tmp_path / "sess")
+    assert not any(entry.type == "prune" for entry in folded.entries()), "the fold did not happen"
+    assert _session_over_dir().restored_usage() is None, "the folded form must be refused too"
 
-    # A healthy turn taken afterwards is still restored: the refusal is scoped
-    # to readings the pass invalidated, not to the conversation.
-    await Transcript(tmp_path / "sess").append_message(_assistant(output=20, context=15_000))
+    # A turn taken AFTER the prune is still restored: the refusal is scoped to
+    # readings the pass invalidated, not to the conversation.
+    await folded.append_message(_assistant(output=20, context=15_000))
     restored = _session_over_dir().restored_usage()
     assert restored is not None and restored.context_tokens == 15_000
 

--- a/tests/unit/tui/test_usage_continuity.py
+++ b/tests/unit/tui/test_usage_continuity.py
@@ -24,6 +24,7 @@ calling the accessors directly would pass while the band stayed wrong.
 from __future__ import annotations
 
 import asyncio
+import json
 from pathlib import Path
 from typing import Any
 from unittest.mock import patch
@@ -585,3 +586,49 @@ async def test_a_turn_end_that_prices_more_than_was_accrued_adds_the_remainder()
             await pilot.pause()
 
             assert app._total_cost == pytest.approx(0.03 + 0.15)
+
+
+@pytest.mark.asyncio
+async def test_a_transcript_folded_by_an_older_build_still_refuses_stale_readings(
+    tmp_path: Path,
+) -> None:
+    """Files folded before the boundary mark existed are already on disk.
+
+    ``compact_file`` records where the newest prune sat, but a transcript folded
+    by an earlier build carries no such mark — only the ``pruned`` flag on the
+    row that was blanked. Reading nothing from it would restore every figure
+    taken before the blanking, which is the defect, on files a user already has.
+
+    So the flag is kept as a FALLBACK, and it is deliberately the weaker one: it
+    says which row was blanked rather than when, so it draws the boundary too
+    early and refuses some readings that were genuinely current. That is the
+    safe direction — a local estimate instead of an exact figure, rather than an
+    exact figure describing a context that no longer exists.
+    """
+    transcript = Transcript(tmp_path / "sess")
+    call = ToolCall(name="read", arguments={"path": "big.py"})
+    await transcript.append_message(Message.user("read it"))
+    await transcript.append_message(_assistant(output=20, context=100_000))
+    tool_row = Message(
+        role="tool",
+        tool_call_id=call.id,
+        tool_name="read",
+        content=[TextContent(text="X" * 30_000)],
+        provider_payload={"details": {"path": "big.py"}},
+    )
+    await transcript.append_message(tool_row)
+    await transcript.append_message(Message.user("q"))
+    await transcript.append_message(_assistant(output=20, context=200_000))
+    await transcript.append_prune(tool_row.id, "[pruned]")
+    await transcript.compact_file(min_reclaim_bytes=1)
+
+    # Strip the mark, leaving exactly what an older build would have written.
+    path = tmp_path / "sess" / "transcript.jsonl"
+    rows = [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+    for row in rows:
+        (row.get("payload") or {}).get("provider_payload", {}).pop("context_shrunk_here", None)
+    path.write_text("".join(json.dumps(row, separators=(",", ":")) + "\n" for row in rows))
+
+    usages = Transcript(tmp_path / "sess").usages_since_compaction()
+    reported = [usage.get("context_tokens") for usage in usages]
+    assert 100_000 not in reported, "the pre-prune reading must not survive a legacy fold"

--- a/tests/unit/tui/test_usage_continuity.py
+++ b/tests/unit/tui/test_usage_continuity.py
@@ -91,11 +91,27 @@ async def _session_over(directory: Path, messages: list[Message]) -> Session:
     )
 
 
-async def _settled(app: OperatorApp, pilot: Any, ticks: int = 8) -> None:
-    """Let the boot worker's measurement land before reading the band."""
+async def _settled(app: OperatorApp, pilot: Any, ticks: int = 80) -> None:
+    """Wait for the session to be ADOPTED, then let its measurement land.
+
+    The app paints before its session exists — the factory is awaited in a boot
+    worker — and everything these tests assert is installed by `_adopt_session`.
+    Waiting on that condition rather than on a fixed tick count is what keeps
+    them from racing the boot on a loaded machine: the same number of frames is
+    plenty in isolation and not enough under a full suite, which is a test that
+    fails for a reason unrelated to what it is about.
+    """
     for _ in range(ticks):
         await pilot.pause()
-        await asyncio.sleep(0.05)
+        await asyncio.sleep(0.01)
+        if app._session is not None:
+            break
+    assert app._session is not None, "the session never booted"
+    # The preload measurement runs in its own worker after adoption; give it a
+    # few frames so the estimate-vs-exact interaction is settled when read.
+    for _ in range(6):
+        await pilot.pause()
+        await asyncio.sleep(0.01)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tui/test_usage_continuity.py
+++ b/tests/unit/tui/test_usage_continuity.py
@@ -239,6 +239,49 @@ async def test_a_compacted_resume_reports_nothing_rather_than_the_old_context(
 
 
 @pytest.mark.asyncio
+async def test_turns_taken_after_a_compaction_are_still_restored(tmp_path: Path) -> None:
+    """The refusal is scoped to readings the pass invalidated, not to the file.
+
+    The complement of the test above, and the reason the boundary is taken from
+    the TRANSCRIPT's append order rather than from the replayed list: a session
+    that compacted and then ran more turns has a perfectly good newest reading.
+    Refusing it because the file contains a marker anywhere would send every
+    such resume back to the local estimate — the original bug, reintroduced for
+    the majority of long conversations, which are exactly the ones that compact.
+    """
+    transcript = Transcript(tmp_path / "sess")
+    stale = _assistant(output=100, context=900_000)
+    await transcript.append_message(Message.user("old"))
+    await transcript.append_message(stale)
+    await transcript.append_compaction(
+        summary="what happened earlier",
+        first_kept_entry_id=stale.id,
+        tokens_before=900_000,
+    )
+    # Three ordinary turns since the pass; the last one is the live reading.
+    for context in (120_000, 140_000, 160_000):
+        await transcript.append_message(Message.user("q"))
+        await transcript.append_message(_assistant(output=50, context=context))
+
+    async def _stream(request: Any, signal: Any = None):  # pragma: no cover - never called
+        if False:
+            yield None
+
+    session = Session(
+        model=_spec(),
+        stream_fn=_stream,
+        tools=[],
+        transcript=Transcript(tmp_path / "sess"),
+        system_blocks_provider=lambda: ["system"],
+    )
+
+    restored = session.restored_usage()
+    assert restored is not None, "a turn taken after the pass is a valid reading"
+    assert restored.context_tokens == 160_000
+    assert restored.context_tokens != 900_000, "and it is not the pre-compaction one"
+
+
+@pytest.mark.asyncio
 async def test_the_baseline_never_loads_the_tokenizer(tmp_path: Path) -> None:
     """The boot-path measurement keeps its documented chars/4 contract.
 

--- a/tests/unit/tui/test_usage_continuity.py
+++ b/tests/unit/tui/test_usage_continuity.py
@@ -30,7 +30,13 @@ from unittest.mock import patch
 
 import pytest
 
-from local_operator.harness.types import Message, ModelSpec, TextContent, Usage
+from local_operator.harness.types import (
+    Message,
+    ModelSpec,
+    TextContent,
+    ToolCall,
+    Usage,
+)
 from local_operator.model.registry import ModelInfo
 from local_operator.session.session import Session
 from local_operator.session.transcript import Transcript
@@ -355,8 +361,11 @@ async def test_a_pruned_reading_is_refused_like_a_compacted_one(tmp_path: Path) 
 
     assert _session_over_dir().restored_usage() is None, "the pre-prune reading must be refused"
 
-    # And after the journal has been FOLDED INTO the rows, where the prune entry
-    # no longer exists and only the flag on the tool row remains.
+    # And after the journal has been FOLDED INTO the rows. `compact_file` drops
+    # the prune entry, so the POSITION it held has to survive some other way —
+    # folding is meant to be semantically invisible, and for this boundary it
+    # was not: the flag on the target row says which row was blanked, not when,
+    # and the target can be far older than the prune. See `_shrink_marked`.
     await transcript.compact_file(min_reclaim_bytes=1)
     folded = Transcript(tmp_path / "sess")
     assert not any(entry.type == "prune" for entry in folded.entries()), "the fold did not happen"
@@ -367,6 +376,53 @@ async def test_a_pruned_reading_is_refused_like_a_compacted_one(tmp_path: Path) 
     await folded.append_message(_assistant(output=20, context=15_000))
     restored = _session_over_dir().restored_usage()
     assert restored is not None and restored.context_tokens == 15_000
+
+
+@pytest.mark.asyncio
+async def test_folding_the_prune_journal_keeps_the_boundary_where_it_was(
+    tmp_path: Path,
+) -> None:
+    """`compact_file` must not promote pre-prune readings back to current.
+
+    The case the target-row flag cannot express: a tool result read EARLY, many
+    turns on top of it, and only then the prune that blanks it. The blanked row
+    sits near the start of the file and the prune near the end, so "the boundary
+    is the pruned row" puts every reading in between on the restorable side —
+    measured as three stale figures (200k, 400k, 640k) restored from a folded
+    transcript that correctly reported none before the fold.
+
+    Both forms of the same file are asserted, because the whole property is that
+    folding is semantically invisible: it reclaims bytes and changes nothing a
+    reader can observe.
+    """
+    transcript = Transcript(tmp_path / "sess")
+    call = ToolCall(name="read", arguments={"path": "big.py"})
+    await transcript.append_message(Message.user("read it"))
+    await transcript.append_message(_assistant(output=20, context=100_000))
+    early_tool = Message(
+        role="tool",
+        tool_call_id=call.id,
+        tool_name="read",
+        content=[TextContent(text="X" * 30_000)],
+        provider_payload={"details": {"path": "big.py"}},
+    )
+    await transcript.append_message(early_tool)
+    for context in (200_000, 400_000, 640_000):
+        await transcript.append_message(Message.user("q"))
+        await transcript.append_message(_assistant(output=20, context=context))
+    # The prune lands LAST, long after the row it blanks.
+    await transcript.append_prune(early_tool.id, "[pruned]")
+
+    unfolded = Transcript(tmp_path / "sess").usages_since_compaction()
+    assert unfolded == [], "every reading predates the prune"
+
+    reclaimed = await transcript.compact_file(min_reclaim_bytes=1)
+    assert reclaimed > 0, "the fold did not happen, so it is not under test"
+    folded = Transcript(tmp_path / "sess")
+    assert not any(entry.type == "prune" for entry in folded.entries())
+    assert (
+        folded.usages_since_compaction() == []
+    ), "folding the journal away restored readings the prune had invalidated"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tui/test_usage_continuity.py
+++ b/tests/unit/tui/test_usage_continuity.py
@@ -41,7 +41,7 @@ from local_operator.harness.types import (
 from local_operator.model.registry import ModelInfo
 from local_operator.session.session import Session
 from local_operator.session.transcript import Transcript
-from local_operator.tui.app import OperatorApp
+from local_operator.tui.app import RESTORED_COST_PREFIX, OperatorApp
 from local_operator.tui.events import ContextUsageReported, TurnEnded
 
 #: $10 in / $100 out per MTok, so a million tokens is a round dollar figure and
@@ -192,6 +192,12 @@ async def test_a_resumed_session_opens_with_the_spend_it_already_has(tmp_path: P
             # back to the input price), plus 1000 output at $100/MTok.
             assert app._total_cost == pytest.approx(0.0002 + 1.9998 + 0.1)
             assert app._status._cost, "a resumed conversation with spend must not read as free"
+            # Marked as a FLOOR. Only the last reported turn's usage survives in
+            # a priceable form, so this can be well under the conversation's real
+            # lifetime spend — and it renders in the same cell a real total does,
+            # where an unmarked figure is indistinguishable from one this session
+            # actually accrued.
+            assert app._status._cost.startswith(RESTORED_COST_PREFIX), app._status._cost
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# PR Description

## Change classification

**C2 — standard / pre-authorized.** Five bounded TUI/session fixes to status-band accounting and dock spacing, with a clean rollback (`git revert` / `lop-update`). No auth, data-isolation, infrastructure, or irreversible data change. No RFC or tracker requested.

## Summary of Changes

Five defects reported from one real session. Four are the same shape: **the status band's numeric segments are fed only by turns that complete while the app is running**, so before that they describe a session that is not the one on screen.

### 1. Resume opened on an almost-empty context reading

Reported as "on resume the initial readout on token usage is inaccurate".

`Session.measure_preloaded_context` summed the system blocks and the tool schemas — but **not the conversation**. That term is zero on a new session and everything on a resumed one, which is exactly why the omission survived: the two readings coincide in the only case anyone tested. A resumed session whose last provider call reported **402k of a 1M window opened reading `0.2%/1M`**, and stayed there until the next turn happened to end.

Under-reporting is the dangerous direction. It is the number a user checks to decide whether there is room to keep going, and it claimed a whole free window while 40% was already spent.

Two changes, because the estimate alone would still only be an estimate:

- The measurement now counts the rendered history, through **`_render_history` — the same renderer a request is built from** (expired todo reminders dropped, images stripped where a provider refused them). Counted with `approx_text_tokens`, this method's own chars/4 ruler, mirroring `_compute_tokens`'s terms (text, a flat charge per image, each tool call's name and serialized arguments). **Deliberately not** compaction's `estimate_messages_tokens`: that is the sharper ruler and it reaches for cl100k_base, which is the ~43.6 MB and cold-cache network fetch this method documents refusing — on the boot path, before the user has typed. See the benchmark below.
- `Session` seeds `_last_usage` from the replayed transcript and exposes `restored_usage()`. The app installs it on adopt as **exact**, since it is the number the band would still be showing had the process never stopped.

The seeded `_last_usage` has a second beneficiary: the **compaction trigger** fell back to a local estimate (7–17% off) for the first turn after every resume, on the gate that decides whether to rewrite the user's history.

### 2. Resume showed no cost for a conversation with real spend

Same adopt path. Cost is seeded from the restored usage and is documented as a **floor, not a lifetime total** — only the last reported turn's usage survives in a priceable form. Seeded anyway, because the alternative on screen is an empty segment, and empty reads as "this session has cost nothing", the one reading that is certainly false.

### 3. Cost did not move until the second message

Reported as "the cost doesn't start tracking until after the second message... once the first message is sent and cost starts to accrue, we should start to see that from the first provider calls".

Cost was only ever taken at `agent_end`. The context reading already moved per model call (`ContextUsageReported`); money did not. A turn that spends ten minutes in tools is at its most expensive precisely while the segment is empty.

`ContextUsageReported` now carries the call's whole `Usage`, and the app bills per call. The hazard that introduces is double-billing — `agent_end` prices the *whole* turn, summing every call — so `_turn_accrued_cost` records what was already taken and the turn end adds **only the remainder** (floored at zero, reset at every boundary and on session swap). A call the per-call path never saw is still paid for, because the turn total remains authoritative.

### 4. A queued message said "queued" forever

Reported with a screenshot: send a message mid-turn, get `· queued — sends when this step finishes`, and that row never changes — "the message doesn't update so we can't tell that it's been received other than the agent's confirmation".

`steer()` is fire-and-forget by design: it drops a message on a queue the loop drains at its next boundary, and **no signal existed between "queued" and the agent's eventual reply**. `Session._drain_steering` now emits `SteeringDeliveredEvent` when it actually takes messages (after persistence — the row claims the message is in the conversation, which is only true once it is on disk), and the app **restates the row it already painted**:

```
· queued — sends when this step finishes   →   ✓ sent — the agent has it now
                                           →   · still queued — sends with your next message
```

Two outcomes, because a promise about the future resolves either way. Every turn end reconciles the rows it is holding, on the invariant that **a row still held when a turn ends is one that turn did not deliver** — whether it was interrupted, failed, or simply ended with the model answering and no further tool calls.

All three of those say the same thing, and that is deliberate. `abort()` stops the run **without draining the steering queue**, so the message really is still there and the next turn's first boundary takes it. An earlier draft said `not sent — the turn was interrupted`; the design review caught that it is false, and that a user who reads it retypes their message, the original arrives anyway, and the agent gets the instruction twice.

Updated in place via `NoticeBlock.restate`, not appended. A second notice would spend a row to correct a row and leave the stale promise above its own retraction. All held rows settle together, because the queue is drained whole at one boundary — three messages typed during one tool call are three promises kept at once. Silent when the queue is empty, since the drain runs at *every* tool and message boundary.

### 5. The dock band was tight above todos and subagents

Reported as "when there are subagents or todos, there needs to be one line of padding above, to be even with the spacing below, it looks a bit tight".

Measured at 100x24: the panel's caption sat directly on the transcript's ground row while **two** surface rows separated its last row from the composer. `#band.has-slot` adds one inset row, and three details make it correct rather than a re-introduction of a bug this repo already fixed once:

- **On `#band`, not `.band-slot`.** The slot's padding repeats per slot, so a per-slot top row would open a second gap *between* the subagent and todo lists, where the existing single row is already right. This is the join between the conversation and the dock, which happens once.
- **`$lo-surface`, not transparent.** The row this replaces was transparent and painted the screen's `$lo-bg` — a trench between two lighter slabs. Verified by fill probe: inset `#1e1a14` == composer `#1e1a14`, and != the transcript's ground `#14110c`.
- **Conditional, on a real fit check.** Container padding applies even when every child is hidden, so the row is carried by a class the app toggles only while a slot is visible — the boot splash's band stays zero rows. It is then granted only while the dock, the composer and one row of conversation still fit beside it (`_band_inset_fits`). A screen-height threshold was the first attempt and is the wrong instrument: it was derived from `TodoPanel`'s floor, and `SubagentPanel` has **no row budget at all** — it mounts one row per job — so its inset row came straight out of the transcript and pushed `virtual_size` past `size` at mid heights. `Screen { overflow: hidden }` does not report that; it silently clips a row off the top.

- **Right on the FIRST painted frame.** A slot that has just been un-hidden measures zero until Textual re-arranges it, which is every mid-session appearance — so a measurement-only check answered "no", the dock painted flush, and the row arrived ~0.46 s later when the 1 Hz poll re-asked, taking a todo item into `… N more` as it went. `_slot_rows` predicts an unmeasured slot by asking the panel (`predicted_rows()`), and takes `max(measured, predicted)`: a slot mid-layout reports a *partial* height, and trusting that was an intermittent overflow. The larger can only ever withhold the inset — a blank row instead of a scrollable screen.

`TodoPanel` charges for the row by reading the **class** rather than the resolved padding — Textual resolves that padding in a later layout pass, so a padding read returns the previous frame's value and the list paints one row too tall, then visibly loses a row. That is motion the user sees. The panel's equality guard now holds `(contents, budget)` so a budget change repaints at all.

## Testing evidence

Static gates, all clean on the final head (`d26c62e`):

```
$ .venv/bin/python -m flake8 .
$ uvx --from black==26.1.0 black --check local_operator tests
All done! 355 files would be left unchanged.
$ uvx isort --check-only --profile black local_operator tests
$ .venv/bin/python -m pyright --pythonpath .venv/bin/python .
0 errors, 0 warnings, 0 informations
```

Full unit suite: **4262-4264 passed, 7 skipped** (~9 min). Between 1 and 4 tests vary run to run; every one of them was checked against a `42e5268` worktree and **fails there too** — they assert wall-clock event-loop latency (`test_loop_liveness`), wait on subprocess children (`test_comms`), or race the boot worker (`test_app_pilot::test_boot_typing_sends_prompt`, which fails standalone on `main`). None touch this change.

The four files this PR adds or touches, three consecutive runs:

```
$ pytest test_usage_continuity.py test_queued_steer_receipt.py test_band_panels.py test_composer_seam.py -q
105 passed (176s) | 105 passed (162s) | 105 passed (194s)
```

### Reproduced before fixing, measured after

Each defect was reproduced by driving the **real `OperatorApp`** (the one that loads `local_operator.tcss`) over a **real `Session`** on a real transcript, per `AGENTS.md`.

**1 & 2 — resume.** A transcript whose last provider call reported `context_tokens=402000` on a 1M window:

| | context_tokens | is_estimate | cost segment |
|---|---|---|---|
| before | `1691` | `True` | `''` |
| after | `402000` | `False` | `'$0.139'` |

And the two compaction cases, which the review rounds proved are different facts:

```
compacted, then exited   -> restored None    (falls through to the estimate; a
                                              pre-compaction reading measured
                                              900_000 against a real 1_707)
compacted, then 3 turns  -> restored 160000  (the live reading, not the stale one)
```

**3 — first-turn cost.** Real `Session` whose stream reports usage per model call:

```
before:  boot ''  |  after turn 1 '$0.017'  |  after turn 2 '$0.034'   (nothing DURING turn 1)
after :  boot ''  |  during turn 1 '$0.017' <- the fix
                  |  after turn 1 '$0.017'  |  after turn 2 '$0.034'
```

Turn totals unchanged ($0.017 → $0.034), which is the double-billing check.

**4 — the baseline never loads the tokenizer.** Counting the history with compaction's own ruler would have spent the two costs `measure_preloaded_context` documents refusing:

```
estimate_messages_tokens : 58.3 ms, RSS +41.3 MB, tiktoken loaded
approx_text_tokens (now) :  0.5 ms, RSS  +0.1 MB, tiktoken NOT loaded
```

**5 — band geometry**, painted rows at 100x24 with three todos docked:

```
before                                  after
row 12: ''                              row 12: ''            <- band top (inset)
row 13: '  Todos · 1/3 resolved' <-band row 13: '  Todos · 1/3 resolved'
...                                     ...
row 17: ''                              row 17: ''
row 18: ''                    <- shell  row 18: ''            <- shell top
```

Fill probe on the new row, and the empty-band case:

```
inset row fill       : #1e1a14
composer fill        : #1e1a14      MATCH  (the dock's own surface)
transcript last row  : #14110c      DIFFERS (not the trench this replaced)
empty band height    : 0            has-slot: False
```

No overflow at 100x12/13/14/16/18/20/24/26/40 across 1-10 docked children and 1-12 todos: `virtual_size == size` and `#todo-body.region.y >= 0` in every cell where the band fits without the inset. The cells that do overflow are `SubagentPanel`'s own pre-existing defect (it has no row cap, unlike `TodoPanel`) and overflow identically on `main` — out of scope here, and called out as such in the test that measures around them.

**No reflow.** Consecutive frames per `AGENTS.md` §5, panel appearing mid-session:

```
tick0 == tick1 ? True    tick1 == tick2 ? True
```

### Rendered frames

Captured with `app.save_screenshot()` and **viewed**, per the repo's visual-validation recipe. Before-frames were taken from a clean tree first, and base comparisons from throwaway `git worktree`s — never `git stash`.

- **Resume, before:** `▦ 0.2%/1M`, no cost segment. **After:** `▦ 40.2%/1M ‹ ◈ ≥$0.139` — the `≥` marks a restored figure as a FLOOR (only the last reported turn's usage survives in a priceable form), and the first live turn replaces it with a real total.
- **Queued, before:** `· queued — sends when this step finishes`. **After delivery:** `✓ sent — the agent has it now`, same row, updated in place. All four states captured and viewed.
- **Dock band, after:** one inset row above the todo slab. (The composer's own padding means the interval below is still two rows — the panel is inset above, not evenly inset on both sides.)

### Tests

**24 new** across two files. `test_usage_continuity.py` (10): resume restores the exact provider reading; resume seeds spend; a new session restores nothing and keeps its estimate (the `None`-vs-`0` distinction); a compacted resume refuses the stale reading; turns taken *after* a compaction are still restored; the baseline grows with history; the baseline never loads the tokenizer; cost appears during turn 1; a turn is not billed twice; a turn end pricing more than was accrued adds the remainder.

`test_queued_steer_receipt.py` (9): the row settles in place; several settle together; only the messages that went are settled; an interrupted turn retires the promise; a clean turn with no drain says the message is deferred; an unusable `count` cannot take the app down; a delivery with no held row is a no-op; `/clear` drops the references; and the engine half — one event per drain that took messages, silence otherwise.

Plus `test_the_band_inset_never_costs_the_subagent_list_its_screen`, which fails against the head where the overflow was live.

### Tests changed rather than added

Four pinned the previous dock rhythm and are updated with reasoning, not just numbers: `test_the_band_join_does_not_double` (now asserts two rows above the body **and** that the inset is the dock's fill rather than ground — a regression to either colour fails it), `test_the_aside_rests_on_whatever_the_dock_puts_first` (the card now meets the band's inset, measured against `#band` where the rule lives), `test_todo_row_cap_...` (the budget spends one more row; the assertions proving nothing is clipped are unchanged), and `SIZES` in the seam suite gains `(100, 24)` — every seam test ran at 40 rows, where the column has rows to spare.

Two test helpers now wait on a condition instead of a frame count (`_settled` on session adoption, `_submit` on the same). The app paints before its session exists, so a fixed pause races the boot worker under load — the same race that costs `test_app_pilot::test_boot_typing_sends_prompt` on `main`.

### Review rounds

Two agent review rounds, both adversarial and both productive. Round 1 found a **blocker** (a compacted resume seeding a 527x-overstated context as *exact*, and handing it to `should_compact`) and three **majors**. Round 2 verified those and found that the dock fix had traded an overflow for a **visible reflow**, and — the finding I'm most glad of — that test-settling loops I had added were *suppressing* that regression rather than accommodating a known lag. Those loops are gone and their single-refresh form is now the regression test.

## Risk / rollback

Behavioural surface is the status band, one transcript notice, and one row of dock padding. The new engine event is additive and ignored by every consumer that does not handle it (server SSE forwards raw, headless print falls through). `restored_usage` is probed with `getattr`, so reduced hosts degrade to previous behaviour. Revert the commit or `lop-update <previous ref>`.

## Merge of `main` (`c631df5`)

`main` advanced 10 commits (#135–#150) while this PR ran its review rounds, so the branch carries a merge rather than being rebased — a rebase would have rewritten the SHAs every recorded review round is scoped to. Three regions took content conflicts and were resolved by hand:

- **`session/transcript.py`, `compact_file`** — this branch added the shrink-boundary mark; #148 moved the O(session) serialization into a `_render_folded` worker. Orthogonal: the mark is applied to `folded`, then the marked list is handed to the worker.
- **`tui/app.py`, boot path** — this branch added `_restore_reported_usage`, main added `_park_unadopted_session`. Unrelated methods at the same offset; both kept, both call sites intact.
- **`tui/app.py`, `on_turn_ended`** — this branch added the queued-steer reconciliation, main added #137's completion notification. Both kept, reconciliation first: the two state sets are disjoint, and settling first means a notification for a turn cannot fire while a row on screen still promises a delivery that turn did not make.

Reviewed as its own round (code round 12, zero findings) with the resolution verified by comparing each side's delta before and after the merge. `aeed9cf` then fixed one import the merge left split, caught by CI lint because CI checks the whole repo at pinned tool versions.

Design round 5 confirmed this PR's band changes and main's UI work (#145's band flex, #137's notifications) coexist correctly: the cost segment's shed boundary moves from 93/94 to 73/74 columns because #145 reclaims width, and #137's notifications are out-of-band so they cannot stack with the receipt rows.




