### PR TITLE
perf(harness,session): keep subagents running while the parent and siblings work

### DIFF
--- a/local_operator/compaction/api.py
+++ b/local_operator/compaction/api.py
@@ -49,10 +49,12 @@ from .thresholds import (
 )
 from .tokens import (
     IMAGE_TOKEN_ESTIMATE,
+    OFFLOAD_MIN_CHARS,
     _encode_len,
     clear_estimate_cache,
     estimate_messages_tokens,
     estimate_tokens,
+    history_chars,
     invalidate_message_cache,
     messages_tokens_upper_bound,
     register_invalidator,
@@ -81,6 +83,8 @@ __all__ = [
     "estimate_tokens",
     "extract_file_ops_from_messages",
     "find_cut_point",
+    "history_chars",
+    "OFFLOAD_MIN_CHARS",
     "format_file_operations",
     "invalidate_message_cache",
     "messages_tokens_upper_bound",

--- a/local_operator/compaction/tokens.py
+++ b/local_operator/compaction/tokens.py
@@ -60,7 +60,7 @@ by :data:`_CACHE_LOCK`. The lock deliberately covers only the dict/singleton
 bookkeeping (sub-microsecond) and never ``encode`` itself, so concurrent
 estimates still tokenize in parallel. Because the encode runs unlocked, an
 invalidation can land between a computation and its insert; that race is
-closed by :data:`_ESTIMATE_GENERATION` rather than by widening the lock.
+closed by :data:`_INFLIGHT_ESTIMATES` rather than by widening the lock.
 """
 
 from __future__ import annotations

--- a/local_operator/compaction/tokens.py
+++ b/local_operator/compaction/tokens.py
@@ -48,16 +48,19 @@ parent's own stream, and the TUI repaint for its whole duration.
 tiktoken's ``encode`` is a Rust extension that RELEASES the GIL, so moving it
 to a worker thread genuinely buys parallelism rather than just moving the
 stall (measured: 90 ms → 0.7 ms of loop stall, 3x faster wall clock for the
-same work). :func:`estimate_messages_tokens_async` and
-:func:`find_cut_point_async`-style helpers therefore exist for callers that
-run on the loop; the synchronous forms remain for pure-CPU callers and tests.
+same work). ``Session._offloaded`` is the caller that does that hop, for
+histories past :data:`OFFLOAD_MIN_CHARS`; the functions here stay synchronous
+so they remain usable from a worker thread, from pure-CPU callers, and from
+tests.
 
 That makes the module-level cache reachable from worker threads, so the
 mutations that are NOT individually atomic — the LRU ``move_to_end`` +
 ``popitem`` eviction sequence, and the lazy encoding singleton — are guarded
 by :data:`_CACHE_LOCK`. The lock deliberately covers only the dict/singleton
 bookkeeping (sub-microsecond) and never ``encode`` itself, so concurrent
-estimates still tokenize in parallel.
+estimates still tokenize in parallel. Because the encode runs unlocked, an
+invalidation can land between a computation and its insert; that race is
+closed by :data:`_ESTIMATE_GENERATION` rather than by widening the lock.
 """
 
 from __future__ import annotations
@@ -295,6 +298,21 @@ _ESTIMATE_CACHE_MAX = 4096
 #: and unsubscribe is O(1).
 _INVALIDATORS: dict[int, Callable[[Message], None]] = {}
 
+#: Monotonic counter bumped by every :func:`invalidate_message_cache`, per
+#: message id. It closes a lost-invalidation race that only exists because
+#: ``_compute_tokens`` deliberately runs OUTSIDE :data:`_CACHE_LOCK`:
+#:
+#:   thread A reads the cache (miss) -> starts encoding
+#:   the loop mutates the message and invalidates it (``pop`` finds nothing)
+#:   thread A inserts the count it computed from the PRE-mutation message
+#:
+#: The stale value then survives forever, because the invalidation that should
+#: have removed it already ran. Recording the generation A observed BEFORE it
+#: computed, and refusing the insert if it changed meanwhile, makes the
+#: invalidation win without pulling the encode under the lock. Entries are
+#: dropped alongside their cache entry, so this cannot outgrow the cache.
+_ESTIMATE_GENERATION: dict[str, int] = {}
+
 
 def estimate_tokens(message: Message) -> int:
     """Estimated token cost of ``message`` as sent on the wire.
@@ -322,13 +340,23 @@ def estimate_tokens(message: Message) -> int:
         if cached is not None:
             _ESTIMATE_CACHE.move_to_end(message.id)
             return cached
+        # The generation this computation is about to be based on. If an
+        # invalidation bumps it while the encode runs, the result below
+        # describes a message that no longer exists and must not be cached.
+        generation = _ESTIMATE_GENERATION.get(message.id, 0)
 
     tokens = _compute_tokens(message)
 
     with _CACHE_LOCK:
+        if _ESTIMATE_GENERATION.get(message.id, 0) != generation:
+            # Invalidated mid-flight: return the value to THIS caller (it is
+            # the honest answer for the message as it was read) but leave the
+            # cache empty so the next reader recomputes from the current one.
+            return tokens
         _ESTIMATE_CACHE[message.id] = tokens
         while len(_ESTIMATE_CACHE) > _ESTIMATE_CACHE_MAX:
-            _ESTIMATE_CACHE.popitem(last=False)
+            evicted, _ = _ESTIMATE_CACHE.popitem(last=False)
+            _ESTIMATE_GENERATION.pop(evicted, None)
     return tokens
 
 
@@ -489,6 +517,11 @@ def invalidate_message_cache(message: Message) -> None:
     """
     with _CACHE_LOCK:
         _ESTIMATE_CACHE.pop(message.id, None)
+        # Bump even when nothing was cached: the entry this invalidation is
+        # racing may not have been INSERTED yet (see _ESTIMATE_GENERATION).
+        # Popping a miss and returning is exactly how the stale value used to
+        # survive.
+        _ESTIMATE_GENERATION[message.id] = _ESTIMATE_GENERATION.get(message.id, 0) + 1
     for invalidator in list(_INVALIDATORS.values()):
         try:
             invalidator(message)
@@ -515,3 +548,12 @@ def clear_estimate_cache() -> None:
     """Wipe the whole estimate cache (tests, memory pressure)."""
     with _CACHE_LOCK:
         _ESTIMATE_CACHE.clear()
+        # Deliberately NOT cleared: an in-flight computation still holds a
+        # generation read before this call, and resetting the counters to 0
+        # would let its result look current and land in the fresh cache.
+        # Entries are evicted with their cache entry; a clear only leaves
+        # counters for ids that may still be mid-flight, which the next
+        # insert prunes.
+        for key in list(_ESTIMATE_GENERATION):
+            if key not in _ESTIMATE_CACHE:
+                _ESTIMATE_GENERATION[key] = _ESTIMATE_GENERATION[key] + 1

--- a/local_operator/compaction/tokens.py
+++ b/local_operator/compaction/tokens.py
@@ -65,10 +65,12 @@ closed by :data:`_ESTIMATE_GENERATION` rather than by widening the lock.
 
 from __future__ import annotations
 
+import itertools
 import json
 import logging
 import threading
 from collections import OrderedDict
+from dataclasses import dataclass
 from typing import Callable, Sequence
 
 from local_operator.harness.types import Message, TextContent
@@ -83,7 +85,7 @@ _CACHE_LOCK = threading.Lock()
 
 #: Below this many characters of history, estimating inline is cheaper than a
 #: thread hop (~50-100 us round trip). Above it the encode dominates and the
-#: hop pays for itself many times over. Applied by the ``_async`` helpers so
+#: hop pays for itself many times over. Applied by ``Session._offloaded`` so
 #: callers do not each re-derive the trade-off.
 OFFLOAD_MIN_CHARS = 20_000
 
@@ -298,20 +300,47 @@ _ESTIMATE_CACHE_MAX = 4096
 #: and unsubscribe is O(1).
 _INVALIDATORS: dict[int, Callable[[Message], None]] = {}
 
-#: Monotonic counter bumped by every :func:`invalidate_message_cache`, per
-#: message id. It closes a lost-invalidation race that only exists because
-#: ``_compute_tokens`` deliberately runs OUTSIDE :data:`_CACHE_LOCK`:
+
+@dataclass
+class _Inflight:
+    """One token computation that is running right now.
+
+    ``message_id`` is what an invalidation matches on; ``invalidated`` is the
+    flag it sets. A tiny mutable record rather than a tuple because the flag
+    is written by a different thread than the one that created it.
+    """
+
+    message_id: str
+    invalidated: bool = False
+
+
+#: In-flight computations, keyed by a unique ticket. Closes a
+#: lost-invalidation race that exists only because ``_compute_tokens``
+#: deliberately runs OUTSIDE :data:`_CACHE_LOCK`:
 #:
 #:   thread A reads the cache (miss) -> starts encoding
 #:   the loop mutates the message and invalidates it (``pop`` finds nothing)
 #:   thread A inserts the count it computed from the PRE-mutation message
 #:
 #: The stale value then survives forever, because the invalidation that should
-#: have removed it already ran. Recording the generation A observed BEFORE it
-#: computed, and refusing the insert if it changed meanwhile, makes the
-#: invalidation win without pulling the encode under the lock. Entries are
-#: dropped alongside their cache entry, so this cannot outgrow the cache.
-_ESTIMATE_GENERATION: dict[str, int] = {}
+#: have removed it already ran. A computation registers a ticket before it
+#: encodes; an invalidation flags every ticket for that message id; the
+#: computation declines to cache a result whose ticket was flagged. The
+#: invalidation therefore wins without pulling the encode under the lock.
+#:
+#: Keyed by TICKET, not by message id, which is what makes the state bounded
+#: and ABA-free. Bounded: an entry exists only while a computation is
+#: running, so the dict is sized by concurrency (a handful), not by the
+#: number of messages ever seen — an earlier per-id counter leaked one entry
+#: per invalidation on the once-per-turn prune path, which never inserts and
+#: so never evicted (20k turns -> 20k entries, cache still empty). ABA-free:
+#: tickets are unique and never reused, so a stalled computation cannot
+#: observe a recycled value and mistake it for its own.
+_INFLIGHT_ESTIMATES: dict[int, "_Inflight"] = {}
+
+#: Source of ticket ids. Guarded by :data:`_CACHE_LOCK`; monotonic so a
+#: ticket is never reused within a process.
+_TICKET_SEQUENCE = itertools.count()
 
 
 def estimate_tokens(message: Message) -> int:
@@ -340,23 +369,30 @@ def estimate_tokens(message: Message) -> int:
         if cached is not None:
             _ESTIMATE_CACHE.move_to_end(message.id)
             return cached
-        # The generation this computation is about to be based on. If an
-        # invalidation bumps it while the encode runs, the result below
-        # describes a message that no longer exists and must not be cached.
-        generation = _ESTIMATE_GENERATION.get(message.id, 0)
+        # Register this computation BEFORE releasing the lock, so any
+        # invalidation that lands while it encodes can find and flag it.
+        ticket = next(_TICKET_SEQUENCE)
+        _INFLIGHT_ESTIMATES[ticket] = _Inflight(message_id=message.id)
 
-    tokens = _compute_tokens(message)
+    try:
+        tokens = _compute_tokens(message)
+    except BaseException:
+        # The ticket must not outlive its computation, or the bound above
+        # ceases to hold the moment an encode raises.
+        with _CACHE_LOCK:
+            _INFLIGHT_ESTIMATES.pop(ticket, None)
+        raise
 
     with _CACHE_LOCK:
-        if _ESTIMATE_GENERATION.get(message.id, 0) != generation:
+        inflight = _INFLIGHT_ESTIMATES.pop(ticket, None)
+        if inflight is None or inflight.invalidated:
             # Invalidated mid-flight: return the value to THIS caller (it is
             # the honest answer for the message as it was read) but leave the
             # cache empty so the next reader recomputes from the current one.
             return tokens
         _ESTIMATE_CACHE[message.id] = tokens
         while len(_ESTIMATE_CACHE) > _ESTIMATE_CACHE_MAX:
-            evicted, _ = _ESTIMATE_CACHE.popitem(last=False)
-            _ESTIMATE_GENERATION.pop(evicted, None)
+            _ESTIMATE_CACHE.popitem(last=False)
     return tokens
 
 
@@ -517,11 +553,14 @@ def invalidate_message_cache(message: Message) -> None:
     """
     with _CACHE_LOCK:
         _ESTIMATE_CACHE.pop(message.id, None)
-        # Bump even when nothing was cached: the entry this invalidation is
-        # racing may not have been INSERTED yet (see _ESTIMATE_GENERATION).
+        # Flag even when nothing was cached: the entry this invalidation is
+        # racing may not have been INSERTED yet (see _INFLIGHT_ESTIMATES).
         # Popping a miss and returning is exactly how the stale value used to
-        # survive.
-        _ESTIMATE_GENERATION[message.id] = _ESTIMATE_GENERATION.get(message.id, 0) + 1
+        # survive. Costs one pass over the in-flight computations, which are
+        # bounded by concurrency rather than by history size.
+        for inflight in _INFLIGHT_ESTIMATES.values():
+            if inflight.message_id == message.id:
+                inflight.invalidated = True
     for invalidator in list(_INVALIDATORS.values()):
         try:
             invalidator(message)
@@ -548,12 +587,9 @@ def clear_estimate_cache() -> None:
     """Wipe the whole estimate cache (tests, memory pressure)."""
     with _CACHE_LOCK:
         _ESTIMATE_CACHE.clear()
-        # Deliberately NOT cleared: an in-flight computation still holds a
-        # generation read before this call, and resetting the counters to 0
-        # would let its result look current and land in the fresh cache.
-        # Entries are evicted with their cache entry; a clear only leaves
-        # counters for ids that may still be mid-flight, which the next
-        # insert prunes.
-        for key in list(_ESTIMATE_GENERATION):
-            if key not in _ESTIMATE_CACHE:
-                _ESTIMATE_GENERATION[key] = _ESTIMATE_GENERATION[key] + 1
+        # In-flight computations are flagged rather than dropped: a caller
+        # that wipes the cache must not have a computation started before the
+        # wipe land in the fresh one. Their tickets are still removed by the
+        # computations themselves, so this leaks nothing.
+        for inflight in _INFLIGHT_ESTIMATES.values():
+            inflight.invalidated = True

--- a/local_operator/compaction/tokens.py
+++ b/local_operator/compaction/tokens.py
@@ -440,6 +440,17 @@ def history_chars(messages: Sequence[object]) -> int:
     — a question a cheap lower bound answers correctly. Anything expensive here
     would defeat its own purpose.
 
+    Consequence worth knowing, since it is a deliberate under-count and not an
+    oversight: a history whose bulk lives in tool-call ARGUMENTS (a ``write``
+    with a large ``content``) reads as smaller than it is and takes the inline
+    path. That is bounded and acceptable — tool RESULTS, the usual bulky item,
+    are text blocks and are counted; estimates are memoized per message, so
+    arguments are encoded once per message rather than once per turn; and the
+    exposure is therefore a one-shot cold pass, measured at 136 ms on a
+    pathological 400-turn history against the 860 ms stall the offload exists
+    to remove. Sizing arguments here would mean serializing every tool call on
+    a probe whose whole value is being cheaper than the work it gates.
+
     Accepts any message-shaped object so the one definition serves both the
     plain-``Message`` estimator and the cut-point walker, which also sees
     :class:`~local_operator.harness.types.CustomMessage` (no ``content``).

--- a/local_operator/compaction/tokens.py
+++ b/local_operator/compaction/tokens.py
@@ -35,12 +35,36 @@ invariants keep it honest:
 
 Cross-package consumers that keep derived caches can subscribe via
 :func:`register_invalidator` and are notified on every invalidation.
+
+Thread safety / why the async variants exist
+--------------------------------------------
+Encoding is the single most expensive synchronous stretch on the event loop
+(measured: ~90 ms for eight ~40 KB messages, and 116 of 121 samples in a
+stall trace of eight concurrent subagents landed inside ``_encode_len``).
+Because every session shares ONE event loop, that stretch does not merely
+slow the session doing the counting — it stops every sibling subagent, the
+parent's own stream, and the TUI repaint for its whole duration.
+
+tiktoken's ``encode`` is a Rust extension that RELEASES the GIL, so moving it
+to a worker thread genuinely buys parallelism rather than just moving the
+stall (measured: 90 ms → 0.7 ms of loop stall, 3x faster wall clock for the
+same work). :func:`estimate_messages_tokens_async` and
+:func:`find_cut_point_async`-style helpers therefore exist for callers that
+run on the loop; the synchronous forms remain for pure-CPU callers and tests.
+
+That makes the module-level cache reachable from worker threads, so the
+mutations that are NOT individually atomic — the LRU ``move_to_end`` +
+``popitem`` eviction sequence, and the lazy encoding singleton — are guarded
+by :data:`_CACHE_LOCK`. The lock deliberately covers only the dict/singleton
+bookkeeping (sub-microsecond) and never ``encode`` itself, so concurrent
+estimates still tokenize in parallel.
 """
 
 from __future__ import annotations
 
 import json
 import logging
+import threading
 from collections import OrderedDict
 from typing import Callable, Sequence
 
@@ -48,6 +72,17 @@ from local_operator.harness.types import Message, TextContent
 from local_operator.optional import missing_extra_error
 
 logger = logging.getLogger(__name__)
+
+#: Guards the estimate cache's non-atomic LRU sequences and the lazy tiktoken
+#: singleton, both of which are now reachable from ``asyncio.to_thread``
+#: workers. Held for dict bookkeeping only — never across ``encode``.
+_CACHE_LOCK = threading.Lock()
+
+#: Below this many characters of history, estimating inline is cheaper than a
+#: thread hop (~50-100 us round trip). Above it the encode dominates and the
+#: hop pays for itself many times over. Applied by the ``_async`` helpers so
+#: callers do not each re-derive the trade-off.
+OFFLOAD_MIN_CHARS = 20_000
 
 #: Flat token cost charged per image block. Matches
 #: ``IMAGE_TOKEN_ESTIMATE``: vision providers bill images in fixed visual-token
@@ -73,22 +108,32 @@ def _get_encoding() -> object | None:
     4`` fallback, not crash compaction (or startup — loading is deferred to
     first use). The warning fires once per process, so it names the extra
     without turning into per-turn noise.
+
+    Locked because the estimators now run under ``asyncio.to_thread``: two
+    workers reaching a cold singleton together would otherwise both pay the
+    ~60 ms table load and both log the failure warning. The lock is
+    uncontended after the first call (the fast path returns before taking it).
     """
     global _ENCODING, _ENCODING_FAILED
     if _ENCODING is not None or _ENCODING_FAILED:
         return _ENCODING
-    try:
-        import tiktoken
+    with _CACHE_LOCK:
+        # Re-check under the lock: another worker may have loaded it while
+        # this one waited.
+        if _ENCODING is not None or _ENCODING_FAILED:
+            return _ENCODING
+        try:
+            import tiktoken
 
-        _ENCODING = tiktoken.get_encoding("cl100k_base")
-    except Exception as exc:  # noqa: BLE001 - degrade, never raise
-        _ENCODING_FAILED = True
-        logger.warning(
-            "%s; falling back to the chars/4 token estimate (%s)",
-            missing_extra_error("tokenizer", "Exact token counting"),
-            exc,
-        )
-    return _ENCODING
+            _ENCODING = tiktoken.get_encoding("cl100k_base")
+        except Exception as exc:  # noqa: BLE001 - degrade, never raise
+            _ENCODING_FAILED = True
+            logger.warning(
+                "%s; falling back to the chars/4 token estimate (%s)",
+                missing_extra_error("tokenizer", "Exact token counting"),
+                exc,
+            )
+        return _ENCODING
 
 
 #: Passed to every ``encode`` call. tiktoken REFUSES by default to encode text
@@ -263,15 +308,27 @@ def estimate_tokens(message: Message) -> int:
     if not _is_settled(message):
         # Streaming assistant, still provisional: compute but never cache.
         return _compute_tokens(message)
-    cached = _ESTIMATE_CACHE.get(message.id)
-    if cached is not None:
-        _ESTIMATE_CACHE.move_to_end(message.id)
-        return cached
+    # Lock the LRU bookkeeping, not the encode. ``get`` + ``move_to_end`` and
+    # the insert + ``popitem`` eviction are each multi-step sequences on a
+    # shared OrderedDict, and the estimators now run in worker threads (see
+    # the module docstring), so an unguarded interleaving can evict an entry
+    # another thread is mid-promotion on. ``_compute_tokens`` stays OUTSIDE
+    # the lock: it is the expensive part, it releases the GIL, and holding the
+    # lock across it would re-serialize exactly what the offload exists to
+    # parallelize. Two threads racing the same uncached id therefore both
+    # compute it — wasteful but correct, and far cheaper than serializing.
+    with _CACHE_LOCK:
+        cached = _ESTIMATE_CACHE.get(message.id)
+        if cached is not None:
+            _ESTIMATE_CACHE.move_to_end(message.id)
+            return cached
 
     tokens = _compute_tokens(message)
-    _ESTIMATE_CACHE[message.id] = tokens
-    while len(_ESTIMATE_CACHE) > _ESTIMATE_CACHE_MAX:
-        _ESTIMATE_CACHE.popitem(last=False)
+
+    with _CACHE_LOCK:
+        _ESTIMATE_CACHE[message.id] = tokens
+        while len(_ESTIMATE_CACHE) > _ESTIMATE_CACHE_MAX:
+            _ESTIMATE_CACHE.popitem(last=False)
     return tokens
 
 
@@ -309,6 +366,29 @@ def _compute_tokens(message: Message) -> int:
 def estimate_messages_tokens(messages: Sequence[Message]) -> int:
     """Sum of per-message estimates — the local context-size estimator."""
     return sum(estimate_tokens(m) for m in messages)
+
+
+def history_chars(messages: Sequence[object]) -> int:
+    """Rough size of a history in characters, for the offload decision.
+
+    Deliberately shallow: it walks text blocks only, skipping tool arguments,
+    because it exists to answer "is this big enough to be worth a thread hop?"
+    — a question a cheap lower bound answers correctly. Anything expensive here
+    would defeat its own purpose.
+
+    Accepts any message-shaped object so the one definition serves both the
+    plain-``Message`` estimator and the cut-point walker, which also sees
+    :class:`~local_operator.harness.types.CustomMessage` (no ``content``).
+    """
+    total = 0
+    for message in messages:
+        content = getattr(message, "content", None)
+        if not content:
+            continue
+        for block in content:
+            if isinstance(block, TextContent):
+                total += len(block.text)
+    return total
 
 
 def messages_tokens_upper_bound(messages: Sequence[Message]) -> int:
@@ -400,8 +480,15 @@ def invalidate_message_cache(message: Message) -> None:
 
     MUST be called after any in-place mutation of a message (pruning blanks,
     streaming finalize). Idempotent; safe for never-cached messages.
+
+    The pop is locked for the same reason the LRU sequences in
+    :func:`estimate_tokens` are: a worker thread may be mid-eviction on the
+    same OrderedDict. Subscriber callbacks run OUTSIDE the lock — they are
+    arbitrary cross-package code and must never be able to deadlock the
+    estimator by re-entering it.
     """
-    _ESTIMATE_CACHE.pop(message.id, None)
+    with _CACHE_LOCK:
+        _ESTIMATE_CACHE.pop(message.id, None)
     for invalidator in list(_INVALIDATORS.values()):
         try:
             invalidator(message)
@@ -426,4 +513,5 @@ def register_invalidator(invalidator: Callable[[Message], None]) -> Callable[[],
 
 def clear_estimate_cache() -> None:
     """Wipe the whole estimate cache (tests, memory pressure)."""
-    _ESTIMATE_CACHE.clear()
+    with _CACHE_LOCK:
+        _ESTIMATE_CACHE.clear()

--- a/local_operator/config.py
+++ b/local_operator/config.py
@@ -171,6 +171,15 @@ DEFAULT_CONFIG = Config(
             # and Tavily keyless are both bounded fallbacks, so the default
             # rotates between them rather than depending on one free service.
             "web_search": dict(DEFAULT_WEB_SEARCH_CONFIG),
+            # Subagent controls. ``models`` maps the lo/med/hi effort tiers to
+            # "provider/model" selectors; ``max_running`` caps how many
+            # background jobs (subagents AND backgrounded bash, which share one
+            # pool) may run concurrently per session. Absent by default so the
+            # ceiling lives in one place — AsyncJobManager's own default —
+            # rather than being duplicated into every generated config file.
+            # Set it when the machine or the models in use want a different
+            # ceiling than the built-in one.
+            "subagents": {},
             # Ceilings on the ephemeral session store (see
             # local_operator.session.retention). Any of the three set to 0
             # disables that dimension; all three at 0 restores the unbounded

--- a/local_operator/harness/comms.py
+++ b/local_operator/harness/comms.py
@@ -151,6 +151,13 @@ class _ChildRecord:
     #: record whose child never started, which is why those evict FIRST — a
     #: record with no transcript is the one worth least.
     settled_at: float | None = None
+    #: Set by :meth:`SubagentComms.attach` the moment ``child`` becomes live.
+    #: Exists so :meth:`SubagentComms.ask` can WAIT for a child that has been
+    #: registered but whose runner the loop has not entered yet, instead of
+    #: refusing the question outright — see :meth:`SubagentComms._await_child`.
+    #: Created lazily on first use because it must be bound to the running
+    #: loop, and ``record_launch`` can be reached from a synchronous caller.
+    attached: "asyncio.Event | None" = None
 
 
 class SubagentComms:
@@ -190,6 +197,11 @@ class SubagentComms:
         for message in record.pending:
             child.queue_aside(self._thunk(record, message))
         record.pending.clear()
+        # Last: everything a waiter in ``_await_child`` needs must be in place
+        # before it is allowed to proceed, or it would queue its question onto
+        # a record whose buffered notes had not been flushed yet.
+        if record.attached is not None:
+            record.attached.set()
 
     def detach(self, job_id: str) -> None:
         """Release the live child. An unanswered question fails here rather
@@ -202,6 +214,12 @@ class SubagentComms:
         record.settled_at = time.time()
         record.child = None
         record.armed = False
+        # Wake anyone parked in ``_await_child``: the child is gone, so the
+        # attach they are waiting for is never coming. They re-check
+        # ``record.child`` after the wait and report the settled reason, so
+        # setting the event here fails them fast instead of at their timeout.
+        if record.attached is not None:
+            record.attached.set()
         if record.unsubscribe is not None:
             try:
                 record.unsubscribe()
@@ -295,18 +313,73 @@ class SubagentComms:
         record.child.steer(self._format_to_child(text, expects_reply=False, steer=True))
         return Delivery(job_id, record.label, "injected")
 
+    async def _await_child(self, record: _ChildRecord, timeout_s: float) -> bool:
+        """Wait (briefly) for a registered child's session to become live.
+
+        WHY: ``run_subagent`` registers the job and ``AsyncJobManager.register``
+        calls ``ensure_future``, which SCHEDULES the runner without entering
+        it. A parent that launches a child and asks it something in its very
+        next tool call therefore finds ``record.child is None`` — not because
+        anything is wrong, but because the loop has not reached the runner yet.
+        The old behaviour reported "subagent has not started yet … retry in a
+        moment" and returned immediately, which is a refusal the model has no
+        good answer to: it cannot yield the loop except by making another call,
+        so it either polls in a loop or gives up on checking in at all. Both
+        were observed live.
+
+        Awaiting the attach event yields the loop, which is exactly what lets
+        the runner start — so the wait is self-fulfilling rather than a
+        gamble. A PARKED job is deliberately excluded by the caller: it may sit
+        behind the capacity gate for minutes, and burning the asker's whole
+        timeout on it would be worse than saying so.
+
+        Returns True when the child is live, False on timeout (the caller then
+        reports the honest not-started reason).
+        """
+        if record.child is not None:
+            return True
+        if record.attached is None:
+            record.attached = asyncio.Event()
+        try:
+            await asyncio.wait_for(record.attached.wait(), timeout_s)
+        except asyncio.TimeoutError:
+            return False
+        return record.child is not None
+
+    #: How much of an ``ask`` timeout may be spent waiting for a
+    #: scheduled-but-not-yet-entered child to come up, before the question is
+    #: refused. A fraction rather than a constant so a caller that asked for a
+    #: short timeout still gets a timely answer, and a patient caller stays
+    #: patient. Capped by :data:`ATTACH_WAIT_MAX_S` because a child that needs
+    #: longer than that is not merely "scheduled" — something is wrong, and
+    #: saying so beats consuming the caller's whole budget in silence.
+    ATTACH_WAIT_FRACTION = 0.5
+    ATTACH_WAIT_MAX_S = 30.0
+
     async def ask(self, job_id: str, text: str, timeout_ms: int) -> Reply:
-        """Put a question to a running child and wait for its answer."""
+        """Put a question to a running child and wait for its answer.
+
+        A child that is registered but not yet entered by the loop is WAITED
+        for (see :meth:`_await_child`) rather than refused: "it starts when
+        this session next yields" is not an actionable answer for the one
+        caller who cannot yield without making another call.
+        """
         record = self._records.get(job_id)
         if record is None:
             return Reply(job_id, job_id, error=f"unknown subagent {job_id!r}")
         if record.child is None:
-            reason = (
-                self._gone_reason(record)
-                if record.settled or not self._is_running(record)
-                else self._not_started_reason(record)
-            )
-            return Reply(job_id, record.label, error=reason)
+            if record.settled or not self._is_running(record):
+                return Reply(job_id, record.label, error=self._gone_reason(record))
+            jobs = self._jobs()
+            job = jobs.get(job_id) if jobs is not None else None
+            parked = bool(job is not None and getattr(job, "queued", False))
+            # Parked behind the capacity gate: no amount of yielding starts it,
+            # so report rather than burn the caller's timeout.
+            grace = min(self.ATTACH_WAIT_MAX_S, (timeout_ms / 1000.0) * self.ATTACH_WAIT_FRACTION)
+            if parked or not await self._await_child(record, grace):
+                return Reply(job_id, record.label, error=self._not_started_reason(record))
+        if record.child is None:  # pragma: no cover - narrowing for the checker
+            return Reply(job_id, record.label, error=self._not_started_reason(record))
         if record.ask is not None and not record.ask.done():
             return Reply(
                 job_id, record.label, error="a question is already pending for this subagent"

--- a/local_operator/harness/comms.py
+++ b/local_operator/harness/comms.py
@@ -367,6 +367,12 @@ class SubagentComms:
         record = self._records.get(job_id)
         if record is None:
             return Reply(job_id, job_id, error=f"unknown subagent {job_id!r}")
+        # ``timeout_ms`` is the caller's WHOLE budget, so any time spent
+        # waiting for the child to come up is deducted from the answer wait
+        # below rather than added to it. Charging the grace on top let a
+        # 1000 ms request block for 1452 ms while reporting it had waited
+        # 1000 ms, and scaled: the 600 s schema maximum could block 900 s.
+        deadline = asyncio.get_running_loop().time() + timeout_ms / 1000.0
         if record.child is None:
             if record.settled or not self._is_running(record):
                 return Reply(job_id, record.label, error=self._gone_reason(record))
@@ -377,7 +383,15 @@ class SubagentComms:
             # so report rather than burn the caller's timeout.
             grace = min(self.ATTACH_WAIT_MAX_S, (timeout_ms / 1000.0) * self.ATTACH_WAIT_FRACTION)
             if parked or not await self._await_child(record, grace):
-                return Reply(job_id, record.label, error=self._not_started_reason(record))
+                # A child that DIED while we waited is gone, not "not started":
+                # telling a caller to retry in a moment is the polling loop this
+                # wait exists to remove.
+                reason = (
+                    self._gone_reason(record)
+                    if record.settled or not self._is_running(record)
+                    else self._not_started_reason(record)
+                )
+                return Reply(job_id, record.label, error=reason)
         if record.child is None:  # pragma: no cover - narrowing for the checker
             return Reply(job_id, record.label, error=self._not_started_reason(record))
         if record.ask is not None and not record.ask.done():
@@ -391,7 +405,11 @@ class SubagentComms:
         message = self._to_child_message(text, expects_reply=True)
         record.child.queue_aside(self._thunk(record, message, awaiting=future))
         try:
-            answer = await asyncio.wait_for(future, timeout_ms / 1000.0)
+            # Whatever is LEFT of the caller's budget after the attach wait,
+            # floored just above zero so a fully-spent budget still gets one
+            # scheduling pass at an answer instead of raising immediately.
+            remaining = max(0.001, deadline - asyncio.get_running_loop().time())
+            answer = await asyncio.wait_for(future, remaining)
         except asyncio.TimeoutError:
             # The question stays in the child's context — it was asked, and a
             # late answer is still useful to the child's own reasoning — but

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -2117,10 +2117,10 @@ class Session:
         # the parent session, every subagent and the TUI repaint, that made one
         # agent's threshold check a global stall: a stall trace of eight
         # concurrent subagents put 116 of 121 blocking samples inside the
-        # encoder reached from here (worst single stall 860 ms). The ``_async``
-        # forms hand large histories to a worker thread, where tiktoken's GIL
-        # release lets them run genuinely in parallel; small ones still run
-        # inline so a short session pays no thread-hop tax.
+        # encoder reached from here (worst single stall 860 ms).
+        # ``_offloaded`` hands large histories to a worker thread, where
+        # tiktoken's GIL release lets them run genuinely in parallel; small
+        # ones still run inline so a short session pays no thread-hop tax.
         local_estimate = await self._offloaded(
             compaction_api, "estimate_messages_tokens", llm_history
         )

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -164,6 +164,46 @@ class _CompactionPlan:
     tokens_before: int
 
 
+def _configured_max_running() -> dict[str, int]:
+    """``{"max_running": N}`` from config, or ``{}`` to keep the default.
+
+    The concurrent-job ceiling governs how many subagents (and backgrounded
+    bash jobs — they share one pool) may run at once. The right number is a
+    property of the operator's machine and models rather than of this code, so
+    it is configurable under ``values.subagents.max_running``, beside the
+    ``values.subagents.models`` tiers the launcher already reads.
+
+    Returns kwargs rather than a value so an unset or unusable config is
+    expressed by passing NOTHING, leaving ``AsyncJobManager``'s own default as
+    the single source of truth for it. Duplicating the default here is how the
+    two would later disagree.
+
+    Never raises: a malformed config must not stop a session from starting.
+    A non-positive value is rejected rather than honoured, because 0 would
+    deadlock every launch behind a gate that can never open.
+    """
+    try:
+        from local_operator.config import ConfigManager
+        from local_operator.paths import config_dir
+
+        raw = ConfigManager(config_dir()).get_config_value("subagents", None)
+        if not isinstance(raw, dict):
+            return {}
+        value = raw.get("max_running")
+        if value is None:
+            return {}
+        parsed = int(value)
+        if parsed < 1:
+            logger.warning(
+                "subagents.max_running=%r must be >= 1; using the built-in default", value
+            )
+            return {}
+        return {"max_running": parsed}
+    except Exception:  # noqa: BLE001 — a bad config must not fail session startup
+        logger.warning("subagents.max_running could not be read; using the built-in default")
+        return {}
+
+
 def _coerce_compaction_settings(settings: Any) -> Any:
     """Defensive coercion (CL-01 belt): a dict-shaped ``compaction_settings``
     is validated into ``CompactionSettings``; already-typed or ``None`` pass
@@ -596,7 +636,17 @@ class Session:
         # on_job_complete: settled model-owned jobs auto-deliver back into the
         # conversation when the session is idle (see _on_job_completed) — the
         # model stops having to poll 'jobs' for work it already started.
-        self.jobs = AsyncJobManager(on_job_complete=self._on_job_completed)
+        #
+        # max_running is operator-configurable (``values.subagents.max_running``)
+        # because the right ceiling is a property of the machine and the models
+        # in use, not of this code: a local model on a laptop wants far fewer
+        # concurrent children than a hosted one. An unset or unusable config
+        # contributes NO kwarg, so the manager's own default stands and the
+        # behaviour is exactly what it was before this was configurable.
+        self.jobs = AsyncJobManager(
+            on_job_complete=self._on_job_completed,
+            **_configured_max_running(),
+        )
         self._wake = WakeScheduler(
             now=lambda: int(time.time() * 1000),
             deliver=self._deliver_wake,
@@ -1932,6 +1982,48 @@ class Session:
             self._compacting = False
             self._turn_lock.release()
 
+    @staticmethod
+    async def _offloaded(compaction_api: Any, name: str, *args: Any) -> Any:
+        """Call one compaction ruler off the event loop when it is worth it.
+
+        The rulers (``estimate_messages_tokens``, ``find_cut_point``) tokenize
+        the whole history and run on EVERY turn. One event loop serves the
+        parent session, every subagent and the TUI repaint, so counting inline
+        made one agent's threshold check stall all of them — measured at up to
+        860 ms with eight children running, with 116 of 121 stall samples
+        inside the encoder. tiktoken's ``encode`` releases the GIL, so a worker
+        thread converts that stall into real parallelism (measured: 90 ms of
+        loop stall becomes 0.7 ms, and the same work finishes ~3x sooner).
+
+        Resolved by NAME off the passed module rather than closed over at
+        import: the module is looked up per call (and tests substitute partial
+        doubles for it), so binding the function early would call the real
+        ruler while a test believed it had pinned one.
+
+        Small histories stay inline because the thread hop costs more than the
+        encode it saves, and a module that does not expose ``history_chars``
+        (a partial test double) is treated the same way — degrading to the
+        inline path is always correct, just slower, and must never be a crash.
+        """
+        func = getattr(compaction_api, name)
+        probe = getattr(compaction_api, "history_chars", None)
+        threshold = getattr(compaction_api, "OFFLOAD_MIN_CHARS", None)
+        if not callable(probe) or not isinstance(threshold, int):
+            return func(*args)
+        # ``args[0]`` is the history for both rulers; anything after it is a
+        # scalar setting, so sizing on the first argument is sufficient. The
+        # probe comes off a module resolved at runtime, so its return type is
+        # unknown here: a double that returns a non-number takes the inline
+        # path rather than raising, same as one that omits the probe entirely.
+        size = probe(args[0])
+        if not isinstance(size, int) or size < threshold:
+            return func(*args)
+        # Snapshot the sequence: the worker must never walk a list the loop
+        # could mutate underneath it (pruning mutates histories in place).
+        snapshot = list(args[0])
+        rest = args[1:]
+        return await asyncio.to_thread(lambda: func(snapshot, *rest))
+
     async def _plan_compaction(
         self, *, respect_threshold: bool
     ) -> _CompactionPlan | CompactionOutcome:
@@ -2020,14 +2112,27 @@ class Session:
             ):
                 return CompactionOutcome(ran=False, reason="below_threshold")
 
-        local_estimate = compaction_api.estimate_messages_tokens(llm_history)
+        # Both of the next two calls tokenize the whole history, and both used
+        # to run inline on the event loop EVERY turn. Because one loop serves
+        # the parent session, every subagent and the TUI repaint, that made one
+        # agent's threshold check a global stall: a stall trace of eight
+        # concurrent subagents put 116 of 121 blocking samples inside the
+        # encoder reached from here (worst single stall 860 ms). The ``_async``
+        # forms hand large histories to a worker thread, where tiktoken's GIL
+        # release lets them run genuinely in parallel; small ones still run
+        # inline so a short session pays no thread-hop tax.
+        local_estimate = await self._offloaded(
+            compaction_api, "estimate_messages_tokens", llm_history
+        )
         context_tokens = compaction_api.compaction_context_tokens(provider_reported, local_estimate)
         if respect_threshold and not compaction_api.should_compact(
             context_tokens, self._model.context_window, settings
         ):
             return CompactionOutcome(ran=False, reason="below_threshold")
 
-        cut = compaction_api.find_cut_point(llm_history, settings.keep_recent_tokens)
+        cut = await self._offloaded(
+            compaction_api, "find_cut_point", llm_history, settings.keep_recent_tokens
+        )
         if cut is None or cut <= 0:
             # ``find_cut_point`` is the ONE definition of "worth summarizing":
             # the kept window has to reach ``keep_recent_tokens`` and at least
@@ -2124,7 +2229,9 @@ class Session:
             # saving a receipt can quote and the recovery band below compares
             # like with like. The provider's own figure is not available until
             # the next request.
-            tokens_after = compaction_api.estimate_messages_tokens(self._render_for_compaction())
+            tokens_after = await self._offloaded(
+                compaction_api, "estimate_messages_tokens", self._render_for_compaction()
+            )
             await self._emit(
                 CompactionEndEvent(
                     reason=reason,

--- a/local_operator/session/transcript.py
+++ b/local_operator/session/transcript.py
@@ -226,34 +226,27 @@ class Transcript:
         )
         async with self._lock:
             self._entries.append(entry)
-            # Serialize + open + write + flush in a worker thread. One event
-            # loop serves the parent session, every subagent and the TUI
-            # repaint, and this runs per message: with several children
-            # persisting turns at once, the flushes queued up on the loop and
-            # became the largest remaining stall once the tokenizer moved off
-            # it (measured at ~94 ms worst case with six children).
+            # DELIBERATELY SYNCHRONOUS, and not an oversight — do not "fix"
+            # this into a to_thread the way :meth:`compact_file` legitimately
+            # is. This append has callers that never await it:
+            # ``Session.queue_aside`` persists a materialized aside through
+            # ``_spawn_background``, i.e. fire-and-forget. Every await inside
+            # this method widens the window between "the message reached the
+            # model" and "the message is on disk", and a reader that opens the
+            # transcript in that window sees a child's context missing a
+            # message it has already acted on.
             #
-            # Correctness is unchanged because the append stays INSIDE the
-            # lock: entries reach the file in the same order they reach
-            # ``_entries``, and a second append waits for this one's flush.
-            # ``to_json`` runs in the worker too — it is the CPU half of the
-            # cost on a message carrying a large tool result.
-            await asyncio.to_thread(self._write_entry, entry)
+            # Measured, because the tradeoff was real: offloading this cut the
+            # worst loop stall at one workload (56 ms -> 22 ms) and made it
+            # WORSE at a larger one (298 ms -> 655 ms), while CI caught the
+            # visibility regression it introduced. The tokenizer offload in
+            # ``Session._offloaded`` is where the loop-responsiveness win
+            # actually comes from (1360 ms -> 56 ms); this write is a few
+            # hundred microseconds and is not worth a correctness hazard.
+            with self.path.open("a", encoding="utf-8") as handle:
+                handle.write(entry.to_json() + "\n")
+                handle.flush()
         return entry
-
-    def _write_entry(self, entry: TranscriptEntry) -> None:
-        """Append one serialized entry to the file (worker-thread half of
-        :meth:`_append`).
-
-        Synchronous by design — ``asyncio.to_thread`` is the only caller, and
-        the ``_lock`` held across that call is what keeps concurrent appends
-        ordered. ``flush`` stays here rather than being dropped: a crashed
-        session must not lose the turn it had already recorded, which is the
-        whole basis of transcript replay and ``--resume``.
-        """
-        with self.path.open("a", encoding="utf-8") as handle:
-            handle.write(entry.to_json() + "\n")
-            handle.flush()
 
     # -- replay -------------------------------------------------------------
 

--- a/local_operator/session/transcript.py
+++ b/local_operator/session/transcript.py
@@ -226,10 +226,34 @@ class Transcript:
         )
         async with self._lock:
             self._entries.append(entry)
-            with self.path.open("a", encoding="utf-8") as handle:
-                handle.write(entry.to_json() + "\n")
-                handle.flush()
+            # Serialize + open + write + flush in a worker thread. One event
+            # loop serves the parent session, every subagent and the TUI
+            # repaint, and this runs per message: with several children
+            # persisting turns at once, the flushes queued up on the loop and
+            # became the largest remaining stall once the tokenizer moved off
+            # it (measured at ~94 ms worst case with six children).
+            #
+            # Correctness is unchanged because the append stays INSIDE the
+            # lock: entries reach the file in the same order they reach
+            # ``_entries``, and a second append waits for this one's flush.
+            # ``to_json`` runs in the worker too — it is the CPU half of the
+            # cost on a message carrying a large tool result.
+            await asyncio.to_thread(self._write_entry, entry)
         return entry
+
+    def _write_entry(self, entry: TranscriptEntry) -> None:
+        """Append one serialized entry to the file (worker-thread half of
+        :meth:`_append`).
+
+        Synchronous by design — ``asyncio.to_thread`` is the only caller, and
+        the ``_lock`` held across that call is what keeps concurrent appends
+        ordered. ``flush`` stays here rather than being dropped: a crashed
+        session must not lose the turn it had already recorded, which is the
+        whole basis of transcript replay and ``--resume``.
+        """
+        with self.path.open("a", encoding="utf-8") as handle:
+            handle.write(entry.to_json() + "\n")
+            handle.flush()
 
     # -- replay -------------------------------------------------------------
 
@@ -378,15 +402,41 @@ class Transcript:
                 if entry.type == ENTRY_MESSAGE and entry.id in prunes:
                     entry = _pruned_entry(entry, prunes[entry.id])
                 folded.append(entry)
-            payload = "".join(entry.to_json() + "\n" for entry in folded)
-            reclaimed = before - len(payload.encode("utf-8"))
+            # Re-serializing and rewriting the WHOLE transcript is proportional
+            # to session length (hundreds of ms on a long one), and it runs on
+            # the loop every session shares. Off to a worker: the ``_lock`` held
+            # across the await keeps it exclusive against appends, and the
+            # ``os.replace`` is still atomic, so an interrupted rewrite leaves
+            # the original intact exactly as before.
+            payload, reclaimed = await asyncio.to_thread(self._render_folded, folded, before)
             if reclaimed < min_reclaim_bytes:
                 return 0
-            tmp = self.path.with_suffix(self.path.suffix + ".compact")
-            tmp.write_text(payload, encoding="utf-8")
-            os.replace(tmp, self.path)
+            await asyncio.to_thread(self._replace_file, payload)
             self._entries = folded
             return reclaimed
+
+    @staticmethod
+    def _render_folded(folded: list[TranscriptEntry], before: int) -> tuple[str, int]:
+        """Serialize the folded entries and price the rewrite.
+
+        Worker-thread half of :meth:`compact_file`: this is the O(session)
+        string building, kept out of the loop. Returns the payload alongside
+        the bytes it reclaims so the caller can decide whether the rewrite is
+        worth doing without re-measuring.
+        """
+        payload = "".join(entry.to_json() + "\n" for entry in folded)
+        return payload, before - len(payload.encode("utf-8"))
+
+    def _replace_file(self, payload: str) -> None:
+        """Write the compacted transcript beside the old one and move it over.
+
+        Worker-thread half of :meth:`compact_file`. Crash safety is the whole
+        point of the temp-file dance: ``os.replace`` is atomic, so an
+        interrupted compaction leaves the original transcript readable.
+        """
+        tmp = self.path.with_suffix(self.path.suffix + ".compact")
+        tmp.write_text(payload, encoding="utf-8")
+        os.replace(tmp, self.path)
 
     def flush(self) -> None:
         """Writes are flushed per append; provided for dispose() symmetry."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,6 +164,14 @@ profile = "black"
 reportMissingTypeArgument = true
 strictListInference = true
 reportPrivateImportUsage = false
+# Resolve imports against the project venv rather than whatever interpreter
+# pyright happens to find. Without this a bare `pyright` run reports hundreds
+# of spurious "import could not be resolved" errors (it picks up the system
+# Python, which has none of the dependencies), so the real errors are buried
+# and the gate looks broken to anyone who runs it without the documented
+# `--pythonpath .venv/bin/python`. Both forms agree now.
+venvPath = "."
+venv = ".venv"
 
 [tool.pytest.ini_options]
 addopts = "-vv -s"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,14 +164,20 @@ profile = "black"
 reportMissingTypeArgument = true
 strictListInference = true
 reportPrivateImportUsage = false
-# NOTE: venvPath/venv are deliberately NOT set here, though a bare local
-# `pyright` run resolves the system interpreter and reports spurious
-# "import could not be resolved" errors. Pinning them fixes the local run and
-# BREAKS CI: `.github/workflows/ci.yml` installs with `pip install -e ".[dev]"`
-# into the runner's own interpreter and never creates a `.venv`, so pyright
-# would warn ".venv subdirectory not found" and fall back to an interpreter
-# without the dependencies — turning the type-check gate into import noise
-# that hides real errors. Verified by removing `.venv` locally and re-running.
+# NOTE: venvPath/venv are deliberately NOT set here, even though a bare local
+# `pyright` run resolves whatever interpreter it finds and reports spurious
+# "import could not be resolved" errors that bury the real ones.
+#
+# Pinning them would fix the local run but couples this file to a layout CI
+# does not have: `.github/workflows/ci.yml` installs with
+# `pip install -e ".[dev]"` into the runner's own interpreter and never creates
+# a `.venv`. Simulating that shape (no `.venv`, dependencies on the PATH
+# interpreter) shows pyright warn ".venv subdirectory not found" and then fall
+# back to that interpreter, finding the dependencies and exiting 0 — so it
+# would not break the gate today. It is left unset because it buys nothing on
+# CI while making the config silently dependent on a directory that only
+# exists locally: with no `.venv` AND no dependencies on the resolved
+# interpreter, the same fallback reports every third-party import as missing.
 #
 # Use the documented invocation instead (see AGENTS.md):
 #   .venv/bin/python -m pyright --pythonpath .venv/bin/python .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,14 +164,17 @@ profile = "black"
 reportMissingTypeArgument = true
 strictListInference = true
 reportPrivateImportUsage = false
-# Resolve imports against the project venv rather than whatever interpreter
-# pyright happens to find. Without this a bare `pyright` run reports hundreds
-# of spurious "import could not be resolved" errors (it picks up the system
-# Python, which has none of the dependencies), so the real errors are buried
-# and the gate looks broken to anyone who runs it without the documented
-# `--pythonpath .venv/bin/python`. Both forms agree now.
-venvPath = "."
-venv = ".venv"
+# NOTE: venvPath/venv are deliberately NOT set here, though a bare local
+# `pyright` run resolves the system interpreter and reports spurious
+# "import could not be resolved" errors. Pinning them fixes the local run and
+# BREAKS CI: `.github/workflows/ci.yml` installs with `pip install -e ".[dev]"`
+# into the runner's own interpreter and never creates a `.venv`, so pyright
+# would warn ".venv subdirectory not found" and fall back to an interpreter
+# without the dependencies — turning the type-check gate into import noise
+# that hides real errors. Verified by removing `.venv` locally and re-running.
+#
+# Use the documented invocation instead (see AGENTS.md):
+#   .venv/bin/python -m pyright --pythonpath .venv/bin/python .
 
 [tool.pytest.ini_options]
 addopts = "-vv -s"

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,2 @@
+# Package marker: keeps pytest's rootdir insertion from putting tests/unit on
+# sys.path as a top-level root (its `mcp/` dir would shadow the real `mcp` SDK).

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,2 +1,0 @@
-# Package marker: keeps pytest's rootdir insertion from putting tests/unit on
-# sys.path as a top-level root (its `mcp/` dir would shadow the real `mcp` SDK).

--- a/tests/unit/compaction/test_tokens.py
+++ b/tests/unit/compaction/test_tokens.py
@@ -447,7 +447,8 @@ class TestThreadSafetyForOffloadedEstimation:
         count describing the PRE-mutation message. Nothing ever clears it, so
         the stale value survives for the life of the process.
 
-        Reproduced at 295/300 before `_ESTIMATE_GENERATION` existed. This is
+        Reproduced at 295/300 before the in-flight ticket bookkeeping existed.
+        This is
         the exact silent-staleness the module contract forbids, and the
         compaction gate's cheap upper-bound early return depends on it not
         happening.
@@ -549,8 +550,16 @@ class TestThreadSafetyForOffloadedEstimation:
             message.content = [TextContent(text="blanked")]
             invalidate_message_cache(message)
 
-            # Churn the cache past its bound so any per-id state would recycle.
+            # Re-cache at the CURRENT content BEFORE churning. This step is
+            # what makes the test able to fail: with per-id race state, this
+            # insert is what created the entry whose later eviction recycled
+            # the id's counter back to its initial value — the value the
+            # stalled worker recorded — reviving the stale insert. Without it
+            # there is nothing for the churn to evict, and the buggy
+            # implementation passes too.
             mod._compute_tokens = real_compute
+            estimate_tokens(message)
+            # Churn the cache past its bound so any per-id state would recycle.
             for i in range(mod._ESTIMATE_CACHE_MAX + 500):
                 estimate_tokens(Message.user(f"churn {i}"))
             worker.join(timeout=5)

--- a/tests/unit/compaction/test_tokens.py
+++ b/tests/unit/compaction/test_tokens.py
@@ -330,3 +330,106 @@ class TestApproxTextTokens:
         assert exact > 0
         assert approx >= exact, "a context readout must not under-report a Latin+JSON payload"
         assert (approx - exact) / exact < 0.20
+
+
+class TestThreadSafetyForOffloadedEstimation:
+    """The estimators run in worker threads now; the shared cache must hold.
+
+    Compaction's rulers are the largest synchronous stretch in a turn, and one
+    event loop serves the parent session, every subagent and the TUI repaint —
+    so counting inline made one agent's threshold check stall all of them
+    (measured: 2.5 s of loop stall with eight children running, 116 of 121
+    stall samples inside the encoder). ``Session._offloaded`` moves large
+    histories to ``asyncio.to_thread``, which makes this module's module-level
+    LRU cache and lazy encoding singleton reachable from several threads at
+    once. These tests pin the properties that makes safe.
+    """
+
+    def test_history_chars_sizes_both_message_kinds(self):
+        """The offload decision is made on this probe, so it must not raise on
+        a CustomMessage — the cut-point walker sees those, and an exception
+        here would abort a compaction rather than merely mis-size it."""
+        from local_operator.compaction.tokens import history_chars
+        from local_operator.harness.types import CustomMessage
+
+        messages = [
+            Message.user("abcde"),
+            CustomMessage(custom_type="compaction_summary", details={"summary": "x" * 100}),
+        ]
+        # Counts the text block, tolerates the content-less custom entry.
+        assert history_chars(messages) == 5
+
+    def test_concurrent_estimation_agrees_with_serial_estimation(self):
+        """Same messages, many threads, one answer.
+
+        Guards the LRU sequences (``get`` + ``move_to_end``, and insert +
+        ``popitem`` eviction) that are individually atomic but not atomic
+        together: an unguarded interleaving can evict an entry another thread
+        is mid-promotion on, which shows up as a wrong total rather than a
+        crash.
+        """
+        import concurrent.futures
+
+        messages = [Message.user(f"message {i} " + "lorem ipsum dolor " * 50) for i in range(40)]
+        expected = estimate_messages_tokens(messages)
+        clear_estimate_cache()
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=8) as pool:
+            results = list(pool.map(lambda _: estimate_messages_tokens(messages), range(24)))
+
+        assert set(results) == {expected}
+
+    def test_cache_stays_within_its_bound_under_concurrent_writers(self):
+        """Eviction must not be defeated (or overrun) by concurrent inserts:
+        the bound is what keeps a long-running process from leaking an entry
+        per message ever estimated."""
+        import concurrent.futures
+
+        def work(batch: int) -> None:
+            estimate_messages_tokens(
+                [Message.user(f"b{batch} m{i} text text text") for i in range(200)]
+            )
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=8) as pool:
+            list(pool.map(work, range(8)))
+
+        assert len(tokens_mod._ESTIMATE_CACHE) <= tokens_mod._ESTIMATE_CACHE_MAX
+
+    def test_the_encoding_singleton_loads_once_under_a_thread_race(self):
+        """Two workers reaching a cold singleton together must not both pay the
+        table load (~60 ms and ~44 MB RSS) nor both log the failure warning."""
+        import concurrent.futures
+
+        loads: list[int] = []
+        real_import = tokens_mod._get_encoding
+
+        tokens_mod._ENCODING = None
+        tokens_mod._ENCODING_FAILED = False
+
+        class _Sentinel:
+            def encode(self, text, **_kwargs):
+                return [0] * (len(text) // 4)
+
+        def fake_get_encoding(_name: str):
+            loads.append(1)
+            return _Sentinel()
+
+        import sys
+        import types
+
+        fake_tiktoken = types.ModuleType("tiktoken")
+        fake_tiktoken.get_encoding = fake_get_encoding  # type: ignore[attr-defined]
+        original = sys.modules.get("tiktoken")
+        sys.modules["tiktoken"] = fake_tiktoken
+        try:
+            with concurrent.futures.ThreadPoolExecutor(max_workers=8) as pool:
+                encodings = list(pool.map(lambda _: real_import(), range(16)))
+            assert len(loads) == 1, f"loaded the encoding {len(loads)} times"
+            assert len({id(e) for e in encodings}) == 1, "workers saw different encodings"
+        finally:
+            if original is not None:
+                sys.modules["tiktoken"] = original
+            else:
+                sys.modules.pop("tiktoken", None)
+            tokens_mod._ENCODING = None
+            tokens_mod._ENCODING_FAILED = False

--- a/tests/unit/compaction/test_tokens.py
+++ b/tests/unit/compaction/test_tokens.py
@@ -488,8 +488,18 @@ class TestThreadSafetyForOffloadedEstimation:
 
         assert stale == 0, f"{stale}/25 invalidations were lost, leaving a stale estimate"
 
-    def test_generation_bookkeeping_cannot_grow_without_bound(self):
-        """The race fix must not become the leak the cache bound exists to stop."""
+    def test_race_bookkeeping_cannot_grow_without_bound(self):
+        """The race fix must not become the leak the cache bound exists to stop.
+
+        Both paths, because the INSERT path alone hides the leak that matters.
+        An earlier per-message-id counter was pruned only on eviction, and
+        eviction only happens on an insert — so the once-per-turn path that
+        invalidates without ever estimating (a prune below the compaction
+        threshold, where the cheap upper bound returns early and the exact
+        estimator never runs) grew one permanent entry per turn, on a
+        module-global dict shared by every session. Measured 20,000 entries
+        after 20,000 such turns with the cache still empty.
+        """
         from local_operator.compaction import tokens as mod
 
         clear_estimate_cache()
@@ -498,4 +508,57 @@ class TestThreadSafetyForOffloadedEstimation:
                 [Message.user(f"b{batch} m{i} hello world") for i in range(400)]
             )
         assert len(mod._ESTIMATE_CACHE) <= mod._ESTIMATE_CACHE_MAX
-        assert len(mod._ESTIMATE_GENERATION) <= mod._ESTIMATE_CACHE_MAX
+
+        # The path that leaked: invalidate, never estimate.
+        for turn in range(5_000):
+            invalidate_message_cache(Message.user(f"turn {turn} tool output"))
+        assert not mod._INFLIGHT_ESTIMATES, (
+            f"{len(mod._INFLIGHT_ESTIMATES)} entries survived invalidations that "
+            "never ran an estimate; the race bookkeeping is leaking"
+        )
+
+    def test_a_stalled_computation_cannot_be_revived_by_cache_turnover(self):
+        """Race state is keyed by a unique ticket, never by message id.
+
+        With a per-id counter, evicting the id dropped its counter, so a later
+        read returned 0 — the same value a stalled computation had recorded
+        before it started encoding. That resurrects the exact lost-invalidation
+        bug the counter was added to fix, just behind a narrower window.
+        """
+        import threading
+
+        from local_operator.compaction import tokens as mod
+
+        real_compute = mod._compute_tokens
+        try:
+            clear_estimate_cache()
+            message = Message.user("lorem ipsum " * 400)
+            computing = threading.Event()
+
+            def slow_compute(msg, _real=real_compute):
+                value = _real(msg)
+                computing.set()
+                time.sleep(0.15)
+                return value
+
+            mod._compute_tokens = slow_compute
+            worker = threading.Thread(target=lambda: estimate_tokens(message))
+            worker.start()
+            computing.wait(timeout=5)
+
+            message.content = [TextContent(text="blanked")]
+            invalidate_message_cache(message)
+
+            # Churn the cache past its bound so any per-id state would recycle.
+            mod._compute_tokens = real_compute
+            for i in range(mod._ESTIMATE_CACHE_MAX + 500):
+                estimate_tokens(Message.user(f"churn {i}"))
+            worker.join(timeout=5)
+
+            cached = mod._ESTIMATE_CACHE.get(message.id)
+            assert cached is None or cached == real_compute(message), (
+                "a stalled computation's pre-mutation count was cached after "
+                "cache turnover recycled its race state"
+            )
+        finally:
+            mod._compute_tokens = real_compute

--- a/tests/unit/compaction/test_tokens.py
+++ b/tests/unit/compaction/test_tokens.py
@@ -1,5 +1,7 @@
 """Token estimation: tiktoken path, fallback, memoization, invalidation."""
 
+import time
+
 import pytest
 
 from local_operator.compaction import tokens as tokens_mod
@@ -433,3 +435,67 @@ class TestThreadSafetyForOffloadedEstimation:
                 sys.modules.pop("tiktoken", None)
             tokens_mod._ENCODING = None
             tokens_mod._ENCODING_FAILED = False
+
+    def test_an_invalidation_during_a_computation_is_not_lost(self):
+        """A mutation that lands mid-encode must not leave a stale count.
+
+        `_compute_tokens` runs OUTSIDE `_CACHE_LOCK` on purpose (holding the
+        lock across the encode would re-serialize what the offload exists to
+        parallelize). That opens a window: a thread reads a cache miss, starts
+        encoding, and while it encodes the loop mutates the message and
+        invalidates it — the `pop` finds nothing, and the thread then inserts a
+        count describing the PRE-mutation message. Nothing ever clears it, so
+        the stale value survives for the life of the process.
+
+        Reproduced at 295/300 before `_ESTIMATE_GENERATION` existed. This is
+        the exact silent-staleness the module contract forbids, and the
+        compaction gate's cheap upper-bound early return depends on it not
+        happening.
+        """
+        import threading
+
+        from local_operator.compaction import tokens as mod
+
+        real_compute = mod._compute_tokens
+        stale = 0
+        try:
+            for _ in range(25):
+                message = Message.user("lorem ipsum dolor " * 400)
+                clear_estimate_cache()
+                computing = threading.Event()
+
+                def slow_compute(msg, _real=real_compute):
+                    value = _real(msg)
+                    computing.set()
+                    time.sleep(0.002)  # hold the compute->insert window open
+                    return value
+
+                mod._compute_tokens = slow_compute
+                worker = threading.Thread(target=lambda: estimate_tokens(message))
+                worker.start()
+                computing.wait(timeout=5)
+                # Mutate + invalidate inside the window, exactly as pruning does.
+                message.content = [TextContent(text="blanked")]
+                invalidate_message_cache(message)
+                worker.join(timeout=5)
+                mod._compute_tokens = real_compute
+
+                cached = mod._ESTIMATE_CACHE.get(message.id)
+                if cached is not None and cached != real_compute(message):
+                    stale += 1
+        finally:
+            mod._compute_tokens = real_compute
+
+        assert stale == 0, f"{stale}/25 invalidations were lost, leaving a stale estimate"
+
+    def test_generation_bookkeeping_cannot_grow_without_bound(self):
+        """The race fix must not become the leak the cache bound exists to stop."""
+        from local_operator.compaction import tokens as mod
+
+        clear_estimate_cache()
+        for batch in range(20):
+            estimate_messages_tokens(
+                [Message.user(f"b{batch} m{i} hello world") for i in range(400)]
+            )
+        assert len(mod._ESTIMATE_CACHE) <= mod._ESTIMATE_CACHE_MAX
+        assert len(mod._ESTIMATE_GENERATION) <= mod._ESTIMATE_CACHE_MAX

--- a/tests/unit/harness/test_comms.py
+++ b/tests/unit/harness/test_comms.py
@@ -288,6 +288,105 @@ async def test_a_starting_child_is_not_reported_as_parked_behind_the_gate():
     assert "designer" not in (parked.error or "")
 
 
+@pytest.mark.asyncio
+async def test_ask_waits_for_a_child_the_loop_has_not_entered_yet():
+    """The reported bug: checking in on a just-launched subagent is refused.
+
+    ``register`` calls ``ensure_future``, which SCHEDULES the runner without
+    entering it, so a parent that launches a child and asks it something in
+    its very next tool call finds no live child — not because anything is
+    wrong, but because the loop has not reached the runner. Refusing with
+    "it starts when this session next yields; retry in a moment" is an answer
+    the model cannot act on: it cannot yield except by making another call, so
+    it either polls or stops checking in. Both were observed live.
+
+    Awaiting the attach is self-fulfilling — the wait IS the yield that lets
+    the runner start — so the question must survive a late attach rather than
+    being rejected the instant it finds ``child is None``.
+    """
+    jobs = FakeJobs()
+    comms = SubagentComms(FakeParent(jobs))  # type: ignore[arg-type]
+    jobs.add("job-1")
+    comms.record_launch("job-1", "designer")
+
+    question = asyncio.create_task(comms.ask("job-1", "status?", 30_000))
+    await asyncio.sleep(0)  # the ask is now parked on the attach, not refused
+    assert not question.done(), "the question was refused instead of waiting"
+
+    # The runner finally gets its turn on the loop and attaches its session.
+    child = FakeChild()
+    comms.attach("job-1", child, tmp_dir())
+    await wait_for(lambda: bool(child.asides))
+    child.materialize()
+    comms.reply_to_parent("job-1", "two findings so far")
+
+    reply = await question
+    assert reply.text == "two findings so far"
+    assert reply.error is None
+
+
+@pytest.mark.asyncio
+async def test_ask_does_not_burn_its_timeout_on_a_parked_child():
+    """A parked job holds no slot and may not start for minutes, so waiting on
+    it is waiting on nothing. It must be reported at once — the opposite call
+    from the scheduled-but-not-entered child above, which one yield starts."""
+    jobs = FakeJobs()
+    comms = SubagentComms(FakeParent(jobs))  # type: ignore[arg-type]
+    jobs.add("job-parked").queued = True
+    comms.record_launch("job-parked", "designer")
+
+    loop = asyncio.get_running_loop()
+    started = loop.time()
+    reply = await comms.ask("job-parked", "status?", 30_000)
+    elapsed = loop.time() - started
+
+    assert "capacity gate" in (reply.error or "")
+    assert elapsed < 1.0, f"waited {elapsed:.1f}s on a job that cannot start"
+
+
+@pytest.mark.asyncio
+async def test_ask_gives_up_when_the_child_never_starts():
+    """The wait is bounded. A child that never attaches must produce the honest
+    not-started reason rather than consuming the caller's whole timeout: the
+    grace is a FRACTION of it, so the caller still gets an answer in time to
+    do something else."""
+    jobs = FakeJobs()
+    comms = SubagentComms(FakeParent(jobs))  # type: ignore[arg-type]
+    jobs.add("job-1")
+    comms.record_launch("job-1", "designer")
+
+    loop = asyncio.get_running_loop()
+    started = loop.time()
+    reply = await comms.ask("job-1", "status?", 400)
+    elapsed = loop.time() - started
+
+    assert "scheduled" in (reply.error or "")
+    # Half of 400 ms, and comfortably less than the full timeout.
+    assert elapsed < 0.4, f"consumed the whole timeout ({elapsed:.2f}s)"
+
+
+@pytest.mark.asyncio
+async def test_a_child_that_settles_before_starting_fails_the_wait_at_once():
+    """``detach`` must wake a waiter: the attach it is parked on is never
+    coming, and burning the full grace on a child that already died is the
+    same stall this wait exists to remove."""
+    jobs = FakeJobs()
+    comms = SubagentComms(FakeParent(jobs))  # type: ignore[arg-type]
+    jobs.add("job-1")
+    comms.record_launch("job-1", "designer")
+
+    question = asyncio.create_task(comms.ask("job-1", "status?", 30_000))
+    await asyncio.sleep(0)
+    assert not question.done()
+
+    jobs.jobs["job-1"].status = "failed"
+    comms.detach("job-1")
+
+    reply = await asyncio.wait_for(question, timeout=2.0)
+    assert reply.text is None
+    assert reply.error
+
+
 def test_send_to_an_unknown_job_fails_without_raising():
     comms, _jobs, _child, _parent = wire()
     delivery = comms.send("nope", "hello")

--- a/tests/unit/harness/test_comms.py
+++ b/tests/unit/harness/test_comms.py
@@ -384,7 +384,47 @@ async def test_a_child_that_settles_before_starting_fails_the_wait_at_once():
 
     reply = await asyncio.wait_for(question, timeout=2.0)
     assert reply.text is None
-    assert reply.error
+    # The REASON matters, not merely that there is one: a child that died must
+    # not be reported as "not started yet ... retry in a moment", which invites
+    # exactly the polling loop this wait exists to remove.
+    assert "failed" in (reply.error or "")
+    assert "retry in a moment" not in (reply.error or "")
+
+
+@pytest.mark.asyncio
+async def test_ask_never_exceeds_the_timeout_it_was_given():
+    """The attach grace is deducted from the caller's budget, not added to it.
+
+    ``timeout_ms`` is the whole budget a caller planned around. Spending the
+    grace first and then granting the full timeout for the answer let a
+    1000 ms request block for ~1450 ms while reporting it had waited 1000 ms,
+    and it scales with the timeout — the 600 s schema maximum could block for
+    900 s.
+    """
+    jobs = FakeJobs()
+    comms = SubagentComms(FakeParent(jobs))  # type: ignore[arg-type]
+    jobs.add("job-1")
+    comms.record_launch("job-1", "designer")
+
+    # Attach late enough to consume part of the grace, then never answer, so
+    # the call spends grace AND answer wait: the sum must still fit the budget.
+    async def attach_soon() -> None:
+        # Late enough to burn most of the 300 ms grace (half of 600 ms).
+        await asyncio.sleep(0.28)
+        comms.attach("job-1", FakeChild(), tmp_dir())
+
+    loop = asyncio.get_running_loop()
+    started = loop.time()
+    attacher = asyncio.create_task(attach_soon())
+    reply = await comms.ask("job-1", "status?", 600)
+    elapsed = loop.time() - started
+    await attacher
+
+    assert reply.timed_out
+    # Measured: 601 ms with the deadline honoured, 884 ms without it. The bound
+    # sits between the two, with enough slack above the correct figure that a
+    # loaded CI box does not flake it.
+    assert elapsed < 0.75, f"overshot a 600 ms budget: took {elapsed * 1000:.0f} ms"
 
 
 def test_send_to_an_unknown_job_fails_without_raising():

--- a/tests/unit/session/test_launch_subagent.py
+++ b/tests/unit/session/test_launch_subagent.py
@@ -732,3 +732,90 @@ async def test_scout_preamble_reaches_the_provider_turn(tmp_path, monkeypatch):
     assert "[scout mode:" in first_user.text
     assert "Map the repo." in first_user.text
     await parent.dispose()
+
+
+class LongStream:
+    """A child turn that streams many deltas, yielding the loop between each.
+
+    A real provider suspends on network I/O between chunks. Reproducing that
+    suspension is what makes this a concurrency test rather than a CPU
+    benchmark: without it the generator never yields and nothing else could
+    run no matter how the harness behaved.
+    """
+
+    def __init__(self, deltas: int = 2000, chunk_chars: int = 1200) -> None:
+        self.deltas = deltas
+        self.chunk = "lorem ipsum dolor " * max(1, chunk_chars // 18)
+
+    def __call__(self, request: ChatRequest, signal: AbortSignal | None):
+        async def gen():
+            for _ in range(self.deltas):
+                await asyncio.sleep(0)
+                yield StreamTextDelta(delta=self.chunk)
+            yield StreamEndEvent(stop_reason="stop")
+
+        return gen()
+
+
+@pytest.mark.asyncio
+async def test_the_loop_stays_responsive_while_several_subagents_run(tmp_path, monkeypatch):
+    """Concurrent children must not stall the event loop they share.
+
+    THE regression this guards. One asyncio loop serves the parent session,
+    every subagent and the TUI's repaint, and the per-turn compaction gate
+    used to tokenize the whole history INLINE on it. With several children
+    streaming at once that made one child's threshold check freeze all of
+    them: measured at 2.5 s of maximum loop stall (worst single stall 860 ms,
+    with 116 of 121 stall samples inside the tokenizer). The user-visible
+    symptom was an agent reporting that its subagents "only run when I yield".
+
+    The measurement is a watchdog that asks to be woken every 5 ms and records
+    how late it actually was. That overshoot IS the window in which nothing
+    else on the loop could be serviced, which is exactly what a starved
+    sibling experiences. Asserting on the watchdog rather than on wall-clock
+    time keeps this about responsiveness and not about machine speed.
+
+    The workload is calibrated, not arbitrary. It has to build a history big
+    enough that the gate's tokenizer pass is expensive, because that is the
+    stretch under test; at a smaller size both variants pass and the test
+    proves nothing. Measured on this workload against the pre-fix tree and
+    this one: worst stall 1353 ms before, 139 ms after. The 1 s bound sits an
+    order of magnitude above the fixed behaviour (so a loaded CI box does not
+    flake it) and comfortably below the broken one.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    parent = make_session(tmp_path, LongStream())
+
+    stop = asyncio.Event()
+    lateness: list[float] = []
+
+    async def watchdog() -> None:
+        loop = asyncio.get_running_loop()
+        while not stop.is_set():
+            before = loop.time()
+            await asyncio.sleep(0.005)
+            lateness.append(loop.time() - before - 0.005)
+
+    watcher = asyncio.create_task(watchdog())
+    await asyncio.sleep(0.05)
+    lateness.clear()
+
+    job_ids = [parent._launch_subagent(label=f"c{i}", prompt="do the work") for i in range(6)]
+
+    def all_settled() -> bool:
+        jobs = [parent.jobs.get(job_id) for job_id in job_ids]
+        return all(job is not None and job.status != "running" for job in jobs)
+
+    try:
+        await wait_for(all_settled, timeout=60.0)
+    finally:
+        stop.set()
+        await watcher
+
+    assert lateness, "the watchdog never ran — the measurement itself is broken"
+    worst = max(lateness)
+    assert worst < 1.0, (
+        f"the event loop stalled for {worst * 1000:.0f} ms while subagents ran; "
+        "a synchronous stretch is starving concurrent children"
+    )
+    await parent.dispose()


### PR DESCRIPTION
# PR Description

## Change classification

**C2 — standard / pre-authorized.** A bounded performance/correctness fix in the harness and session layers with a clean rollback (`git revert`). No foundational auth, data-isolation, infrastructure, or irreversible data change. No RFC or tracker requested. Not release-carrying: this branch does not bump the version.

## Summary of Changes

Reported symptom, from an agent narrating its own run:

> **Design round 3** is launched but was starved — subagents only run when I yield, which is why I'm stopping here rather than continuing to poll.

And, when the parent tried to check in on a child it had just launched:

> `designer-r3b (13345e740bed): subagent has not started yet (it is scheduled, and starts when this session next yields); retry in a moment`

### What the concurrency model actually is

Worth stating plainly, because the first report reads like a scheduling bug and is not one:

- Subagents **are** real `asyncio` tasks. `AsyncJobManager.register` calls `ensure_future`, and the runner drives a full child `Session`. Nothing awaits them serially.
- The ceiling is **15 concurrent jobs, per session**, shared between `task` subagents and backgrounded `bash` jobs. The 16th parks behind a capacity gate and is promoted FIFO as slots free.
- The parent's turn ending does **not** kill children; only `dispose()` does.
- Parent, every subagent, and the TUI repaint all share **one event loop, one thread**.

That last point is the whole problem. The tasks were scheduled correctly and could not run, because the per-turn work on that shared loop was synchronous.

### Root cause: the compaction gate tokenized on the event loop, every turn

Found by sampling the main thread's stack from a watchdog thread whenever the loop failed to tick for >50 ms. With eight children streaming, **116 of 121 stall samples were inside tiktoken**, reached from the compaction gate that runs at the end of every turn:

```
jobs.py:388 _run_job -> subagent.py:269 runner -> session.py prompt
  -> _run_turn -> _maybe_compact -> _plan_compaction
  -> cutpoint.py:123 find_cut_point -> tokens.py:114 _encode_len     <- 860 ms, uninterruptible
```

`_plan_compaction` called `estimate_messages_tokens` and `find_cut_point` inline. Both tokenize the whole history; neither yields. So each child's own threshold check froze every sibling, the parent, and the UI for its duration — which is exactly what "subagents only run when I yield" looks like from inside the model's context.

tiktoken's `encode` is a Rust extension that **releases the GIL**, so a worker thread buys real parallelism here rather than relocating the stall. Measured directly before relying on it: 8 concurrent estimates of ~40 KB each, 90.3 ms of loop stall inline vs **0.7 ms** offloaded, and 95.3 ms → 32.3 ms wall.

### The changes

- **`Session._offloaded`** hands `estimate_messages_tokens` and `find_cut_point` to `asyncio.to_thread` for large histories. Small ones stay inline, where a thread hop costs more than the encode it saves (`OFFLOAD_MIN_CHARS`, 20k chars). It resolves the ruler **by name off the compaction module** rather than closing over an import, because tests substitute those module attributes to pin a context size — a wrapper that bound the function early would call the real ruler while a test believed it had pinned one. A module missing the size probe (a partial test double) degrades to the inline path instead of raising.
- **Thread-safety in `compaction/tokens.py`.** The estimators are now reachable from worker threads, so the module-level LRU cache's non-atomic sequences (`get` + `move_to_end`; insert + `popitem` eviction) and the lazy encoding singleton are guarded by a lock. The lock covers dict bookkeeping and the singleton load **only, never `encode`** — holding it across the encode would re-serialize precisely what the offload exists to parallelize. Two threads racing the same uncached id both compute it, which is wasteful and correct.
- **`compact_file` off the loop.** Its whole-file re-serialize and rewrite is proportional to session length and every caller awaits it, so it moves to a worker while keeping the atomic `os.replace`.

  `Transcript._append` was offloaded too and has been **reverted** — see "A regression CI caught" below. Keeping that honest mattered more than the number.
- **`hub ask` waits for a child the loop has scheduled but not entered.** This is the second report. `register` schedules the runner without entering it, so a parent asking a question in its very next tool call found no live child and was told to "retry in a moment" — advice the model cannot act on, since it cannot yield except by making another call. It therefore polls or gives up; both were observed. The ask now awaits the attach, and **that wait is itself the yield that lets the runner start**, so it is self-fulfilling rather than a gamble. Bounded at half the caller's timeout (capped 30 s). A job genuinely **parked behind the capacity gate is still refused immediately** — no amount of yielding starts it — and `detach` wakes waiters so a child that dies before starting fails the question at once instead of burning the grace.
- **`values.subagents.max_running`** makes the concurrent-job ceiling configurable, beside the `values.subagents.models` tiers the launcher already reads. Unset or invalid values contribute no kwarg, so `AsyncJobManager`'s own default stands as the single source of truth; `0`/negative/garbage are rejected with a warning rather than honoured, because `0` would deadlock every launch behind a gate that can never open.

## Related Issue(s)

None requested. The PR is the system of record.

## Impact

- **Breaking changes:** none. No tool call form, config default, or persisted format changes. `values.subagents.max_running` is new and optional.
- **Behavioural:** `hub ask` on a not-yet-started child now blocks briefly instead of returning an error immediately. A parked child's refusal is unchanged.
- **Correctness:** transcript append ordering and per-entry `flush` are preserved (the lock is held across the offload); `compact_file` keeps its atomic `os.replace`, so an interrupted rewrite still leaves the original readable.
- **Performance:** the point of the change — see below. Small histories are untouched, so short sessions pay no thread-hop tax.
- **Rollback:** `git revert`. No migration, no state change.

## Testing Details

### Automated gates

```text
.venv/bin/python -m flake8 .                                   PASS
uvx --from black==26.1.0 black --check local_operator tests    PASS (353 files unchanged)
uvx isort --check-only --profile black local_operator tests    PASS
.venv/bin/python -m pyright --pythonpath .venv/bin/python .    PASS (0 errors)
.venv/bin/python -m pytest tests/unit -q --ignore=tests/unit/tui
                                                               2818 passed, 3 skipped
env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit/tui -q
                                                               1411 passed, 4 skipped
```

`pyright` caught one real defect during implementation: the size probe is resolved off a module at runtime, so its return type is unknown, and comparing it to an `int` was an unchecked assumption about a value a test double supplies. It is now an explicit `isinstance` check that falls back to the inline path.

**One pre-existing flake, not from this branch.** `test_cancel_backgrounded_bash_kills_process_group` fails intermittently. Verified against a clean `origin/main` worktree at `42e5268`: 1 failure in 6 runs there, with the same assertion. Unrelated to this change (process-group kill timing).

### A regression CI caught, and what it changed

The first push offloaded `Transcript._append`'s write to a thread as well. `test (3.12)` failed on `test_a_question_reaches_a_busy_child_and_its_answer_comes_back` — an **existing** test, not one of mine — with the hub question present in the child's context but absent from the transcript on disk.

That is a real defect, not a flaky test. `Session.queue_aside` persists a materialized aside through `_spawn_background`, i.e. **fire-and-forget**, so every await added inside `_append` widens the window between "the message reached the model" and "the message is on disk". Reduced to the mechanism:

```text
schedule append (not awaited), then read the file back:
  read same tick        : entry on disk = False
  read after sleep(0)   : entry on disk = False   <- with the offload
  read after awaiting   : entry on disk = True
```

After reverting, `read after sleep(0)` is `True` again — the pre-branch window. It passed locally 5/5 and failed on slower CI, which is exactly the profile of a race that a laptop hides.

The measurements agreed with CI independently: offloading that write cut the worst stall at one workload (56 ms → 22 ms) and made it **worse** at a larger one (298 ms → 655 ms). It was buying inconsistent noise at the price of a correctness hazard, so it is gone and the reason is recorded at the call site. `compact_file` keeps its offload — every caller awaits it, so it carries no such window.

### The measurement: event-loop responsiveness

A watchdog coroutine asks to be woken every 5 ms and records how late it actually was. That overshoot **is** the window in which nothing else on the loop could be serviced — precisely what a starved sibling experiences. Reported over identical workloads run against a clean `origin/main` worktree and this branch:

| workload (children × deltas × chunk) | worst loop stall, `origin/main` | worst loop stall, this branch | wall |
|---|---|---|---|
| 6 × 400 × 600 | 112 ms | **64 ms** | 0.20 s → 0.17 s |
| 6 × 2000 × 1200 | 1703 ms | **25 ms** | 3.26 s → 1.64 s |
| 8 × 3000 × 1500 | 3557 ms | **1022 ms** | 14.44 s → 12.54 s |

Measured on an **idle machine** (load average < 12). An earlier revision of this description carried better-looking numbers taken while reviewer subagents were saturating the box at load average 139; these are the honest ones. The tokenizer, which held 116 of 121 stall samples before, no longer appears in a stack sample at all.

### Reproducing both reported bugs, then fixing them

A harness driving the real `Session`/`run_subagent`/`SubagentComms` stack (scripted provider standing in only for the network):

```text
BEFORE                                          AFTER
SCENARIO 1 — child progress while parent blocks the loop
  child ticks gained during 800 ms block: 0       (unchanged: a blocked loop is a blocked loop —
                                                   this scenario measures the harness, and is why
                                                   the fix targets the loop's own synchronous work)
SCENARIO 2 — hub ask immediately after launch
  REFUSED: "subagent has not started yet          reached the child; the question was delivered
  (it is scheduled ...); retry in a moment"       and awaited its answer
```

End-to-end on the real stack, 6 subagents launched as a `task` batch would, with a `hub ask` issued immediately after launch and no yield in between:

```text
launching 6 subagents ...
hub ask immediately after launch -> reached the child (911 ms), not refused
6 subagents settled in 1.67s
event-loop responsiveness while they ran:
   median stall: 0.70 ms
   watchdog ticks: 233    (a starved loop records almost none)
   designer-r0: completed, 2,070,000 chars produced
```

The `hub ask` line is the second reported bug, fixed: on `origin/main` that same call returns `subagent has not started yet ... retry in a moment` immediately.

### The regression guard actually discriminates

A guard that cannot fail is worthless, so this was verified in both directions rather than assumed. `test_the_loop_stays_responsive_while_several_subagents_run` was run against a clean `origin/main` worktree with only the test file copied in:

```text
origin/main:   FAILED — the event loop stalled for 1424 ms while subagents ran;
                        a synchronous stretch is starving concurrent children
this branch:   PASSED
```

The workload is calibrated, not arbitrary: at a smaller size both variants pass and the test proves nothing. The 1 s bound sits an order of magnitude above the fixed behaviour (so a loaded CI box does not flake it) and well below the broken one.

### Config verification, exercised for real

```text
unset                    -> max_running=15  (AsyncJobManager default)
max_running=40           -> max_running=40
max_running=0            -> max_running=15  + warning "must be >= 1"
max_running=-3           -> max_running=15  + warning "must be >= 1"
max_running="abc"        -> max_running=15  + warning (could not be read)
max_running={"nested":1} -> max_running=15  + warning (could not be read)
```

### Adversarial stress testing

Written specifically to try to break the concurrency claims rather than confirm them — 300 concurrent transcript appends, `compact_file` interleaved with concurrent appends, the estimate cache hammered from 12 threads, concurrent invalidation racing eviction, and a message mutated on the loop while a worker thread estimates it:

```text
  transcript: disk=300 mem=300 expected=300 order_match=True -> OK
  compact+append: late msgs on disk=60/60 corrupt_json=False -> OK
  cache under 12 threads: distinct_results={9780} expected={9780} errors=[] -> OK
  cache + concurrent invalidation: errors=[] bound_ok=True -> OK
  mutation during offloaded estimate: errors=[] -> OK (no crash)

  5/5 stress checks passed
```

Ask-wait edge cases, each verified: a 0 ms/1 ms/50 ms timeout returns promptly rather than hanging; a 1-hour timeout is capped at 30 s of grace rather than waiting 30 minutes; a job row swept from the manager mid-wait errors rather than hanging; `detach` with no waiter does not raise; and a parked child with a 600 s timeout is refused in 0.0 ms.

### New tests

- `tests/unit/session/test_launch_subagent.py` — the loop-responsiveness guard above.
- `tests/unit/harness/test_comms.py` (4) — ask waits for a scheduled-but-not-entered child and gets its answer; ask does **not** burn its timeout on a parked child (asserted `< 1 s`); the wait is bounded when a child never starts (asserted it does not consume the full timeout); a child settling before it starts fails the wait at once.
- `tests/unit/compaction/test_tokens.py` (4) — concurrent estimation agrees with serial estimation; the LRU bound holds under 8 concurrent writers; the encoding singleton loads exactly once under a thread race; the size probe tolerates `CustomMessage` (which has no `content`) since the cut-point walker sees those.

### Agent review

Four rounds, each posted on this PR with findings and a per-finding remediation reply. The reviewers found real defects that my own testing had missed, and two of them were introduced by earlier fixes in this same PR:

| round | findings | outcome |
|---|---|---|
| 1 | F1 major (lost invalidation → permanently stale token estimate), F2/F3 minor, F4 nit, F5 confirmation | all fixed |
| 2 | G1 major (the F1 fix leaked unboundedly on the invalidate-without-estimate path), G2 minor (ABA), G3/G4 nits | all fixed |
| 3 | H1 minor (my ABA guard passed on the buggy code), H2 nit, H3 minor (`tests/__init__.py` swept away by a `git add -A`) | all fixed |
| 4 | confirmation round on the current head | — |

The two that are worth reading the diff for:

- **F1/G1/G2** — the token cache's race bookkeeping went through three designs. Keying it by message id closed the race but leaked one permanent entry per turn on the path that invalidates without estimating (measured: 20,000 turns → 20,000 entries, cache still empty), and recycled counters on eviction reopened the original bug via ABA. It is now keyed by a unique, never-reused **ticket**, so the state is bounded by concurrency (peak 2 entries under 8 concurrent estimators, 0 at rest) and immune to recycling.
- **H1** — my own regression guard for the ABA case passed on the pre-fix code, because it never re-cached the message between the invalidation and the churn. Strengthened, and verified to fail at `b588737` with `assert (802 is None or 802 == 2)`.

### Not done

No UI change, so no browser/screenshot evidence applies. The TUI's subagent panel and trajectory rendering are untouched — verified by the full TUI suite passing unchanged.
