### PR TITLE
fix(providers,tui): let every paste-a-key provider actually log in

### DIFF
--- a/local_operator/providers/auth_cli.py
+++ b/local_operator/providers/auth_cli.py
@@ -32,12 +32,12 @@ def _callbacks_interactive(definition: ProviderDefinition) -> LoginCallbacks:
     The paste prompt is attached for providers that ACCEPT one, which is two
     distinct cases and used to be read as one:
 
-    - ``requires_paste_prompt`` \u2014 pasting is the whole login (every
+    - ``requires_paste_prompt`` — pasting is the whole login (every
       "paste your API key" provider). Gating these on ``paste_code_flow``, as
       this did, attached no prompt and made the login fail every time with
-      "requires an interactive code prompt" \u2014 for eight of the eleven
+      "requires an interactive code prompt" — for eight of the eleven
       providers that offer one.
-    - ``paste_code_flow`` \u2014 Anthropic's optional fallback, raced against the
+    - ``paste_code_flow`` — Anthropic's optional fallback, raced against the
       loopback callback for the case where the browser is on another machine.
 
     A loopback-only provider still gets NO prompt: there the prompt races the
@@ -56,18 +56,45 @@ def _callbacks_interactive(definition: ProviderDefinition) -> LoginCallbacks:
         print(message)
 
     # The prompt says what it wants. "Paste the code here" is wrong for the
-    # providers this now serves \u2014 they want an API key off a dashboard, and a
+    # providers this now serves — they want an API key off a dashboard, and a
     # user told to paste a "code" goes looking for an OAuth code that does not
     # exist for them.
+    wants_api_key = definition.paste_prompt_required
     prompt = (
         "Paste your API key here (empty to cancel): "
-        if definition.paste_prompt_required
+        if wants_api_key
         else "Paste the code here (empty to cancel): "
     )
 
+    def read_line() -> str:
+        """Read the pasted value, hiding it when it is a long-lived secret.
+
+        ``getpass`` for an API KEY, which is the discipline ``CredentialManager``
+        and the web-search CLI already apply to this same class of value: a
+        provider key does not expire, and ``input()`` leaves it sitting in the
+        scrollback of a terminal that is frequently being screen-shared while
+        someone sets a tool up. Before this change no paste-a-key provider could
+        reach this prompt at all, so making them work is also what makes the
+        echo reachable. The TUI half masks it for the same reason.
+
+        A plain ``input()`` for an OAuth CODE, the other branch: it is
+        single-use, expires in minutes, and is spent the moment it is redeemed,
+        while being a long opaque string the user genuinely needs to SEE to
+        check their paste landed whole. Hiding it would cost real legibility to
+        protect a value that is not worth protecting.
+        """
+        if wants_api_key:
+            # Imported here rather than at module scope: this module is on the
+            # CLI's startup path and getpass drags in termios/tty for a prompt
+            # only an interactive login reaches.
+            import getpass
+
+            return getpass.getpass(prompt)
+        return input(prompt)
+
     async def on_manual_code_input() -> str | None:
         try:
-            value = await asyncio.to_thread(input, prompt)
+            value = await asyncio.to_thread(read_line)
         except (EOFError, KeyboardInterrupt):
             return None
         return value.strip() or None

--- a/local_operator/providers/auth_cli.py
+++ b/local_operator/providers/auth_cli.py
@@ -29,11 +29,22 @@ if TYPE_CHECKING:  # lazy at runtime: the CLI top level must not import these
 def _callbacks_interactive(definition: ProviderDefinition) -> LoginCallbacks:
     """print-based callbacks for terminal logins.
 
-    The paste-code prompt is attached ONLY for providers that declare
-    ``paste_code_flow`` (a trap otherwise: for the rest it races the loopback HTTP
-    callback and leaves the terminal blocked). It runs in a thread via
-    ``asyncio.to_thread(input, ...)`` so the callback server keeps serving
-    the browser redirect while the prompt is pending.
+    The paste prompt is attached for providers that ACCEPT one, which is two
+    distinct cases and used to be read as one:
+
+    - ``requires_paste_prompt`` \u2014 pasting is the whole login (every
+      "paste your API key" provider). Gating these on ``paste_code_flow``, as
+      this did, attached no prompt and made the login fail every time with
+      "requires an interactive code prompt" \u2014 for eight of the eleven
+      providers that offer one.
+    - ``paste_code_flow`` \u2014 Anthropic's optional fallback, raced against the
+      loopback callback for the case where the browser is on another machine.
+
+    A loopback-only provider still gets NO prompt: there the prompt races the
+    HTTP callback and leaves the terminal blocked on a line nobody will type.
+
+    The prompt runs in a thread via ``asyncio.to_thread(input, ...)`` so the
+    callback server keeps serving the browser redirect while it is pending.
     """
 
     def on_auth_url(url: str, instructions: str | None = None) -> None:
@@ -44,14 +55,24 @@ def _callbacks_interactive(definition: ProviderDefinition) -> LoginCallbacks:
     def on_progress(message: str) -> None:
         print(message)
 
+    # The prompt says what it wants. "Paste the code here" is wrong for the
+    # providers this now serves \u2014 they want an API key off a dashboard, and a
+    # user told to paste a "code" goes looking for an OAuth code that does not
+    # exist for them.
+    prompt = (
+        "Paste your API key here (empty to cancel): "
+        if definition.paste_prompt_required
+        else "Paste the code here (empty to cancel): "
+    )
+
     async def on_manual_code_input() -> str | None:
         try:
-            value = await asyncio.to_thread(input, "Paste the code here (empty to cancel): ")
+            value = await asyncio.to_thread(input, prompt)
         except (EOFError, KeyboardInterrupt):
             return None
         return value.strip() or None
 
-    manual_input = on_manual_code_input if definition.paste_code_flow else None
+    manual_input = on_manual_code_input if definition.accepts_paste_prompt else None
     return LoginCallbacks(
         on_auth_url=on_auth_url, on_progress=on_progress, on_manual_code_input=manual_input
     )

--- a/local_operator/providers/oauth/qwencloud.py
+++ b/local_operator/providers/oauth/qwencloud.py
@@ -29,6 +29,7 @@ import httpx
 from local_operator.harness.types import AbortSignal
 from local_operator.providers.oauth.callback_server import (
     LoginCallbacks,
+    LoginCancelledError,
     LoginError,
     maybe_await,
 )
@@ -99,11 +100,22 @@ async def login_qwencloud_token_plan(
     identity, and ``api_key`` (the ``sk-sp-…`` inference key).
     """
     if callbacks.on_manual_code_input is None:
-        raise ValueError("QwenCloud Token Plan login requires an interactive key prompt")
+        # A contract violation by the host, not a user-facing path: the registry
+        # marks this provider ``requires_paste_prompt`` (via ``_lazy_login``) and
+        # every shipped host attaches a prompt for such providers, so reaching
+        # this means an embedder wired callbacks that cannot complete the flow.
+        raise ValueError(
+            "QwenCloud Token Plan login reads an API key, but this interface "
+            "provided no on_manual_code_input callback to read it with."
+        )
     pasted = await maybe_await(callbacks.on_manual_code_input())
     if pasted is None:
-        raise ValueError("QwenCloud Token Plan login cancelled")
+        raise LoginCancelledError("QwenCloud Token Plan login cancelled")
     api_key = pasted.strip()
+    if not api_key:
+        # Empty paste is a cancel, matching ``create_api_key_login``: a blank
+        # key would be stored as a credential and shadow a working env key.
+        raise LoginCancelledError("QwenCloud Token Plan login cancelled")
     if not api_key.startswith("sk-"):
         raise LoginError(
             "That does not look like a QwenCloud Token Plan key (expected sk-sp-…); "

--- a/local_operator/providers/registry.py
+++ b/local_operator/providers/registry.py
@@ -31,6 +31,12 @@ RefreshFn = Callable[..., Awaitable[dict[str, Any]]]
 GetApiKeyFn = Callable[[dict[str, Any]], str]
 EnvKeys = str | Callable[[], str | None] | None
 
+#: Attribute a login callable sets on itself to declare "I cannot complete
+#: without reading text from the user". Read by
+#: ``ProviderDefinition.__post_init__``, which is what carries the requirement
+#: from the flow that has it out to the hosts that must honour it.
+PASTE_PROMPT_ATTR = "__lo_requires_paste_prompt__"
+
 
 @dataclasses.dataclass(frozen=True)
 class ProviderDefinition:
@@ -49,6 +55,19 @@ class ProviderDefinition:
       Nothing routes on these; they only make the provider findable, which
       matters because the company name and the name on the model a user came
       here for are frequently different.
+
+    Two DIFFERENT things describe "this login may read text from the user", and
+    conflating them is what broke every paste-a-key login (see
+    ``paste_prompt_required`` below):
+
+    - ``paste_code_flow`` — the login has a loopback/device path AND *also*
+      accepts a pasted code as a FALLBACK, raced against the callback. Anthropic
+      only. Attaching a prompt to any other loopback provider deadlocks the
+      terminal, which is why hosts gate on it.
+    - ``paste_prompt_required`` — the login has no other path at all: reading
+      the key IS the flow, so a host that attaches no prompt cannot log in and
+      the flow can only fail. Derived, not stored (see the property), because
+      the login callable already knows.
     """
 
     id: str
@@ -64,10 +83,69 @@ class ProviderDefinition:
     base_url: str | None = None
     wire: WireFormat = "openai-compat"
     search_aliases: tuple[str, ...] = ()
+    #: Whether this login cannot complete without reading text from the user.
+    #: NOT a host preference and not a fallback marker: a host that ignores it
+    #: turns the login into a guaranteed error, which is the defect this field
+    #: exists to make impossible to reintroduce.
+    #:
+    #: Left unset in every registration below and DERIVED in ``__post_init__``
+    #: from the login callable itself, which is the only thing that actually
+    #: knows whether it prompts. Declaring it per provider would be one more
+    #: line to forget, and forgetting it is exactly how the paste-a-key
+    #: providers shipped unloggable-into: the requirement lived in the login
+    #: body and nothing carried it out to the hosts.
+    requires_paste_prompt: bool = False
+
+    def __post_init__(self) -> None:
+        """Adopt the login callable's own paste requirement.
+
+        ``create_api_key_login`` and the QwenCloud thunk tag themselves with
+        :data:`PASTE_PROMPT_ATTR`; a provider built from one inherits the tag
+        with no per-provider bookkeeping, so adding a paste-a-key provider
+        cannot silently produce a login no host can drive. An explicit ``True``
+        passed by a caller is honoured and never downgraded.
+        """
+        if not self.requires_paste_prompt and getattr(self.login, PASTE_PROMPT_ATTR, False):
+            # The dataclass is frozen (definitions are shared, module-level and
+            # read from every surface), so the derivation goes through
+            # ``object.__setattr__`` — the documented way to complete a frozen
+            # instance's own construction.
+            object.__setattr__(self, "requires_paste_prompt", True)
+
+    @property
+    def paste_prompt_required(self) -> bool:
+        """Whether a host MUST attach ``on_manual_code_input`` to log in.
+
+        The one question a host should ask. ``paste_code_flow`` answers a
+        narrower one ("may a prompt race the loopback callback?"), and hosts
+        that asked it instead attached no prompt to the paste-a-key providers —
+        whose login is nothing but that prompt — so `/login alibaba` and every
+        sibling failed with "requires an interactive code prompt" before it
+        could ask for anything.
+        """
+        return self.requires_paste_prompt
+
+    @property
+    def accepts_paste_prompt(self) -> bool:
+        """Whether a host may offer a paste prompt for this provider at all.
+
+        The union of the two cases: a required prompt, and Anthropic's optional
+        fallback. Hosts attach a prompt on this and on nothing else, so a
+        loopback-only provider still never gets one (attaching it there races
+        the HTTP callback and leaves the terminal blocked — the trap the
+        ``paste_code_flow`` gate was originally protecting).
+        """
+        return self.requires_paste_prompt or self.paste_code_flow
 
 
-def _lazy_login(module: str, attr: str) -> LoginFn:
-    """Dynamic-import thunk: keeps OAuth deps out of startup imports."""
+def _lazy_login(module: str, attr: str, *, requires_paste_prompt: bool = False) -> LoginFn:
+    """Dynamic-import thunk: keeps OAuth deps out of startup imports.
+
+    ``requires_paste_prompt`` is carried on the returned callable rather than
+    passed to the provider entry, because the whole point of the thunk is that
+    the real login module is NOT imported at registry build time — so the only
+    place the requirement can be stated without paying that import is here.
+    """
 
     async def login(
         callbacks: LoginCallbacks,
@@ -81,6 +159,8 @@ def _lazy_login(module: str, attr: str) -> LoginFn:
             return await fn(callbacks, signal=signal, open_browser=open_browser, **kwargs)
         return await fn(callbacks, signal=signal, **kwargs)
 
+    if requires_paste_prompt:
+        setattr(login, PASTE_PROMPT_ATTR, True)
     return login
 
 
@@ -113,6 +193,12 @@ def create_api_key_login(provider_label: str, auth_url: str, instructions: str =
     Opens the dashboard URL, prompts for a paste, returns the trimmed key:
     prompt for a paste, return the trimmed key (a ``str`` — AuthStore
     stores it as an ``api_key`` credential with ``source="login"``).
+
+    The prompt is the ENTIRE flow, which is why the returned callable tags
+    itself with :data:`PASTE_PROMPT_ATTR`: a host that attaches no
+    ``on_manual_code_input`` cannot log in to any of these providers, so the
+    requirement has to reach the host rather than being discovered as an error
+    after the browser has already been opened.
     """
 
     async def login(callbacks: LoginCallbacks, **_kwargs: Any) -> str:
@@ -120,17 +206,38 @@ def create_api_key_login(provider_label: str, auth_url: str, instructions: str =
         # http.server, ssl, email and 150-odd other modules (~138 ms), and this
         # registry is on the model picker's path — every interactive session
         # paid for a loopback HTTP server it only needs if the user logs in.
-        from local_operator.providers.oauth.callback_server import maybe_await
+        from local_operator.providers.oauth.callback_server import (
+            LoginCancelledError,
+            maybe_await,
+        )
 
+        if callbacks.on_manual_code_input is None:
+            # Checked BEFORE the URL is surfaced. A host with no prompt cannot
+            # finish this flow, and announcing "opening your browser to
+            # authorize" first told the user to go and get a key that was then
+            # refused — the failure this check replaces. Every shipped host now
+            # attaches a prompt (see ``accepts_paste_prompt``), so this is a
+            # contract violation by an embedder rather than a user-facing path,
+            # and it says which hook is missing instead of naming a key prompt
+            # the user was never offered.
+            raise ValueError(
+                f"{provider_label} login reads an API key, but this interface "
+                "provided no on_manual_code_input callback to read it with."
+            )
         if callbacks.on_auth_url is not None:
             await maybe_await(callbacks.on_auth_url(auth_url, instructions=instructions or None))
-        if callbacks.on_manual_code_input is None:
-            raise ValueError(f"{provider_label} login requires an interactive code prompt")
         pasted = await maybe_await(callbacks.on_manual_code_input())
         if pasted is None:
-            raise ValueError(f"{provider_label} login cancelled")
-        return pasted.strip()
+            raise LoginCancelledError(f"{provider_label} login cancelled")
+        key = pasted.strip()
+        if not key:
+            # An empty paste is a CANCEL, not a credential. Storing it would
+            # write a blank api_key row that shadows a working env key and turns
+            # every later request into an auth error with no visible cause.
+            raise LoginCancelledError(f"{provider_label} login cancelled")
+        return key
 
+    setattr(login, PASTE_PROMPT_ATTR, True)
     return login
 
 
@@ -331,7 +438,15 @@ PROVIDER_REGISTRY: list[ProviderDefinition] = [
         id="alibaba-token-plan-oauth",
         search_aliases=("token-plan",),
         name="QwenCloud Token Plan (usage OAuth)",
-        login=_lazy_login("local_operator.providers.oauth.qwencloud", "login_qwencloud_token_plan"),
+        # Paste-requiring as well as device-flow: this login collects the
+        # ``sk-sp-…`` inference key BEFORE it starts the device flow, so it is
+        # unusable from a host that cannot prompt (see
+        # ``login_qwencloud_token_plan``).
+        login=_lazy_login(
+            "local_operator.providers.oauth.qwencloud",
+            "login_qwencloud_token_plan",
+            requires_paste_prompt=True,
+        ),
         store_credentials_as="alibaba-token-plan",
         base_url="https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1",
     ),

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -2563,7 +2563,7 @@ class OperatorApp(App[None]):
         Cancelling (``None``) rather than submitting whatever was half typed:
         a partial key is not a credential, and storing one would write a
         credential row that shadows a working environment key. Unlike the ask
-        picker \u2014 where a partial answer still tells the agent something \u2014 there
+        picker — where a partial answer still tells the agent something — there
         is no useful partial value here.
         """
         block = self._key_prompt
@@ -2907,6 +2907,14 @@ class OperatorApp(App[None]):
         # but NOT latched: /clear does not stop the turn, and latching here
         # denied every later write/exec tool of the run with no prompt.
         self._settle_live_approval()
+        # The login key prompt is the same hazard and was the worse one: the
+        # widget goes with the transcript, but the login worker parked on its
+        # future is not a turn, so nothing else here reached it. Ctrl+L during
+        # a login left the future pending AND `_login_lock` held, so every
+        # later `/login` in the session reported "a login is already in
+        # progress" and offered no prompt — the session could never log in
+        # again. Cancelling frees both.
+        self._settle_key_prompt()
         self._exit_hint = None  # its widget went with the transcript
         self._streaming_block = None
         self._tool_cards = {}
@@ -5770,9 +5778,21 @@ class OperatorApp(App[None]):
             return LoginCallbacks(on_auth_url=on_auth_url, on_progress=on_progress)
 
         label = getattr(definition, "name", None) or getattr(definition, "id", "this provider")
+        # WHICH value the prompt is reading, which decides both its wording and
+        # whether it masks. ``requires_paste_prompt`` means the paste IS the
+        # login and the value is a long-lived API key; the only other way to
+        # reach here is Anthropic's optional fallback, whose paste is a
+        # single-use OAuth ``code#state`` the user needs to read back.
+        secret = bool(getattr(definition, "paste_prompt_required", False))
 
         async def on_manual_code_input() -> str | None:
-            return await self._request_login_key(str(label))
+            # ``sole_path`` tracks ``secret`` here and is a DIFFERENT question
+            # that happens to have the same answer for every provider in the
+            # registry: "is the paste the only way this login can finish?".
+            # Anthropic's is not (the loopback callback is still listening and a
+            # declined paste re-parks), so declining must not be reported as a
+            # cancelled login.
+            return await self._request_login_key(str(label), secret=secret, sole_path=secret)
 
         return LoginCallbacks(
             on_auth_url=on_auth_url,
@@ -5780,7 +5800,9 @@ class OperatorApp(App[None]):
             on_manual_code_input=on_manual_code_input,
         )
 
-    async def _request_login_key(self, provider_label: str) -> str | None:
+    async def _request_login_key(
+        self, provider_label: str, *, secret: bool = True, sole_path: bool = True
+    ) -> str | None:
         """Put a paste prompt in the transcript and await the key.
 
         Awaited by the login flow on this app's own loop (``_login_flow`` runs
@@ -5801,16 +5823,20 @@ class OperatorApp(App[None]):
         # the same reason.
         self._close_subagent_view()
         self._close_aside()
-        block = KeyPromptBlock(provider_label)
+        block = KeyPromptBlock(provider_label, secret=secret, sole_path=sole_path)
         self._key_prompt = block
         self._append_block(block)
         try:
             return await block.wait()
         except asyncio.CancelledError:
-            # The login was cancelled out from under the prompt (teardown, a
-            # reload). Settle it so the block does not sit in the transcript
-            # holding focus for a flow that no longer exists.
-            block.resolve(None)
+            # The prompt task was cancelled. Two different situations arrive
+            # here and the block cannot tell them apart from the cancellation
+            # alone, so it is told: for Anthropic the paste RACES the loopback
+            # callback, and a browser redirect that wins cancels this task on
+            # the SUCCESS path (``LoopbackFlow._await_code`` cancels every
+            # waiter in a ``finally``). Reporting that as a cancelled login put
+            # "login cancelled" directly above the success notice.
+            block.resolve(None, superseded=True)
             raise
         finally:
             block.restore_focus()

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -761,6 +761,14 @@ class OperatorApp(App[None]):
         # answer a question that has already been reported.
         self._ask_screen: AskPickerScreen | None = None
         self._ask_pending: asyncio.Future[dict[str, list[str]] | None] | None = None
+        #: The live "paste your API key" prompt, for the same reason the two
+        #: references above exist: the login coroutine is parked on a future
+        #: only this app resolves, so a teardown that leaves it pending hangs
+        #: the dispose it is waiting behind. Typed as ``Any`` because the widget
+        #: module is imported lazily inside :meth:`_request_login_key` (it is
+        #: needed only by a login, and every interactive session imports this
+        #: module).
+        self._key_prompt: Any = None
         self._approve_all: bool = False
         # What a NEW session opens in, read from config at mount and rewritten
         # by `/approvals default <mode>`. Held beside `_approve_all` rather than
@@ -1337,6 +1345,10 @@ class OperatorApp(App[None]):
         # tool's call is parked on a future only this app resolves, so a live
         # question would hold the dispose it is waiting behind.
         self._settle_ask_picker()
+        # A login's key prompt is the third future in this family, and it
+        # outlives a turn: the flow runs as a worker, not inside the turn, so
+        # nothing else here would ever settle it.
+        self._settle_key_prompt()
         # The working line belongs to the turn being thrown away. Left standing
         # it does two kinds of damage: the widget goes on animating a turn that
         # no longer exists, and the stale `_working_block` reference makes
@@ -2316,6 +2328,9 @@ class OperatorApp(App[None]):
         # future, and an abort it cannot see leaves the turn waiting on a
         # question the user has just asked to stop.
         self._settle_ask_picker()
+        # And a login's key prompt: Ctrl+C with one on screen otherwise left the
+        # prompt holding focus for a flow the user has just interrupted.
+        self._settle_key_prompt()
         if self._session is not None:
             self._session.abort("interrupted")
 
@@ -2536,6 +2551,28 @@ class OperatorApp(App[None]):
                     screen.remove()
             except Exception:  # pragma: no cover - teardown races only
                 logger.debug("ask picker was already gone", exc_info=True)
+
+    def _settle_key_prompt(self) -> None:
+        """Cancel a live API-key prompt, freeing the login parked on it.
+
+        Called by the paths that END a turn or tear the app down, for the same
+        reason those paths settle the approval card and the ``ask`` picker: the
+        login coroutine is awaiting a future that only this app resolves, so
+        leaving it pending stalls a dispose that awaits teardown.
+
+        Cancelling (``None``) rather than submitting whatever was half typed:
+        a partial key is not a credential, and storing one would write a
+        credential row that shadows a working environment key. Unlike the ask
+        picker \u2014 where a partial answer still tells the agent something \u2014 there
+        is no useful partial value here.
+        """
+        block = self._key_prompt
+        self._key_prompt = None
+        if block is not None:
+            try:
+                block.resolve(None)
+            except Exception:  # pragma: no cover - teardown races only
+                logger.debug("key prompt was already settled", exc_info=True)
 
     def _latch_approval_answer(self, answer: str) -> None:
         """What an answer means beyond the one call. Runs BEFORE the future.
@@ -2985,6 +3022,9 @@ class OperatorApp(App[None]):
         # Same window, same hazard: the ask tool's future is resolved by nothing
         # but this app, so a question still on screen would hold the dispose.
         self._settle_ask_picker()
+        # And the login key prompt, which is awaited by a worker rather than by
+        # a turn and so is not covered by either of the two above.
+        self._settle_key_prompt()
         # First, and synchronously: the restore is one write on a driver that
         # is still up, and everything below it can await. An exception in
         # session teardown would otherwise leave the user's shell wearing this
@@ -5679,12 +5719,28 @@ class OperatorApp(App[None]):
         flow in ``App.suspend()`` and so tore the UI down mid-login, then blocked
         on a paste prompt the user had no reason to expect.
 
-        ``on_manual_code_input`` is deliberately ABSENT. The loopback callback
-        server is the real path — it is already listening before the URL is
-        shown, and the browser redirect completes the flow with no typing. A
-        paste prompt is a fallback for a browser on a different machine, which
-        is a CLI situation; offering it here would mean reading stdin while the
-        app owns it.
+        ``on_manual_code_input`` is attached for providers that ACCEPT a paste
+        and for no others, which is two distinct cases:
+
+        - ``requires_paste_prompt`` — the paste IS the login (every "paste your
+          API key" provider, plus the QwenCloud Token Plan, which reads its key
+          before starting a device flow). These have no loopback server and
+          nothing to fall back FROM, so a TUI with no prompt could not log in to
+          them at all: `/login alibaba` opened the browser and then failed with
+          "requires an interactive code prompt" every time.
+        - ``paste_code_flow`` — Anthropic's optional fallback for a browser on
+          another machine, raced against the loopback callback.
+
+        A loopback-only provider still gets NO prompt, which is what the
+        original blanket omission was protecting: there the callback server is
+        already listening before the URL is shown and the redirect completes the
+        flow with no typing, so a prompt would only compete with it.
+
+        The prompt does NOT read stdin — the objection that produced the
+        omission. It is a focused transcript block
+        (:class:`KeyPromptBlock`), the same device the tool-approval gate uses
+        to answer a question the harness would otherwise put to ``input()`` on a
+        terminal Textual owns in raw mode.
         """
         # ``callback_server`` is imported HERE: it drags in http.server, ssl and
         # email (~138 ms, 150-odd modules) for a loopback listener that only a
@@ -5706,7 +5762,60 @@ class OperatorApp(App[None]):
         def on_progress(message: str) -> None:
             self._append_block(NoticeBlock(message, "info"))
 
-        return LoginCallbacks(on_auth_url=on_auth_url, on_progress=on_progress)
+        # ``getattr`` rather than attribute access: ``definition`` is typed
+        # ``object`` here because an embedding host may pass its own provider
+        # record, and a host whose definitions predate this field must degrade
+        # to "no prompt" rather than raising out of a login.
+        if not getattr(definition, "accepts_paste_prompt", False):
+            return LoginCallbacks(on_auth_url=on_auth_url, on_progress=on_progress)
+
+        label = getattr(definition, "name", None) or getattr(definition, "id", "this provider")
+
+        async def on_manual_code_input() -> str | None:
+            return await self._request_login_key(str(label))
+
+        return LoginCallbacks(
+            on_auth_url=on_auth_url,
+            on_progress=on_progress,
+            on_manual_code_input=on_manual_code_input,
+        )
+
+    async def _request_login_key(self, provider_label: str) -> str | None:
+        """Put a paste prompt in the transcript and await the key.
+
+        Awaited by the login flow on this app's own loop (``_login_flow`` runs
+        as a Textual worker), so the block is mounted directly here rather than
+        marshalled across threads — the same reason
+        :meth:`request_tool_approval` mounts its card inline.
+
+        Returns the pasted text, or ``None`` for a cancel, which is exactly the
+        ``on_manual_code_input`` contract. The value is never logged, never
+        echoed, and is not retained by the block once handed over.
+        """
+        from local_operator.tui.widgets.key_prompt import KeyPromptBlock
+
+        # The aside and the subagent page both hide or float over the
+        # transcript, so a prompt mounted behind either would be invisible while
+        # still holding focus — the login would be parked on an answer the user
+        # can neither see nor reach. Same yield the approval gate performs, for
+        # the same reason.
+        self._close_subagent_view()
+        self._close_aside()
+        block = KeyPromptBlock(provider_label)
+        self._key_prompt = block
+        self._append_block(block)
+        try:
+            return await block.wait()
+        except asyncio.CancelledError:
+            # The login was cancelled out from under the prompt (teardown, a
+            # reload). Settle it so the block does not sit in the transcript
+            # holding focus for a flow that no longer exists.
+            block.resolve(None)
+            raise
+        finally:
+            block.restore_focus()
+            if self._key_prompt is block:
+                self._key_prompt = None
 
     async def _login_flow(self, provider: str) -> None:
         """Run the login on the event loop, reporting into the transcript.
@@ -5718,6 +5827,12 @@ class OperatorApp(App[None]):
 
         async def notice(body: str, kind: NoticeKind = "info") -> None:
             self._append_block(NoticeBlock(body, kind))
+
+        # Imported HERE for the same reason ``_login_callbacks`` imports its
+        # own name lazily: ``callback_server`` drags in http.server, ssl and
+        # email (~138 ms) for a loopback listener only a login needs, and this
+        # module is what every interactive session imports.
+        from local_operator.providers.oauth.callback_server import LoginCancelledError
 
         assert self._providers is not None
         if self._login_lock is None:
@@ -5734,6 +5849,15 @@ class OperatorApp(App[None]):
             # warning whenever it becomes visible again (`set_visible(True)`
             # calls `_poll`), and it is hidden right now because the notice
             # above is a transcript block.
+        except LoginCancelledError:
+            # A cancel is an OUTCOME, not a failure. Reported as a red "login
+            # failed: … cancelled" it told the user their own Escape had broken
+            # something, which is both false and the sort of message that sends
+            # someone looking for a problem to fix. The prompt block has already
+            # painted its own "cancelled" receipt, so this stays quiet about the
+            # detail and only closes the sentence the "logging in to …" notice
+            # opened.
+            await notice("login cancelled.", "info")
         except Exception as error:
             await notice(f"login failed: {error}", "error")
         finally:

--- a/local_operator/tui/local_operator.tcss
+++ b/local_operator/tui/local_operator.tcss
@@ -844,6 +844,32 @@ ApprovalBlock:focus {
     background: $lo-tint-select;
 }
 
+/* The login key prompt. Deliberately the SAME language as the approval card
+ * above rather than a variation on it: both are "the app is parked on you"
+ * blocks that take focus and resolve a future, and giving them two visual
+ * idioms would make the user learn the pattern twice.
+ *
+ * Height is content-sized for the same reason: pending is three or four rows
+ * (question, optional instruction, masked value, key hints) and the receipt
+ * collapses to one. Every count comes from the widget's own state rather than
+ * from a width-dependent measurement. */
+KeyPromptBlock {
+    height: auto;
+    background: $lo-surface;
+}
+
+KeyPromptBlock.key-prompt-pending {
+    background: $lo-raised;
+}
+
+/* Focus matters more here than anywhere else in the transcript: every printable
+ * key is captured by this block rather than reaching the composer, so the user
+ * has to be able to see where their typing is going before they paste a secret
+ * into it. Same `tint-select` the other two focusable transcript blocks use. */
+KeyPromptBlock:focus {
+    background: $lo-tint-select;
+}
+
 /* ── dock band (subagent task list + todo list) ────────────────────────── *
  *
  * Sits between the transcript and the composer: a POSITIONER that reserves

--- a/local_operator/tui/widgets/key_prompt.py
+++ b/local_operator/tui/widgets/key_prompt.py
@@ -71,6 +71,11 @@ MASK_MAX_CELLS = 32
 #: ``ApprovalBlock.CHOICES``. Ordered enter -> esc: the affirmative is what the
 #: user came here to do, and the hint row sheds whole choices from the right,
 #: so the key that submits survives to the narrowest terminals.
+#: Cells between two choices on the hint row. Three spaces, matching the gap
+#: ``ApprovalBlock`` puts between its own key hints, so the two prompts the app
+#: parks on read as one surface rather than two.
+HINT_SEPARATOR = "   "
+
 CHOICES: tuple[tuple[str, str], ...] = (
     ("enter", "submit"),
     ("esc", "cancel"),
@@ -80,6 +85,27 @@ CHOICES: tuple[tuple[str, str], ...] = (
 #: ``approval.SPINE_FLOOR_WIDTH``: an alignment edge that only some blocks
 #: honour is not an edge, so the whole transcript sheds it together.
 SPINE_FLOOR_WIDTH = 24
+
+
+def _short_label(label: str) -> str:
+    """A registry name reduced to the company, for use inside a sentence.
+
+    Registry names carry a parenthetical qualifier that exists to disambiguate
+    ROWS IN A LIST (``xAI (Grok API key)``, ``Anthropic (Claude Pro/Max)``,
+    ``QwenCloud Token Plan (usage OAuth)``). Dropped into this prompt's sentence
+    they read as nonsense — ``Paste your xAI (Grok API key) API key`` names the
+    credential twice and parenthesises the wrong half. The user has already
+    chosen the provider by typing it, so the qualifier has no work left to do
+    here; the sentence needs the company.
+
+    Only the trailing parenthetical is removed, and only when something is left:
+    a name that is nothing but a parenthetical keeps it rather than becoming
+    empty.
+    """
+    head, sep, _tail = label.partition(" (")
+    if sep and head.strip():
+        return head.strip()
+    return label
 
 
 class KeyPromptBlock(TranscriptBlock):
@@ -122,20 +148,50 @@ class KeyPromptBlock(TranscriptBlock):
         provider_label: str,
         instructions: str | None = None,
         on_settled: Callable[[], None] | None = None,
+        *,
+        secret: bool = True,
+        sole_path: bool = True,
     ) -> None:
+        """``secret`` says WHICH kind of value this prompt is reading.
+
+        ``True`` (the default, and every paste-a-key provider): a long-lived API
+        key. It is masked, and the prompt asks for a "key".
+
+        ``False``: an OAuth authorization code, which is Anthropic's optional
+        paste fallback. It is single-use and expires in minutes, and it is a
+        long opaque ``code#state`` string a user needs to SEE to check their
+        paste landed whole, so it is echoed. Masking it would cost real
+        legibility to protect a value that is spent on redemption — and calling
+        it an "API key" would send the user hunting a key Anthropic never
+        issued them.
+
+        ``sole_path`` is whether declining ENDS the login. True for a
+        paste-a-key provider: there is nothing else to wait for. False for
+        Anthropic, where the loopback callback is still listening and
+        ``LoopbackFlow._await_code`` re-parks on a declined paste by design, so
+        the login carries on in the browser. Only the receipt depends on it, and
+        it must: reporting "login cancelled" for a login that is still running
+        told the user something false, and their next `/login` was refused with
+        "a login is already in progress".
+        """
         super().__init__()
         self.add_class("key-prompt-card")
+        self.secret = secret
+        self.sole_path = sole_path
         # Both strings come from the provider registry rather than from a model,
         # but they are stripped on the same principle the approval prompt
         # applies to tool arguments: anything reaching a real terminal is
         # stripped at exactly one place, so a later registry entry (or an
         # embedder's own provider definition) cannot introduce CSI that erases
         # the rows above this prompt and repaints a forged one over them.
-        self.provider_label = strip_control_sequences(provider_label)
+        self.provider_label = _short_label(strip_control_sequences(provider_label))
         self.instructions = strip_control_sequences(instructions or "")
         self._typed: list[str] = []
         self._settled = False
         self._submitted: str | None = None
+        #: Set when the prompt was retired because the login completed another
+        #: way (see :meth:`resolve`), so the receipt does not claim a cancel.
+        self._superseded = False
         # `get_running_loop`, not `get_event_loop`: the future must belong to the
         # loop that awaits it, and stating that precondition turns a construction
         # from a sync context into an immediate error rather than a future nobody
@@ -160,16 +216,25 @@ class KeyPromptBlock(TranscriptBlock):
         tests and the renderer both need the length and neither needs the key."""
         return len(self._typed)
 
-    def resolve(self, value: str | None) -> None:
+    def resolve(self, value: str | None, *, superseded: bool = False) -> None:
         """Settle the prompt (idempotent) and repaint it as a receipt.
 
         Idempotent because several paths end one prompt — enter, escape, an
         abort, a transcript clear, unmount — and a second ``set_result`` on a
         settled future raises. Losing that race must not take the app down.
+
+        ``superseded`` means the prompt was retired because the login finished
+        some OTHER way, and it exists because the block cannot tell the two
+        apart from ``value is None`` alone. For Anthropic the paste races the
+        loopback callback: when the browser redirect wins, the paste task is
+        cancelled and this resolves with ``None`` — a SUCCESSFUL login that
+        painted "login cancelled" underneath its own success notice, telling
+        the user their completed login had been cancelled.
         """
         if self._settled:
             return
         self._settled = True
+        self._superseded = superseded
         self._submitted = value
         # The buffer is dropped as soon as the value has been handed over, so a
         # settled block sitting in the transcript is not still holding the
@@ -239,6 +304,23 @@ class KeyPromptBlock(TranscriptBlock):
             return
         if event.key in ("enter", "escape"):
             return
+        if event.key in ("tab", "shift+tab"):
+            # Tab is SWALLOWED while the prompt is live, and this is a security
+            # boundary rather than a focus preference. Textual's default Tab
+            # moves focus to the next focusable widget, which is the composer:
+            # the prompt went on saying it was waiting (its ground differs from
+            # the focused ground by ~1.04:1, which nobody perceives), the user
+            # kept typing their key into the composer, and Enter SENT THE API
+            # KEY TO THE MODEL as a chat message — where it lands in the
+            # transcript in plain text and in the provider's logs. Verified end
+            # to end before this guard existed.
+            #
+            # A prompt the app is parked on owns the keyboard until it is
+            # answered; both ways out (enter, escape) are on this block and are
+            # advertised in its hint row.
+            event.stop()
+            event.prevent_default()
+            return
         if event.key == "backspace":
             if self._typed:
                 self._typed.pop()
@@ -305,9 +387,19 @@ class KeyPromptBlock(TranscriptBlock):
         count = len(self._typed)
         if count == 0:
             return ""
+        if not self.secret:
+            # An OAuth code is echoed: see the ``secret`` note on __init__. The
+            # row's own truncation keeps a long one inside the card.
+            return "".join(self._typed)
         if count <= MASK_MAX_CELLS:
             return MASK_CHAR * count
-        return f"{MASK_CHAR * MASK_MAX_CELLS} {count} chars"
+        # Past the bar's useful length the COUNT is the message, so it is
+        # written first and the bar takes what is left. Written bar-first, the
+        # row helper truncated the count away at narrow widths — at 40 columns a
+        # 33-character and a 300-character paste rendered as the same row, so
+        # "did the whole key arrive" stopped being answerable exactly where the
+        # bar had already stopped answering it.
+        return f"{count} chars {MASK_CHAR * MASK_MAX_CELLS}"
 
     def _build(self) -> RenderableType:
         width = max((self.size.width or 80) - 2, 10)
@@ -315,6 +407,8 @@ class KeyPromptBlock(TranscriptBlock):
         muted = Style(color=theme_mod.semantic_color("muted"))
         dim = Style(color=theme_mod.semantic_color("dim"))
         accent = Style(color=theme_mod.semantic_color("accent"))
+        success = Style(color=theme_mod.semantic_color("success"))
+        danger = Style(color=theme_mod.semantic_color("danger"))
         # The transcript's shared left edge, given up as a whole below the width
         # where it stops being affordable — see ``SPINE_FLOOR_WIDTH``.
         pad = " " * SPINE_INDENT if width >= SPINE_FLOOR_WIDTH else ""
@@ -346,15 +440,38 @@ class KeyPromptBlock(TranscriptBlock):
             # of unanswered-looking prompts is how a user loses track of which
             # one the app is actually waiting on. The submitted key's LENGTH is
             # the receipt, never the key.
+            # The GLYPH carries the outcome, not the sentence, and that is what
+            # makes the two receipts distinguishable when the row is truncated:
+            # at 10-27 columns "… key received" and "… login cancelled" both cut
+            # to the provider name and rendered byte-identical, so the narrowest
+            # terminals could not tell a stored credential from a cancelled one.
+            # Same device and the same two characters ``ApprovalBlock`` uses for
+            # its own settled receipt, and the same pair the transcript's
+            # success/error notices use.
+            if self._superseded:
+                # Says only what this BLOCK knows: it stopped being needed. The
+                # login's own outcome notice, success or failure, follows it.
+                return row(("· ", dim), (f"{self.provider_label} paste no longer needed", muted))
             if self._submitted is None:
-                return row(("· ", dim), (f"{self.provider_label} login cancelled", muted))
+                if not self.sole_path:
+                    # Declining here does not end the login (see ``sole_path``):
+                    # the browser flow is still live, so the receipt says what
+                    # was actually declined and what is still running. Not a
+                    # failure glyph: nothing failed.
+                    return row(
+                        ("· ", dim),
+                        (f"{self.provider_label} paste skipped ", muted),
+                        ("— still waiting for the browser", dim),
+                    )
+                return row(("✗ ", danger), (f"{self.provider_label} login cancelled", muted))
             return row(
-                ("· ", dim),
-                (f"{self.provider_label} key received ", muted),
+                ("✓ ", success),
+                (f"{self.provider_label} {'key' if self.secret else 'code'} received ", muted),
                 (f"({len(self._submitted)} chars)", dim),
             )
 
-        lines = [row(("? ", accent), (f"Paste your {self.provider_label} API key", fg))]
+        noun = "API key" if self.secret else "authorization code"
+        lines = [row(("? ", accent), (f"Paste your {self.provider_label} {noun}", fg))]
         if self.instructions:
             lines.append(row(("  ", dim), (self.instructions, dim)))
         mask = self._mask()
@@ -364,13 +481,30 @@ class KeyPromptBlock(TranscriptBlock):
             # The empty state says what to do rather than leaving a bare caret,
             # because this prompt appears right after the browser opened and the
             # user's attention was somewhere else entirely.
-            lines.append(row(("  ", dim), ("paste or type the key, then press enter", dim)))
+            hint_noun = "key" if self.secret else "code"
+            lines.append(
+                row(("  ", dim), (f"paste or type the {hint_noun}, then press enter", dim))
+            )
 
+        # The hint row sheds WHOLE choices from the right rather than letting
+        # the last one be cut mid-word: `enter submit   esc ca…` teaches a key
+        # that does not exist, and a half-word is not a shorter way of saying
+        # the same thing. Built by measuring rather than by truncating, which is
+        # what the row helper alone would do. ``CHOICES`` is ordered so the key
+        # that SUBMITS survives longest: a prompt that only tells you how to
+        # give up is one you cannot get past.
         hint_parts: list[tuple[str, Style]] = []
+        used = 0
         for index, (key, label) in enumerate(CHOICES):
-            if index:
-                hint_parts.append(("   ", dim))
+            separator = HINT_SEPARATOR if index else ""
+            width_needed = cell_len(separator) + cell_len(key) + cell_len(f" {label}")
+            if used + width_needed > body:
+                break
+            if separator:
+                hint_parts.append((separator, dim))
             hint_parts.append((key, accent))
             hint_parts.append((f" {label}", muted))
-        lines.append(row(*hint_parts))
+            used += width_needed
+        if hint_parts:
+            lines.append(row(*hint_parts))
         return Group(*lines)

--- a/local_operator/tui/widgets/key_prompt.py
+++ b/local_operator/tui/widgets/key_prompt.py
@@ -71,9 +71,14 @@ MASK_MAX_CELLS = 32
 #: ``ApprovalBlock.CHOICES``. Ordered enter -> esc: the affirmative is what the
 #: user came here to do, and the hint row sheds whole choices from the right,
 #: so the key that submits survives to the narrowest terminals.
-#: Cells between two choices on the hint row. Three spaces, matching the gap
-#: ``ApprovalBlock`` puts between its own key hints, so the two prompts the app
-#: parks on read as one surface rather than two.
+#: Cells between two choices on the hint row.
+#:
+#: Three spaces, which is NOT what ``ApprovalBlock`` uses — its hint row joins
+#: choices with ``" · "``. The difference is deliberate: that row carries four
+#: choices whose labels are single words (``deny``, ``allow``), where a middot
+#: is what stops them reading as one phrase. This row has two, each already a
+#: key plus a verb, and a separator glyph between them competes with the ``·``
+#: the settled receipt opens with.
 HINT_SEPARATOR = "   "
 
 CHOICES: tuple[tuple[str, str], ...] = (
@@ -305,15 +310,23 @@ class KeyPromptBlock(TranscriptBlock):
         if event.key in ("enter", "escape"):
             return
         if event.key in ("tab", "shift+tab"):
-            # Tab is SWALLOWED while the prompt is live, and this is a security
+            # TAB is swallowed while the prompt is live, and that is a security
             # boundary rather than a focus preference. Textual's default Tab
             # moves focus to the next focusable widget, which is the composer:
             # the prompt went on saying it was waiting (its ground differs from
             # the focused ground by ~1.04:1, which nobody perceives), the user
             # kept typing their key into the composer, and Enter SENT THE API
-            # KEY TO THE MODEL as a chat message — where it lands in the
-            # transcript in plain text and in the provider's logs. Verified end
-            # to end before this guard existed.
+            # KEY TO THE MODEL as a chat message — into the transcript in plain
+            # text and into the provider's logs. Verified end to end before this
+            # guard existed.
+            #
+            # SHIFT+TAB never reaches here: the app binds it as a PRIORITY
+            # binding (`cycle_effort`), and Textual matches priority bindings
+            # before the focused widget's handlers. It is listed anyway because
+            # this block's own default for a focus key must be "swallow" — if
+            # that app binding is ever narrowed or moved, the safe behaviour is
+            # already here rather than one forgotten line away. It costs nothing
+            # and it is not what stops shift+tab today.
             #
             # A prompt the app is parked on owns the keyboard until it is
             # answered; both ways out (enter, escape) are on this block and are
@@ -448,10 +461,18 @@ class KeyPromptBlock(TranscriptBlock):
             # Same device and the same two characters ``ApprovalBlock`` uses for
             # its own settled receipt, and the same pair the transcript's
             # success/error notices use.
+            # The two informational receipts put their DISTINGUISHING word before
+            # the provider label, because truncation eats the tail: with the
+            # label first, "paste skipped" and "paste no longer needed" both cut
+            # to "· Alibaba Cloud paste…" at 24 columns and below, and those two
+            # are opposites (the login is still running / the login is over).
+            # Same defect the glyphs fixed for success-vs-cancel, one row over.
+            # Success and cancel keep the label first: their glyphs already
+            # separate them, and the label is the more useful lead there.
             if self._superseded:
                 # Says only what this BLOCK knows: it stopped being needed. The
                 # login's own outcome notice, success or failure, follows it.
-                return row(("· ", dim), (f"{self.provider_label} paste no longer needed", muted))
+                return row(("· ", dim), ("no longer needed ", muted), (self.provider_label, dim))
             if self._submitted is None:
                 if not self.sole_path:
                     # Declining here does not end the login (see ``sole_path``):
@@ -460,8 +481,8 @@ class KeyPromptBlock(TranscriptBlock):
                     # failure glyph: nothing failed.
                     return row(
                         ("· ", dim),
-                        (f"{self.provider_label} paste skipped ", muted),
-                        ("— still waiting for the browser", dim),
+                        ("paste skipped ", muted),
+                        (f"{self.provider_label} — still waiting for the browser", dim),
                     )
                 return row(("✗ ", danger), (f"{self.provider_label} login cancelled", muted))
             return row(

--- a/local_operator/tui/widgets/key_prompt.py
+++ b/local_operator/tui/widgets/key_prompt.py
@@ -1,0 +1,376 @@
+"""The in-TUI "paste your API key" prompt.
+
+Why this exists: eleven providers offer an interactive login and eight of them
+have no OAuth at all — their entire login is "open the dashboard, copy the key,
+paste it here" (`create_api_key_login` in the provider registry), plus the
+QwenCloud Token Plan, which reads a key *before* starting its device flow. The
+TUI deliberately shipped no ``on_manual_code_input`` hook, on the reasoning that
+the loopback callback server is the real path and a paste prompt is a CLI
+fallback. That reasoning holds for a loopback provider and is exactly wrong for
+these: there is no callback server, nothing to fall back FROM, so `/login
+alibaba` opened the browser, told the user to copy a key, and then failed with
+"Alibaba Cloud login requires an interactive code prompt" — the login could
+only ever fail, on every one of those providers.
+
+So the TUI answers the paste itself, the same way it already answers tool
+approvals rather than letting the harness call ``input()`` on a terminal Textual
+owns in raw mode.
+
+Design constraints, all inherited from :class:`ApprovalBlock` because this is
+the same kind of surface (a focused transcript block resolving a future the
+flow is parked on):
+
+- The block takes FOCUS, so typed characters reach it rather than the composer.
+- Focus is RESTORED to whatever held it, so pasting a key does not silently
+  move the user out of the composer.
+- Every exit path resolves the future EXACTLY once (:meth:`resolve`). A dropped
+  future is a login coroutine parked forever, so the app also resolves it on
+  abort, on transcript clear, and on unmount.
+
+What it does that the approval prompt does not:
+
+- **The typed value is never echoed.** An API key is a secret that stays on
+  screen in the scrollback of a shared terminal, and screen shares and recorded
+  demos are exactly where `/login` gets run. The row shows the key's LENGTH as
+  a mask, which is the feedback a paste actually needs (did it arrive, did it
+  arrive whole) without the value.
+- **Bracketed paste is handled**, because pasting is the primary input here and
+  a terminal delivers it as one ``Paste`` event rather than as keystrokes.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+
+from rich.cells import cell_len
+from rich.console import Group, RenderableType
+from rich.style import Style
+from rich.text import Text
+from textual import events
+
+from local_operator.ansi import strip_control_sequences
+from local_operator.tui import theme as theme_mod
+from local_operator.tui.widgets.tool_card import truncate_cells
+from local_operator.tui.widgets.transcript import SPINE_INDENT, TranscriptBlock
+
+#: The mask character standing in for one typed/pasted character. A block
+#: rather than an asterisk so a long key reads as a bar whose length is
+#: comparable at a glance, which is the one property of the value the user
+#: needs to check before pressing enter.
+MASK_CHAR = "•"
+
+#: Cells of mask the row will draw before it stops growing and switches to a
+#: count. A 200-character key would otherwise wrap the transcript in dots and
+#: push the hint row off the bottom, and past a certain length the bar has
+#: already answered "did the whole thing arrive".
+MASK_MAX_CELLS = 32
+
+#: What each key does, in the order the hint row prints them. Data rather than
+#: prose so the hint row and the key handler cannot disagree, matching
+#: ``ApprovalBlock.CHOICES``. Ordered enter -> esc: the affirmative is what the
+#: user came here to do, and the hint row sheds whole choices from the right,
+#: so the key that submits survives to the narrowest terminals.
+CHOICES: tuple[tuple[str, str], ...] = (
+    ("enter", "submit"),
+    ("esc", "cancel"),
+)
+
+#: Below this width the two-cell spine indent is given up, matching
+#: ``approval.SPINE_FLOOR_WIDTH``: an alignment edge that only some blocks
+#: honour is not an edge, so the whole transcript sheds it together.
+SPINE_FLOOR_WIDTH = 24
+
+
+class KeyPromptBlock(TranscriptBlock):
+    """One pending API-key paste: a focused prompt row that never echoes.
+
+    Lifecycle: constructed with the provider's label and the instruction the
+    registry entry carries, mounted, focused. :meth:`resolve` settles the future
+    and repaints the row as a receipt — what was asked and whether a key was
+    given — so the transcript keeps the outcome instead of the question simply
+    vanishing.
+
+    The future carries ``str | None``: the pasted text, or ``None`` for a
+    cancel, which is precisely the ``on_manual_code_input`` contract the
+    provider flows expect.
+    """
+
+    #: Always give the prompt a blank row above it: it interrupts the login's
+    #: own progress notices, and flush against them it reads as more output
+    #: rather than as a question waiting on the user.
+    SPACING_LEAD = True
+    SPACING_KIND = "approval"
+
+    #: Focusable so typed characters reach it rather than the composer's buffer.
+    can_focus = True
+
+    #: Escape is bound HERE, unlike ``ApprovalBlock`` which deliberately lets it
+    #: bubble to the app's global stop. The difference is what Escape would
+    #: otherwise do: there it aborts a running turn, which is a coherent answer
+    #: to "may this tool run". Here no turn is running — the app is parked on a
+    #: login — so a bubbling Escape would stop nothing and leave the prompt on
+    #: screen with no way out but typing. Cancelling the login IS the local
+    #: meaning of "stop" while this block owns the keyboard.
+    BINDINGS = [
+        ("enter", "submit", "Submit"),
+        ("escape", "cancel", "Cancel"),
+    ]
+
+    def __init__(
+        self,
+        provider_label: str,
+        instructions: str | None = None,
+        on_settled: Callable[[], None] | None = None,
+    ) -> None:
+        super().__init__()
+        self.add_class("key-prompt-card")
+        # Both strings come from the provider registry rather than from a model,
+        # but they are stripped on the same principle the approval prompt
+        # applies to tool arguments: anything reaching a real terminal is
+        # stripped at exactly one place, so a later registry entry (or an
+        # embedder's own provider definition) cannot introduce CSI that erases
+        # the rows above this prompt and repaints a forged one over them.
+        self.provider_label = strip_control_sequences(provider_label)
+        self.instructions = strip_control_sequences(instructions or "")
+        self._typed: list[str] = []
+        self._settled = False
+        self._submitted: str | None = None
+        # `get_running_loop`, not `get_event_loop`: the future must belong to the
+        # loop that awaits it, and stating that precondition turns a construction
+        # from a sync context into an immediate error rather than a future nobody
+        # ever resolves. (3.14 removed the implicit-loop fallback.)
+        self._future: asyncio.Future[str | None] = asyncio.get_running_loop().create_future()
+        self._on_settled = on_settled
+        self._restore_focus: object | None = None
+        self._refresh_row()
+
+    # -- the awaited half ----------------------------------------------------
+    def wait(self) -> asyncio.Future[str | None]:
+        """The future the login flow awaits. Resolved exactly once."""
+        return self._future
+
+    @property
+    def answered(self) -> bool:
+        return self._settled
+
+    @property
+    def typed_length(self) -> int:
+        """How many characters are held. The value itself is never exposed:
+        tests and the renderer both need the length and neither needs the key."""
+        return len(self._typed)
+
+    def resolve(self, value: str | None) -> None:
+        """Settle the prompt (idempotent) and repaint it as a receipt.
+
+        Idempotent because several paths end one prompt — enter, escape, an
+        abort, a transcript clear, unmount — and a second ``set_result`` on a
+        settled future raises. Losing that race must not take the app down.
+        """
+        if self._settled:
+            return
+        self._settled = True
+        self._submitted = value
+        # The buffer is dropped as soon as the value has been handed over, so a
+        # settled block sitting in the transcript is not still holding the
+        # user's key in memory for the rest of the session.
+        self._typed = []
+        if not self._future.done():
+            self._future.set_result(value)
+        self.remove_class("key-prompt-pending")
+        self._refresh_row()
+        self.finalize()
+        if self._on_settled is not None:
+            self._on_settled()
+
+    # -- keys ---------------------------------------------------------------
+    def action_submit(self) -> None:
+        """Enter: hand over what was typed, or cancel when nothing was.
+
+        An empty submit is a CANCEL rather than an empty key, matching the CLI
+        prompt's "empty to cancel" and the registry's own guard. Storing an
+        empty string would write a blank credential row that shadows a working
+        environment key and turns every later request into an auth failure with
+        no visible cause.
+        """
+        typed = "".join(self._typed).strip()
+        self.resolve(typed or None)
+
+    def action_cancel(self) -> None:
+        self.resolve(None)
+
+    async def _on_paste(self, event: events.Paste) -> None:
+        """Take a bracketed paste as a whole.
+
+        Pasting is the PRIMARY way a key arrives here, and a terminal delivers
+        it as one ``Paste`` event, not as a stream of key events — without this
+        handler a pasted key would be silently dropped and the user would be
+        looking at an empty prompt after a paste that appeared to work.
+
+        Newlines are stripped rather than treated as a submit: a key copied out
+        of a dashboard frequently carries a trailing newline, and letting that
+        submit would make the paste and the confirmation the same gesture, with
+        no chance to see the mask first. Control characters are stripped for the
+        same reason the constructor strips its labels.
+        """
+        if self._settled:
+            return
+        text = strip_control_sequences(event.text).replace("\n", "").replace("\r", "")
+        if text:
+            self._typed.extend(text)
+            self._refresh_row()
+        event.stop()
+        event.prevent_default()
+
+    async def _on_key(self, event: events.Key) -> None:
+        """Collect printable characters and handle backspace.
+
+        Runs BEFORE ``BINDINGS`` (Textual dispatches the focused widget's own
+        handlers first), so enter and escape are excluded by hand and left to
+        their actions.
+
+        Unlike ``ApprovalBlock``, a printable key is NOT passed through to the
+        composer. There the answer keys are a tiny set and anything else is the
+        user typing their next instruction; here every printable character is
+        the answer, and forwarding them would scatter a secret across the
+        composer one character at a time.
+        """
+        if self._settled:
+            return
+        if event.key in ("enter", "escape"):
+            return
+        if event.key == "backspace":
+            if self._typed:
+                self._typed.pop()
+                self._refresh_row()
+            event.stop()
+            event.prevent_default()
+            return
+        if event.is_printable and event.character:
+            self._typed.append(event.character)
+            self._refresh_row()
+            event.stop()
+            event.prevent_default()
+
+    def on_click(self, event) -> None:  # type: ignore[no-untyped-def]
+        """Clicking an unsettled prompt takes focus back so typing works again.
+
+        The way back if focus moved elsewhere; without it the question would sit
+        on screen with no discoverable way to answer it.
+        """
+        if self._settled:
+            return
+        self.focus()
+        event.stop()
+
+    def on_mount(self) -> None:
+        """Take focus, remembering what had it so it can be handed back."""
+        self.add_class("key-prompt-pending")
+        screen = self.screen
+        self._restore_focus = screen.focused if screen is not None else None
+        self.focus()
+
+    def restore_focus(self) -> None:
+        """Return focus to whatever held it when the prompt appeared."""
+        widget = self._restore_focus
+        self._restore_focus = None
+        if widget is not None and getattr(widget, "is_attached", False):
+            widget.focus()  # type: ignore[attr-defined]
+
+    # -- rendering ----------------------------------------------------------
+    def _refresh_row(self) -> None:
+        """Rebuild the card at its own width.
+
+        Bypasses the finalize guard on purpose: a settled prompt still has to
+        re-fit on resize, and the content is a pure function of state — the same
+        discipline ``ApprovalBlock._refresh_row`` applies.
+        """
+        was_finalized = self._finalized
+        self._finalized = False
+        try:
+            self.set_content(self._build())
+        finally:
+            self._finalized = was_finalized
+
+    def on_resize(self, event: object) -> None:
+        self._refresh_row()
+
+    def _mask(self) -> str:
+        """The typed value as a mask, or a count once it outgrows the row.
+
+        The count is the honest degradation: past ``MASK_MAX_CELLS`` the bar has
+        stopped being comparable at a glance anyway, and a number still answers
+        the only question the user has (did the whole key arrive).
+        """
+        count = len(self._typed)
+        if count == 0:
+            return ""
+        if count <= MASK_MAX_CELLS:
+            return MASK_CHAR * count
+        return f"{MASK_CHAR * MASK_MAX_CELLS} {count} chars"
+
+    def _build(self) -> RenderableType:
+        width = max((self.size.width or 80) - 2, 10)
+        fg = Style(color=theme_mod.semantic_color("fg"))
+        muted = Style(color=theme_mod.semantic_color("muted"))
+        dim = Style(color=theme_mod.semantic_color("dim"))
+        accent = Style(color=theme_mod.semantic_color("accent"))
+        # The transcript's shared left edge, given up as a whole below the width
+        # where it stops being affordable — see ``SPINE_FLOOR_WIDTH``.
+        pad = " " * SPINE_INDENT if width >= SPINE_FLOOR_WIDTH else ""
+        body = max(width - len(pad), 1)
+
+        def row(*parts: tuple[str, Style]) -> Text:
+            """One line, truncated to the body width with its styling intact.
+
+            Truncation is applied PER PART against the room the earlier parts
+            left, rather than to a flattened string: cutting the joined plain
+            text and restyling it afterwards is how a row ends up with its
+            colours one character out of step with its words.
+            """
+            line = Text(pad)
+            remaining = body
+            for text, style in parts:
+                if remaining <= 0:
+                    break
+                fitted = truncate_cells(text, remaining)
+                if not fitted:
+                    break
+                line.append(fitted, style=style)
+                remaining -= cell_len(fitted)
+            return line
+
+        if self._settled:
+            # The receipt. It states the OUTCOME rather than repeating the
+            # question, because the question is answered and a transcript full
+            # of unanswered-looking prompts is how a user loses track of which
+            # one the app is actually waiting on. The submitted key's LENGTH is
+            # the receipt, never the key.
+            if self._submitted is None:
+                return row(("· ", dim), (f"{self.provider_label} login cancelled", muted))
+            return row(
+                ("· ", dim),
+                (f"{self.provider_label} key received ", muted),
+                (f"({len(self._submitted)} chars)", dim),
+            )
+
+        lines = [row(("? ", accent), (f"Paste your {self.provider_label} API key", fg))]
+        if self.instructions:
+            lines.append(row(("  ", dim), (self.instructions, dim)))
+        mask = self._mask()
+        if mask:
+            lines.append(row(("  ", dim), (mask, accent)))
+        else:
+            # The empty state says what to do rather than leaving a bare caret,
+            # because this prompt appears right after the browser opened and the
+            # user's attention was somewhere else entirely.
+            lines.append(row(("  ", dim), ("paste or type the key, then press enter", dim)))
+
+        hint_parts: list[tuple[str, Style]] = []
+        for index, (key, label) in enumerate(CHOICES):
+            if index:
+                hint_parts.append(("   ", dim))
+            hint_parts.append((key, accent))
+            hint_parts.append((f" {label}", muted))
+        lines.append(row(*hint_parts))
+        return Group(*lines)

--- a/scripts/shot_login.py
+++ b/scripts/shot_login.py
@@ -1,0 +1,74 @@
+"""Capture a real ``/login <paste-key provider>`` frame from the real OperatorApp.
+
+Evidence harness for the paste-key login prompt, not test infrastructure: it
+drives ``OperatorApp`` (the host that actually loads ``local_operator.tcss`` —
+the lightweight hosts in ``tests/unit/tui`` do not, so a still from one of them
+cannot show a stylesheet change at all) through a genuine ``/login alibaba``
+and exports what the terminal painted.
+
+Usage:
+    env -u NO_COLOR TERM=xterm-256color .venv/bin/python \
+        scripts/shot_login.py out.svg [provider] [keys]
+
+``keys`` is a comma-separated list of Textual key NAMES (``s,k,minus,enter``),
+not a string of characters: ``enter`` and ``escape`` have no character form, so
+a frame of the settled receipt cannot be captured by pressing characters alone.
+
+The provider controller is the REAL one over a throwaway AuthStore in a temp
+directory, so the registry entry, the login thunk and the callbacks under test
+are the shipped ones. Nothing here may reach the network: the paste-key logins
+only open a browser URL and read a key, and ``webbrowser.open`` is stubbed out
+so a capture run cannot fling a browser window at whoever is running it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import tempfile
+import webbrowser
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from local_operator.providers.auth_store import AuthStore  # noqa: E402
+from local_operator.providers.controller import ProviderController  # noqa: E402
+from local_operator.tui.app import OperatorApp  # noqa: E402
+from tests.unit.tui.test_app_pilot import FakeSession, _factory  # noqa: E402
+
+
+async def main() -> None:
+    out = sys.argv[1]
+    provider = sys.argv[2] if len(sys.argv) > 2 else "alibaba"
+    keys = [k for k in (sys.argv[3].split(",") if len(sys.argv) > 3 else []) if k]
+
+    webbrowser.open = lambda *_args, **_kwargs: True  # type: ignore[assignment]
+
+    with tempfile.TemporaryDirectory() as tmp:
+        controller = ProviderController(AuthStore(Path(tmp) / "auth.db"))
+        app = OperatorApp(lambda: _factory(FakeSession()), provider_controller=controller)
+        async with app.run_test(size=(100, 30)) as pilot:
+            await pilot.pause()
+            from local_operator.tui.widgets.editor import Editor
+
+            app.query_one(Editor).text = f"/login {provider}"
+            await pilot.press("enter")
+            # Two settles: the login worker has to start, reach the prompt and
+            # paint it. A single pause captures the frame before the flow runs.
+            for _ in range(20):
+                await pilot.pause()
+                await asyncio.sleep(0.05)
+            for key in keys:
+                await pilot.press(key)
+            # Settle after the keys: submitting resolves the login's future, and
+            # the receipt is painted by the flow that wakes on it, not by the
+            # keystroke — a single pause captures the frame before it lands.
+            for _ in range(10):
+                await pilot.pause()
+                await asyncio.sleep(0.05)
+            app.save_screenshot(out)
+            print(f"wrote {out}")
+
+
+asyncio.run(main())

--- a/tests/unit/providers/test_oauth_flows.py
+++ b/tests/unit/providers/test_oauth_flows.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import hashlib
+import inspect
 import json
 import urllib.parse
 from datetime import datetime, timezone
@@ -674,6 +675,51 @@ async def test_every_paste_key_provider_can_actually_be_logged_into() -> None:
         login = definition.login
         assert login is not None, definition.id
         assert await login(callbacks) == "sk-pasted-key", definition.id
+
+
+def test_cli_hides_an_api_key_and_echoes_an_oauth_code(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Round 1 F2: an API key must not be echoed into the terminal scrollback.
+
+    ``CredentialManager`` and the web-search CLI already read this same class of
+    value through ``getpass``; the login prompt used ``input()``, and making the
+    paste-a-key providers work is what made that path reachable for nine real
+    provider keys.
+
+    The OAuth code branch deliberately stays echoed: it is single-use, expires
+    in minutes, and is a long opaque string the user needs to read back to check
+    the paste landed whole. Asserting BOTH is what makes this a discriminating
+    test rather than one that would pass on a blanket change either way.
+    """
+    import getpass as getpass_mod
+
+    from local_operator.providers.auth_cli import _callbacks_interactive
+    from local_operator.providers.registry import get_provider_definition
+
+    used: list[str] = []
+    monkeypatch.setattr(getpass_mod, "getpass", lambda *a, **k: used.append("getpass") or "sk-x")
+    monkeypatch.setattr("builtins.input", lambda *a, **k: used.append("input") or "code#state")
+
+    key_def = get_provider_definition("alibaba")
+    assert key_def is not None
+    prompt = _callbacks_interactive(key_def).on_manual_code_input
+    assert prompt is not None
+    assert asyncio.run(_maybe(prompt())) == "sk-x"
+    assert used == ["getpass"], used
+
+    used.clear()
+    code_def = get_provider_definition("anthropic")
+    assert code_def is not None
+    prompt = _callbacks_interactive(code_def).on_manual_code_input
+    assert prompt is not None
+    assert asyncio.run(_maybe(prompt())) == "code#state"
+    assert used == ["input"], used
+
+
+async def _maybe(value: Any) -> Any:
+    """Await ``value`` when it is awaitable; the prompts are coroutines."""
+    if inspect.isawaitable(value):
+        return await value
+    return value
 
 
 async def test_paste_key_login_treats_an_empty_paste_as_a_cancel() -> None:

--- a/tests/unit/providers/test_oauth_flows.py
+++ b/tests/unit/providers/test_oauth_flows.py
@@ -603,9 +603,15 @@ def test_xai_refresh_keeps_old_refresh_token_when_response_omits_one() -> None:
     assert creds["expires"] < int(time.time() * 1000) + 3600_000
 
 
-async def test_paste_prompt_gated_to_paste_code_flow_providers() -> None:
-    """PR-02: the CLI attaches the paste prompt ONLY for paste_code_flow
-    providers, and it is async (loop-friendly)."""
+async def test_paste_prompt_gated_to_providers_that_accept_one() -> None:
+    """PR-02: the CLI attaches the paste prompt to providers that ACCEPT one,
+    and to no others, and it is async (loop-friendly).
+
+    Three cases, because there are three and reading them as two is the defect:
+    a provider whose login IS the paste (``alibaba``), Anthropic's optional
+    fallback beside its loopback flow, and a loopback-only provider where a
+    prompt would race the HTTP callback and block the terminal.
+    """
     from local_operator.providers.auth_cli import _callbacks_interactive
     from local_operator.providers.registry import get_provider_definition
 
@@ -615,9 +621,100 @@ async def test_paste_prompt_gated_to_paste_code_flow_providers() -> None:
     assert paste_callbacks.on_manual_code_input is not None
     assert asyncio.iscoroutinefunction(paste_callbacks.on_manual_code_input)
 
+    # The regression this file previously asserted the wrong way round: a
+    # paste-a-key provider has no loopback path at all, so a host that attaches
+    # no prompt makes its login fail every single time.
+    alibaba_def = get_provider_definition("alibaba")
+    assert alibaba_def is not None and alibaba_def.paste_prompt_required
+    key_callbacks = _callbacks_interactive(alibaba_def)
+    assert key_callbacks.on_manual_code_input is not None
+    assert asyncio.iscoroutinefunction(key_callbacks.on_manual_code_input)
+
     openai_def = get_provider_definition("openai")
-    assert openai_def is not None and not openai_def.paste_code_flow
+    assert openai_def is not None and not openai_def.accepts_paste_prompt
     assert _callbacks_interactive(openai_def).on_manual_code_input is None
+
+
+async def test_every_paste_key_provider_can_actually_be_logged_into() -> None:
+    """The class-level regression: `/login <provider>` must never be a flow
+    that can only fail.
+
+    Enumerates every provider offering an interactive login and drives each
+    one's registered login callable with the CLI's own callbacks, rather than
+    checking the two the bug report happened to name. The reported failure
+    ("QwenCloud Token Plan login requires an interactive key prompt") was one
+    of EIGHT providers in this state, and a test naming providers individually
+    is exactly what let the other seven ship.
+
+    Only the paste-a-key providers are driven to completion here: they are the
+    ones whose whole login is local. A loopback/device provider is asserted to
+    be offered no prompt, which is the other half of the contract.
+    """
+    from local_operator.providers.auth_cli import _callbacks_interactive
+    from local_operator.providers.registry import PROVIDER_REGISTRY
+
+    drivable = [
+        p
+        for p in PROVIDER_REGISTRY
+        # The QwenCloud Token Plan requires a paste too, but continues into a
+        # device flow that would reach the network; it is driven with a mock
+        # transport in ``test_qwencloud_token_plan_login_captures_key_and_device_grant``.
+        if p.login is not None and p.paste_prompt_required and p.id != "alibaba-token-plan-oauth"
+    ]
+    # A non-zero control: if the filter ever matches nothing (a renamed field, a
+    # registry refactor) the loop below would pass by doing nothing at all.
+    assert len(drivable) >= 8, [p.id for p in drivable]
+
+    for definition in drivable:
+        callbacks = _callbacks_interactive(definition)
+        assert callbacks.on_manual_code_input is not None, definition.id
+        # Substitute the terminal read; everything else is the shipped path,
+        # including the registry's own login callable.
+        callbacks.on_manual_code_input = lambda: "sk-pasted-key"
+        login = definition.login
+        assert login is not None, definition.id
+        assert await login(callbacks) == "sk-pasted-key", definition.id
+
+
+async def test_paste_key_login_treats_an_empty_paste_as_a_cancel() -> None:
+    """An empty submit must not become a stored blank credential.
+
+    A blank ``api_key`` row is worse than no row: it shadows a working
+    environment key in the stream-time cascade, so every later request fails to
+    authenticate with nothing on screen to explain why.
+    """
+    from local_operator.providers.oauth.callback_server import LoginCancelledError
+    from local_operator.providers.registry import get_provider_definition
+
+    definition = get_provider_definition("alibaba")
+    assert definition is not None and definition.login is not None
+
+    for pasted in ("", "   ", None):
+        callbacks = LoginCallbacks(
+            on_auth_url=lambda url, instructions=None: None,
+            on_manual_code_input=lambda value=pasted: value,
+        )
+        with pytest.raises(LoginCancelledError):
+            await definition.login(callbacks)
+
+
+async def test_paste_key_login_reports_a_missing_prompt_without_opening_a_browser() -> None:
+    """A host that provides no prompt is told which hook it is missing, and the
+    user is not first sent to a dashboard to fetch a key that will be refused.
+
+    The ordering is the assertion: before this, the URL was surfaced and only
+    then did the flow discover it could not read anything.
+    """
+    from local_operator.providers.registry import get_provider_definition
+
+    definition = get_provider_definition("alibaba")
+    assert definition is not None and definition.login is not None
+
+    urls: list[str] = []
+    callbacks = LoginCallbacks(on_auth_url=lambda url, instructions=None: urls.append(url))
+    with pytest.raises(ValueError, match="on_manual_code_input"):
+        await definition.login(callbacks)
+    assert urls == [], "the browser must not be opened for a login that cannot complete"
 
 
 async def test_anthropic_login_via_browser_redirect_without_paste(
@@ -749,19 +846,55 @@ async def test_the_loopback_completes_a_login_with_no_manual_input() -> None:
     assert credentials["email"] == "you@example.com"
 
 
-def test_only_anthropic_offers_a_pasted_code_and_none_require_one() -> None:
-    """`paste_code_flow` is a FALLBACK marker, not a requirement.
+def test_only_anthropic_races_a_pasted_code_against_its_callback() -> None:
+    """`paste_code_flow` is a FALLBACK marker, and ONLY that.
 
     It matches the reference implementation exactly: Anthropic is the one
     loopback provider that also accepts a pasted code (for a browser on another
-    machine), and it is raced against the callback rather than awaited. Every
-    other interactive provider must be loopback-or-device-code only, because a
-    provider that silently demands typing is indistinguishable from a hang.
+    machine), raced against the callback rather than awaited. Attaching such a
+    prompt to any other loopback provider blocks the terminal on a line nobody
+    will type.
+
+    This test used to assert something wider and false in its name and
+    docstring — that no provider REQUIRES a paste — while asserting only the
+    narrow set below. Eight providers require one: their whole login is
+    "open the dashboard, paste the key", which is a different property with a
+    different field (``requires_paste_prompt``), asserted in the companion test.
+    Reading the two as one is what shipped `/login alibaba` unable to succeed.
     """
     from local_operator.providers.registry import PROVIDER_REGISTRY
 
     paste = {p.id for p in PROVIDER_REGISTRY if p.login is not None and p.paste_code_flow}
     assert paste == {"anthropic"}, paste
+
+
+def test_paste_key_providers_declare_that_they_require_a_prompt() -> None:
+    """Every paste-a-key login carries the flag hosts gate on.
+
+    Derived from the login callable rather than declared per provider, so this
+    also pins the derivation: a new ``create_api_key_login`` provider must show
+    up here without anyone remembering to set a field.
+    """
+    from local_operator.providers.registry import PROVIDER_REGISTRY
+
+    required = {p.id for p in PROVIDER_REGISTRY if p.login is not None and p.paste_prompt_required}
+    assert required == {
+        "xai",
+        "deepseek",
+        "google",
+        "mistral",
+        "openrouter",
+        "radient",
+        "alibaba",
+        "alibaba-token-plan",
+        "alibaba-token-plan-oauth",
+    }, required
+
+    # And the union a host actually gates on: required plus Anthropic's optional
+    # fallback, and nothing else. A loopback-only provider appearing here would
+    # mean a prompt racing its HTTP callback.
+    accepts = {p.id for p in PROVIDER_REGISTRY if p.login is not None and p.accepts_paste_prompt}
+    assert accepts == required | {"anthropic"}, accepts
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tui/test_login_key_prompt.py
+++ b/tests/unit/tui/test_login_key_prompt.py
@@ -415,21 +415,28 @@ async def test_receipts_stay_distinguishable_when_the_row_is_truncated() -> None
     columns, so the narrowest terminals could not tell a stored credential from
     a cancelled login. The glyph carries the outcome, as it does on the sibling
     approval card."""
-    for width in (100, 27, 20, 14, 10):
+    for width in (100, 27, 24, 20, 14, 10):
         app = _PromptHost()
         async with app.run_test(size=(width, 20)) as pilot:
-            stored = KeyPromptBlock("Alibaba Cloud (Qwen)")
-            await app.mount(stored)
-            await pilot.pause()
-            stored.resolve("sk-abc123")
+            # All FOUR settled states, not just the pair originally filed:
+            # design round 2 (D7) found the two informational receipts
+            # colliding at 14-24 columns by the same mechanism, and they are
+            # opposites — the login is still running versus the login is over.
+            rendered: list[str] = []
+            for value, sole_path, superseded in (
+                ("sk-abc123", True, False),  # key received
+                (None, True, False),  # login cancelled
+                (None, False, False),  # paste skipped, browser still listening
+                (None, True, True),  # superseded: the login finished elsewhere
+            ):
+                block = KeyPromptBlock("Alibaba Cloud (Qwen)", sole_path=sole_path)
+                await app.mount(block)
+                await pilot.pause()
+                block.resolve(value, superseded=superseded)
+                await pilot.pause()
+                rendered.append(_rendered(block))
 
-            cancelled = KeyPromptBlock("Alibaba Cloud (Qwen)")
-            await app.mount(cancelled)
-            await pilot.pause()
-            cancelled.resolve(None)
-            await pilot.pause()
-
-            assert _rendered(stored) != _rendered(cancelled), width
+            assert len(set(rendered)) == 4, (width, rendered)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tui/test_login_key_prompt.py
+++ b/tests/unit/tui/test_login_key_prompt.py
@@ -334,6 +334,292 @@ async def test_every_paste_provider_gets_a_prompt_from_the_tui(tmp_path: Path) -
 
 
 @pytest.mark.asyncio
+async def test_tab_cannot_move_focus_off_a_live_prompt(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Design round 1 D1: one Tab used to send the API key to the MODEL.
+
+    Textual's default Tab moves focus to the next focusable widget, which is the
+    composer. The prompt went on looking live (its unfocused and focused grounds
+    differ by ~1.04:1, which nobody perceives), so the user kept typing, pressed
+    Enter, and the key was submitted as a chat message: into the transcript in
+    plain text and into the provider's logs. Verified end to end before the
+    guard existed.
+
+    The last assertion is the one that matters. Asserting focus alone would pass
+    on a widget that keeps focus and drops the characters.
+    """
+    monkeypatch.setattr("webbrowser.open", lambda *a, **k: True)
+    controller = _controller(tmp_path)
+    session = _LoginSession()
+    app = OperatorApp(lambda: _factory(session), provider_controller=controller)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(pilot, app)
+        await _run_login(pilot, app, "alibaba")
+        prompt = app._key_prompt
+        assert prompt is not None and prompt.has_focus
+
+        for key in ("tab", "shift+tab", "tab"):
+            await pilot.press(key)
+        await pilot.pause()
+        assert prompt.has_focus, "Tab moved focus off a prompt the app is parked on"
+
+        for char in "sk-live9f3c":
+            await pilot.press(char)
+        await pilot.press("enter")
+        for _ in range(40):
+            await pilot.pause()
+            await asyncio.sleep(0.01)
+            if prompt.answered:
+                break
+
+        assert app.query_one(Editor).text == "", "the key was typed into the composer"
+        assert session.prompts == [], "the API key was sent to the model"
+        assert prompt.wait().result() == "sk-live9f3c"
+
+
+@pytest.mark.asyncio
+async def test_declining_anthropics_paste_is_not_reported_as_a_cancelled_login() -> None:
+    """Design round 1 D2: the receipt claimed a cancel while the login ran on.
+
+    Anthropic's paste races the loopback callback, and `_await_code` RE-PARKS on
+    a declined paste by design — the browser flow is still listening. Reporting
+    "login cancelled" told the user something false, and their next `/login` was
+    then refused with "a login is already in progress".
+    """
+    app = _PromptHost()
+    async with app.run_test() as pilot:
+        fallback = KeyPromptBlock("Anthropic (Claude Pro/Max)", secret=False, sole_path=False)
+        await app.mount(fallback)
+        await pilot.pause()
+        await pilot.press("escape")
+        await pilot.pause()
+
+        receipt = _rendered(fallback)
+        assert "cancelled" not in receipt, receipt
+        assert "still waiting for the browser" in receipt, receipt
+
+        # Non-zero control: where the paste IS the only path, the same gesture
+        # still reports a cancelled login, so the assertion above is about
+        # `sole_path` and not about the widget never saying "cancelled".
+        sole = await app.open_prompt("Alibaba Cloud")
+        await pilot.pause()
+        await pilot.press("escape")
+        await pilot.pause()
+        assert "cancelled" in _rendered(sole)
+
+
+@pytest.mark.asyncio
+async def test_receipts_stay_distinguishable_when_the_row_is_truncated() -> None:
+    """Design round 1 D5: success and cancel rendered byte-identical at 10-27
+    columns, so the narrowest terminals could not tell a stored credential from
+    a cancelled login. The glyph carries the outcome, as it does on the sibling
+    approval card."""
+    for width in (100, 27, 20, 14, 10):
+        app = _PromptHost()
+        async with app.run_test(size=(width, 20)) as pilot:
+            stored = KeyPromptBlock("Alibaba Cloud (Qwen)")
+            await app.mount(stored)
+            await pilot.pause()
+            stored.resolve("sk-abc123")
+
+            cancelled = KeyPromptBlock("Alibaba Cloud (Qwen)")
+            await app.mount(cancelled)
+            await pilot.pause()
+            cancelled.resolve(None)
+            await pilot.pause()
+
+            assert _rendered(stored) != _rendered(cancelled), width
+
+
+@pytest.mark.asyncio
+async def test_the_prompt_names_the_provider_once() -> None:
+    """Design round 1 D3: `Paste your xAI (Grok API key) API key`.
+
+    Registry names carry a parenthetical that disambiguates rows in a LIST; in
+    this sentence it names the credential twice. The user has already chosen the
+    provider by typing it.
+    """
+    app = _PromptHost()
+    async with app.run_test(size=(100, 20)) as pilot:
+        block = await app.open_prompt("xAI (Grok API key)")
+        await pilot.pause()
+        assert "Paste your xAI API key" in _rendered(block)
+
+        # A name that is nothing but a parenthetical keeps it rather than
+        # collapsing to an empty provider name.
+        odd = await app.open_prompt("(unnamed)")
+        await pilot.pause()
+        assert "(unnamed)" in _rendered(odd)
+
+
+@pytest.mark.asyncio
+async def test_hint_row_sheds_whole_choices_and_keeps_submit_longest() -> None:
+    """Design round 1 D6: the row cut mid-word (`esc ca…`), teaching a key that
+    does not exist. It sheds whole choices instead, and `enter submit` is the
+    last to go: a prompt that only tells you how to give up is one you cannot
+    get past."""
+    seen = []
+    for width in (100, 24, 16, 12):
+        app = _PromptHost()
+        async with app.run_test(size=(width, 20)) as pilot:
+            block = await app.open_prompt("Alibaba Cloud")
+            await pilot.pause()
+            lines = _rendered(block).split("\n")
+            hint = [line for line in lines if "submit" in line or "cancel" in line]
+            seen.append((width, hint))
+            for line in hint:
+                assert "ca…" not in line and "canc…" not in line, (width, line)
+
+    assert any("cancel" in "".join(h) for _w, h in seen), seen
+    assert any(h and "cancel" not in "".join(h) for _w, h in seen), seen
+
+
+@pytest.mark.asyncio
+async def test_a_long_paste_reports_its_length_at_narrow_widths() -> None:
+    """Design round 1 D4: past the bar's useful length the COUNT is the message.
+
+    Written bar-first it was truncated away, so at 40 columns a 33-character and
+    a 300-character paste rendered as the same row and "did the whole key
+    arrive" stopped being answerable exactly where the bar had stopped answering
+    it.
+    """
+    from textual.events import Paste
+
+    for width in (100, 40, 24, 16):
+        app = _PromptHost()
+        async with app.run_test(size=(width, 20)) as pilot:
+            short = KeyPromptBlock("Alibaba Cloud")
+            await app.mount(short)
+            await pilot.pause()
+            short.post_message(Paste("k" * 33))
+
+            long = KeyPromptBlock("Alibaba Cloud")
+            await app.mount(long)
+            await pilot.pause()
+            long.post_message(Paste("k" * 300))
+            await pilot.pause()
+
+            assert "33 chars" in _rendered(short), width
+            assert "300 chars" in _rendered(long), width
+            assert _rendered(short) != _rendered(long), width
+
+
+@pytest.mark.asyncio
+async def test_clearing_the_transcript_frees_the_login(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Round 1 F1: Ctrl+L during a login used to wedge `/login` for the session.
+
+    The widget goes with the transcript, but the login worker parked on its
+    future is NOT a turn, so neither the approval settle nor anything else in
+    the clear hook reached it. The future stayed pending and `_login_lock`
+    stayed held, so every later `/login` answered "a login is already in
+    progress" and offered no prompt — unrecoverable without restarting.
+
+    The second login at the end is the part that matters: settling the future
+    alone would satisfy a weaker assertion while leaving the lock held.
+    """
+    monkeypatch.setattr("webbrowser.open", lambda *a, **k: True)
+    controller = _controller(tmp_path)
+    app = OperatorApp(lambda: _factory(_LoginSession()), provider_controller=controller)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(pilot, app)
+        await _run_login(pilot, app, "alibaba")
+        block = app._key_prompt
+        assert block is not None
+
+        await pilot.press("ctrl+l")
+        for _ in range(30):
+            await pilot.pause()
+            await asyncio.sleep(0.01)
+
+        assert block.answered, "the login is parked on a future nothing will resolve"
+        assert block.wait().result() is None
+        assert app._login_lock is None or not app._login_lock.locked()
+
+        await _run_login(pilot, app, "xai")
+        assert len(list(app.query(KeyPromptBlock))) == 1, "a later /login must still work"
+
+
+@pytest.mark.asyncio
+async def test_an_oauth_code_paste_is_echoed_and_named_a_code() -> None:
+    """Round 1 F3: the prompt must not call an OAuth code an "API key".
+
+    Anthropic's fallback pastes a single-use `code#state`, not a key. Calling it
+    a key sends the user hunting a credential Anthropic never issued, and
+    masking it hides a long opaque string they need to read back to check the
+    paste landed whole. It is spent on redemption, so echoing costs nothing.
+    """
+    app = _PromptHost()
+    async with app.run_test() as pilot:
+        block = KeyPromptBlock("Anthropic (Claude Pro/Max)", secret=False)
+        await app.mount(block)
+        await pilot.pause()
+        text = _rendered(block)
+        assert "authorization code" in text, text
+        assert "API key" not in text, text
+
+        for char in "abc123":
+            await pilot.press(char)
+        await pilot.pause()
+        # Echoed, not masked — the opposite of the API-key case.
+        assert "abc123" in _rendered(block)
+        assert MASK_CHAR not in _rendered(block)
+
+
+@pytest.mark.asyncio
+async def test_secret_and_code_prompts_are_wired_from_the_registry(tmp_path: Path) -> None:
+    """The `secret` choice is the registry's, not a per-call guess.
+
+    Non-zero control on both sides: a paste-a-key provider masks, Anthropic's
+    fallback echoes, so neither answer can be a constant.
+    """
+    controller = _controller(tmp_path)
+    app = OperatorApp(lambda: _factory(_LoginSession()), provider_controller=controller)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(pilot, app)
+        alibaba = controller.provider("alibaba")
+        anthropic = controller.provider("anthropic")
+        assert alibaba is not None and anthropic is not None
+        assert alibaba.paste_prompt_required and not anthropic.paste_prompt_required
+        # Both are offered a prompt; they differ only in what it reads.
+        assert app._login_callbacks(alibaba).on_manual_code_input is not None
+        assert app._login_callbacks(anthropic).on_manual_code_input is not None
+
+
+@pytest.mark.asyncio
+async def test_a_superseded_prompt_does_not_claim_a_cancel() -> None:
+    """Round 1 F4: a SUCCESSFUL Anthropic login painted "login cancelled".
+
+    The paste races the loopback callback; when the browser redirect wins,
+    `_await_code` cancels every waiter in a `finally`, so the prompt task is
+    cancelled on the success path. Resolving that as a plain `None` printed
+    "login cancelled" directly above the success notice.
+    """
+    app = _PromptHost()
+    async with app.run_test() as pilot:
+        block = await app.open_prompt("Anthropic (Claude Pro/Max)")
+        await pilot.pause()
+        block.resolve(None, superseded=True)
+        await pilot.pause()
+
+        receipt = _rendered(block)
+        assert "cancelled" not in receipt, receipt
+        assert "no longer needed" in receipt, receipt
+        # Still a cancel to the flow: no value was pasted.
+        assert block.wait().result() is None
+
+        # And the ordinary cancel still says cancelled, or the assertion above
+        # would pass on a block that never says it either way.
+        other = await app.open_prompt("Alibaba Cloud")
+        await pilot.pause()
+        other.resolve(None)
+        await pilot.pause()
+        assert "cancelled" in _rendered(other)
+
+
+@pytest.mark.asyncio
 async def test_teardown_settles_a_live_prompt(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/unit/tui/test_login_key_prompt.py
+++ b/tests/unit/tui/test_login_key_prompt.py
@@ -1,0 +1,353 @@
+"""`/login <paste-a-key provider>`: the prompt the TUI never had.
+
+The reported failure was `/login alibaba-token-plan` ending in
+`login failed: QwenCloud Token Plan login requires an interactive key prompt`.
+Eleven providers offer an interactive login and nine of them read a key from the
+user; the TUI attached no `on_manual_code_input` at all, so for those nine the
+flow could only ever fail. It was not a QwenCloud bug and it was not reachable
+from any provider-specific test.
+
+So the tests here are split by what they can each see:
+
+* The REGISTRY-driven test at the bottom runs the real `ProviderController`
+  over a temp `AuthStore` and drives `/login` end to end, because the defect
+  lived in the seam between the registry's requirement and the app's callbacks
+  and neither side alone could show it.
+* The widget tests drive real keys against `KeyPromptBlock`, because the
+  masking and the never-echo property are keystroke-level guarantees a test
+  calling the actions directly would not check.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any
+
+import pytest
+from textual.app import App, ComposeResult
+
+from local_operator.tui.app import OperatorApp
+from local_operator.tui.widgets.editor import Editor
+from local_operator.tui.widgets.key_prompt import MASK_CHAR, KeyPromptBlock
+from local_operator.tui.widgets.transcript import NoticeBlock, TranscriptView
+from tests.unit.tui.test_app_pilot import FakeSession, _factory
+
+
+class _PromptHost(App[None]):
+    """A host whose only job is to own the block under test."""
+
+    def compose(self) -> ComposeResult:
+        return iter(())
+
+    async def open_prompt(self, label: str = "Alibaba Cloud") -> KeyPromptBlock:
+        block = KeyPromptBlock(label)
+        await self.mount(block)
+        return block
+
+
+def _rendered(block: KeyPromptBlock) -> str:
+    """Everything the block draws, flattened — what a user could read off it."""
+    from tests.unit.tui.test_app_pilot import _renderable_plain
+
+    content = block._content
+    assert content is not None
+    return _renderable_plain(content)
+
+
+@pytest.mark.asyncio
+async def test_typed_key_is_masked_and_never_rendered() -> None:
+    """The value is a secret: it is masked on screen and absent from the render.
+
+    `/login` gets run on shared screens and in recorded demos, and the key stays
+    in the scrollback afterwards. The mask still has to answer "did my paste
+    arrive, and did it arrive whole", which is what the per-character length is
+    for.
+    """
+    app = _PromptHost()
+    async with app.run_test() as pilot:
+        block = await app.open_prompt()
+        await pilot.pause()
+        for char in "sk-secret1":
+            await pilot.press(char)
+        await pilot.pause()
+
+        text = _rendered(block)
+        assert "sk-secret1" not in text, text
+        assert MASK_CHAR * 10 in text, text
+        assert block.typed_length == 10
+
+
+@pytest.mark.asyncio
+async def test_backspace_edits_and_enter_submits_the_real_value() -> None:
+    """The block reports what was typed, not what it displayed."""
+    app = _PromptHost()
+    async with app.run_test() as pilot:
+        block = await app.open_prompt()
+        await pilot.pause()
+        for char in "sk-abcX":
+            await pilot.press(char)
+        await pilot.press("backspace")
+        await pilot.pause()
+        assert block.typed_length == 6
+
+        await pilot.press("enter")
+        await pilot.pause()
+        assert block.wait().result() == "sk-abc"
+        assert block.answered
+
+
+@pytest.mark.asyncio
+async def test_pasted_key_arrives_whole() -> None:
+    """A bracketed paste is ONE event, not a stream of keys.
+
+    Pasting is the primary gesture here, so without a `Paste` handler the key
+    would be silently dropped and the user would be looking at an empty prompt
+    after a paste that appeared to work. The trailing newline a dashboard copy
+    carries must not submit on its own, or the paste and the confirmation become
+    the same gesture.
+    """
+    from textual.events import Paste
+
+    app = _PromptHost()
+    async with app.run_test() as pilot:
+        block = await app.open_prompt()
+        await pilot.pause()
+        block.post_message(Paste("sk-pasted-secret\n"))
+        await pilot.pause()
+
+        assert block.typed_length == len("sk-pasted-secret")
+        assert not block.answered, "a trailing newline must not submit the paste"
+        assert "sk-pasted-secret" not in _rendered(block)
+
+        await pilot.press("enter")
+        await pilot.pause()
+        assert block.wait().result() == "sk-pasted-secret"
+
+
+@pytest.mark.asyncio
+async def test_escape_and_empty_enter_both_cancel() -> None:
+    """Two ways out, one outcome: `None`, never an empty-string credential.
+
+    An empty key stored as a credential shadows a working environment key in the
+    stream-time cascade, so every later request fails to authenticate with
+    nothing on screen to explain it.
+    """
+    for keys in (["escape"], ["enter"], ["space", "enter"]):
+        app = _PromptHost()
+        async with app.run_test() as pilot:
+            block = await app.open_prompt()
+            await pilot.pause()
+            for key in keys:
+                await pilot.press(key)
+            await pilot.pause()
+            assert block.answered, keys
+            assert block.wait().result() is None, keys
+
+
+@pytest.mark.asyncio
+async def test_resolve_is_idempotent() -> None:
+    """Several paths end one prompt (enter, escape, abort, unmount, clear) and a
+    second `set_result` on a settled future raises. Losing that race must not
+    take the app down."""
+    app = _PromptHost()
+    async with app.run_test() as pilot:
+        block = await app.open_prompt()
+        await pilot.pause()
+        block.resolve("sk-first")
+        block.resolve("sk-second")
+        block.resolve(None)
+        assert block.wait().result() == "sk-first"
+
+
+@pytest.mark.asyncio
+async def test_settled_block_stops_holding_the_key() -> None:
+    """A settled prompt sits in the transcript for the rest of the session; it
+    must not still be holding the user's key in memory while it does."""
+    app = _PromptHost()
+    async with app.run_test() as pilot:
+        block = await app.open_prompt()
+        await pilot.pause()
+        for char in "sk-xyz":
+            await pilot.press(char)
+        await pilot.press("enter")
+        await pilot.pause()
+        assert block.typed_length == 0
+        assert "sk-xyz" not in _rendered(block)
+
+
+# --- the seam: registry requirement -> app callbacks -> stored credential ----
+
+
+class _LoginSession(FakeSession):
+    pass
+
+
+async def _boot(pilot, app: OperatorApp) -> None:
+    for _ in range(40):
+        await pilot.pause()
+        if app._session is not None:
+            return
+
+
+def _controller(tmp_path: Path):
+    """The REAL ProviderController over a throwaway store.
+
+    A fake controller cannot show this defect: the requirement is declared by
+    the shipped registry and honoured (or not) by the app's callbacks, so a
+    stub standing in for either end is a test of the stub.
+    """
+    from local_operator.providers.auth_store import AuthStore
+    from local_operator.providers.controller import ProviderController
+
+    return ProviderController(AuthStore(tmp_path / "auth.db"))
+
+
+async def _run_login(pilot, app: OperatorApp, provider: str) -> None:
+    editor = app.query_one(Editor)
+    editor.text = f"/login {provider}"
+    await pilot.pause()
+    if editor.picker.is_open():
+        await pilot.press("escape")
+        await pilot.pause()
+    await pilot.press("enter")
+    for _ in range(40):
+        await pilot.pause()
+        await asyncio.sleep(0.01)
+        if app.query(KeyPromptBlock):
+            return
+
+
+def _notices(app: OperatorApp) -> list[str]:
+    return [
+        block._text
+        for block in app.query_one(TranscriptView).blocks()
+        if isinstance(block, NoticeBlock)
+    ]
+
+
+@pytest.mark.asyncio
+async def test_login_to_a_paste_key_provider_stores_the_key(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The reported bug, end to end, through the real registry and store.
+
+    Before this change the flow reached `login failed: … requires an
+    interactive code prompt` with nothing to type into.
+    """
+    monkeypatch.setattr("webbrowser.open", lambda *a, **k: True)
+    controller = _controller(tmp_path)
+    app = OperatorApp(lambda: _factory(_LoginSession()), provider_controller=controller)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(pilot, app)
+        await _run_login(pilot, app, "alibaba")
+
+        prompts = list(app.query(KeyPromptBlock))
+        assert prompts, f"no key prompt was offered; notices={_notices(app)}"
+        prompt = prompts[0]
+        assert prompt.has_focus, "the prompt must take focus or the keys reach the composer"
+
+        for char in "sk-real-key":
+            await pilot.press(char)
+        await pilot.press("enter")
+        for _ in range(40):
+            await pilot.pause()
+            await asyncio.sleep(0.01)
+            if any("Stored API key" in note for note in _notices(app)):
+                break
+
+    stored = [c for c in controller.auth_store.list_credentials(provider=None)]
+    assert [c.provider for c in stored] == ["alibaba"], stored
+    assert stored[0].data["key"] == "sk-real-key"
+    assert stored[0].data["source"] == "login"
+
+
+@pytest.mark.asyncio
+async def test_cancelling_a_login_stores_nothing_and_is_not_an_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Escape is an outcome, not a failure.
+
+    Reported as a red `login failed: … cancelled` it tells the user their own
+    Escape broke something, which is both false and the kind of message that
+    sends someone hunting a problem that does not exist.
+    """
+    monkeypatch.setattr("webbrowser.open", lambda *a, **k: True)
+    controller = _controller(tmp_path)
+    app = OperatorApp(lambda: _factory(_LoginSession()), provider_controller=controller)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(pilot, app)
+        await _run_login(pilot, app, "alibaba")
+        assert list(app.query(KeyPromptBlock)), _notices(app)
+
+        await pilot.press("escape")
+        for _ in range(40):
+            await pilot.pause()
+            await asyncio.sleep(0.01)
+            if any("cancelled" in note for note in _notices(app)):
+                break
+
+        notices = _notices(app)
+        assert any("cancelled" in note for note in notices), notices
+        assert not any("failed" in note for note in notices), notices
+
+    assert controller.auth_store.list_credentials(provider=None) == []
+
+
+@pytest.mark.asyncio
+async def test_loopback_provider_is_offered_no_prompt(tmp_path: Path) -> None:
+    """The other half of the contract, and the reason the blanket omission
+    existed: for a loopback provider the callback server is already listening,
+    and a prompt racing it leaves the terminal blocked on a line nobody types.
+    """
+    controller = _controller(tmp_path)
+    app = OperatorApp(lambda: _factory(_LoginSession()), provider_controller=controller)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(pilot, app)
+        loopback = controller.provider("openai")
+        assert loopback is not None and not loopback.accepts_paste_prompt
+        assert app._login_callbacks(loopback).on_manual_code_input is None
+
+        # Non-zero control: the same method DOES attach one for a paste provider,
+        # so the None above cannot be a callbacks builder that attaches nothing.
+        paste = controller.provider("alibaba")
+        assert paste is not None
+        assert app._login_callbacks(paste).on_manual_code_input is not None
+
+
+@pytest.mark.asyncio
+async def test_every_paste_provider_gets_a_prompt_from_the_tui(tmp_path: Path) -> None:
+    """Enumerated over the registry rather than checked for the one provider in
+    the bug report: eight others were in the identical state, and a test naming
+    providers individually is what let them ship.
+    """
+    from local_operator.providers.registry import PROVIDER_REGISTRY
+
+    controller = _controller(tmp_path)
+    app = OperatorApp(lambda: _factory(_LoginSession()), provider_controller=controller)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(pilot, app)
+        wanted = [p for p in PROVIDER_REGISTRY if p.login is not None and p.paste_prompt_required]
+        assert len(wanted) >= 8, [p.id for p in wanted]
+        missing = [p.id for p in wanted if app._login_callbacks(p).on_manual_code_input is None]
+        assert missing == [], missing
+
+
+@pytest.mark.asyncio
+async def test_teardown_settles_a_live_prompt(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A prompt still on screen at teardown holds a future the login worker is
+    parked on, and `dispose` awaits teardown — the same hang the approval card
+    and the ask picker are settled to prevent."""
+    monkeypatch.setattr("webbrowser.open", lambda *a, **k: True)
+    controller = _controller(tmp_path)
+    app = OperatorApp(lambda: _factory(_LoginSession()), provider_controller=controller)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(pilot, app)
+        await _run_login(pilot, app, "alibaba")
+        prompt: Any = app._key_prompt
+        assert prompt is not None
+
+    assert prompt.answered, "unmount left the login parked on an unresolved future"
+    assert prompt.wait().result() is None


### PR DESCRIPTION
# PR Description

## Change classification

**C2 — standard / pre-authorized.** A bounded fix to interactive login plus one new TUI widget, with a clean rollback (`git revert`). No foundational auth model change: the credential store, the wire cascade, and every OAuth flow are untouched. No RFC or tracker requested.

## Summary of Changes

Reported symptom, from a live session:

```text
· logging in to alibaba-token-plan-oauth…
✗ login failed: QwenCloud Token Plan login requires an interactive key prompt
· logging in to alibaba-token-plan…

opening your browser to authorize…
https://home.qwencloud.com/billing/subscription/token-plan-individual
Paste your Token Plan API key (sk-sp-…)

✗ login failed: QwenCloud Token Plan login requires an interactive code prompt
```

**It is not a QwenCloud bug.** Eleven providers offer an interactive login and **nine of them read an API key from the user**; no host attached a prompt for any of them. `/login` opened the browser, told the user to copy a key, and then refused it. Those nine logins could only ever fail — in the TUI always, and in the CLI too.

### Root cause: one flag answering two questions

`paste_code_flow` means *"this loopback login **also** accepts a pasted code as a fallback"* — Anthropic only, raced against the HTTP callback. Both hosts gated their paste prompt on it:

```python
manual_input = on_manual_code_input if definition.paste_code_flow else None   # auth_cli.py
```

The paste-a-key providers have **no loopback path at all**. Gating on `paste_code_flow` attached no prompt to precisely the providers whose entire login *is* that prompt, and `create_api_key_login` then raised on the hook it had just been denied. The TUI omitted `on_manual_code_input` deliberately and documented why — the reasoning is correct for a loopback provider and inverted for these.

### The fix

- **`ProviderDefinition` now states the requirement.** `requires_paste_prompt` is derived in `__post_init__` from a tag the login callable sets on itself, so a new `create_api_key_login` provider inherits it rather than depending on someone remembering a field — forgetting it is how this shipped. `accepts_paste_prompt` is the union hosts gate on (required **or** Anthropic's fallback), so a loopback-only provider is still offered nothing: that deadlock is what the original gate protected against and it stays protected.
- **CLI** attaches its prompt on `accepts_paste_prompt`, and asks for an *"API key"* rather than a *"code"* — a user told to paste a "code" goes looking for an OAuth code that does not exist for them.
- **TUI grows `KeyPromptBlock`**, a focused transcript block on the same frame as the approval card (which exists because the harness would otherwise call `input()` on a terminal Textual owns in raw mode — the identical problem). It **never echoes the key**, takes bracketed paste as one event, and resolves exactly once, so a teardown cannot leave a login parked on a dropped future.
- **An empty paste is a cancel, not a blank credential.** A stored empty `api_key` row shadows a working env key in the stream-time cascade, turning every later request into an auth failure with nothing on screen to explain it.
- **A cancel reports as a cancel.** It was surfacing as a red `login failed: … cancelled`, telling the user their own Escape had broken something.
- **The missing-prompt error now names the missing callback and is raised BEFORE the browser opens**, so an embedder is told what it failed to wire instead of a user being sent to fetch a key that will be refused.

## Related Issue(s)

None requested. The PR is the system of record.

## Impact

- **Breaking changes:** none. `paste_code_flow` keeps its meaning and its one member; the two new properties are additive and derived.
- **Security:** the key is masked on screen (`•` per character), never rendered, never logged, and dropped from the widget the moment it is handed over — a settled block in the transcript holds nothing. `/login` is run on shared screens and in recorded demos, and the value stays in scrollback.
- **Rollback:** `git revert` this PR.

## Testing Details

### The bug, reproduced and then fixed

Every paste-a-key provider driven through the **real** CLI entry point (`local-operator login <provider>`), against a throwaway `LOCAL_OPERATOR_CONFIG_DIR`:

```text
BEFORE (origin/main @ 42e5268)
$ echo "sk-test" | local-operator login alibaba
ValueError: Alibaba Cloud login requires an interactive code prompt
$ echo "sk-test" | local-operator login xai
ValueError: xAI login requires an interactive code prompt

AFTER (this branch)
$ echo "sk-test-alibaba" | local-operator login alibaba
Open this URL to authorize:
  https://dashscope-intl.console.aliyun.com/
Paste your DashScope API key
Paste your API key here (empty to cancel): Stored API key for 'alibaba'.
```

All nine, after the fix — each one previously failed:

```text
alibaba              Stored API key for 'alibaba'.
alibaba-token-plan   Stored API key for 'alibaba-token-plan'.
xai                  Stored API key for 'xai'.
openrouter           Stored API key for 'openrouter'.
deepseek             Stored API key for 'deepseek'.
google               Stored API key for 'google'.
mistral              Stored API key for 'mistral'.
radient              Stored API key for 'radient'.
```

Cancel path (empty paste), which must store nothing:

```text
$ printf '\n' | local-operator login alibaba
Paste your API key here (empty to cancel): Login failed: Alibaba Cloud login cancelled
$ # credential rows in the temp store afterwards: none
```

### TUI, driven in the real app

Captured from `OperatorApp` — the host that actually loads `local_operator.tcss`; the lightweight test hosts do not, so a still from one cannot show a stylesheet change at all. Harness: `scripts/shot_login.py`. The provider controller is the **real** `ProviderController` over a temp `AuthStore`, so the registry entry, the login thunk, and the callbacks under test are the shipped ones.

**Before** — `/login alibaba` on `origin/main` @ `42e5268`. The browser is opened, the key is requested, and the login then refuses it. This frame is captured at the base commit and is still current for the defect:

![before](https://raw.githubusercontent.com/damianvtran/local-operator/evidence/login-paste-prompt/shots/before.png)

The frames below are captured at `77065d1`, after the round 1 review remediation, and are current for everything except the two informational receipts, which round 2 reordered (`29a94d3`) and which are shown as measured rows in the round 2 remediation comment rather than as stills.

**After**, empty state — the prompt is focused (`tint-select` ground) and says what to do:

![prompt](https://raw.githubusercontent.com/damianvtran/local-operator/evidence/login-paste-prompt/shots/r2_empty.png)

**After**, characters typed — masked, one dot per character, the value nowhere on screen:

![typed](https://raw.githubusercontent.com/damianvtran/local-operator/evidence/login-paste-prompt/shots/r2_typed.png)

**After**, submitted — the receipt states the length, never the key, and the credential is stored:

![submitted](https://raw.githubusercontent.com/damianvtran/local-operator/evidence/login-paste-prompt/shots/r2_submitted.png)

**After**, Escape — reported as a cancellation, not a failure, and nothing is stored:

![cancelled](https://raw.githubusercontent.com/damianvtran/local-operator/evidence/login-paste-prompt/shots/r2_cancel.png)

### Mutation testing: do the new tests actually catch the bug?

A test that cannot fail proves nothing, so both fixes were reverted in place and the suites re-run.

```text
MUTATION 1 — TUI host never attaches a prompt (pre-fix behaviour)
  tests/unit/tui/test_login_key_prompt.py            5 failed, 6 passed

MUTATION 2 — CLI gates on paste_code_flow again (the original line)
  tests/unit/providers/test_oauth_flows.py           2 failed, 38 passed
    FAILED test_paste_prompt_gated_to_providers_that_accept_one
    FAILED test_every_paste_key_provider_can_actually_be_logged_into - AssertionError: xai

RESTORED — both files restored from copies and re-verified by content, not by
`git diff`: `manual_input = ... if definition.accepts_paste_prompt else None`
  tests/unit/providers                               367 passed
  tests/unit/tui/test_login_key_prompt.py             11 passed
```

The coverage is **enumerated over the registry**, not written per provider — naming providers individually is exactly what let eight of them ship unusable. Both new enumerations carry a non-zero control (`assert len(drivable) >= 8`) so a renamed field cannot make the loop pass by iterating nothing.

Two existing tests asserted the buggy belief and were corrected rather than deleted: `test_only_anthropic_offers_a_pasted_code_and_none_require_one` claimed in its name and docstring that no provider requires a paste, while asserting only the narrow `paste_code_flow` set. Nine require one.

### Automated gates

```text
.venv/bin/python -m flake8 .                                      PASS
uvx --from black==26.1.0 black --check local_operator tests       PASS (355 files)
uvx isort --check-only --profile black local_operator tests       PASS
.venv/bin/python -m pyright --pythonpath .venv/bin/python .       PASS (0 errors)
env -u NO_COLOR TERM=xterm-256color pytest tests/unit -q          PASS (4236 passed, 7 skipped)
```

### Review rounds

Three rounds, both kinds, all recorded as comments on this PR.

| Round | Code | Design | Head reviewed |
| --- | --- | --- | --- |
| 1 | Changes requested (F1-F4) | Changes requested (D1-D6, one blocker) | `5d1b581` |
| 2 | Approve (F5, minor) | Approve (D7/D8, minor) | `77065d1` |
| 3 | see comments | see comments | `29a94d3` |

The blocker was D1: `tab` moved focus off the live prompt to the composer while
the prompt still read as waiting, so the next keystrokes went into the composer
and Enter **sent the API key to the model** as a chat message. Reproduced end to
end, fixed, and pinned by a test whose final assertion is that the session
received nothing.

Two majors were the same class of defect one layer down: F1, where Ctrl+L during
a login left the login lock held and permanently wedged `/login` for the rest of
the session; and F2, where the CLI read API keys through an echoing `input()`.

One finding is explicitly **deferred** rather than fixed: the D3 residual, where
the registry instruction still names the credential a second time above the
prompt row for five providers. The instruction carries the dashboard's own term
for the key, so collapsing it is a copy change across nine registry entries and a
per-provider judgement rather than a rendering fix. Raised for a follow-up.

### Not covered

No live provider call is made with a real key: that needs real third-party credentials. What is proven locally is the whole path up to and including the credential row being written — the flow, the prompt, the storage, and the cancel paths. Sending a stored key over the wire is unchanged by this PR (`get_api_key` and the wire cascade are untouched).

