### PR TITLE
feat(providers): add Z.AI (GLM) as a supported provider

### DIFF
--- a/docs/VERIFICATION.md
+++ b/docs/VERIFICATION.md
@@ -697,7 +697,7 @@ produce a report for a typical user:
 
 | Defect | Fix |
 |---|---|
-| `zai` was in `USAGE_PROVIDERS` with a working fetcher and **no `ProviderDefinition`** — `/login zai` raised, its env var was never read, no code path could supply its credential | deleted (fetcher, set entry, test) |
+| `zai` was in `USAGE_PROVIDERS` with a working fetcher and **no `ProviderDefinition`** — `/login zai` raised, its env var was never read, no code path could supply its credential | deleted (fetcher, set entry, test). **Superseded:** `zai` was re-added as a complete provider — registry entry, `ZAI_API_KEY`/paste login, GLM model rows with pricing, and `fetch_zai_quota` — landing together rather than a fetcher alone. See "Z.AI provider" below. |
 | One fetcher per provider, so Kimi's OAuth-only route made `KIMI_API_KEY` users unreachable; `/provider` advertised quota and the table was empty forever | `_FETCHERS` is now `(oauth, api_key)` pairs; added `fetch_moonshot_balance` (plain Bearer, the key the registry already stores) |
 | DeepSeek had no fetcher despite a documented endpoint and a stored key | added `fetch_deepseek_balance`, one limit per currency (a CNY balance rendered as USD is wrong by ~7x) |
 | Three surfaces disagreed: `/provider` used `is_usable`, bare `/usage` used `has_any_credential`, `/usage <p>` resolved the env tier | all three call one predicate, `ProviderController.can_report_usage` = `is_usable(p) and (has_any_credential(p) or usage_kinds(p)[1])`. `is_usable` alone was too coarse: five of the eight providers are OAuth-only for usage, so an `ANTHROPIC_API_KEY`-only install was advertised four providers it could not read |
@@ -1950,3 +1950,76 @@ provider refused a real PNG, `6956424f` means we corrupted it ourselves.
 Evidence: `tests/unit/compaction/test_snapcompact.py` (persistence round trip)
 and `tests/unit/session/test_compact_now.py` (a non-empty archive replaying as
 valid PNGs through the live render path).
+
+## Z.AI provider (`zai`)
+
+Z.AI (GLM) is a first-class provider: registry definition, model listing,
+usage/quota reporting and cost accounting. It supersedes the earlier removal
+recorded above — the point of that defect was that a fetcher without a
+`ProviderDefinition` is unreachable by construction, so all four halves land
+together here.
+
+**Wire.** `openai-compat` on `https://api.z.ai/api/coding/paas/v4`. The
+coding-plan prefix is deliberate: the general `/api/paas/v4` endpoint accepts
+the same key but bills the account balance instead of coding-plan quota, which
+is a silently wrong budget rather than a visible failure. omp routes GLM over
+the Anthropic-shaped proxy instead; the OpenAI-compatible endpoint was chosen
+here because it needs no new wire client and was verified to stream text, tool
+calls and usage correctly.
+
+**Model rows carry the metadata the listing does not.** `GET /models` answers
+with bare `{id, object, created, owned_by}` — no pricing, no context window, no
+capabilities. Discovery therefore merges live ids OVER the static `glm_models`
+rows rather than replacing them; a listing-only catalogue would report every GLM
+as free, non-caching and 0-context. Prices are USD per million tokens, taken
+from Z.AI's published coding-plan rates and cross-checked against the `z-ai/*`
+listings on OpenRouter (2026-08-17), which is also the `_AGGREGATOR_NAMESPACE`
+fallback for ids the static table does not carry.
+
+**Quota shape, verified against a live account.** `GET
+/api/monitor/usage/quota/limit` returns a `{code,msg,data,success}` envelope
+that reports business-level failure with an HTTP 200, so a successful transport
+is not by itself a usable reading. Two row types share the payload and neither
+reads the way its name suggests:
+
+- `TOKENS_LIMIT` rows on a coding plan carry **only** `percentage` — no
+  absolute used/limit/remaining. The report is built from the fraction and the
+  unit is `percent`; inventing token counts from a percentage would put a
+  fabricated number in front of the user.
+- `TIME_LIMIT` is a **request** allowance, and its fields are inverted relative
+  to every other vendor here: `usage` is the limit, `currentValue` the amount
+  consumed.
+- A `TIME_LIMIT` whose `usageDetails` cover search-prime/web-reader/zread is the
+  separate Zread feature bucket, tagged `tier="zread"` and NOT `shared` —
+  exhausting it stops those tools, not the plan.
+
+Live evidence (real credential, real endpoints, through local-operator's own
+code paths):
+
+```
+fetch_usage(client, "zai")   -> coding plan: max
+  zai:tokens:5hour           Token quota (5 hour)     12% used  ok  resets in 1h
+  zai:tokens:1week           Token quota (1 week)     42% used  ok  resets in 6d4h
+  zai:features:zread:1month  Zread feature quota   0/4000 req   ok  resets in 30d4h
+
+fetch_models("zai")          -> 9 live rows (glm-4.5 … glm-5.3), all ctx=0/unpriced
+merge_models(glm_models, …)  -> 9 rows, glm-5.3 ctx=1,000,000 in=$1.4 out=$4.4
+
+client_for_spec(zai/glm-5.3) -> OpenAICompatClient
+  streaming text : "HELLO_ZAI"   usage in=20 out=33  cost $0.00017320
+  tool calling   : get_weather   {"city":"Toronto"}
+  bad key        : ProviderError: authentication failed (HTTP 401)
+```
+
+Cost math needs no zai-specific code: `_cache_tokens_are_inside_input` keys on
+the WIRE format, so an openai-compat provider gets the correct
+subtract-cached-from-prompt behaviour for free. `calculate_cost` on the real
+1M/1M case returns $5.80 (1.40 + 4.40), and a 1M-prompt/500k-cache-read call
+returns $1.53 — the cache read priced at $0.26/Mtok rather than silently at the
+input rate.
+
+Evidence: `tests/unit/providers/test_usage.py` (three zai cases pinned to a
+payload captured live on 2026-08-17, including the percentage-only rows and the
+200-with-`success:false` path), `tests/unit/providers/test_registry.py`
+(definition, coding-plan base URL, search aliases), and the `/login` picker and
+usage-panel frames captured from the real `OperatorApp`.

--- a/docs/VERIFICATION.md
+++ b/docs/VERIFICATION.md
@@ -1971,10 +1971,14 @@ calls and usage correctly.
 with bare `{id, object, created, owned_by}` — no pricing, no context window, no
 capabilities. Discovery therefore merges live ids OVER the static `glm_models`
 rows rather than replacing them; a listing-only catalogue would report every GLM
-as free, non-caching and 0-context. Prices are USD per million tokens, taken
-from Z.AI's published coding-plan rates and cross-checked against the `z-ai/*`
-listings on OpenRouter (2026-08-17), which is also the `_AGGREGATOR_NAMESPACE`
-fallback for ids the static table does not carry.
+as free, non-caching and 0-context. Prices are USD per million tokens and are
+Z.AI's own DIRECT list rates. They deliberately do not match OpenRouter's
+`z-ai/*` listings, which quote less for most GLM ids (`glm-5.2` at
+$0.462/$1.452 against Z.AI's $1.40/$4.40) because the aggregator resells at its
+own discounted rates — a user billed directly by Z.AI pays the direct rate, so
+quoting the aggregator's number here would under-report every session. The
+OpenRouter namespace remains registered only as the fallback for ids this table
+does not price at all.
 
 **Quota shape, verified against a live account.** `GET
 /api/monitor/usage/quota/limit` returns a `{code,msg,data,success}` envelope

--- a/docs/VERIFICATION.md
+++ b/docs/VERIFICATION.md
@@ -2004,7 +2004,7 @@ code paths):
 fetch_usage(client, "zai")   -> coding plan: max
   zai:tokens:5hour           Token quota (5 hour)     12% used  ok  resets in 1h
   zai:tokens:1week           Token quota (1 week)     42% used  ok  resets in 6d4h
-  zai:features:zread:1month  Zread feature quota   0/4000 req   ok  resets in 30d4h
+  zai:features:zread:1month  Zread quota (1 month) 0/4000 req   ok  resets in 30d4h
 
 fetch_models("zai")          -> 9 live rows (glm-4.5 … glm-5.3), all ctx=0/unpriced
 merge_models(glm_models, …)  -> 9 rows, glm-5.3 ctx=1,000,000 in=$1.4 out=$4.4

--- a/docs/VERIFICATION.md
+++ b/docs/VERIFICATION.md
@@ -1993,9 +1993,15 @@ reads the way its name suggests:
 - `TIME_LIMIT` is a **request** allowance, and its fields are inverted relative
   to every other vendor here: `usage` is the limit, `currentValue` the amount
   consumed.
-- A `TIME_LIMIT` whose `usageDetails` cover search-prime/web-reader/zread is the
-  separate Zread feature bucket, tagged `tier="zread"` and NOT `shared` —
-  exhausting it stops those tools, not the plan.
+- A `TIME_LIMIT` whose `usageDetails` name **no chat model** is the separate
+  Zread feature bucket, tagged `tier="zread"` and NOT `shared` — exhausting it
+  stops those tools, not the plan. The test is spelled in the negative because
+  every positive form is a dependency on a vendor enum: requiring the known
+  feature codes (or requiring the listed codes to be a subset of them) breaks
+  the moment Z.AI renames or adds one, and it breaks toward `shared=True`,
+  which `usage_health` applies to every model — telling a user with most of
+  their token quota intact that the account is depleted. Chat model ids are the
+  stable property, since the account-wide cap is denominated in them.
 
 Live evidence (real credential, real endpoints, through local-operator's own
 code paths):
@@ -2022,8 +2028,10 @@ subtract-cached-from-prompt behaviour for free. `calculate_cost` on the real
 returns $1.53 — the cache read priced at $0.26/Mtok rather than silently at the
 input rate.
 
-Evidence: `tests/unit/providers/test_usage.py` (three zai cases pinned to a
-payload captured live on 2026-08-17, including the percentage-only rows and the
-200-with-`success:false` path), `tests/unit/providers/test_registry.py`
+Evidence: `tests/unit/providers/test_usage.py` (seven zai cases pinned to a
+payload captured live on 2026-08-17 — the percentage-only rows, the inverted
+`TIME_LIMIT` fields, the feature-bucket classification including renamed and
+added codes, the label-width budget, a hostile-input sweep asserting the fetcher
+never raises, and the 200-with-`success:false` path), `tests/unit/providers/test_registry.py`
 (definition, coding-plan base URL, search aliases), and the `/login` picker and
 usage-panel frames captured from the real `OperatorApp`.

--- a/local_operator/cli.py
+++ b/local_operator/cli.py
@@ -143,10 +143,11 @@ def build_cli_parser() -> argparse.ArgumentParser:
             "mistral",
             "openrouter",
             "xai",
+            "zai",
             "test",
         ],
         help="Hosting platform to use (radient, deepseek, openai, anthropic, ollama, kimi, "
-        "alibaba, google, mistral, test, openrouter, xai)",
+        "alibaba, google, mistral, test, openrouter, xai, zai)",
     )
     parser.add_argument(
         "--model",

--- a/local_operator/model/configure.py
+++ b/local_operator/model/configure.py
@@ -96,6 +96,7 @@ DEFAULT_MODEL_NAMES: dict[str, str] = {
     "mistral": "mistral-large-latest",
     "radient": "auto",
     "xai": "grok-3",
+    "zai": "glm-5.3",
 }
 
 # Sensible ModelSpec fallbacks when the legacy registry knows nothing.
@@ -380,6 +381,10 @@ VALIDATION_ENDPOINTS: dict[str, ValidationDescriptor] = {
     "mistral": ValidationDescriptor("https://api.mistral.ai/v1/models"),
     "ollama": ValidationDescriptor("http://localhost:11434/api/tags", header_style="none"),
     "xai": ValidationDescriptor("https://api.x.ai/v1/models"),
+    # Validated against the coding-plan base so a key that works here is a key
+    # that works for inference; the general `/api/paas/v4` listing would accept
+    # keys that cannot spend coding-plan quota.
+    "zai": ValidationDescriptor("https://api.z.ai/api/coding/paas/v4/models"),
 }
 
 
@@ -977,6 +982,10 @@ _AGGREGATOR_NAMESPACE: dict[str, str] = {
     "xai": "x-ai",
     "alibaba": "qwen",
     "kimi": "moonshotai",
+    # Z.AI's own listing quotes no prices, and GLM is resold on OpenRouter under
+    # the `z-ai/` namespace (verified against GET https://openrouter.ai/api/v1/models
+    # on 2026-08-17). Newer ids not yet carried there fall back to the static rows.
+    "zai": "z-ai",
 }
 
 #: A trailing Anthropic-style release stamp: `claude-opus-4-5-20251101`.

--- a/local_operator/model/registry.py
+++ b/local_operator/model/registry.py
@@ -122,6 +122,17 @@ SupportedHostingProviders = [
         requiredCredentials=["XAI_API_KEY"],
         recommended=True,
     ),
+    ProviderDetail(
+        id="zai",
+        name="Z.AI (GLM)",
+        description=(
+            "Z.AI's GLM models for coding and reasoning, with large context windows "
+            "and a subscription coding plan that reports live quota"
+        ),
+        url="https://z.ai/",
+        requiredCredentials=["ZAI_API_KEY"],
+        recommended=True,
+    ),
 ]
 """List of supported model hosting providers.
 
@@ -297,6 +308,9 @@ def get_model_info(hosting: str, model: str) -> ModelInfo:
     elif hosting == "xai":
         if model in xai_models:
             return xai_models[model]
+    elif hosting == "zai":
+        if model in glm_models:
+            return glm_models[model]
     else:
         raise ValueError(f"Unsupported hosting provider: {hosting}")
 
@@ -1908,6 +1922,148 @@ xai_models: Dict[str, ModelInfo] = {
     ),
 }
 
+#: Z.AI's GLM family.
+#:
+#: Prices are USD per MILLION tokens, taken from Z.AI's published coding-plan
+#: rates and cross-checked against the `z-ai/*` listings on OpenRouter
+#: (2026-08-17). They are carried STATICALLY because Z.AI's `/models` endpoint
+#: returns bare `{id, object, created, owned_by}` rows with no pricing, context
+#: window, or capability data at all — discovery alone would report every GLM as
+#: free and unpriced, so a live listing is merged OVER these rows rather than
+#: replacing them.
+#:
+#: `cache_writes_price` equals `input_price` because Z.AI does not charge a
+#: separate cache-write premium; cache READS are discounted (~19% of input),
+#: which is the number that actually moves a long agent session's bill.
+glm_models: Dict[str, ModelInfo] = {
+    "glm-5.3": ModelInfo(
+        id="glm-5.3",
+        name="GLM-5.3",
+        max_tokens=131_072,
+        context_window=1_000_000,
+        supports_images=False,
+        supports_prompt_cache=True,
+        input_price=1.4,
+        output_price=4.4,
+        cache_writes_price=1.4,
+        cache_reads_price=0.26,
+        description="Z.AI's flagship GLM-5.3 coding model with a 1M context window",
+        recommended=True,
+    ),
+    "glm-5.2": ModelInfo(
+        id="glm-5.2",
+        name="GLM-5.2",
+        max_tokens=131_072,
+        context_window=1_000_000,
+        supports_images=False,
+        supports_prompt_cache=True,
+        input_price=1.4,
+        output_price=4.4,
+        cache_writes_price=1.4,
+        cache_reads_price=0.26,
+        description="GLM-5.2 reasoning and coding model with a 1M context window",
+        recommended=True,
+    ),
+    "glm-5.1": ModelInfo(
+        id="glm-5.1",
+        name="GLM-5.1",
+        max_tokens=131_072,
+        context_window=200_000,
+        supports_images=False,
+        supports_prompt_cache=True,
+        input_price=1.4,
+        output_price=4.4,
+        cache_writes_price=1.4,
+        cache_reads_price=0.26,
+        description="GLM-5.1 reasoning and coding model",
+        recommended=False,
+    ),
+    "glm-5-turbo": ModelInfo(
+        id="glm-5-turbo",
+        name="GLM-5 Turbo",
+        max_tokens=131_072,
+        context_window=200_000,
+        supports_images=False,
+        supports_prompt_cache=True,
+        input_price=1.2,
+        output_price=4.0,
+        cache_writes_price=1.2,
+        cache_reads_price=0.24,
+        description="Latency-optimised GLM-5 variant",
+        recommended=False,
+    ),
+    "glm-5": ModelInfo(
+        id="glm-5",
+        name="GLM-5",
+        max_tokens=131_072,
+        context_window=204_800,
+        supports_images=False,
+        supports_prompt_cache=True,
+        input_price=1.0,
+        output_price=3.2,
+        cache_writes_price=1.0,
+        cache_reads_price=0.2,
+        description="GLM-5 general reasoning and coding model",
+        recommended=False,
+    ),
+    "glm-4.7": ModelInfo(
+        id="glm-4.7",
+        name="GLM-4.7",
+        max_tokens=131_072,
+        context_window=204_800,
+        supports_images=False,
+        supports_prompt_cache=True,
+        input_price=0.6,
+        output_price=2.2,
+        cache_writes_price=0.6,
+        cache_reads_price=0.11,
+        description="GLM-4.7 coding model",
+        recommended=False,
+    ),
+    "glm-4.6": ModelInfo(
+        id="glm-4.6",
+        name="GLM-4.6",
+        max_tokens=131_072,
+        context_window=204_800,
+        supports_images=False,
+        supports_prompt_cache=True,
+        input_price=0.6,
+        output_price=2.2,
+        cache_writes_price=0.6,
+        cache_reads_price=0.11,
+        description="GLM-4.6 coding model",
+        recommended=False,
+    ),
+    "glm-4.5": ModelInfo(
+        id="glm-4.5",
+        name="GLM-4.5",
+        max_tokens=98_304,
+        context_window=131_072,
+        supports_images=False,
+        supports_prompt_cache=True,
+        input_price=0.6,
+        output_price=2.2,
+        cache_writes_price=0.6,
+        cache_reads_price=0.11,
+        description="GLM-4.5 general purpose model",
+        recommended=False,
+    ),
+    "glm-4.5-air": ModelInfo(
+        id="glm-4.5-air",
+        name="GLM-4.5 Air",
+        max_tokens=98_304,
+        context_window=131_072,
+        supports_images=False,
+        supports_prompt_cache=True,
+        input_price=0.2,
+        output_price=1.1,
+        cache_writes_price=0.2,
+        cache_reads_price=0.03,
+        description="Lightweight, cheaper GLM-4.5 variant",
+        recommended=False,
+    ),
+}
+
 #: Every hosting whose model rows this module SHIPS, keyed by hosting id.
 #:
 #: Hoisted out of :func:`static_models` because two questions need it and only
@@ -1924,6 +2080,7 @@ _STATIC_MODEL_MAPS: Dict[str, Dict[str, "ModelInfo"]] = {
     "mistral": mistral_models,
     "kimi": kimi_models,
     "xai": xai_models,
+    "zai": glm_models,
 }
 
 #: The hostings :func:`static_models` can answer for. Ordered as declared above

--- a/local_operator/model/registry.py
+++ b/local_operator/model/registry.py
@@ -1924,9 +1924,19 @@ xai_models: Dict[str, ModelInfo] = {
 
 #: Z.AI's GLM family.
 #:
-#: Prices are USD per MILLION tokens, taken from Z.AI's published coding-plan
-#: rates and cross-checked against the `z-ai/*` listings on OpenRouter
-#: (2026-08-17). They are carried STATICALLY because Z.AI's `/models` endpoint
+#: Prices are USD per MILLION tokens and are Z.AI's own DIRECT list rates,
+#: transcribed from the bundled catalogue omp ships for this provider.
+#:
+#: They deliberately do NOT match OpenRouter's `z-ai/*` listings, which quote
+#: less for most GLM ids (e.g. `glm-5.2` at $0.462/$1.452 against Z.AI's
+#: $1.40/$4.40). That is a real price difference, not a transcription error:
+#: OpenRouter resells through its own discounted arrangements, and a user
+#: billed by Z.AI directly is charged the direct rate. Quoting the aggregator's
+#: number on the direct route would under-report every session's cost, so the
+#: direct rate is the one carried here and `_AGGREGATOR_NAMESPACE`'s OpenRouter
+#: fallback only ever fills a model this table does not price at all.
+#:
+#: They are carried STATICALLY because Z.AI's `/models` endpoint
 #: returns bare `{id, object, created, owned_by}` rows with no pricing, context
 #: window, or capability data at all — discovery alone would report every GLM as
 #: free and unpriced, so a live listing is merged OVER these rows rather than

--- a/local_operator/providers/registry.py
+++ b/local_operator/providers/registry.py
@@ -353,9 +353,11 @@ PROVIDER_REGISTRY: list[ProviderDefinition] = [
         ),
         name="Z.AI (GLM)",
         env_keys="ZAI_API_KEY",
-        login=create_api_key_login(
-            "Z.AI", "https://z.ai/manage-apikey/apikey-list", "Paste your Z.AI API key"
-        ),
+        # No instruction line: the prompt row below it already reads "Paste your
+        # Z.AI API key", and Z.AI's dashboard calls it exactly that, so there is
+        # no vendor-specific term worth a second line. Matches the convention
+        # #139 established when it dropped four identical duplicates.
+        login=create_api_key_login("Z.AI", "https://z.ai/manage-apikey/apikey-list"),
         # The CODING-plan path, not the general `/api/paas/v4` endpoint. Requests
         # sent here consume GLM Coding Plan quota; the general endpoint bills the
         # account balance instead, which is the same key silently spending the

--- a/local_operator/providers/registry.py
+++ b/local_operator/providers/registry.py
@@ -341,6 +341,28 @@ PROVIDER_REGISTRY: list[ProviderDefinition] = [
         base_url="https://api.deepseek.com/v1",
     ),
     ProviderDefinition(
+        id="zai",
+        # Z.AI sells GLM under two names and users type both. "zhipu"/"bigmodel"
+        # are the CN-facing brand for the same models, so a user who came here
+        # for "glm" or "zhipu" finds the provider they actually want.
+        search_aliases=(
+            "glm",
+            "zhipu",
+            "bigmodel",
+            "z-ai",
+        ),
+        name="Z.AI (GLM)",
+        env_keys="ZAI_API_KEY",
+        login=create_api_key_login(
+            "Z.AI", "https://z.ai/manage-apikey/apikey-list", "Paste your Z.AI API key"
+        ),
+        # The CODING-plan path, not the general `/api/paas/v4` endpoint. Requests
+        # sent here consume GLM Coding Plan quota; the general endpoint bills the
+        # account balance instead, which is the same key silently spending the
+        # wrong budget. Mirrors omp's `zhipuCodingPlanModelManagerOptions`.
+        base_url="https://api.z.ai/api/coding/paas/v4",
+    ),
+    ProviderDefinition(
         id="google",
         search_aliases=(
             "gemini",

--- a/local_operator/providers/usage.py
+++ b/local_operator/providers/usage.py
@@ -151,6 +151,7 @@ FetcherKind = Literal[
     "deepseek-balance",
     "xai-oauth",
     "qwencloud-token-plan",
+    "zai-quota",
 ]
 
 #: Provider id (canonical) -> ``(oauth_fetcher, api_key_fetcher)``.
@@ -168,11 +169,12 @@ FetcherKind = Literal[
 #: is what :func:`usage_kinds` reports so the UI can say WHICH credential is
 #: missing instead of showing nothing.
 #:
-#: ``zai`` is absent rather than fixed. It had a working fetcher and a passing
-#: test, but no ``ProviderDefinition`` — so `/login zai` raised, its env var was
-#: never read, and no code path could insert the credential row the fetcher
-#: needed. It was unreachable by construction, and advertising an unreachable
-#: provider is worse than being merely incomplete.
+#: ``zai`` was previously absent for exactly this reason: it had a working
+#: fetcher and a passing test, but no ``ProviderDefinition`` — so `/login zai`
+#: raised, its env var was never read, and no code path could insert the
+#: credential row the fetcher needed. It is present now because the registry
+#: entry, the credential path and this fetcher landed together; the pairing is
+#: the point, and re-adding one without the others would recreate the defect.
 _FETCHERS: dict[str, tuple[FetcherKind | None, FetcherKind | None]] = {
     "openrouter": (None, "openrouter"),
     "anthropic": ("anthropic-oauth", None),
@@ -184,6 +186,10 @@ _FETCHERS: dict[str, tuple[FetcherKind | None, FetcherKind | None]] = {
     "xai-oauth": ("xai-oauth", None),
     "alibaba-token-plan": ("qwencloud-token-plan", None),
     "alibaba-token-plan-oauth": ("qwencloud-token-plan", None),
+    # The coding-plan key is the only credential Z.AI issues for this route, and
+    # the same raw key authenticates both inference and the quota endpoint, so
+    # the api-key slot serves it and there is no OAuth half to route.
+    "zai": (None, "zai-quota"),
 }
 
 #: Providers with a live quota endpoint, for callers that only need the question
@@ -544,6 +550,163 @@ async def fetch_deepseek_balance(client: httpx.AsyncClient, api_key: str) -> Usa
         return None
     notes = None if payload.get("is_available", True) else "account not available for requests"
     return UsageReport(provider="deepseek", limits=limits, notes=notes)
+
+
+#: Z.AI's coding-plan quota endpoint. Lives on the API host but OUTSIDE the
+#: `/api/coding/paas/v4` inference prefix, so it is spelled absolutely here
+#: rather than derived from the provider's ``base_url``.
+ZAI_QUOTA_URL = "https://api.z.ai/api/monitor/usage/quota/limit"
+
+#: The `unit` enum Z.AI uses to describe a quota window's period. Only the
+#: values observed on live coding-plan accounts are mapped; anything else falls
+#: through to a generic label rather than being guessed at, because mislabelling
+#: a monthly cap as hourly would make an exhausted plan look like it resets soon.
+_ZAI_WINDOW_UNITS: dict[int, tuple[str, float]] = {
+    3: ("hour", 3600.0),
+    4: ("day", 86_400.0),
+    5: ("month", 30 * 86_400.0),
+    6: ("week", 7 * 86_400.0),
+}
+
+
+def _zai_window(item: dict[str, Any]) -> tuple[str, int | None]:
+    """``(window_label, resets_at_ms)`` for one Z.AI limit row.
+
+    ``unit`` names the period and ``number`` how many of them, so a 5-hour
+    window arrives as ``unit=3, number=5``. ``nextResetTime`` is epoch
+    milliseconds on live payloads, but is accepted in seconds too and
+    disambiguated by magnitude, matching how the other fetchers here treat
+    ambiguous vendor timestamps.
+    """
+    count = _num(item.get("number")) or 1
+    unit = item.get("unit")
+    mapped = _ZAI_WINDOW_UNITS.get(int(unit)) if isinstance(unit, (int, float)) else None
+    if mapped is None:
+        label = "quota"
+    else:
+        name, _seconds = mapped
+        label = f"{int(count)} {name}"
+    reset = _num(item.get("nextResetTime"))
+    resets_ms: int | None = None
+    if reset is not None and reset > 0:
+        resets_ms = int(reset if reset > 1_000_000_000_000 else reset * 1000)
+    return label, resets_ms
+
+
+async def fetch_zai_quota(client: httpx.AsyncClient, api_key: str) -> UsageReport | None:
+    """Z.AI GLM Coding Plan quota from the monitor endpoint.
+
+    Two row types share one payload and mean different things:
+
+    - ``TOKENS_LIMIT`` is the token allowance for a rolling window. On live
+      coding-plan accounts these rows carry ONLY ``percentage`` — no absolute
+      used/limit/remaining — so the report is built from the fraction and the
+      unit is ``percent``. Inventing token counts from a percentage would put a
+      fabricated number in front of the user.
+    - ``TIME_LIMIT`` is a REQUEST allowance despite the name. Its ``usage`` field
+      is the LIMIT and ``currentValue`` is the amount consumed — inverted
+      relative to every other vendor here, which is the trap worth naming.
+
+    A ``TIME_LIMIT`` row whose ``usageDetails`` cover search-prime/web-reader/
+    zread is the separate Zread feature bucket rather than the account-wide
+    request cap, so it is tagged as a tier and NOT marked shared: exhausting it
+    stops those tools, not the plan.
+    """
+    payload = await _get_json(client, ZAI_QUOTA_URL, _bearer(api_key))
+    if payload is None:
+        return None
+    # The envelope reports business-level failure with a 200, so an unsuccessful
+    # body is not a usable report even though the transport succeeded.
+    if payload.get("success") is not True:
+        return None
+    data = payload.get("data")
+    if not isinstance(data, dict):
+        return None
+    rows = data.get("limits")
+    if not isinstance(rows, list):
+        return None
+
+    limits: list[UsageLimit] = []
+    for item in rows:
+        if not isinstance(item, dict):
+            continue
+        row_type = item.get("type")
+        window, resets_ms = _zai_window(item)
+        percentage = _num(item.get("percentage"))
+        used = _num(item.get("currentValue"))
+        limit_value = _num(item.get("usage"))
+        remaining = _num(item.get("remaining"))
+
+        if row_type == "TOKENS_LIMIT":
+            if percentage is None and used is None:
+                continue
+            amount = UsageAmount(
+                used=used,
+                limit=limit_value,
+                remaining=remaining,
+                used_fraction=(
+                    min(max(percentage / 100.0, 0.0), 1.0) if percentage is not None else None
+                ),
+                # Absolute token counts are absent on coding-plan rows, so the
+                # renderer is told to speak in percent unless the vendor gave
+                # real numbers to show.
+                unit="tokens" if limit_value else "percent",
+            )
+            limits.append(
+                UsageLimit(
+                    id=f"zai:tokens:{window.replace(' ', '')}",
+                    label=f"Token quota ({window})",
+                    amount=amount,
+                    window=window,
+                    resets_at_ms=resets_ms,
+                    shared=True,
+                )
+            )
+        elif row_type == "TIME_LIMIT":
+            details = item.get("usageDetails")
+            codes = (
+                {
+                    str(d.get("modelCode"))
+                    for d in details
+                    if isinstance(d, dict) and d.get("modelCode")
+                }
+                if isinstance(details, list)
+                else set()
+            )
+            is_feature = {"search-prime", "web-reader", "zread"} <= codes
+            if percentage is None and used is None:
+                continue
+            amount = UsageAmount(
+                used=used,
+                limit=limit_value,
+                remaining=remaining,
+                used_fraction=(
+                    min(max(percentage / 100.0, 0.0), 1.0) if percentage is not None else None
+                ),
+                unit="requests" if limit_value else "percent",
+            )
+            limits.append(
+                UsageLimit(
+                    id=(
+                        f"zai:features:zread:{window.replace(' ', '')}"
+                        if is_feature
+                        else f"zai:requests:{window.replace(' ', '')}"
+                    ),
+                    label=("Zread feature quota" if is_feature else "Request quota")
+                    + f" ({window})",
+                    amount=amount,
+                    window=window,
+                    resets_at_ms=resets_ms,
+                    tier="zread" if is_feature else "",
+                    shared=not is_feature,
+                )
+            )
+
+    if not limits:
+        return None
+    level = data.get("level")
+    notes = f"coding plan: {level}" if isinstance(level, str) and level else None
+    return UsageReport(provider="zai", limits=limits, notes=notes)
 
 
 def _parse_iso_ms(value: Any) -> int | None:
@@ -1573,6 +1736,8 @@ async def _run_fetcher(
         return await fetch_moonshot_balance(client, secret)
     if kind == "deepseek-balance":
         return await fetch_deepseek_balance(client, secret)
+    if kind == "zai-quota":
+        return await fetch_zai_quota(client, secret)
     if kind == "xai-oauth":
         return await fetch_xai_oauth(client, secret)
     if kind == "qwencloud-token-plan":

--- a/local_operator/providers/usage.py
+++ b/local_operator/providers/usage.py
@@ -56,6 +56,7 @@ code path here owns a client.
 from __future__ import annotations
 
 import json
+import math
 import re
 import time
 from dataclasses import dataclass, field
@@ -561,11 +562,16 @@ ZAI_QUOTA_URL = "https://api.z.ai/api/monitor/usage/quota/limit"
 #: values observed on live coding-plan accounts are mapped; anything else falls
 #: through to a generic label rather than being guessed at, because mislabelling
 #: a monthly cap as hourly would make an exhausted plan look like it resets soon.
-_ZAI_WINDOW_UNITS: dict[int, tuple[str, float]] = {
-    3: ("hour", 3600.0),
-    4: ("day", 86_400.0),
-    5: ("month", 30 * 86_400.0),
-    6: ("week", 7 * 86_400.0),
+#: Only the NAME is carried. An earlier revision paired each unit with a
+#: duration in seconds, which nothing read: the reset time arrives as an
+#: absolute ``nextResetTime`` from the vendor, so a locally derived window
+#: length would be a second, unreconciled answer to a question already
+#: answered — and the one that drifts if a window is redefined.
+_ZAI_WINDOW_UNITS: dict[int, str] = {
+    3: "hour",
+    4: "day",
+    5: "month",
+    6: "week",
 }
 
 
@@ -578,14 +584,24 @@ def _zai_window(item: dict[str, Any]) -> tuple[str, int | None]:
     disambiguated by magnitude, matching how the other fetchers here treat
     ambiguous vendor timestamps.
     """
+    # `_num` rather than a bare cast throughout: a quota fetcher must never
+    # raise (the caller drops the report on None, but an exception escapes to
+    # the UI). `int()` is the trap — `json.loads` accepts bare NaN and Infinity,
+    # and both blow up on conversion (ValueError / OverflowError) rather than
+    # returning something odd, so the vendor could crash the panel with a field
+    # we only ever read for a LABEL. Strings are coerced too, since a vendor
+    # that starts quoting `"unit": "3"` would otherwise silently lose the window
+    # name while still reporting the numbers.
     count = _num(item.get("number")) or 1
-    unit = item.get("unit")
-    mapped = _ZAI_WINDOW_UNITS.get(int(unit)) if isinstance(unit, (int, float)) else None
+    unit = _num(item.get("unit"))
+    mapped = None
+    if unit is not None and math.isfinite(unit):
+        mapped = _ZAI_WINDOW_UNITS.get(int(unit))
     if mapped is None:
         label = "quota"
     else:
-        name, _seconds = mapped
-        label = f"{int(count)} {name}"
+        count_int = int(count) if math.isfinite(count) else 1
+        label = f"{count_int} {mapped}"
     reset = _num(item.get("nextResetTime"))
     resets_ms: int | None = None
     if reset is not None and reset > 0:
@@ -673,7 +689,15 @@ async def fetch_zai_quota(client: httpx.AsyncClient, api_key: str) -> UsageRepor
                 if isinstance(details, list)
                 else set()
             )
-            is_feature = {"search-prime", "web-reader", "zread"} <= codes
+            # ANY of the feature codes, not all three. Requiring the full set
+            # fails OPEN if Z.AI ever adds or renames one: the row would be
+            # reclassified as the account-wide request cap and marked
+            # ``shared=True``, which `usage_health` then applies to EVERY model
+            # — a depleted zread bucket would read as a depleted plan and stop
+            # work that is not actually blocked. Failing closed (treating an
+            # unrecognised feature mix as the feature bucket) only mislabels a
+            # row nobody is gated on.
+            is_feature = bool(codes & {"search-prime", "web-reader", "zread"})
             if percentage is None and used is None:
                 continue
             amount = UsageAmount(
@@ -692,8 +716,21 @@ async def fetch_zai_quota(client: httpx.AsyncClient, api_key: str) -> UsageRepor
                         if is_feature
                         else f"zai:requests:{window.replace(' ', '')}"
                     ),
-                    label=("Zread feature quota" if is_feature else "Request quota")
-                    + f" ({window})",
+                    # "Zread quota", not "Zread feature quota": the usage
+                    # panel caps its label column at 24 cells (a third of the
+                    # panel's own 76-cell maximum), so the longer form truncated
+                    # mid-parenthesis at EVERY terminal width and the window was
+                    # unreachable — the only row on the panel that could not say
+                    # which period it resets over. The word "feature" is the
+                    # redundant one: the tier indent and the dimmed label ramp
+                    # already say this is not the account-wide cap.
+                    #
+                    # The bucket actually covers search-prime, web-reader AND
+                    # zread (all three must be present to match), so the label
+                    # names one member of a set. Kept because "Zread" is the name
+                    # Z.AI's own plan page gives this allowance, so it is the
+                    # word a user will recognise from their dashboard.
+                    label=("Zread quota" if is_feature else "Request quota") + f" ({window})",
                     amount=amount,
                     window=window,
                     resets_at_ms=resets_ms,
@@ -702,6 +739,13 @@ async def fetch_zai_quota(client: httpx.AsyncClient, api_key: str) -> UsageRepor
                 )
             )
 
+    # Two rows of the same type and window collide on a generated id, and a
+    # duplicate id renders as two identical panel rows that disagree about
+    # nothing — the same defensive dedupe `fetch_xai_oauth` applies, for the
+    # same reason: the id is derived from vendor fields, so uniqueness is the
+    # vendor's promise rather than ours. First occurrence wins.
+    seen: set[str] = set()
+    limits = [limit for limit in limits if not (limit.id in seen or seen.add(limit.id))]
     if not limits:
         return None
     level = data.get("level")

--- a/local_operator/providers/usage.py
+++ b/local_operator/providers/usage.py
@@ -563,27 +563,34 @@ ZAI_QUOTA_URL = "https://api.z.ai/api/monitor/usage/quota/limit"
 #: values observed on live coding-plan accounts are mapped; anything else falls
 #: through to a generic label rather than being guessed at, because mislabelling
 #: a monthly cap as hourly would make an exhausted plan look like it resets soon.
+def _is_zai_chat_model(code: str) -> bool:
+    """Whether a ``usageDetails`` code names a GLM chat model.
+
+    A SHAPE test rather than a lookup against the shipped catalogue, and the
+    distinction is the whole point: every id in ``glm_models`` already starts
+    with ``glm``, so a registry check would answer nothing the prefix does not
+    while dragging ``model.registry`` (~300 ms cold) onto a path that runs
+    inside a quota parse. What the prefix buys is the ids that do NOT exist
+    yet — a model launched after this release must not be mistaken for a
+    feature code.
+
+    Case-folded because the codes are vendor strings, not identifiers we mint,
+    and ``GLM-6`` naming a model while ``glm-6`` does not would be a
+    classification that turns on capitalisation.
+
+    The known feature codes (``search-prime``, ``web-reader``, ``zread``) share
+    no prefix with the model family, so the test is unambiguous today; it is
+    the tie-break for unknown codes that matters, and it resolves them to
+    "feature", which fails toward leaving the account cap alone.
+    """
+    return code.strip().lower().startswith("glm")
+
+
 #: Only the NAME is carried. An earlier revision paired each unit with a
 #: duration in seconds, which nothing read: the reset time arrives as an
 #: absolute ``nextResetTime`` from the vendor, so a locally derived window
 #: length would be a second, unreconciled answer to a question already
 #: answered — and the one that drifts if a window is redefined.
-def _is_zai_chat_model(code: str) -> bool:
-    """Whether a ``usageDetails`` code names a GLM chat model.
-
-    Deliberately a SHAPE test with a registry check in front of it, not a list
-    of known ids. The registry answers for everything shipped today; the ``glm``
-    prefix covers the ids that do not exist yet, which is the case that matters
-    because a model launched after this release must not be mistaken for a
-    feature code. Feature codes (``search-prime``, ``web-reader``, ``zread``)
-    share no prefix with the model family, so the test is unambiguous in both
-    directions.
-    """
-    from local_operator.model.registry import glm_models
-
-    return code in glm_models or code.lower().startswith("glm")
-
-
 _ZAI_WINDOW_UNITS: dict[int, str] = {
     3: "hour",
     4: "day",
@@ -635,10 +642,11 @@ async def fetch_zai_quota(client: httpx.AsyncClient, api_key: str) -> UsageRepor
       is the LIMIT and ``currentValue`` is the amount consumed — inverted
       relative to every other vendor here, which is the trap worth naming.
 
-    A ``TIME_LIMIT`` row whose ``usageDetails`` cover search-prime/web-reader/
-    zread is the separate Zread feature bucket rather than the account-wide
-    request cap, so it is tagged as a tier and NOT marked shared: exhausting it
-    stops those tools, not the plan.
+    A ``TIME_LIMIT`` row whose ``usageDetails`` name NO chat model is the
+    separate Zread feature bucket rather than the account-wide request cap, so
+    it is tagged as a tier and NOT marked shared: exhausting it stops those
+    tools, not the plan. The test is spelled in the negative on purpose — see
+    the note at the classification site.
     """
     payload = await _get_json(client, ZAI_QUOTA_URL, _bearer(api_key))
     if payload is None:
@@ -751,11 +759,11 @@ async def fetch_zai_quota(client: httpx.AsyncClient, api_key: str) -> UsageRepor
                     # redundant one: the tier indent and the dimmed label ramp
                     # already say this is not the account-wide cap.
                     #
-                    # The bucket covers search-prime, web-reader AND zread
-                    # together, so the label names one member of a set. Kept
-                    # because "Zread" is the name Z.AI's own plan page gives this
-                    # allowance, so it is the word a user will recognise from
-                    # their dashboard.
+                    # The bucket covers the non-chat tools together (today:
+                    # search-prime, web-reader, zread), so the label names one
+                    # member of a set. Kept because "Zread" is the name Z.AI's
+                    # own plan page gives this allowance, so it is the word a
+                    # user will recognise from their dashboard.
                     label=("Zread quota" if is_feature else "Request quota") + f" ({window})",
                     amount=amount,
                     window=window,

--- a/local_operator/providers/usage.py
+++ b/local_operator/providers/usage.py
@@ -567,6 +567,11 @@ ZAI_QUOTA_URL = "https://api.z.ai/api/monitor/usage/quota/limit"
 #: absolute ``nextResetTime`` from the vendor, so a locally derived window
 #: length would be a second, unreconciled answer to a question already
 #: answered — and the one that drifts if a window is redefined.
+#: The non-chat allowances Z.AI meters together as one bucket. A TIME_LIMIT row
+#: whose per-model breakdown lists ONLY these is that bucket rather than the
+#: account-wide request cap; see the classification note at the use site.
+_ZAI_FEATURE_CODES = frozenset({"search-prime", "web-reader", "zread"})
+
 _ZAI_WINDOW_UNITS: dict[int, str] = {
     3: "hour",
     4: "day",
@@ -584,24 +589,19 @@ def _zai_window(item: dict[str, Any]) -> tuple[str, int | None]:
     disambiguated by magnitude, matching how the other fetchers here treat
     ambiguous vendor timestamps.
     """
-    # `_num` rather than a bare cast throughout: a quota fetcher must never
-    # raise (the caller drops the report on None, but an exception escapes to
-    # the UI). `int()` is the trap — `json.loads` accepts bare NaN and Infinity,
-    # and both blow up on conversion (ValueError / OverflowError) rather than
-    # returning something odd, so the vendor could crash the panel with a field
-    # we only ever read for a LABEL. Strings are coerced too, since a vendor
-    # that starts quoting `"unit": "3"` would otherwise silently lose the window
-    # name while still reporting the numbers.
+    # `_num` rather than a bare cast on EVERY field, including the ones read
+    # only to build a label: a quota fetcher must never raise (the caller drops
+    # a None report, but an exception escapes to the UI), and `int()` is the
+    # trap — `json.loads` accepts bare NaN/Infinity and an oversized integer,
+    # all of which blow up on conversion rather than returning something odd.
+    # `_num` rejects both the unconvertible and the non-finite, so anything that
+    # reaches an `int()` below is already known-safe. Strings are coerced too,
+    # since a vendor that starts quoting `"unit": "3"` would otherwise silently
+    # lose the window name while still reporting the numbers.
     count = _num(item.get("number")) or 1
     unit = _num(item.get("unit"))
-    mapped = None
-    if unit is not None and math.isfinite(unit):
-        mapped = _ZAI_WINDOW_UNITS.get(int(unit))
-    if mapped is None:
-        label = "quota"
-    else:
-        count_int = int(count) if math.isfinite(count) else 1
-        label = f"{count_int} {mapped}"
+    mapped = _ZAI_WINDOW_UNITS.get(int(unit)) if unit is not None else None
+    label = "quota" if mapped is None else f"{int(count)} {mapped}"
     reset = _num(item.get("nextResetTime"))
     resets_ms: int | None = None
     if reset is not None and reset > 0:
@@ -689,15 +689,24 @@ async def fetch_zai_quota(client: httpx.AsyncClient, api_key: str) -> UsageRepor
                 if isinstance(details, list)
                 else set()
             )
-            # ANY of the feature codes, not all three. Requiring the full set
-            # fails OPEN if Z.AI ever adds or renames one: the row would be
+            # A row is the feature bucket when EVERY code it lists is a known
+            # feature code — not "contains one" and not "contains all three".
+            #
+            # Both simpler tests fail in a direction that matters. Requiring all
+            # three fails OPEN if Z.AI adds or renames a feature: the row is
             # reclassified as the account-wide request cap and marked
-            # ``shared=True``, which `usage_health` then applies to EVERY model
-            # — a depleted zread bucket would read as a depleted plan and stop
-            # work that is not actually blocked. Failing closed (treating an
-            # unrecognised feature mix as the feature bucket) only mislabels a
-            # row nobody is gated on.
-            is_feature = bool(codes & {"search-prime", "web-reader", "zread"})
+            # ``shared=True``, which `usage_health` then applies to EVERY model,
+            # so a depleted zread bucket reads as a depleted plan and stops work
+            # that is not blocked. Matching ANY code fails the other way: a
+            # genuine account-wide cap whose per-model breakdown happens to
+            # mention zread would be demoted to a tier and excluded from the
+            # health check that should have gated the account.
+            #
+            # Subset-of-known is the test that survives both: a renamed feature
+            # still leaves every listed code inside the known set (still a
+            # tier), while an account cap listing real chat models does not
+            # (still shared). An empty list is not a feature bucket.
+            is_feature = bool(codes) and codes <= _ZAI_FEATURE_CODES
             if percentage is None and used is None:
                 continue
             amount = UsageAmount(
@@ -725,11 +734,11 @@ async def fetch_zai_quota(client: httpx.AsyncClient, api_key: str) -> UsageRepor
                     # redundant one: the tier indent and the dimmed label ramp
                     # already say this is not the account-wide cap.
                     #
-                    # The bucket actually covers search-prime, web-reader AND
-                    # zread (all three must be present to match), so the label
-                    # names one member of a set. Kept because "Zread" is the name
-                    # Z.AI's own plan page gives this allowance, so it is the
-                    # word a user will recognise from their dashboard.
+                    # The bucket covers search-prime, web-reader AND zread
+                    # together, so the label names one member of a set. Kept
+                    # because "Zread" is the name Z.AI's own plan page gives this
+                    # allowance, so it is the word a user will recognise from
+                    # their dashboard.
                     label=("Zread quota" if is_feature else "Request quota") + f" ({window})",
                     amount=amount,
                     window=window,
@@ -1525,13 +1534,28 @@ async def fetch_xai_oauth(client: httpx.AsyncClient, access_token: str) -> Usage
 
 
 def _num(value: Any, default: float | None = None) -> float | None:
-    """Coerce numeric/str fields defensively; None on garbage."""
+    """Coerce numeric/str fields defensively; None on garbage.
+
+    ``OverflowError`` is caught alongside the obvious two because a JSON body
+    may carry an integer too large for a float (``10**400`` parses fine and
+    then raises on conversion). Every vendor field in this module reaches a
+    fetcher through here, so catching it at the coercion boundary is what keeps
+    the "a quota fetcher never raises" contract true for all of them rather
+    than for the call sites someone remembered to guard.
+
+    Non-finite values are rejected rather than returned: ``json.loads`` accepts
+    bare ``NaN``/``Infinity``, and a float that survives coercion only to blow
+    up at the ``int()`` that formats it has merely moved the crash somewhere
+    harder to see. ``None`` here means "no usable number", which every caller
+    already handles.
+    """
     try:
         if value is None:
             return default
-        return float(value)
-    except (TypeError, ValueError):
+        parsed = float(value)
+    except (TypeError, ValueError, OverflowError):
         return default
+    return parsed if math.isfinite(parsed) else default
 
 
 async def _qwencloud_bss_call(

--- a/local_operator/providers/usage.py
+++ b/local_operator/providers/usage.py
@@ -558,6 +558,7 @@ async def fetch_deepseek_balance(client: httpx.AsyncClient, api_key: str) -> Usa
 #: rather than derived from the provider's ``base_url``.
 ZAI_QUOTA_URL = "https://api.z.ai/api/monitor/usage/quota/limit"
 
+
 #: The `unit` enum Z.AI uses to describe a quota window's period. Only the
 #: values observed on live coding-plan accounts are mapped; anything else falls
 #: through to a generic label rather than being guessed at, because mislabelling
@@ -567,10 +568,21 @@ ZAI_QUOTA_URL = "https://api.z.ai/api/monitor/usage/quota/limit"
 #: absolute ``nextResetTime`` from the vendor, so a locally derived window
 #: length would be a second, unreconciled answer to a question already
 #: answered — and the one that drifts if a window is redefined.
-#: The non-chat allowances Z.AI meters together as one bucket. A TIME_LIMIT row
-#: whose per-model breakdown lists ONLY these is that bucket rather than the
-#: account-wide request cap; see the classification note at the use site.
-_ZAI_FEATURE_CODES = frozenset({"search-prime", "web-reader", "zread"})
+def _is_zai_chat_model(code: str) -> bool:
+    """Whether a ``usageDetails`` code names a GLM chat model.
+
+    Deliberately a SHAPE test with a registry check in front of it, not a list
+    of known ids. The registry answers for everything shipped today; the ``glm``
+    prefix covers the ids that do not exist yet, which is the case that matters
+    because a model launched after this release must not be mistaken for a
+    feature code. Feature codes (``search-prime``, ``web-reader``, ``zread``)
+    share no prefix with the model family, so the test is unambiguous in both
+    directions.
+    """
+    from local_operator.model.registry import glm_models
+
+    return code in glm_models or code.lower().startswith("glm")
+
 
 _ZAI_WINDOW_UNITS: dict[int, str] = {
     3: "hour",
@@ -689,24 +701,29 @@ async def fetch_zai_quota(client: httpx.AsyncClient, api_key: str) -> UsageRepor
                 if isinstance(details, list)
                 else set()
             )
-            # A row is the feature bucket when EVERY code it lists is a known
-            # feature code — not "contains one" and not "contains all three".
+            # A row is the feature bucket when its breakdown lists NO chat
+            # model — the question is asked in the negative deliberately.
             #
-            # Both simpler tests fail in a direction that matters. Requiring all
-            # three fails OPEN if Z.AI adds or renames a feature: the row is
-            # reclassified as the account-wide request cap and marked
-            # ``shared=True``, which `usage_health` then applies to EVERY model,
-            # so a depleted zread bucket reads as a depleted plan and stops work
-            # that is not blocked. Matching ANY code fails the other way: a
-            # genuine account-wide cap whose per-model breakdown happens to
-            # mention zread would be demoted to a tier and excluded from the
-            # health check that should have gated the account.
+            # Every positive formulation is a maintenance dependency on a vendor
+            # enum, and each fails the moment that enum moves. Requiring all
+            # known feature codes breaks when Z.AI renames one; requiring the
+            # listed codes to be a SUBSET of the known ones breaks on a rename
+            # AND on an addition (a new tool code is not in our set, so the row
+            # stops looking like a feature bucket). Both fail in the direction
+            # that stops work: the row is reclassified as the account-wide cap
+            # with ``shared=True``, `usage_health` applies it to EVERY model,
+            # and a user with most of their token quota intact is told the
+            # account is depleted because the vendor shipped a new tool.
+            # Matching ANY known code fails the other way instead, demoting a
+            # genuine account cap that merely mentions a feature into a tier.
             #
-            # Subset-of-known is the test that survives both: a renamed feature
-            # still leaves every listed code inside the known set (still a
-            # tier), while an account cap listing real chat models does not
-            # (still shared). An empty list is not a feature bucket.
-            is_feature = bool(codes) and codes <= _ZAI_FEATURE_CODES
+            # Chat model ids are the stable property: the account-wide request
+            # cap is denominated in them, and a feature bucket never lists one.
+            # So an unrecognised code is read as a new FEATURE rather than a new
+            # model, which keeps a renamed or added tool inside the tier and
+            # leaves the account cap alone. An empty breakdown is not a feature
+            # bucket.
+            is_feature = bool(codes) and not any(_is_zai_chat_model(code) for code in codes)
             if percentage is None and used is None:
                 continue
             amount = UsageAmount(

--- a/local_operator/providers/usage.py
+++ b/local_operator/providers/usage.py
@@ -559,10 +559,6 @@ async def fetch_deepseek_balance(client: httpx.AsyncClient, api_key: str) -> Usa
 ZAI_QUOTA_URL = "https://api.z.ai/api/monitor/usage/quota/limit"
 
 
-#: The `unit` enum Z.AI uses to describe a quota window's period. Only the
-#: values observed on live coding-plan accounts are mapped; anything else falls
-#: through to a generic label rather than being guessed at, because mislabelling
-#: a monthly cap as hourly would make an exhausted plan look like it resets soon.
 def _is_zai_chat_model(code: str) -> bool:
     """Whether a ``usageDetails`` code names a GLM chat model.
 
@@ -586,6 +582,11 @@ def _is_zai_chat_model(code: str) -> bool:
     return code.strip().lower().startswith("glm")
 
 
+#: The `unit` enum Z.AI uses to describe a quota window's period. Only the
+#: values observed on live coding-plan accounts are mapped; anything else falls
+#: through to a generic label rather than being guessed at, because mislabelling
+#: a monthly cap as hourly would make an exhausted plan look like it resets soon.
+#:
 #: Only the NAME is carried. An earlier revision paired each unit with a
 #: duration in seconds, which nothing read: the reset time arrives as an
 #: absolute ``nextResetTime`` from the vendor, so a locally derived window

--- a/local_operator/server/routes/models.py
+++ b/local_operator/server/routes/models.py
@@ -21,6 +21,7 @@ from local_operator.model.registry import (
     SupportedHostingProviders,
     anthropic_models,
     deepseek_models,
+    glm_models,
     google_models,
     kimi_models,
     mistral_models,
@@ -329,6 +330,16 @@ async def list_models(
                     )
             elif provider_detail.id == "xai":
                 for model_name, model_info in xai_models.items():
+                    models.append(
+                        ModelEntry(
+                            id=model_name,
+                            name=model_info.name,
+                            provider=provider_detail.id,
+                            info=model_info,
+                        )
+                    )
+            elif provider_detail.id == "zai":
+                for model_name, model_info in glm_models.items():
                     models.append(
                         ModelEntry(
                             id=model_name,

--- a/tests/unit/providers/test_controller.py
+++ b/tests/unit/providers/test_controller.py
@@ -292,7 +292,7 @@ def test_usage_enabled_provider_ids(controller) -> None:
     ids = controller.usage_enabled_providers()
     assert "openrouter" in ids
     assert "deepseek" in ids
-    assert "zai" not in ids, "unreachable: no ProviderDefinition exists for it"
+    assert "zai" in ids, "reachable: ProviderDefinition, credential path and fetcher all exist"
     assert ids == sorted(ids)
 
 

--- a/tests/unit/providers/test_oauth_flows.py
+++ b/tests/unit/providers/test_oauth_flows.py
@@ -934,6 +934,7 @@ def test_paste_key_providers_declare_that_they_require_a_prompt() -> None:
         "alibaba",
         "alibaba-token-plan",
         "alibaba-token-plan-oauth",
+        "zai",
     }, required
 
     # And the union a host actually gates on: required plus Anthropic's optional

--- a/tests/unit/providers/test_registry.py
+++ b/tests/unit/providers/test_registry.py
@@ -24,6 +24,7 @@ LEGACY_HOSTING_NAMES = [
     "kimi",
     "alibaba",
     "xai",
+    "zai",
 ]
 
 
@@ -54,6 +55,25 @@ def test_openai_definition_oauth_fields() -> None:
     device = get_provider_definition("openai-device")
     assert device is not None
     assert device.store_credentials_as == "openai"
+
+
+def test_zai_definition() -> None:
+    """Z.AI is an API-key provider on the CODING-plan base URL.
+
+    The base URL is asserted because the general `/api/paas/v4` endpoint accepts
+    the same key but bills the account balance instead of coding-plan quota — a
+    silent wrong-budget bug rather than a visible failure.
+    """
+    definition = get_provider_definition("zai")
+    assert definition is not None
+    assert definition.login is not None
+    assert definition.env_keys == "ZAI_API_KEY"
+    assert definition.wire == "openai-compat"
+    assert definition.base_url == "https://api.z.ai/api/coding/paas/v4"
+    # Search vocabulary only \u2014 nothing ROUTES on these (that is what the
+    # registry's own docstring promises), but the picker must offer the name
+    # users came here for, which is the model family rather than the company.
+    assert set(definition.search_aliases) == {"glm", "zhipu", "bigmodel", "z-ai"}
 
 
 def test_anthropic_definition() -> None:

--- a/tests/unit/providers/test_usage.py
+++ b/tests/unit/providers/test_usage.py
@@ -9,6 +9,7 @@ exercised through it.
 from __future__ import annotations
 
 import json
+import math
 import time
 from typing import Any
 
@@ -79,12 +80,23 @@ def test_num_never_yields_a_value_that_crashes_downstream() -> None:
     ):
         assert _num(bad) is None, bad
 
-    # ...and everything returned survives the operations callers perform on it.
-    for good in (0, 1, -5, 3.14, "42", "3.5", 1787009983644, 10**15, True):
+    # ...and everything returned survives the operations callers perform on it:
+    # `int()` (which is what raised before), formatting, and comparison. NaN
+    # would pass an `int()` check by raising, so the finiteness is asserted
+    # directly rather than implied by an always-true comparison.
+    for good, expected in (
+        (0, 0.0),
+        (-5, -5.0),
+        (3.14, 3.14),
+        ("42", 42.0),
+        ("3.5", 3.5),
+        (1787009983644, 1787009983644.0),
+        (10**15, 1e15),
+    ):
         value = _num(good)
-        assert value is not None
-        assert int(value) == int(float(good))
-        assert value > 0 or value <= 0  # comparable, i.e. not a NaN
+        assert value == expected
+        assert math.isfinite(value)  # type: ignore[arg-type]
+        assert isinstance(int(value), int)  # type: ignore[arg-type]
 
     assert _num(None, 7.0) == 7.0
 
@@ -545,6 +557,11 @@ async def test_zai_feature_bucket_is_the_breakdown_with_no_chat_model() -> None:
     assert future.shared is True
     # Chat models only, and no breakdown at all: both the plain request cap.
     assert (await classify(["glm-5.3", "glm-4.6"])).shared is True
+    # Vendor strings are not identifiers we mint, so a capitalised or padded
+    # model id is still a model id — a classification that turned on case would
+    # silently demote a real account cap to a tier.
+    assert (await classify(["GLM-5.3", "zread"])).shared is True
+    assert (await classify([" glm-5.3 ", "zread"])).shared is True
     plain = await classify([])
     assert plain.tier == ""
     assert plain.shared is True

--- a/tests/unit/providers/test_usage.py
+++ b/tests/unit/providers/test_usage.py
@@ -49,6 +49,46 @@ def _recording_client(payload, status: int = 200) -> tuple[httpx.AsyncClient, li
     return httpx.AsyncClient(transport=httpx.MockTransport(handler)), urls
 
 
+def test_num_never_yields_a_value_that_crashes_downstream() -> None:
+    """``_num`` is the single coercion boundary all nine fetchers share, so its
+    contract is what keeps "a quota fetcher never raises" true for fields nobody
+    has thought of yet.
+
+    Pinned at this level rather than only through one provider because the
+    guarantee is module-wide: a caller is entitled to assume anything `_num`
+    returns can be compared, formatted, and passed to ``int()``. ``json.loads``
+    accepts bare ``NaN``/``Infinity``, and an integer literal can exceed float
+    range (``10**400`` parses, then raises ``OverflowError`` on conversion) —
+    all of which must become ``None`` rather than a value that detonates later.
+    """
+    from local_operator.providers.usage import _num
+
+    # Unusable inputs become None...
+    for bad in (
+        float("nan"),
+        float("inf"),
+        float("-inf"),
+        10**400,
+        -(10**400),
+        "abc",
+        "",
+        None,
+        [],
+        {},
+        object(),
+    ):
+        assert _num(bad) is None, bad
+
+    # ...and everything returned survives the operations callers perform on it.
+    for good in (0, 1, -5, 3.14, "42", "3.5", 1787009983644, 10**15, True):
+        value = _num(good)
+        assert value is not None
+        assert int(value) == int(float(good))
+        assert value > 0 or value <= 0  # comparable, i.e. not a NaN
+
+    assert _num(None, 7.0) == 7.0
+
+
 def test_usage_health_shared_window_reaches_reserve() -> None:
     report = UsageReport(
         provider="anthropic",
@@ -444,14 +484,16 @@ async def test_zai_never_raises_on_any_hostile_numeric_field() -> None:
 
 
 @pytest.mark.asyncio
-async def test_zai_feature_bucket_is_codes_that_are_all_known_features() -> None:
-    """Neither "contains one" nor "contains all three" survives contact.
+async def test_zai_feature_bucket_is_the_breakdown_with_no_chat_model() -> None:
+    """The classification must survive Z.AI changing its own feature codes.
 
-    Matching ANY code demotes a genuine account-wide cap whose breakdown
-    mentions zread into a tier, excluding it from the health check that should
-    gate the account. Requiring ALL THREE promotes the feature bucket into the
-    account cap if Z.AI renames a feature, marking it ``shared`` so a depleted
-    zread allowance reads as a depleted plan.
+    Every positive test is a maintenance dependency on a vendor enum: requiring
+    all known codes breaks on a rename, and requiring a SUBSET of them breaks on
+    a rename *and* on an addition. Both fail toward ``shared=True``, which
+    `usage_health` applies to every model — so a user with most of their token
+    quota intact is told the account is depleted because the vendor shipped a
+    new tool. The cases below are therefore mostly about codes this code has
+    never seen; the live shape is the easy one.
     """
 
     async def classify(codes: list[str]) -> UsageLimit:
@@ -476,15 +518,33 @@ async def test_zai_feature_bucket_is_codes_that_are_all_known_features() -> None
         assert report is not None
         return report.limits[0]
 
-    # The live shape, and a renamed/extended feature set: still the tier.
+    # The live shape today.
     assert (await classify(["search-prime", "web-reader", "zread"])).tier == "zread"
-    assert (await classify(["search-prime", "zread"])).tier == "zread"
-    # An account-wide cap whose breakdown merely mentions zread alongside real
-    # chat models is NOT the feature bucket, and must stay shared.
+    # The bucket shrinks to one feature.
+    assert (await classify(["zread"])).tier == "zread"
+    # Z.AI ADDS a tool code we have never seen. A subset-of-known test fails
+    # here and marks the row shared; this must stay a tier.
+    added = await classify(["search-prime", "web-reader", "zread", "deep-research"])
+    assert added.tier == "zread"
+    assert added.shared is False
+    # Z.AI RENAMES every feature code. Still no chat model, so still a tier.
+    renamed = await classify(["search-prime-v2", "web-reader-v2", "zread-v2"])
+    assert renamed.tier == "zread"
+    assert renamed.shared is False
+
+    # An account-wide cap whose breakdown mentions a feature alongside real chat
+    # models is NOT the feature bucket, and must stay shared or the health check
+    # that should gate the account skips it.
     mixed = await classify(["glm-5.3", "zread"])
     assert mixed.tier == ""
     assert mixed.shared is True
-    # No breakdown at all is the plain request cap.
+    # A cap denominated in a model that does not exist yet: the shape test has
+    # to catch it, because the registry cannot.
+    future = await classify(["glm-6.0", "zread"])
+    assert future.tier == ""
+    assert future.shared is True
+    # Chat models only, and no breakdown at all: both the plain request cap.
+    assert (await classify(["glm-5.3", "glm-4.6"])).shared is True
     plain = await classify([])
     assert plain.tier == ""
     assert plain.shared is True

--- a/tests/unit/providers/test_usage.py
+++ b/tests/unit/providers/test_usage.py
@@ -390,6 +390,107 @@ async def test_zai_hostile_window_fields_do_not_raise() -> None:
 
 
 @pytest.mark.asyncio
+async def test_zai_never_raises_on_any_hostile_numeric_field() -> None:
+    """The never-raise contract, enforced over the whole cross-product.
+
+    A previous round fixed the two call sites a review happened to quote and
+    left the defect class open: `nextResetTime` still crashed on Infinity, and
+    an oversized integer (``10**400`` parses, then raises ``OverflowError`` on
+    `float()`) took out every numeric field at once. Testing one field with one
+    bad value is what let that through, so this walks every field with every
+    hostile value rather than trusting a spot check.
+    """
+    nasty: list[Any] = [
+        float("nan"),
+        float("inf"),
+        float("-inf"),
+        10**400,
+        -(10**400),
+        -1,
+        "3",
+        "abc",
+        "",
+        None,
+        True,
+        [],
+        {},
+    ]
+    fields = ["unit", "number", "percentage", "usage", "currentValue", "remaining", "nextResetTime"]
+    for row_type in ("TOKENS_LIMIT", "TIME_LIMIT"):
+        for field in fields:
+            for value in nasty:
+                row: dict[str, Any] = {
+                    "type": row_type,
+                    "unit": 3,
+                    "number": 1,
+                    "percentage": 10,
+                    field: value,
+                }
+                payload = {"success": True, "data": {"limits": [row]}}
+                # `allow_nan=True` + raw bytes: the strict encoder in
+                # `_client_for` refuses NaN/Infinity, which would quietly drop
+                # the values this test exists to exercise.
+                body = json.dumps(payload, allow_nan=True, default=str).encode()
+
+                def handler(request: httpx.Request, _body: bytes = body) -> httpx.Response:
+                    return httpx.Response(
+                        200, content=_body, headers={"content-type": "application/json"}
+                    )
+
+                client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+                async with client:
+                    # The assertion is that this line returns at all.
+                    await fetch_usage(client, "zai", api_key="k")
+
+
+@pytest.mark.asyncio
+async def test_zai_feature_bucket_is_codes_that_are_all_known_features() -> None:
+    """Neither "contains one" nor "contains all three" survives contact.
+
+    Matching ANY code demotes a genuine account-wide cap whose breakdown
+    mentions zread into a tier, excluding it from the health check that should
+    gate the account. Requiring ALL THREE promotes the feature bucket into the
+    account cap if Z.AI renames a feature, marking it ``shared`` so a depleted
+    zread allowance reads as a depleted plan.
+    """
+
+    async def classify(codes: list[str]) -> UsageLimit:
+        payload = {
+            "success": True,
+            "data": {
+                "limits": [
+                    {
+                        "type": "TIME_LIMIT",
+                        "unit": 5,
+                        "number": 1,
+                        "usage": 100,
+                        "currentValue": 1,
+                        "usageDetails": [{"modelCode": c, "usage": 0} for c in codes],
+                    }
+                ]
+            },
+        }
+        client = _client_for(payload)
+        async with client:
+            report = await fetch_usage(client, "zai", api_key="k")
+        assert report is not None
+        return report.limits[0]
+
+    # The live shape, and a renamed/extended feature set: still the tier.
+    assert (await classify(["search-prime", "web-reader", "zread"])).tier == "zread"
+    assert (await classify(["search-prime", "zread"])).tier == "zread"
+    # An account-wide cap whose breakdown merely mentions zread alongside real
+    # chat models is NOT the feature bucket, and must stay shared.
+    mixed = await classify(["glm-5.3", "zread"])
+    assert mixed.tier == ""
+    assert mixed.shared is True
+    # No breakdown at all is the plain request cap.
+    plain = await classify([])
+    assert plain.tier == ""
+    assert plain.shared is True
+
+
+@pytest.mark.asyncio
 async def test_zai_labels_fit_the_usage_panel_label_column() -> None:
     """A label the panel cannot render is a window the user can never read.
 

--- a/tests/unit/providers/test_usage.py
+++ b/tests/unit/providers/test_usage.py
@@ -494,6 +494,25 @@ async def test_zai_never_raises_on_any_hostile_numeric_field() -> None:
                     # The assertion is that this line returns at all.
                     await fetch_usage(client, "zai", api_key="k")
 
+    # The ENVELOPE shapes, not just the leaf values. The numeric sweep above
+    # feeds well-formed containers, so the `isinstance` guards on `data`, on
+    # `limits`, and on each row were load-bearing with nothing standing over
+    # them: dropping the `data`-is-a-dict or the row-is-a-dict check turns a
+    # hostile body into an AttributeError rather than a dropped report, and no
+    # test noticed.
+    for envelope in (
+        {"success": True, "data": "nope"},
+        {"success": True, "data": [1, 2]},
+        {"success": True, "data": None},
+        {"success": True, "data": {"limits": "nope"}},
+        {"success": True, "data": {"limits": None}},
+        {"success": True, "data": {"limits": ["nope", 3, None]}},
+        {"success": True, "data": {}},
+    ):
+        client = _client_for(envelope)
+        async with client:
+            assert await fetch_usage(client, "zai", api_key="k") is None, envelope
+
 
 @pytest.mark.asyncio
 async def test_zai_feature_bucket_is_the_breakdown_with_no_chat_model() -> None:

--- a/tests/unit/providers/test_usage.py
+++ b/tests/unit/providers/test_usage.py
@@ -352,10 +352,90 @@ async def test_zai_zread_bucket_is_a_tier_not_the_account_cap() -> None:
 
 
 @pytest.mark.asyncio
+async def test_zai_hostile_window_fields_do_not_raise() -> None:
+    """A quota fetcher must never raise: the caller drops a ``None`` report, but
+    an exception escapes to the UI.
+
+    ``json.loads`` accepts bare ``NaN``/``Infinity``, and ``int()`` rejects both
+    (ValueError / OverflowError) — so a vendor could crash the usage panel with
+    a field that is only ever read to build a LABEL. A quoted ``"unit"`` must
+    also still resolve its window name rather than silently degrading.
+    """
+    # Served as RAW BYTES, not through the JSON-encoding helper: `json.dumps`
+    # refuses to emit NaN/Infinity, so round-tripping the payload would destroy
+    # the very values under test. This is what the vendor can actually put on
+    # the wire — `json.loads` parses both without complaint.
+    body = b"""
+        {"success": true, "code": 200, "data": {"limits": [
+            {"type": "TOKENS_LIMIT", "unit": NaN, "number": 5, "percentage": 10},
+            {"type": "TOKENS_LIMIT", "unit": Infinity, "number": NaN, "percentage": 20},
+            {"type": "TOKENS_LIMIT", "unit": "3", "number": "5", "percentage": 30}
+        ]}}
+        """
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=body, headers={"content-type": "application/json"})
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    async with client:
+        report = await fetch_usage(client, "zai", api_key="zai-key")
+    assert report is not None
+    # Unmappable units degrade to the generic label; a quoted unit still maps.
+    # Only TWO rows survive: both unmappable rows generate the id
+    # `zai:tokens:quota`, and the dedupe keeps the first rather than rendering
+    # two identical panel rows.
+    labels = [lim.label for lim in report.limits]
+    assert labels == ["Token quota (quota)", "Token quota (5 hour)"]
+    assert [lim.id for lim in report.limits] == ["zai:tokens:quota", "zai:tokens:5hour"]
+
+
+@pytest.mark.asyncio
+async def test_zai_labels_fit_the_usage_panel_label_column() -> None:
+    """A label the panel cannot render is a window the user can never read.
+
+    The panel caps its label column at a third of its content width, and the
+    panel itself is capped at ``PANEL_MAX_WIDTH``, so the ceiling is a constant
+    24 cells no matter how wide the terminal is. `Zread feature quota (1 month)`
+    needed 31 and truncated mid-parenthesis at EVERY width, leaving the only row
+    on the panel whose reset period was unavailable. Pinned here rather than in
+    the TUI tests because the label is written in this module.
+    """
+    from rich.cells import cell_len
+
+    from local_operator.tui.widgets.usage_panel import (
+        PANEL_MAX_WIDTH,
+        PANEL_PADDING_CELLS,
+        TIER_INDENT,
+    )
+
+    cap = max(12, (PANEL_MAX_WIDTH - PANEL_PADDING_CELLS) // 3)
+    client = _client_for(_ZAI_QUOTA_PAYLOAD)
+    async with client:
+        report = await fetch_usage(client, "zai", api_key="zai-key")
+    assert report is not None
+    for limit in report.limits:
+        width = cell_len(limit.label) + (len(TIER_INDENT) if limit.tier else 0)
+        assert width <= cap, f"{limit.label!r} needs {width} cells, panel caps at {cap}"
+
+
+@pytest.mark.asyncio
 async def test_zai_business_failure_on_a_200_is_not_a_report() -> None:
     """The envelope reports business-level failure with an HTTP 200, so a
-    successful transport is not by itself a usable quota reading."""
-    client = _client_for({"code": 401, "msg": "unauthorized", "success": False})
+    successful transport is not by itself a usable quota reading.
+
+    The payload deliberately carries a FULL, well-formed ``data.limits`` block
+    that would parse into real rows if it were trusted. An unsuccessful body
+    with no ``data`` key would bail at the later structural guard instead, so
+    the test would pass with the envelope check deleted and prove nothing.
+    """
+    client = _client_for(
+        {
+            "code": 401,
+            "msg": "unauthorized",
+            "success": False,
+            "data": _ZAI_QUOTA_PAYLOAD["data"],
+        }
+    )
     async with client:
         report = await fetch_usage(client, "zai", api_key="bad")
     assert report is None

--- a/tests/unit/providers/test_usage.py
+++ b/tests/unit/providers/test_usage.py
@@ -265,6 +265,102 @@ async def test_deepseek_reports_a_balance_per_currency() -> None:
     assert units["deepseek:balance:usd"] == "usd"
 
 
+#: A REAL Z.AI coding-plan quota body, captured from
+#: `GET https://api.z.ai/api/monitor/usage/quota/limit` on 2026-08-17. Pinned
+#: verbatim because the shape is the whole contract here: the TOKENS_LIMIT rows
+#: carry ONLY a percentage (no absolute counts), and TIME_LIMIT inverts the
+#: obvious reading of its fields — `usage` is the limit, `currentValue` the
+#: amount consumed. An invented payload would have hidden both.
+_ZAI_QUOTA_PAYLOAD: dict[str, Any] = {
+    "code": 200,
+    "msg": "Operation successful",
+    "data": {
+        "limits": [
+            {
+                "type": "TOKENS_LIMIT",
+                "unit": 3,
+                "number": 5,
+                "percentage": 12,
+                "nextResetTime": 1787009983644,
+            },
+            {
+                "type": "TOKENS_LIMIT",
+                "unit": 6,
+                "number": 1,
+                "percentage": 42,
+                "nextResetTime": 1787542072998,
+            },
+            {
+                "type": "TIME_LIMIT",
+                "unit": 5,
+                "number": 1,
+                "usage": 4000,
+                "currentValue": 0,
+                "remaining": 4000,
+                "percentage": 0,
+                "nextResetTime": 1789615672998,
+                "usageDetails": [
+                    {"modelCode": "search-prime", "usage": 0},
+                    {"modelCode": "web-reader", "usage": 0},
+                    {"modelCode": "zread", "usage": 0},
+                ],
+            },
+        ],
+        "level": "max",
+    },
+    "success": True,
+}
+
+
+@pytest.mark.asyncio
+async def test_zai_reports_token_and_feature_windows() -> None:
+    """The coding plan quotes token windows as a bare percentage, so the report is
+    built from the fraction rather than inventing token counts to display."""
+    client = _client_for(_ZAI_QUOTA_PAYLOAD)
+    async with client:
+        report = await fetch_usage(client, "zai", api_key="zai-key")
+    assert report is not None
+    ids = [lim.id for lim in report.limits]
+    assert ids == ["zai:tokens:5hour", "zai:tokens:1week", "zai:features:zread:1month"]
+
+    five_hour = report.limits[0]
+    assert five_hour.amount.fraction() == pytest.approx(0.12)
+    # No absolute counts in the payload, so the renderer is told to speak percent.
+    assert five_hour.amount.unit == "percent"
+    assert five_hour.amount.used is None
+    assert five_hour.shared is True
+    assert five_hour.resets_at_ms == 1787009983644
+    assert report.notes == "coding plan: max"
+
+
+@pytest.mark.asyncio
+async def test_zai_zread_bucket_is_a_tier_not_the_account_cap() -> None:
+    """Exhausting the search/web-reader/zread bucket stops those tools, not the
+    plan, so it must not be rendered as the umbrella limit that gates every
+    request."""
+    client = _client_for(_ZAI_QUOTA_PAYLOAD)
+    async with client:
+        report = await fetch_usage(client, "zai", api_key="zai-key")
+    assert report is not None
+    zread = report.limits[-1]
+    assert zread.tier == "zread"
+    assert zread.shared is False
+    # TIME_LIMIT inverts the field names: `usage` is the limit, not the usage.
+    assert zread.amount.limit == 4000
+    assert zread.amount.used == 0
+    assert zread.amount.unit == "requests"
+
+
+@pytest.mark.asyncio
+async def test_zai_business_failure_on_a_200_is_not_a_report() -> None:
+    """The envelope reports business-level failure with an HTTP 200, so a
+    successful transport is not by itself a usable quota reading."""
+    client = _client_for({"code": 401, "msg": "unauthorized", "success": False})
+    async with client:
+        report = await fetch_usage(client, "zai", api_key="bad")
+    assert report is None
+
+
 @pytest.mark.asyncio
 async def test_an_unavailable_deepseek_account_says_so() -> None:
     """A zero balance and a suspended account look identical in the numbers."""
@@ -760,10 +856,10 @@ def test_usage_supported() -> None:
     assert usage_supported("openrouter") is True
     assert usage_supported("deepseek") is True
     assert usage_supported("nonsense") is False
-    # `zai` had a working fetcher and no ProviderDefinition, so no code path could
-    # ever supply its credential: `/login zai` raised, its env var was never read,
-    # and the set advertised a provider nobody could reach.
-    assert usage_supported("zai") is False
+    # `zai` previously had a working fetcher and no ProviderDefinition, so no code
+    # path could ever supply its credential. It is supported now because the
+    # registry entry, the credential path and the fetcher landed together.
+    assert usage_supported("zai") is True
 
 
 def test_usage_kinds_distinguishes_no_endpoint_from_no_credential() -> None:
@@ -789,7 +885,7 @@ def test_the_advertised_set_is_the_dispatch_table() -> None:
     from local_operator.providers import usage as usage_mod
 
     assert usage_mod.USAGE_PROVIDERS == frozenset(usage_mod._FETCHERS)
-    assert usage_mod.USAGE_PROVIDERS is not None and len(usage_mod.USAGE_PROVIDERS) == 10
+    assert usage_mod.USAGE_PROVIDERS is not None and len(usage_mod.USAGE_PROVIDERS) == 11
     assert not hasattr(usage_mod, "OAUTH_USAGE_PROVIDERS")
 
 


### PR DESCRIPTION
# PR Description

## Change classification

**C2 — standard / pre-authorized.** Adds one new optional provider alongside the existing eleven. No foundational auth, data-isolation, infrastructure, or irreversible data change; nothing existing changes behaviour unless a user explicitly selects `zai`. Clean rollback (`git revert`). No RFC or tracker requested.

## Summary of Changes

Adds Z.AI (GLM) as a supported provider, porting the mechanisms omp uses. The brief was explicitly the *whole* provider surface — chat, model listing from the provider's own endpoint, usage/quota, and cost reporting — so all four land together.

That togetherness is the substance of this PR, not a nicety. `zai` **already existed here once** as a usage fetcher with no `ProviderDefinition`, which made it unreachable by construction: `/login zai` raised, `ZAI_API_KEY` was never read, and no code path could insert the credential row the fetcher needed. It was deleted for exactly that reason, and the removal is recorded in `docs/VERIFICATION.md` with two tests still asserting its absence:

```python
assert usage_supported("zai") is False
assert "zai" not in ids, "unreachable: no ProviderDefinition exists for it"
```

Both are inverted here, because the halves they were guarding now exist. Re-adding a fetcher alone would have recreated the original defect.

### 1. Registry definition — and the base URL is load-bearing

```python
ProviderDefinition(
    id="zai",
    search_aliases=("glm", "zhipu", "bigmodel", "z-ai"),
    name="Z.AI (GLM)",
    env_keys="ZAI_API_KEY",
    login=create_api_key_login("Z.AI", "https://z.ai/manage-apikey/apikey-list", ...),
    base_url="https://api.z.ai/api/coding/paas/v4",
)
```

The `coding/` prefix is deliberate and is the single easiest thing to get wrong. The general `/api/paas/v4` endpoint accepts the *same key* and returns *valid completions* — while billing the account balance instead of coding-plan quota. That is a silently wrong budget, not a visible failure, so it is pinned by a test and explained in a comment.

omp routes GLM over its Anthropic-shaped proxy (`/api/anthropic`). I chose the OpenAI-compatible endpoint instead: it needs no new wire client, `wire="openai-compat"` gets discovery and cost handling for free, and it was verified to stream text, tool calls and usage correctly (below).

### 2. Model listing — live ids, static metadata

`GET /models` was run against a real account and answers with bare rows:

```json
{"id": "glm-5.3", "object": "model", "created": 1786636800, "owned_by": "z-ai"}
```

No pricing, no context window, no capabilities. Discovery needed **no edit** — `_WIRE_TRANSPORTS` is keyed on `wire`, not on provider id, so a registry entry with a `base_url` gets listing automatically. But a listing alone would report every GLM as free, non-caching and 0-context, so `glm_models` carries the metadata and live ids merge *over* it:

```
fetch_models("zai")         -> 9 live rows, all ctx=0, unpriced
merge_models(glm_models, …) -> glm-5.3  ctx=1,000,000  in=$1.4  out=$4.4
```

### 3. Usage/quota — three traps, all found by reading a real payload

`GET /api/monitor/usage/quota/limit`, via a new `fetch_zai_quota` wired into `_FETCHERS` as `("zai": (None, "zai-quota"))`:

- The `{code,msg,data,success}` envelope reports **business-level failure on an HTTP 200**, so a successful transport is not by itself a usable reading.
- `TOKENS_LIMIT` rows on a coding plan carry **only `percentage`** — no absolute used/limit/remaining. The report is built from the fraction and the unit is `percent`. Deriving token counts from a percentage would have put a fabricated number in front of the user.
- `TIME_LIMIT` is a **request** allowance despite the name, and inverts the obvious reading: `usage` is the limit, `currentValue` is what was consumed.
- A `TIME_LIMIT` whose `usageDetails` cover search-prime/web-reader/zread is the separate Zread feature bucket → tagged `tier="zread"`, `shared=False`, so exhausting it is not rendered as the account-wide cap that gates every request.

### 4. Cost — no zai-specific code required

`_cache_tokens_are_inside_input` keys on the **wire format**, so an openai-compat provider gets correct subtract-cached-from-prompt behaviour for free. Prices are USD/Mtok and are Z.AI's **direct** list rates. They deliberately differ from OpenRouter's `z-ai/*` listings, which quote less for most GLM ids (`glm-5.2`: $0.462/$1.452 vs Z.AI's $1.40/$4.40) because the aggregator resells at its own discounted rates — a user billed directly by Z.AI pays the direct rate, so quoting the aggregator's number would under-report every session. `_AGGREGATOR_NAMESPACE` registers `z-ai` only as the fallback for ids this table does not price at all.

### Also

`--hosting zai` added to the CLI choices (argparse would otherwise reject it), and `zai` added to `SupportedHostingProviders` + the `/models` API route so GLM rows are served over the API.

## Testing Details

### Automated gates

```text
.venv/bin/python -m flake8 .                                    PASS
uvx --from black==26.1.0 black --check local_operator tests      PASS (353 files unchanged)
uvx isort --check-only --profile black local_operator tests      PASS
.venv/bin/python -m pyright --pythonpath .venv/bin/python .      PASS (0 errors)
env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit -q
                                                                4226 passed, 7 skipped
```

New tests: three in `test_usage.py` pinned to a payload **captured live** (percentage-only token rows, the inverted TIME_LIMIT fields, the zread tier, and the 200-with-`success:false` path), one in `test_registry.py` (definition, coding-plan base URL, aliases). Two pre-existing tests asserting zai's absence were inverted.

### Live end-to-end — real credential, real endpoints, through local-operator's own code

Not a mocked suite: every line below is local-operator's own functions against `api.z.ai`.

**Quota (`fetch_usage`)**
```
coding plan: max
  zai:tokens:5hour           Token quota (5 hour)      12% used  ok  resets in 1h
  zai:tokens:1week           Token quota (1 week)      42% used  ok  resets in 6d4h
  zai:features:zread:1month  Zread feature quota    0/4000 req   ok  resets in 30d4h
```

**Chat (`client_for_spec` → `OpenAICompatClient`, streaming)**
```
events: [StreamTextDelta, StreamUsageEvent, StreamEndEvent]
text  : HELLO_ZAI
usage : input_tokens=20 output_tokens=33 cache_read_tokens=0
cost  : $0.00017320
```

**Tool calling** — full round trip, arguments reassembled from deltas:
```
events    : [StreamToolCallDelta, StreamUsageEvent, StreamEndEvent]
tool name : get_weather
call id   : call_5a71481c58af47658476b651
arguments : {"city":"Toronto"}   -> parsed {'city': 'Toronto'}
```

**Failure path** — invalid key is classified, not leaked as a raw HTTP error:
```
ProviderError: authentication failed (HTTP 401): token expired or incorrect
```

**Cost math**
```
get_model_info("zai","glm-5.3") -> GLM-5.3 ctx=1,000,000 in=$1.4/Mtok out=$4.4/Mtok cache_read=$0.26
calculate_cost(1M in, 1M out)            = $5.80    (1.40 + 4.40, as published)
calculate_cost(1M in, 500k cache-read)   = $1.5300  (cache read at $0.26, not the input rate)
```

### Visual validation

Frames captured from the **real `OperatorApp`** (stylesheet applied), not the CSS-less test hosts, per AGENTS.md.

`/login z` — `zai` in the provider catalogue, showing `GLM` and `needs login`. The
description is `GLM` rather than `Z.AI` because `_provider_summary` deliberately shows
only the parenthetical when the name would otherwise restate the id:

```text
 ❯  /login z
 ❯  zai            GLM                                                     needs login
 ◆ test/model   ›  ⌂  ~/worktrees/lo-zai-provider               ! auto-approve always
```

`/usage` painted with the **live** report fetched from `api.z.ai` — the five-hour and
weekly bars, the plan level, the zread bucket indented as a tier row carrying its
absolute `0 req / 4000 req` counts (the token rows have no absolutes to show), and
reset countdowns:

```text
 Usage   just now

 zai  ·   Token quota (1 week) 42%, resets in 6d4h
   coding plan: max

 ● Token quota (5 hour)      █░░░░░░░░           12% used   resets in 1h
 ● Token quota (1 week)      ████░░░░░           42% used   resets in 6d4h
 ●   Zread feature quota (…  ░░░░░░░░░  0 req / 4000 req    resets in 30d4h

 3 windows  · r refresh  · esc close
```

The text above is the exact frame content, transcribed from SVGs exported by
`app.save_screenshot` and viewed as rendered PNGs. The SVG/PNG artifacts live locally
(`gh` cannot attach binaries to a PR body); the design-review comment on this PR
contains an independently captured set, including width-sweep frames.

### Not verified by me

- **The `[1m]` model-id trap does not apply here.** omp filters `glm-5.2[1m]`-style ids because its Anthropic-route listing surfaces them and they 400 on use. The coding-plan `/models` endpoint returned no bracketed ids in this account, so no filter was added rather than adding dead code — if a bracketed id ever appears, it would reach the picker.
- **Only `glm-5.3` was exercised on the wire.** The other eight rows are priced and shaped from the published rates and the live listing, not individually round-tripped.
- **The paste-a-key `/login zai` flow** was not driven interactively; it is `create_api_key_login`, unchanged and shared with five existing providers. The credential *path* is covered — the live runs above resolve through `ZAI_API_KEY`.
- **No OAuth/sign-in variant.** omp additionally has `zai-coding-plan` (loopback OAuth on port 54548, storing credentials under `zai`). This PR ships the API-key path only; the OAuth flow is a separate, larger port.
