### PR TITLE
fix(tui,harness): name sessions from their opener, and generate the title during the turn

### DIFF
--- a/local_operator/harness/types.py
+++ b/local_operator/harness/types.py
@@ -1115,13 +1115,54 @@ class ChatRequest(BaseModel):
     #:
     #: ``False`` for a turn and for an aside: their deltas reach the transcript
     #: as they arrive, and a retry would re-render text the user already read.
-    #: ``True`` for the one-shot errands that collect the whole stream before
-    #: returning a string — the compaction summary and auto-naming — where a
-    #: stalled read (``_guarded_chunks`` gives up after 180s of silence) used to
-    #: be a permanent failure because the driver had already forwarded events it
+    #: ``True`` for the one-shot errand that collects the whole stream before
+    #: returning a string — the compaction summary — where a stalled read
+    #: (``_guarded_chunks`` gives up after 180s of silence) used to be a
+    #: permanent failure because the driver had already forwarded events it
     #: could not take back. A failed compaction is not cosmetic: the context it
-    #: was meant to shrink keeps growing.
+    #: was meant to shrink keeps growing. Auto-naming is the opposite case and
+    #: sets ``isolated`` instead — see below.
     replayable: bool = False
+    #: This call is DECORATION running alongside a user turn, and it must not be
+    #: able to change anything the turn depends on.
+    #:
+    #: Transport policy like ``replayable`` above, and it exists because
+    #: auto-naming stopped waiting for the turn to finish. A title that arrives
+    #: after the work is done is a title nobody needed, so the naming call now
+    #: runs CONCURRENTLY with the turn — and a second in-flight request shares
+    #: more than bandwidth with it. FIVE pieces of session-wide state sit in
+    #: the path of an ordinary request, and each was a live route by which a
+    #: decorative 429 could have degraded the user's turn:
+    #:
+    #: 1. ``FailoverRouteState`` is session-sticky. A naming failure that walked
+    #:    to a fallback target would ``activate`` it with a 60-second cooldown,
+    #:    moving the TURN onto the fallback model — and a naming SUCCESS on the
+    #:    primary would ``clear`` a pin the turn is relying on.
+    #: 2. ``AuthStore.rotate_sibling`` mutates the session's sticky credential,
+    #:    so an auth failure on a title would re-point the turn's account.
+    #: 3. ``SessionStreamFn`` consumes a pending message boundary to classify
+    #:    auto-effort. Whoever arrives first spends it, so a naming call would
+    #:    freeze the turn's effort from ITS prompt and emit an "auto effort"
+    #:    notice for a request the user never made.
+    #: 4. The quota preflight can block a credential and activate a fallback
+    #:    route for the whole session.
+    #: 5. The session's prompt cache key identifies a request PREFIX. A naming
+    #:    call's prefix is a different system block, so sharing the key buys no
+    #:    hit and writes a competing entry under the turn's name.
+    #:
+    #: So an isolated request gets exactly ONE attempt on the model it names:
+    #: no fallback chain, no sticky route read or written, no credential
+    #: rotation, no backoff sleep, no preflight, no boundary classification and
+    #: not the session's cache key. It still resolves credentials under the
+    #: session id — that READ picks the same account the turn is on, which is
+    #: the point; what it cannot do is move off it. It fails fast and alone,
+    #: which is what lets the caller swallow the failure (see
+    #: ``session.naming.generate_title``) without the turn ever knowing a
+    #: second call happened.
+    #:
+    #: Enforced in two places, tested in two: ``stream_with_failover`` (1, 2,
+    #: and the retry budget) and ``SessionStreamFn.__call__`` (3, 4, 5).
+    isolated: bool = False
 
 
 class StreamTextDelta(BaseModel):

--- a/local_operator/harness/types.py
+++ b/local_operator/harness/types.py
@@ -1130,38 +1130,75 @@ class ChatRequest(BaseModel):
     #: auto-naming stopped waiting for the turn to finish. A title that arrives
     #: after the work is done is a title nobody needed, so the naming call now
     #: runs CONCURRENTLY with the turn — and a second in-flight request shares
-    #: more than bandwidth with it. FIVE pieces of session-wide state sit in
-    #: the path of an ordinary request, and each was a live route by which a
-    #: decorative 429 could have degraded the user's turn:
+    #: more than bandwidth with it. SIX pieces of session-wide state sit in the
+    #: path of an ordinary request, and each is a live route by which a
+    #: decorative failure could degrade the user's turn. Each line names where
+    #: the denial is enforced, because an enumeration with an unlisted member is
+    #: worse than no enumeration:
     #:
     #: 1. ``FailoverRouteState`` is session-sticky. A naming failure that walked
     #:    to a fallback target would ``activate`` it with a 60-second cooldown,
     #:    moving the TURN onto the fallback model — and a naming SUCCESS on the
     #:    primary would ``clear`` a pin the turn is relying on.
+    #:    *Denied in* ``stream_with_failover``: ``route_state = None``, which
+    #:    kills the target narrowing, the ``activate`` and the ``clear``.
     #: 2. ``AuthStore.rotate_sibling`` mutates the session's sticky credential,
     #:    so an auth failure on a title would re-point the turn's account.
+    #:    *Denied in* ``stream_with_failover``: ``retry.enabled = False``, which
+    #:    also removes the fallback chain and the backoff budget — every
+    #:    rotation path sits behind it.
     #: 3. ``SessionStreamFn`` consumes a pending message boundary to classify
     #:    auto-effort. Whoever arrives first spends it, so a naming call would
     #:    freeze the turn's effort from ITS prompt and emit an "auto effort"
     #:    notice for a request the user never made.
+    #:    *Denied in* ``SessionStreamFn.__call__``: the isolated branch returns
+    #:    before the classification.
     #: 4. The quota preflight can block a credential and activate a fallback
     #:    route for the whole session.
+    #:    *Denied in* ``SessionStreamFn.__call__``: same early return, which is
+    #:    also what leaves ``_message_boundary_pending`` unspent (the preflight
+    #:    is what clears it).
     #: 5. The session's prompt cache key identifies a request PREFIX. A naming
     #:    call's prefix is a different system block, so sharing the key buys no
     #:    hit and writes a competing entry under the turn's name.
+    #:    *Denied in* ``SessionStreamFn.__call__``: same early return, so the
+    #:    key is never copied onto the request.
+    #: 6. The credential CASCADE mutates routing state on what looks like a
+    #:    read: ``AuthStore._resolve`` blocks an OAuth row whose refresh raises
+    #:    (so ``_usable_key_rows`` hides it from every later resolve, and the
+    #:    turn re-resolves on each tool-loop request) and writes or clears the
+    #:    session's sticky credential on the way through its tiers. A transient
+    #:    failure on the token endpoint during a title call could therefore
+    #:    block the credential the turn is transacting on and repoint stickiness
+    #:    to a sibling — the "cold cache prefix, alternating identity headers"
+    #:    failure ``create_stream_fn`` warns about. This one is upstream of both
+    #:    switches above, so neither reaches it.
+    #:    *Denied in* ``_resolve_access_for_provider``, which passes
+    #:    ``read_only=request.isolated`` into ``get_oauth_access`` /
+    #:    ``get_api_key`` → ``AuthStore._resolve``: no ``block_credential``, no
+    #:    ``_set_sticky`` write and none cleared.
     #:
     #: So an isolated request gets exactly ONE attempt on the model it names:
     #: no fallback chain, no sticky route read or written, no credential
-    #: rotation, no backoff sleep, no preflight, no boundary classification and
-    #: not the session's cache key. It still resolves credentials under the
-    #: session id — that READ picks the same account the turn is on, which is
-    #: the point; what it cannot do is move off it. It fails fast and alone,
-    #: which is what lets the caller swallow the failure (see
-    #: ``session.naming.generate_title``) without the turn ever knowing a
-    #: second call happened.
+    #: rotation, no backoff sleep, no preflight, no boundary classification, no
+    #: routing decision taken by its credential resolve, and not the session's
+    #: cache key. It still resolves credentials under the session id, so that
+    #: READ lands on the same account the turn is on whenever that account is
+    #: usable, which is the point. What it cannot do is take the turn anywhere:
+    #: if its own resolve finds the sticky credential's refresh broken it may
+    #: serve ITSELF from a sibling, but the sticky pointer and the block list
+    #: come out of the call exactly as they went in, so the turn's next resolve
+    #: still lands where it did before. A successful OAuth refresh does persist
+    #: the rotated token, which is that account's own bookkeeping rather than a
+    #: decision about where requests go. It fails fast and alone, which is what
+    #: lets the caller swallow the failure (see
+    #: ``session.naming.generate_title``) without the turn ever knowing a second
+    #: call happened.
     #:
-    #: Enforced in two places, tested in two: ``stream_with_failover`` (1, 2,
-    #: and the retry budget) and ``SessionStreamFn.__call__`` (3, 4, 5).
+    #: Enforced in three places, tested in three: ``stream_with_failover``
+    #: (1, 2, and the retry budget), ``SessionStreamFn.__call__`` (3, 4, 5) and
+    #: the read-only resolve (6). That the naming call actually SETS this flag
+    #: is tested separately, over a real ``Session`` and a capturing stream fn.
     isolated: bool = False
 
 

--- a/local_operator/model/configure.py
+++ b/local_operator/model/configure.py
@@ -1733,6 +1733,33 @@ class SessionStreamFn:
     ) -> AsyncIterator[StreamEvent]:
         from local_operator.providers.failover import stream_with_failover
 
+        if request.isolated:
+            # Decoration runs alongside the turn, so it must not consume or move
+            # any of this session's shared state — see ``ChatRequest.isolated``.
+            # Three things are skipped rather than one, and each was a real
+            # route by which a title could have degraded a turn:
+            #
+            # * the message-boundary effort classification, which is CONSUMED by
+            #   whoever reaches it first. A naming call arriving before the turn
+            #   would spend the boundary, freeze `_message_effort` from its own
+            #   prompt, and emit an "auto effort" notice for a request the user
+            #   never made.
+            # * the quota preflight, which can block a credential and activate a
+            #   fallback route for the whole session.
+            # * the session's prompt cache key, which identifies a request
+            #   PREFIX. The naming call's prefix is a different system block, so
+            #   sharing the key buys no hit and dirties the turn's cache entry.
+            async for event in stream_with_failover(
+                request,
+                self._auth_store,
+                self._settings,
+                self._client_for,
+                signal=signal,
+                session_id=self._session_id,
+            ):
+                yield event
+            return
+
         # Classify only at the user-message boundary, then freeze the chosen
         # effort for every tool-loop request under it. The tiny local linear
         # model is sub-millisecond / zero tokens — an extra "small LLM" call

--- a/local_operator/providers/auth_store.py
+++ b/local_operator/providers/auth_store.py
@@ -540,14 +540,30 @@ class AuthStore:
     # -- the cascade ---------------------------------------------------------
 
     async def get_api_key(
-        self, provider: str, session_id: str | None = None, *, force_refresh: bool = False
+        self,
+        provider: str,
+        session_id: str | None = None,
+        *,
+        force_refresh: bool = False,
+        read_only: bool = False,
     ) -> str | None:
-        """Resolve the API key for ``provider`` via the 7-step cascade."""
-        key, _row = await self._resolve(provider, session_id, force_refresh=force_refresh)
+        """Resolve the API key for ``provider`` via the 7-step cascade.
+
+        ``read_only`` makes the resolve decide nothing about routing — see
+        :meth:`_resolve`.
+        """
+        key, _row = await self._resolve(
+            provider, session_id, force_refresh=force_refresh, read_only=read_only
+        )
         return key
 
     async def get_oauth_access(
-        self, provider: str, session_id: str | None = None, *, force_refresh: bool = False
+        self,
+        provider: str,
+        session_id: str | None = None,
+        *,
+        force_refresh: bool = False,
+        read_only: bool = False,
     ) -> OAuthAccess | None:
         """The identity-carrying record for wire clients.
 
@@ -556,10 +572,17 @@ class AuthStore:
         row wins, ``kind == "api_key"`` otherwise. Runtime/config overrides
         deliberately short-circuit to ``None`` (they aim at gateways where
         stored identity does not apply).
+
+        ``read_only`` resolves without blocking a credential or moving session
+        stickiness, for a decorative call running beside a live turn — see
+        :meth:`_resolve` and
+        :attr:`~local_operator.harness.types.ChatRequest.isolated`.
         """
         if self._runtime_overrides.get(provider) or self._config_overrides.get(provider):
             return None
-        key, row = await self._resolve(provider, session_id, force_refresh=force_refresh)
+        key, row = await self._resolve(
+            provider, session_id, force_refresh=force_refresh, read_only=read_only
+        )
         if key is None:
             return None
         if row is not None and row.credential_type == "oauth":
@@ -604,10 +627,13 @@ class AuthStore:
         - **No stickiness.** ``_set_sticky`` pins which credential a SESSION
           transacts on. Reading a quota must not repoint the session's account
           as a side effect.
-        - **No blocking on refresh failure.** The cascade blocks a row that
+        - **No blocking on refresh failure.** A routing resolve blocks a row that
           fails to refresh so it can rotate to a sibling for the request in
           hand. Here the row is simply omitted: taking a credential out of
           service is a routing decision, and a read is not entitled to make it.
+          The last two are the same principle ``_resolve``'s ``read_only`` mode
+          applies to a decorative REQUEST, which needs a bearer but is likewise
+          not entitled to route the session.
 
         Logged-out rows are still excluded — ``list_credentials`` filters on
         ``disabled_cause``, and an account the user signed out of is genuinely
@@ -652,10 +678,33 @@ class AuthStore:
         return accesses
 
     async def _resolve(
-        self, provider: str, session_id: str | None, *, force_refresh: bool = False
+        self,
+        provider: str,
+        session_id: str | None,
+        *,
+        force_refresh: bool = False,
+        read_only: bool = False,
     ) -> tuple[str | None, StoredCredential | None]:
-        """The 7-step cascade; returns ``(key, winning row or None)``."""
+        """The 7-step cascade; returns ``(key, winning row or None)``.
+
+        ``read_only`` resolves WITHOUT making any routing decision: no
+        credential blocked when its refresh fails, no session stickiness
+        written and none cleared. It exists for a request that runs beside a
+        user's turn and must not be able to move that turn's account — see
+        :attr:`~local_operator.harness.types.ChatRequest.isolated`. The cascade
+        still READS stickiness, so a read-only resolve lands on the same
+        credential the turn is transacting on, which is the point. A successful
+        OAuth refresh still persists the rotated token: that is the same
+        account's own bookkeeping, not a decision about where requests go, and
+        dropping it would throw away a single-use refresh token.
+        """
         definition: ProviderDefinition | None = get_provider_definition(provider)
+
+        def pin(credential_id: int | None) -> None:
+            """Write (or, with ``None``, clear) session stickiness — unless this
+            resolve is read-only, in which case it is not ours to move."""
+            if not read_only:
+                self._set_sticky(provider, session_id, credential_id)
 
         # 1. Runtime override
         runtime = self._runtime_overrides.get(provider)
@@ -673,12 +722,13 @@ class AuthStore:
             try:
                 creds = await self._ensure_oauth_fresh(row, force=force_refresh)
             except AuthStoreError:
-                self.block_credential(row.id, provider)  # try a sibling
+                if not read_only:
+                    self.block_credential(row.id, provider)  # try a sibling
                 continue
             key_fn = definition.get_api_key if definition else None
             key = key_fn(creds) if key_fn else creds.get("access")
             if key:
-                self._set_sticky(provider, session_id, row.id)
+                pin(row.id)
                 refreshed = self.get_credential(row.id)
                 return key, refreshed or row
         if oauth_rows and force_refresh:
@@ -692,13 +742,13 @@ class AuthStore:
         for row in self._selection_order(login_rows, provider, session_id):
             key = row.data.get("key")
             if key:
-                self._set_sticky(provider, session_id, row.id)
+                pin(row.id)
                 return key, row
 
         # Leaving the OAuth tier: clear session stickiness so identity
         # attribution stops for non-OAuth requests (PR-16; cleared before
         # step 5, regardless of which later tier ends up winning).
-        self._set_sticky(provider, session_id, None)
+        pin(None)
 
         # 5. Env var tier (process env, then legacy credentials.env).
         env_key = self._env_api_key(provider)
@@ -714,7 +764,7 @@ class AuthStore:
         for row in self._selection_order(stored_rows, provider, session_id):
             key = row.data.get("key")
             if key:
-                self._set_sticky(provider, session_id, row.id)
+                pin(row.id)
                 return key, row
         # 7. Fallback resolver
         resolver = self._fallback_resolvers.get(provider)

--- a/local_operator/providers/failover.py
+++ b/local_operator/providers/failover.py
@@ -1030,7 +1030,12 @@ class FailoverAuthStore(Protocol):
     """
 
     async def get_api_key(
-        self, provider: str, session_id: str | None = None, *, force_refresh: bool = False
+        self,
+        provider: str,
+        session_id: str | None = None,
+        *,
+        force_refresh: bool = False,
+        read_only: bool = False,
     ) -> str | None: ...  # pragma: no cover
 
     def rotate_sibling(
@@ -1053,7 +1058,12 @@ class OAuthAccessSource(Protocol):
     """
 
     async def get_oauth_access(
-        self, provider: str, session_id: str | None = None, *, force_refresh: bool = False
+        self,
+        provider: str,
+        session_id: str | None = None,
+        *,
+        force_refresh: bool = False,
+        read_only: bool = False,
     ) -> "OAuthAccess | None": ...  # pragma: no cover
 
 
@@ -1157,7 +1167,10 @@ async def stream_with_failover(
         # no transport-retry budget, and no credential rotation (every rotation
         # `continue` sits behind a `retry.enabled` raise). Dropping the route
         # state removes the fourth: a decorative call neither pins the session
-        # to a fallback nor clears a pin the turn is relying on.
+        # to a fallback nor clears a pin the turn is relying on. The fifth is
+        # not expressible here — the credential cascade takes routing decisions
+        # of its own on a read — so the resolve below is asked for read-only
+        # (`read_only=request.isolated`).
         retry = dataclasses.replace(retry, enabled=False)
         route_state = None
 
@@ -1239,7 +1252,12 @@ async def stream_with_failover(
                 )
             if not retry_same_key:
                 access = await _resolve_access_for_provider(
-                    auth, provider, session_id, state, error
+                    auth,
+                    provider,
+                    session_id,
+                    state,
+                    error,
+                    read_only=request.isolated,
                 )
                 token = access.access_token if access is not None else None
                 if token != current_token:
@@ -1346,39 +1364,58 @@ async def _resolve_access_for_provider(
     session_id: str | None,
     state: AuthRetryKeyState,
     error: BaseException | None,
+    *,
+    read_only: bool = False,
 ) -> "OAuthAccess | None":
     """Bridge AuthStore into the a/b/c resolver shape, returning the
     :class:`~local_operator.providers.auth_store.OAuthAccess` record (or
-    ``None``) so wire clients get identity headers alongside the bearer."""
+    ``None``) so wire clients get identity headers alongside the bearer.
+
+    ``read_only`` is the isolated request's sixth denial: the cascade itself
+    mutates session-shared routing state on a READ — it blocks an OAuth row
+    whose refresh raises and it writes (or clears) the session's sticky
+    credential — and neither ``retry.enabled=False`` nor a dropped
+    ``route_state`` is upstream of that. A decorative call resolves the account
+    the turn is already on and decides nothing.
+    """
     # Presence test, not a nominal one: stores exposing only get_api_key take
     # the bare-bearer path and get wrapped at the bottom of this function.
     oauth_store = auth if isinstance(auth, OAuthAccessSource) else None
     records: dict[str, "OAuthAccess"] = {}
 
+    def _flags(force_refresh: bool) -> dict[str, bool]:
+        """Each flag is passed only when set, so stores declaring the bare
+        ``(provider, session_id)`` signature keep working."""
+        flags: dict[str, bool] = {}
+        if force_refresh:
+            flags["force_refresh"] = True
+        if read_only:
+            flags["read_only"] = True
+        return flags
+
     async def _access(*, force_refresh: bool = False) -> "OAuthAccess | None":
         if oauth_store is None:
             return None
-        # force_refresh is only passed when set so stores declaring the bare
-        # (provider, session_id) signature keep working.
-        if force_refresh:
-            return await oauth_store.get_oauth_access(provider, session_id, force_refresh=True)
-        return await oauth_store.get_oauth_access(provider, session_id)
+        return await oauth_store.get_oauth_access(provider, session_id, **_flags(force_refresh))
+
+    async def _key(*, force_refresh: bool = False) -> str | None:
+        return await auth.get_api_key(provider, session_id, **_flags(force_refresh))
 
     async def resolver(ctx: ApiKeyResolveContext) -> str | None:
         try:
             if ctx.error is None:
                 record = await _access()
                 if record is None:
-                    return await auth.get_api_key(provider, session_id)
+                    return await _key()
             elif ctx.last_chance:
                 auth.rotate_sibling(provider, session_id, ctx.error, api_key=ctx.previous_key)
                 record = await _access()
                 if record is None:
-                    return await auth.get_api_key(provider, session_id)
+                    return await _key()
             else:
                 record = await _access(force_refresh=True)
                 if record is None:
-                    return await auth.get_api_key(provider, session_id, force_refresh=True)
+                    return await _key(force_refresh=True)
         except Exception:
             return None
         if record is None:

--- a/local_operator/providers/failover.py
+++ b/local_operator/providers/failover.py
@@ -1149,6 +1149,18 @@ async def stream_with_failover(
     primary_selector = _selector_for_request(request)
     primary_target = FallbackTarget(primary_selector, request.model.reasoning_effort)
 
+    if request.isolated:
+        # DECORATION: one attempt on the model it named, and no reach into
+        # anything the concurrent turn depends on. Expressed by disabling retry
+        # rather than by a second code path, because "retry disabled" already
+        # means exactly the three things needed here — no fallback chain below,
+        # no transport-retry budget, and no credential rotation (every rotation
+        # `continue` sits behind a `retry.enabled` raise). Dropping the route
+        # state removes the fourth: a decorative call neither pins the session
+        # to a fallback nor clears a pin the turn is relying on.
+        retry = dataclasses.replace(retry, enabled=False)
+        route_state = None
+
     targets = [primary_target]
     if retry.enabled and retry.model_fallback:
         chain = resolve_chain(primary_selector, retry.fallback_chains)

--- a/local_operator/resume.py
+++ b/local_operator/resume.py
@@ -17,6 +17,7 @@ transcript-directory decision, so the rule has one definition.
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 from typing import NamedTuple
 
@@ -39,6 +40,31 @@ NAME_MAX_CHARS = 64
 #: pathological first line (a pasted file, a base64 image) must not turn
 #: opening the picker into reading megabytes off disk for every row.
 NAME_SCAN_CHARS = 64_000
+
+#: How far into a half-read first line the scan will look for the marker that
+#: says the fragment is a user message. The writer emits ``id``/``ts``/``type``
+#: before the payload, so the role sits ~110 characters in; a few hundred is
+#: slack for a longer id without letting the marker match something deep in a
+#: pasted body.
+_FRAGMENT_HEAD_CHARS = 400
+
+#: The marker that says a fragment is a user message, and the first COMPLETE
+#: JSON string value of a ``text`` key. Both tolerate whitespace around the
+#: colon: the session writer emits compact JSON, but a transcript written by
+#: anything else (a test fixture, a hand-edited file, a future exporter) is
+#: still the same document, and a scan that only matched the compact spelling
+#: silently returned no name for it.
+#:
+#: The closing quote is what makes the text value complete: a value still
+#: running when the read window ended cannot match, so a name is never a word
+#: cut in half. ``(?:[^"\\]|\\.)*`` steps over escaped quotes rather than
+#: stopping at the first one.
+_FRAGMENT_USER_RE = re.compile(r'"role"\s*:\s*"user"')
+_TEXT_VALUE_RE = re.compile(r'"text"\s*:\s*"((?:[^"\\]|\\.)*)"')
+
+#: The image-payload key, whose position relative to the text decides whether a
+#: fragment is trustworthy. Same whitespace tolerance, same reason.
+_DATA_KEY_RE = re.compile(r'"data"\s*:')
 
 
 class ResumeNotFound(Exception):
@@ -185,16 +211,19 @@ def session_name(session_dir: Path, *, max_chars: int = NAME_MAX_CHARS) -> str:
             head = handle.read(NAME_SCAN_CHARS)
     except OSError:
         return ""
-    # A final line with no newline after it is dropped ONLY when the window was
-    # actually filled — i.e. the read stopped because of the cap, so that line
-    # is a half-READ one and parsing it would be parsing a fragment. When the
-    # whole file fitted, the same shape is a complete last line that simply has
-    # no trailing newline, and dropping it lost the name of any session whose
-    # transcript is a single entry.
+    # A final line with no newline after it is HELD BACK from the strict parse
+    # only when the window was actually filled — i.e. the read stopped because
+    # of the cap, so that line is a half-READ one and parsing it as JSON would
+    # be parsing a fragment. When the whole file fitted, the same shape is a
+    # complete last line that simply has no trailing newline, and dropping it
+    # lost the name of any session whose transcript is a single entry. Held
+    # rather than discarded because the fragment still carries the opener's
+    # text: see ``_text_from_fragment``.
     truncated = len(head) >= NAME_SCAN_CHARS
     lines = head.splitlines()
+    fragment = ""
     if truncated and lines and not head.endswith("\n"):
-        lines.pop()
+        fragment = lines.pop()
     for line in lines:
         line = line.strip()
         if not line:
@@ -218,7 +247,46 @@ def session_name(session_dir: Path, *, max_chars: int = NAME_MAX_CHARS) -> str:
         text = _first_text(payload.get("content"))
         if text:
             return _condense(text, max_chars)
-    return ""
+    # The window held no COMPLETE line, so the opener is a fragment. Dropping
+    # it (which is all this used to do) left every session that begins with a
+    # pasted screenshot permanently nameless: one base64 image puts the first
+    # line past the cap, and the picker then showed `(unnamed session)` for the
+    # rest of that conversation's life. Measured on two real sessions whose
+    # first lines were 115,289 and 733,034 chars.
+    return _condense(_text_from_fragment(fragment), max_chars) if fragment else ""
+
+
+def _text_from_fragment(fragment: str) -> str:
+    """The opening user message's text, recovered from a HALF-READ first line.
+
+    Deliberately a scan and not a parse: the fragment is an incomplete JSON
+    object, so there is nothing `json.loads` can do with it. What makes the scan
+    safe is the ORDER the writer emits: a user message with attachments
+    serializes its text block before the image data (``Message.user(text,
+    images)`` keeps that order), so on a line whose tail is megabytes of base64
+    the topic sits in the first few hundred characters — measured at offset 135,
+    with the image ``data`` key at 443.
+
+    Three guards, because a wrong name here is worse than none. The fragment
+    must identify itself as a user message, the text value must be COMPLETE (a
+    closing quote inside the window, never a mid-word cut), and it must appear
+    before any ``data`` key so a session can never be named after base64.
+    """
+    if _FRAGMENT_USER_RE.search(fragment[:_FRAGMENT_HEAD_CHARS]) is None:
+        return ""
+    match = _TEXT_VALUE_RE.search(fragment)
+    if match is None:
+        return ""
+    data = _DATA_KEY_RE.search(fragment)
+    if data is not None and data.start() < match.start():
+        return ""
+    try:
+        # Through the JSON decoder rather than a hand-rolled unescape: the
+        # captured span is a JSON string body, and a title showing a literal
+        # ``\u2014`` would be its own bug.
+        return json.loads(f'"{match.group(1)}"')
+    except ValueError:
+        return ""
 
 
 def _first_text(content: object) -> str:

--- a/local_operator/session/naming.py
+++ b/local_operator/session/naming.py
@@ -56,11 +56,16 @@ MAX_TITLE_WORDS = 12
 #: so this is the WHOLE budget — there is no retry behind it, which is what
 #: makes the number worth measuring rather than guessing: seven naming and
 #: re-titling calls against anthropic/claude-opus-5 at its lowest effort came
-#: back in 5.4–5.8 s each, so the 8 s this was first set to was clipping the
-#: tail of a healthy provider. Generous instead, because a late title costs
-#: nothing here: the call is detached, the failure is swallowed, and the
-#: provisional excerpt is already on the band. The bound exists so a wedged
-#: connection cannot leave a task alive for the life of the session.
+#: back in 5.4–5.8 s each. This was 20.0 while the call still waited for the
+#: turn to settle, which is three and a half times that tail — room only a
+#: wedged connection could ever use. Tightened to 15 s by the same change that
+#: put the call ALONGSIDE the turn: the ceiling now bounds a task running
+#: beside the user's work, and a title that has not arrived in two and a half
+#: times the measured latency has nothing left to win — the failure is
+#: swallowed and the provisional excerpt is already on the band. Not tighter
+#: than that, because 2.5x the slowest call measured is the headroom that keeps
+#: a call which was going to answer from being cut off. The bound exists at all
+#: so a wedged connection cannot leave a task alive for the life of the session.
 TITLE_TIMEOUT_S = 15.0
 
 #: Caps on a PROVISIONAL title — the opener-derived label worn until the
@@ -285,22 +290,29 @@ def provisional_title(text: str) -> str:
     Returns ``""`` for anything :func:`is_low_signal` rejects, so the caller
     gets the same "no title" answer from both halves of this module.
 
-    Why this exists at all. The generated title cannot be asked for until the
-    turn settles: it shares the turn's provider lane, and a second simultaneous
-    request at minute zero 429s both (see the TUI's naming worker). On this
-    product a first turn routinely runs for minutes, so that wait meant the
-    band and the terminal tab wore the `lo › <cwd>` fallback for the entire
-    time the user was looking at them, and became a title only once the work
-    was already on screen. Measured on a real provider before this existed: a
-    29.7-second opening turn, a title stored 31.5 seconds after the prompt was
-    submitted. A name that arrives after the answer is a name nobody needed.
+    Why this exists at all. A model call cannot be instant. The generated title
+    goes out WITH the turn now — it carries ``ChatRequest.isolated``, so it is
+    not in the turn's way and nothing has to wait for it — but it is still a
+    round trip, and the seven calls measured for :data:`TITLE_TIMEOUT_S` came
+    back in 5.4–5.8 s. Without a stand-in the band and the terminal tab wear
+    the `lo › <cwd>` fallback for those seconds, on the exact frame the user is
+    looking at: the one right after they pressed Enter.
 
-    The opener fixes that for free. It is in hand the moment it is submitted,
-    it costs no network and no lane, and it is the SAME text ``/resume``'s
-    picker derives its row labels from — so the tab, the band and the picker
-    agree on what a conversation is called by construction rather than by
-    coincidence. The model's title, being an answer rather than a quote, is
-    still better, and replaces this one when the lane frees up.
+    The wait used to be minutes rather than seconds, which is what made a
+    stand-in worth writing: the title waited for the turn to settle, and
+    a first turn on this product routinely runs for minutes, so the fallback
+    was worn for the whole turn and became a title only once the work was
+    already on screen. Measured on a real provider on that version: a
+    29.7-second opening turn, the title stored 31.5 seconds after the prompt
+    was submitted. Concurrency took the minutes out; this takes the seconds.
+
+    The opener fixes those seconds for free. It is in hand the moment it is
+    submitted, it costs no provider call at all, and it is the SAME text
+    ``/resume``'s picker derives its row labels from (``resume.session_name``)
+    — so the tab, the band and the picker agree on what a conversation is
+    called by construction rather than by coincidence. The model's title, being
+    an answer rather than a quote, is still better, and displaces this one the
+    moment it lands (``OperatorApp._store_title``).
 
     Truncation, not rejection, and that is the one deliberate disagreement
     with :func:`parse_title`. An over-long answer from the model is evidence

--- a/local_operator/session/naming.py
+++ b/local_operator/session/naming.py
@@ -10,7 +10,7 @@ because the obvious implementation gets it wrong:
   nonsense yields ``None`` and the band keeps whatever it had. The call also
   runs alongside the turn rather than in front of it, and carries
   ``ChatRequest.isolated`` so a failure cannot move the turn's model, its
-  credential, or its effort — see that field's docstring for the five pieces
+  credential, or its effort — see that field's docstring for the six pieces
   of session-wide state that shuts off.
 - **Most messages do not deserve a call.** "hi", "thanks", "test" carry no
   topic; asking a model to title them spends money to produce noise. The

--- a/local_operator/session/naming.py
+++ b/local_operator/session/naming.py
@@ -1,7 +1,7 @@
 """Conversation auto-naming — a short title derived from the opening message.
 
 A conversation with no name is a row of timestamps in a picker, so the first
-substantive user message buys one cheap title. Three properties govern the
+substantive user message buys one cheap title. Four properties govern the
 design, and each one exists because the obvious implementation gets it wrong:
 
 - **It must never cost a turn.** The title is a nicety; the turn is the
@@ -18,6 +18,12 @@ design, and each one exists because the obvious implementation gets it wrong:
   inside ``<title></title>``; anything longer than the caps is REJECTED
   rather than truncated, because a title cut mid-word reads like a bug while
   an absent title reads like a conversation that has not been named yet.
+- **A late title is nearly no title.** The generated title cannot be asked
+  for until the turn settles, and a first turn on this product runs for
+  minutes, so waiting for it left the tab wearing `lo › <cwd>` for the whole
+  time anyone was looking. :func:`provisional_title` therefore names the
+  conversation from the opener the instant it is submitted — no network, no
+  provider lane, no wait — and the generated title upgrades it later.
 
 The holder (:class:`ConversationName`) mirrors ``GoalState``: a small mutable
 object the session and its host share, so a name that lands asynchronously is
@@ -42,6 +48,15 @@ MAX_TITLE_WORDS = 12
 #: — it is about not leaking a task that hangs for the life of the session
 #: against a wedged provider connection.
 TITLE_TIMEOUT_S = 20.0
+
+#: Caps on a PROVISIONAL title — the opener-derived label worn until the
+#: model's title lands. Tighter than the caps above on purpose: those bound an
+#: ANSWER ("what is this about"), while this quotes a REQUEST, and the first
+#: twelve words of a request are usually still mid-sentence. Eight words at 48
+#: characters is the point past which the band's trailing segment stops being
+#: a label and starts being a sentence.
+MAX_PROVISIONAL_WORDS = 8
+MAX_PROVISIONAL_CHARS = 48
 
 #: The system block for the naming call. It asks for the sentinel form
 #: explicitly so "this input has no topic" is expressible as an ANSWER rather
@@ -189,6 +204,72 @@ def _sentence_case(words: list[str]) -> str:
     if first[:1].islower() and first.islower():
         first = first[:1].upper() + first[1:]
     return " ".join([first, *words[1:]])
+
+
+def provisional_title(text: str) -> str:
+    """An opener-derived label to wear until the generated title lands.
+
+    Returns ``""`` for anything :func:`is_low_signal` rejects, so the caller
+    gets the same "no title" answer from both halves of this module.
+
+    Why this exists at all. The generated title cannot be asked for until the
+    turn settles: it shares the turn's provider lane, and a second simultaneous
+    request at minute zero 429s both (see the TUI's naming worker). On this
+    product a first turn routinely runs for minutes, so that wait meant the
+    band and the terminal tab wore the `lo › <cwd>` fallback for the entire
+    time the user was looking at them, and became a title only once the work
+    was already on screen. Measured on a real provider before this existed: a
+    29.7-second opening turn, a title stored 31.5 seconds after the prompt was
+    submitted. A name that arrives after the answer is a name nobody needed.
+
+    The opener fixes that for free. It is in hand the moment it is submitted,
+    it costs no network and no lane, and it is the SAME text ``/resume``'s
+    picker derives its row labels from — so the tab, the band and the picker
+    agree on what a conversation is called by construction rather than by
+    coincidence. The model's title, being an answer rather than a quote, is
+    still better, and replaces this one when the lane frees up.
+
+    Truncation, not rejection, and that is the one deliberate disagreement
+    with :func:`parse_title`. An over-long answer from the model is evidence
+    the model ignored the format, so it is thrown away; an over-long opener is
+    just a long request, and the excerpt is the point. The cut is on a word
+    boundary with an ellipsis so it reads as a quotation rather than as a
+    string that ran out of buffer.
+    """
+    if is_low_signal(text):
+        return ""
+    words = " ".join((text or "").split()).split()
+    kept: list[str] = []
+    used = 0
+    for word in words[:MAX_PROVISIONAL_WORDS]:
+        width = used + len(word) + (1 if kept else 0)
+        if kept and width > MAX_PROVISIONAL_CHARS:
+            break
+        kept.append(word)
+        used = width
+    if not kept:
+        return ""
+    # `_sentence_case` lifts an all-lower-case leading word, which is right for
+    # the model's prose and wrong for a quote of whatever the user pasted: an
+    # opener starting with a URL or a path came out as `Https://example.com/…`
+    # and `Src/main.py …`, which reads as a rendering bug rather than as a
+    # quotation. So the lift applies only to something that is actually a word —
+    # letters, with an apostrophe or hyphen allowed ("don't", "well-known").
+    if all(char.isalpha() or char in "'-" for char in kept[0]):
+        label = _sentence_case(kept)
+    else:
+        label = " ".join(kept)
+    # A single word longer than the whole cap (a URL, a stack frame, a base64
+    # blob) is cut mid-token rather than dropped. Dropping it would return ""
+    # for an opener that plainly had content, which puts the cwd fallback back
+    # on screen for exactly the paste-heavy openers this feature is aimed at.
+    if len(label) > MAX_PROVISIONAL_CHARS:
+        return label[:MAX_PROVISIONAL_CHARS].rstrip() + "…"
+    if len(kept) < len(words):
+        # Strip the punctuation the cut landed on first: "fix the parser," +
+        # "…" reads as a typo, while "fix the parser…" reads as an excerpt.
+        return label.rstrip(_TRAILING_PUNCTUATION) + "…"
+    return label
 
 
 async def generate_title(

--- a/local_operator/session/naming.py
+++ b/local_operator/session/naming.py
@@ -1,16 +1,18 @@
 """Conversation auto-naming — a short title derived from the opening message.
 
-A conversation with no name is a row of timestamps in a picker, so the first
-substantive user message buys one cheap title. Four properties govern the
-design, and each one exists because the obvious implementation gets it wrong:
+A conversation with no name is a row of timestamps in a picker, so a message
+buys a cheap title. Five properties govern the design, and each one exists
+because the obvious implementation gets it wrong:
 
 - **It must never cost a turn.** The title is a nicety; the turn is the
-  product. ``generate_title`` therefore swallows every exception and bounds
-  itself with a timeout, so a provider that raises, stalls, or returns
-  nonsense yields ``None`` and the band simply stays nameless. Callers run it
-  detached from the turn (see the TUI's naming worker) — awaiting it inline
-  would put a second provider round trip in front of the user's first reply.
-- **Most openers do not deserve a call.** "hi", "thanks", "test" carry no
+  product. Both generators here swallow every exception and bound themselves
+  with a timeout, so a provider that raises, stalls, rate-limits, or returns
+  nonsense yields ``None`` and the band keeps whatever it had. The call also
+  runs alongside the turn rather than in front of it, and carries
+  ``ChatRequest.isolated`` so a failure cannot move the turn's model, its
+  credential, or its effort — see that field's docstring for the five pieces
+  of session-wide state that shuts off.
+- **Most messages do not deserve a call.** "hi", "thanks", "test" carry no
   topic; asking a model to title them spends money to produce noise. The
   deterministic :func:`is_low_signal` filter answers those without any
   network at all, which is also what makes the behaviour testable offline.
@@ -18,18 +20,25 @@ design, and each one exists because the obvious implementation gets it wrong:
   inside ``<title></title>``; anything longer than the caps is REJECTED
   rather than truncated, because a title cut mid-word reads like a bug while
   an absent title reads like a conversation that has not been named yet.
-- **A late title is nearly no title.** The generated title cannot be asked
-  for until the turn settles, and a first turn on this product runs for
-  minutes, so waiting for it left the tab wearing `lo › <cwd>` for the whole
-  time anyone was looking. :func:`provisional_title` therefore names the
-  conversation from the opener the instant it is submitted — no network, no
-  provider lane, no wait — and the generated title upgrades it later.
+- **A late title is nearly no title.** The generated title used to wait for
+  the turn to settle, and a first turn on this product runs for minutes, so
+  the tab wore `lo › <cwd>` for the whole time anyone was looking.
+  :func:`provisional_title` names the conversation from the opener the instant
+  it is submitted — no network at all — and the model's title now lands a
+  second or two later, concurrently with the turn, rather than after it.
+- **A conversation drifts, so a title has to be allowed to.**
+  :func:`generate_retitle` gives the model the current title and a new message
+  and lets IT judge whether the subject or the goals have materially moved.
+  That judgement is not expressible as a keyword rule, and a title still
+  naming the first of five subjects misidentifies the session rather than
+  merely under-describing it.
 
 The holder (:class:`ConversationName`) mirrors ``GoalState``: a small mutable
 object the session and its host share, so a name that lands asynchronously is
 visible to the next reader without rebuilding anything. ``user_set`` is the
 precedence flag — an explicit rename outranks a generated title forever,
-including one still in flight when the rename happens.
+including one still in flight when the rename happens, and including every
+later re-title.
 """
 
 from __future__ import annotations
@@ -43,11 +52,16 @@ from dataclasses import dataclass
 MAX_TITLE_CHARS = 80
 MAX_TITLE_WORDS = 12
 
-#: How long a title generation may run before it is abandoned. The call is
-#: detached from the turn, so this bound is not about latency the user feels
-#: — it is about not leaking a task that hangs for the life of the session
-#: against a wedged provider connection.
-TITLE_TIMEOUT_S = 20.0
+#: How long a title generation may run before it is abandoned. Single attempt,
+#: so this is the WHOLE budget — there is no retry behind it, which is what
+#: makes the number worth measuring rather than guessing: seven naming and
+#: re-titling calls against anthropic/claude-opus-5 at its lowest effort came
+#: back in 5.4–5.8 s each, so the 8 s this was first set to was clipping the
+#: tail of a healthy provider. Generous instead, because a late title costs
+#: nothing here: the call is detached, the failure is swallowed, and the
+#: provisional excerpt is already on the band. The bound exists so a wedged
+#: connection cannot leave a task alive for the life of the session.
+TITLE_TIMEOUT_S = 15.0
 
 #: Caps on a PROVISIONAL title — the opener-derived label worn until the
 #: model's title lands. Tighter than the caps above on purpose: those bound an
@@ -58,28 +72,60 @@ TITLE_TIMEOUT_S = 20.0
 MAX_PROVISIONAL_WORDS = 8
 MAX_PROVISIONAL_CHARS = 48
 
-#: The system block for the naming call. It asks for the sentinel form
-#: explicitly so "this input has no topic" is expressible as an ANSWER rather
+#: The system block for the naming call. Deliberately terse: it rides on EVERY
+#: naming call and it is the half of the request we control, so every clause
+#: has to earn its tokens. Measured against anthropic/claude-opus-5 on a short
+#: opener, trimming the wordier first draft took the call from 177 to 120
+#: input tokens for the same title. The sentinel form survives the trim
+#: because "this input has no topic" must be expressible as an ANSWER rather
 #: than as a malformed one — without it, models invent a title for "hi".
 TITLE_SYSTEM_PROMPT = (
-    "You name conversations. Given the user's opening message, reply with a "
-    "title of 3 to 7 words that names what the conversation is about.\n"
-    "Reply with nothing but the title wrapped in <title></title>.\n"
-    "If the message is a greeting, a pleasantry, or carries no topic, reply "
-    "with exactly <title/> and nothing else.\n"
-    "Do not use quotation marks, trailing punctuation, or the word "
-    "'conversation'."
+    "Name this conversation from the user's message.\n"
+    "Reply with only <title>3 to 7 words</title>.\n"
+    "No topic (a greeting or pleasantry): reply exactly <title/>.\n"
+    "No quotes, no trailing punctuation."
 )
 
-#: How much of the opening message the naming call sees. A title needs the
-#: topic, not the whole essay, and an unbounded prompt would make the cheap
-#: call the expensive one on a pasted log.
-MAX_PROMPT_CHARS = 2000
+#: The system block for a RE-titling call. It carries the current title and
+#: asks the model — not a keyword heuristic here — whether the subject or the
+#: goals have materially moved. Keeping the sentinel as "no change" makes the
+#: common answer the cheapest one to produce and the cheapest one to parse:
+#: `parse_title` already reads `<title/>` as "no title from this call".
+RETITLE_SYSTEM_PROMPT = (
+    "A conversation is titled: {current}\n"
+    "Given the user's new message, decide if the SUBJECT or GOALS have "
+    "materially changed.\n"
+    "Unchanged, or a follow-up on the same subject: reply exactly <title/>.\n"
+    "Materially changed: reply with only <title>3 to 7 words</title> naming "
+    "the new subject.\n"
+    "No quotes, no trailing punctuation."
+)
 
-#: Openers that are content-free on their own. Matched against the message
-#: with punctuation and case stripped, so "Hi!" and "hi" are one entry.
+#: How much of a message the naming call sees. Was 2000, which made the cheap
+#: call the expensive one on exactly the input most likely to be pasted: a log.
+#: Measured against anthropic/claude-opus-5 on a 3 KB traceback paste, with the
+#: prefix cache defeated by a nonce — 2000 chars billed 899 input tokens (2
+#: uncached plus an 897-token cache WRITE that nothing will ever read back,
+#: since every naming prompt is different), 320 chars billed 237 and stayed
+#: under the provider's cache-write floor entirely. Both produced the same
+#: title. A title needs the ASK, and the ask is at the top of the message — a
+#: request whose subject first appears 300 characters in is a request whose
+#: first sentence would have named it anyway.
+MAX_PROMPT_CHARS = 320
+
+#: Messages that are content-free on their own. Matched with punctuation and
+#: case stripped, so "Hi!" and "hi" are one entry.
+#:
+#: Two groups, and the second one is newer than the feature. The filter used
+#: to see only OPENERS, where the content-free case is a greeting. Re-titling
+#: (:func:`generate_retitle`) runs this over every FOLLOW-UP too, and the
+#: content-free case there is an acknowledgement — "looks good", "lgtm",
+#: "carry on". Those are most of the messages in a long session and not one of
+#: them can have moved a subject, so recognising them here is what keeps the
+#: re-title check off the common path entirely rather than merely throttled.
 _LOW_SIGNAL_PHRASES = frozenset(
     {
+        # Openers with no topic.
         "hi",
         "hii",
         "hey",
@@ -95,7 +141,16 @@ _LOW_SIGNAL_PHRASES = frozenset(
         "hi there",
         "hey there",
         "hello there",
+        "test",
+        "testing",
+        "ping",
+        "hello world",
+        "are you there",
+        "you there",
+        "help",
+        # Follow-ups that acknowledge rather than ask.
         "thanks",
+        "thanks again",
         "thank you",
         "thx",
         "ty",
@@ -105,19 +160,37 @@ _LOW_SIGNAL_PHRASES = frozenset(
         "k",
         "cool",
         "nice",
+        "nice one",
+        "nice work",
+        "good work",
         "great",
+        "great thanks",
+        "awesome",
+        "excellent",
+        "perfect",
+        "beautiful",
+        "looks good",
+        "that looks good",
+        "looks great",
+        "lgtm",
+        "works",
+        "it works",
+        "that works",
+        "all good",
+        "sounds good",
         "yes",
         "no",
         "yep",
+        "yup",
         "nope",
         "sure",
-        "test",
-        "testing",
-        "ping",
-        "hello world",
-        "are you there",
-        "you there",
-        "help",
+        "done",
+        "go ahead",
+        "go on",
+        "carry on",
+        "keep going",
+        "continue",
+        "proceed",
     }
 )
 
@@ -272,6 +345,35 @@ def provisional_title(text: str) -> str:
     return label
 
 
+async def _ask_for_title(system: str, prompt: str, complete_fn, timeout: float) -> str | None:
+    """One bounded call, every failure resolving to ``None``.
+
+    Shared by :func:`generate_title` and :func:`generate_retitle` so the two
+    have exactly one error policy between them. There is no retry here and
+    none underneath (the session marks the request single-attempt), so the
+    timeout is the entire budget.
+    """
+    try:
+        raw = await asyncio.wait_for(complete_fn(system, prompt), timeout)
+    except (asyncio.TimeoutError, asyncio.CancelledError):
+        # CancelledError is caught deliberately: the naming task is detached
+        # and routinely cancelled at shutdown, and letting that propagate
+        # would surface a teardown traceback for a feature nobody waited on.
+        return None
+    except Exception:
+        # EVERY provider failure, 429 included. The turn is running alongside
+        # this call and must never learn it happened; the request is `isolated`
+        # so the failure cannot have moved the turn's route or credential
+        # either. See ``ChatRequest.isolated``.
+        return None
+    return parse_title(str(raw or ""))
+
+
+def _errand_prompt(text: str) -> str:
+    """``text`` collapsed to one line and trimmed to the prompt budget."""
+    return " ".join((text or "").split())[:MAX_PROMPT_CHARS]
+
+
 async def generate_title(
     text: str,
     complete_fn,
@@ -289,17 +391,49 @@ async def generate_title(
     """
     if is_low_signal(text):
         return None
-    prompt = " ".join((text or "").split())[:MAX_PROMPT_CHARS]
-    try:
-        raw = await asyncio.wait_for(complete_fn(TITLE_SYSTEM_PROMPT, prompt), timeout)
-    except (asyncio.TimeoutError, asyncio.CancelledError):
-        # CancelledError is caught deliberately: the naming task is detached
-        # and routinely cancelled at shutdown, and letting that propagate
-        # would surface a teardown traceback for a feature nobody waited on.
+    return await _ask_for_title(TITLE_SYSTEM_PROMPT, _errand_prompt(text), complete_fn, timeout)
+
+
+async def generate_retitle(
+    current: str,
+    text: str,
+    complete_fn,
+    *,
+    timeout: float = TITLE_TIMEOUT_S,
+) -> str | None:
+    """A REPLACEMENT title when ``text`` has moved the subject; else ``None``.
+
+    A long conversation drifts. It opens as "Fix the login redirect loop" and
+    four messages later it is about the billing importer, and a title that
+    still names the first thing is worse than one that names nothing — it
+    actively misidentifies the session in a tab bar of five.
+
+    The DECISION belongs to the model, and that is deliberate rather than
+    convenient. "The subject has materially changed" is a judgement about
+    meaning: any keyword rule written here would fire on "actually, forget the
+    parser" and miss "right, and now the same thing for invoices". So the model
+    is given the current title and the new message and answers with the
+    sentinel to keep what it has. ``None`` therefore means BOTH "no change" and
+    "the call failed", which are the same instruction to the caller: leave the
+    title alone.
+
+    Same cost and the same isolation as :func:`generate_title` — one bounded,
+    single-attempt, tools-free call. What keeps it cheap in aggregate is the
+    CALLER's throttle, not this function: see the TUI's re-title policy.
+    """
+    if not current or is_low_signal(text):
         return None
-    except Exception:
+    system = RETITLE_SYSTEM_PROMPT.format(current=current)
+    title = await _ask_for_title(system, _errand_prompt(text), complete_fn, timeout)
+    if title is None:
         return None
-    return parse_title(str(raw or ""))
+    # A model that "changes" the title to the one it already has has answered
+    # "no change" in the expensive spelling. Treat it as the sentinel so the
+    # caller never repaints, never journals, and never resets its throttle on a
+    # non-event.
+    if title.casefold() == current.casefold():
+        return None
+    return title
 
 
 @dataclass

--- a/local_operator/session/protocol.py
+++ b/local_operator/session/protocol.py
@@ -28,6 +28,7 @@ from local_operator.harness.types import (
     ModelSpec,
     Usage,
 )
+from local_operator.session.naming import ConversationName
 
 
 @dataclass(frozen=True, slots=True)
@@ -114,6 +115,17 @@ class SessionProtocol(Protocol):
         """The conversation's title ("" until one is set or generated)."""
         ...
 
+    @property
+    def conversation_name_state(self) -> ConversationName:
+        """The title holder, not just the string.
+
+        A host that re-titles a drifting conversation needs the ``user_set``
+        precedence flag before it spends a call: an explicit rename outranks
+        every generated title forever, and reading only the text cannot tell
+        a human's name from a model's.
+        """
+        ...
+
     def set_conversation_name(self, text: str, *, user_set: bool = True) -> str:
         """Name the conversation; returns the title in force afterwards.
 
@@ -123,11 +135,13 @@ class SessionProtocol(Protocol):
         ...
 
     async def complete_once(self, system: str, prompt: str) -> str:
-        """One non-tool provider call for host-side side errands.
+        """One cheap, isolated, single-attempt provider call for a host errand.
 
         Not a turn: no tools, no history, no transcript entry. Hosts use it
         for small derived text (conversation auto-naming) without rebuilding
-        the provider's auth cascade. Never await it on a turn's critical path.
+        the provider's auth cascade. It runs CONCURRENTLY with a live turn, so
+        an implementation must make it unable to move anything the turn
+        depends on — see ``ChatRequest.isolated``.
         """
         ...
 

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -2350,17 +2350,18 @@ class Session:
 
         * ``isolated`` — one attempt, no fallback chain, no credential
           rotation, no sticky-route read or write, no quota preflight, no
-          effort-boundary classification and not the session's prompt cache
-          key. See the field's docstring for the five pieces of session-wide
-          state that protects, and why each one mattered.
+          effort-boundary classification, a read-only credential resolve and
+          not the session's prompt cache key. See the field's docstring for the
+          six pieces of session-wide state that protects, and why each one
+          mattered.
         * ``replayable=False`` — deliberately the opposite of the compaction
           errand below. Replay exists so a stalled read does not permanently
           lose an EXPENSIVE result; a title is worth one attempt and no more.
         * ``max_tokens`` — bounds a model that ignores the output format.
         * cheapest route available: the ``lo`` subagent tier when the operator
-          has configured one, otherwise this session's model clamped to the
-          lowest reasoning effort it accepts. Naming is a formatting job, not a
-          thinking job, and thinking tokens are most of what it would bill.
+          has configured one, otherwise this session's model — either way
+          clamped to the lowest reasoning effort the spec accepts, because that
+          128-token cap counts thinking tokens as well as the title.
         """
         model = self._errand_model()
         request = ChatRequest(
@@ -2380,23 +2381,38 @@ class Session:
         return "".join(parts)
 
     def _errand_model(self) -> ModelSpec:
-        """The cheapest spec this session can reach for a decorative errand.
+        """The cheapest spec this session can reach for a decorative errand,
+        always on the bottom rung of whatever reasoning ladder it has.
 
         Prefers the operator's ``lo`` tier (``values.subagents.models.lo``),
         which is the same ladder a scout subagent runs on — an operator who has
         already said "this is my cheap model" should not have to say it twice.
-        With no tier configured this falls back to the session's own model with
-        its reasoning effort clamped to the bottom rung, which is a real saving
-        on a reasoning model (thinking tokens dominate a 10-token answer) and a
-        no-op on a model that exposes no knob.
+        With no tier configured it falls back to the session's own model.
+
+        The clamp is applied to WHICHEVER of the two this returns, and it is not
+        only a cost argument. ``ERRAND_MAX_TOKENS`` becomes
+        ``max_output_tokens``, which counts reasoning tokens too, so a spec left
+        on its provider's default effort can spend the whole 128-token budget
+        thinking, emit no ``<title>`` at all and make ``parse_title`` return
+        ``None`` — auto-naming would silently never produce a title for that
+        operator while still billing the thinking. ``build_model_spec`` seeds
+        ``reasoning_effort`` from ``default_effort``, which is ``None`` for
+        several reasoning families (no ``reasoning.effort`` goes on the wire, so
+        the provider applies its own default), and that is exactly how a
+        configured ``lo`` tier used to reach the wire unclamped. Naming is a
+        formatting job, not a thinking job. A model with no effort knob is
+        unaffected.
         """
         tier = self._resolve_subagent_model("task", "lo")
-        if tier is not None:
-            return tier
-        efforts = self._model.reasoning_efforts
-        if not efforts or self._model.reasoning_effort == efforts[0]:
-            return self._model
-        return self._model.model_copy(update={"reasoning_effort": efforts[0]})
+        return self._lowest_effort(tier if tier is not None else self._model)
+
+    @staticmethod
+    def _lowest_effort(spec: ModelSpec) -> ModelSpec:
+        """``spec`` on the bottom rung of its own effort ladder, if it has one."""
+        efforts = spec.reasoning_efforts
+        if not efforts or spec.reasoning_effort == efforts[0]:
+            return spec
+        return spec.model_copy(update={"reasoning_effort": efforts[0]})
 
     async def _one_shot_complete(self, system: str, prompt: str) -> str:
         """One non-tool provider call used to produce the compaction summary.

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -2324,17 +2324,79 @@ class Session:
             return entry.payload.get("summary")
         return None
 
-    async def complete_once(self, system: str, prompt: str) -> str:
-        """One non-tool provider call, exposed for host-side helpers.
+    #: Output cap for :meth:`complete_once`, and the only bound on what a model
+    #: that ignores the output format can bill us for. Not tight, deliberately:
+    #: the cap counts EVERY response token, and on a provider with adaptive
+    #: thinking (Anthropic's ``thinking: adaptive``, which this session sends
+    #: whenever the model has an effort ladder) some of them are thinking. Seven
+    #: measured naming calls emitted 18–38 tokens, so a 64-token cap was running
+    #: at 60% of budget on a title we would then have to REJECT for being
+    #: truncated. Only the tokens produced are billed, so headroom is free.
+    ERRAND_MAX_TOKENS = 128
 
-        Hosts need the session's configured provider and credentials for
-        small side errands — conversation auto-naming is the first — and
+    async def complete_once(self, system: str, prompt: str) -> str:
+        """One CHEAP, ISOLATED, single-attempt provider call for a host errand.
+
+        Hosts need the session's configured provider and credentials for small
+        side errands — conversation auto-naming is the only caller — and
         rebuilding a client from the spec would duplicate the whole auth
-        cascade. The call carries no tools, no history and no abort signal:
-        it is not a turn, must not appear in the transcript, and must never
-        be awaited on the turn's critical path.
+        cascade. The call carries no tools, no history and no abort signal: it
+        is not a turn and must not appear in the transcript.
+
+        It used to be deferred until the turn settled, because a second
+        simultaneous request at minute zero could rate-limit both. It now runs
+        CONCURRENTLY with the turn, so the safety comes from the shape of the
+        request instead of from the timing:
+
+        * ``isolated`` — one attempt, no fallback chain, no credential
+          rotation, no sticky-route read or write, no quota preflight, no
+          effort-boundary classification and not the session's prompt cache
+          key. See the field's docstring for the five pieces of session-wide
+          state that protects, and why each one mattered.
+        * ``replayable=False`` — deliberately the opposite of the compaction
+          errand below. Replay exists so a stalled read does not permanently
+          lose an EXPENSIVE result; a title is worth one attempt and no more.
+        * ``max_tokens`` — bounds a model that ignores the output format.
+        * cheapest route available: the ``lo`` subagent tier when the operator
+          has configured one, otherwise this session's model clamped to the
+          lowest reasoning effort it accepts. Naming is a formatting job, not a
+          thinking job, and thinking tokens are most of what it would bill.
         """
-        return await self._one_shot_complete(system, prompt)
+        model = self._errand_model()
+        request = ChatRequest(
+            model=model,
+            system_blocks=[system],
+            messages=[Message.user(prompt)],
+            tools=[],
+            tool_choice="none",
+            max_tokens=self.ERRAND_MAX_TOKENS,
+            replayable=False,
+            isolated=True,
+        )
+        parts: list[str] = []
+        async for event in self._stream_fn(request, None):
+            if isinstance(event, StreamTextDelta):
+                parts.append(event.delta)
+        return "".join(parts)
+
+    def _errand_model(self) -> ModelSpec:
+        """The cheapest spec this session can reach for a decorative errand.
+
+        Prefers the operator's ``lo`` tier (``values.subagents.models.lo``),
+        which is the same ladder a scout subagent runs on — an operator who has
+        already said "this is my cheap model" should not have to say it twice.
+        With no tier configured this falls back to the session's own model with
+        its reasoning effort clamped to the bottom rung, which is a real saving
+        on a reasoning model (thinking tokens dominate a 10-token answer) and a
+        no-op on a model that exposes no knob.
+        """
+        tier = self._resolve_subagent_model("task", "lo")
+        if tier is not None:
+            return tier
+        efforts = self._model.reasoning_efforts
+        if not efforts or self._model.reasoning_effort == efforts[0]:
+            return self._model
+        return self._model.model_copy(update={"reasoning_effort": efforts[0]})
 
     async def _one_shot_complete(self, system: str, prompt: str) -> str:
         """One non-tool provider call used to produce the compaction summary.

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -341,6 +341,18 @@ LOOP_PROMPT = (
 #: when the count actually CHANGES.
 JOB_POLL_INTERVAL_S = 1.0
 
+#: Minimum seconds between two re-title CHECKS on one conversation. The check
+#: is a provider call (the model, not a keyword rule, judges whether the
+#: subject moved — see :meth:`OperatorApp._maybe_retitle_conversation`), so
+#: unthrottled it would bill once per follow-up. Measured against
+#: anthropic/claude-opus-5 at its lowest effort, one check is 167 input + 18
+#: output tokens — real money at Opus rates on a chatty session, but the
+#: sharper cost is CHURN: a tab label that can change every twenty seconds is
+#: one nobody can read. Two minutes is longer than a burst of follow-ups on
+#: one subject (which then costs exactly one check) and much shorter than the
+#: time it takes a session to genuinely move on to something else.
+RETITLE_MIN_GAP_S = 120.0
+
 #: TUI diagnostics go to the log FILE, never the terminal — stderr belongs to
 #: the rendered app (see ``local_operator.logger.file_logging``).
 logger = logging.getLogger("local_operator.tui.app")
@@ -714,25 +726,22 @@ class OperatorApp(App[None]):
         # here and not on the session because it is a DISPLAY stand-in, not a
         # stored title — see :meth:`_show_provisional_name`.
         self._provisional_name: str = ""
-        # Ownership token for the latch above. Turn start can supersede an
-        # in-flight naming worker synchronously, then schedule its replacement
-        # from the follow-up message before cancellation has unwound; only the
-        # current generation may clear the new latch or store a title.
+        # Ownership token for the latch above. Reload can supersede an
+        # in-flight naming worker synchronously, then let the replacement
+        # session schedule its own attempt before cancellation has unwound;
+        # only the current generation may clear the new latch or store a title.
         self._name_generation: int = 0
-        # Cleared while a turn is live, set the moment it settles. The naming
-        # errand waits on this rather than racing the turn's own provider
-        # call: OAuth accounts enforce low concurrent-request ceilings, and a
-        # second simultaneous request at minute zero was the reliable recipe
-        # for a 429 on BOTH — early "provider failure" notices on the turn
-        # and a dead naming call whose failure the latch above then made
-        # permanent (the `lo › tmp` tab that never became a title).
-        self._turn_settled: asyncio.Event = asyncio.Event()
-        self._turn_settled.set()
-        # The live turn and the decorative title request share one provider
-        # lane. A follow-up can arrive during the title call's own 20-second
-        # timeout; turn start cancels naming, then waits for this lock, so the
-        # user request begins only after cancellation has released the route.
-        # Naming takes it only while the turn-settled event is still set.
+        # Monotonic stamp of the last moment a title was DECIDED — either
+        # stored, or checked against a new message and left alone. The re-title
+        # throttle measures its gap from here; see
+        # :meth:`_maybe_retitle_conversation` for why the gap exists.
+        self._retitle_checked_at: float = 0.0
+        # A turn holds this for its whole provider round trip, and `_dispose`
+        # waits on it so a session is never torn down under a live request.
+        # Naming does NOT take it: the title call is `isolated` (see
+        # `ChatRequest.isolated`) and runs concurrently with the turn on
+        # purpose, so serialising it here would restore the very latency this
+        # feature exists to remove.
         self._turn_provider_lock: asyncio.Lock = asyncio.Lock()
         # Last subagent count painted, so the 1 Hz poll repaints only on a
         # real change instead of every tick.
@@ -1520,11 +1529,11 @@ class OperatorApp(App[None]):
         # describes the conversation that just died, and a swap that kept it
         # would put the dead session's first sentence on the new session's tab.
         self._provisional_name = ""
-        # The old conversation's turn can no longer settle anything for the
-        # new one: release any naming errand still waiting on it. Its
-        # session-identity guard then drops the stale attempt, and the reset
-        # latch lets the fresh conversation schedule its own.
-        self._turn_settled.set()
+        # The throttle is a property of the title that was in force, and that
+        # title just died with its conversation. Left standing, a swap landing
+        # inside the window would make the new conversation's first follow-up
+        # unable to correct a title generated from an opener it never had.
+        self._retitle_checked_at = 0.0
         # The spend ledger is the dead conversation's — unless the reload lands
         # back on the SAME conversation, which `/reload` now does. Reset it here
         # so `/new` and `/resume` cannot inherit a figure they did not spend,
@@ -3116,9 +3125,10 @@ class OperatorApp(App[None]):
             self._maybe_name_conversation(text)
             return
         self._start_turn(text, images)
-        # Detached, and deliberately AFTER the turn is dispatched: the title
-        # is decoration, and decoration must never sit in front of the user's
-        # first reply.
+        # AFTER the turn is dispatched, and then concurrently with it: the
+        # title is decoration, so it must never sit in front of the user's
+        # first reply — but it must also not wait for the whole turn, which is
+        # what used to make it arrive minutes late.
         self._maybe_name_conversation(text)
 
     def _start_turn(self, text: str, images: list[ImageContent] | None = None) -> None:
@@ -3132,18 +3142,14 @@ class OperatorApp(App[None]):
         session = self._session
         if session is None or self._status is None:
             return
-        # A user prompt always outranks decoration. Invalidate the old
-        # worker's latch ownership synchronously so `_submit_prompt` can
-        # schedule this follow-up's replacement naming attempt immediately;
-        # then cancellation + the provider lock ensure the prompt cannot
-        # overlap the old courtesy call.
-        self._cancel_naming_attempt()
+        # Naming is deliberately NOT cancelled here. It used to be, because the
+        # title call took the same provider lane the turn takes and a follow-up
+        # had to be able to evict it. The call is now `isolated` and concurrent,
+        # so an in-flight title cannot delay this prompt — and cancelling it
+        # would throw away a title generated from the OPENER and re-derive one
+        # from the follow-up, which names the conversation after its second
+        # subject. Reload still cancels: see `_cancel_naming_attempt`.
         self._status.update(streaming=True)
-        # Marked busy for the naming errand BEFORE the worker exists: the
-        # worker is scheduled from `_submit_prompt` a moment after this, and
-        # an event cleared only inside the coroutine would race the errand's
-        # first peek at it.
-        self._turn_settled.clear()
 
         async def run_prompt() -> None:
             try:
@@ -3156,44 +3162,52 @@ class OperatorApp(App[None]):
                 # no-op, and this covers sessions that end without agent_end.
                 assert self._status is not None
                 self._status.update(streaming=False)
-                self._turn_settled.set()
 
         self.run_worker(run_prompt(), thread=False, group="turns")
 
     # -- conversation naming --------------------------------------------------
     def _cancel_naming_attempt(self) -> None:
-        """Supersede and cancel the current naming worker, if any."""
+        """Supersede and cancel the current naming worker, if any.
+
+        Reload/dispose only. A live turn no longer calls this: an isolated
+        title call cannot delay the prompt, so the only reason left to cancel
+        one is that the conversation it was naming is going away.
+        """
         self._name_generation += 1
         self._name_requested = False
         self.workers.cancel_group(self, "naming")
 
     def _maybe_name_conversation(self, text: str) -> None:
-        """Name this conversation: the opener now, the model's title later.
+        """Name this conversation, or re-name it when the subject has moved.
 
-        Skipping a low-signal opener does NOT spend the attempt: "hi" is
-        usually followed by the actual request, and latching on the greeting
+        One entry point for both, called from every place a user message is
+        accepted, because "is this conversation named yet" is the only thing
+        that separates the two cases and the caller should not have to know.
+
+        Skipping a low-signal message does NOT spend the naming attempt: "hi"
+        is usually followed by the actual request, and latching on the greeting
         would leave the conversation permanently unnamed.
         """
         session = self._session
-        if session is None or self._name_requested:
+        if session is None or naming.is_low_signal(text):
             return
         if session.conversation_name:
-            return  # already named: a restored session, or an explicit rename
-        if naming.is_low_signal(text):
+            # Already named. The message may still have moved the subject —
+            # that is the re-title path, which has its own throttle.
+            self._maybe_retitle_conversation(text)
+            return
+        if self._name_requested:
             return
         self._name_requested = True
         self._name_generation += 1
         generation = self._name_generation
         # The band and the tab stop saying `lo › <cwd>` HERE, from the opener,
-        # with no provider call at all. The errand below cannot ask for a title
-        # until the turn settles — it shares the turn's provider lane, and two
-        # simultaneous requests at minute zero 429 both — and a first turn on
-        # this product routinely runs for minutes. Measured against a real
-        # provider before this line existed: a 29.7-second opening turn, the
-        # cwd fallback on the tab for all 29.7 of those seconds, and the title
-        # stored 1.8 seconds after the answer was already on screen. That is
-        # the whole reported bug ("the tab never becomes a title"): the title
-        # did arrive, just after everyone had stopped waiting for it.
+        # with no provider call at all. The model's title follows a second or
+        # two later, concurrently with the turn — but not instantly, and the
+        # instant is what this buys. Measured against a real provider on the
+        # version that waited for the turn: a 29.7-second opening turn, the cwd
+        # fallback on the tab for all 29.7 of those seconds, and the title
+        # stored 1.8 seconds after the answer was already on screen.
         self._show_provisional_name(text)
         self.run_worker(
             self._name_conversation_worker(session, text, generation),
@@ -3227,58 +3241,126 @@ class OperatorApp(App[None]):
         self._provisional_name = label
         self._status.update(conversation_name=label)
 
+    def _clock(self) -> float:
+        """Monotonic seconds, as one overridable seam.
+
+        Monotonic and not ``time.time``: the only reader is the re-title
+        throttle, and a wall clock stepped backwards by NTP would silently
+        widen its window. A method rather than a direct call so a test can
+        cross a two-minute gap without sleeping through it.
+        """
+        return time.monotonic()
+
+    def _maybe_retitle_conversation(self, text: str) -> None:
+        """Ask whether ``text`` has moved the subject, at most once per window.
+
+        A long session drifts. It opens as "Fix the login redirect loop" and an
+        hour later it is about the billing importer, and a tab still naming the
+        first subject actively misidentifies the session rather than merely
+        under-describing it. So a named conversation keeps asking — but the
+        asking has to stay cheap, and three gates do that:
+
+        * **The user renamed it.** ``user_set`` outranks everything, forever.
+          Checked HERE as well as at the store, so an explicitly named
+          conversation does not even spend the call.
+        * **Low signal.** Already filtered by the caller; "ok", "thanks" and
+          "continue" are most follow-ups in a long session and none of them
+          can have moved a subject.
+        * **A minimum gap.** ``RETITLE_MIN_GAP_S`` since the title in force was
+          last decided — stamped when a check is DISPATCHED (below) and again
+          by :meth:`_store_title` when a title actually lands. Unthrottled, a
+          40-message session would spend 40 checks; measured on
+          anthropic/claude-opus-5, one check is 167 input + 18 output tokens.
+          The cap is as much about CHURN as money — a tab label that can
+          change every twenty seconds is one nobody can read. A burst of
+          follow-ups on one subject costs exactly one check.
+
+        The decision itself is the MODEL's (see ``naming.generate_retitle``):
+        "the subject has materially changed" is a judgement about meaning, and
+        any keyword rule here would fire on "actually, forget the parser" and
+        miss "right, now the same thing for invoices".
+        """
+        session = self._session
+        if session is None or self._status is None:
+            return
+        if session.conversation_name_state.user_set:
+            return
+        now = self._clock()
+        if now - self._retitle_checked_at < RETITLE_MIN_GAP_S:
+            return
+        # Stamped BEFORE the call, not after it: a second submit arriving while
+        # this one is in flight must be throttled by the attempt already
+        # running, or a fast typist gets one call per message anyway.
+        self._retitle_checked_at = now
+        self._name_generation += 1
+        generation = self._name_generation
+        self.run_worker(
+            self._retitle_conversation_worker(session, session.conversation_name, text, generation),
+            thread=False,
+            group="naming",
+        )
+
+    async def _retitle_conversation_worker(
+        self, session: SessionProtocol, current: str, text: str, generation: int
+    ) -> None:
+        """One isolated re-title call; ``None`` from it means "leave it alone".
+
+        Same shape and the same failure policy as the first naming call: it runs
+        alongside the turn, it is single-attempt and isolated, and every failure
+        resolves to "no change" rather than to a notice. The band therefore
+        never flickers on a failed check — nothing repaints unless a genuinely
+        different title came back.
+        """
+        try:
+            title = await naming.generate_retitle(current, text, session.complete_once)
+        except asyncio.CancelledError:
+            return
+        if not title:
+            return  # unchanged subject, or the call failed: same instruction
+        if generation != self._name_generation or session is not self._session:
+            return
+        # Re-read rather than trusting `current`: a rename or a reload may have
+        # landed during the call, and both outrank a check made against a title
+        # that is no longer in force.
+        if session.conversation_name != current:
+            return
+        self._store_title(session, title)
+
     async def _name_conversation_worker(
         self, session: SessionProtocol, text: str, generation: int
     ) -> None:
-        """Name only while no live turn owns (or is waiting for) the provider.
+        """Ask the model for a title NOW, alongside the turn it decorates.
 
-        The errand first waits for the current turn to settle, then takes the
-        same provider lock every user turn takes. Turn start cancels this
-        worker before waiting on that lock, so a follow-up submitted during
-        ``complete_once`` preempts decoration and cannot overlap it. There is
-        deliberately no timeout on the turn-settled wait: a title may be
-        absent, but a courtesy call must never make a user request worse.
+        This errand used to wait for the turn to settle and then take the same
+        provider lock the turn takes, because two simultaneous requests at
+        minute zero could rate-limit both. That was correct about the risk and
+        wrong about the remedy: a first turn here runs for minutes, so the wait
+        meant the title arrived after the answer, which is to say after anyone
+        still wanted it.
 
-        That wait is unbounded and can therefore be minutes long, which is
-        exactly what made this errand look broken from the outside. It is no
-        longer VISIBLE, because ``_maybe_name_conversation`` has already put
-        the opener's own words on the band and the tab before scheduling this
-        worker; what lands here is an upgrade, not the first label. The wait
-        stays because the reason for it has not changed — the turn owns the
-        provider lane and a second simultaneous request 429s both.
+        So the safety moved from the TIMING into the SHAPE of the request, which
+        is what ``session.complete_once`` now builds: one attempt, no fallback
+        chain, no credential rotation, no sticky-route read or write, no quota
+        preflight, no boundary classification, not the session's prompt cache
+        key, a 128-token cap, the cheapest route the session can reach, and a
+        15-second ceiling. A 429 here is swallowed by ``generate_title`` and
+        cannot have touched anything the turn depends on — see
+        ``ChatRequest.isolated`` for the enumeration.
 
-        The generation owns the shared latch. A follow-up supersedes it
-        synchronously before scheduling the replacement worker, so cancellation
-        from the old attempt cannot clear or store into the new attempt.
-        Reload/user rename are checked after every wait, immediately before
-        the provider side effect.
+        What the user sees: the opener's excerpt the instant they submit, then
+        the model's title about five seconds later (measured against
+        anthropic/claude-opus-5), both while the turn is still running.
+
+        The generation owns the shared latch. Reload supersedes this attempt
+        synchronously (``_cancel_naming_attempt``) before the replacement
+        session can schedule its own, so cancellation from the dead attempt
+        cannot clear or store into the new one. A follow-up TURN does not
+        supersede it: this call is not in the turn's way, and the opener names
+        the conversation better than the second message would. Reload and user
+        rename are re-checked immediately before the store.
         """
         try:
-            if session is self._session and not session.conversation_name:
-                await self._turn_settled.wait()
-            if (
-                generation != self._name_generation
-                or session is not self._session
-                or session.conversation_name
-            ):
-                return
-            async with self._turn_provider_lock:
-                # A follow-up may clear the event while this worker waits for
-                # the lock. Never turn that race into provider concurrency.
-                if (
-                    generation != self._name_generation
-                    or session is not self._session
-                    or session.conversation_name
-                    or not self._turn_settled.is_set()
-                ):
-                    if (
-                        generation == self._name_generation
-                        and session is self._session
-                        and not session.conversation_name
-                    ):
-                        self._name_requested = False
-                    return
-                title = await naming.generate_title(text, session.complete_once)
+            title = await naming.generate_title(text, session.complete_once)
         except asyncio.CancelledError:
             if (
                 generation == self._name_generation
@@ -3298,13 +3380,33 @@ class OperatorApp(App[None]):
             if not session.conversation_name:
                 self._name_requested = False
             return
+        self._store_title(session, title)
+
+    def _store_title(self, session: SessionProtocol, title: str) -> str:
+        """Store a generated title and put it on both surfaces.
+
+        One writer for the first title and for every later re-title, so the
+        band and the terminal tab cannot disagree about which is in force. The
+        store itself owns precedence: ``user_set=False`` means an explicit
+        rename always wins, including one that landed while this call was in
+        flight, so this may store nothing and return the name already there.
+        """
         stored = session.set_conversation_name(title, user_set=False)
+        # A title just took effect, so the re-title window restarts from here
+        # rather than from whenever the last CHECK was dispatched. Without
+        # this, a title landing at the tail of an open window would be eligible
+        # for replacement by the very next message.
+        self._retitle_checked_at = self._clock()
         # Superseded: an answer beats a quote of the question. Cleared rather
         # than left set so nothing downstream still believes the band is
         # showing a stand-in.
         self._provisional_name = ""
         if self._status is not None:
+            # The band's setter also pushes the terminal title (see
+            # `StatusLine._sync_terminal_title`), so both surfaces follow from
+            # this one call and neither can lag the other by a frame.
             self._status.update(conversation_name=stored)
+        return stored
 
     # -- background jobs ------------------------------------------------------
     def _poll_subagents(self) -> None:

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -499,7 +499,7 @@ class Chrome(Static):
         First line of the answer.
         Second paragraph here.
         ❯
-        ◆ test/model › ⌂ ~/local-operator                     ! auto-approve always
+        ◆ test/model › ⌂ ~/local-operator            ! ‹ Summarise the ingest path
 
     The last two rows are the composer's chevron and the status band — the
     app's own furniture, pasted into the middle of someone's bug report,
@@ -706,6 +706,14 @@ class OperatorApp(App[None]):
         # next substantive message retries, which is bounded by the user's own
         # sends and only ever fires while no name exists to displace.
         self._name_requested: bool = False
+        # The opener-derived label the band and the tab wear until the
+        # generated title lands. Latched to the FIRST substantive message on
+        # purpose: a conversation is identified by what it was opened for, and
+        # a label that rewrote itself on every follow-up would walk the tab bar
+        # through the session's history instead of naming the session. Held
+        # here and not on the session because it is a DISPLAY stand-in, not a
+        # stored title — see :meth:`_show_provisional_name`.
+        self._provisional_name: str = ""
         # Ownership token for the latch above. Turn start can supersede an
         # in-flight naming worker synchronously, then schedule its replacement
         # from the follow-up message before cancellation has unwound; only the
@@ -1508,6 +1516,10 @@ class OperatorApp(App[None]):
         # session. A `/reload` that continues this conversation re-derives the
         # name from the session it boots, exactly as a `--resume` launch does.
         self._name_requested = False
+        # The opener-derived label goes with the attempt it stood in for: it
+        # describes the conversation that just died, and a swap that kept it
+        # would put the dead session's first sentence on the new session's tab.
+        self._provisional_name = ""
         # The old conversation's turn can no longer settle anything for the
         # new one: release any naming errand still waiting on it. Its
         # session-identity guard then drops the stale attempt, and the reset
@@ -3156,7 +3168,7 @@ class OperatorApp(App[None]):
         self.workers.cancel_group(self, "naming")
 
     def _maybe_name_conversation(self, text: str) -> None:
-        """Schedule the one auto-naming call for this conversation.
+        """Name this conversation: the opener now, the model's title later.
 
         Skipping a low-signal opener does NOT spend the attempt: "hi" is
         usually followed by the actual request, and latching on the greeting
@@ -3172,11 +3184,48 @@ class OperatorApp(App[None]):
         self._name_requested = True
         self._name_generation += 1
         generation = self._name_generation
+        # The band and the tab stop saying `lo › <cwd>` HERE, from the opener,
+        # with no provider call at all. The errand below cannot ask for a title
+        # until the turn settles — it shares the turn's provider lane, and two
+        # simultaneous requests at minute zero 429 both — and a first turn on
+        # this product routinely runs for minutes. Measured against a real
+        # provider before this line existed: a 29.7-second opening turn, the
+        # cwd fallback on the tab for all 29.7 of those seconds, and the title
+        # stored 1.8 seconds after the answer was already on screen. That is
+        # the whole reported bug ("the tab never becomes a title"): the title
+        # did arrive, just after everyone had stopped waiting for it.
+        self._show_provisional_name(text)
         self.run_worker(
             self._name_conversation_worker(session, text, generation),
             thread=False,
             group="naming",
         )
+
+    def _show_provisional_name(self, text: str) -> None:
+        """Wear an opener-derived label until the generated title arrives.
+
+        DISPLAY-only, deliberately: ``session.conversation_name`` stays the
+        store of record and stays empty. Every gate in the naming errand below
+        reads that string to mean "something already named this conversation,
+        do not displace it" — a restored session, an explicit rename — so
+        writing a stand-in into it would have the errand cancel the very call
+        this label is standing in for, and the conversation would keep the
+        excerpt forever. Keeping the stand-in on the host also means the
+        precedence rules on ``ConversationName`` need no third state.
+
+        The band already substitutes the working directory in this slot when
+        there is no name (see ``StatusLine._sync_terminal_title``), so this is
+        a better answer inside an existing fallback rather than a new kind of
+        state: the slot has always held "the best label we have", and the
+        opening request beats the directory at describing a conversation.
+        """
+        if self._provisional_name or self._status is None:
+            return
+        label = naming.provisional_title(text)
+        if not label:
+            return
+        self._provisional_name = label
+        self._status.update(conversation_name=label)
 
     async def _name_conversation_worker(
         self, session: SessionProtocol, text: str, generation: int
@@ -3189,6 +3238,14 @@ class OperatorApp(App[None]):
         ``complete_once`` preempts decoration and cannot overlap it. There is
         deliberately no timeout on the turn-settled wait: a title may be
         absent, but a courtesy call must never make a user request worse.
+
+        That wait is unbounded and can therefore be minutes long, which is
+        exactly what made this errand look broken from the outside. It is no
+        longer VISIBLE, because ``_maybe_name_conversation`` has already put
+        the opener's own words on the band and the tab before scheduling this
+        worker; what lands here is an upgrade, not the first label. The wait
+        stays because the reason for it has not changed — the turn owns the
+        provider lane and a second simultaneous request 429s both.
 
         The generation owns the shared latch. A follow-up supersedes it
         synchronously before scheduling the replacement worker, so cancellation
@@ -3236,10 +3293,16 @@ class OperatorApp(App[None]):
         if not title:
             # Provider failure, cancellation, or "no topic": a later
             # substantive message may retry while the conversation is unnamed.
+            # The opener's excerpt stays on the band and the tab meanwhile —
+            # that is the point of it being a stand-in and not a placeholder.
             if not session.conversation_name:
                 self._name_requested = False
             return
         stored = session.set_conversation_name(title, user_set=False)
+        # Superseded: an answer beats a quote of the question. Cleared rather
+        # than left set so nothing downstream still believes the band is
+        # showing a stand-in.
+        self._provisional_name = ""
         if self._status is not None:
             self._status.update(conversation_name=stored)
 

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -3579,8 +3579,8 @@ class OperatorApp(App[None]):
                 # excerpt visible one row up would read as a bug, so this names
                 # what the label actually is.
                 notice(
-                    f"unnamed — the band is quoting the opener ({self._provisional_name}); "
-                    "/rename <title> names it"
+                    f"unnamed — the label above is a quote of your first message "
+                    f"({self._provisional_name}); /rename <title> names it"
                 )
             else:
                 notice("unnamed — /rename <title> names this conversation")

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -1139,13 +1139,50 @@ class OperatorApp(App[None]):
 
     async def _boot_session(self) -> None:
         """Await the session factory; on failure surface + offer /reload."""
+        # Built as its own future and adopted from THIS frame: if the app quits
+        # while construction is in flight, the worker is cancelled at the await
+        # below and a session the factory had already finished building would
+        # otherwise be lost with it — a coroutine's locals die with the
+        # `CancelledError`, but the completed future's result does not. See
+        # `_park_unadopted_session`.
+        built = asyncio.ensure_future(self._construct_session())
         try:
-            session = await self._construct_session()
+            session = await built
+        except asyncio.CancelledError:
+            self._park_unadopted_session(built)
+            raise
         except Exception as error:  # TUI-012: construction error path
             self._on_boot_failed(error)
             return
         self._adopt_session(session)
         await self._preflight_usage(session)
+
+    def _park_unadopted_session(self, built: asyncio.Future[Any]) -> None:
+        """Hand a built-but-never-adopted session to teardown, if there is one.
+
+        Only reachable on the cancellation path above: the app is going away
+        (``_shutdown`` cancels its workers before the tree is pruned), and the
+        factory finished building a session this frame never got to adopt. Left
+        alone that session is unreachable — nothing holds it, so nothing disposes
+        it, and whatever it opened (MCP subprocesses among them) outlives the
+        process exit that caused it.
+
+        Published on ``self._session`` rather than disposed inline, because this
+        runs while the app is shutting down and ``on_unmount`` is the app's own
+        place for awaiting session teardown — it runs after ``_shutdown`` has
+        finished, on a DOM already gone, and looks no further than this
+        attribute. Adoption it is not: no controller, no handlers, no history
+        replay — none of which a session nobody will talk to again needs.
+        """
+        if self._session is not None or not built.done() or built.cancelled():
+            return
+        try:
+            session = built.result()
+        except asyncio.CancelledError:
+            return
+        except Exception:
+            return  # construction failed as well; _on_boot_failed owns that
+        self._session = session
 
     def _measure_preloaded_context(self, session: Any) -> None:
         """Fill the context segment before the first turn, off the boot path.
@@ -1512,8 +1549,14 @@ class OperatorApp(App[None]):
         # gets a splash on any frame that manages to land in the gap.
         self._swapping_session = True
         try:
+            # Its own future, for the same reason as boot: a quit landing
+            # mid-swap must not orphan a replacement the factory finished.
+            built = asyncio.ensure_future(self._construct_session())
             try:
-                session = await self._construct_session()
+                session = await built
+            except asyncio.CancelledError:
+                self._park_unadopted_session(built)
+                raise
             except Exception as error:  # TUI-012: construction error path
                 # The clear happens on the failure path too, and this is the
                 # discipline it protects: the ledger is only ever as old as the
@@ -3094,6 +3137,53 @@ class OperatorApp(App[None]):
             self._status.set_terminal_title(None)
         self._terminal_title.stop()
         self._terminal_title = None
+
+    async def _shutdown(self) -> None:
+        """Cancel this app's workers BEFORE Textual dismantles the widget tree.
+
+        Textual's own order is the reverse: ``App._shutdown`` prunes every screen
+        and widget (``_close_all``, awaited by the ``super()`` call below) and the
+        workers are cancelled only afterwards, in ``_process_messages``'s
+        ``finally`` (verified against textual 8.2.8). Pruning awaits, so a worker
+        that wakes inside that window runs against a screen with no children
+        left — and the workers here are the ones that PAINT.
+
+        The boot worker is the case that shows: ``_construct_session`` is a
+        thread hop over ~700 ms of imports (see :meth:`_warm_session_imports`)
+        plus the factory itself, and it resumes straight into
+        ``_adopt_session`` → ``_render_resumed_history`` → ``_transcript_view()``,
+        whose ``#transcript`` re-lookup for a transcript that is no longer in the
+        tree raises ``NoMatches``. ``run_worker`` defaults to
+        ``exit_on_error=True``, so that arrived as ``WorkerFailed(NoMatches(…))``
+        through ``_handle_exception``: quitting while the session was still
+        starting printed a traceback instead of handing the terminal back. Under
+        the pilot it is the same crash, and that is where it was found — a
+        per-width app loop that tore one app down with adoption still in flight.
+        Measured by sweeping only the hop's duration across the app's lifetime:
+        6 crashes in 301 apps before this, 0 in 301 after. The turn, compaction,
+        usage, login and aside workers all share the same await-then-append
+        shape, so the window belongs to the app rather than to boot.
+
+        Cancelling here closes the crash rather than narrowing it: the loop is
+        single-threaded and every worker that paints is a coroutine worker, so at
+        this point each one is parked at an await, and a cancelled task cannot
+        resume its normal path — the ``CancelledError`` lands at that await
+        instead of the worker running on into the DOM. (The app's one thread
+        worker, ``SubagentPanel._read_stats``, reaches the tree only through
+        ``call_from_thread`` and carries ``exit_on_error=False``, so it is not in
+        this hazard.) What is NOT changed is where a worker's own ``finally``
+        unwinds: cancellation is delivered whenever the loop next schedules that
+        task, which can be mid-prune, exactly as stock Textual leaves it — so a
+        cleanup block must not paint, the same rule that already applied to every
+        other path here. Nothing is lost by the earlier cancel either — these
+        workers were going to be cancelled a moment later, and a worker has
+        nowhere to paint once the tree is going away. One thing IS gained by the
+        app rather than lost: a session the boot worker had finished building is
+        parked for ``on_unmount`` instead of dying with the frame
+        (``_park_unadopted_session``).
+        """
+        self.workers.cancel_all()
+        await super()._shutdown()
 
     async def on_unmount(self) -> None:
         # Before disposing the session: dispose awaits teardown, and a turn
@@ -6099,7 +6189,17 @@ class OperatorApp(App[None]):
         self._key_prompt = block
         self._append_block(block)
         try:
-            return await block.wait()
+            # SHIELDED, because the future is the app's to settle, not the
+            # scheduler's: a task cancelled while directly awaiting a future
+            # cancels that future too, and the login worker is now cancelled at
+            # teardown BEFORE the tree is pruned (see `_shutdown`). Without the
+            # shield that propagation beat `on_unmount`'s `_settle_key_prompt`
+            # to it, so the prompt died cancelled instead of resolved — and a
+            # cancelled future is indistinguishable, from the block's side, from
+            # one that was superseded by a successful paste (the Anthropic race
+            # below). The await itself still takes the CancelledError either
+            # way; only the future's fate changes.
+            return await asyncio.shield(block.wait())
         except asyncio.CancelledError:
             # The prompt task was cancelled. Two different situations arrive
             # here and the block cannot tell them apart from the cancellation

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -38,8 +38,11 @@ from textual.app import App, ComposeResult
 from textual.binding import Binding
 from textual.containers import Container, Horizontal
 from textual.css.query import NoMatches
-from textual.events import DescendantBlur, DescendantFocus, TextSelected
+from textual.events import DescendantBlur, DescendantFocus, Resize, TextSelected
 from textual.geometry import Size
+
+# Aliased: `Message` in this module is the harness's conversation message.
+from textual.message import Message as TextualMessage
 from textual.screen import Screen
 from textual.widgets import Static
 
@@ -213,6 +216,12 @@ SLASH_COMMANDS: list[SlashCommand] = [
         "Pick a past conversation to resume, or resume one (id)",
         aliases=("recall",),
     ),
+    # Beside `/resume` because it names the thing the picker lists. NOT an echo:
+    # the argument is the conversation's own label — it goes on the band and the
+    # terminal tab, never into anything the model is told — and the receipt
+    # quotes the title that ended up in force, which is strictly more than the
+    # typed words (the store trims and caps them).
+    SlashCommand("rename", "Rename this conversation; auto-naming never overrides it"),
     # The switch receipt names the old AND new label — strictly more than the
     # typed selector, which may have been elided to `default`.
     SlashCommand(
@@ -527,6 +536,34 @@ class Chrome(Static):
     """
 
     ALLOW_SELECT = False
+
+
+class Band(Chrome):
+    """The status band's own widget: it reports when its BOX changes.
+
+    The band's content is fitted to its width by an overflow ladder, so the row
+    is only correct for the box it was measured against — and the box changes for
+    reasons that are not terminal resizes. The boot card is the one that shows:
+    while the splash is up, `Screen.boot.boot-card #input-shell` clamps the shell
+    to the card's width, and the first substantive prompt dismisses the splash and
+    hands the shell the full width back. No resize event happens, so the band kept
+    painting the card's narrower row — measured at a 150-column terminal, the two
+    frames straight after the opening submit carried a basename cwd, no effort
+    segment and an 18-cell name, fitted to a 97-cell box in a 145-cell band, on
+    exactly the frames a user is watching when they press Enter.
+
+    A ``Resize`` on the band itself is the authoritative trigger, so this asks the
+    app to repaint on that rather than on each thing that might have caused it.
+    ``Resize`` does not bubble, hence the message: the app owns the
+    :class:`StatusLine`, the widget owns its geometry, and neither has to know the
+    other's reasons.
+    """
+
+    class BoxChanged(TextualMessage):
+        """The band's content box is a different size than it was."""
+
+    def on_resize(self, event: Resize) -> None:
+        self.post_message(self.BoxChanged())
 
 
 class TranscriptScreen(Screen[None]):
@@ -903,7 +940,7 @@ class OperatorApp(App[None]):
                 yield self._subagent_panel
                 yield self._todo_panel
             with Container(id="input-shell"):
-                yield Chrome(id="status-band")
+                yield Band(id="status-band")
                 editor = Editor(commands=SLASH_COMMANDS)
                 with Horizontal(id="input-row"):
                     yield Chrome("❯", id="prompt-chevron")
@@ -1952,9 +1989,13 @@ class OperatorApp(App[None]):
 
     # -- resize (TUI-017 / D5) ----------------------------------------------
     def on_resize(self, event) -> None:  # type: ignore[no-untyped-def]
-        """Re-fit size-sensitive chrome after a terminal resize."""
-        if self._status is not None:
-            self.call_after_refresh(self._status.refresh)
+        """Re-fit size-sensitive chrome after a terminal resize.
+
+        The status band is NOT re-fitted here: it answers to its own ``Resize``
+        instead (see :class:`Band` and :meth:`on_band_box_changed`), which covers
+        this case and the boot-card handover, where the band's box changes and the
+        terminal's does not.
+        """
         # The EVENT's size, not the app's: during a resize `self.size` is still the
         # previous frame's, and one stale cell is enough to put the card threshold on
         # the wrong side of itself — at 85 columns it decided "bar" for a box that was
@@ -1985,6 +2026,16 @@ class OperatorApp(App[None]):
         # can currently hold keeps the ~50 ms before the timer from showing a
         # card overhanging the frame with its prose clipped mid-word.
         self.call_after_refresh(self._sync_overlay_layout, force=True)
+
+    def on_band_box_changed(self, event: Band.BoxChanged) -> None:
+        """Repaint the band for the box it now has.
+
+        Its content is fitted to a width by the overflow ladder, so a row measured
+        against the old box is wrong for the new one — and the band cannot notice
+        that for itself: ``StatusLine`` is not a widget and has no events.
+        """
+        if self._status is not None:
+            self._status.refresh()
 
     def on_welcome_view_block_resized(self, message: WelcomeView.BlockResized) -> None:
         """The splash changed height, so the composition around it has moved.
@@ -3408,6 +3459,60 @@ class OperatorApp(App[None]):
             self._status.update(conversation_name=stored)
         return stored
 
+    def _cmd_rename(self, arg: str, notice: NoticeFn) -> None:
+        """``/rename`` — report the title; ``/rename <text>`` — set it by hand.
+
+        The ONE production writer of ``user_set=True``, which is what the
+        precedence flag on :class:`ConversationName` is for: a title a human
+        typed outranks every generated one, including a naming call already in
+        flight (the flag is read at STORE time, not at request time — see
+        ``ConversationName.set``) and every later re-title, which
+        :meth:`_maybe_retitle_conversation` declines to even spend a call on.
+
+        No provider call on either branch. The words are the user's, so the only
+        work is putting them on the two surfaces that show a conversation's name.
+        """
+        session = self._session
+        if session is None:
+            # A rejected command changed nothing, so the conversation has not
+            # started: `_system_notice` keeps the boot composition intact where
+            # `notice` would collapse it. The rule `_cmd_goal` follows.
+            self._system_notice("session is still starting…", "warning")
+            return
+        if not arg:
+            current = session.conversation_name
+            if current:
+                notice(f"conversation: {current} — /rename <title> to change it")
+            elif self._provisional_name:
+                # The band is wearing a stand-in, not a name (see
+                # `_show_provisional_name`). Answering a bare "unnamed" with an
+                # excerpt visible one row up would read as a bug, so this names
+                # what the label actually is.
+                notice(
+                    f"unnamed — the band is quoting the opener ({self._provisional_name}); "
+                    "/rename <title> names it"
+                )
+            else:
+                notice("unnamed — /rename <title> names this conversation")
+            return
+        stored = session.set_conversation_name(arg, user_set=True)
+        # Superseded, and by the best possible answer: cleared for the reason
+        # `_store_title` clears it, so nothing downstream still believes the
+        # band is showing a stand-in.
+        self._provisional_name = ""
+        if self._status is not None:
+            # One call paints the band AND pushes the terminal title (see
+            # `StatusLine._sync_terminal_title`), so neither surface can lag the
+            # other by a frame.
+            self._status.update(conversation_name=stored)
+        # `stored`, not `arg`: the store collapses whitespace and caps the length
+        # (`MAX_TITLE_CHARS`), and the receipt's whole job is to show the title
+        # that is actually in force. Truncated rather than REJECTED, unlike a
+        # model's over-long answer — an over-long answer is evidence the model
+        # ignored the format, while this is just a long name the user chose, and
+        # refusing it outright would lose a title they typed.
+        notice(f"renamed: {stored} — auto-naming will not override it")
+
     # -- background jobs ------------------------------------------------------
     def _poll_subagents(self) -> None:
         """Repaint the counter segments only when a running count changes."""
@@ -3883,6 +3988,8 @@ class OperatorApp(App[None]):
             self._cmd_new(notice)
         elif command == "/resume":
             self._cmd_resume(arg, notice)
+        elif command == "/rename":
+            self._cmd_rename(arg, notice)
         elif command == "/model":
             self._cmd_model(arg, notice)
         elif command == "/effort":

--- a/local_operator/tui/widgets/session_picker.py
+++ b/local_operator/tui/widgets/session_picker.py
@@ -170,7 +170,6 @@ def render_rows(
     fg = theme_mod.semantic_color("fg")
     muted = theme_mod.semantic_color("muted")
     dim = theme_mod.semantic_color("dim")
-    accent = theme_mod.semantic_color("label")
 
     ages = [format_age(max(0.0, now - row.mtime)) for row in rows]
     name_col, age_col, id_col = plan_columns(rows, width, ages)
@@ -179,7 +178,7 @@ def render_rows(
     for index, (row, age) in enumerate(zip(rows, ages)):
         current = index == selected
         # A ground behind the whole row, as the command picker paints: a bare
-        # accent chevron gives a mouse user almost nothing, and it is the only
+        # caret gives a mouse user almost nothing, and the ground is the only
         # selection signal an unnamed row would otherwise have.
         if current:
             ground = theme_mod.semantic_color(
@@ -192,9 +191,16 @@ def render_rows(
         row_bg = Style(bgcolor=ground)
 
         line = Text(no_wrap=True, overflow="ellipsis")
+        # The caret is MUTED, like both sibling pickers — command_picker's D17
+        # note gives the reason and ask_picker restates it: the row GROUND says
+        # "selected", so the mark only has to point. It was `label`, the ramp's
+        # violet meta ink for tips and skill labels, which said "meta" where the
+        # frame meant "position", made the one cool mark on a warm card, and on
+        # paper measured 4.45:1 on `tint-select` — under AA on the one row being
+        # read. `muted` is 7.53:1 dark / 6.37:1 light there (D5).
         line.append(
             _pad_cells(CURSOR if current else "", GUTTER_CELLS),
-            style=row_bg + Style(color=accent),
+            style=row_bg + Style(color=muted),
         )
         # An unnamed session is one whose transcript could not be read or that
         # has no user turn yet. Saying so beats an empty cell, which reads as a

--- a/local_operator/tui/widgets/status_line.py
+++ b/local_operator/tui/widgets/status_line.py
@@ -94,6 +94,24 @@ ICON_MCP = "⊙"
 #: warning glyph so it reads the same as a warning notice in the transcript.
 ICON_APPROVALS = "!"
 
+#: Cells the session name may occupy in the band's trailing segment, at full
+#: width and after the ladder's shorten step. The name has no natural bound — a
+#: model writes it, or it is an excerpt of whatever the user typed first — and
+#: the band is a fixed two-row box, so an uncapped segment does not wrap, it
+#: evicts the left group. 40 fits every title the naming caps allow
+#: (``MAX_TITLE_CHARS`` is 80, but a 3-7 word answer lands well inside 40) and
+#: leaves the identity group its ordinary width at 120 cells.
+#:
+#: 18 for the stub is a MEASURED choice, not a round number: it sets the width
+#: below which the name cannot appear at all. Swept on a fully populated band
+#: (model, effort, cwd, healthy MCP, context, cost, the alarm) the floor runs
+#: 14 → 90 cells, 18 → 94, 22 → 98, 26 → 101. Anything above 22 loses the name
+#: on a 100-column terminal, which is the width this feature is mostly read at,
+#: and 14 leaves too little of a title to tell two sessions apart. 18 is the
+#: widest stub that still survives 100 columns with everything else on screen.
+NAME_CELLS = 40
+NAME_CELLS_SHORT = 18
+
 #: Separators point INWARD: the left group's chevrons aim right and the right
 #: group's aim left, so both runs converge on the centre gap and frame it. A
 #: symmetric separator (the middot this replaced) left the two groups reading as
@@ -118,15 +136,19 @@ _MIN_GROUP_GAP = 4
 #: The ordering principle: shed what the user already knows or can re-derive,
 #: and protect what predicts their next decision. In order —
 #:
-#: * ``name`` is a label the user typed; they know it.
+#: * ``shorten-name`` is the cheapest useful move in the band: the session name
+#:   is the widest rung, and a stub of it still tells two tiled sessions apart.
 #: * ``duration`` is re-derivable from the transcript.
 #: * ``subagents`` is a counter, but NOT re-derivable without scrolling, which
 #:   is why it outlasts the two above rather than going first.
-#: * the two SHORTEN steps outrank every remaining drop, because they recover
-#:   width while keeping the segment: a basename still answers "where am I" and
-#:   a bare model id still answers "who is replying". Together they free ~35
-#:   cells on a realistic label, more than cost and context cost combined, so
-#:   dropping numbers to preserve a fully-qualified path would be a bad trade.
+#: * the other two SHORTEN steps outrank every remaining drop, because they
+#:   recover width while keeping the segment: a basename still answers "where am
+#:   I" and a bare model id still answers "who is replying". Together they free
+#:   ~35 cells on a realistic label, more than cost and context cost combined,
+#:   so dropping numbers to preserve a fully-qualified path would be a bad trade.
+#: * ``name`` drops once shortening it has stopped paying, ahead of the numbers:
+#:   even a stub is the widest thing left, and a title predicts no action. The
+#:   terminal tab still carries it, which is where it earns its keep anyway.
 #: * ``effort`` is a static setting the user chose. It does not change while
 #:   they watch, so it goes before either live number — an earlier version had
 #:   it OUTLIVING context usage, which meant a band could show `high` but not
@@ -134,9 +156,9 @@ _MIN_GROUP_GAP = 4
 #:   says compaction is coming.
 #: * ``cost``, then ``cwd``, then ``context``, then ``mcp``: context usage is the
 #:   one an operator acts on, and the MCP indicator outlives even that WHEN IT IS
-#:   AN ALARM — it is the cheapest segment to keep and the only one that can turn
-#:   into one. A healthy count is only a courtesy, so it sheds like one; see
+#:   AN ALARM — a healthy count is only a courtesy, so it sheds like one; see
 #:   :func:`drop_ladder`.
+#: * ``approvals`` is last in every variant: one cell, and an alarm. See the rung.
 #:
 #: The brand glyph, the streaming spinner and the model label are NEVER dropped.
 #: When even the irreducible row overflows, ``_render`` emits spinner, glyph and a
@@ -145,15 +167,22 @@ _MIN_GROUP_GAP = 4
 #: reads as broken rather than as compressed, and a streaming band that renders
 #: identically to an idle one is the one thing the colour budget must never allow.
 _DROP_LADDER: tuple[str, ...] = (
-    # A label the user typed and already knows.
-    "name",
     # Re-derivable from the transcript.
     "duration",
-    # Counters. Not re-derivable without scrolling, so they outlast the two
+    # Counters. Not re-derivable without scrolling, so they outlast the one
     # above; jobs go before agents because a backgrounded shell command is
     # visible in the transcript as a tool card, while a subagent is not.
     "jobs",
     "subagents",
+    # The name shortens next, and it is the most productive single step in the
+    # ladder: it is the widest rung, so cutting it to a stub recovers more cells
+    # than dropping any number below, and a stub still does the segment's one
+    # job. `Fix the login redi…` and `Bulk export columns` are as
+    # distinguishable at 18 cells as at 40, which is what a user tiling four
+    # sessions reads it for. It comes AFTER the three drops above rather than
+    # first because those cost the user nothing they cannot re-derive, and
+    # mutilating a label to keep a counter would be the wrong way round.
+    "shorten-name",
     # Shorten before dropping: a basename still answers "where am I" and a bare
     # model id still answers "who is replying".
     "shorten-cwd",
@@ -161,6 +190,16 @@ _DROP_LADDER: tuple[str, ...] = (
     # A static session setting the user chose — it does not change while they
     # watch, so it goes before either live number.
     "effort",
+    # The name's own drop, and it lands HERE by measurement rather than by
+    # argument. Sat two rungs earlier (ahead of `effort`) the walk shed the name
+    # at 100 cells on a fully populated band and then fitted with 19 cells to
+    # spare — the walk is monotone, so it never discovers that keeping an
+    # 18-cell stub and dropping a 7-cell static setting was the better trade.
+    # One rung later the same band keeps `▦ 49.6%/1M ‹ ◈ $73.92 ‹ ! ‹ Add todo
+    # guardrai…` at 100. Below it are only figures an operator acts on, which is
+    # where a title stops competing.
+    "name",
+    # The one figure that is not a live reading of this turn.
     "cost",
     # The working directory goes before the context number. Its shorten step has
     # already reduced it to a basename by now, so what remains is ~7 cells of
@@ -169,31 +208,29 @@ _DROP_LADDER: tuple[str, ...] = (
     # these the other way round, which contradicted this very ladder's rationale.
     "cwd",
     "context",
-    # Second-to-last, just ahead of mcp — but only while mcp is an ALARM, which
-    # is the one case something here beats it for last place (see
-    # :func:`_narrowest_survivor_last`; in every quiet ladder this rung IS the
-    # last survivor). It only EXISTS while the tool-approval gate is disarmed,
-    # so it is an alarm by the same argument mcp's failure branch is one — but
-    # it is the WIDEST segment in the band (`! auto-approve` is 14 cells against
-    # `⊙ 3 MCP`'s 7), and this ladder sheds by what a drop BUYS. Dropping the
-    # widest alarm first is what lets the narrow one survive to the very last
-    # step, so a cramped terminal keeps saying something rather than falling
-    # straight to the truncated tail. The mode is still not silent when it goes:
-    # `/approvals` reports it, and the notice that latched it is in the
-    # transcript.
-    "approvals",
-    # DEAD LAST *when it is an alarm*, mirroring the reference's
-    # `flexShrink={0}` on this indicator. Two reasons it then outlives even the
-    # context number. It is the narrowest segment in the band — `⊙ 3 MCP` is 7
-    # cells against context's ~9 and a path's 7-plus — so dropping it buys the
-    # least width of anything here. And its failure branch is an ALARM: the
-    # danger-tinted glyph is the only place the band admits the agent is missing
-    # tools it was configured to have, and a cramped terminal is exactly where a
-    # user would otherwise conclude the tools were never configured. Kept in the
-    # ladder rather than omitted from it so the very narrowest widths still get
-    # one graceful aligned step before ``_render`` falls back to the truncated
-    # tail.
+    # Second-to-last. Its failure branch is an ALARM: the danger-tinted glyph is
+    # the only place the band admits the agent is missing tools it was
+    # configured to have, and a cramped terminal is exactly where a user would
+    # otherwise conclude the tools were never configured. Kept in the ladder
+    # rather than omitted from it so the very narrowest widths still get one
+    # graceful aligned step before ``_render`` falls back to the truncated tail.
     "mcp",
+    # DEAD LAST, in every variant. This rung only EXISTS while the tool-approval
+    # gate is disarmed, and it is now a BARE GLYPH — one cell, the narrowest
+    # thing in the band by a factor of seven. Last place goes to the narrowest
+    # bounded rung and an alarm outranks a reading; `!` is both, so it wins
+    # outright and no variant needs a repair to keep it there.
+    #
+    # It used to be first, which looks like the opposite judgement and was the
+    # same one: the segment then spelled out `! auto-approve always` at up to 20
+    # cells, making it the WIDEST rung, and this ladder sheds by what a drop
+    # buys. Shrinking it to the glyph moved it from one end of that argument to
+    # the other. What has not changed is the reason it is here at all: nothing
+    # else in the UI says the gate is disarmed for longer than a scroll — a
+    # saved `tool_approval_mode: auto` is adopted at boot with no notice at all
+    # (see ``_adopt_saved_approvals``), so this is the only standing indication
+    # that no tool will ask before it runs.
+    "approvals",
 )
 
 
@@ -207,44 +244,19 @@ _DROP_LADDER: tuple[str, ...] = (
 _UNBOUNDED_RUNGS = frozenset({"cwd"})
 
 
-def _narrowest_survivor_last(rungs: list[str]) -> list[str]:
-    """Re-seat ``approvals`` off last place — but only when ``mcp`` can take it.
-
-    Every ``_x_before_cwd`` helper below promotes one rung, and promoting a rung
-    leaves whatever FOLLOWED it at the end of the ladder. In this ladder that is
-    reliably ``approvals`` — the 14-cell segment the authored order sheds FIRST,
-    precisely because dropping it buys the most width.
-
-    Last place goes to the narrowest BOUNDED rung, and that rule was written
-    when the only rung competing for it was ``mcp``: 7 cells against 14, and its
-    failure branch is an alarm too, so it wins on both counts. The rule then
-    fired in ladders where ``mcp`` had been promoted away, and handed last place
-    to whatever happened to be there instead — the context percentage — which is
-    not the same trade at all. Measured by a design pass across 13 widths with a
-    healthy MCP: at 56 cells the band read ``◆ Claude Opus 5 › ⣿  ▦ 49.6%/1M ‹ !
-    auto-approve`` and at 48 it read ``◆ Claude Opus 5 › ⣟  ▦ 49.6%/1M``. A
-    narrow terminal quietly stopped saying that every tool runs without asking,
-    in order to keep a compaction forecast.
-
-    So the rule is: last place goes to the narrowest bounded rung, and an ALARM
-    outranks a reading. ``mcp`` is the only rung that beats ``approvals`` on
-    both, so the repair applies exactly when ``mcp`` would land there. Anywhere
-    else the alarm stays last, which also settles a disagreement the two quiet
-    ladders used to have with each other: with an estimated context reading the
-    alarm already survived to the end (the repair was refused there because it
-    would have stranded the unbounded ``cwd`` last), and with an exact one it
-    did not.
-
-    The alarm is not silent when it finally goes: ``/approvals`` reports the
-    mode, and the notice that latched it is in the transcript.
-    """
-    if rungs[-1] != "approvals":
-        return rungs
-    repaired = [step for step in rungs if step != "approvals"]
-    repaired.insert(len(repaired) - 1, "approvals")
-    if repaired[-1] != "mcp":
-        return rungs
-    return repaired
+#: Last place is not repaired any more, and that is worth recording because a
+#: whole helper used to do it. Promoting a rung out of the tail leaves whatever
+#: FOLLOWED it at the end, and while ``approvals`` spelled out
+#: `! auto-approve always` it was the widest rung in the band, authored first,
+#: so every promotion stranded a 20-cell alarm in the one slot reserved for the
+#: narrowest thing that reliably fits. The old fix re-seated it behind ``mcp``
+#: whenever ``mcp`` would have landed last — a rule with an exception, a
+#: docstring longer than the ladder, and four ladder variants to keep honest.
+#:
+#: The alarm is one cell now (see the ``approvals`` rung), which makes it the
+#: narrowest bounded rung outright as well as an alarm — both halves of the rule
+#: last place was always meant to follow. So it is simply authored last, every
+#: promotion leaves it there, and the repair has nothing left to repair.
 
 
 def _mcp_before_cwd(ladder: tuple[str, ...]) -> tuple[str, ...]:
@@ -256,7 +268,7 @@ def _mcp_before_cwd(ladder: tuple[str, ...]) -> tuple[str, ...]:
     """
     rungs = [step for step in ladder if step != "mcp"]
     rungs.insert(rungs.index("cwd"), "mcp")
-    return tuple(_narrowest_survivor_last(rungs))
+    return tuple(rungs)
 
 
 #: The ladder for a band whose MCP segment is NOT an alarm. Precomputed rather
@@ -278,13 +290,11 @@ def _context_before_cwd(ladder: tuple[str, ...]) -> tuple[str, ...]:
 
     Shedding the estimate first is therefore the same trade ``_mcp_before_cwd``
     exists to make: rank by what the segment is worth RIGHT NOW, not by what
-    its slot is usually worth. It inherits the same tail rule for the same
-    reason — promoting context out of last place in the quiet ladder is exactly
-    what left ``approvals`` stranded there.
+    its slot is usually worth.
     """
     rungs = [step for step in ladder if step != "context"]
     rungs.insert(rungs.index("cwd"), "context")
-    return tuple(_narrowest_survivor_last(rungs))
+    return tuple(rungs)
 
 
 #: Estimate variants of both ladders, precomputed for the same reason.
@@ -1043,7 +1053,7 @@ class StatusLine:
                 target = step.partition("shorten-")[2]
                 (short if target else dropped).add(target or step)
             left = self._left_text(dropped, short, dim, muted, seam, accent)
-            right = self._right_text(dropped, dim, seam)
+            right = self._right_text(dropped, short, dim, seam)
             # The fit test reserves the group gap rather than asking whether the
             # composed row happens to fit. `_compose` pads with `max(1, …)`, so a
             # row could "fit" with the two groups ONE cell apart — tighter than
@@ -1205,8 +1215,8 @@ class StatusLine:
                 left.append(" working", style=dim)
         return left
 
-    def _right_text(self, dropped: set[str], dim: Style, seam: Style) -> Text:
-        """agents ‹ jobs ‹ context ‹ cost ‹ duration ‹ name.
+    def _right_text(self, dropped: set[str], short: set[str], dim: Style, seam: Style) -> Text:
+        """agents ‹ jobs ‹ context ‹ cost ‹ duration ‹ [!] ‹ name.
 
         Colour groups by KIND rather than giving every field its own hue, which
         would be a rainbow: counters share `label`, the two numbers an operator
@@ -1247,33 +1257,58 @@ class StatusLine:
             # 0s task. Any real turn banks at least a few ms.
             if elapsed > 0:
                 parts.append((ICON_DURATION, format_duration(elapsed), dim))
-        if self._conversation_name and "name" not in dropped:
-            parts.append(
-                ("", self._conversation_name, Style(color=theme_mod.semantic_color("muted")))
-            )
         if self._approvals_auto and "approvals" not in dropped:
-            # LAST, so its right edge is the band's right edge: everything else
-            # here is right-ALIGNED as a group, which means a segment placed first
-            # slides left every time a sibling appears (measured: column 86 -> 74
-            # -> 64 -> 51 at a fixed 100 cells). An alarm that moves is an alarm
-            # the eye has to find.
+            # A BARE GLYPH, and second-to-last rather than last. It used to spell
+            # out `! auto-approve always` and own the band's right edge, on the
+            # argument that an alarm which slides left as siblings appear is an
+            # alarm the eye has to hunt for. That argument was sound and the slot
+            # is now spoken for: the session NAME is what an operator reads this
+            # corner for, and 20 cells of prose about a mode that has not changed
+            # since boot was crowding out the one field that says which
+            # conversation this is.
+            #
+            # What survives is the alarm itself, because nothing else in the UI
+            # carries it for longer than a scroll: `/approvals` answers on
+            # demand, the notice that latched the mode scrolls away (and `/clear`
+            # deletes it), and a saved `tool_approval_mode: auto` is adopted at
+            # boot with NO notice at all — see ``OperatorApp._adopt_saved_approvals``.
+            # So `!` alone stays, in the same warning ink and bold, and it still
+            # means exactly what it has always meant here: no tool will ask
+            # before it runs. It no longer distinguishes `auto` from `always`;
+            # that was the answer to "until when", which is a question worth a
+            # command rather than worth the band's last segment.
             #
             # The glyph rides INSIDE the styled text rather than in the icon slot,
             # because the loop below paints icons `dim` — which made the one alarm
             # in the band its quietest mark (4.18:1, against the same `!` at
             # 9.4:1 in the transcript).
-            # `always` when the mode is the SAVED default, and nothing when it is
-            # only this session's. The alarm already answers "is the gate
-            # disarmed"; the one extra word answers the question that follows it,
-            # "until when", which is otherwise only reachable by running a
-            # command. Six cells, and the segment sheds as one unit, so the
-            # narrow-width behaviour is unchanged.
-            armed = f"{ICON_APPROVALS} auto-approve"
             parts.append(
                 (
                     "",
-                    f"{armed} always" if self._approvals_always else armed,
+                    ICON_APPROVALS,
                     Style(color=theme_mod.semantic_color("warning"), bold=True),
+                )
+            )
+        if self._conversation_name and "name" not in dropped:
+            # LAST, so its right edge is the band's right edge — the position the
+            # approval mode used to hold, and the one the user asked for it in.
+            # `muted` and not the accent: the accent budget is spent on "what the
+            # turn is on" (``local_operator.tcss`` enumerates every site), and a
+            # session's name is metadata, so it takes the same secondary ink as
+            # the duration beside it.
+            #
+            # Truncated, never wrapped: the name is model-generated or an excerpt
+            # of the user's opener, so it has no natural bound, and the band is a
+            # fixed two-row box. The ladder shortens it before it drops anything
+            # (see ``_DROP_LADDER``), which is why there are two widths here.
+            parts.append(
+                (
+                    "",
+                    truncate_cells(
+                        self._conversation_name,
+                        NAME_CELLS_SHORT if "name" in short else NAME_CELLS,
+                    ),
+                    Style(color=theme_mod.semantic_color("muted")),
                 )
             )
 

--- a/local_operator/tui/widgets/status_line.py
+++ b/local_operator/tui/widgets/status_line.py
@@ -89,28 +89,43 @@ ICON_DURATION = "◷"
 #: was checked rather than assumed, because the band's arithmetic is exact and
 #: a two-cell glyph would drift the right group's edge by one column.
 ICON_MCP = "⊙"
-#: Auto-approve indicator. Deliberately NOT one of the geometric segment icons
+#: Disarmed-gate alarm. Deliberately NOT one of the geometric segment icons
 #: above: this one is an ALARM, not a reading, and it reuses the app-wide
 #: warning glyph so it reads the same as a warning notice in the transcript.
 ICON_APPROVALS = "!"
 
-#: Cells the session name may occupy in the band's trailing segment, at full
-#: width and after the ladder's shorten step. The name has no natural bound — a
-#: model writes it, or it is an excerpt of whatever the user typed first — and
-#: the band is a fixed two-row box, so an uncapped segment does not wrap, it
-#: evicts the left group. 40 fits every title the naming caps allow
-#: (``MAX_TITLE_CHARS`` is 80, but a 3-7 word answer lands well inside 40) and
-#: leaves the identity group its ordinary width at 120 cells.
+#: The name's cell BUDGET: the widest box the trailing segment may take, and
+#: the narrowest it is worth showing at. Everything between is available — the
+#: segment is elastic, and which width it gets is decided by :meth:`_walk` from
+#: the row's geometry ALONE, never from the length of the string in it.
 #:
-#: 18 for the stub is a MEASURED choice, not a round number: it sets the width
+#: That last clause is the whole design of this segment, and it is worth stating
+#: plainly because the obvious implementation gets it wrong. The name is
+#: model-authored and it CHANGES UNDER THE READER: an opener excerpt lands on
+#: submit, the generated title replaces it ~1.5 s later, and a re-title can
+#: land at any time after that (see ``local_operator.session.naming``). Size the
+#: box to the string and every one of those arrivals re-flows the row —
+#: measured at a fixed 150 columns, the alarm glyph sat at column 144, then 101,
+#: 102, 110 across four consecutive frames, two of those moves with no user
+#: input at all, and a ONE-cell difference in title length flipped the whole
+#: 13-cell `◍ 2 agents` segment in and out. Size the box to the geometry and the
+#: name is the only thing on the band that a title can change: the box is
+#: reserved, the name is left-aligned in it, and the leftover cells sit at the
+#: band's own edge where nothing else lives.
+#:
+#: 40 for the cap: it fits every title the naming caps allow (``MAX_TITLE_CHARS``
+#: is 80, but a 3-7 word answer lands well inside 40) and leaves the identity
+#: group its ordinary width at 120 cells.
+#:
+#: 18 for the floor is a MEASURED choice, not a round number: it sets the width
 #: below which the name cannot appear at all. Swept on a fully populated band
 #: (model, effort, cwd, healthy MCP, context, cost, the alarm) the floor runs
 #: 14 → 90 cells, 18 → 94, 22 → 98, 26 → 101. Anything above 22 loses the name
 #: on a 100-column terminal, which is the width this feature is mostly read at,
 #: and 14 leaves too little of a title to tell two sessions apart. 18 is the
-#: widest stub that still survives 100 columns with everything else on screen.
+#: widest floor that still survives 100 columns with everything else on screen.
 NAME_CELLS = 40
-NAME_CELLS_SHORT = 18
+NAME_CELLS_FLOOR = 18
 
 #: Separators point INWARD: the left group's chevrons aim right and the right
 #: group's aim left, so both runs converge on the centre gap and frame it. A
@@ -133,27 +148,37 @@ _MIN_GROUP_GAP = 4
 #: Reduction order, cheapest loss first. Each entry is applied in turn until
 #: the row fits the available width.
 #:
+#: The ladder DROPS, SHORTENS, and — for the name only — FLEXES. The name is
+#: still on it twice, but the first entry is no longer a step from one fixed
+#: width to another: ``flex-name`` is where the segment stops being a rigid box
+#: of :data:`NAME_CELLS` and becomes elastic down to its floor, taking back
+#: whatever the row needs and giving back whatever it does not. What remains
+#: below is its DROP — the point where even the floor has stopped fitting.
+#:
 #: The ordering principle: shed what the user already knows or can re-derive,
 #: and protect what predicts their next decision. In order —
 #:
-#: * ``shorten-name`` is the cheapest useful move in the band: the session name
-#:   is the widest rung, and a stub of it still tells two tiled sessions apart.
 #: * ``duration`` is re-derivable from the transcript.
 #: * ``subagents`` is a counter, but NOT re-derivable without scrolling, which
-#:   is why it outlasts the two above rather than going first.
-#: * the other two SHORTEN steps outrank every remaining drop, because they
-#:   recover width while keeping the segment: a basename still answers "where am
-#:   I" and a bare model id still answers "who is replying". Together they free
-#:   ~35 cells on a realistic label, more than cost and context cost combined,
-#:   so dropping numbers to preserve a fully-qualified path would be a bad trade.
-#: * ``name`` drops once shortening it has stopped paying, ahead of the numbers:
-#:   even a stub is the widest thing left, and a title predicts no action. The
-#:   terminal tab still carries it, which is where it earns its keep anyway.
+#:   is why it outlasts the one above rather than going first.
+#: * ``flex-name`` comes next, and it comes AFTER those three drops for the
+#:   reason its predecessor did: they cost the user nothing they cannot
+#:   re-derive, and narrowing the one field that says which conversation this is
+#:   in order to keep a counter would be the wrong way round.
+#: * the two SHORTEN steps outrank every remaining drop, because they recover
+#:   width while keeping the segment: a basename still answers "where am I" and
+#:   a bare model id still answers "who is replying". Together they free ~35
+#:   cells on a realistic label, more than cost and context cost combined, so
+#:   dropping numbers to preserve a fully-qualified path would be a bad trade.
 #: * ``effort`` is a static setting the user chose. It does not change while
 #:   they watch, so it goes before either live number — an earlier version had
 #:   it OUTLIVING context usage, which meant a band could show `high` but not
 #:   `49.6%/1M`: it kept the field nobody re-reads and dropped the one that
 #:   says compaction is coming.
+#: * ``name`` drops once the floor has stopped fitting, ahead of the numbers: it
+#:   is still the widest thing left, and a title predicts no action. The terminal
+#:   tab still carries it, which is where it earns its keep anyway. Dropping it
+#:   RE-WALKS the ladder from the top — see :meth:`StatusLine._fit`.
 #: * ``cost``, then ``cwd``, then ``context``, then ``mcp``: context usage is the
 #:   one an operator acts on, and the MCP indicator outlives even that WHEN IT IS
 #:   AN ALARM — a healthy count is only a courtesy, so it sheds like one; see
@@ -174,15 +199,20 @@ _DROP_LADDER: tuple[str, ...] = (
     # visible in the transcript as a tool card, while a subagent is not.
     "jobs",
     "subagents",
-    # The name shortens next, and it is the most productive single step in the
-    # ladder: it is the widest rung, so cutting it to a stub recovers more cells
-    # than dropping any number below, and a stub still does the segment's one
-    # job. `Fix the login redi…` and `Bulk export columns` are as
-    # distinguishable at 18 cells as at 40, which is what a user tiling four
-    # sessions reads it for. It comes AFTER the three drops above rather than
-    # first because those cost the user nothing they cannot re-derive, and
-    # mutilating a label to keep a counter would be the wrong way round.
-    "shorten-name",
+    # The name stops being a rigid box here and becomes elastic: from this rung
+    # down it is measured at its FLOOR and handed back whatever the fitting row
+    # left over, so its width runs continuously from 18 cells to 40 instead of
+    # jumping between two values. This rung replaced a `shorten-name` that halved
+    # it outright, and the halving is what made the segment idle: across 30-180
+    # columns the name rendered at only 0, 18 or 40 cells, so a 130-column
+    # terminal showed an 18-cell stub beside an 18-cell hole with 32 cells
+    # available, and the excerpt-to-title moment this feature exists for read as
+    # `The /resume picke…` → `Fix unnamed sessi…` at every width under 138.
+    #
+    # The flex is measured from the geometry, never from the string: a title is
+    # model-authored and lands while the user is reading, so a box sized to it
+    # would re-flow the row on its own. See :data:`NAME_CELLS`.
+    "flex-name",
     # Shorten before dropping: a basename still answers "where am I" and a bare
     # model id still answers "who is replying".
     "shorten-cwd",
@@ -190,14 +220,19 @@ _DROP_LADDER: tuple[str, ...] = (
     # A static session setting the user chose — it does not change while they
     # watch, so it goes before either live number.
     "effort",
-    # The name's own drop, and it lands HERE by measurement rather than by
-    # argument. Sat two rungs earlier (ahead of `effort`) the walk shed the name
-    # at 100 cells on a fully populated band and then fitted with 19 cells to
-    # spare — the walk is monotone, so it never discovers that keeping an
-    # 18-cell stub and dropping a 7-cell static setting was the better trade.
-    # One rung later the same band keeps `▦ 49.6%/1M ‹ ◈ $73.92 ‹ ! ‹ Add todo
-    # guardrai…` at 100. Below it are only figures an operator acts on, which is
-    # where a title stops competing.
+    # The name's own drop, and the one rung that is not simply a step down. By
+    # here the segment has already given back every cell between its cap and its
+    # floor, and the three drops above were made to keep that floor on screen; if
+    # the floor still does not fit, those concessions bought nothing. So this
+    # rung is a RESTART rather than a step: ``_fit`` re-walks the whole ladder
+    # with the name off the table, which hands `▴ high`, `◍ 2 agents` and the
+    # duration back. Without the restart the walk was monotone and could not roll
+    # a concession back, and a named session at 83-94 columns rendered strictly
+    # worse than the same session unnamed — no effort segment, no name either,
+    # and 9 more cells of hole in exchange.
+    #
+    # Its place in the order is unchanged: below it are only figures an operator
+    # acts on, which is where a title stops competing.
     "name",
     # The one figure that is not a live reading of this turn.
     "cost",
@@ -225,22 +260,25 @@ _DROP_LADDER: tuple[str, ...] = (
     # same one: the segment then spelled out `! auto-approve always` at up to 20
     # cells, making it the WIDEST rung, and this ladder sheds by what a drop
     # buys. Shrinking it to the glyph moved it from one end of that argument to
-    # the other. What has not changed is the reason it is here at all: nothing
-    # else in the UI says the gate is disarmed for longer than a scroll — a
-    # saved `tool_approval_mode: auto` is adopted at boot with no notice at all
-    # (see ``_adopt_saved_approvals``), so this is the only standing indication
-    # that no tool will ask before it runs.
+    # the other, and took its ink with it — one cell of `warning` amber was the
+    # same ink as `◈ $73.92` three cells away, so `danger` carries it now (see
+    # :data:`ICON_APPROVALS`). What has not changed is the reason it is here at
+    # all: nothing else in the UI says the gate is disarmed for longer than a
+    # scroll — a saved `tool_approval_mode: auto` is adopted at boot with no
+    # notice at all (see ``_adopt_saved_approvals``), so this is the only
+    # standing indication that no tool will ask before it runs.
     "approvals",
 )
 
 
 #: Rungs whose painted width is not knowable from the ladder. ``cwd`` is as wide
 #: as the user's path — a basename alone runs from 3 cells to 30 — so it can
-#: never be relied on as the thing that still fits at the narrowest width. The
-#: render walk is monotone (it sheds until the row fits and can never add a
-#: segment back), so a ladder ending on one of these sheds a bounded segment to
-#: make room for a path that then does not fit either, and paints neither. No
-#: ladder may end on one; ``test_status_line`` holds every variant to it.
+#: never be relied on as the thing that still fits at the narrowest width. A
+#: render walk only ever sheds (``_walk`` cannot add a segment back, and the one
+#: restart ``_fit`` makes starts a fresh walk rather than un-shedding one), so a
+#: ladder ending on one of these sheds a bounded segment to make room for a path
+#: that then does not fit either, and paints neither. No ladder may end on one;
+#: ``test_status_line`` holds every variant to it.
 _UNBOUNDED_RUNGS = frozenset({"cwd"})
 
 
@@ -577,6 +615,37 @@ def format_model_label(label: str, *, short: bool, name: str = "") -> str:
     return forms.compact if short else forms.full
 
 
+def truncate_name(name: str, cells: int) -> str:
+    """The session name cut to ``cells``, on a word boundary where one is close.
+
+    ``truncate_cells`` alone is width-aware and word-blind, and the string it is
+    handed here was cut on a word boundary ON PURPOSE one call earlier:
+    ``provisional_title`` stops on a word "so it reads as a quotation rather than
+    as a string that ran out of buffer", and re-cutting it mid-word throws that
+    away — `The /resume picker shows (unnamed session) for…` came back as `The
+    /resume picker shows (unnamed sessi…`.
+
+    A word cut is only taken when it costs less than a third of the box, which is
+    the same trade ``resume._condense`` makes for the picker's row labels (there
+    stated as a fixed 12 characters against a fixed cap; here proportional,
+    because this box is elastic and runs from 18 cells to 40). Past that the
+    segment has stopped doing its one job: `Add todo…` in an 18-cell box tells two
+    tiled sessions apart less well than `Add todo guardrai…` does, and half a box
+    of blank is not a tidier cut, it is a smaller one.
+
+    Trailing punctuation goes with the cut word for the same reason ``_condense``
+    strips it: `(unnamed session),…` reads as a rendering fault.
+    """
+    if cells <= 0 or cell_len(name) <= cells:
+        return name[:cells] if cells <= 0 else name
+    cut = truncate_cells(name, cells)
+    stem = cut[:-1] if cut.endswith("…") else cut
+    spaced = stem.rsplit(" ", 1)[0].rstrip(" ,.;:") if " " in stem else ""
+    if spaced and cell_len(spaced) * 3 >= cells * 2:
+        return spaced + "…"
+    return cut
+
+
 @dataclass(frozen=True)
 class SubagentBand:
     """The CHILD's readings, shown in place of the session's own.
@@ -773,11 +842,17 @@ class StatusLine:
         # beneath it: everything on screen is the child's, and a title naming
         # the parent would be the one contradicting label in the frame.
         label = self._subagent.label if self._subagent is not None else self._conversation_name
-        # Unnamed conversations fall back to the working directory, which is
-        # every session for its first minute or two: naming is a detached call
-        # made off the first substantive prompt. A sidebar row reading `lo ›`
-        # five times over is the exact failure this feature exists to fix, and
-        # the directory is what the user opened the session for.
+        # No name in that slot falls back to the working directory. That used to
+        # be every session for its first minute or two, when the only name came
+        # from a detached model call made off the first substantive prompt. It
+        # no longer is: `OperatorApp._show_provisional_name` paints an excerpt of
+        # the opener in the SAME frame as the submit, with no provider call at
+        # all. What still reaches the directory is a conversation nobody has
+        # prompted yet — boot, `/new`, or a resume, since `ConversationName` is
+        # never journalled — and one whose opener had no topic to quote ("hi",
+        # "thanks"), which `naming.is_low_signal` refuses to label. A sidebar row
+        # reading `lo ›` five times over is the exact failure this feature exists
+        # to fix, and the directory is what the user opened the session for.
         title.set_label(label or cwd_label(self._cwd))
         title.set_state(self._title_state())
         title.set_frame(self._spinner_index)
@@ -1039,43 +1114,18 @@ class StatusLine:
         seam = Style(color=theme_mod.semantic_color("faint"))
         accent = Style(color=theme_mod.semantic_color("accent"))
 
-        dropped: set[str] = set()
-        short: set[str] = set()
-        # Walk the ladder until the row fits. Building the row is a handful of
-        # string joins and the ladder is nine steps, so the worst case is ten
-        # cheap rebuilds on a resize — far cheaper than measuring segments
-        # independently and getting the separator arithmetic subtly wrong.
-        for step in (
-            None,
-            *drop_ladder(self._mcp, context_estimated=self._shown_context_is_estimate()),
-        ):
-            if step is not None:
-                target = step.partition("shorten-")[2]
-                (short if target else dropped).add(target or step)
-            left = self._left_text(dropped, short, dim, muted, seam, accent)
-            right = self._right_text(dropped, short, dim, seam)
-            # The fit test reserves the group gap rather than asking whether the
-            # composed row happens to fit. `_compose` pads with `max(1, …)`, so a
-            # row could "fit" with the two groups ONE cell apart — tighter than
-            # the 3-cell ` · ` separator used inside each group, which makes the
-            # whole left/right architecture read as one undifferentiated run and
-            # abuts a filesystem path against a percentage. Reachable by dragging
-            # a window one cell at ordinary widths like 98 or 116 (D3).
-            #
-            # Reserved only when there IS a right group. Charged unconditionally,
-            # the gap bought separation from nothing: the two-group layout was
-            # abandoned four columns early and the spinner hopped across the model
-            # label at a width where the row it reflowed to was no narrower.
-            gap = _MIN_GROUP_GAP if right.plain else 0
-            if cell_len(left.plain) + cell_len(right.plain) + gap <= width:
-                # Recorded so a caller can ask whether the band actually SAID
-                # what it was asked to show. The effort segment needs it: it is
-                # the one segment a keystroke changes, so when the ladder has
-                # shed it the app owes the user a receipt somewhere else (see
-                # ``OperatorApp.action_cycle_effort``). Set on the fitting pass
-                # only — the intermediate rungs are attempts, not what shipped.
-                self._dropped = frozenset(dropped)
-                return self._compose(left, right, width, dim)
+        fitted = self._fit(width, dim, muted, seam, accent)
+        if fitted is not None:
+            dropped, left, right = fitted
+            # Recorded so a caller can ask whether the band actually SAID
+            # what it was asked to show. The effort segment needs it: it is
+            # the one segment a keystroke changes, so when the ladder has
+            # shed it the app owes the user a receipt somewhere else (see
+            # ``OperatorApp.action_cycle_effort``). Set from the row that
+            # SHIPPED — the rungs the walk tried on the way are attempts, and
+            # so is a whole walk the restart threw away.
+            self._dropped = dropped
+            return self._compose(left, right, width, dim)
 
         # Even the irreducible row overflows. Truncate the model label rather
         # than shedding it (D7): `deepse…` still answers which model is
@@ -1126,6 +1176,118 @@ class StatusLine:
             )
         tail.truncate(width, overflow="ellipsis")
         return tail
+
+    def _fit(
+        self, width: int, dim: Style, muted: Style, seam: Style, accent: Style
+    ) -> tuple[frozenset[str], Text, Text] | None:
+        """The row this width gets: ``(dropped, left, right)``, or ``None``.
+
+        ``None`` means not even the last rung fitted, and :meth:`_render` falls
+        back to the irreducible tail.
+
+        Two walks at most, and the second one is the point of this method. A walk
+        is monotone — it sheds down the ladder and can never take a concession
+        back — so every rung it spends BEFORE the name's own drop was spent to
+        keep the name on screen, and when the name then goes those cells are
+        already gone. Measured on a fully populated band at 83-94 columns (all
+        four ladder variants; 79-90 with the alarm disarmed): a NAMED session lost
+        `▴ high` **and** its name and gained 9 cells of hole, so naming a session
+        made its band strictly worse than leaving it unnamed. So dropping the name
+        restarts: the same ladder is re-walked with the name off the table
+        entirely, and the wider-surviving of the two rows wins.
+
+        The comparison is by segments SURVIVING rather than by cells painted,
+        because the padded name box makes "cells" the wrong measure — a row can
+        paint more cells and say less. The restart wins nearly always (a walk with
+        21 fewer cells to place fits no later than one with them), and it is
+        compared rather than assumed so the rule stays true if a future rung
+        changes what a concession costs.
+        """
+        ladder = drop_ladder(self._mcp, context_estimated=self._shown_context_is_estimate())
+        fitted = self._walk(ladder, width, dim, muted, seam, accent)
+        if fitted is None or "name" not in fitted[0]:
+            return fitted
+        restart = self._walk(
+            tuple(rung for rung in ladder if rung not in ("name", "flex-name")),
+            width,
+            dim,
+            muted,
+            seam,
+            accent,
+            forgo_name=True,
+        )
+        if restart is None:
+            return fitted
+        return restart if len(restart[0]) <= len(fitted[0]) else fitted
+
+    def _walk(
+        self,
+        ladder: tuple[str, ...],
+        width: int,
+        dim: Style,
+        muted: Style,
+        seam: Style,
+        accent: Style,
+        *,
+        forgo_name: bool = False,
+    ) -> tuple[frozenset[str], Text, Text] | None:
+        """One monotone pass down ``ladder``, stopping at the first row that fits.
+
+        Building a row is a handful of string joins and the ladder is ten steps,
+        so the worst case is eleven cheap rebuilds on a resize — far cheaper than
+        measuring segments independently and getting the separator arithmetic
+        subtly wrong.
+
+        The name is measured at its RESERVE — the full :data:`NAME_CELLS` until
+        the ``flex-name`` rung fires, its floor after — and then grown into
+        whatever the fitting rung left over, capped. Three properties come out of
+        that, and all three are the point:
+
+        * The reserve is a function of the row's geometry and never of the name's
+          text, so a title arriving or being rewritten cannot move a sibling.
+        * A long title never sheds a neighbour that a short one would have kept,
+          because the fit test measured the box either way.
+        * The leftover goes to the one segment that can use it rather than into
+          the hole between the groups.
+        """
+        dropped: set[str] = {"name"} if forgo_name else set()
+        short: set[str] = set()
+        flexed = False
+        for step in (None, *ladder):
+            if step == "flex-name":
+                flexed = True
+            elif step is not None:
+                target = step.partition("shorten-")[2]
+                (short if target else dropped).add(target or step)
+            reserve = (
+                0
+                if "name" in dropped or not self._conversation_name
+                else NAME_CELLS_FLOOR if flexed else NAME_CELLS
+            )
+            left = self._left_text(dropped, short, dim, muted, seam, accent)
+            right = self._right_text(dropped, short, reserve, dim, seam)
+            # The fit test reserves the group gap rather than asking whether the
+            # composed row happens to fit. `_compose` pads with `max(1, …)`, so a
+            # row could "fit" with the two groups ONE cell apart — tighter than
+            # the 3-cell ` · ` separator used inside each group, which makes the
+            # whole left/right architecture read as one undifferentiated run and
+            # abuts a filesystem path against a percentage. Reachable by dragging
+            # a window one cell at ordinary widths like 98 or 116 (D3).
+            #
+            # Reserved only when there IS a right group. Charged unconditionally,
+            # the gap bought separation from nothing: the two-group layout was
+            # abandoned four columns early and the spinner hopped across the model
+            # label at a width where the row it reflowed to was no narrower.
+            gap = _MIN_GROUP_GAP if right.plain else 0
+            slack = width - cell_len(left.plain) - cell_len(right.plain) - gap
+            if slack < 0:
+                continue
+            if reserve and slack and reserve < NAME_CELLS:
+                right = self._right_text(
+                    dropped, short, min(NAME_CELLS, reserve + slack), dim, seam
+                )
+            return frozenset(dropped), left, right
+        return None
 
     def _left_text(
         self,
@@ -1215,8 +1377,15 @@ class StatusLine:
                 left.append(" working", style=dim)
         return left
 
-    def _right_text(self, dropped: set[str], short: set[str], dim: Style, seam: Style) -> Text:
+    def _right_text(
+        self, dropped: set[str], short: set[str], name_cells: int, dim: Style, seam: Style
+    ) -> Text:
         """agents ‹ jobs ‹ context ‹ cost ‹ duration ‹ [!] ‹ name.
+
+        ``name_cells`` is the box :meth:`_walk` reserved for the trailing name —
+        zero when the ladder dropped it. The name is PADDED to that box rather
+        than measured, which is what pins every other segment's column; see
+        :data:`NAME_CELLS`.
 
         Colour groups by KIND rather than giving every field its own hue, which
         would be a rainbow: counters share `label`, the two numbers an operator
@@ -1265,18 +1434,30 @@ class StatusLine:
             # is now spoken for: the session NAME is what an operator reads this
             # corner for, and 20 cells of prose about a mode that has not changed
             # since boot was crowding out the one field that says which
-            # conversation this is.
+            # conversation this is. The argument is answered rather than ignored —
+            # the name's box is RESERVED (:data:`NAME_CELLS`), so this glyph has
+            # one column per terminal width and a title landing under it cannot
+            # move it.
             #
             # What survives is the alarm itself, because nothing else in the UI
             # carries it for longer than a scroll: `/approvals` answers on
             # demand, the notice that latched the mode scrolls away (and `/clear`
             # deletes it), and a saved `tool_approval_mode: auto` is adopted at
             # boot with NO notice at all — see ``OperatorApp._adopt_saved_approvals``.
-            # So `!` alone stays, in the same warning ink and bold, and it still
-            # means exactly what it has always meant here: no tool will ask
-            # before it runs. It no longer distinguishes `auto` from `always`;
-            # that was the answer to "until when", which is a question worth a
-            # command rather than worth the band's last segment.
+            # So `!` alone stays, bold, and it still means exactly what it has
+            # always meant here: no tool will ask before it runs. It no longer
+            # distinguishes `auto` from `always`; that was the answer to "until
+            # when", which is a question worth a command rather than worth the
+            # band's last segment.
+            #
+            # `danger`, not `warning`, and that is the D4 fix rather than a
+            # preference: at one cell the ink is ALL the segment has, and in
+            # `warning` it was the identical hue to `◈ $73.92` three cells away
+            # (both `#e0b04b`, both 8.64:1 on the band's ground), so the band's
+            # only alarm read as another figure. `danger` reads as an alarm and
+            # measures 6.62:1 dark / 4.94:1 on the paper ramp, and it is the same
+            # ink the `⊙` lamp takes when MCP discovery fails — in this band red
+            # is the ALARM category, which is why two of them do not conflict.
             #
             # The glyph rides INSIDE the styled text rather than in the icon slot,
             # because the loop below paints icons `dim` — which made the one alarm
@@ -1286,12 +1467,13 @@ class StatusLine:
                 (
                     "",
                     ICON_APPROVALS,
-                    Style(color=theme_mod.semantic_color("warning"), bold=True),
+                    Style(color=theme_mod.semantic_color("danger"), bold=True),
                 )
             )
-        if self._conversation_name and "name" not in dropped:
-            # LAST, so its right edge is the band's right edge — the position the
-            # approval mode used to hold, and the one the user asked for it in.
+        if self._conversation_name and name_cells:
+            # LAST, so the corner is the name's — the position the approval mode
+            # used to hold, and the one the user asked for it in.
+            #
             # `muted` and not the accent: the accent budget is spent on "what the
             # turn is on" (``local_operator.tcss`` enumerates every site), and a
             # session's name is metadata, so it takes the same secondary ink as
@@ -1299,15 +1481,19 @@ class StatusLine:
             #
             # Truncated, never wrapped: the name is model-generated or an excerpt
             # of the user's opener, so it has no natural bound, and the band is a
-            # fixed two-row box. The ladder shortens it before it drops anything
-            # (see ``_DROP_LADDER``), which is why there are two widths here.
+            # fixed two-row box.
+            #
+            # PADDED to its box, and left-aligned in it. The box is the reserved
+            # width, so the padding is what holds every sibling's column still
+            # while a model rewrites the string in it; left-aligned because the
+            # eye reads a title from its first cell, and a fixed first cell is
+            # exactly what a string that changes on its own needs. The leftover
+            # lands at the band's right edge, which is the one place on this row
+            # where nothing else was ever going to be.
             parts.append(
                 (
                     "",
-                    truncate_cells(
-                        self._conversation_name,
-                        NAME_CELLS_SHORT if "name" in short else NAME_CELLS,
-                    ),
+                    truncate_name(self._conversation_name, name_cells).ljust(name_cells),
                     Style(color=theme_mod.semantic_color("muted")),
                 )
             )
@@ -1328,6 +1514,11 @@ class StatusLine:
         the filler is not emitted at all. Padding unconditionally pushed a row
         that exactly fitted its frame `_MIN_GROUP_GAP` cells past it, on trailing
         blanks that aligned nothing.
+
+        The right group is aligned by its BOX, not by its ink: the name arrives
+        padded to the cells :meth:`_walk` reserved (:data:`NAME_CELLS`), so this
+        arithmetic is the same at every title length and a short title leaves its
+        leftover at the band's edge rather than shunting the group right.
         """
         if not right.plain:
             return left

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.17.4"
+version = "0.17.5"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@radienthq.com" }]

--- a/tests/unit/model/test_configure.py
+++ b/tests/unit/model/test_configure.py
@@ -832,3 +832,120 @@ class TestInfoFromListing:
         listing, _ = self._listing()
         with pytest.raises(ValueError, match="Model not found"):
             _info_from_listing(listing, "vendor/other", openrouter_default_model_info, "or")
+
+
+class TestAnIsolatedRequestTouchesNoneOfTheSessionsSharedState:
+    """``SessionStreamFn`` skips three session-wide steps for decoration.
+
+    Auto-naming runs CONCURRENTLY with the user's turn now, so a title call and
+    the turn reach this object at the same moment. Each step below is consumed
+    or mutated by whichever request arrives first, which is why a decorative
+    call must not take part in any of them.
+    """
+
+    @staticmethod
+    def _handler(captured: dict[str, Any]) -> Any:
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured["body"] = json.loads(request.content)
+            return httpx.Response(
+                200,
+                content=(
+                    b'data: {"type":"response.completed","response":{"id":"resp_1",'
+                    b'"usage":{"input_tokens":1,"output_tokens":1}}}\n\ndata: [DONE]\n\n'
+                ),
+                headers={"content-type": "text/event-stream"},
+            )
+
+        return handler
+
+    @staticmethod
+    def _stream(tmp_path: Any) -> tuple[Any, Any]:
+        store = AuthStore(tmp_path / "auth.db")
+        store.upsert_credential("openai", {"key": "sk-openai", "source": "login"})
+        # Auto effort is off by default, and off it cannot consume the message
+        # boundary — which would make "the isolated call did not consume it"
+        # true of every request and prove nothing.
+        stream = create_stream_fn(store, {"effort": {"auto": True}}, session_id="session-isolation")
+        return stream, store
+
+    async def _run(self, tmp_path: Any, *, isolated: bool) -> dict[str, Any]:
+        captured: dict[str, Any] = {}
+        stream, store = self._stream(tmp_path)
+        await stream._http.aclose()
+        stream._http = httpx.AsyncClient(transport=httpx.MockTransport(self._handler(captured)))
+        preflights: list[Any] = []
+        real_preflight = stream.preflight_usage
+
+        # Wraps rather than replaces: `preflight_usage` is also what CONSUMES
+        # the message boundary, so a stub would make the boundary assertion
+        # below pass for the wrong reason on the ordinary-request control.
+        async def spy_preflight(model: Any) -> None:
+            preflights.append(model)
+            await real_preflight(model)
+
+        stream.preflight_usage = spy_preflight  # type: ignore[method-assign]
+        notices: list[tuple[str, str]] = []
+        stream.set_notice_handler(lambda text, kind: notices.append((text, kind)))
+        spec = build_model_spec("openai", "gpt-5.4")
+        try:
+            await _collect_stream(
+                stream(
+                    ChatRequest(
+                        model=spec,
+                        messages=[
+                            Message.user(
+                                "refactor the compaction cut-point selector and prove it "
+                                "with an end-to-end test against the real transcript store"
+                            )
+                        ],
+                        isolated=isolated,
+                    ),
+                    None,
+                )
+            )
+        finally:
+            await stream.close()
+            store.close()
+        return {
+            "body": captured["body"],
+            "preflights": preflights,
+            "notices": notices,
+            "boundary_pending": stream._message_boundary_pending,
+            "message_effort": stream._message_effort,
+        }
+
+    @pytest.mark.asyncio
+    async def test_it_leaves_the_message_boundary_for_the_turn(self, tmp_path) -> None:
+        """The boundary is CONSUMED by the first request through. A title call
+        arriving first would classify effort from its own prompt, freeze it for
+        the turn's whole tool loop, and emit an "auto effort" notice for a
+        request the user never made."""
+        result = await self._run(tmp_path, isolated=True)
+        assert result["boundary_pending"] is True
+        assert result["message_effort"] is None
+        assert result["notices"] == []
+
+    @pytest.mark.asyncio
+    async def test_it_runs_no_quota_preflight(self, tmp_path) -> None:
+        """The preflight can BLOCK a credential and activate a fallback route
+        for the whole session — an outcome no title is worth."""
+        result = await self._run(tmp_path, isolated=True)
+        assert result["preflights"] == []
+
+    @pytest.mark.asyncio
+    async def test_it_does_not_ride_the_sessions_prompt_cache_key(self, tmp_path) -> None:
+        """The key identifies a request PREFIX. A naming call's prefix is a
+        different system block, so sharing the key buys no hit and writes a
+        competing entry under the name the turn's prefix is cached as."""
+        result = await self._run(tmp_path, isolated=True)
+        assert "prompt_cache_key" not in result["body"]
+
+    @pytest.mark.asyncio
+    async def test_an_ordinary_request_does_all_three(self, tmp_path) -> None:
+        """The control. Without it, each assertion above could be passing
+        because this fixture never reaches those code paths at all."""
+        result = await self._run(tmp_path, isolated=False)
+        assert result["boundary_pending"] is False
+        assert result["message_effort"] is not None
+        assert result["preflights"], "no preflight ran on an ordinary request"
+        assert result["body"]["prompt_cache_key"] == "session-isolation"

--- a/tests/unit/providers/test_failover.py
+++ b/tests/unit/providers/test_failover.py
@@ -1577,3 +1577,173 @@ def test_the_rendered_form_is_gated_on_the_kind_not_on_a_guessed_status() -> Non
     transient = ProviderError(503, "Could not process image")
     assert str(transient).startswith("transient provider error")
     assert not is_image_rejection(str(transient))
+
+
+class TestAnIsolatedRequestCannotDegradeTheTurnBesideIt:
+    """``ChatRequest.isolated``: decoration runs concurrently with a user turn.
+
+    Auto-naming stopped waiting for the turn to settle, so a title call is now a
+    SECOND in-flight request on the same session. Each test here pins one route
+    by which that call's failure used to be able to reach the turn — and each
+    fails if ``stream_with_failover``'s ``isolated`` branch is removed, because
+    every one of these behaviours is on by default for an ordinary request.
+    """
+
+    @staticmethod
+    def _isolated(provider: str = "openai", model_id: str = "gpt-4o") -> ChatRequest:
+        return ChatRequest(model=ModelSpec(provider=provider, model_id=model_id), isolated=True)
+
+    async def test_it_never_walks_the_model_fallback_chain(self) -> None:
+        """A fallback hop would put the title on a model the turn is not using —
+        and, with a route state, would drag the turn there too."""
+        specs_seen: list[str] = []
+
+        async def client_for(spec: ModelSpec) -> Any:
+            specs_seen.append(spec.model_id)
+            return ScriptedClient(ProviderError(500, "boom", retryable=True))
+
+        settings = {
+            "retry": {"baseDelayMs": 1, "fallbackChains": {"default": ["anthropic/claude-x"]}}
+        }
+        auth = FakeAuth({"openai": ["k1"], "anthropic": ["k2"]})
+        with pytest.raises(ProviderError):
+            _ = [
+                event
+                async for event in stream_with_failover(
+                    self._isolated(), auth, settings, client_for
+                )
+            ]
+        assert specs_seen == ["gpt-4o"], "an isolated call walked onto a fallback model"
+
+    async def test_it_never_rotates_the_sessions_credential(self) -> None:
+        """``rotate_sibling`` moves the session's STICKY credential, so an auth
+        failure on a title would re-point the account the turn transacts on."""
+        auth = FakeAuth({"openai": ["bad-key", "good-key"]})
+        used_keys: list[str | None] = []
+
+        async def client_for(spec: ModelSpec) -> Any:
+            def wrapper(
+                request: ChatRequest, api_key: str | None, oauth_access: Any = None
+            ) -> AsyncIterator[Any]:
+                used_keys.append(api_key)
+                return ScriptedClient(
+                    ProviderError(401, "invalid api key", auth_error=True)
+                ).stream(request, api_key)
+
+            return _FnClient(wrapper)
+
+        with pytest.raises(ProviderError):
+            _ = [
+                event
+                async for event in stream_with_failover(
+                    self._isolated(), auth, {"retry": {"baseDelayMs": 1}}, client_for
+                )
+            ]
+        assert used_keys == ["bad-key"], "an isolated call retried on a second credential"
+        assert auth.rotations == [], "an isolated call rotated the session's credential"
+
+    async def test_it_neither_pins_nor_clears_the_sticky_route(self) -> None:
+        """The route state is session-wide: a title pinning a fallback would move
+        the TURN's model, and a title CLEARING a pin would send the turn back to
+        a primary the turn already knows is down."""
+        pinned = FallbackTarget("anthropic/claude-opus-5", "high")
+        state = FailoverRouteState()
+        await state.activate(pinned, "an earlier turn failed over")
+
+        async def client_for(spec: ModelSpec) -> Any:
+            return ScriptedClient([StreamEndEvent(stop_reason="stop")])
+
+        auth = FakeAuth({"openai": ["k1"], "anthropic": ["k2"]})
+        _ = [
+            event
+            async for event in stream_with_failover(
+                self._isolated(), auth, None, client_for, route_state=state
+            )
+        ]
+        assert state.active == pinned, "an isolated call cleared the turn's sticky route"
+
+    async def test_it_never_sleeps_on_a_backoff(self) -> None:
+        """A retry budget would hold the naming worker (and its 8-second overall
+        ceiling) open across sleeps for a result nobody is waiting on."""
+        slept: list[float] = []
+
+        async def spy_sleep(delay_ms: float, signal: Any = None) -> None:
+            slept.append(delay_ms)
+
+        original = failover_module._abortable_sleep
+        failover_module._abortable_sleep = spy_sleep  # type: ignore[assignment]
+        try:
+
+            async def client_for(spec: ModelSpec) -> Any:
+                return ScriptedClient(ProviderError(500, "boom", retryable=True))
+
+            auth = FakeAuth({"openai": ["k1"]})
+            with pytest.raises(ProviderError):
+                _ = [
+                    event
+                    async for event in stream_with_failover(
+                        self._isolated(),
+                        auth,
+                        {"retry": {"baseDelayMs": 50, "maxRetries": 3}},
+                        client_for,
+                    )
+                ]
+        finally:
+            failover_module._abortable_sleep = original  # type: ignore[assignment]
+        assert slept == [], "an isolated call spent a backoff sleep"
+
+    async def test_one_attempt_is_all_it_gets(self) -> None:
+        """The sum of the four above: exactly one call reaches the wire."""
+        client = ScriptedClient(ProviderError(429, "rate limited", retryable=True))
+
+        async def client_for(spec: ModelSpec) -> Any:
+            return client
+
+        auth = FakeAuth({"openai": ["k1", "k2"]})
+        settings = {
+            "retry": {"baseDelayMs": 1, "fallbackChains": {"default": ["anthropic/claude-x"]}}
+        }
+        with pytest.raises(ProviderError):
+            _ = [
+                event
+                async for event in stream_with_failover(
+                    self._isolated(), auth, settings, client_for
+                )
+            ]
+        assert client.calls == 1
+
+    async def test_the_same_failure_on_an_ORDINARY_request_does_all_four(self) -> None:
+        """The control. Without this, every assertion above could be passing
+        because the fake never triggers those paths at all."""
+        client = ScriptedClient(ProviderError(500, "boom", retryable=True))
+        specs_seen: list[str] = []
+        slept: list[float] = []
+
+        async def spy_sleep(delay_ms: float, signal: Any = None) -> None:
+            slept.append(delay_ms)
+
+        async def client_for(spec: ModelSpec) -> Any:
+            specs_seen.append(spec.model_id)
+            return client
+
+        original = failover_module._abortable_sleep
+        failover_module._abortable_sleep = spy_sleep  # type: ignore[assignment]
+        try:
+            auth = FakeAuth({"openai": ["k1"], "anthropic": ["k2"]})
+            settings = {
+                "retry": {"baseDelayMs": 1, "fallbackChains": {"default": ["anthropic/claude-x"]}}
+            }
+            state = FailoverRouteState()
+            with pytest.raises(ProviderError):
+                _ = [
+                    event
+                    async for event in stream_with_failover(
+                        _request(), auth, settings, client_for, route_state=state
+                    )
+                ]
+        finally:
+            failover_module._abortable_sleep = original  # type: ignore[assignment]
+        assert specs_seen == ["gpt-4o", "claude-x"], "the chain was not walked"
+        assert slept, "no backoff was spent"
+        assert client.calls > 1, "only one attempt was made"
+        assert state.active is not None, "no route was pinned"

--- a/tests/unit/providers/test_failover.py
+++ b/tests/unit/providers/test_failover.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import asyncio
 import random
+import time
 from collections.abc import AsyncIterator
 from http import HTTPStatus
 from types import SimpleNamespace
@@ -21,6 +22,7 @@ from local_operator.harness.types import (
 )
 from local_operator.model.configure import build_model_spec
 from local_operator.providers import failover as failover_module
+from local_operator.providers.auth_store import AuthStore
 from local_operator.providers.failover import (
     AUTH_RETRY_MAX_ATTEMPTS,
     CHAIN_EFFORT_LADDER,
@@ -1584,9 +1586,11 @@ class TestAnIsolatedRequestCannotDegradeTheTurnBesideIt:
 
     Auto-naming stopped waiting for the turn to settle, so a title call is now a
     SECOND in-flight request on the same session. Each test here pins one route
-    by which that call's failure used to be able to reach the turn — and each
-    fails if ``stream_with_failover``'s ``isolated`` branch is removed, because
-    every one of these behaviours is on by default for an ordinary request.
+    by which that call's failure used to be able to reach the turn, and each
+    fails if its denial is removed, because every one of these behaviours is on
+    by default for an ordinary request: the first five come from
+    ``stream_with_failover``'s ``isolated`` branch, the sixth from the read-only
+    credential resolve it asks for.
     """
 
     @staticmethod
@@ -1663,8 +1667,9 @@ class TestAnIsolatedRequestCannotDegradeTheTurnBesideIt:
         assert state.active == pinned, "an isolated call cleared the turn's sticky route"
 
     async def test_it_never_sleeps_on_a_backoff(self) -> None:
-        """A retry budget would hold the naming worker (and its 8-second overall
-        ceiling) open across sleeps for a result nobody is waiting on."""
+        """A retry budget would hold the naming worker (and the 15-second
+        ceiling ``TITLE_TIMEOUT_S`` puts on it) open across sleeps for a result
+        nobody is waiting on."""
         slept: list[float] = []
 
         async def spy_sleep(delay_ms: float, signal: Any = None) -> None:
@@ -1711,6 +1716,86 @@ class TestAnIsolatedRequestCannotDegradeTheTurnBesideIt:
                 )
             ]
         assert client.calls == 1
+
+    async def test_its_credential_read_neither_blocks_nor_repoints_the_turn(
+        self, tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The sixth route, and the only one the two switches above do not reach:
+        the cascade takes routing decisions on what looks like a READ.
+
+        ``AuthStore._resolve`` passes an OAuth row whose refresh RAISED to
+        ``block_credential`` — which hides it from ``_usable_key_rows`` on every
+        later resolve, and the turn re-resolves on each tool-loop request — and
+        writes session stickiness to whichever row wins instead. So a transient
+        token-endpoint failure inside a decorative title call could take the
+        credential the turn is transacting on out of service and move the turn
+        onto a sibling account mid-conversation. Both switches are downstream of
+        this: it happens inside the resolver, before any error reaches the retry
+        or route logic.
+
+        A real ``AuthStore`` on a temp DB, because the mutation being denied is
+        the real cascade's, not a fake's.
+        """
+        store = AuthStore(db_path=tmp_path / "auth.db")
+        session_id = "session-with-a-live-turn"
+        # Row A is the account the turn is on and its refresh is due; row B is a
+        # healthy sibling, so the cascade has somewhere to move to.
+        turn_row = store.upsert_credential(
+            "openai",
+            {"refresh": "r-a", "access": "stale-a", "expires": 0, "account_id": "acct-a"},
+        )
+        sibling_row = store.upsert_credential(
+            "openai",
+            {
+                "refresh": "r-b",
+                "access": "good-b",
+                "expires": int(time.time() * 1000) + 3_600_000,
+                "account_id": "acct-b",
+            },
+        )
+
+        async def refresh_always_fails(creds: dict[str, Any]) -> dict[str, Any]:
+            raise RuntimeError("token endpoint 503")
+
+        monkeypatch.setattr(store, "_refresh_fn", lambda provider: refresh_always_fails)
+
+        async def client_for(spec: ModelSpec) -> Any:
+            return ScriptedClient([StreamEndEvent(stop_reason="stop")])
+
+        def the_turn_is_on_row_a() -> None:
+            store._sticky[("openai", session_id)] = turn_row.id
+
+        try:
+            the_turn_is_on_row_a()
+            _ = [
+                event
+                async for event in stream_with_failover(
+                    self._isolated(), store, None, client_for, session_id=session_id
+                )
+            ]
+            assert not store.is_blocked(
+                turn_row.id, "openai"
+            ), "an isolated call blocked the credential the turn is transacting on"
+            assert (
+                store._sticky[("openai", session_id)] == turn_row.id
+            ), "an isolated call repointed the session's sticky credential"
+
+            # CONTROL, on the same store and the same failing refresh: an
+            # ordinary request DOES both, so neither assertion above can be
+            # passing because this fixture never reaches the path.
+            the_turn_is_on_row_a()
+            _ = [
+                event
+                async for event in stream_with_failover(
+                    _request(), store, None, client_for, session_id=session_id
+                )
+            ]
+            assert store.is_blocked(turn_row.id, "openai"), "the refresh failure blocked nothing"
+            assert (
+                store._sticky[("openai", session_id)] == sibling_row.id
+            ), "stickiness did not move on an ordinary request"
+        finally:
+            store.close()
 
     async def test_the_same_failure_on_an_ORDINARY_request_does_all_four(self) -> None:
         """The control. Without this, every assertion above could be passing

--- a/tests/unit/session/test_session.py
+++ b/tests/unit/session/test_session.py
@@ -100,7 +100,7 @@ def echo_tool(executed: list[str], delay: float = 0.0, name: str = "echo") -> Ag
 def make_session(tmp_path, stream, tools=None, **kwargs) -> Session:
     transcript = Transcript(tmp_path / "sess")
     return Session(
-        model=MODEL,
+        model=kwargs.pop("model", MODEL),
         stream_fn=stream,
         tools=tools or [],
         transcript=transcript,
@@ -1503,3 +1503,95 @@ def test_context_breakdown_counts_wire_schemas_and_messages(tmp_path):
             "messages",
         )
     )
+
+
+def _config_dir_with(tmp_path, monkeypatch, subagents: dict[str, object] | None):
+    """Point the process at a throwaway config dir, optionally with a tier map.
+
+    ``_errand_model`` reads ``subagents.models.lo`` from the real user config,
+    so a test that did not redirect this would answer differently on a machine
+    that happens to have a cheap tier configured.
+    """
+    from local_operator.config import ConfigManager
+
+    config = tmp_path / f"config-{'tiered' if subagents else 'bare'}"
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(config))
+    manager = ConfigManager(config)
+    manager.set_config_value("subagents", subagents or {})
+    return config
+
+
+@pytest.mark.asyncio
+async def test_the_naming_errand_leaves_the_session_isolated_and_cheap(tmp_path, monkeypatch):
+    """``complete_once`` is auto-naming's only route to a provider, and it now
+    runs CONCURRENTLY with the user's turn, so everything that makes it safe to
+    do so lives on the REQUEST it builds.
+
+    The transport suites prove those flags are honoured, but they construct the
+    flag themselves, and every host suite that reaches naming replaces
+    ``complete_once`` on a fake — so nothing watched the one line that SETS it.
+    This asserts the request exactly as it leaves the session.
+    """
+    _config_dir_with(tmp_path, monkeypatch, None)  # no `lo` tier configured
+    captured: list[tuple[ChatRequest, AbortSignal | None]] = []
+
+    def stream_fn(request: ChatRequest, signal: AbortSignal | None):
+        captured.append((request, signal))
+
+        async def gen():
+            yield StreamTextDelta(delta="<title>the login redirect loop</title>")
+            yield StreamEndEvent(stop_reason="stop")
+
+        return gen()
+
+    session = make_session(tmp_path, stream_fn)
+    text = await session.complete_once("name this conversation", "fix the login redirect loop")
+    await session.dispose()
+
+    assert text == "<title>the login redirect loop</title>"
+    assert len(captured) == 1, "the errand is one call, not a loop"
+    request, signal = captured[0]
+    assert request.isolated is True, "the naming call reached the wire un-isolated"
+    assert request.replayable is False, "a title is worth one attempt, not a replay"
+    assert request.max_tokens == Session.ERRAND_MAX_TOKENS
+    assert request.model == session._errand_model()
+    assert request.model.model_id == MODEL.model_id, "no `lo` tier is configured here"
+    assert request.tools == [] and request.tool_choice == "none"
+    assert signal is None, "the errand carries no abort signal"
+    # It is not a turn: nothing about it may reach the transcript.
+    assert [entry.type for entry in session._transcript.entries()] == []
+
+
+@pytest.mark.asyncio
+async def test_the_errand_model_is_effort_clamped_on_both_routes(tmp_path, monkeypatch):
+    """``ERRAND_MAX_TOKENS`` is an output cap that COUNTS REASONING TOKENS, so a
+    128-token errand left on a reasoning model's default effort can spend the
+    whole budget thinking, emit no ``<title>`` at all and make ``parse_title``
+    return ``None`` — auto-naming would silently never work for that operator
+    while still billing the thinking.
+
+    Both routes out of ``_errand_model`` therefore clamp: the configured ``lo``
+    tier (whose ``build_model_spec`` effort is ``None`` for OpenAI reasoning
+    models, i.e. no ``reasoning.effort`` on the wire and the provider's own
+    default applied) and the fallback to the session's own model.
+    """
+    from local_operator.model.configure import build_model_spec
+
+    _config_dir_with(tmp_path, monkeypatch, {"models": {"lo": "openai/gpt-5-mini"}})
+    reasoning_model = build_model_spec("anthropic", "claude-opus-5")
+    session = make_session(tmp_path, ScriptedStream([]), model=reasoning_model)
+
+    tier = build_model_spec("openai", "gpt-5-mini")
+    assert tier.reasoning_efforts, "this test needs a tier WITH an effort ladder"
+    assert tier.reasoning_effort is None, "unclamped, this spec sends no effort at all"
+
+    errand = session._errand_model()
+    assert (errand.provider, errand.model_id) == ("openai", "gpt-5-mini"), "the tier is preferred"
+    assert errand.reasoning_effort == tier.reasoning_efforts[0]
+
+    # Same clamp on the other route: no tier, so the session's own model.
+    _config_dir_with(tmp_path, monkeypatch, None)
+    fallback = session._errand_model()
+    assert fallback.model_id == reasoning_model.model_id
+    assert reasoning_model.reasoning_effort != reasoning_model.reasoning_efforts[0]
+    assert fallback.reasoning_effort == reasoning_model.reasoning_efforts[0]

--- a/tests/unit/test_exec_mode.py
+++ b/tests/unit/test_exec_mode.py
@@ -39,8 +39,8 @@ from local_operator.harness.types import (
     ToolResult,
 )
 from local_operator.headless_print import PrintRenderer, printable_event, run_print_mode
-from local_operator.session.protocol import CompactionOutcome
 from local_operator.session.naming import ConversationName
+from local_operator.session.protocol import CompactionOutcome
 
 # --- Fakes ---------------------------------------------------------------------
 

--- a/tests/unit/test_exec_mode.py
+++ b/tests/unit/test_exec_mode.py
@@ -40,6 +40,7 @@ from local_operator.harness.types import (
 )
 from local_operator.headless_print import PrintRenderer, printable_event, run_print_mode
 from local_operator.session.protocol import CompactionOutcome
+from local_operator.session.naming import ConversationName
 
 # --- Fakes ---------------------------------------------------------------------
 
@@ -88,11 +89,21 @@ class FakeSession:
 
     @property
     def conversation_name(self) -> str:
-        return getattr(self, "_conversation_name", "")
+        return self.conversation_name_state.text
+
+    @property
+    def conversation_name_state(self) -> ConversationName:
+        # The real holder, created on first read: `user_set` precedence (a
+        # human rename outranks every generated title, forever) is behaviour
+        # the TUI reads before it spends a re-title call, so a fake that
+        # reimplemented it as a bare string would hide a regression in it.
+        state = getattr(self, "_name_state", None)
+        if state is None:
+            state = self._name_state = ConversationName()
+        return state
 
     def set_conversation_name(self, text: str, *, user_set: bool = True) -> str:
-        self._conversation_name = (text or "").strip()
-        return self._conversation_name
+        return self.conversation_name_state.set(text, user_set=user_set)
 
     async def complete_once(self, system: str, prompt: str) -> str:
         return ""

--- a/tests/unit/tools/test_loop_liveness.py
+++ b/tests/unit/tools/test_loop_liveness.py
@@ -5,50 +5,155 @@ synchronous stretch inside a tool — a multi-megabyte decode, a PIL image
 re-encode, a spill write — is a stretch the frame does not animate. Reported
 as "the TUI intermittently freezes on multiple concurrent tool calls": a
 batch of reads finishing together put several hundred milliseconds of
-blocking work back-to-back on the loop and the whole screen stood still.
+blocking work back-to-back on the loop and the whole screen stood still
+(measured: 649 ms for three concurrent image reads).
 
 The fixes moved those stretches into ``asyncio.to_thread`` (see
 ``execute_read``/``execute_write``/``execute_edit``/``execute_bash``/
-``execute_grep``). These tests hold that property with a heartbeat: a task
-that wakes every 20 ms and records the gap between wakes. While the tools
-run, a loop-bound stretch shows up as one gap the size of the stretch; a
-threaded one leaves the cadence untouched.
+``execute_grep``). These tests hold that property two ways at once, from a
+single run of the real workload:
 
-The bounds sit between the two worlds with margin on both sides: the
-heartbeat's own cadence plus scheduler noise is tens of milliseconds, while
-the workloads here block for 200 ms+ when run on the loop (measured: 214 ms
-for the image fixture's decode+re-encode alone). A slower machine widens
-only the loop-bound side, so the assertions stay decisive.
+* structurally — the function that moved off the loop is observed running on
+  a thread that is not the loop's. That is the contract stated exactly, and
+  no amount of machine load can perturb it.
+* temporally — a heartbeat task wakes every 20 ms and records how much CPU
+  time THE LOOP THREAD accumulated since its last wake. A synchronous
+  stretch on the loop is, by definition, the loop thread executing without
+  yielding, so it shows up as one sample the size of the stretch.
+
+The temporal half deliberately measures loop-thread CPU rather than the
+wall-clock gap between wakes, because the wall-clock gap does not measure
+what it looks like it measures. It goes wide whenever the loop thread is not
+SCHEDULED, which is a different thing from the loop thread being BUSY — and
+the leading cause of the loop thread not being scheduled is the fix itself:
+three CPU-bound Pillow threads in-process delay the main thread's next wake
+through GIL handoff and allocator contention. Measured on an idle 14-core
+M3 Max with the decode correctly threaded, the widest wall gap ranged from
+156 ms to 375 ms run to run, and a control of three 220 ms pure-CPU spins in
+``asyncio.to_thread`` — nothing at all on the loop — already produced gaps
+of 86-130 ms. A wall-clock bound tight enough to catch a re-introduced stall
+therefore fails on the fixed tree roughly one run in two; the old 0.12 s one
+did, which is what sent this file red on load and often without it.
+
+Loop-thread CPU separates the two worlds by two orders of magnitude and does
+not move with load, because a busy machine steals wall time from the loop
+thread without handing it CPU time. Measured over 25 repetitions each: the
+widest sample is 4.3 ms for the image workload and 12.7 ms for the bash one,
+against 512-725 ms with the image decode put back on the loop, and 2.4-4.1 ms
+for the image workload under eight competing CPU hogs — i.e. load moves this
+statistic by a millisecond where it moved the wall gap by 300.
+
+Which half is decisive differs by the SHAPE of the stretch, which is why both
+are here rather than either alone.
+
+* CPU on the loop — the shape PR #129 fixed. The temporal half owns it: the
+  decode is pure CPU, so putting it back on the loop lands 512-725 ms on one
+  sample (a single image's worth, 147 ms, is still caught). It owns it for the
+  whole path too, including stretches nobody thought to spy on.
+* A BLOCKING CALL on the loop — a synchronous file read, the spill's write.
+  Those cost the loop thread wall time and no CPU at all, so no CPU bound can
+  see them; measured, the file snapshot put back on the loop moves the widest
+  sample only to 6.7 ms. The structural half owns that shape, which is why it
+  watches every hop on the path and not just the expensive one.
+
+:data:`MAX_LOOP_CPU_S` is set from those measurements: 6x clear of the widest
+legitimate sample, so a machine six times slower than this one still passes,
+and 6x under the cheapest re-introduced stretch actually observed. A slower
+machine only widens the loop-bound side.
 """
 
 from __future__ import annotations
 
 import asyncio
 import io
+import threading
 import time
+from collections.abc import Callable
 from pathlib import Path
+from typing import Any
 
 import pytest
 from PIL import Image
 
+import local_operator.tools.builtin as builtin
 from local_operator.tools.builtin import execute_bash, execute_read
 
-# Cadence of the liveness probe, and the bound a single wake may exceed it by.
+# Cadence of the liveness probe.
 HEARTBEAT_S = 0.02
-#: The largest acceptable gap between wakes while tools are running. Chosen
-#: against the measured loop-bound cost of the fixtures (200 ms+ each) with
-#: an order of magnitude of headroom over the cadence itself.
-MAX_GAP_S = 0.12
+#: The most CPU time the loop thread may accumulate between two heartbeat
+#: wakes. Servicing the tools' completion callbacks costs it up to 12.7 ms per
+#: sample; running the image workload on the loop costs it 512-725 ms.
+MAX_LOOP_CPU_S = 0.08
 
 
-async def _heartbeat(stop: asyncio.Event, gaps: list[float]) -> None:
-    """Record inter-wake gaps until told to stop; the probe itself is trivial."""
-    last = time.monotonic()
-    while not stop.is_set():
-        await asyncio.sleep(HEARTBEAT_S)
-        now = time.monotonic()
-        gaps.append(now - last)
-        last = now
+class LoopCpuProbe:
+    """Heartbeat that records the loop thread's CPU time between its wakes.
+
+    ``time.thread_time`` is per-thread and excludes time asleep or waiting on
+    the GIL, so a sample is large only when the loop thread genuinely ran
+    without yielding — never merely because the machine was busy.
+    """
+
+    def __init__(self) -> None:
+        self.samples: list[float] = []
+        self._stop = asyncio.Event()
+        self._task: asyncio.Task[None] | None = None
+
+    async def _run(self) -> None:
+        last = time.thread_time()
+        while not self._stop.is_set():
+            await asyncio.sleep(HEARTBEAT_S)
+            now = time.thread_time()
+            self.samples.append(now - last)
+            last = now
+
+    def start(self) -> None:
+        self._task = asyncio.create_task(self._run())
+
+    async def stop(self) -> None:
+        self._stop.set()
+        assert self._task is not None
+        await self._task
+
+    @property
+    def worst(self) -> float:
+        return max(self.samples)
+
+
+class OffLoopSpy:
+    """Records the threads a to_thread'd function was actually called on.
+
+    A spy, not a stub: the real function still runs, so the same workload
+    feeds the structural and the temporal assertion at once.
+    """
+
+    def __init__(self, monkeypatch: pytest.MonkeyPatch, *names: str) -> None:
+        self.threads: dict[str, list[int]] = {name: [] for name in names}
+        # Constructed from inside the test coroutine, so this IS the loop's
+        # thread — asyncio offers no other way to name it.
+        self.loop_thread = threading.get_ident()
+        for name in names:
+            monkeypatch.setattr(builtin, name, self._wrap(name, getattr(builtin, name)))
+
+    def _wrap(self, name: str, real: Callable[..., Any]) -> Callable[..., Any]:
+        def spy(*args: Any, **kwargs: Any) -> Any:
+            self.threads[name].append(threading.get_ident())
+            return real(*args, **kwargs)
+
+        return spy
+
+    def assert_all_off_loop(self) -> None:
+        for name, idents in self.threads.items():
+            assert idents, (
+                f"{name} never ran — the work it carries no longer goes through it, "
+                "so this test is no longer watching anything"
+            )
+            on_loop = [i for i in idents if i == self.loop_thread]
+            assert not on_loop, (
+                f"{name} ran on the event-loop thread {len(on_loop)} of "
+                f"{len(idents)} times — the asyncio.to_thread hop is gone and the "
+                "work is back on the render loop"
+            )
 
 
 def _noisy_png(path: Path) -> None:
@@ -66,44 +171,55 @@ def _noisy_png(path: Path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_concurrent_image_reads_keep_the_loop_live(tmp_path: Path) -> None:
+async def test_concurrent_image_reads_keep_the_loop_live(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Three simultaneous image reads must not stop the frame from animating."""
     png = tmp_path / "noise.png"
     _noisy_png(png)
 
-    stop = asyncio.Event()
-    gaps: list[float] = []
-    probe = asyncio.create_task(_heartbeat(stop, gaps))
+    # Both hops an image read makes: the blocking file snapshot and the
+    # decode+re-encode. A blocking syscall put back on the loop costs the loop
+    # thread wall time but no CPU, so the structural half is the only one that
+    # can see it, and it must therefore watch the whole path — not just the
+    # expensive end of it.
+    spy = OffLoopSpy(monkeypatch, "_read_file_snapshot", "_encode_image_for_model")
+    probe = LoopCpuProbe()
+    probe.start()
     try:
         results = await asyncio.gather(
             *(execute_read(f"read-{i}", {"path": str(png)}, None, None, None) for i in range(3))
         )
     finally:
-        stop.set()
-        await probe
+        await probe.stop()
 
     assert not any(r.is_error for r in results), "reads failed; liveness proved nothing"
-    assert gaps, "heartbeat never woke"
-    assert max(gaps) < MAX_GAP_S, (
-        f"event loop blocked for {max(gaps):.3f}s while tools ran — "
-        "a synchronous stretch is back on the render loop"
+    spy.assert_all_off_loop()
+    assert probe.samples, "heartbeat never woke"
+    assert probe.worst < MAX_LOOP_CPU_S, (
+        f"the loop thread burned {probe.worst:.3f}s of CPU without yielding while "
+        "the reads ran — a synchronous stretch is back on the render loop"
     )
 
 
 @pytest.mark.asyncio
-async def test_oversized_bash_output_keeps_the_loop_live(tmp_path: Path) -> None:
+async def test_oversized_bash_output_keeps_the_loop_live(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """A command that prints megabytes settles without freezing the frame.
 
     The oversized tail (join, decode, spill write, elide) is the part that
-    moved into a thread; the fixture size is what makes that tail expensive
-    enough to see from the heartbeat.
+    moved into a thread, and the fixture size is what makes it expensive: 20 MB
+    costs 80 ms of CPU plus a spill write. Most of that is the write, so on
+    this path the structural assertion is the one with teeth — see the module
+    docstring on which half owns which shape.
     """
     big = tmp_path / "big.txt"
     big.write_text("x" * (20 * 1024 * 1024) + "\n")
 
-    stop = asyncio.Event()
-    gaps: list[float] = []
-    probe = asyncio.create_task(_heartbeat(stop, gaps))
+    spy = OffLoopSpy(monkeypatch, "_decode_chunks", "_bash_oversized_streams")
+    probe = LoopCpuProbe()
+    probe.start()
     try:
         result = await execute_bash(
             "bash-1",
@@ -113,12 +229,12 @@ async def test_oversized_bash_output_keeps_the_loop_live(tmp_path: Path) -> None
             None,
         )
     finally:
-        stop.set()
-        await probe
+        await probe.stop()
 
     assert not result.is_error, result.text
-    assert gaps, "heartbeat never woke"
-    assert max(gaps) < MAX_GAP_S, (
-        f"event loop blocked for {max(gaps):.3f}s while bash settled — "
-        "the oversized-output tail is back on the render loop"
+    spy.assert_all_off_loop()
+    assert probe.samples, "heartbeat never woke"
+    assert probe.worst < MAX_LOOP_CPU_S, (
+        f"the loop thread burned {probe.worst:.3f}s of CPU without yielding while "
+        "bash settled — the oversized-output tail is back on the render loop"
     )

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -20,6 +20,7 @@ import pytest
 
 from local_operator.harness.types import ImageContent, NoticeEvent, TextContent
 from local_operator.session.mcp_status import McpStartupOutcome
+from local_operator.session.naming import ConversationName
 from local_operator.session.protocol import CompactionOutcome
 from local_operator.tui import theme as theme_mod
 from local_operator.tui.app import (
@@ -69,6 +70,11 @@ class FakeSession:
         )
         self.preflight_calls = 0
         self.preflight_notice: str | None = None
+        # The REAL holder, not a bare string: `user_set` precedence (a human
+        # rename outranks every generated title, forever) is behaviour the TUI
+        # relies on, and a fake that reimplements it as a plain assignment
+        # would let a regression in that rule pass every pilot test.
+        self._name_state = ConversationName()
 
     @property
     def session_id(self) -> str:
@@ -139,11 +145,14 @@ class FakeSession:
 
     @property
     def conversation_name(self) -> str:
-        return getattr(self, "_name", "")
+        return self._name_state.text
+
+    @property
+    def conversation_name_state(self) -> ConversationName:
+        return self._name_state
 
     def set_conversation_name(self, text: str, *, user_set: bool = True) -> str:
-        self._name = (text or "").strip()
-        return self._name
+        return self._name_state.set(text, user_set=user_set)
 
     async def complete_once(self, system: str, prompt: str) -> str:
         # No title: the naming worker must be inert in the pilot tests, and

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -3281,6 +3281,73 @@ async def test_boot_warms_session_imports_before_awaiting_the_factory() -> None:
     assert warm_thread and warm_thread[0] != loop_thread
 
 
+@pytest.mark.asyncio
+async def test_quitting_during_boot_never_paints_into_the_dismantled_screen() -> None:
+    """The boot worker must be cancelled BEFORE the widget tree is pruned.
+
+    Textual's shutdown prunes every screen and widget first and cancels workers
+    afterwards, so a boot worker that wakes in between resumes into
+    ``_adopt_session`` → ``_render_resumed_history`` → ``_transcript_view()``,
+    where the ``#transcript`` re-lookup for a transcript that is no longer in the
+    tree raises ``NoMatches`` — and ``exit_on_error`` turns it into
+    ``WorkerFailed``, i.e. a traceback for anyone who quits while the session is
+    still starting (the import warm-up alone is ~700 ms; see
+    ``_warm_session_imports``). It is that crash which surfaced in this suite's
+    per-width app loops as a ``NoMatches`` on a screen still wearing ``boot``:
+    sweeping only the hop's duration across an app's lifetime hit it 6 times in
+    301 apps, so a loop that tears one app down per width meets it eventually.
+
+    So the ordering is the contract, and the arrangement below pins it rather
+    than sampling it: the factory is held until the prune has FINISHED, then
+    released with ticks to spare before Textual's own ``cancel_all``. Patching
+    ``App._close_all`` is the only seam that brackets the prune — nothing public
+    runs between it and the cancellation it races. Restoring the app's order
+    (dropping ``OperatorApp._shutdown``, or textual renaming what it overrides)
+    fails here again.
+    """
+    from textual.app import App
+    from textual.worker import WorkerState
+
+    factory_gate = asyncio.Event()
+
+    async def warm() -> None:
+        await factory_gate.wait()
+
+    pruned_then_released: list[str] = []
+    original_close_all = App._close_all
+
+    async def close_all(self: App) -> None:
+        await original_close_all(self)
+        pruned_then_released.append("pruned")
+        factory_gate.set()
+        # Ticks for the boot worker to be scheduled in the window Textual leaves
+        # open between the prune and its own `workers.cancel_all()`.
+        for _ in range(4):
+            await asyncio.sleep(0)
+
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(OperatorApp, "_warm_session_imports", staticmethod(warm))
+    monkeypatch.setattr(App, "_close_all", close_all)
+    try:
+        app = OperatorApp(lambda: _factory(FakeSession()))
+        async with app.run_test(size=(80, 24)) as pilot:
+            await pilot.pause()
+            boot_worker = next(w for w in app.workers if w.group == "session")
+            # The premise: boot is still in flight, so teardown genuinely races
+            # it. Without this the test could pass by never having a race.
+            assert app._session is None
+    finally:
+        monkeypatch.undo()
+
+    assert pruned_then_released == ["pruned"]
+    # Cancelled at its own await instead of resuming into the dead tree: no
+    # adoption, no query, and the worker carries no error for `_handle_exception`
+    # to exit the app with.
+    assert boot_worker.state is WorkerState.CANCELLED, boot_worker.state
+    assert app._session is None
+    assert app._exception is None, app._exception
+
+
 class _MeasuredSession(FakeSession):
     """A session that can report what it is already carrying."""
 

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -3316,7 +3316,7 @@ async def test_quitting_during_boot_never_paints_into_the_dismantled_screen() ->
     pruned_then_released: list[str] = []
     original_close_all = App._close_all
 
-    async def close_all(self: App) -> None:
+    async def close_all(self: App[None]) -> None:
         await original_close_all(self)
         pruned_then_released.append("pruned")
         factory_gate.set()

--- a/tests/unit/tui/test_approvals_ux.py
+++ b/tests/unit/tui/test_approvals_ux.py
@@ -222,7 +222,10 @@ async def test_the_saved_default_is_in_force_in_the_next_session(config_dir: Pat
         # assertion above and still stop the first tool of the session.
         assert await _gate(session)("bash", "run: ls") is True
         assert not relaunched.query(ApprovalBlock), "auto-approve still mounted a prompt"
-        assert "auto-approve always" in _band(relaunched)
+        # The band's trailing cell is the alarm. It no longer spells the mode out
+        # — the session NAME owns that slot now — so `auto` and `always` are one
+        # glyph here, and `/approvals` is what distinguishes them.
+        assert _band(relaunched).rstrip().endswith("!")
 
 
 @pytest.mark.asyncio
@@ -291,8 +294,9 @@ async def test_an_unwritable_config_still_switches_the_session(
         assert app._approve_all is True, "the session was denied the mode it asked for"
         assert app._approvals_default_auto is False
         assert "could not save default" in _notices(app)[-1]
-        band = _band(app)
-        assert "auto-approve" in band and "always" not in band
+        # Still alarmed: the session got the mode, only the promise about the
+        # NEXT session failed, and the band never claimed that part anyway.
+        assert _band(app).rstrip().endswith("!")
 
 
 # -- the list: offered, not remembered ----------------------------------------
@@ -518,20 +522,29 @@ async def test_the_band_and_the_gate_agree_through_every_route(config_dir: Path)
             await asyncio.wait_for(pending, 2)
             return False
 
+        def band_is_alarmed() -> bool:
+            """Whether the band's trailing cell is the disarmed-gate alarm.
+
+            The segment is a bare `!` now — the session name took the words —
+            so both scopes look identical here on purpose: the band's promise is
+            "no tool will ask", and "until when" is `/approvals`' answer.
+            """
+            return _band(app).rstrip().endswith("!")
+
         assert await gate_runs_without_asking() is False
-        assert "auto-approve" not in _band(app)
+        assert band_is_alarmed() is False
 
         await _submit(pilot, app, "/approvals auto")
         assert await gate_runs_without_asking() is True
-        assert "auto-approve" in _band(app) and "always" not in _band(app)
+        assert band_is_alarmed() is True
 
         await _submit(pilot, app, "/approvals default auto")
         assert await gate_runs_without_asking() is True
-        assert "auto-approve always" in _band(app)
+        assert band_is_alarmed() is True
 
         await _submit(pilot, app, "/approvals ask")
         assert await gate_runs_without_asking() is False
-        assert "auto-approve" not in _band(app)
+        assert band_is_alarmed() is False
 
 
 @pytest.mark.asyncio
@@ -597,6 +610,8 @@ async def test_the_allow_all_key_reports_and_paints_like_the_command(
         assert await asyncio.wait_for(pending, 2) is True
 
         assert app._approve_all is True
-        assert "auto-approve" in _band(app)
-        assert "always" not in _band(app), "a keystroke must not claim a saved default"
+        # One glyph for both scopes: the band says "no tool will ask", and the
+        # keystroke's session-only scope is proved by the config below staying
+        # unwritten rather than by a word in the band.
+        assert _band(app).rstrip().endswith("!")
         assert _saved_mode(config_dir) is None

--- a/tests/unit/tui/test_band_panels.py
+++ b/tests/unit/tui/test_band_panels.py
@@ -24,6 +24,7 @@ from local_operator.tui import theme as theme_mod
 from local_operator.tui.app import OperatorApp
 from local_operator.tui.widgets.subagent_panel import SubagentPanel
 from local_operator.tui.widgets.todo_panel import MAX_TODO_ROWS, TodoPanel
+from local_operator.session.naming import ConversationName
 
 
 class FakeSession:
@@ -101,10 +102,21 @@ class FakeSession:
 
     @property
     def conversation_name(self) -> str:
-        return ""
+        return self.conversation_name_state.text
+
+    @property
+    def conversation_name_state(self) -> ConversationName:
+        # The real holder, created on first read: `user_set` precedence (a
+        # human rename outranks every generated title, forever) is behaviour
+        # the TUI reads before it spends a re-title call, so a fake that
+        # reimplemented it as a bare string would hide a regression in it.
+        state = getattr(self, "_name_state", None)
+        if state is None:
+            state = self._name_state = ConversationName()
+        return state
 
     def set_conversation_name(self, text: str, *, user_set: bool = True) -> str:
-        return (text or "").strip()
+        return self.conversation_name_state.set(text, user_set=user_set)
 
     async def complete_once(self, system: str, prompt: str) -> str:
         return ""

--- a/tests/unit/tui/test_band_panels.py
+++ b/tests/unit/tui/test_band_panels.py
@@ -19,12 +19,12 @@ from rich.text import Text
 from textual.app import App, ComposeResult
 
 from local_operator.harness.types import ImageContent
+from local_operator.session.naming import ConversationName
 from local_operator.session.protocol import CompactionOutcome
 from local_operator.tui import theme as theme_mod
 from local_operator.tui.app import OperatorApp
 from local_operator.tui.widgets.subagent_panel import SubagentPanel
 from local_operator.tui.widgets.todo_panel import MAX_TODO_ROWS, TodoPanel
-from local_operator.session.naming import ConversationName
 
 
 class FakeSession:

--- a/tests/unit/tui/test_boot_layout.py
+++ b/tests/unit/tui/test_boot_layout.py
@@ -35,6 +35,7 @@ from typing import Any
 
 import pytest
 from rich.cells import cell_len
+from rich.text import Text
 from textual.css.query import NoMatches
 from textual.screen import Screen
 
@@ -46,6 +47,7 @@ from local_operator.tui.app import (
     BOOT_CARD_CLASS,
     BOOT_CARD_MIN_INSET,
     BOOT_LAYOUT_CLASS,
+    Band,
     OperatorApp,
 )
 from local_operator.tui.widgets.editor import Editor
@@ -774,6 +776,47 @@ async def test_the_conversation_layout_reserves_nothing_and_clear_puts_it_back()
         await _settle(pilot)
         assert app.screen.has_class(BOOT_LAYOUT_CLASS)
         assert _reserve(app) != (False, 0), "and the centring comes back"
+
+
+@pytest.mark.asyncio
+async def test_the_band_is_refitted_when_the_card_hands_back_the_width() -> None:
+    """The band's row belongs to the box it is painted in, across the handover.
+
+    The status band is the input panel's last row, so the boot card's clamp is its
+    clamp too: while the splash is up it is fitted to ~97 cells of a 150-column
+    terminal, and the first substantive prompt hands it the full 145 back. That
+    hand-back is a class change on the Screen, not a terminal resize, so nothing
+    told the band — and the frames straight after the opening submit, which are
+    exactly the frames a user is watching when they press Enter, kept the card's
+    row: a basename cwd, no effort segment, and a stub of the name the prompt had
+    just earned.
+
+    The band answers to its OWN ``Resize`` now (``Band.BoxChanged``), so this
+    holds for any cause rather than for this one; the assertion is the general
+    one, that what is painted is what the current box fits.
+    """
+    app = _make_app()
+    async with app.run_test(size=(150, 24)) as pilot:
+        await pilot.pause()
+        await _settle(pilot)
+        band = app.query_one("#status-band", Band)
+        status = app._status
+        assert status is not None
+        clamped = band.content_size.width
+        assert clamped < 145, "premise: the boot card has the band clamped"
+
+        app.query_one(Editor).text = "add todo guardrails to the operator loop"
+        await pilot.press("enter")
+        await _settle(pilot)
+
+        assert band.content_size.width > clamped, "premise: the card gave the width back"
+        painted = band.content
+        assert isinstance(painted, Text), "the band is painted as a rich Text"
+        assert (
+            painted.plain == status._render(band.content_size.width).plain
+        ), "the band is still painting the row it fitted to the boot card's box"
+        # And the name the prompt just earned is on the row it is painted on.
+        assert "Add todo guardrails" in painted.plain
 
 
 #: Sizes where the composition has rows to spare, so the reserve is non-zero and

--- a/tests/unit/tui/test_boot_layout.py
+++ b/tests/unit/tui/test_boot_layout.py
@@ -38,6 +38,7 @@ from rich.cells import cell_len
 from textual.css.query import NoMatches
 from textual.screen import Screen
 
+from local_operator.session.naming import ConversationName
 from local_operator.harness.types import AgentMessage, ImageContent
 from local_operator.session.protocol import CompactionOutcome
 from local_operator.tui import theme as theme_mod
@@ -113,10 +114,21 @@ class FakeSession:
 
     @property
     def conversation_name(self) -> str:
-        return ""
+        return self.conversation_name_state.text
+
+    @property
+    def conversation_name_state(self) -> ConversationName:
+        # The real holder, created on first read: `user_set` precedence (a
+        # human rename outranks every generated title, forever) is behaviour
+        # the TUI reads before it spends a re-title call, so a fake that
+        # reimplemented it as a bare string would hide a regression in it.
+        state = getattr(self, "_name_state", None)
+        if state is None:
+            state = self._name_state = ConversationName()
+        return state
 
     def set_conversation_name(self, text: str, *, user_set: bool = True) -> str:
-        return text
+        return self.conversation_name_state.set(text, user_set=user_set)
 
     async def complete_once(self, system: str, prompt: str) -> str:
         return ""

--- a/tests/unit/tui/test_boot_layout.py
+++ b/tests/unit/tui/test_boot_layout.py
@@ -38,8 +38,8 @@ from rich.cells import cell_len
 from textual.css.query import NoMatches
 from textual.screen import Screen
 
-from local_operator.session.naming import ConversationName
 from local_operator.harness.types import AgentMessage, ImageContent
+from local_operator.session.naming import ConversationName
 from local_operator.session.protocol import CompactionOutcome
 from local_operator.tui import theme as theme_mod
 from local_operator.tui.app import (

--- a/tests/unit/tui/test_conversation_naming.py
+++ b/tests/unit/tui/test_conversation_naming.py
@@ -276,7 +276,7 @@ async def test_a_dead_naming_call_leaves_the_opener_on_the_band() -> None:
 
 @pytest.mark.asyncio
 async def test_a_low_signal_opener_names_nothing_at_all() -> None:
-    """"hi" is not a title in either half of the module.
+    """ "hi" is not a title in either half of the module.
 
     The deterministic filter gates the stand-in as well as the provider call, so
     a greeting leaves the band on its directory fallback rather than putting the

--- a/tests/unit/tui/test_conversation_naming.py
+++ b/tests/unit/tui/test_conversation_naming.py
@@ -441,7 +441,7 @@ async def test_a_human_rename_is_never_overwritten_by_a_retitle() -> None:
 
 @pytest.mark.asyncio
 async def test_a_chatty_follow_up_makes_no_call_at_all() -> None:
-    """"thanks" cannot have moved a subject, and the filter is free."""
+    """ "thanks" cannot have moved a subject, and the filter is free."""
     app, session = await _boot(title="<title>Fix the login flow</title>")
     async with app.run_test(size=(100, 30)) as pilot:
         await pilot.pause()

--- a/tests/unit/tui/test_conversation_naming.py
+++ b/tests/unit/tui/test_conversation_naming.py
@@ -1,17 +1,27 @@
 """Auto-naming scheduling: when the title call fires, and what a failure costs.
 
 The naming errand is decoration with one hard rule — it must never make the
-session it decorates worse. Two regressions motivated this suite:
+session it decorates worse. Three regressions shaped it:
 
 * Launched concurrently with the opening turn, it was a second simultaneous
-  request on the same OAuth account at the account's busiest moment, and the
-  concurrency ceilings made BOTH calls fail: the turn surfaced early
-  provider-failure notices and the title died. The errand now waits for the
-  turn to settle.
+  request that could rotate the turn's credential, pin the turn to a fallback
+  model, or spend the turn's effort boundary. Naming was deferred until the
+  turn settled to avoid that, which cured the symptom and created the next
+  one. The safety now lives in the SHAPE of the request instead
+  (``ChatRequest.isolated``, covered in ``tests/unit/providers/test_failover.py``
+  and ``tests/unit/model/test_configure.py``), so the call is concurrent again.
+* Deferred, the title landed after the turn. Measured against a real provider:
+  a 29.7-second opening turn, the ``lo › <cwd>`` fallback on the tab for all
+  29.7 of those seconds, and the title stored 1.8 seconds after the answer was
+  already on screen. On a product whose first turn runs for minutes, "the tab
+  never becomes a title" was an accurate description of what a user saw.
 * A failed attempt used to spend the conversation's one naming request, so a
   minute-zero failure left the session (and the terminal title, which names
   the surface) on the cwd fallback forever. The latch now releases on
   failure and the next substantive message retries.
+
+The re-title half is here too: a conversation drifts, and the MODEL — not a
+keyword rule — judges whether a new message moved the subject.
 """
 
 from __future__ import annotations
@@ -22,7 +32,8 @@ from typing import Any
 import pytest
 
 from local_operator.session import naming
-from local_operator.tui.app import OperatorApp
+from local_operator.tui.app import RETITLE_MIN_GAP_S, OperatorApp
+from local_operator.tui.terminal_title import TerminalTitle
 from tests.unit.tui.test_app_pilot import FakeSession, _factory
 
 
@@ -56,8 +67,14 @@ class _GatedSession(FakeSession):
 
 
 async def _settle() -> None:
-    """Let app-thread workers run; two pauses is what the suite's timing needs."""
-    for _ in range(4):
+    """Let app-thread workers run to a standstill.
+
+    Twelve short yields rather than four: a turn worker, a naming worker and a
+    re-title worker can now be scheduled in one submit, and on a loaded machine
+    four ticks was enough to make the ORDER of those observable — this suite
+    started failing only when run alongside its neighbours.
+    """
+    for _ in range(12):
         await asyncio.sleep(0.02)
 
 
@@ -71,60 +88,65 @@ async def _boot(title: str = "") -> tuple[OperatorApp, _GatedSession]:
 
 
 @pytest.mark.asyncio
-async def test_naming_waits_for_the_live_turn_to_settle(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """No second provider request, even beyond the old courtesy timeout."""
-    # The old implementation fell through after 2 × TITLE_TIMEOUT_S and
-    # called the provider while the turn was still live. Shrink that clock so
-    # the regression is deterministic without making the test wait 40s.
-    monkeypatch.setattr(naming, "TITLE_TIMEOUT_S", 0.01)
+async def test_the_title_is_generated_DURING_the_live_turn() -> None:
+    """THE latency regression, pinned at the scheduler.
+
+    The errand used to await ``_turn_settled`` before asking for a title, and a
+    first turn on this product runs for minutes. Here the turn is parked
+    indefinitely on its gate and the title must still arrive: no provider call
+    at all before the gate opens is the bug, not the contract.
+    """
     app, session = await _boot(title="<title>Fix the login flow</title>")
     async with app.run_test(size=(100, 30)) as pilot:
         await pilot.pause()
-        app._start_turn("fix the login flow")
-        app._maybe_name_conversation("fix the login flow")
+        app._submit_prompt("fix the login redirect loop")
         await _settle()
-        assert session.completions == [], "naming raced the live turn"
 
-        session.gate.set()  # the turn settles
-        await _settle()
-        assert len(session.completions) == 1, "naming did not fire once the turn settled"
+        # The turn has not finished and never will until the gate opens.
+        assert session.prompts == ["fix the login redirect loop"]
+        assert not session.gate.is_set()
+        # ...and the title is already stored and painted.
+        assert len(session.completions) == 1, "the title call waited for the turn"
+        assert session.conversation_name == "Fix the login flow"
+        assert app._status is not None
+        assert app._status._conversation_name == "Fix the login flow"
+        session.gate.set()
 
 
 @pytest.mark.asyncio
-async def test_follow_up_preempts_an_inflight_naming_call() -> None:
-    """A follow-up provider call starts only after naming cancellation unwinds."""
+async def test_a_follow_up_turn_leaves_an_inflight_naming_call_alone() -> None:
+    """A second prompt neither waits for the title nor throws it away.
+
+    Turn start used to cancel naming, because the title call took the same
+    provider lane and a user request had to be able to evict it. An isolated
+    call is not in that lane, and cancelling one would re-derive the title from
+    the SECOND message — naming the conversation after its follow-up.
+    """
     app, session = await _boot(title="<title>Fix the login flow</title>")
-    session.name_gate = asyncio.Event()  # hold complete_once inside the provider lane
+    session.name_gate = asyncio.Event()  # hold the title call open
     async with app.run_test(size=(100, 30)) as pilot:
         await pilot.pause()
-        app._start_turn("opening turn")
-        app._maybe_name_conversation("fix the login flow")
-        await _settle()
-        assert not session.name_started.is_set()
-
-        session.gate.set()  # opening turn settles; naming takes the provider lane
+        app._submit_prompt("fix the login redirect loop")
         await asyncio.wait_for(session.name_started.wait(), timeout=1)
 
-        app._start_turn("follow-up turn")
-        # Mirrors `_submit_prompt`: latch ownership is transferred
-        # synchronously, so this follow-up schedules the replacement naming
-        # worker before the canceled one has finished unwinding.
-        app._maybe_name_conversation("follow-up turn")
+        session.gate.set()  # let the opening turn finish
+        app._submit_prompt("also add the assignee email column")
         await _settle()
 
-        assert "name:cancel" in session.timeline
-        assert session.timeline.index("name:cancel") < session.timeline.index(
-            "prompt:follow-up turn"
-        )
-        starts = [index for index, item in enumerate(session.timeline) if item == "name:start"]
-        assert len(starts) == 2
-        assert session.timeline.index("prompt:follow-up turn") < starts[1]
+        # The follow-up ran without waiting for the title...
+        assert session.prompts == [
+            "fix the login redirect loop",
+            "also add the assignee email column",
+        ]
+        # ...and did not evict it.
+        assert "name:cancel" not in session.timeline
+        assert [item for item in session.timeline if item == "name:start"] == ["name:start"]
 
         session.name_gate.set()
         await _settle()
+        # The title names the OPENER, which is what the conversation is about.
         assert session.conversation_name == "Fix the login flow"
+        assert session.completions[0][1] == "fix the login redirect loop"
 
 
 @pytest.mark.asyncio
@@ -194,7 +216,10 @@ async def test_landed_title_paints_the_band_and_keeps_the_latch() -> None:
         assert app._status is not None
         assert app._status._conversation_name == "Fix the login flow"
 
-        # A second substantive message must NOT rename what the user is reading.
+        # A second substantive message inside the re-title window must not
+        # spend a call: the title was decided seconds ago, and a tab label that
+        # can change on every message is one nobody can read. (Past the window,
+        # the model gets asked — see the re-title tests below.)
         session.title = "<title>A different title</title>"
         app._maybe_name_conversation("now something else entirely")
         await _settle()
@@ -203,31 +228,21 @@ async def test_landed_title_paints_the_band_and_keeps_the_latch() -> None:
 
 
 @pytest.mark.asyncio
-async def test_the_band_is_named_from_the_opener_before_the_turn_settles() -> None:
-    """THE regression. The title used to arrive only after the whole turn.
+async def test_the_band_is_named_from_the_opener_before_any_provider_call() -> None:
+    """The instant label: the user's own words, no network, same frame.
 
-    Measured against a real provider on the pre-fix code: a 29.7-second opening
-    turn during which the band and the terminal tab read `lo › <cwd>`, and a
-    generated title stored 1.8 seconds after the answer was already on screen.
-    Since a first turn on this product routinely runs for minutes, "the tab
-    never becomes a title" was an accurate description of what a user saw.
-
-    The errand still waits for the turn — it shares the provider lane, which is
-    what the rest of this suite is about — so the fix is that the OPENER names
-    the conversation immediately, for free, and the generated title upgrades it.
-    This test therefore asserts the band while the turn is deliberately parked.
+    The generated title now lands a second or two later rather than after the
+    turn, but "a second or two" is still visible on a tab bar, and the excerpt
+    costs nothing. So the band is asserted SYNCHRONOUSLY after submit, before
+    the naming worker has had a scheduler tick.
     """
     app, session = await _boot(title="<title>Fix the login flow</title>")
     async with app.run_test(size=(100, 30)) as pilot:
         await pilot.pause()
         app._submit_prompt("summarise how compaction picks a cut point in this repo")
-        await _settle()
 
-        # The turn is still live and the naming call has not been made.
-        assert session.prompts == ["summarise how compaction picks a cut point in this repo"]
-        assert not app._turn_settled.is_set()
+        # No await between the submit and here: nothing asynchronous has run.
         assert session.completions == []
-        # ...and the band is already named, from the user's own words.
         assert app._status is not None
         assert app._status._conversation_name == "Summarise how compaction picks a cut point in…"
         # The STORE is untouched: every gate in the errand reads it to mean
@@ -235,12 +250,14 @@ async def test_the_band_is_named_from_the_opener_before_the_turn_settles() -> No
         # cancel the call it is standing in for.
         assert session.conversation_name == ""
 
-        session.gate.set()
         await _settle()
-        # The generated title supersedes the excerpt on both the store and the band.
+        # The generated title supersedes the excerpt on both the store and the
+        # band — and while the turn is still parked on its gate.
+        assert not session.gate.is_set()
         assert session.conversation_name == "Fix the login flow"
         assert app._status._conversation_name == "Fix the login flow"
         assert app._provisional_name == ""
+        session.gate.set()
 
 
 @pytest.mark.asyncio
@@ -292,6 +309,245 @@ async def test_a_low_signal_opener_names_nothing_at_all() -> None:
         assert app._provisional_name == ""
         assert app._status is not None
         assert app._status._conversation_name == ""
+
+
+# -- re-titling a conversation that has drifted -------------------------------
+
+
+def _fake_clock(app: OperatorApp) -> list[float]:
+    """Replace the app's monotonic seam with a one-cell list the test drives.
+
+    Installed BEFORE the first title lands: ``_store_title`` stamps the
+    re-title window from this same clock, so a fake swapped in afterwards
+    would leave the window stamped at real monotonic time and no amount of
+    advancing would ever open it.
+
+    Starts well away from zero, because zero is also ``_retitle_checked_at``'s
+    initial value: a clock starting at 0 makes "the window was never stamped"
+    and "the window was stamped just now" indistinguishable, which is exactly
+    the bug these tests have to be able to see. Real monotonic time is a large
+    number for the same reason this one is.
+    """
+    now = [10_000.0]
+    app._clock = lambda: now[0]  # type: ignore[method-assign]
+    return now
+
+
+async def _named(app: OperatorApp, session: _GatedSession, opener: str) -> list[float]:
+    """Drive ``app`` to a stored, model-generated title on a controlled clock.
+
+    Leaves the re-title window CLOSED, which is where a freshly named
+    conversation genuinely is: a caller that wants to exercise the re-title
+    path advances the returned clock itself, so no test is quietly relying on
+    a helper to decide the throttle for it.
+    """
+    now = _fake_clock(app)
+    app._submit_prompt(opener)
+    session.gate.set()
+    await _settle()
+    assert session.conversation_name, "the first title never landed"
+    # A fresh gate, already open, so the follow-up turns below run through
+    # instead of parking on the opener's spent one.
+    session.gate = asyncio.Event()
+    session.gate.set()
+    return now
+
+
+async def _named_a_while_ago(app: OperatorApp, session: _GatedSession, opener: str) -> list[float]:
+    """:func:`_named`, then far enough past ``RETITLE_MIN_GAP_S`` to ask again."""
+    now = await _named(app, session, opener)
+    now[0] += RETITLE_MIN_GAP_S + 1
+    return now
+
+
+@pytest.mark.asyncio
+async def test_a_material_change_of_subject_retitles_both_surfaces() -> None:
+    """The whole point of the re-title: a drifted session names its subject.
+
+    The model — not this code — decides that the subject moved; the fake stands
+    in for it by answering with a replacement title instead of the sentinel.
+    """
+    app, session = await _boot(title="<title>Fix the login flow</title>")
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        assert app._status is not None
+        # A real title writer over a capture sink: the terminal tab is the
+        # surface the whole feature is named after, and asserting the band
+        # alone would not notice the two drifting apart.
+        written: list[str] = []
+        title = TerminalTitle(written.append)
+        title.start()
+        app._status.set_terminal_title(title)
+
+        await _named_a_while_ago(app, session, "fix the login redirect loop")
+        assert "Fix the login flow" in title.current
+
+        session.title = "<title>Billing importer rewrite</title>"
+        app._submit_prompt("forget that, rewrite the billing importer instead")
+        await _settle()
+
+        assert len(session.completions) == 2, "no re-title check was made"
+        assert session.completions[1][0].startswith("A conversation is titled: Fix the login flow")
+        assert session.conversation_name == "Billing importer rewrite"
+        assert app._status._conversation_name == "Billing importer rewrite"
+        assert "Billing importer rewrite" in title.current
+        assert any("Billing importer rewrite" in chunk for chunk in written)
+
+
+@pytest.mark.asyncio
+async def test_the_sentinel_answer_leaves_the_title_and_the_band_alone() -> None:
+    """A "same subject" answer must not repaint. A band that rewrites itself
+    mid-turn with the same words is a flicker the user reads as a glitch."""
+    app, session = await _boot(title="<title>Fix the login flow</title>")
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await _named_a_while_ago(app, session, "fix the login redirect loop")
+        assert app._status is not None
+        painted: list[str] = []
+        real_update = app._status.update
+
+        def spy_update(**kwargs: Any) -> None:
+            if kwargs.get("conversation_name") is not None:
+                painted.append(kwargs["conversation_name"])
+            real_update(**kwargs)
+
+        app._status.update = spy_update  # type: ignore[method-assign]
+
+        session.title = "<title/>"  # the model says: unchanged
+        app._submit_prompt("and make the redirect preserve the query string")
+        await _settle()
+
+        assert len(session.completions) == 2, "the model was never asked"
+        assert session.conversation_name == "Fix the login flow"
+        assert painted == [], "the band repainted on a no-change answer"
+
+
+@pytest.mark.asyncio
+async def test_a_human_rename_is_never_overwritten_by_a_retitle() -> None:
+    """``user_set`` wins permanently, and costs no call to defend."""
+    app, session = await _boot(title="<title>Fix the login flow</title>")
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await _named_a_while_ago(app, session, "fix the login redirect loop")
+        session.set_conversation_name("Ledger reconciliation", user_set=True)
+
+        session.title = "<title>Billing importer rewrite</title>"
+        app._submit_prompt("forget that, rewrite the billing importer instead")
+        await _settle()
+
+        assert session.conversation_name == "Ledger reconciliation"
+        assert len(session.completions) == 1, "a renamed conversation spent a re-title call"
+
+
+@pytest.mark.asyncio
+async def test_a_chatty_follow_up_makes_no_call_at_all() -> None:
+    """"thanks" cannot have moved a subject, and the filter is free."""
+    app, session = await _boot(title="<title>Fix the login flow</title>")
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await _named_a_while_ago(app, session, "fix the login redirect loop")
+
+        for chatter in ("thanks", "looks good", "ok"):
+            app._submit_prompt(chatter)
+        await _settle()
+
+        assert len(session.completions) == 1, "a pleasantry spent a provider call"
+        assert session.conversation_name == "Fix the login flow"
+
+
+@pytest.mark.asyncio
+async def test_a_burst_of_substantive_follow_ups_costs_exactly_one_check() -> None:
+    """The throttle. Unthrottled this is one provider call per message."""
+    app, session = await _boot(title="<title>Fix the login flow</title>")
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await _named_a_while_ago(app, session, "fix the login redirect loop")
+
+        session.title = "<title/>"
+        for follow_up in (
+            "also handle the oauth callback path",
+            "and the logout redirect too",
+            "check the session cookie flags while you are there",
+        ):
+            app._submit_prompt(follow_up)
+            await _settle()
+
+        assert len(session.completions) == 2, "the burst was not throttled to one check"
+
+
+@pytest.mark.asyncio
+async def test_a_landed_title_starts_the_re_title_window() -> None:
+    """The window is measured from when the title took EFFECT.
+
+    The first title comes from the naming path, which stamps nothing on its way
+    out — only ``_store_title`` does, and only when a title actually lands.
+    Without that stamp the window is still sitting at its initial zero when the
+    conversation gets its name, so the very next message would be allowed to
+    replace a title the user has had on screen for one second.
+    """
+    app, session = await _boot(title="<title>Fix the login flow</title>")
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        now = await _named(app, session, "fix the login redirect loop")
+
+        session.title = "<title>Billing importer rewrite</title>"
+        app._submit_prompt("forget that, rewrite the billing importer instead")
+        await _settle()
+        assert len(session.completions) == 1, "a one-second-old title was up for replacement"
+        assert session.conversation_name == "Fix the login flow"
+
+        # Past the window the model does get asked, and its answer is taken.
+        now[0] += RETITLE_MIN_GAP_S + 1
+        app._submit_prompt("forget that, rewrite the billing importer instead")
+        await _settle()
+        assert len(session.completions) == 2
+        assert session.conversation_name == "Billing importer rewrite"
+
+
+# -- the re-title call itself -------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_generate_retitle_reads_the_sentinel_as_no_change() -> None:
+    async def answer(system: str, prompt: str) -> str:
+        return "<title/>"
+
+    assert await naming.generate_retitle("Fix the login flow", "and the logout too", answer) is None
+
+
+@pytest.mark.asyncio
+async def test_generate_retitle_treats_a_restatement_as_no_change() -> None:
+    """A model that "changes" the title to the one already in force has said
+    "no change" in the expensive spelling; repainting it would be a flicker."""
+
+    async def answer(system: str, prompt: str) -> str:
+        return "<title>fix the LOGIN flow</title>"
+
+    assert await naming.generate_retitle("Fix the login flow", "and the logout too", answer) is None
+
+
+@pytest.mark.asyncio
+async def test_generate_retitle_never_asks_without_a_title_or_about_chatter() -> None:
+    calls: list[str] = []
+
+    async def answer(system: str, prompt: str) -> str:
+        calls.append(prompt)
+        return "<title>Never reached</title>"
+
+    assert await naming.generate_retitle("", "rewrite the billing importer", answer) is None
+    assert await naming.generate_retitle("Fix the login flow", "thanks!", answer) is None
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_generate_retitle_swallows_a_provider_failure_as_no_change() -> None:
+    """``None`` means both "unchanged" and "the call died", because they are the
+    same instruction to the caller: leave the title alone."""
+
+    async def boom(system: str, prompt: str) -> str:
+        raise RuntimeError("429 rate limited")
+
+    assert await naming.generate_retitle("Fix the login flow", "rewrite the importer", boom) is None
 
 
 # -- the opener-derived label itself -----------------------------------------

--- a/tests/unit/tui/test_conversation_naming.py
+++ b/tests/unit/tui/test_conversation_naming.py
@@ -27,6 +27,7 @@ keyword rule — judges whether a new message moved the subject.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 from typing import Any
 
 import pytest
@@ -34,6 +35,8 @@ import pytest
 from local_operator.session import naming
 from local_operator.tui.app import RETITLE_MIN_GAP_S, OperatorApp
 from local_operator.tui.terminal_title import TerminalTitle
+from local_operator.tui.widgets.editor import Editor
+from local_operator.tui.widgets.transcript import NoticeBlock, TranscriptView
 from tests.unit.tui.test_app_pilot import FakeSession, _factory
 
 
@@ -45,12 +48,19 @@ class _GatedSession(FakeSession):
         self.gate = asyncio.Event()
         self.title = ""
         self.name_gate: asyncio.Event | None = None
+        # The two "this worker got here" barriers. `_settle` yields for a fixed
+        # number of ticks, which is a guess about the scheduler rather than a
+        # fact about it, so a test asserting something a WORKER produces waits
+        # for the worker to say it got there instead of counting ticks. (The
+        # flake that started this was not the scheduler at all — see `_ready`.)
         self.name_started = asyncio.Event()
+        self.prompt_started = asyncio.Event()
         self.timeline: list[str] = []
 
     async def prompt(self, text: str, images: Any = None) -> None:  # noqa: ANN401
         self.prompts.append(text)
         self.timeline.append(f"prompt:{text}")
+        self.prompt_started.set()
         await self.gate.wait()
 
     async def complete_once(self, system: str, prompt: str) -> str:
@@ -67,15 +77,41 @@ class _GatedSession(FakeSession):
 
 
 async def _settle() -> None:
-    """Let app-thread workers run to a standstill.
+    """Let the app's workers run to a standstill.
 
     Twelve short yields rather than four: a turn worker, a naming worker and a
-    re-title worker can now be scheduled in one submit, and on a loaded machine
-    four ticks was enough to make the ORDER of those observable — this suite
-    started failing only when run alongside its neighbours.
+    re-title worker can be scheduled by one submit, and each of them has to get
+    from `run_worker` to its first await. Bounded ticks are only sound AFTER a
+    submit that actually dispatched something — see :func:`_ready` for the race
+    that no number of ticks here could ever have fixed.
     """
     for _ in range(12):
         await asyncio.sleep(0.02)
+
+
+async def _ready(pilot: Any, app: OperatorApp) -> None:  # noqa: ANN401
+    """Pump the app until the session has been adopted.
+
+    THE flake this file kept hitting, and it was never about naming.
+    ``_submit_prompt`` early-returns a "session is still starting…" notice while
+    ``app._session`` is None: no turn, no naming call, no ``session.prompts`` —
+    which is the bare `+ []` / `- ['fix the login redirect loop']` diff the suite
+    failed with beside its neighbours. Instrumented under 16 CPU hogs, 3 of 3
+    failures reported ``prompts=[] workers=[]`` with that notice in the
+    transcript, so the submit had beaten adoption rather than the workers being
+    slow afterwards.
+
+    One ``pilot.pause()`` is enough on an idle machine and a coin flip on a
+    loaded one, because adoption takes an unknown NUMBER of pumps, not an
+    interval. So this waits on boot progress and is bounded by pumps rather than
+    by the clock — a starved machine takes longer instead of failing, while a
+    session that genuinely never arrives still fails instead of hanging.
+    """
+    for _ in range(200):
+        if app._session is not None:
+            return
+        await pilot.pause()
+    raise AssertionError("the session was never adopted")
 
 
 async def _boot(title: str = "") -> tuple[OperatorApp, _GatedSession]:
@@ -98,8 +134,18 @@ async def test_the_title_is_generated_DURING_the_live_turn() -> None:
     """
     app, session = await _boot(title="<title>Fix the login flow</title>")
     async with app.run_test(size=(100, 30)) as pilot:
-        await pilot.pause()
+        await _ready(pilot, app)
         app._submit_prompt("fix the login redirect loop")
+        # `_ready` above is what fixed this test's flake (the submit was beating
+        # session adoption); these two barriers are what make the ASSERTIONS
+        # below independent of tick counts, since both facts they check are
+        # produced by workers rather than by the submit. The naming one is
+        # suppressed rather than awaited outright so a real regression — no title
+        # call at all — still fails on the assertion that names it instead of on
+        # a timeout that does not.
+        await asyncio.wait_for(session.prompt_started.wait(), timeout=5)
+        with contextlib.suppress(asyncio.TimeoutError):
+            await asyncio.wait_for(session.name_started.wait(), timeout=2)
         await _settle()
 
         # The turn has not finished and never will until the gate opens.
@@ -125,7 +171,7 @@ async def test_a_follow_up_turn_leaves_an_inflight_naming_call_alone() -> None:
     app, session = await _boot(title="<title>Fix the login flow</title>")
     session.name_gate = asyncio.Event()  # hold the title call open
     async with app.run_test(size=(100, 30)) as pilot:
-        await pilot.pause()
+        await _ready(pilot, app)
         app._submit_prompt("fix the login redirect loop")
         await asyncio.wait_for(session.name_started.wait(), timeout=1)
 
@@ -172,7 +218,7 @@ async def test_reload_cancels_and_drains_naming_before_adoption() -> None:
 
     app = OperatorApp(factory)
     async with app.run_test(size=(100, 30)) as pilot:
-        await pilot.pause()
+        await _ready(pilot, app)
         app._maybe_name_conversation("name the old session")
         await asyncio.wait_for(first.name_started.wait(), timeout=1)
 
@@ -190,7 +236,7 @@ async def test_failed_attempt_releases_the_latch_for_a_retry() -> None:
     """A dead naming call costs a delayed title, not a nameless session."""
     app, session = await _boot(title="")  # complete_once answers nothing usable
     async with app.run_test(size=(100, 30)) as pilot:
-        await pilot.pause()
+        await _ready(pilot, app)
         app._maybe_name_conversation("please review the export columns")
         await _settle()
         assert session.completions, "attempt never ran"
@@ -208,7 +254,7 @@ async def test_landed_title_paints_the_band_and_keeps_the_latch() -> None:
     """A successful attempt stores the name, paints the band, and stays spent."""
     app, session = await _boot(title="<title>Fix the login flow</title>")
     async with app.run_test(size=(100, 30)) as pilot:
-        await pilot.pause()
+        await _ready(pilot, app)
         app._maybe_name_conversation("fix the login flow")
         await _settle()
         assert session.conversation_name == "Fix the login flow"
@@ -238,7 +284,7 @@ async def test_the_band_is_named_from_the_opener_before_any_provider_call() -> N
     """
     app, session = await _boot(title="<title>Fix the login flow</title>")
     async with app.run_test(size=(100, 30)) as pilot:
-        await pilot.pause()
+        await _ready(pilot, app)
         app._submit_prompt("summarise how compaction picks a cut point in this repo")
 
         # No await between the submit and here: nothing asynchronous has run.
@@ -270,7 +316,7 @@ async def test_a_dead_naming_call_leaves_the_opener_on_the_band() -> None:
     """
     app, session = await _boot(title="")  # a reply with no <title> at all
     async with app.run_test(size=(100, 30)) as pilot:
-        await pilot.pause()
+        await _ready(pilot, app)
         app._submit_prompt("fix the login redirect loop")
         session.gate.set()
         await _settle()
@@ -301,7 +347,7 @@ async def test_a_low_signal_opener_names_nothing_at_all() -> None:
     """
     app, session = await _boot(title="<title>Fix the login flow</title>")
     async with app.run_test(size=(100, 30)) as pilot:
-        await pilot.pause()
+        await _ready(pilot, app)
         app._submit_prompt("hi")
         session.gate.set()
         await _settle()
@@ -344,6 +390,13 @@ async def _named(app: OperatorApp, session: _GatedSession, opener: str) -> list[
     now = _fake_clock(app)
     app._submit_prompt(opener)
     session.gate.set()
+    # The naming barrier, because this helper is a PRECONDITION for seven tests:
+    # its own `assert` below is what a slipped tick surfaces as, and "the first
+    # title never landed" describes the scheduler rather than anything about
+    # re-titling. (The boot race that made it fail in the first place is handled
+    # by `_ready` in each test, before this runs.)
+    with contextlib.suppress(asyncio.TimeoutError):
+        await asyncio.wait_for(session.name_started.wait(), timeout=5)
     await _settle()
     assert session.conversation_name, "the first title never landed"
     # A fresh gate, already open, so the follow-up turns below run through
@@ -369,7 +422,7 @@ async def test_a_material_change_of_subject_retitles_both_surfaces() -> None:
     """
     app, session = await _boot(title="<title>Fix the login flow</title>")
     async with app.run_test(size=(100, 30)) as pilot:
-        await pilot.pause()
+        await _ready(pilot, app)
         assert app._status is not None
         # A real title writer over a capture sink: the terminal tab is the
         # surface the whole feature is named after, and asserting the band
@@ -400,7 +453,7 @@ async def test_the_sentinel_answer_leaves_the_title_and_the_band_alone() -> None
     mid-turn with the same words is a flicker the user reads as a glitch."""
     app, session = await _boot(title="<title>Fix the login flow</title>")
     async with app.run_test(size=(100, 30)) as pilot:
-        await pilot.pause()
+        await _ready(pilot, app)
         await _named_a_while_ago(app, session, "fix the login redirect loop")
         assert app._status is not None
         painted: list[str] = []
@@ -427,7 +480,7 @@ async def test_a_human_rename_is_never_overwritten_by_a_retitle() -> None:
     """``user_set`` wins permanently, and costs no call to defend."""
     app, session = await _boot(title="<title>Fix the login flow</title>")
     async with app.run_test(size=(100, 30)) as pilot:
-        await pilot.pause()
+        await _ready(pilot, app)
         await _named_a_while_ago(app, session, "fix the login redirect loop")
         session.set_conversation_name("Ledger reconciliation", user_set=True)
 
@@ -439,12 +492,148 @@ async def test_a_human_rename_is_never_overwritten_by_a_retitle() -> None:
         assert len(session.completions) == 1, "a renamed conversation spent a re-title call"
 
 
+# -- `/rename`: the human's title ---------------------------------------------
+
+
+async def _type_command(pilot: Any, app: OperatorApp, text: str) -> None:  # noqa: ANN401
+    """Type a slash command into the real editor and press Enter.
+
+    The reported path rather than ``_run_slash_command``: the submit handler is
+    what decides a line beginning with `/` is a command at all, and a rename
+    that only works when its handler is called by hand is not one a user has.
+
+    Esc first when the picker is open — Enter on an open command picker
+    COMPLETES the highlighted row and submits THAT, so a bare ``/rename`` would
+    never reach the branch under test.
+    """
+    editor = app.query_one(Editor)
+    editor.text = text
+    await pilot.pause()
+    if editor._picker.is_open():
+        await pilot.press("escape")
+        await pilot.pause()
+    await pilot.press("enter")
+    await pilot.pause()
+
+
+def _notices(app: OperatorApp) -> list[str]:
+    """Notice bodies, unwrapped — the receipt a rename leaves behind."""
+    return [
+        block._text
+        for block in app.query_one(TranscriptView).blocks()
+        if isinstance(block, NoticeBlock)
+    ]
+
+
+@pytest.mark.asyncio
+async def test_a_typed_rename_names_both_surfaces_and_asks_no_provider() -> None:
+    """``/rename <title>`` is the entry point ``user_set`` exists for.
+
+    Both surfaces, in the frame it was typed: the band and the terminal tab are
+    what a name IS to the user, and a rename that needed a turn to take effect
+    would read as a command that did nothing. No provider call either — the
+    words are already the user's, so there is nothing to ask anyone.
+    """
+    app, session = await _boot(title="<title>Fix the login flow</title>")
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _ready(pilot, app)
+        assert app._status is not None
+        written: list[str] = []
+        title = TerminalTitle(written.append)
+        title.start()
+        app._status.set_terminal_title(title)
+
+        await _type_command(pilot, app, "/rename Ledger reconciliation")
+
+        assert session.conversation_name == "Ledger reconciliation"
+        assert session.conversation_name_state.user_set is True
+        assert app._status._conversation_name == "Ledger reconciliation"
+        assert "Ledger reconciliation" in title.current
+        assert any("Ledger reconciliation" in chunk for chunk in written)
+        assert session.completions == [], "the rename asked a provider for a title"
+        assert session.prompts == [], "the rename was sent to the model as a turn"
+
+
+@pytest.mark.asyncio
+async def test_a_typed_rename_outranks_a_later_material_change() -> None:
+    """The precedence gate, reached the way the product reaches it.
+
+    ``test_a_human_rename_is_never_overwritten_by_a_retitle`` sets ``user_set``
+    by hand; this drives the only writer of it the shipped TUI has, so the gate
+    is exercised end to end — a genuine change of subject arrives afterwards and
+    must neither repaint the name nor spend a call to be refused.
+    """
+    app, session = await _boot(title="<title>Fix the login flow</title>")
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _ready(pilot, app)
+        await _named_a_while_ago(app, session, "fix the login redirect loop")
+        await _type_command(pilot, app, "/rename Ledger reconciliation")
+        assert session.conversation_name == "Ledger reconciliation"
+
+        session.title = "<title>Billing importer rewrite</title>"
+        app._submit_prompt("forget that, rewrite the billing importer instead")
+        await _settle()
+
+        assert session.conversation_name == "Ledger reconciliation"
+        assert app._status is not None
+        assert app._status._conversation_name == "Ledger reconciliation"
+        assert len(session.completions) == 1, "a renamed conversation spent a re-title call"
+
+
+@pytest.mark.asyncio
+async def test_a_rename_before_the_first_prompt_spends_no_naming_call() -> None:
+    """A conversation the user has already named has nothing left to name.
+
+    ``_maybe_name_conversation`` reads the stored name, so the opener takes the
+    re-title path and is refused there by ``user_set`` — and the excerpt never
+    goes up, because a stand-in for a name that exists would be a downgrade.
+    """
+    app, session = await _boot(title="<title>Fix the login flow</title>")
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _ready(pilot, app)
+        await _type_command(pilot, app, "/rename Ledger reconciliation")
+
+        app._submit_prompt("fix the login redirect loop")
+        await asyncio.wait_for(session.prompt_started.wait(), timeout=5)
+        await _settle()
+
+        assert session.completions == [], "a named conversation asked for a title"
+        assert session.conversation_name == "Ledger reconciliation"
+        assert app._status is not None
+        assert app._status._conversation_name == "Ledger reconciliation"
+        assert app._provisional_name == "", "an opener excerpt displaced the user's name"
+        session.gate.set()
+
+
+@pytest.mark.asyncio
+async def test_a_bare_rename_reports_the_title_and_changes_nothing() -> None:
+    """The empty-argument form answers; it does not clear the name.
+
+    ``ConversationName.set("")`` would store an empty string as a USER-SET
+    title, permanently un-naming the conversation and locking out every
+    generated one — so the bare form has to be a report and nothing else.
+    """
+    app, session = await _boot(title="<title>Fix the login flow</title>")
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _ready(pilot, app)
+        await _type_command(pilot, app, "/rename")
+        assert session.conversation_name == ""
+        assert session.conversation_name_state.user_set is False
+        assert any("unnamed" in text for text in _notices(app)), _notices(app)
+
+        await _type_command(pilot, app, "/rename Ledger reconciliation")
+        await _type_command(pilot, app, "/rename")
+
+        assert session.conversation_name == "Ledger reconciliation"
+        assert any("Ledger reconciliation" in text for text in _notices(app))
+
+
 @pytest.mark.asyncio
 async def test_a_chatty_follow_up_makes_no_call_at_all() -> None:
     """ "thanks" cannot have moved a subject, and the filter is free."""
     app, session = await _boot(title="<title>Fix the login flow</title>")
     async with app.run_test(size=(100, 30)) as pilot:
-        await pilot.pause()
+        await _ready(pilot, app)
         await _named_a_while_ago(app, session, "fix the login redirect loop")
 
         for chatter in ("thanks", "looks good", "ok"):
@@ -460,7 +649,7 @@ async def test_a_burst_of_substantive_follow_ups_costs_exactly_one_check() -> No
     """The throttle. Unthrottled this is one provider call per message."""
     app, session = await _boot(title="<title>Fix the login flow</title>")
     async with app.run_test(size=(100, 30)) as pilot:
-        await pilot.pause()
+        await _ready(pilot, app)
         await _named_a_while_ago(app, session, "fix the login redirect loop")
 
         session.title = "<title/>"
@@ -487,7 +676,7 @@ async def test_a_landed_title_starts_the_re_title_window() -> None:
     """
     app, session = await _boot(title="<title>Fix the login flow</title>")
     async with app.run_test(size=(100, 30)) as pilot:
-        await pilot.pause()
+        await _ready(pilot, app)
         now = await _named(app, session, "fix the login redirect loop")
 
         session.title = "<title>Billing importer rewrite</title>"

--- a/tests/unit/tui/test_conversation_naming.py
+++ b/tests/unit/tui/test_conversation_naming.py
@@ -200,3 +200,167 @@ async def test_landed_title_paints_the_band_and_keeps_the_latch() -> None:
         await _settle()
         assert len(session.completions) == 1
         assert session.conversation_name == "Fix the login flow"
+
+
+@pytest.mark.asyncio
+async def test_the_band_is_named_from_the_opener_before_the_turn_settles() -> None:
+    """THE regression. The title used to arrive only after the whole turn.
+
+    Measured against a real provider on the pre-fix code: a 29.7-second opening
+    turn during which the band and the terminal tab read `lo › <cwd>`, and a
+    generated title stored 1.8 seconds after the answer was already on screen.
+    Since a first turn on this product routinely runs for minutes, "the tab
+    never becomes a title" was an accurate description of what a user saw.
+
+    The errand still waits for the turn — it shares the provider lane, which is
+    what the rest of this suite is about — so the fix is that the OPENER names
+    the conversation immediately, for free, and the generated title upgrades it.
+    This test therefore asserts the band while the turn is deliberately parked.
+    """
+    app, session = await _boot(title="<title>Fix the login flow</title>")
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        app._submit_prompt("summarise how compaction picks a cut point in this repo")
+        await _settle()
+
+        # The turn is still live and the naming call has not been made.
+        assert session.prompts == ["summarise how compaction picks a cut point in this repo"]
+        assert not app._turn_settled.is_set()
+        assert session.completions == []
+        # ...and the band is already named, from the user's own words.
+        assert app._status is not None
+        assert app._status._conversation_name == "Summarise how compaction picks a cut point in…"
+        # The STORE is untouched: every gate in the errand reads it to mean
+        # "something already named this", so a stand-in written there would
+        # cancel the call it is standing in for.
+        assert session.conversation_name == ""
+
+        session.gate.set()
+        await _settle()
+        # The generated title supersedes the excerpt on both the store and the band.
+        assert session.conversation_name == "Fix the login flow"
+        assert app._status._conversation_name == "Fix the login flow"
+        assert app._provisional_name == ""
+
+
+@pytest.mark.asyncio
+async def test_a_dead_naming_call_leaves_the_opener_on_the_band() -> None:
+    """A provider failure costs the better title, not the label.
+
+    Before, this case fell all the way back to the working directory: the one
+    naming attempt had been spent on a call that returned nothing. The excerpt
+    is strictly better than `lo › tmp` and it is already on screen, so it stays.
+    """
+    app, session = await _boot(title="")  # a reply with no <title> at all
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        app._submit_prompt("fix the login redirect loop")
+        session.gate.set()
+        await _settle()
+
+        assert session.completions, "the naming call never ran"
+        assert session.conversation_name == ""
+        assert app._status is not None
+        assert app._status._conversation_name == "Fix the login redirect loop"
+        # The latch released, so a later substantive message may still retry...
+        assert app._name_requested is False
+        # ...but the label does NOT churn to the newer message: a conversation is
+        # identified by what it was opened for.
+        session.title = "<title>Bulk export columns</title>"
+        app._submit_prompt("now add a csv export")
+        session.gate.set()
+        await _settle()
+        assert session.conversation_name == "Bulk export columns"
+        assert app._status._conversation_name == "Bulk export columns"
+
+
+@pytest.mark.asyncio
+async def test_a_low_signal_opener_names_nothing_at_all() -> None:
+    """"hi" is not a title in either half of the module.
+
+    The deterministic filter gates the stand-in as well as the provider call, so
+    a greeting leaves the band on its directory fallback rather than putting the
+    word "Hi" on the user's tab bar.
+    """
+    app, session = await _boot(title="<title>Fix the login flow</title>")
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        app._submit_prompt("hi")
+        session.gate.set()
+        await _settle()
+        assert session.completions == []
+        assert app._provisional_name == ""
+        assert app._status is not None
+        assert app._status._conversation_name == ""
+
+
+# -- the opener-derived label itself -----------------------------------------
+
+
+def test_a_short_opener_is_quoted_whole_and_sentence_cased() -> None:
+    assert naming.provisional_title("fix the login redirect loop") == "Fix the login redirect loop"
+    # The model's own casing survives, exactly as in `parse_title`: a stand-in
+    # that rewrote "macOS" would be a worse label than the sentence it quotes.
+    assert naming.provisional_title("macOS build fails") == "macOS build fails"
+
+
+def test_a_long_opener_is_cut_on_a_word_boundary_with_an_ellipsis() -> None:
+    """Truncation, not rejection — the one place this module differs.
+
+    An over-long ANSWER from the model is evidence it ignored the format, so
+    ``parse_title`` throws it away. An over-long opener is just a long request,
+    and an excerpt of it is the point.
+    """
+    label = naming.provisional_title(
+        "please go through the compaction module and explain how it picks a cut point"
+    )
+    assert label == "Please go through the compaction module and…"
+    assert len(label) <= naming.MAX_PROVISIONAL_CHARS + 1  # the ellipsis rides outside the cap
+    # Both caps bind: eight words is the ceiling, and the character cap cut this
+    # one at seven.
+    assert len(label.split()) <= naming.MAX_PROVISIONAL_WORDS
+    assert (
+        len(naming.provisional_title("one two three four five six seven eight nine ten").split())
+        == naming.MAX_PROVISIONAL_WORDS
+    )
+
+
+def test_the_cut_does_not_leave_punctuation_stranded_before_the_ellipsis() -> None:
+    """`endpoint,…` reads as a typo; `endpoint…` reads as a quote."""
+    label = naming.provisional_title(
+        "add pagination to the search results endpoint, then update the docs"
+    )
+    assert label == "Add pagination to the search results endpoint…"
+    assert ",…" not in label
+
+
+def test_an_opener_leading_with_a_url_or_path_is_not_sentence_cased() -> None:
+    """`Https://example.com/…` reads as a rendering bug, not as a quotation."""
+    assert naming.provisional_title("https://example.com/a/b fails to load").startswith("https://")
+    assert naming.provisional_title("src/main.py raises on empty input").startswith("src/main.py")
+    # A real word still gets its capital, apostrophes and hyphens included.
+    assert naming.provisional_title("don't let the parser crash") == "Don't let the parser crash"
+
+
+def test_one_enormous_word_is_cut_rather_than_dropped() -> None:
+    """A pasted URL or stack frame still names the session.
+
+    Returning "" here would put the cwd fallback back on the tab for exactly the
+    paste-heavy openers this feature is aimed at.
+    """
+    label = naming.provisional_title("https://example.com/" + "x" * 200)
+    assert label.endswith("…")
+    assert len(label) == naming.MAX_PROVISIONAL_CHARS + 1
+
+
+def test_low_signal_openers_get_no_label() -> None:
+    """Both halves of the module answer "no title" the same way."""
+    for opener in ("hi", "thanks!", "", "   ", "???"):
+        assert naming.provisional_title(opener) == ""
+
+
+def test_a_multi_line_opener_is_collapsed_onto_one_row() -> None:
+    """The band is one row and the terminal title is one string."""
+    label = naming.provisional_title("fix the parser\n\nit crashes on empty input")
+    assert "\n" not in label
+    assert label.startswith("Fix the parser it crashes")

--- a/tests/unit/tui/test_events.py
+++ b/tests/unit/tui/test_events.py
@@ -11,7 +11,6 @@ from typing import Any
 
 import pytest
 
-from local_operator.session.naming import ConversationName
 from local_operator.harness.types import (
     AgentEndEvent,
     AgentStartEvent,
@@ -25,6 +24,7 @@ from local_operator.harness.types import (
     ToolExecutionStartEvent,
     ToolResult,
 )
+from local_operator.session.naming import ConversationName
 from local_operator.session.protocol import CompactionOutcome, SessionProtocol
 from local_operator.tui.events import (
     AssistantDelta,

--- a/tests/unit/tui/test_events.py
+++ b/tests/unit/tui/test_events.py
@@ -11,6 +11,7 @@ from typing import Any
 
 import pytest
 
+from local_operator.session.naming import ConversationName
 from local_operator.harness.types import (
     AgentEndEvent,
     AgentStartEvent,
@@ -151,11 +152,21 @@ class FakeSession:
 
     @property
     def conversation_name(self) -> str:
-        return getattr(self, "_name", "")
+        return self.conversation_name_state.text
+
+    @property
+    def conversation_name_state(self) -> ConversationName:
+        # The real holder, created on first read: `user_set` precedence (a
+        # human rename outranks every generated title, forever) is behaviour
+        # the TUI reads before it spends a re-title call, so a fake that
+        # reimplemented it as a bare string would hide a regression in it.
+        state = getattr(self, "_name_state", None)
+        if state is None:
+            state = self._name_state = ConversationName()
+        return state
 
     def set_conversation_name(self, text: str, *, user_set: bool = True) -> str:
-        self._name = (text or "").strip()
-        return self._name
+        return self.conversation_name_state.set(text, user_set=user_set)
 
     async def complete_once(self, system: str, prompt: str) -> str:
         return ""

--- a/tests/unit/tui/test_session_picker.py
+++ b/tests/unit/tui/test_session_picker.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 import pytest
 from rich.cells import cell_len
+from rich.style import Style
 from textual import events
 from textual.app import App, ComposeResult
 
@@ -543,6 +544,35 @@ async def test_the_cursor_is_always_on_a_row_the_card_actually_draws() -> None:
 
 
 # --- selection legibility ---------------------------------------------------
+
+
+@pytest.mark.parametrize("theme_name", ["dark", "light"])
+def test_the_caret_is_muted_like_both_sibling_pickers(theme_name: str) -> None:
+    """The caret is `muted`, never the violet meta ink.
+
+    It was `label` — the ramp's violet for tips and skill labels — held in a
+    local named `accent`, which put the one cool mark on a warm card and said
+    "meta" where the frame meant "position". Asserted per ramp and against the
+    TOKEN rather than a hex, because the defect was a token choice: violet is
+    `#b48cd6` on dark and `#7c5a9e` on paper, and pinning one hex would let the
+    other ramp keep the bug.
+    """
+    original = theme_mod.current_theme()
+    theme_mod.set_theme(theme_name)
+    try:
+        rows = [_row("aaa111", "a named session"), _row("bbb222", "")]
+        for selected in (0, 1):  # named and unnamed: one caret, one ink
+            span = render_rows(rows, selected, 74, NOW)[selected].spans[0]
+            # Rich types ``Span.style`` as ``str | Style``; a span this file
+            # built carries the object, and parsing narrows it either way.
+            style = span.style if isinstance(span.style, Style) else Style.parse(span.style)
+            colour = style.color
+            assert colour is not None and colour.triplet is not None
+            assert colour.triplet.hex == theme_mod.semantic_color("muted")
+            assert colour.triplet.hex != theme_mod.semantic_color("label")
+            assert colour.triplet.hex != theme_mod.semantic_color("accent")
+    finally:
+        theme_mod.set_theme(original)
 
 
 def test_selecting_an_unnamed_row_brightens_it_like_any_other() -> None:

--- a/tests/unit/tui/test_session_picker.py
+++ b/tests/unit/tui/test_session_picker.py
@@ -115,6 +115,99 @@ def test_an_unreadable_or_empty_transcript_yields_no_name(tmp_path: Path) -> Non
     assert session_name(tmp_path / "sessions" / "missing") == ""
 
 
+def _message_with_image(text: str, data_chars: int) -> dict[str, object]:
+    """A user message carrying a pasted image, text block first — the order
+    ``Message.user(text, images)`` produces and the writer preserves."""
+    return {
+        "id": "e1",
+        "ts": 0,
+        "type": "message",
+        "payload": {
+            "kind": "message",
+            "role": "user",
+            "content": [
+                {"text": text},
+                {"data": "A" * data_chars, "mime_type": "image/png"},
+            ],
+        },
+    }
+
+
+def test_a_session_opening_with_a_screenshot_is_still_named(tmp_path: Path) -> None:
+    """One pasted image puts the first line past the scan window, and the
+    fragment used to be dropped — which left every session that begins with a
+    screenshot reading `(unnamed session)` in the picker for the rest of its
+    life. Measured on two real sessions whose first lines were 115,289 and
+    733,034 characters.
+
+    The window still bounds the read; what changed is that a fragment is mined
+    for the opener instead of discarded, which is safe because the text block
+    precedes the image data on the line.
+    """
+    directory = _write_transcript(
+        tmp_path,
+        "shot01",
+        [_message_with_image("why does the resume picker forget my sessions", NAME_SCAN_CHARS * 2)],
+    )
+    with (directory / "transcript.jsonl").open(encoding="utf-8") as handle:
+        assert len(handle.readline()) > NAME_SCAN_CHARS, "this case needs an oversized line"
+    assert session_name(directory) == "why does the resume picker forget my sessions"
+
+
+def test_a_fragment_is_never_named_after_the_image_it_carries(tmp_path: Path) -> None:
+    """A name taken from base64 would be worse than no name. When the text block
+    does NOT come first, the scan declines rather than reaching past the data."""
+    directory = tmp_path / "sessions" / "shot02"
+    directory.mkdir(parents=True)
+    payload = {
+        "id": "e1",
+        "ts": 0,
+        "type": "message",
+        "payload": {
+            "kind": "message",
+            "role": "user",
+            "content": [
+                {"data": "A" * (NAME_SCAN_CHARS * 2), "mime_type": "image/png"},
+                {"text": "this text is past the image"},
+            ],
+        },
+    }
+    (directory / "transcript.jsonl").write_text(json.dumps(payload) + "\n", encoding="utf-8")
+    assert session_name(directory) == ""
+
+
+def test_a_fragment_whose_text_is_cut_off_yields_no_name(tmp_path: Path) -> None:
+    """A title cut mid-word reads like a bug. The value must close inside the
+    window to be used at all, so an opener longer than the window is declined
+    rather than truncated to whatever the read happened to reach."""
+    directory = tmp_path / "sessions" / "shot03"
+    directory.mkdir(parents=True)
+    line = '{"id":"e1","ts":0,"type":"message","payload":{"kind":"message","role":"user"'
+    line += ',"content":[{"text":"' + "word " * (NAME_SCAN_CHARS // 2)
+    (directory / "transcript.jsonl").write_text(line, encoding="utf-8")
+    assert session_name(directory) == ""
+
+
+def test_a_fragment_from_a_non_user_opener_is_declined(tmp_path: Path) -> None:
+    """The strict path matches ``role`` exactly so a tool result cannot name a
+    session; the fragment path has to hold the same line."""
+    directory = tmp_path / "sessions" / "shot04"
+    directory.mkdir(parents=True)
+    payload = {
+        "id": "e1",
+        "ts": 0,
+        "type": "message",
+        "payload": {
+            "kind": "message",
+            "role": "tool",
+            "tool_call_id": "c1",
+            "content": [{"text": "total 48"}, {"data": "A" * (NAME_SCAN_CHARS * 2)}],
+        },
+    }
+    (directory / "transcript.jsonl").write_text(json.dumps(payload) + "\n", encoding="utf-8")
+    assert session_name(directory) == ""
+
+
 def test_rows_are_newest_first_and_carry_their_name(tmp_path: Path) -> None:
     older = _write_transcript(tmp_path, "older1", [_message("user", "the older one")])
     newer = _write_transcript(tmp_path, "newer1", [_message("user", "the newer one")])

--- a/tests/unit/tui/test_slash_echo.py
+++ b/tests/unit/tui/test_slash_echo.py
@@ -42,6 +42,9 @@ ECHO_POLICY = {
     "new": False,
     "reload": False,
     "resume": False,
+    # The label of the conversation, not words the model is told: the receipt
+    # quotes the title that ended up in force, which is more than what was typed.
+    "rename": False,
     "model": False,
     # A setting, not words the model is told: the receipt names the level that
     # is now in force and the band carries it from then on.

--- a/tests/unit/tui/test_snapshot.py
+++ b/tests/unit/tui/test_snapshot.py
@@ -50,6 +50,7 @@ from local_operator.harness.types import (  # noqa: E402
     TurnStartEvent,
     Usage,
 )
+from local_operator.session.naming import ConversationName  # noqa: E402
 from local_operator.session.protocol import CompactionOutcome  # noqa: E402
 from local_operator.tui.app import OperatorApp  # noqa: E402
 from local_operator.tui.widgets.editor import Editor  # noqa: E402
@@ -145,11 +146,21 @@ class FakeSession:
 
     @property
     def conversation_name(self) -> str:
-        return getattr(self, "_name", "")
+        return self.conversation_name_state.text
+
+    @property
+    def conversation_name_state(self) -> ConversationName:
+        # The real holder, created on first read: `user_set` precedence (a
+        # human rename outranks every generated title, forever) is behaviour
+        # the TUI reads before it spends a re-title call, so a fake that
+        # reimplemented it as a bare string would hide a regression in it.
+        state = getattr(self, "_name_state", None)
+        if state is None:
+            state = self._name_state = ConversationName()
+        return state
 
     def set_conversation_name(self, text: str, *, user_set: bool = True) -> str:
-        self._name = (text or "").strip()
-        return self._name
+        return self.conversation_name_state.set(text, user_set=user_set)
 
     async def complete_once(self, system: str, prompt: str) -> str:
         return ""

--- a/tests/unit/tui/test_status_line.py
+++ b/tests/unit/tui/test_status_line.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 import math
 import re
-from typing import Any, cast
+from typing import Any, NotRequired, TypedDict, cast
 
 from rich.cells import cell_len
 from textual.widgets import Static
@@ -29,10 +29,12 @@ from local_operator.tui.widgets.status_line import (
     _MIN_GROUP_GAP,
     _SPINNER_FRAMES,
     _UNBOUNDED_RUNGS,
+    ICON_APPROVALS,
     ICON_CWD,
     ICON_MCP,
     ICON_MODEL,
     NAME_CELLS,
+    NAME_CELLS_FLOOR,
     McpStatus,
     StatusLine,
     drop_ladder,
@@ -45,6 +47,7 @@ from local_operator.tui.widgets.status_line import (
     format_model_label,
     format_window,
     mcp_semantic,
+    truncate_name,
 )
 
 
@@ -1106,6 +1109,220 @@ def test_the_name_never_takes_the_accent() -> None:
         assert colour is not None
         assert colour.name != accent, "the session name took the accent"
         assert colour.name == muted
+
+
+class _LadderState(TypedDict):
+    """One ladder variant's inputs. Typed because ``mcp`` is the only key whose
+    value is not a bool, and a bare ``dict`` widens both to ``object``.
+    """
+
+    mcp: McpStatus
+    estimated: NotRequired[bool]
+
+
+#: Every ladder variant, by the state that selects it. The eviction defect below
+#: existed in all four, so a sweep that only drove the default one would have
+#: missed three quarters of it.
+_LADDER_STATES: dict[str, _LadderState] = {
+    "healthy-mcp/exact": {"mcp": McpStatus(configured=3, connected=3)},
+    "failed-mcp/exact": {"mcp": McpStatus(configured=3, connected=1, failed=True)},
+    "healthy-mcp/estimated": {"mcp": McpStatus(configured=3, connected=3), "estimated": True},
+    "failed-mcp/estimated": {
+        "mcp": McpStatus(configured=3, connected=1, failed=True),
+        "estimated": True,
+    },
+}
+
+#: Names of the three lengths a real session wears in one conversation: the
+#: opener excerpt (40+ cells), the generated title, and a re-title. Two of the
+#: three arrive with no user input at all.
+_NAMES = (
+    "The /resume picker shows (unnamed session) for image openers",
+    "Fix unnamed sessions from image openers",
+    "Bulk export the invoice columns",
+    "Fix boot",
+)
+
+
+def _swept_band(state: _LadderState, *, alarm: bool) -> StatusLine:
+    """A fully populated band in one ladder variant, ready to render at width."""
+    status, _clock = _full_band()
+    status.update(
+        jobs=1,
+        mcp=state["mcp"],
+        approvals_auto=alarm,
+        context_tokens=496_000,
+        context_window=1_000_000,
+    )
+    status._context_is_estimate = bool(state.get("estimated"))
+    return status
+
+
+def _name_box(row: str, name: str) -> int:
+    """Cells the trailing name segment RESERVED, its padding included.
+
+    The box is what the layout is built on, and it is not the same number as the
+    ink in it: a word-boundary cut can leave `Bulk export the…` in an 18-cell box.
+    Located from the name's own opening characters, which land on the box's first
+    cell because the name is left-aligned in it.
+    """
+    return len(row) - row.rindex(name[:4])
+
+
+def test_naming_a_session_never_costs_a_segment_for_nothing(monkeypatch) -> None:
+    """Every concession the band makes for a name buys a name. All widths.
+
+    The defect this pins was the opposite: between 83 and 94 columns (79-90 with
+    the alarm disarmed, and in all four ladder variants) naming a session removed
+    `▴ high` AND showed no name in exchange, so the band got strictly worse the
+    moment the session earned a title — 7 cells of a setting the user chose by
+    keystroke spent, 9 cells of hole added, nothing bought.
+
+    The cause was the walk, not the rung order: it sheds monotonically, so the
+    duration, the counters and the effort segment it gave up on the way to
+    keeping the name stayed given up when the name was dropped two rungs later.
+    ``_fit`` re-walks with the name off the table instead.
+
+    So the contract has two halves, and both are asserted at every width in every
+    variant. Where the name is DROPPED the band is exactly the band it would have
+    been unnamed — no segment is missing. Where the name is SHOWN a segment may
+    have been traded for it (that trade is the ladder's, and its order is
+    asserted by ``test_segments_disappear_in_the_declared_ladder_order``), but at
+    least a floor's worth of name has to be on the row in return.
+    """
+    monkeypatch.setenv("HOME", "/Users/tester")
+    for label, state in _LADDER_STATES.items():
+        for alarm in (True, False):
+            status = _swept_band(state, alarm=alarm)
+            for width in range(30, 181):
+                status.update(conversation_name="")
+                status.render_text(width)
+                bare = set(status._dropped)
+                for name in _NAMES:
+                    status.update(conversation_name=name)
+                    row = status.render_text(width).plain
+                    where = f"{label} alarm={alarm} width={width}"
+                    lost = set(status._dropped) - bare - {"name"}
+                    if status.is_showing("name"):
+                        box = _name_box(row, name)
+                        assert (
+                            box >= NAME_CELLS_FLOOR
+                        ), f"{where}: {sorted(lost)} spent for a {box}-cell name"
+                    else:
+                        assert (
+                            not lost
+                        ), f"{where}: the name was dropped and {sorted(lost)} went with it"
+
+
+def test_the_alarms_column_does_not_move_when_the_title_changes(monkeypatch) -> None:
+    """One column per width, whatever the name says — the D2 contract.
+
+    The alarm is one cell and it is the band's only standing word that no tool
+    will ask before it runs, so where it sits has to be learnable. Before the
+    name's box was reserved, its column was a function of the model's word count:
+    at a fixed 150 columns the glyph sat at 144, then 101, 102, 110 across four
+    consecutive frames as the excerpt, the title and a re-title landed — two of
+    those moves with no user input at all.
+
+    Asserted over the whole row rather than just the glyph: everything up to the
+    name's own box has to be identical, or something else moved instead.
+    """
+    monkeypatch.setenv("HOME", "/Users/tester")
+    for label, state in _LADDER_STATES.items():
+        status = _swept_band(state, alarm=True)
+        for width in range(30, 181):
+            rows = []
+            for name in _NAMES:
+                status.update(conversation_name=name)
+                rows.append(status.render_text(width).plain)
+            first = rows[0]
+            assert len({row.index("!") for row in rows}) == 1, (
+                f"{label} width={width}: the alarm moved with the title "
+                f"({[row.index('!') for row in rows]})"
+            )
+            head = first[: first.index("!") + 1]
+            for row in rows[1:]:
+                assert row.startswith(head), f"{label} width={width}: the row reflowed"
+                assert len(row) == len(first), f"{label} width={width}: the row changed width"
+
+
+def test_the_name_takes_every_cell_the_row_can_spare(monkeypatch) -> None:
+    """The segment is elastic between its floor and its cap, not one or the other.
+
+    Two fixed widths meant up to 20 cells sat idle beside an 18-cell stub — a
+    130-column terminal showed `Add todo guardrai…` next to an 18-cell hole with
+    32 cells available, and the excerpt-to-title upgrade this feature exists for
+    was invisible below 138 columns because both strings were cut to the same
+    stub. So the test is not "the name is 18 or 40": it is that the gap closes to
+    the seam and the box grows with the terminal.
+    """
+    monkeypatch.setenv("HOME", "/Users/tester")
+    status = _swept_band(_LADDER_STATES["healthy-mcp/exact"], alarm=True)
+    status.update(conversation_name="Add todo guardrails to the operator loop")
+    boxes = []
+    for width in range(100, 181):
+        row = status.render_text(width).plain
+        box = len(row) - row.index("! ‹ ") - len("! ‹ ")
+        boxes.append(box)
+        # Whatever is spare is IN the name's box, so the hole between the groups
+        # is the seam's own width until the box is full.
+        longest_gap = max((len(run) for run in re.findall(r" {2,}", row.rstrip())), default=0)
+        assert (
+            box >= NAME_CELLS or longest_gap <= _MIN_GROUP_GAP
+        ), f"width={width}: {longest_gap} cells idle beside a {box}-cell name"
+    assert min(boxes) >= NAME_CELLS_FLOOR
+    assert max(boxes) == NAME_CELLS
+    # More than the two widths the old constant pair allowed, and monotone in the
+    # terminal's width over the range where the row is otherwise unchanged.
+    assert len(set(boxes)) > 5, f"the name still has only {sorted(set(boxes))} widths"
+
+
+def test_the_bands_cut_lands_on_a_word_like_the_excerpt_it_was_handed() -> None:
+    """``provisional_title`` cuts on a word boundary on purpose — "so it reads as
+    a quotation rather than as a string that ran out of buffer" — and the band
+    used to re-cut the same string mid-word one call later, throwing that away.
+
+    The floor case is the exception the rule needs: at 18 cells a word cut would
+    leave `Add todo…` and nine blank cells, which distinguishes two tiled
+    sessions less well than the mid-word cut does. So the boundary is taken only
+    while it costs less than a third of the box.
+    """
+    excerpt = "The /resume picker shows (unnamed session) for image openers"
+    assert truncate_name(excerpt, 40) == "The /resume picker shows (unnamed…"
+    assert truncate_name(excerpt, 24) == "The /resume picker…"
+    assert truncate_name("Add todo guardrails to the operator loop", 22) == "Add todo guardrails…"
+    # Below the tolerance the cut stays where the cells are.
+    assert truncate_name("Add todo guardrails to the operator loop", 18) == "Add todo guardrai…"
+    # A name that fits is untouched, and a single unbroken token cannot be
+    # word-cut at all.
+    assert truncate_name("Fix boot", 40) == "Fix boot"
+    assert truncate_name("x" * 60, 40) == "x" * 39 + "…"
+
+
+def test_the_alarm_is_not_the_same_ink_as_the_cost_figure() -> None:
+    """One cell of glyph means the INK is the whole signal, and in `warning` it
+    was the identical hue to `◈ $73.92` three cells away (both `#e0b04b`), so the
+    band's only alarm read as another figure. `danger` is the band's alarm ink —
+    the `⊙` lamp already takes it when MCP discovery fails — and it stays legible
+    on both ramps: 6.62:1 dark, 4.94:1 on the paper ramp.
+    """
+    status, _clock = _full_band()
+    status.update(conversation_name="Add todo guardrails", approvals_auto=True)
+    for ramp in ("dark", "light"):
+        theme_mod.set_theme(ramp)
+        try:
+            rendered = status.render_text(200)
+            inks = {
+                rendered.plain[span.start : span.end].strip(): getattr(span.style, "color", None)
+                for span in rendered.spans
+            }
+            alarm, cost = inks[ICON_APPROVALS], inks["$12.40"]
+            assert alarm is not None and cost is not None
+            assert alarm.name == theme_mod.semantic_color("danger"), ramp
+            assert cost.name == theme_mod.semantic_color("warning"), ramp
+            assert alarm.name != cost.name, f"{ramp}: the alarm and the cost are one ink"
+        finally:
+            theme_mod.set_theme("dark")
 
 
 # -- repaint vs reflow -------------------------------------------------------

--- a/tests/unit/tui/test_status_line.py
+++ b/tests/unit/tui/test_status_line.py
@@ -32,6 +32,7 @@ from local_operator.tui.widgets.status_line import (
     ICON_CWD,
     ICON_MCP,
     ICON_MODEL,
+    NAME_CELLS,
     McpStatus,
     StatusLine,
     drop_ladder,
@@ -336,13 +337,16 @@ def test_the_model_segment_survives_a_terminal_far_too_narrow() -> None:
 # -- overflow priority -------------------------------------------------------
 
 
-def test_the_label_the_user_typed_is_the_first_segment_to_go(monkeypatch) -> None:
-    """The conversation name goes first, and every NUMBER outlives it.
+def test_the_session_name_outlives_the_counters_it_used_to_precede(monkeypatch) -> None:
+    """The name is now the band's TRAILING segment, and it earns its place.
 
-    The name is a label the user typed and already knows; the counters and live
-    figures beside it are not re-derivable at a glance. An earlier order shed the
-    subagent count first, which meant a three-agent fan-out went invisible while
-    a title the user had chosen was still on screen.
+    It used to be the first rung on the ladder, on the reasoning that "the name
+    is a label the user typed and already knows". Both halves of that stopped
+    being true: the name is generated (or excerpted from the opening prompt),
+    and it is the field an operator reads this corner for when four sessions are
+    tiled — which is exactly when the terminal is narrow. So it now outlives the
+    re-derivable duration and the two counters, and sheds only once nothing but
+    live figures is left.
     """
     monkeypatch.setenv("HOME", "/Users/tester")
     status, _clock = _full_band()
@@ -351,19 +355,34 @@ def test_the_label_the_user_typed_is_the_first_segment_to_go(monkeypatch) -> Non
     # Walk down to the first width that sheds it rather than computing it from
     # the 200-cell row. That row is PADDED to the full width (the right group is
     # edge-aligned), so its length is 200 whatever the content measures and
-    # `len(row) - 1` says nothing about when the band overflows.
+    # `len(row) - 1` says nothing about when the band overflows. The stub is
+    # what is probed for: the ladder shortens the name before it drops it.
     for width in range(200, 4, -1):
         tight = status.render_text(width).plain
-        if "Status band enrichment" not in tight:
+        if "Status band enric" not in tight:
             break
     else:  # pragma: no cover - the band always sheds something by width 5
         raise AssertionError("no width shed the conversation name")
 
-    # At the very width that drops the name, everything numeric survives.
-    assert "3 agents" in tight
-    assert "41m1s" in tight
+    # The counters and the duration are already gone by the time the name is:
+    # they are cheap to lose, and this band has stopped shedding the one field
+    # that says which conversation it belongs to in order to keep them.
+    assert "3 agents" not in tight
+    assert "41m1s" not in tight
+    # The live figures an operator acts on do outlive it, which is the half of
+    # the old contract that was right.
     assert "49.6%/1M" in tight
     assert "$12.40" in tight
+
+    # And there is a real band of widths where the name survives and the
+    # counters do not — the whole point of the reorder, not just its rung order.
+    kept = [
+        width
+        for width in range(60, 201)
+        if "Status band enric" in status.render_text(width).plain
+        and "3 agents" not in status.render_text(width).plain
+    ]
+    assert kept, "the name never outlived the subagent counter"
 
 
 def test_segments_disappear_in_the_declared_ladder_order(monkeypatch) -> None:
@@ -383,7 +402,8 @@ def test_segments_disappear_in_the_declared_ladder_order(monkeypatch) -> None:
     probes = {
         "subagents": "3 agents",
         "duration": "41m1s",
-        "name": "Status band enrichment",
+        "name-full": "Status band enrichment",
+        "name-short": "Status band enric",
         "cost": "$12.40",
         "context": "49.6%/1M",
         "effort": "high",
@@ -407,12 +427,17 @@ def test_segments_disappear_in_the_declared_ladder_order(monkeypatch) -> None:
                 order.append(key)
 
     assert order == [
-        "name",  # a label the user typed and already knows
         "duration",  # re-derivable from the transcript
         "subagents",  # a counter, but not re-derivable without scrolling
+        # Shortened to a stub, not dropped: the widest rung, so the cut recovers
+        # more than any drop below it, and a stub still names the session.
+        "name-full",
         "cwd-full",  # shortened to its basename, not dropped
         "model-full",  # shortened to the bare model id, not dropped
         "effort",  # a static setting: it does not change while they watch
+        # Only now does the name go — one rung later than it used to sit in
+        # ENTIRETY, and after everything above it has already been spent.
+        "name-short",
         "cost",
         # The shortened cwd goes BEFORE the context number. By this rung it is a
         # basename — ~7 cells of "where am I" against ~9 cells of "how close is
@@ -818,26 +843,25 @@ def test_a_healthy_mcp_count_sheds_before_the_cwd_and_the_model_label() -> None:
     assert alarm_alone, "a danger count must survive a width the cwd cannot"
 
 
-def test_the_quiet_ladder_moves_mcp_and_leaves_the_alarm_last() -> None:
+def test_the_quiet_ladder_moves_mcp_and_the_alarm_is_last_either_way() -> None:
     """One ordering, two positions for one rung — not two hand-maintained
     ladders that can drift apart on the next reordering.
 
-    Lifting `mcp` out of last place leaves whatever followed it at the end, and
-    that is `approvals`. An earlier pass treated that as damage and re-seated it
-    behind the context number, on the rule "the narrowest bounded rung goes
-    last". That rule was written against `mcp` — 7 cells, and an alarm — and
-    handing last place to a READING instead is not the same trade: with a
-    healthy MCP the band stopped saying `! auto-approve` at 48 cells in order to
-    keep `▦ 49.6%/1M`. An alarm outranks a reading, so the widest alarm stays
-    last in every ladder where `mcp` is not there to take it.
+    Last place goes to the narrowest BOUNDED rung, and an alarm outranks a
+    reading. `approvals` is now both: a bare `!` at one cell against `⊙ 3 MCP`'s
+    seven. So it is authored last and every promotion leaves it there, which is
+    what deleted the repair helper this test used to be about — that helper
+    existed only because the segment then spelled out `! auto-approve always`
+    and was the WIDEST rung in the band.
     """
     assert drop_ladder(McpStatus(configured=2, connected=1, failed=True)) is _DROP_LADDER
     assert drop_ladder(McpStatus(configured=2, connected=2)) is _DROP_LADDER_QUIET
     assert drop_ladder(McpStatus()) is _DROP_LADDER_QUIET
-    assert _DROP_LADDER[-1] == "mcp"
+    assert _DROP_LADDER[-1] == "approvals"
+    assert _DROP_LADDER[-2] == "mcp", "the danger count still outlives every reading"
     assert _DROP_LADDER_QUIET.index("mcp") == _DROP_LADDER_QUIET.index("cwd") - 1
-    # With mcp promoted there is no narrower ALARM to take last place, so the
-    # gate's own alarm keeps it — and outlives the context number.
+    # Promoting mcp cannot dislodge the alarm, because the alarm was never
+    # sitting behind it.
     assert _DROP_LADDER_QUIET[-1] == "approvals"
     assert _DROP_LADDER_QUIET.index("context") < _DROP_LADDER_QUIET.index("approvals")
     # Same rungs in both ladders: the reorder moves things, it never drops one.
@@ -916,11 +940,11 @@ def test_the_last_surviving_rung_is_always_bounded() -> None:
     ladder with a 24-character basename, that cost the alarm across 34-46 cells
     and paid for it with up to 29 blank ones.
 
-    ``approvals`` is kept off the end only where ``mcp`` can take it. At 14
-    cells it is the widest rung, which is why the authored order sheds it first
-    — but "widest" outranks "is an alarm" only when the rung taking last place
-    is an alarm too, and ``mcp`` is the only one that is. In both quiet ladders
-    it has been promoted away, so the gate's alarm goes last there.
+    ``approvals`` takes last place in every variant now: it is a bare ``!``, so
+    it is both the narrowest bounded rung and an alarm, which is the whole rule.
+    It used to be the WIDEST rung (``! auto-approve always``, up to 20 cells) and
+    was authored first for that reason, which is what made a repair helper
+    necessary to keep promotions from stranding it at the end.
     """
     variants = {
         "full": _DROP_LADDER,
@@ -933,11 +957,10 @@ def test_the_last_surviving_rung_is_always_bounded() -> None:
         # A promotion reorders; it never adds or loses a rung.
         assert sorted(ladder) == sorted(_DROP_LADDER), f"{name} changed the rung set"
 
-    # The widest alarm is kept off the end only where the narrower ALARM exists
-    # to take it; a reading never displaces it.
-    assert _DROP_LADDER[-1] == "mcp"
+    # One position, all four variants: nothing needs repairing any more.
+    assert _DROP_LADDER[-1] == "approvals"
     assert _DROP_LADDER_QUIET[-1] == "approvals"
-    assert _DROP_LADDER_ESTIMATE[-1] == "mcp"
+    assert _DROP_LADDER_ESTIMATE[-1] == "approvals"
     assert _DROP_LADDER_QUIET_ESTIMATE[-1] == "approvals"
     assert _DROP_LADDER_QUIET_ESTIMATE.index("context") < _DROP_LADDER_QUIET_ESTIMATE.index(
         "cwd"
@@ -951,6 +974,12 @@ def test_an_armed_alarm_outlives_a_path_that_would_not_have_fitted() -> None:
     failed to fit, so a session with the approval gate DISARMED painted no
     indication of it — a regression against main, where the same terminal keeps
     the alarm because a band with no estimate uses the quiet ladder.
+
+    The alarm is a bare ``!`` now rather than ``! auto-approve``, which is why
+    this probes the glyph as the band's last cell: the word is gone, the warning
+    is not, and it is the ONE thing in the UI that says the gate is disarmed for
+    longer than a scroll (a saved ``tool_approval_mode: auto`` is adopted at boot
+    with no notice at all).
     """
     status, _clock = _full_band()
     status.update(
@@ -959,7 +988,7 @@ def test_an_armed_alarm_outlives_a_path_that_would_not_have_fitted() -> None:
         approvals_auto=True,
         mcp=McpStatus(configured=2, connected=2),
     )
-    armed = [w for w in range(36, 52) if "auto-approve" in status.render_text(w).plain]
+    armed = [w for w in range(36, 52) if status.render_text(w).plain.rstrip().endswith("!")]
     assert armed, "the disarmed-gate alarm vanished at every narrow width"
     for width in armed:
         assert ICON_CWD not in status.render_text(width).plain
@@ -968,6 +997,115 @@ def test_an_armed_alarm_outlives_a_path_that_would_not_have_fitted() -> None:
     # paints nothing, so the path still gets the width.
     status.update(approvals_auto=False)
     assert ICON_CWD in status.render_text(50).plain
+
+
+# -- the trailing segment: the session name ----------------------------------
+
+
+def test_the_session_name_is_the_bands_last_segment() -> None:
+    """The slot the approval mode used to own.
+
+    Asked for directly: "instead of auto approve indicator at the bottom right,
+    let's change that to show the session name which is more valuable than
+    showing the approval status". The right group is edge-aligned, so "last
+    segment" means the last non-blank run in the row.
+    """
+    status, _clock = _full_band()
+    status.update(conversation_name="Add todo guardrails", approvals_auto=False)
+    assert status.render_text(200).plain.rstrip().endswith("Add todo guardrails")
+
+
+def test_the_alarm_sits_beside_the_name_rather_than_replacing_it() -> None:
+    """Both, in a fixed order — the name last, the one-cell alarm before it.
+
+    The alarm is not removed, because nothing else in the UI says the gate is
+    disarmed for longer than a scroll: `/approvals` answers on demand, the
+    notice that latched the mode scrolls away, and a saved
+    ``tool_approval_mode: auto`` is adopted at boot with no notice at all. What
+    it loses is the prose — `auto` and `always` are one glyph now.
+    """
+    status, _clock = _full_band()
+    status.update(
+        conversation_name="Add todo guardrails", approvals_auto=True, approvals_always=True
+    )
+    row = status.render_text(200).plain.rstrip()
+    assert row.endswith("Add todo guardrails")
+    assert "auto-approve" not in row, "the alarm's prose was crowding out the name"
+    assert "always" not in row
+    # The glyph, immediately before the name and after its seam.
+    assert row.endswith("! ‹ Add todo guardrails")
+
+
+def test_an_unnamed_session_leaves_the_trailing_slot_to_whatever_is_left() -> None:
+    """What the segment shows BEFORE a name exists — the decision, pinned.
+
+    The band never invents a label here. It carries no name until the first
+    substantive message, at which point the opener names it (see
+    ``local_operator.session.naming.provisional_title``), so this state lasts
+    seconds rather than the minutes it used to. Meanwhile the trailing slot is
+    simply the next segment along, and NO segment changes meaning: `!` always
+    means the gate is disarmed, and the duration is always the duration. The
+    working directory is not substituted, because the band already carries it in
+    the identity group on the left — the terminal TITLE is the surface with
+    nothing else to fall back on, and that one does substitute the cwd.
+    """
+    status, _clock = _full_band()
+    status.update(conversation_name="", approvals_auto=True)
+    assert status.render_text(200).plain.rstrip().endswith("!")
+    status.update(approvals_auto=False)
+    assert status.render_text(200).plain.rstrip().endswith("41m1s")
+
+
+def test_a_long_name_is_truncated_rather_than_crowding_the_left_group() -> None:
+    """The name is model-generated: it has no natural bound, and the band is a
+    fixed two-row box, so an uncapped segment would evict the identity group
+    instead of wrapping."""
+    status, _clock = _full_band()
+    status.update(conversation_name="x" * 200, approvals_auto=False)
+    row = status.render_text(200).plain
+    # `truncate_cells` spends one of the cells on the ellipsis, so the segment
+    # measures NAME_CELLS in total rather than NAME_CELLS plus a marker.
+    assert "x" * (NAME_CELLS - 1) + "…" in row
+    assert "x" * NAME_CELLS not in row
+    # The left group is intact at a width where an uncapped name would have
+    # pushed the model label off the row entirely.
+    assert ICON_MODEL in row
+
+
+def test_a_late_arriving_name_repaints_the_segment() -> None:
+    """Auto-naming lands asynchronously and a rename can land at any time; both
+    reach the band through the same ``update`` call, so neither needs a
+    restart."""
+    status, _clock = _full_band()
+    status.update(conversation_name="", approvals_auto=False)
+    assert "Fix the login flow" not in status.render_text(200).plain
+    status.update(conversation_name="Fix the login flow")
+    assert status.render_text(200).plain.rstrip().endswith("Fix the login flow")
+    status.update(conversation_name="Something the user typed")
+    assert status.render_text(200).plain.rstrip().endswith("Something the user typed")
+
+
+def test_the_name_never_takes_the_accent() -> None:
+    """The accent budget is spent on "what the turn is on" (``local_operator.tcss``
+    enumerates every site). A session's name is metadata, so it takes the same
+    secondary ink as the numbers beside it."""
+    status, _clock = _full_band()
+    status.update(conversation_name="Add todo guardrails", approvals_auto=False)
+    rendered = status.render_text(200)
+    accent = theme_mod.semantic_color("accent")
+    muted = theme_mod.semantic_color("muted")
+    spans = [
+        span
+        for span in rendered.spans
+        if "Add todo guardrails" in rendered.plain[span.start : span.end]
+    ]
+    assert spans, "the name was not painted as its own span"
+    for span in spans:
+        style = span.style
+        colour = getattr(style, "color", None)
+        assert colour is not None
+        assert colour.name != accent, "the session name took the accent"
+        assert colour.name == muted
 
 
 # -- repaint vs reflow -------------------------------------------------------

--- a/tests/unit/tui/test_steering_approval.py
+++ b/tests/unit/tui/test_steering_approval.py
@@ -492,12 +492,14 @@ async def test_approvals_command_restores_prompting() -> None:
         app._run_slash_command("/approvals auto")
         await pilot.pause(0.1)
         assert app._approve_all is True
-        assert any("auto-approve" in row for row in rows(app))  # band says so
+        # The band's alarm is a bare `!` in the trailing cell now — the session
+        # name took the words that used to be there.
+        assert any(row.rstrip().endswith("!") for row in rows(app))
 
         app._run_slash_command("/approvals ask")
         await pilot.pause(0.1)
         assert app._approve_all is False
-        assert not any("auto-approve" in row for row in rows(app))
+        assert not any(row.rstrip().endswith("!") for row in rows(app))
         # And the gate really asks again.
         pending = asyncio.ensure_future(_approval_gate(session)("bash", "run: x"))
         await pilot.pause(0.3)

--- a/tests/unit/tui/test_welcome.py
+++ b/tests/unit/tui/test_welcome.py
@@ -28,8 +28,8 @@ from rich.style import Style
 from rich.text import Text
 from textual.color import Color
 
-from local_operator.session.naming import ConversationName
 from local_operator.harness.types import AgentMessage, ImageContent
+from local_operator.session.naming import ConversationName
 from local_operator.session.protocol import CompactionOutcome
 from local_operator.tui import theme as theme_mod
 from local_operator.tui.app import SLASH_COMMANDS, OperatorApp

--- a/tests/unit/tui/test_welcome.py
+++ b/tests/unit/tui/test_welcome.py
@@ -28,6 +28,7 @@ from rich.style import Style
 from rich.text import Text
 from textual.color import Color
 
+from local_operator.session.naming import ConversationName
 from local_operator.harness.types import AgentMessage, ImageContent
 from local_operator.session.protocol import CompactionOutcome
 from local_operator.tui import theme as theme_mod
@@ -453,7 +454,6 @@ class FakeSession:
         self.aborts: list[str] = []
         self.disposed = False
         self.model_label = model_label
-        self.conversation_name = ""
         self._handlers: list[Any] = []
         self.asides: list[list[Any]] = []
         self.adopted: list[list[Any]] = []
@@ -487,9 +487,23 @@ class FakeSession:
     async def seed_history(self, messages: list[Any]) -> None:
         pass
 
+    @property
+    def conversation_name(self) -> str:
+        return self.conversation_name_state.text
+
+    @property
+    def conversation_name_state(self) -> ConversationName:
+        # The real holder, created on first read: `user_set` precedence (a
+        # human rename outranks every generated title, forever) is behaviour
+        # the TUI reads before it spends a re-title call, so a fake that
+        # reimplemented it as a bare string would hide a regression in it.
+        state = getattr(self, "_name_state", None)
+        if state is None:
+            state = self._name_state = ConversationName()
+        return state
+
     def set_conversation_name(self, text: str, *, user_set: bool = True) -> str:
-        self.conversation_name = text
-        return text
+        return self.conversation_name_state.set(text, user_set=user_set)
 
     async def complete_once(self, system: str, prompt: str) -> str:
         # Parameter names AND order must match SessionProtocol.complete_once:


### PR DESCRIPTION
# PR Description

## Change classification

**C2 — standard / pre-authorized.** Four bounded fixes to conversation naming and one
transport-isolation flag they depend on, with a clean rollback (`git revert` / reinstall
0.17.4). No foundational auth, data-isolation, infrastructure, or irreversible data
change. No RFC or tracker requested.

## Summary of Changes

This releases **local-operator 0.17.5** and closes four naming defects observed live in
one `lop` session, plus the transport work the third one required.

### 1. `/resume` forgot every session whose opener had a screenshot

A conversation is labelled in the picker by its opening user message, read back from the
transcript — titles live in memory and were never journalled. `session_name` read a
64 KB window and dropped a final line that had no newline, which is correct for a
half-read line but fatal when the whole opener is one line longer than the window: a
message with a pasted image is 115 KB, so the window held **no complete line** and the
row fell back to `(unnamed session)`.

The opening text sits at offset 135 — before the base64 `data` at 443 — so it was always
recoverable. A fragment scan now recovers the opener from a half-read first line, guarded
so a session can never be named after base64: the fragment must identify itself as a user
message, and the first complete `"text"` value must appear *before* any `data` key.
Whitespace-tolerant, because a transcript written by anything other than the session
writer is still the same document.

Measured on the real session directory: **8/8 recent sessions now named, 0 unnamed**,
including the 115 KB and 733 KB openers.

### 2. The status band showed an indicator nobody needed

The trailing segment was `! auto-approve always`. It now carries the **session name**,
which is the more valuable thing to have on screen; the approval mode collapses to a bare
`!` alarm, and `/approvals` remains the place that answers "until when".

### 3. The title arrived after the work it was naming

Auto-naming waited on `_turn_settled` — unbounded by design, so decoration could never
make a user request worse. But a first turn on this product runs for minutes, so the title
landed after the turn. **Measured before: a 29.7 s turn with the title stored 1.8 s after
it** (106% of the turn).

The naming call is now dispatched at turn launch and runs concurrently. That is only safe
because it is **isolated**, and that is the bulk of this diff: a second in-flight request
shared five things with the user's turn, each a live route by which a *decorative* failure
could have degraded it.

| Shared state | What a title failure would have done to the turn |
|---|---|
| `FailoverRouteState` (session-sticky) | `activate` a fallback with a 60 s cooldown — moving the **turn** onto the fallback model |
| `AuthStore.rotate_sibling` | re-point the session's sticky credential, changing the turn's account |
| pending message boundary | auto-effort classification **consumes** it; the title would spend the turn's boundary and emit an "auto effort" notice for a request the user never made |
| quota preflight | can block a credential and activate a fallback route session-wide |
| prompt-cache key | a different prefix, so it bought no hit and dirtied the turn's entry |

`ChatRequest.isolated` gets exactly one attempt: no chain hop, no route read or write, no
rotation, no backoff sleep, no preflight, no boundary classification, no cache key. One
honest caveat, recorded in the docstring rather than glossed: an isolated call still
*reads* credentials under `session_id`, deliberately picking the same account the turn is
on — it cannot rotate off it, because every rotation `continue` sits behind a
`retry.enabled` raise.

### 4. The title never followed the conversation

A substantive follow-up now asks the model whether the subject still holds; it answers with
a sentinel to keep the current title or with a replacement. **The judgement is the model's,
not a keyword rule.** An explicit rename (`user_set=True`) still wins permanently, checked
at store time rather than request time.

Throttled at 120 s and gated by the deterministic low-signal filter — which had to grow an
acknowledgement group, because re-titling made that filter read **follow-ups** for the
first time and "looks good" / "lgtm" / "carry on" were going to the provider.

### The prompt is minimal

`MAX_PROMPT_CHARS` 2000 → 320. All figures below are the provider's own usage numbers,
cache-busted with a nonce, not estimates:

| Case | Before | After |
|---|---|---|
| Short opener | 177 in + 23 out | **120 in + 19 out** |
| Pasted log | 899 in (2 uncached + an 897-token cache **write**) | **237 in, no cache write** |
| Re-title check | — | 167 in + 18 out |

The wasted cache write mattered: every naming prompt differs, so that entry was billed at
1.25× and could never be read.

Two bounds moved on measurement rather than instinct, in opposite directions.
`TITLE_TIMEOUT_S` **20 → 15 s** — a tightening, not a loosening: seven calls measured
5.4–5.8 s, so 15 s is ~2.6× the observed worst case and 20 s was simply holding a detached
task open longer than any healthy provider needs. The errand output cap went the other way,
**64 → 128 tokens**, because measured outputs were 18–38, adaptive thinking counts against
the same cap, a truncated title is rejected outright by `parse_title`, and only tokens
produced are billed — so the larger cap costs nothing and prevents a silent empty title.

### One deliberate behaviour change beyond the four fixes

A follow-up turn no longer cancels an in-flight naming call. Under the old serialized
design cancelling was right; under concurrency it named the conversation after its
**second** message.

## Testing Details

### Live evidence — reproduced by the integrator on the merged tree

Real `OperatorApp` + real session on `anthropic/claude-opus-5`, driven under Textual
`run_test`, probe at `/tmp/lo_naming_live.py`:

```
[  2.015] t+0.011s  band after submit = 'Summarise how compaction picks a cut point in…'  (excerpt, no network)
[  3.555]   <- title call IN   '<title>Compaction Cut Point Selection Logic</title>' after 1.53s
[  3.569] t+1.566s  model title stored = 'Compaction Cut Point Selection Logic' turn_running=True
[  3.569] TITLE LANDED DURING THE TURN: True
[ 33.679] t+31.676s  turn finished (ok=True)
[ 40.157] calls made by chatter: 0 (title still 'Compaction Cut Point Selection Logic')
[ 41.654] t+1.496s  title now 'Rewriting the Billing Importer' (changed=True, calls=1)
```

- **Requirement "model-generated, not the first message":** the wire response is
  `<title>Compaction Cut Point Selection Logic</title>` — not a substring of
  `"summarise how compaction picks a cut point in this repo"`.
- **Requirement "concurrent with launch":** title at t+1.57 s of a 31.7 s turn, **5% in**,
  with `turn_running=True`. Was 106% of the turn.
- **Requirement "changes when the subject materially changes":** re-titled in 1.50 s, 1 call.
- **Negative control:** "thanks" / "looks good" → **0 provider calls**, throttle forced
  open so it could not be the reason.

### `/resume` picker, real session directory

```
rows: 8   named 8/8
```

### Isolation — five properties, each with an ordinary-request control

Every isolation test has a control on the same fake that *does* take the shared path, so
no assertion can pass because the fixture never reached it. Both classes falsified by
stubbing the branch to `if False`.

| Property | Test |
|---|---|
| sticky route neither pinned nor cleared | `test_failover.py::test_it_neither_pins_nor_clears_the_sticky_route` |
| credential never rotated (401 → one key) | `::test_it_never_rotates_the_sessions_credential` |
| message boundary left for the turn | `test_configure.py::test_it_leaves_the_message_boundary_for_the_turn` |
| no quota preflight (spy wraps, not stubs) | `::test_it_runs_no_quota_preflight` |
| no prompt-cache key on the wire | `::test_it_does_not_ride_the_sessions_prompt_cache_key` |

Also pinned: no chain hop, no backoff sleep, exactly one wire attempt on a retryable 429.
The turn's `RetrySettings` is never mutated — `dataclasses.replace` copies it for the
isolated call only.

### Falsification — 10 reverts, all fail, all restore

Every new test was proved capable of failing by reverting its fix in place. **Two tests
were found worthless this way and rewritten:**

- `test_a_landed_retitle_restarts_the_window` passed with `_store_title`'s stamp removed
  (the dispatch stamp already covered it). Replaced with a test that exercises the *first*
  title, and needed the fake clock moved off `0.0` — which is also `_retitle_checked_at`'s
  initial value, making "never stamped" indistinguishable from "stamped just now".
- `test_a_chatty_follow_up_makes_no_call_at_all` passed with the app-level low-signal guard
  removed, because `generate_retitle` guards it too. The revert now removes **both**.

The four pre-existing naming tests that failed were each triaged rather than loosened: three
encoded the *old* serialized contract and were replaced with tests of the new one; one was a
genuine code defect (`conversation_name_state` missing from `SessionProtocol` and from six
test fakes — `test_events.py`'s protocol-conformance test caught it).

### Automated gates

- `pytest tests/unit` — **4261 passed, 7 skipped**
- `flake8` clean · `black --check` clean · `isort --check-only` clean · `pyright` **0 errors**

## Rollback

`git revert` this PR and run `lop-update` (or install 0.17.4).

### 5. Two pre-existing defects found and fixed while gating

**Quitting during boot gave a traceback instead of the shell back.** Textual
8.2.8 prunes the whole widget tree in `App._close_all` and cancels workers only
afterwards; a boot worker waking in that window paints into a dismantled screen
— `NoMatches('#transcript')` from `_render_resumed_history`. Reproduced at will
on unmodified `origin/main` (6 crashes in 301 app lifetimes). `OperatorApp._shutdown`
now cancels workers first, so each coroutine worker takes the `CancelledError`
at its await while the DOM still exists. Cancelling earlier exposed two leaks,
both fixed: an unadopted session the factory had finished building would be
orphaned (MCP subprocesses among its survivors) — it is now parked on
`self._session` for `on_unmount` to dispose — and the login key prompt's future
died cancelled by propagation instead of being settled by `on_unmount` — it is
now awaited under `asyncio.shield`.

**The loop-liveness test measured the wrong quantity.** It bounded the widest
wall-clock gap between heartbeat wakes, which measures whether the loop thread
was *scheduled*, not whether it was *busy* — and the leading cause of it not
being scheduled is the very fix it guards (three CPU-bound Pillow worker
threads starving the loop thread through GIL handoff). A control of three pure
spins in `to_thread` with nothing on the loop already produced 86–130 ms gaps
against the 0.12 s bound; the correct tree measured 0.156–0.375 s. The contract
is now asserted twice from one run of the real workload: structurally (an
`OffLoopSpy` requires the hops to run off the loop thread, immune to load) and
temporally (the heartbeat records `time.thread_time()` deltas on the loop
thread — 4.3 ms worst idle, 2.4–4.1 ms under eight CPU hogs, 512–725 ms with
the decode put back on the loop). Both are needed: a blocking call on the loop
costs wall time and no CPU, so the structural half owns that shape, and the
temporal half owns CPU-on-the-loop and paths nobody thought to spy on.
