### PR TITLE
fix(tests,providers): wait on conditions instead of the clock, and stop naming the credential twice

### DIFF
--- a/local_operator/providers/registry.py
+++ b/local_operator/providers/registry.py
@@ -319,7 +319,7 @@ PROVIDER_REGISTRY: list[ProviderDefinition] = [
         search_aliases=("grok",),
         name="xAI (Grok API key)",
         env_keys="XAI_API_KEY",
-        login=create_api_key_login("xAI", "https://console.x.ai/", "Paste your xAI API key"),
+        login=create_api_key_login("xAI", "https://console.x.ai/"),
         base_url="https://api.x.ai/v1",
     ),
     ProviderDefinition(
@@ -337,9 +337,7 @@ PROVIDER_REGISTRY: list[ProviderDefinition] = [
         search_aliases=("ds",),
         name="DeepSeek",
         env_keys="DEEPSEEK_API_KEY",
-        login=create_api_key_login(
-            "DeepSeek", "https://platform.deepseek.com/api_keys", "Paste your DeepSeek API key"
-        ),
+        login=create_api_key_login("DeepSeek", "https://platform.deepseek.com/api_keys"),
         base_url="https://api.deepseek.com/v1",
     ),
     ProviderDefinition(
@@ -354,7 +352,7 @@ PROVIDER_REGISTRY: list[ProviderDefinition] = [
         login=create_api_key_login(
             "Google AI Studio",
             "https://aistudio.google.com/apikey",
-            "Paste your Google AI Studio API key",
+            "The console calls it an AI Studio API key.",
         ),
         base_url="https://generativelanguage.googleapis.com",
         wire="google",
@@ -367,9 +365,7 @@ PROVIDER_REGISTRY: list[ProviderDefinition] = [
         ),
         name="Mistral AI",
         env_keys="MISTRAL_API_KEY",
-        login=create_api_key_login(
-            "Mistral", "https://console.mistral.ai/api-keys", "Paste your Mistral API key"
-        ),
+        login=create_api_key_login("Mistral", "https://console.mistral.ai/api-keys"),
         base_url="https://api.mistral.ai/v1",
     ),
     ProviderDefinition(
@@ -387,9 +383,7 @@ PROVIDER_REGISTRY: list[ProviderDefinition] = [
         ),
         name="OpenRouter",
         env_keys="OPENROUTER_API_KEY",
-        login=create_api_key_login(
-            "OpenRouter", "https://openrouter.ai/keys", "Paste your OpenRouter API key"
-        ),
+        login=create_api_key_login("OpenRouter", "https://openrouter.ai/keys"),
         base_url="https://openrouter.ai/api/v1",
     ),
     ProviderDefinition(
@@ -397,7 +391,7 @@ PROVIDER_REGISTRY: list[ProviderDefinition] = [
         name="Radient",
         env_keys="RADIENT_API_KEY",
         login=create_api_key_login(
-            "Radient", "https://radienthq.com/", "Paste your Radient Pass key"
+            "Radient", "https://radienthq.com/", "The console calls it a Radient Pass key."
         ),
         base_url="https://api.radienthq.com/v1",
     ),
@@ -413,7 +407,7 @@ PROVIDER_REGISTRY: list[ProviderDefinition] = [
         login=create_api_key_login(
             "Alibaba Cloud",
             "https://dashscope-intl.console.aliyun.com/",
-            "Paste your DashScope API key",
+            "The console calls it a DashScope API key.",
         ),
         base_url="https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
     ),
@@ -429,7 +423,7 @@ PROVIDER_REGISTRY: list[ProviderDefinition] = [
         login=create_api_key_login(
             "QwenCloud Token Plan",
             "https://home.qwencloud.com/billing/subscription/token-plan-individual",
-            "Paste your Token Plan API key (sk-sp-…)",
+            "It starts with sk-sp-.",
         ),
         get_api_key=_token_plan_wire_key,
         base_url="https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1",

--- a/tests/unit/tui/test_steering_approval.py
+++ b/tests/unit/tui/test_steering_approval.py
@@ -101,6 +101,34 @@ def rows(app: OperatorApp) -> list[str]:
     return [strip.text.rstrip() for strip in app.screen._compositor.render_strips()]
 
 
+async def _boot(pilot: Any, app: OperatorApp) -> None:
+    """Wait for the session to be ADOPTED, rather than for a fixed duration.
+
+    Every test here begins by submitting into a booted app, and the boot is
+    asynchronous: ``OperatorApp`` awaits a session factory and adopts the result.
+    Waiting a flat ``pause(0.25)`` for that assumed a duration nothing enforces
+    — measured on this machine, adoption takes ~0.03s on a warm run and **2.3s**
+    on a cold one (first import of the session graph). On the cold run the first
+    submit landed before ``self._session`` existed, was dropped on the floor, and
+    the test failed on an assertion two lines later with no hint that the boot
+    was the cause: ``assert [] == ['first task']``.
+
+    That made the whole file load-dependent. It failed deterministically on a
+    cold cache and passed on a warm one, which is exactly the shape that reads as
+    "flaky" and gets re-run instead of fixed.
+
+    Polls the same condition the app's own readiness depends on, with a generous
+    ceiling: the ceiling is a deadlock guard, not a timing assumption, so a slow
+    machine costs nothing and a genuinely broken boot still fails rather than
+    hanging.
+    """
+    for _ in range(400):
+        if app._session is not None:
+            return
+        await pilot.pause()
+    raise AssertionError("the app never adopted a session")
+
+
 async def _submit(pilot: Any, app: OperatorApp, text: str) -> None:
     app.query_one(Editor).text = text
     await pilot.press("enter")
@@ -118,7 +146,7 @@ async def test_mid_turn_submit_steers_instead_of_prompting() -> None:
     session = SteerableSession()
     app = OperatorApp(lambda: _factory(session))
     async with app.run_test(size=(100, 30)) as pilot:
-        await pilot.pause(0.25)
+        await _boot(pilot, app)
         await _submit(pilot, app, "first task")
         assert session.prompts == ["first task"]
 
@@ -143,7 +171,7 @@ async def test_escape_stops_a_running_turn() -> None:
     session = SteerableSession()
     app = OperatorApp(lambda: _factory(session))
     async with app.run_test(size=(100, 30)) as pilot:
-        await pilot.pause(0.25)
+        await _boot(pilot, app)
 
         editor = app.query_one(Editor)
         editor.text = "kept"
@@ -175,7 +203,7 @@ async def test_empty_assistant_message_mounts_no_block() -> None:
     session = SteerableSession()
     app = OperatorApp(lambda: _factory(session))
     async with app.run_test(size=(100, 30)) as pilot:
-        await pilot.pause(0.25)
+        await _boot(pilot, app)
         await _submit(pilot, app, "make a game")
         app.post_message(TurnStarted())
         app.post_message(AssistantMessageStart())
@@ -213,7 +241,7 @@ async def test_approval_prompt_resolves_from_a_keystroke() -> None:
     session = SteerableSession()
     app = OperatorApp(lambda: _factory(session))
     async with app.run_test(size=(100, 30)) as pilot:
-        await pilot.pause(0.25)
+        await _boot(pilot, app)
         assert session.approval_handler is not None
 
         ask = _approval_gate(session)
@@ -236,7 +264,7 @@ async def test_n_denies_one_tool_and_lets_the_turn_continue() -> None:
     session = SteerableSession()
     app = OperatorApp(lambda: _factory(session))
     async with app.run_test(size=(100, 30)) as pilot:
-        await pilot.pause(0.25)
+        await _boot(pilot, app)
         session.streaming = True
         ask = _approval_gate(session)
         pending = asyncio.ensure_future(ask("write", "write: /etc/hosts"))
@@ -259,7 +287,7 @@ async def test_escape_denies_the_prompt_and_stops_the_turn() -> None:
     session = SteerableSession()
     app = OperatorApp(lambda: _factory(session))
     async with app.run_test(size=(100, 30)) as pilot:
-        await pilot.pause(0.25)
+        await _boot(pilot, app)
         session.streaming = True
         ask = _approval_gate(session)
         first = asyncio.ensure_future(ask("write", "write: /etc/hosts"))
@@ -281,7 +309,7 @@ async def test_allow_all_latches_for_the_session() -> None:
     session = SteerableSession()
     app = OperatorApp(lambda: _factory(session))
     async with app.run_test(size=(100, 30)) as pilot:
-        await pilot.pause(0.25)
+        await _boot(pilot, app)
         ask = _approval_gate(session)
         first = asyncio.ensure_future(ask("bash", "run: make"))
         await pilot.pause(0.3)
@@ -308,7 +336,7 @@ async def test_interrupt_denies_a_parked_approval() -> None:
     session = SteerableSession()
     app = OperatorApp(lambda: _factory(session))
     async with app.run_test(size=(100, 30)) as pilot:
-        await pilot.pause(0.25)
+        await _boot(pilot, app)
         session.streaming = True
         ask = _approval_gate(session)
         pending = asyncio.ensure_future(ask("bash", "run: sleep 99"))
@@ -325,7 +353,7 @@ async def test_clearing_the_transcript_settles_a_pending_approval() -> None:
     session = SteerableSession()
     app = OperatorApp(lambda: _factory(session))
     async with app.run_test(size=(100, 30)) as pilot:
-        await pilot.pause(0.25)
+        await _boot(pilot, app)
         ask = _approval_gate(session)
         pending = asyncio.ensure_future(ask("bash", "run: make"))
         await pilot.pause(0.3)
@@ -348,7 +376,7 @@ async def test_escape_closes_an_open_picker_before_it_stops_anything() -> None:
     session = SteerableSession()
     app = OperatorApp(lambda: _factory(session))
     async with app.run_test(size=(100, 30)) as pilot:
-        await pilot.pause(0.25)
+        await _boot(pilot, app)
         session.streaming = True  # a stop IS available, so precedence is observable
 
         editor = app.query_one(Editor)
@@ -382,7 +410,7 @@ async def test_a_queued_ask_is_denied_rather_than_re_asked_after_a_stop() -> Non
     session = SteerableSession()
     app = OperatorApp(lambda: _factory(session))
     async with app.run_test(size=(100, 30)) as pilot:
-        await pilot.pause(0.25)
+        await _boot(pilot, app)
         session.streaming = True
         ask = _approval_gate(session)
         first = asyncio.ensure_future(ask("bash", "run: one"))
@@ -408,7 +436,7 @@ async def test_allow_all_is_seen_by_an_already_queued_ask() -> None:
     session = SteerableSession()
     app = OperatorApp(lambda: _factory(session))
     async with app.run_test(size=(100, 30)) as pilot:
-        await pilot.pause(0.25)
+        await _boot(pilot, app)
         ask = _approval_gate(session)
         first = asyncio.ensure_future(ask("bash", "run: one"))
         second = asyncio.ensure_future(ask("write", "write: two"))
@@ -432,7 +460,7 @@ async def test_lowercase_a_does_not_disarm_the_gate() -> None:
     session = SteerableSession()
     app = OperatorApp(lambda: _factory(session))
     async with app.run_test(size=(100, 30)) as pilot:
-        await pilot.pause(0.25)
+        await _boot(pilot, app)
         ask = _approval_gate(session)
         pending = asyncio.ensure_future(ask("bash", "run: one"))
         await pilot.pause(0.3)
@@ -460,7 +488,7 @@ async def test_approvals_command_restores_prompting() -> None:
     session = SteerableSession()
     app = OperatorApp(lambda: _factory(session))
     async with app.run_test(size=(100, 30)) as pilot:
-        await pilot.pause(0.25)
+        await _boot(pilot, app)
         app._run_slash_command("/approvals auto")
         await pilot.pause(0.1)
         assert app._approve_all is True
@@ -496,7 +524,7 @@ async def test_ctrl_c_twice_exits_and_offers_the_resume_command(
     session = SteerableSession()
     app = OperatorApp(lambda: _factory(session))
     async with app.run_test(size=(100, 30)) as pilot:
-        await pilot.pause(0.25)
+        await _boot(pilot, app)
         session.streaming = True
 
         await pilot.press("ctrl+c")
@@ -528,7 +556,7 @@ async def test_a_slow_second_ctrl_c_is_a_fresh_interrupt_not_an_exit() -> None:
     session = SteerableSession()
     app = OperatorApp(lambda: _factory(session))
     async with app.run_test(size=(100, 30)) as pilot:
-        await pilot.pause(0.25)
+        await _boot(pilot, app)
         session.streaming = True
 
         await pilot.press("ctrl+c")
@@ -549,7 +577,7 @@ async def test_an_empty_message_end_keeps_the_streamed_prose() -> None:
     session = SteerableSession()
     app = OperatorApp(lambda: _factory(session))
     async with app.run_test(size=(100, 30)) as pilot:
-        await pilot.pause(0.25)
+        await _boot(pilot, app)
         await _submit(pilot, app, "say something")
         app.post_message(TurnStarted())
         app.post_message(AssistantMessageStart())
@@ -598,7 +626,7 @@ async def test_clearing_the_transcript_does_not_disarm_later_prompts() -> None:
     session = SteerableSession()
     app = OperatorApp(lambda: _factory(session))
     async with app.run_test(size=(100, 30)) as pilot:
-        await pilot.pause(0.25)
+        await _boot(pilot, app)
         session.streaming = True
         ask = _approval_gate(session)
 
@@ -628,7 +656,7 @@ async def test_approvals_ask_clears_a_latched_deny() -> None:
     session = SteerableSession()
     app = OperatorApp(lambda: _factory(session))
     async with app.run_test(size=(100, 30)) as pilot:
-        await pilot.pause(0.25)
+        await _boot(pilot, app)
         session.streaming = True
         app._deny_queued_approvals()  # what a stop leaves behind
         assert app._approvals_are_denied(app._turn_epoch) is True
@@ -654,7 +682,7 @@ async def test_the_resume_hint_is_withheld_until_the_session_is_on_disk() -> Non
     session = SteerableSession()
     app = OperatorApp(lambda: _factory(session))
     async with app.run_test(size=(100, 30)) as pilot:
-        await pilot.pause(0.25)
+        await _boot(pilot, app)
         # FakeSession's id has no directory on disk, so there is nothing to offer.
         assert app.resume_hint() == ""
         await pilot.press("ctrl+c")
@@ -836,7 +864,7 @@ async def test_a_turn_start_racing_the_stop_cannot_revive_a_denied_ask() -> None
     session = SteerableSession()
     app = OperatorApp(lambda: _factory(session))
     async with app.run_test(size=(100, 30)) as pilot:
-        await pilot.pause(0.25)
+        await _boot(pilot, app)
         session.streaming = True
         first = asyncio.ensure_future(_approval_gate(session)("bash", "run: one"))
         await pilot.pause(0.25)
@@ -865,7 +893,7 @@ async def test_approvals_auto_answers_the_question_on_screen() -> None:
     session = SteerableSession()
     app = OperatorApp(lambda: _factory(session))
     async with app.run_test(size=(100, 30)) as pilot:
-        await pilot.pause(0.25)
+        await _boot(pilot, app)
         session.streaming = True
         pending = asyncio.ensure_future(_approval_gate(session)("bash", "run: make"))
         await pilot.pause(0.3)
@@ -922,7 +950,7 @@ async def test_a_pending_prompt_does_not_widen_the_tool_ledger() -> None:
     session = SteerableSession()
     app = OperatorApp(lambda: _factory(session))
     async with app.run_test(size=(90, 30)) as pilot:
-        await pilot.pause(0.25)
+        await _boot(pilot, app)
         view = app.query_one(TranscriptView)
         view.append_block(ToolCard("t1", "bash", {}, ""))
         await pilot.pause(0.1)
@@ -944,7 +972,7 @@ async def test_clearing_the_transcript_forgets_the_ledger_width() -> None:
     session = SteerableSession()
     app = OperatorApp(lambda: _factory(session))
     async with app.run_test(size=(120, 30)) as pilot:
-        await pilot.pause(0.25)
+        await _boot(pilot, app)
         view = app.query_one(TranscriptView)
         view.append_block(ToolCard("t1", "mcp__linear_create_initiative", {}, ""))
         await pilot.pause(0.1)
@@ -966,7 +994,7 @@ async def test_a_tall_notice_is_separated_from_what_precedes_it() -> None:
     session = SteerableSession()
     app = OperatorApp(lambda: _factory(session))
     async with app.run_test(size=(40, 30)) as pilot:
-        await pilot.pause(0.25)
+        await _boot(pilot, app)
         view = app.query_one(TranscriptView)
         short = NoticeBlock("resumed session 4c1f", "info")
         tall = NoticeBlock(
@@ -1187,15 +1215,34 @@ async def test_a_marker_rung_exists_between_the_words_and_the_glyph() -> None:
         async with app.run_test(size=(width, 20)) as pilot:
             view = app.query_one(TranscriptView)
             view.append_block(ApprovalBlock("write_file", f"{OUTSIDE_MARKER} write: /etc/hosts"))
-            await pilot.pause(0.05)
-            row = next(
-                (
-                    strip.text
-                    for strip in app.screen._compositor.render_strips()
-                    if "write_file" in strip.text
-                ),
-                "",
-            )
+            # Wait for the row to be PAINTED, not for 50ms. A flat pause is a
+            # guess about how long a compositor pass takes, and when it lost the
+            # race the row came back "" — which is not "this width shows no
+            # hazard", it is "this width was not measured". The empty string
+            # then fell through the membership test below, dropped that width
+            # out of `both`, and SPLIT THE BAND, so the `len(runs) == 1`
+            # assertion failed with a plausible-looking two-run result
+            # ([49, 39, 28]) that pointed at the ladder instead of at the clock.
+            # Measured ~1-2 failures in 9 full-suite runs on unmodified main.
+            #
+            # The retry loop closes that: a width now yields a row or the test
+            # says so, and an unpainted frame can no longer masquerade as a
+            # measurement. The ceiling is a deadlock guard rather than a timing
+            # assumption.
+            row = ""
+            for _ in range(200):
+                row = next(
+                    (
+                        strip.text
+                        for strip in app.screen._compositor.render_strips()
+                        if "write_file" in strip.text
+                    ),
+                    "",
+                )
+                if row:
+                    break
+                await pilot.pause()
+            assert row, f"the approval row never painted at width {width}"
         if PROMPT_GLYPH in row and HAZARD_GLYPH in row:
             both.append(width)
 

--- a/tests/unit/tui/test_steering_approval.py
+++ b/tests/unit/tui/test_steering_approval.py
@@ -705,7 +705,7 @@ async def test_the_prompt_never_hides_its_target_or_overflows(width: int) -> Non
     session = SteerableSession()
     app = OperatorApp(lambda: _factory(session))
     async with app.run_test(size=(width, 24)) as pilot:
-        await pilot.pause(0.2)
+        await _boot(pilot, app)
         view = app.query_one(TranscriptView)
         view.append_block(
             ApprovalBlock("write_file", "[outside workspace] write: /Users/x/deep/config.yml")
@@ -735,7 +735,7 @@ async def test_the_answered_receipt_stays_on_one_row(width: int) -> None:
     session = SteerableSession()
     app = OperatorApp(lambda: _factory(session))
     async with app.run_test(size=(width, 24)) as pilot:
-        await pilot.pause(0.2)
+        await _boot(pilot, app)
         block = ApprovalBlock("write_file", "[outside workspace] write: /Users/x/deep/config.yml")
         app.query_one(TranscriptView).append_block(block)
         await pilot.pause(0.1)
@@ -769,7 +769,7 @@ async def test_the_hint_row_sheds_whole_choices(width: int) -> None:
     session = SteerableSession()
     app = OperatorApp(lambda: _factory(session))
     async with app.run_test(size=(width, 24)) as pilot:
-        await pilot.pause(0.2)
+        await _boot(pilot, app)
         app.query_one(TranscriptView).append_block(ApprovalBlock("bash", "run: make"))
         await pilot.pause(0.2)
         painted = [strip.text.rstrip() for strip in app.screen._compositor.render_strips()]
@@ -805,7 +805,7 @@ async def test_a_dangerous_ask_never_paints_like_a_safe_one(width: int) -> None:
     session = SteerableSession()
     app = OperatorApp(lambda: _factory(session))
     async with app.run_test(size=(width, 24)) as pilot:
-        await pilot.pause(0.2)
+        await _boot(pilot, app)
         view = app.query_one(TranscriptView)
         view.append_block(ApprovalBlock("write_file", f"{OUTSIDE_MARKER} write: /tmp/x/keys"))
         view.append_block(ApprovalBlock("write_file", "write: /tmp/x/keys"))
@@ -842,7 +842,7 @@ async def test_a_narrow_prompt_keeps_the_end_of_the_path(detail: str, expected_t
     session = SteerableSession()
     app = OperatorApp(lambda: _factory(session))
     async with app.run_test(size=(52, 24)) as pilot:
-        await pilot.pause(0.2)
+        await _boot(pilot, app)
         app.query_one(TranscriptView).append_block(ApprovalBlock("write_file", detail))
         await pilot.pause(0.2)
         painted = [strip.text.rstrip() for strip in app.screen._compositor.render_strips()]
@@ -925,7 +925,7 @@ async def test_the_prompt_cannot_be_repainted_from_a_tool_argument() -> None:
     session = SteerableSession()
     app = OperatorApp(lambda: _factory(session))
     async with app.run_test(size=(90, 24)) as pilot:
-        await pilot.pause(0.2)
+        await _boot(pilot, app)
         block = ApprovalBlock("bash", f"run: {payload}")
         app.query_one(TranscriptView).append_block(block)
         await pilot.pause(0.2)
@@ -1025,7 +1025,7 @@ async def test_a_call_being_dictated_shows_a_row_that_moves() -> None:
     session = SteerableSession()
     app = OperatorApp(lambda: _factory(session))
     async with app.run_test(size=(100, 30)) as pilot:
-        await pilot.pause(0.2)
+        await _boot(pilot, app)
         app.post_message(ToolComposing(ToolCallComposeEvent(tool_call_id="c1", tool_name="write")))
         await pilot.pause(0.1)
         painted = [strip.text for strip in app.screen._compositor.render_strips()]
@@ -1069,7 +1069,7 @@ async def test_an_adopted_row_times_the_tool_not_the_dictation() -> None:
     session = SteerableSession()
     app = OperatorApp(lambda: _factory(session))
     async with app.run_test(size=(100, 30)) as pilot:
-        await pilot.pause(0.2)
+        await _boot(pilot, app)
         app.post_message(ToolComposing(ToolCallComposeEvent(tool_call_id="c1", tool_name="write")))
         await pilot.pause(0.55)  # "dictation" time that must not be billed
         app.post_message(
@@ -1105,7 +1105,7 @@ async def test_the_composing_row_sheds_its_label_before_its_facts() -> None:
     session = SteerableSession()
     app = OperatorApp(lambda: _factory(session))
     async with app.run_test(size=(34, 24)) as pilot:
-        await pilot.pause(0.2)
+        await _boot(pilot, app)
         app.post_message(
             ToolComposing(
                 ToolCallComposeEvent(tool_call_id="c1", tool_name="write", argument_bytes=12700)
@@ -1156,6 +1156,7 @@ async def test_a_dictated_name_moves_its_own_row_but_not_the_shared_column() -> 
     session = SteerableSession()
     app = OperatorApp(lambda: _factory(session))
     async with app.run_test(size=(110, 24)) as pilot:
+        await _boot(pilot, app)
         view = app.query_one(TranscriptView)
         settled = ToolCard("s1", "read", {}, None)
         view.append_block(settled)
@@ -1213,25 +1214,35 @@ async def test_a_marker_rung_exists_between_the_words_and_the_glyph() -> None:
     for width in range(90, 19, -1):
         app = OperatorApp(lambda: _factory(SteerableSession()))
         async with app.run_test(size=(width, 20)) as pilot:
+            await _boot(pilot, app)
             view = app.query_one(TranscriptView)
             view.append_block(ApprovalBlock("write_file", f"{OUTSIDE_MARKER} write: /etc/hosts"))
-            # Wait for the row to be PAINTED, not for 50ms. A flat pause is a
-            # guess about how long a compositor pass takes, and when it lost the
-            # race the row came back "" — which is not "this width shows no
-            # hazard", it is "this width was not measured". The empty string
-            # then fell through the membership test below, dropped that width
-            # out of `both`, and SPLIT THE BAND, so the `len(runs) == 1`
-            # assertion failed with a plausible-looking two-run result
-            # ([49, 39, 28]) that pointed at the ladder instead of at the clock.
-            # Measured ~1-2 failures in 9 full-suite runs on unmodified main.
+            # Wait for the row to SETTLE, not for 50ms and not merely for it to
+            # be non-empty. A flat pause is a guess about how long a compositor
+            # pass takes, and when it lost the race the width was measured off a
+            # frame the user never sees, dropped out of `both`, and SPLIT THE
+            # BAND — so `len(runs) == 1` failed with a plausible two-run result
+            # ([49, 39, 28]) that pointed at the hazard ladder instead of at the
+            # clock. Measured ~1-2 failures in 9 full-suite runs on unmodified
+            # main, and 2 in 8 under CPU contention.
             #
-            # The retry loop closes that: a width now yields a row or the test
-            # says so, and an unpainted frame can no longer masquerade as a
-            # measurement. The ceiling is a deadlock guard rather than a timing
-            # assumption.
+            # Waiting for a NON-EMPTY row does not fix it, which is the trap
+            # here: instrumenting the failing sweep shows `empties=0` and ~33
+            # frames carrying the intermediate "words" rung — `?` present, `!`
+            # absent. That frame is non-empty, so a first-non-empty read accepts
+            # it and classifies the width false exactly as an unpainted frame
+            # would. The defect was never emptiness; it is reading a frame that
+            # has not finished reflowing.
+            #
+            # So the read is repeated until it stops changing: two consecutive
+            # identical rows with a pause between them. That is the same rule
+            # the rest of this suite follows — wait for the condition, not for a
+            # duration — and it holds the band under the load that splits it.
+            # The ceiling is a deadlock guard rather than a timing assumption.
             row = ""
             for _ in range(200):
-                row = next(
+                await pilot.pause()
+                current = next(
                     (
                         strip.text
                         for strip in app.screen._compositor.render_strips()
@@ -1239,9 +1250,9 @@ async def test_a_marker_rung_exists_between_the_words_and_the_glyph() -> None:
                     ),
                     "",
                 )
-                if row:
+                if current and current == row:
                     break
-                await pilot.pause()
+                row = current
             assert row, f"the approval row never painted at width {width}"
         if PROMPT_GLYPH in row and HAZARD_GLYPH in row:
             both.append(width)
@@ -1277,6 +1288,7 @@ async def test_the_two_hazards_spell_out_different_sentences() -> None:
     for label, (detail, expected) in cases.items():
         app = OperatorApp(lambda: _factory(SteerableSession()))
         async with app.run_test(size=(96, 20)) as pilot:
+            await _boot(pilot, app)
             app.query_one(TranscriptView).append_block(ApprovalBlock("write_file", detail))
             await pilot.pause(0.1)
             row = next(
@@ -1311,6 +1323,7 @@ async def test_the_verbose_threshold_measures_this_row_s_own_clause() -> None:
     for width in range(66, 61, -1):
         app = OperatorApp(lambda: _factory(SteerableSession()))
         async with app.run_test(size=(width, 20)) as pilot:
+            await _boot(pilot, app)
             app.query_one(TranscriptView).append_block(ApprovalBlock("write_file", detail))
             await pilot.pause(0.05)
             row = next(
@@ -1346,6 +1359,7 @@ async def test_a_background_jobs_approval_survives_the_parents_stop_latch() -> N
     session = SteerableSession()
     app = OperatorApp(lambda: _factory(session))
     async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(pilot, app)
         for _ in range(12):
             await pilot.pause()
         # Arm the latch exactly as a stop during the parent's turn does.


### PR DESCRIPTION
# PR Description

## Change classification

**C2 — standard / pre-authorized.** Two test repairs and one copy change, with a clean rollback (`git revert`). No behavioural change to any runtime path except eight registry instruction strings. No RFC or tracker requested.

## Summary of Changes

Three follow-ups raised during the review of #134 and deferred out of it, so that PR stayed scoped to the login defect it was fixing.

### 1. `main` was shipping a deterministically red test

`test_mid_turn_submit_steers_instead_of_prompting` fails **9 out of 9** runs on a cold cache and passes on a warm one, which is why nobody had chased it: whoever ran it had usually just run something else.

The failing assertion was not where the bug was. The test opens with `pause(0.25)` and then submits, assuming the session is adopted by then — but adoption is asynchronous, and measured on this machine it takes **~0.03s warm and 2.3s cold** (first import of the session graph). On a cold run the first submit landed before `self._session` existed, was dropped, and the failure surfaced two lines later as `assert [] == ['first task']` — pointing at steering rather than at boot.

All 39 `run_test` blocks in the file now poll for adoption through a `_boot` helper, with a generous ceiling that is a deadlock guard rather than a timing assumption. (The first version converted only the 25 sites a pattern match found; enumerating the blocks instead surfaced 14 more, four of which could kill a run outright with `NoMatches` by racing the boot screen.)

### 2. The flaky one had the same shape, one layer down

`test_a_marker_rung_exists_between_the_words_and_the_glyph` fails roughly **1-2 in 9** full-suite runs on unmodified `main`. Its `pause(0.05)` waits for a paint, and when it lost that race the row came back `""`.

That empty string is the actual defect: `""` is not *"this width shows no hazard"*, it is *"this width was not measured"*. It fell through the membership test, silently dropped that width out of the set, and **split the contiguous band** the test asserts — failing with a plausible-looking two-run result (`[49, 39, 28]`) that sent a reader to the hazard ladder instead of to the clock. The read now waits for the row to **stop changing** — two consecutive identical reads — rather than merely for it to be non-empty. That distinction is the whole fix: round 1 review showed the dropped widths are *not* empty (`empties=0`), they carry an intermediate frame with `?` and no `!`, so a first-non-empty read accepts exactly the frame that mis-measures.

### 3. The credential was named twice on screen

The residual half of design finding **D3** on #134. The registry instruction rendered directly above the prompt row, and for four providers said exactly what the row below it already said:

```text
Paste your DeepSeek API key        <- registry instruction
? Paste your DeepSeek API key      <- the prompt row
```

Four instructions were verbatim duplicates and are dropped (the field is already optional — `instructions or None`). Four carried genuinely useful information, the **vendor's own term for the key**, and now say only that:

| Provider | Instruction now reads |
| --- | --- |
| Google | The console calls it an AI Studio API key. |
| Radient | The console calls it a Radient Pass key. |
| Alibaba Cloud | The console calls it a DashScope API key. |
| QwenCloud Token Plan | It starts with sk-sp-. |

## Related Issue(s)

Follow-ups from #134. No tracker requested.

## Impact

- **Breaking changes:** none.
- **Risk:** the two test changes cannot affect the product — they touch one test file. The registry change alters eight strings rendered during an interactive login and nothing that routes.
- **Rollback:** `git revert`.

## Testing Details

### The tests were verified against the FAILURE, at a load that discriminates

A test repair that is only observed to pass is indistinguishable from one that got lucky. The first version of this PR made that mistake twice, and round 1 review caught both: the repair fixed a mechanism that is not the one that fails, and the contention experiment used a load at which *both* versions pass. Corrected below.

Host: **14 cores** (`sysctl -n hw.ncpu`). Load: N background CPU spinners. The load is chosen so the **old** code fails, which is the only thing that makes the comparison meaningful:

```text
6 spinners   OLD code                        4 passed, 0 failed   <- does not discriminate
24 spinners  OLD code (f0ae8c0)              2 passed, 2 failed   <- discriminating load
24 spinners  NEW code (settled read)         6 passed, 0 failed
24 spinners  first attempt (non-empty poll)  2 of 8 failed
unloaded     NEW code, whole file            74 passed
```

**Why the first attempt failed, and why "wait for non-empty" was the wrong fix.** The original diagnosis was that a lost paint race returns `""`. Instrumenting the failing sweep falsifies it:

```text
empties=0  words_rung_frames=33  runs=[50, 28]    <- band split, nothing empty
```

The dropped widths carry an intermediate **words rung** — `?` present, `!` absent — which is non-empty, so breaking on the first non-empty row accepted precisely the frame that mis-measures. The read now waits for the row to **stop changing** (two consecutive identical reads), which is the same rule the rest of the file follows after this PR.

**The deterministic failure needed no contention at all:**

```text
BEFORE (origin/main @ f0ae8c0)
$ pytest tests/unit/tui/test_steering_approval.py::test_mid_turn_submit_steers_instead_of_prompting
AssertionError: assert [] == ['first task']          # 9 of 9 runs

AFTER (this branch)
$ pytest tests/unit/tui/test_steering_approval.py
74 passed
```

Its root cause was measured rather than inferred:

```text
trial 0: session adopted after 2.284s (29 pauses)    <- cold; pause(0.25) is not enough
trial 1: session adopted after 0.079s (0 pauses)
trial 2: session adopted after 0.032s (0 pauses)
```

**Coverage was enumerated, not searched for.** The first version selected boot waits by matching `pause(0.25)` preceded by `run_test`, which is blind by construction to blocks that open some other way. Enumerating all 39 `run_test` blocks instead found 14 with no boot wait — nine opening with `pause(0.2)` (the same bug, one constant over), four calling `query_one(TranscriptView)` immediately (which races the boot screen and dies with `NoMatches`), and one opening with a loop:

```text
before:  run_test blocks: 39 | with boot wait: 25 | WITHOUT: 14
after:   run_test blocks: 39 | ALL have a boot wait: True
```

### The copy change, in a rendered frame

Captured from the real `OperatorApp` (the host that loads `local_operator.tcss`), `/login alibaba-token-plan`:

![deduplicated instruction](https://raw.githubusercontent.com/damianvtran/local-operator/evidence/login-paste-prompt/shots/r4_dedup.png)

The instruction now reads `It starts with sk-sp-.` above `? Paste your QwenCloud Token Plan API key`, so the two lines say different things. Verified across all eight paste-a-key providers that no instruction repeats its prompt row.

### Automated gates

```text
.venv/bin/python -m flake8 .                                 PASS
uvx --from black==26.1.0 black --check local_operator tests   PASS (355 files)
uvx isort --check-only --profile black local_operator tests   PASS
.venv/bin/python -m pyright --pythonpath .venv/bin/python .   PASS (0 errors)
pytest tests/unit -q                                          4259 passed, 7 skipped, 1 failed
pytest tests/unit/providers tests/unit/tui/test_login_key_prompt.py   389 passed
```

**Both target tests pass in that full-suite run**, which is the result that matters:

```text
tests/unit/tui/test_steering_approval.py::test_mid_turn_submit_steers_instead_of_prompting PASSED
tests/unit/tui/test_steering_approval.py::test_a_marker_rung_exists_between_the_words_and_the_glyph PASSED
```

### The one remaining failure is a third, unrelated flake

`tests/unit/tools/test_builtin_tools.py::test_bash_steering_cancellation_backgrounds_the_command` — `CancelledError`. It passes **3 of 3** in isolation, this branch does not touch that file (`git diff --name-only` does not list it), and its last modification predates this branch by two commits. Same family as the two fixed here (a timing assumption under full-suite load) but a different mechanism in a different file; left alone rather than folded in, so this PR's diff stays reviewable against its own claims.

### Not covered

No runtime behaviour changes here beyond eight rendered strings, so there is no end-to-end path to exercise that #134 has not already exercised. The strings themselves are shown in the rendered frame above.

