### PR TITLE
perf(harness): agent role profiles and event-driven waits for faster review cycles

### DIFF
--- a/local_operator/agent_profiles.py
+++ b/local_operator/agent_profiles.py
@@ -74,12 +74,34 @@ SEEDS_DIR = Path(__file__).parent / "agent_seeds"
 #: bounded enough that a pasted log cannot become a permanent tax.
 MAX_INSTRUCTIONS_CHARS = 8_000
 
+#: The tag that marks a registry row as a delegation ROLE. A registry also
+#: holds ordinary conversational agents and autosave rows in the same flat
+#: namespace, keyed by user-visible name, so without this marker any agent that
+#: merely happened to be called ``reviewer`` would be launched AS the reviewer
+#: role — with no allowlist, and therefore the full write inventory, while the
+#: child was still told it was a reviewer. Written by seed installation and by
+#: the ``agent`` tool; required by :func:`resolve_profile`.
+ROLE_TAG = "role"
+
 #: Tool names a read-only role is filtered to. Allowlist, not a tier filter:
 #: approval tiers drift as tools are added, and these roles promise "no side
 #: effects at all", which is narrower than "nothing marked write". ``browser``
 #: drives the user's real browser and ``eval`` executes code, so both are
 #: excluded by NAME even where a tier check alone would admit them.
 READ_ONLY_TOOLS = ("read", "glob", "grep", "list_variables", "read_variable")
+
+
+class NameTakenError(RuntimeError):
+    """An agent of that name exists but is not a role.
+
+    Its own class rather than a bare ``RuntimeError`` so the caller can tell
+    "this name is occupied by something else" apart from a registry failure,
+    and say so instead of reporting a successful install that wrote nothing.
+    """
+
+    def __init__(self, name: str) -> None:
+        super().__init__(f"an agent named {name!r} exists and is not a role")
+        self.name = name
 
 
 @dataclass(frozen=True)
@@ -260,6 +282,17 @@ def _agent_instructions(registry: "AgentRegistry", agent: "AgentData") -> str:
         return ""
 
 
+def is_role(agent: "AgentData") -> bool:
+    """Whether a registry row is marked as a delegation role.
+
+    One implementation, because two readers that disagree about what a role is
+    are how ``op='list'`` came to hide a row that ``task(agent=...)`` would
+    happily run.
+    """
+
+    return any(str(tag).strip().lower() == ROLE_TAG for tag in (agent.tags or []))
+
+
 def _profile_from_agent(registry: "AgentRegistry", agent: "AgentData") -> AgentProfile:
     """Convert a registered agent into a role profile.
 
@@ -334,10 +367,31 @@ def resolve_profile(
     if registry is not None:
         try:
             agent = registry.get_agent_by_name(key)
+            if agent is None:
+                # Case-insensitive retry, because ``load_seed`` folds case and
+                # an exact-only registry lookup would invert this function's
+                # whole point: ``task(agent="Reviewer")`` would find the
+                # PACKAGED seed while silently ignoring the operator's own
+                # ``Reviewer``. Exact match still wins; this only runs when it
+                # found nothing.
+                folded = key.casefold()
+                agent = next(
+                    (
+                        row
+                        for row in registry.list_agents()
+                        if str(row.name).strip().casefold() == folded and is_role(row)
+                    ),
+                    None,
+                )
         except Exception:  # noqa: BLE001 - registry problems must not fail a launch
             agent = None
             logger.warning("agent registry lookup failed for %r", key)
-        if agent is not None:
+        # The row must be MARKED a role. An unmarked same-named agent falls
+        # through to the packaged seed rather than being run as the role: the
+        # registry is a flat namespace of user-visible names shared with
+        # ordinary chat agents, and honouring one of those would hand a child
+        # the full write inventory under a role's name.
+        if agent is not None and is_role(agent):
             return _profile_from_agent(registry, agent)
     return load_seed(key)
 
@@ -356,9 +410,14 @@ def install_seed(
     has never created materializes it here, once, as an ordinary editable
     registry row.
 
-    Idempotent: an existing agent of the same name is returned untouched
-    unless ``overwrite`` is set, so a concurrent second launch of the same role
-    cannot duplicate the profile or clobber edits the operator has made.
+    Idempotent: an existing ROLE of the same name is returned untouched unless
+    ``overwrite`` is set, so a concurrent second launch of the same role cannot
+    duplicate the profile or clobber edits the operator has made.
+
+    Raises :class:`NameTakenError` when the name belongs to an agent that is
+    NOT a role. Returning that row (which is what this used to do) reported a
+    successful install while writing nothing, so an operator recovering from a
+    misbehaving role was told the fix had landed when it had not.
     """
 
     seed = load_seed(name)
@@ -372,6 +431,8 @@ def install_seed(
         existing = registry.get_agent_by_name(seed.name)
     except Exception:  # noqa: BLE001
         existing = None
+    if existing is not None and not is_role(existing) and not overwrite:
+        raise NameTakenError(seed.name)
     if existing is not None and not overwrite:
         return _profile_from_agent(registry, existing)
 

--- a/local_operator/agent_profiles.py
+++ b/local_operator/agent_profiles.py
@@ -454,7 +454,16 @@ def install_seed(
         agent = registry.create_agent(
             AgentEditFields(
                 name=seed.name,
-                description=seed.description or seed.when_to_use,
+                # ``when_to_use`` FIRST, and the order is load-bearing. The
+                # registry has one description field; a profile has two texts,
+                # and this one is the ROUTING text — it is what ``search``
+                # embeds and match against. Persisting ``description`` instead
+                # silently dropped the trigger phrasings on install, so a role
+                # that was discoverable as a packaged starter became
+                # undiscoverable the moment an operator installed it, and
+                # search then recommended a confidently wrong role rather than
+                # failing visibly ("check the UI looks right" -> manager).
+                description=seed.when_to_use or seed.description,
                 tags=tags,
                 categories=["role"],
                 security_prompt=None,

--- a/local_operator/agent_profiles.py
+++ b/local_operator/agent_profiles.py
@@ -410,7 +410,7 @@ def install_seed(
     registry: "AgentRegistry",
     overwrite: bool = False,
 ) -> tuple[AgentProfile, bool] | None:
-    """Copy a packaged seed into the registry; return ``(profile, was_already_there)``.
+    """Copy a packaged seed into the registry; return ``(profile, already_installed)``.
 
     The second element is why this returns a tuple: the caller has to be able
     to tell "I installed it" from "it was already there and I left it alone",

--- a/local_operator/agent_profiles.py
+++ b/local_operator/agent_profiles.py
@@ -409,8 +409,13 @@ def install_seed(
     *,
     registry: "AgentRegistry",
     overwrite: bool = False,
-) -> AgentProfile | None:
-    """Copy a packaged seed into the user's registry and return the profile.
+) -> tuple[AgentProfile, bool] | None:
+    """Copy a packaged seed into the registry; return ``(profile, was_already_there)``.
+
+    The second element is why this returns a tuple: the caller has to be able
+    to tell "I installed it" from "it was already there and I left it alone",
+    because reporting the first when the second happened misleads an operator
+    who is trying to restore a role they broke.
 
     This is the "readily available, pulled in as needed" step: seeds are not
     installed at startup (an empty registry should stay empty until something
@@ -442,7 +447,14 @@ def install_seed(
     if existing is not None and not is_role(existing) and not overwrite:
         raise NameTakenError(seed.name)
     if existing is not None and not overwrite:
-        return profile_from_agent(registry, existing)
+        # Already a role: return it UNTOUCHED (that idempotence is what keeps a
+        # concurrent second launch from clobbering operator edits) and say so
+        # via ``already_installed``, so the caller does not report a write that
+        # did not happen. The natural recovery guess after breaking a role is
+        # "install it again", and answering "installed" to a no-op leaves the
+        # operator believing the packaged guidance is back when their own
+        # edited prompt is what the next delegation will run.
+        return profile_from_agent(registry, existing), True
 
     tags = list(seed_tags(seed))
     if existing is None:
@@ -484,7 +496,7 @@ def install_seed(
     else:
         agent = existing
     registry.set_agent_system_prompt(agent.id, seed.instructions)
-    return profile_from_agent(registry, agent)
+    return profile_from_agent(registry, agent), False
 
 
 def seed_tags(profile: AgentProfile) -> tuple[str, ...]:

--- a/local_operator/agent_profiles.py
+++ b/local_operator/agent_profiles.py
@@ -1,0 +1,446 @@
+"""Agent PROFILES: the role half of a registered agent, and how a role is chosen.
+
+WHY THIS EXISTS
+===============
+
+Delegation used to carry a role only in the prose a parent happened to write
+into a ``task`` prompt. Measured over 99 sessions in one day, 58 were review
+children, and the prompts hand-written for them ranged from 161 to 9551
+characters — a 59x spread for what is the same job every time. Everything that
+makes a review fast (read the diff before the tree, classify by severity, stop
+when nothing blocking is left, do not rewrite the code you are reviewing) had
+to be re-derived by the parent on every launch, and whatever it forgot, the
+child did not do.
+
+The fix is NOT a hardcoded table of roles in the harness. Roles are user data:
+which ones exist, what they say, and when they apply all differ per operator
+and per repository, and they must be editable by the person — or the agent —
+who notices the guidance was wrong. So a role is a REGISTERED AGENT
+(:mod:`local_operator.agents`), which already persists a name, description,
+tags, model, sampling settings, and a ``system_prompt.md``. This module adds
+only what the registry lacked:
+
+1. **Applicability** — ``when_to_use`` on the profile, so a row can say what it
+   is FOR rather than leaving an embedder to infer it from a name. It rides in
+   the same semantic index that already routes skills and guides, so choosing
+   an agent costs no extra context: the registry is never enumerated into the
+   prompt (see :func:`local_operator.session_factory._registered_agent_hints`).
+
+2. **A tool surface** — ``tools`` on the profile, so a reviewer physically
+   cannot push a "helpful" fix (the failure that forces a re-review of a diff
+   the reviewer itself changed). Enforced at child construction.
+
+3. **Seeds** — a small set of packaged starter profiles (reviewer, coder,
+   architect, manager, designer, scout) written as plain markdown with
+   frontmatter, installed into the user's registry ON DEMAND. They are a
+   starting point the operator owns and edits, not a fixed enum: after install
+   they are ordinary registry rows with no special status, and a task can
+   equally use a profile the operator (or an agent, via the ``agent`` tool)
+   wrote from scratch.
+
+The seeds ship as files rather than string constants so that "read what the
+reviewer is told" and "change what the reviewer is told" are the same
+operation for a human and for an agent.
+
+TOKEN BUDGET
+============
+
+A profile's instructions are prepended to the child's prompt, so every line is
+billed on each launch of that role and again on every turn of that child's own
+loop. Seed bodies are therefore short and imperative: a line earns its place by
+changing what the child DOES, not by describing good practice in general. The
+seed catalogue itself never enters a prompt — it is discovered semantically and
+only the selected row's body is loaded.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Sequence, TypeVar
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from local_operator.agents import AgentData, AgentRegistry
+
+logger = logging.getLogger(__name__)
+
+#: Where the packaged starter profiles live (one ``<name>.md`` per role).
+SEEDS_DIR = Path(__file__).parent / "agent_seeds"
+
+#: Cap on an instruction body admitted from a profile. A profile is user data
+#: and rides in front of a child's prompt on every turn, so an unbounded body
+#: is an unbounded per-turn bill. Generous enough for a detailed role brief,
+#: bounded enough that a pasted log cannot become a permanent tax.
+MAX_INSTRUCTIONS_CHARS = 8_000
+
+#: Tool names a read-only role is filtered to. Allowlist, not a tier filter:
+#: approval tiers drift as tools are added, and these roles promise "no side
+#: effects at all", which is narrower than "nothing marked write". ``browser``
+#: drives the user's real browser and ``eval`` executes code, so both are
+#: excluded by NAME even where a tier check alone would admit them.
+READ_ONLY_TOOLS = ("read", "glob", "grep", "list_variables", "read_variable")
+
+
+@dataclass(frozen=True)
+class AgentProfile:
+    """A role resolved from the registry (or from a packaged seed).
+
+    ``tools=None`` means "whatever the parent would build"; a non-empty tuple
+    filters the child's inventory to exactly those names. ``effort`` is the
+    default model tier for the role and is always overridable per launch,
+    because the right model for a role depends on the operator's provider mix
+    rather than on anything this file can know.
+    """
+
+    name: str
+    description: str = ""
+    when_to_use: str = ""
+    instructions: str = ""
+    tools: tuple[str, ...] | None = None
+    effort: str | None = None
+    #: Whether a child in this role may delegate further. A reviewer that
+    #: spawns its own children turns one review into a fan-out nobody is
+    #: watching; a read-only role that delegates autonomous work is not
+    #: read-only.
+    may_delegate: bool = False
+    #: Registry id when this profile came from a registered agent, else None
+    #: for a packaged seed resolved without installing it.
+    agent_id: str | None = None
+    #: Provider/model selector (``provider/model-id``) the profile pins, if any.
+    model: str = ""
+    hosting: str = ""
+
+    @property
+    def preamble(self) -> str:
+        """The text stamped in front of a child's prompt for this role.
+
+        Empty instructions yield an empty preamble rather than a header with
+        nothing under it — a role that says nothing must cost nothing.
+        """
+
+        body = self.instructions.strip()
+        if not body:
+            return ""
+        return f"[role: {self.name}]\n{body}\n\n"
+
+
+def _split_frontmatter(text: str) -> tuple[dict[str, object], str]:
+    """Return ``(frontmatter, body)`` for a seed/profile markdown file.
+
+    Reuses the skills frontmatter parser so a profile file and a SKILL.md are
+    parsed by exactly one implementation; a second YAML-ish parser beside it is
+    how the two would later disagree about the same bytes.
+    """
+
+    from local_operator.skills.discovery import parse_frontmatter
+
+    meta = parse_frontmatter(text)
+    if not text.startswith("---"):
+        return meta, text
+    lines = text.split("\n")
+    for i in range(1, len(lines)):
+        if lines[i].strip() == "---":
+            return meta, "\n".join(lines[i + 1 :]).strip()
+    return meta, ""
+
+
+def _as_tuple(raw: object) -> tuple[str, ...] | None:
+    """Normalize a ``tools`` frontmatter value to a tuple, or None.
+
+    Accepts a YAML list or a comma-separated string, because both are what a
+    human writes and neither is worth an error. An explicit empty list is
+    treated as "unset": a child with zero tools cannot do anything, so it is
+    always a mistake rather than an intent.
+    """
+
+    if raw is None:
+        return None
+    if isinstance(raw, str):
+        names = [part.strip() for part in raw.split(",")]
+    elif isinstance(raw, (list, tuple)):
+        names = [str(part).strip() for part in raw]
+    else:
+        return None
+    names = [name for name in names if name]
+    return tuple(dict.fromkeys(names)) or None
+
+
+def _profile_from_text(name: str, text: str, *, agent_id: str | None = None) -> AgentProfile:
+    """Build a profile from markdown with frontmatter."""
+
+    meta, body = _split_frontmatter(text)
+
+    def _str(key: str) -> str:
+        value = meta.get(key)
+        return str(value).strip() if value is not None else ""
+
+    # ``delegate`` and ``may_delegate`` both work: the tag encoding on a
+    # registered profile spells it ``delegate:yes``, and a human editing a seed
+    # file should not have to remember which of the two spellings this parser
+    # happens to prefer.
+    delegate_raw = meta.get("delegate", meta.get("may_delegate", False))
+    if isinstance(delegate_raw, str):
+        may_delegate = delegate_raw.strip().lower() in {"1", "true", "yes", "on"}
+    else:
+        may_delegate = bool(delegate_raw)
+
+    return AgentProfile(
+        name=_str("name") or name,
+        description=_str("description"),
+        when_to_use=_str("when_to_use"),
+        instructions=body[:MAX_INSTRUCTIONS_CHARS],
+        tools=_as_tuple(meta.get("tools")),
+        effort=_str("effort") or None,
+        may_delegate=may_delegate,
+        agent_id=agent_id,
+        model=_str("model"),
+        hosting=_str("hosting"),
+    )
+
+
+# -- packaged seeds ---------------------------------------------------------
+
+
+def list_seeds() -> list[str]:
+    """Names of the packaged starter profiles, deterministically ordered.
+
+    Never raises: a missing or unreadable seeds directory means "no starters
+    available", which degrades to the operator writing their own, not to a
+    failed session.
+    """
+
+    try:
+        return sorted(path.stem for path in SEEDS_DIR.glob("*.md"))
+    except OSError:  # pragma: no cover - unreadable package dir
+        logger.warning("agent seed catalogue unreadable at %s", SEEDS_DIR)
+        return []
+
+
+def load_seed(name: str) -> AgentProfile | None:
+    """Read one packaged seed by name, or None when it does not exist.
+
+    The name is resolved against the catalogue rather than joined onto the
+    directory, so a caller passing ``../../etc/passwd`` gets None instead of a
+    path traversal.
+    """
+
+    key = (name or "").strip().lower()
+    if not key or key not in set(list_seeds()):
+        return None
+    try:
+        text = (SEEDS_DIR / f"{key}.md").read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        logger.warning("agent seed %s could not be read", key)
+        return None
+    return _profile_from_text(key, text)
+
+
+def seed_catalogue() -> list[AgentProfile]:
+    """Every packaged seed, for listing and for semantic routing."""
+
+    return [profile for profile in (load_seed(name) for name in list_seeds()) if profile]
+
+
+# -- registry-backed profiles ----------------------------------------------
+
+
+def _agent_instructions(registry: "AgentRegistry", agent: "AgentData") -> str:
+    """The agent's own ``system_prompt.md``, bounded, or ''.
+
+    Never raises: a profile whose instructions cannot be read still names a
+    valid role with a valid tool surface, and losing the delegation over a
+    read error would be a worse outcome than running it with less guidance.
+    """
+
+    try:
+        return (registry.get_agent_system_prompt(agent.id) or "")[:MAX_INSTRUCTIONS_CHARS]
+    except Exception:  # noqa: BLE001 - guidance is best-effort
+        logger.warning("could not read instructions for agent %s", agent.id)
+        return ""
+
+
+def _profile_from_agent(registry: "AgentRegistry", agent: "AgentData") -> AgentProfile:
+    """Convert a registered agent into a role profile.
+
+    ``when_to_use`` and the tool surface are carried in the agent's tags with a
+    ``key:value`` shape (``tools:read,grep`` / ``effort:lo`` / ``delegate:yes``)
+    because ``AgentData`` is a persisted, API-exposed model whose schema is
+    shared with the server routes and desktop UI: encoding two optional role
+    fields in tags keeps every existing profile, export archive, and client
+    valid, where adding columns would force a migration on all of them. The
+    ``when_to_use`` prose itself rides in ``description``, which is already the
+    semantic routing text.
+    """
+
+    tags = [str(tag) for tag in (agent.tags or [])]
+    tools: tuple[str, ...] | None = None
+    effort: str | None = None
+    may_delegate = False
+    for tag in tags:
+        key, sep, value = tag.partition(":")
+        if not sep:
+            continue
+        key = key.strip().lower()
+        value = value.strip()
+        if key == "tools":
+            tools = _as_tuple(value)
+        elif key == "effort":
+            effort = value or None
+        elif key == "delegate":
+            may_delegate = value.lower() in {"1", "true", "yes", "on"}
+
+    return AgentProfile(
+        name=agent.name,
+        description=str(agent.description or ""),
+        when_to_use=str(agent.description or ""),
+        instructions=_agent_instructions(registry, agent),
+        tools=tools,
+        effort=effort,
+        may_delegate=may_delegate,
+        agent_id=agent.id,
+        model=str(agent.model or ""),
+        hosting=str(agent.hosting or ""),
+    )
+
+
+def resolve_profile(
+    name: str | None,
+    *,
+    registry: Any = None,
+) -> AgentProfile | None:
+    """Resolve a role NAME to a profile: registry first, then packaged seeds.
+
+    Registry first is the whole point of making these editable — once an
+    operator has a ``reviewer`` of their own, theirs is the one that runs, and
+    the packaged seed of the same name becomes irrelevant rather than
+    competing with it.
+
+    Returns None for an unknown name. The caller decides what that means:
+    ``task`` treats it as "no role" and launches a full child rather than
+    failing, because the parent already decided the work should happen and a
+    typo in a role name is not a reason to lose the delegation.
+
+    ``registry`` is typed ``Any`` rather than ``AgentRegistry``: it is reached
+    through ``getattr`` off a session (whose host may attach any object that
+    answers the two methods used here), and every access below is already
+    guarded, so a narrower annotation would claim a coupling the code does not
+    actually require.
+    """
+
+    key = (name or "").strip()
+    if not key:
+        return None
+    if registry is not None:
+        try:
+            agent = registry.get_agent_by_name(key)
+        except Exception:  # noqa: BLE001 - registry problems must not fail a launch
+            agent = None
+            logger.warning("agent registry lookup failed for %r", key)
+        if agent is not None:
+            return _profile_from_agent(registry, agent)
+    return load_seed(key)
+
+
+def install_seed(
+    name: str,
+    *,
+    registry: "AgentRegistry",
+    overwrite: bool = False,
+) -> AgentProfile | None:
+    """Copy a packaged seed into the user's registry and return the profile.
+
+    This is the "readily available, pulled in as needed" step: seeds are not
+    installed at startup (an empty registry should stay empty until something
+    needs a role), so the first delegation that asks for a role the operator
+    has never created materializes it here, once, as an ordinary editable
+    registry row.
+
+    Idempotent: an existing agent of the same name is returned untouched
+    unless ``overwrite`` is set, so a concurrent second launch of the same role
+    cannot duplicate the profile or clobber edits the operator has made.
+    """
+
+    seed = load_seed(name)
+    if seed is None:
+        return None
+
+    from local_operator.agents import AgentEditFields
+
+    existing = None
+    try:
+        existing = registry.get_agent_by_name(seed.name)
+    except Exception:  # noqa: BLE001
+        existing = None
+    if existing is not None and not overwrite:
+        return _profile_from_agent(registry, existing)
+
+    tags = list(seed_tags(seed))
+    if existing is None:
+        # Every other field is explicitly None so the profile inherits the
+        # session's model and sampling settings: a seed pinning a model would
+        # silently override the operator's provider choice. Spelled out rather
+        # than defaulted because ``AgentEditFields`` is validated in strict
+        # mode, which is the convention every other caller here follows.
+        agent = registry.create_agent(
+            AgentEditFields(
+                name=seed.name,
+                description=seed.description or seed.when_to_use,
+                tags=tags,
+                categories=["role"],
+                security_prompt=None,
+                hosting=None,
+                model=None,
+                last_message=None,
+                temperature=None,
+                top_p=None,
+                top_k=None,
+                max_tokens=None,
+                stop=None,
+                frequency_penalty=None,
+                presence_penalty=None,
+                seed=None,
+                current_working_directory=None,
+            )
+        )
+    else:
+        agent = existing
+    registry.set_agent_system_prompt(agent.id, seed.instructions)
+    return _profile_from_agent(registry, agent)
+
+
+def seed_tags(profile: AgentProfile) -> tuple[str, ...]:
+    """The ``key:value`` tags encoding a profile's role fields.
+
+    Shared by seed installation and the ``agent`` tool so both write the exact
+    same encoding; two writers with two spellings is how a ``tools:`` tag would
+    later stop being read.
+    """
+
+    tags: list[str] = ["role"]
+    if profile.tools:
+        tags.append("tools:" + ",".join(profile.tools))
+    if profile.effort:
+        tags.append(f"effort:{profile.effort}")
+    if profile.may_delegate:
+        tags.append("delegate:yes")
+    return tuple(tags)
+
+
+#: Anything with a ``.name``; the tool types live in ``harness.types`` and
+#: importing them here would pull the tool layer into this module's graph.
+_ToolT = TypeVar("_ToolT")
+
+
+def filter_tools(tools: Sequence[_ToolT], profile: AgentProfile | None) -> list[_ToolT]:
+    """Filter a built tool inventory down to the profile's allowlist.
+
+    A profile naming a tool that does not exist in this session (an MCP tool
+    from another machine, a renamed builtin) simply matches nothing rather than
+    raising: the role still runs, with the tools it does have.
+    """
+
+    if profile is None or not profile.tools:
+        return list(tools)
+    allowed = set(profile.tools)
+    return [tool for tool in tools if getattr(tool, "name", None) in allowed]

--- a/local_operator/agent_profiles.py
+++ b/local_operator/agent_profiles.py
@@ -293,7 +293,7 @@ def is_role(agent: "AgentData") -> bool:
     return any(str(tag).strip().lower() == ROLE_TAG for tag in (agent.tags or []))
 
 
-def _profile_from_agent(registry: "AgentRegistry", agent: "AgentData") -> AgentProfile:
+def profile_from_agent(registry: "AgentRegistry", agent: "AgentData") -> AgentProfile:
     """Convert a registered agent into a role profile.
 
     ``when_to_use`` and the tool surface are carried in the agent's tags with a
@@ -367,13 +367,21 @@ def resolve_profile(
     if registry is not None:
         try:
             agent = registry.get_agent_by_name(key)
+            if agent is not None and not is_role(agent):
+                # An exact match that is NOT a role must not end the search.
+                # It used to, which reopened the very bug the fold was added
+                # for: with an ordinary agent named `reviewer` beside the
+                # operator's own `Reviewer` role, the exact hit was discarded
+                # as a non-role and the fold never ran, so the packaged seed
+                # silently shadowed the operator's role.
+                agent = None
             if agent is None:
                 # Case-insensitive retry, because ``load_seed`` folds case and
                 # an exact-only registry lookup would invert this function's
                 # whole point: ``task(agent="Reviewer")`` would find the
                 # PACKAGED seed while silently ignoring the operator's own
-                # ``Reviewer``. Exact match still wins; this only runs when it
-                # found nothing.
+                # ``Reviewer``. An exact ROLE match still wins; this only runs
+                # when the exact lookup yielded no role.
                 folded = key.casefold()
                 agent = next(
                     (
@@ -392,7 +400,7 @@ def resolve_profile(
         # ordinary chat agents, and honouring one of those would hand a child
         # the full write inventory under a role's name.
         if agent is not None and is_role(agent):
-            return _profile_from_agent(registry, agent)
+            return profile_from_agent(registry, agent)
     return load_seed(key)
 
 
@@ -434,7 +442,7 @@ def install_seed(
     if existing is not None and not is_role(existing) and not overwrite:
         raise NameTakenError(seed.name)
     if existing is not None and not overwrite:
-        return _profile_from_agent(registry, existing)
+        return profile_from_agent(registry, existing)
 
     tags = list(seed_tags(seed))
     if existing is None:
@@ -467,7 +475,7 @@ def install_seed(
     else:
         agent = existing
     registry.set_agent_system_prompt(agent.id, seed.instructions)
-    return _profile_from_agent(registry, agent)
+    return profile_from_agent(registry, agent)
 
 
 def seed_tags(profile: AgentProfile) -> tuple[str, ...]:

--- a/local_operator/agent_seeds/architect.md
+++ b/local_operator/agent_seeds/architect.md
@@ -1,0 +1,23 @@
+---
+name: architect
+description: "Explores a codebase and produces a design or technical proposal with trade-offs; may draft documents but never modifies existing source."
+when_to_use: "Deciding how to build something, comparing approaches, or writing an RFC/design doc before implementation starts."
+tools: read, glob, grep, list_variables, read_variable, bash, todo, write, web_search
+---
+
+You produce a design, not an implementation.
+
+You may read anything and draft new documents; you cannot modify existing
+source. Ground every recommendation in what the code ACTUALLY does — cite
+file:line — because a design built on an assumed architecture is worse than no
+design at all.
+
+State the trade-offs, then name the option you recommend and why. Where you are
+uncertain, say what evidence would settle it instead of hedging.
+
+Prefer the smallest change that solves the problem. Say so explicitly when the
+right answer is to do nothing, or to fix the existing thing rather than add a
+second one beside it.
+
+Your deliverable is the proposal: the problem as you found it, the options, the
+recommendation, and the risks you would want watched during rollout.

--- a/local_operator/agent_seeds/architect.md
+++ b/local_operator/agent_seeds/architect.md
@@ -1,7 +1,7 @@
 ---
 name: architect
 description: "Explores a codebase and produces a design or technical proposal with trade-offs; may draft documents but never modifies existing source."
-when_to_use: "Deciding how to build something, comparing approaches, or writing an RFC/design doc before implementation starts."
+when_to_use: "Deciding HOW to build something before writing it: comparing approaches or architectures, weighing trade-offs, planning a refactor, or writing an RFC or design document."
 tools: read, glob, grep, list_variables, read_variable, bash, todo, write, web_search
 ---
 

--- a/local_operator/agent_seeds/coder.md
+++ b/local_operator/agent_seeds/coder.md
@@ -1,0 +1,23 @@
+---
+name: coder
+description: "Implements one bounded slice of work end to end with the full toolset, then reports what changed and how it was verified."
+when_to_use: "An independent, well-specified implementation slice that can proceed without further decisions from the delegator."
+---
+
+You implement one bounded slice and report what you changed.
+
+Match the conventions already in the files you touch; a second way of doing
+something beside an established one is a defect. Comment the WHY and the
+constraint, never the what.
+
+Before you claim it works, exercise the real path — run the command, call the
+endpoint, load the page — and read the actual output. A green test proves the
+code does what you expected, not that the feature works.
+
+Do not expand the slice. If you find adjacent problems, note them in your
+report rather than fixing them: an unrequested change is one the delegator has
+to review without having asked for it.
+
+Your final message is the handoff: what changed, which files, what you verified
+and how, and anything you deliberately did not do. Keep it under 40 lines — the
+diff carries the detail.

--- a/local_operator/agent_seeds/coder.md
+++ b/local_operator/agent_seeds/coder.md
@@ -1,7 +1,7 @@
 ---
 name: coder
 description: "Implements one bounded slice of work end to end with the full toolset, then reports what changed and how it was verified."
-when_to_use: "An independent, well-specified implementation slice that can proceed without further decisions from the delegator."
+when_to_use: "Writing or changing code: implementing a ticket, building a feature, fixing a bug, adding a function — an independent, well-specified slice that can proceed without further decisions."
 ---
 
 You implement one bounded slice and report what you changed.

--- a/local_operator/agent_seeds/designer.md
+++ b/local_operator/agent_seeds/designer.md
@@ -1,0 +1,29 @@
+---
+name: designer
+description: "Design and UX review of a user-visible change, judged from rendered frames rather than source; reports D-prefixed findings."
+when_to_use: "A change alters something the user sees — a screen, a terminal UI, an email, a document — and needs a design/UX round."
+---
+
+You review the user-visible surface, not the implementation.
+
+Judge what the user SEES. Look at the rendered frame — a screenshot, a captured
+SVG, the live page — and never review a UI from source alone. If you have no
+rendered artifact, say so and ask for one rather than guessing; a design review
+of code you imagined rendering is worthless.
+
+Cover the states that actually break: loading, empty, error, populated, and the
+narrow or overflowing case. When something animates or settles, look at
+consecutive frames — a first frame that differs from the settled one is motion
+the user sees.
+
+Check alignment, spacing rhythm, contrast, focus order, and whether the copy
+says what it means. Back a visual claim with the geometry when you can: the
+still shows the symptom, the numbers show the cause.
+
+Use `D`-prefixed finding ids (D1, D2, ...) and the same severity ladder as a
+code review: BLOCKER, MAJOR, MINOR, NIT. Report at most 5 MINOR and 5 NIT — a
+long tail of nits buries the real problems and costs a remediation round to
+answer.
+
+End with a verdict. When no BLOCKER and no MAJOR remains, say the round is
+TERMINAL and record the rest as follow-ups.

--- a/local_operator/agent_seeds/designer.md
+++ b/local_operator/agent_seeds/designer.md
@@ -1,7 +1,7 @@
 ---
 name: designer
 description: "Design and UX review of a user-visible change, judged from rendered frames rather than source; reports D-prefixed findings."
-when_to_use: "A change alters something the user sees — a screen, a terminal UI, an email, a document — and needs a design/UX round."
+when_to_use: "Checking how something LOOKS to the user: reviewing a screen or terminal UI, whether a layout, spacing, colour or copy reads well, making an interface nicer — a design/UX round on a user-visible change."
 ---
 
 You review the user-visible surface, not the implementation.

--- a/local_operator/agent_seeds/manager.md
+++ b/local_operator/agent_seeds/manager.md
@@ -1,0 +1,23 @@
+---
+name: manager
+description: "Coordinates delegated work and reports honest status: what is done, what is in flight, what is blocked and on whom."
+when_to_use: "Tracking multi-part work across several agents or repositories, chasing blocked items, or producing a status roll-up."
+tools: read, glob, grep, list_variables, read_variable, bash, todo
+effort: lo
+delegate: yes
+---
+
+You coordinate and report. You do not implement.
+
+Track the work, chase what is blocked, and report status honestly: what is
+done, what is in flight, what is stuck and on whom.
+
+Never report progress you have not verified from a primary source — read the
+PR, run the status command, check the job. "The agent said it was done" is not
+verification; the merged commit or the passing pipeline is.
+
+Surface a slip early and plainly. A summary that hides a blocker to sound
+positive is the exact failure this role exists to prevent.
+
+Keep the roll-up short and scannable: status per item, then the blockers, then
+what you need a decision on. Detail belongs behind links, not in the summary.

--- a/local_operator/agent_seeds/manager.md
+++ b/local_operator/agent_seeds/manager.md
@@ -1,7 +1,7 @@
 ---
 name: manager
 description: "Coordinates delegated work and reports honest status: what is done, what is in flight, what is blocked and on whom."
-when_to_use: "Tracking multi-part work across several agents or repositories, chasing blocked items, or producing a status roll-up."
+when_to_use: "Coordinating and tracking multi-part work across several agents or repositories, chasing what is blocked, or producing a status roll-up or progress report."
 tools: read, glob, grep, list_variables, read_variable, bash, todo
 effort: lo
 delegate: yes

--- a/local_operator/agent_seeds/reviewer.md
+++ b/local_operator/agent_seeds/reviewer.md
@@ -1,0 +1,37 @@
+---
+name: reviewer
+description: "Independent code review of a diff, MR, or PR: finds defects, classifies them by severity, and never edits the code it reviews."
+when_to_use: "Reviewing a pull request, merge request, commit range, or patch; auditing a change someone else (or another agent) wrote."
+tools: read, glob, grep, list_variables, read_variable, bash, todo
+---
+
+You are an INDEPENDENT reviewer. You did not write this code.
+
+You cannot edit, write, or push — say what is wrong, do not fix it. If a fix is
+obvious, describe it in one line rather than producing a patch.
+
+Work in this order and stop when the budget is spent:
+
+1. Read the DIFF first (`git diff <base>..<head>`), not the file tree. The diff
+   is the review; the tree is context you fetch only where the diff is unclear.
+2. Open a file only when the diff cannot answer a specific question you can
+   state. Re-reading a file you have already read is nearly always waste.
+3. Verify what you can cheaply check — run the tests, run the command the
+   description claims works. A finding you reproduced outranks one you inferred.
+
+Classify EVERY finding, and be honest about severity:
+
+- **BLOCKER** — wrong, unsafe, or loses data. Ship it and something breaks.
+- **MAJOR** — a real defect or missing case that will bite, but not stop-ship.
+- **MINOR** — correctness-preserving improvement.
+- **NIT** — style, naming, wording.
+
+Report at most 5 MINOR and at most 5 NIT findings, the highest-value ones. A
+long tail of nits buries the blockers and costs a whole remediation round to
+answer. Prefer one precise finding with file:line evidence over three
+speculative ones. If you find nothing blocking, say so plainly — being
+agreeable is a failure mode, and so is padding a report to look thorough.
+
+End with a verdict. When no BLOCKER and no MAJOR remains, the verdict is
+`clean` and you state that the round is TERMINAL: remaining minors and nits are
+follow-ups, not a reason for another round.

--- a/local_operator/agent_seeds/reviewer.md
+++ b/local_operator/agent_seeds/reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: reviewer
 description: "Independent code review of a diff, MR, or PR: finds defects, classifies them by severity, and never edits the code it reviews."
-when_to_use: "Reviewing a pull request, merge request, commit range, or patch; auditing a change someone else (or another agent) wrote."
+when_to_use: "Reviewing a pull request, merge request, diff, commit range or patch for defects and bugs; auditing or critiquing code someone else (or another agent) wrote."
 tools: read, glob, grep, list_variables, read_variable, bash, todo
 ---
 

--- a/local_operator/agent_seeds/scout.md
+++ b/local_operator/agent_seeds/scout.md
@@ -1,7 +1,7 @@
 ---
 name: scout
 description: "Read-only research: investigates a question across the workspace and reports findings with file:line evidence. No side effects."
-when_to_use: "Answering a question about how something works, locating code, or gathering evidence, where nothing should be modified."
+when_to_use: "Answering a question about how something works, locating code, finding where a function or class is defined, tracing a flow, understanding existing behaviour, or gathering evidence — read-only, nothing is modified."
 tools: read, glob, grep, list_variables, read_variable
 effort: lo
 ---

--- a/local_operator/agent_seeds/scout.md
+++ b/local_operator/agent_seeds/scout.md
@@ -1,0 +1,21 @@
+---
+name: scout
+description: "Read-only research: investigates a question across the workspace and reports findings with file:line evidence. No side effects."
+when_to_use: "Answering a question about how something works, locating code, or gathering evidence, where nothing should be modified."
+tools: read, glob, grep, list_variables, read_variable
+effort: lo
+---
+
+You are a READ-ONLY research agent. Investigate, read, search, and report
+findings with file:line evidence; you cannot edit, write, or run anything.
+
+Answer the question you were asked. Resist mapping the whole system: the
+delegator wants the specific finding, not a tour, and every file you open that
+does not bear on the question is cost with no return.
+
+Say plainly when the evidence does not settle the question, and name what would
+settle it. A confident wrong answer is the expensive failure here — the
+delegator cannot tell it from a right one.
+
+Your final message is the deliverable. Lead with the answer, then the evidence
+that supports it.

--- a/local_operator/guides/agents/GUIDE.md
+++ b/local_operator/guides/agents/GUIDE.md
@@ -1,6 +1,6 @@
 ---
 name: agents
-description: "Use Local Operator agent profiles and subagents: discover, create, select, interact, delegate, and choose the correct collaboration mode."
+description: "Use Local Operator agent profiles, roles, and subagents: discover, create, select, interact, delegate, and choose the correct collaboration mode."
 ---
 
 # Agent profiles and subagents
@@ -47,12 +47,37 @@ Use the `task` tool when the current job contains an independent, well-bounded s
 - is one level deep and cannot spawn grandchildren
 - is ephemeral; it does not become a registered profile or keep durable specialist state
 
-Use `jobs` to inspect background work and `wait` only when no other useful work remains.
+## Roles: `task(agent=...)`
+
+`agent` names the ROLE a subagent runs as. A role supplies standing guidance and may restrict the child's tools, so the delegating prompt carries the TASK and the role carries how that kind of work is done well.
+
+```
+task(label="review-135", prompt="Review PR #135 ...", agent="reviewer")
+```
+
+Roles resolve from the operator's registry first, then from packaged starters (`reviewer`, `coder`, `architect`, `manager`, `designer`, `scout`). An unknown name is not an error: it launches an ordinary full child.
+
+A role's tool allowlist is a capability boundary, not advice. A `reviewer` has no `edit`/`write` — it reads and runs tests but cannot alter what it reviews, which is what stops a reviewer from silently reviewing its own patch. Roles that do not coordinate also lose `task`/`wait`/`jobs`.
+
+Use the `agent` tool to work with roles:
+
+- `search` — which role fits a task, by meaning. Use it when you are about to delegate something specialized and are not sure a role exists.
+- `list` / `show` — what exists, and what a role actually says.
+- `install` — pull a packaged starter into the registry on first need.
+- `create` / `update` — author a role, or FIX one whose guidance produced a bad run. Write `description` as the trigger condition ("reviewing a merge request"), not as a job title, because that text is what `search` matches.
+
+When a delegated run goes wrong in a way the role should have prevented, update the role rather than only patching this one prompt. That is the mechanism by which review guidance improves instead of being re-derived every time.
+
+## Awaiting delegated work
+
+`wait` returns the moment a job settles, so prefer ONE generous wait over repeated short ones — a short budget does not make the result arrive sooner, it just costs a model round trip to learn the work is still running. Pass a LIST of job ids to wake on the first of several to finish, which is how to await a fan-out without polling each child in turn.
+
+Use `jobs` to inspect background work, and `hub` to question or steer a running child rather than cancelling and relaunching it.
 
 ## Selection rule
 
 - Existing specialist with relevant durable instructions or state: list the registry, inspect the descriptions, then run that registered agent.
-- Independent slice of the current task: spawn a task subagent.
+- Independent slice of the current task: spawn a task subagent, with a role when one fits.
 - Work that shares mutable decisions or must happen in order: keep it in the current agent rather than paying coordination overhead.
 - No clear specialization or concurrency benefit: do not delegate.
 

--- a/local_operator/harness/jobs.py
+++ b/local_operator/harness/jobs.py
@@ -170,6 +170,14 @@ class AsyncJobManager:
         self._tasks: dict[str, asyncio.Task[None]] = {}
         self._sinks: dict[str, DeliverySink] = {}
         self._queued_runners: dict[str, JobRunFn] = {}
+        # One event per job, set exactly once when the job settles. This is
+        # what lets ``wait`` sleep until there is news instead of re-checking
+        # a status field on a timer: a 50 ms poll loop wakes 6000 times over a
+        # five-minute wait, and every one of those wakeups runs on the SAME
+        # event loop that serves the parent turn, every sibling subagent, and
+        # the TUI repaint. Created lazily (most jobs are never waited on) and
+        # dropped by the retention sweep with the job row.
+        self._settled_events: dict[str, asyncio.Event] = {}
 
     # -- queries ------------------------------------------------------------
 
@@ -367,6 +375,12 @@ class AsyncJobManager:
         self._tasks.clear()
         self._sinks.clear()
         self._queued_runners.clear()
+        # Wake anything still parked on a job before dropping the events: a
+        # waiter that outlives dispose must observe "settled" (cancel() set
+        # each event on its way through) rather than sleeping to its deadline
+        # against a manager that will never run again.
+        for event in self._settled_events.values():
+            event.set()
 
     # -- internals ----------------------------------------------------------
 
@@ -451,10 +465,37 @@ class AsyncJobManager:
         if self._on_job_complete is not None:
             await self._maybe_await(self._on_job_complete(job.id, text, job))
 
+    def settled_event(self, job_id: str) -> asyncio.Event:
+        """The event set when ``job_id`` settles, created on first request.
+
+        Pre-set for a job that has ALREADY settled (including one this manager
+        has never heard of, which cannot ever settle): a waiter that arrives
+        after the transition must not block forever on news that already
+        happened. This is the race the poll loop hid by re-reading status.
+        """
+
+        event = self._settled_events.get(job_id)
+        if event is None:
+            event = asyncio.Event()
+            self._settled_events[job_id] = event
+        job = self._jobs.get(job_id)
+        if job is None or job.status != "running":
+            event.set()
+        return event
+
     def _settle(self, job: AsyncJob) -> None:
-        """Record the settle timestamp on the status transition (idempotent)."""
+        """Record the settle timestamp on the status transition (idempotent).
+
+        Also wakes every waiter. This is the ONE place a job becomes settled,
+        which is why the notification belongs here rather than beside each of
+        the three call sites: a future fourth transition would otherwise leave
+        its waiters asleep until their deadline.
+        """
         if job.settled_at is None:
             job.settled_at = time.time()
+        event = self._settled_events.get(job.id)
+        if event is not None:
+            event.set()
 
     def _sweep_due(self) -> None:
         """Drop settled jobs older than the retention window.
@@ -472,6 +513,7 @@ class AsyncJobManager:
             del self._jobs[job_id]
             self._signals.pop(job_id, None)
             self._tasks.pop(job_id, None)
+            self._settled_events.pop(job_id, None)
 
     @staticmethod
     async def _maybe_await(value: Any) -> Any:

--- a/local_operator/harness/jobs.py
+++ b/local_operator/harness/jobs.py
@@ -474,12 +474,20 @@ class AsyncJobManager:
         happened. This is the race the poll loop hid by re-reading status.
         """
 
+        job = self._jobs.get(job_id)
+        if job is None:
+            # No row: nothing will ever settle this id, so hand back a pre-set
+            # event WITHOUT storing it. Storing one would strand an entry that
+            # no cleanup path can reach — ``_sweep_due`` only pops ids it finds
+            # in ``self._jobs``, and this id is by definition not one of them.
+            settled = asyncio.Event()
+            settled.set()
+            return settled
         event = self._settled_events.get(job_id)
         if event is None:
             event = asyncio.Event()
             self._settled_events[job_id] = event
-        job = self._jobs.get(job_id)
-        if job is None or job.status != "running":
+        if job.status != "running":
             event.set()
         return event
 

--- a/local_operator/harness/subagent.py
+++ b/local_operator/harness/subagent.py
@@ -91,6 +91,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Awaitable, Callable
 
+from local_operator.agent_profiles import filter_tools
 from local_operator.harness.intent import (
     ACTIVITY_RESPONDING,
     ACTIVITY_THINKING,
@@ -115,6 +116,7 @@ from local_operator.harness.types import (
 from local_operator.paths import config_dir
 
 if TYPE_CHECKING:
+    from local_operator.agent_profiles import AgentProfile
     from local_operator.harness.jobs import AsyncJobManager
     from local_operator.mcp.manager import McpManager
     from local_operator.session.session import Session
@@ -133,16 +135,47 @@ TRAJECTORY_CAP = 500
 #: side effects at all (browser drives the user's browser; eval executes
 #: code; both are excluded by name for that reason even where a tier alone
 #: would admit them).
+#:
+#: Kept as the FALLBACK for ``agent="scout"`` when no profile resolves (a
+#: stripped install with no packaged seeds, a registry that cannot be read):
+#: the read-only promise is a safety property, so it must not depend on a file
+#: being present. Role guidance generally lives in
+#: :mod:`local_operator.agent_profiles`.
 SCOUT_TOOL_ALLOWLIST = frozenset({"read", "glob", "grep", "list_variables", "read_variable"})
 
-#: Preamble stamped onto every scout prompt. The tool filter enforces the
-#: letter; this states the intent, so the scout REPORTS rather than trying to
-#: route around its missing tools.
+#: Preamble stamped onto a scout prompt when no profile resolves. The tool
+#: filter enforces the letter; this states the intent, so the scout REPORTS
+#: rather than trying to route around its missing tools.
 SCOUT_PREAMBLE = (
     "[scout mode: you are a READ-ONLY research agent. Investigate, read, "
     "search, and report findings with file:line evidence; you cannot edit, "
     "write, or run anything. Your final message is the deliverable.]\n\n"
 )
+
+
+def _resolve_role(agent: str, parent_session: "Session") -> "AgentProfile | None":
+    """The profile for ``agent``, or None for a plain full child.
+
+    ``"task"`` is the no-role default and never resolves, so the common launch
+    pays no registry lookup at all. Anything else is looked up in the
+    operator's registry first and then in the packaged starters, which is what
+    lets ``task(agent="reviewer")`` work on a machine where nobody has authored
+    a reviewer while still preferring the operator's own once they have.
+
+    Never raises: an unresolvable role degrades to a full child, because the
+    parent already decided the work should happen and a typo in a role name is
+    not a reason to lose the delegation.
+    """
+
+    if not agent or agent == "task":
+        return None
+    try:
+        from local_operator.agent_profiles import resolve_profile
+
+        return resolve_profile(agent, registry=getattr(parent_session, "agent_registry", None))
+    except Exception:  # noqa: BLE001 - role guidance is enrichment, not a gate
+        logger.warning("could not resolve agent role %r; launching a full child", agent)
+        return None
 
 
 def run_subagent(
@@ -219,7 +252,15 @@ def _make_runner(
     # accessors. ``_emit`` gives the parent's isolated handler fan-out.
     emit = parent_session._emit
     comms = getattr(parent_session, "subagent_comms", None)
-    effective_prompt = SCOUT_PREAMBLE + prompt if agent == "scout" else prompt
+    # Resolved ONCE per launch, not per turn: the profile decides the child's
+    # preamble and tool surface, both of which are fixed for the run.
+    profile = _resolve_role(agent, parent_session)
+    if profile is not None:
+        effective_prompt = profile.preamble + prompt
+    elif agent == "scout":
+        effective_prompt = SCOUT_PREAMBLE + prompt
+    else:
+        effective_prompt = prompt
 
     async def runner(
         job_id: str, signal: Any, report_progress: Callable[[str], None]
@@ -242,6 +283,7 @@ def _make_runner(
                 job_id=job_id,
                 resume_dir=resume_dir,
                 agent=agent,
+                profile=profile,
             )
             if job is not None:
                 # Off the CHILD, not the parent: ``model_spec`` may have put
@@ -617,9 +659,16 @@ async def _build_child_session(
     job_id: str,
     resume_dir: "Path | None" = None,
     agent: str = "task",
+    profile: "AgentProfile | None" = None,
 ) -> "Session":
     """Compose the child Session directly (see module docstring for why the
-    factory is not reused, and for the full inherit/do-not-inherit list)."""
+    factory is not reused, and for the full inherit/do-not-inherit list).
+
+    ``profile`` is the resolved role (see :func:`_resolve_role`), passed in
+    rather than re-resolved here so one launch performs exactly one registry
+    lookup and the prompt the caller stamped cannot disagree with the tool
+    surface applied here.
+    """
     from datetime import datetime
 
     from local_operator.config import ConfigManager
@@ -693,15 +742,28 @@ async def _build_child_session(
         request_approval=request_approval,
         resolve_internal_url=resolve_internal_url,
         subagent_comms=getattr(parent_session, "subagent_comms", None),
+        # The child can work with roles too (look one up, or record what it
+        # learned about a bad one), and role resolution for its OWN launches
+        # needs the same registry the parent used.
+        agent_registry=getattr(parent_session, "agent_registry", None),
         web_search_settings=ConfigManager(config_dir()).get_config_value("web_search", None),
     )
     tools = create_tools(tool_context)
-    if agent == "scout":
-        # Scouts get lookups only — MCP tools execute arbitrary server calls,
-        # so they are excluded from the allowlist filter entirely rather than
-        # trusted per tool.
+    # A role's tool allowlist is a capability boundary, not advice: a reviewer
+    # that cannot call ``edit`` cannot "helpfully" fix what it was asked to
+    # review and thereby end up reviewing its own patch.
+    restricted = profile is not None and bool(profile.tools)
+    if restricted:
+        tools = filter_tools(tools, profile)
+    elif agent == "scout":
+        # Fallback for a scout with no resolvable profile — the read-only
+        # promise must not depend on a seed file being present.
         tools = [tool for tool in tools if tool.name in SCOUT_TOOL_ALLOWLIST]
-    if mcp is not None and agent != "scout":
+        restricted = True
+    # MCP tools execute arbitrary server calls, so a role filtered to an
+    # allowlist never receives them: they are excluded wholesale rather than
+    # trusted per tool, since the allowlist cannot name servers it has not met.
+    if mcp is not None and not restricted:
         tools = tools + mcp.tools
 
     def system_blocks_provider() -> list[str]:
@@ -762,6 +824,10 @@ async def _build_child_session(
         # The parent's variable store: same cwd, same config overrides, so a
         # child reading a variable must see exactly what its parent would.
         variables=parent_session._variables,
+        # The same registry the parent resolves roles against, so a child that
+        # delegates (a manager) or inspects a role sees the operator's profiles
+        # rather than falling back to the packaged starters.
+        agent_registry=getattr(parent_session, "agent_registry", None),
         skill_resolver=resolve_internal_url,
         # How the transcript renders into LLM messages. Today every host uses
         # the default, so this changes nothing; it is plumbed because a host
@@ -803,7 +869,12 @@ async def _build_child_session(
     # hook and it keeps the loop's ``context.tools`` in step.
     merged_in = {tool.name for tool in child._tools} - {tool.name for tool in tools}
     parent_is_child = parent_session._job_id is not None
-    if agent == "scout" or parent_is_child:
+    # A role that does not delegate loses the whole capability set, for the
+    # same reason a scout does: a reviewer or coder spawning its own children
+    # turns one delegated slice into a fan-out nobody is watching. Roles that
+    # coordinate (``delegate: yes``) keep it.
+    role_forbids_delegation = profile is not None and not profile.may_delegate
+    if agent == "scout" or parent_is_child or role_forbids_delegation:
         drop = merged_in
     else:
         drop = {name for name in merged_in if name == "wake"}

--- a/local_operator/harness/types.py
+++ b/local_operator/harness/types.py
@@ -391,6 +391,15 @@ class JobManagerProtocol(Protocol):
 
     async def cancel(self, job_id: str, *, owner_id: str | None = None) -> bool: ...
 
+    # ``settled_event(job_id) -> asyncio.Event`` is deliberately NOT declared
+    # here. This Protocol is ``runtime_checkable`` and ``ToolContext.jobs``
+    # validates against it, so every method added becomes mandatory for every
+    # existing implementation — a host (or a test double) written against the
+    # older surface would stop validating the moment this shipped. ``wait``
+    # therefore probes for it with ``getattr`` and falls back to polling, which
+    # keeps the optimization opt-in for third-party managers rather than
+    # breaking them. See ``tools.builtin._await_any_settled``.
+
 
 @runtime_checkable
 class SubagentLauncher(Protocol):
@@ -549,6 +558,14 @@ class ToolContext(BaseModel):
     # (createIf) rather than advertised and always failing — the same
     # convention ``wake_scheduler`` uses.
     subagent_launcher: "SubagentLauncher | None" = None
+    # The user's persistent agent registry (``local_operator.agents``), behind
+    # the ``agent`` tool and behind role resolution for ``task(agent=...)``.
+    # Typed ``Any`` because that module is heavy (dill, yaml, the whole agent
+    # state machine) and importing it here would pull it into every process
+    # that merely wants a tool type. ``None`` means the host keeps no registry:
+    # the ``agent`` tool is then not advertised (createIf) and delegation falls
+    # back to packaged starter profiles.
+    agent_registry: Any = None
     # The session's background job manager. Declared as a Protocol because
     # the concrete class lives in ``harness.jobs``, which imports this
     # module (import cycle). The ``wait``/``job`` tools read it; ``None``

--- a/local_operator/prompts_md/system.md
+++ b/local_operator/prompts_md/system.md
@@ -79,9 +79,16 @@ or `drop` what is no longer needed.
 
 `task` delegates to subagents that run in the background — one, or a whole
 batch of independent slices in a single call (`tasks` + a shared `context`
-stating the goal and constraints once). `agent="scout"` is a read-only
-research child for investigation; `effort` picks a configured model tier.
-`jobs` lists what is running and `wait` blocks for a result. A
+stating the goal and constraints once). `agent` names the child's ROLE
+(`reviewer`, `coder`, `architect`, `manager`, `designer`, `scout`, or one from
+the `agent` tool): it carries vetted guidance and may restrict tools, so your
+prompt states the TASK and the role supplies how that work is done well. Use
+`agent="reviewer"` instead of hand-writing review instructions, and when a
+role's guidance proves wrong, fix it with the `agent` tool rather than
+patching one prompt. `effort` picks a configured model tier.
+`jobs` lists what is running and `wait` blocks for a result — it returns the
+moment work settles, so prefer one generous wait over repeated short ones, and
+pass a LIST of job ids to wake on the first of several to finish. A
 running subagent is not out of reach: `hub` sends it a note, asks it a
 question and waits for its answer (use that when one has gone quiet rather
 than guessing whether it is stuck), steers it onto a different course,

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -514,6 +514,14 @@ class Session:
         #: delegated to it. Held here for the ``_build_tool_context`` reason
         #: above: a rebuilt context must keep pointing at the same instance.
         subagent_comms: Any | None = None,
+        #: The user's persistent agent registry, when the host keeps one. Two
+        #: readers: the ``agent`` tool (list/author role profiles) and role
+        #: resolution for ``task(agent=...)``. Held on the session for the
+        #: ``_build_tool_context`` reason above, and typed ``Any`` to keep the
+        #: heavy ``local_operator.agents`` module out of this import graph.
+        #: ``None`` means no registry: the ``agent`` tool is not advertised and
+        #: delegation falls back to the packaged starter profiles.
+        agent_registry: Any | None = None,
         conversation_name: ConversationName | None = None,
         system_blocks_provider: Callable[[], list[str]] | Callable[[], Awaitable[list[str]]],
     ) -> None:
@@ -535,6 +543,7 @@ class Session:
         self._variables = variables
         self._job_id = job_id
         self._subagent_comms = subagent_comms
+        self.agent_registry = agent_registry
         # The conversation's title. A holder rather than a plain string for
         # the same reason the goal is one: the title arrives on a DETACHED
         # naming task after the host already built its status chrome, and
@@ -1571,6 +1580,7 @@ class Session:
             subagent_comms=self.subagent_comms,
             variables=self._variables,
             job_id=self._job_id,
+            agent_registry=self.agent_registry,
             delegated_tools={
                 tool.name: tool for tool in self._tools if tool.name.startswith("mcp__")
             },
@@ -1606,8 +1616,25 @@ class Session:
         )
 
     def _resolve_subagent_model(self, agent: str, effort: str | None) -> ModelSpec | None:
-        """Effort tier -> ModelSpec via config; None keeps the parent's model."""
-        wanted = effort or ("lo" if agent == "scout" else None)
+        """Effort tier -> ModelSpec via config; None keeps the parent's model.
+
+        Precedence: an explicit ``effort`` on the launch beats the role's own
+        default, which beats the session model. That order is what lets a role
+        say "this job is usually cheap" while a caller who knows this instance
+        is hard can still pay for the better model.
+        """
+        wanted = effort
+        if wanted is None and agent and agent != "task":
+            try:
+                from local_operator.agent_profiles import resolve_profile
+
+                profile = resolve_profile(agent, registry=self.agent_registry)
+            except Exception:  # noqa: BLE001 - tier lookup must not fail a spawn
+                profile = None
+            if profile is not None:
+                wanted = profile.effort
+        if wanted is None and agent == "scout":
+            wanted = "lo"
         if wanted is None:
             return None
         try:

--- a/local_operator/session_factory.py
+++ b/local_operator/session_factory.py
@@ -1008,6 +1008,9 @@ async def _prepare(
         has_ui=has_ui,
         request_approval=request_approval,
         variables=variable_store,
+        # Role profiles and the ``agent`` tool are backed by this registry; a
+        # host without one keeps working off the packaged starters.
+        agent_registry=agent_registry,
         web_search_settings=config_manager.get_config_value("web_search", None),
     )
     tools = create_tools(tool_context)
@@ -1087,6 +1090,7 @@ async def _prepare(
         request_approval=request_approval,
         goal_state=goal_state,
         variables=variable_store,
+        agent_registry=agent_registry,
     )
     return _SessionPlan(
         session_kwargs=session_kwargs,

--- a/local_operator/tools/agent_tool.py
+++ b/local_operator/tools/agent_tool.py
@@ -1,0 +1,433 @@
+"""The ``agent`` tool: discover, create, and refine reusable agent profiles.
+
+WHY A TOOL RATHER THAN A FIXED TABLE
+====================================
+
+Roles (reviewer, coder, architect, manager, ...) are not harness constants.
+Which roles exist, what they are told, and when they apply differ per operator
+and per repository, and the guidance only improves if whoever notices it was
+wrong can change it — including an agent, mid-session, right after the bad
+delegation that revealed the gap.
+
+So the profiles live in the user's own agent registry
+(:mod:`local_operator.agents`), the harness ships a handful of starter profiles
+as ordinary editable markdown (:mod:`local_operator.agent_profiles`), and this
+tool is how an agent works with them:
+
+- ``list`` / ``show`` — what roles exist and what they say.
+- ``search`` — which existing role fits a task, by meaning rather than by
+  exact name, over the same local embedding index that routes skills.
+- ``install`` — pull a packaged starter into the registry on first need, so a
+  fresh machine can delegate to a ``reviewer`` without the operator having
+  authored one.
+- ``create`` / ``update`` — author a new role, or fix one whose instructions
+  produced a bad run. ``when_to_use`` is stored as the routing description, so
+  a role written today is discoverable by ``search`` tomorrow.
+
+CONTEXT DISCIPLINE
+==================
+
+The registry is NEVER enumerated into the prompt: it can be large and its
+descriptions are private user content. ``list`` returns one line per profile
+and only when called; ``show`` is the only op that returns a full instruction
+body. This mirrors how skills are handled — semantic routing decides what is
+relevant, and the body loads on demand.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+from local_operator.agent_profiles import (
+    MAX_INSTRUCTIONS_CHARS,
+    AgentProfile,
+    install_seed,
+    list_seeds,
+    load_seed,
+    seed_tags,
+)
+from local_operator.harness.types import (
+    AbortSignal,
+    AgentTool,
+    AgentToolUpdate,
+    ToolContext,
+    ToolResult,
+)
+from local_operator.tools.builtin import (
+    _error,
+    _text,
+    _validation_error,
+    spill_truncate,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class AgentParams(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    op: Literal["list", "show", "search", "install", "create", "update"] = Field(
+        description=(
+            "search: find a role by meaning; list/show: what exists and what it "
+            "says; install: add a packaged starter; create/update: author or fix "
+            "a role."
+        )
+    )
+    name: str | None = Field(default=None, description="Role name (all ops but search).")
+    query: str | None = Field(default=None, description="search: the task, in a sentence.")
+    description: str | None = Field(
+        default=None,
+        description=(
+            "create/update: when to use this role. Semantic routing matches this, "
+            "so write the trigger condition, not a job title."
+        ),
+    )
+    instructions: str | None = Field(
+        default=None,
+        description=(
+            "create/update: standing guidance prepended to every run of the role. "
+            "Imperative and short — it is billed on each of that role's turns."
+        ),
+    )
+    tools: list[str] | None = Field(
+        default=None,
+        description="create/update: restrict the role to these tools. Omit for all.",
+    )
+    effort: str | None = Field(
+        default=None, description="create/update: default model tier (lo/med/hi)."
+    )
+
+
+def _profile_line(profile: AgentProfile, *, installed: bool) -> str:
+    """One scannable row: name, where it came from, and what it is for."""
+
+    marks: list[str] = [] if installed else ["starter"]
+    if profile.tools:
+        marks.append(f"{len(profile.tools)} tools")
+    if profile.effort:
+        marks.append(profile.effort)
+    suffix = f" [{', '.join(marks)}]" if marks else ""
+    summary = (profile.when_to_use or profile.description or "").strip()
+    return f"- {profile.name}{suffix}: {summary}"[:400]
+
+
+def _registry(context: ToolContext | None) -> Any:
+    return getattr(context, "agent_registry", None) if context else None
+
+
+def _registered_profiles(registry: Any) -> list[AgentProfile]:
+    """Registry rows that carry a role, newest listing order aside.
+
+    Only profiles tagged ``role`` are returned. A registry also holds ordinary
+    conversational agents and autosave rows, and listing those as delegation
+    targets would be noise at best and a privacy leak at worst.
+    """
+
+    from local_operator.agent_profiles import _profile_from_agent
+
+    try:
+        agents = registry.list_agents()
+    except Exception:  # noqa: BLE001 - registry problems degrade to "no roles"
+        logger.warning("agent registry listing failed")
+        return []
+    profiles: list[AgentProfile] = []
+    for agent in agents:
+        tags = {str(tag).strip().lower() for tag in (agent.tags or [])}
+        if "role" not in tags:
+            continue
+        try:
+            profiles.append(_profile_from_agent(registry, agent))
+        except Exception:  # noqa: BLE001
+            continue
+    return sorted(profiles, key=lambda profile: profile.name.lower())
+
+
+async def _op_list(context: ToolContext | None, tool_call_id: str) -> ToolResult:
+    registry = _registry(context)
+    installed = _registered_profiles(registry) if registry is not None else []
+    installed_names = {profile.name.lower() for profile in installed}
+    lines = [_profile_line(profile, installed=True) for profile in installed]
+    starters = [
+        profile
+        for profile in (load_seed(name) for name in list_seeds())
+        if profile is not None and profile.name.lower() not in installed_names
+    ]
+    body = ""
+    if lines:
+        body += "registered roles:\n" + "\n".join(lines)
+    if starters:
+        if body:
+            body += "\n\n"
+        body += "installable starters (op='install'):\n" + "\n".join(
+            _profile_line(profile, installed=False) for profile in starters
+        )
+    if not body:
+        body = "no roles registered and no starters packaged."
+    text, spill = spill_truncate(body, "agent", context)
+    return _text(tool_call_id, "agent", text, details=spill or None)
+
+
+async def _op_show(context: ToolContext | None, tool_call_id: str, name: str) -> ToolResult:
+    from local_operator.agent_profiles import resolve_profile
+
+    profile = resolve_profile(name, registry=_registry(context))
+    if profile is None:
+        return _error(tool_call_id, "agent", f"no role named {name!r} (try op='list')")
+    origin = "registered" if profile.agent_id else "packaged starter (not installed)"
+    header = [
+        f"{profile.name} — {origin}",
+        f"when to use: {profile.when_to_use or profile.description or '(unstated)'}",
+        f"tools: {', '.join(profile.tools) if profile.tools else 'full inventory'}",
+    ]
+    if profile.effort:
+        header.append(f"effort: {profile.effort}")
+    body = "\n".join(header) + "\n\ninstructions:\n" + (profile.instructions or "(none)")
+    text, spill = spill_truncate(body, "agent", context)
+    return _text(tool_call_id, "agent", text, details=spill or None)
+
+
+async def _op_search(context: ToolContext | None, tool_call_id: str, query: str) -> ToolResult:
+    """Rank roles against a task description.
+
+    Uses the offline :class:`LocalEmbedder` over the same index used for
+    skills, so a role added a minute ago is searchable without a rebuild step
+    and no registry text ever leaves the machine.
+    """
+
+    from local_operator.skills.discovery import Skill
+    from local_operator.skills.embeddings import LocalEmbedder
+    from local_operator.skills.index import SkillIndex
+
+    registry = _registry(context)
+    candidates = _registered_profiles(registry) if registry is not None else []
+    known = {profile.name.lower() for profile in candidates}
+    candidates += [
+        profile
+        for profile in (load_seed(name) for name in list_seeds())
+        if profile is not None and profile.name.lower() not in known
+    ]
+    if not candidates:
+        return _text(tool_call_id, "agent", "no roles available to search.")
+
+    rows = [
+        Skill(
+            name=profile.name,
+            description=(profile.when_to_use or profile.description or profile.name)[:512],
+            file_path=__import__("pathlib").Path(f"{profile.name}.md"),
+            base_dir=__import__("pathlib").Path("."),
+            source="agent-profile",
+            resource_type="agent_hint",
+        )
+        for profile in candidates
+    ]
+    by_name = {profile.name: profile for profile in candidates}
+    try:
+        index = SkillIndex(rows, LocalEmbedder())
+        await index.build()
+        picked = await index.select(query, k=3)
+    except Exception as exc:  # noqa: BLE001 - degrade to listing, never fail
+        logger.warning("role search failed: %s", exc)
+        picked = rows[:3]
+    if not picked:
+        return _text(
+            tool_call_id,
+            "agent",
+            "no role matched that task closely; use op='list' or launch task without a role.",
+        )
+    lines = []
+    for row in picked:
+        profile = by_name.get(row.name)
+        if profile is None:
+            continue
+        lines.append(_profile_line(profile, installed=bool(profile.agent_id)))
+    return _text(
+        tool_call_id,
+        "agent",
+        "best matching roles:\n" + "\n".join(lines) + "\n\nlaunch with task(agent='<name>').",
+    )
+
+
+async def _op_install(context: ToolContext | None, tool_call_id: str, name: str) -> ToolResult:
+    registry = _registry(context)
+    if registry is None:
+        return _error(
+            tool_call_id, "agent", "no agent registry attached to this session; cannot install."
+        )
+    if load_seed(name) is None:
+        return _error(
+            tool_call_id,
+            "agent",
+            f"no packaged starter named {name!r}; starters: {', '.join(list_seeds())}",
+        )
+    profile = install_seed(name, registry=registry)
+    if profile is None:
+        return _error(tool_call_id, "agent", f"could not install starter {name!r}")
+    return _text(
+        tool_call_id,
+        "agent",
+        f"installed role {profile.name!r} into the registry; "
+        f"launch with task(agent={profile.name!r}). Edit it with op='update'.",
+    )
+
+
+async def _op_write(
+    context: ToolContext | None,
+    tool_call_id: str,
+    params: AgentParams,
+    *,
+    creating: bool,
+) -> ToolResult:
+    from local_operator.agents import AgentEditFields
+
+    registry = _registry(context)
+    if registry is None:
+        return _error(
+            tool_call_id, "agent", "no agent registry attached to this session; cannot save roles."
+        )
+    name = (params.name or "").strip()
+    try:
+        existing = registry.get_agent_by_name(name)
+    except Exception:  # noqa: BLE001
+        existing = None
+
+    if creating and existing is not None:
+        return _error(
+            tool_call_id,
+            "agent",
+            f"role {name!r} already exists; use op='update' to change it.",
+        )
+    if not creating and existing is None:
+        return _error(tool_call_id, "agent", f"no registered role named {name!r} to update.")
+
+    instructions = (params.instructions or "").strip()
+    if creating and not instructions:
+        return _error(tool_call_id, "agent", "create needs 'instructions' — the role's guidance.")
+    if len(instructions) > MAX_INSTRUCTIONS_CHARS:
+        return _error(
+            tool_call_id,
+            "agent",
+            f"instructions exceed {MAX_INSTRUCTIONS_CHARS} chars; they ride in front of every "
+            "run of this role, so they must stay short.",
+        )
+
+    profile = AgentProfile(
+        name=name,
+        description=(params.description or "").strip(),
+        when_to_use=(params.description or "").strip(),
+        instructions=instructions,
+        tools=tuple(params.tools) if params.tools else None,
+        effort=(params.effort or "").strip() or None,
+    )
+    tags = list(seed_tags(profile))
+
+    # Every field is spelled out (``AgentEditFields`` is validated in strict
+    # mode, and every other caller in the tree does the same): a role inherits
+    # the session's model and sampling settings rather than pinning any.
+    def _fields(**overrides: Any) -> AgentEditFields:
+        base: dict[str, Any] = dict(
+            name=None,
+            description=None,
+            tags=None,
+            categories=None,
+            security_prompt=None,
+            hosting=None,
+            model=None,
+            last_message=None,
+            temperature=None,
+            top_p=None,
+            top_k=None,
+            max_tokens=None,
+            stop=None,
+            frequency_penalty=None,
+            presence_penalty=None,
+            seed=None,
+            current_working_directory=None,
+        )
+        base.update(overrides)
+        return AgentEditFields(**base)
+
+    if existing is None:
+        agent = registry.create_agent(
+            _fields(name=name, description=profile.description, tags=tags, categories=["role"])
+        )
+    else:
+        agent = existing
+        # An update carries only what changed: passing a None description here
+        # would blank the routing text a previous create had set.
+        overrides: dict[str, Any] = {"tags": tags}
+        if profile.description:
+            overrides["description"] = profile.description
+        registry.update_agent(agent.id, _fields(**overrides))
+    if instructions:
+        registry.set_agent_system_prompt(agent.id, instructions)
+    verb = "created" if existing is None else "updated"
+    return _text(
+        tool_call_id,
+        "agent",
+        f"{verb} role {name!r}; launch with task(agent={name!r}).",
+    )
+
+
+async def execute_agent(
+    tool_call_id: str,
+    args: dict[str, Any],
+    signal: AbortSignal | None = None,
+    on_update: Callable[[AgentToolUpdate], None] | None = None,
+    context: ToolContext | None = None,
+) -> ToolResult:
+    """Discover, install, and author reusable agent role profiles."""
+
+    try:
+        params = AgentParams(**args)
+    except ValidationError as exc:
+        return _validation_error(tool_call_id, "agent", exc)
+
+    if params.op in {"show", "install", "create", "update"} and not (params.name or "").strip():
+        return _error(tool_call_id, "agent", f"op={params.op!r} needs 'name'.")
+    if params.op == "search" and not (params.query or "").strip():
+        return _error(tool_call_id, "agent", "op='search' needs 'query'.")
+
+    if params.op == "list":
+        return await _op_list(context, tool_call_id)
+    if params.op == "show":
+        return await _op_show(context, tool_call_id, str(params.name))
+    if params.op == "search":
+        return await _op_search(context, tool_call_id, str(params.query))
+    if params.op == "install":
+        return await _op_install(context, tool_call_id, str(params.name))
+    return await _op_write(context, tool_call_id, params, creating=params.op == "create")
+
+
+def build_agent_tool(context: ToolContext) -> AgentTool | None:
+    """createIf: the tool exists only where a registry can back it.
+
+    Without a registry the read-only ops would still work off packaged
+    starters, but ``install``/``create``/``update`` could not persist anything
+    — a tool that can show a role and never keep one is a worse surface than
+    no tool, so it is not advertised at all.
+    """
+
+    if getattr(context, "agent_registry", None) is None:
+        return None
+    return AgentTool(
+        name="agent",
+        label="Agent roles",
+        description=(
+            "Reusable role profiles for delegation (reviewer, coder, architect, "
+            "manager, designer, scout). Find, install, or author one; launch it "
+            "with task(agent='<name>')."
+        ),
+        parameters=AgentParams.model_json_schema(),
+        # Writes land in the user's own configuration directory, never in the
+        # workspace, and are trivially reversible by editing the profile back.
+        # Gating them behind an approval prompt would make an agent improving
+        # its own reviewer guidance an interruption, which is exactly the
+        # friction that keeps the registry empty.
+        approval_tier="read",
+        concurrency="exclusive",
+        interruptible=False,
+        execute=execute_agent,
+    )

--- a/local_operator/tools/agent_tool.py
+++ b/local_operator/tools/agent_tool.py
@@ -46,11 +46,11 @@ from local_operator.agent_profiles import (
     MAX_INSTRUCTIONS_CHARS,
     AgentProfile,
     NameTakenError,
-    _profile_from_agent,
     install_seed,
     is_role,
     list_seeds,
     load_seed,
+    profile_from_agent,
     seed_tags,
 )
 from local_operator.harness.types import (
@@ -62,6 +62,7 @@ from local_operator.harness.types import (
 )
 from local_operator.tools.builtin import (
     _error,
+    _guard,
     _text,
     _validation_error,
     spill_truncate,
@@ -103,6 +104,13 @@ class AgentParams(BaseModel):
     effort: str | None = Field(
         default=None, description="create/update: default model tier (lo/med/hi)."
     )
+    delegate: bool | None = Field(
+        default=None,
+        description=(
+            "create/update: may this role launch its own subagents? Default no — "
+            "only coordinating roles should."
+        ),
+    )
 
 
 def _profile_line(profile: AgentProfile, *, installed: bool) -> str:
@@ -130,7 +138,7 @@ def _registered_profiles(registry: Any) -> list[AgentProfile]:
     targets would be noise at best and a privacy leak at worst.
     """
 
-    from local_operator.agent_profiles import _profile_from_agent
+    from local_operator.agent_profiles import profile_from_agent
 
     try:
         agents = registry.list_agents()
@@ -145,7 +153,7 @@ def _registered_profiles(registry: Any) -> list[AgentProfile]:
         if not is_role(agent):
             continue
         try:
-            profiles.append(_profile_from_agent(registry, agent))
+            profiles.append(profile_from_agent(registry, agent))
         except Exception:  # noqa: BLE001
             continue
     return sorted(profiles, key=lambda profile: profile.name.lower())
@@ -346,7 +354,7 @@ async def _op_write(
     # and handed the role the full write inventory, failing OPEN and reporting
     # success. An omitted field means "leave it alone", never "clear it";
     # clearing is done by naming the field with an empty value.
-    current = _profile_from_agent(registry, existing) if existing is not None else None
+    current = profile_from_agent(registry, existing) if existing is not None else None
 
     if params.tools is not None:
         tools = tuple(params.tools) or None
@@ -357,6 +365,11 @@ async def _op_write(
         effort = params.effort.strip() or None
     else:
         effort = current.effort if current is not None else None
+
+    if params.delegate is not None:
+        may_delegate = params.delegate
+    else:
+        may_delegate = current.may_delegate if current is not None else False
 
     description = (params.description or "").strip()
     if not description and current is not None:
@@ -369,10 +382,12 @@ async def _op_write(
         instructions=instructions,
         tools=tools,
         effort=effort,
-        # Preserved for the same reason as the allowlist: a role that
-        # coordinates must not stop coordinating because someone fixed a typo
-        # in its guidance.
-        may_delegate=current.may_delegate if current is not None else False,
+        # Settable, and preserved when not set, for the same reason as the
+        # allowlist: a role that coordinates must not stop coordinating
+        # because someone fixed a typo in its guidance — but a role authored
+        # here must also be ABLE to coordinate, which previously required
+        # hand-editing the tags.
+        may_delegate=may_delegate,
     )
     tags = list(seed_tags(profile))
 
@@ -424,6 +439,7 @@ async def _op_write(
     )
 
 
+@_guard("agent")
 async def execute_agent(
     tool_call_id: str,
     args: dict[str, Any],
@@ -431,7 +447,16 @@ async def execute_agent(
     on_update: Callable[[AgentToolUpdate], None] | None = None,
     context: ToolContext | None = None,
 ) -> ToolResult:
-    """Discover, install, and author reusable agent role profiles."""
+    """Discover, install, and author reusable agent role profiles.
+
+    ``@_guard`` for the same reason every sibling executor has it: the harness
+    contract is that tools never throw into the loop, and this one has live
+    raising paths — a read-only agents directory (PermissionError from
+    create/install) and a transient registry read failure followed by a name
+    that does exist (ValueError out of ``create_agent``'s uniqueness check).
+    The loop's outer net would catch those, but without the traceback tail that
+    makes them debuggable from a transcript.
+    """
 
     try:
         params = AgentParams(**args)

--- a/local_operator/tools/agent_tool.py
+++ b/local_operator/tools/agent_tool.py
@@ -432,8 +432,8 @@ async def _op_install(context: ToolContext | None, tool_call_id: str, name: str)
         )
     if installed is None:
         return _error(tool_call_id, "agent", f"could not install starter {name!r}")
-    profile, already_there = installed
-    if already_there:
+    profile, already_installed = installed
+    if already_installed:
         # Say the no-op out loud. `install` is the only verb here that sounds
         # like "put the shipped one back", so answering "installed" to a
         # deliberate skip leaves an operator believing they restored the

--- a/local_operator/tools/agent_tool.py
+++ b/local_operator/tools/agent_tool.py
@@ -114,9 +114,16 @@ class AgentParams(BaseModel):
     )
 
 
-#: Cap on one rendered row. Long enough for a full trigger sentence, short
-#: enough that a list of them stays scannable at 80 columns.
-_ROW_CAP = 400
+#: Cap on one rendered row. Two lines at 80 columns: enough for a role to say
+#: what it is for, short enough that six of them stay scannable in a 24-row
+#: terminal. It was 400, which let the enriched retrieval text render six roles
+#: as 22 physical lines with no indent to mark where one ended.
+_ROW_CAP = 160
+
+#: Hybrid score at or above which a search result is worded as a match rather
+#: than as a nearest neighbour. Not a cut: everything is still returned, ranked.
+#: Measured true-positive floor 0.118, false-positive ceiling ~0.106.
+_STRONG_MATCH = 0.115
 
 
 def _name_taken_message(name: str, *, installing: bool = False) -> str:
@@ -150,7 +157,15 @@ def _profile_line(profile: AgentProfile, *, installed: bool) -> str:
     if profile.effort:
         marks.append(profile.effort)
     suffix = f" [{', '.join(marks)}]" if marks else ""
-    summary = (profile.when_to_use or profile.description or "").strip()
+    # DISPLAY prefers the short ``description``; RETRIEVAL (in ``_op_search``)
+    # prefers the long ``when_to_use``. The two texts exist for different
+    # readers, and drawing both from the same field is what made the list 69%
+    # taller at 80 columns once the trigger text was enriched for search. An
+    # INSTALLED role collapses to one registry column (the routing text, so
+    # search keeps working across install), which is why the row cap does the
+    # remaining work rather than this preference alone. ``show`` is where a
+    # role's full applicability is read.
+    summary = (profile.description or profile.when_to_use or "").strip()
     if not summary:
         # A role with no description is invisible to `search`, which matches on
         # exactly this text. Saying so is more useful than a dangling colon.
@@ -211,8 +226,7 @@ async def _op_list(context: ToolContext | None, tool_call_id: str) -> ToolResult
         if body:
             body += "\n\n"
         body += (
-            "installable starters (packaged roles, not yet in your registry — "
-            "op='install' to keep and edit one):\n"
+            "installable starters (packaged, not yet in your registry — op='install'):\n"
         ) + "\n".join(_profile_line(profile, installed=False) for profile in starters)
     if not body:
         body = "no roles registered and no starters packaged."
@@ -247,14 +261,18 @@ async def _op_show(context: ToolContext | None, tool_call_id: str, name: str) ->
     return _text(tool_call_id, "agent", text, details=spill or None)
 
 
-async def _ranked_names(index: Any, query: str) -> list[str]:
-    """Role names ordered by SCORE, best first.
+async def _ranked_names(index: Any, query: str) -> tuple[list[str], float]:
+    """Role names ordered by SCORE (best first), and the best score.
 
     ``SkillIndex.select`` returns its picks sorted by NAME so that two turns
     selecting the same set render byte-identically for the prompt cache. That
     is right for the knowledge block and wrong here: printing an alphabetical
     list under the words "best first" would be a claim the reader cannot check.
     This recomputes the ranking from the same hybrid score the selection used.
+
+    The score comes back too so the caller can HEDGE its wording: with no
+    absolute threshold, an unrelated query still returns three roles, and
+    nothing in a bare list distinguishes a 0.65 hit from 0.03 noise.
 
     Best-effort: any failure returns an empty list and the caller keeps
     ``select``'s own order, because an unranked answer beats no answer.
@@ -266,9 +284,10 @@ async def _ranked_names(index: Any, query: str) -> list[str]:
         query_vector = (await index.backend.embed([query]))[0]
         scores = _hybrid_scores(query, index.skills, index._scores(query_vector), None)
     except Exception:  # noqa: BLE001 - ordering is a nicety, never a failure
-        return []
+        return [], 0.0
     ranked = sorted(range(len(index.skills)), key=lambda position: -scores[position])
-    return [index.skills[position].name for position in ranked]
+    best = float(scores[ranked[0]]) if ranked else 0.0
+    return [index.skills[position].name for position in ranked], best
 
 
 async def _op_search(context: ToolContext | None, tool_call_id: str, query: str) -> ToolResult:
@@ -325,12 +344,13 @@ async def _op_search(context: ToolContext | None, tool_call_id: str, query: str)
         # would silently present an alphabetical list as if it were ranked, so
         # the ordering is recovered here from the scores themselves.
         picked = await index.select(query, k=3, threshold=0.0)
-        ranking = await _ranked_names(index, query)
+        ranking, best_score = await _ranked_names(index, query)
         order = {name: position for position, name in enumerate(ranking)}
         picked = sorted(picked, key=lambda row: order.get(row.name, len(order)))
     except Exception as exc:  # noqa: BLE001 - degrade to listing, never fail
         logger.warning("role search failed: %s", exc)
         picked = rows[:3]
+        best_score = 0.0
     if not picked:
         return _text(
             tool_call_id,
@@ -343,10 +363,21 @@ async def _op_search(context: ToolContext | None, tool_call_id: str, query: str)
         if profile is None:
             continue
         lines.append(_profile_line(profile, installed=bool(profile.agent_id)))
+    # Measured on a query set: true matches score 0.118 and up, while
+    # unrelated queries ("order me a pizza") top out near 0.10. The margin is
+    # too thin to CUT on (that was the old behaviour, and it hid roles whose
+    # own text promised the query), but wide enough to change the wording, so a
+    # weak result reads as a nearest neighbour rather than a recommendation.
+    header = (
+        "closest roles (best first):"
+        if best_score >= _STRONG_MATCH
+        else "nothing scored strongly; the closest roles are:"
+    )
     return _text(
         tool_call_id,
         "agent",
-        "closest roles (best first):\n"
+        header
+        + "\n"
         + "\n".join(lines)
         + "\n\nlaunch with task(agent='<name>'), or op='list' to see them all.",
     )

--- a/local_operator/tools/agent_tool.py
+++ b/local_operator/tools/agent_tool.py
@@ -101,8 +101,9 @@ class AgentParams(BaseModel):
         default=None,
         description="create/update: restrict the role to these tools. Omit for all.",
     )
-    effort: str | None = Field(
-        default=None, description="create/update: default model tier (lo/med/hi)."
+    effort: Literal["lo", "med", "hi", ""] | None = Field(
+        default=None,
+        description="create/update: default model tier. '' clears it.",
     )
     delegate: bool | None = Field(
         default=None,
@@ -113,17 +114,51 @@ class AgentParams(BaseModel):
     )
 
 
+#: Cap on one rendered row. Long enough for a full trigger sentence, short
+#: enough that a list of them stays scannable at 80 columns.
+_ROW_CAP = 400
+
+
+def _name_taken_message(name: str, *, installing: bool = False) -> str:
+    """One wording for the same condition, wherever it is detected.
+
+    `install` and `create`/`update` used to phrase this differently, and only
+    one of them stated the no-op guarantee and named the escape route.
+    """
+
+    lead = (
+        f"an agent named {name!r} already exists and is not a role, so nothing was installed."
+        if installing
+        else f"an agent named {name!r} already exists and is not a role."
+    )
+    return f"{lead} Rename that agent, or use a different name for the role."
+
+
 def _profile_line(profile: AgentProfile, *, installed: bool) -> str:
     """One scannable row: name, where it came from, and what it is for."""
 
     marks: list[str] = [] if installed else ["starter"]
-    if profile.tools:
-        marks.append(f"{len(profile.tools)} tools")
+    # ALWAYS say something about the tool surface. Emitting `[7 tools]` only
+    # when an allowlist exists inverted the signal it is supposed to carry:
+    # `None` means the FULL inventory, so the unrestricted roles (coder,
+    # designer — which can edit, write and run anything) rendered as a bare
+    # `[starter]` while read-only `scout` showed `[5 tools]` and looked
+    # heavier. Tool restriction is the one attribute the guide calls "a
+    # capability boundary, not advice", so the row must not communicate its
+    # absence by saying nothing. `show` already spells this out; this matches.
+    marks.append(f"{len(profile.tools)} tools" if profile.tools else "all tools")
     if profile.effort:
         marks.append(profile.effort)
     suffix = f" [{', '.join(marks)}]" if marks else ""
     summary = (profile.when_to_use or profile.description or "").strip()
-    return f"- {profile.name}{suffix}: {summary}"[:400]
+    if not summary:
+        # A role with no description is invisible to `search`, which matches on
+        # exactly this text. Saying so is more useful than a dangling colon.
+        summary = "(no description — not searchable; add one with op='update')"
+    row = f"- {profile.name}{suffix}: {summary}"
+    # Ellipsis when the cut fires: a bare slice ends mid-word, and the reader
+    # cannot tell an author's fragment from text we dropped.
+    return row if len(row) <= _ROW_CAP else row[: _ROW_CAP - 1].rstrip() + "…"
 
 
 def _registry(context: ToolContext | None) -> Any:
@@ -175,9 +210,10 @@ async def _op_list(context: ToolContext | None, tool_call_id: str) -> ToolResult
     if starters:
         if body:
             body += "\n\n"
-        body += "installable starters (op='install'):\n" + "\n".join(
-            _profile_line(profile, installed=False) for profile in starters
-        )
+        body += (
+            "installable starters (packaged roles, not yet in your registry — "
+            "op='install' to keep and edit one):\n"
+        ) + "\n".join(_profile_line(profile, installed=False) for profile in starters)
     if not body:
         body = "no roles registered and no starters packaged."
     text, spill = spill_truncate(body, "agent", context)
@@ -199,8 +235,40 @@ async def _op_show(context: ToolContext | None, tool_call_id: str, name: str) ->
     if profile.effort:
         header.append(f"effort: {profile.effort}")
     body = "\n".join(header) + "\n\ninstructions:\n" + (profile.instructions or "(none)")
+    # The highest-intent moment in the flow: someone has just read a role's
+    # guidance and decided they want it. Every other op ends by naming the next
+    # command; this one used to stop at "not installed" and leave them there.
+    body += (
+        f"\n\nlaunch with task(agent={profile.name!r})"
+        + ("" if profile.agent_id else f", or op='install' name={profile.name!r} to edit it")
+        + "."
+    )
     text, spill = spill_truncate(body, "agent", context)
     return _text(tool_call_id, "agent", text, details=spill or None)
+
+
+async def _ranked_names(index: Any, query: str) -> list[str]:
+    """Role names ordered by SCORE, best first.
+
+    ``SkillIndex.select`` returns its picks sorted by NAME so that two turns
+    selecting the same set render byte-identically for the prompt cache. That
+    is right for the knowledge block and wrong here: printing an alphabetical
+    list under the words "best first" would be a claim the reader cannot check.
+    This recomputes the ranking from the same hybrid score the selection used.
+
+    Best-effort: any failure returns an empty list and the caller keeps
+    ``select``'s own order, because an unranked answer beats no answer.
+    """
+
+    try:
+        from local_operator.skills.index import _hybrid_scores
+
+        query_vector = (await index.backend.embed([query]))[0]
+        scores = _hybrid_scores(query, index.skills, index._scores(query_vector), None)
+    except Exception:  # noqa: BLE001 - ordering is a nicety, never a failure
+        return []
+    ranked = sorted(range(len(index.skills)), key=lambda position: -scores[position])
+    return [index.skills[position].name for position in ranked]
 
 
 async def _op_search(context: ToolContext | None, tool_call_id: str, query: str) -> ToolResult:
@@ -241,7 +309,25 @@ async def _op_search(context: ToolContext | None, tool_call_id: str, query: str)
     try:
         index = SkillIndex(rows, LocalEmbedder())
         await index.build()
-        picked = await index.select(query, k=3)
+        # threshold=0 and RANKED, deliberately, on both counts.
+        #
+        # The shared index default (0.19) is calibrated for full skill bodies;
+        # a role description is one sentence, so correct matches score
+        # 0.118-0.177 and were being cut. Measured against a query set, the
+        # true best role ranked first 10/10 while unrelated queries ("order me
+        # a pizza") topped out at 0.106 — so the RANKING is trustworthy while
+        # the absolute scores sit either side of a knife-edge cut. Showing a
+        # ranked shortlist is therefore both more useful and more honest than
+        # "no role matched": the caller is an agent choosing among six options,
+        # and the copy says these are the closest rather than that they fit.
+        #
+        # `select` sorts its result by NAME (for prompt-cache stability), which
+        # would silently present an alphabetical list as if it were ranked, so
+        # the ordering is recovered here from the scores themselves.
+        picked = await index.select(query, k=3, threshold=0.0)
+        ranking = await _ranked_names(index, query)
+        order = {name: position for position, name in enumerate(ranking)}
+        picked = sorted(picked, key=lambda row: order.get(row.name, len(order)))
     except Exception as exc:  # noqa: BLE001 - degrade to listing, never fail
         logger.warning("role search failed: %s", exc)
         picked = rows[:3]
@@ -249,7 +335,7 @@ async def _op_search(context: ToolContext | None, tool_call_id: str, query: str)
         return _text(
             tool_call_id,
             "agent",
-            "no role matched that task closely; use op='list' or launch task without a role.",
+            "no roles available to search; use op='list'.",
         )
     lines = []
     for row in picked:
@@ -260,7 +346,9 @@ async def _op_search(context: ToolContext | None, tool_call_id: str, query: str)
     return _text(
         tool_call_id,
         "agent",
-        "best matching roles:\n" + "\n".join(lines) + "\n\nlaunch with task(agent='<name>').",
+        "closest roles (best first):\n"
+        + "\n".join(lines)
+        + "\n\nlaunch with task(agent='<name>'), or op='list' to see them all.",
     )
 
 
@@ -282,17 +370,15 @@ async def _op_install(context: ToolContext | None, tool_call_id: str, name: str)
         return _error(
             tool_call_id,
             "agent",
-            f"an agent named {name!r} already exists and is not a role, so nothing was "
-            "installed. Rename that agent, or author the role under a different name "
-            "with op='create'.",
+            _name_taken_message(name, installing=True),
         )
     if profile is None:
         return _error(tool_call_id, "agent", f"could not install starter {name!r}")
     return _text(
         tool_call_id,
         "agent",
-        f"installed role {profile.name!r} into the registry; "
-        f"launch with task(agent={profile.name!r}). Edit it with op='update'.",
+        f"installed role {profile.name!r}: launch with task(agent={profile.name!r}), "
+        f"or change what it is told with op='update' name={profile.name!r}.",
     )
 
 
@@ -324,8 +410,7 @@ async def _op_write(
         return _error(
             tool_call_id,
             "agent",
-            f"an agent named {name!r} exists and is not a role; rename it, or use a "
-            "different name for the role.",
+            _name_taken_message(name),
         )
     if creating and existing is not None:
         return _error(

--- a/local_operator/tools/agent_tool.py
+++ b/local_operator/tools/agent_tool.py
@@ -275,7 +275,19 @@ async def _ranked_names(index: Any, query: str) -> tuple[list[str], float]:
     nothing in a bare list distinguishes a 0.65 hit from 0.03 noise.
 
     Best-effort: any failure returns an empty list and the caller keeps
-    ``select``'s own order, because an unranked answer beats no answer.
+    ``select``'s own order AND drops its "best first" claim, because an
+    unranked answer beats no answer but a false claim about it does not.
+
+    KNOWN COUPLING (accepted, not overlooked): this reaches two private names,
+    ``skills.index._hybrid_scores`` and ``index._scores``, to recompute a
+    ranking ``_select_with_backend`` already computes and then discards by
+    sorting on name. It also passes ``cwd=None``, opting out of the glob boosts
+    ``select`` applies — inert today because agent-profile rows carry no globs,
+    but it is the seam where the two rankings could diverge. The clean fix is
+    for ``select`` to grow an ordering option (or return scores) so the ranking
+    has ONE owner; that is a change to shared knowledge-routing code and does
+    not belong in this PR. The fallback above is what bounds the blast radius
+    until then.
     """
 
     try:
@@ -284,6 +296,11 @@ async def _ranked_names(index: Any, query: str) -> tuple[list[str], float]:
         query_vector = (await index.backend.embed([query]))[0]
         scores = _hybrid_scores(query, index.skills, index._scores(query_vector), None)
     except Exception:  # noqa: BLE001 - ordering is a nicety, never a failure
+        # LOGGED, unlike a bare degrade: the caller cannot tell a working
+        # ranking from a broken one by looking at the output, so silence here
+        # would make a signature drift in the private helpers below invisible
+        # in both the result and the logs.
+        logger.warning("role ranking unavailable; falling back to unordered", exc_info=True)
         return [], 0.0
     ranked = sorted(range(len(index.skills)), key=lambda position: -scores[position])
     best = float(scores[ranked[0]]) if ranked else 0.0
@@ -351,6 +368,7 @@ async def _op_search(context: ToolContext | None, tool_call_id: str, query: str)
         logger.warning("role search failed: %s", exc)
         picked = rows[:3]
         best_score = 0.0
+        ranking = []
     if not picked:
         return _text(
             tool_call_id,
@@ -368,11 +386,16 @@ async def _op_search(context: ToolContext | None, tool_call_id: str, query: str)
     # too thin to CUT on (that was the old behaviour, and it hid roles whose
     # own text promised the query), but wide enough to change the wording, so a
     # weak result reads as a nearest neighbour rather than a recommendation.
-    header = (
-        "closest roles (best first):"
-        if best_score >= _STRONG_MATCH
-        else "nothing scored strongly; the closest roles are:"
-    )
+    # "(best first)" is claimed ONLY when the ranking actually succeeded. With
+    # `ranking` empty the rows keep `select`'s NAME order, so the phrase would
+    # be a claim the reader cannot check — the exact hazard `_ranked_names`'
+    # docstring names, reintroduced by its own fallback.
+    if not ranking:
+        header = "closest roles:"
+    elif best_score >= _STRONG_MATCH:
+        header = "closest roles (best first):"
+    else:
+        header = "nothing scored strongly; the closest roles are:"
     return _text(
         tool_call_id,
         "agent",

--- a/local_operator/tools/agent_tool.py
+++ b/local_operator/tools/agent_tool.py
@@ -37,6 +37,7 @@ relevant, and the body loads on demand.
 from __future__ import annotations
 
 import logging
+from pathlib import Path
 from typing import Any, Callable, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
@@ -44,7 +45,10 @@ from pydantic import BaseModel, ConfigDict, Field, ValidationError
 from local_operator.agent_profiles import (
     MAX_INSTRUCTIONS_CHARS,
     AgentProfile,
+    NameTakenError,
+    _profile_from_agent,
     install_seed,
+    is_role,
     list_seeds,
     load_seed,
     seed_tags,
@@ -135,8 +139,10 @@ def _registered_profiles(registry: Any) -> list[AgentProfile]:
         return []
     profiles: list[AgentProfile] = []
     for agent in agents:
-        tags = {str(tag).strip().lower() for tag in (agent.tags or [])}
-        if "role" not in tags:
+        # One shared predicate with role RESOLUTION: two readers that disagree
+        # about what a role is are how listing came to hide a row that
+        # ``task(agent=...)`` would still have run.
+        if not is_role(agent):
             continue
         try:
             profiles.append(_profile_from_agent(registry, agent))
@@ -216,8 +222,8 @@ async def _op_search(context: ToolContext | None, tool_call_id: str, query: str)
         Skill(
             name=profile.name,
             description=(profile.when_to_use or profile.description or profile.name)[:512],
-            file_path=__import__("pathlib").Path(f"{profile.name}.md"),
-            base_dir=__import__("pathlib").Path("."),
+            file_path=Path(f"{profile.name}.md"),
+            base_dir=Path("."),
             source="agent-profile",
             resource_type="agent_hint",
         )
@@ -262,7 +268,16 @@ async def _op_install(context: ToolContext | None, tool_call_id: str, name: str)
             "agent",
             f"no packaged starter named {name!r}; starters: {', '.join(list_seeds())}",
         )
-    profile = install_seed(name, registry=registry)
+    try:
+        profile = install_seed(name, registry=registry)
+    except NameTakenError:
+        return _error(
+            tool_call_id,
+            "agent",
+            f"an agent named {name!r} already exists and is not a role, so nothing was "
+            "installed. Rename that agent, or author the role under a different name "
+            "with op='create'.",
+        )
     if profile is None:
         return _error(tool_call_id, "agent", f"could not install starter {name!r}")
     return _text(
@@ -293,6 +308,17 @@ async def _op_write(
     except Exception:  # noqa: BLE001
         existing = None
 
+    # A name occupied by a NON-role is refused on both paths rather than being
+    # converted into one: an ordinary chat agent silently acquiring a role's
+    # tags and guidance is a surprising way to lose an agent, and on the update
+    # path it would be the same fail-open hijack the role tag exists to stop.
+    if existing is not None and not is_role(existing):
+        return _error(
+            tool_call_id,
+            "agent",
+            f"an agent named {name!r} exists and is not a role; rename it, or use a "
+            "different name for the role.",
+        )
     if creating and existing is not None:
         return _error(
             tool_call_id,
@@ -313,13 +339,40 @@ async def _op_write(
             "run of this role, so they must stay short.",
         )
 
+    # An UPDATE merges onto the stored profile; only a CREATE starts from
+    # nothing. Rebuilding the tags from this call's params alone silently
+    # stripped whatever it did not mention — so refining a reviewer's wording
+    # (the very operation this tool advertises) dropped its `tools:` allowlist
+    # and handed the role the full write inventory, failing OPEN and reporting
+    # success. An omitted field means "leave it alone", never "clear it";
+    # clearing is done by naming the field with an empty value.
+    current = _profile_from_agent(registry, existing) if existing is not None else None
+
+    if params.tools is not None:
+        tools = tuple(params.tools) or None
+    else:
+        tools = current.tools if current is not None else None
+
+    if params.effort is not None:
+        effort = params.effort.strip() or None
+    else:
+        effort = current.effort if current is not None else None
+
+    description = (params.description or "").strip()
+    if not description and current is not None:
+        description = current.description
+
     profile = AgentProfile(
         name=name,
-        description=(params.description or "").strip(),
-        when_to_use=(params.description or "").strip(),
+        description=description,
+        when_to_use=description,
         instructions=instructions,
-        tools=tuple(params.tools) if params.tools else None,
-        effort=(params.effort or "").strip() or None,
+        tools=tools,
+        effort=effort,
+        # Preserved for the same reason as the allowlist: a role that
+        # coordinates must not stop coordinating because someone fixed a typo
+        # in its guidance.
+        may_delegate=current.may_delegate if current is not None else False,
     )
     tags = list(seed_tags(profile))
 

--- a/local_operator/tools/agent_tool.py
+++ b/local_operator/tools/agent_tool.py
@@ -153,7 +153,11 @@ def _profile_line(profile: AgentProfile, *, installed: bool) -> str:
     # heavier. Tool restriction is the one attribute the guide calls "a
     # capability boundary, not advice", so the row must not communicate its
     # absence by saying nothing. `show` already spells this out; this matches.
-    marks.append(f"{len(profile.tools)} tools" if profile.tools else "all tools")
+    if not profile.tools:
+        marks.append("all tools")
+    else:
+        count = len(profile.tools)
+        marks.append(f"{count} tool" if count == 1 else f"{count} tools")
     if profile.effort:
         marks.append(profile.effort)
     suffix = f" [{', '.join(marks)}]" if marks else ""
@@ -419,15 +423,29 @@ async def _op_install(context: ToolContext | None, tool_call_id: str, name: str)
             f"no packaged starter named {name!r}; starters: {', '.join(list_seeds())}",
         )
     try:
-        profile = install_seed(name, registry=registry)
+        installed = install_seed(name, registry=registry)
     except NameTakenError:
         return _error(
             tool_call_id,
             "agent",
             _name_taken_message(name, installing=True),
         )
-    if profile is None:
+    if installed is None:
         return _error(tool_call_id, "agent", f"could not install starter {name!r}")
+    profile, already_there = installed
+    if already_there:
+        # Say the no-op out loud. `install` is the only verb here that sounds
+        # like "put the shipped one back", so answering "installed" to a
+        # deliberate skip leaves an operator believing they restored the
+        # packaged guidance while their own edited prompt is what the next
+        # delegation runs. Same failure shape C4 fixed on the non-role branch.
+        return _text(
+            tool_call_id,
+            "agent",
+            f"role {profile.name!r} is already installed and was left as-is (your edits are "
+            f"kept): op='show' name={profile.name!r} to read it, or op='update' "
+            f"name={profile.name!r} to change it.",
+        )
     return _text(
         tool_call_id,
         "agent",

--- a/local_operator/tools/builtin.py
+++ b/local_operator/tools/builtin.py
@@ -5580,26 +5580,43 @@ async def execute_wait(
                 return job
         return None
 
+    def _still_running() -> list[str]:
+        """The awaited ids that are still running, in the order given.
+
+        The unsettled branches report THIS rather than ``job_ids[0]``: on the
+        multi-id path the first id is simply the first the caller passed and
+        may itself have settled, so pinning it in ``details`` tells a caller
+        that reads the payload (rather than parsing the text) about the wrong
+        job.
+        """
+
+        return [
+            job_id
+            for job_id in job_ids
+            if (row := jobs.get(job_id)) is not None and row.status == "running"
+        ]
+
     deadline = time.monotonic() + params.wait_ms / 1000.0
     job = _settled()
     while job is None:
         if signal is not None and signal.aborted:
+            running = _still_running()
             return _text(
                 tool_call_id,
                 "wait",
-                f"job {', '.join(job_ids)} still running (wait aborted)",
-                details={"job_id": job_ids[0], "status": "running"},
+                f"job {', '.join(running or job_ids)} still running (wait aborted)",
+                details={"job_id": (running or job_ids)[0], "status": "running"},
             )
         remaining = deadline - time.monotonic()
         if remaining <= 0:
-            running = [job_id for job_id in job_ids if jobs.get(job_id) is not None]
+            running = _still_running()
             return _text(
                 tool_call_id,
                 "wait",
-                f"job {', '.join(running)} still running after {params.wait_ms}ms",
-                details={"job_id": job_ids[0], "status": "running"},
+                f"job {', '.join(running or job_ids)} still running after {params.wait_ms}ms",
+                details={"job_id": (running or job_ids)[0], "status": "running"},
             )
-        await _await_any_settled(jobs, job_ids, remaining)
+        await _await_any_settled(jobs, job_ids, remaining, signal)
         job = _settled()
         if job is None and all(jobs.get(job_id) is None for job_id in job_ids):
             return _error(tool_call_id, "wait", f"job {', '.join(job_ids)} disappeared")
@@ -5629,14 +5646,29 @@ async def execute_wait(
     )
 
 
-async def _await_any_settled(jobs: Any, job_ids: list[str], remaining: float) -> None:
-    """Sleep until one of ``job_ids`` settles, or ``remaining`` seconds pass.
+async def _await_any_settled(
+    jobs: Any,
+    job_ids: list[str],
+    remaining: float,
+    signal: AbortSignal | None = None,
+) -> None:
+    """Sleep until one of ``job_ids`` settles, the wait is aborted, or
+    ``remaining`` seconds pass.
 
     Event-driven where the host supports it. The measured problem this fixes:
     across recorded sessions, 70% of ``wait`` calls hit their deadline, and the
     old implementation spent those waits re-reading a status field every 50 ms
     — 6000 wakeups per five-minute wait, all on the one event loop shared by
     the parent turn, every sibling child, and the TUI repaint.
+
+    The ABORT is raced alongside the settle events, not checked between
+    sleeps. The old 50 ms poll re-read ``signal.aborted`` on every tick, so
+    parking on the settle events alone silently made the abort branch dead for
+    a job that never settles: an aborted wait sat for its whole budget (up to
+    five minutes) instead of returning. The TUI masks that through its own
+    interruptible-tool poll, but that is a different mechanism and does not
+    cover deadline-tripped signals or non-TUI embedders relying on the
+    documented ``AbortSignal`` contract.
 
     Falls back to the poll loop when the manager predates ``settled_event``
     (a third-party job manager satisfying the older protocol must keep
@@ -5655,6 +5687,8 @@ async def _await_any_settled(jobs: Any, job_ids: list[str], remaining: float) ->
         await asyncio.sleep(min(0.1, remaining))
         return
     waiters = [asyncio.ensure_future(event.wait()) for event in events]
+    if signal is not None:
+        waiters.append(asyncio.ensure_future(signal.wait()))
     try:
         await asyncio.wait(waiters, timeout=remaining, return_when=asyncio.FIRST_COMPLETED)
     finally:

--- a/local_operator/tools/builtin.py
+++ b/local_operator/tools/builtin.py
@@ -5682,9 +5682,21 @@ async def _await_any_settled(
         await asyncio.sleep(min(0.1, remaining))
         return
     try:
-        events = [getter(job_id) for job_id in job_ids]
+        # Only ids that STILL HAVE A ROW. An id whose row the retention sweep
+        # evicted mid-wait gets a pre-set event (nothing will ever settle it),
+        # which would return from `asyncio.wait` immediately and spin the
+        # caller's `while` loop at full speed until its deadline — burning the
+        # event loop this function exists to protect, and faster than the poll
+        # it replaced. Skipping those ids parks on the siblings that can still
+        # fire; when NONE can, there is nothing to wait for and the caller's
+        # own disappeared/timeout branches are the right answer, so sleep out
+        # the remainder rather than returning into a hot loop.
+        events = [getter(job_id) for job_id in job_ids if jobs.get(job_id) is not None]
     except Exception:  # noqa: BLE001 - a manager that cannot make events polls
         await asyncio.sleep(min(0.1, remaining))
+        return
+    if not events and signal is None:
+        await asyncio.sleep(remaining)
         return
     waiters = [asyncio.ensure_future(event.wait()) for event in events]
     if signal is not None:

--- a/local_operator/tools/builtin.py
+++ b/local_operator/tools/builtin.py
@@ -5307,18 +5307,29 @@ def build_browser_tool(context: ToolContext | None) -> AgentTool | None:
 
 
 class TaskItem(BaseModel):
-    """One slice of a task batch. ``agent`` picks the tier: "task" is the
-    full child; "scout" is a read-only research child (lookups only) for
-    investigation that should not pay for — or risk — write tools. ``effort``
-    routes to a configured model tier (values.subagents.models lo/med/hi)."""
+    """One slice of a task batch. ``agent`` names the ROLE the child runs as —
+    a registered profile or a packaged starter (reviewer, coder, architect,
+    manager, designer, scout); the role supplies standing guidance and may
+    restrict the child's tools. ``effort`` routes to a configured model tier
+    (values.subagents.models lo/med/hi)."""
 
     model_config = ConfigDict(extra="forbid")
 
     label: str = Field(description="Short label for this subagent (shown in the jobs list).")
     prompt: str = Field(description="The full instructions this subagent runs.")
-    agent: Literal["task", "scout"] = Field(
+    # Free-form rather than a Literal: roles are user data, so the valid set is
+    # whatever the operator's registry holds plus the packaged starters, and
+    # baking today's names into the schema would make an operator-authored role
+    # unlaunchable. An unknown name degrades to a full child (see
+    # ``harness.subagent._resolve_role``) rather than failing the launch.
+    agent: str = Field(
         default="task",
-        description='"task" = full child; "scout" = read-only research child.',
+        description=(
+            "Role for this subagent: 'task' (full child, no role), 'scout' "
+            "(read-only research), or any role from the `agent` tool — e.g. "
+            "'reviewer', 'coder', 'architect', 'manager', 'designer'. A role "
+            "carries vetted guidance and may restrict tools."
+        ),
     )
     effort: Literal["lo", "med", "hi"] | None = Field(
         default=None,
@@ -5336,6 +5347,20 @@ class TaskParams(BaseModel):
     prompt: str | None = Field(
         default=None,
         description="Single-task form: the instructions the subagent runs.",
+    )
+    # Mirrors of the TaskItem fields for the SINGLE-task form. Without these,
+    # ``task(label=..., prompt=..., agent="reviewer")`` — the most natural way
+    # to ask for one reviewer — fails schema validation (extra="forbid"), and
+    # the caller has to discover that a role is only reachable through the
+    # batch form. Observed live: a model hit exactly that error, then retried
+    # with ``tasks=[...]``, paying a wasted round trip to learn it.
+    agent: str | None = Field(
+        default=None,
+        description="Single-task form: role for the subagent (see 'tasks[].agent').",
+    )
+    effort: Literal["lo", "med", "hi"] | None = Field(
+        default=None,
+        description="Single-task form: model tier for the subagent.",
     )
     context: str = Field(
         default="",
@@ -5363,6 +5388,11 @@ class TaskParams(BaseModel):
         single = self.label is not None
         if single and self.tasks:
             raise ValueError("pass either 'tasks' (batch) or label/prompt, not both")
+        if not single and (self.agent or self.effort):
+            # Silently ignoring these would be worse than refusing: the caller
+            # believes it asked for a role, and every child in the batch would
+            # run without one.
+            raise ValueError("in the batch form, set 'agent'/'effort' on each tasks[] item")
         if not single and not self.tasks:
             raise ValueError("nothing to launch: pass 'tasks' or label/prompt")
         if not single and not self.context.strip() and len(self.tasks) == 1:
@@ -5376,12 +5406,22 @@ class TaskParams(BaseModel):
 class WaitParams(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    job_id: str = Field(description="Job id returned by the 'task' tool (or listed by 'jobs').")
+    job_id: str | list[str] = Field(
+        description=(
+            "Job id from 'task' (or 'jobs'). Pass a LIST to wake on the first "
+            "of several to finish — the way to await a fan-out without polling "
+            "each child in turn."
+        )
+    )
     wait_ms: int = Field(
-        default=30_000,
+        default=300_000,
         gt=0,
         le=300_000,
-        description="Max ms to block for the job to settle (capped at 300000).",
+        description=(
+            "Max ms to block before reporting back (capped at 300000). The "
+            "call returns as soon as a job settles, so a generous budget costs "
+            "nothing when the work finishes early."
+        ),
     )
 
 
@@ -5433,7 +5473,17 @@ async def execute_task(
         )
     items: list[TaskItem] = list(params.tasks)
     if params.label is not None and params.prompt is not None:
-        items.append(TaskItem(label=params.label, prompt=params.prompt))
+        # ``agent`` falls back to TaskItem's own default rather than being
+        # passed as None, which the field does not accept; ``effort`` is
+        # already Optional there and passes through unchanged.
+        items.append(
+            TaskItem(
+                label=params.label,
+                prompt=params.prompt,
+                agent=params.agent or "task",
+                effort=params.effort,
+            )
+        )
 
     def _full_prompt(item: TaskItem) -> str:
         if not params.context.strip():
@@ -5477,8 +5527,10 @@ def build_task_tool(context: ToolContext) -> AgentTool | None:
         describe_approval=_describe_task_approval,
         description=(
             "Launch background subagents — one, or a whole concurrent batch "
-            "('tasks' + shared 'context') in a single call. agent='scout' is "
-            "a read-only research child; effort picks a configured model tier."
+            "('tasks' + shared 'context') in a single call. 'agent' names a "
+            "role carrying vetted guidance (reviewer, coder, architect, "
+            "manager, designer, scout — see the `agent` tool); effort picks a "
+            "configured model tier."
         ),
         parameters=TaskParams.model_json_schema(),
         # Spawns autonomous child work, so it rides the write gate just like
@@ -5511,36 +5563,61 @@ async def execute_wait(
             "wait",
             "job tracking is not available in this session (no job manager attached).",
         )
-    job = jobs.get(params.job_id)
-    if job is None:
-        return _error(tool_call_id, "wait", f"unknown job {params.job_id}")
+    job_ids = [params.job_id] if isinstance(params.job_id, str) else list(params.job_id)
+    job_ids = [job_id for job_id in dict.fromkeys(job_ids) if job_id]
+    if not job_ids:
+        return _error(tool_call_id, "wait", "no job id given")
+    missing = [job_id for job_id in job_ids if jobs.get(job_id) is None]
+    if missing:
+        return _error(tool_call_id, "wait", f"unknown job {', '.join(missing)}")
+
+    def _settled() -> Any:
+        """The first of the awaited jobs that is no longer running, or None."""
+
+        for job_id in job_ids:
+            job = jobs.get(job_id)
+            if job is not None and job.status != "running":
+                return job
+        return None
 
     deadline = time.monotonic() + params.wait_ms / 1000.0
-    while job.status == "running":
+    job = _settled()
+    while job is None:
         if signal is not None and signal.aborted:
             return _text(
                 tool_call_id,
                 "wait",
-                f"job {params.job_id} still running (wait aborted)",
-                details={"job_id": params.job_id, "status": "running"},
+                f"job {', '.join(job_ids)} still running (wait aborted)",
+                details={"job_id": job_ids[0], "status": "running"},
             )
         remaining = deadline - time.monotonic()
         if remaining <= 0:
+            running = [job_id for job_id in job_ids if jobs.get(job_id) is not None]
             return _text(
                 tool_call_id,
                 "wait",
-                f"job {params.job_id} still running after {params.wait_ms}ms",
-                details={"job_id": params.job_id, "status": "running"},
+                f"job {', '.join(running)} still running after {params.wait_ms}ms",
+                details={"job_id": job_ids[0], "status": "running"},
             )
-        await asyncio.sleep(min(0.05, remaining))
-        job = jobs.get(params.job_id)
-        if job is None:
-            return _error(tool_call_id, "wait", f"job {params.job_id} disappeared")
+        await _await_any_settled(jobs, job_ids, remaining)
+        job = _settled()
+        if job is None and all(jobs.get(job_id) is None for job_id in job_ids):
+            return _error(tool_call_id, "wait", f"job {', '.join(job_ids)} disappeared")
     # Handing the result to the model HERE means auto-delivery must not
     # repeat it when the session next goes idle (see Session._on_job_completed
     # and AsyncJob.consumed).
-    cast(Any, jobs).mark_consumed(params.job_id)
+    cast(Any, jobs).mark_consumed(job.id)
     text, spill_details = _job_summary(job, context)
+    if len(job_ids) > 1:
+        still = [
+            job_id
+            for job_id in job_ids
+            if job_id != job.id
+            and (other := jobs.get(job_id)) is not None
+            and other.status == "running"
+        ]
+        if still:
+            text += f"\n({len(still)} still running: {', '.join(still)})"
     details = {"job_id": job.id, "status": job.status}
     if spill_details:
         details.update(spill_details)
@@ -5552,6 +5629,43 @@ async def execute_wait(
     )
 
 
+async def _await_any_settled(jobs: Any, job_ids: list[str], remaining: float) -> None:
+    """Sleep until one of ``job_ids`` settles, or ``remaining`` seconds pass.
+
+    Event-driven where the host supports it. The measured problem this fixes:
+    across recorded sessions, 70% of ``wait`` calls hit their deadline, and the
+    old implementation spent those waits re-reading a status field every 50 ms
+    — 6000 wakeups per five-minute wait, all on the one event loop shared by
+    the parent turn, every sibling child, and the TUI repaint.
+
+    Falls back to the poll loop when the manager predates ``settled_event``
+    (a third-party job manager satisfying the older protocol must keep
+    working), and the poll there is 100 ms rather than 50 ms because nothing
+    observes the difference: the caller is a model waiting on a job that runs
+    for minutes.
+    """
+
+    getter = getattr(jobs, "settled_event", None)
+    if getter is None:
+        await asyncio.sleep(min(0.1, remaining))
+        return
+    try:
+        events = [getter(job_id) for job_id in job_ids]
+    except Exception:  # noqa: BLE001 - a manager that cannot make events polls
+        await asyncio.sleep(min(0.1, remaining))
+        return
+    waiters = [asyncio.ensure_future(event.wait()) for event in events]
+    try:
+        await asyncio.wait(waiters, timeout=remaining, return_when=asyncio.FIRST_COMPLETED)
+    finally:
+        # Every waiter is cancelled, including the one that completed: leaving
+        # a pending future behind on the timeout path would leak one task per
+        # wait call for the life of the session.
+        for waiter in waiters:
+            waiter.cancel()
+        await asyncio.gather(*waiters, return_exceptions=True)
+
+
 def build_wait_tool(context: ToolContext) -> AgentTool | None:
     if context.jobs is None:
         return None
@@ -5559,8 +5673,10 @@ def build_wait_tool(context: ToolContext) -> AgentTool | None:
         name="wait",
         label="Wait for job",
         description=(
-            "Block up to wait_ms for a background job to settle, returning its "
-            "final output/status. Times out if still running."
+            "Block until a background job settles (or wait_ms elapses), returning "
+            "its final output/status. Pass a LIST of job ids to wake on the first "
+            "one to finish. Returns the moment work settles, so prefer one "
+            "generous wait over repeated short ones."
         ),
         parameters=WaitParams.model_json_schema(),
         # read-only observation of job state; blocks the turn but changes nothing.

--- a/local_operator/tools/registry.py
+++ b/local_operator/tools/registry.py
@@ -16,6 +16,7 @@ from collections.abc import Callable, Sequence
 from local_operator.harness.intent import apply_intent_schema
 from local_operator.harness.types import AgentTool, ToolContext
 from local_operator.tools import builtin
+from local_operator.tools.agent_tool import build_agent_tool
 from local_operator.tools.eval import build_eval_tool
 from local_operator.tools.lsp import build_lsp_tool
 from local_operator.web_search.tool import build_web_search_tool
@@ -44,6 +45,7 @@ TOOL_BUILDERS: dict[str, Callable[[ToolContext], AgentTool | None]] = {
     "list_variables": lambda _context: builtin.build_list_variables_tool(),
     "read_variable": lambda _context: builtin.build_read_variable_tool(),
     "browser": lambda _context: builtin.build_browser_tool(_context),
+    "agent": lambda context: build_agent_tool(context),
 }
 
 #: Tool set used when the session does not restrict the names. Kept explicit
@@ -70,6 +72,7 @@ DEFAULT_TOOL_NAMES: list[str] = [
     "list_variables",
     "read_variable",
     "browser",
+    "agent",
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,7 +134,15 @@ dev = [
 include = ["local_operator*"]
 
 [tool.setuptools.package-data]
-local_operator = ["prompts_md/*.md", "guides/*/*.md", "tui/*.tcss"]
+local_operator = [
+    "prompts_md/*.md",
+    "guides/*/*.md",
+    "tui/*.tcss",
+    # Packaged starter role profiles. Without this they are absent from a
+    # wheel, and ``task(agent="reviewer")`` silently degrades to an unguided
+    # child on every non-source install.
+    "agent_seeds/*.md",
+]
 
 [project.urls]
 Homepage = "https://github.com/damianvtran/local-operator"

--- a/scripts/bench_role_overhead.py
+++ b/scripts/bench_role_overhead.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Always-on prompt overhead of the role/delegation surface.
+
+Every token in the system prompt and in an advertised tool's schema is paid on
+EVERY request of every session, cached-prefix or not. A feature that adds a tool
+therefore has a standing cost that is invisible in review unless someone
+measures it, and easy to misreport: two successive attempts to state this PR's
+cost were wrong because rows were measured on different bases (schema only vs
+the serialized entry a provider actually receives).
+
+So the basis is fixed here, in code, and it is the same for every row:
+
+- a tool costs the tokens of ``{"name", "description", "parameters"}`` as JSON,
+  which is what rides in the provider's ``tools`` array;
+- the system prompt costs the tokens of its rendered markdown.
+
+Run it in a worktree of the branch and again in one of the base commit, then
+diff the two JSON blobs. Reporting a delta measured any other way is how the
+number drifts from what the user is billed.
+
+    python scripts/bench_role_overhead.py
+
+``cl100k_base`` is a stand-in for "a typical BPE tokenizer": absolute counts
+differ per provider, but the deltas this is used for do not move enough to
+change a decision.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import tiktoken  # noqa: E402
+
+from local_operator.harness.types import ToolContext  # noqa: E402
+from local_operator.tools.registry import create_tools  # noqa: E402
+
+#: Tools whose cost this benchmark tracks. Not every tool: these are the ones
+#: the delegation surface owns, so a regression here is attributable.
+TRACKED = ("task", "wait", "jobs", "hub", "agent")
+
+
+class _StubComms:
+    """Enough of ``SubagentComms`` for ``hub``'s createIf gate.
+
+    ``is_child`` decides which SHAPE of the tool is built (address peers vs
+    message your parent), and the two differ in schema size — so this reports
+    the parent shape, which is what a top-level session pays.
+    """
+
+    def is_child(self, job_id: str | None) -> bool:
+        return False
+
+
+class _StubJobs:
+    """Satisfies ``JobManagerProtocol`` so the job-gated tools are built."""
+
+    def get(self, job_id: str, *, owner_id: str | None = None) -> None:
+        return None
+
+    def list(self, *, owner_id: str | None = None) -> list[object]:
+        return []
+
+    async def cancel(self, job_id: str, *, owner_id: str | None = None) -> bool:
+        return True
+
+
+def main() -> int:
+    encoding = tiktoken.get_encoding("cl100k_base")
+
+    def tokens(text: str) -> int:
+        return len(encoding.encode(text))
+
+    # A FULLY capable context: every createIf gate satisfied, so a tool missing
+    # from the output is a tool that does not exist on this commit rather than
+    # one this fixture failed to enable.
+    context = ToolContext(
+        cwd=".",
+        subagent_launcher=lambda *args, **kwargs: "job",
+        jobs=_StubJobs(),
+        agent_registry=object(),
+        subagent_comms=_StubComms(),
+        has_ui=True,
+    )
+    built = {tool.name: tool for tool in create_tools(context)}
+
+    report: dict[str, int] = {}
+    prompt_path = Path(__file__).resolve().parent.parent / "local_operator" / "prompts_md"
+    report["system_prompt"] = tokens((prompt_path / "system.md").read_text(encoding="utf-8"))
+    for name in TRACKED:
+        tool = built.get(name)
+        report[name] = (
+            0
+            if tool is None
+            else tokens(
+                json.dumps(
+                    {
+                        "name": tool.name,
+                        "description": tool.description,
+                        "parameters": tool.parameters,
+                    }
+                )
+            )
+        )
+    report["total"] = sum(report.values())
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/bench_role_overhead.py
+++ b/scripts/bench_role_overhead.py
@@ -88,25 +88,41 @@ def main() -> int:
     built = {tool.name: tool for tool in create_tools(context)}
 
     report: dict[str, int] = {}
+    missing: list[str] = []
     prompt_path = Path(__file__).resolve().parent.parent / "local_operator" / "prompts_md"
     report["system_prompt"] = tokens((prompt_path / "system.md").read_text(encoding="utf-8"))
     for name in TRACKED:
         tool = built.get(name)
-        report[name] = (
-            0
-            if tool is None
-            else tokens(
-                json.dumps(
-                    {
-                        "name": tool.name,
-                        "description": tool.description,
-                        "parameters": tool.parameters,
-                    }
-                )
+        if tool is None:
+            # RECORDED, not silently zeroed. A tool absent because this commit
+            # does not have it and a tool absent because the fixture failed to
+            # satisfy its createIf gate produce the same 0, and diffing two
+            # commits is this script's whole purpose: a degraded fixture would
+            # quietly report a SAVING where there is a cost. The caller decides
+            # which case it is; the script refuses to guess.
+            missing.append(name)
+            report[name] = 0
+            continue
+        report[name] = tokens(
+            json.dumps(
+                {
+                    "name": tool.name,
+                    "description": tool.description,
+                    "parameters": tool.parameters,
+                }
             )
         )
     report["total"] = sum(report.values())
     print(json.dumps(report, indent=2, sort_keys=True))
+    if missing:
+        print(
+            "WARNING: not built on this commit (a 0 above may mean a broken fixture "
+            f"rather than an absent tool): {', '.join(missing)}",
+            file=sys.stderr,
+        )
+        # Non-zero exit so a scripted before/after diff cannot silently compare
+        # a full inventory against a degraded one.
+        return 1
     return 0
 
 

--- a/tests/unit/session/test_launch_subagent.py
+++ b/tests/unit/session/test_launch_subagent.py
@@ -729,8 +729,15 @@ async def test_scout_preamble_reaches_the_provider_turn(tmp_path, monkeypatch):
     await wait_for(settled)
     assert stream.requests
     first_user = next(message for message in stream.requests[0].messages if message.role == "user")
-    assert "[scout mode:" in first_user.text
+    # The ROLE framing reaches the turn ahead of the task, and the task itself
+    # survives verbatim. Asserted by behaviour rather than by the seed's exact
+    # wording: the scout guidance now lives in an editable profile
+    # (``local_operator/agent_seeds/scout.md``), so pinning its prose here
+    # would make every improvement to it a test failure.
+    assert first_user.text.startswith("[role: scout]"), first_user.text[:80]
+    assert "READ-ONLY" in first_user.text
     assert "Map the repo." in first_user.text
+    assert first_user.text.index("Map the repo.") > first_user.text.index("READ-ONLY")
     await parent.dispose()
 
 

--- a/tests/unit/session/test_role_subagents.py
+++ b/tests/unit/session/test_role_subagents.py
@@ -1,0 +1,198 @@
+"""Launching a subagent in a ROLE: guidance and tool surface reach the child.
+
+The contract under test is the boundary, not the wording: a role's guidance
+must arrive ahead of the task on the child's first turn, and a role's tool
+allowlist must be a capability the child physically lacks rather than advice it
+is asked to respect.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from local_operator.agents import AgentEditFields, AgentRegistry
+from local_operator.harness.types import (
+    AbortSignal,
+    ChatRequest,
+    StreamEndEvent,
+    StreamTextDelta,
+)
+from local_operator.session.session import Session
+from local_operator.session.transcript import Transcript
+from tests.unit.session.test_launch_subagent import MODEL, wait_for
+
+
+class RecordingStream:
+    """Serves one text-only turn and keeps the requests it was handed."""
+
+    def __init__(self) -> None:
+        self.requests: list[ChatRequest] = []
+
+    def __call__(self, request: ChatRequest, signal: AbortSignal | None):
+        self.requests.append(request)
+
+        async def gen():
+            yield StreamTextDelta(delta="ok")
+            yield StreamEndEvent(stop_reason="stop")
+
+        return gen()
+
+
+def make_parent(tmp_path, stream, **kwargs) -> Session:
+    return Session(
+        model=MODEL,
+        stream_fn=stream,
+        tools=[],
+        transcript=Transcript(tmp_path / "sess"),
+        system_blocks_provider=lambda: ["stable"],
+        **kwargs,
+    )
+
+
+async def run_role(parent: Session, role: str, prompt: str = "Do the thing.") -> None:
+    job_id = parent._launch_subagent(label=role, prompt=prompt, agent=role)
+    await wait_for(lambda: (job := parent.jobs.get(job_id)) is not None and job.status != "running")
+
+
+@pytest.mark.asyncio
+async def test_a_roles_guidance_arrives_ahead_of_the_task(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    stream = RecordingStream()
+    parent = make_parent(tmp_path, stream)
+
+    await run_role(parent, "reviewer", "Review PR 42.")
+
+    assert stream.requests
+    first_user = next(m for m in stream.requests[0].messages if m.role == "user")
+    assert first_user.text.startswith("[role: reviewer]")
+    assert "Review PR 42." in first_user.text
+    assert first_user.text.index("Review PR 42.") > first_user.text.index("[role: reviewer]")
+    await parent.dispose()
+
+
+@pytest.mark.asyncio
+async def test_a_reviewer_child_cannot_edit_but_can_run_commands(tmp_path, monkeypatch) -> None:
+    """The capability boundary: a reviewer that could edit would end up
+    reviewing a diff it had itself changed."""
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    stream = RecordingStream()
+    parent = make_parent(tmp_path, stream)
+
+    await run_role(parent, "reviewer")
+
+    names = {tool.name for tool in stream.requests[0].tools}
+    assert "edit" not in names and "write" not in names
+    assert "bash" in names and "read" in names
+    await parent.dispose()
+
+
+@pytest.mark.asyncio
+async def test_a_non_delegating_role_gets_no_task_tool(tmp_path, monkeypatch) -> None:
+    """A reviewer spawning its own children turns one review into a fan-out
+    nobody is watching."""
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    stream = RecordingStream()
+    parent = make_parent(tmp_path, stream)
+
+    await run_role(parent, "reviewer")
+
+    names = {tool.name for tool in stream.requests[0].tools}
+    assert not names & {"task", "wait", "jobs", "wake"}
+    await parent.dispose()
+
+
+@pytest.mark.asyncio
+async def test_an_unknown_role_still_launches_a_full_child(tmp_path, monkeypatch) -> None:
+    """A typo in a role name must not lose work the parent already decided to
+    delegate."""
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    stream = RecordingStream()
+    parent = make_parent(tmp_path, stream)
+
+    await run_role(parent, "no-such-role", "Still do it.")
+
+    first_user = next(m for m in stream.requests[0].messages if m.role == "user")
+    assert first_user.text == "Still do it.", "no role framing should be stamped"
+    names = {tool.name for tool in stream.requests[0].tools}
+    assert "edit" in names, "an unknown role must not silently restrict the child"
+    await parent.dispose()
+
+
+@pytest.mark.asyncio
+async def test_the_operators_own_role_overrides_the_packaged_one(tmp_path, monkeypatch) -> None:
+    """Editing the guidance has to actually change what the child is told —
+    otherwise the registry is decoration."""
+    config = tmp_path / "config"
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(config))
+    registry = AgentRegistry(config)
+    agent = registry.create_agent(
+        AgentEditFields(
+            name="reviewer",
+            description="house reviewer",
+            tags=["role", "tools:read"],
+            categories=["role"],
+            security_prompt=None,
+            hosting=None,
+            model=None,
+            last_message=None,
+            temperature=None,
+            top_p=None,
+            top_k=None,
+            max_tokens=None,
+            stop=None,
+            frequency_penalty=None,
+            presence_penalty=None,
+            seed=None,
+            current_working_directory=None,
+        )
+    )
+    registry.set_agent_system_prompt(agent.id, "ONLY CHECK THE MIGRATIONS.")
+
+    stream = RecordingStream()
+    parent = make_parent(tmp_path, stream, agent_registry=registry)
+
+    await run_role(parent, "reviewer")
+
+    first_user = next(m for m in stream.requests[0].messages if m.role == "user")
+    assert "ONLY CHECK THE MIGRATIONS." in first_user.text
+    names = {tool.name for tool in stream.requests[0].tools}
+    assert names == {"read"}, f"the operator's allowlist should win, got {names}"
+    await parent.dispose()
+
+
+@pytest.mark.asyncio
+async def test_a_plain_task_child_is_unchanged(tmp_path, monkeypatch) -> None:
+    """The default launch must pay nothing for the role machinery."""
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    stream = RecordingStream()
+    parent = make_parent(tmp_path, stream)
+
+    job_id = parent._launch_subagent(label="plain", prompt="Just do it.")
+    await wait_for(lambda: (job := parent.jobs.get(job_id)) is not None and job.status != "running")
+
+    first_user = next(m for m in stream.requests[0].messages if m.role == "user")
+    assert first_user.text == "Just do it."
+    await parent.dispose()
+
+
+@pytest.mark.asyncio
+async def test_the_single_task_form_accepts_a_role(tmp_path, monkeypatch) -> None:
+    """Found live: a model asked for one reviewer the obvious way and the call
+    was rejected, costing a round trip to rediscover that a role was only
+    reachable through the batch form."""
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    from local_operator.tools.builtin import TaskParams
+
+    params = TaskParams(label="review", prompt="Review it.", agent="reviewer")
+    assert params.agent == "reviewer"
+
+
+def test_the_batch_form_refuses_a_top_level_role() -> None:
+    """Silently ignoring it would leave every child in the batch unroled while
+    the caller believed it had asked for one."""
+    import pytest as _pytest
+
+    from local_operator.tools.builtin import TaskItem, TaskParams
+
+    with _pytest.raises(ValueError, match="each tasks"):
+        TaskParams(tasks=[TaskItem(label="a", prompt="b")], agent="reviewer")

--- a/tests/unit/session/test_tool_context_parity.py
+++ b/tests/unit/session/test_tool_context_parity.py
@@ -60,6 +60,11 @@ SENTINELS: dict[str, Any] = {
     # the way to the executor the child's hub tool would answer into a private
     # object nobody is waiting on.
     "subagent_comms": object(),
+    # The agent registry backs the ``agent`` tool and role resolution for
+    # ``task(agent=...)``. Dropped on the way to the executor, the tool would
+    # silently see no registry: role lookups would fall back to the packaged
+    # starters and every profile the operator authored would be invisible.
+    "agent_registry": object(),
 }
 
 #: ToolContext fields the Session takes under a DIFFERENT name. Kept tiny and

--- a/tests/unit/test_agent_profiles.py
+++ b/tests/unit/test_agent_profiles.py
@@ -242,3 +242,79 @@ def test_both_delegate_spellings_are_accepted(spelling: str, tmp_path) -> None:
 
     text = f"---\nname: x\ndescription: d\n{spelling}: yes\n---\nbody"
     assert _profile_from_text("x", text).may_delegate is True
+
+
+# ---------------------------------------------------------------------------
+# Round-1 review regressions on resolution itself.
+# ---------------------------------------------------------------------------
+
+
+def test_a_same_named_non_role_agent_does_not_become_the_role(tmp_path) -> None:
+    """C2: `get_agent_by_name` searches a flat namespace shared with ordinary
+    chat agents, so without the role tag an agent merely CALLED `reviewer` was
+    launched as one — with no allowlist, i.e. the full write inventory, while
+    the child was still told it was a reviewer."""
+    registry = AgentRegistry(tmp_path)
+    agent = registry.create_agent(_edit_fields(name="reviewer", description="my chat agent"))
+    registry.set_agent_system_prompt(agent.id, "Be agreeable.")
+
+    profile = resolve_profile("reviewer", registry=registry)
+
+    assert profile is not None
+    assert profile.agent_id is None, "must fall through to the packaged seed"
+    assert profile.tools, "a role without an allowlist is the fail-open case"
+    assert "Be agreeable." not in profile.instructions
+
+
+def test_a_role_tagged_agent_is_still_honoured(tmp_path) -> None:
+    """The guard must not break the feature it protects."""
+    registry = AgentRegistry(tmp_path)
+    agent = registry.create_agent(
+        _edit_fields(name="reviewer", description="house", tags=["role", "tools:read"])
+    )
+    registry.set_agent_system_prompt(agent.id, "HOUSE RULES")
+
+    profile = resolve_profile("reviewer", registry=registry)
+
+    assert profile is not None and profile.agent_id == agent.id
+    assert profile.tools == ("read",)
+    assert profile.instructions == "HOUSE RULES"
+
+
+def test_installing_over_a_non_role_name_refuses_rather_than_lying(tmp_path) -> None:
+    """C4 at the source: it used to return the existing row, which reads as a
+    successful install to every caller."""
+    import pytest as _pytest
+
+    from local_operator.agent_profiles import NameTakenError
+
+    registry = AgentRegistry(tmp_path)
+    registry.create_agent(_edit_fields(name="reviewer", description="chat"))
+    with _pytest.raises(NameTakenError):
+        install_seed("reviewer", registry=registry)
+
+
+def test_role_lookup_folds_case_like_the_seed_lookup_does(tmp_path) -> None:
+    """C9: seeds fold case and the registry did not, so `agent="Reviewer"`
+    found the PACKAGED seed while ignoring the operator's own."""
+    registry = AgentRegistry(tmp_path)
+    agent = registry.create_agent(_edit_fields(name="Reviewer", description="house", tags=["role"]))
+    registry.set_agent_system_prompt(agent.id, "HOUSE RULES")
+
+    for spelling in ("Reviewer", "reviewer", "REVIEWER"):
+        profile = resolve_profile(spelling, registry=registry)
+        assert profile is not None, spelling
+        assert profile.instructions == "HOUSE RULES", spelling
+
+
+def test_an_exact_match_still_wins_over_a_case_folded_one(tmp_path) -> None:
+    """The fold is a fallback, not a replacement: it runs only when the exact
+    lookup found nothing."""
+    registry = AgentRegistry(tmp_path)
+    exact = registry.create_agent(_edit_fields(name="triage", description="d", tags=["role"]))
+    registry.set_agent_system_prompt(exact.id, "EXACT")
+    other = registry.create_agent(_edit_fields(name="TRIAGE", description="d", tags=["role"]))
+    registry.set_agent_system_prompt(other.id, "FOLDED")
+
+    profile = resolve_profile("triage", registry=registry)
+    assert profile is not None and profile.instructions == "EXACT"

--- a/tests/unit/test_agent_profiles.py
+++ b/tests/unit/test_agent_profiles.py
@@ -318,3 +318,21 @@ def test_an_exact_match_still_wins_over_a_case_folded_one(tmp_path) -> None:
 
     profile = resolve_profile("triage", registry=registry)
     assert profile is not None and profile.instructions == "EXACT"
+
+
+def test_a_non_role_exact_match_does_not_shadow_the_operators_own_role(tmp_path) -> None:
+    """C11: the round-1 fold fix stopped at the exact lookup, so a non-role row
+    matching exactly discarded the hit and the fold never ran — reopening the
+    very bug the fold was added for, in the one arrangement its test missed."""
+    registry = AgentRegistry(tmp_path)
+    registry.create_agent(_edit_fields(name="reviewer", description="my chat agent"))
+    role = registry.create_agent(
+        _edit_fields(name="Reviewer", description="house", tags=["role", "tools:read"])
+    )
+    registry.set_agent_system_prompt(role.id, "HOUSE RULES")
+
+    profile = resolve_profile("reviewer", registry=registry)
+
+    assert profile is not None
+    assert profile.agent_id == role.id, "the operator's own role must win"
+    assert profile.instructions == "HOUSE RULES"

--- a/tests/unit/test_agent_profiles.py
+++ b/tests/unit/test_agent_profiles.py
@@ -194,8 +194,8 @@ class TestInstall:
         registry = AgentRegistry(tmp_path)
         result = install_seed("reviewer", registry=registry)
         assert result is not None
-        profile, already_there = result
-        assert profile.agent_id and not already_there
+        profile, already_installed = result
+        assert profile.agent_id and not already_installed
         agent = registry.get_agent_by_name("reviewer")
         assert agent is not None
         assert "role" in agent.tags
@@ -207,14 +207,14 @@ class TestInstall:
         registry = AgentRegistry(tmp_path)
         first_result = install_seed("reviewer", registry=registry)
         assert first_result is not None
-        first, first_already = first_result
-        assert not first_already
+        first, first_already_installed = first_result
+        assert not first_already_installed
         registry.set_agent_system_prompt(str(first.agent_id), "EDITED")
 
         second_result = install_seed("reviewer", registry=registry)
         assert second_result is not None
-        second, second_already = second_result
-        assert second_already, "a second install is a deliberate no-op and must say so"
+        second, second_already_installed = second_result
+        assert second_already_installed, "a second install is a deliberate no-op and must say so"
         assert second.agent_id == first.agent_id
         assert second.instructions == "EDITED"
         assert len([a for a in registry.list_agents() if a.name == "reviewer"]) == 1

--- a/tests/unit/test_agent_profiles.py
+++ b/tests/unit/test_agent_profiles.py
@@ -1,0 +1,244 @@
+"""Agent role profiles: seeds, registry resolution, and the tool surface.
+
+The behaviour under test is the CONTRACT of a role, never the prose of a
+particular seed: the seed bodies are editable operator-facing files, so a test
+that pinned their wording would turn every improvement to the guidance into a
+test failure.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from local_operator.agent_profiles import (
+    MAX_INSTRUCTIONS_CHARS,
+    AgentProfile,
+    filter_tools,
+    install_seed,
+    list_seeds,
+    load_seed,
+    resolve_profile,
+    seed_tags,
+)
+from local_operator.agents import AgentRegistry
+
+
+class _Tool:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+ALL_TOOLS: list[_Tool] = [
+    _Tool(name)
+    for name in ("bash", "read", "write", "edit", "glob", "grep", "eval", "todo", "browser")
+]
+
+
+def seed(name: str) -> AgentProfile:
+    """A packaged seed that must exist; keeps the type checker (and the reader)
+    from having to reason about None at every call site."""
+    profile = load_seed(name)
+    assert profile is not None, f"packaged seed {name} is missing"
+    return profile
+
+
+def _edit_fields(**overrides: Any):
+    """``AgentEditFields`` with every field spelled out (it is validated in
+    strict mode), overridden by the few a test cares about."""
+    from local_operator.agents import AgentEditFields
+
+    base: dict[str, Any] = dict(
+        name=None,
+        description=None,
+        tags=None,
+        categories=None,
+        security_prompt=None,
+        hosting=None,
+        model=None,
+        last_message=None,
+        temperature=None,
+        top_p=None,
+        top_k=None,
+        max_tokens=None,
+        stop=None,
+        frequency_penalty=None,
+        presence_penalty=None,
+        seed=None,
+        current_working_directory=None,
+    )
+    base.update(overrides)
+    return AgentEditFields(**base)
+
+
+def test_the_packaged_starters_are_all_loadable() -> None:
+    """A seed that cannot parse would be invisible at exactly the moment a
+    delegation asked for it, so every packaged file is checked here."""
+    names = list_seeds()
+    assert {"reviewer", "coder", "architect", "manager", "designer", "scout"} <= set(names)
+    for name in names:
+        profile = load_seed(name)
+        assert profile is not None, name
+        assert profile.name == name
+        assert profile.description, f"{name} has no routing description"
+        assert profile.when_to_use, f"{name} does not say when it applies"
+        assert profile.instructions.strip(), f"{name} has no guidance"
+
+
+def test_a_seed_name_cannot_escape_the_catalogue() -> None:
+    """The name is resolved against the catalogue, never joined onto a path."""
+    assert load_seed("../../etc/passwd") is None
+    assert load_seed("") is None
+    assert load_seed("does-not-exist") is None
+
+
+def test_the_reviewer_cannot_edit_but_can_run_the_tests() -> None:
+    """The role's whole point: a reviewer that could edit would end up
+    reviewing its own patch, and one that could not run anything would file
+    findings it never verified."""
+    names = {tool.name for tool in filter_tools(ALL_TOOLS, seed("reviewer"))}
+    assert "edit" not in names and "write" not in names
+    assert "bash" in names and "read" in names
+
+
+def test_a_read_only_role_gets_no_side_effect_tools() -> None:
+    names = {tool.name for tool in filter_tools(ALL_TOOLS, seed("scout"))}
+    assert names <= {"read", "glob", "grep"}
+    assert not names & {"bash", "eval", "browser", "write", "edit"}
+
+
+def test_a_role_without_an_allowlist_keeps_the_full_inventory() -> None:
+    coder = seed("coder")
+    assert coder.tools is None
+    assert filter_tools(ALL_TOOLS, coder) == ALL_TOOLS
+    assert filter_tools(ALL_TOOLS, None) == ALL_TOOLS
+
+
+def test_an_allowlist_naming_absent_tools_matches_nothing_rather_than_raising() -> None:
+    """A profile written on another machine (or naming an MCP tool this
+    session never loaded) must still run, with the tools it does have."""
+    profile = AgentProfile(name="x", tools=("read", "mcp__elsewhere__thing"))
+    assert [tool.name for tool in filter_tools(ALL_TOOLS, profile)] == ["read"]
+
+
+def test_only_the_delegating_roles_may_delegate() -> None:
+    """A reviewer spawning children turns one review into an unwatched
+    fan-out; a manager coordinating is the case that legitimately needs it."""
+    assert seed("manager").may_delegate is True
+    for name in ("reviewer", "coder", "scout", "architect", "designer"):
+        assert seed(name).may_delegate is False, name
+
+
+def test_the_preamble_is_empty_when_a_role_says_nothing() -> None:
+    """It rides in front of every prompt, so a role with no guidance must
+    cost nothing rather than emitting a header with nothing under it."""
+    assert AgentProfile(name="bare").preamble == ""
+    assert seed("reviewer").preamble.startswith("[role: reviewer]")
+
+
+def test_instructions_are_bounded(tmp_path) -> None:
+    """A profile is user data prepended to every turn of every run of the
+    role, so an unbounded body would be an unbounded per-turn bill."""
+    registry = AgentRegistry(tmp_path)
+    agent = registry.create_agent(_edit_fields(name="verbose", tags=["role"]))
+    registry.set_agent_system_prompt(agent.id, "x" * (MAX_INSTRUCTIONS_CHARS * 2))
+    profile = resolve_profile("verbose", registry=registry)
+    assert profile is not None
+    assert len(profile.instructions) == MAX_INSTRUCTIONS_CHARS
+
+
+class TestResolution:
+    def test_task_never_resolves_a_profile(self, tmp_path) -> None:
+        """The common launch must pay no registry lookup at all."""
+        assert resolve_profile("task", registry=AgentRegistry(tmp_path)) is None
+        assert resolve_profile(None) is None
+        assert resolve_profile("") is None
+
+    def test_an_unknown_role_resolves_to_nothing(self, tmp_path) -> None:
+        """The caller degrades to a full child; a typo must not lose the work."""
+        assert resolve_profile("no-such-role", registry=AgentRegistry(tmp_path)) is None
+
+    def test_a_packaged_starter_resolves_without_being_installed(self) -> None:
+        profile = resolve_profile("reviewer")
+        assert profile is not None and profile.agent_id is None
+
+    def test_the_operators_own_profile_wins_over_the_starter(self, tmp_path) -> None:
+        """Once an operator has a reviewer of their own, theirs is the one that
+        runs — otherwise editing the guidance would have no effect."""
+        registry = AgentRegistry(tmp_path)
+        installed = install_seed("reviewer", registry=registry)
+        assert installed is not None
+        registry.set_agent_system_prompt(str(installed.agent_id), "MY HOUSE RULES")
+
+        profile = resolve_profile("reviewer", registry=registry)
+        assert profile is not None
+        assert profile.instructions == "MY HOUSE RULES"
+        assert profile.agent_id == installed.agent_id
+
+    def test_a_broken_registry_falls_back_instead_of_failing(self) -> None:
+        """Role guidance is enrichment; losing the delegation over a registry
+        problem would be a worse outcome than running without the role."""
+
+        class Broken:
+            def get_agent_by_name(self, name):  # noqa: ANN001
+                raise RuntimeError("registry on fire")
+
+        profile = resolve_profile("reviewer", registry=Broken())
+        assert profile is not None and profile.agent_id is None
+
+
+class TestInstall:
+    def test_installing_makes_an_ordinary_editable_registry_row(self, tmp_path) -> None:
+        registry = AgentRegistry(tmp_path)
+        profile = install_seed("reviewer", registry=registry)
+        assert profile is not None and profile.agent_id
+        agent = registry.get_agent_by_name("reviewer")
+        assert agent is not None
+        assert "role" in agent.tags
+        assert registry.get_agent_system_prompt(agent.id).strip()
+
+    def test_installing_twice_neither_duplicates_nor_clobbers(self, tmp_path) -> None:
+        """Two launches of the same role can race; the second must not undo an
+        edit the operator made to the first."""
+        registry = AgentRegistry(tmp_path)
+        first = install_seed("reviewer", registry=registry)
+        assert first is not None
+        registry.set_agent_system_prompt(str(first.agent_id), "EDITED")
+
+        second = install_seed("reviewer", registry=registry)
+        assert second is not None and second.agent_id == first.agent_id
+        assert second.instructions == "EDITED"
+        assert len([a for a in registry.list_agents() if a.name == "reviewer"]) == 1
+
+    def test_an_unknown_starter_installs_nothing(self, tmp_path) -> None:
+        assert install_seed("nope", registry=AgentRegistry(tmp_path)) is None
+
+    def test_the_role_fields_survive_a_round_trip(self, tmp_path) -> None:
+        """Tools/effort/delegate are encoded in tags because AgentData is a
+        persisted, API-exposed model; this is the guard that the encoding and
+        the decoding still agree."""
+        registry = AgentRegistry(tmp_path)
+        install_seed("manager", registry=registry)
+        packaged = seed("manager")
+        profile = resolve_profile("manager", registry=registry)
+        assert profile is not None
+        assert profile.tools == packaged.tools
+        assert profile.effort == packaged.effort
+        assert profile.may_delegate == packaged.may_delegate
+
+
+def test_seed_tags_encode_only_what_is_set() -> None:
+    assert seed_tags(AgentProfile(name="plain")) == ("role",)
+    tags = seed_tags(AgentProfile(name="x", tools=("read",), effort="lo", may_delegate=True))
+    assert set(tags) == {"role", "tools:read", "effort:lo", "delegate:yes"}
+
+
+@pytest.mark.parametrize("spelling", ["delegate", "may_delegate"])
+def test_both_delegate_spellings_are_accepted(spelling: str, tmp_path) -> None:
+    """A human editing a seed should not have to remember which key the parser
+    happens to prefer."""
+    from local_operator.agent_profiles import _profile_from_text
+
+    text = f"---\nname: x\ndescription: d\n{spelling}: yes\n---\nbody"
+    assert _profile_from_text("x", text).may_delegate is True

--- a/tests/unit/test_agent_profiles.py
+++ b/tests/unit/test_agent_profiles.py
@@ -169,6 +169,7 @@ class TestResolution:
         registry = AgentRegistry(tmp_path)
         installed = install_seed("reviewer", registry=registry)
         assert installed is not None
+        installed = installed[0]
         registry.set_agent_system_prompt(str(installed.agent_id), "MY HOUSE RULES")
 
         profile = resolve_profile("reviewer", registry=registry)
@@ -191,8 +192,10 @@ class TestResolution:
 class TestInstall:
     def test_installing_makes_an_ordinary_editable_registry_row(self, tmp_path) -> None:
         registry = AgentRegistry(tmp_path)
-        profile = install_seed("reviewer", registry=registry)
-        assert profile is not None and profile.agent_id
+        result = install_seed("reviewer", registry=registry)
+        assert result is not None
+        profile, already_there = result
+        assert profile.agent_id and not already_there
         agent = registry.get_agent_by_name("reviewer")
         assert agent is not None
         assert "role" in agent.tags
@@ -202,12 +205,17 @@ class TestInstall:
         """Two launches of the same role can race; the second must not undo an
         edit the operator made to the first."""
         registry = AgentRegistry(tmp_path)
-        first = install_seed("reviewer", registry=registry)
-        assert first is not None
+        first_result = install_seed("reviewer", registry=registry)
+        assert first_result is not None
+        first, first_already = first_result
+        assert not first_already
         registry.set_agent_system_prompt(str(first.agent_id), "EDITED")
 
-        second = install_seed("reviewer", registry=registry)
-        assert second is not None and second.agent_id == first.agent_id
+        second_result = install_seed("reviewer", registry=registry)
+        assert second_result is not None
+        second, second_already = second_result
+        assert second_already, "a second install is a deliberate no-op and must say so"
+        assert second.agent_id == first.agent_id
         assert second.instructions == "EDITED"
         assert len([a for a in registry.list_agents() if a.name == "reviewer"]) == 1
 

--- a/tests/unit/test_prompts_api.py
+++ b/tests/unit/test_prompts_api.py
@@ -260,6 +260,10 @@ def test_inventory_block_matches_default_tool_order() -> None:
             # has to carry both or the tool drops out of the inventory.
             has_ui=True,
             ask_user=_fake_ask_for_blocks,
+            # `agent` is createIf-gated on a registry to persist roles into;
+            # only its PRESENCE is read here, since this test is about the
+            # ORDER of a fully-capable inventory.
+            agent_registry=object(),
         )
     )
     blocks = build_system_blocks(tools, "", ENV, DATE)

--- a/tests/unit/tools/test_agent_tool.py
+++ b/tests/unit/tools/test_agent_tool.py
@@ -53,7 +53,7 @@ def _edit_fields(**overrides: Any) -> AgentEditFields:
 
 
 async def call(context: ToolContext, **args) -> str:
-    result = await execute_agent("tc", args, context=context)
+    result = await execute_agent("tc", args, None, None, context)
     return result.text
 
 
@@ -259,3 +259,51 @@ async def test_authoring_refuses_a_name_owned_by_a_non_role(context, registry, o
     registry.create_agent(_edit_fields(name="reviewer", description="my chat agent"))
     body = await call(context, op=op, name="reviewer", description="d", instructions="x")
     assert "not a role" in body
+
+
+@pytest.mark.asyncio
+async def test_a_role_can_be_authored_as_a_delegating_one(context, registry) -> None:
+    """C14: `may_delegate` was preserved across updates but unreachable — no
+    role authored through this tool could ever coordinate, and an installed
+    manager's flag could not be revoked."""
+    await call(
+        context,
+        op="create",
+        name="lead",
+        description="coordinates multi-part work",
+        instructions="Coordinate.",
+        delegate=True,
+    )
+
+    def delegates() -> bool:
+        profile = resolve_profile("lead", registry=registry)
+        assert profile is not None
+        return profile.may_delegate
+
+    assert delegates() is True
+
+    await call(context, op="update", name="lead", instructions="Coordinate well.")
+    assert delegates() is True, "preserved across an unrelated update"
+
+    await call(context, op="update", name="lead", delegate=False)
+    assert delegates() is False, "revocable"
+
+
+@pytest.mark.asyncio
+async def test_the_tool_returns_an_error_result_instead_of_raising(context, registry) -> None:
+    """C13: `agent` was the only executor in the tree without `@_guard`, and
+    the harness contract is that tools never throw into the loop."""
+
+    def explode(*args, **kwargs):
+        raise PermissionError("agents dir is read-only")
+
+    registry.create_agent = explode  # type: ignore[method-assign]
+    result = await execute_agent(
+        "tc",
+        {"op": "create", "name": "x", "description": "d", "instructions": "i"},
+        None,
+        None,
+        context,
+    )
+    assert result.is_error
+    assert "PermissionError" in result.text or "read-only" in result.text

--- a/tests/unit/tools/test_agent_tool.py
+++ b/tests/unit/tools/test_agent_tool.py
@@ -187,3 +187,75 @@ async def test_search_needs_a_query(context) -> None:
 async def test_installing_an_unknown_starter_lists_the_real_ones(context) -> None:
     body = await call(context, op="install", name="nope")
     assert "no packaged starter" in body and "reviewer" in body
+
+
+# ---------------------------------------------------------------------------
+# Round-1 review regressions. The originals all passed a green suite because
+# they only ever exercised a freshly INSTALLED seed; these exercise the state
+# after an edit, and the collision with a same-named non-role agent.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_update_keeps_the_allowlist_it_was_not_asked_to_change(context, registry) -> None:
+    """C1: refining a role's wording used to strip its `tools:` tag, handing a
+    reviewer `edit`/`write` — failing OPEN while reporting success."""
+    await call(context, op="install", name="reviewer")
+    before = resolve_profile("reviewer", registry=registry)
+    assert before is not None and before.tools
+
+    await call(context, op="update", name="reviewer", instructions="Read the diff first.")
+
+    after = resolve_profile("reviewer", registry=registry)
+    assert after is not None
+    assert after.tools == before.tools, "the allowlist is a capability boundary"
+    assert "Read the diff first." in after.instructions
+
+
+@pytest.mark.asyncio
+async def test_update_keeps_the_effort_tier_and_delegation_flag(context, registry) -> None:
+    """C1, the same bug on the other two role fields."""
+    await call(context, op="install", name="manager")
+    before = resolve_profile("manager", registry=registry)
+    assert before is not None and before.effort == "lo" and before.may_delegate
+
+    await call(context, op="update", name="manager", description="new routing text")
+
+    after = resolve_profile("manager", registry=registry)
+    assert after is not None
+    assert after.effort == before.effort
+    assert after.may_delegate == before.may_delegate
+    assert after.tools == before.tools
+
+
+@pytest.mark.asyncio
+async def test_an_explicit_empty_tools_list_still_clears_the_allowlist(context, registry) -> None:
+    """Preserving an omitted field must not make the field unclearable:
+    NAMING it with an empty value is how you widen a role deliberately."""
+    await call(context, op="install", name="reviewer")
+    await call(context, op="update", name="reviewer", tools=[])
+    profile = resolve_profile("reviewer", registry=registry)
+    assert profile is not None and profile.tools is None
+
+
+@pytest.mark.asyncio
+async def test_install_refuses_a_name_owned_by_a_non_role(context, registry) -> None:
+    """C4: it used to report a successful install while writing nothing, which
+    is the worst possible answer to someone recovering from a broken role."""
+    agent = registry.create_agent(_edit_fields(name="reviewer", description="my chat agent"))
+    registry.set_agent_system_prompt(agent.id, "Be agreeable.")
+
+    body = await call(context, op="install", name="reviewer")
+
+    assert "not a role" in body and "nothing was installed" in body
+    assert registry.get_agent_system_prompt(agent.id) == "Be agreeable.", "must not overwrite"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("op", ["create", "update"])
+async def test_authoring_refuses_a_name_owned_by_a_non_role(context, registry, op: str) -> None:
+    """An ordinary agent must not silently become a role, and on the update
+    path converting one would be the same fail-open hijack."""
+    registry.create_agent(_edit_fields(name="reviewer", description="my chat agent"))
+    body = await call(context, op=op, name="reviewer", description="d", instructions="x")
+    assert "not a role" in body

--- a/tests/unit/tools/test_agent_tool.py
+++ b/tests/unit/tools/test_agent_tool.py
@@ -1,0 +1,189 @@
+"""The ``agent`` tool: role discovery, installation, and authoring."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from local_operator.agent_profiles import resolve_profile
+from local_operator.agents import AgentEditFields, AgentRegistry
+from local_operator.harness.types import ToolContext
+from local_operator.tools.agent_tool import build_agent_tool, execute_agent
+
+
+@pytest.fixture()
+def registry(tmp_path) -> AgentRegistry:
+    return AgentRegistry(tmp_path)
+
+
+@pytest.fixture()
+def context(registry: AgentRegistry) -> ToolContext:
+    return _context(agent_registry=registry)
+
+
+def _context(**kwargs: Any) -> ToolContext:
+    return ToolContext(cwd=".", **kwargs)
+
+
+def _edit_fields(**overrides: Any) -> AgentEditFields:
+    """``AgentEditFields`` with every field spelled out (it is validated in
+    strict mode), overridden by the few a test cares about."""
+    base: dict[str, Any] = dict(
+        name=None,
+        description=None,
+        tags=None,
+        categories=None,
+        security_prompt=None,
+        hosting=None,
+        model=None,
+        last_message=None,
+        temperature=None,
+        top_p=None,
+        top_k=None,
+        max_tokens=None,
+        stop=None,
+        frequency_penalty=None,
+        presence_penalty=None,
+        seed=None,
+        current_working_directory=None,
+    )
+    base.update(overrides)
+    return AgentEditFields(**base)
+
+
+async def call(context: ToolContext, **args) -> str:
+    result = await execute_agent("tc", args, context=context)
+    return result.text
+
+
+def test_the_tool_is_not_advertised_without_a_registry() -> None:
+    """createIf: a tool that could show a role but never keep one is a worse
+    surface than no tool."""
+    assert build_agent_tool(_context()) is None
+    assert build_agent_tool(_context(agent_registry=object())) is not None
+
+
+@pytest.mark.asyncio
+async def test_list_offers_starters_before_anything_is_installed(context) -> None:
+    body = await call(context, op="list")
+    assert "installable starters" in body
+    assert "reviewer" in body
+
+
+@pytest.mark.asyncio
+async def test_list_separates_registered_roles_from_starters(context, registry) -> None:
+    await call(context, op="install", name="reviewer")
+    body = await call(context, op="list")
+    registered, _, starters = body.partition("installable starters")
+    assert "reviewer" in registered
+    assert "reviewer" not in starters, "an installed role must not still be offered"
+    assert "architect" in starters
+
+
+@pytest.mark.asyncio
+async def test_list_ignores_agents_that_are_not_roles(context, registry) -> None:
+    """A registry also holds ordinary conversational agents; listing those as
+    delegation targets would be noise at best and a privacy leak at worst."""
+    registry.create_agent(_edit_fields(name="my-private-notes", description="personal"))
+    body = await call(context, op="list")
+    assert "my-private-notes" not in body
+
+
+@pytest.mark.asyncio
+async def test_search_finds_the_right_role_from_a_task_description(context) -> None:
+    """The routing case: the delegator describes the work, not the role name."""
+    body = await call(context, op="search", query="check this pull request diff for bugs")
+    assert "reviewer" in body
+
+
+@pytest.mark.asyncio
+async def test_search_finds_a_role_authored_a_moment_ago(context) -> None:
+    """No rebuild step: a role created in this session is routable now."""
+    await call(
+        context,
+        op="create",
+        name="sec-auditor",
+        description="Security audit of authentication and tenant isolation code paths",
+        instructions="Audit for authz gaps and tenant leakage. Cite file:line.",
+    )
+    body = await call(context, op="search", query="look for tenant isolation problems in auth")
+    assert "sec-auditor" in body
+
+
+@pytest.mark.asyncio
+async def test_show_returns_the_full_instructions(context) -> None:
+    body = await call(context, op="show", name="reviewer")
+    assert "instructions:" in body
+    assert "BLOCKER" in body
+    assert "not installed" in body
+
+
+@pytest.mark.asyncio
+async def test_install_makes_the_role_launchable(context, registry) -> None:
+    body = await call(context, op="install", name="reviewer")
+    assert "installed role" in body
+    assert resolve_profile("reviewer", registry=registry) is not None
+
+
+@pytest.mark.asyncio
+async def test_create_then_update_changes_what_the_role_is_told(context, registry) -> None:
+    await call(
+        context,
+        op="create",
+        name="triager",
+        description="Triage incoming bug reports and route them",
+        instructions="ORIGINAL",
+        tools=["read", "grep"],
+        effort="lo",
+    )
+    profile = resolve_profile("triager", registry=registry)
+    assert profile is not None
+    assert profile.instructions == "ORIGINAL"
+    assert profile.tools == ("read", "grep")
+    assert profile.effort == "lo"
+
+    await call(context, op="update", name="triager", instructions="REVISED")
+    revised = resolve_profile("triager", registry=registry)
+    assert revised is not None and revised.instructions == "REVISED"
+
+
+@pytest.mark.asyncio
+async def test_create_refuses_to_clobber_an_existing_role(context) -> None:
+    await call(context, op="create", name="triager", description="d", instructions="ORIGINAL")
+    body = await call(context, op="create", name="triager", description="d", instructions="NEW")
+    assert "already exists" in body
+
+
+@pytest.mark.asyncio
+async def test_update_refuses_an_unknown_role(context) -> None:
+    assert "no registered role" in await call(context, op="update", name="ghost", instructions="x")
+
+
+@pytest.mark.asyncio
+async def test_create_needs_instructions(context) -> None:
+    assert "needs 'instructions'" in await call(context, op="create", name="empty", description="d")
+
+
+@pytest.mark.asyncio
+async def test_oversized_instructions_are_refused(context) -> None:
+    """They ride in front of every run of the role, so the bound is the point."""
+    body = await call(context, op="create", name="huge", description="d", instructions="x" * 20_000)
+    assert "exceed" in body
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("op", ["show", "install", "create", "update"])
+async def test_ops_that_need_a_name_say_so(context, op: str) -> None:
+    assert "needs 'name'" in await call(context, op=op)
+
+
+@pytest.mark.asyncio
+async def test_search_needs_a_query(context) -> None:
+    assert "needs 'query'" in await call(context, op="search")
+
+
+@pytest.mark.asyncio
+async def test_installing_an_unknown_starter_lists_the_real_ones(context) -> None:
+    body = await call(context, op="install", name="nope")
+    assert "no packaged starter" in body and "reviewer" in body

--- a/tests/unit/tools/test_agent_tool.py
+++ b/tests/unit/tools/test_agent_tool.py
@@ -455,3 +455,25 @@ async def test_a_weak_search_result_is_worded_as_a_nearest_neighbour(context) ->
     weak = await call(context, op="search", query="order me a pizza")
     assert weak.startswith("nothing scored strongly")
     assert "- " in weak, "the shortlist is still shown, just not as a recommendation"
+
+
+@pytest.mark.asyncio
+async def test_search_only_claims_best_first_when_it_ranked(context, monkeypatch) -> None:
+    """C20: `_ranked_names`' fallback returns [], which leaves the rows in
+    `select`'s NAME order — so the header claimed "best first" over an
+    alphabetical list, the exact hazard the helper's docstring names. The
+    header is honest exactly when the helper works and wrong when it does not.
+    """
+    import local_operator.skills.index as index_module
+
+    healthy = await call(context, op="search", query="review a merge request for defects")
+    assert healthy.startswith("closest roles (best first):")
+
+    def boom(*args: Any, **kwargs: Any):
+        raise TypeError("signature drifted")
+
+    monkeypatch.setattr(index_module, "_hybrid_scores", boom)
+    degraded = await call(context, op="search", query="review a merge request for defects")
+    assert degraded.startswith("closest roles:")
+    assert "best first" not in degraded
+    assert "- " in degraded, "the shortlist is still returned, just unordered"

--- a/tests/unit/tools/test_agent_tool.py
+++ b/tests/unit/tools/test_agent_tool.py
@@ -389,3 +389,69 @@ async def test_an_overlong_row_is_marked_as_truncated(context, registry) -> None
     await call(context, op="create", name="wordy", description="x " * 400, instructions="i")
     row = next(line for line in (await call(context, op="list")).splitlines() if "wordy" in line)
     assert row.endswith("…")
+
+
+# ---------------------------------------------------------------------------
+# Design review round-2 regressions.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("query", "expected"),
+    [
+        ("check the UI looks right", "designer"),
+        ("find where this function is defined", "scout"),
+        ("write the code for this ticket", "coder"),
+        ("make the button look nicer", "designer"),
+        ("fix this bug", "coder"),
+    ],
+)
+async def test_search_still_works_after_the_roles_are_installed(
+    context, query: str, expected: str
+) -> None:
+    """D10: `install_seed` persisted `description` while the enriched trigger
+    text lived in `when_to_use`, so installing a role — the flow the list
+    header advertises — discarded exactly the text `search` matches on. Four of
+    five of the round-1 queries then resolved to the WRONG role, and because
+    the absolute threshold had been removed the failure was confident rather
+    than visible ("check the UI looks right" -> manager).
+
+    The round-1 tests only exercised packaged starters, which is why this
+    escaped; this one installs first.
+    """
+    for name in ("reviewer", "coder", "designer", "scout", "architect", "manager"):
+        await call(context, op="install", name=name)
+
+    body = await call(context, op="search", query=query)
+    rows = [line for line in body.splitlines() if line.startswith("- ")]
+    assert rows, f"{query!r} matched no role after install"
+    assert rows[0].split()[1] == expected, f"{query!r} -> {rows[0]}"
+
+
+@pytest.mark.asyncio
+async def test_the_listing_stays_scannable(context) -> None:
+    """D11: enriching the trigger text for retrieval pushed rows to 188-246
+    chars, so six roles rendered as 22 physical lines at 80 columns with no
+    indent marking where one ended. Display now prefers the short description
+    and the row cap bounds the rest."""
+    body = await call(context, op="list")
+    rows = [line for line in body.splitlines() if line.startswith("- ")]
+    assert rows
+    assert all(len(row) <= 160 for row in rows), sorted(len(row) for row in rows)
+    physical = sum(-(-len(row) // 80) for row in rows)
+    assert physical <= 14, f"{physical} physical lines at 80 columns"
+    header = next(line for line in body.splitlines() if "installable starters" in line)
+    assert len(header) <= 80, len(header)
+
+
+@pytest.mark.asyncio
+async def test_a_weak_search_result_is_worded_as_a_nearest_neighbour(context) -> None:
+    """D12: with no absolute cut, an unrelated query still returns three roles,
+    and nothing in a bare list distinguished a 0.65 hit from 0.03 noise."""
+    strong = await call(context, op="search", query="review a merge request for defects")
+    assert strong.startswith("closest roles (best first):")
+
+    weak = await call(context, op="search", query="order me a pizza")
+    assert weak.startswith("nothing scored strongly")
+    assert "- " in weak, "the shortlist is still shown, just not as a recommendation"

--- a/tests/unit/tools/test_agent_tool.py
+++ b/tests/unit/tools/test_agent_tool.py
@@ -307,3 +307,85 @@ async def test_the_tool_returns_an_error_result_instead_of_raising(context, regi
     )
     assert result.is_error
     assert "PermissionError" in result.text or "read-only" in result.text
+
+
+# ---------------------------------------------------------------------------
+# Design review round-1 regressions (copy surface).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_an_unrestricted_role_is_not_shown_as_the_smallest_one(context) -> None:
+    """D2: the badge was emitted only when an allowlist existed, so the roles
+    with FULL write access rendered as a bare `[starter]` while read-only
+    `scout` showed `[5 tools]` — inverting the one attribute the guide calls a
+    capability boundary."""
+    body = await call(context, op="list")
+    rows = {line.split()[1]: line for line in body.splitlines() if line.startswith("- ")}
+    assert "all tools" in rows["coder"], rows["coder"]
+    assert "all tools" in rows["designer"], rows["designer"]
+    assert "5 tools" in rows["scout"], rows["scout"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("query", "expected"),
+    [
+        ("find where this function is defined", "scout"),
+        ("write the code for this ticket", "coder"),
+        ("make the button look nicer", "designer"),
+        ("audit this diff for problems", "reviewer"),
+        ("decide between two architectures", "architect"),
+    ],
+)
+async def test_search_answers_the_phrasings_the_seeds_advertise(
+    context, query: str, expected: str
+) -> None:
+    """D1: the shared index threshold (0.19) is calibrated for full skill
+    bodies, so one-sentence role descriptions scored 0.118-0.177 and were cut —
+    `scout.md` promises "locating code" while that query returned nothing. The
+    ranking is now surfaced best-first rather than gated on an absolute score.
+    """
+    body = await call(context, op="search", query=query)
+    rows = [line for line in body.splitlines() if line.startswith("- ")]
+    assert rows, f"{query!r} matched no role"
+    assert rows[0].split()[1] == expected, f"{query!r} -> {rows[0]}"
+
+
+@pytest.mark.asyncio
+async def test_show_on_an_uninstalled_starter_names_the_next_command(context) -> None:
+    """D3: it stated "not installed" and stopped, at the moment the reader has
+    just decided they want the role."""
+    body = await call(context, op="show", name="coder")
+    assert "task(agent='coder')" in body
+    assert "op='install'" in body
+
+
+@pytest.mark.asyncio
+async def test_a_role_with_no_description_says_it_is_undiscoverable(context) -> None:
+    """D6: an empty description rendered as a dangling `- name: `, hiding that
+    `search` matches on exactly that text."""
+    await call(context, op="create", name="nodesc", instructions="does a thing")
+    row = next(line for line in (await call(context, op="list")).splitlines() if "nodesc" in line)
+    assert "not searchable" in row
+
+
+@pytest.mark.asyncio
+async def test_an_invalid_effort_tier_is_refused(context) -> None:
+    """D5: it was accepted silently and then rendered in the badge slot as
+    though it were a real tier, teaching the reader that any token belongs
+    there."""
+    body = await call(
+        context, op="create", name="e1", description="d", instructions="i", effort="ludicrous"
+    )
+    assert "invalid arguments" in body
+    assert "effort" in body
+
+
+@pytest.mark.asyncio
+async def test_an_overlong_row_is_marked_as_truncated(context, registry) -> None:
+    """D4: a bare slice ends mid-word, so a reader cannot tell an author's
+    fragment from text the tool dropped."""
+    await call(context, op="create", name="wordy", description="x " * 400, instructions="i")
+    row = next(line for line in (await call(context, op="list")).splitlines() if "wordy" in line)
+    assert row.endswith("…")

--- a/tests/unit/tools/test_agent_tool.py
+++ b/tests/unit/tools/test_agent_tool.py
@@ -477,3 +477,31 @@ async def test_search_only_claims_best_first_when_it_ranked(context, monkeypatch
     assert degraded.startswith("closest roles:")
     assert "best first" not in degraded
     assert "- " in degraded, "the shortlist is still returned, just unordered"
+
+
+@pytest.mark.asyncio
+async def test_reinstalling_an_edited_role_reports_the_no_op(context, registry) -> None:
+    """D14: `install_seed` is deliberately idempotent, but the message did not
+    say so — and `install` is the only verb here that sounds like "put the
+    shipped one back". An operator recovering from a role they broke was told
+    `installed role 'reviewer'` while their own edited prompt remained what the
+    next delegation would run. Same failure shape C4 fixed on the non-role
+    branch.
+    """
+    await call(context, op="install", name="reviewer")
+    await call(context, op="update", name="reviewer", instructions="ONLY CHECK THE MIGRATIONS.")
+
+    body = await call(context, op="install", name="reviewer")
+
+    assert "already installed" in body and "left as-is" in body
+    profile = resolve_profile("reviewer", registry=registry)
+    assert profile is not None
+    assert "MIGRATIONS" in profile.instructions, "the edit must survive, and it does"
+
+
+@pytest.mark.asyncio
+async def test_a_single_tool_role_is_not_labelled_one_tools(context) -> None:
+    """D15: the badge was built unconditionally as `{n} tools`."""
+    await call(context, op="create", name="one", description="d", instructions="i", tools=["read"])
+    row = next(line for line in (await call(context, op="list")).splitlines() if "one" in line)
+    assert "[1 tool]" in row and "1 tools" not in row

--- a/tests/unit/tools/test_registry.py
+++ b/tests/unit/tools/test_registry.py
@@ -56,14 +56,18 @@ async def _ask_user(questions: list[Any]) -> dict[str, list[str]] | None:
 def _engine_context(**kwargs) -> ToolContext:
     """A context carrying every capability the default surface reads, so the
     whole table can build: the wake scheduler, the subagent launcher, the job
-    manager, and the ask hook plus the ``has_ui`` flag ``ask`` needs (it is
-    gated on both — the hook is what a subagent lacks, the flag is what a
-    headless host declares)."""
+    manager, the agent registry, and the ask hook plus the ``has_ui`` flag
+    ``ask`` needs (it is gated on both — the hook is what a subagent lacks,
+    the flag is what a headless host declares)."""
     base: dict[str, Any] = dict(
         wake_scheduler=_FakeScheduler(),
         subagent_launcher=_launcher,
         jobs=_FakeJobs(),
         subagent_comms=_FakeComms(),
+        # Only its PRESENCE is read by the createIf gate for the ``agent``
+        # tool; the ops themselves are exercised in the agent-tool tests
+        # against a real registry.
+        agent_registry=object(),
         has_ui=True,
         ask_user=_ask_user,
     )

--- a/tests/unit/tools/test_wait_settles_on_events.py
+++ b/tests/unit/tools/test_wait_settles_on_events.py
@@ -242,3 +242,34 @@ async def test_the_timeout_names_a_job_that_is_actually_running() -> None:
     assert result.details["job_id"] == second
     assert first not in result.text
     await manager.dispose()
+
+
+@pytest.mark.asyncio
+async def test_a_job_swept_mid_wait_does_not_spin_the_loop() -> None:
+    """C12: an evicted row yields a pre-set event, so `asyncio.wait` returned
+    at once, `_settled()` found nothing, and the caller's loop re-entered at
+    full speed — burning the event loop this path exists to protect, and faster
+    than the poll it replaced (measured 635/s)."""
+    import local_operator.tools.builtin as builtin_module
+
+    manager = AsyncJobManager(retention_ms=0)
+    context = ToolContext(cwd=".", jobs=manager)
+    calls = {"n": 0}
+    original = builtin_module._await_any_settled
+
+    async def counted(*args: Any, **kwargs: Any) -> None:
+        calls["n"] += 1
+        await original(*args, **kwargs)
+
+    settles_soon = manager.register("task", "A", _runner(0.15, "done"))
+    keeps_running = manager.register("task", "B", _runner(60.0))
+
+    builtin_module._await_any_settled = counted
+    try:
+        result = await _wait(context, job_id=[settles_soon, keeps_running], wait_ms=800)
+    finally:
+        builtin_module._await_any_settled = original
+
+    assert "still running" in result.text
+    assert calls["n"] < 20, f"spun {calls['n']} times; the wait is busy-looping"
+    await manager.dispose()

--- a/tests/unit/tools/test_wait_settles_on_events.py
+++ b/tests/unit/tools/test_wait_settles_on_events.py
@@ -273,3 +273,29 @@ async def test_a_job_swept_mid_wait_does_not_spin_the_loop() -> None:
     assert "still running" in result.text
     assert calls["n"] < 20, f"spun {calls['n']} times; the wait is busy-looping"
     await manager.dispose()
+
+
+@pytest.mark.asyncio
+async def test_waiting_on_only_vanished_ids_does_not_raise() -> None:
+    """C17: the empty-events early return is load-bearing and nothing pinned
+    it — deleting it left the whole suite green, while `asyncio.wait([])`
+    raises `ValueError: Set of Tasks/Futures is empty.`
+
+    Asserted against the HELPER, not through `execute_wait`: the tool's own
+    "disappeared" check fires first and would mask the raise, which is exactly
+    why the round-2 suite did not notice. Round-2's spin test evicts only ONE
+    of two jobs, so a surviving sibling always kept the list non-empty.
+    """
+    from local_operator.tools.builtin import _await_any_settled
+
+    manager = AsyncJobManager(retention_ms=0)
+    job_id = manager.register("task", "A", _runner(0.01, "a"))
+    await asyncio.sleep(0.1)
+    assert manager.get(job_id) is None, "the retention sweep should have evicted it"
+
+    # Must return cleanly rather than raising, and must not return instantly
+    # (that is the busy spin C12 fixed).
+    started = time.perf_counter()
+    await asyncio.wait_for(_await_any_settled(manager, [job_id], 0.2, None), timeout=5.0)
+    assert time.perf_counter() - started >= 0.1
+    await manager.dispose()

--- a/tests/unit/tools/test_wait_settles_on_events.py
+++ b/tests/unit/tools/test_wait_settles_on_events.py
@@ -290,12 +290,23 @@ async def test_waiting_on_only_vanished_ids_does_not_raise() -> None:
 
     manager = AsyncJobManager(retention_ms=0)
     job_id = manager.register("task", "A", _runner(0.01, "a"))
-    await asyncio.sleep(0.1)
+
+    # POLL for the eviction rather than sleeping a fixed budget. Measured over
+    # 40 samples the register->evicted interval averages 18ms but reached 51ms
+    # under load, so any fixed budget is a wall-clock bet against scheduler
+    # jitter — the same defect as the `test_loop_liveness` threshold, and it
+    # cost this test 2 failures in 47 runs on the SETUP assertion rather than
+    # on the behaviour it exists to pin.
+    deadline = time.perf_counter() + 5.0
+    while manager.get(job_id) is not None and time.perf_counter() < deadline:
+        await asyncio.sleep(0.01)
     assert manager.get(job_id) is None, "the retention sweep should have evicted it"
 
     # Must return cleanly rather than raising, and must not return instantly
-    # (that is the busy spin C12 fixed).
+    # (that is the busy spin C12 fixed). The lower bound is checked against the
+    # budget actually requested, so it cannot drift from the argument above.
+    budget = 0.2
     started = time.perf_counter()
-    await asyncio.wait_for(_await_any_settled(manager, [job_id], 0.2, None), timeout=5.0)
-    assert time.perf_counter() - started >= 0.1
+    await asyncio.wait_for(_await_any_settled(manager, [job_id], budget, None), timeout=5.0)
+    assert time.perf_counter() - started >= budget / 2
     await manager.dispose()

--- a/tests/unit/tools/test_wait_settles_on_events.py
+++ b/tests/unit/tools/test_wait_settles_on_events.py
@@ -173,3 +173,72 @@ async def test_dispose_wakes_a_waiter_instead_of_stranding_it() -> None:
 
     result = await asyncio.wait_for(waiter, timeout=5.0)
     assert "cancelled" in result.text.lower()
+
+
+# ---------------------------------------------------------------------------
+# Round-1 review regressions.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_an_aborted_wait_returns_promptly() -> None:
+    """C3: the old 50ms poll re-read `signal.aborted` every tick. Parking on
+    the settle events alone made the abort branch dead for a job that never
+    settles — an aborted wait sat for its whole budget (up to five minutes).
+    The TUI masks this through its own interruptible-tool poll, but that is a
+    different mechanism and does not cover deadline signals or non-TUI hosts.
+    """
+    from local_operator.harness.types import AbortSignal
+
+    manager = AsyncJobManager()
+    context = ToolContext(cwd=".", jobs=manager)
+    job_id = manager.register("task", "slow", _runner(30.0))
+    signal = AbortSignal()
+
+    async def abort_soon() -> None:
+        await asyncio.sleep(0.1)
+        signal.abort("user")
+
+    asyncio.ensure_future(abort_soon())
+    started = time.perf_counter()
+    result = await execute_wait("wc", {"job_id": job_id, "wait_ms": 10_000}, signal, None, context)
+    elapsed = time.perf_counter() - started
+
+    assert "aborted" in result.text
+    assert elapsed < 3.0, f"abort took {elapsed:.2f}s to be noticed"
+    await manager.dispose()
+
+
+@pytest.mark.asyncio
+async def test_an_event_is_not_stored_for_a_job_that_has_no_row() -> None:
+    """C5: the pre-set branch also STORED the event, and `_sweep_due` only pops
+    ids it finds in `_jobs`, so those entries were unreachable by every cleanup
+    path."""
+    manager = AsyncJobManager()
+    for index in range(50):
+        event = manager.settled_event(f"ghost-{index}")
+        assert event.is_set(), "an id with no row can never settle"
+    assert manager._settled_events == {}
+    await manager.dispose()
+
+
+@pytest.mark.asyncio
+async def test_the_timeout_names_a_job_that_is_actually_running() -> None:
+    """C6: `details` pinned `job_ids[0]`, which on the multi-id path is just
+    the first id the caller passed and may itself have settled."""
+    manager = AsyncJobManager()
+    context = ToolContext(cwd=".", jobs=manager)
+    first = manager.register("task", "A", _runner(30.0))
+    second = manager.register("task", "B", _runner(30.0))
+
+    async def evict() -> None:
+        await asyncio.sleep(0.05)
+        del manager._jobs[first]
+
+    asyncio.ensure_future(evict())
+    result = await _wait(context, job_id=[first, second], wait_ms=250)
+
+    assert result.details is not None
+    assert result.details["job_id"] == second
+    assert first not in result.text
+    await manager.dispose()

--- a/tests/unit/tools/test_wait_settles_on_events.py
+++ b/tests/unit/tools/test_wait_settles_on_events.py
@@ -1,0 +1,175 @@
+"""``wait`` returns on the settle EVENT, not on the next poll tick.
+
+The measured problem: across recorded sessions 70% of ``wait`` calls hit their
+deadline and returned "still running", and each of those cost a full parent
+model round trip to learn nothing. Two things fix that — waking the instant a
+job settles (so a generous budget is free), and being able to wait on several
+jobs at once (so a fan-out does not need one poll per child).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Any
+
+import pytest
+
+from local_operator.harness.jobs import AsyncJobManager
+from local_operator.harness.types import ToolContext
+from local_operator.tools.builtin import execute_wait
+
+
+def _runner(delay: float, result: str = "done") -> Any:
+    """A JobRunFn that finishes after ``delay`` seconds."""
+
+    async def run(job_id: str, signal: Any, report_progress: Any) -> str:
+        await asyncio.sleep(delay)
+        return result
+
+    return run
+
+
+async def _wait(context: ToolContext, **args: Any):
+    return await execute_wait("wc", args, None, None, context)
+
+
+@pytest.mark.asyncio
+async def test_wait_returns_as_soon_as_the_job_settles() -> None:
+    """A generous budget must cost nothing when the work finishes early."""
+    manager = AsyncJobManager()
+    context = ToolContext(cwd=".", jobs=manager)
+    job_id = manager.register("task", "reviewer", _runner(0.2, "reviewed"))
+
+    started = time.perf_counter()
+    result = await _wait(context, job_id=job_id, wait_ms=300_000)
+    elapsed = time.perf_counter() - started
+
+    assert "reviewed" in result.text
+    assert elapsed < 2.0, f"waited {elapsed:.2f}s for a job that took 0.2s"
+    await manager.dispose()
+
+
+@pytest.mark.asyncio
+async def test_a_job_that_already_settled_returns_immediately() -> None:
+    """The race the poll loop hid by re-reading status: a waiter arriving after
+    the transition must not block on news that already happened."""
+    manager = AsyncJobManager()
+    context = ToolContext(cwd=".", jobs=manager)
+    job_id = manager.register("task", "quick", _runner(0.01))
+    await _wait(context, job_id=job_id, wait_ms=5_000)
+
+    started = time.perf_counter()
+    result = await _wait(context, job_id=job_id, wait_ms=300_000)
+    assert time.perf_counter() - started < 1.0
+    assert "completed" in result.text
+    await manager.dispose()
+
+
+@pytest.mark.asyncio
+async def test_waiting_on_several_jobs_wakes_on_the_first_to_finish() -> None:
+    """Awaiting a fan-out without polling each child in turn."""
+    manager = AsyncJobManager()
+    context = ToolContext(cwd=".", jobs=manager)
+    slow = manager.register("task", "slow", _runner(30.0, "slow"))
+    fast = manager.register("task", "fast", _runner(0.2, "fast"))
+
+    started = time.perf_counter()
+    result = await _wait(context, job_id=[slow, fast], wait_ms=300_000)
+    elapsed = time.perf_counter() - started
+
+    text = result.text
+    assert "fast" in text
+    assert elapsed < 5.0, f"waited {elapsed:.2f}s for the first of two"
+    assert "still running" in text, "the caller must learn the others are unfinished"
+    assert result.details is not None and result.details["job_id"] == fast
+    await manager.dispose()
+
+
+@pytest.mark.asyncio
+async def test_the_timeout_path_still_reports_honestly() -> None:
+    manager = AsyncJobManager()
+    context = ToolContext(cwd=".", jobs=manager)
+    job_id = manager.register("task", "slow", _runner(30.0))
+
+    result = await _wait(context, job_id=job_id, wait_ms=150)
+    assert "still running after 150ms" in result.text
+    assert result.details is not None and result.details["status"] == "running"
+    await manager.dispose()
+
+
+@pytest.mark.asyncio
+async def test_an_unknown_job_is_an_error_not_a_hang() -> None:
+    manager = AsyncJobManager()
+    context = ToolContext(cwd=".", jobs=manager)
+    result = await _wait(context, job_id="nope", wait_ms=100)
+    assert result.is_error
+    assert "unknown job" in result.text
+    await manager.dispose()
+
+
+@pytest.mark.asyncio
+async def test_repeated_timed_out_waits_leak_no_tasks() -> None:
+    """Each wait registers one waiter per job; leaving them pending would leak
+    a task per call for the life of the session."""
+    manager = AsyncJobManager()
+    context = ToolContext(cwd=".", jobs=manager)
+    job_id = manager.register("task", "slow", _runner(30.0))
+
+    await _wait(context, job_id=job_id, wait_ms=10)
+    await asyncio.sleep(0.05)
+    before = len(asyncio.all_tasks())
+    for _ in range(15):
+        await _wait(context, job_id=job_id, wait_ms=10)
+    await asyncio.sleep(0.05)
+    assert len(asyncio.all_tasks()) <= before
+    await manager.dispose()
+
+
+@pytest.mark.asyncio
+async def test_a_manager_without_the_event_hook_still_works() -> None:
+    """A third-party job manager satisfying only the older protocol must keep
+    working — which is why ``wait`` probes for the hook instead of requiring
+    it on JobManagerProtocol."""
+
+    class LegacyManager:
+        """Old surface: get/list/cancel and nothing else."""
+
+        def __init__(self) -> None:
+            self._inner = AsyncJobManager()
+            self.register = self._inner.register
+            self.mark_consumed = self._inner.mark_consumed
+
+        def get(self, job_id: str, *, owner_id: str | None = None) -> Any:
+            return self._inner.get(job_id, owner_id=owner_id)
+
+        def list(self, *, owner_id: str | None = None) -> list[Any]:
+            return self._inner.list(owner_id=owner_id)
+
+        async def cancel(self, job_id: str, *, owner_id: str | None = None) -> bool:
+            return await self._inner.cancel(job_id, owner_id=owner_id)
+
+    manager = LegacyManager()
+    assert not hasattr(manager, "settled_event")
+    context = ToolContext(cwd=".", jobs=manager)
+    job_id = manager.register("task", "legacy", _runner(0.2, "legacy done"))
+
+    result = await _wait(context, job_id=job_id, wait_ms=10_000)
+    assert "legacy done" in result.text
+    await manager._inner.dispose()
+
+
+@pytest.mark.asyncio
+async def test_dispose_wakes_a_waiter_instead_of_stranding_it() -> None:
+    """A waiter must not sleep to its deadline against a manager that will
+    never run again."""
+    manager = AsyncJobManager()
+    context = ToolContext(cwd=".", jobs=manager)
+    job_id = manager.register("task", "slow", _runner(30.0))
+
+    waiter = asyncio.ensure_future(_wait(context, job_id=job_id, wait_ms=300_000))
+    await asyncio.sleep(0.05)
+    await manager.dispose()
+
+    result = await asyncio.wait_for(waiter, timeout=5.0)
+    assert "cancelled" in result.text.lower()


### PR DESCRIPTION
# PR Description

## Change classification

**C2 — standard / pre-authorized.** Adds one new optional tool and a new resolution path for `task(agent=...)`. Nothing existing changes behaviour unless a role is named: `task` without `agent` builds exactly the child it built before, and `wait` keeps its old contract (including for third-party job managers). Clean rollback (`git revert`). No RFC requested.

## The problem, measured

Review rounds — not implementation — are what make delegated work slow. I read the recorded session transcripts under `~/.local-operator/sessions` (201 sessions, 86MB) and the PR comment timelines rather than guessing:

| Finding | Evidence |
|---|---|
| Review dominates the session mix | **58 of 99** sessions in a 24h window were review children (59%), 3,910 model calls |
| Reviewer prompts are re-derived every time | **161 → 9,551 chars**, a **59x spread** for the same job. Median 4,643 |
| Reviewers rediscover the repo cold | 3 reviewers on PR #124 did **30+ `read` calls over 8–11 unique files** each — 3–4x redundant |
| Late rounds find nothing but cost the most | PR #135 (Z.AI): **4.1h**, 4 code rounds. **Rounds 3 and 4 found ZERO blockers** — all MINOR/NIT — yet cost **100 minutes** |
| Nit volume drives the churn | Round 1 carried **39 nits**; each one needs a remediation reply |
| Waiting burns round trips to learn nothing | **88 of 125 `wait` calls (70%) timed out**, burning **407 minutes** of wait budget |

The Z.AI round-by-round timeline, which is the shape of the complaint:

```
+ 27m  Agent review — round 1   (2 blockers, 5 majors, 39 nits)
+ 43m  remediation — round 1
+ 65m  Agent review — round 2   (Δ22m)
+ 77m  remediation — round 2
+132m  Agent review — round 3   (Δ55m)  0 blockers
+169m  remediation — round 3
+214m  Agent review — round 4   (Δ45m)  0 blockers
+239m  remediation — round 4
```

## Summary of Changes

### 1. Roles are user data, not a hardcoded table

The obvious fix — an enum of archetypes in the harness — is the wrong shape: which roles exist, what they say, and when they apply differ per operator and per repo, and guidance only improves if whoever notices it was wrong can change it. So a role IS a registered agent (`local_operator/agents.py`), which already persists a name, description, model, and `system_prompt.md`. This adds only what was missing:

- **`local_operator/agent_profiles.py`** — resolves a role name to guidance, a tool surface, and a default model tier. **Registry first, then packaged starters**, so an operator's own `reviewer` overrides the shipped one and editing it actually changes what the child is told.
- **`local_operator/agent_seeds/*.md`** — six starters (reviewer, coder, architect, manager, designer, scout) as plain editable markdown with frontmatter, installed **on demand** rather than at startup. "Read what the reviewer is told" and "change what the reviewer is told" are the same operation, for a human and for an agent.
- **The `agent` tool** — `search` (by meaning, over the same local embedding index that already routes skills), `list`/`show`, `install`, and `create`/`update`. That last one is the point: when a delegated run goes wrong in a way the role should have prevented, fix the ROLE, not just this one prompt.

`scout` folds into this mechanism (it was a hardcoded preamble + allowlist) with behaviour unchanged, so there is one place a role is defined.

### 2. A role's tool surface is a capability boundary

```
reviewer   -> bash, read, glob, grep, todo          (no edit/write)
scout      -> read, glob, grep                       (no side effects at all)
architect  -> + write, web_search                    (drafts docs, cannot modify source)
coder      -> full inventory
manager    -> read-only + bash/todo, may delegate
```

A reviewer that *could* edit ends up reviewing a diff it has itself changed — the failure that forces an extra round. A reviewer that *cannot run tests* files findings it never verified, which is the expensive kind of wrong; hence `bash` is in, `edit`/`write` are out. Roles that do not coordinate also lose `task`/`wait`/`jobs`.

### 3. The reviewer guidance encodes what the measurements showed was missing

Diff before tree; open a file only to answer a question you can state; verify what you can cheaply check; classify **every** finding (BLOCKER/MAJOR/MINOR/NIT); **cap MINOR and NIT at 5 each**; and when no blocker or major remains, the verdict is `clean` and **the round is TERMINAL** — remaining nits are follow-ups, not another round. That is enforcement of the existing rule ("until no blocker/major findings remain"), not a new policy.

### 4. `wait` sleeps on an event, and can await a fan-out

The old loop re-read a status field every 50ms — **6,000 wakeups per five-minute wait**, all on the one event loop shared by the parent turn, every sibling subagent, and the TUI repaint — and 70% of calls ended in a timeout that cost a full parent round trip. Now `AsyncJobManager` sets a per-job event on the single `_settle` transition, and `wait` accepts a **list** of job ids to wake on the first to finish.

`JobManagerProtocol` deliberately does **not** declare the new hook: it is `runtime_checkable` and `ToolContext.jobs` validates against it, so adding a method would break every existing implementation and test double. `wait` probes with `getattr` and falls back to polling.

## Testing Evidence

### Live end-to-end — a real reviewer subagent on a real diff

Not a mock. A throwaway git repo, a real commit, a real child session against a real model:

```console
$ python -m local_operator.cli --no-tui --yolo --run-in /tmp/role-demo exec \
    "Launch ONE subagent using the single-task form: task(label='rev', \
     prompt='Review the diff HEAD~1..HEAD in /tmp/role-demo', agent='reviewer'). \
     Then wait for it with one generous wait call and report only its final verdict line."

● bash Checking repo history
● agent Listing available agent roles
● task Launching reviewer subagent
● wait Awaiting reviewer verdict
**`clean` — this round is TERMINAL.**
```

An earlier live run of the same scenario returned the full report, and it is the behaviour this PR is for:

> ## Verdict: `clean` — this round is **TERMINAL**
>
> No BLOCKER and no MAJOR findings. The four items above are follow-ups, not grounds for another review round.

0 blockers, 0 majors, **2 minors, 2 nits** (the cap holding), and it verified the new function by *running it across five cases including the empty-list case* rather than inferring. It also correctly refused to post an MR comment where no MR existed. **This is the round that, under the old behaviour, would have been rounds 3 and 4.**

### A bug the live run found, and this PR fixes

The first live attempt failed:

```
✗ task failed
"`agent=` isn't accepted at the top level of `task` — it belongs on a `tasks[]` item"
```

The single-task form had no `agent`/`effort`, so the most natural way to ask for one reviewer cost a wasted round trip to rediscover. Fixed, with a regression test; the batch form now *refuses* a top-level role rather than silently ignoring it (which would leave every child unroled while the caller believed otherwise).

### The role lifecycle, through the real tool registry

```console
$ # createIf gating
tools without registry: [... 'browser']            # no `agent` tool
with registry:          [... 'browser', 'agent']

$ agent op=search query="I need to review a merge request for defects before merging"
best matching roles:
- reviewer [starter, 7 tools]: Reviewing a pull request, merge request, commit range...

$ agent op=install name=reviewer
installed role 'reviewer' into the registry; launch with task(agent='reviewer').

$ agent op=update name=reviewer instructions="Read the diff first. Cap nits at 5..."
updated role 'reviewer'; launch with task(agent='reviewer').
```

Semantic search picks `reviewer` from natural-language task text, and finds a role **authored seconds earlier** with no rebuild step:

```console
$ agent op=create name=sec-auditor description="Security audit of auth and tenancy code paths"
$ agent op=search query="look for tenant isolation problems in auth"
- sec-auditor: Security audit of auth and tenancy code paths before release
```

### Tool surface actually enforced at child construction

Asserted against the real child session's advertised tools, not the profile object:

```
reviewer child tools: bash, read, glob, grep, todo
  edit present?  False        task/wait/jobs/wake present?  False
operator override: tags ["role","tools:read"] -> child tools == {'read'}, and its
  instructions ("ONLY CHECK THE MIGRATIONS.") reached the provider turn
unknown role: prompt unchanged, `edit` still present (degrades to a full child)
```

### `wait` latency and loop health

```
job takes 0.6s, wait budget 30s   -> returned after 0.601s
max event-loop stall during wait  -> 91ms (was a 50ms busy-poll)
first-of-3 (0.3s / 1.0s / 2.0s)   -> returned after 0.33s, reports "2 still running"
already-settled job               -> 0.000s (no hang on news that already happened)
20 consecutive timed-out waits    -> task leak: 0
```

### Gates

```
pytest tests/unit/test_agent_profiles.py                 21 passed
pytest tests/unit/tools/test_agent_tool.py               19 passed
pytest tests/unit/tools/test_wait_settles_on_events.py    8 passed
pytest tests/unit/session/test_role_subagents.py          8 passed
pytest tests/unit/{tools,session} + factory              99 passed
flake8 . / isort --check-only . / black --check .        clean
pyright --pythonpath .venv/bin/python .                  0 errors
```

Two pre-existing failures on this machine (`test_loop_liveness`, a 120ms loop-stall threshold, and a `215.0s` string match) were **confirmed failing on clean `origin/main`** in a separate worktree — unrelated to this change, this box is simply loaded.

## Cost accounting

Token efficiency was an explicit requirement. **Corrected twice under review** (C7, then C10): both earlier tables mixed measurement bases across rows. The basis is now fixed in committed code — `scripts/bench_role_overhead.py` — so the claim is checkable rather than asserted:

```console
$ python scripts/bench_role_overhead.py          # on this branch
$ python scripts/bench_role_overhead.py          # on origin/main, then diff
```

Every row is the serialized tool entry a provider actually receives (`{name, description, parameters}` as JSON), plus the rendered system prompt:

| item | base | new | delta |
|---|---:|---:|---:|
| system prompt | 1839 | 1969 | **+130** |
| `task` entry | 663 | 837 | **+174** |
| `wait` entry | 222 | 311 | **+89** |
| `agent` entry | — | 593 | **+593** |
| **always-on total** | **3376** | **4362** | **+986** |

Against that: a hand-written reviewer prompt in the measured window had a median of 4,643 chars (~1,160 tokens) of parent **output**, and the role now supplies the reusable half of it. I have labelled the "~580 saved per review" figure as what it is — **an estimate derived from those measured prompt lengths, not an instrumented measurement** — since it depends on parent behaviour rather than on anything in the diff.

Honest summary: **+986 cached-prefix input tokens per turn**, read from cache, against generated-output savings on delegated reviews plus the wall-clock savings (70% of `wait` calls previously timed out, each costing a full parent round trip).

## Risk / rollback

- `task` without `agent` is byte-identical in behaviour; `scout` keeps its allowlist even if the seed files are missing (the read-only promise is a safety property, so it does not depend on a file being present).
- An unresolvable role degrades to a full child; a broken registry degrades to packaged starters; neither loses the delegation.
- `agent_seeds/*.md` added to `package-data` — without it the starters vanish from a wheel and every non-source install silently degrades to unguided children.
- Revert is clean.

## Related

Does not overlap the other open PRs (#132 usage continuity, #137 notifications, #138 ask picker, #139 test repairs). Builds on #133 (subagent parallelism, merged), which fixed *concurrency*; this fixes the *review loop* that concurrency exposed as the real bottleneck.


