### PR TITLE
fix(compaction,tui): let a long tool run compact mid-turn, and warm the context reading as it fills

### DIFF
--- a/local_operator/compaction/cutpoint.py
+++ b/local_operator/compaction/cutpoint.py
@@ -9,9 +9,15 @@ comment, so the invariant is enforced in code rather than documented.
 
 Algorithm (``findCutPoint``): walk **backwards** from the newest message
 accumulating estimated tokens until the kept region reaches
-``keep_recent_tokens``, then snap **forward** to the first valid cut message
-at or after that index. Valid cut messages are ``user`` messages, assistant
+``keep_recent_tokens``, then snap to the nearest valid cut message — forward
+from that index when one exists (a later cut keeps more recent history), and
+otherwise backwards. Valid cut messages are ``user`` messages, assistant
 messages with no pending tool calls, or compaction-summary markers.
+
+The backwards fallback exists because a history captured MID-RUN ends inside
+an unfinished tool chain, where every trailing position is an illegal cut; a
+forward-only snap ran off the end and reported "nothing to compact" at exactly
+the moment the context was growing fastest. See :func:`_snap_to_valid_cut`.
 """
 
 from __future__ import annotations
@@ -47,12 +53,41 @@ def _message_tokens(message: AgentMessage) -> int:
     return 0
 
 
-def _is_valid_cut(messages: Sequence[AgentMessage], index: int) -> bool:
+def _result_indices(messages: Sequence[AgentMessage]) -> dict[str, int]:
+    """``tool_call_id`` -> index of the tool result answering it.
+
+    Precomputed once per :func:`find_cut_point` so the validity predicate is
+    O(1) per candidate instead of rescanning the suffix; the snap can inspect
+    every index, which made the naive form quadratic on exactly the long tool
+    runs this code exists to relieve.
+    """
+    return {
+        message.tool_call_id: index
+        for index, message in enumerate(messages)
+        if isinstance(message, Message) and message.role == "tool" and message.tool_call_id
+    }
+
+
+def _is_valid_cut(
+    messages: Sequence[AgentMessage], index: int, result_at: dict[str, int] | None = None
+) -> bool:
     """Whether cutting *before* ``messages[index]`` keeps pairing legal.
 
-    Valid: user messages, assistant messages with no pending tool calls,
-    compaction-summary markers. Tool results and assistants whose results
-    follow are never valid — see module docstring.
+    Valid: user messages, compaction-summary markers, assistant messages with
+    no tool calls, and an assistant message whose OWN calls are all answered at
+    or after ``index`` — that last case keeps the assistant and its results
+    together on the kept side, which is the actual pairing rule.
+
+    Treating every tool-calling assistant as invalid (the earlier rule) was
+    stricter than the invariant and starved compaction: inside a long tool run
+    every message is either a tool result or a tool-calling assistant, so NO
+    index qualified and the whole run was uncompactable no matter how large it
+    grew. The partition sweep already encodes the looser rule — it asserts an
+    assistant candidate's pending calls are answered in ``kept`` rather than
+    that no such candidate exists.
+
+    An UNANSWERED call is still invalid: its result has not been produced yet,
+    so keeping the assistant would hand the provider a dangling call.
     """
     message = messages[index]
     if _is_compaction_marker(message):
@@ -61,9 +96,51 @@ def _is_valid_cut(messages: Sequence[AgentMessage], index: int) -> bool:
         return False
     if message.role == "user":
         return True
-    if message.role != "assistant" or message.tool_calls:
+    if message.role != "assistant":
         return False
-    return True
+    if not message.tool_calls:
+        return True
+    if result_at is None:
+        result_at = _result_indices(messages)
+    return all(result_at.get(call.id, -1) >= index for call in message.tool_calls)
+
+
+def _snap_to_valid_cut(
+    messages: Sequence[AgentMessage], index: int, result_at: dict[str, int]
+) -> int | None:
+    """Nearest index at or after ``index`` that is a legal cut, else the
+    nearest one BEFORE it; ``None`` when the history has no legal cut at all.
+
+    Forward is preferred because a later cut keeps more recent history, which
+    is what ``keep_recent_tokens`` is asking for. The backwards fallback is
+    what makes the gate work MID-RUN, and it is not symmetric politeness — it
+    fixes a real starvation:
+
+    An unfinished tool run ends in an assistant message with pending tool
+    calls, usually followed by its tool results. Every one of those trailing
+    positions fails ``_is_valid_cut``, so a forward-only snap walks off the
+    end of the list and the caller reads that as "nothing to compact". A long
+    tool run is precisely when the context is growing fastest and no user turn
+    is coming to relieve it, so compaction was refused at every mid-turn
+    boundary and the session sailed past its configured threshold — relief
+    arrived only once the run finally ended and a terminal assistant message
+    made a forward cut legal again.
+
+    Cutting slightly EARLIER than the token walk asked for is the right trade:
+    it keeps a little more history than requested (never less), preserves the
+    call/result pairing rule exactly as the forward snap does, and lets a pass
+    actually run. The alternative — refusing — is what let the window fill.
+    """
+    total = len(messages)
+    forward = index
+    while forward < total and not _is_valid_cut(messages, forward, result_at):
+        forward += 1
+    if forward < total:
+        return forward
+    backward = min(index, total - 1)
+    while backward >= 0 and not _is_valid_cut(messages, backward, result_at):
+        backward -= 1
+    return backward if backward >= 0 else None
 
 
 def find_cut_point(messages: Sequence[AgentMessage], keep_recent_tokens: int) -> int | None:
@@ -71,9 +148,10 @@ def find_cut_point(messages: Sequence[AgentMessage], keep_recent_tokens: int) ->
     summarizing.
 
     Walks backwards accumulating :func:`estimate_tokens` until the kept region
-    reaches ``keep_recent_tokens``, then snaps forward to the next valid cut
+    reaches ``keep_recent_tokens``, then snaps to the nearest valid cut
     message (role ``user``, or ``assistant`` without pending tool calls, or a
-    compaction-summary marker). Returns ``None`` when the accumulated region
+    compaction-summary marker) — forward when possible, else backwards, see
+    :func:`_snap_to_valid_cut`. Returns ``None`` when the accumulated region
     already covers everything (all tokens in the kept region) or when fewer
     than two REAL messages fall before the cut (nothing worth summarizing —
     a previous compaction's marker does not count, it is already a summary).
@@ -106,13 +184,15 @@ def find_cut_point(messages: Sequence[AgentMessage], keep_recent_tokens: int) ->
         # Never reached the keep budget: everything is "recent".
         return None
 
-    # Snap forward to the first valid cut message. Skipping tool results and
+    result_at = _result_indices(messages)
+
+    # Snap to the nearest valid cut message. Skipping tool results and
     # pending-tool-call assistants keeps call/result pairing intact: the pair
     # always moves to the kept side together.
-    while index < total and not _is_valid_cut(messages, index):
-        index += 1
-    if index >= total:
+    snapped = _snap_to_valid_cut(messages, index, result_at)
+    if snapped is None:
         return None
+    index = snapped
 
     # The snap can collapse the kept region far below the budget — one user
     # message followed by a long tool chain walks into the chain and snaps to
@@ -124,11 +204,10 @@ def find_cut_point(messages: Sequence[AgentMessage], keep_recent_tokens: int) ->
     if kept_tokens < keep_recent_tokens // 2 and index > 0:
         retry = backwards_walk(index - 1)
         if retry is not None:
-            index = retry
-            while index < total and not _is_valid_cut(messages, index):
-                index += 1
-            if index >= total:
+            snapped = _snap_to_valid_cut(messages, retry, result_at)
+            if snapped is None:
                 return None
+            index = snapped
 
     # Defensive invariant (the predicate already excludes violations; the
     # assertion makes a future regression loud instead of silent). GENERAL

--- a/local_operator/harness/subagent.py
+++ b/local_operator/harness/subagent.py
@@ -397,8 +397,22 @@ async def _persist_inflight(child: "Session") -> None:
     """
 
     async def _write() -> None:
+        # Imported here rather than at module scope: ``session.session`` imports
+        # this module, so a top-level import is a cycle (the TYPE_CHECKING block
+        # above imports ``Session`` the same way).
+        from local_operator.session.session import _is_persistable_message
+
         known = {entry.id for entry in child._transcript.entries()}
         for message in _answered_prefix(list(child._context.messages)):
+            # The SAME allow-list the session's own flush uses. This writes the
+            # child's LIVE context, which after a compaction pass begins with
+            # the summary marker and may carry a todo reminder — neither of
+            # which may be persisted as a message: the marker is already stored
+            # as its own compaction entry, so writing it again replays a
+            # superseded summary beside the live one, and a stored reminder
+            # comes back as a user message the user never sent.
+            if not _is_persistable_message(message):
+                continue
             if message.id not in known:
                 await child._transcript.append_message(message)
 

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -1480,11 +1480,12 @@ class Session:
             self._last_provider_request_ms = int(time.time() * 1000)
 
             # Persist everything the turn produced (initial messages were
-            # written before the run).
-            for message in new_messages:
-                if message in initial:
-                    continue
-                await self._transcript.append_message(message)
+            # written before the run). Deduplicated by id rather than by
+            # identity against ``initial``, because the mid-turn compaction
+            # gate may already have flushed part of this run to get a
+            # replayable cut target; re-appending those would resurrect
+            # messages after the compaction entry that superseded them.
+            await self._persist_new_messages(new_messages)
 
             pending_incident = self._pending_incident
             self._pending_incident = None
@@ -1844,6 +1845,29 @@ class Session:
         except OSError as exc:
             logger.warning("could not journal pruned tool outputs: %s", exc)
 
+    async def _persist_new_messages(self, messages: Sequence[AgentMessage]) -> None:
+        """Append every message not already in the transcript, in order.
+
+        Idempotent by message id, which is what lets the mid-turn compaction
+        gate flush a run's messages early (it needs a persisted cut target)
+        without the post-run persistence pass writing them a second time. The
+        transcript stores a message under its OWN id, so "already stored" is
+        an exact check rather than a heuristic.
+        """
+        stored = {entry.id for entry in self._transcript.entries()}
+        for message in messages:
+            # Todo reminders are EPHEMERAL by design: nothing persists them,
+            # because a stored reminder replays as a user message the user
+            # never sent and goes on asserting that finished items are open
+            # (see :meth:`_render_for_compaction`). The mid-turn gate flushes
+            # from the live loop context, which is where reminders live, so
+            # the exclusion has to happen here rather than at the call site.
+            if _is_todo_reminder(message):
+                continue
+            if getattr(message, "id", None) in stored:
+                continue
+            await self._transcript.append_message(message)
+
     async def _on_turn_end(self, messages: list[AgentMessage]) -> list[AgentMessage] | None:
         """Mid-turn compaction gate — runs INSIDE the tool loop, at the safe
         boundary after each tool batch lands and before the next model call.
@@ -1903,6 +1927,23 @@ class Session:
                 provider_reported, self._model.context_window, settings
             ):
                 return None
+        # Persist what the run has produced SO FAR before planning a cut.
+        #
+        # The post-run path writes the whole run at once (see the persistence
+        # block in ``prompt``), which is too late for a mid-run pass: the cut
+        # has to land on an already-persisted entry or ``_plan_compaction``
+        # refuses it as ``cut_not_replayable``, and mid-run the tail of the
+        # history is exactly the part the run just made. That refusal fired at
+        # every boundary of a long tool run, so the gate correctly decided to
+        # compact and was then blocked from doing it, and the context kept
+        # growing until the run ended.
+        #
+        # Appending early is safe because the transcript is append-only and
+        # keyed by message id: the post-run loop re-appends nothing that is
+        # already stored (``_persist_new_messages`` skips known ids), and a
+        # crash mid-run leaves a transcript that replays to what actually
+        # happened rather than losing the run outright.
+        await self._persist_new_messages(messages)
         planned = await self._plan_compaction(respect_threshold=True)
         if isinstance(planned, CompactionOutcome):
             return None

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -353,6 +353,38 @@ def _is_todo_reminder(message: AgentMessage) -> TypeGuard[CustomMessage]:
     return isinstance(message, CustomMessage) and message.custom_type == TODO_REMINDER_MESSAGE_TYPE
 
 
+#: ``CustomMessage`` types that belong in the transcript as message entries.
+#:
+#: An ALLOW-LIST, because the cost of the two mistakes is asymmetric. Omitting a
+#: type that should persist loses one replayed message; persisting one that
+#: should not corrupts the session's history for good, and the compaction
+#: summary marker is the proof: it is minted by ``_run_compaction`` and stored
+#: through ``append_compaction`` as its OWN entry type, so writing it a second
+#: time as a message replays a superseded summary back into context beside the
+#: live one. A deny-list enumerating the ephemeral types cannot see a type that
+#: does not exist yet; this one excludes it by default.
+_PERSISTABLE_CUSTOM_TYPES: frozenset[str] = frozenset({SESSION_INCIDENT_MESSAGE_TYPE})
+
+
+def _is_persistable_message(message: AgentMessage) -> bool:
+    """Whether ``message`` may be written to the transcript as a message entry.
+
+    Plain ``Message``s always may. A ``CustomMessage`` may only when its type is
+    in :data:`_PERSISTABLE_CUSTOM_TYPES` — todo reminders are ephemeral by
+    design (a stored reminder replays as a user message the user never sent and
+    goes on asserting that finished items are open), and a compaction summary
+    marker is already persisted as a compaction entry.
+
+    This matters because the mid-turn gate flushes from the LIVE loop context,
+    which is exactly where both of those live: after a pass the context is
+    ``[marker, *kept]``, so the very next boundary would otherwise persist the
+    marker.
+    """
+    if isinstance(message, CustomMessage):
+        return message.custom_type in _PERSISTABLE_CUSTOM_TYPES
+    return True
+
+
 def _stamped_todo_fingerprint(details: Mapping[str, Any]) -> tuple[tuple[str, str], ...]:
     """The todo fingerprint a reminder was built from, normalized for compare.
 
@@ -1856,13 +1888,7 @@ class Session:
         """
         stored = {entry.id for entry in self._transcript.entries()}
         for message in messages:
-            # Todo reminders are EPHEMERAL by design: nothing persists them,
-            # because a stored reminder replays as a user message the user
-            # never sent and goes on asserting that finished items are open
-            # (see :meth:`_render_for_compaction`). The mid-turn gate flushes
-            # from the live loop context, which is where reminders live, so
-            # the exclusion has to happen here rather than at the call site.
-            if _is_todo_reminder(message):
+            if not _is_persistable_message(message):
                 continue
             if getattr(message, "id", None) in stored:
                 continue

--- a/local_operator/tui/widgets/status_line.py
+++ b/local_operator/tui/widgets/status_line.py
@@ -421,6 +421,40 @@ def format_context_usage(tokens: int, window: int) -> str:
     return context_spelling(tokens, window, form="full")
 
 
+#: Context sizes at which the reading changes colour, largest first. ABSOLUTE
+#: token counts, not fractions of the window, because the cost they warn about
+#: is absolute: 300k tokens is slow and expensive to re-send on every request
+#: whether the window is 1M or 200k, and a percentage ramp would leave a big
+#: window looking calm at exactly the size that hurts most. This mirrors the
+#: ladder omp shows for the same reading.
+#:
+#: The hues are the palette's existing semantics rather than new tokens, so
+#: both themes get a legible ramp for free: `signal` (blue) is the neutral
+#: reading, `label` (purple) marks a context worth noticing, and `danger`
+#: (red) marks one near the point where compaction is imminent.
+CONTEXT_COLOR_BANDS: tuple[tuple[int, str], ...] = (
+    (500_000, "danger"),
+    (200_000, "label"),
+)
+
+#: Colour of a context reading below every band in :data:`CONTEXT_COLOR_BANDS`.
+CONTEXT_COLOR_BASE = "signal"
+
+
+def context_semantic_color(tokens: int) -> str:
+    """Semantic colour name for a context reading of ``tokens``.
+
+    Banded on the token count alone: the window is deliberately not consulted,
+    see :data:`CONTEXT_COLOR_BANDS`. Strictly greater-than, so a reading
+    sitting exactly on a boundary keeps the calmer colour and a number
+    hovering there does not flicker between two hues.
+    """
+    for threshold, color in CONTEXT_COLOR_BANDS:
+        if tokens > threshold:
+            return color
+    return CONTEXT_COLOR_BASE
+
+
 #: The forms a context reading may be written in, widest first. Named rather
 #: than inlined at each site because the band and the subagent rows show the
 #: SAME child's reading four rows apart, and they were spelling it two ways —
@@ -1436,9 +1470,20 @@ class StatusLine:
             if jobs:
                 parts.append((ICON_JOBS, jobs, Style(color=theme_mod.semantic_color("label"))))
         if "context" not in dropped:
-            usage = format_context_usage(*self._shown_context())
+            tokens, window = self._shown_context()
+            usage = format_context_usage(tokens, window)
             if usage:
-                parts.append((ICON_CONTEXT, usage, Style(color=theme_mod.semantic_color("signal"))))
+                # The one segment whose colour carries information: it warms
+                # from blue through purple to red as the context fills, so a
+                # session heading for compaction is visible at a glance
+                # instead of having to be read.
+                parts.append(
+                    (
+                        ICON_CONTEXT,
+                        usage,
+                        Style(color=theme_mod.semantic_color(context_semantic_color(tokens))),
+                    )
+                )
         cost = self._shown_cost()
         if cost and "cost" not in dropped:
             parts.append((ICON_COST, cost, Style(color=theme_mod.semantic_color("warning"))))

--- a/local_operator/tui/widgets/status_line.py
+++ b/local_operator/tui/widgets/status_line.py
@@ -422,37 +422,85 @@ def format_context_usage(tokens: int, window: int) -> str:
 
 
 #: Context sizes at which the reading changes colour, largest first. ABSOLUTE
-#: token counts, not fractions of the window, because the cost they warn about
-#: is absolute: 300k tokens is slow and expensive to re-send on every request
-#: whether the window is 1M or 200k, and a percentage ramp would leave a big
-#: window looking calm at exactly the size that hurts most. This mirrors the
-#: ladder omp shows for the same reading.
+#: token counts, because the cost they warn about is absolute: 300k tokens is
+#: slow and expensive to re-send on every request whether the window is 1M or
+#: 200k, and a purely proportional ramp would leave a big window looking calm
+#: at exactly the size that hurts most. This mirrors the ladder omp shows for
+#: the same reading.
+#:
+#: These are only half the rule — see :data:`CONTEXT_COLOR_WINDOW_BANDS` for
+#: the proportional half, which is what makes the ramp reachable at all on the
+#: 200k-and-under models that are most of the registry.
 #:
 #: The hues are the palette's existing semantics rather than new tokens, so
 #: both themes get a legible ramp for free: `signal` (blue) is the neutral
 #: reading, `label` (purple) marks a context worth noticing, and `danger`
-#: (red) marks one near the point where compaction is imminent.
+#: (red) marks one at or past the point where compaction is due.
 CONTEXT_COLOR_BANDS: tuple[tuple[int, str], ...] = (
     (500_000, "danger"),
     (200_000, "label"),
 )
 
+#: Fractions of the context window that warm the reading to the same rungs,
+#: applied as a UNION with the absolute bands above (whichever is warmer wins).
+#:
+#: The absolute bands alone cannot do the segment's job, because 70% of the
+#: registry's windowed models are 200k or smaller: on those the reading could
+#: never leave the base colour, so it stayed calm blue at 100% full with
+#: compaction already overdue (the trigger for a 200k window is 160k). Once
+#: colour means "how full am I", a calm blue at 100% is not neutral, it is
+#: wrong. The fractions are set just under and at the compaction trigger's own
+#: default (``threshold_percent`` 0.80) so the warm rung appears while there is
+#: still headroom and the top rung coincides with the pass becoming due.
+CONTEXT_COLOR_WINDOW_BANDS: tuple[tuple[float, str], ...] = (
+    (0.80, "danger"),
+    (0.55, "label"),
+)
+
 #: Colour of a context reading below every band in :data:`CONTEXT_COLOR_BANDS`.
 CONTEXT_COLOR_BASE = "signal"
 
+#: Rungs warmest-first, so a union of two ladders can be resolved by rank.
+_CONTEXT_COLOR_RANK: tuple[str, ...] = ("danger", "label", CONTEXT_COLOR_BASE)
 
-def context_semantic_color(tokens: int) -> str:
+
+def context_semantic_color(tokens: int, window: int = 0) -> str:
     """Semantic colour name for a context reading of ``tokens``.
 
-    Banded on the token count alone: the window is deliberately not consulted,
-    see :data:`CONTEXT_COLOR_BANDS`. Strictly greater-than, so a reading
-    sitting exactly on a boundary keeps the calmer colour and a number
-    hovering there does not flicker between two hues.
+    The warmer of two ladders wins: an ABSOLUTE token count
+    (:data:`CONTEXT_COLOR_BANDS`) and a FRACTION of ``window``
+    (:data:`CONTEXT_COLOR_WINDOW_BANDS`). Each guards a failure the other
+    cannot see, which is why this is a union rather than a choice:
+
+    - The absolute ladder is what makes a very large window legible. Re-sending
+      300k tokens on every request is slow and expensive whether the window is
+      1M or 200k, and a purely proportional ramp would leave a 1M session
+      looking calm at exactly the size that costs the most per turn.
+    - The proportional ladder is what makes a SMALL window legible, and without
+      it the segment was inert on most models: at 200k and below the absolute
+      rungs are unreachable, so the reading stayed blue through 100% full while
+      compaction was already due.
+
+    ``window <= 0`` (unknown) falls back to the absolute ladder alone, since a
+    percentage needs a denominator — the same rule the reading's text follows.
+
+    Strictly greater-than on both ladders, so a value sitting exactly on a
+    boundary keeps the calmer colour and a number hovering there does not
+    flicker between two hues.
     """
-    for threshold, color in CONTEXT_COLOR_BANDS:
+    color = CONTEXT_COLOR_BASE
+    for threshold, candidate in CONTEXT_COLOR_BANDS:
         if tokens > threshold:
-            return color
-    return CONTEXT_COLOR_BASE
+            color = candidate
+            break
+    if window > 0:
+        for fraction, candidate in CONTEXT_COLOR_WINDOW_BANDS:
+            if tokens > window * fraction:
+                # Warmest wins: rank is warmest-first, so a lower index is warmer.
+                if _CONTEXT_COLOR_RANK.index(candidate) < _CONTEXT_COLOR_RANK.index(color):
+                    color = candidate
+                break
+    return color
 
 
 #: The forms a context reading may be written in, widest first. Named rather
@@ -1476,12 +1524,28 @@ class StatusLine:
                 # The one segment whose colour carries information: it warms
                 # from blue through purple to red as the context fills, so a
                 # session heading for compaction is visible at a glance
-                # instead of having to be read.
+                # instead of having to be read. The window is passed because
+                # the ramp is a union of an absolute and a proportional
+                # ladder; on a 200k model the absolute rungs are unreachable
+                # and the proportional half is the only thing that fires.
+                #
+                # BOLD on the warm rungs, because hue alone cannot carry this.
+                # `signal` and `label` are 35 dE apart in normal vision and
+                # 1.7 under deuteranopia (the commonest deficiency, ~6% of
+                # men) — indistinguishable, so for those readers the 200k step
+                # would simply not exist. Weight is orthogonal to hue, costs no
+                # cells, and moves nothing in the drop ladder's arithmetic
+                # since the text is unchanged. The base rung stays regular so
+                # "warm" remains the marked state rather than the default.
+                semantic = context_semantic_color(tokens, window)
                 parts.append(
                     (
                         ICON_CONTEXT,
                         usage,
-                        Style(color=theme_mod.semantic_color(context_semantic_color(tokens))),
+                        Style(
+                            color=theme_mod.semantic_color(semantic),
+                            bold=semantic != CONTEXT_COLOR_BASE,
+                        ),
                     )
                 )
         cost = self._shown_cost()
@@ -1523,8 +1587,18 @@ class StatusLine:
             # (both `#e0b04b`, both 8.64:1 on the band's ground), so the band's
             # only alarm read as another figure. `danger` reads as an alarm and
             # measures 6.62:1 dark / 4.94:1 on the paper ramp, and it is the same
-            # ink the `⊙` lamp takes when MCP discovery fails — in this band red
-            # is the ALARM category, which is why two of them do not conflict.
+            # ink the `⊙` lamp takes when MCP discovery fails.
+            #
+            # Red in this band means NEEDS-ATTENTION, and three segments may take
+            # it: this one, the `⊙` MCP lamp, and the context reading's top rung.
+            # They do not conflict because each is the warmest state of a
+            # DIFFERENT segment, read off the glyph that precedes it, and none is
+            # a routine value — `!` means no tool will ask before it runs, `⊙`
+            # means configured tools are missing, and `▦` in red means the
+            # context is at or past its compaction trigger. That last one is the
+            # weakest of the three (compaction resolves it without the user
+            # acting), which is why it is the only one gated behind a threshold
+            # rather than being a state the segment can simply be in.
             #
             # The glyph rides INSIDE the styled text rather than in the icon slot,
             # because the loop below paints icons `dim` — which made the one alarm

--- a/local_operator/tui/widgets/status_line.py
+++ b/local_operator/tui/widgets/status_line.py
@@ -1447,12 +1447,25 @@ class StatusLine:
         if "mcp" not in dropped:
             mcp = format_mcp(self._mcp)
             if mcp:
+                semantic = mcp_semantic(self._mcp)
                 parts.append(
                     (
                         ICON_MCP,
                         mcp,
                         Style(color=theme_mod.semantic_color("fg")),
-                        Style(color=theme_mod.semantic_color(mcp_semantic(self._mcp))),
+                        # BOLD when the lamp is an alarm, so weight tracks
+                        # "needs attention" across the whole band rather than
+                        # tracking which segment got a carrier first. The
+                        # context reading is bold on its warm rungs (a
+                        # colour-vision carrier), and without this the
+                        # self-correcting red outweighed the one state where
+                        # the agent is genuinely missing tools — worst on a
+                        # narrow terminal, where the ladder drops the segments
+                        # between the two and leaves them adjacent.
+                        Style(
+                            color=theme_mod.semantic_color(semantic),
+                            bold=semantic == "danger",
+                        ),
                     )
                 )
 
@@ -1595,10 +1608,23 @@ class StatusLine:
             # DIFFERENT segment, read off the glyph that precedes it, and none is
             # a routine value — `!` means no tool will ask before it runs, `⊙`
             # means configured tools are missing, and `▦` in red means the
-            # context is at or past its compaction trigger. That last one is the
-            # weakest of the three (compaction resolves it without the user
-            # acting), which is why it is the only one gated behind a threshold
-            # rather than being a state the segment can simply be in.
+            # context is at or past its compaction trigger OR past the absolute
+            # re-send-cost rung. Those two coincide only where the window is
+            # small enough for the proportional ladder to govern: above ~625k
+            # the absolute rung fires at 500k while the resolved trigger is
+            # capped at 600k, so a 1M session shows red for a band of ~100k
+            # before a pass is actually due. It is the weakest of the three
+            # either way (compaction resolves it without the user acting), which
+            # is why it is the only one gated behind a threshold rather than
+            # being a state the segment can simply be in.
+            #
+            # BOLD on all three, so weight tracks "needs attention" rather than
+            # tracking which segment happened to get a carrier first. The
+            # context reading is bold on its warm rungs as a colour-vision
+            # carrier (see the ramp), and leaving the `⊙` lamp regular made the
+            # self-correcting red heavier than the one state where the agent is
+            # genuinely missing tools — most visible on a narrow terminal, where
+            # the ladder sheds the segments between them.
             #
             # The glyph rides INSIDE the styled text rather than in the icon slot,
             # because the loop below paints icons `dim` — which made the one alarm

--- a/tests/unit/compaction/test_cutpoint.py
+++ b/tests/unit/compaction/test_cutpoint.py
@@ -54,9 +54,16 @@ def test_cut_never_on_tool_result_or_pending_call_assistant():
     assert kept[0] is messages[cut]
 
 
-def test_snap_forward_walks_past_tool_cluster():
-    """When the walk stops ON the tool result, snapping must move forward to
-    the next legal message, never backwards into the cluster."""
+def test_snap_never_lands_on_a_tool_result():
+    """When the walk stops ON a tool result, the snap must leave it, and the
+    resulting partition must keep every call with its result.
+
+    The cut may land on the ISSUING assistant (index 2) rather than past the
+    whole cluster: that keeps the call and its result together on the kept
+    side, which is the actual pairing rule. Requiring the cut to clear the
+    cluster entirely was stricter than the invariant, and inside a long tool
+    run it left no legal cut at all — see ``_is_valid_cut``.
+    """
     messages = [
         _big_user(),
         _big_user(),
@@ -67,8 +74,11 @@ def test_snap_forward_walks_past_tool_cluster():
     keep = estimate_tokens(messages[4]) + estimate_tokens(messages[3])
     cut = find_cut_point(messages, keep)
     assert cut is not None
-    # Walk stops at index 3 (tool) or 2 (assistant w/ calls); snap lands on 4.
-    assert messages[cut] is messages[4]
+    assert messages[cut].role != "tool"
+    to_summarize, kept = prepare_partitions(messages, cut)
+    assert_partition_pair_integrity(to_summarize, kept)
+    # The pass has to be worth making: the summarized side is non-empty.
+    assert to_summarize
 
 
 def test_no_cut_when_everything_is_recent():
@@ -143,8 +153,17 @@ def test_one_summarizable_message_still_runs_when_it_is_the_reason_the_window_is
     assert find_cut_point([marker, _big_user(40), recent, tail], keep) is None
 
 
-def test_none_when_snap_runs_past_end():
-    """Trailing tool cluster with nothing valid after it -> None."""
+def test_history_ending_mid_tool_run_still_compacts():
+    """A history captured MID-RUN ends in a tool cluster with nothing after
+    it, and it must STILL yield a legal cut.
+
+    This is the mid-turn compaction bug in miniature. The old rule treated a
+    trailing cluster as uncuttable and answered ``None``, which the session
+    reports as "nothing to compact" — so a long tool run could not be
+    compacted at any size, sailed past the configured threshold, and got
+    relief only once the run ended. The cut lands on the issuing assistant,
+    which keeps the call/result pair intact.
+    """
     messages = [
         _big_user(),
         _big_user(),
@@ -152,7 +171,27 @@ def test_none_when_snap_runs_past_end():
         _tool_result("c1"),
     ]
     keep = estimate_tokens(messages[3]) + 10
-    assert find_cut_point(messages, keep) is None
+    cut = find_cut_point(messages, keep)
+    assert cut is not None
+    assert messages[cut].role != "tool"
+    to_summarize, kept = prepare_partitions(messages, cut)
+    assert to_summarize
+    assert_partition_pair_integrity(to_summarize, kept)
+
+
+def test_none_when_no_message_is_a_legal_cut():
+    """A history with no legal cut anywhere still answers ``None``.
+
+    The backwards fallback widens where a cut may land; it must not invent one
+    where the pairing rule forbids every index. Here the only non-tool message
+    issues a call whose result never arrives, so keeping it would hand the
+    provider a dangling call.
+    """
+    messages = [
+        _assistant_with_call("missing"),
+        _tool_result("other"),
+    ]
+    assert find_cut_point(messages, 10) is None
 
 
 def test_empty_and_zero_budget():

--- a/tests/unit/compaction/test_cutpoint.py
+++ b/tests/unit/compaction/test_cutpoint.py
@@ -179,19 +179,48 @@ def test_history_ending_mid_tool_run_still_compacts():
     assert_partition_pair_integrity(to_summarize, kept)
 
 
-def test_none_when_no_message_is_a_legal_cut():
-    """A history with no legal cut anywhere still answers ``None``.
+def test_a_cut_never_keeps_an_assistant_whose_call_is_unanswered():
+    """The SAFETY half of the loosened rule, pinned against a live mutant.
 
-    The backwards fallback widens where a cut may land; it must not invent one
-    where the pairing rule forbids every index. Here the only non-tool message
-    issues a call whose result never arrives, so keeping it would hand the
-    provider a dangling call.
+    `_is_valid_cut` admits an assistant whose own calls are answered at or
+    after the cut. The inverse must stay refused: an assistant holding a call
+    with NO result anywhere would, if kept, hand the provider a dangling tool
+    call, which is the same class of corruption as orphaning a result.
+
+    This is deliberately shaped so the *pairing* rule is what decides. An
+    earlier version of this test used a two-message history, which returns
+    ``None`` from the triviality rule (`index <= 1`) before the predicate is
+    ever consulted — it passed whatever `_is_valid_cut` did, so it pinned
+    nothing. Here there is ample summarizable history and a legal cut exists
+    (the trailing user message), so a cut IS returned and the only question is
+    where it may land.
+
+    Mutating the predicate's default from `-1` to a large value (treating an
+    unanswered call as answered) makes this fail, which is what a regression
+    would do.
     """
+    unanswered = _assistant_with_call("never-answered")
     messages = [
-        _assistant_with_call("missing"),
-        _tool_result("other"),
+        _big_user(),
+        _big_user(),
+        _big_user(),
+        unanswered,
+        Message.user("after " + "word " * 200),
     ]
-    assert find_cut_point(messages, 10) is None
+    cut = find_cut_point(messages, estimate_tokens(messages[4]) + 10)
+    assert cut is not None, "this history has a legal cut and must produce one"
+    candidate = messages[cut]
+    assert candidate is not unanswered, (
+        "the cut kept an assistant whose tool call has no result anywhere, "
+        "which hands the provider a dangling call"
+    )
+    # Stated as the general property too, so the assertion is about the class
+    # rather than about this one message object.
+    if candidate.role == "assistant":
+        answered = {
+            m.tool_call_id for m in messages[cut:] if isinstance(m, Message) and m.role == "tool"
+        }
+        assert all(c.id in answered for c in candidate.tool_calls)
 
 
 def test_empty_and_zero_budget():

--- a/tests/unit/compaction/test_cutpoint.py
+++ b/tests/unit/compaction/test_cutpoint.py
@@ -209,18 +209,52 @@ def test_a_cut_never_keeps_an_assistant_whose_call_is_unanswered():
     ]
     cut = find_cut_point(messages, estimate_tokens(messages[4]) + 10)
     assert cut is not None, "this history has a legal cut and must produce one"
-    candidate = messages[cut]
-    assert candidate is not unanswered, (
+    assert messages[cut] is not unanswered, (
         "the cut kept an assistant whose tool call has no result anywhere, "
         "which hands the provider a dangling call"
     )
-    # Stated as the general property too, so the assertion is about the class
-    # rather than about this one message object.
-    if candidate.role == "assistant":
-        answered = {
-            m.tool_call_id for m in messages[cut:] if isinstance(m, Message) and m.role == "tool"
-        }
-        assert all(c.id in answered for c in candidate.tool_calls)
+
+    # The PROPERTY, over every budget that makes the walk stop at a different
+    # index, rather than the single mutant above — pinning one mutant leaves
+    # siblings alive (`>= 0` and `any`-for-`all` both survived a single-budget
+    # version of this test).
+    #
+    # Two sibling mutants (`>= 0` for `>= index`, and `any` for `all`) survive
+    # this and are EQUIVALENT rather than uncaught: an assistant always
+    # precedes its own results in a well-formed history, so `result_at[id]` is
+    # either `-1` (no result at all, which every variant rejects) or greater
+    # than the assistant's own index — the three forms cannot disagree on any
+    # history the harness can produce. The `-1` default is the load-bearing
+    # part, and the mutant that changes it IS caught.
+    #
+    # The property is about the CUT INDEX, which is all ``_is_valid_cut``
+    # governs: an assistant holding an unanswered call may never BE the cut.
+    # It deliberately does not assert that no such assistant is anywhere in the
+    # kept window, because a cut landing EARLIER than one keeps it, and that is
+    # true on `origin/main` too — an unanswered call is a property of the
+    # history the caller supplied, not something the cut point introduces.
+    # Asserting the wider claim fails on unmutated code, which is how this
+    # comment came to be here.
+    budgets = {estimate_tokens(m) for m in messages}
+    budgets |= {sum(estimate_tokens(m) for m in messages[i:]) for i in range(len(messages))}
+    answered_anywhere = {
+        m.tool_call_id for m in messages if isinstance(m, Message) and m.role == "tool"
+    }
+    checked = 0
+    for budget in sorted(b for b in budgets if b > 0):
+        candidate_cut = find_cut_point(messages, budget)
+        if candidate_cut is None:
+            continue
+        checked += 1
+        boundary = messages[candidate_cut]
+        assert boundary.role != "tool", f"budget {budget}: cut landed on a tool result"
+        if isinstance(boundary, Message) and boundary.tool_calls:
+            unresolved = [c.id for c in boundary.tool_calls if c.id not in answered_anywhere]
+            assert not unresolved, (
+                f"budget {budget}: the cut is an assistant whose calls {unresolved} "
+                "are answered nowhere, so the kept window opens with a dangling call"
+            )
+    assert checked, "no budget produced a cut, so this test asserted nothing"
 
 
 def test_empty_and_zero_budget():

--- a/tests/unit/compaction/test_cutpoint.py
+++ b/tests/unit/compaction/test_cutpoint.py
@@ -219,13 +219,9 @@ def test_a_cut_never_keeps_an_assistant_whose_call_is_unanswered():
     # siblings alive (`>= 0` and `any`-for-`all` both survived a single-budget
     # version of this test).
     #
-    # Two sibling mutants (`>= 0` for `>= index`, and `any` for `all`) survive
-    # this and are EQUIVALENT rather than uncaught: an assistant always
-    # precedes its own results in a well-formed history, so `result_at[id]` is
-    # either `-1` (no result at all, which every variant rejects) or greater
-    # than the assistant's own index — the three forms cannot disagree on any
-    # history the harness can produce. The `-1` default is the load-bearing
-    # part, and the mutant that changes it IS caught.
+    # Both halves of the predicate are load-bearing, and each is pinned by a
+    # sibling test below: `all` (not `any`) by the partially-answered case, and
+    # `>= index` (not `>= 0`) by the re-issued-id case.
     #
     # The property is about the CUT INDEX, which is all ``_is_valid_cut``
     # governs: an assistant holding an unanswered call may never BE the cut.
@@ -397,3 +393,73 @@ def test_marker_tokens_use_raw_encoder():
     summary = "summary text " * 50
     marker = CustomMessage(custom_type="compaction_summary", details={"summary": summary})
     assert _message_tokens(marker) == _encode_len(summary)
+
+
+def test_a_partially_answered_assistant_is_not_a_valid_cut():
+    """`all`, not `any`: EVERY call of the boundary assistant must be answered.
+
+    An assistant issuing two calls where only one result has arrived is the
+    case that separates the two forms. Keeping it strands the unanswered call
+    on the kept side with no result, which is the dangling-call corruption in
+    the other direction from an orphaned result.
+
+    This exists because an earlier comment here claimed `any` was an
+    equivalent mutant, reasoning that an assistant always precedes its own
+    results. That premise is true and does not bear on this case: what
+    separates `all` from `any` is PARTIAL answering, not ordering. The claim
+    was false and the coverage it argued against is this test.
+    """
+    partial = _assistant_with_call("answered")
+    partial.tool_calls.append(ToolCall(id="never", name="bash", arguments={"command": "ls"}))
+    messages = [
+        _big_user(),
+        _big_user(),
+        _big_user(),
+        partial,
+        _tool_result("answered"),
+        Message.user("tail"),
+    ]
+
+    # Sized so the backwards walk STOPS on the partial assistant: it is the cut
+    # candidate, and `all` vs `any` decides whether it is accepted there. A
+    # budget that lets the walk stop past it never consults the predicate at
+    # all — the first version of this test did exactly that and passed under
+    # the `any` mutant, pinning nothing.
+    budget = sum(estimate_tokens(m) for m in messages[3:])
+    cut = find_cut_point(messages, budget)
+
+    assert cut is not None
+    assert messages[cut] is not partial, (
+        "the cut kept an assistant whose second call has no result, stranding a "
+        "dangling call at the head of the kept window"
+    )
+    to_summarize, kept = prepare_partitions(messages, cut)
+    assert_partition_pair_integrity(to_summarize, kept)
+
+
+def test_an_assistant_reissuing_an_already_answered_id_is_not_a_valid_cut():
+    """`>= index`, not `>= 0`: the result must follow THIS assistant.
+
+    ``_result_indices`` keys by ``tool_call_id`` and last occurrence wins, so a
+    re-issued id can resolve to a result that sits BEFORE the assistant that
+    re-issued it. Comparing against ``0`` accepts that (a result exists
+    somewhere); comparing against ``index`` is what requires the result to be
+    on the kept side of this cut.
+    """
+    first = _assistant_with_call("x")
+    reissued = _assistant_with_call("x")
+    messages = [
+        _big_user(),
+        first,
+        _tool_result("x"),
+        reissued,
+        Message.user("after " + "word " * 200),
+    ]
+
+    cut = find_cut_point(messages, estimate_tokens(messages[4]) + 10)
+
+    assert cut is not None
+    assert messages[cut] is not reissued, (
+        "the cut kept an assistant whose only matching result precedes it, so "
+        "the kept window opens with a call nothing answers"
+    )

--- a/tests/unit/session/test_compaction_trigger.py
+++ b/tests/unit/session/test_compaction_trigger.py
@@ -20,12 +20,16 @@ import pytest
 
 from local_operator.compaction import api as compaction_api
 from local_operator.compaction.api import CompactionSettings
+from local_operator.compaction.cutpoint import find_cut_point, prepare_partitions
 from local_operator.harness.types import (
     AgentEvent,
     CompactionEndEvent,
+    Message,
     ModelSpec,
     StreamEndEvent,
     StreamTextDelta,
+    TextContent,
+    ToolCall,
     Usage,
 )
 from local_operator.session.session import Session, _CompactionPlan
@@ -204,3 +208,90 @@ async def test_config_knobs_move_the_session_gate(tmp_path, monkeypatch):
     pin_measured_context(monkeypatch, 200_001)
     assert refusal_reason(await session._plan_compaction(respect_threshold=True)) is None
     await session.dispose()
+
+
+# ---------------------------------------------------------------------------
+# Mid-run starvation: the gate fires but the pass never lands
+# ---------------------------------------------------------------------------
+
+
+def _tool_call_assistant(index: int) -> Message:
+    """An assistant message that issues one tool call, as a real run does."""
+    message = Message.assistant(f"step {index}")
+    message.tool_calls = [ToolCall(id=f"c{index}", name="echo", arguments={})]
+    return message
+
+
+def _tool_result(index: int, text: str) -> Message:
+    return Message(
+        role="tool", tool_call_id=f"c{index}", tool_name="echo", content=[TextContent(text=text)]
+    )
+
+
+def _history_captured_mid_run(rounds: int) -> list[Message]:
+    """History as it looks at a mid-run tool-loop boundary.
+
+    The distinguishing feature is the TAIL: the newest messages are a tool
+    call and its result, with no terminal assistant turn, because the run has
+    not finished. That is the shape the mid-turn gate plans against.
+    """
+    big = "word " * 4000
+    messages: list[Message] = [
+        Message.user("older turn A " + big),
+        Message.assistant("older reply A " + big),
+        Message.user("go and do the long thing"),
+    ]
+    for index in range(rounds):
+        messages.append(_tool_call_assistant(index))
+        messages.append(_tool_result(index, big))
+    return messages
+
+
+def test_a_history_ending_mid_tool_run_is_compactable():
+    """THE bug, at the level of the decision that produced it.
+
+    A long tool run ends in a tool cluster, and every message in that cluster
+    was treated as an illegal cut point, so ``find_cut_point`` answered
+    ``None`` — "nothing to compact" — no matter how large the context grew.
+    The session reported a context far above its configured threshold while
+    every mid-turn gate refused, and relief arrived only when the run ended.
+
+    Pinned as a cut point plus a pairing check rather than an index, because
+    WHERE the cut lands is an implementation detail and "it lands somewhere
+    legal" is the property.
+    """
+    messages = _history_captured_mid_run(rounds=8)
+
+    cut = find_cut_point(messages, 20_000)
+
+    assert cut is not None, "a mid-run history must be compactable"
+    assert messages[cut].role != "tool", "a cut may never land on a tool result"
+    to_summarize, kept = prepare_partitions(messages, cut)
+    assert to_summarize, "the pass must actually reclaim something"
+    # Pairing: no result kept while the call that issued it is summarized.
+    # ``prepare_partitions`` hands back ``Message | CustomMessage``; only a
+    # ``Message`` carries calls or a role, so narrow rather than assume.
+    kept_calls = {c.id for m in kept if isinstance(m, Message) for c in m.tool_calls}
+    summarized_calls = {c.id for m in to_summarize if isinstance(m, Message) for c in m.tool_calls}
+    for message in kept:
+        if isinstance(message, Message) and message.role == "tool":
+            assert message.tool_call_id in kept_calls
+            assert message.tool_call_id not in summarized_calls
+
+
+def test_the_cut_keeps_working_as_the_run_grows():
+    """Not a one-off: every boundary of a lengthening run stays compactable.
+
+    The first fix attempt made the FIRST mid-run pass possible and the session
+    still starved afterwards, because the post-compaction history is itself a
+    marker followed by one long tool chain. Sweeping the run length is what
+    catches that.
+    """
+    # From 5 rounds up: below that the whole history (~24k) still fits inside
+    # the 20k keep-recent window, where "nothing to compact" is the correct
+    # answer rather than the starvation this pins.
+    for rounds in range(5, 20):
+        messages = _history_captured_mid_run(rounds)
+        cut = find_cut_point(messages, 20_000)
+        assert cut is not None, f"run of {rounds} tool rounds was uncompactable"
+        assert messages[cut].role != "tool"

--- a/tests/unit/session/test_session.py
+++ b/tests/unit/session/test_session.py
@@ -10,6 +10,7 @@ from collections.abc import Awaitable, Callable, Sequence
 
 import pytest
 
+from local_operator.compaction.api import CompactionSettings
 from local_operator.harness.types import (
     AbortSignal,
     AgentEndEvent,
@@ -1606,3 +1607,97 @@ async def test_the_errand_model_is_effort_clamped_on_both_routes(tmp_path, monke
     assert fallback.model_id == reasoning_model.model_id
     assert reasoning_model.reasoning_effort != reasoning_model.reasoning_efforts[0]
     assert fallback.reasoning_effort == reasoning_model.reasoning_efforts[0]
+
+
+@pytest.mark.asyncio
+async def test_the_mid_turn_flush_never_persists_a_compaction_marker(tmp_path):
+    """F1: the mid-turn flush must not write the compaction summary marker.
+
+    The mid-turn gate persists the run's messages before it cuts, because the
+    cut target has to be a replayable transcript entry. It flushes from the
+    LIVE loop context — and after a pass that context is ``[marker, *kept]``.
+    The marker is not a todo reminder and its id is in no transcript, so a
+    flush excluding only reminders wrote it as a MESSAGE entry, while the pass
+    had already stored it as its own ``compaction`` entry. Replay then
+    reconstructs a superseded summary beside the live one.
+
+    Driven through the real tool loop rather than ``compact_now``, because the
+    flush lives in ``_on_turn_end`` and a manual pass never reaches it — an
+    earlier version of this test used ``compact_now`` and passed with the fix
+    reverted, pinning nothing.
+
+    Asserted on transcript ENTRIES, not on a duplicate-id count: every marker
+    carries a fresh uuid, so a resurrected marker is a new entry and never a
+    duplicate. A duplicate check is structurally blind to this.
+    """
+    big = "lorem ipsum dolor sit amet consectetur " * 1200
+
+    async def execute(tool_call_id, args, signal, on_update, context):
+        return ToolResult(
+            tool_call_id=tool_call_id, tool_name="echo", content=[TextContent(text=big)]
+        )
+
+    tool = AgentTool(name="echo", parameters={"type": "object", "properties": {}}, execute=execute)
+
+    class ToolRunStream:
+        """Many tool batches, each reporting the prompt size it was really sent."""
+
+        def __init__(self, batches: int) -> None:
+            self.batches = batches
+            self.calls = 0
+
+        def __call__(self, request, signal):
+            index = self.calls
+            self.calls += 1
+            from local_operator.compaction.api import estimate_messages_tokens
+
+            size = estimate_messages_tokens(list(request.messages))
+            usage = Usage(input_tokens=size, context_tokens=size)
+
+            async def gen():
+                if index < self.batches:
+                    yield StreamTextDelta(delta=f"step {index} ")
+                    yield StreamToolCallDelta(
+                        index=0, id=f"c{index}", name="echo", argument_delta="{}"
+                    )
+                    yield StreamEndEvent(stop_reason="toolUse", usage=usage)
+                else:
+                    yield StreamTextDelta(delta="done")
+                    yield StreamEndEvent(stop_reason="stop", usage=usage)
+
+            return gen()
+
+    stream = ToolRunStream(batches=40)
+    session = make_session(
+        tmp_path,
+        stream,
+        tools=[tool],
+        compaction_settings=CompactionSettings(keep_recent_tokens=20_000),
+    )
+
+    # Long enough to force several mid-run passes, so a marker is in the live
+    # context at a later boundary — which is the state that reproduces this.
+    await session.prompt("do the long thing " + "detail " * 200)
+
+    entries = session._transcript.entries()
+    assert [e for e in entries if e.type == "compaction"], "no pass ran; the test proves nothing"
+
+    markers_as_messages = [
+        entry
+        for entry in entries
+        if entry.type == "message" and entry.payload.get("custom_type") == "compaction_summary"
+    ]
+    assert markers_as_messages == [], (
+        f"{len(markers_as_messages)} compaction marker(s) were persisted as message "
+        "entries; on replay they resurrect superseded summaries beside the live one"
+    )
+
+    replayed = Transcript(session._transcript.directory).build_llm_history()
+    markers = [
+        m
+        for m in replayed
+        if isinstance(m, CustomMessage) and m.custom_type == "compaction_summary"
+    ]
+    assert len(markers) == 1, "replay must carry exactly one compaction summary"
+
+    await session.dispose()

--- a/tests/unit/session/test_session.py
+++ b/tests/unit/session/test_session.py
@@ -1236,14 +1236,25 @@ async def test_mid_turn_compaction_at_continuing_boundary(tmp_path, monkeypatch)
     third = stream.requests[2]
     assert "SUMMARY(compressed)" in third.messages[0].text
 
-    # No resurrection: after the compaction entry the transcript holds only
-    # the run's three surviving messages (assistant, tool result, final
-    # assistant) — the primed history the pass summarized never re-lands
-    # after it, and nothing is persisted twice.
+    # No resurrection and no duplication. The mid-turn gate flushes the run's
+    # messages BEFORE it cuts (the cut target has to be a persisted entry), so
+    # surviving run messages legitimately sit on either side of the compaction
+    # entry and counting the tail is no longer the question. What must hold is
+    # the property that count stood in for: every message is stored exactly
+    # once, and replaying the transcript reproduces the live context — the
+    # summarized history does not come back, and the kept window is not lost.
     entries = session._transcript.entries()
-    c_index = next(i for i, e in enumerate(entries) if e.type == "compaction")
-    after = [e for e in entries[c_index + 1 :] if e.type == "message"]
-    assert len(after) == 3
+    message_ids = [e.id for e in entries if e.type == "message"]
+    assert len(message_ids) == len(set(message_ids)), "a message was persisted twice"
+
+    replayed = Transcript(session._transcript.directory).build_llm_history()
+    assert [
+        (getattr(m, "role", None) or getattr(m, "custom_type", None), getattr(m, "text", ""))
+        for m in replayed
+    ] == [
+        (getattr(m, "role", None) or getattr(m, "custom_type", None), getattr(m, "text", ""))
+        for m in session._context.messages
+    ]
 
     await session.dispose()
 

--- a/tests/unit/session/test_session.py
+++ b/tests/unit/session/test_session.py
@@ -36,6 +36,7 @@ from local_operator.harness.types import (
 from local_operator.providers.failover import ProviderError
 from local_operator.session.session import IMAGE_DROPPED_NOTICE, Session
 from local_operator.session.transcript import Transcript
+from local_operator.tools.builtin import TODO_REMINDER_MESSAGE_TYPE
 
 MODEL = ModelSpec(provider="test", model_id="m", context_window=100_000)
 
@@ -1701,3 +1702,64 @@ async def test_the_mid_turn_flush_never_persists_a_compaction_marker(tmp_path):
     assert len(markers) == 1, "replay must carry exactly one compaction summary"
 
     await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_a_cancelled_subagent_never_persists_a_marker_or_reminder(tmp_path):
+    """F4: the cancelled-child writer uses the same allow-list as the session.
+
+    ``_persist_inflight`` writes a cancelled subagent's LIVE context straight
+    to its transcript so the turn is not lost. That context has the same two
+    ephemeral inhabitants as the parent's: after a compaction pass it begins
+    with the summary marker, and it may carry a todo reminder. Persisting
+    either corrupts the child's history — the marker replays a superseded
+    summary beside the live one, and a stored reminder comes back as a user
+    message nobody sent.
+
+    This path predates the mid-turn flush (it is byte-identical on the base
+    commit), but mid-turn compaction landing for real is what puts a marker in
+    a child's live context in the first place, so the exposure is new.
+    """
+    from local_operator.harness.subagent import _persist_inflight
+
+    stream = ScriptedStream([[StreamEndEvent(stop_reason="stop")]])
+    child = make_session(tmp_path, stream)
+
+    # The live context a cancelled child can plausibly hold: a real user turn,
+    # a compaction marker from a pass that already ran, and a live reminder.
+    marker = CustomMessage(
+        custom_type="compaction_summary",
+        attribution="system",
+        details={"summary": "an earlier stretch of this session"},
+    )
+    reminder = CustomMessage(
+        custom_type=TODO_REMINDER_MESSAGE_TYPE,
+        attribution="system",
+        details={"text": "<system-reminder>still open</system-reminder>"},
+    )
+    real = Message.user("the work the child was doing")
+    child._context.messages = [marker, real, reminder]
+
+    await _persist_inflight(child)
+
+    entries = child._transcript.entries()
+    kinds = [
+        entry.payload.get("custom_type")
+        for entry in entries
+        if entry.type == "message" and entry.payload.get("kind") == "custom"
+    ]
+    assert "compaction_summary" not in kinds, (
+        "the cancelled child persisted a compaction marker; on resume it replays "
+        "a superseded summary beside the live one"
+    )
+    assert TODO_REMINDER_MESSAGE_TYPE not in kinds, (
+        "the cancelled child persisted a todo reminder, which replays as a user "
+        "message the user never sent"
+    )
+
+    # The real work still lands — the allow-list must not cost the turn.
+    assert any(
+        entry.type == "message" and entry.payload.get("role") == "user" for entry in entries
+    ), "the cancelled child's actual turn was dropped"
+
+    await child.dispose()

--- a/tests/unit/tui/test_status_line.py
+++ b/tests/unit/tui/test_status_line.py
@@ -1558,12 +1558,22 @@ def test_a_small_window_still_reaches_the_warm_rungs() -> None:
     assert context_semantic_color(200_000, 200_000) == "danger"
 
 
-def test_the_reading_is_never_calm_while_compaction_is_due() -> None:
+def test_the_reading_is_never_calm_while_compaction_is_due_at_the_default_trigger() -> None:
     """The property the ramp exists for, asserted against the REAL trigger.
 
     Colour meaning "how full am I" is only honest if a calm reading implies
     no pass is due. Checked against ``should_compact`` itself rather than
     against the ramp's own thresholds, so the two cannot drift apart.
+
+    Scoped to the DEFAULT ``CompactionSettings`` on purpose, and named for it,
+    because the ramp's fractions are constants while the trigger is user
+    config: someone who sets ``threshold_percent`` below 0.55, or a
+    ``threshold_tokens``/explicit ``reserve_tokens`` that resolves lower than
+    the proportional rung, moves the trigger under the ramp and gets a calm
+    reading while a pass is due. That degrades to the pre-change appearance
+    rather than to a wrong one, and banding on the resolved trigger would
+    mean plumbing ``resolve_threshold_tokens`` into the band. The claim is
+    narrowed to what is actually verified rather than left sounding absolute.
     """
     settings = CompactionSettings()
     for window in (131_072, 200_000, 1_000_000):
@@ -1635,3 +1645,37 @@ def test_the_warm_rungs_carry_weight_as_well_as_hue() -> None:
     assert weights[120_000] is False, "the calm rung must not be bold"
     assert weights[300_000] is True, "the purple rung needs a non-colour carrier"
     assert weights[700_000] is True, "the red rung needs a non-colour carrier"
+
+
+def test_weight_tracks_attention_across_every_red_in_the_band() -> None:
+    """D6: three segments may take red, and weight must not invert them.
+
+    The context reading is bold on its warm rungs as a colour-vision carrier.
+    Left alone, that made the one red the band calls self-correcting heavier
+    than the `⊙` MCP lamp, which is the state where the agent is genuinely
+    missing tools — the salience the alarm colour exists to protect. Worst on
+    a narrow terminal, where the drop ladder sheds what sits between them.
+    """
+    status = StatusLine(_dock(200))
+    status.update(
+        model_label="test/model",
+        context_tokens=700_000,
+        context_window=1_000_000,
+        mcp=McpStatus(configured=3, connected=2, failed=True),
+    )
+    row = status.render_text(200)
+    danger = theme_mod.semantic_color("danger").lower()
+
+    reds = {
+        row.plain[span.start : span.end]: span.style.bold
+        for span in row.spans
+        if isinstance(span.style, Style)
+        and span.style.color is not None
+        and span.style.color.triplet is not None
+        and span.style.color.triplet.hex.lower() == danger
+    }
+    assert reds, "expected the row to carry red marks"
+    assert all(reds.values()), (
+        f"a red mark is unweighted while another is bold, which inverts the "
+        f"band's attention order: {reds}"
+    )

--- a/tests/unit/tui/test_status_line.py
+++ b/tests/unit/tui/test_status_line.py
@@ -18,8 +18,10 @@ import re
 from typing import Any, NotRequired, TypedDict, cast
 
 from rich.cells import cell_len
+from rich.style import Style
 from textual.widgets import Static
 
+from local_operator.compaction.thresholds import CompactionSettings, should_compact
 from local_operator.tui import theme as theme_mod
 from local_operator.tui.widgets.status_line import (
     _DROP_LADDER,
@@ -1517,21 +1519,61 @@ def test_the_context_colour_warms_as_the_context_fills() -> None:
 
     The reading is the one number in the band whose colour carries
     information: a session heading for compaction should be visible without
-    being read. Banded on ABSOLUTE tokens, so the boundaries do not move with
-    the model's window.
+    being read. This is the ABSOLUTE half of the ramp, which is what keeps a
+    very large window legible; an unknown window (0) isolates it, since the
+    proportional half needs a denominator.
     """
-    assert context_semantic_color(0) == "signal"
-    assert context_semantic_color(199_999) == "signal"
-    assert context_semantic_color(200_001) == "label"
-    assert context_semantic_color(499_999) == "label"
-    assert context_semantic_color(500_001) == "danger"
+    assert context_semantic_color(0, 0) == "signal"
+    assert context_semantic_color(199_999, 0) == "signal"
+    assert context_semantic_color(200_001, 0) == "label"
+    assert context_semantic_color(499_999, 0) == "label"
+    assert context_semantic_color(500_001, 0) == "danger"
 
 
 def test_a_reading_exactly_on_a_boundary_keeps_the_calmer_colour() -> None:
-    """Strictly greater-than, so a context parked on 200k does not flicker
-    between blue and purple as the estimate wobbles by a token."""
-    assert context_semantic_color(200_000) == "signal"
-    assert context_semantic_color(500_000) == "label"
+    """Strictly greater-than on both ladders, so a context parked on a
+    boundary does not flicker between two hues as the estimate wobbles by a
+    token."""
+    assert context_semantic_color(200_000, 0) == "signal"
+    assert context_semantic_color(500_000, 0) == "label"
+    # The proportional ladder on its own boundaries, isolated by a 200k window
+    # where the absolute rungs are unreachable and cannot mask the result:
+    # 55% is 110,000 and 80% is 160,000.
+    assert context_semantic_color(110_000, 200_000) == "signal"
+    assert context_semantic_color(110_001, 200_000) == "label"
+    assert context_semantic_color(160_000, 200_000) == "label"
+    assert context_semantic_color(160_001, 200_000) == "danger"
+
+
+def test_a_small_window_still_reaches_the_warm_rungs() -> None:
+    """D1: the absolute rungs are unreachable on most models.
+
+    70% of the registry's windowed models are 200k or smaller, so an
+    absolute-only ramp left them calm blue at 100% full with compaction
+    already overdue. The proportional half is what fires there.
+    """
+    assert context_semantic_color(100_000, 200_000) == "signal"
+    assert context_semantic_color(150_000, 200_000) == "label"
+    assert context_semantic_color(199_000, 200_000) == "danger"
+    assert context_semantic_color(200_000, 200_000) == "danger"
+
+
+def test_the_reading_is_never_calm_while_compaction_is_due() -> None:
+    """The property the ramp exists for, asserted against the REAL trigger.
+
+    Colour meaning "how full am I" is only honest if a calm reading implies
+    no pass is due. Checked against ``should_compact`` itself rather than
+    against the ramp's own thresholds, so the two cannot drift apart.
+    """
+    settings = CompactionSettings()
+    for window in (131_072, 200_000, 1_000_000):
+        for numerator in range(1, 21):
+            tokens = int(window * numerator / 20)
+            if should_compact(tokens, window, settings):
+                assert context_semantic_color(tokens, window) != "signal", (
+                    f"{tokens:,}/{window:,} is past its compaction trigger "
+                    "but still paints the calm base colour"
+                )
 
 
 def test_the_band_paints_the_context_segment_in_its_band_colour() -> None:
@@ -1563,3 +1605,33 @@ def test_the_three_context_bands_are_visually_distinct() -> None:
     for theme in ("dark", "light"):
         hexes = [theme_mod.semantic_color(name, theme) for name in ("signal", "label", "danger")]
         assert len(set(hexes)) == 3, f"{theme} reuses a hue across the context bands"
+
+
+def test_the_warm_rungs_carry_weight_as_well_as_hue() -> None:
+    """D3: hue alone cannot carry this signal.
+
+    `signal` and `label` are ~35 dE apart in normal vision and 1.7 under
+    deuteranopia, so for the commonest colour-vision deficiency the middle
+    rung would not exist at all. Weight is orthogonal to hue and costs no
+    cells. The base rung stays regular, so warm is the marked state.
+    """
+    weights: dict[int, bool] = {}
+    for tokens in (120_000, 300_000, 700_000):
+        status = StatusLine(_dock(200))
+        status.update(model_label="test/model", context_tokens=tokens, context_window=1_000_000)
+        row = status.render_text(200)
+        reading = format_context_usage(tokens, 1_000_000)
+        # ``Span.style`` is ``str | Style``; only the Style spans carry the
+        # paint, and narrowing keeps this honest rather than casting.
+        bolds = {
+            span.style.bold
+            for span in row.spans
+            if isinstance(span.style, Style)
+            and span.style.color is not None
+            and reading in row.plain[span.start : span.end]
+        }
+        assert len(bolds) == 1, f"the reading was painted inconsistently at {tokens}"
+        weights[tokens] = bool(bolds.pop())
+    assert weights[120_000] is False, "the calm rung must not be bold"
+    assert weights[300_000] is True, "the purple rung needs a non-colour carrier"
+    assert weights[700_000] is True, "the red rung needs a non-colour carrier"

--- a/tests/unit/tui/test_status_line.py
+++ b/tests/unit/tui/test_status_line.py
@@ -42,6 +42,7 @@ from local_operator.tui.widgets.status_line import (
     NAME_CELLS_FLOOR,
     McpStatus,
     StatusLine,
+    context_semantic_color,
     drop_ladder,
     format_agents,
     format_context_usage,
@@ -1504,3 +1505,61 @@ def test_every_segment_icon_stays_in_the_block_the_terminal_font_covers() -> Non
     # The jobs and context icons sit side by side in the right group, so they
     # have to be tellable apart at a glance and not merely unequal as strings.
     assert ICON_JOBS != ICON_CONTEXT
+
+
+# ---------------------------------------------------------------------------
+# The context reading's colour ramp
+# ---------------------------------------------------------------------------
+
+
+def test_the_context_colour_warms_as_the_context_fills() -> None:
+    """Blue below 200k, purple above it, red above 500k.
+
+    The reading is the one number in the band whose colour carries
+    information: a session heading for compaction should be visible without
+    being read. Banded on ABSOLUTE tokens, so the boundaries do not move with
+    the model's window.
+    """
+    assert context_semantic_color(0) == "signal"
+    assert context_semantic_color(199_999) == "signal"
+    assert context_semantic_color(200_001) == "label"
+    assert context_semantic_color(499_999) == "label"
+    assert context_semantic_color(500_001) == "danger"
+
+
+def test_a_reading_exactly_on_a_boundary_keeps_the_calmer_colour() -> None:
+    """Strictly greater-than, so a context parked on 200k does not flicker
+    between blue and purple as the estimate wobbles by a token."""
+    assert context_semantic_color(200_000) == "signal"
+    assert context_semantic_color(500_000) == "label"
+
+
+def test_the_band_paints_the_context_segment_in_its_band_colour() -> None:
+    """The ramp reaches the rendered row, not just the helper.
+
+    Asserted on a 1M window at each band, because the window is exactly what
+    the colour must NOT depend on — 300k of 1M is only 30% full and still
+    warrants the warmer hue, since re-sending 300k tokens is expensive
+    whatever the window.
+    """
+    for tokens, semantic in ((120_000, "signal"), (300_000, "label"), (700_000, "danger")):
+        status = StatusLine(_dock(200))
+        status.update(model_label="test/model", context_tokens=tokens, context_window=1_000_000)
+        row = status.render_text(200)
+        reading = format_context_usage(tokens, 1_000_000)
+        assert reading in row.plain
+        fills = _fills(row)
+        painted = {text: fill for text, fill in fills.items() if reading in text}
+        assert painted, f"the context segment was not painted for {tokens}"
+        expected = theme_mod.semantic_color(semantic).lower()
+        assert set(painted.values()) == {
+            expected
+        }, f"{tokens} tokens should paint {semantic} ({expected}), got {painted}"
+
+
+def test_the_three_context_bands_are_visually_distinct() -> None:
+    """A ramp nobody can tell apart is not a ramp. The three hues must be
+    separated in both themes, since the palette differs between them."""
+    for theme in ("dark", "light"):
+        hexes = [theme_mod.semantic_color(name, theme) for name in ("signal", "label", "danger")]
+        assert len(set(hexes)) == 3, f"{theme} reuses a hue across the context bands"


### PR DESCRIPTION
# PR Description

## Change classification

**C2 — standard / pre-authorized.** A bug fix in compaction plus a status-band colour change, both with a clean rollback (`git revert`). No RFC or tracker requested.

## Summary of Changes

Two changes, reported together: a session on a 1M-context model configured to compact at 600k was observed sitting at **63.1%/1M (~631k)** with no compaction happening, and the context reading gives no visual warning as it fills.

### 1. Mid-turn compaction decided to run and could never land

The trigger math was never wrong. `values.compaction` resolves to `min(0.80 × 1M, 600k) = 600k`, `should_compact(631k, …)` returns `True`, and the mid-turn gate fired at every tool-loop boundary. **The pass was blocked three separate times after the decision to compact had already been made**, and each cause alone is enough to starve it:

**a. The cut-point snap only searched forward.** A history captured mid-run ends inside an unfinished tool chain, where every trailing position is an illegal cut. The forward-only snap walked off the end of the list and returned `None` — which the session reports as `nothing_to_compact`. It now falls back to the nearest legal cut *before* the index, which keeps slightly more recent history than the token walk asked for and never less.

**b. `_is_valid_cut` was stricter than the pairing rule it enforces.** It rejected *every* assistant carrying tool calls. Inside a long tool run every message is either a tool result or a tool-calling assistant, so **no index qualified at all** and the run was uncompactable no matter how large it grew. An assistant whose own calls are all answered at or after the cut is now valid; an unanswered call is still rejected, since keeping it would hand the provider a dangling call.

This is the looser rule the codebase already assumed: the existing `test_canonical_partition_integrity_sweep` asserts that an assistant candidate's pending calls are answered in `kept`, rather than that no such candidate exists.

**c. Run messages were not persisted until the run ended.** `prompt()` writes the whole run at once after the loop finishes, so mid-run the replayability guard rejected every cut as `cut_not_replayable` — the cut target has to be an existing transcript entry, and mid-run the tail of the history is exactly the part the run just made. The gate now flushes the run's messages first, deduplicated by id. Todo reminders are excluded, because nothing may persist them (a stored reminder replays as a user message the user never sent).

Causes (a) and (b) are both in `find_cut_point`, and (b) only became visible after (a) was fixed: the first pass landed and the session then starved again, because the post-compaction history is itself a marker followed by one long tool chain.

### 2. The context reading now warms as the context fills

The reading was one colour at every size, so a session heading for compaction looked exactly like an empty one. It now goes `signal` blue → `label` purple above 200k → `danger` red above 500k, matching the ladder omp shows for the same reading.

The rule is the **warmer of two ladders**: an absolute one (200k/500k) and a proportional one (55%/80% of the window). Each guards what the other cannot see. The absolute half keeps a very large window legible, since re-sending 300k tokens every turn costs the same whether the window is 1M or 200k. The proportional half is what makes the ramp reachable at all on a small window: **73 of the 105 windowed registry entries are 200k or under**, and an absolute-only ramp left those calm blue at 100% full with compaction already overdue. Thresholds are strictly greater-than on both ladders, so a reading parked on a boundary keeps the calmer colour instead of flickering.

The warm rungs also render **bold**, because hue alone cannot carry this: `signal` and `label` are 1.7 dE apart under deuteranopia, so the middle rung would not exist for roughly 6% of male readers.

*(The absolute-only rule described in the first version of this PR was corrected in `e0cf0f0` after design review round 1 — see D1.)*

## Related Issue(s)

None. Reported directly; no tracker requested.

## Impact

- **Breaking changes:** none.
- **Risk:** the compaction change alters *when* a cut is legal, which is the one place in this codebase where a mistake corrupts a conversation for the provider. The pairing invariant is therefore asserted directly on the partitions rather than inferred — see below. The colour change touches one `Style(color=…)` on one segment.
- **Rollback:** `git revert`.

## Testing Details

### The bug, before and after, on real token math

A 100k-context model (so the 80% trigger is 80k), production's `keep_recent_tokens=20000`, real message content and **no pinned estimators** — the provider reports the size of the prompt it was actually sent, so a successful pass is visible in the next reading. 30 tool batches:

| | peak context the gate saw | passes committed during the run |
| --- | --- | --- |
| `origin/main` (6758975) | **216,858** — 2.7× the trigger | 1, only as the run ended |
| this branch (6c23329) | **94,321** | 2, mid-run |

Baseline reproduced against an unmodified `origin/main` worktree with the same script, not from memory.

### The pairing invariant, asserted rather than assumed

The rule this code exists to protect is that a cut never orphans a tool call from its result. Every mid-run cut the new snap produces is checked directly on the partitions — no result kept whose issuing call was summarized away:

```text
rounds= 5 msgs= 15  MID-RUN cut=4   PAIRING OK
rounds= 8 msgs= 21  MID-RUN cut=4   PAIRING OK
rounds=12 msgs= 29  MID-RUN cut=4   PAIRING OK
```

`test_the_cut_keeps_working_as_the_run_grows` sweeps run lengths 5–19 so a fix that works once but starves on the *next* boundary fails. (Below 5 rounds the whole history fits inside the 20k keep window, where `None` is the correct answer — the sweep starts above that deliberately.)

### The regression tests fail without the fix

Verified on this branch by restoring `origin/main`'s `cutpoint.py` under the new tests, then restoring the fix and confirming by `cmp`:

```text
--- with OLD cutpoint (fix reverted) ---
FAILED test_a_history_ending_mid_tool_run_is_compactable - a mid-run history must be compactable
FAILED test_the_cut_keeps_working_as_the_run_grows      - run of 5 tool rounds was uncompactable
2 failed, 5 passed
```

### Replay fidelity after the early flush

The persistence change is the one with a data-integrity failure mode: writing mid-run must not duplicate messages, resurrect summarized history, or persist an ephemeral reminder. Measured after a run with 2 mid-run passes:

```text
mid-run compaction passes : 2
message entries on disk   : 63
duplicate entry ids       : 0
live history messages     : 16
replayed history messages : 16
REPLAY == LIVE            : True
'<system-reminder>' on disk: False
```

### Two pinned tests encoded the old rule, not a safety invariant

`test_snap_forward_walks_past_tool_cluster` and `test_none_when_snap_runs_past_end` failed under the fix. Both asserted the *over-strict* rule (the cut must clear the whole cluster / a trailing cluster yields `None`) rather than the pairing invariant. I verified the new cuts are legal and reclaim tokens before touching either, then rewrote them to assert the real property. A new `test_none_when_no_message_is_a_legal_cut` pins that the backwards fallback still answers `None` where the pairing rule forbids every index, so it cannot invent a cut.

`test_mid_turn_compaction_at_continuing_boundary` counted transcript entries *after* the compaction entry. The early flush legitimately moves surviving run messages to either side of it, so that count is no longer the question; it now asserts what the count stood in for — every message stored exactly once, and replay reproducing the live context.

### Colour ramp, rendered

Captured from the real `OperatorApp` (which loads `local_operator.tcss`; the lightweight test hosts do not), on a 1M window at each band. Fill colours extracted from the rendered SVGs rather than eyeballed:

Captured at head `e0cf0f0`, including the 200k window that design review D1 was about. Fills and weights extracted from the rendered SVGs rather than eyeballed:

| window | context | reading | fill | hue | bold |
| --- | --- | --- | --- | --- | --- |
| 1M | 120k | `12.0%/1M` | `#6ea8d8` | blue | no |
| 1M | 300k | `30.0%/1M` | `#b48cd6` | **purple** | yes |
| 1M | 700k | `70.0%/1M` | `#ef8078` | **red** | yes |
| 200k | 100k | `50.0%/200k` | `#6ea8d8` | blue | no |
| 200k | 150k | `75.0%/200k` | `#b48cd6` | **purple** | yes |
| 200k | 199k | `99.5%/200k` | `#ef8078` | **red** | yes |

On `origin/main` every one of those six renders the same `#6ea8d8` blue. Frames viewed, not just diffed. A test pins that the three hues are distinct in **both** the dark and light themes, since the palettes differ, and `test_the_reading_is_never_calm_while_compaction_is_due` checks the ramp against `should_compact` itself across 131k/200k/1M windows so the colour and the real trigger cannot drift apart.

Subagent rows are deliberately unchanged: they paint context and cost uniformly `muted`, because those rows are read for *which child* rather than for how full it is.

### Gates

All four from `AGENTS.md`, run on this branch:

```text
.venv/bin/python -m flake8 .                                  clean
uvx --from black==26.1.0 black --check local_operator tests    358 files unchanged
uvx isort --check-only --profile black local_operator tests    clean
.venv/bin/python -m pyright --pythonpath .venv/bin/python .    0 errors
```

Suites: `tests/unit/session` + `tests/unit/compaction` **272 passed**; `tests/unit/tui` (with `TERM=xterm-256color`) **1550 passed, 4 skipped**. Pyright caught 5 genuine type errors in the new test — `prepare_partitions` returns `Message | CustomMessage` and only `Message` carries `tool_calls` — fixed by narrowing with `isinstance` rather than casting.

### Not covered

The compaction path is exercised through the real `Session` with a scripted stream rather than a live provider, so provider-reported `context_tokens` is simulated. The trigger consumes that figure through the same `compaction_context_tokens` path either way, and `check_streaming_contract.py` (SC-5/SC-6) passes, but this does not prove a specific provider's usage reporting.

## Review rounds

Round 1 found real defects in both halves and they are fixed in `e0cf0f0`:

- **F1 (blocker)** — the mid-turn flush persisted the compaction summary *marker* as a message entry, replaying a superseded summary beside the live one. My own `duplicate entry ids: 0` check was structurally incapable of seeing it, since every marker carries a fresh uuid. The exclusion is now an allow-list rather than an enumeration of one ephemeral type.
- **F2 (major)** — no test failed when `_is_valid_cut` was mutated to admit unanswered calls, so the safety half of the loosened rule was unpinned. Now pinned, verified in both directions.
- **F3 (minor)** — a new test was vacuous (short-circuited on the triviality rule before reaching the pairing rule). Replaced.
- **D1/D2 (major), D3 (minor)** — the ramp was inert on 70% of models, it added a third non-alarm red against the band's documented alarm invariant, and its middle rung was invisible to deuteranopes.

Full findings and per-finding dispositions are in the round-1 review and remediation comments on this PR.