### PR TITLE
chore(release): 0.18.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.17.5"
+version = "0.18.0"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@radienthq.com" }]


### PR DESCRIPTION
## What changed

Bumps the package version from `0.17.5` to `0.18.0` for the reviewed work now on `main`:

- #140 — agent role profiles (a role is a registered agent, resolved registry-first over packaged starters), the `agent` tool (`search`/`list`/`show`/`install`/`create`/`update`) with semantic search over the same local embedding index that routes skills, per-role tool surfaces as a capability boundary, and event-driven `wait` that sleeps on a job's settle transition instead of polling every 50ms.

Minor rather than patch: this adds a new optional tool and a new resolution path for `task(agent=...)`. Nothing existing changes behaviour unless a role is named — `task` without `agent` builds exactly the child it built before, and `wait` keeps its old contract including for third-party job managers.

## Change classification

**C1 — release metadata.** One line, one file. No runtime path. Clean rollback (`git revert`).

## Validation

No runtime behaviour changes in this PR; release metadata only. The behavioural evidence lives on #140, which carried 8 code review rounds and 5 design rounds, all terminal on its merged head.

```console
$ grep '^version' pyproject.toml
version = "0.18.0"

$ python -m flake8 .
(clean)
```

The merged feature was verified on `main` by blob after the squash, rather than by ancestry:

```console
$ git show origin/main:local_operator/agent_profiles.py | grep -c already_installed
2
$ git ls-tree origin/main local_operator/agent_seeds/ --name-only
local_operator/agent_seeds/architect.md
local_operator/agent_seeds/coder.md
local_operator/agent_seeds/designer.md
local_operator/agent_seeds/manager.md
local_operator/agent_seeds/reviewer.md
local_operator/agent_seeds/scout.md
```

`agent_seeds/*.md` is in `package-data`, so the starters ship in the wheel — without it every non-source install would silently degrade to unguided children. That is exercised after release by installing the built artifact and listing roles.
