### PR TITLE
fix(tui): flex the band's name and swap the tofu jobs icon

### DIFF
--- a/local_operator/tui/widgets/status_line.py
+++ b/local_operator/tui/widgets/status_line.py
@@ -80,7 +80,22 @@ ICON_MODEL = "◆"
 ICON_EFFORT = "▴"
 ICON_CWD = "⌂"
 ICON_AGENTS = "◍"
-ICON_JOBS = "⊞"
+#: Background jobs. Kept inside **Geometric Shapes (U+25xx)** like every other
+#: segment icon above, and that block is a hard constraint rather than a
+#: stylistic preference. This was `⊞` (U+229E SQUARED PLUS, Mathematical
+#: Operators) and it rendered as TOFU — an empty replacement box — in the
+#: operator's terminal, while every U+25xx glyph beside it on the same row
+#: painted correctly. One band screenshot showed `◆ ◍ ▦ ◈ ◷` all fine and the
+#: single U+22xx glyph among them broken, which is what identifies the block
+#: rather than the individual codepoint as the problem: terminal fonts that
+#: cover Geometric Shapes routinely stop short of Mathematical Operators.
+#: `▣` also stays visually distinct from `▦` (U+25A6), which sits directly
+#: beside it in the right group — a filled-square icon that reads as a
+#: crosshatched one at a glance would make two adjacent readings look alike.
+#: **Any new icon here belongs in U+25xx unless it has been checked in a real
+#: terminal**, because `cell_len` cannot see this: tofu still measures one cell,
+#: so the band's width arithmetic stays correct while the glyph is invisible.
+ICON_JOBS = "▣"
 ICON_CONTEXT = "▦"
 ICON_COST = "◈"
 ICON_DURATION = "◷"
@@ -88,6 +103,13 @@ ICON_DURATION = "◷"
 #: in ``rich.cells.cell_len``, so it satisfies the single-cell rule above; it
 #: was checked rather than assumed, because the band's arithmetic is exact and
 #: a two-cell glyph would drift the right group's edge by one column.
+#:
+#: NOTE: this is now the ONLY U+22xx (Mathematical Operators) glyph left in the
+#: palette, and so carries the same latent tofu risk that took `ICON_JOBS` above
+#: out of that block. It is deliberately left alone: it has not been observed
+#: broken, and swapping a working glyph on suspicion would trade a known state
+#: for an unknown one. Recorded so that a future report of an empty box next to
+#: the MCP count is diagnosed in one step instead of rediscovered.
 ICON_MCP = "⊙"
 #: Disarmed-gate alarm. Deliberately NOT one of the geometric segment icons
 #: above: this one is an ALARM, not a reading, and it reuses the app-wide
@@ -1519,6 +1541,32 @@ class StatusLine:
         padded to the cells :meth:`_walk` reserved (:data:`NAME_CELLS`), so this
         arithmetic is the same at every title length and a short title leaves its
         leftover at the band's edge rather than shunting the group right.
+
+        That leftover is then CUT from the painted row, and the order of those
+        two steps is the whole point — it is NOT the same thing as aligning the
+        group by its ink. The gap above is still computed from the PADDED box, so
+        every column up to and including the name's first cell remains a function
+        of the row's geometry alone and nothing to the LEFT of the name can see
+        this cut. Aligning by ink instead was tried and reintroduces the exact
+        defect the reserve exists for: the alarm glyph goes back to moving with
+        the title, measured at 120/150/160 columns across the four titles in
+        ``_NAMES`` as columns 91/90/85/108, 121/120/115/138 and 122/117/125/148.
+        Here the only cells removed are the run of blanks BETWEEN the name's last
+        inked cell and the band's right edge, and nothing is ever painted there:
+        the name is the row's last segment by construction.
+
+        Worth removing because those blanks are not nothing. They are ordinary
+        cells carrying the band's own style, so anything that READS the row
+        rather than looking at it carries them: the SVG export writes 35 trailing
+        spaces after a `short` title at a 160-column terminal (0 after the cut),
+        and a reflow or a copy would take them the same way. A row whose right
+        edge is flush for a long title and 35 cells short for a brief one reads
+        as a rendering fault rather than as a band with less to say.
+
+        ``rstrip`` mutates, so it is applied to the freshly built row and never
+        to ``right``: trimming the caller's group in place would leave the fit
+        arithmetic in :meth:`_walk` measuring a different string than the box it
+        reserved, which is the bug this method exists to avoid.
         """
         if not right.plain:
             return left
@@ -1527,6 +1575,7 @@ class StatusLine:
         row.append_text(left)
         row.append(" " * gap, style=dim)
         row.append_text(right)
+        row.rstrip()
         return row
 
     def render_text(self, width: int) -> Text:

--- a/local_operator/tui/widgets/subagent_panel.py
+++ b/local_operator/tui/widgets/subagent_panel.py
@@ -1,6 +1,6 @@
 """The dock-band subagent panel (item 6-TUI).
 
-The status band already carries the ◍/⊞ counters; this panel is the DETAIL
+The status band already carries the ◍/▣ counters; this panel is the DETAIL
 surface — one row per task job in the session's job manager: label, state
 glyph (a moving spinner while running, ✓/✗ once settled), elapsed time, and
 the latest progress the engine relayed. A row is the click/Enter target for

--- a/tests/unit/tui/test_status_line.py
+++ b/tests/unit/tui/test_status_line.py
@@ -1310,22 +1310,33 @@ def test_a_brief_title_leaves_no_dead_run_at_the_bands_right_edge(monkeypatch) -
     The reserve is what holds every sibling's column still while a model rewrites
     the title (D2), so it stays — but it used to be painted out to the band's
     right edge as well, which left a brief title trailed by a long run of blank
-    cells that no segment would ever occupy. Measured before this fix on a band
-    carrying model, agents, jobs, context and cost: 39 cells after `a` and 35
-    after `short`, at 100, 120 and 160 columns.
+    cells that no segment would ever occupy.
 
-    The run's SIZE is not a constant, and an earlier version of this docstring
-    said it was. It tracks the name's box, which is itself elastic — on a fully
-    populated band (cwd and the alarm both present) the same measurement gives
-    29/35/39 for `a` and 25/31/35 for `short`, because the box only reaches the
-    full ``NAME_CELLS`` once the row is wide enough to spare it. The invariance
-    above is a property of one band shape, not of the defect.
+    The run's SIZE is not a constant. Two earlier versions of this docstring
+    implied otherwise, and the second was written to fix the first — which is
+    the more useful half of the story, because a correction carries more
+    authority than an original and nobody re-checks a sentence whose commit
+    message says it is the fix.
 
-    What identifies the padding is therefore not a constant width but the
-    RELATIONSHIP: the run is exactly the box minus the ink, so it grows as the
-    box grows and vanishes when the title fills it. That is what this test pins,
-    by asserting the row ends on the title's last inked cell at every width
-    rather than by asserting any particular number of dead cells.
+    The first version said the run was "identical at every width". The second
+    retracted that and then quoted a second illustrative triple, which reproduces
+    only under a band shape it did not name: the width-100 figure moves with the
+    cwd's length and with whether the alarm is armed, so the same measurement
+    yields a different first entry on a shorter path or a disarmed gate. A
+    figure quoted without the conditions that produce it is the same unenforced
+    universal in a narrower costume.
+
+    So no illustrative numbers are quoted here at all. What identifies the
+    padding is the RELATIONSHIP, which needs none: the run is exactly the box
+    minus the ink, so it grows as the box grows and vanishes when the title
+    fills it — while a layout gap would not track the title's length. The box is
+    itself elastic and only reaches the full ``NAME_CELLS`` once the row can
+    spare it, which is why any single measurement of the run is a fact about one
+    band shape rather than about the defect.
+
+    That relationship is what this test pins, by asserting the row ends on the
+    title's last inked cell at every width rather than by asserting any
+    particular number of dead cells.
 
     Those cells are ordinary styled cells, so everything that reads the row
     rather than looking at it carried them — the app's own SVG export wrote 35

--- a/tests/unit/tui/test_status_line.py
+++ b/tests/unit/tui/test_status_line.py
@@ -29,8 +29,13 @@ from local_operator.tui.widgets.status_line import (
     _MIN_GROUP_GAP,
     _SPINNER_FRAMES,
     _UNBOUNDED_RUNGS,
+    ICON_AGENTS,
     ICON_APPROVALS,
+    ICON_CONTEXT,
+    ICON_COST,
     ICON_CWD,
+    ICON_DURATION,
+    ICON_JOBS,
     ICON_MCP,
     ICON_MODEL,
     NAME_CELLS,
@@ -1158,15 +1163,23 @@ def _swept_band(state: _LadderState, *, alarm: bool) -> StatusLine:
     return status
 
 
-def _name_box(row: str, name: str) -> int:
-    """Cells the trailing name segment RESERVED, its padding included.
+def _name_box(row: str, name: str, width: int) -> int:
+    """Cells the trailing name segment RESERVED, its unpainted tail included.
 
     The box is what the layout is built on, and it is not the same number as the
     ink in it: a word-boundary cut can leave `Bulk export the…` in an 18-cell box.
     Located from the name's own opening characters, which land on the box's first
     cell because the name is left-aligned in it.
+
+    Measured to ``width`` rather than to ``len(row)``, and that is the difference
+    between the box and the ink now that ``_compose`` stops painting the box's
+    trailing blanks. The reserve still runs to the band's right edge — the row is
+    laid out to exactly ``width`` and only then trimmed — so the edge, not the
+    last inked cell, is where the box ends. Reading ``len(row)`` here would make
+    this helper return the INK and quietly turn every caller into a test of the
+    string's length instead of the layout's reserve.
     """
-    return len(row) - row.rindex(name[:4])
+    return width - row.rindex(name[:4])
 
 
 def test_naming_a_session_never_costs_a_segment_for_nothing(monkeypatch) -> None:
@@ -1204,7 +1217,7 @@ def test_naming_a_session_never_costs_a_segment_for_nothing(monkeypatch) -> None
                     where = f"{label} alarm={alarm} width={width}"
                     lost = set(status._dropped) - bare - {"name"}
                     if status.is_showing("name"):
-                        box = _name_box(row, name)
+                        box = _name_box(row, name, width)
                         assert (
                             box >= NAME_CELLS_FLOOR
                         ), f"{where}: {sorted(lost)} spent for a {box}-cell name"
@@ -1226,6 +1239,13 @@ def test_the_alarms_column_does_not_move_when_the_title_changes(monkeypatch) -> 
 
     Asserted over the whole row rather than just the glyph: everything up to the
     name's own box has to be identical, or something else moved instead.
+
+    The row's painted LENGTH is deliberately not the assertion. ``_compose`` no
+    longer paints the name box's trailing blanks, so a brief title ends earlier
+    than a long one by design and comparing lengths would pin the ink instead of
+    the layout. What has to hold is that the box each title was given is the same
+    size — asserted below through ``_name_box``, which measures to the band's
+    right edge — and that is the property the length comparison stood in for.
     """
     monkeypatch.setenv("HOME", "/Users/tester")
     for label, state in _LADDER_STATES.items():
@@ -1243,7 +1263,14 @@ def test_the_alarms_column_does_not_move_when_the_title_changes(monkeypatch) -> 
             head = first[: first.index("!") + 1]
             for row in rows[1:]:
                 assert row.startswith(head), f"{label} width={width}: the row reflowed"
-                assert len(row) == len(first), f"{label} width={width}: the row changed width"
+            # The reserve itself, which is what the old length comparison meant:
+            # every title at this width was handed a box of the same size, so a
+            # title arriving or being rewritten cannot resize the segment under
+            # the reader. Measurable only where the name survived the ladder.
+            boxes = {
+                _name_box(row, name, width) for row, name in zip(rows, _NAMES) if name[:4] in row
+            }
+            assert len(boxes) <= 1, f"{label} width={width}: the name's box changed size {boxes}"
 
 
 def test_the_name_takes_every_cell_the_row_can_spare(monkeypatch) -> None:
@@ -1275,6 +1302,48 @@ def test_the_name_takes_every_cell_the_row_can_spare(monkeypatch) -> None:
     # More than the two widths the old constant pair allowed, and monotone in the
     # terminal's width over the range where the row is otherwise unchanged.
     assert len(set(boxes)) > 5, f"the name still has only {sorted(set(boxes))} widths"
+
+
+def test_a_brief_title_leaves_no_dead_run_at_the_bands_right_edge(monkeypatch) -> None:
+    """The name's box is RESERVED, but its unused tail is not PAINTED.
+
+    The reserve is what holds every sibling's column still while a model rewrites
+    the title (D2), so it stays — but it used to be painted out to the band's
+    right edge as well, which left a brief title trailed by a long run of blank
+    cells that no segment would ever occupy. Measured on a fully populated band
+    before this fix, the run was the SAME size at every terminal width, which is
+    the tell that it was the box's padding rather than a layout gap: 35 cells
+    after `short` and 39 after `a`, identical at 100, 120 and 160 columns.
+
+    Those cells are ordinary styled cells, so everything that reads the row
+    rather than looking at it carried them — the app's own SVG export wrote 35
+    trailing spaces after `short` at a 160-column terminal.
+
+    The two halves are asserted together on purpose. Trimming the tail is only
+    correct while the reserve behind it is untouched, so this pins that the row
+    ends on the title's last inked character AND that the box measured to the
+    band's edge is unchanged by how long the title is.
+    """
+    monkeypatch.setenv("HOME", "/Users/tester")
+    for label, state in _LADDER_STATES.items():
+        status = _swept_band(state, alarm=True)
+        for width in (100, 120, 160):
+            boxes = set()
+            for name in ("a", "short", "Bulk export the invoice columns"):
+                status.update(conversation_name=name)
+                row = status.render_text(width).plain
+                if not status.is_showing("name"):
+                    continue
+                where = f"{label} width={width} name={name!r}"
+                assert (
+                    row == row.rstrip()
+                ), f"{where}: {len(row) - len(row.rstrip())} dead cells at the band's edge"
+                # The ink really is the title's, not a coincidence of truncation.
+                assert row.endswith(truncate_name(name, _name_box(row, name, width))), where
+                boxes.add(_name_box(row, name, width))
+            # ...and the reserve behind that trimmed tail did not move with the
+            # title's length, which is the property the padding used to provide.
+            assert len(boxes) <= 1, f"{label} width={width}: the box moved with the title {boxes}"
 
 
 def test_the_bands_cut_lands_on_a_word_like_the_excerpt_it_was_handed() -> None:
@@ -1362,3 +1431,53 @@ def test_the_band_still_paints_what_it_was_told() -> None:
 
     assert dock.painted is not None
     assert "$12.40" in dock.painted.plain
+
+
+def test_every_segment_icon_stays_in_the_block_the_terminal_font_covers() -> None:
+    """Segment icons live in Geometric Shapes (U+25xx), and that is a fix.
+
+    `ICON_JOBS` was `⊞` (U+229E SQUARED PLUS, Mathematical Operators) and
+    rendered as TOFU — an empty replacement box — in a real terminal, while
+    every U+25xx glyph on the same row painted correctly. That is what makes
+    this a property of the BLOCK rather than of one unlucky codepoint: fonts
+    that cover Geometric Shapes routinely stop short of Mathematical Operators.
+
+    This is asserted here because **no other check in the repo can see it**.
+    `cell_len` returns 1 for tofu exactly as it does for a real glyph, so the
+    band's width arithmetic stays correct and every layout test keeps passing
+    while the icon is invisible to the user. An SVG export embeds the character
+    rather than the rendered shape, so it cannot see it either. The only
+    instruments are a human looking at a terminal, and this rule.
+
+    `ICON_MCP` is deliberately EXCLUDED and left in U+22xx: it has not been
+    observed broken, so it is recorded as a known risk at its definition rather
+    than swapped on suspicion. If it is ever reported as an empty box, the fix
+    is to move it into U+25xx and add it to this test.
+
+    `ICON_APPROVALS` is excluded because it is plain ASCII `!`, and `ICON_CWD`
+    because `⌂` (U+2302) predates the band and has been on screen in every
+    release since without a report.
+    """
+    icons = {
+        "ICON_MODEL": ICON_MODEL,
+        "ICON_AGENTS": ICON_AGENTS,
+        "ICON_JOBS": ICON_JOBS,
+        "ICON_CONTEXT": ICON_CONTEXT,
+        "ICON_COST": ICON_COST,
+        "ICON_DURATION": ICON_DURATION,
+    }
+    for name, glyph in icons.items():
+        assert len(glyph) == 1, f"{name} is not a single codepoint: {glyph!r}"
+        point = ord(glyph)
+        assert 0x2500 <= point <= 0x25FF, (
+            f"{name} is U+{point:04X}, outside Geometric Shapes (U+25xx). "
+            "cell_len cannot detect tofu, so a glyph outside this block has to "
+            "be confirmed in a real terminal before it ships."
+        )
+        # The width rule the band's arithmetic depends on, checked on the same
+        # pass: a two-cell glyph would drift the right group's edge by a column.
+        assert cell_len(glyph) == 1, f"{name} is not one cell wide"
+
+    # The jobs and context icons sit side by side in the right group, so they
+    # have to be tellable apart at a glance and not merely unequal as strings.
+    assert ICON_JOBS != ICON_CONTEXT

--- a/tests/unit/tui/test_status_line.py
+++ b/tests/unit/tui/test_status_line.py
@@ -1310,10 +1310,22 @@ def test_a_brief_title_leaves_no_dead_run_at_the_bands_right_edge(monkeypatch) -
     The reserve is what holds every sibling's column still while a model rewrites
     the title (D2), so it stays — but it used to be painted out to the band's
     right edge as well, which left a brief title trailed by a long run of blank
-    cells that no segment would ever occupy. Measured on a fully populated band
-    before this fix, the run was the SAME size at every terminal width, which is
-    the tell that it was the box's padding rather than a layout gap: 35 cells
-    after `short` and 39 after `a`, identical at 100, 120 and 160 columns.
+    cells that no segment would ever occupy. Measured before this fix on a band
+    carrying model, agents, jobs, context and cost: 39 cells after `a` and 35
+    after `short`, at 100, 120 and 160 columns.
+
+    The run's SIZE is not a constant, and an earlier version of this docstring
+    said it was. It tracks the name's box, which is itself elastic — on a fully
+    populated band (cwd and the alarm both present) the same measurement gives
+    29/35/39 for `a` and 25/31/35 for `short`, because the box only reaches the
+    full ``NAME_CELLS`` once the row is wide enough to spare it. The invariance
+    above is a property of one band shape, not of the defect.
+
+    What identifies the padding is therefore not a constant width but the
+    RELATIONSHIP: the run is exactly the box minus the ink, so it grows as the
+    box grows and vanishes when the title fills it. That is what this test pins,
+    by asserting the row ends on the title's last inked cell at every width
+    rather than by asserting any particular number of dead cells.
 
     Those cells are ordinary styled cells, so everything that reads the row
     rather than looking at it carried them — the app's own SVG export wrote 35


### PR DESCRIPTION
## Change classification

**C2 — standard / pre-authorized.** Two presentation fixes in one widget. No contract, no data path, no new dependency. Clean rollback (`git revert`).

## The problems, measured

Both were reported from a real terminal, and both were reproduced before being fixed.

### 1. A brief title left dead space at the band's right edge

The name is the band's last segment and was **painted** to its reserved box, not merely measured at it. The reserve itself is deliberate and stays: it is what holds every sibling's column still while a model rewrites the title mid-turn. Painting the unused tail is what left the gap.

The name is the band's last segment and was **painted** to its reserved box, not merely measured at it. The reserve itself is deliberate and stays: it is what holds every sibling's column still while a model rewrites the title mid-turn. Painting the unused tail is what left the gap.

**No illustrative width figures are quoted here, and that is deliberate — corrected twice under review (C1, then C3).** The first version of this table claimed the dead run was "identical at every width". The second retracted that and quoted a second triple for a "fully populated" band, which reproduces only under conditions it did not name: the width-100 figure moves with the cwd's length and with whether the alarm is armed. A figure quoted without the conditions that produce it is the same unenforced universal in a narrower costume, so the digits are gone rather than corrected a third time.

**What identifies the padding is the relationship, which needs no numbers: the run is exactly the box minus the ink**, so it grows as the box grows and vanishes when the title fills it. A layout gap would not track the title's length at all. Any single measurement of the run is a fact about one band shape, not about the defect.

### 2. The jobs icon rendered as tofu

`ICON_JOBS` was `⊞` (**U+229E SQUARED PLUS**, Mathematical Operators). In the operator's terminal it rendered as an empty replacement box, while every other icon on the same row painted correctly:

| icon | glyph | block | rendered? |
|---|---|---|---|
| model | `◆` U+25C6 | Geometric Shapes | yes |
| agents | `◍` U+25CD | Geometric Shapes | yes |
| **jobs** | **`⊞` U+229E** | **Mathematical Operators** | **NO — tofu** |
| context | `▦` U+25A6 | Geometric Shapes | yes |
| cost | `◈` U+25C8 | Geometric Shapes | yes |
| duration | `◷` U+25F7 | Geometric Shapes | yes |

The single U+22xx glyph among them was the only broken one, which identifies the **block** rather than the codepoint: fonts that cover Geometric Shapes routinely stop short of Mathematical Operators.

## The fixes

**Name.** `_compose` trims the painted row; the reserve is untouched. The order is the whole point — the group gap is still computed from the **padded** box, so every column up to and including the name's first cell remains a function of the row's geometry and nothing to the left of the name can see the cut. Aligning by ink instead was tried and reintroduces the exact defect the reserve exists for: the alarm glyph goes back to moving with the title (measured at 120/150/160 columns).

**Icon.** `⊞` → `▣` (U+25A3), inside the proven U+25xx family and visually distinct from `▦` (U+25A6) sitting beside it in the same group. `ICON_MCP` (`⊙` U+2299) is the last U+22xx glyph left and is **deliberately not changed** — it has not been observed broken, and swapping a working glyph on suspicion trades a known state for an unknown one. The risk is recorded at its definition so a future report is diagnosed in one step.

## Testing evidence

### Before / after, in the real app

Captured by driving the real `OperatorApp` (which loads `local_operator.tcss`), at a 160-column terminal:

```
BEFORE  ◆ claude-sonnet-4-5 › ⌂ /private/tmp/lo-band-before       ◍ 1 agent ‹ ⊞ 1 job ‹ ▦ 14.7%/1M ‹ ◈ $13.63 ‹ ◷ 0s ‹ ! ‹ short                                   
        trailing_blanks=35        ^^ tofu

AFTER   ◆ claude-sonnet-4-5 › ⌂ ~/worktrees/lo-band-name          ◍ 1 agent ‹ ▣ 1 job ‹ ▦ 14.7%/1M ‹ ◈ $13.63 ‹ ◷ 0s ‹ ! ‹ short
        trailing_blanks=0         ^^ renders
```

| frame | title | trailing blanks |
|---|---|---:|
| before | `short` | **35** |
| after | `short` | **0** |
| before | `Run releases and lop-update` | **13** |
| after | `Run releases and lop-update` | **0** |

The dead space is legible in the exported SVG as real cells — the before-frame's text run ends in a 35-character `&#160;` tail, the after-frame's ends at `short`:

```console
$ # decoded from the SVG text runs
before_short   trailing_blank_cells_in_svg= 35  tail='                  '
after_short    trailing_blank_cells_in_svg=  0  tail='short'
before_Run_r   trailing_blank_cells_in_svg= 13  tail='pdate             '
after_Run_r    trailing_blank_cells_in_svg=  0  tail='ses and lop-update'
```

**Frame provenance** was proved rather than assumed, since a frame from the wrong tree looks entirely plausible. Each frame carries the glyph unique to its tree:

```console
before_short   old⊞=True   new▣=False
after_short    old⊞=False  new▣=True
before_Run_r   old⊞=True   new▣=False
after_Run_r    old⊞=False  new▣=True
```

The capture harness also **rejects a frame that lost the segments under test** rather than filing it. That control fired repeatedly and caught two real traps worth recording:

- The **boot splash clamps the input shell** (`Screen.boot.boot-card #input-shell`), so the band paints into a 97-cell box regardless of terminal width and the drop ladder correctly sheds `jobs` — the segment under test. A real submit dismisses it and hands back the full width: **97 → 155 cells at a 160-column terminal**. Without the control, four frames that simply did not contain the icon would have been captured as evidence.
- The app **re-syncs the band from live session state**, so counters set before the last pause are silently overwritten.

### The column-stability property that had to survive

The reserve exists so a title arriving or being rewritten cannot shift its siblings. Verified across four title lengths at 160 columns:

```console
a            agents@74 context@96 cost@109
short        agents@74 context@96 cost@109
Run releas   agents@74 context@96 cost@109
xxxxxxxxxx   agents@74 context@96 cost@109

columns identical across all title lengths: True
```

### Mutation testing

Both guards were proved to bite by breaking the fix and watching them go red.

```console
$ # revert the icon to U+229E
FAILED test_every_segment_icon_stays_in_the_block_the_terminal_font_covers
  AssertionError: ICON_JOBS is U+229E, outside Geometric Shapes (U+25xx).

$ # remove the row trim
FAILED test_a_brief_title_leaves_no_dead_run_at_the_bands_right_edge
  - ... ‹ a
  + ... ‹ a                    
  ?         ++++++++++++++++++++
```

The icon guard would have caught the original bug, which is the stronger claim: had it existed, `⊞` could not have shipped.

**Why that test has to exist at all:** no other instrument in the repo can see tofu. `cell_len` returns 1 for a replacement box exactly as for a real glyph, so the band's width arithmetic stays correct and every layout test keeps passing while the icon is invisible. An SVG export embeds the *character*, not the rendered shape, so it cannot see it either.

### Gates

```console
$ pytest tests/unit/tui/test_status_line.py     62 passed
$ flake8 local_operator tests                   clean
$ black --check local_operator tests            358 files unchanged
$ isort --check-only local_operator tests       clean
$ pyright status_line.py                        0 errors, 0 warnings
```

## Honest limitation

An SVG export embeds the glyph rather than the shape a font paints, so **these frames cannot prove the operator's terminal font has U+25A3** — they prove the character changed and the layout is right. The real confirmation is the operator seeing `▣` in their own terminal after the next release. The block rule is the durable protection; the frames are evidence for the layout half.


