### PR TITLE
fix(tools): stop eval waiting out its whole timeout, and let agents watch long jobs

### DIFF
--- a/local_operator/harness/jobs.py
+++ b/local_operator/harness/jobs.py
@@ -36,6 +36,14 @@ logger = logging.getLogger(__name__)
 DEFAULT_MAX_RUNNING_JOBS = 15
 DEFAULT_RETENTION_MS = 5 * 60_000
 
+#: Cap on a job's retained live-output tail (``AsyncJob.output_tail``). Sized
+#: to hold a meaningful working window of a chatty job (a terraform plan, a
+#: training loop's recent epochs) while staying far below the per-call result
+#: budget, so even a full drain of the tail cannot dominate a peek's cost.
+#: Bytes past this drop from the FRONT; ``output_seq`` still counts them, which
+#: is what lets a peek report the loss instead of hiding it.
+OUTPUT_TAIL_CHARS = 64_000
+
 #: ``result_text`` stamped by :meth:`AsyncJobManager.cancel` on a job whose
 #: runner was never entered, so the one fact the cancellation destroys — that
 #: the job never ran — survives on the row every settled surface already reads.
@@ -85,6 +93,21 @@ class AsyncJob(BaseModel):
     result_text: str | None = None
     error_text: str | None = None
     latest_details: dict[str, Any] | None = None
+    # -- live output tail (``peek``) -----------------------------------------
+    # Rolling tail of what a RUNNING job has emitted so far, so a caller can
+    # observe progress without waiting for the job to settle. ``result_text``
+    # cannot serve this: it is written once, at settle, which is exactly the
+    # moment observation stops being useful for a job that runs for an hour.
+    #
+    # Two fields, because a peek must be able to report incrementally. The
+    # buffer is a BOUNDED tail (oldest bytes drop past ``OUTPUT_TAIL_CHARS``),
+    # while ``output_seq`` counts every char ever appended and never rewinds.
+    # A reader that remembers the ``output_seq`` it last saw can therefore ask
+    # "what is new since N?" and be told truthfully — including the case where
+    # output scrolled past the tail between two peeks, which a length-only
+    # cursor silently misreports as "nothing new".
+    output_tail: str = ""
+    output_seq: int = 0
     owner_id: str | None = None
     # Set when a caller (the `wait` tool) has already returned this job's
     # result to the model: auto-delivery must then stay quiet, or the same
@@ -381,6 +404,52 @@ class AsyncJobManager:
         # against a manager that will never run again.
         for event in self._settled_events.values():
             event.set()
+
+    # -- live output ---------------------------------------------------------
+
+    def append_output(self, job_id: str, text: str) -> None:
+        """Append live output to a job's rolling tail.
+
+        Called from a job's own runner as bytes arrive. Unknown ids are
+        ignored rather than raising: a runner draining a pipe must not be able
+        to kill the job it is reporting for because the row was already swept
+        by retention.
+        """
+        job = self._jobs.get(job_id)
+        if job is None or not text:
+            return
+        job.output_seq += len(text)
+        combined = job.output_tail + text
+        # Drop from the FRONT past the cap: for a job that is still running the
+        # recent end is the informative one (the current step, the error that
+        # just landed), while the opening lines have usually already been read.
+        job.output_tail = combined[-OUTPUT_TAIL_CHARS:]
+
+    def read_output(self, job_id: str, since: int = 0) -> tuple[str, int, bool] | None:
+        """``(text, seq, gap)`` for a peek, or ``None`` when the job is unknown.
+
+        ``since`` is an ``output_seq`` value from a previous peek. The return
+        is only what was appended after it, so polling a quiet job costs
+        almost nothing and a caller's context grows by what is genuinely new
+        rather than re-receiving the whole tail every time.
+
+        ``gap`` reports that output between ``since`` and the returned text
+        was evicted from the bounded tail before this peek read it — the
+        caller has an incomplete record and is told so rather than being
+        handed a contiguous-looking excerpt that silently skips a step.
+        """
+        job = self._jobs.get(job_id)
+        if job is None:
+            return None
+        seq = job.output_seq
+        if since >= seq:
+            return "", seq, False
+        available = len(job.output_tail)
+        # How many chars back from the head the caller asked to resume.
+        wanted = seq - max(since, 0)
+        if wanted <= available:
+            return job.output_tail[-wanted:], seq, False
+        return job.output_tail, seq, True
 
     # -- internals ----------------------------------------------------------
 

--- a/local_operator/harness/jobs.py
+++ b/local_operator/harness/jobs.py
@@ -193,6 +193,11 @@ class AsyncJobManager:
         self._tasks: dict[str, asyncio.Task[None]] = {}
         self._sinks: dict[str, DeliverySink] = {}
         self._queued_runners: dict[str, JobRunFn] = {}
+        # Teardown for a job whose runner has NOT been entered yet. See
+        # ``register(on_cancel=...)``: a runner's own ``finally`` cannot clean
+        # up a coroutine that never ran, so ownership of an already-spawned
+        # resource lives here until the runner takes it over.
+        self._pending_cleanups: dict[str, Callable[[], None]] = {}
         # One event per job, set exactly once when the job settles. This is
         # what lets ``wait`` sleep until there is news instead of re-checking
         # a status field on a timer: a 50 ms poll loop wakes 6000 times over a
@@ -235,6 +240,7 @@ class AsyncJobManager:
         owner_id: str | None = None,
         agent_id: str | None = None,
         queued: bool = False,
+        on_cancel: Callable[[], None] | None = None,
     ) -> str:
         """Register and start a background job. Returns the job id.
 
@@ -242,6 +248,17 @@ class AsyncJobManager:
         execution slot and are not started here — the run coroutine must call
         the job (the manager merely tracks it) via ``start_queued`` once its
         gate opens.
+
+        ``on_cancel`` is teardown for a resource the CALLER already created
+        before registering — a spawned process, an open kernel. It exists
+        because ``register`` only ``ensure_future``s the runner: the coroutine
+        is scheduled, not entered, so a ``cancel``/``dispose`` landing in the
+        same event-loop turn never executes the runner body and never reaches
+        its ``finally``. The resource would then outlive the job row that was
+        supposed to own it, reparented to init with nothing holding a
+        reference. It fires ONLY while the runner has not started; the first
+        statement of ``_run_job`` hands ownership over, after which the
+        runner's own cleanup is authoritative and this is dropped.
         """
         # Capacity is checked BEFORE any row is inserted: a rejected register
         # must never leave a phantom job occupying or shadowing a slot.
@@ -260,6 +277,8 @@ class AsyncJobManager:
         signal = AbortSignal()
         self._jobs[job_id] = job
         self._signals[job_id] = signal
+        if on_cancel is not None:
+            self._pending_cleanups[job_id] = on_cancel
 
         if not queued:
             progress = self._progress_fn(job_id)
@@ -378,6 +397,19 @@ class AsyncJobManager:
                     raise
             except Exception:
                 logger.warning("job %s task raised on cancel", job_id, exc_info=True)
+        # Teardown for a runner that was never entered. Awaiting the cancelled
+        # task above does NOT run the coroutine body, so a resource the caller
+        # spawned before registering (a process group, a kernel) still has no
+        # owner at this point; without this it survives the job row that was
+        # meant to own it. Popped first so it can only ever fire once, and
+        # AFTER the task await so a runner that did start has already claimed
+        # ownership and removed it — the two paths cannot both kill.
+        cleanup = self._pending_cleanups.pop(job_id, None)
+        if cleanup is not None:
+            try:
+                cleanup()
+            except Exception:  # noqa: BLE001 — teardown must not fail a cancel
+                logger.warning("job %s pre-start cleanup raised", job_id, exc_info=True)
         self._settle(job)
         self._sweep_due()
         return True
@@ -398,6 +430,16 @@ class AsyncJobManager:
         self._tasks.clear()
         self._sinks.clear()
         self._queued_runners.clear()
+        # Any cleanup still pending belongs to a job that was not ``running``
+        # (so ``cancel`` above skipped it) yet never entered its runner. Firing
+        # them here is what makes dispose a complete teardown rather than one
+        # that leaks whatever those jobs had already spawned.
+        for job_id, cleanup in list(self._pending_cleanups.items()):
+            del self._pending_cleanups[job_id]
+            try:
+                cleanup()
+            except Exception:  # noqa: BLE001 — teardown must not fail a dispose
+                logger.warning("job %s pre-start cleanup raised", job_id, exc_info=True)
         # Wake anything still parked on a job before dropping the events: a
         # waiter that outlives dispose must observe "settled" (cancel() set
         # each event on its way through) rather than sleeping to its deadline
@@ -467,6 +509,11 @@ class AsyncJobManager:
         # reads it. Stamping it later would leave a window where the coroutine
         # is running and the row still says it never started.
         job.started_at = time.time()
+        # The runner is now entered, so its own teardown (its ``finally``, its
+        # CancelledError handler) is authoritative for the resources it owns.
+        # Dropping the pre-start cleanup here is what keeps a cancel from
+        # killing the same process twice through two different owners.
+        self._pending_cleanups.pop(job.id, None)
         try:
             result = await coro
             if job.status == "cancelled":

--- a/local_operator/harness/types.py
+++ b/local_operator/harness/types.py
@@ -391,14 +391,21 @@ class JobManagerProtocol(Protocol):
 
     async def cancel(self, job_id: str, *, owner_id: str | None = None) -> bool: ...
 
-    # ``settled_event(job_id) -> asyncio.Event`` is deliberately NOT declared
-    # here. This Protocol is ``runtime_checkable`` and ``ToolContext.jobs``
-    # validates against it, so every method added becomes mandatory for every
-    # existing implementation — a host (or a test double) written against the
-    # older surface would stop validating the moment this shipped. ``wait``
-    # therefore probes for it with ``getattr`` and falls back to polling, which
-    # keeps the optimization opt-in for third-party managers rather than
-    # breaking them. See ``tools.builtin._await_any_settled``.
+    # Three methods are deliberately NOT declared here: ``settled_event``
+    # (event-driven ``wait``) and ``append_output``/``read_output`` (the live
+    # output channel behind ``jobs(op="peek")``).
+    #
+    # This Protocol is ``runtime_checkable`` and ``ToolContext.jobs`` validates
+    # against it, so every method added becomes mandatory for every existing
+    # implementation — a host, an embedder's manager, or a test double written
+    # against the older surface would stop validating the moment it shipped.
+    # Adding the output pair here really did break eight such doubles outright.
+    #
+    # Each caller therefore probes with ``getattr`` and degrades: ``wait`` falls
+    # back to polling (``tools.builtin._await_any_settled``), and peek reports
+    # "this manager records no live output" (``tools.builtin._peek_job``, and
+    # bash's output mirror). That costs one branch and keeps the capability
+    # opt-in for third-party managers rather than breaking them.
 
 
 @runtime_checkable

--- a/local_operator/tools/builtin.py
+++ b/local_operator/tools/builtin.py
@@ -1396,10 +1396,16 @@ async def execute_bash(
                 "bash",
                 f"bash: {command[:60]}",
                 _detached,
-                # Scope the job to whoever asked for it: an unowned job escapes
-                # owner-scoped cancel/list and delivers to the top-level
-                # session's fallback sink instead of the subagent's own.
-                owner_id=context.job_id if context is not None else None,
+                # Unowned ON PURPOSE, matching how ``run_subagent`` registers
+                # its ``task`` jobs. An owner is only useful with a registered
+                # delivery sink, and nothing in this codebase calls
+                # ``register_delivery_sink`` — so setting one guarantees the
+                # opposite of what it looks like: the completion is
+                # DEAD-LETTERED ("no live sink for owner ...") and the caller
+                # is never told its background job finished, which is the whole
+                # point of running it detached. Revisit together with a sink
+                # implementation, not before.
+                owner_id=None,
                 on_cancel=_kill_unstarted,
             )
         except Exception:  # noqa: BLE001 — no manager slot: kill, don't leak
@@ -5981,18 +5987,21 @@ async def execute_jobs(
     if params.op in ("peek", "cancel"):
         if not params.job_id:
             return _error(tool_call_id, "jobs", f"op='{params.op}' requires job_id")
-        # Owner-scoped on both ops, matching the manager's invariant that a
-        # subagent cannot reach its parent's jobs: ``owner_id`` is None for the
-        # top-level session (which legitimately sees everything) and the
-        # subagent's job id inside a child, where a mismatch reads as
-        # not-found. Without it a child could cancel or read the output of work
-        # it does not own.
-        owner = context.job_id if context else None
-        job = jobs.get(params.job_id, owner_id=owner)
+        # Deliberately NOT owner-scoped, and the same choice ``op="list"``
+        # already makes. Scoping these by ``context.job_id`` looked like
+        # defence in depth and was a regression: ``run_subagent`` registers
+        # every ``task`` job with ``owner_id=None``, so inside a child session
+        # a scoped lookup misses its own grandchildren — the tool listed a job
+        # and then called that same id "unknown job". The isolation it was
+        # meant to add is structural rather than per-call anyway: each
+        # ``Session`` builds its own ``AsyncJobManager`` and nothing reassigns
+        # a child's, so a child's manager never holds its parent's rows and
+        # there is no cross-session id to reach in the first place.
+        job = jobs.get(params.job_id)
         if job is None:
             return _error(tool_call_id, "jobs", f"unknown job {params.job_id}")
         if params.op == "cancel":
-            cancelled = await jobs.cancel(params.job_id, owner_id=owner)
+            cancelled = await jobs.cancel(params.job_id)
             if not cancelled:
                 # cancel() refuses a job that already settled, which is not a
                 # failure worth erroring on: the caller wanted it stopped and

--- a/local_operator/tools/builtin.py
+++ b/local_operator/tools/builtin.py
@@ -1091,6 +1091,32 @@ class BashParams(BaseModel):
         le=BASH_MAX_TIMEOUT_SECONDS,
         description="Max seconds before the command is killed.",
     )
+    background: bool = Field(
+        default=False,
+        description=(
+            "Start the command and return a job id immediately instead of "
+            "waiting. Use for long work (builds, training, terraform apply, "
+            "pipeline polling); follow it with jobs(op='peek') to read new "
+            "output as it arrives, and jobs(op='cancel') to stop it. 'timeout' "
+            "still bounds the run."
+        ),
+    )
+
+
+def _bash_progress_line(stdout_chunks: list[bytes], stderr_chunks: list[bytes]) -> str:
+    """One short status line for a running background command.
+
+    Reports the LAST non-empty line the command printed, which for the work
+    that gets backgrounded (builds, training loops, terraform, pollers) is the
+    step it is currently on. Bounded hard: this is written on every poll tick
+    and read by a renderer, so an unbounded line from a command printing a
+    megabyte without newlines must not become a per-frame cost.
+    """
+    tail = b"".join(stdout_chunks[-4:] + stderr_chunks[-4:]).decode("utf-8", errors="replace")
+    for line in reversed(tail.splitlines()):
+        if line.strip():
+            return line.strip()[:200]
+    return "running"
 
 
 def _bash_output_summary(stdout: str, stderr: str) -> str:
@@ -1178,6 +1204,26 @@ async def execute_bash(
 
     stdout_chunks: list[bytes] = []
     stderr_chunks: list[bytes] = []
+    # Set once the command is owned by a background job, so the pipe readers
+    # know where to mirror output for `jobs(op="peek")`. Held in a mutable cell
+    # rather than captured by value because the readers start BEFORE the job id
+    # exists on the steering-detach path: the command is already running when
+    # the interrupt arrives, and re-creating the readers at that point would
+    # race the drain and lose whatever is in flight.
+    live_job: dict[str, Any] = {"id": None, "jobs": None}
+
+    def _mirror(chunk: bytes) -> None:
+        """Publish a freshly-read chunk to the job's peekable tail."""
+        job_id = live_job["id"]
+        manager = live_job["jobs"]
+        if job_id is None or manager is None:
+            return
+        appender = getattr(manager, "append_output", None)
+        if appender is None:
+            # Third-party embedders may supply a manager predating live output;
+            # peek degrades to "no output recorded" rather than breaking the run.
+            return
+        appender(job_id, chunk.decode("utf-8", errors="replace"))
 
     async def _pump(stream: asyncio.StreamReader | None, sink: list[bytes]) -> None:
         # Both pipes were requested at spawn, so neither is ever None here;
@@ -1190,6 +1236,7 @@ async def execute_bash(
                 if not chunk:
                     break
                 sink.append(chunk)
+                _mirror(chunk)
         except (ConnectionResetError, BrokenPipeError):
             pass
 
@@ -1224,47 +1271,17 @@ async def execute_bash(
     aborted = False
     next_update = loop.time() + 0.5
 
-    try:
-        while True:
-            waiters: list[asyncio.Task[object]] = [wait_task, stdout_task, stderr_task]
-            if abort_waiter is not None:
-                waiters.append(abort_waiter)
-            if wait_task.done():
-                break  # finished already — never misreport as timeout
-            remaining = deadline - loop.time()
-            if remaining <= 0:
-                timed_out = True
-                _kill()
-                break
-            done, _pending = await asyncio.wait(waiters, timeout=min(0.25, remaining))
-            if wait_task in done:
-                break
-            if abort_waiter is not None and abort_waiter in done:
-                aborted = True
-                _kill()
-                break
-            if loop.time() >= next_update:
-                _emit_update()
-                next_update = loop.time() + 0.5
-    except asyncio.CancelledError:
-        # Steering interrupted the tool task (the loop cancels interruptible
-        # tools at its 0.25s poll). Killing the process here used to (a)
-        # destroy minutes of a long build on a one-line user aside and (b)
-        # leak the child anyway when cancellation raced the kill. Instead the
-        # command DETACHES: it keeps running (it was spawned start_new_session
-        # so it survives its own process group), its readers keep draining so
-        # a full pipe cannot block it, and it is tracked as a background job
-        # whose completion auto-delivers when the session is idle. A REAL
-        # abort (Ctrl+C, jobs cancel) still kills: that is a stop, not a
-        # redirect.
-        if signal is not None and signal.aborted:
-            _kill()
-            raise
-        jobs = context.jobs if context is not None else None
-        if jobs is None:
-            # No job manager to own a detached child: kill rather than leak.
-            _kill()
-            raise
+    def _detach_to_job(jobs: Any, headline: str) -> ToolResult:
+        """Hand the running process to a background job and return its id.
+
+        Shared by the two ways a command stops being awaited: the caller asked
+        for ``background=True`` up front, and steering interrupted a foreground
+        call. Both want identical ownership semantics — the process keeps
+        running in its own session group, the pipe readers stay alive so a full
+        pipe cannot block it, output keeps flowing to the peek buffer, and the
+        original timeout budget still applies — so they share one
+        implementation rather than two that drift.
+        """
         partial = _bash_output_summary(
             b"".join(stdout_chunks).decode("utf-8", errors="replace"),
             b"".join(stderr_chunks).decode("utf-8", errors="replace"),
@@ -1279,7 +1296,7 @@ async def execute_bash(
             # Owns the process from here: waits with the ORIGINAL timeout
             # budget, keeps the readers alive to drain the pipes, and reports
             # the exit status + bounded output as the job result.
-            del job_id, report_progress
+            del job_id
             timed_out_bg = False
             cancelled_bg = False
             bg_deadline = asyncio.get_running_loop().time() + remaining_timeout
@@ -1330,6 +1347,12 @@ async def execute_bash(
                         timed_out_bg = True
                         break
                     await asyncio.wait({bg_wait}, timeout=0.25)
+                    # The status line a human reads in the TUI while the job
+                    # runs. Deliberately a heartbeat and not the output itself:
+                    # the OUTPUT has a dedicated bounded channel (the peek
+                    # tail), and mirroring it into a field every renderer
+                    # repaints per frame would pay for it many times over.
+                    report_progress(_bash_progress_line(stdout_chunks, stderr_chunks))
                 await cleanup(kill=cancelled_bg or timed_out_bg)
             except asyncio.CancelledError:
                 # Manager cancellation is deliberately immediate. Convert it
@@ -1360,13 +1383,96 @@ async def execute_bash(
         except Exception:  # noqa: BLE001 — no manager slot: kill, don't leak
             _kill()
             raise
+        # Point the pipe readers at the job BEFORE reporting it, and seed the
+        # tail with what the foreground phase already collected, so a peek
+        # covers the command's whole life rather than starting from whenever it
+        # happened to be backgrounded.
+        live_job["jobs"] = jobs
+        live_job["id"] = bg_job_id
+        appender = getattr(jobs, "append_output", None)
+        if appender is not None:
+            already = b"".join(stdout_chunks + stderr_chunks).decode("utf-8", errors="replace")
+            if already:
+                appender(bg_job_id, already)
         return _text(
             tool_call_id,
             "bash",
-            f"steering interrupted; command continues in the background as job "
-            f"{bg_job_id} (use 'jobs'/'wait'; its result auto-delivers when "
-            f"the session is idle)\ncommand: {command}\n{partial}",
+            f"job {bg_job_id}: {headline}\ncommand: {command}\n{partial}",
             details={"job_id": bg_job_id, "backgrounded": True},
+        )
+
+    if params.background:
+        # Deliberate backgrounding: hand the command straight to a job and give
+        # the model its id, so the very next call can peek at or cancel it.
+        # Without this the ONLY route to a background job was a steering
+        # interrupt — an accident the model cannot ask for — which left long
+        # work (training, terraform, pipeline polls) with no option but to
+        # block a turn for its whole duration.
+        background_jobs = context.jobs if context is not None else None
+        if background_jobs is None:
+            _kill()
+            for reader in readers:
+                reader.cancel()
+            return _error(
+                tool_call_id,
+                "bash",
+                "background=true needs a job manager, which this session has "
+                "not attached; re-run without background.",
+            )
+        return _detach_to_job(
+            background_jobs,
+            "started in the background. Use jobs(op='peek', job_id=..., "
+            "since=<seq>) for new output and jobs(op='cancel') to stop it; "
+            "its result auto-delivers when it finishes.",
+        )
+
+    try:
+        while True:
+            waiters: list[asyncio.Task[object]] = [wait_task, stdout_task, stderr_task]
+            if abort_waiter is not None:
+                waiters.append(abort_waiter)
+            if wait_task.done():
+                break  # finished already — never misreport as timeout
+            remaining = deadline - loop.time()
+            if remaining <= 0:
+                timed_out = True
+                _kill()
+                break
+            done, _pending = await asyncio.wait(waiters, timeout=min(0.25, remaining))
+            if wait_task in done:
+                break
+            if abort_waiter is not None and abort_waiter in done:
+                aborted = True
+                _kill()
+                break
+            if loop.time() >= next_update:
+                _emit_update()
+                next_update = loop.time() + 0.5
+    except asyncio.CancelledError:
+        # Steering interrupted the tool task (the loop cancels interruptible
+        # tools at its 0.25s poll). Killing the process here used to (a)
+        # destroy minutes of a long build on a one-line user aside and (b)
+        # leak the child anyway when cancellation raced the kill. Instead the
+        # command DETACHES: it keeps running (it was spawned start_new_session
+        # so it survives its own process group), its readers keep draining so
+        # a full pipe cannot block it, and it is tracked as a background job
+        # whose completion auto-delivers when the session is idle. A REAL
+        # abort (Ctrl+C, jobs cancel) still kills: that is a stop, not a
+        # redirect.
+        if signal is not None and signal.aborted:
+            _kill()
+            raise
+        jobs = context.jobs if context is not None else None
+        if jobs is None:
+            # No job manager to own a detached child: kill rather than leak.
+            _kill()
+            raise
+        return _detach_to_job(
+            jobs,
+            "steering interrupted; the command continues in the background. "
+            "Use jobs(op='peek', job_id=..., since=<seq>) for new output and "
+            "jobs(op='cancel') to stop it; its result auto-delivers when the "
+            "session is idle.",
         )
 
     # Bounded drain: the kill above EOFs both pipes; give the readers 250 ms
@@ -5428,6 +5534,26 @@ class WaitParams(BaseModel):
 class JobsParams(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
+    op: Literal["list", "peek", "cancel"] = Field(
+        default="list",
+        description=(
+            "list: all jobs with status and age. peek: NEW output from one "
+            "running job since your last peek. cancel: stop a running job."
+        ),
+    )
+    job_id: str | None = Field(
+        default=None,
+        description="Job to peek at or cancel (required for those ops).",
+    )
+    since: int | None = Field(
+        default=None,
+        description=(
+            "For peek: resume from this 'seq' value (returned by the previous "
+            "peek) so only new output comes back. Omit to read the tail from "
+            "the start; pass 0 explicitly for the same."
+        ),
+    )
+
 
 #: Formatted status text shared by ``wait``'s settled return and its detail
 #: payload.  A child report can dwarf an ordinary tool result, so it uses the
@@ -5733,6 +5859,74 @@ def build_wait_tool(context: ToolContext) -> AgentTool | None:
     )
 
 
+def _peek_job(
+    tool_call_id: str,
+    jobs: Any,
+    job: Any,
+    since: int,
+    context: ToolContext | None,
+) -> ToolResult:
+    """Return only what a job has printed since ``since``.
+
+    The incremental contract is what makes polling affordable. A caller
+    watching a 40-minute training run peeks every so often; returning the whole
+    tail each time would re-send the same bytes on every poll, and because each
+    result is appended to the transcript verbatim it would also grow the
+    context by the same bytes repeatedly. Returning only the delta means a
+    quiet job costs one short line, and a busy one costs exactly what it
+    actually produced.
+
+    The ``seq`` in the reply is the cursor for the NEXT peek, so the caller
+    never has to reason about offsets — it echoes back what it was given.
+    """
+    reader = getattr(jobs, "read_output", None)
+    if reader is None:
+        return _error(
+            tool_call_id,
+            "jobs",
+            "this session's job manager does not record live output.",
+        )
+    window = reader(job.id, since)
+    if window is None:
+        return _error(tool_call_id, "jobs", f"unknown job {job.id}")
+    text, seq, gap = window
+
+    status = job.status
+    header = f"job {job.id} [{status}] seq={seq}"
+    if status != "running":
+        # A settled job's full result is already on its way to the caller (or
+        # readable through `wait`), so peek does not duplicate it; it says the
+        # watching is over, which is the fact that changes what to do next.
+        header += " — finished; use 'wait' for its result"
+    parts = [header]
+    if gap:
+        parts.append(
+            "[warning: output between your cursor and this window was dropped "
+            "from the buffer — this excerpt is not contiguous with your last peek]"
+        )
+    if text:
+        parts.append(text)
+    elif status == "running":
+        parts.append("(no new output since last peek)")
+    body = "\n".join(parts)
+    # Same bounded/spill path as every other verbose tool: a job that dumped
+    # more than the per-call budget between two peeks stays readable without
+    # letting one peek blow the result budget.
+    summary, spill_details = _capped_list_body(
+        body, body[:TOOL_OUTPUT_LIMIT_CHARS], "jobs", context
+    )
+    details: dict[str, Any] = {
+        "job_id": job.id,
+        "status": status,
+        "seq": seq,
+        "new_chars": len(text),
+        "gap": gap,
+    }
+    if spill_details:
+        details.update(spill_details)
+    return _text(tool_call_id, "jobs", summary, details=details)
+
+
 @_guard("jobs")
 async def execute_jobs(
     tool_call_id: str,
@@ -5741,9 +5935,9 @@ async def execute_jobs(
     on_update: Callable[[AgentToolUpdate], None] | None = None,
     context: ToolContext | None = None,
 ) -> ToolResult:
-    """List running and recently-settled background jobs."""
+    """List background jobs, peek at a running one's output, or cancel one."""
     try:
-        JobsParams(**args)
+        params = JobsParams(**args)
     except ValidationError as exc:
         return _validation_error(tool_call_id, "jobs", exc)
 
@@ -5754,6 +5948,34 @@ async def execute_jobs(
             "jobs",
             "job tracking is not available in this session (no job manager attached).",
         )
+
+    if params.op in ("peek", "cancel"):
+        if not params.job_id:
+            return _error(tool_call_id, "jobs", f"op='{params.op}' requires job_id")
+        job = jobs.get(params.job_id)
+        if job is None:
+            return _error(tool_call_id, "jobs", f"unknown job {params.job_id}")
+        if params.op == "cancel":
+            cancelled = await jobs.cancel(params.job_id)
+            if not cancelled:
+                # cancel() refuses a job that already settled, which is not a
+                # failure worth erroring on: the caller wanted it stopped and
+                # it is stopped. Report the terminal status so the caller does
+                # not retry a cancel that can never succeed.
+                return _text(
+                    tool_call_id,
+                    "jobs",
+                    f"job {params.job_id} was not cancelled (status: {job.status})",
+                    details={"job_id": params.job_id, "status": job.status, "cancelled": False},
+                )
+            return _text(
+                tool_call_id,
+                "jobs",
+                f"cancelled job {params.job_id} ({job.label})",
+                details={"job_id": params.job_id, "cancelled": True},
+            )
+        return _peek_job(tool_call_id, jobs, job, params.since or 0, context)
+
     rows = jobs.list()
     if not rows:
         return _text(tool_call_id, "jobs", "no background jobs", details={"count": 0})
@@ -5828,11 +6050,17 @@ def build_jobs_tool(context: ToolContext) -> AgentTool | None:
         name="jobs",
         label="List jobs",
         description=(
-            "List running and recently-settled background jobs (task/bash) "
-            "with their id, status and age — 'up' is how long a running job "
-            "has been going, 'wait' is how long a parked one has been waiting "
-            "for a slot, 'ago' is how long since a settled one finished, and "
-            "'old' is a settled job whose finish time was not recorded."
+            "Inspect background jobs (task/bash). op='list' shows every "
+            "running and recently-settled job with its id, status and age — "
+            "'up' is how long a running job has been going, 'wait' is how long "
+            "a parked one has been waiting for a slot, 'ago' is how long since "
+            "a settled one finished, and 'old' is a settled job whose finish "
+            "time was not recorded. op='peek' (job_id, and since=<seq from the "
+            "last peek>) returns ONLY the output produced since that cursor, so "
+            "polling a long job stays cheap — use it to watch a build, a "
+            "training run, a terraform apply, or a pipeline poll without "
+            "blocking. op='cancel' (job_id) stops a running job and kills its "
+            "process tree."
         ),
         parameters=JobsParams.model_json_schema(),
         approval_tier="read",

--- a/local_operator/tools/builtin.py
+++ b/local_operator/tools/builtin.py
@@ -1376,9 +1376,31 @@ async def execute_bash(
             )
             return "\n".join(part for part in (head, f"exit code: {code}", summary) if part)
 
+        def _kill_unstarted() -> None:
+            """Teardown for a cancel that lands before the runner is entered.
+
+            The process is spawned before ``register``, and ``register`` only
+            SCHEDULES the runner — so a cancel (or a session ``dispose``) in
+            the same event-loop turn settles the row without ``_detached``
+            ever running, leaving the process group alive and reparented to
+            init with nothing tracking it. The manager drops this hook the
+            instant the runner starts, so the group is never killed twice.
+            """
+            _kill()
+            for reader in readers:
+                if not reader.done():
+                    reader.cancel()
+
         try:
             bg_job_id = cast(Any, jobs).register(
-                "bash", f"bash: {command[:60]}", _detached, owner_id=None
+                "bash",
+                f"bash: {command[:60]}",
+                _detached,
+                # Scope the job to whoever asked for it: an unowned job escapes
+                # owner-scoped cancel/list and delivers to the top-level
+                # session's fallback sink instead of the subagent's own.
+                owner_id=context.job_id if context is not None else None,
+                on_cancel=_kill_unstarted,
             )
         except Exception:  # noqa: BLE001 — no manager slot: kill, don't leak
             _kill()
@@ -1410,7 +1432,14 @@ async def execute_bash(
         # block a turn for its whole duration.
         background_jobs = context.jobs if context is not None else None
         if background_jobs is None:
+            # Tear down everything this call created before refusing. The
+            # readers are not the only owners: ``wait_task`` and the abort
+            # waiter were created above and would outlive the refusal as
+            # pending tasks holding the process handle.
             _kill()
+            wait_task.cancel()
+            if abort_waiter is not None and not abort_waiter.done():
+                abort_waiter.cancel()
             for reader in readers:
                 reader.cancel()
             return _error(
@@ -5952,11 +5981,18 @@ async def execute_jobs(
     if params.op in ("peek", "cancel"):
         if not params.job_id:
             return _error(tool_call_id, "jobs", f"op='{params.op}' requires job_id")
-        job = jobs.get(params.job_id)
+        # Owner-scoped on both ops, matching the manager's invariant that a
+        # subagent cannot reach its parent's jobs: ``owner_id`` is None for the
+        # top-level session (which legitimately sees everything) and the
+        # subagent's job id inside a child, where a mismatch reads as
+        # not-found. Without it a child could cancel or read the output of work
+        # it does not own.
+        owner = context.job_id if context else None
+        job = jobs.get(params.job_id, owner_id=owner)
         if job is None:
             return _error(tool_call_id, "jobs", f"unknown job {params.job_id}")
         if params.op == "cancel":
-            cancelled = await jobs.cancel(params.job_id)
+            cancelled = await jobs.cancel(params.job_id, owner_id=owner)
             if not cancelled:
                 # cancel() refuses a job that already settled, which is not a
                 # failure worth erroring on: the caller wanted it stopped and

--- a/local_operator/tools/eval.py
+++ b/local_operator/tools/eval.py
@@ -42,7 +42,7 @@ import uuid
 from collections import OrderedDict
 from typing import Any, Callable, cast
 
-from pydantic import BaseModel, ConfigDict, Field, ValidationError
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
 
 from local_operator.harness.types import (
     AbortSignal,
@@ -72,6 +72,12 @@ EVAL_DEFAULT_TIMEOUT_SECONDS = 30.0
 #: Hard cap on the caller-chosen timeout — same role as bash's: a call longer
 #: than this is a session bug, not a tool feature.
 EVAL_MAX_TIMEOUT_SECONDS = 300.0
+#: Cap for a BACKGROUND run. The foreground cap exists to stop one call
+#: blocking a turn for minutes; a background job blocks nothing, so that reason
+#: does not apply and holding it there would have contradicted the mode's own
+#: description ("training, large fetches, polling loops" — none of which fit in
+#: five minutes). Matches bash's background ceiling so the two modes agree.
+EVAL_MAX_BACKGROUND_TIMEOUT_SECONDS = 3600.0
 #: A kernel untouched for this long is closed on the NEXT eval call. On-access
 #: reaping rather than a background task: a timer would have to be owned by an
 #: event loop that outlives sessions, and 5 minutes of staleness costs nothing
@@ -94,9 +100,32 @@ class EvalParams(BaseModel):
     timeout: float = Field(
         default=EVAL_DEFAULT_TIMEOUT_SECONDS,
         gt=0,
-        le=EVAL_MAX_TIMEOUT_SECONDS,
-        description="Max seconds before the kernel is killed (state is lost).",
+        le=EVAL_MAX_BACKGROUND_TIMEOUT_SECONDS,
+        description=(
+            "Max seconds before the kernel is killed (state is lost). "
+            f"Foreground calls are capped at {EVAL_MAX_TIMEOUT_SECONDS:.0f}s; "
+            f"background=true allows up to "
+            f"{EVAL_MAX_BACKGROUND_TIMEOUT_SECONDS:.0f}s."
+        ),
     )
+
+    @model_validator(mode="after")
+    def _timeout_within_mode_cap(self) -> "EvalParams":
+        """Hold foreground calls to the lower cap.
+
+        The field bound has to admit the larger background ceiling, so the
+        foreground limit is enforced here instead of being quietly dropped.
+        Rejecting is the honest outcome: silently clamping would run the call
+        for a different duration than the caller asked for.
+        """
+        if not self.background and self.timeout > EVAL_MAX_TIMEOUT_SECONDS:
+            raise ValueError(
+                f"timeout must be <= {EVAL_MAX_TIMEOUT_SECONDS:.0f}s for a "
+                f"foreground call; pass background=true to run up to "
+                f"{EVAL_MAX_BACKGROUND_TIMEOUT_SECONDS:.0f}s as a job."
+            )
+        return self
+
     background: bool = Field(
         default=False,
         description=(
@@ -134,6 +163,14 @@ _KERNELS: OrderedDict[str, _Kernel] = OrderedDict()
 #: before it runs, which would strand the kill half-done — the same reason
 #: bash keeps its reader tasks referenced.
 _CLOSING: set[asyncio.Task[None]] = set()
+
+#: Live background kernels by job id. These are deliberately NOT in
+#: ``_KERNELS``: that registry is the per-SESSION namespace cache with its own
+#: LRU and idle reaping, and a background job's kernel is owned by the job, not
+#: the session. Tracked anyway so a background worker is never an untracked
+#: process — the entry is removed as soon as the kernel is retired, on every
+#: path (completion, timeout, cancel, pre-start teardown).
+_BACKGROUND_KERNELS: dict[str, asyncio.subprocess.Process] = {}
 
 
 class _WorkerCrash(Exception):
@@ -543,7 +580,7 @@ async def _run_in_background(
                 except _WorkerCrash as exc:
                     tail = exc.stderr[-_CRASH_STDERR_TAIL_CHARS:].strip() or "(no stderr)"
                     return f"Python kernel crashed.\n--- stderr (tail) ---\n{tail}"
-                return _background_summary(response)
+                return _background_summary(response, context)
             if abort_waiter is not None and abort_waiter in done:
                 return "CANCELLED: background kernel killed mid-run"
             return f"TIMEOUT after {timeout}s: background kernel killed mid-run"
@@ -556,18 +593,55 @@ async def _run_in_background(
                     task.cancel()
                     with contextlib.suppress(BaseException):
                         await task
+            _forget_kernel()
             _retire(kernel)
+
+    # Filled in once ``register`` returns the id; the runner and the teardown
+    # hook both need it to drop their tracking entry.
+    job_slot: dict[str, str | None] = {"id": None}
+
+    def _forget_kernel() -> None:
+        job_id = job_slot["id"]
+        if job_id is not None:
+            _BACKGROUND_KERNELS.pop(job_id, None)
+
+    def _kill_unstarted_kernel() -> None:
+        """Teardown for a cancel that lands before the runner is ever entered.
+
+        The kernel is spawned above, BEFORE ``register``, so between those two
+        points it is owned by nothing the manager can see. ``register`` only
+        schedules the runner, so a cancel in that same event-loop turn would
+        settle the row without the runner's ``finally`` ever running and leave
+        this interpreter alive, reparented to init. The manager drops this the
+        moment the runner starts, so the kernel is never killed twice.
+        """
+        _forget_kernel()
+        _retire(kernel)
 
     try:
         job_id = cast(Any, jobs).register(
+            # ``"bash"``, not a new ``"eval"`` literal, and that is
+            # load-bearing: ``session`` only auto-delivers jobs whose type is
+            # in ``("task", "bash")``, so a third literal would silently strip
+            # background evals of the completion message that is the whole
+            # point of running them detached. ``JobType`` would have to gain
+            # the member and every reader branch on it before this can change;
+            # the label carries the distinction meanwhile.
             "bash",
             f"eval: {code.strip().splitlines()[0][:60] if code.strip() else 'code'}",
             _runner,
-            owner_id=None,
+            # The owner is whoever asked for the work: a subagent's background
+            # job must stay inside that subagent's scope, or owner-scoped
+            # ``cancel``/``list`` stop containing it and its completion routes
+            # to the parent's fallback sink instead of the child's.
+            owner_id=context.job_id if context is not None else None,
+            on_cancel=_kill_unstarted_kernel,
         )
     except Exception:  # noqa: BLE001 — no slot for the job: kill, don't leak
         _retire(kernel)
         raise
+    job_slot["id"] = job_id
+    _BACKGROUND_KERNELS[job_id] = kernel.process
     return _text(
         tool_call_id,
         "eval",
@@ -579,8 +653,16 @@ async def _run_in_background(
     )
 
 
-def _background_summary(response: dict[str, Any]) -> str:
-    """Render a finished background run the way the foreground result reads."""
+def _background_summary(response: dict[str, Any], context: ToolContext | None) -> str:
+    """Render a finished background run the way the foreground result reads.
+
+    Passed through ``spill_truncate`` like every other eval and bash result:
+    the worker caps each stream at 1 MB, and a job that produced that much
+    would otherwise store it whole in ``result_text`` and hand all of it to the
+    model when the completion auto-delivers. The full text stays reachable
+    through the spill handle, which is the same bargain the foreground path
+    already makes.
+    """
     stdout = str(response.get("stdout") or "")
     stderr = str(response.get("stderr") or "")
     error = response.get("error")
@@ -592,7 +674,8 @@ def _background_summary(response: dict[str, Any]) -> str:
         parts.append(f"result: {result}")
     parts.append(f"--- stdout ---\n{stdout if stdout else '(empty)'}")
     parts.append(f"--- stderr ---\n{stderr if stderr else '(empty)'}")
-    return "\n".join(parts)
+    text, _spill_details = spill_truncate("\n".join(parts), "eval", context)
+    return text
 
 
 def _lost_state_error(tool_call_id: str, reason: str) -> ToolResult:

--- a/local_operator/tools/eval.py
+++ b/local_operator/tools/eval.py
@@ -40,7 +40,7 @@ import sys
 import time
 import uuid
 from collections import OrderedDict
-from typing import Any, Callable
+from typing import Any, Callable, cast
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
@@ -96,6 +96,16 @@ class EvalParams(BaseModel):
         gt=0,
         le=EVAL_MAX_TIMEOUT_SECONDS,
         description="Max seconds before the kernel is killed (state is lost).",
+    )
+    background: bool = Field(
+        default=False,
+        description=(
+            "Run in a DEDICATED kernel and return a job id immediately instead "
+            "of waiting. Use for long work (training, large fetches, polling "
+            "loops); follow it with jobs(op='peek') to read new output as it "
+            "prints, and jobs(op='cancel') to stop it. The background kernel is "
+            "separate, so it neither sees nor changes the session namespace."
+        ),
     )
 
 
@@ -413,13 +423,23 @@ async def _read_crash_stderr(kernel: _Kernel) -> str:
     return raw.decode("utf-8", errors="replace")
 
 
-async def _exchange(kernel: _Kernel, request: dict[str, Any], request_id: str) -> dict[str, Any]:
+async def _exchange(
+    kernel: _Kernel,
+    request: dict[str, Any],
+    request_id: str,
+    on_stream: Callable[[str, str], None] | None = None,
+) -> dict[str, Any]:
     """Send one request line, await its response line by id.
 
     Lines that are not this request's response are skipped, not fatal: user
     code can write to fd 1 directly (the worker only intercepts the
     ``sys.stdout`` OBJECT), and a protocol that dies on stray bytes would
     lose a healthy kernel over noise. EOF before a response is a crash.
+
+    ``on_stream`` receives intermediate ``stream`` frames (channel, text) when
+    the request asked for them. They are progress only: the response still
+    carries the complete captured streams, so this callback never has to be
+    reconciled with the final result.
     """
     stdin = kernel.process.stdin
     assert stdin is not None  # piped at spawn
@@ -446,8 +466,133 @@ async def _exchange(kernel: _Kernel, request: dict[str, Any], request_id: str) -
             response = json.loads(line)
         except (ValueError, UnicodeError):
             continue
-        if isinstance(response, dict) and response.get("id") == request_id:
-            return response
+        if not isinstance(response, dict) or response.get("id") != request_id:
+            continue
+        channel = response.get("stream")
+        if channel:
+            # A progress frame, not the answer: publish it and keep reading.
+            if on_stream is not None:
+                with contextlib.suppress(Exception):
+                    on_stream(str(channel), str(response.get("text") or ""))
+            continue
+        return response
+
+
+async def _run_in_background(
+    tool_call_id: str,
+    params: EvalParams,
+    context: ToolContext | None,
+) -> ToolResult:
+    """Run ``code`` as a background job in a kernel of its own.
+
+    A DEDICATED kernel rather than the session's, for the same reason the tool
+    is ``exclusive`` in the first place: the namespace is state, and a job that
+    keeps mutating it for the next half hour would interleave with every
+    foreground call the model makes meanwhile. Isolation is the honest trade —
+    the background run cannot see session variables, and the tool description
+    says so, which is far better than a shared namespace that silently
+    corrupts. The kernel is never registered in ``_KERNELS``: it belongs to the
+    job, and it is killed when the job settles, times out, or is cancelled.
+    """
+    jobs = context.jobs if context is not None else None
+    if jobs is None:
+        return _error(
+            tool_call_id,
+            "eval",
+            "background=true needs a job manager, which this session has not "
+            "attached; re-run without background.",
+        )
+    try:
+        kernel = await _spawn(_safe_cwd(context))
+    except OSError as exc:
+        return _error(tool_call_id, "eval", f"failed to start Python kernel: {exc}")
+
+    code = params.code
+    timeout = params.timeout
+
+    async def _runner(job_id: str, job_signal: Any, report_progress: Any) -> str:
+        appender = getattr(jobs, "append_output", None)
+
+        def _publish(channel: str, text: str) -> None:
+            if appender is not None:
+                appender(job_id, text)
+            line = text.strip().splitlines()
+            if line:
+                report_progress(line[-1][:200])
+
+        request_id = uuid.uuid4().hex
+        exchange = asyncio.create_task(
+            _exchange(
+                kernel,
+                {"id": request_id, "code": code, "stream": True},
+                request_id,
+                _publish,
+            )
+        )
+        abort_waiter = asyncio.create_task(job_signal.wait()) if job_signal is not None else None
+        waiters: list[asyncio.Task[Any]] = [exchange]
+        if abort_waiter is not None:
+            waiters.append(abort_waiter)
+        try:
+            done, _pending = await asyncio.wait(
+                waiters, timeout=timeout, return_when=asyncio.FIRST_COMPLETED
+            )
+            if exchange in done:
+                try:
+                    response = exchange.result()
+                except _WorkerCrash as exc:
+                    tail = exc.stderr[-_CRASH_STDERR_TAIL_CHARS:].strip() or "(no stderr)"
+                    return f"Python kernel crashed.\n--- stderr (tail) ---\n{tail}"
+                return _background_summary(response)
+            if abort_waiter is not None and abort_waiter in done:
+                return "CANCELLED: background kernel killed mid-run"
+            return f"TIMEOUT after {timeout}s: background kernel killed mid-run"
+        finally:
+            # The kernel is this job's alone; it dies with the job on every
+            # path, including cancellation, so a killed job cannot leave an
+            # interpreter (and whatever it spawned) running untracked.
+            for task in (exchange, abort_waiter):
+                if task is not None and not task.done():
+                    task.cancel()
+                    with contextlib.suppress(BaseException):
+                        await task
+            _retire(kernel)
+
+    try:
+        job_id = cast(Any, jobs).register(
+            "bash",
+            f"eval: {code.strip().splitlines()[0][:60] if code.strip() else 'code'}",
+            _runner,
+            owner_id=None,
+        )
+    except Exception:  # noqa: BLE001 — no slot for the job: kill, don't leak
+        _retire(kernel)
+        raise
+    return _text(
+        tool_call_id,
+        "eval",
+        f"started in the background as job {job_id} (use jobs op='peek' for new "
+        f"output, op='cancel' to stop it); its result auto-delivers when it "
+        f"finishes.\nNOTE: a background run uses its own kernel, so it does not "
+        f"share the session namespace.",
+        details={"job_id": job_id, "backgrounded": True},
+    )
+
+
+def _background_summary(response: dict[str, Any]) -> str:
+    """Render a finished background run the way the foreground result reads."""
+    stdout = str(response.get("stdout") or "")
+    stderr = str(response.get("stderr") or "")
+    error = response.get("error")
+    result = response.get("result")
+    parts: list[str] = []
+    if error:
+        parts.append(str(error))
+    elif result is not None:
+        parts.append(f"result: {result}")
+    parts.append(f"--- stdout ---\n{stdout if stdout else '(empty)'}")
+    parts.append(f"--- stderr ---\n{stderr if stderr else '(empty)'}")
+    return "\n".join(parts)
 
 
 def _lost_state_error(tool_call_id: str, reason: str) -> ToolResult:
@@ -490,6 +635,9 @@ async def execute_eval(
             f"aborted ({signal.reason or 'aborted'}): code not run",
         )
 
+    if params.background:
+        return await _run_in_background(tool_call_id, params, context)
+
     key = _session_key(context)
     _reap_idle(time.monotonic())
 
@@ -520,7 +668,19 @@ async def execute_eval(
         waiters: list[asyncio.Task[Any]] = [exchange]
         if abort_waiter is not None:
             waiters.append(abort_waiter)
-        done, _pending = await asyncio.wait(waiters, timeout=params.timeout)
+        # FIRST_COMPLETED is load-bearing, not a micro-optimisation. asyncio.wait
+        # defaults to ALL_COMPLETED, and ``abort_waiter`` only completes if the
+        # session is aborted — so with a signal attached (which is every real
+        # call: the loop hands one to every tool) the default made this await
+        # block for the WHOLE ``timeout`` even after the kernel had already
+        # answered. The response was still correct, so the bug was invisible in
+        # the output and visible only as wall clock: a call whose code raised a
+        # NameError in microseconds sat for the full 300s the caller allowed.
+        # That also inverted the parameter's contract — ``timeout`` is a MAX, and
+        # raising it must never make a fast call slower.
+        done, _pending = await asyncio.wait(
+            waiters, timeout=params.timeout, return_when=asyncio.FIRST_COMPLETED
+        )
         if exchange in done:
             try:
                 response = exchange.result()

--- a/local_operator/tools/eval.py
+++ b/local_operator/tools/eval.py
@@ -630,11 +630,12 @@ async def _run_in_background(
             "bash",
             f"eval: {code.strip().splitlines()[0][:60] if code.strip() else 'code'}",
             _runner,
-            # The owner is whoever asked for the work: a subagent's background
-            # job must stay inside that subagent's scope, or owner-scoped
-            # ``cancel``/``list`` stop containing it and its completion routes
-            # to the parent's fallback sink instead of the child's.
-            owner_id=context.job_id if context is not None else None,
+            # Unowned ON PURPOSE — see the matching note in bash's
+            # ``_detach_to_job``. An ``owner_id`` without a registered delivery
+            # sink (nothing calls ``register_delivery_sink``) dead-letters the
+            # completion instead of scoping it, so a subagent would never be
+            # told its own background job had finished.
+            owner_id=None,
             on_cancel=_kill_unstarted_kernel,
         )
     except Exception:  # noqa: BLE001 — no slot for the job: kill, don't leak

--- a/local_operator/tools/eval_worker.py
+++ b/local_operator/tools/eval_worker.py
@@ -13,9 +13,20 @@ Protocol
 --------
 One JSON object per line, both directions, request then response, forever:
 
-    request:  {"id": "<hex>", "code": "<python source>"}
+    request:  {"id": "<hex>", "code": "<python source>", "stream": bool}
     response: {"id": "<hex>", "ok": true|false, "stdout": str, "stderr": str,
                "error": str|null, "result": str|null, "display": [str, ...]}
+
+When the request sets ``stream``, the worker ALSO writes zero or more frames
+before the response, one per write to stdout/stderr:
+
+    stream:   {"id": "<hex>", "stream": "stdout"|"stderr", "text": str}
+
+A stream frame carries the same ``id`` and is distinguished by the ``stream``
+key. They are advisory progress only — the response still carries the complete
+captured streams — so a reader may ignore them entirely without losing data.
+That redundancy is deliberate: it keeps a dropped or malformed frame from
+costing output the caller would otherwise never see.
 
 The ``id`` is echoed verbatim so the tool can discard lines that are not its
 own response — user code writing to file descriptor 1 directly (``os.write``)
@@ -54,6 +65,13 @@ from typing import Any
 STREAM_CHAR_LIMIT = 1_000_000
 DISPLAY_CHAR_LIMIT = 256_000
 TRUNCATED_MARKER = "\n[…worker output truncated before protocol serialization]"
+
+#: The protocol's own stdout, captured at import BEFORE any request can
+#: redirect ``sys.stdout``. Streaming frames are written through this handle so
+#: they reach the parent even though user code's ``print`` is being captured at
+#: the same moment — writing to ``sys.stdout`` there would land in the capture
+#: buffer and never be seen.
+_PROTOCOL_OUT = sys.stdout
 
 _REPR = reprlib.Repr()
 _REPR.maxstring = 4096
@@ -214,14 +232,63 @@ def _execute(namespace: dict[str, Any], code: str) -> str | None:
     return _safe_repr(value)
 
 
+class _StreamingTextIO(_CappedTextIO):
+    """A capped sink that also forwards each write to the parent immediately.
+
+    Plain ``_CappedTextIO`` only surrenders its contents in the final response,
+    which is correct for a short call and useless for a long one: a training
+    loop printing an epoch a minute would show nothing for an hour and then
+    everything at once. When a request asks to stream, each write is ALSO
+    emitted as its own protocol frame so the parent can publish it to the
+    job's peek buffer while the code is still running.
+
+    It still caps and still accumulates: the final response stays byte-for-byte
+    what a non-streaming run would produce, so streaming changes only WHEN the
+    parent learns something, never WHAT it ends up with.
+    """
+
+    def __init__(self, limit: int, emit: Callable[[str], None]) -> None:
+        super().__init__(limit)
+        self._emit = emit
+
+    def write(self, value: str) -> int:
+        written = super().write(value)
+        if value:
+            # A failure to emit must never break the user's code, which is what
+            # an exception raised inside ``print`` would do. The frame is
+            # advisory; the authoritative copy rides the final response.
+            with contextlib.suppress(Exception):
+                self._emit(value)
+        return written
+
+
 def _handle(namespace: dict[str, Any], request: dict[str, Any]) -> dict[str, Any]:
     """Execute one request and build its response mapping."""
     display_sink = _DisplaySink(DISPLAY_CHAR_LIMIT)
     # Rebound per request (see _make_display).
     namespace["display"] = _make_display(display_sink)
 
-    stdout = _CappedTextIO(STREAM_CHAR_LIMIT)
-    stderr = _CappedTextIO(STREAM_CHAR_LIMIT)
+    request_id = request.get("id", "")
+    if request.get("stream"):
+
+        def _emit(channel: str, text: str) -> None:
+            # Written straight to the real stdout while the redirect is active:
+            # ``sys.stdout`` is the captured object during the run, so the
+            # protocol keeps its own handle (``_PROTOCOL_OUT``) captured at
+            # import, before any redirect could reach it.
+            frame = {"id": request_id, "stream": channel, "text": text}
+            _PROTOCOL_OUT.write(json.dumps(frame) + "\n")
+            _PROTOCOL_OUT.flush()
+
+        stdout: _CappedTextIO = _StreamingTextIO(
+            STREAM_CHAR_LIMIT, lambda text: _emit("stdout", text)
+        )
+        stderr: _CappedTextIO = _StreamingTextIO(
+            STREAM_CHAR_LIMIT, lambda text: _emit("stderr", text)
+        )
+    else:
+        stdout = _CappedTextIO(STREAM_CHAR_LIMIT)
+        stderr = _CappedTextIO(STREAM_CHAR_LIMIT)
     ok = True
     error: str | None = None
     result: str | None = None
@@ -266,8 +333,8 @@ def main() -> None:
             # means the pipe is not worth trusting further.
             continue
         response = _handle(namespace, request)
-        sys.stdout.write(json.dumps(response) + "\n")
-        sys.stdout.flush()
+        _PROTOCOL_OUT.write(json.dumps(response) + "\n")
+        _PROTOCOL_OUT.flush()
 
 
 if __name__ == "__main__":

--- a/tests/unit/harness/test_jobs.py
+++ b/tests/unit/harness/test_jobs.py
@@ -10,6 +10,7 @@ import pytest
 from local_operator.harness.jobs import (
     CANCELLED_BEFORE_START,
     DEFAULT_MAX_RUNNING_JOBS,
+    OUTPUT_TAIL_CHARS,
     AsyncJob,
     AsyncJobManager,
 )
@@ -30,6 +31,13 @@ def require_job(manager: AsyncJobManager, job_id: str) -> AsyncJob:
     job = manager.get(job_id)
     assert job is not None
     return job
+
+
+def require_output(manager: AsyncJobManager, job_id: str, since: int = 0) -> tuple[str, int, bool]:
+    """``manager.read_output`` narrowed to non-None for assertions."""
+    window = manager.read_output(job_id, since)
+    assert window is not None
+    return window
 
 
 async def quick_runner(job_id, signal, report_progress):
@@ -417,4 +425,75 @@ async def test_a_completion_promotes_the_longest_queued_job():
     # b is still running; free it so dispose is clean.
     gate[1].set()
     await wait_for(lambda: require_job(manager, b).status == "completed")
+    await manager.dispose()
+
+
+# ---------------------------------------------------------------------------
+# live output tail: the data behind `jobs(op="peek")`
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_read_output_returns_only_what_is_new() -> None:
+    """The incremental contract: a cursor read never re-sends what it saw.
+
+    This is what makes polling a long job affordable — re-sending the whole
+    tail on every peek would grow the caller's context by the same bytes over
+    and over.
+    """
+    manager = AsyncJobManager()
+    job_id = manager.register("bash", "long", quick_runner)
+    manager.append_output(job_id, "first\n")
+    text, seq, gap = require_output(manager, job_id, 0)
+    assert (text, gap) == ("first\n", False)
+
+    # Nothing appended since: the same cursor yields nothing, not a repeat.
+    assert require_output(manager, job_id, seq) == ("", seq, False)
+
+    manager.append_output(job_id, "second\n")
+    text, seq2, gap = require_output(manager, job_id, seq)
+    assert (text, gap) == ("second\n", False)
+    assert seq2 > seq
+    # A cursor from the very start still replays everything retained.
+    assert require_output(manager, job_id, 0)[0] == "first\nsecond\n"
+    await manager.dispose()
+
+
+@pytest.mark.asyncio
+async def test_output_tail_is_bounded_and_reports_the_gap() -> None:
+    """Past the cap the oldest bytes go, and a stale cursor is TOLD they went.
+
+    Silently returning the surviving tail would hand the caller an excerpt that
+    looks contiguous with its last peek but has a hole in it — the caller would
+    conclude a step never happened.
+    """
+    manager = AsyncJobManager()
+    job_id = manager.register("bash", "chatty", quick_runner)
+    manager.append_output(job_id, "A" * 10)
+    cursor = require_job(manager, job_id).output_seq
+    manager.append_output(job_id, "B" * (OUTPUT_TAIL_CHARS + 100))
+
+    job = require_job(manager, job_id)
+    assert len(job.output_tail) == OUTPUT_TAIL_CHARS  # bounded
+    assert job.output_seq == 10 + OUTPUT_TAIL_CHARS + 100  # counts everything
+
+    text, _seq, gap = require_output(manager, job_id, cursor)
+    assert gap is True, "a cursor whose bytes were evicted must be told"
+    assert "A" not in text  # the evicted prefix is genuinely gone
+
+    # A fresh cursor at the head is contiguous again: no false gap.
+    assert require_output(manager, job_id, job.output_seq)[2] is False
+    await manager.dispose()
+
+
+@pytest.mark.asyncio
+async def test_output_helpers_tolerate_unknown_and_empty() -> None:
+    """An unknown id reads as None (not an exception): a runner draining a pipe
+    must not die because retention already swept its row."""
+    manager = AsyncJobManager()
+    assert manager.read_output("nope") is None
+    manager.append_output("nope", "ignored")  # must not raise
+    job_id = manager.register("bash", "quiet", quick_runner)
+    manager.append_output(job_id, "")  # empty write is a no-op, not a bump
+    assert require_job(manager, job_id).output_seq == 0
     await manager.dispose()

--- a/tests/unit/harness/test_jobs.py
+++ b/tests/unit/harness/test_jobs.py
@@ -497,3 +497,126 @@ async def test_output_helpers_tolerate_unknown_and_empty() -> None:
     manager.append_output(job_id, "")  # empty write is a no-op, not a bump
     assert require_job(manager, job_id).output_seq == 0
     await manager.dispose()
+
+
+@pytest.mark.asyncio
+async def test_cancel_before_the_runner_starts_still_runs_cleanup() -> None:
+    """A resource spawned before ``register`` is torn down even if the runner
+    is never entered.
+
+    ``register`` only ``ensure_future``s the runner, so a cancel landing in the
+    SAME event-loop turn settles the row without the coroutine body — and
+    therefore without its ``finally`` — ever running. Anything the caller had
+    already spawned would outlive the job that was supposed to own it. Note the
+    zero intervening awaits: that is the whole window.
+    """
+    manager = AsyncJobManager()
+    torn_down: list[str] = []
+    entered: list[str] = []
+
+    async def runner(job_id, signal, report_progress):
+        entered.append(job_id)
+        await asyncio.sleep(30)
+        return "never"
+
+    job_id = manager.register(
+        "bash", "spawned-already", runner, on_cancel=lambda: torn_down.append("cleaned")
+    )
+    await manager.cancel(job_id)  # no awaits in between: runner never stepped
+
+    assert entered == [], "precondition: the runner must not have started"
+    assert torn_down == ["cleaned"], "pre-start cleanup did not run"
+    assert require_job(manager, job_id).status == "cancelled"
+    await manager.dispose()
+
+
+@pytest.mark.asyncio
+async def test_cleanup_does_not_fire_once_the_runner_owns_the_resource() -> None:
+    """Exactly one owner. Once the runner starts, its own teardown is
+    authoritative and the pre-start hook must be dropped — firing both would
+    kill the same process twice (or kill one a retry had just replaced)."""
+    manager = AsyncJobManager()
+    torn_down: list[str] = []
+    started = asyncio.Event()
+
+    async def runner(job_id, signal, report_progress):
+        started.set()
+        await asyncio.sleep(30)
+        return "never"
+
+    job_id = manager.register(
+        "bash", "running", runner, on_cancel=lambda: torn_down.append("cleaned")
+    )
+    await started.wait()  # the runner is now entered and owns its resources
+    await manager.cancel(job_id)
+    assert torn_down == [], "pre-start cleanup ran for a job whose runner owned it"
+    await manager.dispose()
+
+
+@pytest.mark.asyncio
+async def test_dispose_leaves_no_job_uncleaned() -> None:
+    """Session teardown is the realistic trigger, and it must clean EVERY job.
+
+    Each job is torn down by exactly one of the two owners, and which one is a
+    scheduling detail rather than a guarantee: ``dispose`` awaits ``cancel``
+    per job, and that await lets a later job's runner start, after which the
+    runner's own ``finally`` is what cleans it. So this asserts the property
+    that actually matters — every job cleaned, none cleaned twice — rather than
+    pinning which path did it.
+    """
+    manager = AsyncJobManager()
+    cleaned: list[str] = []
+
+    def runner_for(name: str):
+        async def runner(job_id, signal, report_progress):
+            try:
+                await asyncio.sleep(30)
+            finally:
+                cleaned.append(name)  # the runner-owned path
+            return "never"
+
+        return runner
+
+    for name in ("a", "b", "c"):
+        manager.register(
+            "bash",
+            name,
+            runner_for(name),
+            on_cancel=lambda name=name: cleaned.append(name),  # the pre-start path
+        )
+    await manager.dispose()
+    # Let any runner that had started finish unwinding its `finally`.
+    await asyncio.sleep(0.05)
+    assert sorted(cleaned) == ["a", "b", "c"], "every job must be cleaned exactly once"
+
+
+@pytest.mark.asyncio
+async def test_a_raising_cleanup_does_not_break_the_cancel() -> None:
+    """Teardown is best-effort: a hook that throws must not leave the job row
+    un-settled or propagate out of ``cancel``."""
+    manager = AsyncJobManager()
+
+    async def runner(job_id, signal, report_progress):
+        await asyncio.sleep(30)
+        return "never"
+
+    def _boom() -> None:
+        raise RuntimeError("cleanup failed")
+
+    job_id = manager.register("bash", "bad-cleanup", runner, on_cancel=_boom)
+    assert await manager.cancel(job_id) is True
+    assert require_job(manager, job_id).status == "cancelled"
+    await manager.dispose()
+
+
+@pytest.mark.asyncio
+async def test_read_output_handles_a_cursor_from_another_job() -> None:
+    """A ``since`` past the head (e.g. a cursor copied from a busier job) reads
+    as 'nothing new' rather than slicing backwards into old output."""
+    manager = AsyncJobManager()
+    job_id = manager.register("bash", "quiet", quick_runner)
+    manager.append_output(job_id, "hello")
+    text, seq, gap = require_output(manager, job_id, 10_000)
+    assert (text, gap) == ("", False)
+    assert seq == 5
+    await manager.dispose()

--- a/tests/unit/tools/test_builtin_tools.py
+++ b/tests/unit/tools/test_builtin_tools.py
@@ -14,6 +14,7 @@ import io
 import os
 import random
 import struct
+import subprocess
 import threading
 import time
 import zlib
@@ -166,6 +167,56 @@ async def test_bash_background_returns_a_job_id_without_waiting(tmp_path) -> Non
 
     await manager.cancel(job_id)
     await manager.dispose()
+
+
+@pytest.mark.asyncio
+async def test_bash_background_cancelled_before_start_kills_the_process_group(tmp_path) -> None:
+    """Cancel with ZERO intervening awaits must still kill the child.
+
+    `register` only schedules the runner, so a cancel in the same event-loop
+    turn never enters `_detached` and never reaches its cleanup — the process
+    was spawned before `register` and would survive, reparented to init. The
+    existing process-group test misses this because it sleeps before
+    cancelling, which lets the runner start.
+    """
+    from local_operator.harness.jobs import AsyncJobManager
+
+    manager = AsyncJobManager()
+    ctx = ToolContext(cwd=str(tmp_path), session_id="bgleak", jobs=manager)
+    tool = builtin.build_bash_tool()
+    marker = f"sleep {random.randint(700, 899)}"
+    result = await tool.execute(  # type: ignore[operator]
+        "c1", {"command": marker, "background": True, "timeout": 900}, None, None, ctx
+    )
+    job_id = str((result.details or {})["job_id"])
+
+    def _alive() -> int:
+        found = subprocess.run(["pgrep", "-f", marker], capture_output=True, text=True)
+        return len([pid for pid in found.stdout.split() if pid])
+
+    assert _alive() >= 1, "precondition: the command should be running"
+    await manager.cancel(job_id)  # no awaits in between
+    await asyncio.sleep(1.0)
+    assert _alive() == 0, "process survived a cancel that landed before the runner started"
+    await manager.dispose()
+
+
+@pytest.mark.asyncio
+async def test_bash_background_survives_dispose_without_leaking(tmp_path) -> None:
+    """Session teardown right after backgrounding must not orphan the child."""
+    from local_operator.harness.jobs import AsyncJobManager
+
+    manager = AsyncJobManager()
+    ctx = ToolContext(cwd=str(tmp_path), session_id="bgdisp", jobs=manager)
+    tool = builtin.build_bash_tool()
+    marker = f"sleep {random.randint(900, 1099)}"
+    await tool.execute(  # type: ignore[operator]
+        "c1", {"command": marker, "background": True, "timeout": 1200}, None, None, ctx
+    )
+    await manager.dispose()  # no awaits in between
+    await asyncio.sleep(1.0)
+    found = subprocess.run(["pgrep", "-f", marker], capture_output=True, text=True)
+    assert [pid for pid in found.stdout.split() if pid] == [], "dispose orphaned the child"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tools/test_builtin_tools.py
+++ b/tests/unit/tools/test_builtin_tools.py
@@ -123,6 +123,61 @@ async def test_bash_timeout_kills_and_marks(tools, context) -> None:
 
 
 @pytest.mark.asyncio
+async def test_bash_background_returns_a_job_id_without_waiting(tmp_path) -> None:
+    """`background=True` hands the command to a job instead of blocking a turn.
+
+    The command sleeps far longer than this call may take, so returning fast
+    is only possible if it really was detached rather than awaited.
+    """
+    from local_operator.harness.jobs import AsyncJobManager
+
+    manager = AsyncJobManager()
+    ctx = ToolContext(cwd=str(tmp_path), session_id="bgbash", jobs=manager)
+    tool = builtin.build_bash_tool()
+    loop = asyncio.get_running_loop()
+    started = loop.time()
+    result = await tool.execute(  # type: ignore[operator]
+        "c1",
+        {"command": "echo starting; sleep 30", "background": True, "timeout": 120},
+        None,
+        None,
+        ctx,
+    )
+    elapsed = loop.time() - started
+    assert result.is_error is False
+    assert elapsed < 5.0, f"background bash blocked for {elapsed:.1f}s"
+    details = result.details or {}
+    job_id = str(details["job_id"])
+    assert details["backgrounded"] is True
+
+    # Output reaches the peek buffer while the command is still running.
+    deadline = loop.time() + 10
+    seen = ""
+    while loop.time() < deadline:
+        window = manager.read_output(job_id)
+        assert window is not None
+        seen = window[0]
+        if "starting" in seen:
+            break
+        await asyncio.sleep(0.05)
+    assert "starting" in seen
+    running = manager.get(job_id)
+    assert running is not None and running.status == "running"
+
+    await manager.cancel(job_id)
+    await manager.dispose()
+
+
+@pytest.mark.asyncio
+async def test_bash_background_without_a_job_manager_is_refused(tools, context) -> None:
+    """Refused, not silently run in the foreground: a caller that asked not to
+    block must never be handed a call that blocks for the whole timeout."""
+    result = await _call(tools, "bash", {"command": "echo hi", "background": True}, context)
+    assert result.is_error is True
+    assert "job manager" in result.text
+
+
+@pytest.mark.asyncio
 async def test_bash_timeout_rejects_zero_and_huge(tools, context) -> None:
     zero = await _call(tools, "bash", {"command": "echo hi", "timeout": 0}, context)
     assert zero.is_error is True

--- a/tests/unit/tools/test_eval_tool.py
+++ b/tests/unit/tools/test_eval_tool.py
@@ -400,7 +400,14 @@ def test_tool_shape() -> None:
     # The `i` intent field is the registry's injection, not ours.
     assert "i" not in properties
     assert "timeout" in properties
-    assert tool.parameters["properties"]["timeout"]["maximum"] == eval_tool.EVAL_MAX_TIMEOUT_SECONDS
+    # The SCHEMA bound is the background ceiling, because one field serves both
+    # modes; the lower foreground cap is enforced by the model validator, which
+    # is asserted by test_background_timeout_may_exceed_the_foreground_cap.
+    assert (
+        tool.parameters["properties"]["timeout"]["maximum"]
+        == eval_tool.EVAL_MAX_BACKGROUND_TIMEOUT_SECONDS
+    )
+    assert eval_tool.EVAL_MAX_TIMEOUT_SECONDS < eval_tool.EVAL_MAX_BACKGROUND_TIMEOUT_SECONDS
 
 
 def test_describe_approval_shows_code_first_line() -> None:
@@ -635,3 +642,85 @@ async def test_background_without_a_job_manager_is_refused(context) -> None:
     )
     assert result.is_error is True
     assert "job manager" in result.text
+
+
+@pytest.mark.asyncio
+async def test_background_cancelled_before_start_kills_the_kernel(tmp_path) -> None:
+    """Cancel with ZERO intervening awaits must still kill the worker.
+
+    The kernel is spawned before ``register``, and ``register`` only schedules
+    the runner — so a cancel in the same event-loop turn never enters it and
+    never reaches its ``finally``. Without a pre-start teardown the interpreter
+    survives, reparented to init, owned by nothing.
+    """
+    from local_operator.harness.jobs import AsyncJobManager
+
+    manager = AsyncJobManager()
+    context = ToolContext(cwd=str(tmp_path), session_id="bg-leak", jobs=manager)
+    tool = eval_tool.build_eval_tool()
+    result = await tool.execute(  # type: ignore[operator]
+        "c1",
+        {"code": "import time\ntime.sleep(300)", "background": True, "timeout": 600},
+        None,
+        None,
+        context,
+    )
+    job_id = str((result.details or {})["job_id"])
+    process = eval_tool._BACKGROUND_KERNELS.get(job_id)
+    assert process is not None, "the background kernel should be tracked while unstarted"
+    assert process.returncode is None, "precondition: the kernel is alive"
+
+    await manager.cancel(job_id)  # no awaits in between
+    await asyncio.sleep(1.0)
+    assert process.returncode is not None, "kernel survived a cancel before the runner started"
+    await manager.dispose()
+
+
+@pytest.mark.asyncio
+async def test_background_timeout_may_exceed_the_foreground_cap(tmp_path) -> None:
+    """The mode advertises training runs and polling loops, so its ceiling has
+    to allow them; the foreground cap still applies to blocking calls."""
+    from local_operator.harness.jobs import AsyncJobManager
+
+    manager = AsyncJobManager()
+    context = ToolContext(cwd=str(tmp_path), session_id="bg-cap", jobs=manager)
+    tool = eval_tool.build_eval_tool()
+    long_bg = await tool.execute(  # type: ignore[operator]
+        "c1", {"code": "1", "background": True, "timeout": 1800}, None, None, context
+    )
+    assert long_bg.is_error is False
+
+    too_long_fg = await tool.execute(  # type: ignore[operator]
+        "c2", {"code": "1", "timeout": 1800}, None, None, context
+    )
+    assert too_long_fg.is_error is True
+    assert "background=true" in too_long_fg.text
+    await manager.dispose()
+
+
+@pytest.mark.asyncio
+async def test_background_job_is_scoped_to_its_owner(tmp_path) -> None:
+    """A subagent's background work stays inside that subagent's scope, so an
+    owner-scoped cancel from elsewhere cannot reach it."""
+    from local_operator.harness.jobs import AsyncJobManager
+
+    manager = AsyncJobManager()
+    context = ToolContext(
+        cwd=str(tmp_path), session_id="bg-own", jobs=manager, job_id="child-job-1"
+    )
+    tool = eval_tool.build_eval_tool()
+    result = await tool.execute(  # type: ignore[operator]
+        "c1",
+        {"code": "import time\ntime.sleep(30)", "background": True, "timeout": 60},
+        None,
+        None,
+        context,
+    )
+    job_id = str((result.details or {})["job_id"])
+    row = manager.get(job_id)
+    assert row is not None and row.owner_id == "child-job-1"
+    # A different owner cannot see or cancel it.
+    assert manager.get(job_id, owner_id="someone-else") is None
+    assert await manager.cancel(job_id, owner_id="someone-else") is False
+    assert await manager.cancel(job_id, owner_id="child-job-1") is True
+    await manager.dispose()

--- a/tests/unit/tools/test_eval_tool.py
+++ b/tests/unit/tools/test_eval_tool.py
@@ -212,6 +212,89 @@ async def test_timeout_reports_lost_state_and_next_call_is_fresh(context) -> Non
 
 
 @pytest.mark.asyncio
+async def test_fast_call_returns_immediately_despite_a_long_timeout(context) -> None:
+    """``timeout`` is a MAX, not a fixed wall clock the call is held against.
+
+    Regression for the ALL_COMPLETED default in ``asyncio.wait``: with a live
+    (never-aborted) signal attached, the tool waited on the abort task too, so
+    a call that had already answered was still held for the entire timeout.
+    Raising ``timeout`` must never make a fast call slower, so this asserts on
+    elapsed time an order of magnitude under the timeout it allows.
+    """
+    signal = AbortSignal()
+    await _call(context, "warm = 1", signal=signal)  # pay the spawn cost first
+    loop = asyncio.get_running_loop()
+    started = loop.time()
+    result = await _call(context, "1 + 1", timeout=30, signal=signal)
+    elapsed = loop.time() - started
+    assert result.is_error is False
+    assert "result: 2" in result.text
+    assert elapsed < 5.0, f"fast call held for {elapsed:.1f}s of its 30s timeout"
+
+
+@pytest.mark.asyncio
+async def test_failing_code_returns_immediately_despite_a_long_timeout(context) -> None:
+    """The reported symptom: code that raises returns its traceback at once.
+
+    A ``NameError`` is raised in microseconds, but the hang was in the parent's
+    wait rather than in the worker, so an erroring call burned the full timeout
+    before showing a traceback that had been ready the whole time.
+    """
+    signal = AbortSignal()
+    await _call(context, "warm = 1", signal=signal)
+    loop = asyncio.get_running_loop()
+    started = loop.time()
+    result = await _call(context, "undefined_name_here()", timeout=30, signal=signal)
+    elapsed = loop.time() - started
+    assert result.is_error is True
+    assert "NameError" in result.text
+    assert elapsed < 5.0, f"failing call held for {elapsed:.1f}s of its 30s timeout"
+
+
+@pytest.mark.asyncio
+async def test_timeout_still_fires_with_a_live_signal_attached(context) -> None:
+    """The fix must not cost the timeout itself: genuinely slow code is killed.
+
+    Pairs with the two tests above — together they pin ``timeout`` as an upper
+    bound that is enforced but never waited out.
+    """
+    signal = AbortSignal()
+    loop = asyncio.get_running_loop()
+    started = loop.time()
+    result = await _call(context, "while True:\n    pass", timeout=0.5, signal=signal)
+    elapsed = loop.time() - started
+    assert result.is_error is True
+    assert "TIMEOUT" in result.text
+    assert elapsed < 10.0, f"timeout kill took {elapsed:.1f}s"
+
+
+@pytest.mark.asyncio
+async def test_abort_mid_run_still_interrupts_with_a_long_timeout(context) -> None:
+    """Abort must still win the race it shares with the exchange.
+
+    ``FIRST_COMPLETED`` is what makes whichever of the two finishes first the
+    outcome; this asserts the abort branch is still reachable and prompt, so
+    the fix cannot be mistaken for "just drop the abort waiter".
+    """
+    signal = AbortSignal()
+    await _call(context, "warm = 1", signal=signal)
+    loop = asyncio.get_running_loop()
+
+    async def abort_soon() -> None:
+        await asyncio.sleep(0.2)
+        signal.abort("user steering")
+
+    started = loop.time()
+    aborter = asyncio.create_task(abort_soon())
+    result = await _call(context, "import time\ntime.sleep(60)", timeout=120, signal=signal)
+    elapsed = loop.time() - started
+    await aborter
+    assert result.is_error is True
+    assert "aborted" in result.text
+    assert elapsed < 10.0, f"abort took {elapsed:.1f}s to interrupt"
+
+
+@pytest.mark.asyncio
 async def test_worker_crash_reports_stderr_tail_and_restarts(context) -> None:
     await _call(context, "x = 1")
     crashed = await _call(context, "import os\nos._exit(3)")
@@ -437,3 +520,118 @@ async def test_windows_spawn_assigns_kill_on_close_job_before_use(tmp_path, monk
     assert closed == [77]
     assert kernel.windows_job is None
     assert process._transport.closed is True
+
+
+# ---------------------------------------------------------------------------
+# background mode: long work observed through the job, not by blocking a turn
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_background_returns_a_job_id_without_waiting(tmp_path) -> None:
+    """The point of the mode: a long run costs the caller no wall clock.
+
+    The code below sleeps far longer than this call is allowed to take, so a
+    fast return is only possible if the work really was handed to a job.
+    """
+    from local_operator.harness.jobs import AsyncJobManager
+
+    manager = AsyncJobManager()
+    context = ToolContext(cwd=str(tmp_path), session_id="bg", jobs=manager)
+    tool = eval_tool.build_eval_tool()
+    loop = asyncio.get_running_loop()
+    started = loop.time()
+    result = await tool.execute(  # type: ignore[operator]
+        "call-bg",
+        {"code": "import time\ntime.sleep(30)", "background": True, "timeout": 60},
+        None,
+        None,
+        context,
+    )
+    elapsed = loop.time() - started
+    assert result.is_error is False
+    assert elapsed < 5.0, f"background eval blocked for {elapsed:.1f}s"
+    job_id = str((result.details or {})["job_id"])
+    assert manager.get(job_id) is not None
+    await manager.cancel(job_id)
+    await manager.dispose()
+
+
+@pytest.mark.asyncio
+async def test_background_streams_output_while_it_runs(tmp_path) -> None:
+    """Output is observable BEFORE the job settles.
+
+    A run whose output only appeared at the end would leave the caller blind
+    for exactly as long as the work is interesting, which is the failure this
+    mode exists to fix.
+    """
+    from local_operator.harness.jobs import AsyncJobManager
+
+    manager = AsyncJobManager()
+    context = ToolContext(cwd=str(tmp_path), session_id="bg-stream", jobs=manager)
+    tool = eval_tool.build_eval_tool()
+    code = "import time\nfor i in range(20):\n    print('tick', i, flush=True)\n    time.sleep(0.3)"
+    result = await tool.execute(  # type: ignore[operator]
+        "call-bg2", {"code": code, "background": True, "timeout": 60}, None, None, context
+    )
+    job_id = str((result.details or {})["job_id"])
+
+    # Poll until output appears while the job is still running.
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + 10
+    seen = ""
+    while loop.time() < deadline:
+        window = manager.read_output(job_id)
+        assert window is not None
+        seen = window[0]
+        live = manager.get(job_id)
+        if "tick 0" in seen and live is not None and live.status == "running":
+            break
+        await asyncio.sleep(0.1)
+    assert "tick 0" in seen, "no streamed output observed while the job ran"
+    live = manager.get(job_id)
+    assert live is not None and live.status == "running"
+
+    await manager.cancel(job_id)
+    await manager.dispose()
+
+
+@pytest.mark.asyncio
+async def test_background_uses_its_own_kernel_and_leaves_the_session_alone(tmp_path) -> None:
+    """Isolation is the documented trade for not blocking the turn.
+
+    A background run sharing the session namespace would mutate it under every
+    foreground call the model makes meanwhile — the exact interleaving the
+    tool's ``exclusive`` concurrency exists to prevent.
+    """
+    from local_operator.harness.jobs import AsyncJobManager
+
+    manager = AsyncJobManager()
+    context = ToolContext(cwd=str(tmp_path), session_id="bg-iso", jobs=manager)
+    tool = eval_tool.build_eval_tool()
+    execute = tool.execute  # type: ignore[operator]
+    await execute("s1", {"code": "session_only = 'here'"}, None, None, context)
+    bg = await execute(
+        "s2",
+        {"code": "import time\ntime.sleep(20)", "background": True, "timeout": 60},
+        None,
+        None,
+        context,
+    )
+    # The session kernel is untouched by the background run.
+    kept = await execute("s3", {"code": "session_only"}, None, None, context)
+    assert kept.is_error is False
+    assert "result: 'here'" in kept.text
+    await manager.cancel(str((bg.details or {})["job_id"]))
+    await manager.dispose()
+
+
+@pytest.mark.asyncio
+async def test_background_without_a_job_manager_is_refused(context) -> None:
+    """Refusing beats silently running in the foreground for 5 minutes."""
+    tool = eval_tool.build_eval_tool()
+    result = await tool.execute(  # type: ignore[operator]
+        "call-nojobs", {"code": "1", "background": True}, None, None, context
+    )
+    assert result.is_error is True
+    assert "job manager" in result.text

--- a/tests/unit/tools/test_eval_tool.py
+++ b/tests/unit/tools/test_eval_tool.py
@@ -699,28 +699,40 @@ async def test_background_timeout_may_exceed_the_foreground_cap(tmp_path) -> Non
 
 
 @pytest.mark.asyncio
-async def test_background_job_is_scoped_to_its_owner(tmp_path) -> None:
-    """A subagent's background work stays inside that subagent's scope, so an
-    owner-scoped cancel from elsewhere cannot reach it."""
+async def test_background_job_stays_deliverable_inside_a_subagent(tmp_path) -> None:
+    """A background job must be registered UNOWNED, even in a child session.
+
+    Setting ``owner_id`` looks like scoping and is not: the manager routes an
+    owned completion exclusively through that owner's registered delivery sink,
+    nothing in this codebase registers one, so the completion is dead-lettered
+    and the caller is never told its job finished. That silently defeats the
+    entire mode, so the ownership is pinned here rather than left to look like
+    an oversight.
+    """
     from local_operator.harness.jobs import AsyncJobManager
 
-    manager = AsyncJobManager()
+    delivered: list[str] = []
+
+    async def fallback(job_id: str, text: str, job: object) -> None:
+        delivered.append(job_id)
+
+    manager = AsyncJobManager(on_job_complete=fallback)
     context = ToolContext(
         cwd=str(tmp_path), session_id="bg-own", jobs=manager, job_id="child-job-1"
     )
     tool = eval_tool.build_eval_tool()
     result = await tool.execute(  # type: ignore[operator]
-        "c1",
-        {"code": "import time\ntime.sleep(30)", "background": True, "timeout": 60},
-        None,
-        None,
-        context,
+        "c1", {"code": "'done'", "background": True, "timeout": 60}, None, None, context
     )
     job_id = str((result.details or {})["job_id"])
     row = manager.get(job_id)
-    assert row is not None and row.owner_id == "child-job-1"
-    # A different owner cannot see or cancel it.
-    assert manager.get(job_id, owner_id="someone-else") is None
-    assert await manager.cancel(job_id, owner_id="someone-else") is False
-    assert await manager.cancel(job_id, owner_id="child-job-1") is True
+    assert row is not None and row.owner_id is None
+
+    for _ in range(100):
+        await asyncio.sleep(0.05)
+        settled = manager.get(job_id)
+        if settled is not None and settled.status != "running":
+            break
+    await asyncio.sleep(0.2)
+    assert delivered == [job_id], "the child was never told its background job finished"
     await manager.dispose()

--- a/tests/unit/tools/test_task_wait_jobs.py
+++ b/tests/unit/tools/test_task_wait_jobs.py
@@ -14,7 +14,7 @@ from typing import Any
 
 import pytest
 
-from local_operator.harness.jobs import AsyncJobManager
+from local_operator.harness.jobs import OUTPUT_TAIL_CHARS, AsyncJobManager
 from local_operator.harness.types import AgentTool, ToolContext, ToolResult
 from local_operator.tools import builtin
 from local_operator.tools.registry import create_tools
@@ -27,6 +27,12 @@ async def wait_for(predicate, timeout: float = 2.0) -> None:
         if loop.time() > deadline:
             raise AssertionError("timed out waiting for condition")
         await asyncio.sleep(0.005)
+
+
+def _status(manager: AsyncJobManager, job_id: str) -> str | None:
+    """A job's status, narrowed for predicates that poll for a transition."""
+    job = manager.get(job_id)
+    return job.status if job is not None else None
 
 
 async def _quick_runner(job_id: str, signal: Any, report_progress) -> str:
@@ -536,3 +542,112 @@ async def test_task_partial_batch_failure_reports_survivors(tmp_path):
     assert result.is_error is False  # 1 of 2 launched: not a total failure
     assert "1 subagent(s)" in result.text
     assert "failed to launch: b" in result.text
+
+
+# ---------------------------------------------------------------------------
+# jobs(op="peek") / jobs(op="cancel") — observing and stopping live work
+# ---------------------------------------------------------------------------
+
+
+async def _emitting_runner(job_id: str, signal: Any, report_progress) -> str:
+    """A job that prints, then blocks — the shape peek exists to observe."""
+    await asyncio.sleep(30)
+    return "never"
+
+
+@pytest.mark.asyncio
+async def test_peek_returns_only_new_output_and_advances_the_cursor(tmp_path):
+    """Polling stays cheap: each peek costs what the job newly produced.
+
+    The second peek is the assertion that matters — a peek that re-sent the
+    whole tail would make watching a long job cost the same bytes repeatedly.
+    """
+    manager = AsyncJobManager()
+    context = ToolContext(cwd=str(tmp_path), session_id="s", jobs=manager)
+    tools = _tools(context)
+    job_id = manager.register("bash", "watched", _emitting_runner)
+
+    manager.append_output(job_id, "line one\n")
+    first = await _call(tools, "jobs", {"op": "peek", "job_id": job_id}, context)
+    assert first.is_error is False
+    assert "line one" in first.text
+    cursor = int((first.details or {})["seq"])
+
+    # Nothing new: the reply carries no output at all, only status.
+    quiet = await _call(tools, "jobs", {"op": "peek", "job_id": job_id, "since": cursor}, context)
+    assert (quiet.details or {})["new_chars"] == 0
+    assert "line one" not in quiet.text, "a peek must not re-send what was already read"
+    assert "no new output" in quiet.text
+
+    manager.append_output(job_id, "line two\n")
+    second = await _call(tools, "jobs", {"op": "peek", "job_id": job_id, "since": cursor}, context)
+    assert "line two" in second.text
+    assert "line one" not in second.text
+    assert int((second.details or {})["seq"]) > cursor
+
+    await manager.cancel(job_id)
+    await manager.dispose()
+
+
+@pytest.mark.asyncio
+async def test_peek_reports_a_settled_job_and_flags_dropped_output(tmp_path):
+    manager = AsyncJobManager()
+    context = ToolContext(cwd=str(tmp_path), session_id="s", jobs=manager)
+    tools = _tools(context)
+    job_id = manager.register("bash", "done-soon", _quick_runner)
+    await wait_for(lambda: _status(manager, job_id) != "running")
+
+    settled = await _call(tools, "jobs", {"op": "peek", "job_id": job_id}, context)
+    # Peek does not duplicate the result body; it says where to get it.
+    assert "finished" in settled.text
+    assert "wait" in settled.text
+
+    # A cursor whose bytes were evicted is warned, never quietly patched over.
+    gap_job = manager.register("bash", "chatty", _emitting_runner)
+    manager.append_output(gap_job, "X")
+    gap_row = manager.get(gap_job)
+    assert gap_row is not None
+    stale = gap_row.output_seq
+    manager.append_output(gap_job, "Y" * (OUTPUT_TAIL_CHARS + 50))
+    gapped = await _call(tools, "jobs", {"op": "peek", "job_id": gap_job, "since": stale}, context)
+    assert (gapped.details or {})["gap"] is True
+    assert "not contiguous" in gapped.text
+    await manager.cancel(gap_job)
+    await manager.dispose()
+
+
+@pytest.mark.asyncio
+async def test_cancel_stops_a_running_job_and_is_honest_about_settled_ones(tmp_path):
+    manager = AsyncJobManager()
+    context = ToolContext(cwd=str(tmp_path), session_id="s", jobs=manager)
+    tools = _tools(context)
+    job_id = manager.register("bash", "long", _slow_runner)
+
+    cancelled = await _call(tools, "jobs", {"op": "cancel", "job_id": job_id}, context)
+    assert cancelled.is_error is False
+    assert (cancelled.details or {})["cancelled"] is True
+    await wait_for(lambda: _status(manager, job_id) == "cancelled")
+
+    # Cancelling again is not an error: the caller's intent is already true.
+    again = await _call(tools, "jobs", {"op": "cancel", "job_id": job_id}, context)
+    assert again.is_error is False
+    assert (again.details or {})["cancelled"] is False
+    assert "cancelled" in again.text
+    await manager.dispose()
+
+
+@pytest.mark.asyncio
+async def test_peek_and_cancel_reject_missing_or_unknown_ids(tmp_path):
+    manager = AsyncJobManager()
+    context = ToolContext(cwd=str(tmp_path), session_id="s", jobs=manager)
+    tools = _tools(context)
+    missing = await _call(tools, "jobs", {"op": "peek"}, context)
+    assert missing.is_error is True
+    assert "requires job_id" in missing.text
+    unknown = await _call(tools, "jobs", {"op": "cancel", "job_id": "nope"}, context)
+    assert unknown.is_error is True
+    assert "unknown job" in unknown.text
+    # The default op is still a plain listing, so existing callers are unaffected.
+    listed = await _call(tools, "jobs", {}, context)
+    assert listed.is_error is False
+    await manager.dispose()

--- a/tests/unit/tools/test_task_wait_jobs.py
+++ b/tests/unit/tools/test_task_wait_jobs.py
@@ -651,3 +651,29 @@ async def test_peek_and_cancel_reject_missing_or_unknown_ids(tmp_path):
     listed = await _call(tools, "jobs", {}, context)
     assert listed.is_error is False
     await manager.dispose()
+
+
+@pytest.mark.asyncio
+async def test_peek_and_cancel_reach_jobs_the_listing_shows(tmp_path):
+    """Whatever `op="list"` shows, `peek` and `cancel` must be able to address.
+
+    Regression: scoping these two ops by `context.job_id` (and leaving `list`
+    unscoped) made the tool contradict itself inside a child session — it
+    listed a grandchild `task` job and then called that same id "unknown job",
+    because `run_subagent` registers those with `owner_id=None`.
+    """
+    manager = AsyncJobManager()
+    grandchild = manager.register("task", "grandchild", _slow_runner)
+    # A CHILD session's context: it carries a job_id of its own.
+    context = ToolContext(cwd=str(tmp_path), session_id="child", jobs=manager, job_id="child-job-1")
+    tools = _tools(context)
+
+    listed = await _call(tools, "jobs", {}, context)
+    assert grandchild in listed.text, "precondition: the listing shows the job"
+
+    peeked = await _call(tools, "jobs", {"op": "peek", "job_id": grandchild}, context)
+    assert peeked.is_error is False, "peek could not address a job the listing showed"
+
+    cancelled = await _call(tools, "jobs", {"op": "cancel", "job_id": grandchild}, context)
+    assert cancelled.is_error is False, "cancel could not address a job the listing showed"
+    await manager.dispose()


### PR DESCRIPTION
# PR Description

## Change classification

**C2 — standard / pre-authorized.** One-line correctness fix to an existing wait, plus new opt-in surface (`background=` on bash/eval, two new `jobs` ops). Nothing existing changes behaviour unless the new arguments are passed: `jobs` with no arguments is still exactly the listing it was, and `bash`/`eval` without `background` take the same path as before. Clean rollback (`git revert`). No RFC requested.

## The bug, measured

`eval` calls were reaching their full timeout and returning a result that had clearly been ready the whole time. The reported case: a `NameError` on line 4 — raised in microseconds — sat for the entire **300s** the call allowed.

`execute_eval` raced the worker exchange against the abort waiter:

```python
done, _pending = await asyncio.wait(waiters, timeout=params.timeout)
```

`asyncio.wait` defaults to **`ALL_COMPLETED`**. The abort waiter only completes if the session aborts, so whenever a signal is attached — which is *every* real call, since the loop hands one to every tool — the await could not return until the timeout expired, however fast the kernel answered. The response was still correct, which is why this never showed up as a wrong answer, only as wall clock.

That inverted the parameter's contract: `timeout` documents a **maximum**, and raising it made fast calls slower. It is also why `eval` looked like the expensive tool it was meant to replace.

Measured directly against the unfixed code (`1+1`, `timeout=6`):

```console
WITH signal: 6.01s -> result: 2
```

Every other multi-waiter site in the codebase already passes `FIRST_COMPLETED` (`mcp/manager.py:1553`, `web_search/tool.py:182`, `providers/failover.py:1075`, `tools/builtin.py:1066`, `oauth/callback_server.py:384`). `eval` was the only one that did not.

### The same defect silently disabled abort

Writing the regression tests surfaced a second consequence that no test covered: because the abort waiter's completion could not end the wait, **abort did nothing**. A 60s sleep aborted at 0.3s ran to completion and returned success. The tests below fail on the old code for that reason, not only on timing.

## The gap this exposed

The reason a 300s timeout was being passed at all is that the tools had no other answer for long work. `eval` and `bash` block a turn for their whole duration, and the only route to a background job was a *steering interrupt* — an accident the model cannot ask for. So polling a pipeline, watching a `terraform apply`, or running a training loop meant blocking and hoping.

Three additions, all opt-in:

### 1. Deliberate backgrounding

`bash(background=True)` and `eval(background=True)` register the work as a job and return its id immediately. bash's detach logic is now **shared** with the steering-interrupt path (one `_detach_to_job`) rather than duplicated, so the two cannot drift.

A background `eval` runs in a **dedicated kernel**, never the session's. The namespace is state and the tool is `exclusive` precisely so two calls cannot interleave on it; a half-hour background job mutating it under every foreground call would reintroduce exactly that hazard. Isolation is the honest trade and the tool description says so.

### 2. `jobs(op="peek")` — incremental, cursor-based

Each peek returns **only what was appended since the caller's cursor**, and hands back the `seq` to use next time. This is what keeps polling affordable: returning the whole tail each time would re-send the same bytes on every poll *and* — since each result is appended to the transcript verbatim — grow context by those bytes repeatedly, invalidating the prefix cache each turn.

Output evicted from the bounded tail (64 KB) is reported as a **gap** rather than passed off as contiguous. A length-only cursor would silently misreport a hole as "nothing new", and the caller would conclude a step never ran.

### 3. `jobs(op="cancel")`

Stops a running job and kills its process tree. Cancelling an already-settled job is reported, not errored — the caller's intent is already satisfied.

## Compatibility: what is deliberately *not* in the protocol

`append_output`/`read_output` are **not** declared on `JobManagerProtocol`. It is `runtime_checkable` and `ToolContext` validates against it, so every method added there becomes mandatory for every implementation. Adding them broke pre-existing embedder-style managers outright — 8 tests in `test_registry.py` and `test_prompts_api.py` failed construction:

```text
Input should be an instance of JobManagerProtocol [type=is_instance_of, input_type=_FakeJobs]
```

The two call sites probe with `getattr` and degrade to "this manager records no live output" instead. Those fake managers are now **unmodified** by this PR and pass as they were.

Rebased onto `main` after #140 landed, which reached the identical conclusion for `settled_event` on the same Protocol. The two notes are merged into one, so the rule is stated once for all three optional methods rather than twice in adjacent comments. Gates and evidence below were re-run on the rebased head.

## Validation

Everything below was run against the real tools and a real `AsyncJobManager`, not mocks.

### A. The reported bug

```console
### A. NameError with timeout=300
  elapsed: 0.01s (was 300s)  error=True

### B. timeout still enforced as a max
  elapsed: 2.00s  -> TIMEOUT after 2.0s: kernel killed mid-run

### C. abort interrupts promptly (was ignored entirely)
  elapsed: 0.31s  -> aborted (user steering): kernel killed mid-run
```

B and C are the guardrails: making the wait return early must not cost the timeout or the abort.

### The tests fail on the unfixed code

Reverting only `eval.py` and running the new tests — this is the check that they test the bug and not the weather:

```console
FAILED test_fast_call_returns_immediately_despite_a_long_timeout
  AssertionError: fast call held for 30.0s of its 30s timeout
  assert 30.00143875007052 < 5.0
FAILED test_failing_code_returns_immediately_despite_a_long_timeout
  AssertionError: failing call held for 30.0s of its 30s timeout
FAILED test_abort_mid_run_still_interrupts_with_a_long_timeout
  AssertionError: assert False is True     # abort was ignored entirely
3 failed, 1 passed, 24 deselected in 210.85s (0:03:30)
```

The same file with the fix in place:

```console
28 passed in 3.97s
```

**211s → 3.97s** for the identical suite.

### B. Background + peek, against a live command

```console
### D. background bash + incremental peek
  returned in 0.01s
  peek0: +39ch  reply=73ch  last='build-step-3'
  peek1: +26ch  reply=60ch  last='build-step-5'
  peek2: +26ch  reply=60ch  last='build-step-7'
  idle poll reply = 65ch (a full-tail peek would resend everything)
  3 peeks cost 193ch total
```

A poll of a job that produced nothing costs **65 characters**. A background `eval` streams the same way — `epoch 2 loss=0.333` was readable while the job was still `running`.

### C. Cancel really kills the tree

Not just the job row — the actual descendant process:

```console
  child pid 75450 alive before cancel: True
  child pid 75450 alive after cancel:  False
```

### D. Isolation and error paths

```console
=== session namespace untouched by a background run ===
result: 'alive'

=== errors ===
  unknown job nope
  op='cancel' requires job_id
  background=true needs a job manager ... re-run without background.
```

### E. No leaked processes

Checked after every run; the only `eval_worker` processes on the box belong to the installed `lop` runtime (other live sessions), none parented to the test run, none orphaned to PID 1.

### Automated gates

```text
.venv/bin/python -m flake8 .                                  PASS
uvx --from black==26.1.0 black --check local_operator tests    PASS (364 files)
uvx isort --check-only --profile black local_operator tests     PASS
.venv/bin/python -m pyright --pythonpath .venv/bin/python .     PASS (0 errors)
pytest tests/unit -q                          4509 passed, 7 skipped in 638.60s
```

New tests: 4 in `test_eval_tool.py` for the timeout/abort contract, 4 for background eval, 2 for background bash, 4 for peek/cancel in `test_task_wait_jobs.py`, 3 for the output buffer in `test_jobs.py`.

### Not covered

No UI change, so no screenshots: `jobs`/`bash`/`eval` results render through the existing tool-result path, and the TUI's progress field already had a renderer — this only starts feeding it for backgrounded bash. Pause/resume (`SIGSTOP`/`SIGCONT`) was considered and left out deliberately: it does not help the polling or plan/apply cases (a stopped `terraform apply` still holds its lock, a stopped poller just goes blind), and it adds a state a job can wedge in.
