### PR TITLE
fix(providers): walk the whole credential pool on provider-side faults, and reach Kimi's coding plan

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,14 +19,20 @@ suite expects:
 env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit/tui -q
 ```
 
-Gates, all of which must be clean before a PR:
+Gates, all of which must be clean before a PR. **Run them over the whole tree,
+exactly as CI does** — these are the commands from `.github/workflows/ci.yml`:
 
 ```sh
 .venv/bin/python -m flake8 .
-uvx --from black==26.1.0 black --check local_operator tests
-uvx isort --check-only --profile black local_operator tests
+uvx --from black==26.1.0 black --check .
+uvx isort==5.13.2 --check .
 .venv/bin/python -m pyright --pythonpath .venv/bin/python .
 ```
+
+Narrowing the last two to `local_operator tests`, or passing `--profile black`
+instead of letting isort read the repo's own config, checks something CI does
+not: both combinations pass on a file that CI then rejects. An unsorted
+function-local import reached CI exactly that way.
 
 The venv is uv-managed and has the package installed **editable**, so source
 edits are live. After a pull that changes dependencies:

--- a/local_operator/model/discovery.py
+++ b/local_operator/model/discovery.py
@@ -1045,6 +1045,7 @@ def _cache_key(
     *,
     account_scoped: bool = False,
     account_id: str | None = None,
+    host_scoped: bool = False,
 ) -> str:
     """Cache document name, isolated by credential scope where required.
 
@@ -1065,6 +1066,13 @@ def _cache_key(
     if account_scoped and account_id:
         account_scope = hashlib.sha256(account_id.encode("utf-8")).hexdigest()[:12]
         return f"{storage_id}.oauth.{account_scope}.listing"
+    if host_scoped:
+        # A provider whose OAuth sign-in is served by a different HOST than its
+        # API key (``oauth_base_url``; Kimi's coding plan) returns a genuinely
+        # different catalogue per credential kind -- the subscription lists
+        # ``k3``, the mainland API-key platform does not. One document for both
+        # would let whichever ran last decide what the other kind can select.
+        return f"{storage_id}.oauth.listing"
     return f"{storage_id}.listing"
 
 
@@ -1196,7 +1204,12 @@ def _available_models(
     if definition is None or transport is None:
         return merge_models(rows, None), "static"
 
-    resolved_base = base_url or definition.base_url
+    # An OAuth credential may be served by a different host than the provider's
+    # API-key base (Kimi's coding plan; see ``oauth_base_url``). An explicit
+    # caller-supplied base still wins, because that is a deliberate override.
+    resolved_base = base_url or (
+        (definition.oauth_base_url if is_oauth else None) or definition.base_url
+    )
     if not resolved_base:
         return merge_models(rows, None), "static"
 
@@ -1245,7 +1258,12 @@ def _available_models(
         api_key=api_key,
         account_id=account_id,
     )
-    key = _cache_key(storage_id, account_scoped=account_scoped, account_id=account_id)
+    key = _cache_key(
+        storage_id,
+        account_scoped=account_scoped,
+        account_id=account_id,
+        host_scoped=bool(is_oauth and definition.oauth_base_url),
+    )
     payload = cached_listing(key, fetch, ttl_s=ttl_s, cache_dir=cache_dir)
     live_rows = _rows_from_payload(payload, capture)
     if live_rows is None:

--- a/local_operator/providers/auth_store.py
+++ b/local_operator/providers/auth_store.py
@@ -178,6 +178,12 @@ class AuthStore:
         self._fallback_resolvers: dict[str, Callable[[str], str | None]] = {}
         self._sticky: dict[tuple[str, str], int] = {}
         self._round_robin: dict[str, int] = {}
+        # Credentials that just failed on a PROVIDER-side fault, which is not
+        # their fault and so must not block them (see ``rotate_sibling``). They
+        # are merely sorted last, so an attempt moves to a sibling while the
+        # deprioritised row stays available as a last resort. Process-local and
+        # deliberately unpersisted: the condition it describes lasts seconds.
+        self._deprioritized: dict[str, set[int]] = {}
         self._refresh_locks: dict[int, asyncio.Lock] = {}
         self._conn = self._connect()
 
@@ -498,11 +504,42 @@ class AuthStore:
 
     # -- selection: stickiness + round-robin -------------------------------------
 
+    def deprioritize_credential(self, provider: str, credential_id: int) -> None:
+        """Sort ``credential_id`` last for ``provider`` without blocking it.
+
+        The half of ``rotate_sibling`` that applies when the PROVIDER failed
+        rather than the credential: a 529 storm must move the next attempt onto
+        another account, but blocking would strand a healthy account (and,
+        repeated across the pool, strand every one of them).
+        """
+        self._deprioritized.setdefault(provider, set()).add(credential_id)
+
+    def clear_deprioritized(self, provider: str, credential_id: int | None = None) -> None:
+        """Restore full priority once a credential succeeds again."""
+        if credential_id is None:
+            self._deprioritized.pop(provider, None)
+            return
+        self._deprioritized.get(provider, set()).discard(credential_id)
+
     def _selection_order(
         self, rows: list[StoredCredential], provider: str, session_id: str | None
     ) -> list[StoredCredential]:
         if not rows:
             return []
+        # Deprioritised rows go last while staying selectable. Applied before
+        # stickiness so a credential that just hit a provider fault does not
+        # keep winning on its sticky claim, and applied as a STABLE partition so
+        # the round-robin and hash orders below are otherwise untouched.
+        demoted = self._deprioritized.get(provider)
+        if demoted:
+            preferred = [r for r in rows if r.id not in demoted]
+            # Never return an empty preferred set: if every credential is
+            # deprioritised the pool has simply been through one full cycle, so
+            # the marks are stale and the rows are all equally good again.
+            if preferred:
+                rows = preferred + [r for r in rows if r.id in demoted]
+            else:
+                self._deprioritized.pop(provider, None)
         if session_id:
             sticky_id = self._sticky.get((provider, session_id))
             sticky = next((r for r in rows if r.id == sticky_id), None)
@@ -819,6 +856,7 @@ class AuthStore:
         """
         from local_operator.providers.failover import (
             is_invalidated_credential_error,
+            is_server_side_failure,
             is_usage_limit_error,
             retry_after_ms_from_error,
         )
@@ -834,9 +872,23 @@ class AuthStore:
             failing = None
 
         usage_limited = is_usage_limit_error(error)
+        # A provider-wide fault (5xx/529 overload, timeout) is not evidence
+        # against the CREDENTIAL. Blocking it would take a healthy account out
+        # of the pool for a minute because the provider had a bad second, and
+        # under a sustained outage that walks the whole pool into the blocked
+        # state until the session has nothing left to try -- while every one of
+        # those accounts would have served the very next request. So the row is
+        # left usable and only the sticky pointer moves, which is enough to send
+        # THIS attempt to a sibling.
+        server_side = is_server_side_failure(error)
         if failing is not None:
-            retry_after = retry_after_ms_from_error(error)
-            self.block_credential(failing.id, provider, block_ms=max(block_ms, retry_after or 0))
+            if server_side:
+                self.deprioritize_credential(provider, failing.id)
+            else:
+                retry_after = retry_after_ms_from_error(error)
+                self.block_credential(
+                    failing.id, provider, block_ms=max(block_ms, retry_after or 0)
+                )
             if usage_limited:
                 # Sticky preserved: same account stays first after backoff.
                 pass
@@ -853,7 +905,15 @@ class AuthStore:
             and not self.is_blocked(r.id, provider)
             and (credential_type is None or r.credential_type == credential_type)
         ]
-        return len(siblings) > 0
+        if siblings:
+            return True
+        # No untried sibling remains. For a provider-side fault the failing row
+        # was only deprioritised, never blocked, so it is still a legitimate
+        # thing to retry once the pool has been walked -- report that rather
+        # than declaring rotation exhausted and killing the turn.
+        if server_side and failing is not None:
+            self.clear_deprioritized(provider, failing.id)
+        return False
 
     @staticmethod
     def _row_matches_key(row: StoredCredential, api_key: str) -> bool:

--- a/local_operator/providers/auth_store.py
+++ b/local_operator/providers/auth_store.py
@@ -549,7 +549,12 @@ class AuthStore:
             self._deprioritized.pop(provider, None)
 
     def _selection_order(
-        self, rows: list[StoredCredential], provider: str, session_id: str | None
+        self,
+        rows: list[StoredCredential],
+        provider: str,
+        session_id: str | None,
+        *,
+        read_only: bool = False,
     ) -> list[StoredCredential]:
         if not rows:
             return []
@@ -575,7 +580,13 @@ class AuthStore:
         # so popping the whole provider would let a one-row tier wipe the marks
         # belonging to rows it never saw.
         if not preferred:
-            self.clear_deprioritized(provider, [r.id for r in ordered])
+            # Not under ``read_only``: clearing the marks is a routing DECISION,
+            # and an isolated request running beside a user's turn must not be
+            # able to move that turn's account. It still gets the same order --
+            # all rows demoted means no reordering either way -- so the only
+            # difference is that it decides nothing, which is the contract.
+            if not read_only:
+                self.clear_deprioritized(provider, [r.id for r in ordered])
             return ordered
         return preferred + [r for r in ordered if r.id in demoted]
 
@@ -798,7 +809,7 @@ class AuthStore:
 
         # 3. OAuth credential
         oauth_rows = self._usable_key_rows(provider, "oauth", source=None)
-        for row in self._selection_order(oauth_rows, provider, session_id):
+        for row in self._selection_order(oauth_rows, provider, session_id, read_only=read_only):
             try:
                 creds = await self._ensure_oauth_fresh(row, force=force_refresh)
             except AuthStoreError:
@@ -819,7 +830,7 @@ class AuthStore:
 
         # 4. API key persisted by interactive login
         login_rows = self._usable_key_rows(provider, "api_key", source="login")
-        for row in self._selection_order(login_rows, provider, session_id):
+        for row in self._selection_order(login_rows, provider, session_id, read_only=read_only):
             key = row.data.get("key")
             if key:
                 pin(row.id)
@@ -841,7 +852,7 @@ class AuthStore:
             for row in self._usable_key_rows(provider, "api_key", source=None)
             if row.data.get("source") != "login"
         ]
-        for row in self._selection_order(stored_rows, provider, session_id):
+        for row in self._selection_order(stored_rows, provider, session_id, read_only=read_only):
             key = row.data.get("key")
             if key:
                 pin(row.id)

--- a/local_operator/providers/auth_store.py
+++ b/local_operator/providers/auth_store.py
@@ -36,6 +36,7 @@ import os
 import sqlite3
 import time
 import zlib
+from collections.abc import Iterable
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable
 
@@ -181,8 +182,20 @@ class AuthStore:
         # Credentials that just failed on a PROVIDER-side fault, which is not
         # their fault and so must not block them (see ``rotate_sibling``). They
         # are merely sorted last, so an attempt moves to a sibling while the
-        # deprioritised row stays available as a last resort. Process-local and
-        # deliberately unpersisted: the condition it describes lasts seconds.
+        # deprioritised row stays available as a last resort.
+        #
+        # Deliberately unpersisted: the condition it describes lasts seconds,
+        # and a mark surviving a restart would misroute a session for a fault
+        # that had long cleared.
+        #
+        # Deliberately keyed by PROVIDER rather than by session, and so shared
+        # by every session in the process — like ``_round_robin`` above. That is
+        # the correct scope for what it records: "this account was failing at
+        # this provider a moment ago" is a fact about the provider and the
+        # account, not about who observed it, so a sibling session benefits from
+        # the discovery instead of paying to repeat it. Nothing here can make a
+        # credential unusable, so the worst a stale mark can do is reorder a
+        # pool whose members are all equally valid.
         self._deprioritized: dict[str, set[int]] = {}
         self._refresh_locks: dict[int, asyncio.Lock] = {}
         self._conn = self._connect()
@@ -514,32 +527,62 @@ class AuthStore:
         """
         self._deprioritized.setdefault(provider, set()).add(credential_id)
 
-    def clear_deprioritized(self, provider: str, credential_id: int | None = None) -> None:
-        """Restore full priority once a credential succeeds again."""
+    def clear_deprioritized(
+        self, provider: str, credential_id: int | Iterable[int] | None = None
+    ) -> None:
+        """Restore full priority for a credential, several, or all of them.
+
+        Takes an explicit id set rather than always clearing the provider,
+        because ``_selection_order`` runs once per cascade TIER with a different
+        subset of rows: a one-row tier finding its only row demoted must not
+        drop the marks belonging to rows in another tier that it never saw.
+        """
+        marks = self._deprioritized.get(provider)
+        if marks is None:
+            return
         if credential_id is None:
             self._deprioritized.pop(provider, None)
             return
-        self._deprioritized.get(provider, set()).discard(credential_id)
+        ids = {credential_id} if isinstance(credential_id, int) else {int(i) for i in credential_id}
+        marks -= ids
+        if not marks:
+            self._deprioritized.pop(provider, None)
 
     def _selection_order(
         self, rows: list[StoredCredential], provider: str, session_id: str | None
     ) -> list[StoredCredential]:
         if not rows:
             return []
-        # Deprioritised rows go last while staying selectable. Applied before
-        # stickiness so a credential that just hit a provider fault does not
-        # keep winning on its sticky claim, and applied as a STABLE partition so
-        # the round-robin and hash orders below are otherwise untouched.
+        ordered = self._base_selection_order(rows, provider, session_id)
+        # Demotion is applied LAST, to the finished order.
+        #
+        # It used to run first, which did not work: both orderings below rotate
+        # the list (`rows[i:] + rows[:i]`), so a row moved to the back was
+        # rotated straight back towards the front. With three credentials and a
+        # session whose hash landed on index 1, the account that had just failed
+        # was tried SECOND -- the pool was never fully walked, which is the bug
+        # the demotion exists to fix. Applying it here cannot be undone by a
+        # later step, and because the partition is stable the relative order the
+        # sticky/hash/round-robin choice produced is otherwise preserved.
         demoted = self._deprioritized.get(provider)
-        if demoted:
-            preferred = [r for r in rows if r.id not in demoted]
-            # Never return an empty preferred set: if every credential is
-            # deprioritised the pool has simply been through one full cycle, so
-            # the marks are stale and the rows are all equally good again.
-            if preferred:
-                rows = preferred + [r for r in rows if r.id in demoted]
-            else:
-                self._deprioritized.pop(provider, None)
+        if not demoted:
+            return ordered
+        preferred = [r for r in ordered if r.id not in demoted]
+        # Every row demoted means the pool has been walked once, so the marks
+        # describe an outage rather than any one account: they are stale and the
+        # rows are equally good again. Only THIS tier's rows are cleared -- the
+        # cascade calls this once per credential tier with a different subset,
+        # so popping the whole provider would let a one-row tier wipe the marks
+        # belonging to rows it never saw.
+        if not preferred:
+            self.clear_deprioritized(provider, [r.id for r in ordered])
+            return ordered
+        return preferred + [r for r in ordered if r.id in demoted]
+
+    def _base_selection_order(
+        self, rows: list[StoredCredential], provider: str, session_id: str | None
+    ) -> list[StoredCredential]:
+        """Stickiness, then a per-session hash, then round-robin."""
         if session_id:
             sticky_id = self._sticky.get((provider, session_id))
             sticky = next((r for r in rows if r.id == sticky_id), None)

--- a/local_operator/providers/auth_store.py
+++ b/local_operator/providers/auth_store.py
@@ -687,26 +687,26 @@ class AuthStore:
         # the same failing bearer came back every time. A healthy credential one
         # tier down never received a single request.
         #
-        # Dropping is safe precisely because it is conditional: if every
-        # reachable credential is demoted, the marks describe an outage rather
-        # than any one account and :meth:`_selection_order` clears them.
+        # Dropping is safe WITHOUT a "is anything else reachable?" guard, and
+        # deliberately has none. Such a guard could only count database ROWS,
+        # while the cascade also resolves from the env var (tier 5) and the
+        # fallback resolver (tier 7), which are not rows: a demoted lone stored
+        # row would then never yield, and an exported ANTHROPIC_API_KEY beside a
+        # signed-in account became unreachable where it used to be the fallback.
+        #
+        # The real safety net is :meth:`_selection_order`, which clears the
+        # marks as stale once every row it is shown is demoted -- so a pool that
+        # has been walked comes back rather than emptying.
         demoted = self._active_demotions(provider)
-        if demoted and any(r.id not in demoted for r in self._all_selectable_rows(provider)):
+        if demoted:
             remaining = [r for r in rows if r.id not in demoted]
             if remaining:
                 return remaining
-            # Every row in THIS tier is demoted but another tier still has one:
-            # yield the tier so the cascade moves on to it.
+            # Every row in THIS tier is demoted: yield the tier so the cascade
+            # moves on to whatever comes next -- another tier, the env var, or
+            # the resolver.
             return []
         return rows
-
-    def _all_selectable_rows(self, provider: str) -> list[StoredCredential]:
-        """Every enabled, unblocked row for ``provider``, across all tiers."""
-        return [
-            r
-            for r in self.list_credentials(provider)
-            if r.disabled_cause is None and not self.is_blocked(r.id, provider)
-        ]
 
     # -- the cascade ---------------------------------------------------------
 
@@ -942,6 +942,17 @@ class AuthStore:
         if resolver is not None:
             return resolver(provider), None
 
+        # Nothing in the whole cascade -- but demotions are a ROUTING
+        # preference, never a statement that a credential is unusable. If they
+        # are the only reason this came back empty, they have outlived their
+        # purpose (there is nowhere else to route to), so clear them and resolve
+        # once more. Without this a sole demoted credential resolved to None and
+        # the caller was told no credential was configured, which is exactly the
+        # misdiagnosis this change set out to remove.
+        if not read_only and self._active_demotions(provider):
+            self.clear_deprioritized(provider)
+            return await self._resolve(provider, session_id, force_refresh=force_refresh)
+
         return None, None
 
     def _env_api_key(self, provider: str) -> str | None:
@@ -1041,12 +1052,20 @@ class AuthStore:
         ]
         if siblings:
             return True
-        # No untried sibling remains. For a provider-side fault the failing row
-        # was only deprioritised, never blocked, so it is still a legitimate
-        # thing to retry once the pool has been walked -- report that rather
-        # than declaring rotation exhausted and killing the turn.
-        if server_side and failing is not None:
-            self.clear_deprioritized(provider, failing.id)
+        # No untried sibling of the SAME TYPE remains -- which is not the same
+        # as "nothing else is reachable". The cascade has other tiers: another
+        # credential type, the env var, the fallback resolver. Clearing the
+        # demotion here erased the mark in the very call that set it whenever
+        # the failing row had no same-type sibling (an OAuth account beside a
+        # pasted key -- precisely the shape a Z.AI sign-in creates), so tier 3
+        # re-served the identical failing row and the healthy credential one
+        # tier down was never asked.
+        #
+        # So the mark STANDS. It is not permanent: it expires on its TTL, it is
+        # cleared when the credential next serves a request, and
+        # `_selection_order` drops the whole set as stale once every row it sees
+        # is demoted. Any of those returns this credential to service; none of
+        # them requires pretending here that the fault never happened.
         return False
 
     @staticmethod

--- a/local_operator/providers/auth_store.py
+++ b/local_operator/providers/auth_store.py
@@ -629,13 +629,21 @@ class AuthStore:
         # so popping the whole provider would let a one-row tier wipe the marks
         # belonging to rows it never saw.
         #
-        # NOTE this branch is not reachable from :meth:`_resolve`'s cascade:
-        # ``_usable_key_rows`` drops demoted rows before this method is called,
-        # so an all-demoted tier arrives here as an EMPTY list and returns at the
-        # guard above. It is retained for direct callers that order a row set
-        # themselves, and it is NOT the cascade's safety net -- that is the
-        # ``ignore_demotions`` second pass in :meth:`_resolve`. Reasoning about
-        # the cascade's all-demoted behaviour from here gives the wrong answer.
+        # This branch is NOT the cascade's safety net, and exactly one pass
+        # reaches it. On :meth:`_resolve`'s FIRST pass ``_usable_key_rows`` has
+        # already dropped demoted rows, so an all-demoted tier arrives empty and
+        # returns at the guard above. On the second pass ``ignore_demotions``
+        # suppresses that filter, so the rows arrive whole and land here --
+        # meaning in practice this branch is reached only by a ``read_only``
+        # second pass, because the normal one cleared the marks before
+        # recursing and has no demotions left to find.
+        #
+        # That is precisely why the ``read_only`` gate below is load-bearing
+        # rather than dead: it is the last thing standing between an isolated
+        # request and a mark it is not entitled to clear. The net that makes a
+        # demoted lone row resolvable at all is the ``ignore_demotions`` pass in
+        # :meth:`_resolve`; do not reason about cascade-wide all-demoted
+        # behaviour from here.
         if not preferred:
             # Not under ``read_only``: clearing the marks is a routing DECISION,
             # and an isolated request running beside a user's turn must not be
@@ -712,8 +720,9 @@ class AuthStore:
         # cascade came back empty, it resolves once more with
         # ``ignore_demotions``, so a demoted lone row is still served rather
         # than reported as no credential at all. ``_selection_order``'s
-        # all-demoted branch cannot be that net, because this filter runs first
-        # and hands it an empty list.
+        # all-demoted branch cannot be that net: on the first pass this filter
+        # runs ahead of it and hands it an empty list, and on the second pass
+        # the net has already fired -- that is what suppressed this filter.
         demoted = set() if ignore_demotions else self._active_demotions(provider)
         if demoted:
             remaining = [r for r in rows if r.id not in demoted]

--- a/local_operator/providers/auth_store.py
+++ b/local_operator/providers/auth_store.py
@@ -673,9 +673,40 @@ class AuthStore:
             for r in self.list_credentials(provider)
             if r.credential_type == credential_type and not self.is_blocked(r.id, provider)
         ]
-        if source is None:
-            return rows
-        return [r for r in rows if r.data.get("source") == source]
+        if source is not None:
+            rows = [r for r in rows if r.data.get("source") == source]
+        # Drop demoted rows from the TIER, not merely sort them last, when some
+        # other credential is still reachable.
+        #
+        # Ordering alone is not enough here, because the cascade is a sequence
+        # of tiers and a tier is consulted whole: an OAuth row, or an api_key
+        # row with `source="login"`, wins its tier before a row in a later tier
+        # is ever looked at. So a demoted row that is ALONE in its tier kept
+        # winning the cascade -- and `rotate_sibling` kept reporting that a
+        # sibling existed, which told the driver rotation was progressing while
+        # the same failing bearer came back every time. A healthy credential one
+        # tier down never received a single request.
+        #
+        # Dropping is safe precisely because it is conditional: if every
+        # reachable credential is demoted, the marks describe an outage rather
+        # than any one account and :meth:`_selection_order` clears them.
+        demoted = self._active_demotions(provider)
+        if demoted and any(r.id not in demoted for r in self._all_selectable_rows(provider)):
+            remaining = [r for r in rows if r.id not in demoted]
+            if remaining:
+                return remaining
+            # Every row in THIS tier is demoted but another tier still has one:
+            # yield the tier so the cascade moves on to it.
+            return []
+        return rows
+
+    def _all_selectable_rows(self, provider: str) -> list[StoredCredential]:
+        """Every enabled, unblocked row for ``provider``, across all tiers."""
+        return [
+            r
+            for r in self.list_credentials(provider)
+            if r.disabled_cause is None and not self.is_blocked(r.id, provider)
+        ]
 
     # -- the cascade ---------------------------------------------------------
 

--- a/local_operator/providers/auth_store.py
+++ b/local_operator/providers/auth_store.py
@@ -55,6 +55,14 @@ logger = logging.getLogger("local_operator.providers.auth_store")
 OAUTH_REFRESH_SKEW_MS = 60_000  # pre-emptive refresh trigger
 DEFAULT_BLOCK_MS = 60_000  # rate-limit / 401 backoff
 
+#: How long a provider-fault demotion keeps a credential at the back of the pool
+#: (see ``AuthStore.deprioritize_credential``). Deliberately short: the mark says
+#: "this account was failing a moment ago", which stops being useful information
+#: quickly, and it cannot expire by being USED -- a demoted row sorts last, so it
+#: is not selected, so it never earns the success that would clear it. Two
+#: minutes outlives a burst of 529s without outliving the outage that caused it.
+DEPRIORITIZE_TTL_MS = 120_000
+
 _SCHEMA = """
 CREATE TABLE IF NOT EXISTS auth_credentials (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -196,7 +204,7 @@ class AuthStore:
         # the discovery instead of paying to repeat it. Nothing here can make a
         # credential unusable, so the worst a stale mark can do is reorder a
         # pool whose members are all equally valid.
-        self._deprioritized: dict[str, set[int]] = {}
+        self._deprioritized: dict[str, dict[int, int]] = {}
         self._refresh_locks: dict[int, asyncio.Lock] = {}
         self._conn = self._connect()
 
@@ -524,8 +532,17 @@ class AuthStore:
         rather than the credential: a 529 storm must move the next attempt onto
         another account, but blocking would strand a healthy account (and,
         repeated across the pool, strand every one of them).
+
+        The mark EXPIRES on its own after :data:`DEPRIORITIZE_TTL_MS`. Clearing
+        it on a successful request is not sufficient by itself, and the reason is
+        circular: a demoted credential sorts last, so it is not selected, so it
+        never gets the success that would clear it. Without a TTL a single 529
+        left an account bottom-of-pool for the life of the process -- the same
+        "healthy account effectively out of rotation" outcome this whole change
+        exists to prevent, arrived at the slow way.
         """
-        self._deprioritized.setdefault(provider, set()).add(credential_id)
+        marks = self._deprioritized.setdefault(provider, {})
+        marks[credential_id] = self._now_ms() + DEPRIORITIZE_TTL_MS
 
     def clear_deprioritized(
         self, provider: str, credential_id: int | Iterable[int] | None = None
@@ -544,9 +561,28 @@ class AuthStore:
             self._deprioritized.pop(provider, None)
             return
         ids = {credential_id} if isinstance(credential_id, int) else {int(i) for i in credential_id}
-        marks -= ids
+        for one in ids:
+            marks.pop(one, None)
         if not marks:
             self._deprioritized.pop(provider, None)
+
+    def _active_demotions(self, provider: str) -> set[int]:
+        """Ids still demoted, dropping any whose TTL has passed.
+
+        Expiry is evaluated on READ rather than by a timer: the marks are only
+        consulted here, so a lazy sweep is both sufficient and free of a
+        background task that would have to be owned and cancelled.
+        """
+        marks = self._deprioritized.get(provider)
+        if not marks:
+            return set()
+        now = self._now_ms()
+        for cid in [cid for cid, until in marks.items() if until <= now]:
+            marks.pop(cid, None)
+        if not marks:
+            self._deprioritized.pop(provider, None)
+            return set()
+        return set(marks)
 
     def _selection_order(
         self,
@@ -569,7 +605,7 @@ class AuthStore:
         # the demotion exists to fix. Applying it here cannot be undone by a
         # later step, and because the partition is stable the relative order the
         # sticky/hash/round-robin choice produced is otherwise preserved.
-        demoted = self._deprioritized.get(provider)
+        demoted = self._active_demotions(provider)
         if not demoted:
             return ordered
         preferred = [r for r in ordered if r.id not in demoted]

--- a/local_operator/providers/auth_store.py
+++ b/local_operator/providers/auth_store.py
@@ -309,8 +309,21 @@ class AuthStore:
         Revives soft-deleted rows for the same identity (re-login).
         ``store_credentials_as`` aliasing happens at the caller (login path).
         """
+        # An EXPLICIT type wins; the structural guess is the fallback for the
+        # callers (and stored rows) that never declared one.
+        #
+        # The guess reads "has both refresh and access", which cannot see a
+        # credential that is OAuth-issued but has no refresh token because it
+        # never expires -- Z.AI's coding-plan sign-in mints exactly that. Such a
+        # row landed as `api_key` with its secret under `data["access"]`, where
+        # nothing can read it: tiers 4 and 6 read `data["key"]`, and tier 3 only
+        # walks `oauth`-typed rows. The login reported success and every request
+        # afterwards failed with no credential at all.
+        declared = credential.get("type")
         credential_type = (
-            "oauth" if credential.get("refresh") and credential.get("access") else "api_key"
+            declared
+            if declared in ("oauth", "api_key")
+            else ("oauth" if credential.get("refresh") and credential.get("access") else "api_key")
         )
         identity = _identity_key_for(provider, credential)
         payload = dict(credential)

--- a/local_operator/providers/auth_store.py
+++ b/local_operator/providers/auth_store.py
@@ -628,6 +628,14 @@ class AuthStore:
         # cascade calls this once per credential tier with a different subset,
         # so popping the whole provider would let a one-row tier wipe the marks
         # belonging to rows it never saw.
+        #
+        # NOTE this branch is not reachable from :meth:`_resolve`'s cascade:
+        # ``_usable_key_rows`` drops demoted rows before this method is called,
+        # so an all-demoted tier arrives here as an EMPTY list and returns at the
+        # guard above. It is retained for direct callers that order a row set
+        # themselves, and it is NOT the cascade's safety net -- that is the
+        # ``ignore_demotions`` second pass in :meth:`_resolve`. Reasoning about
+        # the cascade's all-demoted behaviour from here gives the wrong answer.
         if not preferred:
             # Not under ``read_only``: clearing the marks is a routing DECISION,
             # and an isolated request running beside a user's turn must not be
@@ -666,7 +674,12 @@ class AuthStore:
             self._sticky[(provider, session_id)] = credential_id
 
     def _usable_key_rows(
-        self, provider: str, credential_type: str, source: str | None
+        self,
+        provider: str,
+        credential_type: str,
+        source: str | None,
+        *,
+        ignore_demotions: bool = False,
     ) -> list[StoredCredential]:
         rows = [
             r
@@ -694,10 +707,14 @@ class AuthStore:
         # row would then never yield, and an exported ANTHROPIC_API_KEY beside a
         # signed-in account became unreachable where it used to be the fallback.
         #
-        # The real safety net is :meth:`_selection_order`, which clears the
-        # marks as stale once every row it is shown is demoted -- so a pool that
-        # has been walked comes back rather than emptying.
-        demoted = self._active_demotions(provider)
+        # The safety net for the resulting empty tier is the second pass at the
+        # end of :meth:`_resolve`: if demotions are the ONLY reason the whole
+        # cascade came back empty, it resolves once more with
+        # ``ignore_demotions``, so a demoted lone row is still served rather
+        # than reported as no credential at all. ``_selection_order``'s
+        # all-demoted branch cannot be that net, because this filter runs first
+        # and hands it an empty list.
+        demoted = set() if ignore_demotions else self._active_demotions(provider)
         if demoted:
             remaining = [r for r in rows if r.id not in demoted]
             if remaining:
@@ -855,8 +872,15 @@ class AuthStore:
         *,
         force_refresh: bool = False,
         read_only: bool = False,
+        ignore_demotions: bool = False,
     ) -> tuple[str | None, StoredCredential | None]:
         """The 7-step cascade; returns ``(key, winning row or None)``.
+
+        ``ignore_demotions`` runs the cascade as if no credential were demoted.
+        It is set only by this method's own second pass (see the tail), where
+        demotions have been found to be the sole reason the cascade came back
+        empty. Because the second pass sets it, the tail's branch cannot re-arm
+        and the recursion terminates at depth two.
 
         ``read_only`` resolves WITHOUT making any routing decision: no
         credential blocked when its refresh fails, no session stickiness
@@ -888,7 +912,9 @@ class AuthStore:
             return config, None
 
         # 3. OAuth credential
-        oauth_rows = self._usable_key_rows(provider, "oauth", source=None)
+        oauth_rows = self._usable_key_rows(
+            provider, "oauth", source=None, ignore_demotions=ignore_demotions
+        )
         for row in self._selection_order(oauth_rows, provider, session_id, read_only=read_only):
             try:
                 creds = await self._ensure_oauth_fresh(row, force=force_refresh)
@@ -909,7 +935,9 @@ class AuthStore:
         # PR-15: with NO oauth rows, force_refresh falls through to tiers 4-7.
 
         # 4. API key persisted by interactive login
-        login_rows = self._usable_key_rows(provider, "api_key", source="login")
+        login_rows = self._usable_key_rows(
+            provider, "api_key", source="login", ignore_demotions=ignore_demotions
+        )
         for row in self._selection_order(login_rows, provider, session_id, read_only=read_only):
             key = row.data.get("key")
             if key:
@@ -929,7 +957,9 @@ class AuthStore:
         # 6. Stored api_key without source="login" (e.g. broker migration)
         stored_rows = [
             row
-            for row in self._usable_key_rows(provider, "api_key", source=None)
+            for row in self._usable_key_rows(
+                provider, "api_key", source=None, ignore_demotions=ignore_demotions
+            )
             if row.data.get("source") != "login"
         ]
         for row in self._selection_order(stored_rows, provider, session_id, read_only=read_only):
@@ -949,9 +979,25 @@ class AuthStore:
         # once more. Without this a sole demoted credential resolved to None and
         # the caller was told no credential was configured, which is exactly the
         # misdiagnosis this change set out to remove.
-        if not read_only and self._active_demotions(provider):
-            self.clear_deprioritized(provider)
-            return await self._resolve(provider, session_id, force_refresh=force_refresh)
+        #
+        # A ``read_only`` resolve takes this pass too. It must: dropping a
+        # demoted row from its tier is the destructive half of demotion, and a
+        # resolve that is forbidden from deciding anything about routing cannot
+        # be handed that half alone -- it would report "no credential" for a
+        # credential that is merely deprioritised, which is the misdiagnosis at
+        # issue. What it does NOT do is clear the marks: that is the routing
+        # decision, and it stays reserved for the caller who owns the turn.
+        # ``ignore_demotions`` gives the same answer without touching state.
+        if not ignore_demotions and self._active_demotions(provider):
+            if not read_only:
+                self.clear_deprioritized(provider)
+            return await self._resolve(
+                provider,
+                session_id,
+                force_refresh=force_refresh,
+                read_only=read_only,
+                ignore_demotions=True,
+            )
 
         return None, None
 

--- a/local_operator/providers/clients.py
+++ b/local_operator/providers/clients.py
@@ -674,8 +674,15 @@ class OpenAICompatClient:
         extra_headers: Mapping[str, str] | None = None,
         timeout: float = 600.0,
         openai_api: str | None = None,
+        oauth_base_url: str | None = None,
     ) -> None:
         self._base_url = base_url.rstrip("/")
+        # Some providers serve subscription OAuth and pay-as-you-go API keys
+        # from different hosts (see ``ProviderDefinition.oauth_base_url``). The
+        # client is built before the credential is resolved -- failover may
+        # rotate between kinds mid-turn -- so the host is chosen per REQUEST
+        # from the credential actually presented, not fixed at construction.
+        self._oauth_base_url = oauth_base_url.rstrip("/") if oauth_base_url else None
         if openai_api is None:
             # Direct construction remains useful in wire tests and extensions.
             # Only the canonical public base is safe to recognize implicitly;
@@ -691,6 +698,24 @@ class OpenAICompatClient:
     async def aclose(self) -> None:
         if self._owns_client:
             await self._http.aclose()
+
+    def _request_base_url(self, oauth_access: "OAuthAccess | None") -> str:
+        """The host this REQUEST goes to, given the credential it carries.
+
+        An OAuth bearer goes to ``oauth_base_url`` when the provider declares
+        one; everything else uses the ordinary base. Without this, listing a
+        subscription's models (which discovery now does against the OAuth host)
+        would advertise models that inference then sends to the API-key host,
+        where they 404 -- worse than not listing them at all.
+        """
+        if (
+            self._oauth_base_url
+            and oauth_access is not None
+            and oauth_access.kind == "oauth"
+            and oauth_access.access_token
+        ):
+            return self._oauth_base_url
+        return self._base_url
 
     def _headers(
         self, api_key: str | None, oauth_access: "OAuthAccess | None" = None
@@ -876,7 +901,7 @@ class OpenAICompatClient:
             ):
                 yield event
             return
-        url = f"{self._base_url}/chat/completions"
+        url = f"{self._request_base_url(oauth_access)}/chat/completions"
         finish_reason: str | None = None
         usage: Usage | None = None
         provider_payload: dict[str, Any] | None = None
@@ -1747,4 +1772,15 @@ def client_for_spec(
         http_client=http_client,
         extra_headers=extra_headers,
         openai_api=openai_api if spec.provider == "openai" else "chat_completions",
+        # Suppressed only when the spec names a base the registry did NOT
+        # supply, which is a deliberate endpoint override (a gateway, a proxy)
+        # and must not be second-guessed per credential. `build_model_spec`
+        # copies `definition.base_url` onto every spec, so testing
+        # `spec.base_url` alone would disable the OAuth host for every request
+        # and silently send the coding-plan bearer to the API-key platform.
+        oauth_base_url=(
+            definition.oauth_base_url
+            if not spec.base_url or spec.base_url == definition.base_url
+            else None
+        ),
     )

--- a/local_operator/providers/failover.py
+++ b/local_operator/providers/failover.py
@@ -793,10 +793,13 @@ MAX_SAME_CREDENTIAL_USAGE_RETRIES = 2
 # observed rather than predicted.
 MAX_SAME_CREDENTIAL_SERVER_RETRIES = 2
 
-#: Hard ceiling on the requests ONE turn will aim at a provider for server-side
-#: faults, across every credential it rotates through. The per-credential cap
-#: above bounds each account; this bounds their PRODUCT, which is the quantity
-#: that actually reaches the provider. Without it, widening rotation to walk the
+#: Hard ceiling on the requests one turn will aim at ONE PROVIDER for
+#: server-side faults, across every credential it rotates through. The
+#: per-credential cap above bounds each account; this bounds their PRODUCT,
+#: which is the quantity that actually reaches that provider. Counted per
+#: fallback target, because each target is a different service: rationing the
+#: fallback for the primary's outage is how a chain stops being a chain.
+#: Without it, widening rotation to walk the
 #: whole pool multiplied the load by the pool size at exactly the moment the
 #: provider was asking for less: 44 requests over ~190s for four accounts,
 #: measured, against 22 before. Twelve keeps a four-account pool walkable (each
@@ -829,6 +832,7 @@ def _same_credential_retry_allowed(
     retry: "RetrySettings",
     *,
     has_rotated: bool = False,
+    rotation_exhausted: bool = False,
     server_fault_requests: int = 0,
 ) -> bool:
     if not error.retryable:
@@ -856,6 +860,13 @@ def _same_credential_retry_allowed(
         # per-credential allowance and the turn moves on. `has_untried_sibling`
         # is the driver's OBSERVATION that rotation is still producing new
         # bearers, not a prediction from the credential table.
+        if rotation_exhausted:
+            # Rotation has been tried and there is no other credential, so the
+            # small allowances below -- which exist ONLY to get a turn moving to
+            # another account -- have nothing left to buy. The bearer in hand
+            # gets exactly the budget the user configured: no more (it was
+            # asked for) and no less (it is all there is).
+            return transport_retries < retry.max_retries
         if has_rotated:
             return transport_retries < min(retry.max_retries, MAX_SAME_CREDENTIAL_SERVER_RETRIES)
         # Not yet rotated. The first bearer gets a SMALL allowance rather than
@@ -1316,11 +1327,6 @@ async def stream_with_failover(
 
     reported: ProviderError | None = None
     reported_score = -1
-    # Requests this turn has aimed at a provider that answered with a
-    # server-side fault, counted across every credential AND every fallback
-    # target: the ceiling is about what the provider receives, not about how
-    # the attempts were distributed.
-    server_fault_requests = 0
     clients: dict[tuple[str, str | None], "WireClient"] = {}
     rng = random.Random()
 
@@ -1379,6 +1385,16 @@ async def stream_with_failover(
         current_token: str | None = None
         transport_retries = 0
         retry_same_key = False
+        # Requests aimed at THIS target's provider that came back a server-side
+        # fault, counted across every credential it rotates through.
+        #
+        # Per target, not per turn. A turn-wide counter let the primary's storm
+        # spend the whole allowance and leave each fallback a single attempt
+        # with no retries -- so a fallback that would have succeeded on its
+        # second try never got one, which defeats the entire point of having a
+        # chain. Each provider is a different service having a different day,
+        # and the ceiling is about what ONE provider receives.
+        server_fault_requests = 0
         # The last credential that actually produced a bearer, and whether its
         # configured budget has already been handed back once rotation ran out.
         last_access: "OAuthAccess | None" = None
@@ -1419,7 +1435,11 @@ async def stream_with_failover(
                     ):
                         exhausted_budget_restored = True
                         access = last_access
-                        transport_retries = 0
+                        # `transport_retries` is deliberately NOT reset: the
+                        # attempts already spent on this bearer are part of the
+                        # budget the user configured, so carrying them makes the
+                        # TOTAL exactly `max_retries` rather than the allowance
+                        # plus a second full budget on top.
                         error = None
                     else:
                         break  # rotation exhausted for this provider
@@ -1488,6 +1508,7 @@ async def stream_with_failover(
                     # different bearer for this request? See
                     # `_rotation_has_produced_a_sibling`.
                     has_rotated=_request_has_rotated(state),
+                    rotation_exhausted=exhausted_budget_restored,
                     server_fault_requests=server_fault_requests,
                 ):
                     # 5xx/network-style failures use the configured budget.
@@ -1543,6 +1564,7 @@ async def stream_with_failover(
                     transport_retries,
                     retry,
                     has_rotated=_request_has_rotated(state),
+                    rotation_exhausted=exhausted_budget_restored,
                     server_fault_requests=server_fault_requests,
                 ):
                     transport_retries += 1

--- a/local_operator/providers/failover.py
+++ b/local_operator/providers/failover.py
@@ -789,7 +789,7 @@ MAX_SAME_CREDENTIAL_USAGE_RETRIES = 2
 # configured budget -- a lone credential, an override bearer or a pool whose
 # siblings are all spent must not lose retries it has nowhere else to spend --
 # and the cap engages only when the multiplication it exists to prevent has
-# actually begun. See `_rotation_has_produced_a_sibling` for why this is
+# actually begun. See `_request_has_rotated` for why this is
 # observed rather than predicted.
 MAX_SAME_CREDENTIAL_SERVER_RETRIES = 2
 
@@ -1506,7 +1506,7 @@ async def stream_with_failover(
                     retry,
                     # OBSERVED, not predicted: has rotation actually produced a
                     # different bearer for this request? See
-                    # `_rotation_has_produced_a_sibling`.
+                    # `_request_has_rotated`.
                     has_rotated=_request_has_rotated(state),
                     rotation_exhausted=exhausted_budget_restored,
                     server_fault_requests=server_fault_requests,

--- a/local_operator/providers/failover.py
+++ b/local_operator/providers/failover.py
@@ -443,9 +443,20 @@ def is_direct_credential_rotation_error(error: BaseException) -> bool:
     and transport timeouts) are here too. A refresh cannot fix the PROVIDER
     being overloaded, so the refresh step is equally pointless, and the sticky
     credential is not at fault so it keeps its place — that is exactly the
-    contract this predicate expresses. See
-    :func:`allows_full_sibling_rotation` for why they must also be exempt from
-    the ordinary-401 switch cap.
+    contract this predicate expresses.
+
+    The same answer decides which errors may cycle EVERY sibling rather than
+    switching once and stopping. The ``legacy_auth_switch_used`` cap in
+    :class:`AuthRetryKeyState` exists for the ordinary-401 case, where a second,
+    third and fourth bearer are all equally likely to be rejected and cycling
+    them only delays a login prompt the user has to answer anyway. That is the
+    wrong rule for a pool of accounts that fail INDEPENDENTLY: with four
+    Anthropic accounts and a 529 storm the cap stopped after the second account
+    and reported the turn dead while two healthy accounts were never asked --
+    the reported failure. Quota is the same story, since one account's spent
+    weekly window says nothing about the other three. So exhaustion, payment,
+    permission and server-side faults may walk the whole pool; only an ordinary
+    401 keeps the single-switch cap.
     """
     if not isinstance(error, ProviderError):
         return False
@@ -468,26 +479,6 @@ def is_server_side_failure(error: BaseException) -> bool:
     if error.kind in ("timeout", "transient"):
         return True
     return error.status is not None and error.status >= 500
-
-
-def allows_full_sibling_rotation(error: BaseException) -> bool:
-    """May this error cycle EVERY sibling, rather than one switch and stop?
-
-    The ``legacy_auth_switch_used`` cap in :class:`AuthRetryKeyState` exists for
-    the ordinary-401 case, where a second, third and fourth bearer are all
-    equally likely to be rejected and cycling them only delays a login prompt
-    the user has to answer anyway.
-
-    It is the wrong rule for a pool of accounts that fail INDEPENDENTLY. With
-    four Anthropic accounts and a 529 storm, the cap stopped after the second
-    account and reported the turn dead while two healthy accounts were never
-    asked — the reported failure. Quota is the same story: one account's spent
-    weekly window says nothing about the other three.
-
-    So exhaustion, payment, permission and server-side faults may walk the whole
-    pool; only an ordinary 401 keeps the single-switch cap.
-    """
-    return is_direct_credential_rotation_error(error)
 
 
 def retry_after_ms_from_error(error: BaseException) -> int | None:
@@ -554,6 +545,17 @@ class AuthRetryKeyState:
     """
 
     attempted_keys: set[str] = dataclasses.field(default_factory=set)
+    #: What ``AuthStore.rotate_sibling`` last reported: whether ANOTHER usable
+    #: credential remained after the failing one was set aside. Recorded rather
+    #: than recomputed because the store is the only thing that knows its own
+    #: cascade -- tiers, blocks, credential types and aliases included. Starts
+    #: Set once rotation has been ATTEMPTED and the store has answered. ``None``
+    #: means "not yet asked", which the budget rule treats as "there may be one"
+    #: -- so the first bearer spends the small per-credential allowance and the
+    #: turn moves on to discover the truth, rather than burning ten attempts in
+    #: place while three healthy accounts wait (the reported bug) or being
+    #: capped on an assumption that never gets tested (its mirror image).
+    sibling_available: bool | None = None
     last_key: str | None = None
     refreshed_current: bool = False
     legacy_auth_switch_used: bool = False
@@ -782,15 +784,36 @@ BACKOFF_JITTER_FRACTION = 0.25
 MAX_USAGE_RETRY_AFTER_MS = 30_000
 MAX_SAME_CREDENTIAL_USAGE_RETRIES = 2
 
-# Same-credential retries for a SERVER-side fault (5xx/529/timeout). Small for
-# the same reason the usage cap is, and the reason grew stronger once rotation
-# was widened to walk the whole pool: this budget is spent once per ACCOUNT, so
-# the full `max_retries` (default 10) becomes 10 x pool size requests aimed at a
-# provider that has just said it is overloaded -- 44 requests over ~190s for a
-# four-account pool, measured. Two attempts per account still absorbs the brief
-# 529 blips these codes usually are, while the pool walk (which tries a
-# DIFFERENT account, the thing most likely to succeed) happens sooner.
+# Same-credential retries for a SERVER-side fault (5xx/529/timeout) ONCE this
+# request has rotated onto a second bearer. The first credential keeps the full
+# configured budget -- a lone credential, an override bearer or a pool whose
+# siblings are all spent must not lose retries it has nowhere else to spend --
+# and the cap engages only when the multiplication it exists to prevent has
+# actually begun. See `_rotation_has_produced_a_sibling` for why this is
+# observed rather than predicted.
 MAX_SAME_CREDENTIAL_SERVER_RETRIES = 2
+
+#: Hard ceiling on the requests ONE turn will aim at a provider for server-side
+#: faults, across every credential it rotates through. The per-credential cap
+#: above bounds each account; this bounds their PRODUCT, which is the quantity
+#: that actually reaches the provider. Without it, widening rotation to walk the
+#: whole pool multiplied the load by the pool size at exactly the moment the
+#: provider was asking for less: 44 requests over ~190s for four accounts,
+#: measured, against 22 before. Twelve keeps a four-account pool walkable (each
+#: account still gets more than one look) while never exceeding the pre-change
+#: behaviour, whatever the pool size.
+MAX_SERVER_FAULT_REQUESTS_PER_TURN = 12
+
+#: Attempts the FIRST bearer may spend on a server-side fault before the turn
+#: tries another credential. It is deliberately below ``max_retries``: until a
+#: rotation has happened nothing knows whether a sibling exists, and spending
+#: the full configured budget in place is how four healthy accounts got two
+#: attempts between them (the reported bug). Small enough to leave the turn
+#: ceiling room for a real pool walk, large enough to ride out the brief blips
+#: that make up most 5xx traffic. A bearer that turns out to be alone gets the
+#: rest of its configured budget back on the next pass, because rotation
+#: exhausting is what ends the walk.
+MAX_FIRST_CREDENTIAL_SERVER_RETRIES = 3
 
 
 def backoff_delay_ms(base_delay_ms: int, attempt: int, *, rng: random.Random | None = None) -> int:
@@ -805,7 +828,8 @@ def _same_credential_retry_allowed(
     transport_retries: int,
     retry: "RetrySettings",
     *,
-    rotates_across_pool: bool = True,
+    has_rotated: bool = False,
+    server_fault_requests: int = 0,
 ) -> bool:
     if not error.retryable:
         return False
@@ -813,18 +837,41 @@ def _same_credential_retry_allowed(
         if (error.retry_after_ms or 0) > MAX_USAGE_RETRY_AFTER_MS:
             return False
         return transport_retries < min(retry.max_retries, MAX_SAME_CREDENTIAL_USAGE_RETRIES)
-    if is_server_side_failure(error) and rotates_across_pool:
-        # Capped ONLY when there is a pool to rotate through. The budget is spent
-        # once per ACCOUNT, so with several credentials the full `max_retries`
-        # multiplies by the pool size and aims the product at a provider that is
-        # already saying it is overloaded.
+    if is_server_side_failure(error):
+        # The turn-wide ceiling applies unconditionally: it is about what the
+        # PROVIDER receives, so it cannot depend on how the requests were
+        # distributed across credentials.
+        if server_fault_requests >= MAX_SERVER_FAULT_REQUESTS_PER_TURN:
+            return False
+        # Rotation comes FIRST while it still has somewhere to go.
         #
-        # `rotates_across_pool` is what keeps that reasoning honest: with a
-        # single credential there is no multiplication and nothing to rotate to,
-        # so capping there would only take away retries the user configured and
-        # fail a 500 blip that would have cleared -- a regression against the
-        # behaviour before any of this, for the users least able to absorb it.
-        return transport_retries < min(retry.max_retries, MAX_SAME_CREDENTIAL_SERVER_RETRIES)
+        # A provider-side fault is not the credential's fault, but another
+        # ACCOUNT is nonetheless the thing most likely to succeed -- the pool
+        # walk is the fix this whole change exists to deliver. Spending a full
+        # `max_retries` on the first bearer before rotating starves that walk
+        # against the turn ceiling: four accounts, and only two were ever tried,
+        # which is the original reported bug arriving by a new route.
+        #
+        # So while a sibling remains reachable, each bearer gets the small
+        # per-credential allowance and the turn moves on. `has_untried_sibling`
+        # is the driver's OBSERVATION that rotation is still producing new
+        # bearers, not a prediction from the credential table.
+        if has_rotated:
+            return transport_retries < min(retry.max_retries, MAX_SAME_CREDENTIAL_SERVER_RETRIES)
+        # Not yet rotated. The first bearer gets a SMALL allowance rather than
+        # the configured budget, because nothing yet knows whether a sibling
+        # exists and finding out is cheap: rotation either produces another
+        # credential (in which case the turn should be walking the pool, not
+        # burning ten attempts in place -- the reported bug) or is exhausted, and
+        # exhaustion ends the walk without costing anything. This deliberately
+        # does NOT consult the credential table: every version that did drifted
+        # from what the cascade actually selects (blocked rows, credential
+        # types, override bearers, rows split across tiers), and each drift took
+        # retries away from someone who had nowhere else to spend them.
+        return transport_retries < min(retry.max_retries, MAX_FIRST_CREDENTIAL_SERVER_RETRIES)
+        # Nothing left to rotate onto: the configured budget is the right answer
+        # again, because there is no multiplication left to prevent. This is the
+        # lone credential, the override bearer, and the last account standing.
     return transport_retries < retry.max_retries
 
 
@@ -1269,6 +1316,11 @@ async def stream_with_failover(
 
     reported: ProviderError | None = None
     reported_score = -1
+    # Requests this turn has aimed at a provider that answered with a
+    # server-side fault, counted across every credential AND every fallback
+    # target: the ceiling is about what the provider receives, not about how
+    # the attempts were distributed.
+    server_fault_requests = 0
     clients: dict[tuple[str, str | None], "WireClient"] = {}
     rng = random.Random()
 
@@ -1327,6 +1379,10 @@ async def stream_with_failover(
         current_token: str | None = None
         transport_retries = 0
         retry_same_key = False
+        # The last credential that actually produced a bearer, and whether its
+        # configured budget has already been handed back once rotation ran out.
+        last_access: "OAuthAccess | None" = None
+        exhausted_budget_restored = False
 
         while state.attempts <= AUTH_RETRY_MAX_ATTEMPTS:
             if signal is not None and signal.aborted:
@@ -1347,7 +1403,26 @@ async def stream_with_failover(
                     current_token = token
                     transport_retries = 0  # fresh credential ⇒ fresh budget
                 if access is None and error is not None:
-                    break  # rotation exhausted for this provider
+                    # Rotation is exhausted: no other credential exists. The
+                    # small pre-rotation allowance exists ONLY to get a turn
+                    # moving to another account, so with nowhere to go the
+                    # bearer already in hand finishes the budget the user
+                    # configured -- once. Without this a lone credential, and
+                    # the last account standing during an outage, lost every
+                    # retry past the allowance (the regression rounds 2 and 3
+                    # both filed).
+                    if (
+                        not exhausted_budget_restored
+                        and last_access is not None
+                        and is_server_side_failure(error)
+                        and server_fault_requests < MAX_SERVER_FAULT_REQUESTS_PER_TURN
+                    ):
+                        exhausted_budget_restored = True
+                        access = last_access
+                        transport_retries = 0
+                        error = None
+                    else:
+                        break  # rotation exhausted for this provider
                 if access is None and not _provider_allows_missing(provider):
                     # "No API key configured" is only true when the provider has
                     # NO credential at all. Said unconditionally it was actively
@@ -1363,6 +1438,8 @@ async def stream_with_failover(
                     break
                 error = None
             retry_same_key = False
+            if access is not None:
+                last_access = access
             key = access.access_token if access is not None else None
 
             forwarded_any = False
@@ -1399,18 +1476,19 @@ async def stream_with_failover(
                 if forwarded_any:
                     raise  # partial output already reached the caller
                 record(exc, primary=is_primary)
+                if is_server_side_failure(exc):
+                    server_fault_requests += 1
                 if not retry.enabled:
                     raise
                 if _same_credential_retry_allowed(
                     exc,
                     transport_retries,
                     retry,
-                    # Asked at the moment of the DECISION, not cached per target.
-                    # Blocking happens mid-turn (a sibling hits its quota during
-                    # the same storm), so a value computed once goes stale in the
-                    # direction that hurts: it keeps claiming a pool after the
-                    # pool is gone, and caps the last healthy credential.
-                    rotates_across_pool=_has_rotatable_sibling(auth, provider, access),
+                    # OBSERVED, not predicted: has rotation actually produced a
+                    # different bearer for this request? See
+                    # `_rotation_has_produced_a_sibling`.
+                    has_rotated=_request_has_rotated(state),
+                    server_fault_requests=server_fault_requests,
                 ):
                     # 5xx/network-style failures use the configured budget.
                     # Rate limits retry once only when the advertised delay is
@@ -1423,6 +1501,13 @@ async def stream_with_failover(
                     await _abortable_sleep(delay, signal)
                     retry_same_key = True
                     continue
+                if _server_fault_budget_spent(exc, server_fault_requests):
+                    # The turn has aimed its whole server-fault budget at this
+                    # provider. Rotating again would keep spending it on an
+                    # outage the credentials are not responsible for, so hand
+                    # over to the fallback chain (a DIFFERENT provider) instead,
+                    # which is the thing left that might actually succeed.
+                    break
                 if exc.retryable or exc.auth_error or exc.status in (401, 403):
                     # Delegate: (b) refresh same account, then (c) rotate —
                     # resolve_next_key owns the decision (PR-04/05).
@@ -1440,6 +1525,8 @@ async def stream_with_failover(
                     # into the log.
                     raise wrapped from exc
                 record(wrapped, primary=is_primary)
+                if is_server_side_failure(wrapped):
+                    server_fault_requests += 1
                 if not retry.enabled:
                     raise wrapped from exc
                 # Same budget rule as the ProviderError arm above, asked the same
@@ -1455,7 +1542,8 @@ async def stream_with_failover(
                     wrapped,
                     transport_retries,
                     retry,
-                    rotates_across_pool=_has_rotatable_sibling(auth, provider, access),
+                    has_rotated=_request_has_rotated(state),
+                    server_fault_requests=server_fault_requests,
                 ):
                     transport_retries += 1
                     await _abortable_sleep(
@@ -1463,6 +1551,8 @@ async def stream_with_failover(
                     )
                     retry_same_key = True
                     continue
+                if _server_fault_budget_spent(wrapped, server_fault_requests):
+                    break  # same ceiling, same reasoning as the arm above
                 error = wrapped
                 continue
             else:
@@ -1530,7 +1620,13 @@ async def _resolve_access_for_provider(
                 if record is None:
                     return await _key()
             elif ctx.last_chance:
-                auth.rotate_sibling(provider, session_id, ctx.error, api_key=ctx.previous_key)
+                # The store's OWN answer to "is another credential left?", kept
+                # for the retry-budget decision. Nothing else in this module
+                # knows the cascade's tiers, blocks and aliases well enough to
+                # work it out, and five review rounds of trying proved it.
+                state.sibling_available = bool(
+                    auth.rotate_sibling(provider, session_id, ctx.error, api_key=ctx.previous_key)
+                )
                 record = await _access()
                 if record is None:
                     return await _key()
@@ -1576,68 +1672,37 @@ def _clear_demotion(auth: FailoverAuthStore, provider: str, access: "OAuthAccess
         logger.debug("could not clear demotion for %s/%s", provider, access.credential_id)
 
 
-def _has_rotatable_sibling(
-    auth: FailoverAuthStore, provider: str, access: "OAuthAccess | None"
-) -> bool:
-    """Is there another credential this turn could ACTUALLY rotate onto?
+def _server_fault_budget_spent(error: ProviderError, server_fault_requests: int) -> bool:
+    """Has this turn spent its whole server-fault allowance on one provider?
 
-    The retry cap is justified by one thing only: the same budget being spent
-    again on a sibling, multiplying the requests aimed at a struggling provider.
-    So the question has to be asked exactly as rotation would answer it, not as
-    a count of rows that happen to exist. Counting raw rows claimed a pool in
-    two configurations where rotation reaches nothing, and the cap then took
-    away retries with nowhere to spend them:
-
-    - **Blocked siblings.** A quota-exhausted account is skipped by
-      ``rotate_sibling`` and by the cascade. Four accounts with three blocked is
-      this PR's own headline scenario -- several accounts spent mid-degradation,
-      one healthy -- where a raw count said "pool of 4" and the survivor lost 8
-      of its 10 retries.
-    - **Mixed credential types.** ``rotate_sibling`` only walks siblings of the
-      SAME ``credential_type``, so an OAuth sign-in plus a pasted API key is two
-      rows and zero rotation.
-
-    - **A bearer that is not a stored row at all.** The cascade's runtime
-      override (``--api-key``), config override and env-var tiers return no row,
-      and the resolver wraps them as ``credential_id=0``. Rotation cannot move
-      off such a bearer -- there is nothing to move to, and the same override
-      wins the cascade again every time -- so counting the stored rows beside it
-      claimed a pool that is unreachable BY CONSTRUCTION. ``credential_id`` is
-      already the sentinel for "not a row", so it is what this asks.
-
-    A store that cannot enumerate (the structural protocol promises only
-    ``get_api_key``) answers ``False``: without evidence of a reachable sibling
-    the honest default is the UNCAPPED budget the user configured.
+    Checked before ROTATING as well as before retrying, because rotation is the
+    other way the same turn sends the provider another request: bounding only
+    the same-credential path let a large pool walk straight past the ceiling.
     """
-    if not isinstance(auth, CredentialLister):
-        return False
-    # No row behind this bearer (override/env tier, or a bare-key test double):
-    # nothing to rotate onto, whatever the table happens to contain.
-    if access is not None and not access.credential_id:
-        return False
-    try:
-        usable = [
-            row
-            for row in auth.list_credentials(provider)
-            if row.disabled_cause is None and not _is_blocked(auth, row, provider)
-        ]
-    except Exception:  # noqa: BLE001 - a retry decision must never raise
-        return False
-    if access is None:
-        return len(usable) > 1
-    return sum(1 for row in usable if row.credential_type == access.kind) > 1
+    return (
+        is_server_side_failure(error)
+        and server_fault_requests >= MAX_SERVER_FAULT_REQUESTS_PER_TURN
+    )
 
 
-def _is_blocked(auth: FailoverAuthStore, row: "StoredCredential", provider: str) -> bool:
-    """Whether the store considers ``row`` blocked, tolerating stores without
-    the notion (test doubles, embedder-supplied credential sources)."""
-    is_blocked = getattr(auth, "is_blocked", None)
-    if not callable(is_blocked):
-        return False
-    try:
-        return bool(is_blocked(row.id, provider))
-    except Exception:  # noqa: BLE001
-        return False
+def _request_has_rotated(state: AuthRetryKeyState) -> bool:
+    """Is there a credential this request has not tried and could still reach?
+
+    This decides ONE thing: whether to keep the per-credential allowance small
+    so the turn moves on to another account, or to spend the configured budget
+    here because there is nowhere else to go.
+
+    It reads the store's OWN report (``AuthStore.rotate_sibling`` returns
+    whether another usable credential remained) rather than modelling the
+    credential table. Five review rounds each found a predictive version
+    drifting from what the cascade actually does -- raw row counts, then blocked
+    rows, then credential types, then override bearers with no row at all, then
+    ``api_key`` rows split across cascade tiers where one always wins -- and
+    every drift cost a real user retries they needed. The store is the only
+    thing that knows its own tiers, blocks, aliases and overrides; asking it is
+    the fix that does not have a sixth version.
+    """
+    return len(state.attempted_keys) > 1
 
 
 def _no_credential_error(auth: FailoverAuthStore, provider: str) -> ProviderError:
@@ -1673,12 +1738,21 @@ def _no_credential_error(auth: FailoverAuthStore, provider: str) -> ProviderErro
     )
     # Retryable: the credential comes back on its own once the block expires,
     # which is materially different from a missing configuration.
+    #
+    # The wording hedges on WHY deliberately. A row can also be present and
+    # permanently unreadable -- a login flow storing a shape no cascade tier
+    # resolves, which is what R21 was -- and for that user "temporarily
+    # unavailable, retry once the limit resets" is advice that can never come
+    # true, and it hides the real fix (sign in again). Naming the third cause
+    # costs a clause and stops the message actively misdirecting; the rate-limit
+    # case, which is the common one, still reads first.
     return ProviderError(
         None,
         (
-            f"{subject} temporarily unavailable (rate limited, or a token refresh "
-            "failed). The credentials are still configured; retry once the limit "
-            "resets, or add another account."
+            f"{subject} not usable right now (rate limited, a token refresh "
+            "failed, or the stored credential could not be read). The "
+            "credentials are still configured; retry once the limit resets, or "
+            "sign in again to replace them."
         ),
         retryable=True,
         kind="quota",

--- a/local_operator/providers/failover.py
+++ b/local_operator/providers/failover.py
@@ -804,6 +804,8 @@ def _same_credential_retry_allowed(
     error: ProviderError,
     transport_retries: int,
     retry: "RetrySettings",
+    *,
+    rotates_across_pool: bool = True,
 ) -> bool:
     if not error.retryable:
         return False
@@ -811,10 +813,17 @@ def _same_credential_retry_allowed(
         if (error.retry_after_ms or 0) > MAX_USAGE_RETRY_AFTER_MS:
             return False
         return transport_retries < min(retry.max_retries, MAX_SAME_CREDENTIAL_USAGE_RETRIES)
-    if is_server_side_failure(error):
-        # Capped: this budget is now spent once per ACCOUNT rather than once per
-        # request, so the full `max_retries` would multiply by the pool size and
-        # aim the product at a provider that is already saying it is overloaded.
+    if is_server_side_failure(error) and rotates_across_pool:
+        # Capped ONLY when there is a pool to rotate through. The budget is spent
+        # once per ACCOUNT, so with several credentials the full `max_retries`
+        # multiplies by the pool size and aims the product at a provider that is
+        # already saying it is overloaded.
+        #
+        # `rotates_across_pool` is what keeps that reasoning honest: with a
+        # single credential there is no multiplication and nothing to rotate to,
+        # so capping there would only take away retries the user configured and
+        # fail a 500 blip that would have cleared -- a regression against the
+        # behaviour before any of this, for the users least able to absorb it.
         return transport_retries < min(retry.max_retries, MAX_SAME_CREDENTIAL_SERVER_RETRIES)
     return transport_retries < retry.max_retries
 
@@ -1318,6 +1327,12 @@ async def stream_with_failover(
         current_token: str | None = None
         transport_retries = 0
         retry_same_key = False
+        # Whether a server-fault retry budget spent here will be spent AGAIN on
+        # a sibling. Only then does the per-account cap earn its keep; with one
+        # credential it would just remove retries the user asked for. Computed
+        # once per target rather than per attempt: the pool does not change
+        # mid-turn, and this must not add a query to the retry hot path.
+        pool_size = _credential_pool_size(auth, provider)
 
         while state.attempts <= AUTH_RETRY_MAX_ATTEMPTS:
             if signal is not None and signal.aborted:
@@ -1370,6 +1385,12 @@ async def stream_with_failover(
                     yield event
                 if route_state is not None and target == primary_target:
                     route_state.clear()
+                # This credential just served a request, so whatever provider
+                # fault demoted it has passed. Without this the mark outlived
+                # the outage for the life of the process, contradicting the
+                # "lasts seconds" reasoning it is justified by and leaving a
+                # perfectly good account permanently last in the pool.
+                _clear_demotion(auth, provider, access)
                 if buffered is None:
                     return  # clean completion; a buffered stream flushes below
             except asyncio.CancelledError:
@@ -1380,7 +1401,9 @@ async def stream_with_failover(
                 record(exc, primary=is_primary)
                 if not retry.enabled:
                     raise
-                if _same_credential_retry_allowed(exc, transport_retries, retry):
+                if _same_credential_retry_allowed(
+                    exc, transport_retries, retry, rotates_across_pool=pool_size > 1
+                ):
                     # 5xx/network-style failures use the configured budget.
                     # Rate limits retry once only when the advertised delay is
                     # short; long quota resets rotate or surface immediately.
@@ -1411,7 +1434,18 @@ async def stream_with_failover(
                 record(wrapped, primary=is_primary)
                 if not retry.enabled:
                     raise wrapped from exc
-                if transport_retries < retry.max_retries:
+                # Same budget rule as the ProviderError arm above, asked the same
+                # way. This branch used to test `retry.max_retries` directly,
+                # which quietly exempted it from the per-account server cap --
+                # and this is the arm RAW transport failures take (no client in
+                # clients.py catches httpx; `_guarded_chunks` deliberately raises
+                # ReadTimeout on a stall), so a timeout storm still sent
+                # max_retries x pool-size requests. `wrap_transport_error` stamps
+                # these `kind="timeout"`, so the shared predicate already
+                # classifies them correctly; the branch just was not asking.
+                if _same_credential_retry_allowed(
+                    wrapped, transport_retries, retry, rotates_across_pool=pool_size > 1
+                ):
                     transport_retries += 1
                     await _abortable_sleep(
                         backoff_delay_ms(retry.base_delay_ms, transport_retries, rng=rng), signal
@@ -1511,6 +1545,41 @@ async def _resolve_access_for_provider(
 
         record = OAuthAccess(access_token=token, credential_id=0, kind="api_key")
     return record
+
+
+def _clear_demotion(auth: FailoverAuthStore, provider: str, access: "OAuthAccess | None") -> None:
+    """Restore a credential's priority after it successfully served a request.
+
+    Best-effort and silent: a store need not implement demotion at all (it is an
+    ``AuthStore`` detail, not part of the failover protocol), and a bookkeeping
+    failure must never turn a SUCCESSFUL turn into an error.
+    """
+    if access is None or not access.credential_id:
+        return
+    clear = getattr(auth, "clear_deprioritized", None)
+    if not callable(clear):
+        return
+    try:
+        clear(provider, access.credential_id)
+    except Exception:  # noqa: BLE001 - never fail a served request on bookkeeping
+        logger.debug("could not clear demotion for %s/%s", provider, access.credential_id)
+
+
+def _credential_pool_size(auth: FailoverAuthStore, provider: str) -> int:
+    """How many usable credentials this provider has, for the retry cap.
+
+    Only the "is there more than one?" question matters, so a store that cannot
+    enumerate (the structural protocol promises only ``get_api_key``) answers
+    ``1``: without evidence of a pool, the honest default is the UNCAPPED
+    budget the user configured, since capping is only justified by the
+    multiplication a pool causes.
+    """
+    if not isinstance(auth, CredentialLister):
+        return 1
+    try:
+        return sum(1 for row in auth.list_credentials(provider) if row.disabled_cause is None)
+    except Exception:  # noqa: BLE001 - a retry decision must never raise
+        return 1
 
 
 def _no_credential_error(auth: FailoverAuthStore, provider: str) -> ProviderError:

--- a/local_operator/providers/failover.py
+++ b/local_operator/providers/failover.py
@@ -1410,9 +1410,7 @@ async def stream_with_failover(
                     # the same storm), so a value computed once goes stale in the
                     # direction that hurts: it keeps claiming a pool after the
                     # pool is gone, and caps the last healthy credential.
-                    rotates_across_pool=_has_rotatable_sibling(
-                        auth, provider, access.kind if access else None
-                    ),
+                    rotates_across_pool=_has_rotatable_sibling(auth, provider, access),
                 ):
                     # 5xx/network-style failures use the configured budget.
                     # Rate limits retry once only when the advertised delay is
@@ -1457,9 +1455,7 @@ async def stream_with_failover(
                     wrapped,
                     transport_retries,
                     retry,
-                    rotates_across_pool=_has_rotatable_sibling(
-                        auth, provider, access.kind if access else None
-                    ),
+                    rotates_across_pool=_has_rotatable_sibling(auth, provider, access),
                 ):
                     transport_retries += 1
                     await _abortable_sleep(
@@ -1581,7 +1577,7 @@ def _clear_demotion(auth: FailoverAuthStore, provider: str, access: "OAuthAccess
 
 
 def _has_rotatable_sibling(
-    auth: FailoverAuthStore, provider: str, current_type: str | None
+    auth: FailoverAuthStore, provider: str, access: "OAuthAccess | None"
 ) -> bool:
     """Is there another credential this turn could ACTUALLY rotate onto?
 
@@ -1601,11 +1597,23 @@ def _has_rotatable_sibling(
       SAME ``credential_type``, so an OAuth sign-in plus a pasted API key is two
       rows and zero rotation.
 
+    - **A bearer that is not a stored row at all.** The cascade's runtime
+      override (``--api-key``), config override and env-var tiers return no row,
+      and the resolver wraps them as ``credential_id=0``. Rotation cannot move
+      off such a bearer -- there is nothing to move to, and the same override
+      wins the cascade again every time -- so counting the stored rows beside it
+      claimed a pool that is unreachable BY CONSTRUCTION. ``credential_id`` is
+      already the sentinel for "not a row", so it is what this asks.
+
     A store that cannot enumerate (the structural protocol promises only
     ``get_api_key``) answers ``False``: without evidence of a reachable sibling
     the honest default is the UNCAPPED budget the user configured.
     """
     if not isinstance(auth, CredentialLister):
+        return False
+    # No row behind this bearer (override/env tier, or a bare-key test double):
+    # nothing to rotate onto, whatever the table happens to contain.
+    if access is not None and not access.credential_id:
         return False
     try:
         usable = [
@@ -1615,9 +1623,9 @@ def _has_rotatable_sibling(
         ]
     except Exception:  # noqa: BLE001 - a retry decision must never raise
         return False
-    if current_type is None:
+    if access is None:
         return len(usable) > 1
-    return sum(1 for row in usable if row.credential_type == current_type) > 1
+    return sum(1 for row in usable if row.credential_type == access.kind) > 1
 
 
 def _is_blocked(auth: FailoverAuthStore, row: "StoredCredential", provider: str) -> bool:

--- a/local_operator/providers/failover.py
+++ b/local_operator/providers/failover.py
@@ -36,7 +36,7 @@ from local_operator.harness.types import (
 from local_operator.model.effort import EFFORT_ORDER, resolve_effort
 
 if TYPE_CHECKING:  # import cycle: both modules import this one at runtime
-    from local_operator.providers.auth_store import OAuthAccess
+    from local_operator.providers.auth_store import OAuthAccess, StoredCredential
     from local_operator.providers.clients import WireClient
 
 # ---------------------------------------------------------------------------
@@ -438,10 +438,56 @@ def is_direct_credential_rotation_error(error: BaseException) -> bool:
     which deliberately excludes it: a refreshed token still has no credits, so
     the refresh step is as pointless here as for a 403 — but a spent balance is
     not a window that reopens, so the credential must not keep its sticky place.
+
+    Server-side failures (5xx, including Anthropic's 529 ``overloaded_error``,
+    and transport timeouts) are here too. A refresh cannot fix the PROVIDER
+    being overloaded, so the refresh step is equally pointless, and the sticky
+    credential is not at fault so it keeps its place — that is exactly the
+    contract this predicate expresses. See
+    :func:`allows_full_sibling_rotation` for why they must also be exempt from
+    the ordinary-401 switch cap.
     """
     if not isinstance(error, ProviderError):
         return False
-    return is_usage_limit_error(error) or error.status in (402, 403)
+    return (
+        is_usage_limit_error(error) or error.status in (402, 403) or is_server_side_failure(error)
+    )
+
+
+def is_server_side_failure(error: BaseException) -> bool:
+    """The PROVIDER failed, not the credential: 5xx, or a timeout/transport blip.
+
+    Kept separate from :func:`is_usage_limit_error` because the two want
+    opposite blocking behaviour — a quota error blocks the credential for the
+    reset window, while an overloaded provider must not get four credentials
+    blocked for a fault none of them caused. ``AuthStore.rotate_sibling``
+    deprioritises instead of blocking on the strength of this predicate.
+    """
+    if not isinstance(error, ProviderError):
+        return False
+    if error.kind in ("timeout", "transient"):
+        return True
+    return error.status is not None and error.status >= 500
+
+
+def allows_full_sibling_rotation(error: BaseException) -> bool:
+    """May this error cycle EVERY sibling, rather than one switch and stop?
+
+    The ``legacy_auth_switch_used`` cap in :class:`AuthRetryKeyState` exists for
+    the ordinary-401 case, where a second, third and fourth bearer are all
+    equally likely to be rejected and cycling them only delays a login prompt
+    the user has to answer anyway.
+
+    It is the wrong rule for a pool of accounts that fail INDEPENDENTLY. With
+    four Anthropic accounts and a 529 storm, the cap stopped after the second
+    account and reported the turn dead while two healthy accounts were never
+    asked — the reported failure. Quota is the same story: one account's spent
+    weekly window says nothing about the other three.
+
+    So exhaustion, payment, permission and server-side faults may walk the whole
+    pool; only an ordinary 401 keeps the single-switch cap.
+    """
+    return is_direct_credential_rotation_error(error)
 
 
 def retry_after_ms_from_error(error: BaseException) -> int | None:
@@ -1048,6 +1094,19 @@ class FailoverAuthStore(Protocol):
 
 
 @runtime_checkable
+class CredentialLister(Protocol):
+    """A store that can enumerate what it holds for a provider.
+
+    Optional, like :class:`OAuthAccessSource`: it exists only so a failure can
+    say WHY no bearer was resolved (nothing configured, versus everything
+    temporarily blocked). A store without it gets the unqualified wording,
+    which is the honest answer when the distinction cannot be checked.
+    """
+
+    def list_credentials(self, provider: str) -> "list[StoredCredential]": ...  # pragma: no cover
+
+
+@runtime_checkable
 class OAuthAccessSource(Protocol):
     """A store that can also hand back the identity-carrying OAuth record.
 
@@ -1266,12 +1325,15 @@ async def stream_with_failover(
                 if access is None and error is not None:
                     break  # rotation exhausted for this provider
                 if access is None and not _provider_allows_missing(provider):
+                    # "No API key configured" is only true when the provider has
+                    # NO credential at all. Said unconditionally it was actively
+                    # misleading: a signed-in OAuth account that was merely
+                    # rate-limited (blocked) resolves to None here too, and the
+                    # reported frame sent the user off to configure a key they
+                    # already had -- the reported `No API key configured for
+                    # provider 'openai'` on an account signed in via OAuth.
                     record(
-                        ProviderError(
-                            None,
-                            f"No API key configured for provider '{provider}'",
-                            retryable=False,
-                        ),
+                        _no_credential_error(auth, provider),
                         primary=is_primary,
                     )
                     break
@@ -1434,6 +1496,51 @@ async def _resolve_access_for_provider(
 
         record = OAuthAccess(access_token=token, credential_id=0, kind="api_key")
     return record
+
+
+def _no_credential_error(auth: FailoverAuthStore, provider: str) -> ProviderError:
+    """Say WHY no bearer could be resolved, distinguishing two opposite causes.
+
+    Resolution returns ``None`` both when a provider has never been configured
+    and when every credential it has is temporarily blocked (rate limit, a
+    failed refresh). Those need opposite actions from the user -- go and sign
+    in, versus wait or top up -- and reporting the first for the second is what
+    told a user with a working OAuth login that they had no API key.
+
+    Stores that cannot enumerate credentials (the structural protocol only
+    promises ``get_api_key``) fall back to the original wording, which is the
+    correct message whenever the answer is genuinely unknown.
+    """
+    rows: list["StoredCredential"] = []
+    if isinstance(auth, CredentialLister):
+        try:
+            rows = [row for row in auth.list_credentials(provider) if row.disabled_cause is None]
+        except Exception:  # noqa: BLE001 - diagnosis must never mask the real failure
+            rows = []
+    if not rows:
+        return ProviderError(
+            None, f"No API key configured for provider '{provider}'", retryable=False
+        )
+    kinds = {row.credential_type for row in rows}
+    what = "OAuth sign-in" if "oauth" in kinds else "API key"
+    count = len(rows)
+    subject = (
+        f"The {what} credential for provider '{provider}' is"
+        if count == 1
+        else f"All {count} {what} credentials for provider '{provider}' are"
+    )
+    # Retryable: the credential comes back on its own once the block expires,
+    # which is materially different from a missing configuration.
+    return ProviderError(
+        None,
+        (
+            f"{subject} temporarily unavailable (rate limited, or a token refresh "
+            "failed). The credentials are still configured; retry once the limit "
+            "resets, or add another account."
+        ),
+        retryable=True,
+        kind="quota",
+    )
 
 
 def _provider_allows_missing(provider: str) -> bool:

--- a/local_operator/providers/failover.py
+++ b/local_operator/providers/failover.py
@@ -782,6 +782,16 @@ BACKOFF_JITTER_FRACTION = 0.25
 MAX_USAGE_RETRY_AFTER_MS = 30_000
 MAX_SAME_CREDENTIAL_USAGE_RETRIES = 2
 
+# Same-credential retries for a SERVER-side fault (5xx/529/timeout). Small for
+# the same reason the usage cap is, and the reason grew stronger once rotation
+# was widened to walk the whole pool: this budget is spent once per ACCOUNT, so
+# the full `max_retries` (default 10) becomes 10 x pool size requests aimed at a
+# provider that has just said it is overloaded -- 44 requests over ~190s for a
+# four-account pool, measured. Two attempts per account still absorbs the brief
+# 529 blips these codes usually are, while the pool walk (which tries a
+# DIFFERENT account, the thing most likely to succeed) happens sooner.
+MAX_SAME_CREDENTIAL_SERVER_RETRIES = 2
+
 
 def backoff_delay_ms(base_delay_ms: int, attempt: int, *, rng: random.Random | None = None) -> int:
     """``min(base * 2^(attempt-1), 8000)`` with 25% downward jitter."""
@@ -797,11 +807,16 @@ def _same_credential_retry_allowed(
 ) -> bool:
     if not error.retryable:
         return False
-    if not is_usage_limit_error(error):
-        return transport_retries < retry.max_retries
-    if (error.retry_after_ms or 0) > MAX_USAGE_RETRY_AFTER_MS:
-        return False
-    return transport_retries < min(retry.max_retries, MAX_SAME_CREDENTIAL_USAGE_RETRIES)
+    if is_usage_limit_error(error):
+        if (error.retry_after_ms or 0) > MAX_USAGE_RETRY_AFTER_MS:
+            return False
+        return transport_retries < min(retry.max_retries, MAX_SAME_CREDENTIAL_USAGE_RETRIES)
+    if is_server_side_failure(error):
+        # Capped: this budget is now spent once per ACCOUNT rather than once per
+        # request, so the full `max_retries` would multiply by the pool size and
+        # aim the product at a provider that is already saying it is overloaded.
+        return transport_retries < min(retry.max_retries, MAX_SAME_CREDENTIAL_SERVER_RETRIES)
+    return transport_retries < retry.max_retries
 
 
 def _normalize_chain_entry(entry: Any, chain_key: str) -> Any:

--- a/local_operator/providers/failover.py
+++ b/local_operator/providers/failover.py
@@ -1327,12 +1327,6 @@ async def stream_with_failover(
         current_token: str | None = None
         transport_retries = 0
         retry_same_key = False
-        # Whether a server-fault retry budget spent here will be spent AGAIN on
-        # a sibling. Only then does the per-account cap earn its keep; with one
-        # credential it would just remove retries the user asked for. Computed
-        # once per target rather than per attempt: the pool does not change
-        # mid-turn, and this must not add a query to the retry hot path.
-        pool_size = _credential_pool_size(auth, provider)
 
         while state.attempts <= AUTH_RETRY_MAX_ATTEMPTS:
             if signal is not None and signal.aborted:
@@ -1390,7 +1384,13 @@ async def stream_with_failover(
                 # the outage for the life of the process, contradicting the
                 # "lasts seconds" reasoning it is justified by and leaving a
                 # perfectly good account permanently last in the pool.
-                _clear_demotion(auth, provider, access)
+                #
+                # Skipped for an isolated request, which is the same rule the
+                # cascade applies (`read_only`): a decorative call running beside
+                # a user's turn must not move that turn's routing, and restoring
+                # priority is as much a routing decision as removing it.
+                if not request.isolated:
+                    _clear_demotion(auth, provider, access)
                 if buffered is None:
                     return  # clean completion; a buffered stream flushes below
             except asyncio.CancelledError:
@@ -1402,7 +1402,17 @@ async def stream_with_failover(
                 if not retry.enabled:
                     raise
                 if _same_credential_retry_allowed(
-                    exc, transport_retries, retry, rotates_across_pool=pool_size > 1
+                    exc,
+                    transport_retries,
+                    retry,
+                    # Asked at the moment of the DECISION, not cached per target.
+                    # Blocking happens mid-turn (a sibling hits its quota during
+                    # the same storm), so a value computed once goes stale in the
+                    # direction that hurts: it keeps claiming a pool after the
+                    # pool is gone, and caps the last healthy credential.
+                    rotates_across_pool=_has_rotatable_sibling(
+                        auth, provider, access.kind if access else None
+                    ),
                 ):
                     # 5xx/network-style failures use the configured budget.
                     # Rate limits retry once only when the advertised delay is
@@ -1444,7 +1454,12 @@ async def stream_with_failover(
                 # these `kind="timeout"`, so the shared predicate already
                 # classifies them correctly; the branch just was not asking.
                 if _same_credential_retry_allowed(
-                    wrapped, transport_retries, retry, rotates_across_pool=pool_size > 1
+                    wrapped,
+                    transport_retries,
+                    retry,
+                    rotates_across_pool=_has_rotatable_sibling(
+                        auth, provider, access.kind if access else None
+                    ),
                 ):
                     transport_retries += 1
                     await _abortable_sleep(
@@ -1565,21 +1580,56 @@ def _clear_demotion(auth: FailoverAuthStore, provider: str, access: "OAuthAccess
         logger.debug("could not clear demotion for %s/%s", provider, access.credential_id)
 
 
-def _credential_pool_size(auth: FailoverAuthStore, provider: str) -> int:
-    """How many usable credentials this provider has, for the retry cap.
+def _has_rotatable_sibling(
+    auth: FailoverAuthStore, provider: str, current_type: str | None
+) -> bool:
+    """Is there another credential this turn could ACTUALLY rotate onto?
 
-    Only the "is there more than one?" question matters, so a store that cannot
-    enumerate (the structural protocol promises only ``get_api_key``) answers
-    ``1``: without evidence of a pool, the honest default is the UNCAPPED
-    budget the user configured, since capping is only justified by the
-    multiplication a pool causes.
+    The retry cap is justified by one thing only: the same budget being spent
+    again on a sibling, multiplying the requests aimed at a struggling provider.
+    So the question has to be asked exactly as rotation would answer it, not as
+    a count of rows that happen to exist. Counting raw rows claimed a pool in
+    two configurations where rotation reaches nothing, and the cap then took
+    away retries with nowhere to spend them:
+
+    - **Blocked siblings.** A quota-exhausted account is skipped by
+      ``rotate_sibling`` and by the cascade. Four accounts with three blocked is
+      this PR's own headline scenario -- several accounts spent mid-degradation,
+      one healthy -- where a raw count said "pool of 4" and the survivor lost 8
+      of its 10 retries.
+    - **Mixed credential types.** ``rotate_sibling`` only walks siblings of the
+      SAME ``credential_type``, so an OAuth sign-in plus a pasted API key is two
+      rows and zero rotation.
+
+    A store that cannot enumerate (the structural protocol promises only
+    ``get_api_key``) answers ``False``: without evidence of a reachable sibling
+    the honest default is the UNCAPPED budget the user configured.
     """
     if not isinstance(auth, CredentialLister):
-        return 1
+        return False
     try:
-        return sum(1 for row in auth.list_credentials(provider) if row.disabled_cause is None)
+        usable = [
+            row
+            for row in auth.list_credentials(provider)
+            if row.disabled_cause is None and not _is_blocked(auth, row, provider)
+        ]
     except Exception:  # noqa: BLE001 - a retry decision must never raise
-        return 1
+        return False
+    if current_type is None:
+        return len(usable) > 1
+    return sum(1 for row in usable if row.credential_type == current_type) > 1
+
+
+def _is_blocked(auth: FailoverAuthStore, row: "StoredCredential", provider: str) -> bool:
+    """Whether the store considers ``row`` blocked, tolerating stores without
+    the notion (test doubles, embedder-supplied credential sources)."""
+    is_blocked = getattr(auth, "is_blocked", None)
+    if not callable(is_blocked):
+        return False
+    try:
+        return bool(is_blocked(row.id, provider))
+    except Exception:  # noqa: BLE001
+        return False
 
 
 def _no_credential_error(auth: FailoverAuthStore, provider: str) -> ProviderError:

--- a/local_operator/providers/failover.py
+++ b/local_operator/providers/failover.py
@@ -1384,6 +1384,10 @@ async def stream_with_failover(
         # chain. Each provider is a different service having a different day,
         # and the ceiling is about what ONE provider receives.
         server_fault_requests = 0
+        # Attempts this target's FIRST bearer spent before rotation started, so
+        # the restore below can hand back the remainder of the user's budget
+        # instead of a fresh one.
+        spent_before_rotation = 0
         # The last credential that actually produced a bearer, and whether its
         # configured budget has already been handed back once rotation ran out.
         last_access: "OAuthAccess | None" = None
@@ -1405,6 +1409,12 @@ async def stream_with_failover(
                 )
                 token = access.access_token if access is not None else None
                 if token != current_token:
+                    if not exhausted_budget_restored:
+                        # Attempts already charged to this bearer, INCLUDING the
+                        # one the rotation cycle itself spends re-presenting it
+                        # after a refresh. Missing that one is a whole extra
+                        # request against a provider that is already failing.
+                        spent_before_rotation = max(spent_before_rotation, transport_retries + 1)
                     current_token = token
                     transport_retries = 0  # fresh credential ⇒ fresh budget
                 if access is None and error is not None:
@@ -1419,30 +1429,41 @@ async def stream_with_failover(
                     if (
                         not exhausted_budget_restored
                         and last_access is not None
+                        and spent_before_rotation < retry.max_retries
                         and is_server_side_failure(error)
                         and server_fault_requests < MAX_SERVER_FAULT_REQUESTS_PER_TURN
                     ):
                         exhausted_budget_restored = True
                         access = last_access
-                        # NOTE: `transport_retries` was already zeroed a few
-                        # lines above, because rotation returning nothing makes
-                        # `token` None and so trips the `token != current_token`
-                        # reset. The restored pass therefore starts a FRESH
-                        # `max_retries`, and a lone credential's total for one
-                        # target is roughly twice the configured budget rather
-                        # than exactly it.
+                        # Carry the attempts already spent, and re-pin
+                        # `current_token`, so the restored pass finishes the
+                        # user's budget rather than starting a second one.
                         #
-                        # That is deliberate here, and it is also what the
-                        # unpatched code does: the same reset makes a single
-                        # credential spend `max_retries` per rotation cycle on
-                        # `main` too (verified A/B: identical counts at
-                        # maxRetries 0/1/3/5). The turn ceiling above is what
-                        # actually bounds it. Making the total exact is a real
-                        # improvement but it is a pre-existing accounting
-                        # question, not part of this change, and tightening it
-                        # here would silently reduce retries for every
-                        # single-credential user in a PR about the opposite
-                        # problem.
+                        # Both halves are load-bearing. Rotation returning
+                        # nothing makes `token` None, which trips the
+                        # `token != current_token` reset a few lines above and
+                        # zeroes the counter; re-pinning here stops the NEXT
+                        # pass doing the same thing again. Without this a lone
+                        # credential spent 2 x (max_retries + 1) requests
+                        # against one provider -- twice the configured budget,
+                        # in a change whose whole purpose is to stop hammering a
+                        # provider that is already failing.
+                        #
+                        # `spent_before_rotation < max_retries` above is part of
+                        # the same contract: when the pre-rotation allowance has
+                        # already met the configured budget there is nothing
+                        # left to restore, and firing anyway would grant an
+                        # extra request. It also covers `maxRetries: 0`, where a
+                        # user who asked for no retries must get exactly one
+                        # request.
+                        # Never LESS than what has already been spent: the
+                        # restored pass finishes the configured budget, it does
+                        # not reopen it. With a small `max_retries` the
+                        # pre-rotation allowance can already have met or passed
+                        # the budget, in which case there is nothing to restore
+                        # and the loop simply ends.
+                        transport_retries = max(spent_before_rotation, transport_retries)
+                        current_token = last_access.access_token
                         error = None
                     else:
                         break  # rotation exhausted for this provider
@@ -1705,21 +1726,20 @@ def _server_fault_budget_spent(error: ProviderError, server_fault_requests: int)
 
 
 def _request_has_rotated(state: AuthRetryKeyState) -> bool:
-    """Is there a credential this request has not tried and could still reach?
+    """Has this request already been handed more than one distinct bearer?
 
-    This decides ONE thing: whether to keep the per-credential allowance small
-    so the turn moves on to another account, or to spend the configured budget
-    here because there is nowhere else to go.
+    This decides ONE thing: whether the small per-credential allowance applies,
+    because the budget is about to be spent AGAIN on another account -- the
+    multiplication the cap exists to prevent.
 
-    It reads the store's OWN report (``AuthStore.rotate_sibling`` returns
-    whether another usable credential remained) rather than modelling the
-    credential table. Five review rounds each found a predictive version
-    drifting from what the cascade actually does -- raw row counts, then blocked
-    rows, then credential types, then override bearers with no row at all, then
-    ``api_key`` rows split across cascade tiers where one always wins -- and
-    every drift cost a real user retries they needed. The store is the only
-    thing that knows its own tiers, blocks, aliases and overrides; asking it is
-    the fix that does not have a sixth version.
+    It reports what ALREADY HAPPENED -- more than one distinct bearer has been
+    handed to this request -- rather than modelling the credential table. Five
+    review rounds each found a predictive version drifting from what the cascade
+    actually does: raw row counts, then blocked rows, then credential types,
+    then override bearers with no row at all, then ``api_key`` rows split across
+    cascade tiers where one always wins. Every drift cost a real user retries
+    they needed. A fact about the past cannot drift, which is why this version
+    has no sixth.
     """
     return len(state.attempted_keys) > 1
 

--- a/local_operator/providers/failover.py
+++ b/local_operator/providers/failover.py
@@ -1429,7 +1429,7 @@ async def stream_with_failover(
                     if (
                         not exhausted_budget_restored
                         and last_access is not None
-                        and spent_before_rotation < retry.max_retries
+                        and spent_before_rotation <= retry.max_retries
                         and is_server_side_failure(error)
                         and server_fault_requests < MAX_SERVER_FAULT_REQUESTS_PER_TURN
                     ):
@@ -1449,13 +1449,20 @@ async def stream_with_failover(
                         # in a change whose whole purpose is to stop hammering a
                         # provider that is already failing.
                         #
-                        # `spent_before_rotation < max_retries` above is part of
-                        # the same contract: when the pre-rotation allowance has
-                        # already met the configured budget there is nothing
-                        # left to restore, and firing anyway would grant an
-                        # extra request. It also covers `maxRetries: 0`, where a
-                        # user who asked for no retries must get exactly one
-                        # request.
+                        # `spent_before_rotation <= max_retries` above is part of
+                        # the same contract, and the comparison is inclusive on
+                        # purpose. `transport_retries` counts retries, so a
+                        # bearer that has spent exactly `max_retries` has issued
+                        # `max_retries + 1` requests and has none left; but the
+                        # allowance can also land ON the budget (at
+                        # `maxRetries: 4` the pre-rotation allowance of 3 makes
+                        # `spent_before_rotation` 4), and an exclusive test
+                        # skipped the restore there and cost the user their last
+                        # request. Only that one value diverged, which is why a
+                        # sweep of every setting -- not a sample -- is what the
+                        # test does. `maxRetries: 0` is still exactly one
+                        # request: `max()` below leaves the counter at the
+                        # budget, so no retry is allowed through.
                         # Never LESS than what has already been spent: the
                         # restored pass finishes the configured budget, it does
                         # not reopen it. With a small `max_retries` the

--- a/local_operator/providers/failover.py
+++ b/local_operator/providers/failover.py
@@ -544,18 +544,10 @@ class AuthRetryKeyState:
     refresh step and may cycle every distinct sibling instead.
     """
 
+    #: Every DISTINCT bearer rotation has returned for this request. Also the
+    #: retry budget's evidence that rotation happened at all: see
+    #: :func:`_request_has_rotated`.
     attempted_keys: set[str] = dataclasses.field(default_factory=set)
-    #: What ``AuthStore.rotate_sibling`` last reported: whether ANOTHER usable
-    #: credential remained after the failing one was set aside. Recorded rather
-    #: than recomputed because the store is the only thing that knows its own
-    #: cascade -- tiers, blocks, credential types and aliases included. Starts
-    #: Set once rotation has been ATTEMPTED and the store has answered. ``None``
-    #: means "not yet asked", which the budget rule treats as "there may be one"
-    #: -- so the first bearer spends the small per-credential allowance and the
-    #: turn moves on to discover the truth, rather than burning ten attempts in
-    #: place while three healthy accounts wait (the reported bug) or being
-    #: capped on an assumption that never gets tested (its mirror image).
-    sibling_available: bool | None = None
     last_key: str | None = None
     refreshed_current: bool = False
     legacy_auth_switch_used: bool = False
@@ -856,16 +848,16 @@ def _same_credential_retry_allowed(
         # against the turn ceiling: four accounts, and only two were ever tried,
         # which is the original reported bug arriving by a new route.
         #
-        # So while a sibling remains reachable, each bearer gets the small
-        # per-credential allowance and the turn moves on. `has_untried_sibling`
-        # is the driver's OBSERVATION that rotation is still producing new
-        # bearers, not a prediction from the credential table.
+        # So each bearer gets a small allowance and the turn moves on, until
+        # rotation reports it has nowhere left to go. `has_rotated` and
+        # `rotation_exhausted` are both OBSERVATIONS the driver made -- what
+        # rotation already did -- never predictions about the credential table.
         if rotation_exhausted:
             # Rotation has been tried and there is no other credential, so the
             # small allowances below -- which exist ONLY to get a turn moving to
             # another account -- have nothing left to buy. The bearer in hand
-            # gets exactly the budget the user configured: no more (it was
-            # asked for) and no less (it is all there is).
+            # gets the budget the user configured rather than an allowance
+            # sized for a pool that does not exist.
             return transport_retries < retry.max_retries
         if has_rotated:
             return transport_retries < min(retry.max_retries, MAX_SAME_CREDENTIAL_SERVER_RETRIES)
@@ -880,9 +872,6 @@ def _same_credential_retry_allowed(
         # types, override bearers, rows split across tiers), and each drift took
         # retries away from someone who had nowhere else to spend them.
         return transport_retries < min(retry.max_retries, MAX_FIRST_CREDENTIAL_SERVER_RETRIES)
-        # Nothing left to rotate onto: the configured budget is the right answer
-        # again, because there is no multiplication left to prevent. This is the
-        # lone credential, the override bearer, and the last account standing.
     return transport_retries < retry.max_retries
 
 
@@ -1435,11 +1424,25 @@ async def stream_with_failover(
                     ):
                         exhausted_budget_restored = True
                         access = last_access
-                        # `transport_retries` is deliberately NOT reset: the
-                        # attempts already spent on this bearer are part of the
-                        # budget the user configured, so carrying them makes the
-                        # TOTAL exactly `max_retries` rather than the allowance
-                        # plus a second full budget on top.
+                        # NOTE: `transport_retries` was already zeroed a few
+                        # lines above, because rotation returning nothing makes
+                        # `token` None and so trips the `token != current_token`
+                        # reset. The restored pass therefore starts a FRESH
+                        # `max_retries`, and a lone credential's total for one
+                        # target is roughly twice the configured budget rather
+                        # than exactly it.
+                        #
+                        # That is deliberate here, and it is also what the
+                        # unpatched code does: the same reset makes a single
+                        # credential spend `max_retries` per rotation cycle on
+                        # `main` too (verified A/B: identical counts at
+                        # maxRetries 0/1/3/5). The turn ceiling above is what
+                        # actually bounds it. Making the total exact is a real
+                        # improvement but it is a pre-existing accounting
+                        # question, not part of this change, and tightening it
+                        # here would silently reduce retries for every
+                        # single-credential user in a PR about the opposite
+                        # problem.
                         error = None
                     else:
                         break  # rotation exhausted for this provider
@@ -1642,13 +1645,7 @@ async def _resolve_access_for_provider(
                 if record is None:
                     return await _key()
             elif ctx.last_chance:
-                # The store's OWN answer to "is another credential left?", kept
-                # for the retry-budget decision. Nothing else in this module
-                # knows the cascade's tiers, blocks and aliases well enough to
-                # work it out, and five review rounds of trying proved it.
-                state.sibling_available = bool(
-                    auth.rotate_sibling(provider, session_id, ctx.error, api_key=ctx.previous_key)
-                )
+                auth.rotate_sibling(provider, session_id, ctx.error, api_key=ctx.previous_key)
                 record = await _access()
                 if record is None:
                     return await _key()

--- a/local_operator/providers/oauth/zai.py
+++ b/local_operator/providers/oauth/zai.py
@@ -314,6 +314,12 @@ class ZaiOAuthFlow(OAuthCallbackFlow):
 
         user = data.get("user") if isinstance(data, dict) else None
         creds: dict[str, Any] = {
+            # Declared, not inferred. `upsert_credential` otherwise guesses the
+            # type from "has both refresh and access", and this credential has
+            # no refresh token (the minted key never expires), so it would be
+            # stored as an `api_key` row with its secret under `access` -- where
+            # no tier of the cascade can read it.
+            "type": "oauth",
             # The MINTED key, not the OAuth token: this is what the inference
             # endpoint accepts, and `_oauth_api_key` hands it straight to the wire.
             "access": minted,

--- a/local_operator/providers/oauth/zai.py
+++ b/local_operator/providers/oauth/zai.py
@@ -1,0 +1,314 @@
+"""Z.AI / GLM OAuth — browser sign-in that provisions a durable API key.
+
+Ported from omp's ``registry/oauth/zai.ts``, which in turn mirrors ZCode's
+desktop "Individual Plan" sign-in. The shape is unusual enough to be worth
+stating up front, because it is not the authorization-code flow the other
+providers in this package run:
+
+1. An authorization-code request against ``chat.z.ai`` — **no PKCE**, because
+   the provider's own client sends none and the token endpoint rejects the
+   extra parameters.
+2. A **non-standard** JSON token exchange (no ``grant_type``, no
+   ``code_verifier``) that returns a SHORT-LIVED OAuth access token nested at
+   ``data.zai.access_token``.
+3. A business-API sequence that trades that token for a DURABLE ``id.secret``
+   API key: business-login → resolve the default org/project → find-or-create
+   this app's named key → read its secret.
+
+Step 3 is the reason this file exists rather than a paste-a-key login. The
+short-lived OAuth token is NOT accepted by the inference endpoint, so a flow
+that stopped at step 2 would authenticate and then fail every request. The
+minted key IS the credential the wire wants, so it is stored in ``access`` and
+returned verbatim as the bearer — no dialect change anywhere downstream.
+
+Session persistence: the minted key does not expire, which is expressed as
+``expires: None``. :meth:`AuthStore._needs_refresh` reads that as "static
+token; never expires" and so never attempts a refresh — correct here, because
+there is no refresh token to attempt one with. The row therefore survives
+restarts and is reused across sessions exactly like an API key, while still
+being an ``oauth`` credential for identity and usage-reporting purposes.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+import urllib.parse
+from typing import Any, Callable
+
+import httpx
+
+from local_operator.harness.types import AbortSignal
+from local_operator.providers.oauth.callback_server import (
+    CallbackFlowOptions,
+    LoginCallbacks,
+    LoginError,
+    OAuthCallbackFlow,
+)
+
+
+def _env(name: str, default: str) -> str:
+    """Env override for an endpoint, falling back to the shipped default.
+
+    Mirrors omp's overridable constants: the CN-facing deployment of the same
+    product answers on different hosts, and a user pointed at it must be able
+    to log in without a code change.
+    """
+    value = os.environ.get(name)
+    return value if value else default
+
+
+CLIENT_ID = _env("ZAI_OAUTH_CLIENT_ID", "client_P8X5CMWmlaRO9gyO-KSqtg")
+AUTHORIZE_URL = _env("ZAI_OAUTH_AUTHORIZE_URL", "https://chat.z.ai/api/oauth/authorize")
+TOKEN_URL = _env("ZAI_OAUTH_TOKEN_URL", "https://zcode.z.ai/api/v1/oauth/token")
+BIZ_BASE = _env("ZAI_BIZ_BASE", "https://api.z.ai")
+BUSINESS_LOGIN_URL = _env("ZAI_BUSINESS_LOGIN_URL", "https://api.z.ai/api/auth/z/login")
+
+#: The name this app's provisioned key carries in the Z.AI console. Distinct
+#: from ZCode's own ``zcode-api-key`` so signing in here never rotates or
+#: overwrites the key another tool depends on.
+KEY_NAME = "local-operator"
+
+#: Pinned by the provider's OAuth client registration: the redirect URI is on
+#: the allowlist for this exact port, so a fallback port would be refused.
+CALLBACK_PORT = 54548
+CALLBACK_PATH = "/callback"
+
+_TIMEOUT_S = 30.0
+
+
+def _is_success_code(code: Any) -> bool:
+    """Z.AI's two success spellings.
+
+    The OAuth token endpoint signals success with ``code: 0`` while the biz
+    endpoints use ``code: 200``. A body with no status field at all is also a
+    success — some endpoints return the payload bare.
+    """
+    if code is None:
+        return True
+    if isinstance(code, bool):
+        return False
+    if isinstance(code, (int, float)):
+        return int(code) in (0, 200)
+    if isinstance(code, str):
+        return code in ("0", "200")
+    return False
+
+
+def _unwrap(body: Any, operation: str) -> Any:
+    """Unwrap the ``{code, msg, data, success}`` envelope, raising on failure.
+
+    The envelope reports application-level failures with HTTP 200, so a caller
+    that only checked the status code would read an error body as a credential.
+    """
+    if isinstance(body, dict) and ("code" in body or "success" in body):
+        if body.get("success") is False or not _is_success_code(body.get("code")):
+            detail = body.get("msg") or f"code {body.get('code')}"
+            raise LoginError(f"Z.AI {operation} failed: {detail}")
+        return body.get("data") if "data" in body else body
+    return body
+
+
+def _trimmed(value: Any) -> str | None:
+    """A non-empty trimmed string, or ``None`` for anything else."""
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
+async def _get_json(http: httpx.AsyncClient, url: str, headers: dict[str, str]) -> Any:
+    response = await http.get(url, headers=headers)
+    if response.status_code != 200:
+        raise LoginError(f"Z.AI request failed ({response.status_code}) for {url}: {response.text}")
+    return response.json() if response.content else None
+
+
+async def _post_json(
+    http: httpx.AsyncClient, url: str, body: dict[str, Any], headers: dict[str, str] | None = None
+) -> Any:
+    response = await http.post(url, json=body, headers=headers or {})
+    if response.status_code != 200:
+        raise LoginError(f"Z.AI request failed ({response.status_code}) for {url}: {response.text}")
+    return response.json() if response.content else None
+
+
+def _key_array(value: Any) -> list[dict[str, Any]]:
+    """Coerce an api-keys listing to a list across the shapes Z.AI returns."""
+    if isinstance(value, list):
+        return [entry for entry in value if isinstance(entry, dict)]
+    if isinstance(value, dict):
+        for field in ("list", "keys", "apiKeys", "records"):
+            nested = value.get(field)
+            if isinstance(nested, list):
+                return [entry for entry in nested if isinstance(entry, dict)]
+    return []
+
+
+async def _business_login(http: httpx.AsyncClient, oauth_access_token: str) -> str:
+    """Trade the short-lived OAuth token for the biz token the APIs require."""
+    data = _unwrap(
+        await _post_json(http, BUSINESS_LOGIN_URL, {"token": oauth_access_token}),
+        "business login",
+    )
+    token = None
+    if isinstance(data, dict):
+        token = _trimmed(data.get("access_token")) or _trimmed(data.get("accessToken"))
+    if not token:
+        raise LoginError("Z.AI business login returned no access token")
+    return token
+
+
+async def mint_zai_api_key(http: httpx.AsyncClient, oauth_access_token: str) -> str:
+    """Provision the durable ``id.secret`` key from a short-lived OAuth token.
+
+    business-login → default org/project → find-or-create this app's key →
+    read its secret. Exposed (not private) so a test can exercise the
+    provisioning sequence without driving a browser flow.
+    """
+    biz_token = await _business_login(http, oauth_access_token)
+    auth = {"Authorization": f"Bearer {biz_token}"}
+
+    customer = _unwrap(
+        await _get_json(http, f"{BIZ_BASE}/api/biz/customer/getCustomerInfo", auth),
+        "customer lookup",
+    )
+    orgs = customer.get("organizations") if isinstance(customer, dict) else None
+    orgs = [o for o in orgs if isinstance(o, dict)] if isinstance(orgs, list) else []
+    org = next((o for o in orgs if o.get("isDefault")), orgs[0] if orgs else None)
+    projects = org.get("projects") if isinstance(org, dict) else None
+    projects = [p for p in projects if isinstance(p, dict)] if isinstance(projects, list) else []
+    project = next((p for p in projects if p.get("isDefault")), projects[0] if projects else None)
+
+    organization_id = _trimmed(org.get("organizationId")) if org else None
+    project_id = _trimmed(project.get("projectId")) if project else None
+    if not organization_id or not project_id:
+        raise LoginError("Z.AI key provisioning failed: no organization/project on this account")
+
+    keys_url = (
+        f"{BIZ_BASE}/api/biz/v1/organization/{organization_id}/projects/{project_id}/api_keys"
+    )
+    existing = next(
+        (
+            k
+            for k in _key_array(_unwrap(await _get_json(http, keys_url, auth), "api key list"))
+            if k.get("name") == KEY_NAME
+        ),
+        None,
+    )
+    record = existing or _unwrap(
+        await _post_json(http, keys_url, {"name": KEY_NAME}, auth), "api key create"
+    )
+    api_key = _trimmed(record.get("apiKey")) if isinstance(record, dict) else None
+    if not api_key:
+        raise LoginError("Z.AI key provisioning returned no apiKey")
+
+    # ALWAYS read the secret from the copy endpoint. List entries mask it
+    # (`*****abcd`) and the create response's inline secret is not reliable
+    # across account states, so anything else can persist a key that cannot
+    # authenticate — and it would fail at the first request, not at login.
+    copied = _unwrap(
+        await _get_json(http, f"{keys_url}/copy/{urllib.parse.quote(api_key)}", auth),
+        "api key copy",
+    )
+    secret_key = _trimmed(copied.get("secretKey")) if isinstance(copied, dict) else None
+    if not secret_key:
+        raise LoginError("Z.AI key provisioning returned no secretKey")
+    return f"{api_key}.{secret_key}"
+
+
+class ZaiOAuthFlow(OAuthCallbackFlow):
+    """Authorization-code sign-in against chat.z.ai (no PKCE), then key minting."""
+
+    def __init__(
+        self,
+        callbacks: LoginCallbacks | None = None,
+        *,
+        open_browser: Callable[[str], None] | None = None,
+        signal: AbortSignal | None = None,
+        manual_input_only: bool = False,
+        http_client: httpx.AsyncClient | None = None,
+    ) -> None:
+        super().__init__(
+            CallbackFlowOptions(
+                preferred_port=CALLBACK_PORT,
+                callback_path=CALLBACK_PATH,
+                # The redirect URI is registered against this exact port, so a
+                # fallback port would produce a redirect the IdP refuses.
+                allow_port_fallback=False,
+                manual_input_only=manual_input_only,
+            ),
+            callbacks,
+            open_browser=open_browser,
+            signal=signal,
+        )
+        self._http = http_client
+
+    async def generate_auth_url(self, state: str, redirect_uri: str) -> str:
+        params = {
+            "redirect_uri": redirect_uri,
+            "response_type": "code",
+            "client_id": CLIENT_ID,
+            "state": state,
+        }
+        return f"{AUTHORIZE_URL}?{urllib.parse.urlencode(params)}"
+
+    async def exchange_token(self, code: str, state: str, redirect_uri: str) -> dict[str, Any]:
+        owns_client = self._http is None
+        http = self._http or httpx.AsyncClient(timeout=_TIMEOUT_S)
+        try:
+            body = await _post_json(
+                http,
+                TOKEN_URL,
+                # Deliberately NOT an RFC 6749 body: the provider's own client
+                # posts these fields and the endpoint rejects grant_type.
+                {"provider": "zai", "code": code, "redirect_uri": redirect_uri, "state": state},
+            )
+            data = _unwrap(body, "token exchange")
+            zai = data.get("zai") if isinstance(data, dict) else None
+            access_token = _trimmed(zai.get("access_token")) if isinstance(zai, dict) else None
+            if not access_token:
+                raise LoginError("Z.AI token response is missing an access token")
+
+            minted = await mint_zai_api_key(http, access_token)
+        finally:
+            if owns_client:
+                await http.aclose()
+
+        user = data.get("user") if isinstance(data, dict) else None
+        creds: dict[str, Any] = {
+            # The MINTED key, not the OAuth token: this is what the inference
+            # endpoint accepts, and `_oauth_api_key` hands it straight to the wire.
+            "access": minted,
+            # No refresh token exists and the minted key does not expire.
+            # `expires: None` is AuthStore's "static token" marker, so no
+            # refresh is ever attempted and the row persists across sessions.
+            "expires": None,
+            "authorized_at": int(time.time() * 1000),
+        }
+        if isinstance(user, dict):
+            email = _trimmed(user.get("email"))
+            if email:
+                creds["email"] = email
+            account_id = user.get("id")
+            if isinstance(account_id, (str, int)) and str(account_id).strip():
+                creds["account_id"] = str(account_id).strip()
+        return creds
+
+
+async def login_zai(
+    callbacks: LoginCallbacks,
+    *,
+    signal: AbortSignal | None = None,
+    http_client: httpx.AsyncClient | None = None,
+    open_browser: Callable[[str], None] | None = None,
+    manual_input_only: bool = False,
+) -> dict[str, Any]:
+    """Run the interactive Z.AI sign-in; returns the OAuthCredentials dict."""
+    flow = ZaiOAuthFlow(
+        callbacks,
+        open_browser=open_browser,
+        signal=signal,
+        manual_input_only=manual_input_only,
+        http_client=http_client,
+    )
+    return await flow.run()

--- a/local_operator/providers/oauth/zai.py
+++ b/local_operator/providers/oauth/zai.py
@@ -42,6 +42,7 @@ from local_operator.harness.types import AbortSignal
 from local_operator.providers.oauth.callback_server import (
     CallbackFlowOptions,
     LoginCallbacks,
+    LoginCancelledError,
     LoginError,
     OAuthCallbackFlow,
 )
@@ -116,10 +117,25 @@ def _trimmed(value: Any) -> str | None:
     return None
 
 
+def _failed(url: str, response: httpx.Response) -> LoginError:
+    """A transport failure, named by ENDPOINT and status rather than by body.
+
+    The body is deliberately not echoed. These endpoints are handed bearer
+    tokens and their error payloads quote request context back; a login error is
+    shown in the TUI and written to the log, so a raw body is the one place a
+    token could leak out of this module. The path and status are what a reader
+    needs in order to act.
+    """
+    return LoginError(
+        f"Z.AI request to {urllib.parse.urlsplit(url).path} failed "
+        f"({response.status_code} {response.reason_phrase})".rstrip()
+    )
+
+
 async def _get_json(http: httpx.AsyncClient, url: str, headers: dict[str, str]) -> Any:
     response = await http.get(url, headers=headers)
     if response.status_code != 200:
-        raise LoginError(f"Z.AI request failed ({response.status_code}) for {url}: {response.text}")
+        raise _failed(url, response)
     return response.json() if response.content else None
 
 
@@ -128,7 +144,7 @@ async def _post_json(
 ) -> Any:
     response = await http.post(url, json=body, headers=headers or {})
     if response.status_code != 200:
-        raise LoginError(f"Z.AI request failed ({response.status_code}) for {url}: {response.text}")
+        raise _failed(url, response)
     return response.json() if response.content else None
 
 
@@ -253,6 +269,14 @@ class ZaiOAuthFlow(OAuthCallbackFlow):
         return f"{AUTHORIZE_URL}?{urllib.parse.urlencode(params)}"
 
     async def exchange_token(self, code: str, state: str, redirect_uri: str) -> dict[str, Any]:
+        # Checked BEFORE the exchange, as the reference implementation does.
+        # This flow has a side effect no other login here has: it CREATES a
+        # named API key in the user's Z.AI console. Minting one for a login the
+        # user has already cancelled leaves a credential they never agreed to
+        # and did not see created.
+        if self._signal is not None and self._signal.aborted:
+            raise LoginCancelledError(self._signal.reason or "Z.AI login cancelled")
+
         owns_client = self._http is None
         http = self._http or httpx.AsyncClient(timeout=_TIMEOUT_S)
         try:

--- a/local_operator/providers/oauth/zai.py
+++ b/local_operator/providers/oauth/zai.py
@@ -117,34 +117,40 @@ def _trimmed(value: Any) -> str | None:
     return None
 
 
-def _failed(url: str, response: httpx.Response) -> LoginError:
-    """A transport failure, named by ENDPOINT and status rather than by body.
+def _failed(operation: str, response: httpx.Response) -> LoginError:
+    """A transport failure, named by OPERATION and status.
 
-    The body is deliberately not echoed. These endpoints are handed bearer
-    tokens and their error payloads quote request context back; a login error is
-    shown in the TUI and written to the log, so a raw body is the one place a
-    token could leak out of this module. The path and status are what a reader
-    needs in order to act.
+    Neither the body nor the URL is echoed. The bodies come from endpoints that
+    are handed bearer tokens and quote request context back, and the URLs embed
+    the account's organization id, project id and api-key id -- while a login
+    error is shown in the TUI and written to the log. The operation name says
+    which step failed, which is what a reader needs in order to act, without
+    putting account identifiers in front of them.
     """
     return LoginError(
-        f"Z.AI request to {urllib.parse.urlsplit(url).path} failed "
-        f"({response.status_code} {response.reason_phrase})".rstrip()
+        f"Z.AI {operation} failed ({response.status_code} {response.reason_phrase})".rstrip()
     )
 
 
-async def _get_json(http: httpx.AsyncClient, url: str, headers: dict[str, str]) -> Any:
+async def _get_json(
+    http: httpx.AsyncClient, url: str, headers: dict[str, str], operation: str
+) -> Any:
     response = await http.get(url, headers=headers)
     if response.status_code != 200:
-        raise _failed(url, response)
+        raise _failed(operation, response)
     return response.json() if response.content else None
 
 
 async def _post_json(
-    http: httpx.AsyncClient, url: str, body: dict[str, Any], headers: dict[str, str] | None = None
+    http: httpx.AsyncClient,
+    url: str,
+    body: dict[str, Any],
+    operation: str,
+    headers: dict[str, str] | None = None,
 ) -> Any:
     response = await http.post(url, json=body, headers=headers or {})
     if response.status_code != 200:
-        raise _failed(url, response)
+        raise _failed(operation, response)
     return response.json() if response.content else None
 
 
@@ -163,7 +169,7 @@ def _key_array(value: Any) -> list[dict[str, Any]]:
 async def _business_login(http: httpx.AsyncClient, oauth_access_token: str) -> str:
     """Trade the short-lived OAuth token for the biz token the APIs require."""
     data = _unwrap(
-        await _post_json(http, BUSINESS_LOGIN_URL, {"token": oauth_access_token}),
+        await _post_json(http, BUSINESS_LOGIN_URL, {"token": oauth_access_token}, "business login"),
         "business login",
     )
     token = None
@@ -185,7 +191,9 @@ async def mint_zai_api_key(http: httpx.AsyncClient, oauth_access_token: str) -> 
     auth = {"Authorization": f"Bearer {biz_token}"}
 
     customer = _unwrap(
-        await _get_json(http, f"{BIZ_BASE}/api/biz/customer/getCustomerInfo", auth),
+        await _get_json(
+            http, f"{BIZ_BASE}/api/biz/customer/getCustomerInfo", auth, "customer lookup"
+        ),
         "customer lookup",
     )
     orgs = customer.get("organizations") if isinstance(customer, dict) else None
@@ -206,13 +214,16 @@ async def mint_zai_api_key(http: httpx.AsyncClient, oauth_access_token: str) -> 
     existing = next(
         (
             k
-            for k in _key_array(_unwrap(await _get_json(http, keys_url, auth), "api key list"))
+            for k in _key_array(
+                _unwrap(await _get_json(http, keys_url, auth, "api key list"), "api key list")
+            )
             if k.get("name") == KEY_NAME
         ),
         None,
     )
     record = existing or _unwrap(
-        await _post_json(http, keys_url, {"name": KEY_NAME}, auth), "api key create"
+        await _post_json(http, keys_url, {"name": KEY_NAME}, "api key create", auth),
+        "api key create",
     )
     api_key = _trimmed(record.get("apiKey")) if isinstance(record, dict) else None
     if not api_key:
@@ -223,7 +234,9 @@ async def mint_zai_api_key(http: httpx.AsyncClient, oauth_access_token: str) -> 
     # across account states, so anything else can persist a key that cannot
     # authenticate — and it would fail at the first request, not at login.
     copied = _unwrap(
-        await _get_json(http, f"{keys_url}/copy/{urllib.parse.quote(api_key)}", auth),
+        await _get_json(
+            http, f"{keys_url}/copy/{urllib.parse.quote(api_key)}", auth, "api key copy"
+        ),
         "api key copy",
     )
     secret_key = _trimmed(copied.get("secretKey")) if isinstance(copied, dict) else None
@@ -286,6 +299,7 @@ class ZaiOAuthFlow(OAuthCallbackFlow):
                 # Deliberately NOT an RFC 6749 body: the provider's own client
                 # posts these fields and the endpoint rejects grant_type.
                 {"provider": "zai", "code": code, "redirect_uri": redirect_uri, "state": state},
+                "token exchange",
             )
             data = _unwrap(body, "token exchange")
             zai = data.get("zai") if isinstance(data, dict) else None

--- a/local_operator/providers/registry.py
+++ b/local_operator/providers/registry.py
@@ -47,6 +47,16 @@ class ProviderDefinition:
     - ``allows_missing_api_key``: transport needs no bearer (local servers).
     - ``store_credentials_as``: alias the credential row under another
       provider id (xai-oauth ⇒ xai; openai-device ⇒ openai).
+    - ``oauth_base_url``: host to use when the resolved credential is an OAuth
+      token, for providers that serve subscription sign-ins and pay-as-you-go
+      API keys from DIFFERENT hosts. Kimi is the case that forced it: the
+      coding-plan OAuth grant is only accepted at ``api.kimi.com/coding/v1``
+      (which is where ``k3`` lives), while ``KIMI_API_KEY`` belongs to the
+      mainland ``api.moonshot.cn/v1`` platform and 401s there. One ``base_url``
+      per provider therefore cannot be right for both credential kinds, and the
+      symptom is silent: model discovery 401s, falls back to the static
+      registry, and the picker shows a years-old model list.
+      ``None`` means the provider serves both kinds from ``base_url``.
     - ``wire``: which wire client serves this provider.
     - ``search_aliases``: other names a USER would type for this provider —
       almost always the model family it is known by (``claude`` for anthropic,
@@ -81,6 +91,7 @@ class ProviderDefinition:
     callback_port: int | None = None
     paste_code_flow: bool = False
     base_url: str | None = None
+    oauth_base_url: str | None = None
     wire: WireFormat = "openai-compat"
     search_aliases: tuple[str, ...] = ()
     #: Whether this login cannot complete without reading text from the user.
@@ -306,6 +317,7 @@ PROVIDER_REGISTRY: list[ProviderDefinition] = [
         search_aliases=(
             "moonshot",
             "k2",
+            "k3",
         ),
         name="Kimi (Moonshot)",
         env_keys="KIMI_API_KEY",
@@ -313,6 +325,12 @@ PROVIDER_REGISTRY: list[ProviderDefinition] = [
         refresh_token=_lazy_refresh("local_operator.providers.oauth.kimi", "refresh_kimi_token"),
         get_api_key=_oauth_api_key,
         base_url="https://api.moonshot.cn/v1",
+        # The coding-plan host, used only for OAuth sign-ins. It is a different
+        # PLATFORM from the mainland API-key host above, not merely a different
+        # path: it is where the subscription's models live (`k3`, `k3-256k`,
+        # `kimi-for-coding`), and the mainland host rejects the OAuth bearer
+        # with 401 "Invalid Authentication". Confirmed live against both hosts.
+        oauth_base_url="https://api.kimi.com/coding/v1",
     ),
     ProviderDefinition(
         id="xai",
@@ -363,6 +381,32 @@ PROVIDER_REGISTRY: list[ProviderDefinition] = [
         # account balance instead, which is the same key silently spending the
         # wrong budget. Mirrors omp's `zhipuCodingPlanModelManagerOptions`.
         base_url="https://api.z.ai/api/coding/paas/v4",
+    ),
+    ProviderDefinition(
+        id="zai-oauth",
+        search_aliases=(
+            "glm",
+            "zhipu",
+            "bigmodel",
+            "z-ai",
+        ),
+        name="Z.AI (GLM Coding Plan · Sign in)",
+        # Browser sign-in rather than a pasted key. The flow ends by minting a
+        # durable `id.secret` API key, which is what `access` holds and what the
+        # wire receives -- so this shares `zai`'s credential row, base URL and
+        # models, exactly as `xai-oauth` shares `xai`'s.
+        login=_lazy_login("local_operator.providers.oauth.zai", "login_zai"),
+        get_api_key=_oauth_api_key,
+        store_credentials_as="zai",
+        # Pinned by the provider's OAuth client registration; port fallback is
+        # refused, which `ZaiOAuthFlow` states again as `allow_port_fallback`.
+        callback_port=54548,
+        # Paste-the-redirect-URL fallback for when the browser cannot reach this
+        # machine (a remote or headless session), as for anthropic.
+        paste_code_flow=True,
+        base_url="https://api.z.ai/api/coding/paas/v4",
+        # No refresh_token: the minted key never expires, so there is nothing to
+        # refresh. `expires: None` stops AuthStore from ever trying.
     ),
     ProviderDefinition(
         id="google",

--- a/local_operator/providers/usage.py
+++ b/local_operator/providers/usage.py
@@ -187,10 +187,14 @@ _FETCHERS: dict[str, tuple[FetcherKind | None, FetcherKind | None]] = {
     "xai-oauth": ("xai-oauth", None),
     "alibaba-token-plan": ("qwencloud-token-plan", None),
     "alibaba-token-plan-oauth": ("qwencloud-token-plan", None),
-    # The coding-plan key is the only credential Z.AI issues for this route, and
-    # the same raw key authenticates both inference and the quota endpoint, so
-    # the api-key slot serves it and there is no OAuth half to route.
-    "zai": (None, "zai-quota"),
+    # Both slots run the SAME fetcher, because both credential kinds are the
+    # same secret: the `zai-oauth` browser sign-in ends by minting an ordinary
+    # durable `id.secret` coding-plan key and stores it in `access`, which is
+    # exactly what the quota endpoint authenticates with. Leaving the OAuth slot
+    # empty made `/provider` advertise Z.AI usage and then report nothing at all
+    # for anyone who signed in rather than pasting a key.
+    "zai": ("zai-quota", "zai-quota"),
+    "zai-oauth": ("zai-quota", "zai-quota"),
 }
 
 #: Providers with a live quota endpoint, for callers that only need the question

--- a/tests/unit/providers/test_auth_store.py
+++ b/tests/unit/providers/test_auth_store.py
@@ -773,3 +773,48 @@ class TestADemotionEndsOnItsOwn:
         assert store._active_demotions("anthropic") == set()
         order = store._selection_order(store.list_credentials("anthropic"), "anthropic", "s1")
         assert [r.id for r in order] == [r.id for r in store.list_credentials("anthropic")]
+
+
+class TestARefreshlessOAuthCredentialIsReadable:
+    """R21: a credential that is OAuth-issued but never expires.
+
+    `upsert_credential` guessed the type from "has both refresh and access",
+    which cannot see a credential with no refresh token because it does not
+    expire -- Z.AI's coding-plan sign-in mints exactly that. Such a row landed
+    as `api_key` with its secret under `data["access"]`, where NOTHING can read
+    it: tiers 4 and 6 read `data["key"]`, tier 3 only walks `oauth` rows. The
+    login reported success and every later request failed with no credential,
+    behind this PR's new "temporarily unavailable" message.
+    """
+
+    async def test_an_explicit_type_survives_the_structural_guess(self, tmp_path: Any) -> None:
+        from local_operator.providers.auth_store import AuthStore
+
+        store = AuthStore(db_path=tmp_path / "auth.db")
+        row = store.upsert_credential(
+            "zai",
+            {
+                "type": "oauth",
+                "access": "key-id.sec-ret",
+                "expires": None,  # minted key: never expires, so no refresh exists
+                "email": "damian@example.com",
+                "account_id": "42",
+            },
+        )
+
+        assert row.credential_type == "oauth"
+        assert await store.get_api_key("zai") == "key-id.sec-ret"
+        access = await store.get_oauth_access("zai")
+        assert access is not None and access.kind == "oauth"
+        assert access.email == "damian@example.com"
+
+    async def test_an_undeclared_credential_still_gets_the_old_guess(self, tmp_path: Any) -> None:
+        """The structural fallback is unchanged for every existing caller."""
+        from local_operator.providers.auth_store import AuthStore
+
+        store = AuthStore(db_path=tmp_path / "auth.db")
+        oauth = store.upsert_credential("openai", {"access": "a", "refresh": "r", "expires": 1})
+        pasted = store.upsert_credential("openai", {"key": "sk-1", "source": "login"})
+
+        assert oauth.credential_type == "oauth"
+        assert pasted.credential_type == "api_key"

--- a/tests/unit/providers/test_auth_store.py
+++ b/tests/unit/providers/test_auth_store.py
@@ -698,7 +698,7 @@ class TestDemotionLifecycle:
 
         # Every row demoted is the branch that clears; under read_only it must not.
         store._selection_order(rows, "anthropic", "s1", read_only=True)
-        assert store._deprioritized.get("anthropic") == {rows[0].id, rows[1].id}
+        assert set(store._deprioritized.get("anthropic", {})) == {rows[0].id, rows[1].id}
 
         store._selection_order(rows, "anthropic", "s1")
         assert not store._deprioritized.get("anthropic")
@@ -732,3 +732,44 @@ class TestDemotionLifecycle:
 
         # The row that served the request is no longer demoted.
         assert rows[1].id not in store._deprioritized.get("anthropic", set())
+
+
+class TestADemotionEndsOnItsOwn:
+    """R18: clearing on success cannot be the only exit.
+
+    A demoted credential sorts LAST, so it is not selected, so it never earns
+    the success that would clear it. Without an expiry a single 529 left an
+    account at the back of the pool for the life of the process -- the same
+    "healthy account out of rotation" outcome the demotion exists to prevent.
+    """
+
+    def test_a_mark_expires_after_its_ttl(self, tmp_path: Any) -> None:
+        from local_operator.providers import auth_store as auth_store_mod
+        from local_operator.providers.auth_store import AuthStore
+
+        store = AuthStore(db_path=tmp_path / "auth.db")
+        rows = [
+            store.upsert_credential(
+                "anthropic",
+                {
+                    "type": "oauth",
+                    "access": f"k{i}",
+                    "refresh": "r",
+                    "expires": None,
+                    "email": f"a{i}@example.com",
+                },
+            )
+            for i in range(2)
+        ]
+        store.deprioritize_credential("anthropic", rows[0].id)
+        assert store._active_demotions("anthropic") == {rows[0].id}
+
+        # Travel past the TTL rather than sleeping through it.
+        real_now = store._now_ms()
+        store._now_ms = staticmethod(  # type: ignore[method-assign]
+            lambda: real_now + auth_store_mod.DEPRIORITIZE_TTL_MS + 1
+        )
+
+        assert store._active_demotions("anthropic") == set()
+        order = store._selection_order(store.list_credentials("anthropic"), "anthropic", "s1")
+        assert [r.id for r in order] == [r.id for r in store.list_credentials("anthropic")]

--- a/tests/unit/providers/test_auth_store.py
+++ b/tests/unit/providers/test_auth_store.py
@@ -818,3 +818,50 @@ class TestARefreshlessOAuthCredentialIsReadable:
 
         assert oauth.credential_type == "oauth"
         assert pasted.credential_type == "api_key"
+
+
+class TestADemotedRowDoesNotHoldItsTier:
+    """R34: demotion must move a turn on, even across cascade TIERS.
+
+    The cascade is a sequence of tiers consulted whole -- an OAuth row, or an
+    api_key row with `source="login"`, wins before a later tier is looked at.
+    Sorting a demoted row last therefore did nothing when it was ALONE in its
+    tier: it kept winning the cascade, while `rotate_sibling` kept reporting a
+    sibling existed, so the driver believed rotation was progressing while the
+    same failing bearer came back every time. A healthy credential one tier down
+    never received a single request -- and this is exactly the shape `zai-oauth`
+    creates beside a pasted key.
+    """
+
+    @staticmethod
+    def _store(tmp_path: Any) -> Any:
+        from local_operator.providers.auth_store import AuthStore
+
+        return AuthStore(db_path=tmp_path / "auth.db")
+
+    async def test_a_sibling_in_another_tier_is_reachable(self, tmp_path: Any) -> None:
+        store = self._store(tmp_path)
+        login_row = store.upsert_credential(
+            "anthropic", {"type": "api_key", "key": "login-key", "source": "login"}
+        )
+        store.upsert_credential("anthropic", {"type": "api_key", "key": "migrated-key"})
+
+        # The tier-4 row fails on a PROVIDER fault, so it is demoted, not blocked.
+        store.deprioritize_credential("anthropic", login_row.id)
+
+        # The cascade must now reach the tier-6 row rather than re-serving the
+        # demoted one from the tier above.
+        assert await store.get_api_key("anthropic") == "migrated-key"
+
+    async def test_the_last_credential_is_still_served_when_all_are_demoted(
+        self, tmp_path: Any
+    ) -> None:
+        """Dropping is conditional: with nothing else reachable the marks
+        describe an outage rather than an account, and must not empty the pool."""
+        store = self._store(tmp_path)
+        row = store.upsert_credential(
+            "anthropic", {"type": "api_key", "key": "only-key", "source": "login"}
+        )
+        store.deprioritize_credential("anthropic", row.id)
+
+        assert await store.get_api_key("anthropic") == "only-key"

--- a/tests/unit/providers/test_auth_store.py
+++ b/tests/unit/providers/test_auth_store.py
@@ -865,3 +865,61 @@ class TestADemotedRowDoesNotHoldItsTier:
         store.deprioritize_credential("anthropic", row.id)
 
         assert await store.get_api_key("anthropic") == "only-key"
+
+
+class TestADemotionSurvivesAMixedPool:
+    """R36/R37: the two ways a demotion stopped moving a turn on.
+
+    Both were edges of the same idea -- "is anything else reachable?" answered
+    by looking at the credential TABLE, which is the question this PR has
+    already been wrong about five times on the failover side.
+    """
+
+    async def test_a_row_with_no_same_type_sibling_stays_demoted(self, tmp_path: Any) -> None:
+        """R36: `rotate_sibling`'s sibling list is filtered by credential_type,
+        so an OAuth row beside a pasted key has no same-type sibling. Clearing
+        the mark there erased it in the very call that set it, and tier 3
+        re-served the identical failing row forever -- the exact shape a Z.AI
+        sign-in creates beside an API key."""
+        from local_operator.providers.auth_store import AuthStore
+        from local_operator.providers.failover import ProviderError
+
+        store = AuthStore(db_path=tmp_path / "auth.db")
+        oauth_row = store.upsert_credential(
+            "anthropic",
+            {"type": "oauth", "access": "oauth-down", "refresh": "r", "expires": None},
+        )
+        store.upsert_credential(
+            "anthropic", {"type": "api_key", "key": "apikey-healthy", "source": "login"}
+        )
+
+        store.rotate_sibling(
+            "anthropic",
+            "s1",
+            ProviderError(500, "permanent", retryable=True),
+            api_key="oauth-down",
+        )
+
+        assert oauth_row.id in store._active_demotions("anthropic")
+        # And the cascade now reaches the healthy credential in the next tier.
+        assert await store.get_api_key("anthropic") == "apikey-healthy"
+
+    async def test_a_demoted_lone_row_still_yields_to_the_env_var(
+        self, tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """R37: the cascade also resolves from the env var (tier 5) and the
+        fallback resolver (tier 7), which are not rows -- so a guard that
+        counted rows to decide whether to yield made an exported key
+        unreachable where it used to be the fallback."""
+        from local_operator.providers.auth_store import AuthStore
+
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "env-fallback-key")
+        store = AuthStore(db_path=tmp_path / "auth.db")
+        row = store.upsert_credential(
+            "anthropic",
+            {"type": "oauth", "access": "oauth-down", "refresh": "r", "expires": None},
+        )
+
+        assert await store.get_api_key("anthropic") == "oauth-down"
+        store.deprioritize_credential("anthropic", row.id)
+        assert await store.get_api_key("anthropic") == "env-fallback-key"

--- a/tests/unit/providers/test_auth_store.py
+++ b/tests/unit/providers/test_auth_store.py
@@ -663,3 +663,72 @@ class TestDeprioritizationSurvivesTheOrderingItIsAppliedTo:
 
         assert rows[0].id not in store._deprioritized.get("anthropic", set())
         assert rows[1].id in store._deprioritized.get("anthropic", set())
+
+
+class TestDemotionLifecycle:
+    """A demotion mark must end -- on success, and never from a read."""
+
+    @staticmethod
+    def _store(tmp_path: Any) -> tuple[Any, list[Any]]:
+        from local_operator.providers.auth_store import AuthStore
+
+        store = AuthStore(db_path=tmp_path / "auth.db")
+        rows = [
+            store.upsert_credential(
+                "anthropic",
+                {
+                    "type": "oauth",
+                    "access": f"k{i}",
+                    "refresh": "r",
+                    "expires": None,
+                    "email": f"a{i}@example.com",
+                },
+            )
+            for i in range(2)
+        ]
+        return store, rows
+
+    def test_an_isolated_read_never_clears_a_mark(self, tmp_path: Any) -> None:
+        """`read_only` is the isolated request's contract: it resolves without
+        making any routing decision, and clearing a demotion is one. A
+        decorative call running beside a turn must not move that turn's pool."""
+        store, rows = self._store(tmp_path)
+        for row in rows:
+            store.deprioritize_credential("anthropic", row.id)
+
+        # Every row demoted is the branch that clears; under read_only it must not.
+        store._selection_order(rows, "anthropic", "s1", read_only=True)
+        assert store._deprioritized.get("anthropic") == {rows[0].id, rows[1].id}
+
+        store._selection_order(rows, "anthropic", "s1")
+        assert not store._deprioritized.get("anthropic")
+
+    async def test_a_credential_that_serves_a_request_regains_its_priority(
+        self, tmp_path: Any
+    ) -> None:
+        """Otherwise the mark outlives the outage for the life of the process,
+        leaving a healthy account permanently last."""
+        from local_operator.harness.types import ChatRequest, ModelSpec
+        from local_operator.providers.failover import stream_with_failover
+
+        store, rows = self._store(tmp_path)
+        store.deprioritize_credential("anthropic", rows[0].id)
+
+        class _Ok:
+            async def stream(self, request: Any, key: Any, oauth_access: Any = None) -> Any:
+                return
+                yield
+
+        async def client_for(spec: Any) -> Any:
+            return _Ok()
+
+        request = ChatRequest(
+            model=ModelSpec(provider="anthropic", model_id="claude-opus-5"), messages=[]
+        )
+        async for _ in stream_with_failover(
+            request, store, {"retry": {"enabled": True}}, client_for, session_id="s1"
+        ):
+            pass
+
+        # The row that served the request is no longer demoted.
+        assert rows[1].id not in store._deprioritized.get("anthropic", set())

--- a/tests/unit/providers/test_auth_store.py
+++ b/tests/unit/providers/test_auth_store.py
@@ -488,3 +488,110 @@ class TestListOauthAccesses:
         accesses = await store.list_oauth_accesses("anthropic")
         assert [a.email for a in accesses] == ["b@example.com"]
         assert store.is_blocked(row.id, "anthropic") is False
+
+
+class TestProviderOutageDoesNotBlockHealthyAccounts:
+    """A 529 is the provider failing, not the credential.
+
+    Blocking on a provider-side fault walks the whole pool into the blocked
+    state during an outage -- every account unusable for a minute because the
+    provider had a bad second -- which is how a session with four Anthropic
+    accounts ran out of credentials to try.
+    """
+
+    @staticmethod
+    def _store(tmp_path: Any, count: int = 3) -> tuple[Any, list[Any]]:
+        from local_operator.providers.auth_store import AuthStore
+
+        store = AuthStore(db_path=tmp_path / "auth.db")
+        # Distinct emails: the real pool is several ACCOUNTS, and rows without
+        # a distinct identity dedupe onto one row by design.
+        rows = [
+            store.upsert_credential(
+                "anthropic",
+                {
+                    "type": "oauth",
+                    "access": f"tok-{i}",
+                    "refresh": "r",
+                    "expires": None,
+                    "email": f"damian+{i}@example.com",
+                },
+            )
+            for i in range(count)
+        ]
+        return store, rows
+
+    def test_a_529_deprioritizes_rather_than_blocks(self, tmp_path: Any) -> None:
+        from local_operator.providers.failover import ProviderError
+
+        store, rows = self._store(tmp_path)
+        overloaded = ProviderError(529, "overloaded_error: Overloaded", retryable=True)
+
+        assert store.rotate_sibling("anthropic", "s1", overloaded, api_key="tok-0") is True
+        # Still usable: the account did nothing wrong.
+        assert store.is_blocked(rows[0].id, "anthropic") is False
+        # But it is no longer first choice, so the next attempt moves on.
+        order = store._selection_order(store.list_credentials("anthropic"), "anthropic", None)
+        assert order[-1].id == rows[0].id
+
+    def test_a_quota_error_still_blocks_the_account_that_ran_out(self, tmp_path: Any) -> None:
+        """The distinction is the point: a spent window IS about the credential."""
+        from local_operator.providers.failover import ProviderError
+
+        store, rows = self._store(tmp_path)
+        quota = ProviderError(429, "rate_limit_error: usage limit reached", retryable=True)
+
+        store.rotate_sibling("anthropic", "s1", quota, api_key="tok-0")
+        assert store.is_blocked(rows[0].id, "anthropic") is True
+
+    def test_an_outage_across_the_whole_pool_leaves_every_account_usable(
+        self, tmp_path: Any
+    ) -> None:
+        """The regression, stated directly: after a 529 on each account in turn,
+        the pool must not be empty."""
+        from local_operator.providers.failover import ProviderError
+
+        store, rows = self._store(tmp_path)
+        overloaded = ProviderError(529, "overloaded_error: Overloaded", retryable=True)
+
+        for row in rows:
+            store.rotate_sibling("anthropic", "s1", overloaded, api_key=row.data["access"])
+
+        assert [store.is_blocked(row.id, "anthropic") for row in rows] == [False] * len(rows)
+        # And selection still offers all of them once the pool has been walked.
+        order = store._selection_order(store.list_credentials("anthropic"), "anthropic", None)
+        assert len(order) == len(rows)
+
+
+class TestAggregatorKeysNeverSatisfyANamedProvider:
+    """An aggregator credential must not silently answer for a direct provider.
+
+    A session diagnosed its own `No API key configured for provider 'openai'`
+    as "auth is via RADIENT_API_KEY, so the openai fallback has no key". The
+    first half was right and the second was a guess: the resolution cascade is
+    strictly per-provider, and this pins that so a future convenience shortcut
+    ("fall back to whatever gateway key we have") cannot be added by accident.
+    Spending an aggregator's credit for a provider the user named, and routing
+    through two hops instead of one, are both silent when they happen.
+    """
+
+    async def test_a_radient_key_answers_only_for_radient(
+        self, tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from local_operator.providers.auth_store import AuthStore
+
+        monkeypatch.setenv("RADIENT_API_KEY", "radient-secret")
+        store = AuthStore(db_path=tmp_path / "auth.db")
+
+        assert await store.get_api_key("radient") == "radient-secret"
+        for named in ("openai", "anthropic", "kimi", "zai"):
+            assert await store.get_api_key(named) is None, named
+
+    async def test_an_aggregator_is_reached_only_when_named(self) -> None:
+        """Aggregators are opt-in by SELECTION, not by credential availability:
+        they resell the same models, so nothing may route to one implicitly."""
+        from local_operator.providers.registry import AGGREGATOR_PROVIDERS
+
+        # The set exists and is exactly the resellers -- a direct provider
+        # appearing here would make it reachable as an implicit substitute.
+        assert AGGREGATOR_PROVIDERS == {"openrouter", "radient"}

--- a/tests/unit/providers/test_auth_store.py
+++ b/tests/unit/providers/test_auth_store.py
@@ -923,3 +923,107 @@ class TestADemotionSurvivesAMixedPool:
         assert await store.get_api_key("anthropic") == "oauth-down"
         store.deprioritize_credential("anthropic", row.id)
         assert await store.get_api_key("anthropic") == "env-fallback-key"
+
+    async def test_an_isolated_resolve_is_not_handed_only_the_destructive_half(
+        self, tmp_path: Any
+    ) -> None:
+        """A ``read_only`` resolve must serve a demoted lone row.
+
+        Demotion has a destructive half (``_usable_key_rows`` drops the row from
+        its tier) and a restorative half (the second pass that resolves again
+        once demotions are the only thing left standing in the way). The drop
+        carries no ``read_only`` gate, so gating only the restorative half gave
+        the isolated caller the destructive one alone: a lone credential with a
+        single provider-side fault resolved to ``None`` for it while the normal
+        path still returned the key. That reports "no credential configured" for
+        a credential that is merely deprioritised -- the misdiagnosis this whole
+        change set exists to remove -- and it silently stopped session titling
+        for the mark's full TTL.
+        """
+        from local_operator.providers.auth_store import AuthStore
+
+        store = AuthStore(db_path=tmp_path / "auth.db")
+        row = store.upsert_credential(
+            "anthropic", {"type": "api_key", "key": "only-key", "source": "login"}
+        )
+        store.deprioritize_credential("anthropic", row.id)
+
+        assert await store.get_api_key("anthropic", read_only=True) == "only-key"
+
+    async def test_an_isolated_resolve_serves_a_demoted_row_without_clearing_it(
+        self, tmp_path: Any
+    ) -> None:
+        """...and it gets there WITHOUT taking the routing decision.
+
+        Clearing the marks is what the user's own turn does when it finds
+        nowhere left to route; an isolated request running beside that turn must
+        not be able to move it. So the second pass suppresses the clear under
+        ``read_only`` and re-resolves ignoring the marks instead: same answer,
+        no state touched. A demoted row that still has a healthy sibling must
+        also keep losing to it, or "ignore the marks" would become "resurrect
+        the failing account".
+        """
+        from local_operator.providers.auth_store import AuthStore
+
+        store = AuthStore(db_path=tmp_path / "auth.db")
+        row = store.upsert_credential(
+            "anthropic", {"type": "api_key", "key": "only-key", "source": "login"}
+        )
+        store.deprioritize_credential("anthropic", row.id)
+
+        assert await store.get_api_key("anthropic", read_only=True) == "only-key"
+        assert store._active_demotions("anthropic") == {row.id}
+
+        # The normal path still owns the decision, and still clears.
+        assert await store.get_api_key("anthropic") == "only-key"
+        assert store._active_demotions("anthropic") == set()
+
+        # A healthy sibling still outranks a demoted row under read_only.
+        sibling_store = AuthStore(db_path=tmp_path / "sibling.db")
+        bad = sibling_store.upsert_credential(
+            "anthropic", {"type": "api_key", "key": "bad-key", "source": "login"}
+        )
+        sibling_store.upsert_credential(
+            "anthropic", {"type": "api_key", "key": "good-key", "source": "login"}
+        )
+        sibling_store.deprioritize_credential("anthropic", bad.id)
+
+        assert await sibling_store.get_api_key("anthropic", read_only=True) == "good-key"
+
+    async def test_the_second_pass_leaves_other_providers_marks_alone(self, tmp_path: Any) -> None:
+        """The second pass is provider-keyed.
+
+        It runs at the end of a cascade for ONE provider, so it may only speak
+        for that provider's marks: a concurrent turn on another provider is
+        mid-rotation and its demotions are load-bearing.
+        """
+        from local_operator.providers.auth_store import AuthStore
+
+        store = AuthStore(db_path=tmp_path / "auth.db")
+        anthropic_row = store.upsert_credential(
+            "anthropic", {"type": "api_key", "key": "anthropic-key", "source": "login"}
+        )
+        openai_row = store.upsert_credential(
+            "openai", {"type": "api_key", "key": "openai-key", "source": "login"}
+        )
+        store.deprioritize_credential("anthropic", anthropic_row.id)
+        store.deprioritize_credential("openai", openai_row.id)
+
+        assert await store.get_api_key("anthropic") == "anthropic-key"
+        assert store._active_demotions("openai") == {openai_row.id}
+
+    async def test_a_provider_with_no_credential_still_resolves_to_none(
+        self, tmp_path: Any
+    ) -> None:
+        """The second pass must not invent a credential.
+
+        It only fires when marks exist, so an unconfigured provider (and a
+        blocked one, which the marks do not describe) still comes back ``None``
+        rather than being papered over by the retry.
+        """
+        from local_operator.providers.auth_store import AuthStore
+
+        store = AuthStore(db_path=tmp_path / "auth.db")
+
+        assert await store.get_api_key("anthropic") is None
+        assert await store.get_api_key("anthropic", read_only=True) is None

--- a/tests/unit/providers/test_auth_store.py
+++ b/tests/unit/providers/test_auth_store.py
@@ -595,3 +595,71 @@ class TestAggregatorKeysNeverSatisfyANamedProvider:
         # The set exists and is exactly the resellers -- a direct provider
         # appearing here would make it reachable as an implicit substitute.
         assert AGGREGATOR_PROVIDERS == {"openrouter", "radient"}
+
+
+class TestDeprioritizationSurvivesTheOrderingItIsAppliedTo:
+    """Demotion must not be undone by the ordering that follows it.
+
+    Round 1 review (R1) caught this shipping green: the mark was applied BEFORE
+    the sticky/hash/round-robin step, and both of those rotate the list
+    (``rows[i:] + rows[:i]``), so a row moved to the back was rotated forward
+    again. The tests then in place only asserted ``session_id=None`` on a
+    four-row pool -- the one shape whose rotation happened to be a no-op.
+    """
+
+    @staticmethod
+    def _store(tmp_path: Any, count: int) -> tuple[Any, list[Any]]:
+        from local_operator.providers.auth_store import AuthStore
+
+        store = AuthStore(db_path=tmp_path / "auth.db")
+        rows = [
+            store.upsert_credential(
+                "anthropic",
+                {
+                    "type": "oauth",
+                    "access": f"k{i}",
+                    "refresh": "r",
+                    "expires": None,
+                    "email": f"a{i}@example.com",
+                },
+            )
+            for i in range(count)
+        ]
+        return store, rows
+
+    @pytest.mark.parametrize("pool_size", [2, 3, 4, 5])
+    @pytest.mark.parametrize("session_id", [None, "s1", "s2", "s3", "session-abc"])
+    def test_a_demoted_row_is_last_for_every_pool_size_and_session(
+        self, tmp_path: Any, pool_size: int, session_id: str | None
+    ) -> None:
+        """Swept, because the bug hid in the arithmetic of ONE size/session pair."""
+        store, rows = self._store(tmp_path, pool_size)
+        store.deprioritize_credential("anthropic", rows[0].id)
+
+        order = store._selection_order(store.list_credentials("anthropic"), "anthropic", session_id)
+
+        assert order[-1].id == rows[0].id, [r.data["access"] for r in order]
+        assert len(order) == pool_size  # still selectable, never dropped
+
+    def test_a_demoted_row_outranked_by_nothing_is_still_offered(self, tmp_path: Any) -> None:
+        """A single-credential pool must still return that credential."""
+        store, rows = self._store(tmp_path, 1)
+        store.deprioritize_credential("anthropic", rows[0].id)
+
+        order = store._selection_order(store.list_credentials("anthropic"), "anthropic", "s1")
+        assert [r.id for r in order] == [rows[0].id]
+
+    def test_clearing_one_tiers_marks_leaves_another_tiers_alone(self, tmp_path: Any) -> None:
+        """R3: the cascade calls `_selection_order` once per credential TIER with
+        a different subset, so a one-row tier finding its only row demoted must
+        not wipe marks belonging to rows it never saw."""
+        store, rows = self._store(tmp_path, 3)
+        store.deprioritize_credential("anthropic", rows[0].id)
+        store.deprioritize_credential("anthropic", rows[1].id)
+
+        # A "tier" containing only the first row: every row in it is demoted, so
+        # its marks are treated as stale and cleared.
+        store._selection_order([rows[0]], "anthropic", "s1")
+
+        assert rows[0].id not in store._deprioritized.get("anthropic", set())
+        assert rows[1].id in store._deprioritized.get("anthropic", set())

--- a/tests/unit/providers/test_failover.py
+++ b/tests/unit/providers/test_failover.py
@@ -649,7 +649,11 @@ async def test_transport_retries_honor_budget_same_key_first() -> None:
     assert excinfo.value.status == 503
     # Two same-key retries before rotation, then the sibling once.
     assert attempts == ["k1", "k1", "k1", "k2", "k2", "k2"]
-    assert len(auth.rotations) == 1  # rotation only after the budget is spent
+    # One rotation per exhausted credential. The last key rotates too, and finds
+    # no further sibling: a 5xx is a PROVIDER fault, so every account in the pool
+    # is asked before the turn is declared dead. Capping this at one rotation is
+    # what stranded two healthy Anthropic accounts during a 529 storm.
+    assert [key for _provider, key in auth.rotations] == ["k1", "k2"]
 
 
 async def test_long_rate_limit_retry_after_rotates_without_sleep(monkeypatch) -> None:
@@ -1832,3 +1836,120 @@ class TestAnIsolatedRequestCannotDegradeTheTurnBesideIt:
         assert slept, "no backoff was spent"
         assert client.calls > 1, "only one attempt was made"
         assert state.active is not None, "no route was pinned"
+
+
+class TestProviderOutageWalksTheWholePool:
+    """A provider-side fault must ask every account, and blame none of them.
+
+    The reported incident: four Anthropic OAuth accounts, a 529
+    ``overloaded_error`` storm, and a turn that died reporting the 529 after
+    trying TWO of them. Two accounts with quota were never asked.
+    """
+
+    async def test_a_529_storm_tries_every_credential_in_the_pool(self) -> None:
+        """The regression: rotation stopped at the ordinary-401 switch cap."""
+        tried: list[str | None] = []
+
+        def overloaded(
+            request: ChatRequest, api_key: str | None, oauth_access: Any = None
+        ) -> AsyncIterator[Any]:
+            tried.append(api_key)
+            raise ProviderError(529, "overloaded_error: Overloaded", retryable=True)
+
+        async def client_for(spec: ModelSpec) -> Any:
+            return _FnClient(overloaded)
+
+        auth = FakeAuth({"openai": ["acct-a", "acct-b", "acct-c", "acct-d"]})
+        settings = {"retry": {"baseDelayMs": 0, "maxRetries": 0, "fallbackChains": {}}}
+        with pytest.raises(ProviderError) as excinfo:
+            async for _ in stream_with_failover(_request(), auth, settings, client_for):
+                pass
+
+        assert excinfo.value.status == 529
+        assert set(tried) == {"acct-a", "acct-b", "acct-c", "acct-d"}, tried
+
+    async def test_an_ordinary_401_still_stops_after_one_switch(self) -> None:
+        """The cap is kept where it belongs: a rejected bearer is not a pool problem.
+
+        Cycling every sibling on a 401 only delays the login prompt the user has
+        to answer anyway, so widening rotation must not have widened this.
+        """
+        tried: list[str | None] = []
+
+        def unauthorized(
+            request: ChatRequest, api_key: str | None, oauth_access: Any = None
+        ) -> AsyncIterator[Any]:
+            tried.append(api_key)
+            raise ProviderError(401, "invalid bearer", retryable=False, auth_error=True)
+
+        async def client_for(spec: ModelSpec) -> Any:
+            return _FnClient(unauthorized)
+
+        auth = FakeAuth({"openai": ["acct-a", "acct-b", "acct-c", "acct-d"]})
+        settings = {"retry": {"baseDelayMs": 0, "maxRetries": 0, "fallbackChains": {}}}
+        with pytest.raises(ProviderError):
+            async for _ in stream_with_failover(_request(), auth, settings, client_for):
+                pass
+
+        assert len(tried) < 4, f"a 401 walked the whole pool: {tried}"
+
+
+class TestCredentialErrorSaysWhichProblemItIs:
+    """ "No API key configured" must not be said to a user who is signed in."""
+
+    async def test_a_rate_limited_oauth_account_is_not_reported_as_unconfigured(
+        self, tmp_path: Any
+    ) -> None:
+        """The reported frame: `No API key configured for provider 'openai'`
+        shown while an OAuth sign-in existed and was merely blocked."""
+        from local_operator.providers.auth_store import AuthStore
+
+        store = AuthStore(db_path=tmp_path / "auth.db")
+        row = store.upsert_credential(
+            "openai",
+            {"type": "oauth", "access": "tok", "refresh": "r", "expires": None},
+        )
+        store.block_credential(row.id, "openai", block_ms=600_000)
+
+        def unreachable(
+            request: ChatRequest, api_key: str | None, oauth_access: Any = None
+        ) -> AsyncIterator[Any]:
+            raise AssertionError("no request should be sent without a bearer")
+
+        async def client_for(spec: ModelSpec) -> Any:
+            # Built before the credential is resolved, so the guard belongs on
+            # the STREAM rather than on construction.
+            return _FnClient(unreachable)
+
+        with pytest.raises(ProviderError) as excinfo:
+            async for _ in stream_with_failover(
+                _request(), store, {"retry": {"enabled": True}}, client_for
+            ):
+                pass
+
+        message = str(excinfo.value)
+        assert "No API key configured" not in message, message
+        assert "temporarily unavailable" in message
+        assert "OAuth sign-in" in message
+
+    async def test_a_provider_with_no_credential_still_says_so(self, tmp_path: Any) -> None:
+        """The original wording is correct when it is actually true."""
+        from local_operator.providers.auth_store import AuthStore
+
+        store = AuthStore(db_path=tmp_path / "auth.db")
+
+        def unreachable(
+            request: ChatRequest, api_key: str | None, oauth_access: Any = None
+        ) -> AsyncIterator[Any]:
+            raise AssertionError("no request should be sent without a bearer")
+
+        async def client_for(spec: ModelSpec) -> Any:
+            return _FnClient(unreachable)
+
+        with pytest.raises(ProviderError) as excinfo:
+            async for _ in stream_with_failover(
+                _request(), store, {"retry": {"enabled": True}}, client_for
+            ):
+                pass
+
+        assert "No API key configured for provider 'openai'" in str(excinfo.value)

--- a/tests/unit/providers/test_failover.py
+++ b/tests/unit/providers/test_failover.py
@@ -32,7 +32,7 @@ from local_operator.providers.failover import (
     FallbackTarget,
     ProviderError,
     RetrySettings,
-    _has_rotatable_sibling,
+    _request_has_rotated,
     backoff_delay_ms,
     classify_provider_error,
     expand_fallback_candidates,
@@ -649,12 +649,16 @@ async def test_transport_retries_honor_budget_same_key_first() -> None:
             pass
     assert excinfo.value.status == 503
     # Two same-key retries before rotation, then the sibling once.
-    assert attempts == ["k1", "k1", "k1", "k2", "k2", "k2"]
-    # One rotation per exhausted credential. The last key rotates too, and finds
-    # no further sibling: a 5xx is a PROVIDER fault, so every account in the pool
-    # is asked before the turn is declared dead. Capping this at one rotation is
-    # what stranded two healthy Anthropic accounts during a 529 storm.
-    assert [key for _provider, key in auth.rotations] == ["k1", "k2"]
+    # Each credential spends the configured budget, then the turn rotates; when
+    # rotation runs out the bearer in hand finishes its budget ONCE more, since
+    # the pre-rotation allowance exists only to get a turn moving to another
+    # account and there is no longer one to move to.
+    assert attempts == ["k1", "k1", "k1", "k2", "k2", "k2", "k2", "k2", "k2"]
+    # Every credential in the pool is asked before the turn is declared dead: a
+    # 5xx is a PROVIDER fault, so the next ACCOUNT is the thing most likely to
+    # succeed. Capping rotation at one switch is what stranded two healthy
+    # Anthropic accounts during a 529 storm.
+    assert [key for _provider, key in auth.rotations][:2] == ["k1", "k2"]
 
 
 async def test_long_rate_limit_retry_after_rotates_without_sleep(monkeypatch) -> None:
@@ -1930,7 +1934,13 @@ class TestCredentialErrorSaysWhichProblemItIs:
 
         message = str(excinfo.value)
         assert "No API key configured" not in message, message
-        assert "temporarily unavailable" in message
+        assert "not usable right now" in message
+        # The three causes a present-but-unresolvable row can have. A message
+        # naming only the first two told an R21 user to wait for a limit that
+        # was never the problem.
+        assert "rate limited" in message
+        assert "token refresh" in message
+        assert "could not be read" in message
         assert "OAuth sign-in" in message
 
     async def test_a_provider_with_no_credential_still_says_so(self, tmp_path: Any) -> None:
@@ -2018,9 +2028,11 @@ class TestAnOverloadedProviderIsNotFloodedWhileRotating:
 
         # Every account is still tried -- the pool walk is the point.
         assert set(sent) == {"k1", "k2", "k3", "k4"}, sent
-        # But each is asked a bounded number of times, not `maxRetries` times.
+        # Each is asked a bounded number of times, not `maxRetries` times, and
+        # the TURN total is bounded too -- that is the quantity the provider
+        # actually receives.
         for key in ("k1", "k2", "k3", "k4"):
-            assert sent.count(key) <= 3, (key, sent)
+            assert sent.count(key) <= 4, (key, sent)
         assert len(sent) <= 12, sent
 
     async def test_a_timeout_storm_is_bounded_too(self, tmp_path: Any) -> None:
@@ -2200,93 +2212,32 @@ class TestTheRetryCapAsksWhatRotationWouldAnswer:
         assert await self._recovers(store) == 4
 
 
-class TestRotatableSiblingDirectly:
-    """Direct coverage for `_has_rotatable_sibling`.
+class TestTheCapEngagesOnObservedRotation:
+    """Direct coverage for `_request_has_rotated`.
 
-    Round 4 (R20) noted that this predicate had NO direct test and that no
-    failover test resolved through the cascade's override/env tiers, which is
-    why four consecutive rounds each narrowed "what counts as a pool" by one
-    step and each stopped one step short:
+    Five rounds of review each found the previous PREDICTION of "is there a
+    sibling?" drifting from what the cascade actually does -- rows, then
+    unblocked rows, then same-type rows, then rows behind an override, then
+    rows split across cascade tiers. Each drift cost a real user retries.
 
-    R11 counted rows, R16 counted blocked rows, R20 counted rows the cascade
-    can never select. Enumerating the shapes here, rather than only asserting
-    request counts end to end, is what stops a fifth.
+    The question is now answered by observation: `attempted_keys` is the set of
+    distinct bearers `resolve_next_key` has already returned, so the cap
+    engages exactly when a second one exists and cannot be wrong about a
+    configuration it never enumerates. These tests pin that contract.
     """
 
-    @staticmethod
-    def _store(tmp_path: Any) -> Any:
-        from local_operator.providers.auth_store import AuthStore
+    def test_no_bearer_yet_is_not_a_pool(self) -> None:
+        assert not _request_has_rotated(AuthRetryKeyState())
 
-        return AuthStore(db_path=tmp_path / "auth.db")
+    def test_one_bearer_is_not_a_pool(self) -> None:
+        """A lone credential, an override bearer, or a pool whose siblings are
+        all spent: whatever the table says, ONE bearer cannot multiply."""
+        state = AuthRetryKeyState(attempted_keys={"only"})
+        assert not _request_has_rotated(state)
 
-    @staticmethod
-    def _access(kind: str, credential_id: int) -> Any:
-        from local_operator.providers.auth_store import OAuthAccess
-
-        return OAuthAccess(access_token="t", credential_id=credential_id, kind=kind)
-
-    def _oauth(self, store: Any, n: int, provider: str = "openai") -> list[Any]:
-        return [
-            store.upsert_credential(
-                provider,
-                {
-                    "type": "oauth",
-                    "access": f"k{i}",
-                    "refresh": "r",
-                    "expires": None,
-                    "email": f"a{i}@example.com",
-                },
-            )
-            for i in range(n)
-        ]
-
-    def test_a_lone_credential_is_not_a_pool(self, tmp_path: Any) -> None:
-        store = self._store(tmp_path)
-        rows = self._oauth(store, 1)
-        assert not _has_rotatable_sibling(store, "openai", self._access("oauth", rows[0].id))
-
-    def test_two_healthy_siblings_are_a_pool(self, tmp_path: Any) -> None:
-        store = self._store(tmp_path)
-        rows = self._oauth(store, 2)
-        assert _has_rotatable_sibling(store, "openai", self._access("oauth", rows[0].id))
-
-    def test_blocked_siblings_do_not_count(self, tmp_path: Any) -> None:
-        """R16: a quota-blocked row is skipped by rotation and by the cascade."""
-        store = self._store(tmp_path)
-        rows = self._oauth(store, 4)
-        for row in rows[1:]:
-            store.block_credential(row.id, "openai", block_ms=600_000)
-        assert not _has_rotatable_sibling(store, "openai", self._access("oauth", rows[0].id))
-
-    def test_a_row_of_another_type_is_not_a_sibling(self, tmp_path: Any) -> None:
-        """R16: `rotate_sibling` only walks rows of the same credential_type."""
-        store = self._store(tmp_path)
-        oauth_row = self._oauth(store, 1)[0]
-        store.upsert_credential("openai", {"type": "api_key", "key": "sk", "source": "login"})
-        assert not _has_rotatable_sibling(store, "openai", self._access("oauth", oauth_row.id))
-
-    def test_a_bearer_with_no_row_behind_it_can_rotate_nowhere(self, tmp_path: Any) -> None:
-        """R20: the override/env tiers resolve to `credential_id=0`.
-
-        Rotation cannot move off such a bearer -- the same override wins the
-        cascade every time -- so stored rows beside it are unreachable by
-        construction, however many there are.
-        """
-        store = self._store(tmp_path)
-        self._oauth(store, 3)
-        # SEVERAL api_key rows, so a check that only matched on `kind` would
-        # find a "pool" here and cap the override's budget.
-        for i in range(2):
-            store.upsert_credential(
-                "openai", {"type": "api_key", "key": f"sk-{i}", "source": "login"}
-            )
-
-        assert not _has_rotatable_sibling(store, "openai", self._access("api_key", 0))
-
-    def test_a_store_that_cannot_enumerate_defaults_to_uncapped(self) -> None:
-        """No evidence of a pool means the user's configured budget stands."""
-        auth = FakeAuth({"openai": ["k1", "k2"]})
-        assert not _has_rotatable_sibling(auth, "openai", self._access("api_key", 1))
+    def test_a_second_distinct_bearer_is_a_pool(self) -> None:
+        state = AuthRetryKeyState(attempted_keys={"k1", "k2"})
+        assert _request_has_rotated(state)
 
 
 class TestAnOverrideBearerKeepsItsBudget:
@@ -2338,6 +2289,112 @@ class TestAnOverrideBearerKeepsItsBudget:
         finally:
             failover_module._abortable_sleep = original  # type: ignore[assignment]
 
-        # The override served every attempt, and kept the configured budget.
+        # The override served every attempt: there is no sibling to rotate to,
+        # so it is never starved by a pool that does not exist. It gets the
+        # pre-rotation allowance and then, once rotation reports exhaustion, the
+        # configured budget again -- well beyond the 3 requests the earlier
+        # table-counting versions allowed it.
         assert set(sent) == {"gateway-key"}, sent
-        assert len(sent) == 11, len(sent)
+        assert len(sent) >= 8, len(sent)
+
+
+class TestTheTurnWideCeiling:
+    """The per-credential cap bounds each account; this bounds their PRODUCT.
+
+    Widening rotation to walk the whole pool multiplied the load by the pool
+    size at exactly the moment the provider was asking for less. The quantity
+    that reaches the provider is the total, so that is what is bounded.
+    """
+
+    async def test_a_storm_never_exceeds_the_turn_ceiling(self, tmp_path: Any) -> None:
+        from local_operator.providers.auth_store import AuthStore
+        from local_operator.providers.failover import MAX_SERVER_FAULT_REQUESTS_PER_TURN
+
+        store = AuthStore(db_path=tmp_path / "auth.db")
+        for i in range(6):  # a pool larger than the ceiling would allow per-account
+            store.upsert_credential(
+                "openai",
+                {
+                    "type": "oauth",
+                    "access": f"k{i}",
+                    "refresh": "r",
+                    "expires": None,
+                    "email": f"a{i}@example.com",
+                },
+            )
+        sent: list[str | None] = []
+
+        def overloaded(
+            request: ChatRequest, api_key: str | None, oauth_access: Any = None
+        ) -> AsyncIterator[Any]:
+            sent.append(api_key)
+            raise ProviderError(529, "overloaded_error: Overloaded", retryable=True)
+
+        async def no_sleep(delay_ms: int, signal: Any) -> None:
+            return None
+
+        async def client_for(spec: ModelSpec) -> Any:
+            return _FnClient(overloaded)
+
+        original = failover_module._abortable_sleep
+        failover_module._abortable_sleep = no_sleep  # type: ignore[assignment]
+        try:
+            with pytest.raises(ProviderError):
+                async for _ in stream_with_failover(
+                    _request(), store, {"retry": {"enabled": True, "maxRetries": 10}}, client_for
+                ):
+                    pass
+        finally:
+            failover_module._abortable_sleep = original  # type: ignore[assignment]
+
+        assert len(sent) <= MAX_SERVER_FAULT_REQUESTS_PER_TURN + 1, len(sent)
+        # And it still rotated rather than hammering one account.
+        assert len(set(sent)) > 1, sent
+
+    async def test_api_key_rows_split_across_cascade_tiers_keep_their_budget(
+        self, tmp_path: Any
+    ) -> None:
+        """R22: `api_key` rows live in cascade tier 4 (`source == "login"`) and
+        tier 6, and a tier-4 row always wins -- so two rows of the same type can
+        still yield exactly one reachable bearer. Predicting this from the table
+        is what the observation model removes the need to do."""
+        from local_operator.providers.auth_store import AuthStore
+
+        store = AuthStore(db_path=tmp_path / "auth.db")
+        store.upsert_credential(
+            "openai", {"type": "api_key", "key": "login-key", "source": "login"}
+        )
+        store.upsert_credential("openai", {"type": "api_key", "key": "migrated-key"})
+
+        attempts = [0]
+
+        def blip_then_recover(
+            request: ChatRequest, api_key: str | None, oauth_access: Any = None
+        ) -> AsyncIterator[Any]:
+            attempts[0] += 1
+            if attempts[0] < 6:
+                raise ProviderError(500, "blip", retryable=True)
+            return _clean_stream()
+
+        async def no_sleep(delay_ms: int, signal: Any) -> None:
+            return None
+
+        async def client_for(spec: ModelSpec) -> Any:
+            return _FnClient(blip_then_recover)
+
+        original = failover_module._abortable_sleep
+        failover_module._abortable_sleep = no_sleep  # type: ignore[assignment]
+        try:
+            async for _ in stream_with_failover(
+                _request(),
+                store,
+                {"retry": {"enabled": True, "maxRetries": 10}},
+                client_for,
+                session_id="s",
+            ):
+                pass
+        finally:
+            failover_module._abortable_sleep = original  # type: ignore[assignment]
+
+        # Reached attempt 6 rather than being capped at 3.
+        assert attempts[0] == 6, attempts[0]

--- a/tests/unit/providers/test_failover.py
+++ b/tests/unit/providers/test_failover.py
@@ -32,6 +32,7 @@ from local_operator.providers.failover import (
     FallbackTarget,
     ProviderError,
     RetrySettings,
+    _has_rotatable_sibling,
     backoff_delay_ms,
     classify_provider_error,
     expand_fallback_candidates,
@@ -2197,3 +2198,146 @@ class TestTheRetryCapAsksWhatRotationWouldAnswer:
         store.upsert_credential("openai", {"type": "api_key", "key": "sk-1", "source": "login"})
 
         assert await self._recovers(store) == 4
+
+
+class TestRotatableSiblingDirectly:
+    """Direct coverage for `_has_rotatable_sibling`.
+
+    Round 4 (R20) noted that this predicate had NO direct test and that no
+    failover test resolved through the cascade's override/env tiers, which is
+    why four consecutive rounds each narrowed "what counts as a pool" by one
+    step and each stopped one step short:
+
+    R11 counted rows, R16 counted blocked rows, R20 counted rows the cascade
+    can never select. Enumerating the shapes here, rather than only asserting
+    request counts end to end, is what stops a fifth.
+    """
+
+    @staticmethod
+    def _store(tmp_path: Any) -> Any:
+        from local_operator.providers.auth_store import AuthStore
+
+        return AuthStore(db_path=tmp_path / "auth.db")
+
+    @staticmethod
+    def _access(kind: str, credential_id: int) -> Any:
+        from local_operator.providers.auth_store import OAuthAccess
+
+        return OAuthAccess(access_token="t", credential_id=credential_id, kind=kind)
+
+    def _oauth(self, store: Any, n: int, provider: str = "openai") -> list[Any]:
+        return [
+            store.upsert_credential(
+                provider,
+                {
+                    "type": "oauth",
+                    "access": f"k{i}",
+                    "refresh": "r",
+                    "expires": None,
+                    "email": f"a{i}@example.com",
+                },
+            )
+            for i in range(n)
+        ]
+
+    def test_a_lone_credential_is_not_a_pool(self, tmp_path: Any) -> None:
+        store = self._store(tmp_path)
+        rows = self._oauth(store, 1)
+        assert not _has_rotatable_sibling(store, "openai", self._access("oauth", rows[0].id))
+
+    def test_two_healthy_siblings_are_a_pool(self, tmp_path: Any) -> None:
+        store = self._store(tmp_path)
+        rows = self._oauth(store, 2)
+        assert _has_rotatable_sibling(store, "openai", self._access("oauth", rows[0].id))
+
+    def test_blocked_siblings_do_not_count(self, tmp_path: Any) -> None:
+        """R16: a quota-blocked row is skipped by rotation and by the cascade."""
+        store = self._store(tmp_path)
+        rows = self._oauth(store, 4)
+        for row in rows[1:]:
+            store.block_credential(row.id, "openai", block_ms=600_000)
+        assert not _has_rotatable_sibling(store, "openai", self._access("oauth", rows[0].id))
+
+    def test_a_row_of_another_type_is_not_a_sibling(self, tmp_path: Any) -> None:
+        """R16: `rotate_sibling` only walks rows of the same credential_type."""
+        store = self._store(tmp_path)
+        oauth_row = self._oauth(store, 1)[0]
+        store.upsert_credential("openai", {"type": "api_key", "key": "sk", "source": "login"})
+        assert not _has_rotatable_sibling(store, "openai", self._access("oauth", oauth_row.id))
+
+    def test_a_bearer_with_no_row_behind_it_can_rotate_nowhere(self, tmp_path: Any) -> None:
+        """R20: the override/env tiers resolve to `credential_id=0`.
+
+        Rotation cannot move off such a bearer -- the same override wins the
+        cascade every time -- so stored rows beside it are unreachable by
+        construction, however many there are.
+        """
+        store = self._store(tmp_path)
+        self._oauth(store, 3)
+        # SEVERAL api_key rows, so a check that only matched on `kind` would
+        # find a "pool" here and cap the override's budget.
+        for i in range(2):
+            store.upsert_credential(
+                "openai", {"type": "api_key", "key": f"sk-{i}", "source": "login"}
+            )
+
+        assert not _has_rotatable_sibling(store, "openai", self._access("api_key", 0))
+
+    def test_a_store_that_cannot_enumerate_defaults_to_uncapped(self) -> None:
+        """No evidence of a pool means the user's configured budget stands."""
+        auth = FakeAuth({"openai": ["k1", "k2"]})
+        assert not _has_rotatable_sibling(auth, "openai", self._access("api_key", 1))
+
+
+class TestAnOverrideBearerKeepsItsBudget:
+    """End to end through the cascade tier no failover test previously used.
+
+    R20 was invisible because every failover test resolves through the stored
+    credential tiers. A user who pasted API keys and then pointed at a gateway
+    (`--api-key`) or exported `ANTHROPIC_API_KEY` got 3 requests where `main`
+    gave 11 -- the cap firing on a bearer with nothing to rotate to.
+    """
+
+    async def test_a_runtime_override_is_not_capped_by_the_rows_beside_it(
+        self, tmp_path: Any
+    ) -> None:
+        from local_operator.providers.auth_store import AuthStore
+
+        store = AuthStore(db_path=tmp_path / "auth.db")
+        for i in range(2):
+            store.upsert_credential(
+                "openai", {"type": "api_key", "key": f"sk-{i}", "source": "login"}
+            )
+        store.set_runtime_api_key("openai", "gateway-key")
+
+        sent: list[str | None] = []
+
+        def overloaded(
+            request: ChatRequest, api_key: str | None, oauth_access: Any = None
+        ) -> AsyncIterator[Any]:
+            sent.append(api_key)
+            raise ProviderError(529, "overloaded_error: Overloaded", retryable=True)
+
+        async def no_sleep(delay_ms: int, signal: Any) -> None:
+            return None
+
+        async def client_for(spec: ModelSpec) -> Any:
+            return _FnClient(overloaded)
+
+        original = failover_module._abortable_sleep
+        failover_module._abortable_sleep = no_sleep  # type: ignore[assignment]
+        try:
+            with pytest.raises(ProviderError):
+                async for _ in stream_with_failover(
+                    _request(),
+                    store,
+                    {"retry": {"enabled": True, "maxRetries": 10, "baseDelayMs": 0}},
+                    client_for,
+                ):
+                    pass
+        finally:
+            failover_module._abortable_sleep = original  # type: ignore[assignment]
+
+        # The override served every attempt, and kept the configured budget.
+        assert set(sent) == {"gateway-key"}, sent
+        assert len(sent) == 11, len(sent)

--- a/tests/unit/providers/test_failover.py
+++ b/tests/unit/providers/test_failover.py
@@ -657,7 +657,7 @@ async def test_transport_retries_honor_budget_same_key_first() -> None:
     # 5xx is a PROVIDER fault, so the next ACCOUNT is the thing most likely to
     # succeed. Capping rotation at one switch is what stranded two healthy
     # Anthropic accounts during a 529 storm.
-    assert [key for _provider, key in auth.rotations][:2] == ["k1", "k2"]
+    assert [key for _provider, key in auth.rotations] == ["k1", "k2"]
 
 
 async def test_long_rate_limit_retry_after_rotates_without_sleep(monkeypatch) -> None:
@@ -2510,7 +2510,7 @@ class TestARestoredBudgetIsTheConfiguredOne:
             failover_module._abortable_sleep = original  # type: ignore[assignment]
         return attempts[0]
 
-    @pytest.mark.parametrize("max_retries", [0, 1, 3, 5, 10])
+    @pytest.mark.parametrize("max_retries", list(range(0, 12)))
     async def test_a_lone_credential_spends_exactly_its_configured_budget(
         self, tmp_path: Any, max_retries: int
     ) -> None:
@@ -2523,9 +2523,12 @@ class TestARestoredBudgetIsTheConfiguredOne:
         change whose whole purpose is to stop hammering a provider that is
         already failing.
 
-        Swept across the range because the doubling was nearly invisible at the
-        default (the turn ceiling masked it) and worst for the users who
-        deliberately configured a SMALL budget.
+        Swept across EVERY value rather than a sample. The first version of
+        this test checked 0/1/3/5/10 and stepped straight over the only setting
+        that was wrong: at `maxRetries: 4` the pre-rotation allowance lands
+        exactly ON the budget, and an exclusive `<` comparison skipped the
+        restore and cost the user their last request. A sampled sweep is how a
+        boundary bug survives a test written to catch boundary bugs.
         """
         from local_operator.providers.auth_store import AuthStore
 

--- a/tests/unit/providers/test_failover.py
+++ b/tests/unit/providers/test_failover.py
@@ -2398,3 +2398,134 @@ class TestTheTurnWideCeiling:
 
         # Reached attempt 6 rather than being capped at 3.
         assert attempts[0] == 6, attempts[0]
+
+
+class TestTheCeilingIsPerProviderNotPerTurn:
+    """R23: a chain stops being a chain if the primary spends its allowance.
+
+    The server-fault ceiling was counted across the whole turn, so a primary
+    outage consumed all of it and every fallback target got ONE attempt with no
+    retries -- a fallback that would have succeeded on its second try never got
+    one. Each target is a different service having a different day.
+    """
+
+    async def test_a_fallback_gets_a_real_budget_after_a_primary_storm(self, tmp_path: Any) -> None:
+        from local_operator.providers.auth_store import AuthStore
+
+        store = AuthStore(db_path=tmp_path / "auth.db")
+        for i in range(4):  # enough accounts to exhaust the primary's ceiling
+            store.upsert_credential(
+                "openai",
+                {
+                    "type": "oauth",
+                    "access": f"k{i}",
+                    "refresh": "r",
+                    "expires": None,
+                    "email": f"a{i}@example.com",
+                },
+            )
+        store.upsert_credential(
+            "anthropic",
+            {"type": "oauth", "access": "fallback", "refresh": "r", "expires": None},
+        )
+
+        per_provider: dict[str, int] = {}
+
+        def overloaded_then_fallback_recovers(
+            request: ChatRequest, api_key: str | None, oauth_access: Any = None
+        ) -> AsyncIterator[Any]:
+            provider = request.model.provider
+            per_provider[provider] = per_provider.get(provider, 0) + 1
+            # The fallback succeeds on its SECOND attempt -- it must be given one.
+            if provider == "anthropic" and per_provider[provider] >= 2:
+                return _clean_stream()
+            raise ProviderError(529, "overloaded_error: Overloaded", retryable=True)
+
+        async def no_sleep(delay_ms: int, signal: Any) -> None:
+            return None
+
+        async def client_for(spec: ModelSpec) -> Any:
+            return _FnClient(overloaded_then_fallback_recovers)
+
+        original = failover_module._abortable_sleep
+        failover_module._abortable_sleep = no_sleep  # type: ignore[assignment]
+        try:
+            async for _ in stream_with_failover(
+                _request(),
+                store,
+                {
+                    "retry": {
+                        "enabled": True,
+                        "fallbackChains": {"default": ["anthropic/claude-opus-5"]},
+                    }
+                },
+                client_for,
+                session_id="s",
+            ):
+                pass
+        finally:
+            failover_module._abortable_sleep = original  # type: ignore[assignment]
+
+        assert per_provider.get("anthropic", 0) >= 2, per_provider
+
+
+class TestARestoredBudgetIsTheConfiguredOne:
+    """R24: the restore-once path must express the budget the user asked for.
+
+    Zeroing the counter but re-entering the predicate as "not yet rotated"
+    re-capped the restored pass at the first-bearer allowance: a lone credential
+    got the same 8 requests whatever `maxRetries` said -- short of a configured
+    10, and double a configured 2. Wrong in both directions, which is the tell
+    that the mechanism was not saying what it meant.
+    """
+
+    @staticmethod
+    async def _requests_for(store: Any, max_retries: int) -> int:
+        attempts = [0]
+
+        def always_500(
+            request: ChatRequest, api_key: str | None, oauth_access: Any = None
+        ) -> AsyncIterator[Any]:
+            attempts[0] += 1
+            raise ProviderError(500, "blip", retryable=True)
+
+        async def no_sleep(delay_ms: int, signal: Any) -> None:
+            return None
+
+        async def client_for(spec: ModelSpec) -> Any:
+            return _FnClient(always_500)
+
+        original = failover_module._abortable_sleep
+        failover_module._abortable_sleep = no_sleep  # type: ignore[assignment]
+        try:
+            with pytest.raises(ProviderError):
+                async for _ in stream_with_failover(
+                    _request(),
+                    store,
+                    {"retry": {"enabled": True, "maxRetries": max_retries}},
+                    client_for,
+                    session_id="s",
+                ):
+                    pass
+        finally:
+            failover_module._abortable_sleep = original  # type: ignore[assignment]
+        return attempts[0]
+
+    async def test_a_lone_credential_scales_with_the_configured_budget(self, tmp_path: Any) -> None:
+        """The point is that it MOVES with the setting; the earlier form
+        returned the same number for every value."""
+        from local_operator.providers.auth_store import AuthStore
+
+        counts = []
+        for max_retries in (2, 4, 10):
+            store = AuthStore(db_path=tmp_path / f"auth-{max_retries}.db")
+            store.upsert_credential(
+                "openai",
+                {"type": "oauth", "access": "only", "refresh": "r", "expires": None},
+            )
+            counts.append(await self._requests_for(store, max_retries))
+
+        assert counts[0] < counts[1] < counts[2], counts
+        # And a lone credential rides out a blip that clears late, as it did
+        # before any of this work (main recovered through attempt 11).
+        assert counts[2] >= 11, counts

--- a/tests/unit/providers/test_failover.py
+++ b/tests/unit/providers/test_failover.py
@@ -648,11 +648,17 @@ async def test_transport_retries_honor_budget_same_key_first() -> None:
         async for _ in stream_with_failover(_request(), auth, settings, client_for):
             pass
     assert excinfo.value.status == 503
-    # Two same-key retries before rotation, then the sibling once.
-    # Each credential spends the configured budget, then the turn rotates; when
-    # rotation runs out the bearer in hand finishes its budget ONCE more, since
-    # the pre-rotation allowance exists only to get a turn moving to another
-    # account and there is no longer one to move to.
+    # `k1` spends its budget, the turn rotates to `k2`, and when rotation then
+    # reports no further sibling the bearer in hand is restored for one more
+    # pass -- the pre-rotation allowance exists only to get a turn moving to
+    # another account, and there is no longer one to move to.
+    #
+    # `k2` therefore appears twice over: `transport_retries` is reset whenever
+    # the resolved token changes, and rotation exhausting resolves to None
+    # first, so the restored pass starts a fresh budget rather than the
+    # remainder of the spent one. That accounting is PRE-EXISTING -- `main`
+    # produces the same per-credential counts for the same settings -- and the
+    # turn ceiling is what bounds it; see the note at the restore site.
     assert attempts == ["k1", "k1", "k1", "k2", "k2", "k2", "k2", "k2", "k2"]
     # Every credential in the pool is asked before the turn is declared dead: a
     # 5xx is a PROVIDER fault, so the next ACCOUNT is the thing most likely to

--- a/tests/unit/providers/test_failover.py
+++ b/tests/unit/providers/test_failover.py
@@ -648,18 +648,11 @@ async def test_transport_retries_honor_budget_same_key_first() -> None:
         async for _ in stream_with_failover(_request(), auth, settings, client_for):
             pass
     assert excinfo.value.status == 503
-    # `k1` spends its budget, the turn rotates to `k2`, and when rotation then
-    # reports no further sibling the bearer in hand is restored for one more
-    # pass -- the pre-rotation allowance exists only to get a turn moving to
-    # another account, and there is no longer one to move to.
-    #
-    # `k2` therefore appears twice over: `transport_retries` is reset whenever
-    # the resolved token changes, and rotation exhausting resolves to None
-    # first, so the restored pass starts a fresh budget rather than the
-    # remainder of the spent one. That accounting is PRE-EXISTING -- `main`
-    # produces the same per-credential counts for the same settings -- and the
-    # turn ceiling is what bounds it; see the note at the restore site.
-    assert attempts == ["k1", "k1", "k1", "k2", "k2", "k2", "k2", "k2", "k2"]
+    # Two same-key retries before rotation, then the sibling gets the same --
+    # the sequence this test has always asserted, and the one `main` produces.
+    # The restore-once path hands back the REMAINDER of the configured budget
+    # rather than a fresh one, so it adds nothing here.
+    assert attempts == ["k1", "k1", "k1", "k2", "k2", "k2"]
     # Every credential in the pool is asked before the turn is declared dead: a
     # 5xx is a PROVIDER fault, so the next ACCOUNT is the thing most likely to
     # succeed. Capping rotation at one switch is what stranded two healthy
@@ -2517,21 +2510,29 @@ class TestARestoredBudgetIsTheConfiguredOne:
             failover_module._abortable_sleep = original  # type: ignore[assignment]
         return attempts[0]
 
-    async def test_a_lone_credential_scales_with_the_configured_budget(self, tmp_path: Any) -> None:
-        """The point is that it MOVES with the setting; the earlier form
-        returned the same number for every value."""
+    @pytest.mark.parametrize("max_retries", [0, 1, 3, 5, 10])
+    async def test_a_lone_credential_spends_exactly_its_configured_budget(
+        self, tmp_path: Any, max_retries: int
+    ) -> None:
+        """`max_retries + 1` requests -- the same total as before this change.
+
+        The restore-once path hands back the REMAINDER of the user's budget; it
+        neither zeroes the counter nor reopens the budget. An earlier form let
+        the token-change reset zero it first, so a lone credential spent
+        `2 x (max_retries + 1)` requests -- twice what was asked for, inside a
+        change whose whole purpose is to stop hammering a provider that is
+        already failing.
+
+        Swept across the range because the doubling was nearly invisible at the
+        default (the turn ceiling masked it) and worst for the users who
+        deliberately configured a SMALL budget.
+        """
         from local_operator.providers.auth_store import AuthStore
 
-        counts = []
-        for max_retries in (2, 4, 10):
-            store = AuthStore(db_path=tmp_path / f"auth-{max_retries}.db")
-            store.upsert_credential(
-                "openai",
-                {"type": "oauth", "access": "only", "refresh": "r", "expires": None},
-            )
-            counts.append(await self._requests_for(store, max_retries))
+        store = AuthStore(db_path=tmp_path / f"auth-{max_retries}.db")
+        store.upsert_credential(
+            "openai",
+            {"type": "oauth", "access": "only", "refresh": "r", "expires": None},
+        )
 
-        assert counts[0] < counts[1] < counts[2], counts
-        # And a lone credential rides out a blip that clears late, as it did
-        # before any of this work (main recovered through attempt 11).
-        assert counts[2] >= 11, counts
+        assert await self._requests_for(store, max_retries) == max_retries + 1

--- a/tests/unit/providers/test_failover.py
+++ b/tests/unit/providers/test_failover.py
@@ -1953,3 +1953,76 @@ class TestCredentialErrorSaysWhichProblemItIs:
                 pass
 
         assert "No API key configured for provider 'openai'" in str(excinfo.value)
+
+
+class TestAnOverloadedProviderIsNotFloodedWhileRotating:
+    """Widening rotation must not multiply the load aimed at the outage.
+
+    Round 1 review (R2): the same-credential transport budget is spent once per
+    ACCOUNT, so the default `maxRetries: 10` became 10 x pool size requests sent
+    to a provider that had just answered "overloaded" -- measured at 44 requests
+    over ~190s for a four-account pool, against 22/~100s before the widening.
+    """
+
+    async def test_a_529_storm_is_bounded_per_account(self) -> None:
+        sent: list[str | None] = []
+        slept: list[int] = []
+
+        def overloaded(
+            request: ChatRequest, api_key: str | None, oauth_access: Any = None
+        ) -> AsyncIterator[Any]:
+            sent.append(api_key)
+            raise ProviderError(529, "overloaded_error: Overloaded", retryable=True)
+
+        async def no_sleep(delay_ms: int, signal: Any) -> None:
+            slept.append(delay_ms)
+
+        async def client_for(spec: ModelSpec) -> Any:
+            return _FnClient(overloaded)
+
+        original = failover_module._abortable_sleep
+        failover_module._abortable_sleep = no_sleep  # type: ignore[assignment]
+        try:
+            auth = FakeAuth({"openai": ["k1", "k2", "k3", "k4"]})
+            # The DEFAULT budget, which is the configuration that misbehaved.
+            with pytest.raises(ProviderError):
+                async for _ in stream_with_failover(
+                    _request(), auth, {"retry": {"enabled": True}}, client_for
+                ):
+                    pass
+        finally:
+            failover_module._abortable_sleep = original  # type: ignore[assignment]
+
+        # Every account is still tried -- the pool walk is the point.
+        assert set(sent) == {"k1", "k2", "k3", "k4"}, sent
+        # But each is asked a bounded number of times, not `maxRetries` times.
+        for key in ("k1", "k2", "k3", "k4"):
+            assert sent.count(key) <= 3, (key, sent)
+        assert len(sent) <= 12, sent
+
+    async def test_an_ordinary_5xx_on_a_single_account_keeps_its_full_budget(self) -> None:
+        """The cap is per-account and only for server faults: a lone credential
+        must still get the retries the user configured."""
+        sent: list[str | None] = []
+
+        def flaky(
+            request: ChatRequest, api_key: str | None, oauth_access: Any = None
+        ) -> AsyncIterator[Any]:
+            sent.append(api_key)
+            raise ProviderError(500, "boom", retryable=True)
+
+        async def client_for(spec: ModelSpec) -> Any:
+            return _FnClient(flaky)
+
+        auth = FakeAuth({"openai": ["only"]})
+        with pytest.raises(ProviderError):
+            async for _ in stream_with_failover(
+                _request(),
+                auth,
+                {"retry": {"enabled": True, "baseDelayMs": 0, "maxRetries": 2}},
+                client_for,
+            ):
+                pass
+
+        # maxRetries=2 is below the server cap, so the user's setting governs.
+        assert sent == ["only", "only", "only"], sent

--- a/tests/unit/providers/test_failover.py
+++ b/tests/unit/providers/test_failover.py
@@ -2118,3 +2118,82 @@ class TestAnOverloadedProviderIsNotFloodedWhileRotating:
 
         # The 4th attempt has to be REACHED; a cap of 2 would have stopped at 3.
         assert attempts[0] == 4, attempts[0]
+
+
+class TestTheRetryCapAsksWhatRotationWouldAnswer:
+    """R16: the cap is justified by a sibling the turn can ACTUALLY rotate onto.
+
+    Counting raw credential rows claimed a pool in two configurations where
+    rotation reaches nothing, and the cap then removed retries with nowhere to
+    spend them -- R11's symptom through a different door.
+    """
+
+    @staticmethod
+    def _blip_client(attempts: list[int]) -> Any:
+        def blip_then_recover(
+            request: ChatRequest, api_key: str | None, oauth_access: Any = None
+        ) -> AsyncIterator[Any]:
+            attempts[0] += 1
+            if attempts[0] < 4:
+                raise ProviderError(500, "blip", retryable=True)
+            return _clean_stream()
+
+        return blip_then_recover
+
+    async def _recovers(self, store: Any) -> int:
+        attempts = [0]
+        client = self._blip_client(attempts)
+
+        async def no_sleep(delay_ms: int, signal: Any) -> None:
+            return None
+
+        async def client_for(spec: ModelSpec) -> Any:
+            return _FnClient(client)
+
+        original = failover_module._abortable_sleep
+        failover_module._abortable_sleep = no_sleep  # type: ignore[assignment]
+        try:
+            async for _ in stream_with_failover(
+                _request(), store, {"retry": {"enabled": True}}, client_for, session_id="s"
+            ):
+                pass
+        finally:
+            failover_module._abortable_sleep = original  # type: ignore[assignment]
+        return attempts[0]
+
+    async def test_a_blocked_sibling_is_not_a_pool(self, tmp_path: Any) -> None:
+        """This PR's own headline shape: several accounts spent during a
+        degradation, one healthy. The survivor must keep its full budget."""
+        from local_operator.providers.auth_store import AuthStore
+
+        store = AuthStore(db_path=tmp_path / "auth.db")
+        rows = [
+            store.upsert_credential(
+                "openai",
+                {
+                    "type": "oauth",
+                    "access": f"k{i}",
+                    "refresh": "r",
+                    "expires": None,
+                    "email": f"a{i}@example.com",
+                },
+            )
+            for i in range(4)
+        ]
+        for row in rows[1:]:
+            store.block_credential(row.id, "openai", block_ms=600_000)
+
+        assert await self._recovers(store) == 4
+
+    async def test_a_different_credential_type_is_not_a_sibling(self, tmp_path: Any) -> None:
+        """`rotate_sibling` only walks rows of the SAME credential_type, so an
+        OAuth sign-in beside a pasted API key is two rows and zero rotation."""
+        from local_operator.providers.auth_store import AuthStore
+
+        store = AuthStore(db_path=tmp_path / "auth.db")
+        store.upsert_credential(
+            "openai", {"type": "oauth", "access": "o1", "refresh": "r", "expires": None}
+        )
+        store.upsert_credential("openai", {"type": "api_key", "key": "sk-1", "source": "login"})
+
+        assert await self._recovers(store) == 4

--- a/tests/unit/providers/test_failover.py
+++ b/tests/unit/providers/test_failover.py
@@ -1955,6 +1955,12 @@ class TestCredentialErrorSaysWhichProblemItIs:
         assert "No API key configured for provider 'openai'" in str(excinfo.value)
 
 
+async def _clean_stream() -> AsyncIterator[Any]:
+    """A stream that completes without events: the attempt SUCCEEDED."""
+    return
+    yield
+
+
 class TestAnOverloadedProviderIsNotFloodedWhileRotating:
     """Widening rotation must not multiply the load aimed at the outage.
 
@@ -1964,7 +1970,7 @@ class TestAnOverloadedProviderIsNotFloodedWhileRotating:
     over ~190s for a four-account pool, against 22/~100s before the widening.
     """
 
-    async def test_a_529_storm_is_bounded_per_account(self) -> None:
+    async def test_a_529_storm_is_bounded_per_account(self, tmp_path: Any) -> None:
         sent: list[str | None] = []
         slept: list[int] = []
 
@@ -1980,14 +1986,30 @@ class TestAnOverloadedProviderIsNotFloodedWhileRotating:
         async def client_for(spec: ModelSpec) -> Any:
             return _FnClient(overloaded)
 
+        # A REAL store: the cap only applies when the pool is enumerable and has
+        # more than one member, which is the condition it is justified by.
+        from local_operator.providers.auth_store import AuthStore
+
+        store = AuthStore(db_path=tmp_path / "auth.db")
+        for i in range(1, 5):
+            store.upsert_credential(
+                "openai",
+                {
+                    "type": "oauth",
+                    "access": f"k{i}",
+                    "refresh": "r",
+                    "expires": None,
+                    "email": f"a{i}@example.com",
+                },
+            )
+
         original = failover_module._abortable_sleep
         failover_module._abortable_sleep = no_sleep  # type: ignore[assignment]
         try:
-            auth = FakeAuth({"openai": ["k1", "k2", "k3", "k4"]})
             # The DEFAULT budget, which is the configuration that misbehaved.
             with pytest.raises(ProviderError):
                 async for _ in stream_with_failover(
-                    _request(), auth, {"retry": {"enabled": True}}, client_for
+                    _request(), store, {"retry": {"enabled": True}}, client_for
                 ):
                     pass
         finally:
@@ -2000,29 +2022,99 @@ class TestAnOverloadedProviderIsNotFloodedWhileRotating:
             assert sent.count(key) <= 3, (key, sent)
         assert len(sent) <= 12, sent
 
-    async def test_an_ordinary_5xx_on_a_single_account_keeps_its_full_budget(self) -> None:
-        """The cap is per-account and only for server faults: a lone credential
-        must still get the retries the user configured."""
+    async def test_a_timeout_storm_is_bounded_too(self, tmp_path: Any) -> None:
+        """R10: the cap was installed only on the `except ProviderError` arm.
+
+        Raw transport failures take the `except Exception` arm -- no client in
+        `clients.py` catches httpx, and `_guarded_chunks` deliberately raises
+        `ReadTimeout` on a stall -- which kept its own uncapped budget. That is
+        the failure kind a provider degradation most often produces, so the
+        bound was missing exactly where it was needed: 44 requests/~196s
+        measured, twice the pre-change behaviour.
+        """
+        import httpx
+
+        from local_operator.providers.auth_store import AuthStore
+
+        store = AuthStore(db_path=tmp_path / "auth.db")
+        for i in range(4):
+            store.upsert_credential(
+                "openai",
+                {
+                    "type": "oauth",
+                    "access": f"k{i}",
+                    "refresh": "r",
+                    "expires": None,
+                    "email": f"a{i}@example.com",
+                },
+            )
         sent: list[str | None] = []
 
-        def flaky(
+        def stalled(
             request: ChatRequest, api_key: str | None, oauth_access: Any = None
         ) -> AsyncIterator[Any]:
             sent.append(api_key)
-            raise ProviderError(500, "boom", retryable=True)
+            raise httpx.ReadTimeout("stream stalled")
+
+        async def no_sleep(delay_ms: int, signal: Any) -> None:
+            return None
 
         async def client_for(spec: ModelSpec) -> Any:
-            return _FnClient(flaky)
+            return _FnClient(stalled)
 
-        auth = FakeAuth({"openai": ["only"]})
-        with pytest.raises(ProviderError):
+        original = failover_module._abortable_sleep
+        failover_module._abortable_sleep = no_sleep  # type: ignore[assignment]
+        try:
+            with pytest.raises(ProviderError):
+                async for _ in stream_with_failover(
+                    _request(), store, {"retry": {"enabled": True}}, client_for
+                ):
+                    pass
+        finally:
+            failover_module._abortable_sleep = original  # type: ignore[assignment]
+
+        assert len(sent) <= 12, f"a timeout storm sent {len(sent)} requests"
+
+    async def test_a_lone_credential_keeps_the_budget_the_user_configured(
+        self, tmp_path: Any
+    ) -> None:
+        """R11: the cap is justified by pool MULTIPLICATION, so it must not bite
+        where there is no pool. With one credential the earlier form failed a
+        500 blip that cleared on attempt 4 -- a regression against `main` for
+        the users least able to absorb one.
+        """
+        from local_operator.providers.auth_store import AuthStore
+
+        store = AuthStore(db_path=tmp_path / "auth.db")
+        store.upsert_credential(
+            "openai",
+            {"type": "oauth", "access": "only", "refresh": "r", "expires": None},
+        )
+        attempts = [0]
+
+        def blip_then_recover(
+            request: ChatRequest, api_key: str | None, oauth_access: Any = None
+        ) -> AsyncIterator[Any]:
+            attempts[0] += 1
+            if attempts[0] < 4:
+                raise ProviderError(500, "blip", retryable=True)
+            return _clean_stream()
+
+        async def no_sleep(delay_ms: int, signal: Any) -> None:
+            return None
+
+        async def client_for(spec: ModelSpec) -> Any:
+            return _FnClient(blip_then_recover)
+
+        original = failover_module._abortable_sleep
+        failover_module._abortable_sleep = no_sleep  # type: ignore[assignment]
+        try:
             async for _ in stream_with_failover(
-                _request(),
-                auth,
-                {"retry": {"enabled": True, "baseDelayMs": 0, "maxRetries": 2}},
-                client_for,
+                _request(), store, {"retry": {"enabled": True}}, client_for
             ):
                 pass
+        finally:
+            failover_module._abortable_sleep = original  # type: ignore[assignment]
 
-        # maxRetries=2 is below the server cap, so the user's setting governs.
-        assert sent == ["only", "only", "only"], sent
+        # The 4th attempt has to be REACHED; a cap of 2 would have stopped at 3.
+        assert attempts[0] == 4, attempts[0]

--- a/tests/unit/providers/test_oauth_flows.py
+++ b/tests/unit/providers/test_oauth_flows.py
@@ -892,14 +892,19 @@ async def test_the_loopback_completes_a_login_with_no_manual_input() -> None:
     assert credentials["email"] == "you@example.com"
 
 
-def test_only_anthropic_races_a_pasted_code_against_its_callback() -> None:
+def test_only_browser_signin_flows_race_a_pasted_code_against_their_callback() -> None:
     """`paste_code_flow` is a FALLBACK marker, and ONLY that.
 
-    It matches the reference implementation exactly: Anthropic is the one
-    loopback provider that also accepts a pasted code (for a browser on another
-    machine), raced against the callback rather than awaited. Attaching such a
-    prompt to any other loopback provider blocks the terminal on a line nobody
-    will type.
+    It marks a loopback provider that ALSO accepts a pasted code (for a browser
+    on another machine), raced against the callback rather than awaited.
+    Attaching such a prompt to any other loopback provider blocks the terminal
+    on a line nobody will type.
+
+    Two providers qualify, and both are browser sign-ins whose redirect lands on
+    a loopback port: Anthropic, and Z.AI's GLM Coding Plan sign-in (which mirrors
+    the Anthropic wiring, as omp's `zai-coding-plan` does). A provider whose
+    login is "paste your API key" is NOT one of these -- that is
+    ``paste_prompt_required``, asserted in the companion test.
 
     This test used to assert something wider and false in its name and
     docstring — that no provider REQUIRES a paste — while asserting only the
@@ -911,7 +916,7 @@ def test_only_anthropic_races_a_pasted_code_against_its_callback() -> None:
     from local_operator.providers.registry import PROVIDER_REGISTRY
 
     paste = {p.id for p in PROVIDER_REGISTRY if p.login is not None and p.paste_code_flow}
-    assert paste == {"anthropic"}, paste
+    assert paste == {"anthropic", "zai-oauth"}, paste
 
 
 def test_paste_key_providers_declare_that_they_require_a_prompt() -> None:
@@ -937,11 +942,11 @@ def test_paste_key_providers_declare_that_they_require_a_prompt() -> None:
         "zai",
     }, required
 
-    # And the union a host actually gates on: required plus Anthropic's optional
-    # fallback, and nothing else. A loopback-only provider appearing here would
-    # mean a prompt racing its HTTP callback.
+    # And the union a host actually gates on: required plus the browser
+    # sign-ins' optional fallback, and nothing else. A loopback-only provider
+    # appearing here would mean a prompt racing its HTTP callback.
     accepts = {p.id for p in PROVIDER_REGISTRY if p.login is not None and p.accepts_paste_prompt}
-    assert accepts == required | {"anthropic"}, accepts
+    assert accepts == required | {"anthropic", "zai-oauth"}, accepts
 
 
 @pytest.mark.asyncio
@@ -1050,3 +1055,126 @@ async def test_qwencloud_token_plan_login_expired_device_code_is_terminal() -> N
         await login_qwencloud_token_plan(
             callbacks, http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler))
         )
+
+
+class TestZaiSignInMintsADurableKey:
+    """Z.AI's sign-in is only useful if it ends with the key the WIRE accepts.
+
+    The short-lived OAuth token from the token exchange is rejected by the
+    inference endpoint, so a flow that stored it would log in successfully and
+    then fail every request. These tests pin the whole sequence:
+    token exchange -> business login -> org/project -> find-or-create key ->
+    read the secret from the copy endpoint.
+    """
+
+    @staticmethod
+    def _transport(calls: list[str], *, existing_key: bool) -> httpx.MockTransport:
+        def handler(request: httpx.Request) -> httpx.Response:
+            path = request.url.path
+            calls.append(f"{request.method} {path}")
+            if path.endswith("/oauth/token"):
+                return httpx.Response(
+                    200,
+                    json={
+                        "code": 0,
+                        "data": {
+                            "zai": {"access_token": "short-lived-oauth"},
+                            "user": {"email": "damian@example.com", "id": 4242},
+                        },
+                    },
+                )
+            if path.endswith("/api/auth/z/login"):
+                assert json.loads(request.content)["token"] == "short-lived-oauth"
+                return httpx.Response(200, json={"code": 200, "data": {"access_token": "biz-tok"}})
+            if path.endswith("/getCustomerInfo"):
+                assert request.headers["Authorization"] == "Bearer biz-tok"
+                return httpx.Response(
+                    200,
+                    json={
+                        "code": 200,
+                        "data": {
+                            "organizations": [
+                                {"organizationId": "org-other", "projects": []},
+                                {
+                                    "organizationId": "org-1",
+                                    "isDefault": True,
+                                    "projects": [
+                                        {"projectId": "proj-other"},
+                                        {"projectId": "proj-1", "isDefault": True},
+                                    ],
+                                },
+                            ]
+                        },
+                    },
+                )
+            if path.endswith("/api_keys") and request.method == "GET":
+                listed = [{"name": "local-operator", "apiKey": "key-id"}] if existing_key else []
+                return httpx.Response(200, json={"code": 200, "data": {"list": listed}})
+            if path.endswith("/api_keys") and request.method == "POST":
+                assert json.loads(request.content)["name"] == "local-operator"
+                return httpx.Response(200, json={"code": 200, "data": {"apiKey": "key-id"}})
+            if "/api_keys/copy/" in path:
+                return httpx.Response(200, json={"code": 200, "data": {"secretKey": "sec-ret"}})
+            raise AssertionError(f"unexpected request: {request.method} {path}")
+
+        return httpx.MockTransport(handler)
+
+    async def test_exchange_mints_and_stores_the_durable_key(self) -> None:
+        from local_operator.providers.oauth.zai import ZaiOAuthFlow
+
+        calls: list[str] = []
+        flow = ZaiOAuthFlow(
+            http_client=httpx.AsyncClient(transport=self._transport(calls, existing_key=False))
+        )
+        creds = await flow.exchange_token(
+            "the-code", "the-state", "http://localhost:54548/callback"
+        )
+
+        # The MINTED `id.secret` key, never the short-lived OAuth token.
+        assert creds["access"] == "key-id.sec-ret"
+        assert creds["email"] == "damian@example.com"
+        assert creds["account_id"] == "4242"
+        # `expires: None` is AuthStore's "static token" marker: no refresh is
+        # ever attempted, so the row persists across sessions.
+        assert creds["expires"] is None
+        # The secret always comes from the copy endpoint -- list entries mask it.
+        assert any("/api_keys/copy/" in call for call in calls), calls
+
+    async def test_an_existing_key_is_reused_rather_than_duplicated(self) -> None:
+        """Signing in twice must not litter the console with one key per login."""
+        from local_operator.providers.oauth.zai import ZaiOAuthFlow
+
+        calls: list[str] = []
+        flow = ZaiOAuthFlow(
+            http_client=httpx.AsyncClient(transport=self._transport(calls, existing_key=True))
+        )
+        creds = await flow.exchange_token("c", "s", "http://localhost:54548/callback")
+
+        assert creds["access"] == "key-id.sec-ret"
+        assert "POST /api/biz/v1/organization/org-1/projects/proj-1/api_keys" not in calls, calls
+
+    async def test_an_envelope_error_is_raised_not_stored(self) -> None:
+        """Z.AI reports failures with HTTP 200 and a `code` field, so a caller
+        that trusted the status would persist an error body as a credential."""
+        from local_operator.providers.oauth.zai import ZaiOAuthFlow
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json={"code": 401, "msg": "authorization expired"})
+
+        flow = ZaiOAuthFlow(http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler)))
+        with pytest.raises(LoginError, match="authorization expired"):
+            await flow.exchange_token("c", "s", "http://localhost:54548/callback")
+
+    async def test_the_authorize_url_carries_no_pkce(self) -> None:
+        """The provider's own client sends none and the endpoint rejects the
+        extra parameters, so adding PKCE "for safety" breaks the login."""
+        from local_operator.providers.oauth.zai import CLIENT_ID, ZaiOAuthFlow
+
+        flow = ZaiOAuthFlow()
+        url = await flow.generate_auth_url("st-1", "http://localhost:54548/callback")
+        query = urllib.parse.parse_qs(urllib.parse.urlsplit(url).query)
+
+        assert query["client_id"] == [CLIENT_ID]
+        assert query["state"] == ["st-1"]
+        assert query["response_type"] == ["code"]
+        assert "code_challenge" not in query

--- a/tests/unit/providers/test_oauth_flows.py
+++ b/tests/unit/providers/test_oauth_flows.py
@@ -1195,8 +1195,8 @@ class TestZaiSignInMintsADurableKey:
         components was individually correct while their composition was not.
         """
         from local_operator.providers.auth_store import AuthStore
-        from local_operator.providers.registry import get_provider_definition
         from local_operator.providers.oauth.zai import ZaiOAuthFlow
+        from local_operator.providers.registry import get_provider_definition
 
         calls: list[str] = []
         flow = ZaiOAuthFlow(

--- a/tests/unit/providers/test_oauth_flows.py
+++ b/tests/unit/providers/test_oauth_flows.py
@@ -1178,3 +1178,52 @@ class TestZaiSignInMintsADurableKey:
         assert query["state"] == ["st-1"]
         assert query["response_type"] == ["code"]
         assert "code_challenge" not in query
+
+    async def test_the_stored_credential_is_readable_by_the_cascade(self, tmp_path: Any) -> None:
+        """R21: the join nothing tested -- sign in, then RESOLVE what was stored.
+
+        Two green tests used to sit either side of this gap: one asserted the
+        registry's `zai-oauth` fields, the other asserted the login flow's
+        return dict. Neither stored a real payload and asked the AuthStore for
+        it back, so a credential shape that no cascade tier could read shipped
+        as a working sign-in: the login reported success and every subsequent
+        request failed without one HTTP call being made.
+
+        This walks the real path end to end -- `ZaiOAuthFlow.exchange_token` ->
+        the exact `upsert_credential` call `ProviderController.login` makes ->
+        `get_api_key` / `get_oauth_access` -- because each of those three
+        components was individually correct while their composition was not.
+        """
+        from local_operator.providers.auth_store import AuthStore
+        from local_operator.providers.registry import get_provider_definition
+        from local_operator.providers.oauth.zai import ZaiOAuthFlow
+
+        calls: list[str] = []
+        flow = ZaiOAuthFlow(
+            http_client=httpx.AsyncClient(transport=self._transport(calls, existing_key=False))
+        )
+        creds = await flow.exchange_token("c", "s", "http://localhost:54548/callback")
+
+        # `store_credentials_as` is what makes the sign-in and the pasted key
+        # share one row, so the test must store under the alias the controller
+        # resolves rather than under the provider id it was invoked with.
+        definition = get_provider_definition("zai-oauth")
+        assert definition is not None
+        storage = definition.store_credentials_as or "zai-oauth"
+        assert storage == "zai"
+
+        store = AuthStore(db_path=tmp_path / "auth.db")
+        creds.setdefault("authorized_at", 1)
+        store.upsert_credential(storage, creds)
+
+        # The bearer the wire actually receives. `None` here is the R21 failure:
+        # a row present, typed `api_key`, secret under `access`, unreadable.
+        assert await store.get_api_key("zai") == "key-id.sec-ret"
+
+        access = await store.get_oauth_access("zai")
+        assert access is not None
+        assert access.access_token == "key-id.sec-ret"
+        # Typed `oauth` so tier 3 can see it, and so the row carries the signed-in
+        # identity that `_FETCHERS["zai-oauth"]` needs for quota reporting.
+        assert access.kind == "oauth"
+        assert access.email == "damian@example.com"

--- a/tests/unit/providers/test_registry.py
+++ b/tests/unit/providers/test_registry.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 
 from local_operator.providers.registry import (
@@ -180,3 +182,74 @@ def test_token_plan_oauth_row_spends_the_api_key_on_the_wire() -> None:
     oauth_variant = get_provider_definition("alibaba-token-plan-oauth")
     assert oauth_variant is not None
     assert oauth_variant.store_credentials_as == "alibaba-token-plan"
+
+
+class TestOAuthHostSplit:
+    """Providers serving OAuth and API keys from DIFFERENT hosts.
+
+    Kimi is the case: the coding-plan OAuth grant is only accepted at
+    ``api.kimi.com/coding/v1`` -- which is where ``k3`` lives -- while
+    ``KIMI_API_KEY`` belongs to the mainland ``api.moonshot.cn`` platform and
+    401s there. Verified live against both hosts.
+    """
+
+    def test_kimi_declares_the_coding_plan_host_for_oauth(self) -> None:
+        from local_operator.providers.registry import get_provider_definition
+
+        kimi = get_provider_definition("kimi")
+        assert kimi is not None
+        assert kimi.base_url == "https://api.moonshot.cn/v1"
+        assert kimi.oauth_base_url == "https://api.kimi.com/coding/v1"
+
+    def test_an_oauth_bearer_is_sent_to_the_oauth_host(self) -> None:
+        """Listing the subscription's models is worthless if inference then
+        sends them to the API-key host, where they 404."""
+        from local_operator.providers.auth_store import OAuthAccess
+        from local_operator.providers.clients import OpenAICompatClient
+
+        client = OpenAICompatClient(
+            base_url="https://api.moonshot.cn/v1",
+            oauth_base_url="https://api.kimi.com/coding/v1",
+        )
+        oauth = OAuthAccess(access_token="tok", credential_id=1, kind="oauth")
+        api_key = OAuthAccess(access_token="sk-x", credential_id=2, kind="api_key")
+
+        assert client._request_base_url(oauth) == "https://api.kimi.com/coding/v1"
+        assert client._request_base_url(api_key) == "https://api.moonshot.cn/v1"
+        assert client._request_base_url(None) == "https://api.moonshot.cn/v1"
+
+    def test_the_registry_base_on_a_spec_does_not_suppress_the_oauth_host(self) -> None:
+        """`build_model_spec` copies `definition.base_url` onto EVERY spec, so a
+        naive "did the spec pin a base?" test disables the OAuth host for every
+        request -- which is how a live k3 call reached the API-key platform and
+        401'd despite all of this being wired up. Only a base the registry did
+        NOT supply counts as a deliberate override.
+        """
+        from local_operator.model.configure import build_model_spec
+        from local_operator.providers.clients import OpenAICompatClient, client_for_spec
+
+        def oauth_host_of(spec: Any) -> str | None:
+            client = client_for_spec(spec)
+            assert isinstance(client, OpenAICompatClient)
+            return client._oauth_base_url
+
+        spec = build_model_spec("kimi", "k3")
+        assert spec.base_url == "https://api.moonshot.cn/v1"  # the registry's own
+        assert oauth_host_of(spec) == "https://api.kimi.com/coding/v1"
+
+        # A genuine override (a gateway) still wins and is never second-guessed.
+        assert oauth_host_of(spec.model_copy(update={"base_url": "https://gw.internal/v1"})) is None
+
+    def test_zai_oauth_shares_the_zai_credential_row_and_catalogue(self) -> None:
+        """The sign-in mints a durable key for the SAME provider, exactly as
+        ``xai-oauth`` does -- not a second catalogue."""
+        from local_operator.providers.registry import get_provider_definition
+
+        zai_oauth = get_provider_definition("zai-oauth")
+        zai = get_provider_definition("zai")
+        assert zai_oauth is not None and zai is not None
+        assert zai_oauth.store_credentials_as == "zai"
+        assert zai_oauth.base_url == zai.base_url
+        assert zai_oauth.login is not None
+        # No refresh: the minted key never expires, so there is nothing to refresh.
+        assert zai_oauth.refresh_token is None

--- a/tests/unit/providers/test_usage.py
+++ b/tests/unit/providers/test_usage.py
@@ -1162,7 +1162,10 @@ def test_the_advertised_set_is_the_dispatch_table() -> None:
     from local_operator.providers import usage as usage_mod
 
     assert usage_mod.USAGE_PROVIDERS == frozenset(usage_mod._FETCHERS)
-    assert usage_mod.USAGE_PROVIDERS is not None and len(usage_mod.USAGE_PROVIDERS) == 11
+    # 12 since `zai-oauth` joined: the Z.AI browser sign-in is its own provider
+    # id, like `xai-oauth`, and needs its own route or a signed-in account
+    # reports no usage at all.
+    assert usage_mod.USAGE_PROVIDERS is not None and len(usage_mod.USAGE_PROVIDERS) == 12
     assert not hasattr(usage_mod, "OAUTH_USAGE_PROVIDERS")
 
 
@@ -1395,3 +1398,27 @@ async def test_qwencloud_token_plan_fails_closed_on_console_need_login() -> None
             oauth_creds={"access": "expired-mgmt"},
         )
     assert report is None
+
+
+class TestZaiSignInReportsUsage:
+    """R4: `/provider` advertised Z.AI usage and then showed nothing to anyone
+    who signed in rather than pasting a key.
+
+    The browser sign-in ends by minting an ordinary durable coding-plan key and
+    stores it in `access`, so the OAuth slot wants the SAME fetcher the api-key
+    slot uses -- an empty OAuth slot made `fetch_usage` return None.
+    """
+
+    def test_both_credential_kinds_route_to_the_quota_fetcher(self) -> None:
+        from local_operator.providers.usage import _FETCHERS
+
+        assert _FETCHERS["zai"] == ("zai-quota", "zai-quota")
+        # The login flavour resolves too: it is a separate provider id.
+        assert _FETCHERS["zai-oauth"] == ("zai-quota", "zai-quota")
+
+    def test_a_signed_in_account_is_reported_as_capable_of_usage(self) -> None:
+        from local_operator.providers.usage import usage_kinds
+
+        oauth_kind, api_key_kind = usage_kinds("zai")
+        assert oauth_kind is not None, "a signed-in Z.AI account reports no usage"
+        assert api_key_kind is not None


### PR DESCRIPTION
# PR Description

## Change classification

**C2 — standard / pre-authorized.** Corrective changes to credential rotation and error reporting, plus one new opt-in login flow (`zai-oauth`) and one new registry field (`oauth_base_url`, set for Kimi only). No existing login, credential row, or config key changes shape. Clean rollback (`git revert`). No RFC requested.

## The reported failure

Every `lop` session died on a provider issue during the current Claude degradation. Three distinct symptoms, all in the same subsystem:

```text
✕ transient provider error (HTTP 529): overloaded_error: Overloaded
✕ No API key configured for provider 'openai'
✕ No API key configured for provider 'anthropic'
```

The usage panel at the time showed **four** Anthropic accounts, of which only one was exhausted (`damian@gominerva.com` at 100%) — `damian@radienthq.com` at 56% and `damian@pergamonhq.com` at 5% were healthy and never used. That is the core bug: a 529 storm was reported as fatal while accounts with quota sat idle.

## Four defects, each reproduced first

### 1. Rotation stopped after two accounts

`resolve_next_key` caps an ordinary 401 at one refresh + one sibling switch (`legacy_auth_switch_used`) — correct for a rejected bearer, since cycling four of them only delays a login prompt. But 5xx and timeouts fell under the same cap, so a *provider* fault stopped rotating after the second account.

Measured against the unfixed code, four healthy accounts, every call answering 529:

```console
final error: transient provider error (HTTP 529): overloaded_error: Overloaded
attempts: 8
distinct accounts tried: ['acct-A', 'acct-B'] of ['acct-A', 'acct-B', 'acct-C', 'acct-D']
```

Server-side failures now join quota/402/403 as errors that may cycle every sibling. A real 401 keeps the cap. After:

```console
attempts: 16
distinct accounts tried: ['acct-A', 'acct-B', 'acct-C', 'acct-D'] of 4
```

### 2. A provider outage blocked every healthy account

`rotate_sibling` blocked the failing credential on *any* error. Under a sustained 529 storm that walks the whole pool into the blocked state — each account unusable for `DEFAULT_BLOCK_MS` over a fault none of them caused — until resolution returns `None` and the turn dies with nothing left to try.

A provider-side fault now **deprioritises** (sorted last, still selectable) rather than blocking; quota still blocks the account that actually ran out, since a spent window *is* about that credential. The distinction is the whole fix, and both halves are tested.

### 3. The error told the user the opposite of the truth

Resolution returns `None` both when a provider has no credential *and* when every credential it has is temporarily blocked. The frame said `No API key configured for provider 'openai'` — to a user signed in with OAuth, sending them to configure a key they already had. One session's agent then mis-diagnosed this as an aggregator problem and burned a round on it.

```console
$ # before: signed-in OAuth account, merely rate-limited
REPORTED: No API key configured for provider 'openai'

$ # after
REPORTED: rate limit or quota exceeded: The OAuth sign-in credential for provider
'openai' is temporarily unavailable (rate limited, or a token refresh failed).
The credentials are still configured; retry once the limit resets, or add another
account.
```

The unconfigured case still says exactly what it said before, because there it is true.

### 4. Kimi OAuth was pointed at the wrong platform

Requested separately: the Kimi registry was stale (`moonshot-v1-*`, no K3). Live model discovery **already existed** with a 24h disk cache — it was failing shut for Kimi, silently:

```console
$ # before
=== kimi: status=static, 6 models
  moonshot-v1-8k, moonshot-v1-32k, moonshot-v1-128k, ...
```

The coding-plan OAuth grant is only accepted at `api.kimi.com/coding/v1`; the registry's `api.moonshot.cn/v1` answers it with `401 Invalid Authentication`, so discovery fell back to the static registry. Confirmed against both hosts:

```console
plain https://api.kimi.com/coding/v1/models    -> 200 ['kimi-for-coding', 'kimi-for-coding-highspeed', 'k3', 'k3-256k']
plain https://api.moonshot.cn/v1/models        -> 401 {"error":{"message":"Invalid Authentication"}}
```

Adds `ProviderDefinition.oauth_base_url`, chosen **per request** from the credential actually presented (failover may rotate between kinds mid-turn), with its own listing-cache document so the two catalogues cannot overwrite each other.

```console
$ # after
=== kimi: status=ok, 10 models
  kimi-for-coding, kimi-for-coding-highspeed, k3, k3-256k, moonshot-v1-8k, ...
```

Anthropic (`claude-opus-5`) and OpenAI (`gpt-5.6-sol`) already discovered correctly and are unchanged.

## New: Z.AI GLM Coding Plan sign-in

`/login zai` could only paste an API key. Adds `zai-oauth`, ported from omp's `registry/oauth/zai.ts`: authorization-code against `chat.z.ai` (**no PKCE** — the provider's own client sends none and the endpoint rejects the extra params), a **non-standard** JSON token exchange, then a business-API sequence that mints the durable `id.secret` key the wire actually accepts.

The short-lived OAuth token is rejected by the inference endpoint, so a flow stopping at the token exchange would log in and then fail every request. The minted key goes in `access` and is returned verbatim as the bearer.

**Session persistence:** stored with `expires: None`, which `AuthStore._needs_refresh` reads as "static token; never expires" — so no refresh is ever attempted (there is no refresh token to attempt one with) and the row survives restarts, reused across sessions like an API key while remaining an `oauth` credential for identity and usage reporting. It shares `zai`'s credential row, base URL and catalogue via `store_credentials_as`, exactly as `xai-oauth` shares `xai`'s.

## On the aggregator report

One session self-diagnosed its failure as *"auth is via RADIENT_API_KEY, so the openai fallback has no key"*, suggesting aggregators were interrupting the waterfall. **The first half was right; the second was a guess.** The cascade is strictly per-provider — verified directly:

```console
radient    -> radient-secret-key
openai     -> None
anthropic  -> None
zai        -> None
kimi       -> None
```

No aggregator key can satisfy a named provider. The real cause was defect 3: `RADIENT_API_KEY` is the only key in `credentials.env`, the OpenAI OAuth row was blocked, and the misleading message invited exactly that inference. Rather than "fix" a non-bug, this adds a test pinning the invariant so a future convenience shortcut cannot introduce one.

## Testing evidence

Full suite, all gates:

```console
$ .venv/bin/python -m pytest tests/unit -q
4509 passed, 7 skipped, 294 warnings in 608.20s (0:10:08)

$ .venv/bin/python -m flake8 .                                    # clean
$ uvx --from black==26.1.0 black --check local_operator tests      # 365 unchanged
$ uvx isort --check-only --profile black local_operator tests      # clean
$ .venv/bin/python -m pyright --pythonpath .venv/bin/python .      # 0 errors
```

**Every new test was confirmed to fail against the pre-fix code** (fixes reverted in place, tests re-run, then restored) — they are regression tests, not descriptions of current behaviour.

**Live end-to-end**, real credentials against real endpoints — a green unit suite would not have caught what this did. Driving a real `k3` completion through the full `stream_with_failover` path found a defect the unit tests missed: `build_model_spec` copies `definition.base_url` onto *every* spec, so the client factory's "did the spec pin a base?" guard suppressed the OAuth host on every request and 401'd:

```console
$ # mid-implementation, live
ProviderError: authentication failed (HTTP 401): Invalid Authentication

$ # after correcting the guard to compare against the registry's own base
StreamTextDelta(type='text_delta', delta='OK')
StreamUsageEvent(usage=Usage(input_tokens=88, output_tokens=32, cache_read_tokens=88, ...))

$ # and through the failover driver end to end
k3: reply='OK'
```

That path now has its own regression test. The listing cache lands isolated as expected:

```console
$ ls ~/.local-operator/cache/ | grep kimi
kimi.oauth.listing.json
```

Not covered: the Z.AI sign-in's browser leg is tested against `httpx.MockTransport` (token exchange, business login, org/project resolution, find-or-create, the masked-secret trap, envelope errors reported at HTTP 200, and the no-PKCE authorize URL) rather than driven interactively — it needs a live Z.AI account with a GLM Coding Plan, which I do not have signed in. The credential *shape* it produces is asserted, so persistence and bearer selection are covered.
