### PR TITLE
chore(release): 0.18.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.18.0"
+version = "0.18.1"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@radienthq.com" }]


### PR DESCRIPTION
## What changed

Patch bump from `0.18.0` to `0.18.1` for the reviewed fix now on `main`:

- #145 — the status band's conversation name no longer paints its reserved box out to the band's right edge, and the jobs icon moves from `⊞` (U+229E, Mathematical Operators) to `▣` (U+25A3, Geometric Shapes) because the former rendered as tofu in a real terminal.

Patch rather than minor: both are presentation fixes inside one widget. No contract, no data path, no new dependency.

## Change classification

**C1 — release metadata.** One line, one file. No runtime path. Clean rollback (`git revert`).

## Validation

No runtime behaviour changes in this PR; release metadata only. The behavioural evidence is on #145, which carried three code review rounds and one design round, all terminal on its merged head, with before/after rendered frames.

```console
$ grep '^version' pyproject.toml
version = "0.18.1"
```

Verified on `main` by blob after the squash rather than by ancestry:

```console
$ git show origin/main:local_operator/tui/widgets/status_line.py | grep '^ICON_JOBS'
ICON_JOBS = "▣"
$ git show origin/main:local_operator/tui/widgets/status_line.py | grep -c 'row.rstrip()'
1
```
