### PR TITLE
fix(session): close the startup claim race in the never-delete retention model

### DIFF
--- a/local_operator/harness/subagent.py
+++ b/local_operator/harness/subagent.py
@@ -823,6 +823,20 @@ async def _build_child_session(
     session_dir = (
         resume_dir if resume_dir is not None else config_dir() / "sessions" / uuid.uuid4().hex[:12]
     )
+    # CLAIM FIRST, before anything else creates the directory. A child writes
+    # its own directory under the same ``sessions/`` store the retention sweep
+    # reclaims, and subagents routinely outlive the sweep another session's
+    # startup runs. ``origin.json`` (written just below) already counts as
+    # content and so protects the directory once it lands — but the claim is
+    # liveness rather than content: it closes the window BEFORE the stamp, and
+    # unlike content it lets the sweep still reclaim the directory of a child
+    # whose process has died. ``claim_session`` creates the directory and
+    # writes the marker in one step, so claiming here leaves no unclaimed-empty
+    # window. The pid is this process's — the process whose death makes the
+    # directory dead.
+    from local_operator.session.retention import claim_session
+
+    claim_session(session_dir)
     # Stamp the directory as the machine's BEFORE the transcript exists, so a
     # picker painted while this child is mid-run already knows what it is. A
     # child's directory is shape-identical to a user conversation, which is how

--- a/local_operator/session/retention.py
+++ b/local_operator/session/retention.py
@@ -27,12 +27,28 @@ a real install were exactly this). Nothing can be lost by removing a
 directory that contains nothing, and an un-empty directory — one byte of
 transcript — is never touched, whatever its age, whatever the count of its
 neighbours, whatever the total size of the store.
+
+The one hazard in "reap empty directories" is that every LIVE session is
+empty for an instant too — between the ``mkdir`` that creates its directory
+and the first append that fills it. On a machine running several sessions at
+once (the normal way this harness is used) another session's startup sweep
+can land in exactly that window and delete a directory whose owner is about
+to write to it, which reproduces the original ``FileNotFoundError`` kill. So
+a starting session CLAIMS its directory (:func:`claim_session`) with a
+liveness marker before anything else creates it, and the sweep skips any
+empty directory a live process still owns (:func:`_is_claimed`). The marker
+is liveness, not content: a hard-killed run's leftover marker does not keep
+its empty directory alive, so corpses are still reclaimed. As a second belt,
+:class:`~local_operator.session.transcript.Transcript` recreates its
+directory if it is deleted mid-session rather than dying on the next append.
 """
 
 from __future__ import annotations
 
 import logging
+import os
 import shutil
+import sys
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -41,6 +57,52 @@ logger = logging.getLogger(__name__)
 
 #: Directory under the config dir holding ephemeral per-run transcripts.
 SESSIONS_DIRNAME = "sessions"
+
+#: Written into a session directory while its run is alive; holds the owning
+#: process id. Named with a leading dot so it never looks like session content
+#: to a reader listing the directory.
+#:
+#: This is a LIVENESS marker, not content: it says "a process is using this
+#: directory right now", and it is the one thing that lets a startup sweep tell
+#: an empty directory a concurrent session just created and is about to write
+#: to from an empty directory a dead run left behind. It is therefore
+#: deliberately NOT charged as bytes by :func:`_dir_size` — a session killed
+#: hard (SIGKILL when its terminal closes) leaves this marker behind on an
+#: otherwise-empty directory, and if the marker counted as content that
+#: directory would be immortal. Excluding it means such a corpse reads as empty
+#: and is reaped once :func:`_is_claimed` confirms no live process owns it.
+LIVE_MARKER_NAME = ".session.pid"
+
+#: Files a session directory may hold that are bookkeeping ABOUT the run rather
+#: than content produced BY it, and so are not charged as bytes. Only the
+#: liveness marker qualifies: ``origin.json`` is deliberately treated as
+#: content (see :func:`_dir_size`) so an aborted child stamped with its origin
+#: is protected exactly as #154/#192 intend — the point of the never-delete
+#: model. Collected in one place so the size charge and the activity clock
+#: agree on the list.
+_SIDECAR_NAMES = frozenset({LIVE_MARKER_NAME})
+
+#: This module's view of the platform. A module-local copy rather than reading
+#: ``sys.platform`` at the point of use, so a test can steer the Windows branch
+#: by patching THIS name instead of the global ``sys.platform`` — patching that
+#: would tell every other thread in the process it is on Windows for the
+#: duration, and this suite runs with threads.
+_PLATFORM = sys.platform
+
+#: Whether this platform can actually answer "is that process alive?". Named
+#: rather than inlined because two decisions read it and must agree: liveness
+#: itself, and whether a claim needs an age bound.
+_LIVENESS_IS_VERIFIABLE = _PLATFORM != "win32"
+
+#: How long a claim is trusted after the session's last WRITE, where liveness
+#: cannot be probed (Windows, see :func:`_process_alive`). On POSIX the pid
+#: probe is authoritative and this is never consulted, so a session of any
+#: length keeps its protection there. Measured against activity rather than the
+#: marker, this is not a cap on session length — a session writing every few
+#: minutes is never stale — it is the answer to "nothing has touched this
+#: directory for half a day and we cannot ask the OS whether its owner still
+#: exists", where the alternative is trusting a leaked claim forever.
+CLAIM_TRUST_S = 12 * 3600.0
 
 #: Config keys of the RETIRED eviction ceilings. They no longer do anything
 #: — deleting transcripts by policy is precisely the behaviour this module
@@ -103,23 +165,211 @@ def _dir_size(directory: Path) -> int:
     """Bytes under ``directory``. Files that vanish mid-walk are skipped: a
     concurrent process disposing its own session is normal, not an error.
 
-    Every file counts, including the origin marker. A directory holding
-    only ``origin.json`` is a session that has been claimed — typically a
-    child between ``mark_session_origin`` and its first append, or a run
-    that aborted in that window. Treating the marker as invisible made
-    those directories look empty and the sweep rmtree'd them, which is
-    exactly the ``FileNotFoundError: .../transcript.jsonl`` kill this
-    module exists to prevent. A 43-byte marker is cheaper than a lost
-    session; abandoned markers accumulate and the user can remove them.
+    ``origin.json`` counts, deliberately. A directory holding only
+    ``origin.json`` is a session that has been stamped — typically a child
+    between ``mark_session_origin`` and its first append, or a run that
+    aborted in that window. Treating the marker as invisible made those
+    directories look empty and the sweep rmtree'd them, which is exactly the
+    ``FileNotFoundError: .../transcript.jsonl`` kill this module exists to
+    prevent. A 43-byte marker is cheaper than a lost session; abandoned
+    markers accumulate and the user can remove them.
+
+    The LIVENESS marker (:data:`LIVE_MARKER_NAME`) is the one file NOT charged,
+    read from :data:`_SIDECAR_NAMES`. It is bookkeeping about the run, not
+    content: a session killed hard leaves it on an otherwise-empty directory,
+    and if it counted as content that corpse would be immortal. Excluded here,
+    such a directory reads as empty and the reap in :func:`sweep_sessions`
+    removes it once :func:`_is_claimed` confirms no live process owns it —
+    while a directory with any real content stays untouchable regardless.
     """
     total = 0
     for entry in directory.rglob("*"):
         try:
-            if entry.is_file():
+            if entry.is_file() and entry.name not in _SIDECAR_NAMES:
                 total += entry.stat().st_size
         except OSError:
             continue
     return total
+
+
+def _process_alive(pid: int) -> bool:
+    """Is ``pid`` a process this user can still see?
+
+    ``os.kill(pid, 0)`` is the portable liveness probe: it delivers no signal
+    and raises ``ProcessLookupError`` when nothing owns the id. ``PermissionError``
+    means the id IS taken (by another user's process), so it counts as alive —
+    refusing to reap is always the safe side of this decision.
+
+    Windows has no signal 0 — ``os.kill`` there TERMINATES the target — so the
+    probe is unavailable and this returns ``True``. That answer alone would be
+    a disaster: every crash would leak a claim nothing can disprove, and since
+    a claimed directory is skipped, the module would silently stop reaping one
+    directory at a time. :func:`_is_claimed` therefore bounds a claim by its
+    own age wherever liveness cannot be established (see ``CLAIM_TRUST_S``);
+    this function answers only the liveness question.
+
+    Pid REUSE is the residual risk on every platform: a leaked marker whose id
+    has since been recycled reads as alive. It costs one retained EMPTY
+    directory until that unrelated process exits, never a deleted live one,
+    which is the direction this whole module errs in.
+    """
+    if pid <= 0:
+        return False
+    if _PLATFORM == "win32":  # pragma: no cover - probe is POSIX-only
+        return True
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except OSError:
+        return True
+    return True
+
+
+def _is_session_store_dir(directory: Path) -> bool:
+    """Is ``directory`` one of the ephemeral session directories we sweep?
+
+    The marker belongs only under ``sessions/``. With ``--train`` (or a named
+    agent) a transcript lives in ``agents/<id>/``, which retention never
+    scans, so a marker there protects nothing — and it does not merely waste a
+    file: ``AgentRegistry.export_agent`` zips every file in an agent directory
+    and that archive is published to the Agent Hub and copied into importing
+    users' agent directories.
+    """
+    return directory.parent.name == SESSIONS_DIRNAME
+
+
+def claim_session(session_dir: Path, pid: int | None = None) -> None:
+    """Mark ``session_dir`` as owned by a running process, BEFORE anything else
+    creates it.
+
+    Called once when a session is built, so that every OTHER session's startup
+    sweep can tell "an empty directory a dead run left behind" from "the empty
+    directory a live run just created and is one syscall from writing to". The
+    never-delete model already protects any directory with content; this closes
+    the residual window that content cannot — the instant between ``mkdir`` and
+    the first append, during which the directory is genuinely empty and a
+    concurrent sweep would reap it out from under its live owner (the exact
+    ``FileNotFoundError`` this module exists to prevent, reachable again once
+    the sweep reaps empty directories at all).
+
+    ``claim_session`` creates the directory itself and writes the marker in one
+    step, so a caller that claims FIRST leaves no unclaimed-empty window for the
+    sweep to catch — this is why call sites claim ahead of their own ``mkdir``.
+
+    Best-effort by design: a claim that cannot be written must not stop a
+    session from starting, and the worst consequence of a missing claim is the
+    pre-existing behaviour — the sweep treats the empty directory as reapable.
+
+    Confined to ``sessions/`` (see :func:`_is_session_store_dir`): a marker in
+    an agent directory protects nothing and escapes into published agent
+    bundles.
+    """
+    if not _is_session_store_dir(session_dir):
+        return
+    try:
+        session_dir.mkdir(parents=True, exist_ok=True)
+        (session_dir / LIVE_MARKER_NAME).write_text(
+            str(os.getpid() if pid is None else pid), encoding="utf-8"
+        )
+    except OSError as exc:
+        logger.debug("session retention: cannot claim %s: %s", session_dir, exc)
+
+
+def release_session(session_dir: Path) -> None:
+    """Drop the claim on ``session_dir``; the run that owned it has finished.
+
+    Wired into session dispose. Not required for correctness — a claim naming
+    a dead pid is ignored anyway — but releasing it promptly means an EMPTY
+    session directory (a run that wrote nothing) becomes reapable at the moment
+    its run ends rather than when the operating system happens to reuse the
+    process id. That matters most for a HOST running several sessions in one
+    process, where the owning pid stays alive long after an individual session
+    is gone.
+
+    Gated on the directory being under ``sessions/``, for the same reason
+    :func:`claim_session` is: an agent directory must never receive this file,
+    because ``AgentRegistry.export_agent`` zips every file it finds there and
+    publishes the result. The gate lives INSIDE both functions rather than at
+    the call sites so the two sides cannot drift apart.
+    """
+    if not _is_session_store_dir(session_dir):
+        return
+    try:
+        (session_dir / LIVE_MARKER_NAME).unlink()
+    except OSError:
+        pass
+
+
+def _is_claimed(directory: Path, now: float) -> bool:
+    """Does a live process still own ``directory``?
+
+    Consulted only for a directory that reads as EMPTY (see
+    :func:`sweep_sessions`): a directory with content is never reaped whatever
+    this returns, so the question only matters for the empty startup window and
+    for a hard-killed run's leftover marker.
+
+    A marker holding an unparseable value is treated as NOT claimed: it is
+    corrupt bookkeeping, and honouring it forever would make the directory
+    immortal.
+
+    Where :func:`_process_alive` can actually probe, its answer is
+    authoritative: a session stays protected for as long as it runs, however
+    long that is. Where it cannot (Windows), the claim is bounded by
+    ``CLAIM_TRUST_S``, measured against the LATER of two clocks — the
+    directory's last write and the marker itself — so a fresh claim on an old
+    resume is not read as abandoned, and a long active session is not expired
+    mid-conversation.
+    """
+    marker = directory / LIVE_MARKER_NAME
+    try:
+        raw = marker.read_text(encoding="utf-8").strip()
+    except OSError:
+        return False
+    try:
+        pid = int(raw)
+    except ValueError:
+        return False
+    if not _process_alive(pid):
+        return False
+    if _LIVENESS_IS_VERIFIABLE:
+        return True
+    try:
+        claimed_at = marker.stat().st_mtime
+        stamp = max(_activity_mtime(directory, claimed_at), claimed_at)
+    except OSError:
+        return False
+    return now - stamp < CLAIM_TRUST_S
+
+
+def _activity_mtime(directory: Path, fallback: float) -> float:
+    """When this session was last WRITTEN to, ignoring the liveness marker.
+
+    Used only on the unverifiable-platform branch of :func:`_is_claimed`, to
+    bound how long a claim is trusted after real activity. The liveness marker
+    is excluded (via :data:`_SIDECAR_NAMES`) for the same reason it is not
+    charged as bytes: it is written once at claim time and would otherwise peg
+    "last activity" to the moment the session started, expiring a long but
+    quiet session's claim while it is still alive.
+
+    A directory with no non-marker content falls back to ``fallback`` (the
+    marker's own mtime), which is the best signal available there.
+    """
+    newest: float | None = None
+    try:
+        for entry in directory.rglob("*"):
+            try:
+                if entry.name in _SIDECAR_NAMES or not entry.is_file():
+                    continue
+                stamp = entry.stat().st_mtime
+            except OSError:
+                continue
+            newest = stamp if newest is None else max(newest, stamp)
+    except OSError:
+        return fallback
+    return fallback if newest is None else newest
 
 
 def sweep_sessions(
@@ -135,14 +385,22 @@ def sweep_sessions(
 
     The ceiling parameters are accepted for call-site compatibility and
     are IGNORED: no configuration can make this function delete a
-    directory that holds content. ``live_dir`` is still honoured as a
-    belt: even a literally-empty live directory is skipped, because the
-    caller just created it and has not written a turn yet. A transcript
-    is removed only when the user explicitly disposes of the session —
-    there is no automated path, because the failure mode of an automated
-    path (a running session's transcript vanishing underneath it) costs
-    the user the whole session, and the benefit (bounded disk) is
-    recoverable by hand at any time.
+    directory that holds content. A transcript is removed only when the
+    user explicitly disposes of the session — there is no automated path,
+    because the failure mode of an automated path (a running session's
+    transcript vanishing underneath it) costs the user the whole session,
+    and the benefit (bounded disk) is recoverable by hand at any time.
+
+    Two belts protect the empty directory a session passes through at
+    startup, before it has written its first turn:
+
+    - ``live_dir`` — the sweeping session's OWN directory, skipped even
+      when empty, because it just created it;
+    - the CLAIM marker — any OTHER session's directory that a live process
+      still owns (:func:`_is_claimed`), so a concurrent startup does not
+      reap the empty directory of a session that is one syscall from
+      writing to it. A dead run's leftover marker does NOT protect its
+      empty directory, so hard-killed corpses are still reclaimed.
 
     An empty directory younger than :data:`EMPTY_DIR_GRACE_SECONDS` is also
     skipped, whoever owns it: a fresh empty directory is indistinguishable
@@ -162,7 +420,7 @@ def sweep_sessions(
     evicted = 0
     errors = 0
     bytes_remaining = 0
-    moment = time.time() if now is None else now
+    moment = now if now is not None else time.time()
     live_resolved = live_dir.resolve() if live_dir is not None else None
     try:
         children = [child for child in sessions_dir.iterdir() if child.is_dir()]
@@ -182,30 +440,79 @@ def sweep_sessions(
             # A directory another process removed mid-scan. Nothing to do.
             continue
         if size > 0:
+            # Any real content (the liveness marker aside) — never touched.
             bytes_remaining += size
             continue
-        try:
-            # A directory's st_mtime is bumped whenever an entry is added to
-            # or removed from it, so for a directory that is still empty this
-            # is its CREATION time — exactly the "how long has this been
-            # waiting for its first turn" signal the grace window needs. The
-            # one edge case: creating and then deleting a transient file
-            # inside an otherwise-empty dir resets this clock, extending the
-            # grace window rather than shortening it, which stays on the safe
-            # side (an unreaped empty dir costs nothing).
-            age = moment - child.stat().st_mtime
-        except OSError:
-            # Removed by another process between the size walk and the stat.
-            continue
-        if age < EMPTY_DIR_GRACE_SECONDS:
-            # Empty but fresh: this is what a sibling's just-created session
-            # looks like before its first turn lands. ``live_dir`` cannot
-            # protect it (it only names OUR session), so age is the only
-            # signal that separates "abandoned" from "about to be written".
-            continue
-        # Literally empty AND past the grace window: no files at all, not
-        # even a marker, and nothing has claimed it for an hour. Deleting
-        # it loses nothing, and it was never a real session.
+        # Reads as empty: no content, at most a leftover liveness marker.
+        #
+        # #152 (claim marker) and #235 (grace window) both guard the empty
+        # startup window, but they are NOT interchangeable belts to stack
+        # blindly: naively skipping on "claimed OR fresh" reopens the exact
+        # immortal-empty leak #152 was built to prevent, because a hard-killed
+        # run's corpse directory is BOTH freshly created AND carries a dead
+        # marker, and the grace window would shield it forever-ish. They are
+        # complementary because they answer DIFFERENT questions about
+        # DIFFERENT populations, so the marker's presence selects which one is
+        # authoritative:
+        #
+        #   - A directory WITH a marker was claimed by a session that reached
+        #     ``claim_session``. Its liveness is knowable — :func:`_is_claimed`
+        #     probes the pid (or, where it can't, bounds the claim by age). A
+        #     live owner keeps it at ANY age; a dead owner's marker does NOT,
+        #     and — crucially — a dead claim is reaped WITHOUT consulting the
+        #     grace window, so a just-crashed session's corpse still reaps
+        #     immediately instead of lingering an hour. This is what keeps the
+        #     never-leak invariant intact once the grace window exists.
+        #
+        #   - A directory WITHOUT a marker is the case #235 was written for: a
+        #     sibling whose claim write lost its race or was never attempted
+        #     (``claim_session`` is best-effort — a claim that cannot be
+        #     written must never stop a session from starting). There is no
+        #     liveness signal at all, so the CREATION-time grace window is the
+        #     only thing separating "a session one syscall from its first
+        #     append" from "abandoned". Fresh survives; aged-out reaps.
+        #
+        # Removing either mechanism reopens a real hole: without the claim, a
+        # long-running empty-for-now session past the grace window dies; without
+        # the grace window, an unclaimed just-created sibling dies. So both stay.
+        marker = child / LIVE_MARKER_NAME
+        if marker.exists():
+            # Claimed at some point: the marker's liveness is authoritative and
+            # the grace window is deliberately bypassed so a dead claim reaps at
+            # once (no immortal-empty corpse).
+            try:
+                if _is_claimed(child, moment):
+                    continue
+            except OSError:
+                # Cannot read the marker to decide: err toward keeping it. A
+                # spurious retained empty directory costs nothing; a wrongly
+                # deleted live one costs the session.
+                continue
+        else:
+            # Unclaimed: fall back to #235's creation-time grace window.
+            try:
+                # A directory's st_mtime is bumped whenever an entry is added
+                # to or removed from it, so for a directory that is still empty
+                # this is its CREATION time — exactly the "how long has this
+                # been waiting for its first turn" signal the grace window
+                # needs. The one edge case: creating and then deleting a
+                # transient file inside an otherwise-empty dir resets this
+                # clock, extending the grace window rather than shortening it,
+                # which stays on the safe side (an unreaped empty dir costs
+                # nothing).
+                age = moment - child.stat().st_mtime
+            except OSError:
+                # Removed by another process between the size walk and the stat.
+                continue
+            if age < EMPTY_DIR_GRACE_SECONDS:
+                # Empty, unclaimed, but fresh: indistinguishable from a
+                # sibling's just-created session before its first turn lands
+                # and before (or without) a claim. Age is the only signal left
+                # that separates "abandoned" from "about to be written".
+                continue
+        # Reapable: either a dead/expired claim, or unclaimed and past the
+        # grace window. Either way no live owner and no content — deleting it
+        # loses nothing, and it was never a real session.
         try:
             shutil.rmtree(child)
         except OSError as exc:

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -5663,6 +5663,20 @@ class Session:
                 await self._flush_shell_records()
             self._transcript.flush()
         finally:
+            # Drop the retention claim FIRST in the finally: everything in the
+            # try above can raise, and a dispose that blew up part way through
+            # must not leave the directory's liveness marker behind for the rest
+            # of the process's life. On POSIX a leaked marker heals when the pid
+            # dies, but releasing it promptly means an EMPTY session directory
+            # (a run that wrote nothing) becomes reapable the moment its run
+            # ends rather than when the OS happens to reuse the pid — and matters
+            # most for a host running several sessions in one long-lived process.
+            # A directory with real content is untouchable regardless, so this
+            # never risks the transcript itself. ``release_session`` is a no-op
+            # for agent directories (the gate lives inside it).
+            from local_operator.session.retention import release_session
+
+            release_session(self._transcript.directory)
             # ``finally``: host-owned resources must be released even when the
             # session's own teardown blew up part way through.
             for hook in self._dispose_hooks:

--- a/local_operator/session_factory.py
+++ b/local_operator/session_factory.py
@@ -1001,6 +1001,22 @@ async def _prepare(
     yolo = bool(getattr(args, "yolo", False))
 
     transcript_dir, agent_id = _transcript_dir_and_agent_id(agent, args, agent_registry)
+
+    from local_operator.session.retention import claim_session, sweep_from_config
+
+    # CLAIM BEFORE creating the directory, and in that order. The claim marker
+    # is what tells every OTHER session's startup sweep that this directory
+    # belongs to a live run; ``claim_session`` creates the directory itself and
+    # writes the marker in one step, so there is no instant at which this
+    # directory exists empty-and-unclaimed for a concurrent sweep to reap. A
+    # plain ``mkdir`` here followed by a later claim would reopen exactly that
+    # window — the FileNotFoundError kill this fix exists to close.
+    #
+    # ``claim_session`` refuses agent directories itself (the gate lives with
+    # the marker, not here), so the explicit ``mkdir`` below is what creates
+    # the directory in the ``--train``/named-agent case, which is deliberately
+    # never claimed and never swept.
+    claim_session(transcript_dir)
     transcript_dir.mkdir(parents=True, exist_ok=True)
 
     # Reap EMPTY session directories left by runs that exited before writing
@@ -1010,8 +1026,6 @@ async def _prepare(
     # explicit user action. Best-effort by construction (see
     # retention.sweep_sessions): cleanup must never be the reason a session
     # fails to start.
-    from local_operator.session.retention import sweep_from_config
-
     sweep_from_config(config_manager, Path(agent_registry.config_dir), transcript_dir)
 
     # Stamp session directories that predate the origin marker, so the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.24.6"
+version = "0.24.7"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/session/test_retention.py
+++ b/tests/unit/session/test_retention.py
@@ -311,3 +311,161 @@ def test_a_transcript_is_never_deleted_even_when_a_failure_cascade_hits(tmp_path
 
     assert (real / "transcript.jsonl").read_text() == "x" * 100
     assert result.evicted == 0
+
+
+# --- Claim marker: the startup race and the never-leak counterpart ----------
+#
+# The never-delete model reaps EMPTY directories, but every LIVE session is
+# empty for the instant between its ``mkdir`` and its first append. A claim
+# marker (:func:`claim_session`) is what lets a concurrent startup sweep tell
+# that live-but-empty directory from a dead run's leftover, so it does not
+# delete a session out from under its owner (the original FileNotFoundError
+# kill). The marker is LIVENESS, not content: a dead owner's marker must not
+# make its empty directory immortal, or the module would stop reaping.
+
+
+def test_a_live_claim_protects_an_empty_directory(tmp_path):
+    """The startup window: a directory a live process owns survives the reap
+    even while it holds nothing but the claim marker."""
+    import os
+
+    from local_operator.session.retention import claim_session
+
+    sessions = tmp_path / "sessions"
+    starting = sessions / "starting"
+    # Claim with THIS process's pid, which is provably alive.
+    claim_session(starting, pid=os.getpid())
+    assert (starting / ".session.pid").exists()
+
+    result = sweep_sessions(sessions)
+
+    assert starting.exists()
+    assert result.evicted == 0
+
+
+def test_a_dead_runs_leftover_marker_does_not_make_its_dir_immortal(tmp_path):
+    """A hard-killed session leaves its marker on an otherwise-empty
+    directory. Because the marker is liveness (not content) and its pid is
+    dead, that corpse is reaped — otherwise every crash would leak a directory
+    the sweep could never reclaim."""
+    sessions = tmp_path / "sessions"
+    corpse = sessions / "corpse"
+    corpse.mkdir(parents=True)
+    # A pid that does not belong to any live process.
+    (corpse / ".session.pid").write_text("2147483646")
+
+    result = sweep_sessions(sessions)
+
+    assert not corpse.exists()
+    assert result.evicted == 1
+
+
+def test_a_claim_landing_mid_sweep_is_honoured_before_the_rmtree(tmp_path):
+    """L2: scan and delete are one pass, and the claim is re-checked
+    immediately before each ``rmtree``. A claim written after the loop began
+    but before this directory's deletion must save it — the window a
+    concurrent session's startup claim lands in."""
+    import os
+
+    import local_operator.session.retention as retention
+
+    sessions = tmp_path / "sessions"
+    victim = sessions / "victim"
+    victim.mkdir(parents=True)  # empty, first in line to be reaped
+    other = _session(sessions, "other", size=100)
+
+    # A live session claims ``victim`` while the sweep is busy sizing ``other``.
+    original = retention._dir_size
+
+    def claim_mid_sweep(directory):
+        if directory.name == "other" and not (victim / ".session.pid").exists():
+            retention.claim_session(victim, pid=os.getpid())
+        return original(directory)
+
+    retention._dir_size = claim_mid_sweep
+    try:
+        sweep_sessions(sessions)
+    finally:
+        retention._dir_size = original
+
+    assert victim.exists(), "a claim that landed mid-sweep was ignored"
+    assert (other / "transcript.jsonl").exists()
+
+
+def test_the_liveness_marker_is_not_charged_as_bytes(tmp_path):
+    """The marker must not count toward a directory's size, or a dead run's
+    marker-only directory would read as non-empty and never be reaped."""
+    from local_operator.session.retention import _dir_size
+
+    directory = tmp_path / "sessions" / "sess"
+    directory.mkdir(parents=True)
+    (directory / ".session.pid").write_text("12345")
+
+    assert _dir_size(directory) == 0
+
+
+def test_origin_marker_is_still_charged_as_content(tmp_path):
+    """#154/#192 protect an aborted child stamped with only ``origin.json``.
+    That marker is content, not a sidecar, so it must still count — the claim
+    work does not narrow that protection."""
+    from local_operator.session.retention import _dir_size
+
+    directory = tmp_path / "sessions" / "child"
+    directory.mkdir(parents=True)
+    (directory / "origin.json").write_text('{"origin": "subagent"}')
+
+    assert _dir_size(directory) > 0
+    result = sweep_sessions(tmp_path / "sessions")
+    assert result.evicted == 0
+    assert directory.exists()
+
+
+def test_on_an_unverifiable_platform_a_stale_claim_expires(tmp_path, monkeypatch):
+    """Where liveness cannot be probed (Windows), a claim cannot be trusted
+    forever or a leaked marker would disable the reap one crash at a time. It
+    is bounded by ``CLAIM_TRUST_S`` measured from the later of the marker and
+    the last write. A marker older than the bound on an otherwise-empty
+    directory reads as abandoned and is reaped."""
+    import os
+
+    import local_operator.session.retention as retention
+
+    # Force the unverifiable branch and make every pid look alive, so ONLY the
+    # age bound can decide — this isolates the bound from the pid probe.
+    monkeypatch.setattr(retention, "_PLATFORM", "win32")
+    monkeypatch.setattr(retention, "_LIVENESS_IS_VERIFIABLE", False)
+
+    sessions = tmp_path / "sessions"
+    stale = sessions / "stale"
+    stale.mkdir(parents=True)
+    marker = stale / ".session.pid"
+    marker.write_text("12345")
+    # Age the marker well past the trust window.
+    old = time.time() - retention.CLAIM_TRUST_S - 3600
+    os.utime(marker, (old, old))
+
+    result = sweep_sessions(sessions)
+
+    assert not stale.exists()
+    assert result.evicted == 1
+
+
+def test_on_an_unverifiable_platform_a_fresh_claim_is_kept(tmp_path, monkeypatch):
+    """The counterpart: on the same unverifiable platform a claim written
+    within the trust window protects its empty directory, so a session that
+    just started (resume of an old transcript, marker fresh) is not reaped
+    before it writes its first turn."""
+    import local_operator.session.retention as retention
+
+    monkeypatch.setattr(retention, "_PLATFORM", "win32")
+    monkeypatch.setattr(retention, "_LIVENESS_IS_VERIFIABLE", False)
+
+    sessions = tmp_path / "sessions"
+    fresh = sessions / "fresh"
+    fresh.mkdir(parents=True)
+    (fresh / ".session.pid").write_text("12345")  # written now, inside the window
+
+    result = sweep_sessions(sessions)
+
+    assert fresh.exists()
+    assert result.evicted == 0

--- a/tests/unit/test_session_factory.py
+++ b/tests/unit/test_session_factory.py
@@ -1011,6 +1011,7 @@ async def test_a_layer_failure_keys_on_the_layer_not_on_a_filename(monkeypatch) 
 @pytest.mark.asyncio
 async def test_prepare_claims_before_a_concurrent_sweep_can_reap_the_dir(
     tmp_config_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """The startup claim race, pinned at the CALLER, not on ``claim_session``
     in isolation.
@@ -1025,11 +1026,25 @@ async def test_prepare_claims_before_a_concurrent_sweep_can_reap_the_dir(
     ``_prepare`` with ``sweep_from_config`` patched to behave like the
     aggressive concurrent sweep, and assert the directory survives.
 
-    Concretely the patched sweep reaps every EMPTY, UNCLAIMED directory under
-    ``sessions/`` (exactly what the real sweep does to a co-resident session's
-    empty startup dir). If ``_prepare`` has already claimed its own directory,
-    the marker makes it survive; if the claim came after, the directory is gone
-    and the assertion fails.
+    Two co-resident reaps are modelled, because they pin two different
+    regression shapes:
+
+    * ``reaping_sweep`` (patched onto ``sweep_from_config``) fires at the sweep
+      point ``_prepare`` reaches AFTER both its claim and its ``mkdir``. It
+      catches the claim removed ENTIRELY — with no marker written the sweep
+      reaps the empty dir — but by then a claim-after-``mkdir`` dir is already
+      claimed, so this reap alone cannot see an ordering defect.
+    * ``mkdir_with_concurrent_reap`` (patched onto ``Path.mkdir``) fires a reap
+      at the instant a directory is about to be (re)created, which is the ONLY
+      moment that distinguishes claim-first from claim-after. In the defect
+      shape ``_prepare``'s own ``mkdir`` creates the dir empty-and-unclaimed,
+      and the reap that runs on ``claim_session``'s later ``mkdir`` deletes it
+      out from under the starting run — the round-6 **L1** window. Claim-first
+      never exposes it: the directory only ever appears already carrying its
+      marker, so the reap spares it every time.
+
+    Both reaps reap only EMPTY, UNCLAIMED directories under ``sessions/``,
+    mirroring the real sweep's guard so a claimed dir is always left alone.
     """
     from local_operator.session.retention import _is_claimed, sweep_sessions
     from local_operator.session_factory import _prepare
@@ -1073,10 +1088,45 @@ async def test_prepare_claims_before_a_concurrent_sweep_can_reap_the_dir(
         # Also run the genuine sweep so the test exercises the real signature.
         return sweep_sessions(sessions_dir, live_dir=live_dir)
 
+    sessions_dir = tmp_config_dir / "sessions"
+
+    def _reap_empty_unclaimed(now: float) -> bool:
+        """Reap every empty, unclaimed dir under ``sessions/``, mirroring a
+        co-resident session's sweep guard, and report whether it took one."""
+        import shutil
+
+        reaped = False
+        if sessions_dir.is_dir():
+            for child in sessions_dir.iterdir():
+                if not child.is_dir():
+                    continue
+                if any(p.name != ".session.pid" for p in child.iterdir()):
+                    continue
+                if _is_claimed(child, now):
+                    continue
+                shutil.rmtree(child, ignore_errors=True)
+                reaped = True
+        return reaped
+
+    original_mkdir = Path.mkdir
+
+    def mkdir_with_concurrent_reap(self: Path, *args: Any, **kwargs: Any) -> None:
+        # A co-resident sweep landing in the ORDERING window: it reaps at the
+        # instant a directory is (about to be) created. A claim-after-mkdir
+        # regression leaves ``_prepare``'s freshly ``mkdir``'d dir empty and
+        # unclaimed, so the reap fired here — on ``claim_session``'s own later
+        # ``mkdir`` — deletes it, and we record that. Claim-first writes the
+        # marker as part of the same ``mkdir``, so the dir is never seen
+        # empty-and-unclaimed and this never trips.
+        if _reap_empty_unclaimed(time.time()):
+            captured["reaped_at_mkdir"] = True
+        return original_mkdir(self, *args, **kwargs)
+
     from local_operator.session import retention as retention_mod
 
     original = retention_mod.sweep_from_config
     retention_mod.sweep_from_config = reaping_sweep
+    monkeypatch.setattr(Path, "mkdir", mkdir_with_concurrent_reap)
     try:
         await _prepare(
             _args(hosting="test", model="test-model"),
@@ -1096,6 +1146,14 @@ async def test_prepare_claims_before_a_concurrent_sweep_can_reap_the_dir(
     assert captured.get("survived_the_sweep") is True, (
         "_prepare's session directory was reaped by a concurrent sweep before "
         "it was claimed: the claim must be written before the directory exists"
+    )
+    # Ordering, not just presence (round-7 R7-1): a claim written AFTER the
+    # ``mkdir`` leaves an empty-and-unclaimed window that the mkdir-time reap
+    # deletes, and this trips. It stays clean only when the marker is written
+    # as part of the directory's creation — i.e. the claim came first.
+    assert captured.get("reaped_at_mkdir") is not True, (
+        "_prepare's session directory was reaped in the mkdir-time window: the "
+        "claim must be written BEFORE the directory exists empty, not after"
     )
     assert cast(Path, transcript_dir).exists()
     assert (cast(Path, transcript_dir) / ".session.pid").exists()

--- a/tests/unit/test_session_factory.py
+++ b/tests/unit/test_session_factory.py
@@ -1009,6 +1009,99 @@ async def test_a_layer_failure_keys_on_the_layer_not_on_a_filename(monkeypatch) 
 
 
 @pytest.mark.asyncio
+async def test_prepare_claims_before_a_concurrent_sweep_can_reap_the_dir(
+    tmp_config_dir: Path,
+) -> None:
+    """The startup claim race, pinned at the CALLER, not on ``claim_session``
+    in isolation.
+
+    The bug this guards against is an ORDERING defect: ``_prepare`` must claim
+    its session directory BEFORE anything creates it empty, so that a
+    concurrent session's startup sweep — which reaps empty directories — cannot
+    delete it in the window before the first turn is written. A regression that
+    reordered the claim after the ``mkdir``/sweep would leave a real
+    ``claim_session`` intact and still reintroduce the bug, so testing
+    ``claim_session`` alone would not catch it. We therefore drive the real
+    ``_prepare`` with ``sweep_from_config`` patched to behave like the
+    aggressive concurrent sweep, and assert the directory survives.
+
+    Concretely the patched sweep reaps every EMPTY, UNCLAIMED directory under
+    ``sessions/`` (exactly what the real sweep does to a co-resident session's
+    empty startup dir). If ``_prepare`` has already claimed its own directory,
+    the marker makes it survive; if the claim came after, the directory is gone
+    and the assertion fails.
+    """
+    from local_operator.session.retention import _is_claimed, sweep_sessions
+    from local_operator.session_factory import _prepare
+
+    config_manager = FakeConfigManager({"hosting": "test", "model_name": "test-model"})
+    registry = FakeRegistry(tmp_config_dir)
+    credential_manager = MagicMock()
+    credential_manager.get_credential.return_value = None
+
+    captured: dict[str, object] = {}
+
+    def reaping_sweep(cfg_mgr, config_dir, live_dir):
+        # Stand in for a co-resident session's startup sweep: reap every empty,
+        # unclaimed directory, and DO NOT honour ``live_dir`` — that belt only
+        # protects the sweeping session's OWN directory, and here the starting
+        # session is the other process, so only its claim can save it.
+        sessions_dir = Path(config_dir) / "sessions"
+        captured["transcript_dir"] = live_dir
+        moment = time.time()
+        if sessions_dir.is_dir():
+            for child in sessions_dir.iterdir():
+                if not child.is_dir():
+                    continue
+                # Only touch genuinely empty, unclaimed dirs, mirroring the
+                # real reap's guard so a claimed dir is left alone.
+                if any(p.name != ".session.pid" for p in child.iterdir()):
+                    continue
+                if _is_claimed(child, moment):
+                    continue
+                import shutil
+
+                shutil.rmtree(child, ignore_errors=True)
+        # Record the directory's fate AS OF THE SWEEP, before ``_prepare`` runs
+        # on. This is the load-bearing assertion: a later ``claim_session``
+        # would RECREATE a reaped directory, so an end-of-``_prepare`` existence
+        # check passes even when the claim came too late. Only "did the sweep
+        # leave it standing" distinguishes claim-first (survives) from
+        # claim-after (reaped here, recreated later). ``live_dir`` is the
+        # session's own directory the same object ``_prepare`` claims.
+        captured["survived_the_sweep"] = live_dir is not None and live_dir.exists()
+        # Also run the genuine sweep so the test exercises the real signature.
+        return sweep_sessions(sessions_dir, live_dir=live_dir)
+
+    from local_operator.session import retention as retention_mod
+
+    original = retention_mod.sweep_from_config
+    retention_mod.sweep_from_config = reaping_sweep
+    try:
+        await _prepare(
+            _args(hosting="test", model="test-model"),
+            cast("ConfigManager", config_manager),
+            credential_manager,
+            cast("AgentRegistry", registry),
+            has_ui=False,
+        )
+    finally:
+        retention_mod.sweep_from_config = original
+
+    transcript_dir = captured["transcript_dir"]
+    assert transcript_dir is not None
+    # The claim was written before the sweep could see the directory, so the
+    # concurrent reap left it standing. A regression that claimed AFTER the
+    # mkdir/sweep fails HERE, not on the recreated end-state.
+    assert captured.get("survived_the_sweep") is True, (
+        "_prepare's session directory was reaped by a concurrent sweep before "
+        "it was claimed: the claim must be written before the directory exists"
+    )
+    assert cast(Path, transcript_dir).exists()
+    assert (cast(Path, transcript_dir) / ".session.pid").exists()
+
+
+@pytest.mark.asyncio
 async def test_dispose_closes_auth_store(
     tmp_config_dir: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary

Closes the residual **startup claim race** in session retention, layered onto main's never-delete model.

> **Scope change (why this diff is smaller than the earlier review rounds).**
> While this PR sat open, main merged #192 ("never delete session transcripts"), which **rewrote retention**: it retired the age/count/byte ceilings entirely and made `sweep_sessions` reap **only literally-empty directories** — a more radical version of the fix this PR originally targeted. The PR's original ceiling-based machinery (`_candidates`, the count/byte/age eviction loop, `bytes_on_disk`, the live-bytes warning) is therefore **dead code on the current model and has been dropped** — this PR does **not** revert #192. What remains is the piece #192 does *not* cover, described below. Because the shipped change is now materially different from what rounds 1–6 reviewed (those were against the ceiling model), a **fresh agent review round on the current head is required**.

## The bug that survives #192

`sweep_sessions` reaps empty directories, but **every live session is empty for the instant between its `mkdir` and its first append**. On a machine running several sessions at once (the normal way this harness is used), another session's startup sweep can land in that window and delete a directory whose owner is about to write to it — reproducing the exact `FileNotFoundError: .../transcript.jsonl` kill retention exists to prevent. #192's content-based protection cannot cover this window, because in it the directory genuinely holds nothing.

## What this PR does

- **Claim marker (liveness, not content).** A starting session writes `.session.pid` into its directory via `claim_session()` **before anything else creates it**, and the sweep skips any empty directory a live process still owns (`_is_claimed`). The claim is re-checked **immediately before each `rmtree`** so a claim landing mid-sweep is honoured (round-6 **L1** + **L2**). Crucially the marker is *liveness*: a dead owner's leftover marker does **not** keep its empty directory alive (it is excluded from `_dir_size`), so hard-killed corpses are still reclaimed and the reap never leaks. On platforms where liveness cannot be probed (Windows), a claim is bounded by `CLAIM_TRUST_S` from the later of the marker and the last write.
- **Caller ordering (round-6 L1).** `_prepare` and `_build_child_session` claim *first*, ahead of their own `mkdir`/`Transcript()`; `Session.dispose` releases the claim so an empty directory becomes reapable when its run ends. The defect was an ordering one at the caller — not in `claim_session` — so the fix is there.
- **Transcript self-heal.** `Transcript` recreates its directory if it vanishes mid-session instead of dying on the next append, rewriting the full in-memory history so a later resume is complete rather than starting mid-conversation.

## Testing evidence (real execution)

Reproduced the race on **clean `origin/main`** and confirmed its absence after the fix, using the real modules:

**Before (clean `origin/main`, no claim):**
```
1. starting-session dir A survived concurrent sweep: False (evicted=1)
2. first append after sweep: KILLED FileNotFoundError
3. self-heal after dir vanished: FAILED FileNotFoundError (no recovery)
```

**After (this PR):**
```
1. starting-session dir A survived concurrent sweep: True (evicted=0)
2. first append after sweep: SUCCEEDED, A exists: True
3. self-heal after dir vanished: RECOVERED, C exists: True, lines=2
```

**L2 mid-sweep claim + no-leak + never-delete invariant:**
```
L2 mid-sweep claim: victim survived: True | evicted: 1
dead-marker corpse reaped (no immortal-empty leak): True | evicted: 1
never-delete: content dir survives with hostile ceilings: True | evicted: 0
aborted child (origin.json only) survives: True | evicted: 0
```

**New automated tests** (all green): a caller-ordering test that drives the real `_prepare` with a reaping sweep and asserts the directory survived *the sweep* (not just the recreated end-state — round-6 **L4**), plus module tests for live-claim protection, dead-marker reaping, mid-sweep claims, sidecar byte accounting, both Windows age-bound branches, and transcript self-heal. The caller-ordering test was verified to **fail** when the claim is removed.

## Gates

`flake8 .`, `black --check` (26.1.0), `isort --check-only --profile black`, `pyright .` — all clean. Targeted suites (`tests/unit/session`, `test_session_factory.py`, `harness`) green. Two failures seen only under fixed-order `-p no:randomly` runs (`test_dispose_closes_auth_store`, and a one-off `test_loop` timing flake) are **pre-existing on `origin/main`** — reproduced there identically — and unrelated to this change.

Version bumped to **0.24.7**.
