### PR TITLE
fix(tui,providers): bound pasted images so a screenshot cannot brick a session

### DIFF
--- a/local_operator/imaging.py
+++ b/local_operator/imaging.py
@@ -31,11 +31,25 @@ pasted screenshot. The composer used to forward pasted bytes verbatim at
 whatever size the screen produced, which is exactly how a 2206x266 paste wedged
 a session permanently — the read tool had been bounded since it was written, so
 the hole was only visible from the path that had no bound at all.
+
+TWO KNOWING EXCEPTIONS, so a reader does not conclude the invariant is total:
+
+- ``compaction/snapcompact.py`` renders its own frames and does not come
+  through here. Their geometry is a per-provider billing decision rather than a
+  paste, and under the Google shape they are 2048x2046 — over the many-image
+  ceiling. That is reachable on another provider, since ``session.set_model``
+  can swap mid-session and a Gemini-shaped archive then replays to whatever is
+  current (review round 1, F4). It is left alone here because changing it means
+  re-deciding that billing trade, not because it is safe by construction; the
+  ``is_image_rejection`` degrade is the net under it.
+- ``_forward_undecoded`` cannot resize at all, because on that host there is no
+  decoder. See its own docstring for what it does enforce.
 """
 
 from __future__ import annotations
 
 import io
+from typing import Any
 
 from local_operator.helpers import heif_image_module, pillow_image_module
 from local_operator.media import ImageInfo
@@ -106,9 +120,12 @@ def _forward_undecoded(data: bytes, info: ImageInfo) -> tuple[bytes, str, str]:
 
     The DIMENSION cap cannot be enforced here — enforcing it means resizing,
     and resizing is exactly what is unavailable — so an oversized image on such
-    a host is named in the summary and forwarded anyway. That is a deliberate
-    residual: the caller is told, and the session-level degrade
-    (``providers.failover.is_image_rejection``) is the net underneath it.
+    a host is named in the returned SUMMARY and forwarded anyway. That is a
+    deliberate residual, and the summary is the only warning of it, so a caller
+    that discards the summary also discards the warning: ``read`` puts it in the
+    caption the model sees, while the composer currently drops it (review round
+    1, F2). The session-level degrade
+    (``providers.failover.is_image_rejection``) is the net underneath both.
     """
     if not info.sendable:
         # Not a degrade: no provider accepts HEIC, so forwarding it verbatim
@@ -130,6 +147,51 @@ def _forward_undecoded(data: bytes, info: ImageInfo) -> tuple[bytes, str, str]:
     else:
         summary += ", forwarded without resizing"
     return data, info.mime_type, summary
+
+
+#: EXIF tag number for ``Orientation``. Spelled as the integer rather than
+#: imported from ``PIL.ExifTags`` so that reading it costs no Pillow import on
+#: a path that may never decode anything.
+_EXIF_ORIENTATION_TAG = 274
+
+
+def _needs_exif_rotation(image: Any) -> bool:
+    """Does this image carry an ``Orientation`` tag that actually turns it?
+
+    Asked BEFORE transposing, because ``ImageOps.exif_transpose`` returns a
+    ``copy()`` when there is nothing to do — so "is this a different object?"
+    cannot answer it, and using that as the test silently destroyed the verbatim
+    rung (every tagless image re-encoded for nothing).
+
+    ``1`` means "already upright" and is treated as no rotation, so a camera
+    that writes the tag explicitly still gets the cheap path.
+
+    Best-effort: a corrupt EXIF block raises from deep inside Pillow, and the
+    honest answer to "is this rotated?" when the metadata is unreadable is no.
+    """
+    try:
+        return image.getexif().get(_EXIF_ORIENTATION_TAG, 1) not in (1, None)
+    except Exception:  # noqa: BLE001 — unreadable metadata is not a reason to fail an image
+        return False
+
+
+def _exif_transposed(image: Any) -> Any:
+    """``image`` rotated per its EXIF ``Orientation`` tag.
+
+    ``ImageOps`` is imported here rather than at module scope for the reason
+    given in :func:`~local_operator.helpers.pillow_image_module`: nothing in
+    this package may pay Pillow's import on a path that never decodes an image.
+
+    Best-effort by design. A corrupt or unreadable EXIF block raises from deep
+    inside Pillow, and an unrotated image is a far better outcome than a failed
+    attachment — orientation is a refinement, not the payload.
+    """
+    try:
+        from PIL import ImageOps
+
+        return ImageOps.exif_transpose(image) or image
+    except Exception:  # noqa: BLE001 — see the docstring; never fail an image for this
+        return image
 
 
 def _guard_pixel_budget(width: int, height: int) -> None:
@@ -193,18 +255,49 @@ def bound_image_for_model(data: bytes, info: ImageInfo) -> tuple[bytes, str, str
 
     try:
         image = image_module.open(io.BytesIO(data))
-        width, height = image.size
-        _guard_pixel_budget(width, height)
+        _guard_pixel_budget(*image.size)
         # Multi-frame sources never pass through: providers read frame 0 and
         # ignore the rest, so an animation's other frames are bytes uploaded to
         # be discarded.
         frames = getattr(image, "n_frames", 1)
         image.load()
 
+        # Bake EXIF orientation into the PIXELS before anything else looks at
+        # the size. A phone camera stores the sensor's raw frame plus an
+        # ``Orientation`` tag saying how to turn it, and re-encoding drops the
+        # tag while keeping the pixels — so a resized photo arrives sideways
+        # unless it is transposed first.
+        #
+        # Applied on EVERY rung rather than only before a resize, because the
+        # bug this closes is an INCONSISTENCY: the verbatim rung keeps the tag
+        # and the resize rung silently discarded it, so two identical photos
+        # differing only in resolution were delivered in different orientations
+        # (review round 1, F1). Transposing unconditionally means the delivered
+        # pixels are upright whichever rung runs, and the model never has to
+        # know a tag existed.
+        #
+        # It also settles the question the tag itself raises: a provider that
+        # ignores EXIF would render the untransposed image wrongly, and one that
+        # honours it would double-rotate a transposed image that still carried
+        # the tag. Transposing and re-encoding without the tag is correct under
+        # both, which is why this cannot be left to the provider.
+        #
+        # The tag is READ first and the transpose only runs when it says the
+        # image actually turns. That ordering is load-bearing: a tagless image
+        # must still reach the verbatim rung below with its ORIGINAL bytes, and
+        # ``exif_transpose`` returns a ``copy()`` rather than the same object
+        # when there is nothing to do — so testing identity afterwards would
+        # re-encode every ordinary screenshot for nothing.
+        rotated = _needs_exif_rotation(image)
+        if rotated:
+            image = _exif_transposed(image)
+        width, height = image.size
+
         long_edge = max(width, height)
         if (
             info.sendable
             and frames == 1
+            and not rotated
             and long_edge <= IMAGE_MAX_EDGE
             and len(data) <= IMAGE_MAX_BYTES
         ):

--- a/local_operator/imaging.py
+++ b/local_operator/imaging.py
@@ -1,0 +1,253 @@
+"""Bounding an image so a provider will accept it.
+
+This module exists because of a specific failure mode, and the failure mode is
+worth stating before the code: an image block that a provider refuses does not
+fail once. It is in the conversation HISTORY, so every subsequent request
+carries it again and earns the same 400 — including compaction, which has to
+send the history in order to summarise it. The session is then unrecoverable
+from the inside: reload replays the same block, ``/compact`` cannot run, and
+the user sees the identical error answering every prompt forever. That is the
+shape of anthropics/claude-code#19031, #24387, #47391 and #50708, and it is why
+bounding happens on the way IN rather than being left to the provider.
+
+The dimension rule is the one that is easy to miss, because it is not a
+constant. Anthropic caps a single image at 8000 pixels on its long edge, but a
+request carrying **more than 20 images** switches to a much stricter per-image
+limit of 2000 pixels, and refuses the whole request with
+``At least one of the image dimensions exceed max allowed size for
+many-image requests: 2000 pixels``. So an image that was accepted for hours can
+start being refused purely because the conversation grew past twenty frames —
+no bytes changed, and nothing about that image was ever wrong on its own. A
+long agent session with screenshot evidence crosses twenty images routinely.
+
+:data:`IMAGE_MAX_EDGE` is therefore not a token optimisation that happens to be
+safe; it is BELOW the strict 2000-pixel limit on purpose, so the many-image
+threshold can never be reached no matter how many frames a session accumulates.
+
+Centralised here rather than living next to one caller because "an image is
+about to become an ``ImageContent``" is the invariant, and it has more than one
+site: the ``read`` tool returning an image block, and the composer attaching a
+pasted screenshot. The composer used to forward pasted bytes verbatim at
+whatever size the screen produced, which is exactly how a 2206x266 paste wedged
+a session permanently — the read tool had been bounded since it was written, so
+the hole was only visible from the path that had no bound at all.
+"""
+
+from __future__ import annotations
+
+import io
+
+from local_operator.helpers import heif_image_module, pillow_image_module
+from local_operator.media import ImageInfo
+from local_operator.optional import missing_extra_error
+
+#: Long-edge ceiling in pixels for an image handed to a provider.
+#:
+#: Two independent reasons land on a number this low, and BOTH have to hold.
+#:
+#: Correctness: a request carrying more than 20 images is held to a 2000-pixel
+#: per-image limit (see the module docstring). Anything above that line turns
+#: into a permanently wedged session once the twenty-first frame arrives, so
+#: the cap must sit below 2000 with room to spare — not at it.
+#:
+#: Cost: Anthropic downsizes anything above 1568 server-side and bills the
+#: resized token count either way, so pixels past this line are pure upload
+#: with zero fidelity reaching the model. omp uses the same number and this
+#: repo's snapcompact already renders its frames at 1568. Measured on real
+#: files: a 2560x1600 UI screenshot costs 5,461 image tokens untouched and
+#: 2,049 at 1568 (2.7x), and a 4032x3024 phone photo — 1.5 MB as JPEG, so it
+#: passes any byte cap easily — costs 16,257 tokens untouched against 2,459
+#: resized (6.6x).
+IMAGE_MAX_EDGE = 1568
+#: Refuse to DECODE above this pixel count (~200 MB of RGBA at 4 bytes/pixel).
+#: Checked against the header dimensions BEFORE the decode allocates, because a
+#: decompression bomb is small on disk by construction: a byte cap cannot see
+#: it coming. Measured: a flat 7000x7000 PNG is 0.15 MB on disk and takes 577
+#: ms to decode, resize and re-encode. 50M pixels is ~7000x7000, comfortably
+#: above any camera or display this reads from and comfortably below Pillow's
+#: own 89M bomb threshold, so the refusal is ours and is an error rather than a
+#: warning.
+IMAGE_MAX_PIXELS = 50_000_000
+#: Encoded-byte threshold for the image block, before base64 inflates it by
+#: 4/3. Two jobs. It decides when a small in-bounds image is forwarded VERBATIM
+#: (cheapest and lossless — no re-encode can improve an image the model will
+#: see at its original size), and it decides when the resized PNG is too fat to
+#: keep, which is the only reason lossy JPEG is ever reached.
+#:
+#: A TRIGGER, not a guarantee: the ladder stops after JPEG rather than chasing
+#: quality down, so pathological input still lands above it (uniform noise at
+#: 1568x1176 measured 1.19 MiB of quality-85 JPEG). The guarantee is the wall
+#: this is set against — providers reject images over 5 MB of base64, and the
+#: long-edge cap means even that pathological case encodes to 1.59 MiB, 32% of
+#: the wall. 1 MiB was picked to leave 3.7x headroom on the ordinary path, and
+#: the fat cases are real: a photographic 1568x1176 frame re-encodes to a
+#: 3.3 MiB PNG (4.46 MiB base64, inside 5 MB by only 12%) and to a 804 KiB JPEG.
+IMAGE_MAX_BYTES = 1024 * 1024
+#: JPEG quality used for that fallback. 85 is the standard visually-lossless
+#: point; on the sampled files it turned 1.9 MB of re-encoded PNG into 271 KB.
+IMAGE_JPEG_QUALITY = 85
+
+
+def _forward_undecoded(data: bytes, info: ImageInfo) -> tuple[bytes, str, str]:
+    """Ship image bytes VERBATIM on a host with no usable Pillow.
+
+    Pillow reaches a default install as a pillow-heif dependency rather than a
+    direct one, and pillow-heif is the most platform-fragile wheel this project
+    pulls. When it is missing or broken there is no decoder, so there is also
+    no resize and no validation beyond the header — the two things
+    :func:`bound_image_for_model` normally provides. Refusing every image on
+    such a host would be the worse trade: a screenshot the model can look at
+    beats a paragraph explaining why it cannot, and the format is one the
+    provider clients already serialize.
+
+    What remains enforceable from the header alone is the BYTE cap, so that is
+    the line. Above it the answer is an error, because forwarding an unbounded
+    blob is how a session ends up wedged behind a provider that refuses it.
+
+    The DIMENSION cap cannot be enforced here — enforcing it means resizing,
+    and resizing is exactly what is unavailable — so an oversized image on such
+    a host is named in the summary and forwarded anyway. That is a deliberate
+    residual: the caller is told, and the session-level degrade
+    (``providers.failover.is_image_rejection``) is the net underneath it.
+    """
+    if not info.sendable:
+        # Not a degrade: no provider accepts HEIC, so forwarding it verbatim
+        # would GUARANTEE the refusal rather than risk it. Transcoding is the
+        # only way to send one, and transcoding is what is unavailable.
+        raise ValueError(missing_extra_error("images", "HEIC/HEIF decoding"))
+    if len(data) > IMAGE_MAX_BYTES:
+        raise ValueError(
+            f"it is {len(data)} bytes, over the {IMAGE_MAX_BYTES}-byte cap for an "
+            f"unresized image, and {missing_extra_error('images', 'resizing it')}"
+        )
+    summary = f"{info.mime_type}, {info.dimensions or 'dimensions unknown'}, {len(data)} bytes"
+    if info.width and info.height and max(info.width, info.height) > IMAGE_MAX_EDGE:
+        # Worth saying rather than swallowing: this is the case the resize
+        # exists for, and the model is about to be billed several times the
+        # tokens for it. Naming it is also the only hint anyone gets that the
+        # host is missing the extra.
+        summary += ", too large to send efficiently and no decoder to resize it"
+    else:
+        summary += ", forwarded without resizing"
+    return data, info.mime_type, summary
+
+
+def _guard_pixel_budget(width: int, height: int) -> None:
+    """Refuse an image whose pixel count would dominate the process.
+
+    A decompression bomb is small on disk by construction, so a byte cap cannot
+    see it coming and only the dimensions can.
+    """
+    if width * height > IMAGE_MAX_PIXELS:
+        raise ValueError(
+            f"it is {width}x{height} ({width * height:,} pixels) and the decode limit is "
+            f"{IMAGE_MAX_PIXELS:,} pixels"
+        )
+
+
+def bound_image_for_model(data: bytes, info: ImageInfo) -> tuple[bytes, str, str]:
+    """Decode, bound and re-encode image bytes for a provider.
+
+    Returns ``(payload, wire_mime, summary)``; raises ``ValueError`` with a
+    human-readable message when the bytes will not decode. The raise is
+    load-bearing: a corrupt or truncated image forwarded as an image block
+    earns a ``Could not process image`` 400, and the block is in the history by
+    then. The session layer recovers from that, but a backstop is not a licence
+    — the bad block is still a wasted round trip and a degraded session, and
+    decoding here is where it is cheap to avoid. So the decode is never
+    skipped, not even on the verbatim path.
+
+    CPU-bound and unbounded in duration by the caller's standards: a 20 MP
+    screenshot measures ~315 ms and the 50 MP ceiling ~577 ms on an M3 Max. Any
+    caller on an event loop must run this in a thread.
+
+    The ladder, cheapest first:
+
+    1. Verbatim, when the image is already inside both bounds and in a format
+       the clients serialize. No re-encode can improve an image the model sees
+       at its original size, and PNG round-tripping routinely makes files
+       BIGGER (a 2560x1600 UI screenshot measured 550 KB on disk against 335 KB
+       re-encoded only because the resize came with it).
+    2. Resize to :data:`IMAGE_MAX_EDGE` and re-encode as PNG. Lossless, which
+       is what a screenshot of 9-pixel text needs.
+    3. JPEG when that PNG blows :data:`IMAGE_MAX_BYTES`, and only when it
+       actually comes out smaller. PNG is a bad photographic codec and that is
+       the usual case here — the sampled 1672x941 photographic PNG re-encoded
+       to 1.9 MB of PNG against 271 KB of quality-85 JPEG — but it is not the
+       only one, so the choice is measured rather than assumed.
+
+    With no decoder available the whole ladder collapses to
+    :func:`_forward_undecoded`.
+    """
+    image_module = pillow_image_module() if info.sendable else heif_image_module()
+    if image_module is None:
+        return _forward_undecoded(data, info)
+
+    # The pixel cap wants to fire BEFORE the decode allocates, and for every
+    # format except HEIF the header already answers it. HEIF keeps its size in
+    # a meta-nested ispe box that media.sniff_image deliberately does not walk,
+    # so those are capped below on the decoded size instead — later than ideal,
+    # but the only point at which the number exists.
+    if info.width and info.height:
+        _guard_pixel_budget(info.width, info.height)
+
+    try:
+        image = image_module.open(io.BytesIO(data))
+        width, height = image.size
+        _guard_pixel_budget(width, height)
+        # Multi-frame sources never pass through: providers read frame 0 and
+        # ignore the rest, so an animation's other frames are bytes uploaded to
+        # be discarded.
+        frames = getattr(image, "n_frames", 1)
+        image.load()
+
+        long_edge = max(width, height)
+        if (
+            info.sendable
+            and frames == 1
+            and long_edge <= IMAGE_MAX_EDGE
+            and len(data) <= IMAGE_MAX_BYTES
+        ):
+            return data, info.mime_type, f"{info.mime_type}, {width}x{height}, {len(data)} bytes"
+
+        if long_edge > IMAGE_MAX_EDGE:
+            scale = IMAGE_MAX_EDGE / long_edge
+            size = (max(1, round(width * scale)), max(1, round(height * scale)))
+            image = image.resize(size, image_module.LANCZOS)
+
+        # Palette and high-bit-depth modes are legal PNG but not legal JPEG,
+        # and rung 3 must not be the first place a mode problem shows up.
+        image = image.convert("RGBA" if image.mode in ("RGBA", "LA", "PA", "P") else "RGB")
+        buffer = io.BytesIO()
+        image.save(buffer, format="PNG")
+        payload, wire_mime = buffer.getvalue(), "image/png"
+
+        if len(payload) > IMAGE_MAX_BYTES:
+            if image.mode == "RGBA":
+                # JPEG has no alpha channel. Compositing onto white rather than
+                # dropping the channel keeps a transparent-background diagram
+                # legible instead of rendering it onto black.
+                flat = image_module.new("RGB", image.size, (255, 255, 255))
+                flat.paste(image, mask=image.getchannel("A"))
+                image = flat
+            buffer = io.BytesIO()
+            image.save(buffer, format="JPEG", quality=IMAGE_JPEG_QUALITY)
+            jpeg = buffer.getvalue()
+            # Take the smaller of the two, so the lossy rung can never make the
+            # result WORSE on both axes at once. PNG beats JPEG on flat
+            # synthetic images, and one of those clearing the budget is
+            # possible even though nothing sampled here did it.
+            if len(jpeg) < len(payload):
+                payload, wire_mime = jpeg, "image/jpeg"
+    except ValueError:
+        raise
+    except Exception as exc:  # noqa: BLE001 — Pillow raises OSError, SyntaxError and its own
+        raise ValueError(f"could not decode the image data ({type(exc).__name__}: {exc})") from exc
+
+    summary = f"{wire_mime}, {image.width}x{image.height}, {len(payload)} bytes"
+    if image.size != (width, height) or wire_mime != info.mime_type:
+        # State the source whenever what the model sees is not what is on disk.
+        # Otherwise a model comparing this against `ls -l` output, or against a
+        # later re-read, has no way to reconcile the two.
+        summary += f"; source {width}x{height} {info.mime_type}"
+    return payload, wire_mime, summary

--- a/local_operator/imaging.py
+++ b/local_operator/imaging.py
@@ -289,6 +289,12 @@ def bound_image_for_model(data: bytes, info: ImageInfo) -> tuple[bytes, str, str
         # when there is nothing to do — so testing identity afterwards would
         # re-encode every ordinary screenshot for nothing.
         rotated = _needs_exif_rotation(image)
+        # The size ON DISK, captured BEFORE the transpose can swap the axes.
+        # The summary's "source WxH" clause means "what a model would see from
+        # ``ls`` or a re-read", so reading it after a rotation reported
+        # 3000x4000 for a file every other tool calls 4000x3000 (review round
+        # 2, F7).
+        source_width, source_height = image.size
         if rotated:
             image = _exif_transposed(image)
         width, height = image.size
@@ -338,9 +344,19 @@ def bound_image_for_model(data: bytes, info: ImageInfo) -> tuple[bytes, str, str
         raise ValueError(f"could not decode the image data ({type(exc).__name__}: {exc})") from exc
 
     summary = f"{wire_mime}, {image.width}x{image.height}, {len(payload)} bytes"
-    if image.size != (width, height) or wire_mime != info.mime_type:
+    if image.size != (source_width, source_height) or wire_mime != info.mime_type or rotated:
         # State the source whenever what the model sees is not what is on disk.
         # Otherwise a model comparing this against `ls -l` output, or against a
         # later re-read, has no way to reconcile the two.
-        summary += f"; source {width}x{height} {info.mime_type}"
+        #
+        # ``rotated`` is its own trigger, not a redundancy. A square-ish photo
+        # can come back the same SIZE and the same MIME after a transpose, so
+        # the size/mime tests both go false and the clause would vanish for the
+        # one case where the pixels were most rearranged (review round 2, F7).
+        summary += f"; source {source_width}x{source_height} {info.mime_type}"
+        if rotated:
+            # Name the rotation rather than leaving a bare size disagreement the
+            # model has to explain to itself — it is the only clue that the axes
+            # it might derive coordinates from have been swapped.
+            summary += " (EXIF-rotated)"
     return payload, wire_mime, summary

--- a/local_operator/providers/failover.py
+++ b/local_operator/providers/failover.py
@@ -305,6 +305,23 @@ _IMAGE_REJECTION_MARKERS = (
     "does not match the provided media type",
     "image exceeds",
     "unsupported image",
+    # The DIMENSION refusals, which the list above missed entirely and which
+    # are the ones a long screenshot-taking session actually hits. Anthropic's
+    # wording is "At least one of the image dimensions exceed max allowed
+    # size: 8000 pixels" for a single oversized image, and "... max allowed
+    # size for many-image requests: 2000 pixels" once a request carries more
+    # than twenty images.
+    #
+    # The second is the nasty one: no image changed, the CONVERSATION grew, so
+    # a block that was accepted for a hundred turns starts being refused and
+    # keeps being refused forever. Without a marker here the degrade never
+    # fired, and the session answered every prompt — and every /compact — with
+    # the same 400 until it was abandoned. Observed live on 2026-08-18.
+    #
+    # Matched on the shared prefix so both variants and any future pixel
+    # ceiling are covered by one marker, since the number is the part that
+    # moves.
+    "image dimensions exceed max allowed size",
 )
 
 

--- a/local_operator/tools/builtin.py
+++ b/local_operator/tools/builtin.py
@@ -45,7 +45,6 @@ import base64
 import contextlib
 import difflib
 import fnmatch
-import io
 import json
 import logging
 import mimetypes
@@ -84,9 +83,14 @@ from local_operator.harness.wake import (
     build_wake_schedule,
     format_duration,
 )
-from local_operator.helpers import heif_image_module, pillow_image_module
+from local_operator.imaging import (
+    IMAGE_JPEG_QUALITY,
+    IMAGE_MAX_BYTES,
+    IMAGE_MAX_EDGE,
+    IMAGE_MAX_PIXELS,
+    bound_image_for_model,
+)
 from local_operator.media import ImageInfo, sniff_image_file
-from local_operator.optional import missing_extra_error
 from local_operator.tools.spill import (
     SPILL_ENTRY_LIMIT_BYTES,
     SPILL_SCHEME,
@@ -151,41 +155,16 @@ READ_FILE_LIMIT_BYTES = 2 * 1024 * 1024
 #: paired with :data:`READ_IMAGE_MAX_PIXELS` — compressed bytes bound neither
 #: the pixel count nor the RAM to hold it.
 READ_IMAGE_LIMIT_BYTES = 16 * 1024 * 1024
-#: Refuse to decode above this pixel count (~200 MB of RGBA at 4 bytes/pixel).
-#: Checked against the header dimensions BEFORE the decode allocates, because
-#: a decompression bomb is small on disk by construction: the byte cap above
-#: cannot see it coming. 50M pixels is ~7000x7000, comfortably above any
-#: camera or display this reads from and comfortably below Pillow's own 89M
-#: bomb threshold, so the refusal is ours and is an error rather than a warning.
-READ_IMAGE_MAX_PIXELS = 50_000_000
-#: Long-edge ceiling in pixels for an image handed to the model. Anthropic
-#: downsizes anything above 1568 server-side and bills the resized token count
-#: either way, so pixels past this line are pure upload with zero fidelity
-#: reaching the model; omp uses the same number and this repo's snapcompact
-#: already renders its frames at 1568. Measured on real files: a 2560x1600 UI
-#: screenshot costs 5,461 image tokens untouched and 2,049 at 1568 (2.7x), and
-#: a 4032x3024 phone photo — 1.5 MB as JPEG, so it passes the byte cap easily
-#: — costs 16,257 tokens untouched against 2,459 resized (6.6x).
-READ_IMAGE_MAX_EDGE = 1568
-#: Encoded-byte threshold for the image block, before base64 inflates it by
-#: 4/3. Two jobs. It decides when a small in-bounds image is forwarded
-#: VERBATIM (cheapest and lossless — no re-encode can improve an image the
-#: model will see at its original size), and it decides when the resized PNG
-#: is too fat to keep, which is the only reason lossy JPEG is ever reached.
-#:
-#: A TRIGGER, not a guarantee: the ladder stops after JPEG rather than
-#: chasing quality down, so pathological input still lands above it (uniform
-#: noise at 1568x1176 measured 1.19 MiB of quality-85 JPEG). The guarantee is
-#: the wall this is set against — Anthropic rejects images over 5 MB of
-#: base64, and the long-edge cap means even that pathological case encodes to
-#: 1.59 MiB, 32% of the wall. 1 MiB was picked to leave 3.7x headroom on the
-#: ordinary path, and the fat cases are real: a photographic 1568x1176 frame
-#: re-encodes to a 3.3 MiB PNG (4.46 MiB base64, inside 5 MB by only 12%) and
-#: to a 804 KiB JPEG.
-READ_IMAGE_MAX_BYTES = 1024 * 1024
-#: JPEG quality used for that fallback. 85 is the standard visually-lossless
-#: point; on the sampled files it turned 1.9 MB of re-encoded PNG into 271 KB.
-READ_IMAGE_JPEG_QUALITY = 85
+#: Pixel, edge and byte bounds for an image block live in
+#: :mod:`local_operator.imaging` — ``read`` is one of two callers that turn
+#: bytes into an ``ImageContent`` (the composer's paste handler is the other),
+#: and both have to bound identically or the unbounded one wedges the session
+#: for both. Re-exported under the historical names because they are part of
+#: this module's tested surface.
+READ_IMAGE_MAX_PIXELS = IMAGE_MAX_PIXELS
+READ_IMAGE_MAX_EDGE = IMAGE_MAX_EDGE
+READ_IMAGE_MAX_BYTES = IMAGE_MAX_BYTES
+READ_IMAGE_JPEG_QUALITY = IMAGE_JPEG_QUALITY
 #: Maximum lines read renders; larger files show the head plus a footer
 #: telling the model to continue with a line range.
 READ_LINE_CAP = 2000
@@ -1735,161 +1714,6 @@ def _clamp_file_body(body: str, path: Path, start: int, total: int) -> str:
     )
 
 
-def _forward_image_undecoded(data: bytes, info: ImageInfo) -> tuple[bytes, str, str]:
-    """Ship image bytes VERBATIM on a host with no usable Pillow.
-
-    Pillow reaches a default install as a pillow-heif dependency rather than a
-    direct one, and pillow-heif is the most platform-fragile wheel this
-    project pulls. When it is missing or broken there is no decoder, so there
-    is also no resize and no validation beyond the header — the two things
-    :func:`_encode_image_for_model` normally provides. Refusing every image on
-    such a host would be the worse trade: a screenshot the model can look at
-    beats a paragraph explaining why it cannot, and the format is one the
-    provider clients already serialize.
-
-    What remains enforceable from the header alone is the BYTE cap, so that is
-    the line. Above it the answer is an error, because forwarding an unbounded
-    blob is how a session ends up wedged behind a provider that refuses it.
-    """
-    if not info.sendable:
-        # Not a degrade: no provider accepts HEIC, so forwarding it verbatim
-        # would GUARANTEE the refusal rather than risk it. Transcoding is the
-        # only way to send one, and transcoding is what is unavailable.
-        raise ValueError(missing_extra_error("images", "HEIC/HEIF decoding"))
-    if len(data) > READ_IMAGE_MAX_BYTES:
-        raise ValueError(
-            f"it is {len(data)} bytes, over the {READ_IMAGE_MAX_BYTES}-byte cap for an "
-            f"unresized image, and {missing_extra_error('images', 'resizing it')}"
-        )
-    summary = f"{info.mime_type}, {info.dimensions or 'dimensions unknown'}, {len(data)} bytes"
-    if info.width and info.height and max(info.width, info.height) > READ_IMAGE_MAX_EDGE:
-        # Worth saying rather than swallowing: this is the case the resize
-        # exists for, and the model is about to be billed several times the
-        # tokens for it. Naming it is also the only hint anyone gets that the
-        # host is missing the extra.
-        summary += ", too large to send efficiently and no decoder to resize it"
-    else:
-        summary += ", forwarded without resizing"
-    return data, info.mime_type, summary
-
-
-def _guard_pixel_budget(width: int, height: int) -> None:
-    """Refuse an image whose pixel count would dominate the process.
-
-    A decompression bomb is small on disk by construction, so the byte cap
-    cannot see it coming and only the dimensions can.
-    """
-    if width * height > READ_IMAGE_MAX_PIXELS:
-        raise ValueError(
-            f"it is {width}x{height} ({width * height:,} pixels) and the decode limit is "
-            f"{READ_IMAGE_MAX_PIXELS:,} pixels"
-        )
-
-
-def _encode_image_for_model(data: bytes, info: ImageInfo) -> tuple[bytes, str, str]:
-    """Decode, bound and re-encode image bytes for a provider.
-
-    Returns ``(payload, wire_mime, summary)``; raises ``ValueError`` with a
-    model-readable message when the bytes will not decode. The raise is
-    load-bearing: a corrupt or truncated image forwarded as an image block
-    earns a ``Could not process image`` 400 from Anthropic. The session layer
-    now recovers from that, but a backstop is not a licence — the bad block is
-    still a wasted round trip and a degraded session, and decoding here is
-    where it is cheap to avoid. So the decode is never skipped, not even on
-    the verbatim path.
-
-    The ladder, cheapest first:
-
-    1. Verbatim, when the image is already inside both bounds and in a format
-       the clients serialize. No re-encode can improve an image the model sees
-       at its original size, and PNG round-tripping routinely makes files
-       BIGGER (a 2560x1600 UI screenshot measured 550 KB on disk against
-       335 KB re-encoded only because the resize came with it).
-    2. Resize to :data:`READ_IMAGE_MAX_EDGE` and re-encode as PNG. Lossless,
-       which is what a screenshot of 9-pixel text needs.
-    3. JPEG when that PNG blows :data:`READ_IMAGE_MAX_BYTES`, and only when it
-       actually comes out smaller. PNG is a bad photographic codec and that is
-       the usual case here — the sampled 1672x941 photographic PNG re-encoded
-       to 1.9 MB of PNG against 271 KB of quality-85 JPEG — but it is not the
-       only one, so the choice is measured rather than assumed.
-
-    With no decoder available the whole ladder collapses to
-    :func:`_forward_image_undecoded`.
-    """
-    image_module = pillow_image_module() if info.sendable else heif_image_module()
-    if image_module is None:
-        return _forward_image_undecoded(data, info)
-
-    # The pixel cap wants to fire BEFORE the decode allocates, and for every
-    # format except HEIF the header already answers it. HEIF keeps its size in
-    # a meta-nested ispe box that media.sniff_image deliberately does not walk,
-    # so those are capped below on the decoded size instead — later than ideal,
-    # but the only point at which the number exists.
-    if info.width and info.height:
-        _guard_pixel_budget(info.width, info.height)
-
-    try:
-        image = image_module.open(io.BytesIO(data))
-        width, height = image.size
-        _guard_pixel_budget(width, height)
-        # Multi-frame sources never pass through: providers read frame 0 and
-        # ignore the rest, so an animation's other frames are bytes uploaded
-        # to be discarded.
-        frames = getattr(image, "n_frames", 1)
-        image.load()
-
-        long_edge = max(width, height)
-        if (
-            info.sendable
-            and frames == 1
-            and long_edge <= READ_IMAGE_MAX_EDGE
-            and len(data) <= READ_IMAGE_MAX_BYTES
-        ):
-            return data, info.mime_type, f"{info.mime_type}, {width}x{height}, {len(data)} bytes"
-
-        if long_edge > READ_IMAGE_MAX_EDGE:
-            scale = READ_IMAGE_MAX_EDGE / long_edge
-            size = (max(1, round(width * scale)), max(1, round(height * scale)))
-            image = image.resize(size, image_module.LANCZOS)
-
-        # Palette and high-bit-depth modes are legal PNG but not legal JPEG,
-        # and rung 3 must not be the first place a mode problem shows up.
-        image = image.convert("RGBA" if image.mode in ("RGBA", "LA", "PA", "P") else "RGB")
-        buffer = io.BytesIO()
-        image.save(buffer, format="PNG")
-        payload, wire_mime = buffer.getvalue(), "image/png"
-
-        if len(payload) > READ_IMAGE_MAX_BYTES:
-            if image.mode == "RGBA":
-                # JPEG has no alpha channel. Compositing onto white rather
-                # than dropping the channel keeps a transparent-background
-                # diagram legible instead of rendering it onto black.
-                flat = image_module.new("RGB", image.size, (255, 255, 255))
-                flat.paste(image, mask=image.getchannel("A"))
-                image = flat
-            buffer = io.BytesIO()
-            image.save(buffer, format="JPEG", quality=READ_IMAGE_JPEG_QUALITY)
-            jpeg = buffer.getvalue()
-            # Take the smaller of the two, so the lossy rung can never make the
-            # result WORSE on both axes at once. PNG beats JPEG on flat
-            # synthetic images, and one of those clearing the budget is
-            # possible even though nothing sampled here did it.
-            if len(jpeg) < len(payload):
-                payload, wire_mime = jpeg, "image/jpeg"
-    except ValueError:
-        raise
-    except Exception as exc:  # noqa: BLE001 — Pillow raises OSError, SyntaxError and its own
-        raise ValueError(f"could not decode the image data ({type(exc).__name__}: {exc})") from exc
-
-    summary = f"{wire_mime}, {image.width}x{image.height}, {len(payload)} bytes"
-    if image.size != (width, height) or wire_mime != info.mime_type:
-        # State the source whenever what the model sees is not what is on
-        # disk. Otherwise a model comparing this against `ls -l` output, or
-        # against a later re-read, has no way to reconcile the two.
-        summary += f"; source {width}x{height} {info.mime_type}"
-    return payload, wire_mime, summary
-
-
 def _joined_capped_list_body(
     full_items: list[str],
     shown_items: list[str],
@@ -2361,9 +2185,7 @@ async def execute_read(
 
     if info:
         try:
-            payload, wire_mime, summary = await asyncio.to_thread(
-                _encode_image_for_model, data, info
-            )
+            payload, wire_mime, summary = await asyncio.to_thread(bound_image_for_model, data, info)
         except ValueError as exc:
             # A text error, never an image block. Forwarding undecodable bytes
             # gets a 400 from the provider that no retry clears, because the

--- a/local_operator/tui/widgets/editor.py
+++ b/local_operator/tui/widgets/editor.py
@@ -128,6 +128,21 @@ IMAGE_MARKER = re.compile(r"\[Image #([1-9]\d*)(?:,[^\]\n\[]*)?\]")
 RESIZED_MARK = " ↓"
 
 
+def _was_downscaled(bounded: ImageInfo, source: ImageInfo) -> bool:
+    """Did the bound make the image SMALLER, as opposed to merely different?
+
+    Compares pixel counts rather than the ``WxH`` strings. A portrait phone
+    photo inside the bounds is EXIF-rotated on the way in, so its dimensions
+    change (3024x4032 from 4032x3024) while not one pixel is lost — and a naive
+    string comparison marked it ``↓``, asserting a shrink that never happened
+    (review round 2, F8). The mark is a claim about fidelity, so it has to be
+    tested as one.
+    """
+    if not source.width or not source.height or not bounded.width or not bounded.height:
+        return False
+    return bounded.width * bounded.height < source.width * source.height
+
+
 def _bounded_dimensions(payload: bytes, info: ImageInfo) -> str:
     """The marker's label: ``WxH`` of the bytes actually attached.
 
@@ -149,7 +164,7 @@ def _bounded_dimensions(payload: bytes, info: ImageInfo) -> str:
     bounded = sniff_image(payload)
     if bounded is None or not bounded.dimensions:
         return info.dimensions
-    if bounded.dimensions != info.dimensions and info.dimensions:
+    if _was_downscaled(bounded, info):
         return f"{bounded.dimensions}{RESIZED_MARK}"
     return bounded.dimensions
 

--- a/local_operator/tui/widgets/editor.py
+++ b/local_operator/tui/widgets/editor.py
@@ -44,6 +44,7 @@ never sees the difference.
 
 from __future__ import annotations
 
+import asyncio
 import base64
 import re
 import shlex
@@ -68,7 +69,8 @@ from textual.widgets import TextArea
 from textual.widgets.text_area import Edit, EditResult, Selection
 
 from local_operator.harness.types import ImageContent
-from local_operator.media import sniff_image_file
+from local_operator.imaging import bound_image_for_model
+from local_operator.media import ImageInfo, sniff_image, sniff_image_file
 from local_operator.tui.autocomplete import ArgumentMode, SlashCommand
 from local_operator.tui.widgets.command_picker import (
     CommandPicker,
@@ -109,6 +111,27 @@ _PATH_SEGMENT = re.compile(r"^(?:~|\.{0,2}/|/)")
 #: It also states the assumption `cite`'s ``str.find`` already relies on: a
 #: marker cannot contain another marker.
 IMAGE_MARKER = re.compile(r"\[Image #([1-9]\d*)(?:,[^\]\n\[]*)?\]")
+
+
+def _bounded_dimensions(payload: bytes, info: ImageInfo) -> str:
+    """``WxH`` of the bytes actually attached, for the marker's label.
+
+    Read back from the BOUNDED payload rather than carried over from ``info``,
+    which describes the file on disk. Once the paste path started resizing,
+    reusing the source dimensions would print a marker claiming 2560x1440 next
+    to a 1568x882 attachment — a receipt for something that was never sent.
+
+    A header sniff and not a decode: :func:`sniff_image` reads a fixed prefix,
+    so this costs microseconds and cannot be made expensive by the payload. It
+    is also applied to bytes this process just produced, so failure is not
+    expected — but it stays best-effort anyway, degrading to the source label
+    and then to no label at all, because a marker is a convenience and must
+    never be the reason an attachment is lost.
+    """
+    bounded = sniff_image(payload)
+    if bounded is not None and bounded.dimensions:
+        return bounded.dimensions
+    return info.dimensions
 
 
 def _marker_indices(text: str) -> list[int]:
@@ -1350,15 +1373,23 @@ class Editor(TextArea):
         it, it runs it a second time, and an ordinary text paste came out
         duplicated. Suppressing the base is ``prevent_default``; letting it run
         is doing nothing.
+
+        The ``await`` below is safe against that rule even though it lands
+        BEFORE ``prevent_default``. ``MessagePump._get_dispatch_methods`` is a
+        generator that re-checks ``_no_default_action`` at the top of each MRO
+        step, and the pump fully awaits one handler before resuming it, so the
+        base handler cannot start while this one is suspended. The same
+        sequencing is why two fast pastes cannot interleave: the pump dispatches
+        one message at a time, so marker issuance stays in paste order.
         """
-        attached = self._attach_pasted_images(event.text)
+        attached = await self._attach_pasted_images(event.text)
         if attached is None:
             return
         event.prevent_default()
         event.stop()
         self.insert(attached)
 
-    def _attach_pasted_images(self, pasted: str) -> str | None:
+    async def _attach_pasted_images(self, pasted: str) -> str | None:
         """Load every path in ``pasted`` as an attachment; return the markers.
 
         ``None`` means "this was not an image paste" — the caller then lets
@@ -1369,6 +1400,12 @@ class Editor(TextArea):
         PDF becomes a plain text paste of every path, rather than silently
         attaching two of three and leaving the user to notice which. Mixed
         results are the shape a user cannot see and cannot correct.
+
+        Async because the bytes are BOUNDED before they are attached, and
+        bounding means decoding — see :func:`~local_operator.imaging.
+        bound_image_for_model`. Nothing here may run a multi-hundred-millisecond
+        decode inline: this is a keystroke handler on the event loop, and a
+        20 MP screenshot measures ~315 ms, which is a visibly frozen composer.
         """
         candidates = _pasted_paths(pasted)
         if not candidates:
@@ -1411,13 +1448,42 @@ class Editor(TextArea):
                 # The stat above is the real gate; this catches a file that grew
                 # between the two calls.
                 return None
+            # BOUND before attaching, in a thread. The bytes on disk are
+            # whatever the screen produced, and a provider refuses an image over
+            # 2000 pixels on its long edge as soon as the request carries more
+            # than twenty of them (see local_operator.imaging). Forwarding
+            # verbatim was therefore not "lossless", it was a delayed fault: a
+            # 2206x266 paste sat harmlessly in the history for a hundred turns
+            # and then wedged the session permanently the moment the twenty
+            # first screenshot arrived, because the block is in the HISTORY and
+            # every later request — including the compaction that is supposed to
+            # be the escape hatch — re-sends it and earns the same 400.
+            #
+            # `to_thread` and not an inline call: this runs on the keystroke
+            # that pasted, and a 20 MP screenshot decodes in ~315 ms.
+            try:
+                payload, wire_mime, _summary = await asyncio.to_thread(
+                    bound_image_for_model, data, info
+                )
+            except ValueError:
+                # Undecodable, a decompression bomb, or too large to send with
+                # no decoder available. A text paste of the path is the honest
+                # outcome: the user keeps what they pasted and can see it was
+                # not attached, where a silently dropped attachment is the shape
+                # nobody notices until the model answers about nothing.
+                return None
             loaded.append(
                 (
                     ImageContent(
-                        data=base64.b64encode(data).decode("ascii"),
-                        mime_type=info.mime_type,
+                        data=base64.b64encode(payload).decode("ascii"),
+                        mime_type=wire_mime,
                     ),
-                    info.dimensions,
+                    # The marker reports what was ATTACHED, not what is on disk.
+                    # A marker reading 2560x1440 beside a 1568x882 attachment is
+                    # a receipt for something that was never sent, and the whole
+                    # point of the dimensions is that the user can check them at
+                    # a glance.
+                    _bounded_dimensions(payload, info),
                 )
             )
 

--- a/local_operator/tui/widgets/editor.py
+++ b/local_operator/tui/widgets/editor.py
@@ -113,13 +113,31 @@ _PATH_SEGMENT = re.compile(r"^(?:~|\.{0,2}/|/)")
 IMAGE_MARKER = re.compile(r"\[Image #([1-9]\d*)(?:,[^\]\n\[]*)?\]")
 
 
+#: Appended to a marker whose image was downscaled on the way in. One glyph,
+#: two cells, and it buys back most of what the honest label costs: every 16:9
+#: screenshot now bounds to the same 1568x882, so three different captures
+#: pasted together would otherwise read as three identical markers where the
+#: source dimensions had told them apart (design round 1, D1). It also answers
+#: the question the number itself provokes — "why is this not the size I
+#: pasted?" — which no bare figure can.
+#:
+#: Chosen over spending width on both sizes: the marker sits inline in the
+#: user's prompt text and is an atomic editing unit, so it has to stay short.
+#: ``IMAGE_MARKER`` already matches it, since the tail is matched loosely for
+#: exactly this kind of later change.
+RESIZED_MARK = " ↓"
+
+
 def _bounded_dimensions(payload: bytes, info: ImageInfo) -> str:
-    """``WxH`` of the bytes actually attached, for the marker's label.
+    """The marker's label: ``WxH`` of the bytes actually attached.
 
     Read back from the BOUNDED payload rather than carried over from ``info``,
     which describes the file on disk. Once the paste path started resizing,
     reusing the source dimensions would print a marker claiming 2560x1440 next
     to a 1568x882 attachment — a receipt for something that was never sent.
+
+    Carries :data:`RESIZED_MARK` when the two differ, so the label still
+    distinguishes one paste from another and says why the number moved.
 
     A header sniff and not a decode: :func:`sniff_image` reads a fixed prefix,
     so this costs microseconds and cannot be made expensive by the payload. It
@@ -129,9 +147,11 @@ def _bounded_dimensions(payload: bytes, info: ImageInfo) -> str:
     never be the reason an attachment is lost.
     """
     bounded = sniff_image(payload)
-    if bounded is not None and bounded.dimensions:
-        return bounded.dimensions
-    return info.dimensions
+    if bounded is None or not bounded.dimensions:
+        return info.dimensions
+    if bounded.dimensions != info.dimensions and info.dimensions:
+        return f"{bounded.dimensions}{RESIZED_MARK}"
+    return bounded.dimensions
 
 
 def _marker_indices(text: str) -> list[int]:
@@ -1403,9 +1423,20 @@ class Editor(TextArea):
 
         Async because the bytes are BOUNDED before they are attached, and
         bounding means decoding — see :func:`~local_operator.imaging.
-        bound_image_for_model`. Nothing here may run a multi-hundred-millisecond
-        decode inline: this is a keystroke handler on the event loop, and a
-        20 MP screenshot measures ~315 ms, which is a visibly frozen composer.
+        bound_image_for_model`. This is a keystroke handler, so a
+        multi-hundred-millisecond decode inline would freeze the whole app: a
+        20 MP screenshot measures ~315 ms.
+
+        Be precise about what the thread buys, because it is not everything
+        (review round 1, F3). The LOOP keeps running — the transcript still
+        paints, other widgets still respond, a running turn still streams. This
+        WIDGET's own input does not: the pump awaits one handler before
+        dispatching the next message to the same widget, so keystrokes typed
+        during the decode are queued and flush when it ends. Nothing is lost and
+        the order is preserved, but the composer does go quiet for the duration,
+        which it did not before this bound existed. Accepted rather than hidden
+        behind a worker + late marker insertion, because a marker that appears
+        after the user has typed past its position is a worse bug than a pause.
         """
         candidates = _pasted_paths(pasted)
         if not candidates:

--- a/tests/unit/providers/test_failover.py
+++ b/tests/unit/providers/test_failover.py
@@ -1547,12 +1547,43 @@ def test_an_image_rejection_is_recognised_in_both_the_raised_and_rendered_forms(
         "messages.31.content.4.image.source.base64.data: Image does not match "
         "the provided media type image/jpeg",
         "Unsupported image format",
+        # The DIMENSION refusals. Both were missed by the original marker list,
+        # and the many-image one is the wording that wedged a real session on
+        # 2026-08-18: the composer had attached a 2206x266 screenshot verbatim,
+        # and the request crossed twenty images a hundred turns later.
+        "messages.0.content.2.image.source.base64.data: At least one of the image "
+        "dimensions exceed max allowed size for many-image requests: 2000 pixels",
+        "messages.5.content.1.image.source.base64.data: At least one of the image "
+        "dimensions exceed max allowed size: 8000 pixels",
     ],
 )
 def test_the_wordings_providers_actually_use_are_all_recognised(message: str) -> None:
     """Sampled from the reports this degrade exists for, not invented:
-    anthropics/claude-code#12009, #13594, #31142, #50708."""
+    anthropics/claude-code#12009, #13594, #31142, #50708, #12351, #39185."""
     assert is_image_rejection(ProviderError(400, message))
+
+
+def test_the_many_image_refusal_degrades_in_the_rendered_form_too() -> None:
+    """The form the session actually receives, for the case that wedged a
+    session.
+
+    ``AgentEndEvent.error`` carries the rendered string, and that is the value
+    ``_degrade_if_image_rejected`` is handed. A marker that matched only the
+    raised form would leave the session bricked exactly as before, so this pins
+    the path rather than the predicate's convenient half.
+
+    The many-image limit is worth its own test because of how it ARRIVES: no
+    image changed and no request was malformed, the conversation simply grew
+    past twenty images and a block that had been accepted for a hundred turns
+    started being refused forever.
+    """
+    refusal = ProviderError(
+        400,
+        "messages.0.content.2.image.source.base64.data: At least one of the image "
+        "dimensions exceed max allowed size for many-image requests: 2000 pixels",
+    )
+    assert str(refusal).startswith("invalid request (HTTP 400)")
+    assert is_image_rejection(str(refusal))
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/session/test_session.py
+++ b/tests/unit/session/test_session.py
@@ -1002,6 +1002,12 @@ class PoisonedThenFine:
     request until something stops sending it.
     """
 
+    #: Overridable so a subclass can pin a DIFFERENT provider wording against
+    #: the same end-to-end path. The predicate's own tests cover the strings;
+    #: what this class covers is the session actually recovering, which is the
+    #: part that was broken.
+    refusal = "Could not process image"
+
     def __init__(self) -> None:
         self.requests: list[ChatRequest] = []
         self.calls = 0
@@ -1010,14 +1016,30 @@ class PoisonedThenFine:
         self.requests.append(request)
         self.calls += 1
         first = self.calls == 1
+        refusal = self.refusal
 
         async def gen():
             if first:
-                raise ProviderError(400, "Could not process image")
+                raise ProviderError(400, refusal)
             yield StreamTextDelta(delta="ok")
             yield StreamEndEvent(stop_reason="endTurn")
 
         return gen()
+
+
+class RefusedForTooManyImages(PoisonedThenFine):
+    """The many-image dimension refusal, which is the one seen in the wild.
+
+    Distinct from a malformed block in how it ARRIVES: nothing about the image
+    changed and no request was malformed. The conversation simply grew past
+    twenty images, at which point the provider applies a stricter 2000-pixel
+    per-image limit and refuses a frame it had accepted for a hundred turns.
+    """
+
+    refusal = (
+        "messages.0.content.2.image.source.base64.data: At least one of the image "
+        "dimensions exceed max allowed size for many-image requests: 2000 pixels"
+    )
 
 
 def _image_blocks(request: ChatRequest) -> int:
@@ -1067,6 +1089,38 @@ async def test_an_image_the_provider_refuses_does_not_brick_the_session(tmp_path
     ]
     assert "look at this" in sent, "the surrounding turn was dropped along with the image"
     assert IMAGE_DROPPED_NOTICE in sent, "the model was left with a silent hole"
+    await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_the_many_image_dimension_refusal_also_unbricks_the_session(tmp_path):
+    """The refusal that wedged a real session on 2026-08-18.
+
+    The degrade recognised several provider wordings and not this one, so the
+    session answered every prompt — and every ``/compact``, which has to send
+    the history in order to summarise it — with the same 400 until it was
+    abandoned. The composer no longer attaches an image that can trip the
+    2000-pixel many-image limit, but this backstop still has to hold: history
+    written by an OLDER build already contains such blocks, and a resumed
+    session replays them.
+    """
+    stream = RefusedForTooManyImages()
+    session = make_session(tmp_path, stream)
+    await session.seed_history(
+        [
+            Message(
+                role="user",
+                content=[TextContent(text="look at this"), ImageContent(data="Zm9v")],
+            )
+        ]
+    )
+
+    await session.prompt("does it work")
+    assert session._images_rejected, "the many-image refusal was not recognised"
+
+    await session.prompt("try again")
+    assert stream.calls == 2
+    assert _image_blocks(stream.requests[1]) == 0, "the session is still sending the bad image"
     await session.dispose()
 
 

--- a/tests/unit/test_imaging.py
+++ b/tests/unit/test_imaging.py
@@ -244,16 +244,23 @@ def test_a_rotation_alone_still_declares_that_the_bytes_changed() -> None:
     and the same mime, so both of the old triggers went false and the clause
     vanished entirely — for the one case where the pixels were most rearranged.
     A PNG makes it exact: no format change to fall back on.
+
+    Orientation ``3`` — a 180° flip — and not ``6``, which is what makes this
+    test exercise the ``rotated`` trigger AT ALL. A quarter turn swaps the axes,
+    so the size comparison alone already catches it and the disjunct under test
+    could be deleted with every assertion still passing (review round 3, F9).
+    A half turn leaves the size identical, so nothing but ``rotated`` can fire.
     """
     buffer = io.BytesIO()
     image = Image.new("RGB", (1200, 900), (10, 60, 120))
     exif = Image.Exif()
-    exif[274] = 6
+    exif[274] = 3
     image.save(buffer, format="PNG", exif=exif)
     source = buffer.getvalue()
 
     _payload, wire_mime, summary = bound_image_for_model(source, _sniffed(source))
     assert wire_mime == "image/png", "the fixture must not change format"
+    assert "1200x900, " in summary, "the fixture must come back the same SIZE"
     assert "source 1200x900" in summary
     assert "EXIF-rotated" in summary
 

--- a/tests/unit/test_imaging.py
+++ b/tests/unit/test_imaging.py
@@ -112,6 +112,114 @@ def test_the_summary_names_the_source_whenever_the_bytes_changed() -> None:
     assert "source 2560x1440" in summary
 
 
+def _oriented_jpeg(size: tuple[int, int], orientation: int | None) -> bytes:
+    """A JPEG with an asymmetric mark, optionally carrying an EXIF rotation.
+
+    The mark is what makes rotation OBSERVABLE: a uniform fixture would pass
+    every assertion below whether or not the pixels were ever turned.
+    """
+    image = Image.new("RGB", size, (20, 20, 20))
+    for x in range(size[0] // 4):
+        for y in range(size[1] // 4):
+            image.putpixel((x, y), (255, 0, 0))
+    buffer = io.BytesIO()
+    if orientation is None:
+        image.save(buffer, format="JPEG")
+    else:
+        exif = Image.Exif()
+        exif[274] = orientation
+        image.save(buffer, format="JPEG", exif=exif)
+    return buffer.getvalue()
+
+
+def _red_corner(payload: bytes) -> str:
+    """Which corner the fixture's bright mark ended up in.
+
+    How the rotation is OBSERVED. ``Orientation`` 6 turns the stored frame 90°
+    clockwise, so a mark stored top-left belongs top-right once the tag has been
+    honoured — which makes this the difference between "upright" and "sideways"
+    without asserting on a whole image.
+    """
+    image = Image.open(io.BytesIO(payload)).convert("RGB")
+    width, height = image.size
+
+    def red_at(x: int, y: int) -> bool:
+        pixel = image.getpixel((x, y))
+        assert isinstance(pixel, tuple), "RGB conversion should give a tuple"
+        return pixel[0] > 128
+
+    if red_at(width // 8, height // 8):
+        return "top-left"
+    if red_at(width - width // 8, height // 8):
+        return "top-right"
+    return "elsewhere"
+
+
+def test_orientation_does_not_depend_on_how_big_the_photo_was() -> None:
+    """Review round 1, F1.
+
+    A camera stores the sensor's raw frame plus an ``Orientation`` tag saying
+    how to turn it. Re-encoding drops the tag but not the pixels, so the resize
+    rung delivered a sideways photo while the verbatim rung — same photo, just
+    small enough to skip the resize — delivered an upright one. Two identical
+    images differing only in resolution arrived in different orientations.
+
+    Pinned as AGREEMENT between the two rungs rather than against one expected
+    orientation, because that is the actual defect: whichever way a provider
+    reads EXIF, one of the two answers was wrong.
+    """
+    small = _oriented_jpeg((1200, 900), orientation=6)
+    large = _oriented_jpeg((4000, 3000), orientation=6)
+
+    small_payload, _mime, _summary = bound_image_for_model(small, _sniffed(small))
+    large_payload, _mime, _summary = bound_image_for_model(large, _sniffed(large))
+
+    assert _red_corner(small_payload) == _red_corner(large_payload)
+    # And upright, not merely consistent: orientation 6 turns the frame 90° CW,
+    # so the mark that was top-left in the stored pixels belongs top-right.
+    assert _red_corner(small_payload) == "top-right"
+
+
+def test_a_rotated_photo_is_delivered_without_the_tag_that_rotated_it() -> None:
+    """Once the pixels are upright the tag must NOT survive, or a provider that
+    honours EXIF would rotate an already-rotated image a second time."""
+    source = _oriented_jpeg((1200, 900), orientation=6)
+    payload, _mime, _summary = bound_image_for_model(source, _sniffed(source))
+    assert Image.open(io.BytesIO(payload)).getexif().get(274) is None
+
+
+@pytest.mark.parametrize("orientation", [None, 1])
+def test_an_unrotated_photo_still_takes_the_verbatim_rung(orientation) -> None:
+    """The orientation check must not cost the cheap path.
+
+    ``ImageOps.exif_transpose`` returns a ``copy()`` when there is nothing to
+    do, so testing "did the object change?" reports every tagless image as
+    rotated and re-encodes it for nothing. Orientation ``1`` means "already
+    upright" and has to be read the same way as no tag at all.
+    """
+    source = _oriented_jpeg((800, 600), orientation=orientation)
+    payload, mime, _summary = bound_image_for_model(source, _sniffed(source))
+    assert payload == source
+    assert mime == "image/jpeg"
+
+
+def test_unreadable_exif_metadata_does_not_fail_the_image() -> None:
+    """Orientation is a refinement, not the payload. A corrupt EXIF block raises
+    from deep inside Pillow, and an unrotated image beats a failed attachment."""
+    source = _oriented_jpeg((800, 600), orientation=6)
+
+    class Exploding:
+        def __getattr__(self, name):
+            raise OSError("corrupt EXIF")
+
+    from local_operator import imaging
+
+    assert imaging._needs_exif_rotation(Exploding()) is False
+    # And the real path still delivers the image.
+    payload, _mime, _summary = bound_image_for_model(source, _sniffed(source))
+    assert payload
+
+
 def test_a_decompression_bomb_is_refused_before_it_is_decoded() -> None:
     """A bomb is small on disk by construction, so no byte cap can see it
     coming. The refusal has to come from the header dimensions, BEFORE the

--- a/tests/unit/test_imaging.py
+++ b/tests/unit/test_imaging.py
@@ -220,6 +220,52 @@ def test_unreadable_exif_metadata_does_not_fail_the_image() -> None:
     assert payload
 
 
+def test_the_source_clause_reports_the_size_on_disk_not_the_rotated_size() -> None:
+    """Review round 2, F7.
+
+    ``source WxH`` means "what you would see from ``ls`` or a re-read". Reading
+    it after the transpose swapped the axes reported 3000x4000 for a file every
+    other tool calls 4000x3000 — and this is the caption the MODEL reads, so a
+    model deriving crop coordinates from it gets them transposed.
+    """
+    source = _oriented_jpeg((4000, 3000), orientation=6)
+    info = _sniffed(source)
+    assert info.dimensions == "4000x3000"
+
+    _payload, _mime, summary = bound_image_for_model(source, info)
+    assert "source 4000x3000" in summary
+    assert "source 3000x4000" not in summary
+
+
+def test_a_rotation_alone_still_declares_that_the_bytes_changed() -> None:
+    """Review round 2, F7, second shape.
+
+    An in-bounds image that is only ROTATED can come back with the same size
+    and the same mime, so both of the old triggers went false and the clause
+    vanished entirely — for the one case where the pixels were most rearranged.
+    A PNG makes it exact: no format change to fall back on.
+    """
+    buffer = io.BytesIO()
+    image = Image.new("RGB", (1200, 900), (10, 60, 120))
+    exif = Image.Exif()
+    exif[274] = 6
+    image.save(buffer, format="PNG", exif=exif)
+    source = buffer.getvalue()
+
+    _payload, wire_mime, summary = bound_image_for_model(source, _sniffed(source))
+    assert wire_mime == "image/png", "the fixture must not change format"
+    assert "source 1200x900" in summary
+    assert "EXIF-rotated" in summary
+
+
+def test_an_untouched_image_still_says_nothing_about_a_source() -> None:
+    """The clause is for reconciling a difference. With nothing to reconcile it
+    must stay absent, or every caption carries noise."""
+    source = _oriented_jpeg((800, 600), orientation=None)
+    _payload, _mime, summary = bound_image_for_model(source, _sniffed(source))
+    assert "source" not in summary
+
+
 def test_a_decompression_bomb_is_refused_before_it_is_decoded() -> None:
     """A bomb is small on disk by construction, so no byte cap can see it
     coming. The refusal has to come from the header dimensions, BEFORE the

--- a/tests/unit/test_imaging.py
+++ b/tests/unit/test_imaging.py
@@ -1,0 +1,140 @@
+"""The bound every image block passes through, tested as a shared contract.
+
+The ladder's rungs are exercised in depth through the ``read`` tool
+(``tests/unit/tools/test_builtin_tools.py``) and through the composer
+(``tests/unit/tui/test_paste_images.py``), which is where they were written and
+where the interesting fixtures live. What is tested HERE is the property those
+two callers depend on and neither can state alone: that a bounded image is
+inside the provider's limits, whatever it looked like on the way in.
+
+That property is the whole reason this module exists. It used to hold on the
+``read`` path and not on the composer path, and the resulting 400 does not
+merely fail a turn — the block is in the conversation HISTORY, so every later
+request re-sends it and fails identically, including the compaction that is
+supposed to be the escape hatch.
+"""
+
+from __future__ import annotations
+
+import io
+
+import pytest
+from PIL import Image
+
+from local_operator.imaging import (
+    IMAGE_MAX_EDGE,
+    IMAGE_MAX_PIXELS,
+    bound_image_for_model,
+)
+from local_operator.media import ImageInfo, sniff_image
+
+#: The stricter per-image dimension limit a provider applies once a request
+#: carries more than twenty images. NOT imported from the module under test:
+#: this is the provider's number, and writing it out is what makes the
+#: assertions below a statement about the API rather than a tautology about our
+#: own constant.
+MANY_IMAGE_PIXEL_LIMIT = 2000
+
+
+def _png(size: tuple[int, int]) -> bytes:
+    buffer = io.BytesIO()
+    Image.new("RGB", size, (10, 60, 120)).save(buffer, format="PNG")
+    return buffer.getvalue()
+
+
+def _sniffed(data: bytes) -> ImageInfo:
+    """``sniff_image`` with its ``None`` asserted away.
+
+    Every caller in this file sniffs bytes it just wrote, so ``None`` would be a
+    broken fixture rather than a case under test — and asserting it here keeps
+    that failure legible instead of surfacing as an attribute error inside the
+    function being tested.
+    """
+    info = sniff_image(data)
+    assert info is not None, "fixture bytes were not recognised as an image"
+    return info
+
+
+@pytest.mark.parametrize(
+    ("size", "label"),
+    [
+        ((2206, 266), "the paste that wedged a real session"),
+        ((2560, 1440), "a retina screenshot"),
+        ((3456, 2234), "a native-resolution laptop capture"),
+        ((6016, 3384), "a 6K display"),
+        ((1600, 1000), "just over on one edge only"),
+        ((800, 600), "already inside the bounds"),
+        ((1, 4000), "a degenerate sliver"),
+    ],
+)
+def test_a_bounded_image_is_inside_the_many_image_limit(size, label: str) -> None:
+    """The one invariant every caller relies on.
+
+    An image over 2000 pixels on its long edge is accepted right up until the
+    request carries its twenty-first image, and is then refused forever. So
+    "small enough" cannot be judged per image or per turn — it has to hold for
+    every image that could ever be attached, which is what this pins.
+    """
+    source = _png(size)
+    payload, _mime, _summary = bound_image_for_model(source, _sniffed(source))
+    width, height = Image.open(io.BytesIO(payload)).size
+    assert max(width, height) <= IMAGE_MAX_EDGE
+    assert max(width, height) < MANY_IMAGE_PIXEL_LIMIT, label
+
+
+def test_the_bound_preserves_aspect_ratio() -> None:
+    """A squashed screenshot is an unreadable screenshot, and the model has no
+    way to know it was distorted."""
+    source = _png((2206, 266))
+    payload, _mime, _summary = bound_image_for_model(source, _sniffed(source))
+    width, height = Image.open(io.BytesIO(payload)).size
+    assert width / height == pytest.approx(2206 / 266, rel=0.01)
+
+
+def test_an_image_already_inside_the_bounds_is_returned_verbatim() -> None:
+    """No re-encode can improve an image the model sees at its original size,
+    and PNG round-tripping routinely makes files BIGGER. The common case must
+    stay lossless and free."""
+    source = _png((800, 600))
+    payload, mime, _summary = bound_image_for_model(source, _sniffed(source))
+    assert payload == source
+    assert mime == "image/png"
+
+
+def test_the_summary_names_the_source_whenever_the_bytes_changed() -> None:
+    """The caption is the model's only evidence of what it is looking at. When
+    the delivered image is not what is on disk, a model comparing this against
+    ``ls -l`` or a later re-read has no way to reconcile the two unless the
+    summary says so."""
+    source = _png((2560, 1440))
+    _payload, _mime, summary = bound_image_for_model(source, _sniffed(source))
+    assert "1568x882" in summary
+    assert "source 2560x1440" in summary
+
+
+def test_a_decompression_bomb_is_refused_before_it_is_decoded() -> None:
+    """A bomb is small on disk by construction, so no byte cap can see it
+    coming. The refusal has to come from the header dimensions, BEFORE the
+    decode allocates ~4 bytes per pixel."""
+    # A forged IHDR rather than a real file: the point is that nothing decodes
+    # it, so writing 3.6 GB of RGBA to build the fixture would defeat the test.
+    seed = _png((8, 8))
+    header = bytearray(seed)
+    header[16:20] = (30000).to_bytes(4, "big")
+    header[20:24] = (30000).to_bytes(4, "big")
+    info = sniff_image(bytes(header))
+    assert info is not None and info.width == 30000
+
+    with pytest.raises(ValueError) as excinfo:
+        bound_image_for_model(bytes(header), info)
+    assert f"{IMAGE_MAX_PIXELS:,}" in str(excinfo.value)
+
+
+def test_undecodable_bytes_raise_rather_than_becoming_an_image_block() -> None:
+    """Forwarding bytes that will not decode earns a 400 that no retry clears,
+    because by then the bad block is already in the transcript. Raising here is
+    what keeps that out of the history."""
+    truncated = _png((100, 100))[:60]
+    # The header still parses; only the body is gone.
+    with pytest.raises(ValueError):
+        bound_image_for_model(truncated, _sniffed(truncated))

--- a/tests/unit/tools/test_builtin_tools.py
+++ b/tests/unit/tools/test_builtin_tools.py
@@ -24,6 +24,7 @@ from typing import Any
 import pytest
 from PIL import Image
 
+from local_operator import imaging
 from local_operator.harness.types import (
     AbortSignal,
     AgentTool,
@@ -611,7 +612,7 @@ async def test_read_image_without_pillow_is_forwarded_verbatim(
     # no resize and no validation, but a screenshot the model can look at
     # still beats a paragraph explaining why it cannot.
     source = _write_png(tmp_path / "shot.png", (320, 200))
-    monkeypatch.setattr(builtin, "pillow_image_module", lambda: None)
+    monkeypatch.setattr(imaging, "pillow_image_module", lambda: None)
     result = await _call(tools, "read", {"path": "shot.png"}, context)
 
     assert result.is_error is False
@@ -628,7 +629,7 @@ async def test_read_large_image_without_pillow_is_refused(
     # becomes the line. Forwarding an unbounded unvalidated blob is how a
     # session ends up wedged behind a provider that refuses it.
     _write_png(tmp_path / "fat.png", (2400, 1800), noise="smooth")
-    monkeypatch.setattr(builtin, "pillow_image_module", lambda: None)
+    monkeypatch.setattr(imaging, "pillow_image_module", lambda: None)
     result = await _call(tools, "read", {"path": "fat.png"}, context)
 
     assert result.is_error is True
@@ -644,7 +645,7 @@ async def test_read_heic_without_pillow_heif_refuses_rather_than_forwarding(
     # refusal rather than risk it. Transcoding is the only way to send one,
     # and transcoding is exactly what is unavailable here.
     (tmp_path / "pic.heic").write_bytes(b"\x00\x00\x00\x1cftypheic" + b"\x00" * 64)
-    monkeypatch.setattr(builtin, "heif_image_module", lambda: None)
+    monkeypatch.setattr(imaging, "heif_image_module", lambda: None)
     result = await _call(tools, "read", {"path": "pic.heic"}, context)
 
     assert result.is_error is True

--- a/tests/unit/tools/test_loop_liveness.py
+++ b/tests/unit/tools/test_loop_liveness.py
@@ -183,7 +183,7 @@ async def test_concurrent_image_reads_keep_the_loop_live(
     # thread wall time but no CPU, so the structural half is the only one that
     # can see it, and it must therefore watch the whole path — not just the
     # expensive end of it.
-    spy = OffLoopSpy(monkeypatch, "_read_file_snapshot", "_encode_image_for_model")
+    spy = OffLoopSpy(monkeypatch, "_read_file_snapshot", "bound_image_for_model")
     probe = LoopCpuProbe()
     probe.start()
     try:

--- a/tests/unit/tui/test_paste_images.py
+++ b/tests/unit/tui/test_paste_images.py
@@ -37,6 +37,7 @@ from local_operator.tui.widgets import editor as editor_module
 from local_operator.tui.widgets.editor import (
     IMAGE_MARKER,
     MAX_ATTACHMENT_BYTES,
+    RESIZED_MARK,
     Editor,
     EditorSubmitted,
     _pasted_paths,
@@ -347,7 +348,44 @@ async def test_the_marker_reports_what_was_attached_not_what_is_on_disk(tmp_path
 
         (image,) = editor.referenced_images()
         delivered = Image.open(io.BytesIO(base64.b64decode(image.data))).size
-        assert editor.text == f"[Image #1, {delivered[0]}x{delivered[1]}] "
+        assert editor.text == f"[Image #1, {delivered[0]}x{delivered[1]}{RESIZED_MARK}] "
+
+
+@pytest.mark.asyncio
+async def test_a_resized_marker_says_so_and_stays_one_atomic_token(tmp_path) -> None:
+    """Design round 1, D1.
+
+    Every 16:9 screenshot bounds to the same 1568x882, so three different
+    captures pasted together would read as three identical markers and the label
+    would stop doing the job it exists for — telling one paste from another. The
+    mark restores that and explains why the number is not the size pasted.
+
+    It must not break the marker's grammar: ``IMAGE_MARKER`` still has to match
+    the whole thing, or the chip stops painting and the token stops deleting
+    atomically.
+    """
+    wide = _png(tmp_path / "wide.png", 2560, 1440)
+    tall = _png(tmp_path / "tall.png", 1440, 2560)
+    small = _png(tmp_path / "small.png", 800, 600)
+    app = Host()
+    async with app.run_test() as pilot:
+        editor = app.query_one(Editor)
+        editor.focus()
+        await pilot.pause()
+        await _paste(app, pilot, wide)
+        await _paste(app, pilot, tall)
+        await _paste(app, pilot, small)
+
+        # Resized ones are marked; the in-bounds one is not, because nothing
+        # about it changed and the mark would be a lie.
+        assert editor.text == (
+            f"[Image #1, 1568x882{RESIZED_MARK}] "
+            f"[Image #2, 882x1568{RESIZED_MARK}] "
+            "[Image #3, 800x600] "
+        )
+        # The grammar still holds: three whole markers, numbered in order.
+        assert [m.group(1) for m in IMAGE_MARKER.finditer(editor.text)] == ["1", "2", "3"]
+        assert len(editor.referenced_images()) == 3
 
 
 @pytest.mark.asyncio
@@ -418,6 +456,34 @@ async def test_the_decode_runs_off_the_event_loop_thread(tmp_path, monkeypatch) 
         assert editor.referenced_images(), "the image was not attached at all"
         assert seen, "the paste never bounded the image"
         assert seen[0] != threading.main_thread().name
+
+
+@pytest.mark.asyncio
+async def test_an_unlabelled_bound_falls_back_to_the_source_dimensions(
+    tmp_path, monkeypatch
+) -> None:
+    """The marker's label is a convenience and must never cost an attachment.
+
+    ``_bounded_dimensions`` reads the delivered size back with a header sniff.
+    If that ever fails to answer — a format whose header we cannot parse, or a
+    future encoder — the marker degrades to the source dimensions rather than
+    dropping the image or printing a number it invented. Pinned because the
+    fallback is otherwise unreachable and would rot silently (review round 1,
+    F6).
+    """
+    path = _png(tmp_path / "shot.png", 2560, 1440)
+    monkeypatch.setattr(editor_module, "sniff_image", lambda payload: None)
+    app = Host()
+    async with app.run_test() as pilot:
+        editor = app.query_one(Editor)
+        editor.focus()
+        await pilot.pause()
+        await _paste(app, pilot, path)
+
+        (image,) = editor.referenced_images()
+        # Still bounded, still attached — only the LABEL degraded.
+        assert max(Image.open(io.BytesIO(base64.b64decode(image.data))).size) <= IMAGE_MAX_EDGE
+        assert editor.text == "[Image #1, 2560x1440] "
 
 
 # -- submitting ---------------------------------------------------------------

--- a/tests/unit/tui/test_paste_images.py
+++ b/tests/unit/tui/test_paste_images.py
@@ -459,6 +459,35 @@ async def test_the_decode_runs_off_the_event_loop_thread(tmp_path, monkeypatch) 
 
 
 @pytest.mark.asyncio
+async def test_a_rotation_alone_is_not_marked_as_a_downscale(tmp_path) -> None:
+    """Review round 2, F8.
+
+    A portrait phone photo inside the bounds is EXIF-rotated on the way in, so
+    its dimensions change (900x1200 from 1200x900) while not one pixel is lost.
+    The mark is a claim about FIDELITY, so comparing the ``WxH`` strings made
+    every such photo assert a shrink that never happened.
+    """
+    path = str(tmp_path / "portrait.jpg")
+    image = Image.new("RGB", (1200, 900), (30, 30, 40))
+    exif = Image.Exif()
+    exif[274] = 6
+    image.save(path, format="JPEG", exif=exif)
+
+    app = Host()
+    async with app.run_test() as pilot:
+        editor = app.query_one(Editor)
+        editor.focus()
+        await pilot.pause()
+        await _paste(app, pilot, path)
+
+        assert editor.referenced_images(), "the photo was not attached"
+        assert RESIZED_MARK not in editor.text
+        # The rotated dimensions are still reported, because that IS what was
+        # attached — only the shrink claim was wrong.
+        assert editor.text == "[Image #1, 900x1200] "
+
+
+@pytest.mark.asyncio
 async def test_an_unlabelled_bound_falls_back_to_the_source_dimensions(
     tmp_path, monkeypatch
 ) -> None:

--- a/tests/unit/tui/test_paste_images.py
+++ b/tests/unit/tui/test_paste_images.py
@@ -20,6 +20,7 @@ import base64
 import io
 import os
 import signal
+import threading
 import time
 from pathlib import Path
 
@@ -31,6 +32,8 @@ from textual.widgets import TextArea
 from textual.widgets.text_area import Selection
 
 from local_operator.harness.types import ImageContent
+from local_operator.imaging import IMAGE_MAX_EDGE
+from local_operator.tui.widgets import editor as editor_module
 from local_operator.tui.widgets.editor import (
     IMAGE_MARKER,
     MAX_ATTACHMENT_BYTES,
@@ -291,6 +294,130 @@ async def test_an_oversized_image_is_refused_here_not_by_the_provider(tmp_path) 
         await _paste(app, pilot, str(big))
         assert editor.referenced_images() == []
         assert editor.text == str(big)
+
+
+# -- bounding what gets attached ----------------------------------------------
+@pytest.mark.asyncio
+async def test_a_pasted_screenshot_is_bounded_before_it_is_attached(tmp_path) -> None:
+    """The session-wedging bug, reproduced at its source.
+
+    A provider refuses an image over 2000 pixels on its long edge as soon as a
+    request carries more than twenty images. The composer used to attach
+    whatever the screen produced, so a 2206x266 paste sat harmlessly in the
+    history until the twenty-first screenshot arrived and then wedged the
+    session PERMANENTLY: the block is in the history, so every later request —
+    including the ``/compact`` that is supposed to be the escape hatch — re-sent
+    it and earned the same 400.
+
+    2206x266 is the real screenshot that did it, not a round number.
+    """
+    path = _png(tmp_path / "wide.png", 2206, 266)
+    app = Host()
+    async with app.run_test() as pilot:
+        editor = app.query_one(Editor)
+        editor.focus()
+        await pilot.pause()
+        await _paste(app, pilot, path)
+
+        (image,) = editor.referenced_images()
+        width, height = Image.open(io.BytesIO(base64.b64decode(image.data))).size
+        assert max(width, height) <= IMAGE_MAX_EDGE
+        # Below the strict many-image ceiling with room to spare, which is the
+        # property that actually keeps the session alive.
+        assert max(width, height) < 2000
+        # Aspect ratio survives the resize; a squashed screenshot is unreadable.
+        assert width / height == pytest.approx(2206 / 266, rel=0.01)
+
+
+@pytest.mark.asyncio
+async def test_the_marker_reports_what_was_attached_not_what_is_on_disk(tmp_path) -> None:
+    """The marker's dimensions are the user's only receipt for an attachment.
+
+    Once the paste path started resizing, carrying the SOURCE dimensions into
+    the marker would print ``[Image #1, 2560x1440]`` beside a 1568x882
+    attachment — a receipt for something that was never sent.
+    """
+    path = _png(tmp_path / "retina.png", 2560, 1440)
+    app = Host()
+    async with app.run_test() as pilot:
+        editor = app.query_one(Editor)
+        editor.focus()
+        await pilot.pause()
+        await _paste(app, pilot, path)
+
+        (image,) = editor.referenced_images()
+        delivered = Image.open(io.BytesIO(base64.b64decode(image.data))).size
+        assert editor.text == f"[Image #1, {delivered[0]}x{delivered[1]}] "
+
+
+@pytest.mark.asyncio
+async def test_an_image_already_inside_the_bounds_is_attached_verbatim(tmp_path) -> None:
+    """No re-encode can improve an image the model sees at its original size,
+    and PNG round-tripping routinely makes files BIGGER. The common case — a
+    small crop, an already-bounded frame — must stay lossless and cheap."""
+    path = _png(tmp_path / "small.png", 800, 600)
+    source = Path(path).read_bytes()
+    app = Host()
+    async with app.run_test() as pilot:
+        editor = app.query_one(Editor)
+        editor.focus()
+        await pilot.pause()
+        await _paste(app, pilot, path)
+
+        (image,) = editor.referenced_images()
+        assert base64.b64decode(image.data) == source
+        assert editor.text == "[Image #1, 800x600] "
+
+
+@pytest.mark.asyncio
+async def test_a_decompression_bomb_is_pasted_as_text_not_attached(tmp_path) -> None:
+    """A bomb is small on disk by construction, so the 4 MB cap cannot see it
+    coming — only the dimensions can. The paste stays TEXT so the user can see
+    what happened; a silently dropped attachment is the shape nobody notices
+    until the model answers about nothing."""
+    path = _png(tmp_path / "bomb.png", 9000, 9000)
+    app = Host()
+    async with app.run_test() as pilot:
+        editor = app.query_one(Editor)
+        editor.focus()
+        await pilot.pause()
+        await _paste(app, pilot, path)
+
+        assert editor.referenced_images() == []
+        assert editor.text == path
+
+
+@pytest.mark.asyncio
+async def test_the_decode_runs_off_the_event_loop_thread(tmp_path, monkeypatch) -> None:
+    """The bound runs on the keystroke that pasted it, and a 20 MP screenshot
+    measures ~315 ms on an M3 Max — a visibly frozen composer if it runs inline.
+
+    Asserted as a THREAD IDENTITY rather than as elapsed time or loop progress.
+    Both of those pass trivially on the blocking implementation: a synchronous
+    handler that never awaits also never lets the loop fall behind, so the
+    obvious 'did the loop keep ticking' test is green both ways and pins
+    nothing. Where the work runs is the actual invariant, and it is the thing
+    that breaks if someone later drops the ``to_thread``.
+    """
+    path = _png(tmp_path / "big.png", 2600, 1400)
+    seen: list[str] = []
+    real = editor_module.bound_image_for_model
+
+    def spy(data, info):
+        seen.append(threading.current_thread().name)
+        return real(data, info)
+
+    monkeypatch.setattr(editor_module, "bound_image_for_model", spy)
+    app = Host()
+    async with app.run_test() as pilot:
+        editor = app.query_one(Editor)
+        editor.focus()
+        await pilot.pause()
+        await _paste(app, pilot, path)
+
+        assert editor.referenced_images(), "the image was not attached at all"
+        assert seen, "the paste never bounded the image"
+        assert seen[0] != threading.main_thread().name
 
 
 # -- submitting ---------------------------------------------------------------


### PR DESCRIPTION
# PR Description

## Change classification

**C2 — standard / pre-authorized.** Correctness fix on the two paths that turn bytes into an image block. No new surface, no config, no transcript format change. Clean rollback (`git revert`). No RFC requested.

## The bug

Reported from a real session (`Analytics Dashboard Implementation`) that could not be continued. Every turn — and every attempt to `/compact` out of it — ended with the same error:

```text
× invalid request (HTTP 400): messages.0.content.2.image.source.base64.data:
  At least one of the image dimensions exceed max allowed size for
  many-image requests: 2000 pixels
```

The session was answering every prompt with that error and could only be abandoned.

### Why an image that was fine for hours suddenly is not

Anthropic caps a single image at 8000 pixels on its long edge. But a request carrying **more than 20 images** switches to a much stricter per-image limit of **2000 pixels** ([Vision docs](https://platform.claude.com/docs/en/build-with-claude/vision)).

Nothing about the offending image ever changed. The **conversation grew**. A long agent session that takes screenshots as evidence crosses twenty images routinely, and at that moment a frame that had been accepted for a hundred turns starts being refused — permanently.

Reading the reported session's transcript shows exactly that. `content[2]` of the very first user message is the only block over the line:

```text
content[0] text[1721]
content[1] (1184, 624)
content[2] (2206, 266)    <-- OVER 2000px, and it is content.2 in the error
content[3] (1540, 1032)
...
line 161 role=tool  (1568, 1176)   <-- every `read` image block is already bounded
line 173 role=tool  (1568, 882)
```

Note the asymmetry in that dump: every tool-produced image is already ≤1568, and only the **pasted** ones are raw. That is the defect in one line.

### Why one bad block killed the whole session

The block lives in the conversation **history**, so it is re-sent on every subsequent request. That includes compaction, which has to send the history in order to summarise it — so the escape hatch fails the same way. Reload replays it too. This is the same failure shape as anthropics/claude-code#19031, #24387, #47391, #50708.

## Two independent defects

**1. The composer never bounded what it attached.** `Editor._attach_pasted_images` base64'd the file straight from disk at whatever size the screen produced. The `read` tool had bounded its image blocks since it was written, so the invariant held on one of the two paths that construct an `ImageContent` and not on the other — and one unbounded caller is enough to wedge the session for both.

**2. The degrade that exists to unbrick exactly this never fired.** `is_image_rejection` gates a sticky "stop sending images" recovery, and its marker list did not include the dimension wording:

```console
$ .venv/bin/python -c "...is_image_rejection(ProviderError(400, <the reported message>))"
False   # <-- the backstop was blind to the error that needed it
```

So the one mechanism designed to recover a poisoned history sat out the whole incident.

## The fix

The bounding ladder moves out of `tools/builtin.py` into a new `local_operator/imaging.py`, and **both** callers now share it. "An image is about to become an `ImageContent`" is the invariant, and it now has one implementation instead of one-and-a-half.

- `IMAGE_MAX_EDGE = 1568` is unchanged in value but no longer only a token optimisation — it is documented as sitting **below the 2000px many-image limit on purpose**, so the threshold can never be reached however many frames a session accumulates.
- The paste path runs the bound in `asyncio.to_thread`. It is a keystroke handler on the event loop and a 20 MP screenshot decodes in ~315 ms.
- An undecodable file, or a decompression bomb, now falls back to a plain **text** paste of the path rather than a silently dropped attachment.
- The marker reports the dimensions **actually attached**, not the file's — `[Image #1, 2560x1440]` beside a 1568x882 attachment is a receipt for something that was never sent.
- `is_image_rejection` matches `image dimensions exceed max allowed size`, covering both the 2000px many-image and 8000px single-image refusals. This still matters with the composer fixed: history written by an older build already contains such blocks, and a resumed session replays them.
- EXIF orientation is baked into the pixels on every rung, so a phone photo is delivered upright whether or not it was large enough to be resized (found in review round 1; previously the resize rung dropped the tag without turning the pixels, so the same photo arrived two different ways depending on its resolution).

**Also fixed, found in design review and not originally claimed:** an undecodable `.png` used to be attached and chipped as `[Image #1, 0x0]` — a receipt asserting an attachment of a file nothing could read. It now text-pastes with no chip.

`tools/builtin.py` re-exports the constants under their historical `READ_IMAGE_*` names, which are part of its tested surface.

## Validation

### 1. Against the live Anthropic API — the only test that can actually prove this

The 2000px rule is the provider's, not ours, so the proof has to come from the provider. An identical 21-image request (one 2206x266 frame plus twenty small ones to cross the twenty-image threshold), sent unbounded and bounded:

```console
$ .venv/bin/python /tmp/img-evidence/live_api.py unbounded
mode=unbounded  images=21  largest=2206px
RESULT[unbounded]: REFUSED -> invalid request (HTTP 400):
  messages.0.content.1.image.source.base64.data: At least one of the image
  dimensions exceed max allowed size for many-image requests: 2000 pixels

$ .venv/bin/python /tmp/img-evidence/live_api.py bounded
mode=bounded    images=21  largest=1568px
provider replied: OK
RESULT[bounded]: ACCEPTED
```

The unbounded run reproduces the reported production error **character for character**. The bounded run is answered.

### 2. Before/after through the real composer widget

Driving the actual `Editor` through a real Textual `Paste` event, using the screenshot that wedged the session:

```console
===== BEFORE (origin/main) =====
wedging paste      on disk 2206x266  -> attached 2206x266   marker='[Image #1, 2206x266]'   WOULD WEDGE THE SESSION
retina screenshot  on disk 2560x1440 -> attached 2560x1440  marker='[Image #1, 2560x1440]'  WOULD WEDGE THE SESSION
exit=2

===== AFTER (fix) =====
wedging paste      on disk 2206x266  -> attached 1568x189   marker='[Image #1, 1568x189]'   OK
retina screenshot  on disk 2560x1440 -> attached 1568x882   marker='[Image #1, 1568x882]'   OK
exit=0
```

Aspect ratio is preserved and the marker tracks what was actually sent.

### 3. Regression tests, each confirmed to fail without its fix

Reverting the composer bound:

```text
FAILED test_a_pasted_screenshot_is_bounded_before_it_is_attached - assert 2206 <= 1568
FAILED test_a_decompression_bomb_is_pasted_as_text_not_attached - assert [ImageContent(...)] == []
```

Reverting the `is_image_rejection` marker:

```text
FAILED test_the_wordings_providers_actually_use_are_all_recognised[...many-image requests: 2000 pixels]
FAILED test_the_wordings_providers_actually_use_are_all_recognised[...max allowed size: 8000 pixels]
FAILED test_the_many_image_refusal_degrades_in_the_rendered_form_too
FAILED test_the_many_image_dimension_refusal_also_unbricks_the_session - the many-image refusal was not recognised
```

Replacing `to_thread` with an inline call:

```text
FAILED test_the_decode_runs_off_the_event_loop_thread - assert 'MainThread' != 'MainThread'
```

That last one is asserted as a **thread identity** rather than as elapsed time or loop progress, because the obvious "did the loop keep ticking" test is green on the blocking implementation too and pins nothing.

New coverage:

- `tests/unit/test_imaging.py` (12 tests) — the shared contract, including a parametrised sweep proving every realistic capture size lands under the provider's 2000px limit. The limit is written out as a literal rather than imported from the module under test, so the assertion is about the API and not a tautology about our own constant.
- `tests/unit/tui/test_paste_images.py` — 5 tests covering the bound, the marker, the verbatim path, the bomb, and the thread hop.
- `tests/unit/providers/test_failover.py`, `tests/unit/session/test_session.py` — both dimension wordings, and end-to-end session recovery.

Three existing tests were repointed to follow the moved function (`monkeypatch` targets and one `OffLoopSpy` name); no assertion was weakened.

### 4. Gates

```console
$ .venv/bin/python -m pytest tests/unit -q     # 4559 passed, 7 skipped
$ .venv/bin/python -m flake8 .                 # clean
$ uvx --from black==26.1.0 black --check       # clean
$ uvx isort --check-only --profile black       # clean
$ .venv/bin/python -m pyright                  # 0 errors, 0 warnings
```

One note for reviewers reproducing this in a worktree: `tests/unit/tools/test_eval_tool.py::test_background_streams_output_while_it_runs` fails there unless `PYTHONPATH` points at the worktree root, because the eval kernel runs as a subprocess that must import the package. Confirmed identical on clean `origin/main`, so it is a harness artifact of worktree runs and not related to this change.

## Review rounds

Four agent rounds, each of which caught something the previous round's tests would have let through:

| Round | Verdict | Findings |
|---|---|---|
| 1 (code) | request changes | F1 major — EXIF orientation was size-dependent. F2–F4 doc, F5 rejected, F6 nit |
| 1 (design) | approve with minors | D1 — the honest label collapsed every 16:9 screenshot to the same string; fixed with a `↓` mark |
| 2 (code) | request changes | F7 major — the round 1 fix made the caption's `source WxH` report the rotated size. F8 minor |
| 3 (code) | approve with minors | F9 — a test that passed for the wrong reason and did not guard its own code path |
| 4 (code) | re-confirmation of the test-only F9 fix | |

## Scope note

No transcript format changed and no migration is needed. A session whose history already holds an oversized block is now recovered at replay time by the `is_image_rejection` half of this fix, which is why both halves are here rather than just the composer bound.
