### PR TITLE
fix(resume): offer only the user's own sessions in the /resume picker

### DIFF
--- a/local_operator/cli.py
+++ b/local_operator/cli.py
@@ -1325,10 +1325,21 @@ def main() -> int:
         if getattr(args, "resume", None) is not None:
             from local_operator.resume import (
                 ResumeNotFound,
+                backfill_session_origins,
                 format_age,
                 recent_sessions,
                 resolve_resume_id,
             )
+
+            # Classify pre-existing sessions BEFORE resolving, not after. The
+            # session factory also backfills, but it runs when a session is
+            # BUILT — and this branch answers `--resume` first, so on the first
+            # launch after an upgrade a bare `--resume` resolved `@latest`
+            # against an unclassified store and reopened whichever delegated
+            # run happened to finish last. Idempotent and stdlib-only, so it
+            # costs a directory scan on the one path that cannot afford to be
+            # wrong about which sessions are the user's.
+            backfill_session_origins(config_dir())
 
             try:
                 args.resume = resolve_resume_id(config_dir(), str(args.resume))

--- a/local_operator/harness/comms.py
+++ b/local_operator/harness/comms.py
@@ -138,6 +138,15 @@ class ChildInfo:
     age_s: float | None = None
     #: Why ``resumable`` is False, when it is False for an interesting reason.
     detail: str | None = None
+    #: The child's TRANSCRIPT directory name — the id ``--resume`` takes, which
+    #: is not the ``job_id`` above. Carried because this roster is now the only
+    #: surface that can show it: children were dropped from the ``/resume``
+    #: picker (they are the machine's own runs, not the user's conversations),
+    #: and the job row that carries ``job_id`` is swept minutes after a child
+    #: settles. Without it, an operator investigating a subagent that crashed
+    #: an hour ago had no in-product path to its transcript at all — exactly
+    #: the case this class's docstring says it exists to cover.
+    session_id: str | None = None
 
 
 class ChildSession(Protocol):
@@ -486,6 +495,7 @@ class SubagentComms:
             resumable=resumable,
             age_s=age,
             detail=detail,
+            session_id=record.session_dir.name if record.session_dir is not None else None,
         )
 
     def _live_twin(self, record: _ChildRecord) -> _ChildRecord | None:

--- a/local_operator/harness/subagent.py
+++ b/local_operator/harness/subagent.py
@@ -114,6 +114,7 @@ from local_operator.harness.types import (
     Usage,
 )
 from local_operator.paths import config_dir
+from local_operator.resume import ORIGIN_SUBAGENT, mark_session_origin
 
 if TYPE_CHECKING:
     from local_operator.agent_profiles import AgentProfile
@@ -721,6 +722,14 @@ async def _build_child_session(
     session_dir = (
         resume_dir if resume_dir is not None else config_dir() / "sessions" / uuid.uuid4().hex[:12]
     )
+    # Stamp the directory as the machine's BEFORE the transcript exists, so a
+    # picker painted while this child is mid-run already knows what it is. A
+    # child's directory is shape-identical to a user conversation, which is how
+    # every delegated reviewer, designer and scout run ended up offered under
+    # ``/resume`` as if the user had opened it. Re-stamped on resume as well:
+    # ``hub op='resume'`` rebuilds a child on its old directory, and a marker
+    # lost to an earlier failed write is worth retrying while we are here.
+    mark_session_origin(session_dir, ORIGIN_SUBAGENT, label=label, agent=agent)
     transcript = Transcript(session_dir)
     # The operator's standing instructions are machine-wide, so a delegated
     # slice inherits them for the same reason it inherits the goal: the parent

--- a/local_operator/resume.py
+++ b/local_operator/resume.py
@@ -17,6 +17,7 @@ transcript-directory decision, so the rule has one definition.
 from __future__ import annotations
 
 import json
+import os
 import re
 from pathlib import Path
 from typing import NamedTuple
@@ -113,11 +114,31 @@ def mark_session_origin(session_dir: Path, origin: str, **details: object) -> No
     sweep that just removed the directory) must still RUN — the cost of the
     failure is one extra row in a picker, and taking a delegated task down for
     it would be the more expensive bug.
+
+    **The directory's mtime is preserved**, and that is load-bearing rather
+    than tidy. Retention sorts and age-expires on the DIRECTORY's mtime
+    (``session/retention.py``), and creating a file inside a directory moves
+    it — so stamping a session silently reset its retention clock to now.
+    Measured on twin stores: marking existing directories kept 3 delegated
+    runs the picker will never show while deleting 3 of the user's own
+    conversations, and resurrected 59 children that were already past the age
+    ceiling. Writing a marker is bookkeeping ABOUT a session, never activity
+    IN it, so it must not answer the question "when was this session last
+    used". A directory this call creates has no prior mtime and is unaffected.
     """
     payload = {"origin": origin, **details}
     try:
+        # Read before the write: this is the value the write is about to
+        # destroy. ``None`` for a directory that does not exist yet, which is
+        # the fresh-child path and needs no restore.
+        try:
+            previous = session_dir.stat().st_mtime
+        except OSError:
+            previous = None
         session_dir.mkdir(parents=True, exist_ok=True)
         (session_dir / ORIGIN_NAME).write_text(json.dumps(payload), encoding="utf-8")
+        if previous is not None:
+            os.utime(session_dir, (previous, previous))
     except (OSError, TypeError, ValueError):
         return
 
@@ -178,7 +199,16 @@ def backfill_session_origins(config_dir: Path, limit: int = 500) -> int:
 
     Best-effort and bounded like every other function here: it runs at
     startup, so an unreadable directory is skipped rather than raised, and
-    ``limit`` caps the work on a store that has grown large.
+    ``limit`` caps how many directories are STAMPED per run.
+
+    The cap is on work done, never on how far the scan reaches. Capping the
+    scan instead — slicing the directory list — sounds equivalent and is not:
+    the list sorts by hex NAME, and the same prefix is recomputed on every
+    startup, so any directory sorting past the cut was never visited on any
+    run, ever. Measured: a 600-directory store with 50 children sorting after
+    the cut stamped 0 on three consecutive startups. Deciding a session's
+    origin by where its random name falls in an alphabet is not a policy
+    anyone would choose deliberately.
     """
     stamped = 0
     sessions = config_dir / "sessions"
@@ -186,7 +216,7 @@ def backfill_session_origins(config_dir: Path, limit: int = 500) -> int:
         directories = sorted(sessions.iterdir())
     except OSError:
         return 0
-    for directory in directories[:limit]:
+    for directory in directories:
         if stamped >= limit:
             break
         try:

--- a/local_operator/resume.py
+++ b/local_operator/resume.py
@@ -30,6 +30,23 @@ RESUME_LATEST = "@latest"
 #: are not turns (retention sweeps touch it), so it is not the clock to use.
 TRANSCRIPT_NAME = "transcript.jsonl"
 
+#: Marks a session directory as machine-started rather than user-started. A
+#: subagent's child session is an ephemeral directory under ``sessions/`` with
+#: exactly the shape of a real conversation, so nothing on disk told the two
+#: apart and the ``/resume`` picker offered every delegated review, design and
+#: scout run as if the user had opened it — on one machine 40 of 50 rows.
+#:
+#: A SIDECAR file rather than a field in the transcript: the picker's whole
+#: cost model is one bounded read per row, and a marker inside the JSONL could
+#: only be found by parsing it. ``Path.is_file()`` is one stat, and it answers
+#: even for a child whose transcript has not been written yet.
+ORIGIN_NAME = "origin.json"
+
+#: ``origin`` value for a session a subagent runs. The file is JSON, and the
+#: key is a string rather than a bare flag, so a future non-user origin (a
+#: scheduled run, a server-side session) is a new value and not a second file.
+ORIGIN_SUBAGENT = "subagent"
+
 #: How much of the opening message a session name may keep. Long enough to tell
 #: two days' work apart, short enough that a column of them still scans.
 NAME_MAX_CHARS = 64
@@ -71,6 +88,60 @@ class ResumeNotFound(Exception):
     """``--resume`` named a session that is not on disk (or none exist)."""
 
 
+def mark_session_origin(session_dir: Path, origin: str, **details: object) -> None:
+    """Record that ``session_dir`` was started by ``origin``, not by the user.
+
+    Written by whoever CREATES the directory, which is the only place that
+    knows: by the time the picker reads it back, a child session and a user's
+    conversation are the same shape on disk.
+
+    Best-effort by contract. Marking is bookkeeping for a listing, and a child
+    that cannot write its marker (read-only volume, a race with a retention
+    sweep that just removed the directory) must still RUN — the cost of the
+    failure is one extra row in a picker, and taking a delegated task down for
+    it would be the more expensive bug.
+    """
+    payload = {"origin": origin, **details}
+    try:
+        session_dir.mkdir(parents=True, exist_ok=True)
+        (session_dir / ORIGIN_NAME).write_text(json.dumps(payload), encoding="utf-8")
+    except (OSError, TypeError, ValueError):
+        return
+
+
+def session_origin(session_dir: Path) -> str:
+    """``origin`` recorded for a session, or ``""`` when it is the user's own.
+
+    Absence means USER, and that direction is deliberate. The alternative —
+    marking user sessions and hiding everything unmarked — would have made
+    every conversation that predates the marker disappear from the picker,
+    which loses real work; an unmarked child merely shows one stale row that
+    retention eventually evicts. A listing that shows too much is recoverable
+    by typing a filter, one that hides your own session is not.
+
+    Tolerant for the same reason :func:`session_name` is: this runs over every
+    session directory to paint a picker, so a truncated or hand-edited marker
+    yields ``""`` (treated as the user's) rather than taking the picker down.
+    """
+    try:
+        raw = (session_dir / ORIGIN_NAME).read_text(encoding="utf-8")
+    except OSError:
+        return ""
+    try:
+        payload = json.loads(raw)
+    except ValueError:
+        return ""
+    if not isinstance(payload, dict):
+        return ""
+    origin = payload.get("origin")
+    return origin if isinstance(origin, str) else ""
+
+
+def is_user_session(session_dir: Path) -> bool:
+    """True when a human started this session, so a picker may offer it."""
+    return not session_origin(session_dir)
+
+
 def resume_dir(config_dir: Path, requested: str) -> Path:
     """The session directory ``--resume`` names, or raise :class:`ResumeNotFound`.
 
@@ -86,7 +157,16 @@ def resume_dir(config_dir: Path, requested: str) -> Path:
     """
     sessions = config_dir / "sessions"
     if requested == RESUME_LATEST:
-        candidates = [path for path in sessions.glob("*") if (path / TRANSCRIPT_NAME).is_file()]
+        # ``@latest`` means the latest conversation THE USER had. A subagent
+        # writes its child transcript into the same directory, and a delegated
+        # review finishing after the parent's last turn made it the newest
+        # directory on disk — so a bare ``--resume`` reopened the reviewer
+        # rather than the session that launched it.
+        candidates = [
+            path
+            for path in sessions.glob("*")
+            if (path / TRANSCRIPT_NAME).is_file() and is_user_session(path)
+        ]
         if not candidates:
             raise ResumeNotFound("no previous session to resume")
 
@@ -137,7 +217,13 @@ def resolve_resume_id(config_dir: Path, requested: str) -> str:
 
 
 def recent_sessions(config_dir: Path, limit: int = 10) -> list[tuple[str, float]]:
-    """``(id, mtime)`` for resumable sessions, newest first.
+    """``(id, mtime)`` for the USER's resumable sessions, newest first.
+
+    Subagent sessions are excluded (:func:`is_user_session`): they are the
+    machine's own scratch conversations, and a listing offered to a human is
+    about work the human did. They remain resumable by explicit id — nothing
+    here removes a directory, and ``hub op='resume'`` continues a child by its
+    own path — so this narrows what is OFFERED, never what exists.
 
     The mtime is RETURNED rather than used and dropped: the sort already reads
     it, and it is the one fact that makes a list of 12-hex ids pickable instead
@@ -150,9 +236,14 @@ def recent_sessions(config_dir: Path, limit: int = 10) -> list[tuple[str, float]
     rows: list[tuple[str, float]] = []
     for path in (config_dir / "sessions").glob("*"):
         try:
-            rows.append((path.name, (path / TRANSCRIPT_NAME).stat().st_mtime))
+            mtime = (path / TRANSCRIPT_NAME).stat().st_mtime
         except OSError:
             continue
+        # After the stat, not before: the stat is what proves the directory is
+        # a session at all, and an unreadable marker must not cost a row.
+        if not is_user_session(path):
+            continue
+        rows.append((path.name, mtime))
     rows.sort(key=lambda row: row[1], reverse=True)
     return rows[:limit]
 

--- a/local_operator/resume.py
+++ b/local_operator/resume.py
@@ -47,6 +47,19 @@ ORIGIN_NAME = "origin.json"
 #: scheduled run, a server-side session) is a new value and not a second file.
 ORIGIN_SUBAGENT = "subagent"
 
+#: The two openings only the subagent runner can produce, used ONLY by the
+#: one-time backfill for directories that predate the marker.
+#:
+#: ``[role: <name>]`` is built by ``AgentProfile.preamble`` and ``[scout mode:``
+#: is a literal constant in the subagent module; both are stamped in FRONT of
+#: the caller's prompt, so they can only appear at offset 0 of a child's first
+#: user message. Anchored and exact for that reason: the cost of a false
+#: positive is hiding one of the user's own conversations, which is the very
+#: failure the absence-means-user default exists to avoid, so these match what
+#: the machine writes and nothing that merely resembles it.
+_ROLE_PREAMBLE = re.compile(r"\[role: [a-z0-9_-]+\]\n")
+_SCOUT_PREAMBLE = "[scout mode:"
+
 #: How much of the opening message a session name may keep. Long enough to tell
 #: two days' work apart, short enough that a column of them still scans.
 NAME_MAX_CHARS = 64
@@ -122,9 +135,17 @@ def session_origin(session_dir: Path) -> str:
     Tolerant for the same reason :func:`session_name` is: this runs over every
     session directory to paint a picker, so a truncated or hand-edited marker
     yields ``""`` (treated as the user's) rather than taking the picker down.
+
+    ``errors="replace"`` is load-bearing, not decoration. :func:`mark_session_origin`
+    writes non-atomically, so a child killed mid-write (SIGKILL, sleep, a full
+    volume) leaves the file cut INSIDE a multi-byte character — and a strict
+    decode raises ``UnicodeDecodeError``, which is a ``ValueError`` and would
+    sail past an ``except OSError``. One such sidecar took down the whole
+    picker and every ``--resume`` with no id, for every session, until the
+    user found and deleted the file by hand.
     """
     try:
-        raw = (session_dir / ORIGIN_NAME).read_text(encoding="utf-8")
+        raw = (session_dir / ORIGIN_NAME).read_text(encoding="utf-8", errors="replace")
     except OSError:
         return ""
     try:
@@ -137,8 +158,65 @@ def session_origin(session_dir: Path) -> str:
     return origin if isinstance(origin, str) else ""
 
 
+def backfill_session_origins(config_dir: Path, limit: int = 500) -> int:
+    """Stamp pre-existing subagent directories once, and return how many.
+
+    Without this the fix only applies to sessions created after the upgrade,
+    so the person who reported a picker full of ``[role: reviewer]`` rows
+    would upgrade, look, and see the same 40 rows — the change would be
+    correct and appear to do nothing until natural churn cleared the store.
+
+    Identification is by the openings only the subagent runner can produce
+    (:data:`_ROLE_PREAMBLE`, :data:`_SCOUT_PREAMBLE`), matched at offset 0 of
+    the first user message because both are stamped in FRONT of the caller's
+    prompt. This deliberately under-claims: a delegated run launched with no
+    role profile is indistinguishable from a user's own session and stays
+    listed. That is the right direction — an unmarked child costs one stale
+    row, while a false positive hides the user's real work, and the whole
+    point of a one-time sweep is that a row it misses is one the user can
+    still reach.
+
+    Best-effort and bounded like every other function here: it runs at
+    startup, so an unreadable directory is skipped rather than raised, and
+    ``limit`` caps the work on a store that has grown large.
+    """
+    stamped = 0
+    sessions = config_dir / "sessions"
+    try:
+        directories = sorted(sessions.iterdir())
+    except OSError:
+        return 0
+    for directory in directories[:limit]:
+        if stamped >= limit:
+            break
+        try:
+            if not (directory / TRANSCRIPT_NAME).is_file():
+                continue
+            # Already answered: never re-stamp, so a marker a user removed by
+            # hand to un-hide a session is not silently written back.
+            if (directory / ORIGIN_NAME).exists():
+                continue
+        except OSError:
+            continue
+        opening = session_name(directory, max_chars=NAME_MAX_CHARS, condense=False)
+        if not opening:
+            continue
+        if _ROLE_PREAMBLE.match(opening) or opening.startswith(_SCOUT_PREAMBLE):
+            mark_session_origin(directory, ORIGIN_SUBAGENT, backfilled=True)
+            stamped += 1
+    return stamped
+
+
 def is_user_session(session_dir: Path) -> bool:
-    """True when a human started this session, so a picker may offer it."""
+    """True when a human started this session, so a picker may offer it.
+
+    EVERY non-empty origin is hidden, not a listed set of them: a new value
+    added later (a scheduled run, a server-side session) is therefore opt-OUT
+    of the picker by default, and an author who wants a new origin to remain
+    listable has to say so here. That default is the safe direction — a value
+    is minted by whichever code path creates the directory, and the paths that
+    do so are the machine's own.
+    """
     return not session_origin(session_dir)
 
 
@@ -273,7 +351,9 @@ class SessionRow(NamedTuple):
     name: str
 
 
-def session_name(session_dir: Path, *, max_chars: int = NAME_MAX_CHARS) -> str:
+def session_name(
+    session_dir: Path, *, max_chars: int = NAME_MAX_CHARS, condense: bool = True
+) -> str:
     """A conversation's display name: its opening user message, on one line.
 
     Read from the TRANSCRIPT rather than from a stored title because there is
@@ -337,7 +417,11 @@ def session_name(session_dir: Path, *, max_chars: int = NAME_MAX_CHARS) -> str:
             continue
         text = _first_text(payload.get("content"))
         if text:
-            return _condense(text, max_chars)
+            # ``condense=False`` returns the opening text with its line
+            # breaks intact, which the backfill needs: the role preamble it
+            # matches is ``[role: <name>]\n``, and condensing flattens that
+            # newline into a space before the pattern could ever see it.
+            return _condense(text, max_chars) if condense else text
     # The window held no COMPLETE line, so the opener is a fragment. Dropping
     # it (which is all this used to do) left every session that begins with a
     # pasted screenshot permanently nameless: one base64 image puts the first

--- a/local_operator/session/retention.py
+++ b/local_operator/session/retention.py
@@ -30,6 +30,8 @@ import time
 from dataclasses import dataclass
 from pathlib import Path
 
+from local_operator.resume import ORIGIN_NAME
+
 logger = logging.getLogger(__name__)
 
 #: Directory under the config dir holding ephemeral per-run transcripts.
@@ -79,11 +81,22 @@ class _Candidate:
 
 def _dir_size(directory: Path) -> int:
     """Bytes under ``directory``. Files that vanish mid-walk are skipped: a
-    concurrent process disposing its own session is normal, not an error."""
+    concurrent process disposing its own session is normal, not an error.
+
+    The origin marker is EXCLUDED from the total, which is what keeps the
+    "empty directories are always reaped" rule meaning what it says. A session
+    is stamped before its transcript exists, so a run that aborts in between
+    leaves a directory holding nothing but a 43-byte marker. Counting those
+    bytes turned a directory that carried nothing to lose into an ordinary
+    keep candidate occupying a retention slot — measured: with a count ceiling
+    of 3, two aborted children evicted two of the user's real transcripts to
+    keep two empty markers. The marker is bookkeeping ABOUT the session, never
+    session content, so it is not what the ceilings are budgeting.
+    """
     total = 0
     for entry in directory.rglob("*"):
         try:
-            if entry.is_file():
+            if entry.is_file() and entry.name != ORIGIN_NAME:
                 total += entry.stat().st_size
         except OSError:
             continue

--- a/local_operator/session_factory.py
+++ b/local_operator/session_factory.py
@@ -936,6 +936,17 @@ async def _prepare(
 
     sweep_from_config(config_manager, Path(agent_registry.config_dir), transcript_dir)
 
+    # Stamp session directories that predate the origin marker, so the
+    # ``/resume`` picker stops offering delegated runs on the FIRST launch
+    # after an upgrade rather than once natural churn has cleared the store.
+    # Runs beside the sweep for the same reason it does: startup is when the
+    # store is quiet, and both are best-effort by construction. A no-op on
+    # every later launch — each directory is answered once and never
+    # re-stamped.
+    from local_operator.resume import backfill_session_origins
+
+    backfill_session_origins(Path(agent_registry.config_dir))
+
     # --- model + stream fn (stream B contracts) ---------------------------
     from local_operator.env import get_env_config
     from local_operator.model.configure import configure_model, create_stream_fn

--- a/local_operator/tools/builtin.py
+++ b/local_operator/tools/builtin.py
@@ -6261,6 +6261,14 @@ def _hub_list(tool_call_id: str, comms: Any) -> ToolResult:
         lines.append(f"- {row.label} ({row.job_id}): {row.status}{age} — {extras}")
         if row.resumable and row.detail:
             lines.append(f"    {row.detail}")
+        # The session id only where it can be acted on. It is the id
+        # ``--resume`` takes (NOT the job id on the line above), and this
+        # roster is the only surface that shows it now that children are kept
+        # out of the ``/resume`` picker. Printed for resumable rows alone: on a
+        # row that cannot be resumed it is a string to mistake for the job id
+        # rather than something to type.
+        if row.resumable and row.session_id:
+            lines.append(f"    transcript session id: {row.session_id}")
     if any(row.resumable for row in rows):
         lines.append("")
         lines.append("Resume one with hub op='resume' and an instruction for what to do next.")
@@ -6277,6 +6285,7 @@ def _hub_list(tool_call_id: str, comms: Any) -> ToolResult:
                     "label": row.label,
                     "status": row.status,
                     "resumable": row.resumable,
+                    "session_id": row.session_id,
                 }
                 for row in rows
             ],

--- a/local_operator/tools/builtin.py
+++ b/local_operator/tools/builtin.py
@@ -6268,10 +6268,17 @@ def _hub_list(tool_call_id: str, comms: Any) -> ToolResult:
         # row that cannot be resumed it is a string to mistake for the job id
         # rather than something to type.
         if row.resumable and row.session_id:
-            lines.append(f"    transcript session id: {row.session_id}")
+            lines.append(
+                f"    transcript {row.session_id} (read it with"
+                f" local-operator --resume {row.session_id})"
+            )
     if any(row.resumable for row in rows):
         lines.append("")
-        lines.append("Resume one with hub op='resume' and an instruction for what to do next.")
+        lines.append(
+            "Resume one with hub op='resume' and its JOB id, plus an instruction for "
+            "what to do next. The transcript id above is not a job id: it opens the "
+            "child's history for reading and starts no agent."
+        )
     return _text(
         tool_call_id,
         "hub",

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -134,7 +134,10 @@ from local_operator.tui.widgets.editor import (
     resolve_markers,
 )
 from local_operator.tui.widgets.model_picker import ModelRow
-from local_operator.tui.widgets.session_picker import SessionPickerScreen
+from local_operator.tui.widgets.session_picker import (
+    RESUME_EMPTY_NOTICE,
+    SessionPickerScreen,
+)
 from local_operator.tui.widgets.status_line import (
     McpStatus,
     StatusLine,
@@ -1852,7 +1855,13 @@ class OperatorApp(App[None]):
         if not arg:
             rows = recent_session_rows(config_dir(), limit=RESUME_PICKER_LIMIT)
             if not rows:
-                self._system_notice("no previous sessions to resume", "warning")
+                # Says whose sessions, not that the disk is empty. Delegated
+                # subagent runs live in the same directory and are deliberately
+                # not listed, so on a machine whose only surviving sessions are
+                # children (retention evicts the older parent first) the flat
+                # "none exist" was simply false — and a dead end for a user who
+                # knows work is there.
+                self._system_notice(RESUME_EMPTY_NOTICE, "warning")
                 return
 
             def _resume_choice(session_id: str | None) -> None:

--- a/local_operator/tui/widgets/session_picker.py
+++ b/local_operator/tui/widgets/session_picker.py
@@ -82,7 +82,13 @@ NAME_MIN_CELLS = 16
 #: whose only surviving sessions are children — reachable through retention,
 #: which evicts the older parent before its newer children — "no previous
 #: sessions" was false and told the user nothing about why.
-RESUME_EMPTY_NOTICE = "no conversations of yours to resume — delegated subagent runs are not listed"
+#:
+#: It must also FIT: this string is the card's own empty body, and the card
+#: is capped at :data:`PICKER_MAX_WIDTH` cells. The first wording ran to 76
+#: cells and hung two past the rule at full width — and much further on a
+#: narrow terminal, where every neighbouring row sheds cells to fit. Anything
+#: edited here is measured against that cap, not eyeballed.
+RESUME_EMPTY_NOTICE = "no conversations of yours to resume — subagent runs are not listed"
 
 #: Rows of sessions shown before the list scrolls, when the terminal has room.
 #: A page that fills the screen makes the modal feel like a mode switch rather

--- a/local_operator/tui/widgets/session_picker.py
+++ b/local_operator/tui/widgets/session_picker.py
@@ -146,6 +146,34 @@ def _pad_cells(text: str, width: int) -> str:
     return text + " " * max(0, width - cell_len(text))
 
 
+def _wrap_cells(text: str, width: int) -> list[str]:
+    """Break ``text`` into lines of at most ``width`` CELLS, on word bounds.
+
+    Cells rather than characters for the same reason :func:`_pad_cells`
+    measures in them: a wide glyph occupies two, so a character-counted wrap
+    overflows the card on exactly the scripts that can least afford it.
+
+    A single word longer than the width is truncated rather than allowed to
+    run past the card, which is the only case where losing text beats breaking
+    the layout — every other case keeps all of the words and spends rows.
+    """
+    if width <= 0:
+        return [text]
+    lines: list[str] = []
+    current = ""
+    for word in text.split():
+        candidate = f"{current} {word}" if current else word
+        if cell_len(candidate) <= width:
+            current = candidate
+            continue
+        if current:
+            lines.append(current)
+        current = word if cell_len(word) <= width else truncate_cells(word, width)
+    if current:
+        lines.append(current)
+    return lines or [""]
+
+
 def plan_columns(
     rows: Sequence[SessionRow], width: int, ages: Sequence[str]
 ) -> tuple[int, int, int]:
@@ -624,7 +652,19 @@ class SessionPickerScreen(ModalScreen[str | None]):
         page = self._page_rows()
         counter: tuple[int, int, int] | None = None
         if not self._all:
-            out.append(RESUME_EMPTY_NOTICE, style=dim)
+            # WRAPPED to the measured width, not printed flat. Every other line
+            # in this card is bounded by the runtime width; this one was a
+            # constant, so it fitted the 74-cell ceiling and still overflowed
+            # the actual card on any narrow terminal — at 60 columns it was cut
+            # to "…subagent runs are", losing the clause that explains why the
+            # list is empty, which is the whole reason the wording changed.
+            # Wrapped rather than truncated for that reason: the explanation is
+            # the message, so it must survive the narrow case, not be the first
+            # thing dropped.
+            for index, line in enumerate(_wrap_cells(RESUME_EMPTY_NOTICE, width)):
+                if index:
+                    out.append("\n")
+                out.append(line, style=dim)
         elif not rows:
             # The header already echoes the query; repeating it here — and via
             # ``repr``, whose quoting flips on an apostrophe — said it twice in

--- a/local_operator/tui/widgets/session_picker.py
+++ b/local_operator/tui/widgets/session_picker.py
@@ -72,6 +72,18 @@ PICKER_PADDING_CELLS = 2
 #: the thing being looked up.
 NAME_MIN_CELLS = 16
 
+#: What both empty surfaces say when the picker has nothing to offer: the
+#: card's own body, and the notice ``/resume`` prints instead of opening it.
+#: ONE string because the two are the same statement made in two places, and
+#: they contradicted each other the moment either was edited alone.
+#:
+#: It names WHOSE sessions rather than claiming none exist. Delegated subagent
+#: runs share the directory and are deliberately unlisted, so on a machine
+#: whose only surviving sessions are children — reachable through retention,
+#: which evicts the older parent before its newer children — "no previous
+#: sessions" was false and told the user nothing about why.
+RESUME_EMPTY_NOTICE = "no conversations of yours to resume — delegated subagent runs are not listed"
+
 #: Rows of sessions shown before the list scrolls, when the terminal has room.
 #: A page that fills the screen makes the modal feel like a mode switch rather
 #: than a popup; ten is enough to scan. A CEILING, not the page size — see
@@ -584,7 +596,11 @@ class SessionPickerScreen(ModalScreen[str | None]):
             else:
                 header.append(truncate_cells(self._query, width), style=label)
         else:
-            tally = f"  {len(self._all)} sessions"
+            # Singular when there is one. Pre-existing, but filtering makes a
+            # one-row list the common case rather than the rare one: a machine
+            # whose delegated fan-out dominates now lands there routinely.
+            count = len(self._all)
+            tally = f"  {count} session" if count == 1 else f"  {count} sessions"
             if cell_len(title) + cell_len(tally) > width:
                 header.append(truncate_cells(title, width), style=Style(color=fg_colour))
             else:
@@ -602,7 +618,7 @@ class SessionPickerScreen(ModalScreen[str | None]):
         page = self._page_rows()
         counter: tuple[int, int, int] | None = None
         if not self._all:
-            out.append("no previous sessions to resume", style=dim)
+            out.append(RESUME_EMPTY_NOTICE, style=dim)
         elif not rows:
             # The header already echoes the query; repeating it here — and via
             # ``repr``, whose quoting flips on an apostrophe — said it twice in

--- a/tests/unit/harness/test_comms.py
+++ b/tests/unit/harness/test_comms.py
@@ -1631,3 +1631,42 @@ def test_a_swept_row_with_a_transcript_is_still_resumable(tmp_path):
     assert row.resumable is True
     # And the invariant: nothing in resume() disagrees.
     assert comms._live_twin(comms._records["job-1"]) is None
+
+
+def test_the_roster_carries_the_session_id_a_resume_would_take(tmp_path):
+    """The roster is now the ONLY surface that can show a child's session id.
+
+    Children are deliberately kept out of the `/resume` picker — they are the
+    machine's own runs, not the user's conversations — and the job row that
+    carries `job_id` is swept minutes after a child settles. Without the
+    session id here, an operator investigating a subagent that crashed an hour
+    ago has no in-product path to its transcript, which is precisely the case
+    this roster exists to cover.
+
+    Note it is NOT the job id: `--resume` takes the transcript directory name.
+    """
+    session_dir = tmp_path / "9f2c1a0b7e44"
+    session_dir.mkdir()
+    comms, jobs, _child, _parent = wire()
+    comms.attach("job-1", FakeChild(), session_dir)
+    (session_dir / TRANSCRIPT_FILENAME).write_text("{}\n")
+    comms.record_outcome("job-1", "failed", "provider 500")
+    comms.detach("job-1")
+    del jobs.jobs["job-1"]  # the sweep that used to take the id with it
+
+    [row] = comms.roster()
+
+    assert row.resumable is True
+    assert row.session_id == "9f2c1a0b7e44"
+    assert row.session_id != row.job_id
+
+
+def test_a_child_that_never_started_has_no_session_id_to_offer():
+    """No transcript directory, so there is nothing to print. A blank is
+    honest; the job id in its place would be an id that resumes nothing."""
+    comms, jobs, _child, _parent = wire(attach=False)
+    jobs.jobs["job-1"].status = "cancelled"
+
+    [row] = comms.roster()
+
+    assert row.session_id is None

--- a/tests/unit/harness/test_comms.py
+++ b/tests/unit/harness/test_comms.py
@@ -1670,3 +1670,35 @@ def test_a_child_that_never_started_has_no_session_id_to_offer():
     [row] = comms.roster()
 
     assert row.session_id is None
+
+
+def test_the_roster_text_tells_the_two_ids_apart(tmp_path):
+    """Both ids are `uuid4().hex[:12]`, so they are visually identical.
+
+    The roster prints a job id and a transcript id two lines apart, and the
+    line under them said "Resume one with hub op='resume'" — which takes the
+    JOB id and rejects the transcript id with `unknown subagent`. Two
+    indistinguishable ids beside an instruction that fits only one is a
+    coin-flip, so each id now names what it is for.
+    """
+    from local_operator.tools.builtin import _hub_list
+
+    session_dir = tmp_path / "9f2c1a0b7e44"
+    session_dir.mkdir()
+    comms, jobs, _child, _parent = wire()
+    comms.attach("job-1", FakeChild(), session_dir)
+    (session_dir / TRANSCRIPT_FILENAME).write_text("{}\n")
+    comms.record_outcome("job-1", "failed", "provider 500")
+    comms.detach("job-1")
+    del jobs.jobs["job-1"]
+
+    block = _hub_list("call-1", comms).content[0]
+    assert isinstance(block, TextContent)
+    text = block.text
+
+    # The transcript id is shown with the command that actually takes it.
+    assert "local-operator --resume 9f2c1a0b7e44" in text
+    # And the resume instruction says which id it wants, so the transcript id
+    # sitting above it is not read as the argument.
+    assert "JOB id" in text
+    assert "not a job id" in text

--- a/tests/unit/session/test_launch_subagent.py
+++ b/tests/unit/session/test_launch_subagent.py
@@ -826,3 +826,58 @@ async def test_the_loop_stays_responsive_while_several_subagents_run(tmp_path, m
         "a synchronous stretch is starving concurrent children"
     )
     await parent.dispose()
+
+
+@pytest.mark.asyncio
+async def test_a_launched_subagent_stays_out_of_the_resume_picker(tmp_path, monkeypatch):
+    """The reported bug, end to end: `/resume` listed the machine's own runs.
+
+    A child session is an ephemeral directory under ``sessions/`` with exactly
+    the shape of a real conversation, so nothing on disk told them apart and
+    the picker named each delegated run by its role preamble. This drives the
+    production launch path and then asks the same function the picker calls,
+    rather than asserting on the marker file — the marker is the mechanism, and
+    the row count is the promise.
+    """
+    from local_operator.resume import (
+        ORIGIN_SUBAGENT,
+        recent_session_rows,
+        session_origin,
+    )
+
+    config = tmp_path / "config"
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(config))
+
+    # The parent is a user session: an ephemeral directory under sessions/,
+    # which is what session_factory hands a TUI run.
+    parent_dir = config / "sessions" / "parentsession"
+    transcript = Transcript(parent_dir)
+    await transcript.append_message(Message.user("fix the resume picker"))
+    parent = Session(
+        model=MODEL,
+        stream_fn=OneShotStream(),
+        tools=[],
+        transcript=transcript,
+        system_blocks_provider=lambda: ["stable", "env"],
+    )
+
+    events: list[AgentEvent] = []
+    parent.subscribe(events.append)
+    parent._launch_subagent(label="reviewer", prompt="[role: reviewer] review the diff")
+    await wait_for(lambda: any(e.type == "subagent_end" for e in events))
+
+    sessions = sorted(p.name for p in (config / "sessions").iterdir())
+    assert len(sessions) == 2, f"expected the parent and its child on disk, got {sessions}"
+    child_dir = next(p for p in (config / "sessions").iterdir() if p.name != "parentsession")
+    # The nonzero control: the child really did write a transcript, so an empty
+    # picker row set below cannot be a directory that was never created.
+    assert (child_dir / "transcript.jsonl").is_file()
+
+    # The promise first, then the mechanism that delivers it: a reader who
+    # only trusts one line should trust the row set.
+    rows = recent_session_rows(config, limit=50)
+    assert [row.id for row in rows] == ["parentsession"]
+    assert [row.name for row in rows] == ["fix the resume picker"]
+    assert session_origin(child_dir) == ORIGIN_SUBAGENT
+
+    await parent.dispose()

--- a/tests/unit/session/test_retention.py
+++ b/tests/unit/session/test_retention.py
@@ -224,3 +224,48 @@ def test_directory_stays_under_budget_however_many_sessions_arrive(tmp_path, cei
         # +1 for the live directory, which is exempt from the ceiling.
         assert len(list(sessions.iterdir())) <= ceiling + 1
     assert live.exists()
+
+
+def test_an_aborted_child_leaves_nothing_worth_a_retention_slot(tmp_path):
+    """A session is stamped with its origin BEFORE its transcript exists, so a
+    run that aborts in between leaves a directory holding only the marker.
+
+    Such a directory used to be empty, and empty directories are always reaped
+    regardless of the ceilings — they carry nothing to lose. Counting the
+    marker's 43 bytes turned each one into an ordinary keep candidate holding a
+    slot: measured with a count ceiling of 3, two aborted children evicted two
+    of the user's real transcripts to keep two empty markers.
+    """
+    import os
+
+    from local_operator.resume import ORIGIN_SUBAGENT, mark_session_origin
+
+    sessions = tmp_path / "sessions"
+    # The user's real work, older than the children that abort after it.
+    for i in range(3):
+        _session(sessions, f"user{i}", age_days=3 - i)
+    for i in range(2):
+        hollow = sessions / f"hollow{i}"
+        hollow.mkdir(parents=True)
+        mark_session_origin(hollow, ORIGIN_SUBAGENT, label="review")
+        now = time.time()
+        os.utime(hollow, (now, now))
+
+    sweep_sessions(sessions, max_sessions=3, max_bytes=0, max_age_days=0)
+
+    survivors = sorted(path.name for path in sessions.iterdir())
+    assert survivors == ["user0", "user1", "user2"], survivors
+
+
+def test_the_marker_is_not_charged_against_the_byte_ceiling(tmp_path):
+    """The marker is bookkeeping ABOUT a session, never session content, so it
+    is not what the ceilings are budgeting."""
+    from local_operator.resume import ORIGIN_SUBAGENT, mark_session_origin
+
+    sessions = tmp_path / "sessions"
+    directory = _session(sessions, "one", size=100)
+    before = sweep_sessions(sessions, max_sessions=0, max_bytes=0, max_age_days=0)
+    mark_session_origin(directory, ORIGIN_SUBAGENT, label="review")
+    after = sweep_sessions(sessions, max_sessions=0, max_bytes=0, max_age_days=0)
+
+    assert before.bytes_remaining == after.bytes_remaining == 100

--- a/tests/unit/test_cli_new.py
+++ b/tests/unit/test_cli_new.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import contextlib
 import subprocess
 import sys
 import types
@@ -1061,3 +1062,70 @@ def test_a_background_job_carries_the_session_it_was_told_to_resume() -> None:
 
     # Nothing is emitted when nothing was asked for.
     assert "--resume" not in build_worker_argv("hi", ExecArgs())
+
+
+def test_a_bare_resume_classifies_sessions_before_resolving_latest(tmp_path, monkeypatch) -> None:
+    """``--resume`` is answered in the CLI, BEFORE any session is built.
+
+    The session factory also backfills, but it runs when a session is
+    constructed — which is after this branch has already picked a directory.
+    So on the first launch after an upgrade, a bare ``--resume`` resolved
+    ``@latest`` against an unclassified store and reopened whichever delegated
+    run happened to finish last: the CLI spelling of the exact bug the picker
+    fix is about.
+    """
+    import json
+    import os
+
+    from local_operator import resume as resume_mod
+
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    sessions = tmp_path / "sessions"
+
+    def seed(name: str, opening: str, when: int) -> None:
+        directory = sessions / name
+        directory.mkdir(parents=True)
+        entry = {
+            "id": "e1",
+            "ts": 0,
+            "type": "message",
+            "payload": {"kind": "message", "role": "user", "content": [{"text": opening}]},
+        }
+        transcript = directory / resume_mod.TRANSCRIPT_NAME
+        transcript.write_text(json.dumps(entry) + "\n", encoding="utf-8")
+        os.utime(transcript, (when, when))
+
+    # The child settles AFTER the parent's last turn, which is the ordinary
+    # case: a delegated review outlives the turn that launched it.
+    seed("mine00000000", "fix the resume picker", 1_000_000)
+    seed("child0000000", "[role: reviewer]\nreview the diff", 2_000_000)
+
+    # Neither directory is marked, exactly like a store that predates the fix.
+    assert not any((path / resume_mod.ORIGIN_NAME).exists() for path in sessions.iterdir())
+
+    # Drive the CLI branch itself rather than re-implementing its order here:
+    # the defect was entirely in WHICH function ran first, so a test that
+    # calls them in the right order by hand cannot see it. `main` is stopped
+    # right after the resume block by a sentinel raised from the next call it
+    # makes, leaving `args.resume` holding what the branch resolved.
+    resolved: list[str] = []
+
+    class _Stop(Exception):
+        pass
+
+    monkeypatch.setattr(cli, "setup_cross_platform_environment", lambda: None)
+    monkeypatch.setattr(cli.sys, "argv", ["local-operator", "--resume"])
+    original = resume_mod.resolve_resume_id
+
+    def _record(config_dir, requested):  # noqa: ANN001, ANN202
+        value = original(config_dir, requested)
+        resolved.append(value)
+        raise _Stop
+
+    monkeypatch.setattr(resume_mod, "resolve_resume_id", _record)
+    with contextlib.suppress(_Stop, SystemExit, Exception):
+        cli.main()
+
+    assert resolved == [
+        "mine00000000"
+    ], f"a bare --resume reopened a subagent's transcript: {resolved}"

--- a/tests/unit/test_session_factory.py
+++ b/tests/unit/test_session_factory.py
@@ -1082,6 +1082,83 @@ def test_resume_latest_picks_the_newest_transcript(tmp_path: Path) -> None:
     assert directory == sessions / "newer"
 
 
+def test_resume_latest_skips_a_subagent_that_finished_last(tmp_path: Path) -> None:
+    """``@latest`` means the newest conversation THE USER had.
+
+    A subagent writes its child transcript into the same ``sessions/`` tree, and
+    a delegated review routinely settles after the parent's final turn — which
+    made the child the newest directory on disk, so a bare ``--resume`` reopened
+    the reviewer instead of the session that launched it.
+    """
+    sessions = tmp_path / "sessions"
+    for name, when in (("mine", 1_000_000), ("child", 2_000_000)):
+        (sessions / name).mkdir(parents=True)
+        transcript = sessions / name / "transcript.jsonl"
+        transcript.write_text("{}\n", encoding="utf-8")
+        os.utime(transcript, (when, when))
+    resume_mod.mark_session_origin(sessions / "child", resume_mod.ORIGIN_SUBAGENT, label="review")
+    registry = FakeRegistry(tmp_path)
+
+    directory, _ = session_factory._transcript_dir_and_agent_id(
+        None, _args(resume=resume_mod.RESUME_LATEST), cast("AgentRegistry", registry)
+    )
+    assert directory == sessions / "mine"
+
+
+def test_a_subagent_session_still_resumes_by_explicit_id(tmp_path: Path) -> None:
+    """Filtering narrows what is OFFERED, never what exists.
+
+    ``hub op='resume'`` continues a stopped child on its own directory, and an
+    operator debugging a delegated run has only its id to go on. Hiding the row
+    must not amputate the path that reaches it.
+    """
+    sessions = tmp_path / "sessions"
+    (sessions / "child").mkdir(parents=True)
+    (sessions / "child" / "transcript.jsonl").write_text("{}\n", encoding="utf-8")
+    resume_mod.mark_session_origin(sessions / "child", resume_mod.ORIGIN_SUBAGENT, label="review")
+
+    assert resume_mod.resume_dir(tmp_path, "child") == sessions / "child"
+
+
+def test_an_unreadable_origin_marker_leaves_the_session_the_user_s(tmp_path: Path) -> None:
+    """Absence and corruption both mean USER, and that direction is deliberate.
+
+    Marking user sessions instead would have hidden every conversation that
+    predates the marker. A listing showing one stale row is fixed by typing a
+    filter; one that hides your own work is not recoverable at all.
+    """
+    sessions = tmp_path / "sessions"
+    (sessions / "mine").mkdir(parents=True)
+    (sessions / "mine" / resume_mod.ORIGIN_NAME).write_text("{not json", encoding="utf-8")
+    assert resume_mod.session_origin(sessions / "mine") == ""
+    assert resume_mod.is_user_session(sessions / "mine")
+
+    # A well-formed file that is not an object, and one with a non-string
+    # origin: both are the same "cannot read a claim off this" case.
+    (sessions / "mine" / resume_mod.ORIGIN_NAME).write_text("[1, 2]", encoding="utf-8")
+    assert resume_mod.is_user_session(sessions / "mine")
+    (sessions / "mine" / resume_mod.ORIGIN_NAME).write_text('{"origin": 7}', encoding="utf-8")
+    assert resume_mod.is_user_session(sessions / "mine")
+
+
+def test_marking_a_session_never_takes_the_run_down(tmp_path: Path, monkeypatch) -> None:
+    """Marking is bookkeeping for a listing; a child that cannot write it runs.
+
+    The cost of a failed write is one extra row in a picker. Raising here would
+    take down a delegated task for a directory a retention sweep just removed
+    or a volume that went read-only.
+    """
+    target = tmp_path / "sessions" / "child"
+
+    def denied(*args, **kwargs):  # noqa: ANN002, ANN003, ANN202
+        raise PermissionError("read-only volume")
+
+    monkeypatch.setattr(Path, "write_text", denied)
+    resume_mod.mark_session_origin(target, resume_mod.ORIGIN_SUBAGENT)
+    monkeypatch.undo()
+    assert resume_mod.is_user_session(target)
+
+
 @pytest.mark.parametrize("requested", ["nope", "..", "../../etc", "sub/dir", ""])
 def test_resume_refuses_a_session_it_cannot_verify(tmp_path: Path, requested: str) -> None:
     """A typo must FAIL, not start an empty session that looks resumed.

--- a/tests/unit/test_session_factory.py
+++ b/tests/unit/test_session_factory.py
@@ -11,6 +11,7 @@ import inspect
 import json
 import os
 import sqlite3
+import time
 from collections.abc import Awaitable, Callable
 from pathlib import Path
 from types import SimpleNamespace
@@ -1877,3 +1878,68 @@ def test_the_backfill_stamps_only_what_the_machine_itself_wrote(tmp_path: Path) 
     assert resume_mod.backfill_session_origins(tmp_path) == 0
     (sessions / "child_role" / resume_mod.ORIGIN_NAME).unlink()
     assert resume_mod.backfill_session_origins(tmp_path) == 1
+
+
+def test_stamping_a_session_does_not_reset_its_retention_clock(tmp_path: Path) -> None:
+    """Retention sorts and age-expires on the DIRECTORY's mtime, and creating
+    a file inside a directory moves it.
+
+    So stamping an existing session silently reset its clock to now: the
+    backfill resurrected delegated runs that were already past the age ceiling
+    and, because eviction is oldest-first, spent their retained slots on the
+    user's own conversations. Writing a marker is bookkeeping ABOUT a session,
+    never activity IN it, so it must not answer "when was this last used".
+    """
+    sessions = tmp_path / "sessions"
+    directory = sessions / "child"
+    directory.mkdir(parents=True)
+    (directory / resume_mod.TRANSCRIPT_NAME).write_text("{}\n", encoding="utf-8")
+    aged = time.time() - 40 * 86400
+    os.utime(directory, (aged, aged))
+
+    resume_mod.mark_session_origin(directory, resume_mod.ORIGIN_SUBAGENT, label="review")
+
+    assert not resume_mod.is_user_session(directory), "the marker must still be written"
+    assert abs(directory.stat().st_mtime - aged) < 1, "stamping moved the retention clock"
+
+
+def test_the_backfill_reaches_every_directory_not_just_the_first_page(tmp_path: Path) -> None:
+    """The cap is on work done, never on how far the scan reaches.
+
+    Slicing the directory list instead sounds equivalent and is not: the list
+    sorts by hex NAME and the same prefix is recomputed every startup, so a
+    directory sorting past the cut was never visited on any run, ever — its
+    origin decided by where its random name fell in an alphabet.
+    """
+    sessions = tmp_path / "sessions"
+
+    def seed(name: str, opening: str) -> None:
+        directory = sessions / name
+        directory.mkdir(parents=True)
+        entry = {
+            "id": "e1",
+            "ts": 0,
+            "type": "message",
+            "payload": {"kind": "message", "role": "user", "content": [{"text": opening}]},
+        }
+        (directory / resume_mod.TRANSCRIPT_NAME).write_text(
+            json.dumps(entry) + "\n", encoding="utf-8"
+        )
+
+    # Children sort AFTER every user session, and past a small cap.
+    for index in range(12):
+        seed(f"0{index:04d}", "my own work")
+    for index in range(4):
+        seed(f"f{index:04d}", "[role: reviewer]\nreview the diff")
+
+    assert resume_mod.backfill_session_origins(tmp_path, limit=5) == 4
+    for index in range(4):
+        assert not resume_mod.is_user_session(sessions / f"f{index:04d}")
+
+    # The cap still bounds the work: with more children than the limit, a run
+    # stamps at most ``limit`` and the next startup continues.
+    for index in range(4, 12):
+        seed(f"f{index:04d}", "[role: reviewer]\nreview the diff")
+    assert resume_mod.backfill_session_origins(tmp_path, limit=5) == 5
+    assert resume_mod.backfill_session_origins(tmp_path, limit=5) == 3
+    assert resume_mod.backfill_session_origins(tmp_path, limit=5) == 0

--- a/tests/unit/test_session_factory.py
+++ b/tests/unit/test_session_factory.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import argparse
 import inspect
+import json
 import os
 import sqlite3
 from collections.abc import Awaitable, Callable
@@ -1807,3 +1808,72 @@ async def test_an_unreadable_profile_says_so_in_the_log(
         and "OSError" in record.getMessage()
         for record in caplog.records
     ), [record.getMessage() for record in caplog.records]
+
+
+def test_a_marker_truncated_mid_character_does_not_take_the_picker_down(tmp_path: Path) -> None:
+    """`mark_session_origin` writes non-atomically, so a child killed mid-write
+    leaves the file cut INSIDE a multi-byte character.
+
+    A strict decode raises `UnicodeDecodeError`, which is a `ValueError` and
+    sails past `except OSError` — so one truncated sidecar took down the whole
+    picker, and `--resume` with no id, for every session on the machine until
+    the user found and deleted the file by hand.
+    """
+    sessions = tmp_path / "sessions"
+    (sessions / "cut").mkdir(parents=True)
+    (sessions / "cut" / resume_mod.TRANSCRIPT_NAME).write_text("{}\n", encoding="utf-8")
+    # 0xc3 opens a two-byte sequence that never arrives.
+    (sessions / "cut" / resume_mod.ORIGIN_NAME).write_bytes(b'{"origin": "subagent", "l": "caf\xc3')
+
+    assert resume_mod.session_origin(sessions / "cut") == ""
+    assert resume_mod.recent_sessions(tmp_path) == [
+        ("cut", (sessions / "cut" / resume_mod.TRANSCRIPT_NAME).stat().st_mtime)
+    ]
+    # The `@latest` resolver reads the same marker and must survive it too.
+    assert resume_mod.resume_dir(tmp_path, resume_mod.RESUME_LATEST).name == "cut"
+
+
+def test_the_backfill_stamps_only_what_the_machine_itself_wrote(tmp_path: Path) -> None:
+    """Sessions predating the marker are classified once, at startup.
+
+    Without this the fix applies only to sessions created after the upgrade,
+    so the person who reported a picker full of `[role: reviewer]` rows would
+    upgrade, run `/resume`, and see the same wall.
+
+    The direction of the risk decides the strictness: a false positive HIDES
+    one of the user's own conversations, so only the two openings the subagent
+    runner itself writes are matched, anchored at offset 0.
+    """
+    sessions = tmp_path / "sessions"
+
+    def seed(name: str, opening: str) -> None:
+        directory = sessions / name
+        directory.mkdir(parents=True)
+        entry = {
+            "id": "e1",
+            "ts": 0,
+            "type": "message",
+            "payload": {"kind": "message", "role": "user", "content": [{"text": opening}]},
+        }
+        (directory / resume_mod.TRANSCRIPT_NAME).write_text(
+            json.dumps(entry) + "\n", encoding="utf-8"
+        )
+
+    seed("child_role", "[role: reviewer]\nYou are an INDEPENDENT reviewer.")
+    seed("child_scout", "[scout mode: you are a READ-ONLY research agent.]\n\nfind it")
+    seed("mine_plain", "fix the resume picker")
+    # The user QUOTING a preamble mid-message is not a delegated run: the
+    # machine's preambles are stamped in front, so matching is anchored.
+    seed("mine_quoting", "why does my subagent say [role: reviewer] in its prompt?")
+
+    assert resume_mod.backfill_session_origins(tmp_path) == 2
+    assert not resume_mod.is_user_session(sessions / "child_role")
+    assert not resume_mod.is_user_session(sessions / "child_scout")
+    assert resume_mod.is_user_session(sessions / "mine_plain")
+    assert resume_mod.is_user_session(sessions / "mine_quoting")
+
+    # Idempotent: a second startup stamps nothing, so a marker the user
+    # deleted by hand to un-hide a session is not silently written back.
+    assert resume_mod.backfill_session_origins(tmp_path) == 0
+    (sessions / "child_role" / resume_mod.ORIGIN_NAME).unlink()
+    assert resume_mod.backfill_session_origins(tmp_path) == 1

--- a/tests/unit/tui/test_session_picker.py
+++ b/tests/unit/tui/test_session_picker.py
@@ -926,21 +926,30 @@ def test_one_session_is_not_announced_as_1_sessions() -> None:
     assert "2 sessions" in plural
 
 
-def test_the_empty_notice_fits_inside_the_card() -> None:
-    """The notice is the card's own empty body, and the card is capped.
+@pytest.mark.asyncio
+async def test_the_empty_card_never_renders_wider_than_the_terminal() -> None:
+    """The empty body is the one line with no truncation behind it.
 
-    The first wording ran to 76 cells against a 74-cell cap and hung past the
-    rule at full width — much further on a narrow terminal, where every
-    neighbouring row sheds cells to fit. Measured rather than eyeballed,
-    because this is the one row with no truncation behind it.
+    Every other row is bounded by the width the card MEASURES; the notice was
+    a constant, so it satisfied the 74-cell ceiling and still overflowed the
+    real card on any narrow terminal — at 60 columns it was cut to
+    "…subagent runs are", losing the clause that explains why the list is
+    empty, which is the whole reason the wording changed.
+
+    Asserted against the TERMINAL width like the populated-rows guard above,
+    never against ``PICKER_MAX_WIDTH``: the ceiling is 74 while an 80-column
+    screen gives the card 70, so a constant-based assertion passes on a string
+    that overflows.
     """
-    from local_operator.tui.widgets.session_picker import (
-        PICKER_MAX_WIDTH,
-        RESUME_EMPTY_NOTICE,
-    )
-
-    assert cell_len(RESUME_EMPTY_NOTICE) <= PICKER_MAX_WIDTH
-
-    screen = SessionPickerScreen([], NOW)
-    for line in screen.render_lines_for_test():
-        assert cell_len(line) <= PICKER_MAX_WIDTH, line
+    for width in (60, 70, 80, 100, 120):
+        app = _PickerHost([])
+        async with app.run_test(size=(width, 30)) as pilot:
+            screen = await app.open_picker()
+            await pilot.pause()
+            lines = screen.render_lines_for_test()
+            for line in lines:
+                assert cell_len(line) <= width, (width, line)
+            # The explanation survives the narrow case rather than being the
+            # first thing dropped: it is what makes the empty state honest.
+            body = " ".join(line.strip() for line in lines)
+            assert "subagent runs are not listed" in body, (width, body)

--- a/tests/unit/tui/test_session_picker.py
+++ b/tests/unit/tui/test_session_picker.py
@@ -890,3 +890,37 @@ def test_a_right_click_never_resumes_a_session() -> None:
 
     screen.on_click(_RightClick())
     assert resumed == []
+
+
+def test_the_empty_card_says_whose_sessions_are_missing() -> None:
+    """ "no previous sessions to resume" was false when only children exist.
+
+    Delegated runs share the sessions directory and are deliberately unlisted,
+    and retention evicts an older parent before its newer children — so a
+    machine can reach a state with resumable directories on disk and nothing
+    the picker will offer. The old sentence stated a fact about the disk that
+    was untrue, and named no way forward.
+    """
+    from local_operator.tui.widgets.session_picker import RESUME_EMPTY_NOTICE
+
+    screen = SessionPickerScreen([], NOW)
+    card = "\n".join(screen.render_lines_for_test())
+    assert RESUME_EMPTY_NOTICE in card
+    assert "delegated subagent runs are not listed" in card
+
+
+def test_one_session_is_not_announced_as_1_sessions() -> None:
+    """Filtering makes a one-row list the common case rather than the rare
+    one, so the header's plural now shows up routinely."""
+    single = "\n".join(
+        SessionPickerScreen([_row("aabbcc", "the only one")], NOW).render_lines_for_test()
+    )
+    assert "1 session" in single
+    assert "1 sessions" not in single
+
+    plural = "\n".join(
+        SessionPickerScreen(
+            [_row("aabbcc", "one"), _row("ddeeff", "two")], NOW
+        ).render_lines_for_test()
+    )
+    assert "2 sessions" in plural

--- a/tests/unit/tui/test_session_picker.py
+++ b/tests/unit/tui/test_session_picker.py
@@ -906,7 +906,7 @@ def test_the_empty_card_says_whose_sessions_are_missing() -> None:
     screen = SessionPickerScreen([], NOW)
     card = "\n".join(screen.render_lines_for_test())
     assert RESUME_EMPTY_NOTICE in card
-    assert "delegated subagent runs are not listed" in card
+    assert "subagent runs are not listed" in card
 
 
 def test_one_session_is_not_announced_as_1_sessions() -> None:
@@ -924,3 +924,23 @@ def test_one_session_is_not_announced_as_1_sessions() -> None:
         ).render_lines_for_test()
     )
     assert "2 sessions" in plural
+
+
+def test_the_empty_notice_fits_inside_the_card() -> None:
+    """The notice is the card's own empty body, and the card is capped.
+
+    The first wording ran to 76 cells against a 74-cell cap and hung past the
+    rule at full width — much further on a narrow terminal, where every
+    neighbouring row sheds cells to fit. Measured rather than eyeballed,
+    because this is the one row with no truncation behind it.
+    """
+    from local_operator.tui.widgets.session_picker import (
+        PICKER_MAX_WIDTH,
+        RESUME_EMPTY_NOTICE,
+    )
+
+    assert cell_len(RESUME_EMPTY_NOTICE) <= PICKER_MAX_WIDTH
+
+    screen = SessionPickerScreen([], NOW)
+    for line in screen.render_lines_for_test():
+        assert cell_len(line) <= PICKER_MAX_WIDTH, line

--- a/tests/unit/tui/test_session_picker.py
+++ b/tests/unit/tui/test_session_picker.py
@@ -19,7 +19,9 @@ from textual.app import App, ComposeResult
 from local_operator.resume import (
     NAME_MAX_CHARS,
     NAME_SCAN_CHARS,
+    ORIGIN_SUBAGENT,
     SessionRow,
+    mark_session_origin,
     recent_session_rows,
     session_name,
 )
@@ -219,6 +221,38 @@ def test_rows_are_newest_first_and_carry_their_name(tmp_path: Path) -> None:
     rows = recent_session_rows(tmp_path)
     assert [row.id for row in rows] == ["newer1", "older1"]
     assert [row.name for row in rows] == ["the newer one", "the older one"]
+
+
+def test_the_picker_offers_only_sessions_the_user_started(tmp_path: Path) -> None:
+    """A subagent's child session is not a conversation the user can recognise.
+
+    Children land in the same ``sessions/`` tree with the same shape, so the
+    picker named them by their opening message — which for a delegated run is
+    the role preamble the parent wrote. On one machine 40 of 50 offered rows
+    were ``[role: reviewer] You are an INDEPENDENT reviewer…`` and the user's
+    own sessions were paged off the bottom.
+    """
+    _write_transcript(tmp_path, "mine", [_message("user", "fix the resume picker")])
+    child = _write_transcript(
+        tmp_path, "child", [_message("user", "[role: reviewer] You are an INDEPENDENT reviewer")]
+    )
+    mark_session_origin(child, ORIGIN_SUBAGENT, label="reviewer")
+
+    rows = recent_session_rows(tmp_path)
+    assert [row.id for row in rows] == ["mine"]
+    # Hidden from the listing, still on disk: the transcript is what makes a
+    # stopped child resumable by id and readable after the fact.
+    assert (child / "transcript.jsonl").is_file()
+
+
+def test_a_session_with_no_marker_is_still_the_user_s(tmp_path: Path) -> None:
+    """Every conversation that predates the marker must keep appearing.
+
+    The filter reads absence as "the user's" precisely so an upgrade does not
+    empty the picker of real work.
+    """
+    _write_transcript(tmp_path, "before", [_message("user", "an older conversation")])
+    assert [row.id for row in recent_session_rows(tmp_path)] == ["before"]
 
 
 # --- filtering --------------------------------------------------------------


### PR DESCRIPTION
## Change classification

**C2 — standard / pre-authorized.** Narrows what two existing listings *offer*; adds one sidecar file written by the subagent runner. Nothing is deleted and no resume path is removed — `--resume <id>` and `hub op='resume'` still reach a child by id. Clean rollback (`git revert`), and reverting also leaves the now-harmless `origin.json` files inert. No RFC requested.

## The gap

A subagent's child session is an ephemeral directory under `sessions/` with **exactly** the shape of a real conversation: `_build_child_session` mints `config_dir()/sessions/<hex>` and writes a `transcript.jsonl` whose first entry is a `role: "user"` message — the prompt the *parent* wrote.

`recent_session_rows` globs that directory and names each row by its opening user message. Nothing on disk distinguished the two, so `/resume` offered every delegated reviewer, designer and scout run as if the user had opened it, named by the role preamble:

```
[role: reviewer] You are an INDEPENDENT reviewer…   11m ago  447b4d717b3c
[role: designer] You review the user-visible sur…   20m ago  5113f9670e8b
```

On the reported machine that was **40 of 50 rows**, pushing the user's own conversations off the first page.

Two surfaces were affected, not one:

- the `/resume` picker and the CLI's recovery listing (`recent_sessions`);
- **`@latest`** — a bare `--resume` reopened whichever directory was newest, and a delegated review routinely settles *after* the parent's final turn, so it reopened the reviewer rather than the session that launched it.

### Reproduced first, against the real launch path

Not a fixture: this drives `Session._launch_subagent` → `run_subagent`, lets the child write its own transcript, then calls the same function the picker calls.

```console
$ LOCAL_OPERATOR_CONFIG_DIR=/tmp/lo-repro-cfg .venv/bin/python /tmp/lo-resume-origin-repro.py   # on 09d8440
sessions on disk: ['4a5f5a6644ea', 'parent000user']
rows offered by the /resume picker: 2
  4a5f5a6644ea  '[role: reviewer] You are an INDEPENDENT reviewer.'
  parent000user  'I noticed all the subagent sessions appear under /resume'
```

The same script on this branch — the child still runs and still writes its transcript, it is simply no longer offered:

```console
$ LOCAL_OPERATOR_CONFIG_DIR=/tmp/lo-repro-cfg .venv/bin/python /tmp/lo-resume-origin-repro.py   # on d209a7a
sessions on disk: ['0da8293079b8', 'parent000user']
rows offered by the /resume picker: 1
  parent000user  'I noticed all the subagent sessions appear under /resume'

$ cat /tmp/lo-repro-cfg/sessions/0da8293079b8/origin.json
{"origin": "subagent", "label": "reviewer", "agent": "task"}
$ ls /tmp/lo-repro-cfg/sessions/0da8293079b8/
origin.json  transcript.jsonl
```

## What changed

### 1. `origin.json`, written by whoever creates the directory

`mark_session_origin` / `session_origin` / `is_user_session` in `resume.py`, stamped by `_build_child_session` **before** the `Transcript` is constructed — so a picker painted while a child is mid-run already knows what it is.

Written at creation because that is the only place that knows: by the time the picker reads it back, a child and a user's conversation are indistinguishable.

**A sidecar rather than a field in the transcript.** The picker's whole cost model is one bounded read per row (`NAME_SCAN_CHARS`); a marker inside the JSONL could only be found by parsing it, whereas `is_file()` is one stat and answers even before the child's transcript exists.

**A JSON object rather than a bare flag file**, so a future non-user origin (a scheduled run, a server-side session) is a new *value* and not a second file.

### 2. `recent_sessions` and `@latest` skip non-user sessions

`resume.py` is the one definition both the CLI and the TUI already share, so both surfaces were fixed by one change. The stat comes first and the marker check second: the stat is what proves a directory is a session at all, and an unreadable marker must not cost a row.

### 3. Absence means USER — deliberately, and in this direction

The alternative (mark *user* sessions, hide everything unmarked) would have made **every conversation predating this change disappear** from the picker on upgrade. An unmarked child costs one stale row that retention eventually evicts; a listing that hides your own work is not recoverable by any action the user can take. A too-full list is fixed by typing a filter.

Marking is **best-effort** for the same asymmetry: a child that cannot write its marker (read-only volume, a retention sweep that just removed the directory) still runs. The cost of that failure is one extra row; taking a delegated task down for it would be the more expensive bug.

### Scope check: is anything else writing into `sessions/`?

Enumerated rather than recalled — every caller of `_transcript_dir_and_agent_id`, driven for real:

```console
$ .venv/bin/python -c '<drive the factory with each host shape>'
scheduler run ->  agents/sched-agent          # --train, outside sessions/ entirely
server/plain run -> sessions /<hex>           # user-initiated
```

Scheduled runs land in `agents/`, already outside resume's scope (`resume_dir` confines resumption to `sessions/` by design). Server sessions are user-initiated. **The subagent runner is the only non-user writer into `sessions/`**, which is why it is the only marking site.

## Testing evidence

### The picker, driven for real — before / after

Captured from the **real `OperatorApp`** (which loads `local_operator.tcss`; the `_PickerHost` in the test file declares no `CSS_PATH` and would show none of the styling), seeded with a realistic mix: 5 user conversations and 7 delegated runs carrying the actual role preambles. The same script produced both frames — which rows are hidden is decided by the tree, not the script.

Both frames were exported as SVG stills from the running app (`app.save_screenshot`) and **looked at** as rendered images, per `AGENTS.md` §"Visual validation". The painted card text, captured at the SHAs named:

**Before** — `origin/main` 09d8440. 12 sessions, 7 of them the machine's own work:

```
Resume a conversation  12 sessions
──────────────────────────────────────────────────────────────────────────
❯ PR #132 in ~/local-operator (Textual terminal UI…   2m ago  0b6b2c1069bd   <- subagent
  You are an INDEPENDENT code reviewer for PR #132…   3m ago  056761acaeb8   <- subagent
  Can you check if lop agents can resume stuck/fai…   7m ago  3572f7d23f8
  Searching "Katie Marie Doyle" in core-svc with n…  10m ago  d714655fcb57
  [role: reviewer] You are an INDEPENDENT reviewer…  11m ago  447b4d717b3c   <- subagent
  Can you review my gcp/google cloud spend, previo…  15m ago  16cb1895c11f
  [role: reviewer] You are an INDEPENDENT reviewer…  19m ago  e1c592323dca   <- subagent
  [role: designer] You review the user-visible sur…  20m ago  5113f9670e8b   <- subagent
  [role: reviewer] You are an INDEPENDENT reviewer…  21m ago  1de4c01239c7   <- subagent
  I noticed that mid-turn compaction is not proper…  23m ago  fbee72361c31

showing 1–10 of 12
↑↓ move · pgup/pgdn page · type to filter · enter resume · esc cancel
```

Two of the user's five real conversations are **paged off the bottom** by the machine's own runs.

**After** — d209a7a. 5 sessions, every row a conversation the user started:

```
Resume a conversation  5 sessions
──────────────────────────────────────────────────────────────────────────
❯ Can you check if lop agents can resume stuck/fai…   7m ago  3572f7d23f8
  Searching "Katie Marie Doyle" in core-svc with n…  10m ago  d714655fcb57
  Can you review my gcp/google cloud spend, previo…  15m ago  16cb1895c11f
  I noticed that mid-turn compaction is not proper…  23m ago  fbee72361c31
  Draft the Q3 usage summary for the platform team   31m ago  2ce0fd628083

↑↓ move · pgup/pgdn page · type to filter · enter resume · esc cancel
```

The card reflows correctly to the shorter list: the `showing 1–10 of 12` pager is gone because 5 rows need no paging, and the header count tracks it.

Frame integrity checks, because a screenshot can fail to prove even what you looked at:

```console
$ md5sum picker-before.svg picker-after.svg
e594399004985c5ac82a9578b2b07138  picker-before.svg
f562367714c3562dc3cb56082b477003  picker-after.svg      # distinct — not one capture twice

$ cmp -s picker-before.svg picker-before-settled.svg && echo "settled identical"
settled identical                                        # no post-paint reflow, either tree

$ grep -c "reviewer" picker-before.svg   # branch-discriminating needle, with its nonzero control
4
$ grep -c "reviewer" picker-after.svg
0
```

### The fix is pinned by a mutation, not by a green suite

`test_a_launched_subagent_stays_out_of_the_resume_picker` runs the production launch path and asserts on the **row set** the picker would show. Deleting the one line that writes the marker fails it — proving the test defends the behaviour rather than decorating it:

```console
$ # mutation: remove `mark_session_origin(session_dir, ...)` from _build_child_session
$ .venv/bin/python -m pytest -k resume_picker -q
>       assert [row.id for row in rows] == ["parentsession"]
E       AssertionError: assert ['da6e9ae6249...arentsession'] == ['parentsession']
E         At index 0 diff: 'da6e9ae6249a' != 'parentsession'
FAILED tests/unit/session/test_launch_subagent.py::test_a_launched_subagent_stays_out_of_the_resume_picker

$ cp /tmp/lo-sub-backup.py local_operator/harness/subagent.py   # restore from a COPY, not git checkout
$ cmp local_operator/harness/subagent.py /tmp/lo-sub-backup.py && echo "restore byte-identical"
restore byte-identical
$ grep -c "mark_session_origin(session_dir" local_operator/harness/subagent.py
1
```

The test also carries a nonzero control — it asserts the child's `transcript.jsonl` **exists** before asserting the picker offers one row, so an empty row set cannot be a directory that was never created.

### Coverage added

| Test | What it pins |
| --- | --- |
| `test_a_launched_subagent_stays_out_of_the_resume_picker` | End to end: real launch → real picker listing |
| `test_the_picker_offers_only_sessions_the_user_started` | Child hidden from the listing, transcript still on disk |
| `test_a_session_with_no_marker_is_still_the_user_s` | Pre-existing conversations survive the upgrade |
| `test_resume_latest_skips_a_subagent_that_finished_last` | `@latest` reopens the parent, not the review that outlived it |
| `test_a_subagent_session_still_resumes_by_explicit_id` | Filtering narrows what is offered, never what exists |
| `test_an_unreadable_origin_marker_leaves_the_session_the_user_s` | Corrupt / non-object / non-string marker all read as the user's |
| `test_marking_a_session_never_takes_the_run_down` | A failed marker write does not break a delegated run |

### Gates

```console
$ .venv/bin/python -m pytest tests/unit -q --deselect tests/unit/tools/test_eval_tool.py::test_background_streams_output_while_it_runs
4569 passed, 7 skipped, 1 deselected, 311 warnings in 780.57s (0:13:00)

$ .venv/bin/python -m flake8 .                                    # exit 0
$ uvx --from black==26.1.0 black --check local_operator tests
365 files would be left unchanged.
$ uvx isort --check-only --profile black local_operator tests      # clean
$ .venv/bin/python -m pyright --pythonpath .venv/bin/python .
0 errors, 0 warnings, 0 informations
```

**One deselected test is a pre-existing failure, not this diff.** `test_background_streams_output_while_it_runs` is timing-sensitive and fails identically on unmodified `origin/main`:

```console
$ cd /tmp/lo-picker-base && git rev-parse HEAD   # detached at origin/main, no changes
09d84406ec11f88ba9c85b4d30d1a1753e9334f8
$ .venv/bin/python -m pytest tests/unit/tools/test_eval_tool.py::test_background_streams_output_while_it_runs -q
FAILED — AssertionError: no streamed output observed while the job ran
```

## Round 1 review remediation (head is now `d32ee8e`)

Both rounds requested changes; all findings are fixed and dispositioned in the remediation comments. What changed materially since the frames above were captured:

- **A one-time backfill ships** (`backfill_session_origins`), raised independently as F3 and D1. Without it the fix applied only to sessions created after the upgrade, so the reporting machine's 215 unmarked directories meant the first `/resume` after upgrading looked unchanged. Validated on a copy of the real store: 83 stamped, 16 delegated rows to 0, **zero false positives**, idempotent on the second run.
- **Retention no longer charges the marker against its ceilings.** A session is stamped before its transcript exists, so an aborted child left a marker-only directory that used to be empty and always reaped; counting its 43 bytes made it hold a retention slot and evict real transcripts (measured: 2 of the user's sessions lost at a count ceiling of 3).
- **A marker truncated mid-character no longer takes the picker down.** `UnicodeDecodeError` is a `ValueError` and escaped the `except OSError`; the read now uses `errors="replace"`.
- **The empty state tells the truth.** `no previous sessions to resume` was false when only children exist; both surfaces now share one string naming whose sessions are missing and why.
- **A child's session id is reachable again.** `hub op='list'` prints the transcript session id for resumable rows — the picker was the only surface that ever showed it, and the job row carrying `job_id` is swept minutes after a child settles.

## Round 2 and 3 review remediation (head is now `33b0a51`)

Later rounds found five more issues, two of them introduced by the round-1 remediation itself:

- **The backfill was resetting retention clocks** (blocker). Writing `origin.json` into a directory moves that directory's mtime, which is exactly what retention sorts and age-expires on — so stamping resurrected old delegated runs and evicted the user's real conversations to make room. `mark_session_origin` now preserves the mtime across the write. This is the same harm as the retention finding above, arriving by the opposite route, on the very directories that fix targeted.
- **The backfill could never reach part of the store** (major). Its cap sliced the directory list by hex *name*, recomputing the same prefix every run, so anything sorting past the cut was never visited on any startup. The cap now bounds work done, never how far the scan reaches.
- **`--resume` on the CLI still opened delegated runs** (major). `cli.py` resolves `--resume` *before* any session is built, and the backfill only ran from the session factory — so the first launch after an upgrade still resolved `@latest` against an unclassified store. The CLI now classifies before it resolves.
- **The empty-state notice overflowed the card** (major). The card's width is measured against the terminal every paint (70 cells at 80 columns, 48 at 60) while the notice was a constant, so it overflowed every narrow terminal and lost the clause explaining *why* the list is empty. It is now wrapped to the measured width, and its guard test renders at five widths asserting against the terminal rather than against a constant.
- **The roster showed two indistinguishable ids** (minor). A transcript id and a job id, both `uuid4().hex[:12]`, sat two lines apart under an instruction that accepts only one of them. Each now names what it is for.

Every fix is pinned by a test verified against its own mutation.

Final suite on `33b0a51`: **4582 passed, 7 skipped, 1 deselected**; `flake8`, `black`, `isort`, `pyright` clean.

## Rollout and rollback

No migration, no config, no new setting. Existing session directories are unmarked and therefore treated as the user's, so the picker's contents only change as new subagents run. `git revert` restores the previous listing; the leftover `origin.json` files are ignored by every reader on the old code.

#### Follow-up observations

- `test_background_streams_output_while_it_runs` fails deterministically on `origin/main` on this machine (both in the full suite and in isolation). Worth a look separately — it is not touched by this change and I have not opened a ticket for it.
