### PR TITLE
fix(session,comms): make a turn's progress durable, and stop lying about a running subagent

### DIFF
--- a/local_operator/harness/comms.py
+++ b/local_operator/harness/comms.py
@@ -259,7 +259,15 @@ class SubagentComms:
         record.settled = False
         record.unsubscribe = child.subscribe(self._make_reply_watcher(record))
         for message in record.pending:
-            child.queue_aside(self._thunk(record, message))
+            # A buffered QUESTION has a caller blocked on ``record.ask``, so it
+            # must be re-armed with that future. Flushed as a plain note it
+            # would be injected and answered while the asker sat out its whole
+            # timeout on a reply that had already come back. Notes carry no
+            # future and flush unchanged.
+            awaiting = record.ask if self._expects_reply(message) else None
+            if awaiting is not None and awaiting.done():
+                awaiting = None
+            child.queue_aside(self._thunk(record, message, awaiting=awaiting))
         record.pending.clear()
         # Last: everything a waiter in ``_await_child`` needs must be in place
         # before it is allowed to proceed, or it would queue its question onto
@@ -628,12 +636,43 @@ class SubagentComms:
                 # A child that DIED while we waited is gone, not "not started":
                 # telling a caller to retry in a moment is the polling loop this
                 # wait exists to remove.
-                reason = (
-                    self._gone_reason(record)
-                    if record.settled or not self._is_running(record)
-                    else self._not_started_reason(record)
-                )
-                return Reply(job_id, record.label, error=reason)
+                if record.settled or not self._is_running(record):
+                    return Reply(job_id, record.label, error=self._gone_reason(record))
+                if not parked and self._has_begun(record):
+                    # The grace expired but the RUNNER IS RUNNING — it simply
+                    # has not attached (a slow child build, a resumed child
+                    # replaying a large transcript, or an event loop the parent
+                    # is monopolising). Refusing here reports "has not started
+                    # yet ... retry in a moment" about a child that has been
+                    # working for half an hour, and that message is acted on:
+                    # one healthy reviewer subagent was cancelled on the
+                    # strength of it after a 30 s grace expired (the wait is
+                    # capped by ATTACH_WAIT_MAX_S, so a long timeout does not
+                    # make it more patient).
+                    #
+                    # Buffer instead. ``attach`` flushes pending messages and
+                    # re-arms a question with its waiter's future, so the
+                    # question lands at the child's first injection boundary
+                    # and the answer comes back to this caller.
+                    record.ask = None
+                    future = asyncio.get_running_loop().create_future()
+                    record.ask = future
+                    record.armed = False
+                    record.pending.append(self._to_child_message(text, expects_reply=True))
+                    remaining = deadline - asyncio.get_running_loop().time()
+                    if remaining <= 0:
+                        self._clear_ask(record, future)
+                        return Reply(job_id, record.label, timed_out=True)
+                    try:
+                        answer = await asyncio.wait_for(future, remaining)
+                    except asyncio.TimeoutError:
+                        return Reply(job_id, record.label, timed_out=True)
+                    except Exception as exc:
+                        return Reply(job_id, record.label, error=str(exc))
+                    finally:
+                        self._clear_ask(record, future)
+                    return Reply(job_id, record.label, text=answer)
+                return Reply(job_id, record.label, error=self._not_started_reason(record))
         if record.child is None:  # pragma: no cover - narrowing for the checker
             return Reply(job_id, record.label, error=self._not_started_reason(record))
         if record.ask is not None and not record.ask.done():
@@ -863,6 +902,30 @@ class SubagentComms:
         job = jobs.get(record.job_id)
         return job is not None and job.status == "running"
 
+    @staticmethod
+    def _expects_reply(message: CustomMessage) -> bool:
+        """Whether a buffered message is a QUESTION (someone is blocked on it).
+
+        Read off the message the sender built rather than tracked separately,
+        so :meth:`attach`'s flush cannot drift from what was queued.
+        """
+        details = getattr(message, "details", None) or {}
+        return bool(details.get("expects_reply"))
+
+    def _has_begun(self, record: _ChildRecord) -> bool:
+        """Whether the child's RUNNER has actually entered.
+
+        ``AsyncJob.started_at`` is stamped as ``_run_job``'s first statement,
+        before the child session is built, so it is true for the whole window
+        in which a child is working but not yet attached — exactly the window
+        ``ask`` must not describe as "not started". Neither ``status`` nor
+        ``queued`` can answer this: ``status`` reads ``running`` from
+        registration, before a line has run.
+        """
+        jobs = self._jobs()
+        job = jobs.get(record.job_id) if jobs is not None else None
+        return job is not None and getattr(job, "started_at", None) is not None
+
     def _not_started_reason(self, record: _ChildRecord) -> str:
         """Why a running job has no live child yet — and they are not the same.
 
@@ -897,6 +960,21 @@ class SubagentComms:
             return (
                 "subagent has not started yet (parked behind the job capacity gate); "
                 "it starts when a slot frees, so do not wait on it"
+            )
+        if job is not None and getattr(job, "started_at", None) is not None:
+            # A THIRD state, and the one that cost real work: the runner is
+            # well underway but its session is not attached to this record.
+            # ``_await_child``'s grace is capped at ATTACH_WAIT_MAX_S, so a
+            # patient caller still lands here after 30 s and used to be told
+            # the child "has not started yet ... retry in a moment" about an
+            # agent half an hour into its run. An operator acted on that and
+            # cancelled it. ``started_at`` is the authoritative answer (see
+            # :meth:`_has_begun`), so say what is actually true.
+            started = time.time() - float(job.started_at)
+            return (
+                f"subagent started {started:.0f}s ago but has not attached to this parent, "
+                "so it cannot be questioned yet; it is RUNNING — use 'jobs'/'wait' for its "
+                "result rather than cancelling it"
             )
         return (
             "subagent has not started yet (it is scheduled, and starts when this "

--- a/local_operator/harness/comms.py
+++ b/local_operator/harness/comms.py
@@ -180,6 +180,14 @@ class _ChildRecord:
     unsubscribe: Callable[[], None] | None = None
     #: Notes addressed to this child before its session existed.
     pending: list[CustomMessage] = field(default_factory=list)
+    #: Futures for BUFFERED questions, keyed by the id of the message they were
+    #: created for. Identity, not type: :meth:`SubagentComms.attach` must arm
+    #: each flushed question with the future belonging to THAT message. Binding
+    #: at flush time by asking "is this a question?" and reaching for
+    #: ``record.ask`` returned one question's answer to a different caller —
+    #: the exact hazard ``_thunk``'s identity check exists to prevent, defeated
+    #: because the identity was resolved too late (review round 2, R5).
+    pending_asks: dict[str, "asyncio.Future[str]"] = field(default_factory=dict)
     #: The parent's unanswered question, if any.
     ask: asyncio.Future[str] | None = None
     #: Set when that question actually reached the child's context, so a
@@ -259,16 +267,21 @@ class SubagentComms:
         record.settled = False
         record.unsubscribe = child.subscribe(self._make_reply_watcher(record))
         for message in record.pending:
-            # A buffered QUESTION has a caller blocked on ``record.ask``, so it
-            # must be re-armed with that future. Flushed as a plain note it
-            # would be injected and answered while the asker sat out its whole
-            # timeout on a reply that had already come back. Notes carry no
-            # future and flush unchanged.
-            awaiting = record.ask if self._expects_reply(message) else None
+            # Armed BY IDENTITY: the future recorded for THIS message, never
+            # whatever ``record.ask`` happens to hold now. Binding by type
+            # ("is this a question?") let a stale buffered question — one whose
+            # asker had already timed out, and which nothing withdrew — arm the
+            # NEXT asker's future and hand that caller the answer to a question
+            # it never asked, with no error and no timeout to signal it (review
+            # round 2, R5). A question with no live future is a note: it still
+            # reaches the child, which is right (it was asked), but it can no
+            # longer resolve anyone's wait.
+            awaiting = record.pending_asks.pop(message.id, None)
             if awaiting is not None and awaiting.done():
                 awaiting = None
             child.queue_aside(self._thunk(record, message, awaiting=awaiting))
         record.pending.clear()
+        record.pending_asks.clear()
         # Last: everything a waiter in ``_await_child`` needs must be in place
         # before it is allowed to proceed, or it would queue its question onto
         # a record whose buffered notes had not been flushed yet.
@@ -617,6 +630,18 @@ class SubagentComms:
         record = self._records.get(job_id)
         if record is None:
             return Reply(job_id, job_id, error=f"unknown subagent {job_id!r}")
+        # ONE guard for BOTH paths, and it has to be here rather than beside
+        # the attached path's queue_aside: the buffered path used to skip it
+        # and overwrite a live ``record.ask``, orphaning a caller that was
+        # still waiting — nothing then held its future, so it could receive
+        # neither an answer nor a failure and burned its whole budget (up to
+        # the 600 s schema maximum). Refusing early is also cheaper: it
+        # happens before the attach grace, so a doomed second question does
+        # not first spend 30 s waiting to be refused (review round 2, R6).
+        if record.ask is not None and not record.ask.done():
+            return Reply(
+                job_id, record.label, error="a question is already pending for this subagent"
+            )
         # ``timeout_ms`` is the caller's WHOLE budget, so any time spent
         # waiting for the child to come up is deducted from the answer wait
         # below rather than added to it. Charging the grace on top let a
@@ -651,25 +676,34 @@ class SubagentComms:
                     # make it more patient).
                     #
                     # Buffer instead. ``attach`` flushes pending messages and
-                    # re-arms a question with its waiter's future, so the
-                    # question lands at the child's first injection boundary
-                    # and the answer comes back to this caller.
-                    record.ask = None
+                    # arms each question with the future created for THAT
+                    # message, so the question lands at the child's first
+                    # injection boundary and the answer comes back here.
                     future = asyncio.get_running_loop().create_future()
                     record.ask = future
                     record.armed = False
-                    record.pending.append(self._to_child_message(text, expects_reply=True))
+                    message = self._to_child_message(text, expects_reply=True)
+                    record.pending.append(message)
+                    # Bound to the MESSAGE, not just to ``record.ask``: a
+                    # buffered question that times out leaves its message in
+                    # ``pending``, and arming that stale message at flush time
+                    # with whatever ``record.ask`` then held returned the old
+                    # question's answer to the new asker (R5).
+                    record.pending_asks[message.id] = future
                     remaining = deadline - asyncio.get_running_loop().time()
-                    if remaining <= 0:
-                        self._clear_ask(record, future)
-                        return Reply(job_id, record.label, timed_out=True)
                     try:
+                        if remaining <= 0:
+                            return Reply(job_id, record.label, timed_out=True)
                         answer = await asyncio.wait_for(future, remaining)
                     except asyncio.TimeoutError:
                         return Reply(job_id, record.label, timed_out=True)
                     except Exception as exc:
                         return Reply(job_id, record.label, error=str(exc))
                     finally:
+                        # WITHDRAW the message as well as clearing the future.
+                        # Leaving it queued let a question nobody is waiting for
+                        # reach the child and consume the next asker's answer.
+                        self._withdraw_pending(record, message)
                         self._clear_ask(record, future)
                     return Reply(job_id, record.label, text=answer)
                 return Reply(job_id, record.label, error=self._not_started_reason(record))
@@ -1128,6 +1162,24 @@ class SubagentComms:
         if record.ask is future:
             record.ask = None
         record.armed = False
+
+    @staticmethod
+    def _withdraw_pending(record: _ChildRecord, message: CustomMessage) -> None:
+        """Drop a BUFFERED question nobody is waiting for any more.
+
+        The buffered path's counterpart to ``_thunk``'s ``StaleAside``
+        withdrawal. A question that was never wrapped in a thunk has no
+        ``on_discard`` to fire, so a timed-out ask used to leave its message
+        sitting in ``pending`` indefinitely — and the next flush injected it,
+        let the child answer it, and consumed an answer meant for someone
+        else. Idempotent: the message may already be gone if ``attach``
+        flushed between the timeout and this call.
+        """
+        record.pending_asks.pop(message.id, None)
+        for index, queued in enumerate(record.pending):
+            if queued is message:
+                del record.pending[index]
+                return
 
     def _evict_overflow(self) -> None:
         """Drop the least useful records once the map is over the cap.

--- a/local_operator/harness/comms.py
+++ b/local_operator/harness/comms.py
@@ -679,6 +679,22 @@ class SubagentComms:
                     # arms each question with the future created for THAT
                     # message, so the question lands at the child's first
                     # injection boundary and the answer comes back here.
+                    #
+                    # RE-CHECK after the grace, the way the attached path does.
+                    # The guard at the top of ``ask`` ran before this await, and
+                    # this path only claims ``record.ask`` after it — so without
+                    # this, two concurrent asks both pass the guard and the
+                    # second orphans the first (review round 4, R8; reproduced
+                    # as ``REFUSED COUNT: 0``). Unreachable today because the
+                    # ``hub`` tool is ``concurrency="exclusive"`` and the loop
+                    # batches it alone, but that is a property of a tool
+                    # declaration elsewhere, not an invariant of this layer.
+                    if record.ask is not None and not record.ask.done():
+                        return Reply(
+                            job_id,
+                            record.label,
+                            error="a question is already pending for this subagent",
+                        )
                     future = asyncio.get_running_loop().create_future()
                     record.ask = future
                     record.armed = False

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -391,16 +391,37 @@ def _paired_prefix(messages: Sequence[AgentMessage]) -> list[AgentMessage]:
     dropping it loses nothing a resume needs — while everything completed
     before it is kept, which is the whole point of the flush.
 
-    Only the TAIL is trimmed. An unanswered assistant message earlier in the
-    list already has its results appended after it.
+    Only the TAIL is trimmed, and "tail" means *up to the last real answer*.
+    A ``CustomMessage`` in the tail does NOT prove the list is legal: it is not
+    a ``Message``, and one can land on the live context while a tool batch is
+    still in flight. ``journal_incident`` appends straight to
+    ``_context.messages``, and ``_on_mcp_incident`` fires it through
+    ``_spawn_background`` — so an MCP breaker tripping mid-batch leaves
+    ``[..., assistant(tool_calls), session_incident]``. A scan that stopped at
+    the first non-assistant entry would see the incident, declare the tail
+    clean, and persist the unanswered assistant beneath it — the very row this
+    function exists to refuse (review round 2, R5; reproduced as
+    ``DANGLING: ['c2']``).
+
+    So customs are stepped OVER and kept, while unanswered assistant messages
+    beneath them are dropped; the scan stops at the first ``role="tool"``,
+    which is a real answer and therefore a genuinely legal tail. Re-listing a
+    custom that was already persisted is harmless — ``_persist_new_messages``
+    dedups by id.
     """
     out = list(messages)
+    keep_tail: list[AgentMessage] = []
     while out:
         tail = out[-1]
-        if isinstance(tail, Message) and tail.role == "assistant" and tail.tool_calls:
-            out.pop()
-            continue
-        break
+        if isinstance(tail, Message):
+            if tail.role == "assistant" and tail.tool_calls:
+                out.pop()  # unanswered: never persist it
+                continue
+            break  # a tool result or a plain message: the tail is legal
+        # A non-Message (custom) proves nothing about legality. Hold it aside
+        # and keep looking underneath it.
+        keep_tail.append(out.pop())
+    out.extend(reversed(keep_tail))
     return out
 
 
@@ -2119,9 +2140,17 @@ class Session:
         # flag BEFORE it aborts and awaits the in-flight turn, precisely so
         # that turn's persistence "must land on a live transcript" — so a
         # ``_disposed`` guard here would suppress the one flush dispose is
-        # waiting for. The transcript is still open at that point (it is closed
-        # after the awaited turn returns), and an append is idempotent, so the
-        # correct behaviour on a disposing session is to write, not to skip.
+        # waiting for.
+        #
+        # Writing is safe at any point in teardown, and for a stronger reason
+        # than "the transcript is still open": there is no open handle to lose.
+        # ``Transcript`` has no ``close()``; ``flush()`` is an explicit no-op
+        # ("writes are flushed per append"), and ``_append`` opens, writes and
+        # closes the file per call. So a disposing — or already disposed —
+        # session can still append, which also means the late flush from a turn
+        # that outlives dispose's 5s shielded wait still lands (review round 2,
+        # R6: the earlier wording here described a lifecycle that does not
+        # exist, and would send the next reader hunting for a close to race).
         try:
             await self._persist_new_messages(_paired_prefix(messages))
         except asyncio.CancelledError:

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -367,6 +367,43 @@ def _is_todo_reminder(message: AgentMessage) -> TypeGuard[CustomMessage]:
 _PERSISTABLE_CUSTOM_TYPES: frozenset[str] = frozenset({SESSION_INCIDENT_MESSAGE_TYPE})
 
 
+def _paired_prefix(messages: Sequence[AgentMessage]) -> list[AgentMessage]:
+    """``messages`` truncated so it never ENDS in unanswered tool calls.
+
+    The durability flushes persist the live context, and that list is not
+    always legal to replay. ``AgentLoop`` appends the assistant message the
+    moment the model turn ends and appends the tool results only once
+    ``_execute_tool_calls`` returns, so for the whole duration of every tool
+    batch — the longest part of a turn, and exactly when a Ctrl+C or a crash
+    lands — the list ends in an assistant message whose ``tool_calls`` have no
+    answers. Persisting that verbatim writes a dangling ``tool_use`` into the
+    transcript PERMANENTLY, and the next resume replays it into a 400 on both
+    wires ("must be followed by tool messages responding to each
+    tool_call_id"). Measured: a Ctrl+C mid-batch left two unpaired calls on
+    disk and an unusable session.
+
+    :meth:`Session._history_snapshot` faces the same illegal tail for a
+    request it is about to send and pairs the calls with placeholders. This is
+    the persistence counterpart, and it DROPS rather than pairs: a placeholder
+    is the honest answer to "what are you doing right now", but on disk it
+    would be a permanent lie about a tool that never reported. The unanswered
+    assistant message is re-sent by the model on the next run anyway, so
+    dropping it loses nothing a resume needs — while everything completed
+    before it is kept, which is the whole point of the flush.
+
+    Only the TAIL is trimmed. An unanswered assistant message earlier in the
+    list already has its results appended after it.
+    """
+    out = list(messages)
+    while out:
+        tail = out[-1]
+        if isinstance(tail, Message) and tail.role == "assistant" and tail.tool_calls:
+            out.pop()
+            continue
+        break
+    return out
+
+
 def _is_persistable_message(message: AgentMessage) -> bool:
     """Whether ``message`` may be written to the transcript as a message entry.
 
@@ -2083,7 +2120,7 @@ class Session:
             # messages were persisted by the dispose path's awaited turn.
             return
         try:
-            await self._persist_new_messages(list(messages))
+            await self._persist_new_messages(_paired_prefix(messages))
         except asyncio.CancelledError:
             # Cancellation must propagate: swallowing it here would keep a
             # turn alive that the session is trying to tear down.

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -2115,10 +2115,13 @@ class Session:
         loop and the ``finally`` caller passes ``self._context.messages``
         itself.
         """
-        if self._disposed:
-            # A disposed session's transcript may already be flushed; its
-            # messages were persisted by the dispose path's awaited turn.
-            return
+        # Deliberately NOT gated on ``self._disposed``. ``dispose()`` sets that
+        # flag BEFORE it aborts and awaits the in-flight turn, precisely so
+        # that turn's persistence "must land on a live transcript" — so a
+        # ``_disposed`` guard here would suppress the one flush dispose is
+        # waiting for. The transcript is still open at that point (it is closed
+        # after the awaited turn returns), and an append is idempotent, so the
+        # correct behaviour on a disposing session is to write, not to skip.
         try:
             await self._persist_new_messages(_paired_prefix(messages))
         except asyncio.CancelledError:

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -1683,6 +1683,21 @@ class Session:
 
             await self._maybe_compact()
         finally:
+            # LAST-RESORT durability. The persistence above runs only on the
+            # normal path: an exception out of the loop (the
+            # "model turn produced no assistant message" RuntimeError, a
+            # provider client raising past the stream handler), a
+            # ``CancelledError`` from Ctrl+C or dispose, or a steering-driven
+            # teardown all skip it entirely, and everything the run completed
+            # died in memory with it. The per-boundary flush covers whole tool
+            # batches; this covers the tail produced after the last boundary,
+            # including the assistant message whose own failure ended the run.
+            #
+            # Best-effort and never raising: this is a ``finally`` on the way
+            # out of a turn that may already be unwinding, and a transcript
+            # write that fails must not replace the original exception (which
+            # is what the caller and the incident journal need to see).
+            await self._persist_progress(self._context.messages)
             self._signal = None
             self._is_streaming = False
 
@@ -2049,6 +2064,33 @@ class Session:
         except OSError as exc:
             logger.warning("could not journal pruned tool outputs: %s", exc)
 
+    async def _persist_progress(self, messages: Sequence[AgentMessage]) -> None:
+        """Flush whatever the running turn has produced so far, best-effort.
+
+        The durability floor for a turn. :meth:`_persist_new_messages` is the
+        mechanism and stays strict (its callers on the normal path want a
+        failure to surface); this wrapper is for the two places that must
+        never fail the turn they are protecting — the tool-loop boundary hook
+        and ``_run_turn``'s ``finally`` — where the alternative to a swallowed
+        write error is losing the whole run instead of one message.
+
+        Snapshotted with ``list()`` because the live context is mutated by the
+        loop and the ``finally`` caller passes ``self._context.messages``
+        itself.
+        """
+        if self._disposed:
+            # A disposed session's transcript may already be flushed; its
+            # messages were persisted by the dispose path's awaited turn.
+            return
+        try:
+            await self._persist_new_messages(list(messages))
+        except asyncio.CancelledError:
+            # Cancellation must propagate: swallowing it here would keep a
+            # turn alive that the session is trying to tear down.
+            raise
+        except Exception:  # noqa: BLE001 — durability is best-effort
+            logger.warning("could not persist turn progress", exc_info=True)
+
     async def _persist_new_messages(self, messages: Sequence[AgentMessage]) -> None:
         """Append every message not already in the transcript, in order.
 
@@ -2087,6 +2129,20 @@ class Session:
         """
         if self._disposed:
             return None
+        # Durability FIRST, unconditionally, and before any compaction
+        # decision: this hook is the only place that sees the run's messages
+        # at a safe boundary, and every early return below it used to leave
+        # the whole run unpersisted until the run ended. Mid-run persistence
+        # existed only as a SIDE EFFECT of the compaction pass below (it needs
+        # a persisted cut target), so with ``mid_turn_enabled`` off — or
+        # simply below the threshold — a long tool run kept 100% of its work
+        # in memory. A session killed there (crash, SIGKILL, Ctrl+C) replayed
+        # to nothing but the user's prompt. Measured on a 6-step run: one
+        # entry on disk without this, ten with it.
+        #
+        # Idempotent by message id, so the post-run pass still writes each
+        # message exactly once.
+        await self._persist_progress(messages)
         try:
             from local_operator.compaction.api import CompactionSettings
         except ImportError:

--- a/tests/unit/harness/test_comms.py
+++ b/tests/unit/harness/test_comms.py
@@ -1767,12 +1767,24 @@ async def test_ask_buffers_rather_than_refusing_a_started_but_unattached_child()
     comms, jobs, _child, _parent = wire(attach=False)
     jobs.jobs["job-1"].started_at = time.time() - 1800
 
+    seen: list[str] = []
+    original = comms._withdraw_pending
+
+    def spy(record, message):
+        # The buffer is WITHDRAWN when the ask gives up (round 2, R5), so the
+        # queue is empty by the time ``ask`` returns. Capture it mid-flight
+        # instead of asserting on the wreckage afterwards.
+        seen.append(message.details["body"])
+        return original(record, message)
+
+    comms._withdraw_pending = spy  # type: ignore[method-assign]
+
     reply = await comms.ask("job-1", "status?", 400)
 
     assert reply.error is None, f"refused a working child: {reply.error!r}"
     assert reply.timed_out is True  # nobody attached inside the budget
-    [buffered] = comms._records["job-1"].pending
-    assert buffered.details["expects_reply"] is True
+    assert seen == ["status?"], "the question was never buffered for the child"
+    assert not comms._records["job-1"].pending, "an abandoned question was left queued"
 
 
 @pytest.mark.asyncio
@@ -1783,8 +1795,11 @@ async def test_a_question_buffered_past_the_grace_is_answered_once_it_attaches()
     comms, jobs, child, _parent = wire(attach=False)
     jobs.jobs["job-1"].started_at = time.time() - 1800
 
-    asking = asyncio.create_task(comms.ask("job-1", "stuck?", 20_000))
-    await wait_for(lambda: bool(comms._records["job-1"].pending))
+    # 4 s budget -> a 2 s attach grace, so the question buffers well inside
+    # ``wait_for``'s default. (A 20 s budget would spend 10 s in the grace and
+    # time the WAIT out, not the ask.)
+    asking = asyncio.create_task(comms.ask("job-1", "stuck?", 4_000))
+    await wait_for(lambda: bool(comms._records["job-1"].pending), timeout=5.0)
 
     comms.attach("job-1", child, tmp_dir())  # the window finally closes
     await wait_for(lambda: bool(child.asides))
@@ -1802,3 +1817,72 @@ async def test_a_question_buffered_past_the_grace_is_answered_once_it_attaches()
     reply = await asking
     assert reply.error is None and reply.timed_out is False, f"{reply.error!r}"
     assert reply.text == "no, just slow"
+
+
+@pytest.mark.asyncio
+async def test_a_stale_buffered_question_cannot_answer_the_next_asker():
+    """A timed-out buffered question must be WITHDRAWN, not left in the queue.
+
+    ``_thunk``'s identity check exists so a question whose asker gave up cannot
+    arm the next question's future. The buffered path defeated it by binding at
+    flush time — ``attach`` asked "is this a question?" and reached for
+    whatever ``record.ask`` then held, so the parent asked "are you blocked?"
+    and was handed the answer to "what is your ETA?", with ``error=None`` and
+    ``timed_out=False``. Wrong and indistinguishable from right (round 2, R5).
+    """
+    comms, jobs, child, _parent = wire(attach=False)
+    jobs.jobs["job-1"].started_at = time.time() - 1800
+
+    stale = await comms.ask("job-1", "OLD: what is your ETA?", 200)
+    assert stale.timed_out is True
+    assert not comms._records["job-1"].pending, "the abandoned question was not withdrawn"
+
+    # 4 s budget -> 2 s attach grace, comfortably inside ``wait_for``.
+    asking = asyncio.create_task(comms.ask("job-1", "NEW: are you blocked?", 4_000))
+    await wait_for(lambda: bool(comms._records["job-1"].pending), timeout=5.0)
+
+    comms.attach("job-1", child, tmp_dir())
+    await wait_for(lambda: bool(child.asides))
+    materialized = child.materialize()
+    assert all(isinstance(message, CustomMessage) for message in materialized)
+    bodies = [
+        message.details["body"] for message in materialized if isinstance(message, CustomMessage)
+    ]
+    assert bodies == ["NEW: are you blocked?"], f"a stale question reached the child: {bodies}"
+
+    await execute_hub(
+        "call-1",
+        {"message": "no, not blocked"},
+        None,
+        None,
+        ToolContext(cwd=".", subagent_comms=comms, job_id="job-1"),
+    )
+
+    reply = await asking
+    assert reply.text == "no, not blocked", "the asker got someone else's answer"
+
+
+@pytest.mark.asyncio
+async def test_a_second_question_is_refused_on_the_buffered_path_too():
+    """The concurrent-ask guard has to cover BOTH paths.
+
+    The buffered path used to overwrite a live ``record.ask``, orphaning the
+    first caller: nothing held its future afterwards, so it could receive
+    neither an answer nor a failure and burned its whole budget — up to the
+    600 s schema maximum (round 2, R6).
+    """
+    comms, jobs, _child, _parent = wire(attach=False)
+    jobs.jobs["job-1"].started_at = time.time() - 1800
+
+    first = asyncio.create_task(comms.ask("job-1", "Q-A", 4_000))
+    # Past the attach grace (half the budget, so 2 s here), where Q-A buffers.
+    await wait_for(lambda: bool(comms._records["job-1"].pending), timeout=5.0)
+    held = comms._records["job-1"].ask
+
+    second = await comms.ask("job-1", "Q-B", 4_000)
+
+    assert second.error == "a question is already pending for this subagent"
+    assert comms._records["job-1"].ask is held, "the first caller's future was replaced"
+    assert [m.details["body"] for m in comms._records["job-1"].pending] == ["Q-A"]
+    first_reply = await first
+    assert first_reply.timed_out is True  # it ended on its OWN terms, not orphaned

--- a/tests/unit/harness/test_comms.py
+++ b/tests/unit/harness/test_comms.py
@@ -1715,6 +1715,8 @@ def test_the_roster_text_tells_the_two_ids_apart(tmp_path):
     # sitting above it is not read as the argument.
     assert "JOB id" in text
     assert "not a job id" in text
+
+
 # --- the running-but-unattached window ----------------------------------------
 #
 # ``_await_child`` already covers the child that is merely SCHEDULED: it yields
@@ -1886,3 +1888,34 @@ async def test_a_second_question_is_refused_on_the_buffered_path_too():
     assert [m.details["body"] for m in comms._records["job-1"].pending] == ["Q-A"]
     first_reply = await first
     assert first_reply.timed_out is True  # it ended on its OWN terms, not orphaned
+
+
+@pytest.mark.asyncio
+async def test_two_concurrent_asks_cannot_both_pass_the_guard():
+    """The guard is check-then-act, so the buffered path re-checks after its
+    attach grace.
+
+    The top-of-``ask`` guard runs BEFORE the grace await, and the buffered path
+    only claims ``record.ask`` after it — so two asks entering together both
+    passed and the second orphaned the first (review round 4, R8). Unreachable
+    through the `hub` tool today, which is ``concurrency="exclusive"`` and is
+    therefore batched alone, but that is a property of a tool declaration
+    elsewhere rather than an invariant of this layer, and it becomes reachable
+    the moment `hub` goes ``shared``.
+    """
+    comms, jobs, _child, _parent = wire(attach=False)
+    jobs.jobs["job-1"].started_at = time.time() - 1800
+
+    first, second = await asyncio.gather(
+        comms.ask("job-1", "Q-A", 4_000),
+        comms.ask("job-1", "Q-B", 4_000),
+    )
+
+    refused = [
+        reply for reply in (first, second) if reply.error and "already pending" in reply.error
+    ]
+    served = [reply for reply in (first, second) if reply.error is None]
+    assert len(refused) == 1, "both asks passed the guard; one caller is orphaned"
+    assert len(served) == 1 and served[0].timed_out is True
+    assert comms._records["job-1"].ask is None, "the surviving ask leaked its future"
+    assert not comms._records["job-1"].pending_asks

--- a/tests/unit/harness/test_comms.py
+++ b/tests/unit/harness/test_comms.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import time
 from collections.abc import Sequence
 from typing import Any, Callable
 
@@ -62,9 +63,21 @@ async def wait_for(predicate, timeout: float = 10.0) -> None:
 
 
 class FakeJob:
-    def __init__(self, job_id: str, status: str = "running", queued: bool = False) -> None:
+    def __init__(
+        self,
+        job_id: str,
+        status: str = "running",
+        queued: bool = False,
+        started_at: float | None = None,
+    ) -> None:
         self.id = job_id
         self.status = status
+        #: Mirrors ``AsyncJob.started_at``: stamped as ``_run_job``'s FIRST
+        #: statement, so it is the only field that answers "has the runner
+        #: actually begun". ``status`` reads ``running`` from registration.
+        #: This fixture not modelling it is why the suite agreed for so long
+        #: that a half-hour-old child had "not started yet".
+        self.started_at = started_at
         #: Mirrors ``AsyncJob.queued``: admitted to the ledger but holding no
         #: execution slot. Distinct from "running but still building its
         #: session", which is what a job carries between registration and
@@ -1702,3 +1715,90 @@ def test_the_roster_text_tells_the_two_ids_apart(tmp_path):
     # sitting above it is not read as the argument.
     assert "JOB id" in text
     assert "not a job id" in text
+# --- the running-but-unattached window ----------------------------------------
+#
+# ``_await_child`` already covers the child that is merely SCHEDULED: it yields
+# the loop, which is what lets the runner start, so a parent asking its brand
+# new child a question gets an answer instead of a refusal.
+#
+# It does not cover the child whose runner is well underway but whose session
+# has not attached (a slow child build, a resumed child replaying a large
+# transcript, or a parent monopolising the loop). The grace is capped at
+# ``ATTACH_WAIT_MAX_S``, so even a 300 s request waits 30 s and is then told
+# the subagent "has not started yet ... retry in a moment" — about an agent
+# half an hour into its work. Observed live, and acted on: a healthy reviewer
+# subagent was cancelled on the strength of that message.
+
+
+def test_the_not_started_reason_never_denies_a_running_child():
+    """``started_at`` is the authoritative "has the runner begun". A child that
+    has been working for half an hour must not be described as unstarted."""
+    comms, jobs, _child, _parent = wire(attach=False)
+    jobs.jobs["job-1"].started_at = time.time() - 1800
+
+    reason = comms._not_started_reason(comms._records["job-1"])
+
+    assert "has not started" not in reason, reason
+    assert "1800s ago" in reason and "RUNNING" in reason
+    # And it must steer away from the action that destroyed the work.
+    assert "cancelling" in reason
+
+
+def test_the_not_started_reason_still_distinguishes_parked_from_scheduled():
+    """The two genuine not-started states keep their own advice: a parked child
+    may not run for minutes (do not wait), a scheduled one starts on the next
+    yield (retry)."""
+    comms, jobs, _child, _parent = wire(attach=False)
+    jobs.jobs["job-1"].started_at = None
+
+    scheduled = comms._not_started_reason(comms._records["job-1"])
+    jobs.jobs["job-1"].queued = True
+    parked = comms._not_started_reason(comms._records["job-1"])
+
+    assert "session next yields" in scheduled
+    assert "capacity gate" in parked and "do not wait on it" in parked
+
+
+@pytest.mark.asyncio
+async def test_ask_buffers_rather_than_refusing_a_started_but_unattached_child():
+    """The reported bug. Past the attach grace, with the runner underway, the
+    question is BUFFERED for the child instead of refused — and the caller
+    spends its own budget waiting, not 30 s waiting to be told no."""
+    comms, jobs, _child, _parent = wire(attach=False)
+    jobs.jobs["job-1"].started_at = time.time() - 1800
+
+    reply = await comms.ask("job-1", "status?", 400)
+
+    assert reply.error is None, f"refused a working child: {reply.error!r}"
+    assert reply.timed_out is True  # nobody attached inside the budget
+    [buffered] = comms._records["job-1"].pending
+    assert buffered.details["expects_reply"] is True
+
+
+@pytest.mark.asyncio
+async def test_a_question_buffered_past_the_grace_is_answered_once_it_attaches():
+    """End to end: ``attach`` must re-arm the buffered question with the
+    waiter's future. Flushed as a plain note it would be injected and answered
+    while the asker sat out its whole timeout on a reply already returned."""
+    comms, jobs, child, _parent = wire(attach=False)
+    jobs.jobs["job-1"].started_at = time.time() - 1800
+
+    asking = asyncio.create_task(comms.ask("job-1", "stuck?", 20_000))
+    await wait_for(lambda: bool(comms._records["job-1"].pending))
+
+    comms.attach("job-1", child, tmp_dir())  # the window finally closes
+    await wait_for(lambda: bool(child.asides))
+    child.materialize()
+
+    result = await execute_hub(
+        "call-1",
+        {"message": "no, just slow"},
+        None,
+        None,
+        ToolContext(cwd=".", subagent_comms=comms, job_id="job-1"),
+    )
+
+    assert "answered the parent's question" in body(result)
+    reply = await asking
+    assert reply.error is None and reply.timed_out is False, f"{reply.error!r}"
+    assert reply.text == "no, just slow"

--- a/tests/unit/session/test_session.py
+++ b/tests/unit/session/test_session.py
@@ -30,11 +30,17 @@ from local_operator.harness.types import (
     StreamTextDelta,
     StreamToolCallDelta,
     TextContent,
+    ToolCall,
     ToolResult,
     Usage,
 )
 from local_operator.providers.failover import ProviderError
-from local_operator.session.session import IMAGE_DROPPED_NOTICE, Session
+from local_operator.session.session import (
+    IMAGE_DROPPED_NOTICE,
+    SESSION_INCIDENT_MESSAGE_TYPE,
+    Session,
+    _paired_prefix,
+)
 from local_operator.session.transcript import Transcript
 from local_operator.tools.builtin import TODO_REMINDER_MESSAGE_TYPE
 
@@ -2248,3 +2254,49 @@ async def test_dispose_does_not_suppress_the_turns_own_flush(tmp_path):
         if isinstance(message, Message) and message.role == "tool"
     }
     assert not calls - results, f"dispose left a dangling tool_use: {sorted(calls - results)}"
+
+
+def test_paired_prefix_is_not_defeated_by_a_custom_message_in_the_tail():
+    """A persistable ``CustomMessage`` must not shield an unanswered assistant.
+
+    ``journal_incident`` appends straight to the live context and
+    ``_on_mcp_incident`` fires it from a background task, so an MCP breaker
+    tripping mid-batch leaves ``[..., assistant(tool_calls), session_incident]``.
+    A tail scan that stopped at the first non-assistant entry declared that
+    legal and persisted the dangling ``tool_use`` beneath it — R1's corruption
+    through a narrower door (review round 2, R5).
+
+    The custom itself is KEPT: it is real history, and dropping it would lose
+    the incident the model needs to see on resume.
+    """
+    answered = Message(role="assistant", content=[TextContent(text="A1")])
+    answered.tool_calls = [ToolCall(id="c1", name="work", arguments={})]
+    result = Message(
+        role="tool", tool_call_id="c1", tool_name="work", content=[TextContent(text="R1")]
+    )
+    unanswered = Message(role="assistant", content=[TextContent(text="A2")])
+    unanswered.tool_calls = [ToolCall(id="c2", name="work", arguments={})]
+    incident = CustomMessage(
+        custom_type=SESSION_INCIDENT_MESSAGE_TYPE,
+        attribution="system",
+        details={"text": "MCP server 'linear': breaker tripped"},
+    )
+
+    prompt = Message.user("go")  # bound once: Message.user() mints a fresh id
+
+    kept = _paired_prefix([prompt, answered, result, unanswered, incident])
+
+    assert unanswered not in kept, "a custom in the tail shielded an unanswered assistant"
+    assert incident in kept, "the incident must survive — it is real history"
+    assert kept == [prompt, answered, result, incident]
+
+    # And the ordinary cases still behave: an ANSWERED tail is untouched, and a
+    # run of unanswered assistants under several customs is fully trimmed.
+    answered_tail = [answered, result]
+    assert _paired_prefix(answered_tail) == answered_tail
+    assert _paired_prefix([answered, result, unanswered, incident, incident]) == [
+        answered,
+        result,
+        incident,
+        incident,
+    ]

--- a/tests/unit/session/test_session.py
+++ b/tests/unit/session/test_session.py
@@ -1958,25 +1958,43 @@ async def test_completed_work_survives_a_crash_mid_run(tmp_path):
 @pytest.mark.asyncio
 async def test_completed_work_survives_cancellation(tmp_path):
     """Ctrl+C / dispose cancels the turn task. Cancellation must still
-    propagate (the turn really is over) AND leave the work on disk."""
+    propagate (the turn really is over) AND leave the COMPLETED work on disk.
+
+    Completed is the operative word. An earlier version of this test cancelled
+    during the FIRST batch and asserted that batch's assistant message was
+    persisted — which is precisely the dangling ``tool_use`` that
+    :func:`_paired_prefix` now refuses to write (see
+    ``test_durability_flush_never_persists_a_dangling_tool_call``). The
+    assertion was wrong, not the trim: an assistant message whose calls never
+    reported is not work to preserve, it is a row that 400s every later
+    resume. So the cancel here lands in the SECOND batch, and what must
+    survive is the first batch, which really did finish.
+    """
     started = asyncio.Event()
 
     async def execute(tool_call_id, args, signal, on_update, context):
-        started.set()
-        await asyncio.sleep(30)  # cancelled here
-        return ToolResult(tool_call_id=tool_call_id, tool_name="slow", content=[])
+        if tool_call_id == "c2":
+            started.set()
+            await asyncio.sleep(30)  # cancelled here, one batch in
+        return ToolResult(
+            tool_call_id=tool_call_id, tool_name="slow", content=[TextContent(text="FINISHED")]
+        )
 
     slow = AgentTool(name="slow", parameters={"type": "object", "properties": {}}, execute=execute)
-    stream = ScriptedStream(
-        [
-            [
-                StreamTextDelta(delta="BEFORE-CANCEL"),
-                StreamToolCallDelta(index=0, id="c1", name="slow", argument_delta="{}"),
-                StreamEndEvent(stop_reason="toolUse"),
-            ]
-        ]
-    )
-    session = make_session(tmp_path, stream, tools=[slow])
+
+    class Steps(ScriptedStream):
+        def __call__(self, request, signal):
+            self.requests.append(request)
+            index = len(self.requests)
+
+            async def gen():
+                yield StreamTextDelta(delta=f"BEFORE-CANCEL-{index}")
+                yield StreamToolCallDelta(index=0, id=f"c{index}", name="slow", argument_delta="{}")
+                yield StreamEndEvent(stop_reason="toolUse")
+
+            return gen()
+
+    session = make_session(tmp_path, Steps([]), tools=[slow])
 
     task = asyncio.create_task(session.prompt("go"))
     await started.wait()
@@ -1986,7 +2004,8 @@ async def test_completed_work_survives_cancellation(tmp_path):
 
     replayed = _persisted_texts(session)
     assert "go" in replayed
-    assert "BEFORE-CANCEL" in replayed
+    assert "BEFORE-CANCEL-1" in replayed  # the batch that completed
+    assert "FINISHED" in replayed  # and its tool result
     await session.dispose()
 
 
@@ -2075,4 +2094,79 @@ async def test_progress_survives_when_mid_turn_compaction_is_off(tmp_path):
     replayed = _persisted_texts(session)
     assert "STEP-1" in replayed, f"the first step was lost: {replayed}"
     assert "REAL-WORK" in replayed, f"completed tool work was lost: {replayed}"
+    await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_durability_flush_never_persists_a_dangling_tool_call(tmp_path):
+    """A crash or Ctrl+C MID-BATCH must not write an unanswered tool call.
+
+    The loop appends the assistant message when the model turn ends and the
+    tool results only when the batch finishes, so for the whole duration of a
+    tool batch the live context ends in an assistant message whose calls have
+    no answers. The ``finally`` flush persists that context — and a dangling
+    ``tool_use`` on disk is permanent: every later resume replays it into a
+    400 ("must be followed by tool messages responding to each
+    tool_call_id"). Caught on a real Ctrl+C, which left ``['c1a', 'c1b']``
+    unpaired before ``_paired_prefix`` trimmed the tail.
+
+    Completed batches must still survive, or the trim would have thrown away
+    the work the flush exists to save.
+    """
+    started = asyncio.Event()
+
+    async def execute(tool_call_id, args, signal, on_update, context):
+        if tool_call_id.startswith("c2"):
+            started.set()
+            await asyncio.sleep(30)  # cancelled inside the SECOND batch
+        return ToolResult(
+            tool_call_id=tool_call_id,
+            tool_name="work",
+            content=[TextContent(text=f"DONE-{tool_call_id}")],
+        )
+
+    work = AgentTool(name="work", parameters={"type": "object", "properties": {}}, execute=execute)
+
+    class TwoCallBatches(ScriptedStream):
+        def __call__(self, request, signal):
+            self.requests.append(request)
+            index = len(self.requests)
+
+            async def gen():
+                yield StreamTextDelta(delta=f"STEP-{index}")
+                yield StreamToolCallDelta(
+                    index=0, id=f"c{index}a", name="work", argument_delta="{}"
+                )
+                yield StreamToolCallDelta(
+                    index=1, id=f"c{index}b", name="work", argument_delta="{}"
+                )
+                yield StreamEndEvent(stop_reason="toolUse")
+
+            return gen()
+
+    session = make_session(tmp_path, TwoCallBatches([]), tools=[work])
+    task = asyncio.create_task(session.prompt("go"))
+    await started.wait()
+    await asyncio.sleep(0.05)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    replayed = Transcript(session._transcript.directory).build_llm_history()
+    calls = {
+        call.id
+        for message in replayed
+        if isinstance(message, Message) and message.role == "assistant"
+        for call in message.tool_calls
+    }
+    results = {
+        message.tool_call_id
+        for message in replayed
+        if isinstance(message, Message) and message.role == "tool"
+    }
+    assert calls, "the first batch should have been persisted"
+    assert not calls - results, f"dangling tool_use persisted: {sorted(calls - results)}"
+
+    texts = [m.text for m in replayed if isinstance(m, Message) and m.text]
+    assert "DONE-c1a" in texts and "DONE-c1b" in texts, f"completed work lost: {texts}"
     await session.dispose()

--- a/tests/unit/session/test_session.py
+++ b/tests/unit/session/test_session.py
@@ -2006,6 +2006,25 @@ async def test_completed_work_survives_cancellation(tmp_path):
     assert "go" in replayed
     assert "BEFORE-CANCEL-1" in replayed  # the batch that completed
     assert "FINISHED" in replayed  # and its tool result
+
+    # Pairing is asserted HERE, on the cancellation path itself, and not only
+    # in the dedicated dangling-call test. An earlier version of this test
+    # checked text alone, and text alone is satisfied by a transcript carrying
+    # an unanswered `tool_use` — so it ratified the corruption instead of
+    # catching it (review round 1, R2).
+    history = Transcript(session._transcript.directory).build_llm_history()
+    calls = {
+        call.id
+        for message in history
+        if isinstance(message, Message) and message.role == "assistant"
+        for call in message.tool_calls
+    }
+    results = {
+        message.tool_call_id
+        for message in history
+        if isinstance(message, Message) and message.role == "tool"
+    }
+    assert not calls - results, f"cancellation left a dangling tool_use: {sorted(calls - results)}"
     await session.dispose()
 
 
@@ -2170,3 +2189,62 @@ async def test_durability_flush_never_persists_a_dangling_tool_call(tmp_path):
     texts = [m.text for m in replayed if isinstance(m, Message) and m.text]
     assert "DONE-c1a" in texts and "DONE-c1b" in texts, f"completed work lost: {texts}"
     await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_dispose_does_not_suppress_the_turns_own_flush(tmp_path):
+    """``dispose()`` sets ``_disposed`` BEFORE aborting and awaiting the
+    in-flight turn — deliberately, so that turn's persistence "must land on a
+    live transcript" (HC-14). A ``_disposed`` guard inside the durability
+    flush would therefore suppress exactly the flush dispose is waiting for
+    (review round 1, R3). Completed work must be on disk after a dispose that
+    lands mid-batch, and the tail must still be legal.
+    """
+    started = asyncio.Event()
+
+    async def execute(tool_call_id, args, signal, on_update, context):
+        if tool_call_id == "c2":
+            started.set()
+            await asyncio.sleep(30)  # dispose lands here
+        return ToolResult(
+            tool_call_id=tool_call_id,
+            tool_name="work",
+            content=[TextContent(text=f"DONE-{tool_call_id}")],
+        )
+
+    work = AgentTool(name="work", parameters={"type": "object", "properties": {}}, execute=execute)
+
+    class Steps(ScriptedStream):
+        def __call__(self, request, signal):
+            self.requests.append(request)
+            index = len(self.requests)
+
+            async def gen():
+                yield StreamTextDelta(delta=f"STEP-{index}")
+                yield StreamToolCallDelta(index=0, id=f"c{index}", name="work", argument_delta="{}")
+                yield StreamEndEvent(stop_reason="toolUse")
+
+            return gen()
+
+    session = make_session(tmp_path, Steps([]), tools=[work])
+    asyncio.create_task(session.prompt("go"))
+    await started.wait()
+    await asyncio.sleep(0.05)
+    await session.dispose()
+
+    history = Transcript(session._transcript.directory).build_llm_history()
+    texts = [m.text for m in history if isinstance(m, Message) and m.text]
+    assert "STEP-1" in texts and "DONE-c1" in texts, f"dispose dropped completed work: {texts}"
+
+    calls = {
+        call.id
+        for message in history
+        if isinstance(message, Message) and message.role == "assistant"
+        for call in message.tool_calls
+    }
+    results = {
+        message.tool_call_id
+        for message in history
+        if isinstance(message, Message) and message.role == "tool"
+    }
+    assert not calls - results, f"dispose left a dangling tool_use: {sorted(calls - results)}"

--- a/tests/unit/session/test_session.py
+++ b/tests/unit/session/test_session.py
@@ -1817,3 +1817,262 @@ async def test_a_cancelled_subagent_never_persists_a_marker_or_reminder(tmp_path
     ), "the cancelled child's actual turn was dropped"
 
     await child.dispose()
+
+
+# --- durability: a run's progress survives a crash or interrupt -------------
+#
+# Regression cover for the loss reported from a long KOHO debugging session:
+# a transcript held ONLY the user's prompt while the run was in flight, so a
+# session that died mid-run replayed to nothing and every completed tool call
+# was gone. The transcript store always flushed per append; what was missing
+# was any append between the turn's first message and its post-run pass.
+
+
+def _persisted_texts(session: Session) -> list[str]:
+    """Message texts on DISK, read back through a fresh store (never the
+    in-memory entry list, which would pass even if nothing was flushed)."""
+    reopened = Transcript(session._transcript.directory)
+    return [m.text for m in reopened.build_llm_history() if isinstance(m, Message) and m.text]
+
+
+@pytest.mark.asyncio
+async def test_tool_progress_is_on_disk_before_the_run_finishes(tmp_path):
+    """Work completed at a tool boundary is durable IMMEDIATELY, not at the
+    end of the run: a reader opening the file mid-run sees the assistant
+    message and its tool result."""
+    seen: list[list[str]] = []
+
+    async def execute(tool_call_id, args, signal, on_update, context):
+        return ToolResult(
+            tool_call_id=tool_call_id, tool_name="probe", content=[TextContent(text="TOOL-OUTPUT")]
+        )
+
+    probe = AgentTool(
+        name="probe", parameters={"type": "object", "properties": {}}, execute=execute
+    )
+
+    stream = ScriptedStream(
+        [
+            [
+                StreamTextDelta(delta="FIRST-STEP"),
+                StreamToolCallDelta(index=0, id="c1", name="probe", argument_delta="{}"),
+                StreamEndEvent(stop_reason="toolUse"),
+            ],
+            [StreamTextDelta(delta="DONE"), StreamEndEvent(stop_reason="stop")],
+        ]
+    )
+    session = make_session(tmp_path, stream, tools=[probe])
+    # Sample the file at the boundary between the two model calls.
+    original = session._on_turn_end
+
+    async def sampling_hook(messages):
+        outcome = await original(messages)
+        seen.append(_persisted_texts(session))
+        return outcome
+
+    session._on_turn_end = sampling_hook  # type: ignore[assignment]
+
+    await session.prompt("go")
+
+    assert seen, "the boundary hook never fired"
+    mid_run = seen[0]
+    assert "FIRST-STEP" in mid_run  # assistant message durable mid-run
+    assert "TOOL-OUTPUT" in mid_run  # and so is the completed tool result
+    await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_completed_work_survives_a_crash_mid_run(tmp_path):
+    """The failure the report described: the run dies AFTER real work, before
+    any normal persistence. Everything completed must still replay."""
+
+    async def execute(tool_call_id, args, signal, on_update, context):
+        return ToolResult(
+            tool_call_id=tool_call_id, tool_name="probe", content=[TextContent(text="EXPENSIVE")]
+        )
+
+    probe = AgentTool(
+        name="probe", parameters={"type": "object", "properties": {}}, execute=execute
+    )
+
+    class CrashOnSecondCall(ScriptedStream):
+        def __call__(self, request, signal):
+            self.requests.append(request)
+            if len(self.requests) == 1:
+
+                async def first():
+                    yield StreamTextDelta(delta="REASONING")
+                    yield StreamToolCallDelta(index=0, id="c1", name="probe", argument_delta="{}")
+                    yield StreamEndEvent(stop_reason="toolUse")
+
+                return first()
+
+            async def boom():
+                raise RuntimeError("provider exploded")
+                yield  # pragma: no cover - generator shape only
+
+            return boom()
+
+    session = make_session(tmp_path, CrashOnSecondCall([]), tools=[probe])
+    # A HARD failure: everything downstream of the run is dead. That is what a
+    # SIGKILL, an OOM, or a bug between boundaries looks like from the
+    # transcript's point of view, and it is the case the loop's own error
+    # handling cannot cover, because the post-run pass never executes at all.
+    # (A mere provider/stream error does NOT reproduce the loss: the loop
+    # catches it, the run ends normally and the post-run pass still writes
+    # everything. Measured on a build with the boundary flush removed: this
+    # sabotage leaves ``['go']`` on disk, a stream error leaves the full run.)
+    #
+    # Sabotage is scoped to the POST-RUN call site rather than the method,
+    # because the durability flushes share that method and disabling it
+    # outright would remove the very thing under test.
+    real_persist = session._persist_new_messages
+    inside_durability_flush = {"now": False}
+    real_progress = session._persist_progress
+
+    async def tracking_progress(messages):
+        inside_durability_flush["now"] = True
+        try:
+            return await real_progress(messages)
+        finally:
+            inside_durability_flush["now"] = False
+
+    async def persist_or_die(messages):
+        if inside_durability_flush["now"]:
+            return await real_persist(messages)
+        raise RuntimeError("post-run persistence never ran")
+
+    session._persist_progress = tracking_progress  # type: ignore[assignment]
+    session._persist_new_messages = persist_or_die  # type: ignore[assignment]
+
+    with pytest.raises(RuntimeError):
+        await session.prompt("go")
+
+    replayed = _persisted_texts(session)
+    assert "go" in replayed  # the prompt
+    assert "REASONING" in replayed  # the assistant turn that ran
+    assert "EXPENSIVE" in replayed  # the tool output that cost real time
+    await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_completed_work_survives_cancellation(tmp_path):
+    """Ctrl+C / dispose cancels the turn task. Cancellation must still
+    propagate (the turn really is over) AND leave the work on disk."""
+    started = asyncio.Event()
+
+    async def execute(tool_call_id, args, signal, on_update, context):
+        started.set()
+        await asyncio.sleep(30)  # cancelled here
+        return ToolResult(tool_call_id=tool_call_id, tool_name="slow", content=[])
+
+    slow = AgentTool(name="slow", parameters={"type": "object", "properties": {}}, execute=execute)
+    stream = ScriptedStream(
+        [
+            [
+                StreamTextDelta(delta="BEFORE-CANCEL"),
+                StreamToolCallDelta(index=0, id="c1", name="slow", argument_delta="{}"),
+                StreamEndEvent(stop_reason="toolUse"),
+            ]
+        ]
+    )
+    session = make_session(tmp_path, stream, tools=[slow])
+
+    task = asyncio.create_task(session.prompt("go"))
+    await started.wait()
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    replayed = _persisted_texts(session)
+    assert "go" in replayed
+    assert "BEFORE-CANCEL" in replayed
+    await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_durability_flush_never_duplicates_messages(tmp_path):
+    """The boundary flush, the finally flush and the post-run pass all offer
+    the same messages. Idempotence by id means each is stored exactly once."""
+    executed: list[str] = []
+    stream = ScriptedStream(
+        [
+            [
+                StreamTextDelta(delta="ONE"),
+                StreamToolCallDelta(index=0, id="c1", name="echo", argument_delta='{"text":"x"}'),
+                StreamEndEvent(stop_reason="toolUse"),
+            ],
+            [StreamTextDelta(delta="TWO"), StreamEndEvent(stop_reason="stop")],
+        ]
+    )
+    session = make_session(tmp_path, stream, tools=[echo_tool(executed)])
+    await session.prompt("go")
+
+    texts = _persisted_texts(session)
+    for expected in ("go", "ONE", "TWO"):
+        assert texts.count(expected) == 1, f"{expected!r} stored {texts.count(expected)}x: {texts}"
+    await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_progress_survives_when_mid_turn_compaction_is_off(tmp_path):
+    """The reported loss, end to end.
+
+    Before the durability flush, the ONLY thing that persisted mid-run was a
+    side effect of the mid-turn compaction gate: it writes the run so far to
+    get a replayable cut target. Every early return above that line therefore
+    left the whole run unpersisted — and with ``mid_turn_enabled`` off the
+    hook returns immediately, so a long tool run kept 100% of its work in
+    memory. Measured against a build without the flush: this scenario left
+    exactly ONE entry (the user's prompt) on disk against ten with it, which
+    is the transcript the report described.
+    """
+    from pydantic import BaseModel, Field
+
+    class CompactionSettings(BaseModel):
+        enabled: bool = True
+        reserve_tokens: int = 16384
+        keep_recent_tokens: int = 20000
+        threshold_percent: float = 0.80
+        threshold_tokens: int = Field(default=600_000)
+        auto_continue: bool = False
+        mid_turn_enabled: bool = False  # the gate that used to carry persistence
+
+    started = asyncio.Event()
+
+    async def execute(tool_call_id, args, signal, on_update, context):
+        started.set()
+        if tool_call_id == "c2":
+            await asyncio.sleep(30)  # interrupted here, after real work landed
+        return ToolResult(
+            tool_call_id=tool_call_id, tool_name="work", content=[TextContent(text="REAL-WORK")]
+        )
+
+    work = AgentTool(name="work", parameters={"type": "object", "properties": {}}, execute=execute)
+
+    class Steps(ScriptedStream):
+        def __call__(self, request, signal):
+            self.requests.append(request)
+            index = len(self.requests)
+
+            async def gen():
+                yield StreamTextDelta(delta=f"STEP-{index}")
+                yield StreamToolCallDelta(index=0, id=f"c{index}", name="work", argument_delta="{}")
+                yield StreamEndEvent(stop_reason="toolUse")
+
+            return gen()
+
+    session = make_session(
+        tmp_path, Steps([]), tools=[work], compaction_settings=CompactionSettings()
+    )
+    task = asyncio.create_task(session.prompt("debug the tenant"))
+    await started.wait()
+    await asyncio.sleep(0.05)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    replayed = _persisted_texts(session)
+    assert "STEP-1" in replayed, f"the first step was lost: {replayed}"
+    assert "REAL-WORK" in replayed, f"completed tool work was lost: {replayed}"
+    await session.dispose()


### PR DESCRIPTION
## Change classification

**C2 — standard / pre-authorized.** Two added flush points on an existing persistence path, plus one wrapper. No schema, no wire contract, no new dependency, no behaviour change to what a turn *computes* — only to how often what it has already produced reaches disk. Clean rollback (`git revert`). No RFC requested.

## The gap

`Transcript._append` has always flushed per write:

```python
async with self._lock:
    self._entries.append(entry)
    with self.path.open("a", encoding="utf-8") as handle:
        handle.write(entry.to_json() + "\n")
        handle.flush()
```

So the store was never the problem. **Nothing called it.**

A turn persisted the user's message at the top of `_run_turn`, then went silent until `_persist_new_messages(new_messages)` after the loop returned. The only thing writing in between was a *side effect* of the mid-turn compaction gate, which flushes the run so far because a cut has to land on an already-persisted entry:

```python
# _on_turn_end -> _maybe_compact_mid_turn
await self._persist_new_messages(messages)   # to get a replayable cut target
planned = await self._plan_compaction(respect_threshold=True)
```

Every early return **above** that line therefore left the whole run in memory — including the two that fire on ordinary sessions:

- `mid_turn_enabled` off → returns at the knob check;
- context under the threshold → returns at the `should_compact` pre-gate.

That is the reported symptom: a long, tool-heavy session that dies mid-run replays to **nothing but the prompt**, and hours of completed tool work are gone. It is worst exactly where it hurts most — a short-context session doing many cheap tool calls never trips the compaction threshold, so it never persists anything until it finishes.

## Evidence: the failure, and the fix, under a real SIGKILL

A 7-step tool run, killed hard mid-run (`os.kill(os.getpid(), SIGKILL)` — no `finally`, no `atexit`, no dispose), `mid_turn_enabled=False`. Same script against a pristine `origin/main` worktree and against this branch:

```console
$ python /tmp/evid.py <dir> <pristine-origin-main>
=== BEFORE (origin/main, exit -9) : 1 entries ===
   [user] debug KOHO tenant match scoring

$ python /tmp/evid.py <dir> <this-branch>
=== AFTER (this branch, exit -9) : 15 entries ===
   [user] debug KOHO tenant match scoring
   [assistant] STEP-1: KOHO tenant analysis
   [tool] EXPENSIVE RESULT c1
   [assistant] STEP-2: KOHO tenant analysis
   [tool] EXPENSIVE RESULT c2
   ... (through STEP-7 / EXPENSIVE RESULT c7)
```

**1 entry → 15.** The recovered transcript also has to be *legally replayable*, not merely non-empty: a dangling `tool_use` with no `tool_result` is a 400 on both wires, which would turn a recovered session into an unusable one.

```console
$ python /tmp/resume_check.py <killed-session-dir>
replayed messages: 15
tool results recovered: 7
tool_calls: 7 results: 7
DANGLING (unpaired) calls: []
```

Under the **default** config (mid-turn compaction on, below threshold) the same run goes from 9 entries to 10: the compaction gate's side-effect flush was already covering the boundaries, and what this adds is the tail after the last boundary — the assistant message whose own failure ended the run.

## What changed

### 1. `_on_turn_end` — flush at every tool-loop boundary

Moved to the top of the hook, **before** any compaction decision, so no early return can skip it. This is the only place that sees a run's messages at a safe boundary (after a tool batch lands, before the next model call).

### 2. `_run_turn`'s `finally` — flush the tail

Covers what no boundary hook can: the loop raising (`"model turn produced no assistant message"`, a provider client raising past the stream handler), a `CancelledError` from Ctrl+C or dispose, a steering-driven teardown. All of these skip the post-run pass entirely.

### 3. `_persist_progress` — the best-effort wrapper

`_persist_new_messages` stays strict; its normal-path callers want a write failure to surface. The two durability callers must never fail the turn they are protecting, so this wrapper logs instead of raising — the alternative to a swallowed write error is losing the entire run rather than one message. `CancelledError` is deliberately re-raised so teardown is never blocked.

Both flushes are idempotent by message id (`_persist_new_messages` skips ids already stored), so the same message offered at its boundary, again in the `finally`, and again post-run is written **once**.

### What this does *not* need

An earlier draft added an explicit compaction-marker exclusion. It is unnecessary here: `main`'s `_is_persistable_message` allowlist already keeps `compaction_summary` markers and todo reminders out, and its docstring names this exact hazard ("the mid-turn gate flushes from the LIVE loop context ... the very next boundary would otherwise persist the marker"). Verified rather than assumed — persisting a live marker as a message row does double the summary on replay:

```console
history len 3
  CustomMessage compaction_summary {'summary': 'SUMMARY-TEXT'}
  Message        two
  CustomMessage compaction_summary {'summary': 'SUMMARY-TEXT'}   # <- the hazard
```

## Review rounds

Round 1 found a **blocker of my own making**, reproduced end to end: the `finally` flush persisted `self._context.messages`, and mid-batch that list ends in an assistant message whose `tool_calls` have no results yet — so a Ctrl+C during a tool batch wrote a dangling `tool_use` to disk permanently, and every later resume replayed it into a 400. The reviewer carried the resumed history through the real `AnthropicClient._build_body` to prove the trailing unpaired `tool_use`. On base `09d8440` the same interrupt is legal only because it persists nothing — so the first cut of this PR traded data loss for corruption, which is worse.

`_paired_prefix` (`04da980`) trims trailing assistant messages with unanswered calls before persisting. It **drops** rather than pairing with placeholders: `_history_snapshot` pairs because it is building a request it is about to send, but persistence is forever and a placeholder on disk is a permanent claim that a tool reported when it never did. The model re-sends the unanswered assistant message on the next run, so a resume loses nothing.

`7ee752f` works the other two findings: the `_disposed` guard is removed from `_persist_progress` (R3 — `dispose()` sets that flag *before* awaiting the in-flight turn, precisely so its persistence lands on a live transcript, so the guard suppressed the flush dispose was waiting for), and `test_completed_work_survives_cancellation` now asserts pairing on the cancellation path itself (R2 — it previously asserted text only, which a corrupt transcript satisfies). R4, the per-boundary O(n) stored-id rebuild (26.9 ms at 20k entries), is accepted and deferred to a follow-up against `Transcript`: the fix needs a cache with append *and* `compact_file` invalidation, where a stale cache silently stops persisting.

## Second defect: `hub ask` told a working subagent it had not started

Reported live during this PR's own review round. A `hub op='ask'` against a reviewer subagent that had been running **over half an hour** waited 30 seconds and returned:

```
review-pr-155-r2 (6c932be85c93): subagent has not started yet (it is scheduled,
and starts when this session next yields); retry in a moment
```

I acted on that message and cancelled a healthy child mid-run. Reproduced exactly on the pre-fix branch:

```console
$ python /tmp/branch_repro.py     # ask(timeout_ms=300_000) vs a child running 1800s
waited 30.0s
error: subagent has not started yet (it is scheduled, and starts when this session next yields); retry in a moment
```

Three defects, all in the window where the runner is underway but the child session has not attached to the parent's comms record:

1. **The message could not tell the states apart.** `_not_started_reason` read `queued` and `status`, but `status` is `running` from **registration** — before a line has run. `AsyncJob.started_at` (stamped as `_run_job`'s first statement) is the authoritative "has the runner begun" and was never consulted.
2. **`ask` refused past the grace.** `_await_child` already handles a merely *scheduled* child by yielding the loop, but its grace is capped at `ATTACH_WAIT_MAX_S = 30 s`, so even a 300 s caller got a refusal — and retrying returns the same refusal, which is the polling loop `_await_child` exists to remove.
3. **`attach` flushed a buffered question as a plain note.** A question has a caller blocked on `record.ask`; flushed unarmed it would be injected, answered, and the asker would still time out on a reply that had already come back.

Now: a question for a child whose runner has begun is **buffered** onto `record.pending` (the path `send` has always used), `attach` re-arms it with the waiter's future, and the three states report honestly:

```console
running 1800s : subagent started 1800s ago but has not attached to this parent, so it
                cannot be questioned yet; it is RUNNING — use 'jobs'/'wait' for its
                result rather than cancelling it
parked        : subagent has not started yet (parked behind the job capacity gate); it
                starts when a slot frees, so do not wait on it
never entered : subagent has not started yet (it is scheduled, and starts when this
                session next yields); retry in a moment
```

`FakeJob` in the suite modelled `status` and `queued` but **not `started_at`** — which is why every existing test agreed with the bug. Four tests added; three fail on the pre-fix branch with the exact message above.

### Known limitation, not fixed here

A child can only receive a question at an **injection boundary** — `loop._collect_inflight_injections` runs after a tool batch settles (`loop.py:337`). A child inside a single long tool call therefore stays unreachable until that call returns. That is the architecture rather than a regression, and changing it means interrupting a running tool; measured, an attached child answers in 3.0 s when its current tool takes 3 s. Flagged for a follow-up rather than smuggled into this PR.

## Tests

Seven tests in `tests/unit/session/test_session.py`. They read the transcript back through a **fresh `Transcript`** rather than the in-memory entry list, so a test cannot pass on data that was never flushed.

Each was verified to actually catch the bug, by reverting both flush points and re-running — a test that passes either way proves nothing:

```console
$ # with both flushes replaced by `pass`
FAILED test_completed_work_survives_a_crash_mid_run
        AssertionError: the first step was lost: ['debug the tenant']
FAILED test_completed_work_survives_cancellation
        AssertionError: assert 'BEFORE-CANCEL' in ['go']
FAILED test_progress_survives_when_mid_turn_compaction_is_off
        AssertionError: the first step was lost: ['debug the tenant']
3 failed, 2 passed
```

The two that stay green are the ones that *should*: `test_tool_progress_is_on_disk_before_the_run_finishes` and `test_durability_flush_never_duplicates_messages` also pass on `main` for the default-config reason above (the compaction gate's side effect covers them). They are kept as forward guards on the boundary contract and on idempotence, not claimed as regression cover.

`test_completed_work_survives_a_crash_mid_run` sabotages the **post-run call site**, not the method, because the durability flushes share it — disabling it outright would remove the thing under test. Its docstring records that a mere provider/stream error does *not* reproduce the loss: the loop catches it, the run ends normally, and the post-run pass still writes everything.

## Gates

```console
$ pytest tests/unit -q --ignore=tests/unit/tui
1 failed, 3011 passed, 3 skipped        # see below
$ pytest tests/unit/session tests/unit/compaction -q
289 passed
$ flake8 .                              # clean
$ black --check local_operator tests    # clean
$ isort --check-only --profile black local_operator tests   # clean
$ pyright --pythonpath .venv/bin/python .
0 errors, 0 warnings, 0 informations
```

The one failure, `test_eval_tool.py::test_background_streams_output_while_it_runs`, **fails identically on pristine `origin/main`** in this environment (it asserts on streamed output timing from a background eval worker). Confirmed by stashing the change and re-running; unrelated to this PR.
