### PR TITLE
feat(providers): Z.AI GLM Coding Plan browser sign-in

### DIFF
--- a/local_operator/providers/auth_store.py
+++ b/local_operator/providers/auth_store.py
@@ -282,8 +282,21 @@ class AuthStore:
         Revives soft-deleted rows for the same identity (re-login).
         ``store_credentials_as`` aliasing happens at the caller (login path).
         """
+        # An EXPLICIT type wins; the structural guess is the fallback for the
+        # callers (and stored rows) that never declared one.
+        #
+        # The guess reads "has both refresh and access", which cannot see a
+        # credential that is OAuth-issued but has no refresh token because it
+        # never expires -- Z.AI's coding-plan sign-in mints exactly that. Such a
+        # row landed as `api_key` with its secret under `data["access"]`, where
+        # nothing can read it: tiers 4 and 6 read `data["key"]`, and tier 3 only
+        # walks `oauth`-typed rows. The login reported success and every request
+        # afterwards failed with no credential at all.
+        declared = credential.get("type")
         credential_type = (
-            "oauth" if credential.get("refresh") and credential.get("access") else "api_key"
+            declared
+            if declared in ("oauth", "api_key")
+            else ("oauth" if credential.get("refresh") and credential.get("access") else "api_key")
         )
         identity = _identity_key_for(provider, credential)
         payload = dict(credential)

--- a/local_operator/providers/auth_store.py
+++ b/local_operator/providers/auth_store.py
@@ -146,6 +146,19 @@ def _identity_key_for(provider: str, credential: dict[str, Any]) -> str | None:
         value = credential.get(field)
         if value:
             return str(value)
+    # The per-provider constant asks "is this an OAuth credential?", and it used
+    # to answer by testing for a refresh token. That is the same blind spot the
+    # type derivation above had: an OAuth credential whose token NEVER EXPIRES
+    # carries no refresh token by design (Z.AI's coding-plan sign-in mints
+    # exactly that), so it fell through to `None` and every re-login left
+    # another row. Five sign-ins meant five rows, and `/usage` rendered the one
+    # account five times over.
+    #
+    # A declared type answers the question directly; the refresh/access pair
+    # stays as the fallback for the callers that declare nothing, which is how
+    # every existing provider reaches this line.
+    if credential.get("type") == "oauth" and credential.get("access"):
+        return f"oauth:{provider}"
     if credential.get("refresh") and credential.get("access"):
         return f"oauth:{provider}"
     return None

--- a/local_operator/providers/oauth/callback_server.py
+++ b/local_operator/providers/oauth/callback_server.py
@@ -415,7 +415,28 @@ class OAuthCallbackFlow(ABC):
             while pasted is None:
                 await asyncio.Future()  # declined; keep waiting for the browser
             pasted = pasted.strip()
-            return _parse_pasted_callback(pasted)
+            try:
+                return _parse_pasted_callback(pasted)
+            except LoginError as exc:
+                # A paste this task cannot use must NOT end the login. This
+                # prompt only ever races the loopback callback -- it is the
+                # fallback for a browser that cannot reach this machine, not the
+                # sole path -- and the module already encodes that rule one line
+                # above, where a DECLINED paste re-parks instead of failing.
+                # Raising here would let a mistyped or half-copied URL kill a
+                # sign-in the browser was about to complete on its own, which is
+                # strictly worse than the silence the user would have got by
+                # pasting nothing.
+                #
+                # The reason still reaches the user: it goes to `on_progress`,
+                # which is where the flow's other "here is what just happened"
+                # messages go, and then this task parks so the callback (or the
+                # timeout) decides the login.
+                report = self.callbacks.on_progress
+                if report is not None:
+                    await maybe_await(report(str(exc)))
+                await asyncio.Future()  # park; the browser callback may still win
+                raise AssertionError("unreachable")  # pragma: no cover
 
         async def _abort_watch() -> tuple[str, str]:
             assert self._signal is not None

--- a/local_operator/providers/oauth/callback_server.py
+++ b/local_operator/providers/oauth/callback_server.py
@@ -31,6 +31,58 @@ from local_operator.harness.types import AbortSignal
 DEFAULT_TIMEOUT_SECONDS = 300.0
 
 
+def _parse_pasted_callback(pasted: str) -> tuple[str, str]:
+    """Pull ``(code, state)`` out of whatever the user actually pasted.
+
+    Three shapes reach this prompt, and which one a user produces depends on
+    what their provider's browser page shows them, not on what we asked for:
+
+    1. The whole redirect URL (``http://localhost:54548/callback?code=..&state=..``),
+       which is what a user copies from the address bar when the browser is on
+       another machine and cannot reach this loopback port. This is the shape
+       the "paste the redirect URL" fallback exists for.
+    2. ``code#state``, which Anthropic renders as a single copy target.
+    3. A bare authorization code.
+
+    Handling only (2) and (3) meant a pasted URL was sent to the token endpoint
+    verbatim AS the authorization code, so the fallback advertised for remote
+    and headless sessions could not complete a login at all. Query parameters
+    are tried first because a URL is unambiguous: it has a scheme and a
+    ``code`` parameter, neither of which a bare code or a ``code#state`` pair
+    can produce.
+    """
+    if "://" in pasted:
+        parsed = urllib.parse.urlsplit(pasted)
+        query = urllib.parse.parse_qs(parsed.query)
+        code = (query.get("code") or [""])[0].strip()
+        if code:
+            # `state` may ride in the query (the ordinary case) or in the
+            # fragment, which some providers use to keep it out of server logs.
+            state = (query.get("state") or [""])[0].strip()
+            if not state and parsed.fragment:
+                frag = urllib.parse.parse_qs(parsed.fragment)
+                state = (frag.get("state") or [""])[0].strip() or parsed.fragment.strip()
+            return code, state
+        # A URL with no `code` is an error redirect or a mis-copy. Falling
+        # through would send the whole URL as the code and produce an opaque
+        # provider-side rejection, so say what is wrong while the user is still
+        # at the prompt.
+        error = (query.get("error") or [""])[0].strip()
+        if error:
+            description = (query.get("error_description") or [""])[0].strip()
+            detail = f" ({description})" if description else ""
+            raise LoginError(f"Authorization failed: {error}{detail}")
+        raise LoginError(
+            "That URL carries no authorization code. Copy the full address bar "
+            "contents after approving the sign-in."
+        )
+    # Providers hand users "code#state" in the redirect URL fragment.
+    if "#" in pasted:
+        code, _, frag_state = pasted.partition("#")
+        return code.strip(), frag_state.strip()
+    return pasted, ""
+
+
 class LoginError(Exception):
     """Base error for interactive login failures."""
 
@@ -363,11 +415,7 @@ class OAuthCallbackFlow(ABC):
             while pasted is None:
                 await asyncio.Future()  # declined; keep waiting for the browser
             pasted = pasted.strip()
-            # Providers hand users "code#state" in the redirect URL fragment.
-            if "#" in pasted:
-                code, _, frag_state = pasted.partition("#")
-                return code.strip(), frag_state.strip()
-            return pasted, ""
+            return _parse_pasted_callback(pasted)
 
         async def _abort_watch() -> tuple[str, str]:
             assert self._signal is not None

--- a/local_operator/providers/oauth/callback_server.py
+++ b/local_operator/providers/oauth/callback_server.py
@@ -69,12 +69,20 @@ def _parse_pasted_callback(pasted: str) -> tuple[str, str]:
         # at the prompt.
         error = (query.get("error") or [""])[0].strip()
         if error:
+            # The raw OAuth error code is kept deliberately. This is a
+            # developer-facing CLI, and the code is the string a user searches
+            # for and quotes in a support thread; translating it would remove
+            # the only durable handle on the failure. What follows it is the
+            # part that was missing: what to do next.
             description = (query.get("error_description") or [""])[0].strip()
             detail = f" ({description})" if description else ""
-            raise LoginError(f"Authorization failed: {error}{detail}")
+            raise LoginError(
+                f"Authorization failed: {error}{detail}. Approve the sign-in in "
+                "your browser, then paste the address bar contents again."
+            )
         raise LoginError(
-            "That URL carries no authorization code. Copy the full address bar "
-            "contents after approving the sign-in."
+            "That URL carries no authorization code. Approve the sign-in in your "
+            "browser, then copy the whole address bar and paste it here."
         )
     # Providers hand users "code#state" in the redirect URL fragment.
     if "#" in pasted:
@@ -119,10 +127,29 @@ class LoginCallbacks:
     ``instructions`` string (the short ``/launch`` redirect when a loopback
     server is up). ``on_manual_code_input`` is only invoked for paste-code
     providers; returning ``None`` declines.
+
+    ``on_warning`` reports something that WENT WRONG but did not end the login
+    (a paste the flow could not use), as distinct from ``on_progress``, which
+    narrates what is happening normally. They are separate hooks because a host
+    styles them differently: routed through ``on_progress``, a failed
+    authorization rendered in the same dim treatment as "opening your
+    browser…", so the one line that explained why nothing happened read as
+    routine narration. Optional, and falls back to ``on_progress`` when a host
+    does not implement it, so no existing host loses the message.
+
+    ``on_input_rejected`` fires when a value returned by
+    ``on_manual_code_input`` could not be parsed, just before the flow asks
+    again. It carries no message (``on_warning`` already delivered the reason)
+    and exists so a host that RENDERED the paste can correct what it showed:
+    the TUI settles its prompt into a receipt the moment the value is handed
+    over, so without this it painted a success receipt over a paste the flow
+    had rejected. A host with no such surface simply omits it.
     """
 
     on_auth_url: Callable[..., Awaitable[None] | None] | None = None
     on_progress: Callable[[str], Awaitable[None] | None] | None = None
+    on_warning: Callable[[str], Awaitable[None] | None] | None = None
+    on_input_rejected: Callable[[], Awaitable[None] | None] | None = None
     on_manual_code_input: Callable[[], Awaitable[str | None] | str | None] | None = None
 
 
@@ -411,32 +438,66 @@ class OAuthCallbackFlow(ABC):
             prompt = self.callbacks.on_manual_code_input
             while prompt is None:
                 await asyncio.Future()  # park forever
-            pasted = await maybe_await(prompt())
-            while pasted is None:
-                await asyncio.Future()  # declined; keep waiting for the browser
-            pasted = pasted.strip()
-            try:
-                return _parse_pasted_callback(pasted)
-            except LoginError as exc:
-                # A paste this task cannot use must NOT end the login. This
-                # prompt only ever races the loopback callback -- it is the
-                # fallback for a browser that cannot reach this machine, not the
-                # sole path -- and the module already encodes that rule one line
-                # above, where a DECLINED paste re-parks instead of failing.
-                # Raising here would let a mistyped or half-copied URL kill a
-                # sign-in the browser was about to complete on its own, which is
-                # strictly worse than the silence the user would have got by
-                # pasting nothing.
-                #
-                # The reason still reaches the user: it goes to `on_progress`,
-                # which is where the flow's other "here is what just happened"
-                # messages go, and then this task parks so the callback (or the
-                # timeout) decides the login.
-                report = self.callbacks.on_progress
-                if report is not None:
-                    await maybe_await(report(str(exc)))
-                await asyncio.Future()  # park; the browser callback may still win
-                raise AssertionError("unreachable")  # pragma: no cover
+            while True:
+                pasted = await maybe_await(prompt())
+                while pasted is None:
+                    await asyncio.Future()  # declined; keep waiting for the browser
+                try:
+                    return _parse_pasted_callback(pasted.strip())
+                except LoginError as exc:
+                    # A paste this task cannot use must not end the login, AND
+                    # must not leave the user with nowhere to put a corrected
+                    # one. Two rules meet here:
+                    #
+                    # The prompt RACES the loopback callback -- it is the
+                    # fallback for a browser that cannot reach this machine --
+                    # so raising would let a mistyped URL kill a sign-in the
+                    # browser was about to finish. That is why the line above
+                    # re-parks on a DECLINED paste rather than failing.
+                    #
+                    # But parking is only the right answer when the callback can
+                    # still win, and for the user this fallback EXISTS for it
+                    # cannot: their browser is on another machine. For them a
+                    # single mis-paste meant a settled prompt, a message telling
+                    # them to copy the address bar, and no field left to paste
+                    # it into -- then silence until the timeout. So the reason
+                    # is reported and the prompt is offered AGAIN, which is the
+                    # only outcome that matches what the message asks for.
+                    #
+                    # Declining the re-prompt still parks, so a user who has
+                    # given up waits for the browser or the timeout exactly as
+                    # before, and the callback keeps its chance to win either
+                    # way because this loop never blocks it.
+                    report = self.callbacks.on_warning or self.callbacks.on_progress
+                    if report is not None:
+                        await maybe_await(report(str(exc)))
+                    # Ordered after the message so a host that repaints on
+                    # rejection does so with the reason already on screen
+                    # above it.
+                    rejected = self.callbacks.on_input_rejected
+                    if rejected is not None:
+                        await maybe_await(rejected())
+                    # Yield before asking again. A host may implement
+                    # ``on_manual_code_input`` SYNCHRONOUSLY (the callbacks are
+                    # documented to allow it, and the CLI host and the tests
+                    # both do), in which case nothing in this loop body ever
+                    # suspends: ``maybe_await`` returns without awaiting on a
+                    # plain value, so the loop would spin without returning
+                    # control to the scheduler. That starves the whole event
+                    # loop -- the loopback callback future can never be
+                    # resolved, and the flow's own timeout can never fire, so a
+                    # single bad paste hangs the login forever instead of
+                    # merely ending it. Handing one iteration back to the
+                    # scheduler is what keeps the race the comment above
+                    # describes actually winnable.
+                    #
+                    # A host that returns a value WITHOUT waiting for the user
+                    # (a test double, not a real prompt -- the TUI awaits a
+                    # mounted block's future and the CLI blocks on input) will
+                    # re-offer in a tight loop until another waiter wins or the
+                    # flow's timeout fires. That is bounded and no longer
+                    # blocking, which is the property that matters here.
+                    await asyncio.sleep(0)
 
         async def _abort_watch() -> tuple[str, str]:
             assert self._signal is not None

--- a/local_operator/providers/oauth/callback_server.py
+++ b/local_operator/providers/oauth/callback_server.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import asyncio
 import dataclasses
 import inspect
+import logging
 import secrets
 import urllib.parse
 import webbrowser
@@ -154,6 +155,35 @@ class LoginCallbacks:
 
 
 _T = TypeVar("_T")
+
+
+logger = logging.getLogger(__name__)
+
+
+async def report_safely(
+    hook: Callable[..., Awaitable[None] | None] | None,
+    *args: Any,
+) -> None:
+    """Invoke a host REPORTING hook, swallowing anything it raises.
+
+    Reporting hooks (``on_progress``, ``on_warning``, ``on_input_rejected``)
+    tell the user what is happening; they take no part in deciding the login.
+    An embedding host whose sink raises would otherwise propagate out of the
+    waiter and out of ``_await_code`` -- losing a sign-in the browser callback
+    was about to complete, which is the exact failure the surrounding code
+    exists to prevent. A host that cannot render a message must not be able to
+    destroy a credential grant.
+
+    Deliberately NOT used for ``on_manual_code_input``: that hook returns a
+    value the flow acts on, so an exception there is a real failure and has to
+    surface rather than be swallowed.
+    """
+    if hook is None:
+        return
+    try:
+        await maybe_await(hook(*args))
+    except Exception:  # pragma: no cover - host-defined sinks
+        logger.debug("a login reporting hook raised; continuing", exc_info=True)
 
 
 async def maybe_await(value: Awaitable[_T] | _T) -> _T:
@@ -468,15 +498,13 @@ class OAuthCallbackFlow(ABC):
                     # given up waits for the browser or the timeout exactly as
                     # before, and the callback keeps its chance to win either
                     # way because this loop never blocks it.
-                    report = self.callbacks.on_warning or self.callbacks.on_progress
-                    if report is not None:
-                        await maybe_await(report(str(exc)))
+                    await report_safely(
+                        self.callbacks.on_warning or self.callbacks.on_progress, str(exc)
+                    )
                     # Ordered after the message so a host that repaints on
                     # rejection does so with the reason already on screen
                     # above it.
-                    rejected = self.callbacks.on_input_rejected
-                    if rejected is not None:
-                        await maybe_await(rejected())
+                    await report_safely(self.callbacks.on_input_rejected)
                     # Yield before asking again. A host may implement
                     # ``on_manual_code_input`` SYNCHRONOUSLY (the callbacks are
                     # documented to allow it, and the CLI host and the tests
@@ -493,10 +521,15 @@ class OAuthCallbackFlow(ABC):
                     #
                     # A host that returns a value WITHOUT waiting for the user
                     # (a test double, not a real prompt -- the TUI awaits a
-                    # mounted block's future and the CLI blocks on input) will
-                    # re-offer in a tight loop until another waiter wins or the
-                    # flow's timeout fires. That is bounded and no longer
-                    # blocking, which is the property that matters here.
+                    # mounted block's future and the CLI awaits
+                    # `asyncio.to_thread(read_line)`) will re-offer in a tight
+                    # loop until another waiter wins or the flow's timeout
+                    # fires. Bounded in TIME, not in WORK: the loop also
+                    # reports each rejection, so such a host would see tens of
+                    # thousands of warnings inside one timeout window (~37k in
+                    # 1s when measured). Liveness is what the yield restores;
+                    # an immediate-return prompt is a host bug, and this note
+                    # exists so it reads as one rather than as merely wasteful.
                     await asyncio.sleep(0)
 
         async def _abort_watch() -> tuple[str, str]:

--- a/local_operator/providers/oauth/zai.py
+++ b/local_operator/providers/oauth/zai.py
@@ -180,12 +180,20 @@ async def _business_login(http: httpx.AsyncClient, oauth_access_token: str) -> s
     return token
 
 
-async def mint_zai_api_key(http: httpx.AsyncClient, oauth_access_token: str) -> str:
+async def mint_zai_api_key(
+    http: httpx.AsyncClient, oauth_access_token: str
+) -> tuple[str, str, str]:
     """Provision the durable ``id.secret`` key from a short-lived OAuth token.
 
     business-login → default org/project → find-or-create this app's key →
     read its secret. Exposed (not private) so a test can exercise the
     provisioning sequence without driving a browser flow.
+
+    Returns ``(key, organization_id, project_id)``. The two ids come back with
+    the key because they are the only identity this flow resolves on EVERY
+    sign-in: the token response's ``user`` block is optional per response, so a
+    caller relying on it gets an identity sometimes and none other times, and
+    `AuthStore` then writes a second row for an account it already holds.
     """
     biz_token = await _business_login(http, oauth_access_token)
     auth = {"Authorization": f"Bearer {biz_token}"}
@@ -242,7 +250,7 @@ async def mint_zai_api_key(http: httpx.AsyncClient, oauth_access_token: str) -> 
     secret_key = _trimmed(copied.get("secretKey")) if isinstance(copied, dict) else None
     if not secret_key:
         raise LoginError("Z.AI key provisioning returned no secretKey")
-    return f"{api_key}.{secret_key}"
+    return f"{api_key}.{secret_key}", organization_id, project_id
 
 
 class ZaiOAuthFlow(OAuthCallbackFlow):
@@ -307,7 +315,7 @@ class ZaiOAuthFlow(OAuthCallbackFlow):
             if not access_token:
                 raise LoginError("Z.AI token response is missing an access token")
 
-            minted = await mint_zai_api_key(http, access_token)
+            minted, organization_id, project_id = await mint_zai_api_key(http, access_token)
         finally:
             if owns_client:
                 await http.aclose()
@@ -328,14 +336,37 @@ class ZaiOAuthFlow(OAuthCallbackFlow):
             # refresh is ever attempted and the row persists across sessions.
             "expires": None,
             "authorized_at": int(time.time() * 1000),
+            # The dedupe identity, and the reason it is these fields rather than
+            # the email below: key provisioning resolves an org and a project on
+            # EVERY sign-in (it cannot mint a key without them), while the token
+            # response's `user` block is optional per response. Keying on an
+            # optional field means an identity that appears and disappears
+            # between logins, and `AuthStore` writing a second row for an
+            # account it already holds -- leaving a stale key in rotation.
+            #
+            # Deliberately NOT stored as `org_id`, even though that is what Z.AI
+            # calls it. `org_id` is a ROUTING signal on an OAuth row: an OAuth
+            # credential carrying one is treated by `OpenAICompatClient` as a
+            # ChatGPT subscription grant, which sends this request to ChatGPT's
+            # private Codex Responses endpoint with Codex headers. The two
+            # fields below carry the same identity with no wire meaning, and
+            # `_identity_key_for` reads `account_id` and `project_id` too.
+            "account_id": f"{organization_id}/{project_id}",
+            "project_id": project_id,
         }
         if isinstance(user, dict):
+            # Identity fields from the OPTIONAL `user` block are recorded for
+            # display (whose account is this), and must not overwrite the
+            # dedupe identity above: this block is absent from some responses,
+            # so an `account_id` sourced from it changes between sign-ins and
+            # `AuthStore` writes a second row for the same account. `user_id`
+            # is therefore a separate key rather than a replacement.
             email = _trimmed(user.get("email"))
             if email:
                 creds["email"] = email
-            account_id = user.get("id")
-            if isinstance(account_id, (str, int)) and str(account_id).strip():
-                creds["account_id"] = str(account_id).strip()
+            user_id = user.get("id")
+            if isinstance(user_id, (str, int)) and str(user_id).strip():
+                creds["user_id"] = str(user_id).strip()
         return creds
 
 

--- a/local_operator/providers/oauth/zai.py
+++ b/local_operator/providers/oauth/zai.py
@@ -1,0 +1,358 @@
+"""Z.AI / GLM OAuth — browser sign-in that provisions a durable API key.
+
+Ported from omp's ``registry/oauth/zai.ts``, which in turn mirrors ZCode's
+desktop "Individual Plan" sign-in. The shape is unusual enough to be worth
+stating up front, because it is not the authorization-code flow the other
+providers in this package run:
+
+1. An authorization-code request against ``chat.z.ai`` — **no PKCE**, because
+   the provider's own client sends none and the token endpoint rejects the
+   extra parameters.
+2. A **non-standard** JSON token exchange (no ``grant_type``, no
+   ``code_verifier``) that returns a SHORT-LIVED OAuth access token nested at
+   ``data.zai.access_token``.
+3. A business-API sequence that trades that token for a DURABLE ``id.secret``
+   API key: business-login → resolve the default org/project → find-or-create
+   this app's named key → read its secret.
+
+Step 3 is the reason this file exists rather than a paste-a-key login. The
+short-lived OAuth token is NOT accepted by the inference endpoint, so a flow
+that stopped at step 2 would authenticate and then fail every request. The
+minted key IS the credential the wire wants, so it is stored in ``access`` and
+returned verbatim as the bearer — no dialect change anywhere downstream.
+
+Session persistence: the minted key does not expire, which is expressed as
+``expires: None``. :meth:`AuthStore._needs_refresh` reads that as "static
+token; never expires" and so never attempts a refresh — correct here, because
+there is no refresh token to attempt one with. The row therefore survives
+restarts and is reused across sessions exactly like an API key, while still
+being an ``oauth`` credential for identity and usage-reporting purposes.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+import urllib.parse
+from typing import Any, Callable
+
+import httpx
+
+from local_operator.harness.types import AbortSignal
+from local_operator.providers.oauth.callback_server import (
+    CallbackFlowOptions,
+    LoginCallbacks,
+    LoginCancelledError,
+    LoginError,
+    OAuthCallbackFlow,
+)
+
+
+def _env(name: str, default: str) -> str:
+    """Env override for an endpoint, falling back to the shipped default.
+
+    Mirrors omp's overridable constants: the CN-facing deployment of the same
+    product answers on different hosts, and a user pointed at it must be able
+    to log in without a code change.
+    """
+    value = os.environ.get(name)
+    return value if value else default
+
+
+CLIENT_ID = _env("ZAI_OAUTH_CLIENT_ID", "client_P8X5CMWmlaRO9gyO-KSqtg")
+AUTHORIZE_URL = _env("ZAI_OAUTH_AUTHORIZE_URL", "https://chat.z.ai/api/oauth/authorize")
+TOKEN_URL = _env("ZAI_OAUTH_TOKEN_URL", "https://zcode.z.ai/api/v1/oauth/token")
+BIZ_BASE = _env("ZAI_BIZ_BASE", "https://api.z.ai")
+BUSINESS_LOGIN_URL = _env("ZAI_BUSINESS_LOGIN_URL", "https://api.z.ai/api/auth/z/login")
+
+#: The name this app's provisioned key carries in the Z.AI console. Distinct
+#: from ZCode's own ``zcode-api-key`` so signing in here never rotates or
+#: overwrites the key another tool depends on.
+KEY_NAME = "local-operator"
+
+#: Pinned by the provider's OAuth client registration: the redirect URI is on
+#: the allowlist for this exact port, so a fallback port would be refused.
+CALLBACK_PORT = 54548
+CALLBACK_PATH = "/callback"
+
+_TIMEOUT_S = 30.0
+
+
+def _is_success_code(code: Any) -> bool:
+    """Z.AI's two success spellings.
+
+    The OAuth token endpoint signals success with ``code: 0`` while the biz
+    endpoints use ``code: 200``. A body with no status field at all is also a
+    success — some endpoints return the payload bare.
+    """
+    if code is None:
+        return True
+    if isinstance(code, bool):
+        return False
+    if isinstance(code, (int, float)):
+        return int(code) in (0, 200)
+    if isinstance(code, str):
+        return code in ("0", "200")
+    return False
+
+
+def _unwrap(body: Any, operation: str) -> Any:
+    """Unwrap the ``{code, msg, data, success}`` envelope, raising on failure.
+
+    The envelope reports application-level failures with HTTP 200, so a caller
+    that only checked the status code would read an error body as a credential.
+    """
+    if isinstance(body, dict) and ("code" in body or "success" in body):
+        if body.get("success") is False or not _is_success_code(body.get("code")):
+            detail = body.get("msg") or f"code {body.get('code')}"
+            raise LoginError(f"Z.AI {operation} failed: {detail}")
+        return body.get("data") if "data" in body else body
+    return body
+
+
+def _trimmed(value: Any) -> str | None:
+    """A non-empty trimmed string, or ``None`` for anything else."""
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
+def _failed(operation: str, response: httpx.Response) -> LoginError:
+    """A transport failure, named by OPERATION and status.
+
+    Neither the body nor the URL is echoed. The bodies come from endpoints that
+    are handed bearer tokens and quote request context back, and the URLs embed
+    the account's organization id, project id and api-key id -- while a login
+    error is shown in the TUI and written to the log. The operation name says
+    which step failed, which is what a reader needs in order to act, without
+    putting account identifiers in front of them.
+    """
+    return LoginError(
+        f"Z.AI {operation} failed ({response.status_code} {response.reason_phrase})".rstrip()
+    )
+
+
+async def _get_json(
+    http: httpx.AsyncClient, url: str, headers: dict[str, str], operation: str
+) -> Any:
+    response = await http.get(url, headers=headers)
+    if response.status_code != 200:
+        raise _failed(operation, response)
+    return response.json() if response.content else None
+
+
+async def _post_json(
+    http: httpx.AsyncClient,
+    url: str,
+    body: dict[str, Any],
+    operation: str,
+    headers: dict[str, str] | None = None,
+) -> Any:
+    response = await http.post(url, json=body, headers=headers or {})
+    if response.status_code != 200:
+        raise _failed(operation, response)
+    return response.json() if response.content else None
+
+
+def _key_array(value: Any) -> list[dict[str, Any]]:
+    """Coerce an api-keys listing to a list across the shapes Z.AI returns."""
+    if isinstance(value, list):
+        return [entry for entry in value if isinstance(entry, dict)]
+    if isinstance(value, dict):
+        for field in ("list", "keys", "apiKeys", "records"):
+            nested = value.get(field)
+            if isinstance(nested, list):
+                return [entry for entry in nested if isinstance(entry, dict)]
+    return []
+
+
+async def _business_login(http: httpx.AsyncClient, oauth_access_token: str) -> str:
+    """Trade the short-lived OAuth token for the biz token the APIs require."""
+    data = _unwrap(
+        await _post_json(http, BUSINESS_LOGIN_URL, {"token": oauth_access_token}, "business login"),
+        "business login",
+    )
+    token = None
+    if isinstance(data, dict):
+        token = _trimmed(data.get("access_token")) or _trimmed(data.get("accessToken"))
+    if not token:
+        raise LoginError("Z.AI business login returned no access token")
+    return token
+
+
+async def mint_zai_api_key(http: httpx.AsyncClient, oauth_access_token: str) -> str:
+    """Provision the durable ``id.secret`` key from a short-lived OAuth token.
+
+    business-login → default org/project → find-or-create this app's key →
+    read its secret. Exposed (not private) so a test can exercise the
+    provisioning sequence without driving a browser flow.
+    """
+    biz_token = await _business_login(http, oauth_access_token)
+    auth = {"Authorization": f"Bearer {biz_token}"}
+
+    customer = _unwrap(
+        await _get_json(
+            http, f"{BIZ_BASE}/api/biz/customer/getCustomerInfo", auth, "customer lookup"
+        ),
+        "customer lookup",
+    )
+    orgs = customer.get("organizations") if isinstance(customer, dict) else None
+    orgs = [o for o in orgs if isinstance(o, dict)] if isinstance(orgs, list) else []
+    org = next((o for o in orgs if o.get("isDefault")), orgs[0] if orgs else None)
+    projects = org.get("projects") if isinstance(org, dict) else None
+    projects = [p for p in projects if isinstance(p, dict)] if isinstance(projects, list) else []
+    project = next((p for p in projects if p.get("isDefault")), projects[0] if projects else None)
+
+    organization_id = _trimmed(org.get("organizationId")) if org else None
+    project_id = _trimmed(project.get("projectId")) if project else None
+    if not organization_id or not project_id:
+        raise LoginError("Z.AI key provisioning failed: no organization/project on this account")
+
+    keys_url = (
+        f"{BIZ_BASE}/api/biz/v1/organization/{organization_id}/projects/{project_id}/api_keys"
+    )
+    existing = next(
+        (
+            k
+            for k in _key_array(
+                _unwrap(await _get_json(http, keys_url, auth, "api key list"), "api key list")
+            )
+            if k.get("name") == KEY_NAME
+        ),
+        None,
+    )
+    record = existing or _unwrap(
+        await _post_json(http, keys_url, {"name": KEY_NAME}, "api key create", auth),
+        "api key create",
+    )
+    api_key = _trimmed(record.get("apiKey")) if isinstance(record, dict) else None
+    if not api_key:
+        raise LoginError("Z.AI key provisioning returned no apiKey")
+
+    # ALWAYS read the secret from the copy endpoint. List entries mask it
+    # (`*****abcd`) and the create response's inline secret is not reliable
+    # across account states, so anything else can persist a key that cannot
+    # authenticate — and it would fail at the first request, not at login.
+    copied = _unwrap(
+        await _get_json(
+            http, f"{keys_url}/copy/{urllib.parse.quote(api_key)}", auth, "api key copy"
+        ),
+        "api key copy",
+    )
+    secret_key = _trimmed(copied.get("secretKey")) if isinstance(copied, dict) else None
+    if not secret_key:
+        raise LoginError("Z.AI key provisioning returned no secretKey")
+    return f"{api_key}.{secret_key}"
+
+
+class ZaiOAuthFlow(OAuthCallbackFlow):
+    """Authorization-code sign-in against chat.z.ai (no PKCE), then key minting."""
+
+    def __init__(
+        self,
+        callbacks: LoginCallbacks | None = None,
+        *,
+        open_browser: Callable[[str], None] | None = None,
+        signal: AbortSignal | None = None,
+        manual_input_only: bool = False,
+        http_client: httpx.AsyncClient | None = None,
+    ) -> None:
+        super().__init__(
+            CallbackFlowOptions(
+                preferred_port=CALLBACK_PORT,
+                callback_path=CALLBACK_PATH,
+                # The redirect URI is registered against this exact port, so a
+                # fallback port would produce a redirect the IdP refuses.
+                allow_port_fallback=False,
+                manual_input_only=manual_input_only,
+            ),
+            callbacks,
+            open_browser=open_browser,
+            signal=signal,
+        )
+        self._http = http_client
+
+    async def generate_auth_url(self, state: str, redirect_uri: str) -> str:
+        params = {
+            "redirect_uri": redirect_uri,
+            "response_type": "code",
+            "client_id": CLIENT_ID,
+            "state": state,
+        }
+        return f"{AUTHORIZE_URL}?{urllib.parse.urlencode(params)}"
+
+    async def exchange_token(self, code: str, state: str, redirect_uri: str) -> dict[str, Any]:
+        # Checked BEFORE the exchange, as the reference implementation does.
+        # This flow has a side effect no other login here has: it CREATES a
+        # named API key in the user's Z.AI console. Minting one for a login the
+        # user has already cancelled leaves a credential they never agreed to
+        # and did not see created.
+        if self._signal is not None and self._signal.aborted:
+            raise LoginCancelledError(self._signal.reason or "Z.AI login cancelled")
+
+        owns_client = self._http is None
+        http = self._http or httpx.AsyncClient(timeout=_TIMEOUT_S)
+        try:
+            body = await _post_json(
+                http,
+                TOKEN_URL,
+                # Deliberately NOT an RFC 6749 body: the provider's own client
+                # posts these fields and the endpoint rejects grant_type.
+                {"provider": "zai", "code": code, "redirect_uri": redirect_uri, "state": state},
+                "token exchange",
+            )
+            data = _unwrap(body, "token exchange")
+            zai = data.get("zai") if isinstance(data, dict) else None
+            access_token = _trimmed(zai.get("access_token")) if isinstance(zai, dict) else None
+            if not access_token:
+                raise LoginError("Z.AI token response is missing an access token")
+
+            minted = await mint_zai_api_key(http, access_token)
+        finally:
+            if owns_client:
+                await http.aclose()
+
+        user = data.get("user") if isinstance(data, dict) else None
+        creds: dict[str, Any] = {
+            # Declared, not inferred. `upsert_credential` otherwise guesses the
+            # type from "has both refresh and access", and this credential has
+            # no refresh token (the minted key never expires), so it would be
+            # stored as an `api_key` row with its secret under `access` -- where
+            # no tier of the cascade can read it.
+            "type": "oauth",
+            # The MINTED key, not the OAuth token: this is what the inference
+            # endpoint accepts, and `_oauth_api_key` hands it straight to the wire.
+            "access": minted,
+            # No refresh token exists and the minted key does not expire.
+            # `expires: None` is AuthStore's "static token" marker, so no
+            # refresh is ever attempted and the row persists across sessions.
+            "expires": None,
+            "authorized_at": int(time.time() * 1000),
+        }
+        if isinstance(user, dict):
+            email = _trimmed(user.get("email"))
+            if email:
+                creds["email"] = email
+            account_id = user.get("id")
+            if isinstance(account_id, (str, int)) and str(account_id).strip():
+                creds["account_id"] = str(account_id).strip()
+        return creds
+
+
+async def login_zai(
+    callbacks: LoginCallbacks,
+    *,
+    signal: AbortSignal | None = None,
+    http_client: httpx.AsyncClient | None = None,
+    open_browser: Callable[[str], None] | None = None,
+    manual_input_only: bool = False,
+) -> dict[str, Any]:
+    """Run the interactive Z.AI sign-in; returns the OAuthCredentials dict."""
+    flow = ZaiOAuthFlow(
+        callbacks,
+        open_browser=open_browser,
+        signal=signal,
+        manual_input_only=manual_input_only,
+        http_client=http_client,
+    )
+    return await flow.run()

--- a/local_operator/providers/registry.py
+++ b/local_operator/providers/registry.py
@@ -351,7 +351,11 @@ PROVIDER_REGISTRY: list[ProviderDefinition] = [
             "bigmodel",
             "z-ai",
         ),
-        name="Z.AI (GLM)",
+        # Names the CREDENTIAL, not the plan. Both Z.AI entries route to the
+        # same coding-plan base URL, so a name implying a plan difference sends
+        # a user to the wrong row for the wrong reason. `xai`/`xai-oauth` set
+        # the precedent this follows.
+        name="Z.AI (GLM API key)",
         env_keys="ZAI_API_KEY",
         # No instruction line: the prompt row below it already reads "Paste your
         # Z.AI API key", and Z.AI's dashboard calls it exactly that, so there is
@@ -372,7 +376,7 @@ PROVIDER_REGISTRY: list[ProviderDefinition] = [
             "bigmodel",
             "z-ai",
         ),
-        name="Z.AI (GLM Coding Plan · Sign in)",
+        name="Z.AI (GLM browser sign-in)",
         # Browser sign-in rather than a pasted key. The flow ends by minting a
         # durable `id.secret` API key, which is what `access` holds and what the
         # wire receives -- so this shares `zai`'s credential row, base URL and

--- a/local_operator/providers/registry.py
+++ b/local_operator/providers/registry.py
@@ -383,8 +383,11 @@ PROVIDER_REGISTRY: list[ProviderDefinition] = [
         # Pinned by the provider's OAuth client registration; port fallback is
         # refused, which `ZaiOAuthFlow` states again as `allow_port_fallback`.
         callback_port=54548,
-        # Paste-the-redirect-URL fallback for when the browser cannot reach this
-        # machine (a remote or headless session), as for anthropic.
+        # Paste fallback for when the browser cannot reach this machine (a
+        # remote or headless session), as for anthropic. The prompt accepts the
+        # whole redirect URL from the address bar, which is what a user has in
+        # front of them in that situation, as well as a bare authorization
+        # code; `_parse_pasted_callback` owns the shapes.
         paste_code_flow=True,
         base_url="https://api.z.ai/api/coding/paas/v4",
         # No refresh_token: the minted key never expires, so there is nothing to

--- a/local_operator/providers/registry.py
+++ b/local_operator/providers/registry.py
@@ -365,6 +365,32 @@ PROVIDER_REGISTRY: list[ProviderDefinition] = [
         base_url="https://api.z.ai/api/coding/paas/v4",
     ),
     ProviderDefinition(
+        id="zai-oauth",
+        search_aliases=(
+            "glm",
+            "zhipu",
+            "bigmodel",
+            "z-ai",
+        ),
+        name="Z.AI (GLM Coding Plan · Sign in)",
+        # Browser sign-in rather than a pasted key. The flow ends by minting a
+        # durable `id.secret` API key, which is what `access` holds and what the
+        # wire receives -- so this shares `zai`'s credential row, base URL and
+        # models, exactly as `xai-oauth` shares `xai`'s.
+        login=_lazy_login("local_operator.providers.oauth.zai", "login_zai"),
+        get_api_key=_oauth_api_key,
+        store_credentials_as="zai",
+        # Pinned by the provider's OAuth client registration; port fallback is
+        # refused, which `ZaiOAuthFlow` states again as `allow_port_fallback`.
+        callback_port=54548,
+        # Paste-the-redirect-URL fallback for when the browser cannot reach this
+        # machine (a remote or headless session), as for anthropic.
+        paste_code_flow=True,
+        base_url="https://api.z.ai/api/coding/paas/v4",
+        # No refresh_token: the minted key never expires, so there is nothing to
+        # refresh. `expires: None` stops AuthStore from ever trying.
+    ),
+    ProviderDefinition(
         id="google",
         search_aliases=(
             "gemini",

--- a/local_operator/providers/usage.py
+++ b/local_operator/providers/usage.py
@@ -187,10 +187,14 @@ _FETCHERS: dict[str, tuple[FetcherKind | None, FetcherKind | None]] = {
     "xai-oauth": ("xai-oauth", None),
     "alibaba-token-plan": ("qwencloud-token-plan", None),
     "alibaba-token-plan-oauth": ("qwencloud-token-plan", None),
-    # The coding-plan key is the only credential Z.AI issues for this route, and
-    # the same raw key authenticates both inference and the quota endpoint, so
-    # the api-key slot serves it and there is no OAuth half to route.
-    "zai": (None, "zai-quota"),
+    # Both slots run the SAME fetcher, because both credential kinds are the
+    # same secret: the `zai-oauth` browser sign-in ends by minting an ordinary
+    # durable `id.secret` coding-plan key and stores it in `access`, which is
+    # exactly what the quota endpoint authenticates with. Leaving the OAuth slot
+    # empty made `/provider` advertise Z.AI usage and then report nothing at all
+    # for anyone who signed in rather than pasting a key.
+    "zai": ("zai-quota", "zai-quota"),
+    "zai-oauth": ("zai-quota", "zai-quota"),
 }
 
 #: Providers with a live quota endpoint, for callers that only need the question

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -3576,22 +3576,32 @@ class OperatorApp(App[None]):
         """
         block = self._key_prompt
         self._key_prompt = None
+
+        # Released unless a correction could still be owed, which is true only
+        # while the flow has not yet ruled on a value that was handed over.
+        # Deliberately OUTSIDE the `block is not None` check below: on the
+        # ordinary success path `_request_login_key`'s `finally` has already
+        # cleared `_key_prompt`, so a check nested in there would never run and
+        # the reference would survive every teardown.
+        #
+        # The retained block still holds the pasted secret. `resolve` drops
+        # `_typed` and keeps only `_submitted_length`, but it also resolves the
+        # future, and a future retains its result for as long as the block holds
+        # it -- so this reference is a credential lifetime, not just memory, and
+        # bounding it is the whole point of the retention fix.
+        #
+        # The window it still has to protect is narrow and real: between a paste
+        # being handed over (the block settles, its receipt provisionally reads
+        # "code received") and the flow resuming to parse it, an interrupt can
+        # reach this method. Releasing the reference there left the rejection
+        # nothing to correct and stranded a false success receipt -- design
+        # round 1's D1(b). `_key_prompt` is still set in exactly that window,
+        # which is what distinguishes it from the completed login.
+        pending = self._last_login_prompt
+        if pending is not None and not (block is pending and pending.submitted_length is not None):
+            self._last_login_prompt = None
+
         if block is not None:
-            # Dropped only when this call actually CANCELS a live prompt, so the
-            # reference does not outlive the paths that clear the transcript.
-            #
-            # Keyed on "was it still awaiting an answer?" rather than on the
-            # reference being set, because of the window between a paste being
-            # handed over and the flow resuming to parse it: in there the block
-            # is already settled (its receipt provisionally reads "code
-            # received") while this method can still be reached by an interrupt.
-            # Clearing unconditionally meant the rejection that followed found
-            # nothing to correct and the false success receipt stayed on screen
-            # -- the defect design round 1 filed as D1(b). An already-settled
-            # block may still be owed its correction; a live one never is,
-            # because no value was ever handed over.
-            if not block.answered:
-                self._last_login_prompt = None
             try:
                 block.resolve(None)
             except Exception:  # pragma: no cover - teardown races only

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -883,6 +883,11 @@ class OperatorApp(App[None]):
         #: needed only by a login, and every interactive session imports this
         #: module).
         self._key_prompt: Any = None
+        #: The most recent login paste prompt, retained after it settles so a
+        #: rejected paste can have its receipt corrected (see
+        #: ``_request_login_key``). Distinct from ``_key_prompt``, which is
+        #: cleared the moment the prompt is answered.
+        self._last_login_prompt: Any = None
         self._approve_all: bool = False
         # What a NEW session opens in, read from config at mount and rewritten
         # by `/approvals default <mode>`. Held beside `_approve_all` rather than
@@ -6372,12 +6377,32 @@ class OperatorApp(App[None]):
         def on_progress(message: str) -> None:
             self._append_block(NoticeBlock(message, "info"))
 
+        def on_warning(message: str) -> None:
+            # Something went wrong but the login is still running (see
+            # ``LoginCallbacks.on_warning``). Styled as a warning rather than
+            # progress because it is the line that explains why nothing
+            # happened, and in the `info` treatment it read as narration
+            # alongside "opening your browser…".
+            self._append_block(NoticeBlock(message, "warning"))
+
+        def on_input_rejected() -> None:
+            # The prompt settles into a receipt as soon as the value is handed
+            # over, so by the time the flow decides it cannot use the paste the
+            # transcript is already claiming "✓ … code received". Correct that
+            # block in place rather than appending another line: the false
+            # receipt is what the user is looking at.
+            block = self._last_login_prompt
+            if block is not None:
+                block.mark_unusable()
+
         # ``getattr`` rather than attribute access: ``definition`` is typed
         # ``object`` here because an embedding host may pass its own provider
         # record, and a host whose definitions predate this field must degrade
         # to "no prompt" rather than raising out of a login.
         if not getattr(definition, "accepts_paste_prompt", False):
-            return LoginCallbacks(on_auth_url=on_auth_url, on_progress=on_progress)
+            return LoginCallbacks(
+                on_auth_url=on_auth_url, on_progress=on_progress, on_warning=on_warning
+            )
 
         label = getattr(definition, "name", None) or getattr(definition, "id", "this provider")
         # WHICH value the prompt is reading, which decides both its wording and
@@ -6398,7 +6423,9 @@ class OperatorApp(App[None]):
 
         return LoginCallbacks(
             on_auth_url=on_auth_url,
+            on_warning=on_warning,
             on_progress=on_progress,
+            on_input_rejected=on_input_rejected,
             on_manual_code_input=on_manual_code_input,
         )
 
@@ -6427,6 +6454,13 @@ class OperatorApp(App[None]):
         self._close_aside()
         block = KeyPromptBlock(provider_label, secret=secret, sole_path=sole_path)
         self._key_prompt = block
+        # Kept BEYOND the `finally` that clears `_key_prompt`, because the flow
+        # only learns a paste was unusable after this method has returned the
+        # value and the block has settled. `_key_prompt` means "a prompt is
+        # awaiting an answer" and must stay None once answered; this means "the
+        # last prompt shown", which is the one whose receipt may need
+        # correcting (see ``on_input_rejected``).
+        self._last_login_prompt = block
         self._append_block(block)
         try:
             # SHIELDED, because the future is the app's to settle, not the

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -2760,11 +2760,22 @@ class OperatorApp(App[None]):
         """
         block = self._key_prompt
         self._key_prompt = None
-        # Dropped here too: this is the "the login is over" path, so there is no
-        # longer a receipt anyone can be asked to correct, and keeping the
-        # reference would outlive every path that clears the transcript.
-        self._last_login_prompt = None
         if block is not None:
+            # Dropped only when this call actually CANCELS a live prompt, so the
+            # reference does not outlive the paths that clear the transcript.
+            #
+            # Keyed on "was it still awaiting an answer?" rather than on the
+            # reference being set, because of the window between a paste being
+            # handed over and the flow resuming to parse it: in there the block
+            # is already settled (its receipt provisionally reads "code
+            # received") while this method can still be reached by an interrupt.
+            # Clearing unconditionally meant the rejection that followed found
+            # nothing to correct and the false success receipt stayed on screen
+            # -- the defect design round 1 filed as D1(b). An already-settled
+            # block may still be owed its correction; a live one never is,
+            # because no value was ever handed over.
+            if not block.answered:
+                self._last_login_prompt = None
             try:
                 block.resolve(None)
             except Exception:  # pragma: no cover - teardown races only

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -2760,6 +2760,10 @@ class OperatorApp(App[None]):
         """
         block = self._key_prompt
         self._key_prompt = None
+        # Dropped here too: this is the "the login is over" path, so there is no
+        # longer a receipt anyone can be asked to correct, and keeping the
+        # reference would outlive every path that clears the transcript.
+        self._last_login_prompt = None
         if block is not None:
             try:
                 block.resolve(None)

--- a/local_operator/tui/widgets/key_prompt.py
+++ b/local_operator/tui/widgets/key_prompt.py
@@ -197,6 +197,10 @@ class KeyPromptBlock(TranscriptBlock):
         #: Set when the prompt was retired because the login completed another
         #: way (see :meth:`resolve`), so the receipt does not claim a cancel.
         self._superseded = False
+        #: Set when the value this prompt handed over turned out to be unusable
+        #: (see :meth:`mark_unusable`), so the receipt does not claim a success
+        #: the flow rejected.
+        self._unusable = False
         # `get_running_loop`, not `get_event_loop`: the future must belong to the
         # loop that awaits it, and stating that precondition turns a construction
         # from a sync context into an immediate error rather than a future nobody
@@ -252,6 +256,32 @@ class KeyPromptBlock(TranscriptBlock):
         self.finalize()
         if self._on_settled is not None:
             self._on_settled()
+
+    def mark_unusable(self) -> None:
+        """Repaint a settled receipt to say the pasted value was NOT accepted.
+
+        Called after the fact, because only the login flow can tell: the block
+        hands over whatever was typed, and whether it parses into an
+        authorization code is decided one layer out in
+        ``_parse_pasted_callback``. Same after-the-fact correction as
+        ``superseded``, for the same reason — the block cannot know the outcome
+        from the value alone.
+
+        Without this, a rejected paste settled as ``✓ … code received (107
+        chars)``: a success glyph and the word "received" over a value the flow
+        had just thrown away, directly above the notice explaining why. The
+        count made it worse by looking like corroboration. The login is still
+        live when this fires (the flow re-prompts and the loopback callback is
+        still racing), so this is not a cancel and must not use the cancel
+        wording.
+
+        No-op on a prompt that is not settled or was cancelled: there is no
+        success claim to correct in either case.
+        """
+        if not self._settled or self._submitted is None:
+            return
+        self._unusable = True
+        self._refresh_row()
 
     # -- keys ---------------------------------------------------------------
     def action_submit(self) -> None:
@@ -485,6 +515,17 @@ class KeyPromptBlock(TranscriptBlock):
                         (f"{self.provider_label} — still waiting for the browser", dim),
                     )
                 return row(("✗ ", danger), (f"{self.provider_label} login cancelled", muted))
+            if self._unusable:
+                # A value was handed over and the flow could not use it (see
+                # ``mark_unusable``). Distinguishing word FIRST, as the two
+                # informational receipts above do and for the same truncation
+                # reason. The length is dropped: it read as evidence the paste
+                # was fine, which is the opposite of what happened.
+                return row(
+                    ("✗ ", danger),
+                    ("paste not usable ", muted),
+                    (f"{self.provider_label} — still waiting for the browser", dim),
+                )
             return row(
                 ("✓ ", success),
                 (f"{self.provider_label} {'key' if self.secret else 'code'} received ", muted),

--- a/local_operator/tui/widgets/key_prompt.py
+++ b/local_operator/tui/widgets/key_prompt.py
@@ -227,6 +227,17 @@ class KeyPromptBlock(TranscriptBlock):
         return self._settled
 
     @property
+    def submitted_length(self) -> int | None:
+        """How many characters were handed over, or None when nothing was.
+
+        The question "could this prompt still be owed a correction?" — only a
+        block that produced a value can be, since :meth:`mark_unusable` is a
+        no-op otherwise. Exposed so the app can ask it without reaching into
+        the private field, and never exposes the value itself.
+        """
+        return self._submitted_length
+
+    @property
     def typed_length(self) -> int:
         """How many characters are held. The value itself is never exposed:
         tests and the renderer both need the length and neither needs the key."""

--- a/local_operator/tui/widgets/key_prompt.py
+++ b/local_operator/tui/widgets/key_prompt.py
@@ -193,7 +193,14 @@ class KeyPromptBlock(TranscriptBlock):
         self.instructions = strip_control_sequences(instructions or "")
         self._typed: list[str] = []
         self._settled = False
-        self._submitted: str | None = None
+        #: The LENGTH of the value handed over, or None when nothing was (a
+        #: cancel). Deliberately not the value: the receipt only ever needs how
+        #: many characters arrived, and a settled block outlives the login — it
+        #: sits in the transcript, and the app also retains the last one to
+        #: correct its receipt — so holding the key here would keep a
+        #: credential resident for the rest of the session. Same reason
+        #: ``_typed`` is dropped in :meth:`resolve`.
+        self._submitted_length: int | None = None
         #: Set when the prompt was retired because the login completed another
         #: way (see :meth:`resolve`), so the receipt does not claim a cancel.
         self._superseded = False
@@ -244,7 +251,7 @@ class KeyPromptBlock(TranscriptBlock):
             return
         self._settled = True
         self._superseded = superseded
-        self._submitted = value
+        self._submitted_length = None if value is None else len(value)
         # The buffer is dropped as soon as the value has been handed over, so a
         # settled block sitting in the transcript is not still holding the
         # user's key in memory for the rest of the session.
@@ -278,7 +285,7 @@ class KeyPromptBlock(TranscriptBlock):
         No-op on a prompt that is not settled or was cancelled: there is no
         success claim to correct in either case.
         """
-        if not self._settled or self._submitted is None:
+        if not self._settled or self._submitted_length is None:
             return
         self._unusable = True
         self._refresh_row()
@@ -503,7 +510,7 @@ class KeyPromptBlock(TranscriptBlock):
                 # Says only what this BLOCK knows: it stopped being needed. The
                 # login's own outcome notice, success or failure, follows it.
                 return row(("· ", dim), ("no longer needed ", muted), (self.provider_label, dim))
-            if self._submitted is None:
+            if self._submitted_length is None:
                 if not self.sole_path:
                     # Declining here does not end the login (see ``sole_path``):
                     # the browser flow is still live, so the receipt says what
@@ -529,7 +536,7 @@ class KeyPromptBlock(TranscriptBlock):
             return row(
                 ("✓ ", success),
                 (f"{self.provider_label} {'key' if self.secret else 'code'} received ", muted),
-                (f"({len(self._submitted)} chars)", dim),
+                (f"({self._submitted_length} chars)", dim),
             )
 
         noun = "API key" if self.secret else "authorization code"

--- a/tests/unit/providers/test_auth_store.py
+++ b/tests/unit/providers/test_auth_store.py
@@ -488,3 +488,48 @@ class TestListOauthAccesses:
         accesses = await store.list_oauth_accesses("anthropic")
         assert [a.email for a in accesses] == ["b@example.com"]
         assert store.is_blocked(row.id, "anthropic") is False
+
+
+class TestARefreshlessOAuthCredentialIsReadable:
+    """R21: a credential that is OAuth-issued but never expires.
+
+    `upsert_credential` guessed the type from "has both refresh and access",
+    which cannot see a credential with no refresh token because it does not
+    expire -- Z.AI's coding-plan sign-in mints exactly that. Such a row landed
+    as `api_key` with its secret under `data["access"]`, where NOTHING can read
+    it: tiers 4 and 6 read `data["key"]`, tier 3 only walks `oauth` rows. The
+    login reported success and every later request failed with no credential,
+    behind this PR's new "temporarily unavailable" message.
+    """
+
+    async def test_an_explicit_type_survives_the_structural_guess(self, tmp_path: Any) -> None:
+        from local_operator.providers.auth_store import AuthStore
+
+        store = AuthStore(db_path=tmp_path / "auth.db")
+        row = store.upsert_credential(
+            "zai",
+            {
+                "type": "oauth",
+                "access": "key-id.sec-ret",
+                "expires": None,  # minted key: never expires, so no refresh exists
+                "email": "damian@example.com",
+                "account_id": "42",
+            },
+        )
+
+        assert row.credential_type == "oauth"
+        assert await store.get_api_key("zai") == "key-id.sec-ret"
+        access = await store.get_oauth_access("zai")
+        assert access is not None and access.kind == "oauth"
+        assert access.email == "damian@example.com"
+
+    async def test_an_undeclared_credential_still_gets_the_old_guess(self, tmp_path: Any) -> None:
+        """The structural fallback is unchanged for every existing caller."""
+        from local_operator.providers.auth_store import AuthStore
+
+        store = AuthStore(db_path=tmp_path / "auth.db")
+        oauth = store.upsert_credential("openai", {"access": "a", "refresh": "r", "expires": 1})
+        pasted = store.upsert_credential("openai", {"key": "sk-1", "source": "login"})
+
+        assert oauth.credential_type == "oauth"
+        assert pasted.credential_type == "api_key"

--- a/tests/unit/providers/test_auth_store.py
+++ b/tests/unit/providers/test_auth_store.py
@@ -533,3 +533,43 @@ class TestARefreshlessOAuthCredentialIsReadable:
 
         assert oauth.credential_type == "oauth"
         assert pasted.credential_type == "api_key"
+
+    async def test_signing_in_repeatedly_keeps_one_row(self, tmp_path: Any) -> None:
+        """Z1: a refreshless OAuth credential must dedupe like every other one.
+
+        `_identity_key_for`'s per-provider constant asked "is this OAuth?" by
+        testing for a refresh token -- the same blind spot the type derivation
+        had. A credential whose token never expires carries none, so it fell
+        through to `None` and each re-login left another row. Five sign-ins
+        meant five rows, and `/usage` rendered one account five times.
+
+        Z.AI's token response makes the `user` block optional, so the identity
+        fields cannot be relied on to cover this.
+        """
+        from local_operator.providers.auth_store import AuthStore
+
+        store = AuthStore(db_path=tmp_path / "auth.db")
+        # No email/account_id: the shape Z.AI returns without a `user` block.
+        payload = {"type": "oauth", "access": "key-id.sec-ret", "expires": None}
+        for attempt in range(5):
+            store.upsert_credential("zai", dict(payload, authorized_at=attempt))
+
+        rows = store.list_credentials("zai")
+        assert len(rows) == 1, [r.id for r in rows]
+        assert await store.get_api_key("zai") == "key-id.sec-ret"
+
+    async def test_a_pasted_key_still_gets_its_own_row(self, tmp_path: Any) -> None:
+        """The control: deduping OAuth must not start deduping API keys.
+
+        Each pasted key is a distinct credential and has always earned its own
+        row -- that is what the `source == "login"` guard at the top of
+        `_identity_key_for` is for. Without this, the fix above would read as
+        correct while silently collapsing a user's key pool to one row.
+        """
+        from local_operator.providers.auth_store import AuthStore
+
+        store = AuthStore(db_path=tmp_path / "auth.db")
+        store.upsert_credential("zai", {"key": "sk-1", "source": "login", "type": "api_key"})
+        store.upsert_credential("zai", {"key": "sk-2", "source": "login", "type": "api_key"})
+
+        assert len(store.list_credentials("zai")) == 2

--- a/tests/unit/providers/test_oauth_flows.py
+++ b/tests/unit/providers/test_oauth_flows.py
@@ -892,14 +892,19 @@ async def test_the_loopback_completes_a_login_with_no_manual_input() -> None:
     assert credentials["email"] == "you@example.com"
 
 
-def test_only_anthropic_races_a_pasted_code_against_its_callback() -> None:
+def test_only_browser_signin_flows_race_a_pasted_code_against_their_callback() -> None:
     """`paste_code_flow` is a FALLBACK marker, and ONLY that.
 
-    It matches the reference implementation exactly: Anthropic is the one
-    loopback provider that also accepts a pasted code (for a browser on another
-    machine), raced against the callback rather than awaited. Attaching such a
-    prompt to any other loopback provider blocks the terminal on a line nobody
-    will type.
+    It marks a loopback provider that ALSO accepts a pasted code (for a browser
+    on another machine), raced against the callback rather than awaited.
+    Attaching such a prompt to any other loopback provider blocks the terminal
+    on a line nobody will type.
+
+    Two providers qualify, and both are browser sign-ins whose redirect lands on
+    a loopback port: Anthropic, and Z.AI's GLM Coding Plan sign-in (which mirrors
+    the Anthropic wiring). A provider whose login is "paste your API key" is NOT
+    one of these -- that is ``paste_prompt_required``, asserted in the companion
+    test.
 
     This test used to assert something wider and false in its name and
     docstring — that no provider REQUIRES a paste — while asserting only the
@@ -911,7 +916,7 @@ def test_only_anthropic_races_a_pasted_code_against_its_callback() -> None:
     from local_operator.providers.registry import PROVIDER_REGISTRY
 
     paste = {p.id for p in PROVIDER_REGISTRY if p.login is not None and p.paste_code_flow}
-    assert paste == {"anthropic"}, paste
+    assert paste == {"anthropic", "zai-oauth"}, paste
 
 
 def test_paste_key_providers_declare_that_they_require_a_prompt() -> None:
@@ -937,11 +942,11 @@ def test_paste_key_providers_declare_that_they_require_a_prompt() -> None:
         "zai",
     }, required
 
-    # And the union a host actually gates on: required plus Anthropic's optional
-    # fallback, and nothing else. A loopback-only provider appearing here would
-    # mean a prompt racing its HTTP callback.
+    # And the union a host actually gates on: required plus the browser
+    # sign-ins' optional fallback, and nothing else. A loopback-only provider
+    # appearing here would mean a prompt racing its HTTP callback.
     accepts = {p.id for p in PROVIDER_REGISTRY if p.login is not None and p.accepts_paste_prompt}
-    assert accepts == required | {"anthropic"}, accepts
+    assert accepts == required | {"anthropic", "zai-oauth"}, accepts
 
 
 @pytest.mark.asyncio
@@ -1050,3 +1055,175 @@ async def test_qwencloud_token_plan_login_expired_device_code_is_terminal() -> N
         await login_qwencloud_token_plan(
             callbacks, http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler))
         )
+
+
+class TestZaiSignInMintsADurableKey:
+    """Z.AI's sign-in is only useful if it ends with the key the WIRE accepts.
+
+    The short-lived OAuth token from the token exchange is rejected by the
+    inference endpoint, so a flow that stored it would log in successfully and
+    then fail every request. These tests pin the whole sequence:
+    token exchange -> business login -> org/project -> find-or-create key ->
+    read the secret from the copy endpoint.
+    """
+
+    @staticmethod
+    def _transport(calls: list[str], *, existing_key: bool) -> httpx.MockTransport:
+        def handler(request: httpx.Request) -> httpx.Response:
+            path = request.url.path
+            calls.append(f"{request.method} {path}")
+            if path.endswith("/oauth/token"):
+                return httpx.Response(
+                    200,
+                    json={
+                        "code": 0,
+                        "data": {
+                            "zai": {"access_token": "short-lived-oauth"},
+                            "user": {"email": "damian@example.com", "id": 4242},
+                        },
+                    },
+                )
+            if path.endswith("/api/auth/z/login"):
+                assert json.loads(request.content)["token"] == "short-lived-oauth"
+                return httpx.Response(200, json={"code": 200, "data": {"access_token": "biz-tok"}})
+            if path.endswith("/getCustomerInfo"):
+                assert request.headers["Authorization"] == "Bearer biz-tok"
+                return httpx.Response(
+                    200,
+                    json={
+                        "code": 200,
+                        "data": {
+                            "organizations": [
+                                {"organizationId": "org-other", "projects": []},
+                                {
+                                    "organizationId": "org-1",
+                                    "isDefault": True,
+                                    "projects": [
+                                        {"projectId": "proj-other"},
+                                        {"projectId": "proj-1", "isDefault": True},
+                                    ],
+                                },
+                            ]
+                        },
+                    },
+                )
+            if path.endswith("/api_keys") and request.method == "GET":
+                listed = [{"name": "local-operator", "apiKey": "key-id"}] if existing_key else []
+                return httpx.Response(200, json={"code": 200, "data": {"list": listed}})
+            if path.endswith("/api_keys") and request.method == "POST":
+                assert json.loads(request.content)["name"] == "local-operator"
+                return httpx.Response(200, json={"code": 200, "data": {"apiKey": "key-id"}})
+            if "/api_keys/copy/" in path:
+                return httpx.Response(200, json={"code": 200, "data": {"secretKey": "sec-ret"}})
+            raise AssertionError(f"unexpected request: {request.method} {path}")
+
+        return httpx.MockTransport(handler)
+
+    async def test_exchange_mints_and_stores_the_durable_key(self) -> None:
+        from local_operator.providers.oauth.zai import ZaiOAuthFlow
+
+        calls: list[str] = []
+        flow = ZaiOAuthFlow(
+            http_client=httpx.AsyncClient(transport=self._transport(calls, existing_key=False))
+        )
+        creds = await flow.exchange_token(
+            "the-code", "the-state", "http://localhost:54548/callback"
+        )
+
+        # The MINTED `id.secret` key, never the short-lived OAuth token.
+        assert creds["access"] == "key-id.sec-ret"
+        assert creds["email"] == "damian@example.com"
+        assert creds["account_id"] == "4242"
+        # `expires: None` is AuthStore's "static token" marker: no refresh is
+        # ever attempted, so the row persists across sessions.
+        assert creds["expires"] is None
+        # The secret always comes from the copy endpoint -- list entries mask it.
+        assert any("/api_keys/copy/" in call for call in calls), calls
+
+    async def test_an_existing_key_is_reused_rather_than_duplicated(self) -> None:
+        """Signing in twice must not litter the console with one key per login."""
+        from local_operator.providers.oauth.zai import ZaiOAuthFlow
+
+        calls: list[str] = []
+        flow = ZaiOAuthFlow(
+            http_client=httpx.AsyncClient(transport=self._transport(calls, existing_key=True))
+        )
+        creds = await flow.exchange_token("c", "s", "http://localhost:54548/callback")
+
+        assert creds["access"] == "key-id.sec-ret"
+        assert "POST /api/biz/v1/organization/org-1/projects/proj-1/api_keys" not in calls, calls
+
+    async def test_an_envelope_error_is_raised_not_stored(self) -> None:
+        """Z.AI reports failures with HTTP 200 and a `code` field, so a caller
+        that trusted the status would persist an error body as a credential."""
+        from local_operator.providers.oauth.zai import ZaiOAuthFlow
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json={"code": 401, "msg": "authorization expired"})
+
+        flow = ZaiOAuthFlow(http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler)))
+        with pytest.raises(LoginError, match="authorization expired"):
+            await flow.exchange_token("c", "s", "http://localhost:54548/callback")
+
+    async def test_the_authorize_url_carries_no_pkce(self) -> None:
+        """The provider's own client sends none and the endpoint rejects the
+        extra parameters, so adding PKCE "for safety" breaks the login."""
+        from local_operator.providers.oauth.zai import CLIENT_ID, ZaiOAuthFlow
+
+        flow = ZaiOAuthFlow()
+        url = await flow.generate_auth_url("st-1", "http://localhost:54548/callback")
+        query = urllib.parse.parse_qs(urllib.parse.urlsplit(url).query)
+
+        assert query["client_id"] == [CLIENT_ID]
+        assert query["state"] == ["st-1"]
+        assert query["response_type"] == ["code"]
+        assert "code_challenge" not in query
+
+    async def test_the_stored_credential_is_readable_by_the_cascade(self, tmp_path: Any) -> None:
+        """R21: the join nothing tested -- sign in, then RESOLVE what was stored.
+
+        Two green tests used to sit either side of this gap: one asserted the
+        registry's `zai-oauth` fields, the other asserted the login flow's
+        return dict. Neither stored a real payload and asked the AuthStore for
+        it back, so a credential shape that no cascade tier could read shipped
+        as a working sign-in: the login reported success and every subsequent
+        request failed without one HTTP call being made.
+
+        This walks the real path end to end -- `ZaiOAuthFlow.exchange_token` ->
+        the exact `upsert_credential` call `ProviderController.login` makes ->
+        `get_api_key` / `get_oauth_access` -- because each of those three
+        components was individually correct while their composition was not.
+        """
+        from local_operator.providers.auth_store import AuthStore
+        from local_operator.providers.oauth.zai import ZaiOAuthFlow
+        from local_operator.providers.registry import get_provider_definition
+
+        calls: list[str] = []
+        flow = ZaiOAuthFlow(
+            http_client=httpx.AsyncClient(transport=self._transport(calls, existing_key=False))
+        )
+        creds = await flow.exchange_token("c", "s", "http://localhost:54548/callback")
+
+        # `store_credentials_as` is what makes the sign-in and the pasted key
+        # share one row, so the test must store under the alias the controller
+        # resolves rather than under the provider id it was invoked with.
+        definition = get_provider_definition("zai-oauth")
+        assert definition is not None
+        storage = definition.store_credentials_as or "zai-oauth"
+        assert storage == "zai"
+
+        store = AuthStore(db_path=tmp_path / "auth.db")
+        creds.setdefault("authorized_at", 1)
+        store.upsert_credential(storage, creds)
+
+        # The bearer the wire actually receives. `None` here is the R21 failure:
+        # a row present, typed `api_key`, secret under `access`, unreadable.
+        assert await store.get_api_key("zai") == "key-id.sec-ret"
+
+        access = await store.get_oauth_access("zai")
+        assert access is not None
+        assert access.access_token == "key-id.sec-ret"
+        # Typed `oauth` so tier 3 can see it, and so the row carries the signed-in
+        # identity that `_FETCHERS["zai-oauth"]` needs for quota reporting.
+        assert access.kind == "oauth"
+        assert access.email == "damian@example.com"

--- a/tests/unit/providers/test_oauth_flows.py
+++ b/tests/unit/providers/test_oauth_flows.py
@@ -1521,6 +1521,46 @@ class TestABadPasteDoesNotEndTheLogin:
 
         assert got == ("browser-code", "browser-state")
 
+    async def test_a_raising_host_sink_cannot_kill_the_login(self) -> None:
+        """Agent review round 4, Z8: a host whose reporting sink raises took the
+        sign-in down with it.
+
+        `on_warning` and `on_input_rejected` are REPORTING hooks -- they tell
+        the user what happened and take no part in deciding the login. Letting
+        one propagate out of `_manual` broke this class's premise from a third
+        direction: an embedder with a broken message sink would lose a grant
+        the browser callback was about to deliver. `on_manual_code_input` is
+        deliberately not covered by that guard, since its return value is acted
+        on.
+        """
+        from local_operator.providers.oauth import callback_server as cs
+
+        def _boom(*_args: Any) -> None:
+            raise RuntimeError("this host cannot render messages")
+
+        for hook in ("on_warning", "on_input_rejected", "on_progress"):
+            loop = asyncio.get_running_loop()
+            flow = self._flow("http://localhost:54548/cb?error=access_denied", [])
+            flow.callbacks = cs.LoginCallbacks(
+                on_manual_code_input=lambda: "http://localhost:54548/cb?error=access_denied",
+                **{hook: _boom},
+            )
+            flow._captured = loop.create_future()
+            flow._capture_error = loop.create_future()
+
+            async def browser() -> None:
+                await asyncio.sleep(0.05)
+                if not flow._captured.done():
+                    flow._captured.set_result(("browser-code", "browser-state"))
+
+            task = asyncio.create_task(browser())
+            try:
+                got = await asyncio.wait_for(flow._await_code(), timeout=5.0)
+            finally:
+                task.cancel()
+
+            assert got == ("browser-code", "browser-state"), hook
+
     async def test_re_prompting_does_not_starve_the_event_loop(self) -> None:
         """Design round 1 D1(a) re-prompts after a rejected paste, and the loop
         that does it must yield.

--- a/tests/unit/providers/test_oauth_flows.py
+++ b/tests/unit/providers/test_oauth_flows.py
@@ -1227,3 +1227,91 @@ class TestZaiSignInMintsADurableKey:
         # identity that `_FETCHERS["zai-oauth"]` needs for quota reporting.
         assert access.kind == "oauth"
         assert access.email == "damian@example.com"
+
+
+class TestPastedCallbackParsing:
+    """Z2: the "paste the redirect URL" fallback has to accept a redirect URL.
+
+    This prompt is the escape hatch for a browser that cannot reach this
+    machine's loopback port (a remote or headless session), and what a user
+    copies in that situation is the address bar. The handler only understood
+    `code#state` and a bare code, so a pasted URL was forwarded to the token
+    endpoint verbatim AS the authorization code: the advertised fallback could
+    not complete a login at all.
+    """
+
+    def test_a_pasted_redirect_url_yields_its_code_and_state(self) -> None:
+        from local_operator.providers.oauth.callback_server import (
+            _parse_pasted_callback,
+        )
+
+        assert _parse_pasted_callback("http://localhost:54548/callback?code=abc123&state=st-1") == (
+            "abc123",
+            "st-1",
+        )
+
+    def test_a_url_without_state_still_yields_the_code(self) -> None:
+        from local_operator.providers.oauth.callback_server import (
+            _parse_pasted_callback,
+        )
+
+        assert _parse_pasted_callback("http://localhost:54548/callback?code=abc123") == (
+            "abc123",
+            "",
+        )
+
+    def test_state_carried_in_the_fragment_is_found(self) -> None:
+        """Some providers keep `state` out of the query so it stays out of logs."""
+        from local_operator.providers.oauth.callback_server import (
+            _parse_pasted_callback,
+        )
+
+        assert _parse_pasted_callback("https://example.com/cb?code=c1#state=s9") == ("c1", "s9")
+
+    def test_percent_encoding_is_decoded(self) -> None:
+        from local_operator.providers.oauth.callback_server import (
+            _parse_pasted_callback,
+        )
+
+        code, _ = _parse_pasted_callback("http://localhost:54548/callback?code=sp%20ace&state=s")
+        assert code == "sp ace"
+
+    def test_the_anthropic_code_hash_state_shape_is_unchanged(self) -> None:
+        """The regression guard: Anthropic renders one `code#state` copy target,
+        and adding URL parsing must not disturb it."""
+        from local_operator.providers.oauth.callback_server import (
+            _parse_pasted_callback,
+        )
+
+        assert _parse_pasted_callback("the-code#the-state") == ("the-code", "the-state")
+
+    def test_a_bare_code_is_unchanged(self) -> None:
+        from local_operator.providers.oauth.callback_server import (
+            _parse_pasted_callback,
+        )
+
+        assert _parse_pasted_callback("bare-code-only") == ("bare-code-only", "")
+
+    def test_an_error_redirect_is_reported_rather_than_sent_as_a_code(self) -> None:
+        """A denied grant redirects with `error` and no `code`. Forwarding that
+        URL as the code produces an opaque provider-side rejection; the user is
+        still at the prompt and can be told what actually happened."""
+        from local_operator.providers.oauth.callback_server import (
+            LoginError,
+            _parse_pasted_callback,
+        )
+
+        with pytest.raises(LoginError, match="access_denied"):
+            _parse_pasted_callback(
+                "http://localhost:54548/callback?error=access_denied"
+                "&error_description=User+said+no"
+            )
+
+    def test_a_url_with_no_code_at_all_is_reported(self) -> None:
+        from local_operator.providers.oauth.callback_server import (
+            LoginError,
+            _parse_pasted_callback,
+        )
+
+        with pytest.raises(LoginError, match="no authorization code"):
+            _parse_pasted_callback("http://localhost:54548/callback")

--- a/tests/unit/providers/test_oauth_flows.py
+++ b/tests/unit/providers/test_oauth_flows.py
@@ -1520,3 +1520,47 @@ class TestABadPasteDoesNotEndTheLogin:
         got, _ = await self._race(None)
 
         assert got == ("browser-code", "browser-state")
+
+    async def test_re_prompting_does_not_starve_the_event_loop(self) -> None:
+        """Design round 1 D1(a) re-prompts after a rejected paste, and the loop
+        that does it must yield.
+
+        `on_manual_code_input` may be written SYNCHRONOUSLY -- the contract
+        allows it and the CLI host does it -- and `maybe_await` does not
+        suspend on a plain value. A `while True:` with no other await point
+        therefore never returns control to the scheduler, so the loopback
+        callback future cannot be resolved and the flow's own timeout cannot
+        fire: one bad paste hangs the login forever instead of merely failing
+        it. This is the whole class's premise ("the browser can still win")
+        stated as a liveness property, which is why a re-prompt test that only
+        counts prompts would not catch it.
+
+        Driven on its OWN loop in a worker thread, and joined from this one,
+        because the failure it pins is total loop starvation: an
+        ``asyncio.wait_for`` placed on the starved loop can never fire its own
+        timeout either, so an in-loop timeout turns this regression into a hung
+        suite rather than a failing test. The thread gives the assertion an
+        observer the starvation cannot reach.
+        """
+        import threading
+
+        result: list[Any] = []
+
+        def drive() -> None:
+            try:
+                result.append(
+                    asyncio.run(self._race("http://localhost:54548/cb?error=access_denied"))
+                )
+            except BaseException as exc:  # pragma: no cover - diagnostic only
+                result.append(exc)
+
+        worker = threading.Thread(target=drive, daemon=True)
+        worker.start()
+        worker.join(timeout=10.0)
+
+        assert not worker.is_alive(), (
+            "the re-prompt loop starved its event loop: the browser callback "
+            "could not be delivered and the flow's timeout could not fire"
+        )
+        got, _ = result[0]
+        assert got == ("browser-code", "browser-state")

--- a/tests/unit/providers/test_oauth_flows.py
+++ b/tests/unit/providers/test_oauth_flows.py
@@ -1133,10 +1133,23 @@ class TestZaiSignInMintsADurableKey:
         # The MINTED `id.secret` key, never the short-lived OAuth token.
         assert creds["access"] == "key-id.sec-ret"
         assert creds["email"] == "damian@example.com"
-        assert creds["account_id"] == "4242"
+        # The user id is recorded for display under its OWN key. It must not
+        # land on `account_id`, which is the dedupe identity: the `user` block
+        # it comes from is optional per response, so an identity sourced from it
+        # changes between sign-ins and the store writes a duplicate row.
+        assert creds["user_id"] == "4242"
         # `expires: None` is AuthStore's "static token" marker: no refresh is
         # ever attempted, so the row persists across sessions.
         assert creds["expires"] is None
+        # The dedupe identity, resolved on every sign-in because a key cannot be
+        # minted without an org and a project. See the alternating-`user` test.
+        assert creds["account_id"] == "org-1/proj-1"
+        assert creds["project_id"] == "proj-1"
+        # NOT `org_id`: on an OAuth row that field is a ROUTING signal, and a
+        # credential carrying one is sent to ChatGPT's private Codex Responses
+        # endpoint. Pinned because the obvious name for this value is the
+        # dangerous one. See `test_the_identity_does_not_route_to_codex`.
+        assert "org_id" not in creds
         # The secret always comes from the copy endpoint -- list entries mask it.
         assert any("/api_keys/copy/" in call for call in calls), calls
 
@@ -1228,6 +1241,110 @@ class TestZaiSignInMintsADurableKey:
         assert access.kind == "oauth"
         assert access.email == "damian@example.com"
 
+    async def test_identity_survives_a_response_with_no_user_block(self) -> None:
+        """Z6: Z.AI's `user` block is optional PER RESPONSE, not per account.
+
+        Keying dedupe on `email`/`account_id` therefore gives an identity that
+        appears and disappears between logins: sign in five times with the block
+        arriving only every other time and the store writes a SECOND row for the
+        account it already holds, leaving a stale key in rotation.
+
+        Org and project are resolved on every sign-in -- key provisioning cannot
+        proceed without them -- so they are the stable identity, and
+        `_identity_key_for` reads `org_id` ahead of `email`.
+        """
+        import tempfile
+        from pathlib import Path
+
+        from local_operator.providers.auth_store import AuthStore
+        from local_operator.providers.oauth.zai import ZaiOAuthFlow
+
+        store = AuthStore(db_path=Path(tempfile.mkdtemp()) / "auth.db")
+        for attempt in range(5):
+            calls: list[str] = []
+            transport = self._transport(calls, existing_key=True)
+            if attempt % 2:
+                # Strip the `user` block, as the provider sometimes does.
+                inner = transport
+
+                def handler(request: httpx.Request, _inner: Any = inner) -> httpx.Response:
+                    response = _inner.handler(request)
+                    if request.url.path.endswith("/oauth/token"):
+                        body = json.loads(response.content)
+                        body["data"].pop("user", None)
+                        return httpx.Response(200, json=body)
+                    return response
+
+                transport = httpx.MockTransport(handler)
+
+            flow = ZaiOAuthFlow(http_client=httpx.AsyncClient(transport=transport))
+            creds = await flow.exchange_token("c", "s", "http://localhost:54548/callback")
+            creds["authorized_at"] = attempt
+            store.upsert_credential("zai", creds)
+
+        rows = store.list_credentials("zai")
+        assert len(rows) == 1, [(r.id, r.data.get("email")) for r in rows]
+        assert await store.get_api_key("zai") == "key-id.sec-ret"
+
+    async def test_the_identity_does_not_route_to_codex(self) -> None:
+        """The identity must not be stored under `org_id`, however natural the name.
+
+        `OpenAICompatClient` treats an OAuth credential carrying an `org_id` as
+        a ChatGPT subscription grant: it sends the request to ChatGPT's private
+        Codex Responses endpoint and adds a `chatgpt-account-id` header. Storing
+        Z.AI's organization id under that key therefore breaks inference while
+        looking like a naming choice, so this asserts the wire result rather
+        than the field name alone.
+        """
+        import tempfile
+        from pathlib import Path
+
+        from local_operator.harness.types import ChatRequest, Message, TextContent
+        from local_operator.model.configure import build_model_spec
+        from local_operator.providers.auth_store import AuthStore
+        from local_operator.providers.clients import client_for_spec
+        from local_operator.providers.oauth.zai import ZaiOAuthFlow
+
+        calls: list[str] = []
+        flow = ZaiOAuthFlow(
+            http_client=httpx.AsyncClient(transport=self._transport(calls, existing_key=True))
+        )
+        creds = await flow.exchange_token("c", "s", "http://localhost:54548/callback")
+        creds["authorized_at"] = 1
+
+        store = AuthStore(db_path=Path(tempfile.mkdtemp()) / "auth.db")
+        store.upsert_credential("zai", creds)
+        access = await store.get_oauth_access("zai")
+        assert access is not None
+        assert access.org_id is None, "an org_id here routes Z.AI traffic to ChatGPT"
+
+        seen: dict[str, Any] = {}
+
+        def wire(request: httpx.Request) -> httpx.Response:
+            seen["url"] = str(request.url)
+            seen["codex_header"] = request.headers.get("chatgpt-account-id")
+            return httpx.Response(
+                200,
+                headers={"content-type": "text/event-stream"},
+                content=b'data: {"choices":[{"delta":{"content":"pong"}}]}\n\ndata: [DONE]\n\n',
+            )
+
+        spec = build_model_spec("zai", "glm-4.6")
+        client = client_for_spec(
+            spec, http_client=httpx.AsyncClient(transport=httpx.MockTransport(wire))
+        )
+        request = ChatRequest(
+            model=spec, messages=[Message(role="user", content=[TextContent(text="ping")])]
+        )
+        events = [
+            event
+            async for event in client.stream(request, access.access_token, oauth_access=access)
+        ]
+
+        assert seen["url"] == "https://api.z.ai/api/coding/paas/v4/chat/completions"
+        assert seen["codex_header"] is None
+        assert "".join(getattr(e, "delta", "") for e in events) == "pong"
+
 
 class TestPastedCallbackParsing:
     """Z2: the "paste the redirect URL" fallback has to accept a redirect URL.
@@ -1294,8 +1411,13 @@ class TestPastedCallbackParsing:
 
     def test_an_error_redirect_is_reported_rather_than_sent_as_a_code(self) -> None:
         """A denied grant redirects with `error` and no `code`. Forwarding that
-        URL as the code produces an opaque provider-side rejection; the user is
-        still at the prompt and can be told what actually happened."""
+        URL as the code produces an opaque provider-side rejection a minute
+        later, naming nothing the user can act on.
+
+        The parser raises; the CALLER decides what that means. In the loopback
+        race it is reported and the task re-parks, which
+        `TestABadPasteDoesNotEndTheLogin` pins -- an unusable paste must not be
+        able to lose a login the browser can still finish."""
         from local_operator.providers.oauth.callback_server import (
             LoginError,
             _parse_pasted_callback,
@@ -1315,3 +1437,86 @@ class TestPastedCallbackParsing:
 
         with pytest.raises(LoginError, match="no authorization code"):
             _parse_pasted_callback("http://localhost:54548/callback")
+
+
+class TestABadPasteDoesNotEndTheLogin:
+    """The paste prompt is a FALLBACK, so it must never be able to lose a login.
+
+    `_manual()` races the loopback callback: it exists for a browser that cannot
+    reach this machine, and the module already encodes that rule where a
+    DECLINED paste re-parks rather than failing. Reporting an unusable paste by
+    raising would break the same rule from the other side -- a mistyped or
+    half-copied URL would kill a sign-in the browser was about to complete.
+
+    These drive `_await_code` itself, with a simulated browser callback landing
+    shortly after the paste, because the property only exists in the race: a
+    direct call to the parser cannot see it.
+    """
+
+    @staticmethod
+    def _flow(paste: str | None, progress: list[str]) -> Any:
+        from local_operator.providers.oauth import callback_server as cs
+
+        class _Flow(cs.OAuthCallbackFlow):
+            provider_id = "test"
+
+            async def generate_auth_url(self, state: str, redirect_uri: str) -> str:
+                return "https://example.invalid/auth"
+
+            async def exchange_token(
+                self, code: str, state: str, redirect_uri: str
+            ) -> dict[str, Any]:
+                return {"access": code}
+
+        return _Flow(
+            cs.CallbackFlowOptions(preferred_port=54999, timeout_seconds=2.0),
+            cs.LoginCallbacks(
+                on_manual_code_input=lambda: paste,
+                on_progress=progress.append,
+            ),
+        )
+
+    async def _race(self, paste: str | None) -> tuple[tuple[str, str], list[str]]:
+        loop = asyncio.get_running_loop()
+        progress: list[str] = []
+        flow = self._flow(paste, progress)
+        flow._captured = loop.create_future()
+        flow._capture_error = loop.create_future()
+
+        async def browser() -> None:
+            await asyncio.sleep(0.05)
+            if not flow._captured.done():
+                flow._captured.set_result(("browser-code", "browser-state"))
+
+        task = asyncio.create_task(browser())
+        try:
+            return await flow._await_code(), progress
+        finally:
+            task.cancel()
+
+    async def test_an_error_redirect_paste_lets_the_browser_still_win(self) -> None:
+        got, progress = await self._race("http://localhost:54548/cb?error=access_denied")
+
+        assert got == ("browser-code", "browser-state")
+        # The reason is not swallowed: it reaches the user through the same
+        # channel as the flow's other status messages.
+        assert any("access_denied" in line for line in progress), progress
+
+    async def test_a_url_with_no_code_lets_the_browser_still_win(self) -> None:
+        got, progress = await self._race("http://localhost:54548/cb")
+
+        assert got == ("browser-code", "browser-state")
+        assert any("no authorization code" in line for line in progress), progress
+
+    async def test_a_usable_paste_still_wins_the_race(self) -> None:
+        """The control: re-parking on a BAD paste must not have broken a good one."""
+        got, _ = await self._race("http://localhost:54548/cb?code=good&state=s1")
+
+        assert got == ("good", "s1")
+
+    async def test_a_declined_paste_still_re_parks(self) -> None:
+        """Unchanged pre-existing behaviour, pinned because this change is
+        adjacent to it."""
+        got, _ = await self._race(None)
+
+        assert got == ("browser-code", "browser-state")

--- a/tests/unit/providers/test_registry.py
+++ b/tests/unit/providers/test_registry.py
@@ -38,6 +38,19 @@ def test_unknown_provider_returns_none() -> None:
     assert get_provider_definition("definitely-not-a-provider") is None
 
 
+def test_zai_oauth_shares_the_zai_credential_row_and_catalogue() -> None:
+    """The sign-in mints a durable key for the SAME provider, exactly as
+    ``xai-oauth`` does -- not a second catalogue."""
+    zai_oauth = get_provider_definition("zai-oauth")
+    zai = get_provider_definition("zai")
+    assert zai_oauth is not None and zai is not None
+    assert zai_oauth.store_credentials_as == "zai"
+    assert zai_oauth.base_url == zai.base_url
+    assert zai_oauth.login is not None
+    # No refresh: the minted key never expires, so there is nothing to refresh.
+    assert zai_oauth.refresh_token is None
+
+
 def test_registry_ids_unique() -> None:
     ids = [p.id for p in PROVIDER_REGISTRY]
     assert len(ids) == len(set(ids))

--- a/tests/unit/providers/test_usage.py
+++ b/tests/unit/providers/test_usage.py
@@ -1162,7 +1162,10 @@ def test_the_advertised_set_is_the_dispatch_table() -> None:
     from local_operator.providers import usage as usage_mod
 
     assert usage_mod.USAGE_PROVIDERS == frozenset(usage_mod._FETCHERS)
-    assert usage_mod.USAGE_PROVIDERS is not None and len(usage_mod.USAGE_PROVIDERS) == 11
+    # 12 since `zai-oauth` joined: the Z.AI browser sign-in is its own provider
+    # id, like `xai-oauth`, and needs its own route or a signed-in account
+    # reports no usage at all.
+    assert usage_mod.USAGE_PROVIDERS is not None and len(usage_mod.USAGE_PROVIDERS) == 12
     assert not hasattr(usage_mod, "OAUTH_USAGE_PROVIDERS")
 
 
@@ -1395,3 +1398,27 @@ async def test_qwencloud_token_plan_fails_closed_on_console_need_login() -> None
             oauth_creds={"access": "expired-mgmt"},
         )
     assert report is None
+
+
+class TestZaiSignInReportsUsage:
+    """`/provider` advertised Z.AI usage and then showed nothing to anyone who
+    signed in rather than pasting a key.
+
+    The browser sign-in ends by minting an ordinary durable coding-plan key and
+    stores it in `access`, so the OAuth slot wants the SAME fetcher the api-key
+    slot uses -- an empty OAuth slot made `fetch_usage` return None.
+    """
+
+    def test_both_credential_kinds_route_to_the_quota_fetcher(self) -> None:
+        from local_operator.providers.usage import _FETCHERS
+
+        assert _FETCHERS["zai"] == ("zai-quota", "zai-quota")
+        # The login flavour resolves too: it is a separate provider id.
+        assert _FETCHERS["zai-oauth"] == ("zai-quota", "zai-quota")
+
+    def test_a_signed_in_account_is_reported_as_capable_of_usage(self) -> None:
+        from local_operator.providers.usage import usage_kinds
+
+        oauth_kind, api_key_kind = usage_kinds("zai")
+        assert oauth_kind is not None, "a signed-in Z.AI account reports no usage"
+        assert api_key_kind is not None

--- a/tests/unit/providers/test_usage.py
+++ b/tests/unit/providers/test_usage.py
@@ -1417,8 +1417,20 @@ class TestZaiSignInReportsUsage:
         assert _FETCHERS["zai-oauth"] == ("zai-quota", "zai-quota")
 
     def test_a_signed_in_account_is_reported_as_capable_of_usage(self) -> None:
+        """`usage_kinds` returns BOOLEANS, so this asserts truth, not presence.
+
+        An `is not None` check here would pass for a provider with no quota
+        route at all -- `(False, False)` is two non-None values -- which is
+        exactly the state this test exists to rule out. The negative control
+        below is what makes the positive one mean something.
+        """
         from local_operator.providers.usage import usage_kinds
 
         oauth_kind, api_key_kind = usage_kinds("zai")
-        assert oauth_kind is not None, "a signed-in Z.AI account reports no usage"
-        assert api_key_kind is not None
+        assert oauth_kind is True, "a signed-in Z.AI account reports no usage"
+        assert api_key_kind is True
+        assert usage_kinds("zai-oauth") == (True, True)
+
+        # The control: a provider with no quota endpoint answers False/False on
+        # the same instrument, so the assertions above can distinguish the two.
+        assert usage_kinds("ollama") == (False, False)

--- a/tests/unit/tui/test_login_key_prompt.py
+++ b/tests/unit/tui/test_login_key_prompt.py
@@ -798,9 +798,9 @@ async def test_an_interrupt_mid_paste_still_lets_the_receipt_be_corrected(
         app._settle_key_prompt()  # the interrupt
         await pilot.pause()
 
-        assert app._last_login_prompt is settled, (
-            "the reference was dropped while a correction was still owed"
-        )
+        assert (
+            app._last_login_prompt is settled
+        ), "the reference was dropped while a correction was still owed"
         app._last_login_prompt.mark_unusable()
         await pilot.pause()
         assert "not usable" in _rendered(settled)
@@ -854,9 +854,9 @@ async def test_a_completed_login_stops_holding_the_pasted_key(
         app._settle_key_prompt()  # reached by /clear, reload and unmount
         await pilot.pause()
 
-        assert app._last_login_prompt is None, (
-            "a completed login left the pasted key reachable through the block"
-        )
+        assert (
+            app._last_login_prompt is None
+        ), "a completed login left the pasted key reachable through the block"
         # The value is the thing that must become unreachable, not just the
         # attribute — assert on the credential itself.
         assert block.wait().result() == "sk-real-key"  # the block still has it...

--- a/tests/unit/tui/test_login_key_prompt.py
+++ b/tests/unit/tui/test_login_key_prompt.py
@@ -815,3 +815,54 @@ async def test_an_interrupt_mid_paste_still_lets_the_receipt_be_corrected(
         app._settle_key_prompt()
         await pilot.pause()
         assert app._last_login_prompt is None
+
+
+@pytest.mark.asyncio
+async def test_a_completed_login_stops_holding_the_pasted_key(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Agent review round 6, Z12: the success path kept the credential reachable.
+
+    The block that retains a correction target still holds the pasted secret —
+    `resolve` drops `_typed`, but it also resolves the future, and a future
+    keeps its result for as long as the block holds it. So the retained
+    reference is a credential lifetime, not merely memory.
+
+    On a login that SUCCEEDS, `_request_login_key`'s `finally` has already
+    cleared `_key_prompt`, so a release nested behind "is a prompt live?" never
+    ran and the key survived `/clear` and unmount — reopening the retention
+    finding a previous round landed. The distinguishing signal is that
+    `_key_prompt` is still set during the narrow window a correction can be
+    owed, and cleared once the login is over.
+    """
+    monkeypatch.setattr("webbrowser.open", lambda *a, **k: True)
+    controller = _controller(tmp_path)
+    app = OperatorApp(lambda: _factory(_LoginSession()), provider_controller=controller)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(pilot, app)
+
+        block = KeyPromptBlock("Alibaba Cloud")
+        app._key_prompt = block
+        app._last_login_prompt = block
+        app._append_block(block)
+        await pilot.pause()
+        block.resolve("sk-real-key")
+        await pilot.pause()
+        # What `_request_login_key`'s `finally` does once the value is returned.
+        app._key_prompt = None
+
+        app._settle_key_prompt()  # reached by /clear, reload and unmount
+        await pilot.pause()
+
+        assert app._last_login_prompt is None, (
+            "a completed login left the pasted key reachable through the block"
+        )
+        # The value is the thing that must become unreachable, not just the
+        # attribute — assert on the credential itself.
+        assert block.wait().result() == "sk-real-key"  # the block still has it...
+        held = [
+            b
+            for b in (app._last_login_prompt,)
+            if b is not None and b.wait().done() and b.wait().result() == "sk-real-key"
+        ]
+        assert held == [], "the app still reaches a block holding the pasted key"

--- a/tests/unit/tui/test_login_key_prompt.py
+++ b/tests/unit/tui/test_login_key_prompt.py
@@ -644,3 +644,79 @@ async def test_teardown_settles_a_live_prompt(
 
     assert prompt.answered, "unmount left the login parked on an unresolved future"
     assert prompt.wait().result() is None
+
+
+@pytest.mark.asyncio
+async def test_a_rejected_paste_does_not_claim_a_successful_receipt() -> None:
+    """Design round 1 D1(b): a paste the flow could not use settled as
+    `✓ … code received (107 chars)`.
+
+    The prompt settles the instant the value is handed over, but whether that
+    value parses is decided one layer out in `_parse_pasted_callback`. So a
+    mis-copied URL painted a success glyph, the word "received", and a
+    character count that read as corroboration — directly above the notice
+    saying the authorization had failed. The login is still live at that point
+    (the flow re-prompts, the loopback callback is still racing), so this is
+    not a cancel either.
+    """
+    app = _PromptHost()
+    async with app.run_test() as pilot:
+        block = KeyPromptBlock("Z.AI", secret=False, sole_path=False)
+        await app.mount(block)
+        await pilot.pause()
+        block.resolve("http://localhost:54548/callback?error=access_denied")
+        await pilot.pause()
+
+        # Before the flow rules on it, the receipt is the ordinary success one.
+        assert "received" in _rendered(block)
+
+        block.mark_unusable()
+        await pilot.pause()
+        receipt = _rendered(block)
+        assert "received" not in receipt, receipt
+        assert "cancelled" not in receipt, receipt
+        assert "not usable" in receipt, receipt
+        assert "still waiting for the browser" in receipt, receipt
+        # The length is gone: it read as evidence the paste was fine.
+        assert "chars" not in receipt, receipt
+
+        # Control: an accepted paste is untouched by the same instrument, so
+        # the assertions above distinguish the two outcomes rather than
+        # describing every receipt.
+        good = KeyPromptBlock("Z.AI", secret=False, sole_path=False)
+        await app.mount(good)
+        await pilot.pause()
+        good.resolve("code#state")
+        await pilot.pause()
+        assert "received" in _rendered(good)
+
+
+@pytest.mark.asyncio
+async def test_mark_unusable_cannot_rewrite_a_cancel_or_a_live_prompt() -> None:
+    """`mark_unusable` corrects a SUCCESS claim and nothing else.
+
+    A declined paste and a still-open prompt both reach the flow's rejection
+    path in principle (a host may call the hook at any time), and neither has a
+    success claim to correct — turning either into "paste not usable" would
+    invent a paste the user never made.
+    """
+    app = _PromptHost()
+    async with app.run_test() as pilot:
+        declined = KeyPromptBlock("Z.AI", secret=False, sole_path=False)
+        await app.mount(declined)
+        await pilot.pause()
+        declined.resolve(None)
+        await pilot.pause()
+        before = _rendered(declined)
+        declined.mark_unusable()
+        await pilot.pause()
+        assert _rendered(declined) == before
+
+        live = KeyPromptBlock("Z.AI", secret=False, sole_path=False)
+        await app.mount(live)
+        await pilot.pause()
+        before_live = _rendered(live)
+        live.mark_unusable()
+        await pilot.pause()
+        assert _rendered(live) == before_live
+        assert not live.answered

--- a/tests/unit/tui/test_login_key_prompt.py
+++ b/tests/unit/tui/test_login_key_prompt.py
@@ -759,3 +759,59 @@ async def test_a_settled_prompt_does_not_retain_the_pasted_value() -> None:
         # The receipt still reports the length, or the assertion above could be
         # satisfied by a block that simply stopped describing the paste.
         assert "21 chars" in _rendered(block)
+
+
+@pytest.mark.asyncio
+async def test_an_interrupt_mid_paste_still_lets_the_receipt_be_corrected(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Agent review round 5, Z11: a teardown between handover and parse stranded
+    a false success receipt.
+
+    A paste settles the block immediately — its receipt provisionally reads
+    "code received" — but whether the value parses is decided one layer out, so
+    there is a real window in which the block is settled and the flow has not
+    yet ruled on it. `_settle_key_prompt` clearing the retained reference
+    unconditionally meant an interrupt landing in that window left nothing to
+    correct, and the false `✓` stayed on screen: design round 1's D1(b),
+    reintroduced through the back door.
+
+    Also pins the other half, or the fix would be "never clear it": cancelling a
+    LIVE prompt still drops the reference, because no value was handed over and
+    so no correction can ever be owed.
+    """
+    monkeypatch.setattr("webbrowser.open", lambda *a, **k: True)
+    controller = _controller(tmp_path)
+    app = OperatorApp(lambda: _factory(_LoginSession()), provider_controller=controller)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(pilot, app)
+
+        settled = KeyPromptBlock("Z.AI", secret=False, sole_path=False)
+        app._key_prompt = settled
+        app._last_login_prompt = settled
+        app._append_block(settled)
+        await pilot.pause()
+        # The paste is handed over; the flow has not parsed it yet.
+        settled.resolve("http://localhost:54548/callback?error=access_denied")
+        await pilot.pause()
+
+        app._settle_key_prompt()  # the interrupt
+        await pilot.pause()
+
+        assert app._last_login_prompt is settled, (
+            "the reference was dropped while a correction was still owed"
+        )
+        app._last_login_prompt.mark_unusable()
+        await pilot.pause()
+        assert "not usable" in _rendered(settled)
+
+        # A LIVE prompt cancelled by the same path owes no correction, so the
+        # reference is released rather than retained for the session.
+        live = KeyPromptBlock("Z.AI", secret=False, sole_path=False)
+        app._key_prompt = live
+        app._last_login_prompt = live
+        app._append_block(live)
+        await pilot.pause()
+        app._settle_key_prompt()
+        await pilot.pause()
+        assert app._last_login_prompt is None

--- a/tests/unit/tui/test_login_key_prompt.py
+++ b/tests/unit/tui/test_login_key_prompt.py
@@ -857,12 +857,23 @@ async def test_a_completed_login_stops_holding_the_pasted_key(
         assert (
             app._last_login_prompt is None
         ), "a completed login left the pasted key reachable through the block"
-        # The value is the thing that must become unreachable, not just the
-        # attribute — assert on the credential itself.
-        assert block.wait().result() == "sk-real-key"  # the block still has it...
-        held = [
-            b
-            for b in (app._last_login_prompt,)
-            if b is not None and b.wait().done() and b.wait().result() == "sk-real-key"
+
+        # The block itself still holds the value — that is why the reference
+        # above has to go, and asserting it here is what stops this test from
+        # passing for the wrong reason if the block ever stops carrying it.
+        assert block.wait().result() == "sk-real-key"
+
+        # Scan the app's own attributes rather than re-reading the one already
+        # asserted None: agent review round 7 (Z14) pointed out that iterating
+        # `_last_login_prompt` again cannot fail independently, so it read as
+        # corroboration while proving nothing. This walks every attribute for
+        # any prompt block still holding the pasted key, and so would also
+        # catch the reference being parked somewhere new.
+        reachable = [
+            name
+            for name, value in vars(app).items()
+            if isinstance(value, KeyPromptBlock)
+            and value.wait().done()
+            and value.wait().result() == "sk-real-key"
         ]
-        assert held == [], "the app still reaches a block holding the pasted key"
+        assert reachable == [], f"the app still reaches a block holding the pasted key: {reachable}"

--- a/tests/unit/tui/test_login_key_prompt.py
+++ b/tests/unit/tui/test_login_key_prompt.py
@@ -699,6 +699,13 @@ async def test_mark_unusable_cannot_rewrite_a_cancel_or_a_live_prompt() -> None:
     path in principle (a host may call the hook at any time), and neither has a
     success claim to correct — turning either into "paste not usable" would
     invent a paste the user never made.
+
+    Asserts the FLAG and not only the rendered row (agent review round 4, Z9):
+    `_build`'s precedence tests `_superseded` and "nothing submitted" before it
+    reaches the `_unusable` branch, so the renderer produces the right output
+    even with the guard deleted. A rendering-only assertion therefore passes
+    for a reason other than the one it names, and this test's whole subject is
+    the guard.
     """
     app = _PromptHost()
     async with app.run_test() as pilot:
@@ -710,6 +717,7 @@ async def test_mark_unusable_cannot_rewrite_a_cancel_or_a_live_prompt() -> None:
         before = _rendered(declined)
         declined.mark_unusable()
         await pilot.pause()
+        assert declined._unusable is False, "a cancel was rewritten as an unusable paste"
         assert _rendered(declined) == before
 
         live = KeyPromptBlock("Z.AI", secret=False, sole_path=False)
@@ -718,5 +726,36 @@ async def test_mark_unusable_cannot_rewrite_a_cancel_or_a_live_prompt() -> None:
         before_live = _rendered(live)
         live.mark_unusable()
         await pilot.pause()
+        assert live._unusable is False, "a live prompt was rewritten as an unusable paste"
         assert _rendered(live) == before_live
         assert not live.answered
+
+
+@pytest.mark.asyncio
+async def test_a_settled_prompt_does_not_retain_the_pasted_value() -> None:
+    """Agent review round 4, Z7: the block held the submitted value verbatim.
+
+    `resolve` drops `_typed` precisely so a settled block in the transcript is
+    not still holding the user's key, but the value was then kept under
+    `_submitted` for the receipt's character count — and the app retains the
+    last prompt to correct its receipt, so that reference outlived even
+    `/clear`. The receipt only ever needed the LENGTH.
+    """
+    app = _PromptHost()
+    async with app.run_test() as pilot:
+        block = KeyPromptBlock("Alibaba Cloud")
+        await app.mount(block)
+        await pilot.pause()
+        block.resolve("sk-SUPERSECRET-abcdef")
+        await pilot.pause()
+
+        held = [
+            value
+            for value in vars(block).values()
+            if isinstance(value, str) and "SUPERSECRET" in value
+        ]
+        assert held == [], f"the settled block still holds the pasted value: {held}"
+
+        # The receipt still reports the length, or the assertion above could be
+        # satisfied by a block that simply stopped describing the paste.
+        assert "21 chars" in _rendered(block)


### PR DESCRIPTION
# PR Description

## Change classification

**C2 — standard / pre-authorized.** Adds one provider entry and a login flow; the only change to shared code is a fallback-preserving widening of `upsert_credential`'s type derivation. No schema change, no migration, clean rollback (`git revert`). No RFC requested.

## Why this exists

`/login zai` today can only paste an API key from the dashboard. Z.AI's GLM Coding Plan issues credentials through a browser sign-in, so a subscriber had no way to reach their plan from Local Operator without going and copying a key by hand.

This adds `zai-oauth`: a browser sign-in that ends by minting a durable `id.secret` coding-plan key — which is the credential the inference endpoint actually accepts — and stores it on the **same credential row** as the pasted-key `zai` provider (`store_credentials_as="zai"`), exactly as `xai-oauth` shares `xai`'s. One account, one base URL, one catalogue, two ways in.

## The defect this carries a fix for

The sign-in was written first and did not work, in a way no unit test could see.

`AuthStore.upsert_credential` derived a row's type **structurally**:

```python
credential_type = (
    "oauth" if credential.get("refresh") and credential.get("access") else "api_key"
)
```

Z.AI's minted key **never expires**, so the flow correctly returns no `refresh` token. The row therefore landed as `credential_type="api_key"` with its secret under `data["access"]` — and nothing in the resolution cascade reads that combination. Tiers 4 and 6 read `data["key"]`; tier 3 reads `access` but only walks `oauth`-typed rows. The credential was invisible to every tier.

The user-visible result: the login reports `Logged in to 'zai' (you@example.com).` and then **every request fails without a single HTTP call being made**, behind a "temporarily unavailable, retry once the limit resets" message — advice that could never come true.

An explicitly declared `type` now wins, with the structural guess kept unchanged as the fallback for every caller that never declared one:

```python
declared = credential.get("type")
credential_type = (
    declared
    if declared in ("oauth", "api_key")
    else ("oauth" if credential.get("refresh") and credential.get("access") else "api_key")
)
```

### Why the suite was green on it

Two tests sat either side of the gap. One asserted the registry's `zai-oauth` **fields**; the other asserted the login flow's **return dict**. Nothing joined them — no test stored a real login payload and then asked the store to resolve it. Three individually-correct components composed into a broken sign-in.

The regression test that matters is therefore the joining one (`test_the_stored_credential_is_readable_by_the_cascade`): it drives `ZaiOAuthFlow.exchange_token`, hands the result to the exact `upsert_credential` call `ProviderController.login` makes, and asserts the cascade resolves it.

## Also fixed: usage reporting for signed-in accounts

`_FETCHERS["zai"]` had an empty OAuth slot, on the reasoning that Z.AI issues only one credential kind. With a sign-in that stores into `access`, that made `/provider` advertise Z.AI usage and then report nothing at all for anyone who signed in rather than pasting a key. Both slots now route to the same quota fetcher, because both credential kinds are literally the same secret.

## Validation

### 1. The failure, reproduced on the pre-fix derivation

Same payload, same `upsert_credential` call; only the type derivation differs.

```console
$ .venv/bin/python /tmp/dt-before.py
PRE-FIX  row type ->                     api_key
PRE-FIX  get_api_key('zai')      ->      None
PRE-FIX  get_oauth_access('zai') ->      None
```

A stored credential no tier can read — zero HTTP requests possible.

### 2. The real path, end to end, after the fix

Drives `ZaiOAuthFlow` against a mock Z.AI (the live endpoints require an interactive browser grant), then the **real** `AuthStore`, the **real** resolution cascade, and the **real** wire client:

```console
$ .venv/bin/python /tmp/dt-e2e.py
tree: /private/tmp/dt-zai-split/local_operator/__init__.py

--- 1. BEFORE sign-in: nothing configured ---
   get_api_key('zai') -> None

--- 2. Run the real sign-in through ProviderController.login ---
   Logged in to 'zai' (damian@gominerva.com).

--- 3. AFTER sign-in: the cascade resolves it ---
   stored row  -> (1, 'oauth')
   get_api_key -> key-id.sec-ret
   get_oauth_access -> ('oauth', 'damian@gominerva.com', 'key-id.sec-ret')

--- 4. Real wire client: which bearer reaches the endpoint ---
   Authorization header -> Bearer key-id.sec-ret
   URL                  -> https://api.z.ai/api/coding/paas/v4/chat/completions
   response             -> pong

--- 5. Usage routing for a signed-in account ---
   usage_kinds('zai')      -> (True, True)
   usage_kinds('zai-oauth')-> (True, True)
```

Three things worth reading off that: the row is typed `oauth`, the bearer reaching the wire is the **minted key** and not the short-lived OAuth token, and the URL is the **coding-plan** base (`/api/coding/paas/v4`) rather than the general `/api/paas/v4` endpoint — which accepts the same key but bills account balance instead of coding-plan quota, a silent wrong-budget bug rather than a visible failure.

### 3. Mutation check: the new tests actually bite

Reverted the fix in place and re-ran the two tests that pin it:

```console
FAILED tests/unit/providers/test_oauth_flows.py::TestZaiSignInMintsADurableKey::test_the_stored_credential_is_readable_by_the_cascade
  - AssertionError: assert None == 'key-id.sec-ret'
FAILED tests/unit/providers/test_auth_store.py::TestARefreshlessOAuthCredentialIsReadable::test_an_explicit_type_survives_the_structural_guess
  - AssertionError: assert 'api_key' == 'oauth'
```

Both fail on the mutant, reproducing R21's exact symptom, and the file was restored from a validated copy and confirmed byte-identical afterwards.

### 4. Gates

```console
$ .venv/bin/python -m pytest tests/unit/providers tests/unit/model -q
                                                              # 739 passed
$ .venv/bin/python -m pytest tests/unit -q                    # 4572 passed, 7 skipped
$ .venv/bin/python -m flake8 local_operator tests             # clean
$ .venv/bin/python -m black --check local_operator tests      # 366 files unchanged
$ .venv/bin/python -m isort --check-only local_operator tests # clean
$ .venv/bin/python -m pyright --pythonpath ../../local-operator/.venv/bin/python local_operator
                                                              # 0 errors, 0 warnings
```

One deselection: `tests/unit/tools/test_eval_tool.py::test_background_streams_output_while_it_runs` is a timing-sensitive pre-existing failure — confirmed failing identically on `origin/main` at `00d060f`, unrelated to providers.

## Relationship to #147

This is the Z.AI half of #147, cut against current `origin/main` so it can land on its own. #147's round-5 review found this blocker (R21) plus a separate **major** (R22) in that PR's credential-retry-budget work, which is an independent change to `failover.py` that has now been through five rounds of the same class of defect. Splitting lets the working sign-in ship while that half converges. #147 keeps the retry-budget work and its R22 fix; nothing here depends on it.

## Testing gap, stated honestly

The interactive grant itself (browser redirect to a loopback port on 54548, and the paste-the-URL fallback for a remote session) is exercised against a mock transport rather than live Z.AI, because completing a real OAuth grant needs a human at a browser. Everything downstream of the grant — token exchange, business login, org/project resolution, find-or-create key, secret copy, storage, resolution, and the wire request — runs the real code against realistic envelopes, including Z.AI's habit of reporting business failures on an HTTP 200.


---

## What review added after the original description

The sections above describe the sign-in defect this PR was cut to fix (R21). Eight agent-review rounds and four design rounds since then found a further blocker, three majors and several minors — most of them in the *remediation* of earlier findings rather than in the original change. The gate history is on this PR as comments; this is the summary of what actually changed.

**The sign-in was dead-ending users, then hanging them.**

- **D1 (design blocker)** — the paste fallback told the user to copy their address bar and then gave them nowhere to paste it: a mis-paste settled the prompt as `✓ … code received`, and for the remote-browser case this fallback exists for, the loopback callback can never win, so it was a guaranteed dead end. The flow now re-prompts, and the receipt repaints as `✗ paste not usable … still waiting for the browser`.
- **A hang found while fixing D1** — the re-prompt loop had no await point, and `on_manual_code_input` may be synchronous. The loop starved its own event loop: the loopback callback could not be delivered and the flow's own timeout could not fire, so one bad paste hung the login *forever*. It also hung the existing test file, which is how it surfaced.
- **Z1/Z6** — refreshless sign-ins duplicated a credential row per login (five sign-ins, five rows) because the dedupe identity also asked "is this OAuth?" by testing for a refresh token — the same blind spot as R21, one layer out.
- **Z4/Z5** — a bad paste could kill a login the browser was about to complete.

**Credential lifetime.** The settled prompt held the pasted key: `resolve` drops the typed buffer but resolves a future, and a future keeps its result. The block now stores only a length, and the app releases its reference once the login is over — bounded past `/clear` and past unmount.

**Naming (D2).** Both Z.AI entries carry the *same* coding-plan base URL, so `GLM` vs `GLM Coding Plan · Sign in` stated a plan difference that does not exist and sent users to the wrong row. Now `Z.AI (GLM API key)` / `Z.AI (GLM browser sign-in)`, naming the credential method as the `xai` pair already does.

**Tests that did not test.** Three separate findings (Z3, Z9, Z14) were assertions that could not fail — a `is not None` on a `bool`, a guard masked by renderer precedence, and a filter over an attribute already asserted `None`. Each is fixed and mutation-checked; the pattern is recorded here because it recurred three times in one PR.

### Rendered evidence

Real `OperatorApp` with the stylesheet loaded. Before/after for the D1 blocker:

```
BEFORE — a rejected paste                    AFTER — the same paste
✓ Z.AI code received (82 chars)              ✗ paste not usable Z.AI — still waiting for the browser
· Authorization failed: access_denied        ! Authorization failed: access_denied (User said no).
                                               Approve the sign-in in your browser, then paste the
                                               address bar contents again.
(no prompt — nowhere to correct it)          ? Paste your Z.AI authorization code
```

Picker, at 100 cols:

```
❯  zai          GLM API key            needs login
   zai-oauth    GLM browser sign-in    needs login
```

Design rounds 2–4 additionally verified: three consecutive bad pastes (no block pile-up, each re-prompt interactive, the fourth good paste succeeds), no transient false `✓` across 14 repaint ticks, the re-prompt never scrolling out of the viewport, and all five settled receipt states remaining collision-free at every width from 10 to 100 columns.

### Merge with `origin/main`

`origin/main` advanced past this branch's base (#147, #158) and conflicted in five files. `#147` shipped an **older** copy of the Z.AI module predating the Z6 identity fix, so this branch's copy supersedes it; the test files were rebuilt on main's versions with only the shared classes replaced by this branch's later remediation. Verified by AST set-comparison across both parents — zero definitions lost from either side — which also caught one stale assertion pair spliced in by the merge.

### Gates at `ef99e9a`

```
tests/unit                                   # 4849 passed, 7 skipped
tests/unit/providers tests/unit/model tests/unit/tui
                                             # 2499 passed, 4 skipped
flake8 . / black --check . / isort --check-only .   # clean, whole tree
pyright local_operator                       # 0 errors, 0 warnings
```

One pre-existing flake, recorded so it is not attributed to this diff: `tests/unit/tui/test_subagent_view.py` has a timing-sensitive scroll-offset assertion that failed once in a combined run and passed on every rerun (5/5 in isolation, and in three consecutive full TUI runs here plus two on clean `main`). This branch touches neither that test nor `subagent_view.py`.
