### PR TITLE
fix(tui): keep the promise a deferred queued-steer row makes

### DIFF
--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -912,6 +912,19 @@ class OperatorApp(App[None]):
         #: them together; cleared on a session swap, where the rows belong to a
         #: conversation that is no longer on screen.
         self._queued_steer_notices: list[NoticeBlock] = []
+        #: Rows whose turn ended before any boundary drained them: they now read
+        #: `still queued — sends with your next message`, and the message really
+        #: is still in the engine's queue, so the NEXT turn's first drain is the
+        #: delivery they were promising. Held for exactly that reason — a row
+        #: dropped here is one that goes on saying `still queued` after the user
+        #: has watched the agent act on the instruction (issue #151).
+        #:
+        #: SEPARATE from `_queued_steer_notices` rather than left in it so a
+        #: turn end restates each row once, instead of rewriting every still
+        #: waiting row at every later turn end for the rest of the session.
+        #: The two together are the FIFO the engine drains: these rows were
+        #: queued first, so they settle first (see `on_steering_delivered`).
+        self._deferred_steer_notices: list[NoticeBlock] = []
         #: What the CURRENT turn has already been billed for, per model call, by
         #: `on_context_usage_reported`. `on_turn_ended` prices the same turn as a
         #: whole and is the authoritative figure, so it adds only the difference
@@ -1894,7 +1907,18 @@ class OperatorApp(App[None]):
         # ledger, so the references are to widgets no longer on screen. Left in
         # the list, the replacement session's first delivery would "settle"
         # rows the user cannot see and the rows it CAN see would keep promising.
+        #
+        # The DEFERRED rows go with them, and here the reason is stronger than
+        # "the widget is gone": their messages sit in the OLD session's steering
+        # queue, which is being torn down with it. The replacement session's
+        # first delivery is a different conversation's message entirely, so
+        # settling these against it would be a receipt for something that never
+        # happened. This is the distinction the holding in
+        # `_settle_queued_steer_notices_unsent` has to preserve: a turn that
+        # ended keeps its rows (the message is still coming), a SWAP drops them
+        # (the message left with the session).
         self._queued_steer_notices.clear()
+        self._deferred_steer_notices.clear()
         # The per-call accrual belongs to a turn on the session being replaced.
         # Left standing, the NEXT session's first `agent_end` would subtract the
         # dead conversation's already-billed calls from its own turn total and
@@ -3296,8 +3320,10 @@ class OperatorApp(App[None]):
         # try to settle widgets that are no longer in the transcript. The
         # messages themselves are unaffected — `/clear` empties the screen, not
         # the engine's queue — so the delivery still happens, it just has no row
-        # left to report it on.
+        # left to report it on. The rows still WAITING for a later turn's
+        # delivery are removed by the same clear and go for the same reason.
         self._queued_steer_notices.clear()
+        self._deferred_steer_notices.clear()
         # ``ends_empty_state=False``: the receipt reports on the CLEAR, so the
         # session has not started talking and the splash the clear just restored
         # must survive it. Going through ``_append_block`` rather than straight to
@@ -7766,6 +7792,13 @@ class OperatorApp(App[None]):
         ``note``, the weight the row already had: the state has not got worse,
         so the row has no business getting louder — and the loud ink is already
         spent, once, on the notice that explains why the turn ended.
+
+        The rows are HANDED ON rather than dropped. `still queued — sends with
+        your next message` is still a promise about the future, and it is the
+        one promise in the set that used to be kept off screen: the message goes
+        at the next turn's first boundary, the engine says so, and a row nothing
+        holds cannot hear it. The user then watched the agent act on the
+        instruction with the row above still reading `still queued` (issue #151).
         """
         if not self._queued_steer_notices:
             return
@@ -7774,6 +7807,12 @@ class OperatorApp(App[None]):
                 block.restate(DEFERRED_STEER_NOTICE, "note")
             except Exception:  # a receipt must never take the app down
                 logger.debug("queued-steer notice could not be retired", exc_info=True)
+        # Order matters and is the queue's own: these rows were steered before
+        # anything queued against a LATER turn, and the engine drains FIFO. They
+        # are appended (not prepended) because a turn cannot end with rows
+        # queued against a turn that has not started — `_queued_steer_notices`
+        # is empty of anything newer at this point, by construction.
+        self._deferred_steer_notices.extend(self._queued_steer_notices)
         self._queued_steer_notices.clear()
 
     def on_steering_delivered(self, message: SteeringDelivered) -> None:
@@ -7791,8 +7830,15 @@ class OperatorApp(App[None]):
         boundary, so settling its row here would claim a delivery that has not
         happened. FIFO matches the queue's own order, so "the first ``count``
         rows" and "the messages that went" are the same set.
+
+        DEFERRED rows come first in that order. A row whose turn ended before
+        any boundary is older than anything steered into the turn now running,
+        and the engine's queue never reordered them — it was never drained. So
+        the two lists concatenate into the one FIFO the engine is working
+        through, and this delivery may well settle a row painted several turns
+        ago: that is the point of holding them (issue #151).
         """
-        if not self._queued_steer_notices:
+        if not self._deferred_steer_notices and not self._queued_steer_notices:
             return  # a delivery for rows this app is no longer holding
         # Defensive bounds: a producer that omits `count` (or sends a nonsense
         # one) must not settle nothing, and must not settle more rows than are
@@ -7815,11 +7861,21 @@ class OperatorApp(App[None]):
             # message went.
             logger.debug("steering delivery reported an unusable count", exc_info=True)
             count = 1
-        taken = max(1, min(count, len(self._queued_steer_notices)))
-        settled, self._queued_steer_notices = (
-            self._queued_steer_notices[:taken],
-            self._queued_steer_notices[taken:],
-        )
+        held = self._deferred_steer_notices + self._queued_steer_notices
+        taken = max(1, min(count, len(held)))
+        settled, remaining = held[:taken], held[taken:]
+        # Split back apart by identity rather than by arithmetic on `taken`:
+        # the lists were concatenated for ordering only, and each row goes back
+        # to whichever list it came from so a row that survives this delivery
+        # keeps its meaning (deferred rows are already restated; queued rows are
+        # still promising the current turn).
+        surviving = {id(block) for block in remaining}
+        self._deferred_steer_notices = [
+            block for block in self._deferred_steer_notices if id(block) in surviving
+        ]
+        self._queued_steer_notices = [
+            block for block in self._queued_steer_notices if id(block) in surviving
+        ]
         for block in settled:
             try:
                 block.restate(SENT_STEER_NOTICE, "success")

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -7261,11 +7261,15 @@ class OperatorApp(App[None]):
         self._interrupted_cards = 0
         # EVERY turn end reconciles its queued rows, because the invariant is
         # simply stated: a row still held when a turn ends is one this turn did
-        # not deliver. A clean end can leave one — the model answers with no
-        # further tool calls, so the loop reaches no boundary and never drains
-        # the queue — and that row would otherwise go on promising until some
-        # later turn's first boundary settled it, minutes away and unrelated to
-        # anything on screen.
+        # not deliver. What leaves one behind is an ABORT or a stream error:
+        # both return from the run before the outer loop's yield boundary, which
+        # is where `_collect_yield_injections` drains. A turn that ends cleanly
+        # — even one the model answers with no tool calls at all — does reach
+        # that boundary and does drain (verified against the real `AgentLoop`:
+        # clean turn -> one SteeringDelivered, queue empty; aborted mid-stream
+        # -> no event, message still queued). The reconciliation runs on every
+        # path regardless, because "held when the turn ended" is a fact this
+        # handler can check and "which boundary the loop reached" is not.
         self._settle_queued_steer_notices_unsent()
         # LAST, and only after the turn's outcome is known, because the outcome
         # decides which of the three notifications this is:
@@ -7775,19 +7779,20 @@ class OperatorApp(App[None]):
         """Retire queued-steer rows the turn that just ended did not deliver.
 
         The delivery receipt only fires when ``_drain_steering`` actually takes
-        messages, and three ordinary paths end a turn without one: the turn was
-        interrupted (Ctrl+C), it failed, or it ended cleanly with the model
-        answering and no further tool calls. All three leave a row promising a
-        delivery the app has no receipt for — the defect the receipt exists to
-        prevent, reached by every path that is not the delivery path.
+        messages, and two paths end a turn without one: the turn was interrupted
+        (Ctrl+C) or it failed. Both return from the run before the outer loop's
+        yield boundary, which is where the queue would have been drained, so
+        both leave a row promising a delivery the app has no receipt for — the
+        defect the receipt exists to prevent, reached by every path that is not
+        the delivery path.
 
-        ONE message for all three, because from the user's side they are one
-        fact: the message is still queued (``abort`` stops the run without
-        draining the queue) and goes with their next message. Naming the cause
-        in the row was tried and removed — it restated the ``interrupted`` or
-        error notice sitting a row below it, cost the only string in the set
-        that wraps under 61 columns, and was simply wrong on the error path,
-        where nobody stopped anything.
+        ONE message for both, because from the user's side they are one fact:
+        the message is still queued (``abort`` stops the run without draining
+        the queue) and goes with their next message. Naming the cause in the row
+        was tried and removed — it restated the ``interrupted`` or error notice
+        sitting a row below it, cost the only string in the set that wraps under
+        61 columns, and was simply wrong on the error path, where nobody stopped
+        anything.
 
         ``note``, the weight the row already had: the state has not got worse,
         so the row has no business getting louder — and the loud ink is already
@@ -7807,11 +7812,10 @@ class OperatorApp(App[None]):
                 block.restate(DEFERRED_STEER_NOTICE, "note")
             except Exception:  # a receipt must never take the app down
                 logger.debug("queued-steer notice could not be retired", exc_info=True)
-        # Order matters and is the queue's own: these rows were steered before
-        # anything queued against a LATER turn, and the engine drains FIFO. They
-        # are appended (not prepended) because a turn cannot end with rows
-        # queued against a turn that has not started — `_queued_steer_notices`
-        # is empty of anything newer at this point, by construction.
+        # APPENDED, not prepended: a turn cannot end holding rows queued against
+        # a turn that has not started, so everything already deferred is older
+        # than everything being handed over. See `_deferred_steer_notices` for
+        # why that order is the one the engine settles in.
         self._deferred_steer_notices.extend(self._queued_steer_notices)
         self._queued_steer_notices.clear()
 
@@ -7829,14 +7833,9 @@ class OperatorApp(App[None]):
         already exited. It is genuinely still queued and will go at the next
         boundary, so settling its row here would claim a delivery that has not
         happened. FIFO matches the queue's own order, so "the first ``count``
-        rows" and "the messages that went" are the same set.
-
-        DEFERRED rows come first in that order. A row whose turn ended before
-        any boundary is older than anything steered into the turn now running,
-        and the engine's queue never reordered them — it was never drained. So
-        the two lists concatenate into the one FIFO the engine is working
-        through, and this delivery may well settle a row painted several turns
-        ago: that is the point of holding them (issue #151).
+        rows" and "the messages that went" are the same set — across BOTH held
+        lists, which is why they concatenate here; see
+        `_deferred_steer_notices` for why deferred rows lead.
         """
         if not self._deferred_steer_notices and not self._queued_steer_notices:
             return  # a delivery for rows this app is no longer holding
@@ -7864,17 +7863,26 @@ class OperatorApp(App[None]):
         held = self._deferred_steer_notices + self._queued_steer_notices
         taken = max(1, min(count, len(held)))
         settled, remaining = held[:taken], held[taken:]
-        # Split back apart by identity rather than by arithmetic on `taken`:
-        # the lists were concatenated for ordering only, and each row goes back
-        # to whichever list it came from so a row that survives this delivery
-        # keeps its meaning (deferred rows are already restated; queued rows are
-        # still promising the current turn).
-        surviving = {id(block) for block in remaining}
+        # Split back apart by MEMBERSHIP rather than by arithmetic on `taken`:
+        # the lists were concatenated for ordering only, and each survivor goes
+        # back to whichever list it came from, because the two mean different
+        # things. A deferred row has already been restated and must not be
+        # restated again at the next turn end; a queued row is still promising
+        # the current turn and must be. Arithmetic gets this right only while
+        # `taken == count` and the deferred list is consumed whole — the
+        # defensive coercion above exists precisely because that cannot be
+        # assumed of a field this app does not produce.
+        #
+        # A set of the blocks themselves: `NoticeBlock` inherits identity
+        # equality and hashing from `object` (verified: two rows with identical
+        # text compare unequal and occupy two slots in a set), so membership
+        # here is identity, which is what this needs.
+        surviving = set(remaining)
         self._deferred_steer_notices = [
-            block for block in self._deferred_steer_notices if id(block) in surviving
+            block for block in self._deferred_steer_notices if block in surviving
         ]
         self._queued_steer_notices = [
-            block for block in self._queued_steer_notices if id(block) in surviving
+            block for block in self._queued_steer_notices if block in surviving
         ]
         for block in settled:
             try:

--- a/tests/unit/tui/test_queued_steer_receipt.py
+++ b/tests/unit/tui/test_queued_steer_receipt.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import asyncio
 from pathlib import Path
 from typing import Any, Sequence
+from unittest.mock import patch
 
 import pytest
 
@@ -56,13 +57,22 @@ class _Streaming(FakeSession):
         self.steers.append(text)
 
 
+def _notice_blocks(app: OperatorApp) -> list[NoticeBlock]:
+    """Every notice row, in transcript order.
+
+    The BLOCKS, not their text, for the tests that have to follow one specific
+    row across several deliveries: two rows can carry the same string, and
+    #151's whole failure is a row that never changes — which a text list cannot
+    attribute to the row it belongs to.
+    """
+    return [
+        block for block in app.query_one(TranscriptView).blocks() if isinstance(block, NoticeBlock)
+    ]
+
+
 def _notice_texts(app: OperatorApp) -> list[str]:
     """Every notice row's text, in transcript order."""
-    return [
-        block._text
-        for block in app.query_one(TranscriptView).blocks()
-        if isinstance(block, NoticeBlock)
-    ]
+    return [block._text for block in _notice_blocks(app)]
 
 
 async def _submit(pilot: Any, app: OperatorApp, text: str) -> None:
@@ -213,6 +223,10 @@ async def test_an_interrupted_turn_retires_the_promise_it_can_no_longer_keep() -
         assert QUEUED_STEER_NOTICE not in texts
         assert SENT_STEER_NOTICE not in texts, "nothing was delivered"
         assert app._queued_steer_notices == []
+        # Retired from the CURRENT turn's list, but still held: the message is
+        # genuinely still in the engine's queue, so the row is still waiting on
+        # a delivery that has not happened yet (issue #151).
+        assert len(app._deferred_steer_notices) == 1
         # The message is still in the engine's queue, so the row must not claim
         # it was lost — the user would retype and the agent would get it twice.
         assert "not sent" not in DEFERRED_STEER_NOTICE
@@ -252,6 +266,168 @@ async def test_a_clean_turn_that_never_drained_says_the_message_is_still_queued(
         # message) and the action they take is identical.
         assert SENT_STEER_NOTICE not in texts
         assert app._queued_steer_notices == []
+        assert len(app._deferred_steer_notices) == 1, "the row still awaits its delivery"
+
+
+@pytest.mark.asyncio
+async def test_a_deferred_row_is_settled_by_the_delivery_it_was_waiting_for() -> None:
+    """Issue #151: the one promise in the set that was never kept on screen.
+
+    `still queued — sends with your next message` is TRUE when it is painted and
+    the delivery really does happen — at the next turn's first boundary. The app
+    used to drop its reference to the row at the moment it painted that text, so
+    the delivery arrived with nothing left to settle: the user sent their next
+    message, watched the agent act on the steered instruction, and the row above
+    still read `still queued`.
+
+    Driven end to end through the transition the user actually makes: steer,
+    turn ends undelivered, next turn's boundary drains the queue.
+    """
+    session = _Streaming()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await pilot.pause()
+        await _submit(pilot, app, "and use the staging credentials")
+
+        app.post_message(TurnEnded(True, None))
+        await pilot.pause()
+        assert DEFERRED_STEER_NOTICE in _notice_texts(app)
+
+        # The next turn reaches its first boundary and the engine takes the
+        # message that has been waiting since before the interrupt.
+        app.post_message(SteeringDelivered(1))
+        await pilot.pause()
+
+        texts = _notice_texts(app)
+        assert texts.count(SENT_STEER_NOTICE) == 1
+        assert DEFERRED_STEER_NOTICE not in texts, "the kept promise still reads as waiting"
+        assert QUEUED_STEER_NOTICE not in texts
+        assert app._deferred_steer_notices == []
+
+
+@pytest.mark.asyncio
+async def test_a_deferred_row_settles_before_one_queued_against_the_new_turn() -> None:
+    """The two holders are one FIFO, because the engine's queue is one FIFO.
+
+    A row carried over from an ended turn is OLDER than anything steered into
+    the turn now running, and nothing reordered the engine's queue — it was
+    never drained. So a delivery that takes one message takes the carried-over
+    one, and settling the newer row instead would claim a delivery for a message
+    still sitting behind it.
+    """
+    session = _Streaming()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await pilot.pause()
+        await _submit(pilot, app, "the older instruction")
+        app.post_message(TurnEnded(True, None))
+        await pilot.pause()
+        await _submit(pilot, app, "the newer instruction")
+
+        blocks = _notice_blocks(app)
+        older = next(block for block in blocks if block._text == DEFERRED_STEER_NOTICE)
+        newer = next(block for block in blocks if block._text == QUEUED_STEER_NOTICE)
+
+        # The boundary took ONE message.
+        app.post_message(SteeringDelivered(1))
+        await pilot.pause()
+
+        assert older._text == SENT_STEER_NOTICE, "the older message was the one that went"
+        assert newer._text == QUEUED_STEER_NOTICE, "the newer row must keep promising"
+        assert app._deferred_steer_notices == []
+        assert app._queued_steer_notices == [newer]
+
+
+@pytest.mark.asyncio
+async def test_a_second_turn_end_does_not_restate_a_row_it_already_retired() -> None:
+    """Rows move OUT of the queued list when they are retired, once.
+
+    Holding them in the same list would make every later turn end rewrite every
+    row still waiting — N rebuilds and N gap re-measurements per turn, for text
+    that does not change, for the rest of the session.
+    """
+    session = _Streaming()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await pilot.pause()
+        await _submit(pilot, app, "waiting on a later turn")
+
+        app.post_message(TurnEnded(True, None))
+        await pilot.pause()
+        row = next(block for block in _notice_blocks(app) if block._text == DEFERRED_STEER_NOTICE)
+        restatements: list[str] = []
+        original = type(row).restate
+
+        def _record(self: NoticeBlock, text: str, kind: str) -> None:
+            if self is row:
+                restatements.append(text)
+            original(self, text, kind)  # type: ignore[arg-type]
+
+        with patch.object(type(row), "restate", _record):
+            for _ in range(3):
+                app.post_message(TurnEnded(False, None))
+                await pilot.pause()
+
+        assert restatements == [], "a retired row was rewritten by a later turn end"
+        assert row._text == DEFERRED_STEER_NOTICE
+
+
+@pytest.mark.asyncio
+async def test_a_session_swap_drops_the_rows_waiting_on_the_old_queue() -> None:
+    """The distinction the holding must preserve: swap vs turn ended.
+
+    A carried-over row is waiting on a message in THIS session's steering queue.
+    A swap tears that session down and empties the transcript, so the message is
+    gone with it and the row is off screen — the replacement session's first
+    delivery is a different conversation's message, and settling these rows
+    against it would be a receipt for something that never happened.
+    """
+    session = _Streaming()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await pilot.pause()
+        await _submit(pilot, app, "queued before the swap")
+        app.post_message(TurnEnded(True, None))
+        await pilot.pause()
+        assert app._deferred_steer_notices, "the row should be held before the swap"
+
+        app._session_factory = lambda: _factory(_Streaming())  # type: ignore[assignment]
+        await app._reload_session()
+        for _ in range(4):
+            await pilot.pause()
+
+        assert app._deferred_steer_notices == []
+        assert app._queued_steer_notices == []
+        app.post_message(SteeringDelivered(1))
+        await pilot.pause()
+        assert SENT_STEER_NOTICE not in _notice_texts(app)
+
+
+@pytest.mark.asyncio
+async def test_clearing_the_transcript_drops_the_rows_waiting_on_a_later_turn() -> None:
+    """`/clear` removes carried-over rows for the same reason it removes queued ones.
+
+    The widgets are no longer in the transcript, so a later delivery would
+    "settle" rows nobody can see. The message itself is unaffected — `/clear`
+    empties the screen, not the engine's queue — so it still arrives, it just
+    has no row left to report it on.
+    """
+    session = _Streaming()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await pilot.pause()
+        await _submit(pilot, app, "queued before the clear")
+        app.post_message(TurnEnded(True, None))
+        await pilot.pause()
+        assert app._deferred_steer_notices
+
+        app._clear_transcript()
+        await pilot.pause()
+
+        assert app._deferred_steer_notices == []
+        app.post_message(SteeringDelivered(1))
+        await pilot.pause()
+        assert SENT_STEER_NOTICE not in _notice_texts(app)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tui/test_queued_steer_receipt.py
+++ b/tests/unit/tui/test_queued_steer_receipt.py
@@ -339,6 +339,65 @@ async def test_a_deferred_row_settles_before_one_queued_against_the_new_turn() -
 
 
 @pytest.mark.asyncio
+async def test_a_surviving_deferred_row_stays_deferred_and_is_not_restated_again() -> None:
+    """A PARTIAL settle must not migrate the survivor into the queued list.
+
+    The two lists are concatenated for ordering only, and splitting the
+    survivors back by arithmetic on `taken` instead of by membership silently
+    puts a leftover deferred row into `_queued_steer_notices`. Nothing is
+    visibly wrong at that moment — and then the next turn end finds it there
+    and restates it a second time, which is exactly the redundant rebuild and
+    gap re-measure the two-list split exists to prevent.
+
+    Reached through the count guard rather than a contrived call: `count`
+    crosses a thread boundary from a producer this app does not own, an
+    unusable value degrades to ONE delivery, and one delivery against two held
+    rows is the partial case. Review round 1, F1 \u2014 the arithmetic version of
+    this split passed all fifteen other tests in this file.
+    """
+    session = _Streaming()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await pilot.pause()
+        for text in ("the first instruction", "the second instruction"):
+            await _submit(pilot, app, text)
+
+        app.post_message(TurnEnded(True, None))
+        await pilot.pause()
+        assert len(app._deferred_steer_notices) == 2
+
+        older, younger = app._deferred_steer_notices
+
+        # An unusable `count` degrades to one delivery, so ONE of the two goes.
+        garbled = SteeringDelivered(1)
+        garbled.count = "not a number"  # type: ignore[assignment]
+        app.post_message(garbled)
+        await pilot.pause()
+
+        assert older._text == SENT_STEER_NOTICE
+        assert younger._text == DEFERRED_STEER_NOTICE
+        # The survivor is still DEFERRED. Landing in the queued list instead
+        # would be invisible here and wrong on the next turn end, below.
+        assert app._deferred_steer_notices == [younger]
+        assert app._queued_steer_notices == []
+
+        restatements: list[str] = []
+        original = type(younger).restate
+
+        def _record(self: NoticeBlock, text: str, kind: str) -> None:
+            if self is younger:
+                restatements.append(text)
+            original(self, text, kind)  # type: ignore[arg-type]
+
+        with patch.object(type(younger), "restate", _record):
+            app.post_message(TurnEnded(False, None))
+            await pilot.pause()
+
+        assert restatements == [], "the survivor was retired a second time"
+        assert younger._text == DEFERRED_STEER_NOTICE
+
+
+@pytest.mark.asyncio
 async def test_a_second_turn_end_does_not_restate_a_row_it_already_retired() -> None:
     """Rows move OUT of the queued list when they are retired, once.
 


### PR DESCRIPTION
# PR Description

Closes #151.

## Change classification

**C2 — standard / pre-authorized.** One TUI receipt path: rows are handed to a second list instead of dropped, and the delivery handler reads both. No new surface, no config, no transcript format change, no engine change. Clean rollback (`git revert`). No RFC requested.

## The bug

Filed from design review round 2 (D12) on #132 and deferred from that PR by agreement with the reviewer.

Steer a message into a running turn, then interrupt it (Ctrl+C) — or have the turn fail with a stream error. Both return from the run before the outer loop's yield boundary, which is where the queue would have been drained. The row settles to:

```
· still queued — sends with your next message
```

That statement is **true**, and it is the only promise in the receipt set that was never kept on screen. `_settle_queued_steer_notices_unsent` cleared `self._queued_steer_notices` at the same moment it painted the row, so the app no longer held a reference to it. When the delivery actually happened at the next turn's first boundary, `SteeringDelivered` found nothing to settle.

(Round-1 review correction, F2: a turn that ends *cleanly* — even one the model answers with no tool calls — does drain, at the yield boundary. Only an abort or a stream error strands a message. Verified against the real `AgentLoop`: clean turn → one `SteeringDelivered`, queue empty; aborted mid-stream → no event, message still queued. The handler is correctly defensive on every path either way, but the earlier wording named a repro that does not reproduce.)

The user sends their next message, watches the agent visibly act on the steered instruction, and the row above still reads `still queued`.

Verified end to end on unmodified `main` (full script and output under Validation): the steered text reaches the model — engine queue depth goes 1 → 0, and `and use the staging credentials` is in the request the model saw — while the row on screen never changes.

## The fix

`local_operator/tui/app.py`, three touch points:

- **`_settle_queued_steer_notices_unsent`** extends `_deferred_steer_notices` with the rows it just restated, instead of dropping them. The row is still making a promise about the future; the app now holds the reference that lets it keep it.
- **`on_steering_delivered`** settles `_deferred_steer_notices + _queued_steer_notices` as one FIFO. A carried-over row is *older* than anything steered into the turn now running, and the engine's queue never reordered them because it was never drained — so the two lists concatenate into the one queue the engine is working through. Rows that survive the delivery are split back by identity, so each keeps its own meaning (deferred rows are already restated; queued rows are still promising the current turn).
- **`_reset_ledger_for_swap` / `_clear_transcript`** clear the new list too.

### Two design points worth stating

**Why a separate list rather than leaving the rows in `_queued_steer_notices`.** A turn end must restate each row *once*. Left in one list, every later turn end would rewrite every still-waiting row — an `_build` and a `refresh_gap_around` per row per turn, for text that does not change, for the rest of the session. Pinned by `test_a_second_turn_end_does_not_restate_a_row_it_already_retired`.

**The constraint the issue named, preserved.** The distinction is **swap** vs **turn ended**:

| | rows | why |
|---|---|---|
| turn ended undelivered | **kept** | the message is still in this session's queue and is still going |
| session swap (`/new`, `/resume`, `/reload`) | dropped | the widgets left the transcript *and* the message left with the session it was queued on — the replacement session's first delivery is a different conversation's message entirely |
| `/clear` | dropped | the widgets left the transcript; the message is unaffected and still arrives, it just has no row left to report on |

Both drop paths are pinned by their own test, and both fail if the clear is removed (see the mutation table).

## Validation

### 1. Reproduced end to end through the real engine

Not posted UI events: a real `Session` runs a real `AgentLoop` against a scripted stream, the real `EventController` marshals its events, and the message is steered through the app's own composer. The abort is raised the way `providers/failover.py` raises it (`ProviderError(kind="aborted")`), so the loop reads `stop_reason == "aborted"` and returns **without ever reaching an injection boundary** — the exact timing the issue is about.

**Before** (clean worktree at `origin/main`, no edits):

```console
$ env -u NO_COLOR TERM=xterm-256color .venv/bin/python e2e_151.py
1. steered mid-turn:         queued — sends when this step finishes
   engine queue depth:       1
model stream failed: interrupted
2. after the interrupt:      still queued — sends with your next message
   engine events:            [AgentStartEvent, TurnStartEvent, MessageStartEvent,
                              MessageUpdateEvent, MessageEndEvent, TurnEndEvent, AgentEndEvent]
   engine queue depth:       1 (still waiting)
3. after the next turn ran:  still queued — sends with your next message
   engine queue depth:       0
   steered text in the request the model saw: True

RESULT: BUG: the promise is never kept
```

The last three lines are the defect stated precisely: **the message was delivered** (queue drained, text in the request) and **the row still says it was not**.

**After**, same script, same branch point:

```console
1. steered mid-turn:         queued — sends when this step finishes
   engine queue depth:       1
model stream failed: interrupted
2. after the interrupt:      still queued — sends with your next message
   engine queue depth:       1 (still waiting)
3. after the next turn ran:  sent — the agent has it now
   engine queue depth:       0
   steered text in the request the model saw: True

RESULT: receipt kept, end to end
```

Step 2 is identical on both sides, which is the point: the deferred row is unchanged, and only the row's *fate* after the real delivery differs.

### 2. Rendered frames, before and after

Captured from the real `OperatorApp` (`app.save_screenshot`, so the stylesheet is applied) and viewed as images, per `AGENTS.md` → "Visual validation".

Rows read out of the SVGs, real-engine run:

| step | before (`main`) | after (this branch) |
|---|---|---|
| steered mid-turn | `· queued — sends when this step finishes` | `· queued — sends when this step finishes` |
| turn interrupted | `· still queued — sends with your next message` | `· still queued — sends with your next message` |
| **next turn delivers** | `· still queued — sends with your next message` ❌ | `✓ sent — the agent has it now` ✅ |

The settled row is **updated in place** — the transcript does not grow a row, the glyph goes `·` → `✓` and the tint `muted` → `fg`, and the `! interrupted` notice below it is untouched (one alarm row for one interrupt, as `test_an_interrupt_spends_the_loud_ink_once` requires).

Frames 3 and 4 (consecutive `pilot.pause()`) are **byte-identical SVGs** (`md5 24f5d1448116b4a6eae98a15346893e5` twice), so nothing reflows after paint.

### 3. Regression tests — and proof each one is load-bearing

Five tests added and two updated in `tests/unit/tui/test_queued_steer_receipt.py`. All **six** new/changed assertions fail on `main`:

```console
$ # unmodified origin/main worktree + this branch's test file
$ env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit/tui/test_queued_steer_receipt.py -q
6 failed, 9 passed
```

Then each guarantee was mutation-checked individually against the fixed code — one mutation, one failing test, no overlap:

| mutation applied to the fix | test that catches it |
|---|---|
| deferred rows not carried over (`extend([])`) | `test_a_deferred_row_is_settled_by_the_delivery_it_was_waiting_for` (+4 others) |
| rows left in `_queued_steer_notices` as well | `test_a_second_turn_end_does_not_restate_a_row_it_already_retired` |
| `_deferred_steer_notices.clear()` removed from `_reset_ledger_for_swap` | `test_a_session_swap_drops_the_rows_waiting_on_the_old_queue` |
| `_deferred_steer_notices.clear()` removed from `_clear_transcript` | `test_clearing_the_transcript_drops_the_rows_waiting_on_a_later_turn` |
| FIFO order reversed (`queued + deferred`) | `test_a_deferred_row_settles_before_one_queued_against_the_new_turn` |
| survivors split by arithmetic instead of membership | `test_a_surviving_deferred_row_stays_deferred_and_is_not_restated_again` (added in round-1 remediation, F1) |

Each mutation produced exactly one failing test and no other — including the sixth, which review round 1 found unpinned (F1) and which is now covered.

### 4. Gates

```console
$ env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit/tui/test_queued_steer_receipt.py -q
                                                              # 16 passed
$ env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit/tui tests/unit/session tests/unit/harness -q
                                                              # 2000 passed, 4 skipped  (after round-1 remediation)
$ env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit -q
                                                              # 4623 passed, 7 skipped, 1 failed
$ .venv/bin/python -m flake8 .                                # clean
$ uvx --from black==26.1.0 black --check local_operator tests  # clean
$ uvx isort --check-only --profile black local_operator tests  # clean
$ .venv/bin/python -m pyright --pythonpath .venv/bin/python .  # 0 errors, 0 warnings, 0 informations
```

The one failure is **pre-existing and unrelated**: `tests/unit/tools/test_eval_tool.py::test_background_streams_output_while_it_runs` ("no streamed output observed while the job ran"), a timing-sensitive test. Confirmed failing identically on an unmodified `origin/main` worktree:

```console
$ cd /tmp/lo-151-base   # detached at origin/main, no edits
$ .venv/bin/python -m pytest tests/unit/tools/test_eval_tool.py::test_background_streams_output_while_it_runs -q
1 failed
```

## Rollout / rollback

Pure TUI change with no persisted state: `git revert` restores the previous behaviour exactly, and nothing on disk records the new list. No migration, no flag.
