### PR TITLE
fix(session,imaging): rebound oversized images already in history

### DIFF
--- a/local_operator/imaging.py
+++ b/local_operator/imaging.py
@@ -113,6 +113,22 @@ IMAGE_MAX_EDGE = 1568
 #: of them on every render (review round 1, F1). The ingest bound and the repair
 #: bound answer different questions and only coincide by accident.
 IMAGE_REFUSAL_MAX_EDGE = 2000
+#: What a repaired line-art block is actually resized TO, deliberately a little
+#: under :data:`IMAGE_REFUSAL_MAX_EDGE` rather than exactly at it.
+#:
+#: The provider's wording is "exceed max allowed size ... 2000 pixels", so 2000
+#: itself reads as legal and landing on it would probably work. Probably is the
+#: wrong standard for the one number whose failure mode is a permanently wedged
+#: session, and this module already holds that position for the ingest cap —
+#: "the cap must sit below 2000 with room to spare — not at it". A repair that
+#: lands exactly on a boundary inferred from an error message would be trusting
+#: a strict inequality nobody has tested, on the code path that exists because
+#: the provider changed its mind about what it accepts.
+#:
+#: 1960 keeps a 2% margin, which costs a pixel font nothing measurable (the
+#: Google-shape frame goes to 0.957 scale instead of 0.977) and leaves room for
+#: a provider that reads its own limit as inclusive.
+IMAGE_REPAIR_TARGET_EDGE = 1960
 #: Refuse to DECODE above this pixel count (~200 MB of RGBA at 4 bytes/pixel).
 #: Checked against the header dimensions BEFORE the decode allocates, because a
 #: decompression bomb is small on disk by construction: a byte cap cannot see
@@ -589,8 +605,11 @@ def rebound_oversize_image(data_b64: str) -> tuple[str, str] | None:
     content goes to ``IMAGE_MAX_EDGE``, where the cost argument for 1568 was
     measured. Line art goes only to the refusal ceiling, because its strokes are
     one pixel wide and every pixel removed is a stroke that may disappear — on a
-    snapcompact frame that is the difference between a 2% and a 23% reduction,
+    snapcompact frame that is the difference between a 4% and a 23% reduction,
     and between legible glyphs and glyphs missing strokes (review round 2, F8).
+    The target is :data:`IMAGE_REPAIR_TARGET_EDGE`, which sits just under the
+    refusal line rather than on it — see that constant for why landing exactly
+    on a boundary inferred from an error message is not good enough here.
 
     A block this cannot decode is returned unchanged rather than dropped. It may
     be perfectly acceptable to the provider (a HEIF whose dimensions this cannot
@@ -636,7 +655,7 @@ def rebound_oversize_image(data_b64: str) -> tuple[str, str] | None:
     #
     # Photographic content keeps the 1568 default: it has no strokes to lose,
     # and it is the case the cost argument for 1568 was measured on.
-    edge = IMAGE_REFUSAL_MAX_EDGE if _is_bilevel_bytes(raw, info) else IMAGE_MAX_EDGE
+    edge = IMAGE_REPAIR_TARGET_EDGE if _is_bilevel_bytes(raw, info) else IMAGE_MAX_EDGE
     try:
         payload, wire_mime, _ = bound_image_for_model(raw, info, max_edge=edge)
     except ValueError:

--- a/local_operator/imaging.py
+++ b/local_operator/imaging.py
@@ -267,11 +267,11 @@ _LINE_ART_MAX_TRANSITION_DENSITY = 0.15
 
 #: Rows per strip when measuring that density. The measurement reads EVERY
 #: pixel — see :func:`_is_line_art` for why sampling was abandoned — so this
-#: exists only to bound peak memory, not to bound the work. Each strip
-#: allocates two difference buffers of ``width * band`` bytes, so at the 50M
-#: pixel decode ceiling the walk peaks at a few MB rather than at ~100 MB for a
-#: whole-image diff. 512 rows is ~3.6 MB on a 7000px-wide image; smaller bands
-#: only add per-crop overhead without changing the result.
+#: exists only to bound peak memory, not to bound the work. A band allocates
+#: four buffers of roughly ``width * band`` bytes (the strip crop, its two
+#: shifted copies and their difference), which at 512 rows is 14.3 MB on a
+#: 7000px-wide image against 196 MB for the same walk done whole. Smaller bands
+#: cut that further but add per-crop overhead without changing the result.
 _LINE_ART_BAND_ROWS = 512
 
 
@@ -304,12 +304,16 @@ def _is_line_art(image: Any) -> bool:
     misread halftone is downscaled with NEAREST, which destroys the tone it
     encodes.
 
-    Reading everything removes the premise instead of retuning it, and costs
-    nothing to do so. The comparison is vectorised in Pillow — the image against
-    itself shifted one column, differenced, then histogrammed — so it is the
-    same ~4 ms on a 2048x1200 frame that the 64-row Python loop cost, and it
-    cannot be defeated by any content period. It runs banded so that peak memory
-    stays bounded on a large image.
+    Reading everything removes the premise instead of retuning it. It is not
+    free — the comparison is vectorised in Pillow (the image against itself
+    shifted one column, differenced, then histogrammed), but it touches every
+    pixel where the sample touched 64 rows, so on a 1200x2048 frame it costs
+    ~5 ms against ~2 ms and at the 50M-pixel decode ceiling ~107 ms against
+    ~17 ms. That is the right trade here: the result is exact and cannot be
+    defeated by any content period, the repair it gates is memoized so a given
+    image pays once, and the histogram gate above means photographic content
+    never reaches this walk at all. It runs banded so peak memory stays bounded
+    on a large image.
 
     Asked of the PIXELS rather than the mode: snapcompact renders ``L``, a
     scanner produces ``1``, and an ordinary grayscale photograph is also ``L``.
@@ -348,8 +352,8 @@ def _is_line_art(image: Any) -> bool:
             # histogram()[0] is the count of identical pairs; everything above
             # it is a transition, whatever the magnitude of the change.
             transitions += sum(delta.histogram()[1:])
-        if not compared:
-            return False
+        # ``compared`` cannot be zero: the guard above establishes width >= 2
+        # and height >= 1, so there is always at least one adjacent pair.
         return transitions / compared <= _LINE_ART_MAX_TRANSITION_DENSITY
     except Exception:  # noqa: BLE001 — a heuristic must never fail an image
         return False

--- a/local_operator/imaging.py
+++ b/local_operator/imaging.py
@@ -257,35 +257,69 @@ def _exif_transposed(image: Any) -> Any:
         return image
 
 
-def _is_bilevel(image: Any) -> bool:
-    """Does this image use only two distinct values (black-and-white line art)?
+#: Fraction of horizontally adjacent pixel pairs that may differ before a
+#: two-valued image is judged DITHERED rather than line art. Line art is made of
+#: solid runs — a pixel font measures 0.010 and flat rules 0.000 — while a
+#: halftone encodes tone as alternating pixels and measures ~0.491, so the two
+#: populations are separated by roughly 50x and the exact threshold is not
+#: delicate. 0.15 sits in the empty middle.
+_LINE_ART_MAX_TRANSITION_DENSITY = 0.15
 
-    Asked of the PIXELS rather than of the mode, because mode is not evidence:
-    snapcompact renders its archive frames as ``L`` and a scanner produces
-    ``1``, while an ordinary grayscale photograph is also ``L`` and must not be
-    treated as line art. What matters is whether the content is made of hard
-    one-pixel strokes, and a two-value histogram is exactly that.
+#: Rows sampled when measuring that density. The statistic is a proportion, so
+#: it converges long before a full read; sampling bounds the check at a few
+#: hundred row reads no matter how large the image is.
+_LINE_ART_SAMPLE_ROWS = 64
 
-    ``getcolors`` is given a small ceiling and returns ``None`` the moment the
-    image exceeds it, so this costs one bounded histogram pass and cannot be
-    made expensive by a photographic input — it gives up almost immediately on
-    anything that is not already nearly bilevel.
 
-    Multi-channel images are excluded outright: two distinct RGB tuples is a
-    two-colour graphic rather than the black-and-white glyph rendering this is
-    protecting, and downsampling that with NEAREST would be a guess.
+def _is_line_art(image: Any) -> bool:
+    """Is this image hard-edged black-and-white line art?
+
+    Decides which resampler a downscale may use, so it has to answer a narrower
+    question than "is it two-valued". Two distinct values covers BOTH the pixel
+    font this protects and a dithered halftone, and the correct filter is
+    opposite for the two: NEAREST keeps a glyph's one-pixel strokes crisp, but
+    on a halftone — where tone is encoded as the RATIO of alternating black and
+    white pixels — dropping every other pixel destroys the tone it was encoding.
+    Measured on a dithered gradient, NEAREST scores a mean tone error of 84.5
+    against 11.4 for LANCZOS (review round 3, F11).
+
+    So two tests, in cost order. The histogram is bounded by ``maxcolors`` and
+    bails immediately on anything photographic. Only then is the transition
+    density measured, and only over sampled rows, because by then the image is
+    known to be two-valued and the question is just how its pixels alternate.
+
+    Asked of the PIXELS rather than the mode: snapcompact renders ``L``, a
+    scanner produces ``1``, and an ordinary grayscale photograph is also ``L``.
+    Multi-channel images are excluded outright — two distinct RGB tuples is a
+    two-colour graphic, not a glyph rendering, and NEAREST on it would be a
+    guess.
     """
     if image.mode not in ("1", "L"):
         return False
     try:
-        colors = image.getcolors(maxcolors=2)
-    except Exception:  # noqa: BLE001 — a histogram must never fail an image
+        if image.getcolors(maxcolors=2) is None:
+            return False
+        gray = image if image.mode == "L" else image.convert("L")
+        width, height = gray.size
+        if width < 2 or height < 1:
+            return False
+        pixels = gray.get_flattened_data()
+        step = max(1, height // _LINE_ART_SAMPLE_ROWS)
+        transitions = 0
+        compared = 0
+        for y in range(0, height, step):
+            row = pixels[y * width : (y + 1) * width]
+            compared += width - 1
+            transitions += sum(1 for x in range(width - 1) if row[x] != row[x + 1])
+        if not compared:
+            return False
+        return transitions / compared <= _LINE_ART_MAX_TRANSITION_DENSITY
+    except Exception:  # noqa: BLE001 — a heuristic must never fail an image
         return False
-    return colors is not None and len(colors) <= 2
 
 
-def _is_bilevel_bytes(data: bytes, info: ImageInfo) -> bool:
-    """:func:`_is_bilevel` for bytes that have not been decoded yet.
+def _is_line_art_bytes(data: bytes, info: ImageInfo) -> bool:
+    """:func:`_is_line_art` for bytes that have not been decoded yet.
 
     Separate from the decoded check because the repair path has to make the
     decision BEFORE it calls into the ladder, and must not fail an image just
@@ -298,7 +332,7 @@ def _is_bilevel_bytes(data: bytes, info: ImageInfo) -> bool:
     try:
         with module.open(io.BytesIO(data)) as image:
             image.load()
-            return _is_bilevel(image)
+            return _is_line_art(image)
     except Exception:  # noqa: BLE001 — the ladder reports decode failures, not this
         return False
 
@@ -432,23 +466,24 @@ def bound_image_for_model(
         if long_edge > edge_cap:
             scale = edge_cap / long_edge
             size = (max(1, round(width * scale)), max(1, round(height * scale)))
-            # LANCZOS everywhere EXCEPT a bilevel source, where it is actively
-            # destructive. A two-value image is a rendering of glyphs or line
-            # art whose strokes are one pixel wide; a smooth filter turns each
-            # stroke into a grey ramp, which both destroys the thing that made
-            # it legible and replaces a 2-value image with a 256-value one that
-            # PNG can no longer compress. Measured on a snapcompact archive
-            # frame: 31 KB of bilevel text became 665 KB after a LANCZOS
-            # downscale — 21x LARGER than the source it was shrinking — while
-            # the glyphs themselves smeared (review round 2, F8).
+            # LANCZOS everywhere EXCEPT hard-edged line art, where it is
+            # actively destructive. Line art's strokes are one pixel wide, so a
+            # smooth filter turns each into a grey ramp — destroying the thing
+            # that made it legible AND replacing a 2-value image with a 256-value
+            # one that PNG can no longer compress. Measured on a snapcompact
+            # archive frame: 31 KB of pixel-font text became 665 KB after a
+            # LANCZOS downscale, 21x LARGER than the source it was shrinking,
+            # with the glyphs smeared (review round 2, F8).
             #
             # NEAREST keeps the two values and the compression, and for pixel
-            # fonts it is also the more faithful resampler: dropping whole rows
-            # and columns leaves the surviving strokes crisp instead of making
-            # every stroke uniformly soft. It is the wrong choice for
-            # photographic content, which is why it is gated on the source
-            # actually being bilevel rather than on the mode being ``L``.
-            resample = image_module.NEAREST if _is_bilevel(image) else image_module.LANCZOS
+            # fonts it is the more faithful resampler: dropping whole rows and
+            # columns leaves surviving strokes crisp instead of making every
+            # stroke uniformly soft. It is the WRONG choice for photographic
+            # content and, less obviously, for a dithered halftone — which is
+            # also two-valued but encodes tone as alternating pixels. See
+            # :func:`_is_line_art` for why the predicate is narrower than
+            # "two distinct values" (review round 3, F11).
+            resample = image_module.NEAREST if _is_line_art(image) else image_module.LANCZOS
             image = image.resize(size, resample)
 
         # Palette and high-bit-depth modes are legal PNG but not legal JPEG,
@@ -655,7 +690,7 @@ def rebound_oversize_image(data_b64: str) -> tuple[str, str] | None:
     #
     # Photographic content keeps the 1568 default: it has no strokes to lose,
     # and it is the case the cost argument for 1568 was measured on.
-    edge = IMAGE_REPAIR_TARGET_EDGE if _is_bilevel_bytes(raw, info) else IMAGE_MAX_EDGE
+    edge = IMAGE_REPAIR_TARGET_EDGE if _is_line_art_bytes(raw, info) else IMAGE_MAX_EDGE
     try:
         payload, wire_mime, _ = bound_image_for_model(raw, info, max_edge=edge)
     except ValueError:

--- a/local_operator/imaging.py
+++ b/local_operator/imaging.py
@@ -59,6 +59,14 @@ the invariant is total:
   provider would actually refuse — is shrunk. Gating on 1568 instead rewrote
   every high-res frame on every render, which is the trade this exception
   exists to leave alone.
+
+  These frames are also the reason the ladder cares what an image is MADE of.
+  They are bilevel renderings of a 5x7 pixel font, so a smooth resampler turns
+  every one-pixel stroke into a grey ramp: it destroys the legibility the font
+  was chosen for AND replaces a 2-value image with a 256-value one that PNG can
+  no longer compress, making the "shrunk" frame 21x larger than the source. A
+  bilevel source is therefore resampled with NEAREST and shrunk only as far as
+  the refusal ceiling demands.
 - ``_forward_undecoded`` cannot resize at all, because on that host there is no
   decoder. See its own docstring for what it does enforce.
 """
@@ -68,6 +76,7 @@ from __future__ import annotations
 import base64
 import hashlib
 import io
+from collections import OrderedDict
 from typing import Any
 
 from local_operator.helpers import heif_image_module, pillow_image_module
@@ -131,6 +140,13 @@ IMAGE_MAX_BYTES = 1024 * 1024
 #: JPEG quality used for that fallback. 85 is the standard visually-lossless
 #: point; on the sampled files it turned 1.9 MB of re-encoded PNG into 271 KB.
 IMAGE_JPEG_QUALITY = 85
+#: The base64 wall a REPAIR is measured against, the byte counterpart to
+#: :data:`IMAGE_REFUSAL_MAX_EDGE`. Providers reject an image block over 5 MB of
+#: base64, and dimensions alone cannot see that coming: a 1900x1900 noise PNG is
+#: comfortably under every pixel ceiling and still encodes to 14.5 MB of base64
+#: (review round 2, F9). Set below the wall so a block that would be refused is
+#: repaired before it is sent, not after.
+IMAGE_REFUSAL_MAX_B64_BYTES = 4 * 1024 * 1024
 
 
 def _forward_undecoded(data: bytes, info: ImageInfo) -> tuple[bytes, str, str]:
@@ -225,6 +241,52 @@ def _exif_transposed(image: Any) -> Any:
         return image
 
 
+def _is_bilevel(image: Any) -> bool:
+    """Does this image use only two distinct values (black-and-white line art)?
+
+    Asked of the PIXELS rather than of the mode, because mode is not evidence:
+    snapcompact renders its archive frames as ``L`` and a scanner produces
+    ``1``, while an ordinary grayscale photograph is also ``L`` and must not be
+    treated as line art. What matters is whether the content is made of hard
+    one-pixel strokes, and a two-value histogram is exactly that.
+
+    ``getcolors`` is given a small ceiling and returns ``None`` the moment the
+    image exceeds it, so this costs one bounded histogram pass and cannot be
+    made expensive by a photographic input — it gives up almost immediately on
+    anything that is not already nearly bilevel.
+
+    Multi-channel images are excluded outright: two distinct RGB tuples is a
+    two-colour graphic rather than the black-and-white glyph rendering this is
+    protecting, and downsampling that with NEAREST would be a guess.
+    """
+    if image.mode not in ("1", "L"):
+        return False
+    try:
+        colors = image.getcolors(maxcolors=2)
+    except Exception:  # noqa: BLE001 — a histogram must never fail an image
+        return False
+    return colors is not None and len(colors) <= 2
+
+
+def _is_bilevel_bytes(data: bytes, info: ImageInfo) -> bool:
+    """:func:`_is_bilevel` for bytes that have not been decoded yet.
+
+    Separate from the decoded check because the repair path has to make the
+    decision BEFORE it calls into the ladder, and must not fail an image just
+    because it could not answer the question — an unreadable histogram simply
+    means "treat it as photographic", which is the conservative default.
+    """
+    module = pillow_image_module() if info.sendable else heif_image_module()
+    if module is None:
+        return False
+    try:
+        with module.open(io.BytesIO(data)) as image:
+            image.load()
+            return _is_bilevel(image)
+    except Exception:  # noqa: BLE001 — the ladder reports decode failures, not this
+        return False
+
+
 def _guard_pixel_budget(width: int, height: int) -> None:
     """Refuse an image whose pixel count would dominate the process.
 
@@ -238,7 +300,9 @@ def _guard_pixel_budget(width: int, height: int) -> None:
         )
 
 
-def bound_image_for_model(data: bytes, info: ImageInfo) -> tuple[bytes, str, str]:
+def bound_image_for_model(
+    data: bytes, info: ImageInfo, *, max_edge: int | None = None
+) -> tuple[bytes, str, str]:
     """Decode, bound and re-encode image bytes for a provider.
 
     Returns ``(payload, wire_mime, summary)``; raises ``ValueError`` with a
@@ -268,6 +332,14 @@ def bound_image_for_model(data: bytes, info: ImageInfo) -> tuple[bytes, str, str
        the usual case here — the sampled 1672x941 photographic PNG re-encoded
        to 1.9 MB of PNG against 271 KB of quality-85 JPEG — but it is not the
        only one, so the choice is measured rather than assumed.
+
+    ``max_edge`` overrides :data:`IMAGE_MAX_EDGE` for callers that are REPAIRING
+    rather than ingesting. The default exists to make an image cheap, and it is
+    the right default for anything arriving from a paste or a file read; but a
+    caller shrinking an image that already exists is trading fidelity it did not
+    choose, and for line art the smallest possible reduction is worth real
+    money. See :func:`rebound_oversize_image`, which passes the refusal ceiling
+    for bilevel sources so a pixel font is shrunk by 2% instead of 23%.
 
     With no decoder available the whole ladder collapses to
     :func:`_forward_undecoded`.
@@ -331,19 +403,37 @@ def bound_image_for_model(data: bytes, info: ImageInfo) -> tuple[bytes, str, str
         width, height = image.size
 
         long_edge = max(width, height)
+        edge_cap = IMAGE_MAX_EDGE if max_edge is None else max_edge
         if (
             info.sendable
             and frames == 1
             and not rotated
-            and long_edge <= IMAGE_MAX_EDGE
+            and long_edge <= edge_cap
             and len(data) <= IMAGE_MAX_BYTES
         ):
             return data, info.mime_type, f"{info.mime_type}, {width}x{height}, {len(data)} bytes"
 
-        if long_edge > IMAGE_MAX_EDGE:
-            scale = IMAGE_MAX_EDGE / long_edge
+        if long_edge > edge_cap:
+            scale = edge_cap / long_edge
             size = (max(1, round(width * scale)), max(1, round(height * scale)))
-            image = image.resize(size, image_module.LANCZOS)
+            # LANCZOS everywhere EXCEPT a bilevel source, where it is actively
+            # destructive. A two-value image is a rendering of glyphs or line
+            # art whose strokes are one pixel wide; a smooth filter turns each
+            # stroke into a grey ramp, which both destroys the thing that made
+            # it legible and replaces a 2-value image with a 256-value one that
+            # PNG can no longer compress. Measured on a snapcompact archive
+            # frame: 31 KB of bilevel text became 665 KB after a LANCZOS
+            # downscale — 21x LARGER than the source it was shrinking — while
+            # the glyphs themselves smeared (review round 2, F8).
+            #
+            # NEAREST keeps the two values and the compression, and for pixel
+            # fonts it is also the more faithful resampler: dropping whole rows
+            # and columns leaves the surviving strokes crisp instead of making
+            # every stroke uniformly soft. It is the wrong choice for
+            # photographic content, which is why it is gated on the source
+            # actually being bilevel rather than on the mode being ``L``.
+            resample = image_module.NEAREST if _is_bilevel(image) else image_module.LANCZOS
+            image = image.resize(size, resample)
 
         # Palette and high-bit-depth modes are legal PNG but not legal JPEG,
         # and rung 3 must not be the first place a mode problem shows up.
@@ -429,7 +519,7 @@ def bound_image_for_model(data: bytes, info: ImageInfo) -> tuple[bytes, str, str
 #: this walk into a worker must revisit that, though the failure mode under the
 #: GIL would be duplicated work rather than a corrupt entry (dict get/set are
 #: atomic).
-_REBOUND_CACHE: dict[str, tuple[str, str]] = {}
+_REBOUND_CACHE: OrderedDict[str, tuple[str, str]] = OrderedDict()
 
 #: Cap on :data:`_REBOUND_CACHE` measured in PAYLOAD BYTES, not entries. The
 #: values are full base64 images and their sizes differ by orders of magnitude,
@@ -441,9 +531,21 @@ _REBOUND_CACHE: dict[str, tuple[str, str]] = {}
 #: staying an order of magnitude under what the images themselves cost in
 #: context.
 #:
-#: Cleared wholesale rather than evicted by age: the entries are equally
-#: valuable, a cold cache costs exactly one resize, and a subtle LRU here would
-#: cost a reader's afternoon for no measurable gain.
+#: Evicted OLDEST-FIRST, not cleared wholesale. Clearing looks simpler and is
+#: catastrophic here, because the access pattern is a full walk of the same
+#: history on every render rather than random lookups: once the working set
+#: exceeds the cap, a clear-on-overflow cache is emptied part-way through each
+#: walk and every later frame in that same walk misses, so the memo never warms
+#: at all. Measured on Gemini-shape archive frames, whose working set is exactly
+#: the "fifty-odd frames" a snapcompact archive replays — 38 frames warm-walked
+#: in 3,858 ms under clear-on-overflow against 5 ms when they fit (review round
+#: 2, F7). Dropping the oldest entries instead keeps the cache hot for the
+#: majority of the walk and degrades smoothly.
+#:
+#: Python dicts preserve insertion order, so "oldest" is the head of the map and
+#: no separate bookkeeping is needed. Insertion order rather than true LRU is
+#: deliberate: a walk touches every entry once per render, so recency carries no
+#: information a full pass does not already erase.
 _REBOUND_CACHE_MAX_BYTES = 32 * 1024 * 1024
 
 
@@ -477,9 +579,18 @@ def rebound_oversize_image(data_b64: str) -> tuple[str, str] | None:
     so it earns its keep only on a block that would otherwise be refused; a
     block between the two numbers is one this module would not have created but
     which the provider accepts, and rewriting it would silently overrule the
-    caller that chose that size (review round 1, F1). Blocks that ARE repaired
-    come back bounded to ``IMAGE_MAX_EDGE``, because once a re-encode is
-    unavoidable the cost argument for 1568 applies in full.
+    caller that chose that size (review round 1, F1).
+
+    Size is not the only way to be refused, so :data:`IMAGE_REFUSAL_MAX_B64_BYTES`
+    is checked too: a 1900x1900 noise PNG clears every pixel ceiling and still
+    encodes to 14.5 MB of base64 against a 5 MB wall (review round 2, F9).
+
+    How FAR a repaired block is shrunk then depends on what it is. Photographic
+    content goes to ``IMAGE_MAX_EDGE``, where the cost argument for 1568 was
+    measured. Line art goes only to the refusal ceiling, because its strokes are
+    one pixel wide and every pixel removed is a stroke that may disappear — on a
+    snapcompact frame that is the difference between a 2% and a 23% reduction,
+    and between legible glyphs and glyphs missing strokes (review round 2, F8).
 
     A block this cannot decode is returned unchanged rather than dropped. It may
     be perfectly acceptable to the provider (a HEIF whose dimensions this cannot
@@ -495,7 +606,14 @@ def rebound_oversize_image(data_b64: str) -> tuple[str, str] | None:
     if info is None or info.width is None or info.height is None:
         # Unreadable header: cannot prove it is oversized, so do not touch it.
         return None
-    if max(info.width, info.height) <= IMAGE_REFUSAL_MAX_EDGE:
+    oversized = max(info.width, info.height) > IMAGE_REFUSAL_MAX_EDGE
+    # The byte wall is a SEPARATE refusal that dimensions cannot predict. A
+    # 1900x1900 noise PNG clears every pixel ceiling and still encodes to 14.5 MB
+    # of base64, which the provider refuses exactly as flatly as an oversized
+    # edge (review round 2, F9). Measured on the ENCODED text, because that is
+    # what is actually sent and what the wall is expressed in.
+    too_heavy = len(data_b64) > IMAGE_REFUSAL_MAX_B64_BYTES
+    if not oversized and not too_heavy:
         return None
     # Only oversized blocks reach the cache, so the common path never pays for
     # it. The digest covers the bytes alone, which is the whole key: the result
@@ -508,17 +626,28 @@ def rebound_oversize_image(data_b64: str) -> tuple[str, str] | None:
     cached = _REBOUND_CACHE.get(key)
     if cached is not None:
         return cached
+    # Line art is shrunk to the REFUSAL ceiling rather than to IMAGE_MAX_EDGE:
+    # every pixel removed from a one-pixel stroke is a stroke that may vanish,
+    # so a repair takes the smallest reduction that clears the wall instead of
+    # the cheapest one. On a snapcompact frame that is a 2% downscale rather
+    # than 23%, which is the difference between legible glyphs and glyphs
+    # missing strokes (review round 2, F8). It is also the cheaper choice here,
+    # because a bilevel image compresses to almost nothing either way.
+    #
+    # Photographic content keeps the 1568 default: it has no strokes to lose,
+    # and it is the case the cost argument for 1568 was measured on.
+    edge = IMAGE_REFUSAL_MAX_EDGE if _is_bilevel_bytes(raw, info) else IMAGE_MAX_EDGE
     try:
-        payload, wire_mime, _ = bound_image_for_model(raw, info)
+        payload, wire_mime, _ = bound_image_for_model(raw, info, max_edge=edge)
     except ValueError:
         # Corrupt or bomb-sized. Leaving it is strictly better than dropping it:
         # the block may still be one the provider accepts, and if it is not, the
         # session's image-rejection degrade removes it on the refusal.
         return None
     result = (base64.b64encode(payload).decode("ascii"), wire_mime)
-    if sum(len(data) for data, _ in _REBOUND_CACHE.values()) + len(result[0]) > (
-        _REBOUND_CACHE_MAX_BYTES
-    ):
-        _REBOUND_CACHE.clear()
+    retained = sum(len(data) for data, _ in _REBOUND_CACHE.values()) + len(result[0])
+    while retained > _REBOUND_CACHE_MAX_BYTES and _REBOUND_CACHE:
+        _, (evicted, _mime) = _REBOUND_CACHE.popitem(last=False)
+        retained -= len(evicted)
     _REBOUND_CACHE[key] = result
     return result

--- a/local_operator/imaging.py
+++ b/local_operator/imaging.py
@@ -32,27 +32,41 @@ whatever size the screen produced, which is exactly how a 2206x266 paste wedged
 a session permanently — the read tool had been bounded since it was written, so
 the hole was only visible from the path that had no bound at all.
 
-TWO KNOWING EXCEPTIONS, so a reader does not conclude the invariant is total:
+Bounding on the way in has one structural limit, and it is the reason
+:func:`rebound_oversize_image` exists below. It can only protect blocks created
+AFTER it shipped. A transcript is replayed verbatim on every resume, so history
+written by an older build stays oversized on disk and goes on being refused by a
+build whose composer can no longer produce such a block — observed as a 2206x266
+paste that answered every prompt with the many-image refusal long after the
+paste path was fixed. The repair therefore runs on the rendered history, where
+every request converges, rather than at the two creation sites.
+
+TWO KNOWING EXCEPTIONS to the creation-time bound, so a reader does not conclude
+the invariant is total:
 
 - ``compaction/snapcompact.py`` renders its own frames and does not come
-  through here. Their geometry is a per-provider billing decision rather than a
-  paste, and under the Google shape they are 2048x2046 — over the many-image
-  ceiling. That is reachable on another provider, since ``session.set_model``
-  can swap mid-session and a Gemini-shaped archive then replays to whatever is
-  current (review round 1, F4). It is left alone here because changing it means
-  re-deciding that billing trade, not because it is safe by construction; the
-  ``is_image_rejection`` degrade is the net under it.
+  through :func:`bound_image_for_model`. Their geometry is a per-provider
+  billing decision rather than a paste, and under the Google shape they are
+  2048x2046 — over the many-image ceiling. That is reachable on another
+  provider, since ``session.set_model`` can swap mid-session and a
+  Gemini-shaped archive then replays to whatever is current (review round 1,
+  F4). The billing trade is still not re-decided here; those frames are now
+  caught by the render-time repair like any other oversized block, so the
+  archive is rendered for the provider it was measured against and shrunk only
+  when it would actually be refused.
 - ``_forward_undecoded`` cannot resize at all, because on that host there is no
   decoder. See its own docstring for what it does enforce.
 """
 
 from __future__ import annotations
 
+import base64
+import hashlib
 import io
 from typing import Any
 
 from local_operator.helpers import heif_image_module, pillow_image_module
-from local_operator.media import ImageInfo
+from local_operator.media import ImageInfo, sniff_image
 from local_operator.optional import missing_extra_error
 
 #: Long-edge ceiling in pixels for an image handed to a provider.
@@ -360,3 +374,94 @@ def bound_image_for_model(data: bytes, info: ImageInfo) -> tuple[bytes, str, str
             # it might derive coordinates from have been swapped.
             summary += " (EXIF-rotated)"
     return payload, wire_mime, summary
+
+
+#: Memo for :func:`rebound_oversize_image`, keyed by a digest of the block's
+#: base64 text. The repair runs on the RENDERED history, which is rebuilt from
+#: the transcript on every single turn (and again for every token count), so an
+#: oversized block would otherwise be decoded, resized and re-encoded from
+#: scratch several times a turn for the rest of the session — ~315 ms of CPU per
+#: 20 MP frame, on the loop, forever. The digest is the key rather than the
+#: payload so the cache holds hashes and results instead of a second copy of
+#: every image in the conversation.
+#:
+#: ``None`` results are memoized too, and that is the case that matters most for
+#: cost: it is the answer for every in-bounds block, so this also buys the
+#: ordinary session out of re-hashing... nothing. In-bounds blocks are settled by
+#: a header read before they reach here, so only decisions that cost a decode
+#: are stored.
+_REBOUND_CACHE: dict[str, tuple[str, str]] = {}
+
+#: Cap on :data:`_REBOUND_CACHE` entries. A session that legitimately holds this
+#: many DISTINCT oversized images has bigger problems than a cache miss, and an
+#: unbounded dict keyed by content would otherwise grow for the life of the
+#: process. Cleared wholesale rather than evicted by age: the entries are
+#: equally valuable, the map is tiny, and a correct-but-cold cache costs one
+#: resize while a subtle LRU here would cost a reader's afternoon.
+_REBOUND_CACHE_MAX = 64
+
+
+def rebound_oversize_image(data_b64: str) -> tuple[str, str] | None:
+    """Re-bound an ALREADY-ENCODED image block whose long edge is too big.
+
+    ``None`` means "leave this block exactly as it is", which is the answer for
+    the overwhelming majority of blocks and must stay cheap: the dimensions come
+    from :func:`~local_operator.media.sniff_image`, a header read, so an
+    in-bounds block costs one base64 decode and no Pillow decode at all.
+
+    This is the REPAIR path, and it exists because bounding on the way in
+    (:func:`bound_image_for_model`) can only ever protect blocks created after
+    that code shipped. History written by an older build is already on disk and
+    already oversized, and a transcript is replayed verbatim on every resume —
+    so a session poisoned before the fix stays poisoned after it, which is
+    precisely what was observed: a 2206x266 paste from an unbounded build kept
+    earning ``At least one of the image dimensions exceed max allowed size for
+    many-image requests: 2000 pixels`` on every prompt, on a build whose
+    composer could no longer produce such a block.
+
+    Deliberately keyed on the DIMENSION alone, not on bytes and not on the
+    provider's complaint. The many-image ceiling is the only limit that can be
+    breached by a block that was legal when it was written — the conversation
+    grows past twenty frames and a block that was fine for a hundred turns
+    starts being refused — so the repair has to be able to run BEFORE any
+    refusal has happened, which rules out driving it from the error text.
+
+    A block this cannot decode is returned unchanged rather than dropped. It may
+    be perfectly acceptable to the provider (a HEIF whose dimensions this cannot
+    read, a host with no Pillow), and the ``is_image_rejection`` degrade in the
+    session is still underneath as the net for the genuinely bad ones. Repairing
+    history must never be able to destroy context on its own.
+    """
+    try:
+        raw = base64.b64decode(data_b64, validate=True)
+    except Exception:  # noqa: BLE001 — a malformed block is the degrade's problem, not ours
+        return None
+    info = sniff_image(raw)
+    if info is None or info.width is None or info.height is None:
+        # Unreadable header: cannot prove it is oversized, so do not touch it.
+        return None
+    if max(info.width, info.height) <= IMAGE_MAX_EDGE:
+        return None
+    # Only oversized blocks reach the cache, so the common path never pays for
+    # it. The digest covers the bytes alone, which is the whole key: the result
+    # is derived from the DECODED image, and identical bytes cannot decode two
+    # ways. The block's declared mime type is deliberately not consulted
+    # anywhere here — ``sniff_image`` decides format by CONTENT, because a block
+    # labelled ``image/png`` that is really a JPEG must be resized as what it
+    # actually is.
+    key = hashlib.sha256(raw).hexdigest()
+    cached = _REBOUND_CACHE.get(key)
+    if cached is not None:
+        return cached
+    try:
+        payload, wire_mime, _ = bound_image_for_model(raw, info)
+    except ValueError:
+        # Corrupt or bomb-sized. Leaving it is strictly better than dropping it:
+        # the block may still be one the provider accepts, and if it is not, the
+        # session's image-rejection degrade removes it on the refusal.
+        return None
+    result = (base64.b64encode(payload).decode("ascii"), wire_mime)
+    if len(_REBOUND_CACHE) >= _REBOUND_CACHE_MAX:
+        _REBOUND_CACHE.clear()
+    _REBOUND_CACHE[key] = result
+    return result

--- a/local_operator/imaging.py
+++ b/local_operator/imaging.py
@@ -46,14 +46,19 @@ the invariant is total:
 
 - ``compaction/snapcompact.py`` renders its own frames and does not come
   through :func:`bound_image_for_model`. Their geometry is a per-provider
-  billing decision rather than a paste, and under the Google shape they are
-  2048x2046 — over the many-image ceiling. That is reachable on another
-  provider, since ``session.set_model`` can swap mid-session and a
-  Gemini-shaped archive then replays to whatever is current (review round 1,
-  F4). The billing trade is still not re-decided here; those frames are now
-  caught by the render-time repair like any other oversized block, so the
-  archive is rendered for the provider it was measured against and shrunk only
-  when it would actually be refused.
+  billing decision rather than a paste: 1568px, 1932px for high-res Claude
+  lines, and 2048x2046 under the Google shape. Only the last is over the
+  many-image ceiling, and it is reachable on another provider because
+  ``session.set_model`` can swap mid-session and a Gemini-shaped archive then
+  replays to whatever is current (review round 1, F4).
+
+  The billing trade is genuinely not re-decided here, and that is why the
+  render-time repair triggers at :data:`IMAGE_REFUSAL_MAX_EDGE` rather than at
+  :data:`IMAGE_MAX_EDGE`: the 1932px frame is under the ceiling, so it is left
+  exactly as compaction rendered it, and only the 2048px frame — which a
+  provider would actually refuse — is shrunk. Gating on 1568 instead rewrote
+  every high-res frame on every render, which is the trade this exception
+  exists to leave alone.
 - ``_forward_undecoded`` cannot resize at all, because on that host there is no
   decoder. See its own docstring for what it does enforce.
 """
@@ -87,6 +92,18 @@ from local_operator.optional import missing_extra_error
 #: passes any byte cap easily — costs 16,257 tokens untouched against 2,459
 #: resized (6.6x).
 IMAGE_MAX_EDGE = 1568
+#: The provider ceiling a REPAIR is measured against, which is deliberately not
+#: :data:`IMAGE_MAX_EDGE`. Anything this module CREATES is bounded to 1568 for
+#: the cost reasons above; but a block that already exists is only worth
+#: rewriting when it would actually be refused, and the refusal line is the
+#: many-image limit of 2000 (see the module docstring).
+#:
+#: Conflating the two silently re-decided a billing trade that is not this
+#: module's to make: snapcompact renders Anthropic high-res archive frames at
+#: 1932px — under 2000, never refused — and repairing at 1568 rewrote every one
+#: of them on every render (review round 1, F1). The ingest bound and the repair
+#: bound answer different questions and only coincide by accident.
+IMAGE_REFUSAL_MAX_EDGE = 2000
 #: Refuse to DECODE above this pixel count (~200 MB of RGBA at 4 bytes/pixel).
 #: Checked against the header dimensions BEFORE the decode allocates, because a
 #: decompression bomb is small on disk by construction: a byte cap cannot see
@@ -330,17 +347,33 @@ def bound_image_for_model(data: bytes, info: ImageInfo) -> tuple[bytes, str, str
 
         # Palette and high-bit-depth modes are legal PNG but not legal JPEG,
         # and rung 3 must not be the first place a mode problem shows up.
-        image = image.convert("RGBA" if image.mode in ("RGBA", "LA", "PA", "P") else "RGB")
+        #
+        # ``L`` is deliberately NOT widened. It is legal in both PNG and JPEG,
+        # and promoting it to RGB triples the PNG for no visible gain — which is
+        # not a rounding error on the images that are actually grayscale here.
+        # Snapcompact renders its archive frames as ``L`` pixel-font text, and
+        # widening one measured 19,073 B -> 1,055,335 B (55x) because the
+        # inflated PNG blew IMAGE_MAX_BYTES and fell through to the lossy JPEG
+        # rung, putting ringing artifacts on a 5x7 bitmap font chosen precisely
+        # for being crisp and deterministic (review round 1, F2). Keeping the
+        # mode keeps that frame on the lossless rung at a twentieth of the size.
+        if image.mode not in ("L", "LA", "RGB", "RGBA"):
+            image = image.convert("RGBA" if image.mode in ("PA", "P") else "RGB")
         buffer = io.BytesIO()
         image.save(buffer, format="PNG")
         payload, wire_mime = buffer.getvalue(), "image/png"
 
         if len(payload) > IMAGE_MAX_BYTES:
-            if image.mode == "RGBA":
+            if image.mode in ("RGBA", "LA"):
                 # JPEG has no alpha channel. Compositing onto white rather than
                 # dropping the channel keeps a transparent-background diagram
-                # legible instead of rendering it onto black.
-                flat = image_module.new("RGB", image.size, (255, 255, 255))
+                # legible instead of rendering it onto black. ``LA`` is included
+                # because grayscale is no longer widened to RGBA above, so it can
+                # now reach this rung still carrying alpha; the flat image keeps
+                # the source's own channel count so a gray frame stays gray.
+                flat_mode = "RGB" if image.mode == "RGBA" else "L"
+                fill = (255, 255, 255) if flat_mode == "RGB" else 255
+                flat = image_module.new(flat_mode, image.size, fill)
                 flat.paste(image, mask=image.getchannel("A"))
                 image = flat
             buffer = io.BytesIO()
@@ -385,20 +418,33 @@ def bound_image_for_model(data: bytes, info: ImageInfo) -> tuple[bytes, str, str
 #: payload so the cache holds hashes and results instead of a second copy of
 #: every image in the conversation.
 #:
-#: ``None`` results are memoized too, and that is the case that matters most for
-#: cost: it is the answer for every in-bounds block, so this also buys the
-#: ordinary session out of re-hashing... nothing. In-bounds blocks are settled by
-#: a header read before they reach here, so only decisions that cost a decode
-#: are stored.
+#: In-bounds blocks never reach the cache at all — they are settled by a header
+#: read — so only decisions that actually cost a decode are stored, and an
+#: ordinary session of legal screenshots cannot evict the one entry that is
+#: expensive to recompute.
+#:
+#: NOT synchronized, which is safe only because rendering is loop-bound: the
+#: agent loop calls ``convert_to_llm`` on the event loop, and the token-count
+#: path renders on the loop before it crosses to a thread. Anything that moves
+#: this walk into a worker must revisit that, though the failure mode under the
+#: GIL would be duplicated work rather than a corrupt entry (dict get/set are
+#: atomic).
 _REBOUND_CACHE: dict[str, tuple[str, str]] = {}
 
-#: Cap on :data:`_REBOUND_CACHE` entries. A session that legitimately holds this
-#: many DISTINCT oversized images has bigger problems than a cache miss, and an
-#: unbounded dict keyed by content would otherwise grow for the life of the
-#: process. Cleared wholesale rather than evicted by age: the entries are
-#: equally valuable, the map is tiny, and a correct-but-cold cache costs one
-#: resize while a subtle LRU here would cost a reader's afternoon.
-_REBOUND_CACHE_MAX = 64
+#: Cap on :data:`_REBOUND_CACHE` measured in PAYLOAD BYTES, not entries. The
+#: values are full base64 images and their sizes differ by orders of magnitude,
+#: so an entry count bounds the wrong quantity: 64 resized phone photos at
+#: ~1.3 MB each retain ~81 MB for the life of the PROCESS, shared across every
+#: session and subagent in it (review round 1, F5). 32 MB is chosen to hold a
+#: realistic session's worth of repaired frames — the observed 1568x189 repair
+#: is 46 KB, and even a 1.3 MB worst case leaves room for two dozen — while
+#: staying an order of magnitude under what the images themselves cost in
+#: context.
+#:
+#: Cleared wholesale rather than evicted by age: the entries are equally
+#: valuable, a cold cache costs exactly one resize, and a subtle LRU here would
+#: cost a reader's afternoon for no measurable gain.
+_REBOUND_CACHE_MAX_BYTES = 32 * 1024 * 1024
 
 
 def rebound_oversize_image(data_b64: str) -> tuple[str, str] | None:
@@ -426,6 +472,15 @@ def rebound_oversize_image(data_b64: str) -> tuple[str, str] | None:
     starts being refused — so the repair has to be able to run BEFORE any
     refusal has happened, which rules out driving it from the error text.
 
+    The trigger is :data:`IMAGE_REFUSAL_MAX_EDGE` and NOT
+    :data:`IMAGE_MAX_EDGE`. Repairing is a rewrite of somebody else's decision,
+    so it earns its keep only on a block that would otherwise be refused; a
+    block between the two numbers is one this module would not have created but
+    which the provider accepts, and rewriting it would silently overrule the
+    caller that chose that size (review round 1, F1). Blocks that ARE repaired
+    come back bounded to ``IMAGE_MAX_EDGE``, because once a re-encode is
+    unavoidable the cost argument for 1568 applies in full.
+
     A block this cannot decode is returned unchanged rather than dropped. It may
     be perfectly acceptable to the provider (a HEIF whose dimensions this cannot
     read, a host with no Pillow), and the ``is_image_rejection`` degrade in the
@@ -440,7 +495,7 @@ def rebound_oversize_image(data_b64: str) -> tuple[str, str] | None:
     if info is None or info.width is None or info.height is None:
         # Unreadable header: cannot prove it is oversized, so do not touch it.
         return None
-    if max(info.width, info.height) <= IMAGE_MAX_EDGE:
+    if max(info.width, info.height) <= IMAGE_REFUSAL_MAX_EDGE:
         return None
     # Only oversized blocks reach the cache, so the common path never pays for
     # it. The digest covers the bytes alone, which is the whole key: the result
@@ -461,7 +516,9 @@ def rebound_oversize_image(data_b64: str) -> tuple[str, str] | None:
         # session's image-rejection degrade removes it on the refusal.
         return None
     result = (base64.b64encode(payload).decode("ascii"), wire_mime)
-    if len(_REBOUND_CACHE) >= _REBOUND_CACHE_MAX:
+    if sum(len(data) for data, _ in _REBOUND_CACHE.values()) + len(result[0]) > (
+        _REBOUND_CACHE_MAX_BYTES
+    ):
         _REBOUND_CACHE.clear()
     _REBOUND_CACHE[key] = result
     return result

--- a/local_operator/imaging.py
+++ b/local_operator/imaging.py
@@ -304,16 +304,20 @@ def _is_line_art(image: Any) -> bool:
     misread halftone is downscaled with NEAREST, which destroys the tone it
     encodes.
 
-    Reading everything removes the premise instead of retuning it. It is not
-    free — the comparison is vectorised in Pillow (the image against itself
-    shifted one column, differenced, then histogrammed), but it touches every
-    pixel where the sample touched 64 rows, so on a 1200x2048 frame it costs
-    ~5 ms against ~2 ms and at the 50M-pixel decode ceiling ~107 ms against
-    ~17 ms. That is the right trade here: the result is exact and cannot be
-    defeated by any content period, the repair it gates is memoized so a given
-    image pays once, and the histogram gate above means photographic content
-    never reaches this walk at all. It runs banded so peak memory stays bounded
-    on a large image.
+    Reading everything removes the premise instead of retuning it, and reads
+    MORE pixels in LESS time. The comparison is vectorised in Pillow — the image
+    against itself shifted one column, differenced, then histogrammed — so it
+    replaces a Python-level per-pixel loop with a C-level pass. Measured against
+    the sampled version it supersedes, on the same fixtures: 1200x2048 costs
+    5.3 ms against 15.4 ms, and at the 50M-pixel decode ceiling ~88 ms against
+    ~264 ms. Roughly 2.9x faster while being exact, because the sample's cost
+    was never in the number of pixels it read but in reading them one Python
+    object at a time.
+
+    Cost is bounded twice over regardless: the histogram gate above means
+    photographic content never reaches this walk, and the repair it gates is
+    memoized, so a given image pays once. It runs banded so peak memory stays
+    bounded on a large image.
 
     Asked of the PIXELS rather than the mode: snapcompact renders ``L``, a
     scanner produces ``1``, and an ordinary grayscale photograph is also ``L``.

--- a/local_operator/imaging.py
+++ b/local_operator/imaging.py
@@ -265,10 +265,14 @@ def _exif_transposed(image: Any) -> Any:
 #: delicate. 0.15 sits in the empty middle.
 _LINE_ART_MAX_TRANSITION_DENSITY = 0.15
 
-#: Rows sampled when measuring that density. The statistic is a proportion, so
-#: it converges long before a full read; sampling bounds the check at a few
-#: hundred row reads no matter how large the image is.
-_LINE_ART_SAMPLE_ROWS = 64
+#: Rows per strip when measuring that density. The measurement reads EVERY
+#: pixel — see :func:`_is_line_art` for why sampling was abandoned — so this
+#: exists only to bound peak memory, not to bound the work. Each strip
+#: allocates two difference buffers of ``width * band`` bytes, so at the 50M
+#: pixel decode ceiling the walk peaks at a few MB rather than at ~100 MB for a
+#: whole-image diff. 512 rows is ~3.6 MB on a 7000px-wide image; smaller bands
+#: only add per-crop overhead without changing the result.
+_LINE_ART_BAND_ROWS = 512
 
 
 def _is_line_art(image: Any) -> bool:
@@ -284,9 +288,28 @@ def _is_line_art(image: Any) -> bool:
     against 11.4 for LANCZOS (review round 3, F11).
 
     So two tests, in cost order. The histogram is bounded by ``maxcolors`` and
-    bails immediately on anything photographic. Only then is the transition
-    density measured, and only over sampled rows, because by then the image is
-    known to be two-valued and the question is just how its pixels alternate.
+    bails immediately on anything photographic — which is the gate that keeps
+    this cheap, because only an image already known to be two-valued reaches the
+    second test.
+
+    The density is then measured over EVERY pixel, not over sampled rows. An
+    earlier version read 64 rows at a stride, and every stride is alignable:
+    content whose own vertical period shares a factor with the stride is read at
+    the same phase every time. A round ``height // rows`` stride misreads an
+    image that is solid on exactly the rows it lands on, and switching to a
+    prime stride only moves the collision — at a stride of 31 any height that is
+    a multiple of 31 collapses the walk onto ``height / 31`` distinct rows (a
+    930px image samples 30 rows, a 155px image just 5). Since the two
+    populations are separated by ~50x, the failure is not a near miss: a
+    misread halftone is downscaled with NEAREST, which destroys the tone it
+    encodes.
+
+    Reading everything removes the premise instead of retuning it, and costs
+    nothing to do so. The comparison is vectorised in Pillow — the image against
+    itself shifted one column, differenced, then histogrammed — so it is the
+    same ~4 ms on a 2048x1200 frame that the 64-row Python loop cost, and it
+    cannot be defeated by any content period. It runs banded so that peak memory
+    stays bounded on a large image.
 
     Asked of the PIXELS rather than the mode: snapcompact renders ``L``, a
     scanner produces ``1``, and an ordinary grayscale photograph is also ``L``.
@@ -297,20 +320,34 @@ def _is_line_art(image: Any) -> bool:
     if image.mode not in ("1", "L"):
         return False
     try:
+        # Imported inside the function, like every other Pillow use here:
+        # `imaging` is reachable from the core import path and a module-level
+        # `from PIL import ...` costs ~23 ms and ~7.6 MB RSS on runs that never
+        # touch an image. `tests/unit/test_import_graph.py` pins that.
+        from PIL import ImageChops
+
         if image.getcolors(maxcolors=2) is None:
             return False
         gray = image if image.mode == "L" else image.convert("L")
         width, height = gray.size
         if width < 2 or height < 1:
             return False
-        pixels = gray.get_flattened_data()
-        step = max(1, height // _LINE_ART_SAMPLE_ROWS)
+        # Count horizontally adjacent pairs that differ, one horizontal band at
+        # a time. Within a band the count is the number of non-zero pixels in
+        # |strip - strip shifted left one column|, which Pillow computes in C.
         transitions = 0
-        compared = 0
-        for y in range(0, height, step):
-            row = pixels[y * width : (y + 1) * width]
-            compared += width - 1
-            transitions += sum(1 for x in range(width - 1) if row[x] != row[x + 1])
+        compared = (width - 1) * height
+        for top in range(0, height, _LINE_ART_BAND_ROWS):
+            bottom = min(top + _LINE_ART_BAND_ROWS, height)
+            strip = gray.crop((0, top, width, bottom))
+            rows = bottom - top
+            delta = ImageChops.difference(
+                strip.crop((0, 0, width - 1, rows)),
+                strip.crop((1, 0, width, rows)),
+            )
+            # histogram()[0] is the count of identical pairs; everything above
+            # it is a transition, whatever the magnitude of the change.
+            transitions += sum(delta.histogram()[1:])
         if not compared:
             return False
         return transitions / compared <= _LINE_ART_MAX_TRANSITION_DENSITY

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -424,6 +424,58 @@ def _replayed_user_message(content: list[Content], entry_id: str | None) -> Mess
 IMAGE_DROPPED_NOTICE = "[image omitted: the provider rejected it and it has been dropped]"
 
 
+def _rebound_history_images(messages: list[Message]) -> list[Message]:
+    """Shrink any image block in the rendered history that is over the cap.
+
+    The composer and the ``read`` tool both bound images on the way in, so on a
+    current build nothing reaching here is oversized and this walk is a cheap
+    header check that changes nothing. It exists for the blocks those bounds
+    cannot reach:
+
+    - History written by an OLDER build, which is on disk and is replayed
+      verbatim on every resume. This is the observed failure: a 2206x266 paste
+      from an unbounded build kept earning ``...max allowed size for many-image
+      requests: 2000 pixels`` on every single prompt, on a build whose composer
+      could no longer create such a block. Bounding on the way in fixed the
+      cause and could not fix the sessions already poisoned by it.
+    - Snapcompact archive frames, which are rendered to a per-provider geometry
+      rather than through :func:`~local_operator.imaging.bound_image_for_model`
+      and reach 2048px wide under the Google shape. ``set_model`` can swap
+      providers mid-session, so a Gemini-shaped archive can replay to Anthropic
+      and breach a ceiling it was never measured against.
+
+    Applied to the RENDERED history and never to the transcript, exactly like
+    :func:`_without_images`: the stored frames keep their original resolution,
+    so ``/export`` is unaffected and a provider with laxer limits still gets the
+    full-size image on a later session.
+
+    This is a REPAIR, not a replacement for the ``is_image_rejection`` degrade.
+    It fixes the one cause that is mechanically knowable in advance (the block
+    is too big); the degrade stays underneath for every refusal that is not —
+    corrupt bytes, a format the provider dislikes, or the same bytes being
+    accepted for hours and then refused.
+    """
+    from local_operator.imaging import rebound_oversize_image
+
+    out: list[Message] = []
+    for message in messages:
+        if not any(isinstance(block, ImageContent) for block in message.content):
+            out.append(message)
+            continue
+        content: list[Content] = []
+        changed = False
+        for block in message.content:
+            if isinstance(block, ImageContent):
+                rebound = rebound_oversize_image(block.data)
+                if rebound is not None:
+                    data, mime_type = rebound
+                    block = block.model_copy(update={"data": data, "mime_type": mime_type})
+                    changed = True
+            content.append(block)
+        out.append(message.model_copy(update={"content": content}) if changed else message)
+    return out
+
+
 def _without_images(messages: list[Message]) -> list[Message]:
     """Every message with its image blocks replaced by a one-line notice.
 
@@ -809,7 +861,12 @@ class Session:
         that reaches a provider has to be free of them.
         """
         rendered = self._convert_to_llm(self._live_todo_reminders(messages))
-        return _without_images(rendered) if self._images_rejected else rendered
+        if self._images_rejected:
+            # Nothing to rebound once images are being dropped outright, and
+            # dropping first saves decoding a block that is about to become a
+            # one-line notice.
+            return _without_images(rendered)
+        return _rebound_history_images(rendered)
 
     def _live_todo_reminders(self, messages: list[AgentMessage]) -> list[AgentMessage]:
         """``messages`` without todo reminders the list has since outrun.

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -92,6 +92,7 @@ from local_operator.harness.wake import (
     WakeScheduler,
     format_wake_delivery_text,
 )
+from local_operator.imaging import rebound_oversize_image
 from local_operator.incidents import SESSION_INCIDENT_MESSAGE_TYPE
 from local_operator.session.goal import GoalState
 from local_operator.session.mcp_status import McpStartupOutcome
@@ -455,8 +456,6 @@ def _rebound_history_images(messages: list[Message]) -> list[Message]:
     corrupt bytes, a format the provider dislikes, or the same bytes being
     accepted for hours and then refused.
     """
-    from local_operator.imaging import rebound_oversize_image
-
     out: list[Message] = []
     for message in messages:
         if not any(isinstance(block, ImageContent) for block in message.content):

--- a/tests/unit/session/test_session.py
+++ b/tests/unit/session/test_session.py
@@ -4,6 +4,8 @@ compaction hook, dispose."""
 from __future__ import annotations
 
 import asyncio
+import base64
+import io
 import sys
 import types
 from collections.abc import Awaitable, Callable, Sequence
@@ -1817,3 +1819,97 @@ async def test_a_cancelled_subagent_never_persists_a_marker_or_reminder(tmp_path
     ), "the cancelled child's actual turn was dropped"
 
     await child.dispose()
+
+
+def _sized_png_b64(size: tuple[int, int]) -> str:
+    from PIL import Image
+
+    buffer = io.BytesIO()
+    Image.new("RGB", size, (10, 60, 120)).save(buffer, format="PNG")
+    return base64.b64encode(buffer.getvalue()).decode("ascii")
+
+
+def _rendered_image_sizes(request: ChatRequest) -> list[tuple[int, int]]:
+    from PIL import Image
+
+    return [
+        Image.open(io.BytesIO(base64.b64decode(block.data))).size
+        for message in request.messages
+        for block in message.content
+        if isinstance(block, ImageContent)
+    ]
+
+
+@pytest.mark.asyncio
+async def test_history_written_by_an_older_build_is_rebound_not_refused(tmp_path):
+    """The reported bug, end to end: a resumed session was permanently wedged.
+
+    Bounding images on the way in fixed the CAUSE but could not fix the sessions
+    already poisoned by it. The oversized block is on disk, a transcript is
+    replayed verbatim, and the ``images_rejected`` degrade is in-memory only —
+    so every resume started clean, re-sent the same 2206x266 block, took the
+    same 400, and did it again on the next prompt, forever.
+
+    What makes this the right fix rather than "let the degrade catch it": the
+    degrade costs the model EVERY image in the conversation, and here nothing
+    was wrong with any of them except one that is merely too wide. Shrinking
+    that one keeps the other screenshots the session was reviewing.
+    """
+    stream = ScriptedStream([[StreamTextDelta(delta="ok"), StreamEndEvent(stop_reason="stop")]])
+    session = make_session(tmp_path, stream)
+    await session.seed_history(
+        [
+            Message(
+                role="user",
+                content=[
+                    TextContent(text="review these"),
+                    ImageContent(data=_sized_png_b64((2206, 266)), mime_type="image/png"),
+                    ImageContent(data=_sized_png_b64((1184, 624)), mime_type="image/png"),
+                ],
+            )
+        ]
+    )
+
+    await session.prompt("continue")
+
+    sizes = _rendered_image_sizes(stream.requests[0])
+    assert sizes[0] == (1568, 189), "the oversized block was sent as it was"
+    assert sizes[1] == (1184, 624), "an in-bounds block was resized for no reason"
+    assert not session._images_rejected, "the repair should make the degrade unnecessary"
+    sent = [
+        block.text
+        for message in stream.requests[0].messages
+        for block in message.content
+        if isinstance(block, TextContent)
+    ]
+    assert "review these" in sent
+    await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_the_repair_does_not_resurrect_images_after_a_refusal(tmp_path):
+    """The two mechanisms must compose in one direction only.
+
+    Once a provider has refused an image the session stops sending images at
+    all, and a repair pass that ran afterwards would put a (smaller) block back
+    into the very request the degrade exists to clear.
+    """
+    stream = PoisonedThenFine()
+    session = make_session(tmp_path, stream)
+    await session.seed_history(
+        [
+            Message(
+                role="user",
+                content=[
+                    TextContent(text="look"),
+                    ImageContent(data=_sized_png_b64((2206, 266)), mime_type="image/png"),
+                ],
+            )
+        ]
+    )
+
+    await session.prompt("go")
+    assert session._images_rejected
+    await session.prompt("again")
+    assert _image_blocks(stream.requests[1]) == 0, "the degrade was undone by the repair"
+    await session.dispose()

--- a/tests/unit/test_imaging.py
+++ b/tests/unit/test_imaging.py
@@ -16,15 +16,19 @@ supposed to be the escape hatch.
 
 from __future__ import annotations
 
+import base64
 import io
 
 import pytest
 from PIL import Image
 
 from local_operator.imaging import (
+    _REBOUND_CACHE,
+    _REBOUND_CACHE_MAX,
     IMAGE_MAX_EDGE,
     IMAGE_MAX_PIXELS,
     bound_image_for_model,
+    rebound_oversize_image,
 )
 from local_operator.media import ImageInfo, sniff_image
 
@@ -299,3 +303,79 @@ def test_undecodable_bytes_raise_rather_than_becoming_an_image_block() -> None:
     # The header still parses; only the body is gone.
     with pytest.raises(ValueError):
         bound_image_for_model(truncated, _sniffed(truncated))
+
+
+# ---------------------------------------------------------------------------
+# Repairing history that an older build already poisoned
+# ---------------------------------------------------------------------------
+
+
+def test_an_oversized_block_from_an_older_build_is_rebound() -> None:
+    """The reported bug, at the unit level.
+
+    Bounding on the way in cannot reach a block that was written before it
+    shipped, and a transcript is replayed verbatim on every resume — so the
+    2206x266 paste that wedged a real session kept earning the many-image
+    refusal on a build whose composer could no longer produce it.
+    """
+    source = _png((2206, 266))
+    rebound = rebound_oversize_image(base64.b64encode(source).decode("ascii"))
+    assert rebound is not None, "the oversized block was left as it was"
+    data, mime = rebound
+    width, height = Image.open(io.BytesIO(base64.b64decode(data))).size
+    assert max(width, height) <= IMAGE_MAX_EDGE
+    assert max(width, height) < MANY_IMAGE_PIXEL_LIMIT
+    assert width / height == pytest.approx(2206 / 266, rel=0.01), "aspect ratio was not preserved"
+    assert mime == "image/png"
+
+
+def test_an_in_bounds_block_is_left_completely_alone() -> None:
+    """``None`` means "do not touch it", and it is the answer for almost every
+    block in every conversation. Re-encoding an image the provider already
+    accepts would spend CPU on every turn to make the picture worse."""
+    source = _png((800, 600))
+    assert rebound_oversize_image(base64.b64encode(source).decode("ascii")) is None
+
+
+def test_a_block_that_cannot_be_decoded_is_kept_rather_than_dropped() -> None:
+    """A repair pass must never be able to destroy context on its own.
+
+    Bytes this cannot read may still be perfectly acceptable to the provider,
+    and the ``is_image_rejection`` degrade is the net for the ones that are not.
+    """
+    assert rebound_oversize_image("not base64 at all!!") is None
+
+    truncated = _png((3000, 400))[:60]  # header parses, body is gone
+    assert rebound_oversize_image(base64.b64encode(truncated).decode("ascii")) is None
+
+
+def test_the_repair_is_memoized_so_a_resize_is_not_paid_every_turn() -> None:
+    """The rendered history is rebuilt on every turn and again for every token
+    count, so an uncached repair would re-decode and re-resize the same frame
+    several times a turn for the life of the session."""
+    source = _png((2206, 266))
+    encoded = base64.b64encode(source).decode("ascii")
+    _REBOUND_CACHE.clear()
+
+    first = rebound_oversize_image(encoded)
+    assert len(_REBOUND_CACHE) == 1, "an oversized block was not memoized"
+    second = rebound_oversize_image(encoded)
+    assert first == second, "the memo returned a different image than the resize did"
+
+    # In-bounds blocks are settled by a header read, so they must not consume
+    # cache entries: a long session of ordinary screenshots would otherwise
+    # evict the one entry that actually costs something to recompute.
+    small = base64.b64encode(_png((800, 600))).decode("ascii")
+    rebound_oversize_image(small)
+    assert len(_REBOUND_CACHE) == 1
+
+
+def test_the_memo_cannot_grow_without_bound() -> None:
+    """Keyed by content, so an unbounded map would grow for the life of the
+    process on a session that pastes many distinct oversized frames."""
+    _REBOUND_CACHE.clear()
+    for index in range(_REBOUND_CACHE_MAX + 2):
+        # Distinct sizes, so every one is a distinct cache key.
+        source = _png((2100 + index, 300))
+        rebound_oversize_image(base64.b64encode(source).decode("ascii"))
+    assert len(_REBOUND_CACHE) <= _REBOUND_CACHE_MAX

--- a/tests/unit/test_imaging.py
+++ b/tests/unit/test_imaging.py
@@ -57,6 +57,20 @@ def _noise_png(size: tuple[int, int]) -> bytes:
     return buffer.getvalue()
 
 
+def _bilevel_png(size: tuple[int, int]) -> bytes:
+    """Black-and-white line art: horizontal one-pixel rules, two values only.
+
+    Stands in for the pixel-font renderings this path actually protects, without
+    depending on snapcompact's geometry.
+    """
+    image = Image.new("L", size, 0)
+    for y in range(0, size[1], 3):
+        image.paste(255, (0, y, size[0], y + 1))
+    buffer = io.BytesIO()
+    image.save(buffer, format="PNG")
+    return buffer.getvalue()
+
+
 def _sniffed(data: bytes) -> ImageInfo:
     """``sniff_image`` with its ``None`` asserted away.
 
@@ -466,6 +480,27 @@ def test_a_repaired_archive_frame_stays_a_readable_pixel_font() -> None:
     # pixel taken off a 1px stroke is a stroke that may vanish.
     assert max(repaired.size) <= MANY_IMAGE_PIXEL_LIMIT
     assert max(repaired.size) > IMAGE_MAX_EDGE, "line art was shrunk further than it had to be"
+
+
+def test_a_repair_lands_under_the_refusal_line_not_exactly_on_it() -> None:
+    """The boundary is inferred from an error message, so it must not be sat on.
+
+    The provider says dimensions that "exceed max allowed size ... 2000 pixels",
+    which reads as making 2000 itself legal — but this is the one number whose
+    failure mode is a permanently wedged session, and the module already refuses
+    to sit on it for the ingest cap. A repair that landed exactly on 2000 would
+    be betting the fix on a strict inequality nobody has tested.
+    """
+    source = _bilevel_png((2400, 900))
+    rebound = rebound_oversize_image(base64.b64encode(source).decode("ascii"))
+    assert rebound is not None
+    repaired = Image.open(io.BytesIO(base64.b64decode(rebound[0])))
+    assert max(repaired.size) < MANY_IMAGE_PIXEL_LIMIT, "a repair landed on the refusal line"
+
+    # And the gate itself is exclusive: a block already at the limit is legal
+    # and must not be rewritten.
+    at_limit = _bilevel_png((MANY_IMAGE_PIXEL_LIMIT, 900))
+    assert rebound_oversize_image(base64.b64encode(at_limit).decode("ascii")) is None
 
 
 def test_a_photograph_is_still_resized_smoothly_to_the_cheap_bound() -> None:

--- a/tests/unit/test_imaging.py
+++ b/tests/unit/test_imaging.py
@@ -24,7 +24,7 @@ from PIL import Image
 
 from local_operator.imaging import (
     _REBOUND_CACHE,
-    _REBOUND_CACHE_MAX,
+    _REBOUND_CACHE_MAX_BYTES,
     IMAGE_MAX_EDGE,
     IMAGE_MAX_PIXELS,
     bound_image_for_model,
@@ -43,6 +43,16 @@ MANY_IMAGE_PIXEL_LIMIT = 2000
 def _png(size: tuple[int, int]) -> bytes:
     buffer = io.BytesIO()
     Image.new("RGB", size, (10, 60, 120)).save(buffer, format="PNG")
+    return buffer.getvalue()
+
+
+def _noise_png(size: tuple[int, int]) -> bytes:
+    """An INCOMPRESSIBLE PNG. A flat fill compresses to a few KB whatever its
+    dimensions, so it cannot exercise anything that is measured in bytes."""
+    import os
+
+    buffer = io.BytesIO()
+    Image.frombytes("RGB", size, os.urandom(size[0] * size[1] * 3)).save(buffer, format="PNG")
     return buffer.getvalue()
 
 
@@ -371,11 +381,73 @@ def test_the_repair_is_memoized_so_a_resize_is_not_paid_every_turn() -> None:
 
 
 def test_the_memo_cannot_grow_without_bound() -> None:
-    """Keyed by content, so an unbounded map would grow for the life of the
-    process on a session that pastes many distinct oversized frames."""
+    """Bounded in BYTES, because the values are whole images whose sizes differ
+    by orders of magnitude — an entry count would bound the wrong quantity and
+    let the map retain tens of MB for the life of the process."""
     _REBOUND_CACHE.clear()
-    for index in range(_REBOUND_CACHE_MAX + 2):
-        # Distinct sizes, so every one is a distinct cache key.
-        source = _png((2100 + index, 300))
+    for index in range(40):
+        # Distinct sizes, so every one is a distinct cache key. Photographic
+        # noise, so each result is genuinely large rather than a flat PNG that
+        # compresses to nothing and would never reach the cap.
+        source = _noise_png((2100 + index, 2000))
         rebound_oversize_image(base64.b64encode(source).decode("ascii"))
-    assert len(_REBOUND_CACHE) <= _REBOUND_CACHE_MAX
+    retained = sum(len(data) for data, _ in _REBOUND_CACHE.values())
+    assert retained <= _REBOUND_CACHE_MAX_BYTES
+    assert _REBOUND_CACHE, "the cap evicted so aggressively that nothing is ever cached"
+
+
+# ---------------------------------------------------------------------------
+# Snapcompact archive frames
+#
+# These are the one image source that does NOT come through
+# ``bound_image_for_model`` on the way in: compaction renders them to a
+# per-provider geometry that is a deliberate billing decision. The repair walks
+# over them like any other block, so it must be measured against a REAL frame —
+# a synthetic ``Image.new("RGB", ...)`` shares neither their mode nor their
+# content, and it was exactly that gap that let a 55x size regression and a
+# silent rewrite of the high-res shape pass a green suite (review round 1, F4).
+# ---------------------------------------------------------------------------
+
+
+def _archive_frame(provider: str, model: str) -> bytes:
+    from local_operator.compaction.snapcompact import render_frame, resolve_shape
+
+    page = ("the quick brown fox jumps over the lazy dog 0123456789 " * 40 + "\n") * 40
+    return render_frame(page, resolve_shape(provider, model))
+
+
+def test_an_in_spec_high_res_archive_frame_is_left_alone() -> None:
+    """The Anthropic high-res shape is 1932px: over ``IMAGE_MAX_EDGE`` but UNDER
+    the 2000px ceiling, so no provider would refuse it.
+
+    1932 is a costed choice ("sweet spot under the 4,784 visual-token cap").
+    Repairing it would silently re-decide a billing trade that belongs to the
+    compaction layer, which is the trade this module's docstring promises to
+    leave alone.
+    """
+    frame = _archive_frame("anthropic", "claude-opus-4.7")
+    assert max(Image.open(io.BytesIO(frame)).size) == 1932, "the fixture is not the high-res shape"
+    assert rebound_oversize_image(base64.b64encode(frame).decode("ascii")) is None
+
+
+def test_an_oversized_archive_frame_is_repaired_without_going_lossy() -> None:
+    """The Google shape is 2048px and IS refusable, so it must be repaired —
+    but archive frames are grayscale renderings of a 5x7 bitmap font, and the
+    whole point of that font is that it stays crisp and deterministic.
+
+    Widening the mode to RGB tripled the PNG, blew ``IMAGE_MAX_BYTES`` and
+    dropped the frame onto the lossy JPEG rung, putting ringing artifacts on
+    pixel-font text and inflating one measured frame 55x.
+    """
+    frame = _archive_frame("google", "gemini-2.5-pro")
+    source = Image.open(io.BytesIO(frame))
+    assert max(source.size) > MANY_IMAGE_PIXEL_LIMIT, "the fixture is not refusable"
+    assert source.mode == "L", "the fixture is not the grayscale render"
+
+    rebound = rebound_oversize_image(base64.b64encode(frame).decode("ascii"))
+    assert rebound is not None, "a refusable frame was left in the history"
+    data, mime = rebound
+    assert mime == "image/png", "a pixel-font frame was re-encoded lossily"
+    repaired = Image.open(io.BytesIO(base64.b64decode(data)))
+    assert repaired.mode == "L", "grayscale was widened, which is what forces the JPEG rung"
+    assert max(repaired.size) <= IMAGE_MAX_EDGE

--- a/tests/unit/test_imaging.py
+++ b/tests/unit/test_imaging.py
@@ -17,17 +17,21 @@ supposed to be the escape hatch.
 from __future__ import annotations
 
 import base64
+import hashlib
 import io
+import statistics
 
 import pytest
 from PIL import Image
 
+from local_operator import imaging
 from local_operator.imaging import (
     _REBOUND_CACHE,
     _REBOUND_CACHE_MAX_BYTES,
     IMAGE_MAX_EDGE,
     IMAGE_MAX_PIXELS,
     IMAGE_REFUSAL_MAX_B64_BYTES,
+    _is_line_art,
     bound_image_for_model,
     rebound_oversize_image,
 )
@@ -503,6 +507,42 @@ def test_a_repair_lands_under_the_refusal_line_not_exactly_on_it() -> None:
     assert rebound_oversize_image(base64.b64encode(at_limit).decode("ascii")) is None
 
 
+def test_a_dithered_halftone_is_not_treated_as_line_art() -> None:
+    """Two distinct values is NOT the same predicate as line art, and the right
+    resampler is opposite for the two.
+
+    A halftone encodes tone as the RATIO of alternating black and white pixels,
+    so dropping every other pixel destroys the tone it was encoding — the exact
+    thing NEAREST does. This runs on the INGEST path too (every paste, every
+    ``read``), so getting it wrong silently degrades scans and dithered images
+    that have nothing to do with the archive frames the branch exists for.
+    """
+    dithered = Image.linear_gradient("L").resize((3000, 1200)).convert("1").convert("L")
+    buffer = io.BytesIO()
+    dithered.save(buffer, format="PNG")
+    source = buffer.getvalue()
+
+    assert dithered.getcolors(maxcolors=2) is not None, "the fixture is not two-valued"
+    assert not _is_line_art(Image.open(io.BytesIO(source))), "a halftone was called line art"
+
+    payload, _mime, _summary = bound_image_for_model(source, _sniffed(source))
+    got = Image.open(io.BytesIO(payload)).convert("L")
+    reference = (
+        Image.linear_gradient("L")
+        .resize((3000, 1200))
+        .resize(got.size, Image.Resampling.LANCZOS)
+        .convert("L")
+    )
+    # Both images are single-band ``L``, so the samples are ints; the stub types
+    # these accessors wide enough to include the multi-band tuple form, hence
+    # the explicit narrowing rather than arithmetic on an ``int | tuple``.
+    reference_band = [int(value) for value in reference.tobytes()]
+    got_band = [int(value) for value in got.tobytes()]
+    error = statistics.fmean(abs(a - b) for a, b in zip(reference_band, got_band))
+    # A smooth downscale reconstructs the gradient (~11); NEAREST shreds it (~85).
+    assert error < 30, f"the halftone lost its tone (mean error {error:.1f})"
+
+
 def test_a_photograph_is_still_resized_smoothly_to_the_cheap_bound() -> None:
     """The NEAREST path is for line art only. Photographic content has no
     strokes to lose, is what the 1568 cost argument was measured on, and would
@@ -531,26 +571,60 @@ def test_a_block_under_every_pixel_ceiling_can_still_be_too_heavy() -> None:
     assert len(rebound[0]) < len(encoded), "the repair did not make it lighter"
 
 
-def test_the_memo_survives_a_working_set_larger_than_the_cap() -> None:
+def test_the_memo_survives_a_working_set_larger_than_the_cap(monkeypatch) -> None:
     """Eviction must be oldest-first, not clear-on-overflow.
 
-    The access pattern is a full walk of the same history on every render, not
-    random lookups. Clearing on overflow empties the cache part-way through each
-    walk, so every later frame in that same walk misses and the memo never warms
-    — measured at 3,858 ms per warm walk against 5 ms when the set fits.
+    The access pattern here is a full WALK of the same history on every render,
+    not random lookups, and that is what makes the difference matter: clearing
+    on overflow empties the cache part-way through each walk, so every later
+    frame in that same walk misses and the memo never warms at all — measured at
+    3,858 ms per warm walk against ~5 ms when the set fits.
+
+    The cap is monkeypatched down rather than fed enough real images to reach
+    32 MB. Feeding it the real thing would make this a slow test that only
+    exercises eviction by accident, and the earlier version of this test did
+    exactly that and proved nothing: it used four renders of the SAME text,
+    which are byte-identical and collapse to one cache entry occupying 0.36% of
+    the cap, so eviction never ran and the test passed against the very
+    clear-on-overflow code it was written to forbid (review round 3, F10).
     """
+    sources = [_noise_png((2100 + index * 40, 2000)) for index in range(6)]
+    encoded = [base64.b64encode(source).decode("ascii") for source in sources]
+    assert len({len(item) for item in encoded}) == len(encoded), "fixtures are not distinct"
+
     _REBOUND_CACHE.clear()
-    frames = [_archive_frame("google", "gemini-2.5-pro") for _ in range(4)]
-    encoded = [base64.b64encode(frame).decode("ascii") for frame in frames]
     for item in encoded:
         rebound_oversize_image(item)
-    # Force the cap far below the working set, then walk it twice. Every entry
-    # must still be cached at the end of a walk that exceeded the cap.
-    hits_before = len(_REBOUND_CACHE)
-    assert hits_before >= 1
+    assert len(_REBOUND_CACHE) == len(encoded), "distinct images shared a cache entry"
+
+    # Force a cap that fits THREE entries, then walk the whole set. Three is
+    # the smallest size at which the two policies diverge: at a two-entry cap
+    # both leave the final pair, so a smaller cap would make this test unable to
+    # tell them apart no matter what it asserted.
+    entries = sorted(len(data) for data, _ in _REBOUND_CACHE.values())
+    monkeypatch.setattr(imaging, "_REBOUND_CACHE_MAX_BYTES", sum(entries[:3]))
+    _REBOUND_CACHE.clear()
     for item in encoded:
-        assert rebound_oversize_image(item) is not None
-    assert len(_REBOUND_CACHE) == hits_before, "a walk that fits the cap still evicted"
+        rebound_oversize_image(item)
+
+    retained = sum(len(data) for data, _ in _REBOUND_CACHE.values())
+    assert retained <= imaging._REBOUND_CACHE_MAX_BYTES, "the cap was exceeded"
+
+    # The discriminating assertion, and it has to be about SIZE as well as
+    # identity: clear-on-overflow refills from empty and so ends the walk
+    # holding only the two entries added since it last cleared, while
+    # oldest-first keeps the cache full at three. Both end with a newest-suffix,
+    # so asserting identity alone would pass against either.
+    assert len(_REBOUND_CACHE) == 3, (
+        "eviction did not keep the cache full; a clearing cache refills from "
+        f"empty and ends the walk holding fewer ({len(_REBOUND_CACHE)})"
+    )
+    expected = [hashlib.sha256(source).hexdigest() for source in sources]
+    survivors = list(_REBOUND_CACHE)
+    assert survivors == expected[-len(survivors) :], (
+        "eviction did not keep the newest entries; a clearing cache leaves a "
+        f"different set ({survivors} against {expected[-len(survivors):]})"
+    )
 
 
 def test_an_oversized_archive_frame_is_repaired_without_going_lossy() -> None:

--- a/tests/unit/test_imaging.py
+++ b/tests/unit/test_imaging.py
@@ -543,6 +543,66 @@ def test_a_dithered_halftone_is_not_treated_as_line_art() -> None:
     assert error < 30, f"the halftone lost its tone (mean error {error:.1f})"
 
 
+@pytest.mark.parametrize(
+    ("height", "solid_period"),
+    [
+        # Defeats a ROUND `height // 64` stride: at 2048 that stride is 32, and
+        # every row it reads is one of the solid ones.
+        (2048, 32),
+        (1280, 20),
+        # Defeats a PRIME stride of 31, which collapses whenever the height is a
+        # multiple of 31 — 930 reads 30 distinct rows, 155 reads 5, 62 reads 2,
+        # and every one of them is solid.
+        (930, 31),
+        (155, 31),
+        (62, 31),
+    ],
+)
+def test_a_periodic_dither_is_never_misread_as_line_art(height: int, solid_period: int) -> None:
+    """The density must be measured over every pixel, not over sampled rows.
+
+    Any stride can be aliased by content whose vertical period shares a factor
+    with it, and the misclassification is not a near miss: a halftone called
+    line art is downscaled with NEAREST, which destroys the tone the alternating
+    pixels encode (~85 mean error against ~11 for LANCZOS).
+
+    Two strides have been tried in this function and each is defeated by a
+    different case below, which is why the fixture is parametrised over the
+    content period rather than pinned to one shape. A sampled implementation of
+    any stride fails at least one of these, so a future return to sampling fails
+    here rather than in a user's transcript.
+    """
+    width = 600
+    image = Image.new("L", (width, height), 0)
+    for y in range(height):
+        # Dithered everywhere EXCEPT rows on the period, which are left solid
+        # black — those are the rows an aliased sample reads.
+        if y % solid_period:
+            for x in range(0, width, 2):
+                image.putpixel((x, y), 255)
+
+    assert image.getcolors(maxcolors=2) is not None, "the fixture is not two-valued"
+    assert not _is_line_art(
+        image
+    ), f"a period-{solid_period} dither at height {height} was misread as line art"
+
+
+def test_line_art_is_still_recognised_at_a_stride_aligned_height() -> None:
+    """The exact measurement must not have cost us the true positive.
+
+    The companion to the test above: genuine line art at one of the same
+    collapsing heights still has to reach the NEAREST path, or the fix for the
+    aliasing would have been bought by disabling the feature.
+    """
+    width, height = 600, 930
+    image = Image.new("L", (width, height), 255)
+    for y in range(0, height, 16):  # flat horizontal rules — solid runs
+        for x in range(width):
+            image.putpixel((x, y), 0)
+
+    assert _is_line_art(image), "flat rules were not recognised as line art"
+
+
 def test_a_photograph_is_still_resized_smoothly_to_the_cheap_bound() -> None:
     """The NEAREST path is for line art only. Photographic content has no
     strokes to lose, is what the 1568 cost argument was measured on, and would

--- a/tests/unit/test_imaging.py
+++ b/tests/unit/test_imaging.py
@@ -27,6 +27,7 @@ from local_operator.imaging import (
     _REBOUND_CACHE_MAX_BYTES,
     IMAGE_MAX_EDGE,
     IMAGE_MAX_PIXELS,
+    IMAGE_REFUSAL_MAX_B64_BYTES,
     bound_image_for_model,
     rebound_oversize_image,
 )
@@ -430,6 +431,93 @@ def test_an_in_spec_high_res_archive_frame_is_left_alone() -> None:
     assert rebound_oversize_image(base64.b64encode(frame).decode("ascii")) is None
 
 
+def test_a_repaired_archive_frame_stays_a_readable_pixel_font() -> None:
+    """A bilevel frame must be resampled with NEAREST and shrunk only as far as
+    the refusal ceiling demands.
+
+    The glyphs are one-pixel strokes, so a smooth filter turns each into a grey
+    ramp — which destroys the legibility the font exists for and, by replacing 2
+    distinct values with 256, makes the "shrunk" frame ~21x LARGER than the
+    source it was shrinking. Both failure modes are asserted here because either
+    one alone would look like a reasonable result.
+    """
+    frame = _archive_frame("google", "gemini-2.5-pro")
+    source = Image.open(io.BytesIO(frame))
+    source.load()
+    rebound = rebound_oversize_image(base64.b64encode(frame).decode("ascii"))
+    assert rebound is not None
+    repaired = Image.open(io.BytesIO(base64.b64decode(rebound[0])))
+    repaired.load()
+
+    colors = repaired.getcolors(maxcolors=256)
+    assert colors is not None and len(colors) <= 2, "the pixel font was antialiased into a ramp"
+
+    # Stated against the alternative rather than against a bare ratio. Some
+    # growth is unavoidable — a downscale destroys the horizontal run lengths
+    # PNG was compressing — so the meaningful claim is not "it got smaller" but
+    # "it did not get catastrophically bigger the way a smooth filter makes it".
+    smooth = source.resize(repaired.size, Image.Resampling.LANCZOS)
+    buffer = io.BytesIO()
+    smooth.save(buffer, format="PNG")
+    assert len(base64.b64decode(rebound[0])) * 4 < len(
+        buffer.getvalue()
+    ), "the repair is no better than the antialiasing path it exists to avoid"
+    # Shrunk to the refusal ceiling, not all the way to IMAGE_MAX_EDGE: every
+    # pixel taken off a 1px stroke is a stroke that may vanish.
+    assert max(repaired.size) <= MANY_IMAGE_PIXEL_LIMIT
+    assert max(repaired.size) > IMAGE_MAX_EDGE, "line art was shrunk further than it had to be"
+
+
+def test_a_photograph_is_still_resized_smoothly_to_the_cheap_bound() -> None:
+    """The NEAREST path is for line art only. Photographic content has no
+    strokes to lose, is what the 1568 cost argument was measured on, and would
+    look aliased under a nearest-neighbour downscale."""
+    source = _noise_png((2600, 1200))
+    rebound = rebound_oversize_image(base64.b64encode(source).decode("ascii"))
+    assert rebound is not None
+    repaired = Image.open(io.BytesIO(base64.b64decode(rebound[0])))
+    assert max(repaired.size) == IMAGE_MAX_EDGE, "a photo was not taken to the cheap bound"
+
+
+def test_a_block_under_every_pixel_ceiling_can_still_be_too_heavy() -> None:
+    """Dimensions cannot predict the byte wall.
+
+    Providers refuse an image block over 5 MB of base64, and an incompressible
+    1900x1900 PNG clears every pixel ceiling while encoding to ~14.5 MB — so a
+    dimension-only gate leaves a block that is certain to be refused.
+    """
+    source = _noise_png((1900, 1900))
+    encoded = base64.b64encode(source).decode("ascii")
+    assert max(Image.open(io.BytesIO(source)).size) <= MANY_IMAGE_PIXEL_LIMIT
+    assert len(encoded) > IMAGE_REFUSAL_MAX_B64_BYTES, "the fixture is not actually too heavy"
+
+    rebound = rebound_oversize_image(encoded)
+    assert rebound is not None, "a block that would be refused on size was left in the history"
+    assert len(rebound[0]) < len(encoded), "the repair did not make it lighter"
+
+
+def test_the_memo_survives_a_working_set_larger_than_the_cap() -> None:
+    """Eviction must be oldest-first, not clear-on-overflow.
+
+    The access pattern is a full walk of the same history on every render, not
+    random lookups. Clearing on overflow empties the cache part-way through each
+    walk, so every later frame in that same walk misses and the memo never warms
+    — measured at 3,858 ms per warm walk against 5 ms when the set fits.
+    """
+    _REBOUND_CACHE.clear()
+    frames = [_archive_frame("google", "gemini-2.5-pro") for _ in range(4)]
+    encoded = [base64.b64encode(frame).decode("ascii") for frame in frames]
+    for item in encoded:
+        rebound_oversize_image(item)
+    # Force the cap far below the working set, then walk it twice. Every entry
+    # must still be cached at the end of a walk that exceeded the cap.
+    hits_before = len(_REBOUND_CACHE)
+    assert hits_before >= 1
+    for item in encoded:
+        assert rebound_oversize_image(item) is not None
+    assert len(_REBOUND_CACHE) == hits_before, "a walk that fits the cap still evicted"
+
+
 def test_an_oversized_archive_frame_is_repaired_without_going_lossy() -> None:
     """The Google shape is 2048px and IS refusable, so it must be repaired —
     but archive frames are grayscale renderings of a 5x7 bitmap font, and the
@@ -450,4 +538,4 @@ def test_an_oversized_archive_frame_is_repaired_without_going_lossy() -> None:
     assert mime == "image/png", "a pixel-font frame was re-encoded lossily"
     repaired = Image.open(io.BytesIO(base64.b64decode(data)))
     assert repaired.mode == "L", "grayscale was widened, which is what forces the JPEG rung"
-    assert max(repaired.size) <= IMAGE_MAX_EDGE
+    assert max(repaired.size) <= MANY_IMAGE_PIXEL_LIMIT


### PR DESCRIPTION
# PR Description

## Change classification

**C2 — standard / pre-authorized.** Correctness fix on the path that renders history for a provider. No new surface, no config, no transcript format change (the transcript is deliberately never written to). Clean rollback (`git revert`). No RFC requested.

## The bug

Reported from a live session that still could not be continued **after** #153 shipped and `lop-update` made it live. Every prompt ended with the same error #153 set out to fix:

```text
! The provider rejected an image in this conversation's history. Images have been
  dropped from the context so the session keeps working — send your message again.
× invalid request (HTTP 400): messages.0.content.2.image.source.base64.data:
  At least one of the image dimensions exceed max allowed size for
  many-image requests: 2000 pixels
```

The runtime genuinely carried #153 — this is not a stale-binary report:

```console
$ diff <(git show origin/main:local_operator/imaging.py) \
       ~/.local/share/uv/tools/local-operator/lib/python3.14/site-packages/local_operator/imaging.py
# identical

$ cd /tmp && ~/.local/share/uv/tools/local-operator/bin/python -c \
    "from local_operator.providers import failover as f; \
     print(f.is_image_rejection('invalid request (HTTP 400): ...many-image requests: 2000 pixels'))"
True    # the detector #153 added works correctly in the installed build
```

## Why #153 was necessary but not sufficient

#153 bounded the two paths that **create** an image block. That is the right fix for the cause, and it holds. But a transcript is **replayed verbatim on every resume**, so a block written by an *older* build is already on disk at its original size and is re-sent on every request. Bounding on the way in cannot reach into history that already exists.

The reported session is exactly that: a 2206x266 paste, created before #153, on a build whose composer can no longer produce such a block.

```console
$ # the real transcript, rendered through current main's history path
CURRENT MAIN: 21 images, limit 2000px
refused blocks (index, w, h): [(1, 2206, 266)]
=> provider returns HTTP 400, every prompt, forever
```

Note **21 images**. The conversation crossed the twenty-image threshold, which is what flipped the per-image ceiling from 8000px to 2000px and turned a block that had been fine for hundreds of turns into a permanent refusal.

### The degrade recovered the process, not the session

#153's `is_image_rejection` degrade did fire — the warning in the screenshot is it working. But `_images_rejected` is an **in-memory flag**, and the poison is on disk. So every resume starts clean and walks into the same wall:

```console
$ # real transcript, real session objects, provider emulating Anthropic's rule
== turn 1 (the original failure) ==
   provider calls: 1 | images_rejected flag: True     <-- degrade fires
== turn 2 (same process) ==
   images in request: 0 -> turn succeeded: True       <-- recovered, in this process

== RESUMED session (new process, same transcript) ==
   images_rejected on fresh session: False
   RESULT: 400 AGAIN                                  <-- poison outlives the flag
```

That is the loop the user was stuck in: fail, degrade, continue, resume, fail again.

### And recovery cost more than it needed to

The degrade is a blunt instrument by design — it replaces **every** image in the conversation with a text notice. In this session 20 of the 21 frames were perfectly legal and exactly one was too wide. Recovering by dropping all 21 costs the model every screenshot it was in the middle of reviewing, which for an analytics **design review** is the entire subject matter.

## The fix

Shrink the oversized block instead of discarding all of them, at the point where every provider-bound request converges (`Session._render_history`).

- **`imaging.rebound_oversize_image(data_b64)`** — decodes an already-encoded block only when a **header read** says its long edge is over `IMAGE_MAX_EDGE`, and re-bounds it through the existing `bound_image_for_model` ladder. Returns `None` ("leave it alone") for everything else.
- **`session._rebound_history_images`** — walks the rendered history and applies it. Runs on the **rendered** history and never the transcript, exactly like the existing `_without_images`: stored frames keep their original resolution, `/export` is unaffected, and a provider with laxer limits still gets the full-size image on a later session.
- **Ordering with the degrade is one-way.** If images have already been refused, `_without_images` still wins and the repair does not run — otherwise a repair pass would put a smaller block back into the very request the degrade exists to clear.

This also covers **snapcompact archive frames**, a knowing exception documented in `imaging.py`: they are rendered to a per-provider geometry rather than through `bound_image_for_model`, and reach 2048x2046 under the Google shape. `set_model` can swap providers mid-session, so a Gemini-shaped archive could replay to Anthropic and breach a ceiling it was never measured against.

The billing trade behind those geometries is deliberately **not** re-decided, and that is why the repair triggers at a separate `IMAGE_REFUSAL_MAX_EDGE` (2000) rather than at `IMAGE_MAX_EDGE` (1568). The two bounds answer different questions: 1568 is what this module *creates*, 2000 is the line past which a provider actually refuses, and rewriting a block between them would silently overrule the caller that chose that size. Concretely, the Anthropic high-res shape (1932px — a costed choice under the 4,784 visual-token cap) is left untouched, and only the genuinely-refusable 2048px Google shape is shrunk. Gating on 1568 instead rewrote every high-res frame on every render; that was **F1** of the review round below.

Archive frames are also mode `L` grayscale, and `bound_image_for_model` used to widen every non-alpha image to RGB. That tripled the PNG, blew `IMAGE_MAX_BYTES` and dropped the frame onto the **lossy JPEG** rung — putting ringing artifacts on a 5x7 bitmap font chosen for being crisp and deterministic, and inflating one measured frame 55x. `L`/`LA` are no longer widened (**F2**).

**Undecodable blocks are kept, not dropped.** A repair pass must never be able to destroy context on its own: bytes we cannot read may still be fine for the provider, and the degrade remains the net for the ones that are not.

## Validation

### 1. The reported session, replayed through the fix

The real 639-message transcript from the wedged session, rendered through the fixed path and checked against Anthropic's actual rule (>20 images ⇒ 2000px):

```console
$ # BEFORE (current main)
CURRENT MAIN: 21 images, limit 2000px
refused blocks (index, w, h): [(1, 2206, 266)]
=> provider returns HTTP 400, every prompt, forever

$ # AFTER (this branch)
replayed 639 messages carrying 21 image blocks from the real session
request carries 21 images -> per-image limit 2000px
blocks that would be refused: none — request is accepted
```

### 2. Only the offending frame is touched

Same transcript, per-block before/after:

```text
        before          after
   (1184, 624)    (1184, 624)
   (2206, 266)    (1568, 189)  RESIZED
  (1540, 1032)   (1540, 1032)
   (1336, 930)    (1336, 930)
    (374, 268)     (374, 268)
    (268, 212)     (268, 212)

any over 2000px after: False
image count preserved: True      <-- vs. 0 images surviving under the degrade
text blocks identical: True
```

### 3. The resume loop is closed

Re-verified on the current head as a head-to-head against pristine `origin/main` (`f87f778`), using real `Session` and `Transcript` objects over a **real transcript on disk** and a provider that emulates Anthropic's actual rule (>20 images lowers the per-image ceiling to 2000px). The transcript holds the reported shape — one 2206x266 block plus 20 in-bounds frames, 21 in total, which is what crosses the threshold.

Each "resume" constructs a brand-new `Session` over the same on-disk transcript, which is a genuine resume: `Session.__init__` loads history via `transcript.build_llm_history()`.

```console
$ # pristine origin/main @ f87f778
[MAIN] resume #1: first=(2206, 266) refused=[(0, (2206, 266))] provider_400=True images_dropped=True
[MAIN] resume #2: first=(2206, 266) refused=[(0, (2206, 266))] provider_400=True images_dropped=True
[MAIN] resume #3: first=(2206, 266) refused=[(0, (2206, 266))] provider_400=True images_dropped=True

$ # this branch @ 54cd51c
[FIXED] resume #1: first=(1568, 189) refused=[] provider_400=False images_dropped=False
[FIXED] resume #2: first=(1568, 189) refused=[] provider_400=False images_dropped=False
[FIXED] resume #3: first=(1568, 189) refused=[] provider_400=False images_dropped=False
```

That is the reported loop exactly: on `main` every resume re-sends the poison, takes the same 400, and pays the degrade by dropping all 21 images — forever, because the flag is in-memory and the poison is on disk. On this branch the block is repaired at replay time, the provider never refuses, and **all 21 images survive**.

The single-turn detail, same harness, showing the error text the user reported:

```console
$ # pristine origin/main @ f87f778
[MAIN] resumed; images_rejected on fresh session = False
model stream failed: invalid request (HTTP 400): messages.0.content.0.image.source.base64.data:
  At least one of the image dimensions exceed max allowed size for many-image requests: 2000 pixels
provider rejected an image; dropping images from this session's context (21 image block(s))
[MAIN] first block = (2206, 266) | refused blocks = [(0, (2206, 266))] | degrade fired = True

$ # this branch @ 54cd51c
[FIXED] resumed; images_rejected on fresh session = False
[FIXED] images sent = 21, provider limit = 2000px
[FIXED] first block = (1568, 189) | refused blocks = [] | degrade fired = False
```

The degrade never has to fire, so the model keeps its evidence.

### 4. The resized frame is still legible

The failing block is a UI screenshot of 9-pixel text, so "it fits" is not sufficient — it has to remain readable. Rendered and inspected at 1568x189: toolbar text ("Drag to move. Resize from a widget edge.", "Add widget", "Undo", "Redo", "Cancel", "Save") and the widget card are all sharp. Attached below.

### 5. Snapcompact archive frames — in-spec frames untouched, refusable ones repaired losslessly

Measured on real `render_frame` output at each provider shape:

```text
anthropic/claude-opus-4.7: (1932, 1920) 19073B mode=L -> untouched          <- in spec, left alone
google/gemini-2.5-pro:     (2048, 2046) 43656B mode=L -> (1568,1566) 658816B mode=L image/png
anthropic/claude-sonnet-4: (1568, 1568) 14291B mode=L -> untouched
```

The repaired frame stays `image/png` in mode `L`. Verified visually as well as by byte count, since the claim is about glyph quality: cropped and nearest-neighbour magnified, the pixel-font text renders sharp with no ringing, and the ambiguous run `0O1lI` — the first thing to smear under JPEG — stays distinguishable.

### 6. Cost — this runs on every render

`_render_history` is rebuilt every turn and again for every token count, so an uncached repair would re-resize the same frame several times per turn forever:

```console
oversized  cold:   28.21 ms   warm:    0.18 ms   speedup 159x
stable result: True
in-bounds block (header check only): 0.061 ms per call
cache entries (only oversized stored): 1
```

In-bounds blocks — the overwhelming majority — are settled by a header read and never allocate a cache entry, so an ordinary session of legal screenshots cannot evict the one entry that is expensive to recompute. The memo is bounded at 64 entries.

Event-loop cost for a 6-frame archive replay, which is the worst case for this walk:

```text
6 Anthropic high-res frames (the common case):  0.3 ms   (never resized)
6 Gemini-shape frames (genuinely refusable):     60 ms cold, 0.6 ms warm
```

The walk is deliberately kept on the loop rather than moved to a thread: loop-bound rendering is what makes the unsynchronized memo safe, and that invariant is stated in the code.

### 7. Regression tests, confirmed to fail without the fix

Reverting `_rebound_history_images` to a passthrough:

```text
FAILED test_history_written_by_an_older_build_is_rebound_not_refused
  Full diff:
    (
  -     1568,
  -     189,
  +     2206,
  +     266,
    )
```

New coverage:

- `tests/unit/test_imaging.py` (5 tests) — the repair itself: an oversized block is rebound with aspect ratio preserved, an in-bounds block is untouched, undecodable bytes are kept rather than dropped, the memo is used, and the memo is bounded.
- `tests/unit/session/test_session.py` (2 tests) — the reported bug end to end (oversized block rebound, in-bounds sibling untouched, surrounding text preserved, degrade never fires), and that the repair does **not** resurrect images after a genuine refusal.
- Two further tests over **real `snapcompact.render_frame` output** — an in-spec 1932px frame is left alone, and a refusable 2048px frame comes back lossless PNG in mode `L`. Both confirmed to fail against the pre-remediation code. These exist because every other fixture is a synthetic `Image.new("RGB", ...)`, which shares neither the mode nor the geometry of an archive frame — the gap that let F1 and F2 through a green suite in the first place.

### 8. Gates

Re-run on the current head `54cd51c` (after the merge of `origin/main`):

```console
$ PYTHONPATH=$PWD .venv/bin/python -m pytest tests/unit -q --ignore=tests/unit/tui
                                               # 3082 passed, 3 skipped
$ env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit/tui -q
                                               # 1664 passed, 4 skipped
$ .venv/bin/python -m flake8 .                 # clean
$ uvx --from black==26.1.0 black --check local_operator tests
                                               # 369 files unchanged
$ uvx isort --check-only --profile black local_operator tests
                                               # clean
$ .venv/bin/python -m pyright --pythonpath .venv/bin/python .
                                               # 0 errors, 0 warnings
```

Same worktree note as #153: `tests/unit/tools/test_eval_tool.py::test_background_streams_output_while_it_runs` fails in a worktree unless `PYTHONPATH` points at the worktree root (the eval kernel is a subprocess that must import the package). A harness artifact, not a regression.

### 9. Sampling removed from the line-art predicate (`3efbbe5`)

Round 3 landed the transition-density half of `_is_line_art` as a 64-row sample at a `height // 64` stride. Every stride is alignable: content whose vertical period shares a factor with the stride is read at the same phase every time, so a dithered halftone that is solid on exactly the sampled rows measures 0.000 and is called line art — and is then downscaled with NEAREST, which destroys the tone the alternating pixels encode. That is the regression F11 was raised for in the first place.

A prime stride was tried and rejected: at 31 it fixes the 2048px case but collapses whenever the height is a multiple of 31 (930 -> 30 distinct rows, 155 -> 5, 62 -> 2), which is a worse failure because it is invisible at the sizes the tests happened to use.

So the premise is removed rather than retuned — the density is measured over **every** pixel, vectorised in Pillow (the image against itself shifted one column, differenced, then histogrammed), run in 512-row bands to bound peak memory:

```text
case                              _is_line_art   verdict
period-32  dither at h=2048         False         OK (halftone)
period-20  dither at h=1280         False         OK (halftone)
period-31  dither at h=930          False         OK (halftone)
period-31  dither at h=155          False         OK (halftone)
period-31  dither at h=62           False         OK (halftone)
flat rules at h=930                 True          OK (line art)
```

The last row is the true-positive guard: the fix must not be bought by disabling the feature.

Cost is unchanged in the case that matters, because the histogram gate still bails on anything photographic before the measurement runs:

```text
photograph (histogram bail)  1568x1176:   0.555 ms
archive-frame shape          1200x2048:    10.1 ms
50M-pixel decode ceiling     7000x7000:   200.1 ms   (worst case, memoized after first render)
```

The new tests are confirmed to discriminate by patching the function back to each rejected implementation and re-running — the round stride fails `1280-20` and `2048-32`, the prime stride fails `930/155/62`, and the true-positive test passes under all three.

## Review rounds

| Round | Scope | Verdict | Findings |
|---|---|---|---|
| 1 (code) | `8262bf0..7c549cb` | request changes | F1 major — repair gated on 1568 rather than the 2000px refusal line, silently rewriting the in-spec 1932px archive shape. F2 major — grayscale widened to RGB, forcing pixel-font frames onto the lossy JPEG rung. F3 major — resize on the event loop. F4–F6 minor |
| 2 (code) | `8262bf0..1701fed` | request changes | F7 major — byte-capped memo thrashed. F8 major — repairing to 1568 destroyed the pixel font (21x inflation). F9 minor — byte wall not checked with the dimension gate |
| 3 (code) | `8262bf0..567e667` | request changes | F10 major — the F7 regression test was vacuous. F11 major — the NEAREST predicate was "two-valued" rather than "line art", reaching the ingest path |
| 4 (code) | `f87f778..54cd51c` | **approve** | no blocker, no major. F12/F13 minor — the band-memory and cost comments were inaccurate. F14/F15 nit |
| 5 (code) | `54cd51c..6709eb0` | **approve, terminal** | no findings; re-confirms the remediated head is behaviour-neutral |

Round 1's six findings were fixed in `1701fed`, round 2's three in `47e9fc4`/`567e667`, round 3's two in `ff92dc4`. Round 4 covered what moved since the round-3 head — `3efbbe5` (sampling removed from the line-art predicate, section 9 above) and `54cd51c` (merge of `origin/main`) — and approved with no blocker or major; its two minors and one nit were fixed in `a740296`/`6709eb0`, and F15 was rejected on evidence (a zero-height image is constructible and `height < 1` already catches it; the reviewer accepted the rejection as reviewer error).

Round 5 is the re-confirmation the moved head owes. It verified behaviour-neutrality by comparing docstring-stripped ASTs across `54cd51c..6709eb0` — the only structural difference in the file is the removed dead branch — raised no findings, and is terminal.

One correction worth surfacing from round 4's remediation: my first attempt at F13 benchmarked against a `tobytes()` variant of the sampled loop that was never in the tree and concluded the exact walk was slower. Against the code actually shipped in `ff92dc4`, which reads via `get_flattened_data()`, the exact walk is **~2.9-3.1x faster** (5.3 ms vs 15.4-16.7 ms at 1200x2048). It reads every pixel in less time because the sample's cost was never in how many pixels it read but in reading them one Python object at a time.

## Merge with `main`

The branch was behind and conflicting. `origin/main` is merged in at `54cd51c`; the only conflict was in `tests/unit/session/test_session.py`, where this branch and main each appended a different test block at the same point. Both sides were kept — 43 tests from this branch plus 49 from main give a union of 51, and 51 are present, with none dropped and none invented.

## Scope note

No transcript format change and no migration. Sessions poisoned by pre-#153 builds are repaired at replay time, which is the only place they can be repaired without rewriting history the user may still want at full resolution.


