### PR TITLE
fix(harness,tui): make esc stop everything immediately

### DIFF
--- a/local_operator/harness/loop.py
+++ b/local_operator/harness/loop.py
@@ -1182,10 +1182,26 @@ class AgentLoop:
                     # Duplicate-id and resolution failures never execute: the
                     # synthetic result parks in the slot without a task, so
                     # two slots can never collide on one results entry.
-                    park(
-                        slot,
-                        item,
-                        item.failure or self._synthetic_result(item.call, "Tool not found."),
+                    parked = item.failure or self._synthetic_result(item.call, "Tool not found.")
+                    park(slot, item, parked)
+                    # SAY SO, since the end event no longer does. `park` withholds
+                    # the end event for a call that never started, which is right
+                    # — but the headless renderer printed `✗ <name> failed` off
+                    # that event, so suppressing it alone would turn a visible
+                    # diagnostic into silence and leave an operator watching a
+                    # hallucinated tool name produce nothing at all (R6-3, agent
+                    # review round 6). A notice is the honest carrier: it reports
+                    # the failure without claiming a lifecycle that never began.
+                    # The model is unaffected either way — it still gets the
+                    # `tool_result` parked above.
+                    reason = " ".join(
+                        block.text
+                        for block in parked.content
+                        if isinstance(block, TextContent) and block.text
+                    ).strip()
+                    yield NoticeEvent(
+                        text=f"{item.call.name}: {reason or 'tool not found'}",
+                        kind="error",
                     )
                     continue
                 interruptible = item.tool.interruptible
@@ -1339,10 +1355,18 @@ class AgentLoop:
             # half of R3-1 a snapshot alone does not fix: the loss happens
             # BEFORE the backfill runs, not during its emit.
             #
-            # `claimed` keeps the two halves from colliding. A slot this
-            # backfill has already spoken for must not also emit the runner's
-            # own end event, or a consumer counting by id sees the call end
-            # twice — a worse defect than the one being fixed.
+            # `claimed` is DEFENCE IN DEPTH, not a live guard. It was
+            # load-bearing when the two halves could collide; the source-side
+            # withholding in `park` removes that collision, and `park` is
+            # synchronous, so a slot is filled and its end queued atomically
+            # with respect to the event loop and no `await` separates this
+            # backfill from the flush below. There is therefore no interleaving
+            # in which the flush meets an end for a slot the backfill claimed —
+            # measured: 0 suppressions across the whole harness suite (R6-1,
+            # agent review round 6). It stays as a belt, and it counts rather
+            # than matching because ids collide within a batch, so a future
+            # change that reintroduces an interleaving cannot resurrect R5-1 by
+            # suppressing a started call's end along with its twin's.
             while True:
                 try:
                     queued = queue.get_nowait()

--- a/local_operator/harness/loop.py
+++ b/local_operator/harness/loop.py
@@ -1264,6 +1264,20 @@ class AgentLoop:
             #
             # Yielded rather than queued: the drain loop above has already
             # broken out and nothing will read the queue again.
+            #
+            # DECIDED IN ONE PASS, EMITTED IN ANOTHER, and the split is load
+            # bearing. A generator suspends at every `yield`, handing control to
+            # a consumer that may await; a runner whose cleanup lands in one of
+            # those windows calls `park()`, which writes its end event to the
+            # queue nobody reads any more and fills the slot. A single
+            # interleaved loop then saw the now-filled slot and emitted nothing,
+            # so that call kept its start event and never got an end — the very
+            # damage this backfill exists to prevent, reachable only when the
+            # consumer is slow enough to suspend us (R3-1, agent review round 3).
+            # Snapshotting first means the decision is made while no await can
+            # intervene, so it cannot be invalidated by what happens mid-emit.
+            pending_ends: list[ToolExecutionEndEvent] = []
+            claimed: set[str] = set()
             for slot, item in enumerate(batch):
                 if results_by_slot[slot] is None:
                     result = self._synthetic_result(item.call, ABORTED_RESULT_TEXT)
@@ -1273,13 +1287,42 @@ class AgentLoop:
                         # failure parked its result up front and never emitted a
                         # start event, so an end event for it would be the
                         # mirror image of this bug.
-                        yield ToolExecutionEndEvent(
-                            tool_call_id=item.call.id,
-                            tool_name=item.tool.name,
-                            result=result,
-                            is_error=result.is_error,
+                        claimed.add(item.call.id)
+                        pending_ends.append(
+                            ToolExecutionEndEvent(
+                                tool_call_id=item.call.id,
+                                tool_name=item.tool.name,
+                                result=result,
+                                is_error=result.is_error,
+                            )
                         )
+
+            # THEN drain whatever the runners queued that nobody read. A tool
+            # that parked between the drain loop giving up and this point put a
+            # real end event on the queue and filled its own slot, so the
+            # backfill above correctly skipped it — and without this flush that
+            # event is simply dropped, leaving a start with no end. That is the
+            # half of R3-1 a snapshot alone does not fix: the loss happens
+            # BEFORE the backfill runs, not during its emit.
+            #
+            # `claimed` keeps the two halves from colliding. A slot this
+            # backfill has already spoken for must not also emit the runner's
+            # own end event, or a consumer counting by id sees the call end
+            # twice — a worse defect than the one being fixed.
+            while True:
+                try:
+                    queued = queue.get_nowait()
+                except asyncio.QueueEmpty:
+                    break
+                if isinstance(queued, (_ToolDone, _BatchDone)):
+                    continue
+                if isinstance(queued, ToolExecutionEndEvent) and queued.tool_call_id in claimed:
+                    continue
+                yield queued
+
             results.extend(result for result in results_by_slot if result is not None)
+            for end_event in pending_ends:
+                yield end_event
         finally:
             if watcher is not None and not watcher.done():
                 watcher.cancel()

--- a/local_operator/harness/loop.py
+++ b/local_operator/harness/loop.py
@@ -140,6 +140,28 @@ STEERING_INTERRUPT_POLL_S = 0.25
 ABORT_DRAIN_TIMEOUT_S = 2.0
 
 
+def _consume_claim(claimed: Counter[str], call_id: str) -> bool:
+    """Spend one suppression owed for ``call_id``; say whether there was one.
+
+    Module level, and named, so a test can exercise THIS rule rather than a
+    retyped copy of it. The branch it serves is unreachable today (the
+    source-side guard in ``park`` removes the collision it defends against), so
+    no behavioural test can reach it — which is exactly why the rule needs a
+    handle a unit test can hold (R7-3, agent review round 7).
+
+    COUNTING, not membership, is the whole point. Call ids are not unique within
+    a batch: a duplicate id yields one slot that started and one that did not,
+    and matching by id suppressed the started call's genuine end event along
+    with its twin's parked one (R5-1). Spending one claim per event leaves
+    exactly the right number, and the events are identical to a consumer, so
+    which one survives does not matter.
+    """
+    if not claimed.get(call_id, 0):
+        return False
+    claimed[call_id] -= 1
+    return True
+
+
 @dataclass
 class LoopContext:
     """Mutable host context the loop reads and extends.
@@ -1034,6 +1056,19 @@ class AgentLoop:
         # tell an abort apart from a steering interrupt and label their
         # synthetic results correctly.
         aborting = False
+        # Slots whose ToolExecutionEndEvent has been emitted or queued. Keyed by
+        # SLOT, not call id, because ids collide within a batch — the same
+        # reason `results_by_slot` is. Read by the completeness sweep after the
+        # flush, which is what makes "every started call gets exactly one end"
+        # a guarantee rather than the outcome of a race.
+        announced: set[int] = set()
+        # call id -> the slots carrying it. A model can emit two calls with one
+        # id, so this is a one-to-many map; marking every slot for an id is safe
+        # because the duplicate slot is a planning failure that never starts and
+        # is skipped by the sweep on its own merits.
+        slot_of_call: dict[str, set[int]] = {}
+        for _slot, _item in enumerate(batch):
+            slot_of_call.setdefault(_item.call.id, set()).add(_slot)
 
         def park(slot: int, item: _PlannedCall, result: ToolResult) -> None:
             results_by_slot[slot] = result
@@ -1194,13 +1229,23 @@ class AgentLoop:
                     # the failure without claiming a lifecycle that never began.
                     # The model is unaffected either way — it still gets the
                     # `tool_result` parked above.
+                    #
+                    # The parked result's own text is the whole message, with
+                    # no tool-name prefix bolted on. Both failure kinds already
+                    # name what they need to ("Tool not found: reed_file",
+                    # "Duplicate call id 'c1' skipped."), so a prefix repeated
+                    # the name for an unknown tool and, worse, named the tool
+                    # that DID run for a duplicate id — reading as though the
+                    # user's real call had been dropped (D12/D13, design round
+                    # 3). The call id, not the name, is what distinguishes the
+                    # twins, and it is already in the duplicate's own text.
                     reason = " ".join(
                         block.text
                         for block in parked.content
                         if isinstance(block, TextContent) and block.text
                     ).strip()
                     yield NoticeEvent(
-                        text=f"{item.call.name}: {reason or 'tool not found'}",
+                        text=reason or f"{item.call.name}: tool not found",
                         kind="error",
                     )
                     continue
@@ -1276,6 +1321,14 @@ class AgentLoop:
                         # A per-tool receipt, or the abort watcher's nudge.
                         # Neither is an event a consumer should see.
                         continue
+                    if isinstance(event, ToolExecutionEndEvent):
+                        # EMITTED, so the completeness sweep must not add a
+                        # second one. Marked here rather than where the event is
+                        # queued: queuing is not delivering, and a slot whose
+                        # end is still sitting unread in the queue when the
+                        # batch settles is exactly the case the sweep exists to
+                        # repair.
+                        announced.update(slot_of_call.get(event.tool_call_id, ()))
                     yield event
 
             # Backfill any slot whose runner was cancelled before it could park
@@ -1338,6 +1391,7 @@ class AgentLoop:
                         # start event, so an end event for it would be the
                         # mirror image of this bug.
                         claimed[item.call.id] += 1
+                        announced.add(slot)
                         pending_ends.append(
                             ToolExecutionEndEvent(
                                 tool_call_id=item.call.id,
@@ -1374,12 +1428,42 @@ class AgentLoop:
                     break
                 if isinstance(queued, (_ToolDone, _BatchDone)):
                     continue
-                if isinstance(queued, ToolExecutionEndEvent) and claimed.get(
-                    queued.tool_call_id, 0
+                if isinstance(queued, ToolExecutionEndEvent) and _consume_claim(
+                    claimed, queued.tool_call_id
                 ):
-                    claimed[queued.tool_call_id] -= 1
                     continue
+                if isinstance(queued, ToolExecutionEndEvent):
+                    announced.update(slot_of_call.get(queued.tool_call_id, ()))
                 yield queued
+
+            # FINALLY, guarantee an end for every call that started, by slot.
+            # Neither half above can promise that on its own: a runner racing
+            # the drain's deadline may fill its slot and queue its end AFTER the
+            # flush has emptied the queue, so the backfill skips the slot (it is
+            # no longer `None`) and the flush never sees the event. The result
+            # is on the wire and the end is nowhere — a start with no end, which
+            # is the whole defect this code exists to prevent, surviving as a
+            # ~1-in-8 race rather than a certainty.
+            #
+            # Closed by asking the question that actually matters — "does this
+            # started call have an end yet?" — instead of trusting a queue drain
+            # to have won a race. `announced` tracks by SLOT because ids collide
+            # within a batch, the same reason `results_by_slot` does.
+            for slot, item in enumerate(batch):
+                if slot in announced or item.failure is not None or item.tool is None:
+                    continue
+                result = results_by_slot[slot]
+                if result is None:
+                    continue
+                announced.add(slot)
+                pending_ends.append(
+                    ToolExecutionEndEvent(
+                        tool_call_id=item.call.id,
+                        tool_name=item.tool.name,
+                        result=result,
+                        is_error=result.is_error,
+                    )
+                )
 
             results.extend(result for result in results_by_slot if result is not None)
             for end_event in pending_ends:

--- a/local_operator/harness/loop.py
+++ b/local_operator/harness/loop.py
@@ -1387,17 +1387,28 @@ class AgentLoop:
             # half of R3-1 a snapshot alone does not fix: the loss happens
             # BEFORE the backfill runs, not during its emit.
             #
-            # ONE BOUNDARY REMAINS, and it is inherent rather than unfixed: a
+            # ONE BOUNDARY REMAINS, and it is accepted rather than closed: a
             # cleanup that outruns the whole TURN, not just the drain budget,
             # settles after this generator has closed. There is no longer a
             # stream to emit into, so that call keeps its start and gets no end.
-            # Measured as intermittent at the very edge (a ~2.5s cleanup against
-            # a ~0.5s-per-event consumer) and unreachable below it. Closing it
-            # would mean holding the turn open for the cleanup, which is exactly
-            # what ABORT_DRAIN_TIMEOUT_S exists to refuse — the user pressed Esc
-            # and is owed their prompt back. A consumer that must reconcile such
-            # a record should do it at the turn boundary, as the TUI does when
-            # it retires orphaned cards.
+            #
+            # NOT confined to some extreme corner. It is intermittent wherever a
+            # tool's unwind overshoots ABORT_DRAIN_TIMEOUT_S while a consumer is
+            # slow enough to still owe this generator a resume — observed around
+            # a 2.3s cleanup against a 0.3s-per-event consumer, and an earlier
+            # comment here claiming it was unreachable below ~2.5s/~0.5s was
+            # simply wrong (R9 MAJOR-2). The honest statement is: rare in
+            # practice, reachable in principle, and not bounded by a threshold
+            # anyone should rely on.
+            #
+            # Accepted anyway, because the alternative is worse: closing it
+            # means holding the turn open until the cleanup finishes, which is
+            # exactly what ABORT_DRAIN_TIMEOUT_S exists to refuse — the user
+            # pressed Esc and is owed their prompt back, which is this whole
+            # change's purpose. A consumer holding execution records by id must
+            # therefore reconcile them at the TURN boundary rather than trusting
+            # every start to be followed by an end; the TUI already does exactly
+            # that when it retires orphaned cards.
             #
             # `claimed` is DEFENCE IN DEPTH, not a live guard. It was
             # load-bearing when the two halves could collide; the source-side

--- a/local_operator/harness/loop.py
+++ b/local_operator/harness/loop.py
@@ -580,6 +580,7 @@ class AgentLoop:
         # A resolver returning None is the declared "host has nothing better to
         # say" case (see the field), handled the same as having no resolver.
         return live if live is not None else config.model
+
     # (``_abortable_stream`` is a module-level helper; see below the class.)
 
     async def _model_turn(

--- a/local_operator/harness/loop.py
+++ b/local_operator/harness/loop.py
@@ -1056,19 +1056,6 @@ class AgentLoop:
         # tell an abort apart from a steering interrupt and label their
         # synthetic results correctly.
         aborting = False
-        # Slots whose ToolExecutionEndEvent has been emitted or queued. Keyed by
-        # SLOT, not call id, because ids collide within a batch — the same
-        # reason `results_by_slot` is. Read by the completeness sweep after the
-        # flush, which is what makes "every started call gets exactly one end"
-        # a guarantee rather than the outcome of a race.
-        announced: set[int] = set()
-        # call id -> the slots carrying it. A model can emit two calls with one
-        # id, so this is a one-to-many map; marking every slot for an id is safe
-        # because the duplicate slot is a planning failure that never starts and
-        # is skipped by the sweep on its own merits.
-        slot_of_call: dict[str, set[int]] = {}
-        for _slot, _item in enumerate(batch):
-            slot_of_call.setdefault(_item.call.id, set()).add(_slot)
 
         def park(slot: int, item: _PlannedCall, result: ToolResult) -> None:
             results_by_slot[slot] = result
@@ -1321,14 +1308,6 @@ class AgentLoop:
                         # A per-tool receipt, or the abort watcher's nudge.
                         # Neither is an event a consumer should see.
                         continue
-                    if isinstance(event, ToolExecutionEndEvent):
-                        # EMITTED, so the completeness sweep must not add a
-                        # second one. Marked here rather than where the event is
-                        # queued: queuing is not delivering, and a slot whose
-                        # end is still sitting unread in the queue when the
-                        # batch settles is exactly the case the sweep exists to
-                        # repair.
-                        announced.update(slot_of_call.get(event.tool_call_id, ()))
                     yield event
 
             # Backfill any slot whose runner was cancelled before it could park
@@ -1391,7 +1370,6 @@ class AgentLoop:
                         # start event, so an end event for it would be the
                         # mirror image of this bug.
                         claimed[item.call.id] += 1
-                        announced.add(slot)
                         pending_ends.append(
                             ToolExecutionEndEvent(
                                 tool_call_id=item.call.id,
@@ -1408,6 +1386,18 @@ class AgentLoop:
             # event is simply dropped, leaving a start with no end. That is the
             # half of R3-1 a snapshot alone does not fix: the loss happens
             # BEFORE the backfill runs, not during its emit.
+            #
+            # ONE BOUNDARY REMAINS, and it is inherent rather than unfixed: a
+            # cleanup that outruns the whole TURN, not just the drain budget,
+            # settles after this generator has closed. There is no longer a
+            # stream to emit into, so that call keeps its start and gets no end.
+            # Measured as intermittent at the very edge (a ~2.5s cleanup against
+            # a ~0.5s-per-event consumer) and unreachable below it. Closing it
+            # would mean holding the turn open for the cleanup, which is exactly
+            # what ABORT_DRAIN_TIMEOUT_S exists to refuse — the user pressed Esc
+            # and is owed their prompt back. A consumer that must reconcile such
+            # a record should do it at the turn boundary, as the TUI does when
+            # it retires orphaned cards.
             #
             # `claimed` is DEFENCE IN DEPTH, not a live guard. It was
             # load-bearing when the two halves could collide; the source-side
@@ -1432,38 +1422,7 @@ class AgentLoop:
                     claimed, queued.tool_call_id
                 ):
                     continue
-                if isinstance(queued, ToolExecutionEndEvent):
-                    announced.update(slot_of_call.get(queued.tool_call_id, ()))
                 yield queued
-
-            # FINALLY, guarantee an end for every call that started, by slot.
-            # Neither half above can promise that on its own: a runner racing
-            # the drain's deadline may fill its slot and queue its end AFTER the
-            # flush has emptied the queue, so the backfill skips the slot (it is
-            # no longer `None`) and the flush never sees the event. The result
-            # is on the wire and the end is nowhere — a start with no end, which
-            # is the whole defect this code exists to prevent, surviving as a
-            # ~1-in-8 race rather than a certainty.
-            #
-            # Closed by asking the question that actually matters — "does this
-            # started call have an end yet?" — instead of trusting a queue drain
-            # to have won a race. `announced` tracks by SLOT because ids collide
-            # within a batch, the same reason `results_by_slot` does.
-            for slot, item in enumerate(batch):
-                if slot in announced or item.failure is not None or item.tool is None:
-                    continue
-                result = results_by_slot[slot]
-                if result is None:
-                    continue
-                announced.add(slot)
-                pending_ends.append(
-                    ToolExecutionEndEvent(
-                        tool_call_id=item.call.id,
-                        tool_name=item.tool.name,
-                        result=result,
-                        is_error=result.is_error,
-                    )
-                )
 
             results.extend(result for result in results_by_slot if result is not None)
             for end_event in pending_ends:

--- a/local_operator/harness/loop.py
+++ b/local_operator/harness/loop.py
@@ -25,6 +25,7 @@ import inspect
 import json
 import logging
 import time
+from collections import Counter
 from collections.abc import AsyncIterator, Mapping, Sequence
 from dataclasses import dataclass, field
 from typing import Any
@@ -1036,14 +1037,31 @@ class AgentLoop:
 
         def park(slot: int, item: _PlannedCall, result: ToolResult) -> None:
             results_by_slot[slot] = result
-            queue.put_nowait(
-                ToolExecutionEndEvent(
-                    tool_call_id=item.call.id,
-                    tool_name=item.tool.name if item.tool is not None else item.call.name,
-                    result=result,
-                    is_error=result.is_error,
+            # A call that never STARTED never gets an end. Planning failures —
+            # an unknown tool, or a duplicate id whose twin won the slot — are
+            # parked up front with no task and no `ToolExecutionStartEvent`, so
+            # announcing their end describes a lifecycle no consumer ever saw
+            # begin: the API server matches by id and either resurrects a record
+            # that was never opened or, when a duplicate id collides, closes the
+            # REAL call's record early and publishes two TOOL_ENDs for one
+            # TOOL_START.
+            #
+            # Suppressed HERE, at the single source, rather than downstream.
+            # The event has two readers — the drain loop while the batch is live
+            # and the post-abort flush after it gives up — and a guard in either
+            # one alone leaves the other emitting it (R4-1 fixed the flush, R5-1
+            # was the drain doing the same thing a moment earlier). The result
+            # still parks, so the WIRE stays paired; only the event is withheld.
+            started = item.failure is None and item.tool is not None
+            if started:
+                queue.put_nowait(
+                    ToolExecutionEndEvent(
+                        tool_call_id=item.call.id,
+                        tool_name=item.tool.name if item.tool is not None else item.call.name,
+                        result=result,
+                        is_error=result.is_error,
+                    )
                 )
-            )
             queue.put_nowait(_TOOL_DONE)
 
         async def runner(slot: int, item: _PlannedCall) -> None:
@@ -1277,18 +1295,23 @@ class AgentLoop:
             # Snapshotting first means the decision is made while no await can
             # intervene, so it cannot be invalidated by what happens mid-emit.
             pending_ends: list[ToolExecutionEndEvent] = []
-            # Seeded with the calls that NEVER STARTED. A planning failure
-            # (unknown tool, duplicate id) is parked up front by `park()`, which
-            # queues an end event for it — harmless while nothing drained the
-            # queue, but the flush below reads it and would announce the end of
-            # a call no consumer ever saw begin. That is the same mirror-image
-            # defect the backfill refuses to commit a few lines down, and the
-            # flush has to share the guard rather than sit beneath it (R4-1,
-            # agent review round 4). Reachable from a hallucinated tool name
-            # alone: no abort, no timing window.
-            claimed: set[str] = {
-                item.call.id for item in batch if item.failure is not None or item.tool is None
-            }
+            # HOW MANY queued end events to swallow per call id — a count, not a
+            # set, because call ids are NOT unique within a batch. A model can
+            # emit two calls with one id; the loop keeps the first and turns the
+            # second into a planning failure, so one id can name both a slot
+            # that started and one that did not. A set keyed by id cannot tell
+            # them apart and suppresses BOTH, dropping the genuine end event of
+            # the call that really ran (R5-1, agent review round 5). This is the
+            # same collision that makes `results_by_slot` keyed by slot.
+            #
+            # Counting is exact even though the events are indistinguishable:
+            # with N carrying one id and K owed suppression, swallowing any K
+            # leaves the right number, and they are identical to a consumer.
+            #
+            # Not seeded from the batch: `park` no longer queues an end for a
+            # call that never started, so the only entries here are the ones
+            # this backfill is about to emit itself.
+            claimed: Counter[str] = Counter()
             for slot, item in enumerate(batch):
                 if results_by_slot[slot] is None:
                     result = self._synthetic_result(item.call, ABORTED_RESULT_TEXT)
@@ -1298,7 +1321,7 @@ class AgentLoop:
                         # failure parked its result up front and never emitted a
                         # start event, so an end event for it would be the
                         # mirror image of this bug.
-                        claimed.add(item.call.id)
+                        claimed[item.call.id] += 1
                         pending_ends.append(
                             ToolExecutionEndEvent(
                                 tool_call_id=item.call.id,
@@ -1327,7 +1350,10 @@ class AgentLoop:
                     break
                 if isinstance(queued, (_ToolDone, _BatchDone)):
                     continue
-                if isinstance(queued, ToolExecutionEndEvent) and queued.tool_call_id in claimed:
+                if isinstance(queued, ToolExecutionEndEvent) and claimed.get(
+                    queued.tool_call_id, 0
+                ):
+                    claimed[queued.tool_call_id] -= 1
                     continue
                 yield queued
 

--- a/local_operator/harness/loop.py
+++ b/local_operator/harness/loop.py
@@ -1277,7 +1277,18 @@ class AgentLoop:
             # Snapshotting first means the decision is made while no await can
             # intervene, so it cannot be invalidated by what happens mid-emit.
             pending_ends: list[ToolExecutionEndEvent] = []
-            claimed: set[str] = set()
+            # Seeded with the calls that NEVER STARTED. A planning failure
+            # (unknown tool, duplicate id) is parked up front by `park()`, which
+            # queues an end event for it — harmless while nothing drained the
+            # queue, but the flush below reads it and would announce the end of
+            # a call no consumer ever saw begin. That is the same mirror-image
+            # defect the backfill refuses to commit a few lines down, and the
+            # flush has to share the guard rather than sit beneath it (R4-1,
+            # agent review round 4). Reachable from a hallucinated tool name
+            # alone: no abort, no timing window.
+            claimed: set[str] = {
+                item.call.id for item in batch if item.failure is not None or item.tool is None
+            }
             for slot, item in enumerate(batch):
                 if results_by_slot[slot] is None:
                     result = self._synthetic_result(item.call, ABORTED_RESULT_TEXT)

--- a/local_operator/harness/loop.py
+++ b/local_operator/harness/loop.py
@@ -1249,9 +1249,36 @@ class AgentLoop:
             # request carries a ``tool_use`` with no ``tool_result`` and the
             # provider rejects the whole conversation — so an abort that races
             # a runner's first line must not be able to break the wire.
+            #
+            # The backfill also EMITS the end event, which it previously did
+            # not. Repairing `results_by_slot` alone keeps the wire legal but
+            # tells no consumer anything: a tool whose cleanup outran
+            # ``ABORT_DRAIN_TIMEOUT_S`` had its start event announced and no end
+            # event ever, so the API server holds that execution record
+            # IN_PROGRESS forever and never publishes a TOOL_END on its SSE
+            # stream (R2, agent review round 2). That is the same consumer
+            # damage `interruptible_runner`'s own cancellation handler exists to
+            # prevent — it closes the fast path, and the slow-cleanup path here
+            # reopened it. The TUI happens to survive either way because it
+            # retires orphaned cards at the turn boundary; nothing else does.
+            #
+            # Yielded rather than queued: the drain loop above has already
+            # broken out and nothing will read the queue again.
             for slot, item in enumerate(batch):
                 if results_by_slot[slot] is None:
-                    results_by_slot[slot] = self._synthetic_result(item.call, ABORTED_RESULT_TEXT)
+                    result = self._synthetic_result(item.call, ABORTED_RESULT_TEXT)
+                    results_by_slot[slot] = result
+                    if item.failure is None and item.tool is not None:
+                        # Only for calls that actually STARTED. A planning
+                        # failure parked its result up front and never emitted a
+                        # start event, so an end event for it would be the
+                        # mirror image of this bug.
+                        yield ToolExecutionEndEvent(
+                            tool_call_id=item.call.id,
+                            tool_name=item.tool.name,
+                            result=result,
+                            is_error=result.is_error,
+                        )
             results.extend(result for result in results_by_slot if result is not None)
         finally:
             if watcher is not None and not watcher.done():

--- a/local_operator/harness/loop.py
+++ b/local_operator/harness/loop.py
@@ -20,6 +20,7 @@ placeholder results so tool_use/tool_result pairing stays legal.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import inspect
 import json
 import logging
@@ -61,6 +62,7 @@ from local_operator.harness.types import (
     RenderedStreamError,
     StaleAside,
     StreamEndEvent,
+    StreamEvent,
     StreamTextDelta,
     StreamToolCallDelta,
     StreamUsageEvent,
@@ -95,7 +97,21 @@ class _ToolDone:
     __slots__ = ()
 
 
+class _BatchDone:
+    """Sentinel pushed ONCE, after every runner task in a batch has settled.
+
+    It is what ends the drain, and it exists because ``_ToolDone`` cannot do
+    that job under cancellation: a runner cancelled before its body ran emits
+    no receipt at all, so counting receipts against the number of tasks can
+    wait forever. This is posted by a closer that has already awaited the
+    tasks, so its arrival is proof there is nothing left to come.
+    """
+
+    __slots__ = ()
+
+
 _TOOL_DONE = _ToolDone()
+_BATCH_DONE = _BatchDone()
 
 # Type adapters used to validate tool arguments against JSON-schema scalars.
 _TYPE_ADAPTERS: dict[str, TypeAdapter[Any]] = {
@@ -115,6 +131,12 @@ SKIPPED_RESULT_TEXT = "Tool call skipped: interrupted by steering."
 EMPTY_TOOL_RESULT_TEXT = "[tool returned no output]"
 # Steering-interrupt poll interval for ``interruptible`` tools mid-run.
 STEERING_INTERRUPT_POLL_S = 0.25
+# How long the batch waits for tools to unwind after an ABORT before it stops
+# waiting and settles the turn anyway. An abort is a user pressing Esc, so the
+# turn must end on a human timescale; a tool whose cleanup is slower than this
+# (a process group refusing to die) keeps unwinding in the background while the
+# turn it belonged to is already over.
+ABORT_DRAIN_TIMEOUT_S = 2.0
 
 
 @dataclass
@@ -158,6 +180,112 @@ def _batches_shared(item: _PlannedCall) -> bool:
     forces a batch of one.
     """
     return item.tool is None or item.tool.concurrency == "shared"
+
+
+async def _abortable_stream(
+    stream: AsyncIterator[StreamEvent], signal: AbortSignal | None
+) -> AsyncIterator[StreamEvent]:
+    """Yield from ``stream`` but stop as soon as ``signal`` aborts.
+
+    A provider stream is an ``async for`` parked in ``await``: between two
+    tokens the loop is inside the socket read, and nothing there consults the
+    abort flag. Aborting mid-stream therefore did nothing until the model's
+    NEXT event arrived - for a model that had gone quiet (a long reasoning
+    block, a stalled connection, a slow first token) that is seconds of a UI
+    still painting a turn the user has already stopped, and on a wedged
+    connection it is the read timeout.
+
+    The stream is drained by a PUMP TASK feeding a queue, and the abort cancels
+    that task. The cancellation lands inside the socket read, which is what
+    actually releases the provider connection; the consumer here is woken by
+    the same event and simply stops. Ending quietly rather than raising is what
+    keeps the caller simple - the loop sees the stream finish, and its existing
+    ``signal.aborted`` check labels the turn ``aborted``, pairs every dangling
+    tool call, and emits the events a stopped turn owes the UI.
+
+    A pump rather than the obvious "race each pull against the signal": racing
+    per event costs two tasks and an ``asyncio.wait`` per token. Over a
+    4000-delta response (an ordinary long answer), measured on an M-series Mac:
+    a bare ``async for`` takes single-digit milliseconds, this pump takes
+    single-digit milliseconds too, and the per-event race takes roughly **1.5
+    SECONDS** - three orders of magnitude worse, and a visible stutter in the
+    very stream this function exists to make more responsive. The pump pays one
+    task for the whole stream instead of one per token.
+
+    The queue is unbounded, which is safe for a reason specific to this caller:
+    ``_model_turn`` already accumulates every delta of the response in
+    ``text_parts``, so a transient second reference to data the loop is holding
+    anyway cannot change the memory profile. In practice the queue stays near
+    empty - the producer is network-bound and the consumer is not.
+    """
+    if signal is None:
+        async for event in stream:
+            yield event
+        return
+
+    queue: asyncio.Queue[StreamEvent] = asyncio.Queue()
+    finished = asyncio.Event()
+
+    async def pump() -> None:
+        async for event in stream:
+            queue.put_nowait(event)
+
+    task = asyncio.ensure_future(pump())
+    # A DONE CALLBACK, not the pump's own ``finally``. ``ensure_future`` only
+    # SCHEDULES the coroutine, so a cancel landing before the body runs — which
+    # is exactly the pre-aborted fast path below — never executes any statement
+    # inside ``pump``, ``finally`` included. Waking the consumer from a
+    # ``finally`` therefore deadlocked the turn permanently: the queue stayed
+    # empty, the event was never set, and the drain parked forever on a wake-up
+    # nobody was going to send. A done callback fires for a task cancelled
+    # before it starts, which is the whole difference. (Same hazard the batch
+    # drain documents and defends against; this is the second instance of it.)
+    task.add_done_callback(lambda _task: finished.set())
+    watcher = asyncio.ensure_future(_cancel_when_aborted(signal, task))
+    # An abort that has ALREADY fired must not be missed: the watcher only gets
+    # to run on the next loop pass, by which time the pump could have consumed
+    # the whole stream and spent a request the user had stopped.
+    if signal.aborted:
+        task.cancel()
+
+    try:
+        while True:
+            if not queue.empty():
+                yield queue.get_nowait()
+                continue
+            if task.done():
+                # Drained AND the producer is finished. Surface a provider
+                # failure the way an unwrapped ``async for`` would, so the
+                # caller's error handling is unchanged by this wrapper; a
+                # cancellation is the abort and is deliberately not re-raised.
+                with contextlib.suppress(asyncio.CancelledError):
+                    task.result()
+                return
+            getter = asyncio.ensure_future(queue.get())
+            ended = asyncio.ensure_future(finished.wait())
+            try:
+                done, _pending = await asyncio.wait(
+                    {getter, ended}, return_when=asyncio.FIRST_COMPLETED
+                )
+            finally:
+                for pending in (getter, ended):
+                    if not pending.done():
+                        pending.cancel()
+            if getter in done:
+                yield getter.result()
+    finally:
+        watcher.cancel()
+        if not task.done():
+            task.cancel()
+        with contextlib.suppress(BaseException):
+            await task
+
+
+async def _cancel_when_aborted(signal: AbortSignal, task: asyncio.Task[None]) -> None:
+    """Cancel ``task`` when ``signal`` fires. Split out so the watcher holds no
+    reference to the generator frame it belongs to."""
+    await signal.wait()
+    task.cancel()
 
 
 class AgentLoop:
@@ -304,6 +432,22 @@ class AgentLoop:
                             yield event
                         self._append_results(context, tool_results, new_messages)
 
+                    if signal is not None and signal.aborted:
+                        # The abort landed while the batch was running. Its
+                        # results are already appended above (every call paired,
+                        # cancelled ones as synthetic ``aborted`` results), so
+                        # the context is legal — but the loop must NOT feed them
+                        # back for another model call. Continuing would spend a
+                        # request, and the reply to it, on a turn the user
+                        # stopped: the stop would read as "it kept going, and
+                        # then answered".
+                        yield TurnEndEvent(message=assistant, tool_results=tool_results)
+                        yield AgentEndEvent(
+                            messages=new_messages, aborted=True, generation=generation
+                        )
+                        self._discard_pending_custom(pending)
+                        return
+
                     yield TurnEndEvent(message=assistant, tool_results=tool_results)
                     has_more_tool_calls = bool(assistant.tool_calls)
                     if has_more_tool_calls and config.on_turn_end is not None:
@@ -413,6 +557,7 @@ class AgentLoop:
         # A resolver returning None is the declared "host has nothing better to
         # say" case (see the field), handled the same as having no resolver.
         return live if live is not None else config.model
+    # (``_abortable_stream`` is a module-level helper; see below the class.)
 
     async def _model_turn(
         self,
@@ -457,7 +602,7 @@ class AgentLoop:
         yield MessageStartEvent(message=assistant)
 
         try:
-            stream = config.stream_fn(request, signal)
+            stream = _abortable_stream(config.stream_fn(request, signal), signal)
             async for event in stream:
                 if isinstance(event, StreamTextDelta):
                     text_parts.append(event.delta)
@@ -567,6 +712,16 @@ class AgentLoop:
             )
             stop_reason = "aborted" if (signal is not None and signal.aborted) else "error"
             error = error or str(exc)
+
+        if signal is not None and signal.aborted:
+            # A stream CUT by the abort ends without its ``StreamEndEvent``, so
+            # the local default ("stop") would otherwise stand and the turn
+            # would read as a clean finish — the loop would go on to make
+            # another model call for a turn the user has already stopped.
+            # Recording the truth here is what lets the single ``("error",
+            # "aborted")`` branch upstream pair the dangling calls and end the
+            # run, instead of the abort having to be re-detected in each place.
+            stop_reason = "aborted"
 
         assistant.tool_calls = [
             self._assemble_tool_call(state) for _, state in sorted(tool_states.items())
@@ -724,7 +879,7 @@ class AgentLoop:
         item: _PlannedCall,
         context: LoopContext,
         signal: AbortSignal | None,
-        queue: asyncio.Queue[AgentEvent | _ToolDone],
+        queue: asyncio.Queue[AgentEvent | _ToolDone | _BatchDone],
     ) -> ToolResult:
         """Execute one planned call and return its result.
 
@@ -847,18 +1002,37 @@ class AgentLoop:
         On generator cancellation (GeneratorExit) every runner task is
         cancelled before this generator returns.
 
+        An ABORT is different from steering and stronger than both: a watcher
+        cancels EVERY runner in the batch the instant the signal fires, whether
+        or not the tool declared itself ``interruptible``. Steering is a
+        redirect and may only interrupt a tool that opted in; an abort is the
+        user pressing Esc, and a stop that waits for the slowest call in the
+        batch is not a stop. Before this, a batch of non-interruptible tools
+        (a `read` of a huge tree, an `edit`, an MCP call) ignored the signal
+        entirely and the turn ended only when the last one finished — measured
+        at multiple seconds after the keypress, with the UI still painting the
+        work as live.
+
+        ``interruptible`` therefore keeps exactly one meaning — "steering may
+        interrupt this" — instead of quietly doubling as "the user may stop
+        this", which is not a property any tool should get to decline.
+
         Results are keyed by BATCH SLOT, not call id: a model can emit two
         calls with the same id in one batch, and keying by id made the two
         slots collide into one result (duplicate tool_result ids on the wire,
         which Anthropic rejects). A slot whose call failed planning never
         runs; its synthetic result is parked in its slot up front.
         """
-        queue: asyncio.Queue[AgentEvent | _ToolDone] = asyncio.Queue()
+        queue: asyncio.Queue[AgentEvent | _ToolDone | _BatchDone] = asyncio.Queue()
         results_by_slot: list[ToolResult | None] = [None] * len(batch)
         tasks: list[asyncio.Task[None]] = []
         poll_interruptible = (
             config.interrupt_mode == "immediate" and config.has_steering_messages is not None
         )
+        # Set by the abort watcher so the runners' cancellation handlers can
+        # tell an abort apart from a steering interrupt and label their
+        # synthetic results correctly.
+        aborting = False
 
         def park(slot: int, item: _PlannedCall, result: ToolResult) -> None:
             results_by_slot[slot] = result
@@ -910,33 +1084,80 @@ class AgentLoop:
             )
             tool_task = asyncio.ensure_future(self._runner_result(item, context, signal, queue))
             try:
-                while True:
-                    done, _pending = await asyncio.wait(
-                        {tool_task}, timeout=STEERING_INTERRUPT_POLL_S
-                    )
-                    if tool_task in done:
-                        break
-                    if signal is not None and signal.aborted:
-                        break
-                    if self._peek_steering(config):
+                try:
+                    while True:
+                        done, _pending = await asyncio.wait(
+                            {tool_task}, timeout=STEERING_INTERRUPT_POLL_S
+                        )
+                        if tool_task in done:
+                            break
+                        if signal is not None and signal.aborted:
+                            break
+                        if self._peek_steering(config):
+                            tool_task.cancel()
+                            break
+                finally:
+                    if not tool_task.done():
                         tool_task.cancel()
-                        break
-            finally:
-                if not tool_task.done():
-                    tool_task.cancel()
-            try:
-                result = await tool_task
+                try:
+                    result = await tool_task
+                except asyncio.CancelledError:
+                    # The INNER task was cancelled (steering, or the run
+                    # aborting): synthesize a skipped/aborted result so the
+                    # call stays paired.
+                    text = (
+                        SKIPPED_RESULT_TEXT
+                        if not (signal is not None and signal.aborted)
+                        else ABORTED_RESULT_TEXT
+                    )
+                    result = self._synthetic_result(item.call, text)
+                park(slot, item, result)
             except asyncio.CancelledError:
-                # Cancelled for steering (or by the run aborting): synthesize a
-                # skipped/aborted result so the call stays paired.
-                text = (
-                    SKIPPED_RESULT_TEXT
-                    if not (signal is not None and signal.aborted)
-                    else ABORTED_RESULT_TEXT
-                )
-                result = self._synthetic_result(item.call, text)
-            park(slot, item, result)
+                # THIS coroutine was cancelled from outside — which is what the
+                # batch-wide abort watcher does. Without this the cancellation
+                # unwound straight out and ``park`` was never reached, so the
+                # call got a start event and no END event. The backfill below
+                # keeps the WIRE legal, but it does not emit events: every
+                # consumer other than the TUI (which retires orphaned cards at
+                # the turn boundary) was left with a tool that never finished —
+                # the API server holds the execution record IN_PROGRESS forever
+                # and never publishes a TOOL_END on its SSE stream.
+                #
+                # It matters far more here than for the plain ``runner``:
+                # ``interruptible`` covers bash, eval, wait, hub, ask, web
+                # search and EVERY MCP tool, i.e. most of a real batch.
+                park(slot, item, self._synthetic_result(item.call, ABORTED_RESULT_TEXT))
+                raise
 
+        async def abort_watcher() -> None:
+            """Cancel every runner the moment the abort signal fires.
+
+            The runners' own ``CancelledError`` handlers park a synthetic
+            ``aborted`` result for each call, so the batch still comes back
+            fully paired — cancelling here changes WHEN the turn ends, never
+            whether the wire stays legal.
+            """
+            nonlocal aborting
+            assert signal is not None
+            await signal.wait()
+            aborting = True
+            for task in tasks:
+                if not task.done():
+                    task.cancel()
+            # WAKE THE DRAIN. It is parked in ``queue.get()``, which the abort
+            # does not disturb, so without this nudge it only re-evaluates
+            # ``aborting`` when a runner happens to emit something — and a
+            # batch whose tools are all stuck in a slow unwind emits nothing.
+            # The deadline would then be armed only after the cleanup it is
+            # supposed to bound had already finished. The sentinel is ignored
+            # by the drain's own branches; its only job is to end the wait.
+            queue.put_nowait(_TOOL_DONE)
+
+        watcher: asyncio.Task[None] | None = None
+        # Declared before the ``try`` because ``finally`` reads it: an
+        # exception raised while scheduling the runners must not turn into a
+        # NameError that hides the real failure.
+        close_task: asyncio.Task[None] | None = None
         try:
             for slot, item in enumerate(batch):
                 if item.failure is not None or item.tool is None:
@@ -957,22 +1178,111 @@ class AgentLoop:
                         else runner(slot, item)
                     )
                 )
-            finished = 0
-            while finished < len(tasks):
-                item = await queue.get()
-                if isinstance(item, _ToolDone):
-                    finished += 1
-                    continue
-                yield item
-            await asyncio.gather(*tasks, return_exceptions=True)
+            # Started AFTER the runner tasks exist, so it can see all of them,
+            # and only when there is a signal to watch. An already-aborted
+            # signal is handled by the same path: ``wait()`` returns at once.
+            if signal is not None and tasks:
+                watcher = asyncio.ensure_future(abort_watcher())
+
+            # Termination is keyed on the TASKS settling, not on counting one
+            # ``_TOOL_DONE`` per task, and that is what makes cancellation
+            # safe. ``ensure_future`` only SCHEDULES a runner: a cancel landing
+            # in the same event-loop turn (which is exactly what the abort
+            # watcher does) means the body never runs, so it parks nothing and
+            # a counting drain would wait forever for a receipt no one will
+            # ever send. The closer posts one sentinel after every task has
+            # settled; the queue is FIFO, so everything the runners emitted is
+            # already ahead of it and still drains in order.
+            async def closer() -> None:
+                await asyncio.gather(*tasks, return_exceptions=True)
+                queue.put_nowait(_BATCH_DONE)
+
+            close_task = asyncio.ensure_future(closer()) if tasks else None
+            if close_task is not None:
+                # The deadline is armed by the ABORT, not at entry, and it
+                # bounds THIS loop rather than the cleanup in ``finally``. The
+                # first version bounded the wrong wait: the drain sat here
+                # until every task had settled, so by the time ``finally`` ran
+                # its ``wait_for`` there was nothing left to wait for and the
+                # budget was a no-op — a tool with a six-second unwind still
+                # held the turn open for six seconds. That is the very failure
+                # this PR exists to remove, moved from the tool body into its
+                # cleanup.
+                deadline: float | None = None
+                while True:
+                    if aborting and deadline is None:
+                        deadline = asyncio.get_running_loop().time() + ABORT_DRAIN_TIMEOUT_S
+                    if deadline is None:
+                        event = await queue.get()
+                    else:
+                        remaining = deadline - asyncio.get_running_loop().time()
+                        if remaining <= 0:
+                            logger.warning(
+                                "tool cleanup still running %ss after abort; "
+                                "settling the turn without it",
+                                ABORT_DRAIN_TIMEOUT_S,
+                            )
+                            break
+                        getter = asyncio.ensure_future(queue.get())
+                        try:
+                            event = await asyncio.wait_for(getter, timeout=remaining)
+                        except TimeoutError:
+                            # The tasks are left running: they own their own
+                            # resources, log their own failures, and the
+                            # backfill below pairs whatever they never parked.
+                            logger.warning(
+                                "tool cleanup still running %ss after abort; "
+                                "settling the turn without it",
+                                ABORT_DRAIN_TIMEOUT_S,
+                            )
+                            break
+                    if isinstance(event, _BatchDone):
+                        break
+                    if isinstance(event, _ToolDone):
+                        # A per-tool receipt, or the abort watcher's nudge.
+                        # Neither is an event a consumer should see.
+                        continue
+                    yield event
+
+            # Backfill any slot whose runner was cancelled before it could park
+            # its own result. Every call MUST come back paired or the next
+            # request carries a ``tool_use`` with no ``tool_result`` and the
+            # provider rejects the whole conversation — so an abort that races
+            # a runner's first line must not be able to break the wire.
+            for slot, item in enumerate(batch):
+                if results_by_slot[slot] is None:
+                    results_by_slot[slot] = self._synthetic_result(item.call, ABORTED_RESULT_TEXT)
             results.extend(result for result in results_by_slot if result is not None)
         finally:
+            if watcher is not None and not watcher.done():
+                watcher.cancel()
             # GeneratorExit / abort: never leave runner tasks behind.
             for task in tasks:
                 if not task.done():
                     task.cancel()
-            if tasks:
-                await asyncio.gather(*tasks, return_exceptions=True)
+            if aborting:
+                # Deliberately NOT awaited. The drain above already gave the
+                # cleanup its budget, and the whole point of that deadline is
+                # that the turn ends on a human timescale; awaiting here would
+                # hand the time straight back. The tasks are cancelled, own
+                # their own resources (bash kills its process group, eval tears
+                # down its worker) and cannot write to this batch any more —
+                # every slot is paired by the backfill above. ``gather``
+                # retrieves their exceptions so a raising cleanup cannot
+                # surface as an unobserved-task warning.
+                if tasks:
+                    detached = asyncio.gather(*tasks, return_exceptions=True)
+                    detached.add_done_callback(lambda task: task.exception())
+                if close_task is not None and not close_task.done():
+                    close_task.cancel()
+            else:
+                if tasks:
+                    await asyncio.gather(*tasks, return_exceptions=True)
+                if close_task is not None:
+                    if not close_task.done():
+                        close_task.cancel()
+                    with contextlib.suppress(BaseException):
+                        await close_task
 
     # ------------------------------------------------------------------
     # Helpers

--- a/local_operator/headless_print.py
+++ b/local_operator/headless_print.py
@@ -25,7 +25,7 @@ from typing import Any, Callable
 
 from rich.console import Console
 
-from local_operator.ansi import strip_control_sequences
+from local_operator.ansi import sanitize_prompt_line, strip_control_sequences
 from local_operator.harness.types import (
     AgentEndEvent,
     AgentEvent,
@@ -203,8 +203,29 @@ class PrintRenderer:
             # guard (R7-1, agent review round 7). Applied to every notice rather
             # than to that one call site, because the next notice to carry
             # untrusted text should not have to remember this.
-            text = strip_control_sequences(event.text)
-            self.console.print(f"[{style}]{glyph}{text}[/{style}]", highlight=False)
+            # `sanitize_prompt_line`, not bare stripping, and the style applied
+            # as a Rich STYLE rather than as inline markup. Three hazards, and
+            # the tool name inside this text is model-chosen (D14/D15, design
+            # round 4):
+            #
+            # 1. Control sequences repaint the terminal — what `strip` covered.
+            # 2. Newlines SURVIVE stripping by design (tool output is
+            #    multi-line and the renderers want it), so a name containing one
+            #    forges a second, unmarked row that can read as a clean success.
+            #    `sanitize_prompt_line` collapses whitespace runs, which is the
+            #    same reason it exists for approval prompts.
+            # 3. Square brackets are Rich MARKUP: `[bold]x` silently renders the
+            #    wrong name, and `[/red]oops` raises `MarkupError` inside the
+            #    renderer, which `session._emit` swallows — so the notice
+            #    vanishes entirely. That is precisely the silence this
+            #    diagnostic was added to prevent, reachable from a hallucinated
+            #    tool name. `markup=False` makes the text data rather than code.
+            #
+            # Pre-existing on the `✗ <name> failed` line this replaced; fixed
+            # here rather than deferred because the notice is now the only
+            # report an operator gets.
+            text = sanitize_prompt_line(event.text)
+            self.console.print(f"{glyph}{text}", style=style, highlight=False, markup=False)
         elif isinstance(event, RetryStartEvent):
             self.console.print(f"[dim]retry {event.attempt}: {event.error}[/dim]", highlight=False)
         elif isinstance(event, CompactionStartEvent):

--- a/local_operator/headless_print.py
+++ b/local_operator/headless_print.py
@@ -185,7 +185,26 @@ class PrintRenderer:
                 self.console.print(f"[red]✗ {name} failed[/red]", highlight=False)
         elif isinstance(event, NoticeEvent):
             style = {"error": "red", "warning": "yellow"}.get(event.kind, "dim")
-            self.console.print(f"[{style}]{event.text}[/{style}]", highlight=False)
+            # A GLYPH carries the severity, not just the colour. This renderer
+            # writes to a real terminal but its output is also piped into logs
+            # and read under NO_COLOR, where an ansi-stripped error notice was
+            # indistinguishable from an informational one — and the `✗` line it
+            # replaced for unrunnable tool calls did carry a marker, so dropping
+            # it was a regression in exactly the case that matters (D11, design
+            # round 3). `info` stays bare: a marker on every routine line is
+            # noise, and it is the one kind with nothing to warn about.
+            glyph = {"error": "✗ ", "warning": "! "}.get(event.kind, "")
+            # SANITIZED, like every other line this renderer writes. Notice text
+            # is no longer only ours: the unrunnable-call diagnostic carries a
+            # model-chosen tool name, so an erase-display escape inside it would
+            # clear the operator's terminal — and the `✗ <name> failed` line that
+            # diagnostic replaced was stripped for exactly that reason, two
+            # branches up. Moving the message onto a notice moved it off the
+            # guard (R7-1, agent review round 7). Applied to every notice rather
+            # than to that one call site, because the next notice to carry
+            # untrusted text should not have to remember this.
+            text = strip_control_sequences(event.text)
+            self.console.print(f"[{style}]{glyph}{text}[/{style}]", highlight=False)
         elif isinstance(event, RetryStartEvent):
             self.console.print(f"[dim]retry {event.attempt}: {event.error}[/dim]", highlight=False)
         elif isinstance(event, CompactionStartEvent):

--- a/local_operator/headless_print.py
+++ b/local_operator/headless_print.py
@@ -178,11 +178,20 @@ class PrintRenderer:
             summary = strip_control_sequences(event.intent or _args_summary(event.args))
             name = strip_control_sequences(event.tool_name)
             line = f"● {name} {summary}".rstrip()
-            self.console.print(f"[dim]{line[:_TOOL_LINE_WIDTH]}[/dim]", highlight=False)
+            # `markup=False` and the style passed as a style, for the reason the
+            # notice branch below states at length: the tool NAME is chosen by
+            # the model, and a `[` in it is Rich markup — `[/red]x` raises
+            # `MarkupError` here, which `session._emit` swallows, so the row
+            # vanishes and the operator watches a tool run with no line at all.
+            # Pre-existing on `main`; fixed here because the notice fix
+            # generalised the rule and it should hold for every branch that
+            # renders model-controlled text, not just the newest one (R14-2,
+            # agent review round 14).
+            self.console.print(line[:_TOOL_LINE_WIDTH], style="dim", highlight=False, markup=False)
         elif isinstance(event, ToolExecutionEndEvent):
             if event.is_error:
                 name = strip_control_sequences(event.tool_name)
-                self.console.print(f"[red]✗ {name} failed[/red]", highlight=False)
+                self.console.print(f"✗ {name} failed", style="red", highlight=False, markup=False)
         elif isinstance(event, NoticeEvent):
             style = {"error": "red", "warning": "yellow"}.get(event.kind, "dim")
             # A GLYPH carries the severity, not just the colour. This renderer

--- a/local_operator/session/protocol.py
+++ b/local_operator/session/protocol.py
@@ -249,6 +249,29 @@ class SessionProtocol(Protocol):
         """Abort the running turn; the engine emits an aborted agent_end."""
         ...
 
+    def cancel_subagents(self, reason: str = "interrupted") -> int:
+        """Cancel every running subagent; returns how many were stopped.
+
+        Separate from :meth:`abort`, which stops only THIS session's turn. A
+        subagent is a child session with its own turn and its own spend, so a
+        stopped parent does not stop it. Backgrounded ``bash`` jobs are not
+        touched — ``background=true`` exists to outlive the turn.
+
+        The count is part of the contract: a host prints it, and "nothing was
+        running" has to be distinguishable from "children were stopped".
+        """
+        ...
+
+    def running_subagents(self) -> int:
+        """How many subagents :meth:`cancel_subagents` would stop right now.
+
+        The counterpart to that call, so a host can OFFER the stop ("N still
+        running — press again") with the same number the stop will report. The
+        two must come from one predicate or the confirmation can contradict the
+        offer the user just acted on.
+        """
+        ...
+
     def set_approval_handler(self, handler: ApprovalGate | None) -> None:
         """Replace the host's tool-approval gate for write/exec tier tools.
 

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -1683,6 +1683,90 @@ class Session:
         if self._signal is not None:
             self._signal.abort(reason)
 
+    def cancel_subagents(self, reason: str = "interrupted") -> int:
+        """Cancel every running SUBAGENT and report how many were stopped.
+
+        Deliberately separate from :meth:`abort`, which stops this session's
+        own turn. A subagent is a child session with its own turn, its own
+        tools and its own spend: aborting the parent's signal does nothing to
+        it, so a stopped parent could sit idle while three children carried on
+        calling the provider. That is the gap this closes.
+
+        Split from ``abort`` rather than folded into it because the two answer
+        different presses. The first Esc stops what the user is watching \u2014 the
+        parent's turn \u2014 and a delegated child doing minutes of useful work
+        should survive a keypress aimed at the foreground. The second Esc says
+        the user meant all of it. Folding them together would make the cheap,
+        recoverable stop also the expensive, unrecoverable one.
+
+        ``bash`` jobs are NOT touched, by the same argument in reverse:
+        ``background=true`` exists precisely so a build or a deploy outlives
+        the turn that started it, and killing one on a keypress meant for the
+        agent destroys work the user asked to be insulated from the agent.
+        ``jobs cancel`` remains the way to stop those, and session teardown
+        still cancels everything.
+
+        Synchronous so a key handler can call it without awaiting: the actual
+        cancellation is a task per child, tracked by the session so
+        :meth:`dispose` still awaits it. Each child's abort is bridged onto
+        its own signal by ``AsyncJobManager.cancel``, so the child settles
+        through its own machinery \u2014 persisting the turn it had produced \u2014
+        rather than dying mid-await.
+        """
+        running = self._cancellable_subagents()
+        for job in running:
+            # Fire-and-forget per child, through the session's own tracker: a
+            # child that is slow to unwind must not hold the keystroke, and a
+            # cancel that raises must not take its siblings down with it.
+            self._spawn_background(self._cancel_job_quietly(job.id, reason))
+        return len(running)
+
+    def running_subagents(self) -> int:
+        """How many subagents :meth:`cancel_subagents` would stop right now.
+
+        THE one predicate, so a host that offers "esc again to stop N agents"
+        and the call that then stops them cannot disagree. They previously did:
+        the TUI counted with a filter that excludes jobs parked at the capacity
+        gate, while the cancel took every ``running`` row including those — so
+        the confirmation contradicted the offer ("1 still running" then
+        "stopped 2"), and a press that found ONLY queued children showed
+        nothing, armed nothing, and left children the second press would
+        happily have cancelled unreachable from the keyboard.
+
+        Queued children are deliberately IN scope: they are delegated work the
+        user asked to stop, and one that is merely waiting for a slot is no
+        less cancelled by being stopped before it starts.
+        """
+        return len(self._cancellable_subagents())
+
+    def _cancellable_subagents(self) -> list[Any]:
+        """The job rows both the count and the cancel act on. Never raises: a
+        keystroke handler and a status line both call into this."""
+        try:
+            return [
+                job
+                for job in self.jobs.list()
+                if getattr(job, "type", "") == "task" and job.status == "running"
+            ]
+        except Exception:  # noqa: BLE001 — a count must not take a keypress down
+            logger.warning("listing subagent jobs failed", exc_info=True)
+            return []
+
+    async def _cancel_job_quietly(self, job_id: str, reason: str) -> None:
+        """Cancel one job, logging rather than raising on failure.
+
+        The caller is a keystroke handler with no way to report an error and
+        nothing useful to do about one; a child that fails to tear down cleanly
+        must not stop its siblings from being cancelled.
+        """
+        del reason  # the manager stamps its own "cancelled" reason
+        try:
+            await self.jobs.cancel(job_id)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.warning("cancelling subagent job %s failed", job_id, exc_info=True)
+
     # -- live tool refresh (MCP late-connect / reconnect) ---------------------
 
     def refresh_tools(self, tools: Sequence[AgentTool]) -> None:

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -3295,24 +3295,37 @@ class OperatorApp(App[None]):
         #   from mouse to keyboard `_selecting` is already False and the copy
         #   would otherwise not keep the key it just earned.
         #
-        # That second test is deliberately the CONJUNCTION of `_copied` and a
-        # live selection, and neither half is sufficient. `_copied` alone
-        # retires only on an EDIT, so clicking elsewhere or pressing an arrow
-        # left it set with nothing on screen — the user saw a plain draft and
-        # got the interrupt, then quit on the second tap with the draft lost
-        # (D20, design round 6). A live selection alone was the ORIGINAL bug
-        # (D17): a highlight the user made minutes ago is not a copy.
+        # That second test is THE COPY'S OWN highlight still being on screen,
+        # which took three attempts to state correctly and each wrong one cost
+        # a draft:
         #
-        # Together they are self-retiring and, more importantly, VISIBLE: the
-        # key means "interrupt" exactly while the highlight the copy took is on
-        # screen, and reverts to "clear my draft" the moment that highlight
-        # goes — which is the same instant the user stops perceiving a copy.
-        # The discriminating state is the one thing they can actually see.
+        # * `selected_text` alone — a selection persists until the caret moves,
+        #   so a highlight made minutes ago diverted the key (D17).
+        # * `_copied` alone — it retires on an EDIT but not on a caret move, so
+        #   clicking elsewhere or pressing an arrow left it set with nothing on
+        #   screen: the user saw a plain draft, got the interrupt, and quit on
+        #   the second tap (D20). Stale for a SUPERSET of D17's states.
+        # * `_copied` and *a* live selection — an unrelated shift+arrow
+        #   selection made after the copied range was collapsed re-armed the
+        #   deferral, so two pixel-identical frames carried opposite meanings
+        #   (D22). Same lost draft, third route.
+        #
+        # So the editor pins WHICH range it copied, and this compares against
+        # it. That is the claim the comment has made since D20 and the code did
+        # not implement: the key means "interrupt" exactly while the highlight
+        # THE COPY TOOK is on screen, and reverts to "clear my draft" the
+        # moment it goes or is replaced — the same instant the user stops
+        # perceiving that copy. The discriminating state is the one thing they
+        # can actually see, and it is now the thing actually tested.
         #
         # Checked BEFORE the draft branch, because a composer being dragged over
         # always has text in it and would otherwise take that branch every time.
+        copied_range = getattr(editor, "_copied_selection", None)
         mid_copy = getattr(editor, "_selecting", False) or (
-            getattr(editor, "_copied", False) and bool(getattr(editor, "selected_text", ""))
+            getattr(editor, "_copied", False)
+            and copied_range is not None
+            and getattr(editor, "selection", None) == copied_range
+            and bool(getattr(editor, "selected_text", ""))
         )
         if editor.text.strip() and not mid_copy:
             # `remember_draft` refuses while the aside owns the composer, and a

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -3272,7 +3272,18 @@ class OperatorApp(App[None]):
         aside and hands back the main-chat draft it borrowed.
         """
         editor = self._editor()
-        if editor.text.strip():
+        # A LIVE SELECTION in the composer is not a draft the user is scrapping.
+        # They highlighted text a moment ago, which is a copy gesture in
+        # progress, and Ctrl+C there has to keep its older meaning — the
+        # interrupt and the first rung of the exit ladder — rather than being
+        # captured by this rung. Clearing the composer under a live highlight
+        # would also destroy the very text they were reaching for.
+        #
+        # Checked BEFORE the draft branch, because a highlighted composer always
+        # has text in it and would otherwise take that branch every time. The
+        # composer's copy is hung off the mouse release for the same reason this
+        # defers to it: the copy must not buy itself this key.
+        if editor.text.strip() and not getattr(editor, "selected_text", ""):
             # `remember_draft` refuses while the aside owns the composer, and a
             # draft that cannot be filed must not be thrown away either.
             if not editor.remember_draft():

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -3272,18 +3272,35 @@ class OperatorApp(App[None]):
         aside and hands back the main-chat draft it borrowed.
         """
         editor = self._editor()
-        # A LIVE SELECTION in the composer is not a draft the user is scrapping.
-        # They highlighted text a moment ago, which is a copy gesture in
-        # progress, and Ctrl+C there has to keep its older meaning — the
-        # interrupt and the first rung of the exit ladder — rather than being
-        # captured by this rung. Clearing the composer under a live highlight
-        # would also destroy the very text they were reaching for.
+        # A COPY GESTURE IN FLIGHT is not a draft the user is scrapping, so
+        # Ctrl+C keeps its older meaning there — the interrupt and the first
+        # rung of the exit ladder — rather than being captured by this rung.
         #
-        # Checked BEFORE the draft branch, because a highlighted composer always
-        # has text in it and would otherwise take that branch every time. The
-        # composer's copy is hung off the mouse release for the same reason this
-        # defers to it: the copy must not buy itself this key.
-        if editor.text.strip() and not getattr(editor, "selected_text", ""):
+        # Gated on the GESTURE, never on ``selected_text``. A selection is STATE
+        # that persists until the caret moves, so "has a highlight" diverted the
+        # key long after any gesture ended: a composer holding a stale range
+        # took the interrupt, armed the ladder, and the second reflexive tap
+        # EXITED THE APP with the draft never filed to history — the precise
+        # hazard this rung exists to remove, reintroduced by its own guard (D17,
+        # design round 5). It also caught two things that are not copies at all,
+        # a shift+arrow selection and the app's own marker-click selection.
+        #
+        # Two flags, because a copy spans two moments and the key must defer
+        # through both:
+        #
+        # * ``_selecting`` — this widget is mid-drag. The same predicate
+        #   `Editor._copy_drag` gates on, for the same documented reason.
+        # * ``_copied`` — a drag-copy just completed and has not been edited
+        #   past. The composer's copy lands on mouse RELEASE, so by the time a
+        #   hand moves from mouse to keyboard `_selecting` is already False;
+        #   without this the copy would still buy itself the key back. The
+        #   editor retires this flag on the first edit, so it cannot go stale
+        #   the way a selection does.
+        #
+        # Checked BEFORE the draft branch, because a composer being dragged over
+        # always has text in it and would otherwise take that branch every time.
+        mid_copy = getattr(editor, "_selecting", False) or getattr(editor, "_copied", False)
+        if editor.text.strip() and not mid_copy:
             # `remember_draft` refuses while the aside owns the composer, and a
             # draft that cannot be filed must not be thrown away either.
             if not editor.remember_draft():

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -500,6 +500,15 @@ logger = logging.getLogger("local_operator.tui.app")
 #: resume command — where omp's only clears the editor.)
 DOUBLE_INTERRUPT_WINDOW_S = 1.5
 
+#: How long a second Esc counts as the "also stop the subagents" press. Longer
+#: than the Ctrl+C window because the two gestures answer different questions.
+#: Ctrl+C's second press QUITS, so its window is deliberately too short to hit
+#: by accident; Esc's second press only widens the stop, and the user has to
+#: read a line of text ("N subagents still running — esc again to stop them")
+#: before deciding. A window that expires while they are still reading would
+#: silently demote the press back to a no-op.
+DOUBLE_STOP_WINDOW_S = 4.0
+
 #: Sessions the ``/resume`` picker offers. Higher than the recovery listing's
 #: ten because the picker can scroll and filter, and a conversation from a
 #: fortnight ago is exactly the one worth searching for.
@@ -1132,6 +1141,14 @@ class OperatorApp(App[None]):
         # The one live "ctrl+c again to exit" hint, replaced rather than
         # repeated so a run of interrupts leaves one row instead of N.
         self._exit_hint: NoticeBlock | None = None
+        # Esc ladder: when the first press stopped the parent while subagents
+        # were still running, this stamps WHEN the wider stop was offered. A
+        # second press inside DOUBLE_STOP_WINDOW_S takes the offer up.
+        self._stop_offered_at: float | None = None
+        # The one live stop-ladder line ("N subagents still running…" /
+        # "stopped N subagents"), replaced rather than repeated for the same
+        # reason `_exit_hint` is.
+        self._stop_notice: NoticeBlock | None = None
         # The MAIN transcript, held rather than looked up. Once the full-page
         # subagent view is open there are two `TranscriptView`s in the screen,
         # so `query_one(TranscriptView)` is ambiguous exactly while a turn may
@@ -1893,6 +1910,16 @@ class OperatorApp(App[None]):
         # first aborted turn would suppress its notice on the strength of cards
         # that belonged to a conversation the user cannot see any more.
         self._interrupted_cards = 0
+        # And the stop ladder's offer, which is the sharpest instance of this
+        # family: it is an armed ESCALATION. Left standing across a session
+        # swap, an Esc pressed moments after `/new` or `/reload` would take up
+        # an offer made about the OLD conversation's children and cancel the
+        # new session's subagents instead — destroying work on the strength of
+        # a count the user was shown for a different conversation. The notice
+        # reference goes too; `clear_blocks` unmounts the widget but cannot
+        # clear a reference it does not own.
+        self._stop_offered_at = None
+        self._stop_notice = None
         # And a deferred completion belongs to the dying conversation too. Left
         # set, the replacement session's first settling background job would
         # announce "task complete" for a turn the user can no longer see — the
@@ -3216,7 +3243,49 @@ class OperatorApp(App[None]):
         so a further Ctrl+C never reaches this method — a rung that cannot fire
         is worse than no rung, because the docstring promises an escape the user
         does not have.
+
+        A DRAFT in the composer takes the first press, ahead of every rung
+        below. Ctrl+C on a half-typed prompt means "scrap that", and the exit
+        ladder should not start while there is something cheaper and more
+        likely for the key to mean. It also removes the ladder's sharpest edge:
+        the press that quits was previously two taps away while the user was
+        typing, so a reflexive double-tap at the composer could exit the app
+        with a drafted prompt on screen. Clearing consumes the press WITHOUT
+        arming the ladder, so the next Ctrl+C is a first press again.
+
+        The draft is not silently destroyed: it goes to the editor's own
+        history, which is what ``up`` recalls, so the text is one keystroke
+        away rather than gone.
+
+        The ASIDE is handled by closing the card instead. Its draft may not be
+        recorded — the card promises "off the record", and honouring that is
+        why ``remember_draft`` can refuse — so clearing the composer there
+        would destroy the question outright. ``_close_aside`` is the path that
+        already exists for "the user is done with this card": it discards the
+        aside and hands back the main-chat draft it borrowed.
         """
+        editor = self._editor()
+        if editor.text.strip():
+            # `remember_draft` refuses while the aside owns the composer, and a
+            # draft that cannot be filed must not be thrown away either.
+            if not editor.remember_draft():
+                if self._close_aside():
+                    return
+                # Not the aside, but recording is off for some other reason:
+                # leave the text alone rather than destroying it unrecoverably,
+                # and let the press fall through to its interrupt meaning.
+                pass
+            else:
+                editor.clear_content()
+                # The ladder is NOT armed and any live exit hint is stale: this
+                # press meant the composer, and leaving "ctrl+c again to exit"
+                # on screen would promise an exit the next press does not make.
+                self._last_interrupt_at = 0.0
+                if self._exit_hint is not None:
+                    self._transcript_view().remove_block(self._exit_hint)
+                    self._exit_hint = None
+                return
+
         now = time.monotonic()
         if now - self._last_interrupt_at < DOUBLE_INTERRUPT_WINDOW_S:
             self._interrupt()  # stop the work before dropping the terminal
@@ -3335,6 +3404,20 @@ class OperatorApp(App[None]):
         With nothing running Esc does nothing — in particular it must not clear
         the composer, which would throw away typed text on the key people press
         to cancel.
+
+        SUBAGENTS take the second press. The first Esc stops the parent turn,
+        which is what the user is watching; delegated children keep going,
+        because a child can be minutes into useful work and the foreground key
+        should not be able to destroy it by reflex. When any child is still
+        running the stop says so and offers the wider stop, and a second press
+        within :data:`DOUBLE_STOP_WINDOW_S` cancels every child too. Both
+        presses are honest about what they did: a stop that silently left three
+        agents burning tokens is the bug this ladder exists to fix, and one
+        that silently killed them would be the opposite bug.
+
+        Backgrounded ``bash`` jobs are never touched by either press —
+        ``background=true`` exists to outlive the turn. ``jobs cancel`` stops
+        those.
         """
         if self._close_aside():
             return
@@ -3376,9 +3459,101 @@ class OperatorApp(App[None]):
         ):
             self._settle_ask_picker()
             return
-        pending = self._approval is not None and not self._approval.answered
-        if pending or (self._session is not None and self._session.is_streaming):
+
+        session = self._session
+        now = time.monotonic()
+
+        # The escalation press: offered only after a first press that reported
+        # children still running, and only inside the window. It sits BELOW the
+        # picker branch above for the reason that branch states — answering a
+        # question the agent asked is not an abort — and above the ordinary
+        # stop, because by this point the user has already read the offer and
+        # pressed again to take it.
+        if (
+            self._stop_offered_at is not None
+            and now - self._stop_offered_at < DOUBLE_STOP_WINDOW_S
+            and session is not None
+        ):
+            self._stop_offered_at = None
+            stopped = session.cancel_subagents("interrupted")
+            # Re-aborting the parent is deliberate and not redundant: a child
+            # settling can hand its result back to a parent that has since
+            # started a follow-up turn, and the user's second press means that
+            # too. It is idempotent when the parent is already stopped.
             self._interrupt()
+            self._replace_stop_notice(
+                (
+                    f"stopped {stopped} subagent{'s' if stopped != 1 else ''}"
+                    if stopped
+                    else "no subagents were running"
+                ),
+                "note",
+            )
+            return
+
+        pending = self._approval is not None and not self._approval.answered
+        streaming = session is not None and session.is_streaming
+        # The SESSION's predicate, not the band's `_job_count("task")`. The two
+        # disagree on children parked at the capacity gate, and the number
+        # offered here must be the number the second press actually stops —
+        # otherwise the confirmation contradicts the offer, and a press that
+        # finds only queued children arms nothing and leaves them unstoppable
+        # from the keyboard. `_job_count` remains right for the status band,
+        # which is reporting work in progress rather than work Esc can reach.
+        children = self._running_subagents(session)
+
+        if not (pending or streaming or children):
+            # Nothing to stop. Explicitly NOT clearing the composer.
+            return
+
+        if pending or streaming:
+            self._interrupt()
+
+        if children:
+            # The offer is the whole point of the first press when children are
+            # up: without a line on screen the user has no way to know that a
+            # stop left work running, and no way to learn the second press
+            # exists.
+            self._stop_offered_at = now
+            self._replace_stop_notice(
+                f"{children} subagent{'s' if children != 1 else ''} still running "
+                "— esc again to stop them",
+                "warning",
+            )
+        else:
+            self._stop_offered_at = None
+
+    @staticmethod
+    def _running_subagents(session: Any | None) -> int:
+        """Children the stop ladder can reach, via the session's own predicate.
+
+        ``getattr`` because reduced hosts and the test fakes need not implement
+        every method on the protocol; a host that cannot answer simply has no
+        children to offer. Never raises — this runs on a keystroke.
+        """
+        if session is None:
+            return 0
+        counter = getattr(session, "running_subagents", None)
+        if counter is None:
+            return 0
+        try:
+            return int(counter())
+        except Exception:  # noqa: BLE001 — a stop must never fail on its count
+            logger.warning("counting subagents failed", exc_info=True)
+            return 0
+
+    def _replace_stop_notice(self, text: str, kind: NoticeKind) -> None:
+        """Show the stop ladder's one line, replacing any previous one.
+
+        Replaced rather than appended for the reason the Ctrl+C hint is: a user
+        pressing Esc twice would otherwise leave two contradictory rows ("still
+        running" above "stopped them"), and the stale one is the one that reads
+        as current.
+        """
+        if self._stop_notice is not None:
+            self._transcript_view().remove_block(self._stop_notice)
+        self._stop_notice = NoticeBlock(text, kind)
+        self._append_block(self._stop_notice)
 
     # -- tool approvals -------------------------------------------------------
     async def request_tool_approval(
@@ -4179,6 +4354,13 @@ class OperatorApp(App[None]):
         # again. Cancelling frees both.
         self._settle_key_prompt()
         self._exit_hint = None  # its widget went with the transcript
+        # The stop ladder's line went with it, for the same reason. Left set,
+        # `_replace_stop_notice` would try to remove a block the transcript no
+        # longer holds. The OFFER is dropped with it: the line that explained
+        # what a second Esc would do is no longer on screen, and an escalation
+        # the user can no longer see the terms of must not stay armed.
+        self._stop_notice = None
+        self._stop_offered_at = None
         self._streaming_block = None
         self._tool_cards = {}
         self._composing_cards = {}

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -3297,7 +3297,12 @@ class OperatorApp(App[None]):
                 # can discover is worth very little, because they retype it
                 # anyway (D6, design round 1). One quiet receipt, in the `note`
                 # weight that answers something the user just did.
-                self._append_block(NoticeBlock("draft cleared — up to recover", "note"))
+                #
+                # The GLYPH, not the word: every other arrow hint in the TUI
+                # renders one (`session_picker`, `usage_panel`, `aside_panel`,
+                # `subagent_view`), and "up to" garden-paths on the idiom before
+                # it resolves as a key name (D10, design round 2).
+                self._append_block(NoticeBlock("draft cleared — ↑ to recover", "note"))
                 return
 
         now = time.monotonic()
@@ -3580,6 +3585,11 @@ class OperatorApp(App[None]):
             # lying about what it did (D1, design round 1). The re-armed offer
             # therefore says so, which both acknowledges the press and states
             # the constraint that defeated it.
+            #
+            # "esc again", not "press esc twice": THIS press re-armed the offer,
+            # so the ladder is armed by the time the row is painted and the very
+            # next single press escalates. "Twice" overstated the cost by one on
+            # the one key this change exists to make honest (D9, design round 2).
             expired = self._stop_offered_at is not None
             self._stop_offered_at = now
             self._stop_offer_count = children
@@ -3587,7 +3597,7 @@ class OperatorApp(App[None]):
             self._replace_stop_notice(
                 (
                     f"{children} subagent{plural} still running "
-                    f"— press esc twice within {DOUBLE_STOP_WINDOW_S:g}s to stop them"
+                    f"— too slow; esc again within {DOUBLE_STOP_WINDOW_S:g}s to stop them"
                     if expired
                     else f"{children} subagent{plural} still running " "— esc again to stop them"
                 ),

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -3310,23 +3310,24 @@ class OperatorApp(App[None]):
         #   deferral, so two pixel-identical frames carried opposite meanings
         #   (D22). Same lost draft, third route.
         #
-        # So the editor pins WHICH range it copied, and this compares against
-        # it. That is the claim the comment has made since D20 and the code did
-        # not implement: the key means "interrupt" exactly while the highlight
-        # THE COPY TOOK is on screen, and reverts to "clear my draft" the
-        # moment it goes or is replaced — the same instant the user stops
-        # perceiving that copy. The discriminating state is the one thing they
-        # can actually see, and it is now the thing actually tested.
+        # Fixed at the SOURCE instead, on the reviewer's diagnosis that the
+        # root cause was one flag answering two questions with the wrong
+        # lifetime: `_copied` is an edit-scoped receipt, and this is a
+        # gesture-scoped question. The editor now retires the gesture claim in
+        # its `selection` watcher — the copy's claim ends when the highlight it
+        # took stops being the highlight on screen, whether a caret move
+        # collapses it or a new selection replaces it.
+        #
+        # So `_copied` is self-retiring here and the guard is finally the plain
+        # statement the comment has been making since D20: the key means
+        # "interrupt" exactly while the copy the user just made is still
+        # visible. Three conjunctions were three attempts to patch a lifetime
+        # from the outside; none of them could, because the flag outlived its
+        # own subject.
         #
         # Checked BEFORE the draft branch, because a composer being dragged over
         # always has text in it and would otherwise take that branch every time.
-        copied_range = getattr(editor, "_copied_selection", None)
-        mid_copy = getattr(editor, "_selecting", False) or (
-            getattr(editor, "_copied", False)
-            and copied_range is not None
-            and getattr(editor, "selection", None) == copied_range
-            and bool(getattr(editor, "selected_text", ""))
-        )
+        mid_copy = getattr(editor, "_selecting", False) or getattr(editor, "_copied", False)
         if editor.text.strip() and not mid_copy:
             # `remember_draft` refuses while the aside owns the composer, and a
             # draft that cannot be filed must not be thrown away either.

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -1145,6 +1145,12 @@ class OperatorApp(App[None]):
         # were still running, this stamps WHEN the wider stop was offered. A
         # second press inside DOUBLE_STOP_WINDOW_S takes the offer up.
         self._stop_offered_at: float | None = None
+        # How many children the standing offer NAMED. Kept beside the stamp so
+        # the escalation can tell "nothing was ever delegated" apart from "the
+        # children the offer counted finished before the second press landed" —
+        # two states that otherwise print the same flat denial of a row the user
+        # is still looking at (D2, design round 1).
+        self._stop_offer_count: int = 0
         # The one live stop-ladder line ("N subagents still running…" /
         # "stopped N subagents"), replaced rather than repeated for the same
         # reason `_exit_hint` is.
@@ -1919,6 +1925,7 @@ class OperatorApp(App[None]):
         # reference goes too; `clear_blocks` unmounts the widget but cannot
         # clear a reference it does not own.
         self._stop_offered_at = None
+        self._stop_offer_count = 0
         self._stop_notice = None
         # And a deferred completion belongs to the dying conversation too. Left
         # set, the replacement session's first settling background job would
@@ -3284,6 +3291,13 @@ class OperatorApp(App[None]):
                 if self._exit_hint is not None:
                     self._transcript_view().remove_block(self._exit_hint)
                     self._exit_hint = None
+                # Say where the text went. Filing the draft into history rather
+                # than the bin is the whole point of this rung, but all the user
+                # SEES is their sentence vanishing — and recoverability nobody
+                # can discover is worth very little, because they retype it
+                # anyway (D6, design round 1). One quiet receipt, in the `note`
+                # weight that answers something the user just did.
+                self._append_block(NoticeBlock("draft cleared — up to recover", "note"))
                 return
 
         now = time.monotonic()
@@ -3475,20 +3489,48 @@ class OperatorApp(App[None]):
             and session is not None
         ):
             self._stop_offered_at = None
+            offered = self._stop_offer_count
+            self._stop_offer_count = 0
             stopped = session.cancel_subagents("interrupted")
             # Re-aborting the parent is deliberate and not redundant: a child
             # settling can hand its result back to a parent that has since
             # started a follow-up turn, and the user's second press means that
             # too. It is idempotent when the parent is already stopped.
             self._interrupt()
-            self._replace_stop_notice(
-                (
-                    f"stopped {stopped} subagent{'s' if stopped != 1 else ''}"
-                    if stopped
-                    else "no subagents were running"
-                ),
-                "note",
-            )
+            if stopped:
+                text = f"stopped {stopped} subagent{'s' if stopped != 1 else ''}"
+                # Sparing backgrounded `bash` is deliberate (`background=true`
+                # exists so a build outlives the turn) and genuinely surprising
+                # to a user who just escalated a stop, which reads as "stop all
+                # of it". Naming the survivors here, and only when there ARE
+                # any, prevents the "I stopped everything, why is the build
+                # still running" question at the one moment the answer is
+                # wanted (D3, design round 1). Unconditional, it would be noise.
+                spared = self._job_count("bash")
+                if spared:
+                    text += (
+                        f"; {spared} background job{'s' if spared != 1 else ''} "
+                        "still running — jobs cancel to stop"
+                    )
+            elif offered:
+                # The children finished on their own between the two presses.
+                # `cancel_subagents` recounts at press time, so this is
+                # reachable in production and not a fake-session artifact.
+                #
+                # The wording matters more than it looks. Saying "no subagents
+                # were running" here REPLACES a row that just said "2 subagents
+                # still running", so the user reads a flat denial of what they
+                # were told one keypress ago — which re-raises the exact
+                # credibility problem this whole change exists to fix. What
+                # actually happened is better news than the offer implied, and
+                # the line should say so (D2, design round 1).
+                text = (
+                    f"{offered} subagent{'s' if offered != 1 else ''} "
+                    "finished before the stop landed"
+                )
+            else:
+                text = "no subagents were running"
+            self._replace_stop_notice(text, "note")
             return
 
         pending = self._approval is not None and not self._approval.answered
@@ -3514,14 +3556,65 @@ class OperatorApp(App[None]):
             # up: without a line on screen the user has no way to know that a
             # stop left work running, and no way to learn the second press
             # exists.
+            #
+            # A press that lands here while an offer was ALREADY up is a press
+            # that arrived too late to escalate (the branch above took every
+            # press inside the window). Re-arming and reprinting the identical
+            # string made that press a silent no-op — the rendered frame was
+            # byte-identical, so it was indistinguishable from a dropped
+            # keystroke on the one key whose job in this change is to stop
+            # lying about what it did (D1, design round 1). The re-armed offer
+            # therefore says so, which both acknowledges the press and states
+            # the constraint that defeated it.
+            expired = self._stop_offered_at is not None
             self._stop_offered_at = now
+            self._stop_offer_count = children
+            plural = "s" if children != 1 else ""
             self._replace_stop_notice(
-                f"{children} subagent{'s' if children != 1 else ''} still running "
-                "— esc again to stop them",
+                (
+                    f"{children} subagent{plural} still running "
+                    f"— press esc twice within {DOUBLE_STOP_WINDOW_S:g}s to stop them"
+                    if expired
+                    else f"{children} subagent{plural} still running " "— esc again to stop them"
+                ),
                 "warning",
             )
+            # Retire the INSTRUCTION when the window that makes it true closes.
+            # Nothing else cleared the row, so a transcript kept a warning-amber
+            # line reading "esc again to stop them" for the rest of the session,
+            # scrolling up through the history as a standing offer that no key
+            # would honour — and with no visible expiry there was no way to tell
+            # a live offer from a dead one (D4, design round 1). The fact stays
+            # (the children really are still running); only the promise goes.
+            armed_at = now
+            self.set_timer(DOUBLE_STOP_WINDOW_S, lambda: self._expire_stop_offer(armed_at))
         else:
             self._stop_offered_at = None
+            self._stop_offer_count = 0
+
+    def _expire_stop_offer(self, armed_at: float) -> None:
+        """Drop the escalation promise from a standing offer once it lapses.
+
+        Keyed on the stamp it was armed with, so a timer from an earlier press
+        cannot retire a NEWER offer: a second press inside the window re-arms
+        with a fresh ``now``, and this fires for the old one a moment later.
+        Any other outcome (taken, cleared, session swapped) leaves
+        ``_stop_offered_at`` unequal and this does nothing.
+        """
+        if self._stop_offered_at != armed_at:
+            return
+        self._stop_offered_at = None
+        count = self._stop_offer_count
+        self._stop_offer_count = 0
+        notice = self._stop_notice
+        if notice is None or not notice.is_attached or count <= 0:
+            return
+        # `note`, not `warning`: it is no longer a state the user must act on
+        # within a window, just a fact about what is still running.
+        notice.restate(
+            f"{count} subagent{'s' if count != 1 else ''} still running",
+            "note",
+        )
 
     @staticmethod
     def _running_subagents(session: Any | None) -> int:
@@ -3549,9 +3642,23 @@ class OperatorApp(App[None]):
         pressing Esc twice would otherwise leave two contradictory rows ("still
         running" above "stopped them"), and the stale one is the one that reads
         as current.
+
+        Restated IN PLACE rather than removed and re-appended. Re-appending put
+        the row back at the transcript end, so a notice that arrived between the
+        two presses — the aborted turn's own ``interrupted`` row is the ordinary
+        case — ended up ABOVE a row the user had already read, and the
+        transcript stopped being chronological (D5, design round 1).
+        :meth:`NoticeBlock.restate` exists for exactly this "notice that
+        outlived its own truth" case and is what the queued-steer row uses.
+
+        Falls back to appending when the block is gone (``/clear``, a session
+        swap, or a transcript that never mounted it), because restating a block
+        that is no longer in the view would silently write to nothing.
         """
-        if self._stop_notice is not None:
-            self._transcript_view().remove_block(self._stop_notice)
+        notice = self._stop_notice
+        if notice is not None and notice.is_attached:
+            notice.restate(text, kind)
+            return
         self._stop_notice = NoticeBlock(text, kind)
         self._append_block(self._stop_notice)
 
@@ -4361,6 +4468,7 @@ class OperatorApp(App[None]):
         # the user can no longer see the terms of must not stay armed.
         self._stop_notice = None
         self._stop_offered_at = None
+        self._stop_offer_count = 0
         self._streaming_block = None
         self._tool_cards = {}
         self._composing_cards = {}

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -3285,21 +3285,35 @@ class OperatorApp(App[None]):
         # design round 5). It also caught two things that are not copies at all,
         # a shift+arrow selection and the app's own marker-click selection.
         #
-        # Two flags, because a copy spans two moments and the key must defer
-        # through both:
+        # Two moments, because a copy spans both and the key must defer through
+        # each:
         #
         # * ``_selecting`` — this widget is mid-drag. The same predicate
         #   `Editor._copy_drag` gates on, for the same documented reason.
-        # * ``_copied`` — a drag-copy just completed and has not been edited
-        #   past. The composer's copy lands on mouse RELEASE, so by the time a
-        #   hand moves from mouse to keyboard `_selecting` is already False;
-        #   without this the copy would still buy itself the key back. The
-        #   editor retires this flag on the first edit, so it cannot go stale
-        #   the way a selection does.
+        # * a just-completed drag-copy WHOSE HIGHLIGHT IS STILL ON SCREEN. The
+        #   composer's copy lands on mouse RELEASE, so by the time a hand moves
+        #   from mouse to keyboard `_selecting` is already False and the copy
+        #   would otherwise not keep the key it just earned.
+        #
+        # That second test is deliberately the CONJUNCTION of `_copied` and a
+        # live selection, and neither half is sufficient. `_copied` alone
+        # retires only on an EDIT, so clicking elsewhere or pressing an arrow
+        # left it set with nothing on screen — the user saw a plain draft and
+        # got the interrupt, then quit on the second tap with the draft lost
+        # (D20, design round 6). A live selection alone was the ORIGINAL bug
+        # (D17): a highlight the user made minutes ago is not a copy.
+        #
+        # Together they are self-retiring and, more importantly, VISIBLE: the
+        # key means "interrupt" exactly while the highlight the copy took is on
+        # screen, and reverts to "clear my draft" the moment that highlight
+        # goes — which is the same instant the user stops perceiving a copy.
+        # The discriminating state is the one thing they can actually see.
         #
         # Checked BEFORE the draft branch, because a composer being dragged over
         # always has text in it and would otherwise take that branch every time.
-        mid_copy = getattr(editor, "_selecting", False) or getattr(editor, "_copied", False)
+        mid_copy = getattr(editor, "_selecting", False) or (
+            getattr(editor, "_copied", False) and bool(getattr(editor, "selected_text", ""))
+        )
         if editor.text.strip() and not mid_copy:
             # `remember_draft` refuses while the aside owns the composer, and a
             # draft that cannot be filed must not be thrown away either.

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -3327,7 +3327,7 @@ class OperatorApp(App[None]):
         #
         # Checked BEFORE the draft branch, because a composer being dragged over
         # always has text in it and would otherwise take that branch every time.
-        mid_copy = getattr(editor, "_selecting", False) or getattr(editor, "_copied", False)
+        mid_copy = editor.copy_in_flight
         if editor.text.strip() and not mid_copy:
             # `remember_draft` refuses while the aside owns the composer, and a
             # draft that cannot be filed must not be thrown away either.

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -3628,10 +3628,22 @@ class OperatorApp(App[None]):
         if self._stop_offered_at != armed_at:
             return
         self._stop_offered_at = None
-        count = self._stop_offer_count
         self._stop_offer_count = 0
         notice = self._stop_notice
-        if notice is None or not notice.is_attached or count <= 0:
+        if notice is None or not notice.is_attached:
+            return
+        # RECOUNTED, not the number the offer was armed with. The surviving row
+        # is a present-tense statement of fact in the calm receipt weight, and
+        # children settle on their own schedule — so restating the arm-time
+        # count asserted "2 subagents still running" about children that had
+        # finished during the window, which is a settled-looking lie rather than
+        # a lapsed offer (R3-3, agent review round 3).
+        count = self._running_subagents(self._session)
+        if count <= 0:
+            # Nothing left to report. The row goes rather than settling into a
+            # statement about work that no longer exists.
+            self._transcript_view().remove_block(notice)
+            self._stop_notice = None
             return
         # `note`, not `warning`: it is no longer a state the user must act on
         # within a window, just a fact about what is still running.
@@ -3678,13 +3690,61 @@ class OperatorApp(App[None]):
         Falls back to appending when the block is gone (``/clear``, a session
         swap, or a transcript that never mounted it), because restating a block
         that is no longer in the view would silently write to nothing.
+
+        ...and ALSO when the row has scrolled out of sight, which is the harder
+        case. ``_stop_notice`` outlives the turn that created it, so a later
+        press can find it buried far up the transcript — and restating it there
+        repaints a row the user cannot see, leaving the visible frame unchanged.
+        That is the silent no-op D1 was filed for, reintroduced by D5's in-place
+        restate on a different axis (R3-2, agent review round 3).
+
+        VISIBILITY is the discriminator, not position in the block list. D5's
+        case — a notice arriving between the two presses — leaves the ladder row
+        one row up and plainly on screen, and moving it there is precisely the
+        reordering D5 objected to. R3-2's case has it off screen entirely, where
+        leaving it is indistinguishable from a dropped keystroke. "Can the user
+        see it?" is the question both answers turn on, so it is the one asked.
         """
         notice = self._stop_notice
         if notice is not None and notice.is_attached:
-            notice.restate(text, kind)
-            return
+            if self._is_on_screen(notice):
+                notice.restate(text, kind)
+                return
+            # Out of sight: the row has to move to where the user is looking.
+            # Dropping the old one keeps the replace-don't-stack promise, which
+            # is the whole reason this method exists.
+            self._transcript_view().remove_block(notice)
         self._stop_notice = NoticeBlock(text, kind)
         self._append_block(self._stop_notice)
+
+    def _is_on_screen(self, block: Widget) -> bool:
+        """Whether ``block`` currently occupies rows the user can see.
+
+        Compared against the TRANSCRIPT's own viewport rather than the screen's:
+        the transcript is the scrolling container, so a block scrolled past its
+        fold is out of sight even though it is mounted and inside the app.
+
+        ``block.region`` is already SCREEN-relative — Textual has resolved the
+        scroll offset into it — so the comparison is against the container's
+        on-screen rectangle (``view.region``), not its ``window_region``, which
+        is expressed in the scrolled virtual coordinate space. Mixing the two
+        compares a viewport row number against a virtual one and answers "never
+        visible" for every block once the transcript has scrolled at all.
+
+        Never raises. This runs on a keystroke, and a geometry question that
+        cannot be answered must not be able to swallow a stop — an unanswerable
+        one reports "not visible", which costs a moved row and never a lost
+        press.
+        """
+        try:
+            view = self._transcript_view()
+            region = block.region
+            if not region.height:
+                return False
+            return region.overlaps(view.region)
+        except Exception:  # noqa: BLE001 — visibility is advisory, never fatal
+            logger.debug("could not resolve stop-notice visibility", exc_info=True)
+            return False
 
     # -- tool approvals -------------------------------------------------------
     async def request_tool_approval(

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -3483,10 +3483,24 @@ class OperatorApp(App[None]):
         # question the agent asked is not an abort — and above the ordinary
         # stop, because by this point the user has already read the offer and
         # pressed again to take it.
+        # ...and only when no prompt is waiting on the user. The picker branch
+        # above gates on `_live_prompt()` for this reason; without the same
+        # guard here an APPROVAL raised after the offer was armed was outranked
+        # by the escalation, so one Esc cancelled every child on a press the
+        # user could reasonably have meant for the `rm -rf` prompt in front of
+        # them (R1, agent review round 2). `_live_prompt` ranks an unanswered
+        # approval first precisely because it is a permission gate the engine is
+        # blocked on and the most recently raised thing on screen; an armed
+        # offer is older than it by construction, and the older, cheaper-to-
+        # repeat gesture must not outrank the newer, unrecoverable one.
+        #
+        # The offer is NOT disarmed here: the user answers the prompt and their
+        # next press still escalates if it lands inside the window.
         if (
             self._stop_offered_at is not None
             and now - self._stop_offered_at < DOUBLE_STOP_WINDOW_S
             and session is not None
+            and self._live_prompt() is None
         ):
             self._stop_offered_at = None
             offered = self._stop_offer_count

--- a/local_operator/tui/widgets/editor.py
+++ b/local_operator/tui/widgets/editor.py
@@ -1575,15 +1575,34 @@ class Editor(TextArea):
         if not text:
             return
         self._copied = True
-        #: WHICH range the copy took, not merely that one happened. The app's
-        #: Ctrl+C rung defers to a copy while its highlight is still on screen,
-        #: and `_copied` alone cannot tell the copy's own highlight from an
-        #: unrelated selection made later — so a shift+arrow selection after a
-        #: copied range had been collapsed silently re-armed that deferral and
-        #: the next two presses quit the app with the draft unfiled (D22, design
-        #: round 7). Pinning the range makes "the copy's highlight" checkable.
+        # WHICH range the copy took, so `watch_selection` can tell this copy's
+        # own highlight from any later one and retire the claim when it goes.
+        # Without that distinction a shift+arrow selection made after the copied
+        # range had been collapsed silently re-armed the app's Ctrl+C deferral,
+        # and the next two presses quit with the draft unfiled (D22, design
+        # round 7). `#:` is for attribute declarations, and this is an
+        # assignment in a method body (R17 NIT-1).
         self._copied_selection = self.selection
         self.post_message(EditorCopied(text))
+
+    @property
+    def copy_in_flight(self) -> bool:
+        """Is a copy gesture still in progress or still visible on screen?
+
+        THE predicate the app's Ctrl+C rung asks, named once here rather than
+        duck-typed from outside. It was previously two `getattr` probes into
+        this class's privates, which a rename would have degraded silently to
+        "no copy in flight" — i.e. to always clearing the draft — with no test
+        failing (R17 MINOR-2). A property breaks loudly instead, and gives the
+        question a name that says what it means.
+
+        Two moments, because a copy spans both: the drag itself, and the window
+        after release in which the highlight it took is still the highlight on
+        screen. `watch_selection` ends the second the moment that stops being
+        true, so neither flag can outlive the gesture the way three earlier
+        predicates did.
+        """
+        return self._selecting or self._copied
 
     def watch_selection(self, selection: Selection) -> None:
         """Retire the copy receipt's GESTURE claim when the highlight changes.

--- a/local_operator/tui/widgets/editor.py
+++ b/local_operator/tui/widgets/editor.py
@@ -591,7 +591,15 @@ class Editor(TextArea):
         #: user's copied draft on the widget buys nothing (review round 2, F9).
         #: See :meth:`edit` and :meth:`load_text`.
         self._copied = False
-        #: The selection `_copy_drag` took, when `_copied` is set. See there.
+        #: The GESTURE claim, distinct from the receipt flag above and with a
+        #: different lifetime. `_copied` answers "is the receipt on screen still
+        #: true?", which ends at the first EDIT to the copied text. This answers
+        #: "is a hand still completing a copy?", which ends as soon as the
+        #: highlight the copy took stops being the highlight on screen. Fusing
+        #: them gave one of the two the wrong lifetime in whichever direction
+        #: the fusion leaned (R18-1, agent review round 18).
+        self._copy_gesture = False
+        #: The selection `_copy_drag` took, while `_copy_gesture` holds.
         self._copied_selection: Selection | None = None
         self.set_commands(commands or [])
 
@@ -1575,6 +1583,7 @@ class Editor(TextArea):
         if not text:
             return
         self._copied = True
+        self._copy_gesture = True
         # WHICH range the copy took, so `watch_selection` can tell this copy's
         # own highlight from any later one and retire the claim when it goes.
         # Without that distinction a shift+arrow selection made after the copied
@@ -1602,7 +1611,7 @@ class Editor(TextArea):
         true, so neither flag can outlive the gesture the way three earlier
         predicates did.
         """
-        return self._selecting or self._copied
+        return self._selecting or self._copy_gesture
 
     def watch_selection(self, selection: Selection) -> None:
         """Retire the copy receipt's GESTURE claim when the highlight changes.
@@ -1621,7 +1630,11 @@ class Editor(TextArea):
 
         Deliberately NOT posting ``EditorCopyStale``: moving the caret is not
         the user editing the text their receipt describes, so the toast remains
-        true and stays up. Only the gesture claim ends here.
+        true and stays up. Only ``_copy_gesture`` ends here, and it is a
+        SEPARATE field from ``_copied`` for exactly that reason — pointing the
+        receipt flag at this lifetime left a receipt on screen asserting a copy
+        of characters the user had since deleted, which is design round 1's D3
+        verbatim (R18-1, agent review round 18).
         """
         super_watch = getattr(super(), "watch_selection", None)
         if super_watch is not None:
@@ -1629,10 +1642,10 @@ class Editor(TextArea):
         # `getattr` with a default because a reactive watcher can fire during
         # base-class construction, before this subclass has set its own
         # attributes — an AttributeError there takes the whole widget down.
-        if getattr(self, "_copied", False) and selection != getattr(
+        if getattr(self, "_copy_gesture", False) and selection != getattr(
             self, "_copied_selection", None
         ):
-            self._copied = False
+            self._copy_gesture = False
             self._copied_selection = None
 
     # -- paste ----------------------------------------------------------------
@@ -1833,6 +1846,7 @@ class Editor(TextArea):
         result = super().edit(edit)
         if stale_receipt:
             self._copied = False
+            self._copy_gesture = False
             self._copied_selection = None
             self.post_message(EditorCopyStale())
         self._sync_picker()
@@ -1903,6 +1917,7 @@ class Editor(TextArea):
         up, is about a copy that remains perfectly true.
         """
         self._copied = False
+        self._copy_gesture = False
         self._copied_selection = None
         super().load_text(text)
         self._sync_picker()

--- a/local_operator/tui/widgets/editor.py
+++ b/local_operator/tui/widgets/editor.py
@@ -718,6 +718,35 @@ class Editor(TextArea):
             self._history.pop()
         self._history_index = None
 
+    def remember_draft(self) -> bool:
+        """Push the CURRENT buffer into prompt history without submitting it.
+
+        For the paths that throw a draft away on the user's behalf — Ctrl+C on
+        a half-typed prompt. Discarding text the user typed should never be
+        final when making it recoverable costs one entry: after this, ``up``
+        brings it straight back.
+
+        History is the right home rather than a bespoke stash because it is
+        already the place a user looks for "what I typed a moment ago", and it
+        already de-duplicates, caps itself at ``HISTORY_LIMIT`` and drops
+        blanks. ``_record_history`` also resets ``_history_index``, so the next
+        ``up`` starts from this entry rather than from wherever an interrupted
+        history walk had got to.
+
+        HONOURS ``_records_history``, and returns whether it recorded. While
+        the aside owns the composer that flag is off, and it is a contract the
+        card states out loud — "off the record — nothing here joins the chat".
+        Recording there would put a question the user explicitly kept out of
+        the conversation one ``up`` and one Enter away from being sent to the
+        agent as a real turn, which is the exact failure
+        :meth:`set_records_history` exists to prevent. The caller uses the
+        return value to decide whether the draft is safe to discard.
+        """
+        if not self._records_history:
+            return False
+        self._record_history(self.text)
+        return True
+
     def set_commands(self, commands: list[SlashCommand]) -> None:
         """Slash commands offered to the picker (sync, no I/O).
 

--- a/local_operator/tui/widgets/editor.py
+++ b/local_operator/tui/widgets/editor.py
@@ -1585,6 +1585,37 @@ class Editor(TextArea):
         self._copied_selection = self.selection
         self.post_message(EditorCopied(text))
 
+    def watch_selection(self, selection: Selection) -> None:
+        """Retire the copy receipt's GESTURE claim when the highlight changes.
+
+        ``_copied`` is edit-scoped: `edit` and `load_text` clear it, because the
+        receipt on screen is a claim about text the user can still see. But the
+        app's Ctrl+C rung asks a GESTURE-scoped question — "is a hand still
+        completing a copy?" — and an edit-scoped flag answers it wrongly in two
+        directions that each cost a user their draft (D20, then D22).
+
+        Retiring here makes the flag answer both questions with one lifetime:
+        the copy's claim ends when the highlight it took stops being the
+        highlight on screen, whether that is a caret move collapsing it or a new
+        selection replacing it. `_copied_selection` is what makes "the same
+        highlight" checkable rather than merely "a highlight".
+
+        Deliberately NOT posting ``EditorCopyStale``: moving the caret is not
+        the user editing the text their receipt describes, so the toast remains
+        true and stays up. Only the gesture claim ends here.
+        """
+        super_watch = getattr(super(), "watch_selection", None)
+        if super_watch is not None:
+            super_watch(selection)
+        # `getattr` with a default because a reactive watcher can fire during
+        # base-class construction, before this subclass has set its own
+        # attributes — an AttributeError there takes the whole widget down.
+        if getattr(self, "_copied", False) and selection != getattr(
+            self, "_copied_selection", None
+        ):
+            self._copied = False
+            self._copied_selection = None
+
     # -- paste ----------------------------------------------------------------
     async def _on_paste(self, event: events.Paste) -> None:
         """Attach pasted images instead of pasting the path to them.

--- a/local_operator/tui/widgets/editor.py
+++ b/local_operator/tui/widgets/editor.py
@@ -591,6 +591,8 @@ class Editor(TextArea):
         #: user's copied draft on the widget buys nothing (review round 2, F9).
         #: See :meth:`edit` and :meth:`load_text`.
         self._copied = False
+        #: The selection `_copy_drag` took, when `_copied` is set. See there.
+        self._copied_selection: Selection | None = None
         self.set_commands(commands or [])
 
     def render_line(self, y: int) -> Strip:
@@ -1573,6 +1575,14 @@ class Editor(TextArea):
         if not text:
             return
         self._copied = True
+        #: WHICH range the copy took, not merely that one happened. The app's
+        #: Ctrl+C rung defers to a copy while its highlight is still on screen,
+        #: and `_copied` alone cannot tell the copy's own highlight from an
+        #: unrelated selection made later — so a shift+arrow selection after a
+        #: copied range had been collapsed silently re-armed that deferral and
+        #: the next two presses quit the app with the draft unfiled (D22, design
+        #: round 7). Pinning the range makes "the copy's highlight" checkable.
+        self._copied_selection = self.selection
         self.post_message(EditorCopied(text))
 
     # -- paste ----------------------------------------------------------------
@@ -1773,6 +1783,7 @@ class Editor(TextArea):
         result = super().edit(edit)
         if stale_receipt:
             self._copied = False
+            self._copied_selection = None
             self.post_message(EditorCopyStale())
         self._sync_picker()
         if touched:
@@ -1842,6 +1853,7 @@ class Editor(TextArea):
         up, is about a copy that remains perfectly true.
         """
         self._copied = False
+        self._copied_selection = None
         super().load_text(text)
         self._sync_picker()
 

--- a/scripts/stop_ladder_shot.py
+++ b/scripts/stop_ladder_shot.py
@@ -1,0 +1,101 @@
+"""Capture the Esc stop ladder over a populated transcript.
+
+Run from the worktree root:
+
+    env -u NO_COLOR TERM=xterm-256color .venv/bin/python \
+        scripts/stop_ladder_shot.py OUT.svg <state> [COLSxROWS]
+
+``state`` selects the frame:
+
+``running``   a turn in flight with two delegated children — the "before" shot.
+``offer``     after the first Esc: the parent turn is stopped and the notice
+              offers the wider stop ("esc again to stop them"). This line is
+              load-bearing; a stop that silently leaves children running is the
+              original bug wearing a hat.
+``stopped``   after the second Esc inside the window: the children are stopped
+              and the stale offer is REPLACED rather than stacked, because a
+              "still running" row left above "stopped them" reads as current.
+``nochildren`` first Esc with nothing delegated: the subagent sentence must not
+              appear at all.
+``draft``     a half-typed prompt in the composer (Ctrl+C "before").
+``cleared``   after Ctrl+C: the draft is cleared into prompt history and the
+              exit ladder is NOT armed, so no exit hint is shown.
+
+Uses the real ``OperatorApp``, which loads ``local_operator.tcss`` — a bare test
+host does not, and would capture an unstyled frame that proves nothing about
+what the user sees.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from local_operator.tui.app import OperatorApp  # noqa: E402
+from local_operator.tui.widgets.assistant import AssistantBlock  # noqa: E402
+from local_operator.tui.widgets.editor import Editor  # noqa: E402
+from local_operator.tui.widgets.transcript import UserBlock  # noqa: E402
+from tests.unit.tui.test_steering_approval import (  # noqa: E402
+    SteerableSession,
+    _boot,
+    _factory,
+)
+
+
+async def main() -> None:
+    out = sys.argv[1]
+    state = sys.argv[2]
+    size = (100, 30)
+    if len(sys.argv) > 3:
+        cols, rows = sys.argv[3].split("x")
+        size = (int(cols), int(rows))
+
+    session = SteerableSession()
+    # Two delegated children, except for the state that exists to show none.
+    session.running_children = 0 if state == "nochildren" else 2
+
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=size) as pilot:
+        await _boot(pilot, app)
+        app.query_one(Editor).cursor_blink = False
+
+        app._append_block(UserBlock("split the backfill across two agents and summarise"))
+        prose = AssistantBlock()
+        prose.update_text(
+            "Delegating: one agent walks the 2019-2022 partitions, the other "
+            "the 2023-2025 partitions. I will reconcile the two reports."
+        )
+        app._append_block(prose)
+        await pilot.pause()
+
+        if state in {"draft", "cleared"}:
+            editor = app.query_one(Editor)
+            editor.focus()
+            editor.text = "a half-typed prompt I do not want to lose"
+            await pilot.pause()
+            if state == "cleared":
+                await pilot.press("ctrl+c")
+                await pilot.pause()
+        else:
+            # A turn in flight is the state the user presses Esc in.
+            session.streaming = True
+            await pilot.pause()
+            if state in {"offer", "stopped", "nochildren"}:
+                await pilot.press("escape")
+                await pilot.pause(0.1)
+            if state == "stopped":
+                # Inside DOUBLE_STOP_WINDOW_S, so this is the escalation press.
+                app._stop_offered_at = time.monotonic()
+                await pilot.press("escape")
+                await pilot.pause(0.1)
+
+        for _ in range(4):
+            await pilot.pause()
+        app.save_screenshot(out)
+
+
+asyncio.run(main())

--- a/scripts/stop_ladder_shot.py
+++ b/scripts/stop_ladder_shot.py
@@ -17,6 +17,16 @@ Run from the worktree root:
               "still running" row left above "stopped them" reads as current.
 ``nochildren`` first Esc with nothing delegated: the subagent sentence must not
               appear at all.
+``expired``   a first Esc whose 4s window has since closed: the row keeps the
+              FACT that children are running but drops the escalation promise,
+              because an instruction no key will honour must not stand (D4).
+``late``      a second Esc that arrives after the window: it cannot escalate,
+              so the re-armed offer states the constraint rather than
+              repainting an identical row and reading as a dropped key (D1).
+``finished``  a second Esc landing after the children finished on their own:
+              the confirmation must not flatly deny the offer just read (D2).
+``spared``    a stop that leaves a backgrounded `bash` job running, which it
+              names because escalating reads as "stop all of it" (D3).
 ``draft``     a half-typed prompt in the composer (Ctrl+C "before").
 ``cleared``   after Ctrl+C: the draft is cleared into prompt history and the
               exit ladder is NOT armed, so no exit hint is shown.
@@ -35,7 +45,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
-from local_operator.tui.app import OperatorApp  # noqa: E402
+from local_operator.tui.app import DOUBLE_STOP_WINDOW_S, OperatorApp  # noqa: E402
 from local_operator.tui.widgets.assistant import AssistantBlock  # noqa: E402
 from local_operator.tui.widgets.editor import Editor  # noqa: E402
 from local_operator.tui.widgets.transcript import UserBlock  # noqa: E402
@@ -72,6 +82,9 @@ async def main() -> None:
         app._append_block(prose)
         await pilot.pause()
 
+        if state == "spared":
+            session.running_bash_jobs = 1
+
         if state in {"draft", "cleared"}:
             editor = app.query_one(Editor)
             editor.focus()
@@ -84,14 +97,36 @@ async def main() -> None:
             # A turn in flight is the state the user presses Esc in.
             session.streaming = True
             await pilot.pause()
-            if state in {"offer", "stopped", "nochildren"}:
+            if state in {
+                "offer",
+                "stopped",
+                "nochildren",
+                "expired",
+                "late",
+                "finished",
+                "spared",
+            }:
                 await pilot.press("escape")
                 await pilot.pause(0.1)
-            if state == "stopped":
+            if state in {"stopped", "spared"}:
                 # Inside DOUBLE_STOP_WINDOW_S, so this is the escalation press.
                 app._stop_offered_at = time.monotonic()
                 await pilot.press("escape")
                 await pilot.pause(0.1)
+            if state == "finished":
+                # The children settle on their own before the second press.
+                session.running_children = 0
+                app._stop_offered_at = time.monotonic()
+                await pilot.press("escape")
+                await pilot.pause(0.1)
+            if state == "late":
+                # Past the window: this press cannot escalate.
+                app._stop_offered_at = time.monotonic() - (DOUBLE_STOP_WINDOW_S + 1)
+                await pilot.press("escape")
+                await pilot.pause(0.1)
+            if state == "expired":
+                # Let the real timer retire the promise.
+                await pilot.pause(DOUBLE_STOP_WINDOW_S + 0.5)
 
         for _ in range(4):
             await pilot.pause()

--- a/tests/unit/harness/test_loop.py
+++ b/tests/unit/harness/test_loop.py
@@ -1575,3 +1575,45 @@ async def test_a_late_parking_tool_is_not_robbed_of_its_end_event_mid_backfill()
     # And the wire is still legal: one tool_result per tool_use.
     tool_messages = [m for m in context.messages if isinstance(m, Message) and m.role == "tool"]
     assert sorted(str(m.tool_call_id) for m in tool_messages) == ["c1", "c2"]
+
+
+@pytest.mark.asyncio
+async def test_a_call_that_never_started_is_never_announced_as_ended():
+    """Review round 4, R4-1. The flush must share the backfill's own guard.
+
+    A planning failure — an unknown tool name, a duplicate call id — is parked
+    up front by ``park()``, which queues an end event for a call that never
+    emitted a START. That was harmless only because nothing drained the queue
+    afterwards; the flush added for R3-1 reads it and announces the end of a
+    call no consumer ever saw begin, which is the mirror image of the bug the
+    flush exists to fix and is what the backfill a few lines below explicitly
+    refuses to do.
+
+    Reachable from a hallucinated tool name alone: no abort, no timing window.
+    """
+    stream = ScriptedStream(
+        [
+            [
+                tool_call_delta(0, id="c1", name="no_such_tool", args="{}"),
+                StreamEndEvent(stop_reason="toolUse"),
+            ],
+            [StreamEndEvent(stop_reason="stop")],
+        ]
+    )
+    context = LoopContext(tools=[])
+    config = make_config(stream, interrupt_mode="immediate", has_steering_messages=lambda: False)
+    loop = AgentLoop()
+
+    events: list[Any] = []
+    async for event in loop.run([Message.user("go")], context, config, None):
+        events.append(event)
+
+    started_ids = {e.tool_call_id for e in events if isinstance(e, ToolExecutionStartEvent)}
+    ended_ids = [e.tool_call_id for e in events if isinstance(e, ToolExecutionEndEvent)]
+    assert started_ids == set(), "a call with no resolvable tool must never start"
+    assert [
+        c for c in ended_ids if c not in started_ids
+    ] == [], f"end event(s) {ended_ids} announced for calls that never started"
+    # The wire is still paired: the failure's result reaches the model.
+    tool_messages = [m for m in context.messages if isinstance(m, Message) and m.role == "tool"]
+    assert [str(m.tool_call_id) for m in tool_messages] == ["c1"]

--- a/tests/unit/harness/test_loop.py
+++ b/tests/unit/harness/test_loop.py
@@ -4,12 +4,19 @@ interrupts, validation errors back to the model, gates, follow-ups."""
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
+import time
 from typing import Any, Literal
 
 import pytest
 
-from local_operator.harness.loop import AgentLoop, LoopContext, validate_tool_arguments
+from local_operator.harness.loop import (
+    ABORT_DRAIN_TIMEOUT_S,
+    AgentLoop,
+    LoopContext,
+    validate_tool_arguments,
+)
 from local_operator.harness.types import (
     AbortSignal,
     AgentEndEvent,
@@ -29,6 +36,7 @@ from local_operator.harness.types import (
     ToolCallComposeEvent,
     ToolContext,
     ToolExecutionEndEvent,
+    ToolExecutionStartEvent,
     ToolResult,
 )
 from local_operator.providers.failover import ProviderError
@@ -1011,3 +1019,395 @@ class TestTheModelIsReadAtEveryCall:
             pass
 
         assert self._labels(stream) == ["test/m", "test/m"]
+# ---------------------------------------------------------------------------
+# Immediate abort: Esc must halt the turn NOW, not at the next natural boundary
+# ---------------------------------------------------------------------------
+
+
+def _blocking_tool(
+    name: str,
+    started: asyncio.Event,
+    *,
+    interruptible: bool,
+    outcome: dict[str, str],
+) -> AgentTool:
+    """A tool that parks forever and records how its run ended.
+
+    ``outcome`` is written by the tool itself, so a test can tell "the abort
+    cancelled it" apart from "the tool finished on its own and the loop merely
+    stopped waiting" — a distinction the loop's own events cannot make.
+    """
+
+    async def execute(tool_call_id, args, signal, on_update, context):
+        started.set()
+        try:
+            await asyncio.sleep(30)
+        except asyncio.CancelledError:
+            outcome[name] = "cancelled"
+            raise
+        outcome[name] = "completed"
+        return ToolResult(
+            tool_call_id=tool_call_id, tool_name=name, content=[TextContent(text="late")]
+        )
+
+    return AgentTool(
+        name=name,
+        parameters={"type": "object", "properties": {}},
+        interruptible=interruptible,
+        execute=execute,
+    )
+
+
+@pytest.mark.parametrize("interruptible", [False, True])
+@pytest.mark.asyncio
+async def test_abort_cancels_a_running_tool_whatever_its_interruptible_flag(interruptible):
+    """Esc stops a tool mid-run even when it never opted into interruption.
+
+    ``interruptible`` means "steering may redirect this", which is a different
+    and weaker permission than "the user may stop this". Before this, a batch
+    of non-interruptible calls ignored the abort completely and the turn ended
+    only when the slowest one finished; the user's stop appeared to do nothing.
+    """
+    started = asyncio.Event()
+    outcome: dict[str, str] = {}
+    stream = ScriptedStream(
+        [
+            [
+                tool_call_delta(0, id="c1", name="block", args="{}"),
+                StreamEndEvent(stop_reason="toolUse"),
+            ],
+            [StreamEndEvent(stop_reason="stop")],
+        ]
+    )
+    context = LoopContext(
+        tools=[_blocking_tool("block", started, interruptible=interruptible, outcome=outcome)]
+    )
+    config = make_config(stream, interrupt_mode="immediate", has_steering_messages=lambda: False)
+    signal = AbortSignal()
+    loop = AgentLoop()
+
+    events: list[Any] = []
+
+    async def run() -> None:
+        async for event in loop.run([Message.user("go")], context, config, signal):
+            events.append(event)
+
+    task = asyncio.ensure_future(run())
+    await asyncio.wait_for(started.wait(), timeout=5)
+    signal.abort("interrupted")
+    # Generous relative to the ~0s the fix achieves, but far below the 30 s the
+    # tool would otherwise run: the assertion is "promptly", not a stopwatch.
+    await asyncio.wait_for(task, timeout=5)
+
+    assert outcome == {"block": "cancelled"}
+    end = events[-1]
+    assert isinstance(end, AgentEndEvent)
+    assert end.aborted is True
+    # Still paired: an abort must not leave a tool_use without its tool_result,
+    # or the next request is rejected outright by the provider.
+    tool_messages = [m for m in context.messages if isinstance(m, Message) and m.role == "tool"]
+    assert [m.tool_call_id for m in tool_messages] == ["c1"]
+    assert all(m.is_error for m in tool_messages)
+
+
+@pytest.mark.asyncio
+async def test_abort_cancels_every_tool_in_a_parallel_batch():
+    """One press stops the whole batch, not just the call that noticed first."""
+    started_a, started_b = asyncio.Event(), asyncio.Event()
+    outcome: dict[str, str] = {}
+    stream = ScriptedStream(
+        [
+            [
+                tool_call_delta(0, id="c1", name="a", args="{}"),
+                tool_call_delta(1, id="c2", name="b", args="{}"),
+                StreamEndEvent(stop_reason="toolUse"),
+            ],
+            [StreamEndEvent(stop_reason="stop")],
+        ]
+    )
+    context = LoopContext(
+        tools=[
+            _blocking_tool("a", started_a, interruptible=False, outcome=outcome),
+            _blocking_tool("b", started_b, interruptible=True, outcome=outcome),
+        ]
+    )
+    config = make_config(stream, interrupt_mode="immediate", has_steering_messages=lambda: False)
+    signal = AbortSignal()
+    loop = AgentLoop()
+
+    async def run() -> None:
+        async for _ in loop.run([Message.user("go")], context, config, signal):
+            pass
+
+    task = asyncio.ensure_future(run())
+    await asyncio.wait_for(asyncio.gather(started_a.wait(), started_b.wait()), timeout=5)
+    signal.abort("interrupted")
+    await asyncio.wait_for(task, timeout=5)
+
+    assert outcome == {"a": "cancelled", "b": "cancelled"}
+    tool_messages = [m for m in context.messages if isinstance(m, Message) and m.role == "tool"]
+    assert {m.tool_call_id for m in tool_messages} == {"c1", "c2"}
+
+
+@pytest.mark.asyncio
+async def test_abort_cuts_a_stalled_model_stream():
+    """A model that has gone quiet is dropped on abort, not waited out.
+
+    The provider stream sits in an ``await`` between tokens, so an abort used
+    to take effect only when the NEXT event arrived. On a stalled or
+    slow-reasoning stream that is seconds of a UI painting a turn the user has
+    already stopped.
+    """
+    reached_second_token = False
+    first_token = asyncio.Event()
+
+    def stream_fn(request: ChatRequest, signal: AbortSignal | None):
+        async def gen():
+            nonlocal reached_second_token
+            yield StreamTextDelta(delta="thinking")
+            first_token.set()
+            await asyncio.sleep(30)  # the model goes quiet
+            reached_second_token = True
+            yield StreamTextDelta(delta="never")
+            yield StreamEndEvent(stop_reason="stop")
+
+        return gen()
+
+    context = LoopContext(tools=[])
+    config = make_config(stream_fn, interrupt_mode="immediate", has_steering_messages=lambda: False)
+    signal = AbortSignal()
+    loop = AgentLoop()
+
+    events: list[Any] = []
+
+    async def run() -> None:
+        async for event in loop.run([Message.user("go")], context, config, signal):
+            events.append(event)
+
+    task = asyncio.ensure_future(run())
+    await asyncio.wait_for(first_token.wait(), timeout=5)
+    signal.abort("interrupted")
+    await asyncio.wait_for(task, timeout=5)
+
+    assert not reached_second_token, "the stalled stream was waited out instead of dropped"
+    end = events[-1]
+    assert isinstance(end, AgentEndEvent)
+    assert end.aborted is True
+    # The text produced BEFORE the abort survives: a stop keeps what was said.
+    assistant = next(
+        m for m in context.messages if isinstance(m, Message) and m.role == "assistant"
+    )
+    assert assistant.text == "thinking"
+
+
+@pytest.mark.asyncio
+async def test_an_unaborted_stream_is_untouched_by_the_abort_wrapper():
+    """The abort-aware pull must not drop, reorder or duplicate events."""
+    stream = ScriptedStream(
+        [
+            [
+                StreamTextDelta(delta="a"),
+                StreamTextDelta(delta="b"),
+                tool_call_delta(0, id="c1", name="echo", args='{"text":"x"}'),
+                StreamEndEvent(stop_reason="toolUse"),
+            ],
+            [StreamTextDelta(delta="done"), StreamEndEvent(stop_reason="stop")],
+        ]
+    )
+    executed: list[str] = []
+    context = LoopContext(tools=[echo_tool(executed)])
+    signal = AbortSignal()  # present but never fired
+    loop = AgentLoop()
+
+    events = []
+    async for event in loop.run([Message.user("go")], context, make_config(stream), signal):
+        events.append(event)
+
+    assert executed == ["echo"]
+    end = events[-1]
+    assert isinstance(end, AgentEndEvent)
+    assert end.aborted is False
+    assistants = [m for m in context.messages if isinstance(m, Message) and m.role == "assistant"]
+    assert assistants[0].text == "ab"
+    assert assistants[-1].text == "done"
+
+
+@pytest.mark.asyncio
+async def test_a_provider_failure_still_surfaces_through_the_abort_wrapper():
+    """The stream wrapper must not swallow errors.
+
+    It drains the provider on a pump task, so a failure now reaches the loop as
+    that task's exception rather than as a raise from the ``async for``. If it
+    were dropped, a dead provider would look like a clean empty turn — the loop
+    would report success and the user would see a turn that did nothing.
+    """
+
+    def stream_fn(request: ChatRequest, signal: AbortSignal | None):
+        async def gen():
+            yield StreamTextDelta(delta="partial")
+            raise ProviderError(500, "upstream exploded", retryable=False)
+
+        return gen()
+
+    context = LoopContext(tools=[])
+    signal = AbortSignal()  # present but never fired
+    loop = AgentLoop()
+
+    events = []
+    async for event in loop.run([Message.user("go")], context, make_config(stream_fn), signal):
+        events.append(event)
+
+    end = events[-1]
+    assert isinstance(end, AgentEndEvent)
+    assert end.aborted is False, "a provider failure is an error, not a user abort"
+    assert end.error is not None and "upstream exploded" in end.error
+
+
+@pytest.mark.asyncio
+async def test_a_signal_aborted_before_the_run_does_not_wedge_the_turn():
+    """Review round 1, B1. An abort that has ALREADY fired must end the run.
+
+    The stream is drained by a pump task, and ``ensure_future`` only SCHEDULES
+    it — so a cancel landing before the body runs executed no statement inside
+    it, ``finally`` included. Waking the consumer from that ``finally`` left
+    the drain parked on a notification nobody would ever send, and the turn
+    never ended: `is_streaming` stayed True and every later prompt was
+    rejected, from the very keypress this feature is about.
+
+    Reachable without touching internals: `Session._emit` awaits every handler,
+    so an Esc during `turn_end` delivery lands after the loop's post-batch
+    abort check and before the next model call.
+    """
+    stream = ScriptedStream([[StreamTextDelta(delta="hi"), StreamEndEvent(stop_reason="stop")]])
+    context = LoopContext(tools=[])
+    signal = AbortSignal()
+    signal.abort("interrupted")  # fired BEFORE the run starts
+    loop = AgentLoop()
+
+    events = []
+
+    async def run() -> None:
+        async for event in loop.run([Message.user("go")], context, make_config(stream), signal):
+            events.append(event)
+
+    # The bug was an infinite hang; the timeout IS the assertion.
+    await asyncio.wait_for(run(), timeout=5)
+
+    end = events[-1]
+    assert isinstance(end, AgentEndEvent)
+    assert end.aborted is True
+
+
+@pytest.mark.parametrize("interruptible", [False, True])
+@pytest.mark.asyncio
+async def test_an_aborted_tool_still_emits_its_end_event(interruptible):
+    """Review round 1, B2. Every start event needs its end event.
+
+    The batch-wide abort watcher cancels the runner coroutine from OUTSIDE.
+    ``interruptible_runner``'s handler only caught its INNER task's
+    cancellation, so an outer cancel unwound past ``park`` — which is what
+    emits ``tool_execution_end``. The backfill kept the wire legal, but it
+    emits no events, so every consumer other than the TUI was left with a tool
+    that never finished: the API server holds the record IN_PROGRESS forever
+    and never publishes a TOOL_END. It hits bash, eval, wait, hub, ask, web
+    search and every MCP tool, which set ``interruptible=True``.
+    """
+    started = asyncio.Event()
+    outcome: dict[str, str] = {}
+    stream = ScriptedStream(
+        [
+            [
+                tool_call_delta(0, id="c1", name="block", args="{}"),
+                StreamEndEvent(stop_reason="toolUse"),
+            ],
+            [StreamEndEvent(stop_reason="stop")],
+        ]
+    )
+    context = LoopContext(
+        tools=[_blocking_tool("block", started, interruptible=interruptible, outcome=outcome)]
+    )
+    config = make_config(stream, interrupt_mode="immediate", has_steering_messages=lambda: False)
+    signal = AbortSignal()
+    loop = AgentLoop()
+
+    events: list[Any] = []
+
+    async def run() -> None:
+        async for event in loop.run([Message.user("go")], context, config, signal):
+            events.append(event)
+
+    task = asyncio.ensure_future(run())
+    await asyncio.wait_for(started.wait(), timeout=5)
+    signal.abort("interrupted")
+    await asyncio.wait_for(task, timeout=10)
+
+    starts = [e for e in events if isinstance(e, ToolExecutionStartEvent)]
+    ends = [e for e in events if isinstance(e, ToolExecutionEndEvent)]
+    assert len(starts) == 1
+    assert len(ends) == len(starts), "a started tool card was never settled"
+    assert {e.tool_call_id for e in ends} == {e.tool_call_id for e in starts}
+
+
+@pytest.mark.asyncio
+async def test_a_slow_tool_unwind_does_not_hold_the_turn_open():
+    """Review round 1, M1. ``ABORT_DRAIN_TIMEOUT_S`` must actually bound.
+
+    A cancelled tool is entitled to unwind — bash kills its process group — but
+    not to hold the turn while it does. The first implementation bounded the
+    wrong wait: the drain sat until every task had settled, so the ``finally``
+    budget had nothing left to bound and a six-second unwind still cost six
+    seconds. That is this feature's own bug, moved from the tool body into its
+    cleanup.
+    """
+    started = asyncio.Event()
+    unwind = 6.0
+
+    async def execute(tool_call_id, args, signal, on_update, context) -> ToolResult:
+        started.set()
+        try:
+            await asyncio.sleep(30)
+        except asyncio.CancelledError:
+            with contextlib.suppress(asyncio.CancelledError):
+                await asyncio.sleep(unwind)  # a process group refusing to die
+            raise
+        return ToolResult(
+            tool_call_id=tool_call_id, tool_name="stubborn", content=[TextContent(text="late")]
+        )
+
+    tool = AgentTool(
+        name="stubborn",
+        parameters={"type": "object", "properties": {}},
+        execute=execute,
+    )
+    stream = ScriptedStream(
+        [
+            [
+                tool_call_delta(0, id="c1", name="stubborn", args="{}"),
+                StreamEndEvent(stop_reason="toolUse"),
+            ],
+            [StreamEndEvent(stop_reason="stop")],
+        ]
+    )
+    context = LoopContext(tools=[tool])
+    config = make_config(stream, interrupt_mode="immediate", has_steering_messages=lambda: False)
+    signal = AbortSignal()
+    loop = AgentLoop()
+
+    async def run() -> None:
+        async for _ in loop.run([Message.user("go")], context, config, signal):
+            pass
+
+    task = asyncio.ensure_future(run())
+    await asyncio.wait_for(started.wait(), timeout=5)
+    began = time.monotonic()
+    signal.abort("interrupted")
+    await asyncio.wait_for(task, timeout=unwind + 10)
+    elapsed = time.monotonic() - began
+
+    assert elapsed < unwind - 1, (
+        f"the turn waited {elapsed:.1f}s for a {unwind}s unwind despite a "
+        f"{ABORT_DRAIN_TIMEOUT_S}s budget"
+    )
+    # Still paired, even though the tool never parked its own result.
+    tool_messages = [m for m in context.messages if isinstance(m, Message) and m.role == "tool"]
+    assert [m.tool_call_id for m in tool_messages] == ["c1"]

--- a/tests/unit/harness/test_loop.py
+++ b/tests/unit/harness/test_loop.py
@@ -1525,7 +1525,14 @@ async def test_a_late_parking_tool_is_not_robbed_of_its_end_event_mid_backfill()
                 # A RIDGE, NOT A FLOOR: moving this value in EITHER direction
                 # blinds the test. Swept against a tree with the flush deleted,
                 # it detects at +0.30 and is blind at +0.15, +0.35, +0.40, +0.45
-                # and +0.60 (R10). Too short and the park lands in the range the
+                # and +0.60 (R10/R11).
+                #
+                # Detection is PROBABILISTIC — roughly 3 runs in 4 (measured
+                # 7/8, 9/12, 11/16, 12/16 red). Anyone spot-checking by deleting
+                # the flush must repeat the run: a single green one proves
+                # nothing and would wrongly suggest the test is already dead.
+                #
+                # Too short and the park lands in the range the
                 # backfill already handles; too long and it lands after the
                 # batch has stopped emitting. Both ends pass with the flush
                 # gone, which means the test silently stops testing the thing it
@@ -1585,10 +1592,15 @@ async def test_a_late_parking_tool_is_not_robbed_of_its_end_event_mid_backfill()
             # and is worse (3/40): it lets the generator finish before the park
             # it is supposed to be racing.
             #
-            # The sibling `test_a_slow_unwind_still_reports_the_tool_as_ENDED`
-            # carries a similar-looking overshoot that is INDEPENDENT of this
-            # one: it is a single-call batch testing the backfill, not the
-            # flush, and nothing about it needs to move if this does.
+            # `test_a_duplicate_call_id_does_not_suppress_the_real_calls_end`
+            # `_event` carries the IDENTICAL literal
+            # `ABORT_DRAIN_TIMEOUT_S + 0.3`, which
+            # is what a grep or a search-and-replace would actually collide with
+            # — and it is INDEPENDENT of this one: it exercises the duplicate-id
+            # suppression rule, not the flush window, so nothing about it needs
+            # to move if this does. (`test_a_slow_unwind_still_reports_the_tool
+            # _as_ENDED` overshoots by `+ 2` and is independent for the same
+            # reason; only the identical literal is a real hazard.)
             await asyncio.sleep(0.3)
 
     task = asyncio.ensure_future(run())

--- a/tests/unit/harness/test_loop.py
+++ b/tests/unit/harness/test_loop.py
@@ -1617,3 +1617,79 @@ async def test_a_call_that_never_started_is_never_announced_as_ended():
     # The wire is still paired: the failure's result reaches the model.
     tool_messages = [m for m in context.messages if isinstance(m, Message) and m.role == "tool"]
     assert [str(m.tool_call_id) for m in tool_messages] == ["c1"]
+
+
+@pytest.mark.asyncio
+async def test_a_duplicate_call_id_does_not_suppress_the_real_calls_end_event():
+    """Review round 5, R5-1. The flush's suppression must not be keyed by id.
+
+    Call ids are NOT unique within a batch: a model can emit two calls with one
+    id, and the loop keeps the first and turns the second into a planning
+    failure. That leaves one id owned by two slots — one that STARTED and one
+    that never did — so a suppression set keyed by id cannot tell them apart
+    and swallows the genuine end event along with the parked one. The started
+    call then keeps its start forever with no end, which is the same consumer
+    damage the flush exists to prevent, arrived at from the other side.
+
+    Counting per id is what makes it exact: swallow as many as are owed, no
+    more. This asserts the invariant that survives either implementation —
+    every call that STARTED gets exactly one end.
+    """
+    started = asyncio.Event()
+
+    async def slow(tool_call_id, args, signal, on_update, context) -> ToolResult:
+        started.set()
+        try:
+            await asyncio.sleep(30)
+        except asyncio.CancelledError:
+            with contextlib.suppress(asyncio.CancelledError):
+                await asyncio.sleep(ABORT_DRAIN_TIMEOUT_S + 0.3)
+            raise
+        return ToolResult(
+            tool_call_id=tool_call_id, tool_name="slow", content=[TextContent(text="late")]
+        )
+
+    tool = AgentTool(
+        name="slow",
+        parameters={"type": "object", "properties": {}},
+        execute=slow,
+    )
+    stream = ScriptedStream(
+        [
+            [
+                # One id, twice: the second is dropped to a planning failure.
+                tool_call_delta(0, id="dup", name="slow", args="{}"),
+                tool_call_delta(1, id="dup", name="slow", args="{}"),
+                StreamEndEvent(stop_reason="toolUse"),
+            ],
+            [StreamEndEvent(stop_reason="stop")],
+        ]
+    )
+    context = LoopContext(tools=[tool])
+    config = make_config(stream, interrupt_mode="immediate", has_steering_messages=lambda: False)
+    signal = AbortSignal()
+    loop = AgentLoop()
+
+    events: list[Any] = []
+
+    async def run() -> None:
+        async for event in loop.run([Message.user("go")], context, config, signal):
+            events.append(event)
+            await asyncio.sleep(0.05)
+
+    task = asyncio.ensure_future(run())
+    await asyncio.wait_for(started.wait(), timeout=5)
+    signal.abort("interrupted")
+    await asyncio.wait_for(task, timeout=ABORT_DRAIN_TIMEOUT_S + 15)
+
+    started_ids = [e.tool_call_id for e in events if isinstance(e, ToolExecutionStartEvent)]
+    ended_ids = [e.tool_call_id for e in events if isinstance(e, ToolExecutionEndEvent)]
+    assert started_ids == ["dup"], "exactly one of the colliding calls should run"
+    assert ended_ids.count("dup") >= 1, (
+        "the started call's end event was suppressed along with the duplicate's, "
+        "leaving a start with no end"
+    )
+    # The duplicate never started, so it must not add an end of its own.
+    assert ended_ids.count("dup") == len(
+        started_ids
+    ), f"expected one end per started call, got ends={ended_ids} starts={started_ids}"

--- a/tests/unit/harness/test_loop.py
+++ b/tests/unit/harness/test_loop.py
@@ -7,6 +7,7 @@ import asyncio
 import contextlib
 import logging
 import time
+from collections import Counter
 from typing import Any, Literal
 
 import pytest
@@ -28,6 +29,7 @@ from local_operator.harness.types import (
     LoopConfig,
     Message,
     ModelSpec,
+    NoticeEvent,
     StreamEndEvent,
     StreamEvent,
     StreamTextDelta,
@@ -1693,3 +1695,79 @@ async def test_a_duplicate_call_id_does_not_suppress_the_real_calls_end_event():
     assert ended_ids.count("dup") == len(
         started_ids
     ), f"expected one end per started call, got ends={ended_ids} starts={started_ids}"
+
+
+@pytest.mark.asyncio
+async def test_a_call_that_never_ran_still_reports_itself_to_the_operator():
+    """Review round 6, R6-3. Suppressing the end event must not mean silence.
+
+    `park` withholds the end event for a call that never started, which is
+    right — but the headless renderer printed `✗ <name> failed` off exactly
+    that event, so withholding it alone turned a visible diagnostic into
+    nothing at all: an operator watching a hallucinated tool name saw the run
+    simply produce no output about it.
+
+    A notice is the honest carrier. It reports the failure without claiming a
+    lifecycle that never began, and the model is unaffected either way because
+    it still receives the parked `tool_result`.
+    """
+    executed: list[str] = []
+    stream = ScriptedStream(
+        [
+            [
+                tool_call_delta(0, id="c1", name="echo", args='{"text":"hi"}'),
+                tool_call_delta(1, id="c2", name="no_such_tool", args="{}"),
+                StreamEndEvent(stop_reason="toolUse"),
+            ],
+            [StreamEndEvent(stop_reason="stop")],
+        ]
+    )
+    context = LoopContext(tools=[echo_tool(executed)])
+    config = make_config(stream, interrupt_mode="immediate", has_steering_messages=lambda: False)
+    loop = AgentLoop()
+
+    events: list[Any] = []
+    async for event in loop.run([Message.user("go")], context, config, None):
+        events.append(event)
+
+    notices = [e.text for e in events if isinstance(e, NoticeEvent)]
+    assert any(
+        "no_such_tool" in text for text in notices
+    ), f"the unresolvable call produced no operator-visible diagnostic: {notices}"
+    # Still no orphan end event, which is what R4-1/R5-1 fixed.
+    started_ids = {e.tool_call_id for e in events if isinstance(e, ToolExecutionStartEvent)}
+    ended_ids = [e.tool_call_id for e in events if isinstance(e, ToolExecutionEndEvent)]
+    assert [c for c in ended_ids if c not in started_ids] == []
+    # And the model still gets both results, so the wire stays legal.
+    tool_messages = [m for m in context.messages if isinstance(m, Message) and m.role == "tool"]
+    assert sorted(str(m.tool_call_id) for m in tool_messages) == ["c1", "c2"]
+
+
+def test_the_flush_suppression_counts_rather_than_matching():
+    """Review round 6, R6-2. Pin the mechanism R5-1 was about.
+
+    The behavioural tests above cannot reach this: the source-side guard in
+    `park` means the flush's `claimed` bookkeeping is currently unreachable
+    (R6-1), so reverting it to a `set` leaves them all green. That is exactly
+    why it needs pinning directly — the next change that reintroduces an
+    interleaving would silently restore R5-1, where one id names both a call
+    that started and a duplicate that did not, and a set suppresses BOTH.
+
+    A unit test on the rule itself, not the loop: with N queued ends carrying
+    one id and K of them owed suppression, exactly N-K must survive.
+    """
+    # Two slots, one id: one started, one a duplicate that never did.
+    owed = Counter(["dup"])  # one suppression owed
+    queued = ["dup", "dup"]  # the twin's parked end, and the real one
+
+    survived = []
+    for call_id in queued:
+        if owed.get(call_id, 0):
+            owed[call_id] -= 1
+            continue
+        survived.append(call_id)
+
+    assert survived == ["dup"], (
+        "counting must swallow only what is owed; matching by id swallows the "
+        "started call's genuine end event too, which is R5-1"
+    )

--- a/tests/unit/harness/test_loop.py
+++ b/tests/unit/harness/test_loop.py
@@ -16,6 +16,7 @@ from local_operator.harness.loop import (
     ABORT_DRAIN_TIMEOUT_S,
     AgentLoop,
     LoopContext,
+    _consume_claim,
     validate_tool_arguments,
 )
 from local_operator.harness.types import (
@@ -1744,30 +1745,30 @@ async def test_a_call_that_never_ran_still_reports_itself_to_the_operator():
 
 
 def test_the_flush_suppression_counts_rather_than_matching():
-    """Review round 6, R6-2. Pin the mechanism R5-1 was about.
+    """Review round 6/7, R6-2 and R7-3. Pin the mechanism R5-1 was about.
 
-    The behavioural tests above cannot reach this: the source-side guard in
-    `park` means the flush's `claimed` bookkeeping is currently unreachable
-    (R6-1), so reverting it to a `set` leaves them all green. That is exactly
-    why it needs pinning directly — the next change that reintroduces an
-    interleaving would silently restore R5-1, where one id names both a call
-    that started and a duplicate that did not, and a set suppresses BOTH.
+    Exercises the REAL helper rather than a retyped copy of its logic. The
+    behavioural tests cannot reach this branch: the source-side guard in `park`
+    removes the collision it defends against (R6-1), so the code path is
+    unreachable and a revert to a plain `set` leaves every other test green.
+    A test that reproduced the rule inline had the same blind spot as the code
+    it was meant to guard (R7-3) — this calls the function the loop calls.
 
-    A unit test on the rule itself, not the loop: with N queued ends carrying
-    one id and K of them owed suppression, exactly N-K must survive.
+    The rule: with N queued ends carrying one id and K owed suppression,
+    exactly N-K survive. Matching by id instead of counting swallows both, and
+    the one it must not swallow is the started call's genuine end.
     """
-    # Two slots, one id: one started, one a duplicate that never did.
-    owed = Counter(["dup"])  # one suppression owed
-    queued = ["dup", "dup"]  # the twin's parked end, and the real one
+    # Two slots, one id: one started, one a duplicate that never did, so
+    # exactly one suppression is owed.
+    claimed: Counter[str] = Counter(["dup"])
 
-    survived = []
-    for call_id in queued:
-        if owed.get(call_id, 0):
-            owed[call_id] -= 1
-            continue
-        survived.append(call_id)
+    survived = [call_id for call_id in ("dup", "dup") if not _consume_claim(claimed, call_id)]
 
     assert survived == ["dup"], (
         "counting must swallow only what is owed; matching by id swallows the "
         "started call's genuine end event too, which is R5-1"
     )
+    # And the claim is spent, not standing: a later end for the same id lives.
+    assert _consume_claim(claimed, "dup") is False
+    # An id nobody claimed is never suppressed.
+    assert _consume_claim(Counter(), "other") is False

--- a/tests/unit/harness/test_loop.py
+++ b/tests/unit/harness/test_loop.py
@@ -1411,3 +1411,72 @@ async def test_a_slow_tool_unwind_does_not_hold_the_turn_open():
     # Still paired, even though the tool never parked its own result.
     tool_messages = [m for m in context.messages if isinstance(m, Message) and m.role == "tool"]
     assert [m.tool_call_id for m in tool_messages] == ["c1"]
+
+
+@pytest.mark.asyncio
+async def test_a_slow_unwind_still_reports_the_tool_as_ENDED():
+    """Review round 2, R2. The drain timeout must not swallow the end event.
+
+    A tool whose cleanup outruns ``ABORT_DRAIN_TIMEOUT_S`` had its start event
+    announced and no end event ever: the backfill repaired the RESULTS so the
+    wire stayed legal, but emitted nothing, so a consumer holding execution
+    records by id kept that one IN_PROGRESS forever and never published a
+    TOOL_END on its stream. The TUI survives it by retiring orphaned cards at
+    the turn boundary; the API server does not.
+
+    That is the same damage ``interruptible_runner``'s cancellation handler
+    exists to prevent — it closes the fast path, and this closes the slow one.
+    """
+    started = asyncio.Event()
+
+    async def execute(tool_call_id, args, signal, on_update, context) -> ToolResult:
+        started.set()
+        try:
+            await asyncio.sleep(30)
+        except asyncio.CancelledError:
+            with contextlib.suppress(asyncio.CancelledError):
+                await asyncio.sleep(ABORT_DRAIN_TIMEOUT_S + 2)  # outruns the budget
+            raise
+        return ToolResult(
+            tool_call_id=tool_call_id, tool_name="stubborn", content=[TextContent(text="late")]
+        )
+
+    tool = AgentTool(
+        name="stubborn",
+        parameters={"type": "object", "properties": {}},
+        execute=execute,
+    )
+    stream = ScriptedStream(
+        [
+            [
+                tool_call_delta(0, id="c1", name="stubborn", args="{}"),
+                StreamEndEvent(stop_reason="toolUse"),
+            ],
+            [StreamEndEvent(stop_reason="stop")],
+        ]
+    )
+    context = LoopContext(tools=[tool])
+    config = make_config(stream, interrupt_mode="immediate", has_steering_messages=lambda: False)
+    signal = AbortSignal()
+    loop = AgentLoop()
+
+    events: list[Any] = []
+
+    async def run() -> None:
+        async for event in loop.run([Message.user("go")], context, config, signal):
+            events.append(event)
+
+    task = asyncio.ensure_future(run())
+    await asyncio.wait_for(started.wait(), timeout=5)
+    signal.abort("interrupted")
+    await asyncio.wait_for(task, timeout=ABORT_DRAIN_TIMEOUT_S + 10)
+
+    starts = [e for e in events if isinstance(e, ToolExecutionStartEvent)]
+    ends = [e for e in events if isinstance(e, ToolExecutionEndEvent)]
+    assert len(starts) == 1, "the tool never announced its start"
+    assert len(ends) == 1, (
+        "the tool was announced as started and never as ended, so a consumer "
+        "holding it by id keeps that execution IN_PROGRESS forever"
+    )
+    assert ends[0].tool_call_id == starts[0].tool_call_id
+    assert ends[0].is_error, "an aborted tool must not be reported as a clean success"

--- a/tests/unit/harness/test_loop.py
+++ b/tests/unit/harness/test_loop.py
@@ -1592,15 +1592,16 @@ async def test_a_late_parking_tool_is_not_robbed_of_its_end_event_mid_backfill()
             # and is worse (3/40): it lets the generator finish before the park
             # it is supposed to be racing.
             #
-            # `test_a_duplicate_call_id_does_not_suppress_the_real_calls_end`
-            # `_event` carries the IDENTICAL literal
-            # `ABORT_DRAIN_TIMEOUT_S + 0.3`, which
-            # is what a grep or a search-and-replace would actually collide with
-            # — and it is INDEPENDENT of this one: it exercises the duplicate-id
-            # suppression rule, not the flush window, so nothing about it needs
-            # to move if this does. (`test_a_slow_unwind_still_reports_the_tool
-            # _as_ENDED` overshoots by `+ 2` and is independent for the same
-            # reason; only the identical literal is a real hazard.)
+            # The IDENTICAL literal `ABORT_DRAIN_TIMEOUT_S + 0.3` appears once
+            # more in this file, in the duplicate-call-id suppression test —
+            # grep `does_not_suppress_the_real_calls` — and that is the copy a
+            # search-and-replace would collide with. It is INDEPENDENT of this
+            # one: it exercises the suppression rule, not the flush window, so
+            # nothing about it needs to move if this does.
+            #
+            # (The slow-unwind test — grep `still_reports_the_tool_as_ENDED` —
+            # overshoots by `+ 2` and is independent for the same reason. Only
+            # the identical literal is a real hazard.)
             await asyncio.sleep(0.3)
 
     task = asyncio.ensure_future(run())

--- a/tests/unit/harness/test_loop.py
+++ b/tests/unit/harness/test_loop.py
@@ -1501,6 +1501,7 @@ async def test_a_late_parking_tool_is_not_robbed_of_its_end_event_mid_backfill()
     reach it: with one slot there is nothing to suspend on before it.
     """
     started = asyncio.Event()
+    parked = asyncio.Event()
 
     async def never_parks(tool_call_id, args, signal, on_update, context) -> ToolResult:
         started.set()
@@ -1516,7 +1517,13 @@ async def test_a_late_parking_tool_is_not_robbed_of_its_end_event_mid_backfill()
             # Settles just past the drain budget: the batch has given up
             # waiting, so this lands while the backfill is mid-emit.
             with contextlib.suppress(asyncio.CancelledError):
-                await asyncio.sleep(ABORT_DRAIN_TIMEOUT_S + 0.3)
+                # Parks just past the drain budget, and the CONSUMER below is
+                # slow enough that the batch is still emitting when it lands.
+                # Both halves matter: overshoot too far and the tool parks after
+                # the batch has settled entirely, which is a different (and
+                # untestable-from-here) shape that made this assertion flaky.
+                await asyncio.sleep(ABORT_DRAIN_TIMEOUT_S + 0.15)
+            parked.set()
             raise
         return ToolResult(
             tool_call_id=tool_call_id, tool_name="slow", content=[TextContent(text="late")]
@@ -1566,6 +1573,10 @@ async def test_a_late_parking_tool_is_not_robbed_of_its_end_event_mid_backfill()
     await asyncio.wait_for(started.wait(), timeout=5)
     signal.abort("interrupted")
     await asyncio.wait_for(task, timeout=ABORT_DRAIN_TIMEOUT_S + 15)
+    # The scenario only exists once the slow tool has actually parked. Without
+    # this the assertion sometimes ran against a turn that ended BEFORE the
+    # cleanup finished — a different shape, and the source of a ~1-in-8 flake.
+    await asyncio.wait_for(parked.wait(), timeout=5)
 
     started_ids = [e.tool_call_id for e in events if isinstance(e, ToolExecutionStartEvent)]
     ended_ids = [e.tool_call_id for e in events if isinstance(e, ToolExecutionEndEvent)]

--- a/tests/unit/harness/test_loop.py
+++ b/tests/unit/harness/test_loop.py
@@ -1480,3 +1480,98 @@ async def test_a_slow_unwind_still_reports_the_tool_as_ENDED():
     )
     assert ends[0].tool_call_id == starts[0].tool_call_id
     assert ends[0].is_error, "an aborted tool must not be reported as a clean success"
+
+
+@pytest.mark.asyncio
+async def test_a_late_parking_tool_is_not_robbed_of_its_end_event_mid_backfill():
+    """Review round 3, R3-1. The backfill must decide before it emits.
+
+    A generator suspends at every ``yield``, handing control to a consumer that
+    may await. A runner whose cleanup lands in one of those windows parks its
+    own result — writing its end event to the queue nobody reads any more — and
+    an interleaved backfill then saw the filled slot and emitted nothing. That
+    call kept its start event and never got an end, which is the exact damage
+    the backfill exists to prevent.
+
+    Needs BOTH a multi-call batch (so there is an earlier slot to suspend on)
+    and a consumer that actually awaits. The single-tool guard above cannot
+    reach it: with one slot there is nothing to suspend on before it.
+    """
+    started = asyncio.Event()
+
+    async def never_parks(tool_call_id, args, signal, on_update, context) -> ToolResult:
+        started.set()
+        await asyncio.sleep(30)
+        return ToolResult(
+            tool_call_id=tool_call_id, tool_name="stuck", content=[TextContent(text="late")]
+        )
+
+    async def parks_late(tool_call_id, args, signal, on_update, context) -> ToolResult:
+        try:
+            await asyncio.sleep(30)
+        except asyncio.CancelledError:
+            # Settles just past the drain budget: the batch has given up
+            # waiting, so this lands while the backfill is mid-emit.
+            with contextlib.suppress(asyncio.CancelledError):
+                await asyncio.sleep(ABORT_DRAIN_TIMEOUT_S + 0.3)
+            raise
+        return ToolResult(
+            tool_call_id=tool_call_id, tool_name="slow", content=[TextContent(text="late")]
+        )
+
+    tools = [
+        AgentTool(
+            name="stuck",
+            parameters={"type": "object", "properties": {}},
+            execute=never_parks,
+        ),
+        AgentTool(
+            name="slow",
+            parameters={"type": "object", "properties": {}},
+            execute=parks_late,
+        ),
+    ]
+    stream = ScriptedStream(
+        [
+            [
+                tool_call_delta(0, id="c1", name="stuck", args="{}"),
+                tool_call_delta(1, id="c2", name="slow", args="{}"),
+                StreamEndEvent(stop_reason="toolUse"),
+            ],
+            [StreamEndEvent(stop_reason="stop")],
+        ]
+    )
+    context = LoopContext(tools=tools)
+    config = make_config(stream, interrupt_mode="immediate", has_steering_messages=lambda: False)
+    signal = AbortSignal()
+    loop = AgentLoop()
+
+    events: list[Any] = []
+
+    async def run() -> None:
+        async for event in loop.run([Message.user("go")], context, config, signal):
+            events.append(event)
+            # A consumer that awaits — the TUI paints, the API server writes.
+            # Without this the generator never suspends and the loss is not
+            # reachable. These two durations are not arbitrary: the tool must
+            # park AFTER the drain gives up at ABORT_DRAIN_TIMEOUT_S but while
+            # the consumer still owes the generator a resume, which is the
+            # window in which its end event lands on a queue nobody reads.
+            await asyncio.sleep(0.3)
+
+    task = asyncio.ensure_future(run())
+    await asyncio.wait_for(started.wait(), timeout=5)
+    signal.abort("interrupted")
+    await asyncio.wait_for(task, timeout=ABORT_DRAIN_TIMEOUT_S + 15)
+
+    started_ids = [e.tool_call_id for e in events if isinstance(e, ToolExecutionStartEvent)]
+    ended_ids = [e.tool_call_id for e in events if isinstance(e, ToolExecutionEndEvent)]
+    assert sorted(started_ids) == ["c1", "c2"]
+    for call_id in started_ids:
+        assert ended_ids.count(call_id) == 1, (
+            f"{call_id} was announced as started and ended {ended_ids.count(call_id)} "
+            f"times; every started call needs exactly one end (ends={ended_ids})"
+        )
+    # And the wire is still legal: one tool_result per tool_use.
+    tool_messages = [m for m in context.messages if isinstance(m, Message) and m.role == "tool"]
+    assert sorted(str(m.tool_call_id) for m in tool_messages) == ["c1", "c2"]

--- a/tests/unit/harness/test_loop.py
+++ b/tests/unit/harness/test_loop.py
@@ -1517,12 +1517,16 @@ async def test_a_late_parking_tool_is_not_robbed_of_its_end_event_mid_backfill()
             # Settles just past the drain budget: the batch has given up
             # waiting, so this lands while the backfill is mid-emit.
             with contextlib.suppress(asyncio.CancelledError):
-                # Parks just past the drain budget, and the CONSUMER below is
-                # slow enough that the batch is still emitting when it lands.
-                # Both halves matter: overshoot too far and the tool parks after
-                # the batch has settled entirely, which is a different (and
-                # untestable-from-here) shape that made this assertion flaky.
-                await asyncio.sleep(ABORT_DRAIN_TIMEOUT_S + 0.15)
+                # Parks past the drain budget by enough that the event lands on
+                # a queue the drain loop has already abandoned — which is the
+                # window the FLUSH exists to cover, and the only window in which
+                # this test can detect the flush going missing. Shortening this
+                # overshoot moves the park into the range the backfill already
+                # handles, and the test then passes with the flush deleted:
+                # measured 32/32 green at +0.15 against a flush-less tree,
+                # versus 7/8 red at +0.3 (R9 MAJOR-1). The flakiness this once
+                # had is fixed by the `parked` gate below, not by moving this.
+                await asyncio.sleep(ABORT_DRAIN_TIMEOUT_S + 0.3)
             parked.set()
             raise
         return ToolResult(
@@ -1563,10 +1567,18 @@ async def test_a_late_parking_tool_is_not_robbed_of_its_end_event_mid_backfill()
             events.append(event)
             # A consumer that awaits — the TUI paints, the API server writes.
             # Without this the generator never suspends and the loss is not
-            # reachable. These two durations are not arbitrary: the tool must
-            # park AFTER the drain gives up at ABORT_DRAIN_TIMEOUT_S but while
-            # the consumer still owes the generator a resume, which is the
-            # window in which its end event lands on a queue nobody reads.
+            # reachable at all.
+            #
+            # The duration is deliberate and must not be shortened to settle a
+            # flake: the tool has to park AFTER the drain gives up at
+            # ABORT_DRAIN_TIMEOUT_S but while the consumer still owes the
+            # generator a resume, and that window is what the flush covers.
+            # Moving either number moves the park into the range the BACKFILL
+            # already handles, and the test then passes with the flush deleted
+            # (measured 32/32 green against a flush-less tree) — i.e. it stops
+            # testing the thing it is named for. Waiting on the park event
+            # instead was tried and is worse (3/40): it lets the generator
+            # finish before the park it is supposed to be racing.
             await asyncio.sleep(0.3)
 
     task = asyncio.ensure_future(run())

--- a/tests/unit/harness/test_loop.py
+++ b/tests/unit/harness/test_loop.py
@@ -1520,12 +1520,17 @@ async def test_a_late_parking_tool_is_not_robbed_of_its_end_event_mid_backfill()
                 # Parks past the drain budget by enough that the event lands on
                 # a queue the drain loop has already abandoned — which is the
                 # window the FLUSH exists to cover, and the only window in which
-                # this test can detect the flush going missing. Shortening this
-                # overshoot moves the park into the range the backfill already
-                # handles, and the test then passes with the flush deleted:
-                # measured 32/32 green at +0.15 against a flush-less tree,
-                # versus 7/8 red at +0.3 (R9 MAJOR-1). The flakiness this once
-                # had is fixed by the `parked` gate below, not by moving this.
+                # this test can detect the flush going missing.
+                #
+                # A RIDGE, NOT A FLOOR: moving this value in EITHER direction
+                # blinds the test. Swept against a tree with the flush deleted,
+                # it detects at +0.30 and is blind at +0.15, +0.35, +0.40, +0.45
+                # and +0.60 (R10). Too short and the park lands in the range the
+                # backfill already handles; too long and it lands after the
+                # batch has stopped emitting. Both ends pass with the flush
+                # gone, which means the test silently stops testing the thing it
+                # is named for. The flakiness this once had is fixed by the
+                # `parked` gate below, not by moving this.
                 await asyncio.sleep(ABORT_DRAIN_TIMEOUT_S + 0.3)
             parked.set()
             raise
@@ -1573,12 +1578,17 @@ async def test_a_late_parking_tool_is_not_robbed_of_its_end_event_mid_backfill()
             # flake: the tool has to park AFTER the drain gives up at
             # ABORT_DRAIN_TIMEOUT_S but while the consumer still owes the
             # generator a resume, and that window is what the flush covers.
-            # Moving either number moves the park into the range the BACKFILL
-            # already handles, and the test then passes with the flush deleted
-            # (measured 32/32 green against a flush-less tree) — i.e. it stops
-            # testing the thing it is named for. Waiting on the park event
-            # instead was tried and is worse (3/40): it lets the generator
-            # finish before the park it is supposed to be racing.
+            # Moving either number moves the park out of that window — see the
+            # ridge measurements on the tool's own sleep above — and the test
+            # then passes with the flush deleted, i.e. it stops testing the
+            # thing it is named for. Waiting on the park event instead was tried
+            # and is worse (3/40): it lets the generator finish before the park
+            # it is supposed to be racing.
+            #
+            # The sibling `test_a_slow_unwind_still_reports_the_tool_as_ENDED`
+            # carries a similar-looking overshoot that is INDEPENDENT of this
+            # one: it is a single-call batch testing the backfill, not the
+            # flush, and nothing about it needs to move if this does.
             await asyncio.sleep(0.3)
 
     task = asyncio.ensure_future(run())

--- a/tests/unit/harness/test_loop.py
+++ b/tests/unit/harness/test_loop.py
@@ -1022,6 +1022,8 @@ class TestTheModelIsReadAtEveryCall:
             pass
 
         assert self._labels(stream) == ["test/m", "test/m"]
+
+
 # ---------------------------------------------------------------------------
 # Immediate abort: Esc must halt the turn NOW, not at the next natural boundary
 # ---------------------------------------------------------------------------

--- a/tests/unit/session/test_session.py
+++ b/tests/unit/session/test_session.py
@@ -2527,3 +2527,127 @@ class TestASwitchedModelTakesEffectAtTheNextCall:
             assert session.model_label == "test/other"
         finally:
             await session.dispose()
+# ---------------------------------------------------------------------------
+# cancel_subagents: the second Esc press
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cancel_subagents_stops_children_and_spares_background_bash(tmp_path):
+    """The wider stop cancels delegated agents ONLY.
+
+    ``task`` jobs are the parent's own work, delegated: a stop the user aimed
+    at the agent must reach them, and before this it did not — ``abort`` only
+    ever touched the parent's turn signal, so children carried on calling the
+    provider after the turn that launched them had ended.
+
+    ``bash`` jobs are the opposite case and must survive. ``background=true``
+    exists precisely so a build or a deploy outlives the turn that started it;
+    killing one on a keypress meant for the agent destroys work the user asked
+    to be insulated from the agent.
+    """
+    session = make_session(tmp_path, ScriptedStream([[StreamEndEvent(stop_reason="stop")]]))
+    child_cancelled = asyncio.Event()
+    bash_running = asyncio.Event()
+    started = asyncio.Event()
+
+    async def child(job_id, signal, report_progress):
+        started.set()
+        try:
+            await asyncio.sleep(30)
+        except asyncio.CancelledError:
+            child_cancelled.set()
+            raise
+        return "never"
+
+    async def build(job_id, signal, report_progress):
+        bash_running.set()
+        await asyncio.sleep(0.4)
+        return "build finished"
+
+    child_id = session.jobs.register("task", "child", child)
+    bash_id = session.jobs.register("bash", "build", build)
+    await asyncio.wait_for(asyncio.gather(started.wait(), bash_running.wait()), timeout=5)
+
+    stopped = session.cancel_subagents()
+
+    assert stopped == 1, "the running child should be reported as stopped"
+    await asyncio.wait_for(child_cancelled.wait(), timeout=5)
+    child_job = session.jobs.get(child_id)
+    assert child_job is not None and child_job.status == "cancelled"
+    # The build is untouched and still runs to completion.
+    await asyncio.sleep(0.6)
+    bash_job = session.jobs.get(bash_id)
+    assert bash_job is not None
+    assert bash_job.status == "completed"
+    assert bash_job.result_text == "build finished"
+    await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_cancel_subagents_reports_zero_when_nothing_is_delegated(tmp_path):
+    """The count is what the UI prints, so "nothing was running" must be
+    distinguishable from "children were stopped"."""
+    session = make_session(tmp_path, ScriptedStream([[StreamEndEvent(stop_reason="stop")]]))
+    assert session.cancel_subagents() == 0
+    await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_abort_alone_leaves_subagents_running(tmp_path):
+    """The FIRST Esc press is deliberately narrow.
+
+    A delegated child can be minutes into useful work, and the key that quiets
+    the foreground should not destroy it by reflex — that is why stopping the
+    children is a separate, explicitly offered second press rather than a
+    silent consequence of the first.
+    """
+    session = make_session(tmp_path, ScriptedStream([[StreamEndEvent(stop_reason="stop")]]))
+    started = asyncio.Event()
+
+    async def child(job_id, signal, report_progress):
+        started.set()
+        await asyncio.sleep(0.3)
+        return "finished anyway"
+
+    job_id = session.jobs.register("task", "child", child)
+    await asyncio.wait_for(started.wait(), timeout=5)
+
+    session.abort("interrupted")
+
+    await asyncio.sleep(0.5)
+    job = session.jobs.get(job_id)
+    assert job is not None and job.status == "completed"
+    await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_the_offered_count_and_the_stopped_count_agree(tmp_path):
+    """Review round 1, M3. One predicate behind both numbers.
+
+    The count a host OFFERS ("2 still running — esc again") and the count the
+    stop REPORTS must come from the same filter. They did not: the TUI counted
+    with a filter that excludes jobs parked at the capacity gate while the
+    cancel took every ``running`` row including those. The confirmation
+    contradicted the offer, and — worse — a press that found only queued
+    children showed nothing and armed nothing, leaving children the second
+    press would happily have cancelled unreachable from the keyboard.
+    """
+    session = make_session(tmp_path, ScriptedStream([[StreamEndEvent(stop_reason="stop")]]))
+
+    async def child(job_id, signal, report_progress):
+        await asyncio.sleep(30)
+        return "never"
+
+    session.jobs.register("task", "running-child", child)
+    # Parked at the capacity gate: `status == "running"` while `queued` is set.
+    session.jobs.register("task", "queued-child", child, queued=True)
+    await asyncio.sleep(0.2)
+
+    offered = session.running_subagents()
+    stopped = session.cancel_subagents()
+
+    assert offered == 2, "a queued child is still a child the user asked to stop"
+    assert stopped == offered, "the confirmation must not contradict the offer"
+    await asyncio.sleep(0.3)
+    await session.dispose()

--- a/tests/unit/session/test_session.py
+++ b/tests/unit/session/test_session.py
@@ -2527,6 +2527,8 @@ class TestASwitchedModelTakesEffectAtTheNextCall:
             assert session.model_label == "test/other"
         finally:
             await session.dispose()
+
+
 # ---------------------------------------------------------------------------
 # cancel_subagents: the second Esc press
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_exec_mode.py
+++ b/tests/unit/test_exec_mode.py
@@ -440,6 +440,39 @@ def test_a_notice_cannot_smuggle_control_sequences_to_the_terminal() -> None:
     assert out.startswith("✗ Tool not found: ")
 
 
+def test_a_notice_cannot_forge_a_row_or_crash_the_renderer() -> None:
+    """Design round 4, D14/D15. The tool name in a notice is model-chosen.
+
+    Three hazards beyond control sequences, all reachable from a hallucinated
+    tool name and none covered by stripping alone:
+
+    * square brackets are Rich MARKUP — `[bold]x` renders the wrong name, and
+      `[/red]oops` raises `MarkupError` inside the renderer, which the session's
+      emit path swallows, so the notice disappears entirely. That is the exact
+      silence this diagnostic exists to prevent;
+    * newlines survive stripping by design, so a name containing one forges a
+      second, unmarked row that can read as a clean success;
+    * both were pre-existing on the `✗ <name> failed` line this replaced.
+    """
+
+    def render(name: str) -> str:
+        buffer = io.StringIO()
+        console = Console(file=buffer, no_color=True, highlight=False, width=100)
+        PrintRenderer(json_mode=False, console=console).handle(
+            NoticeEvent(text=f"Tool not found: {name}", kind="error")
+        )
+        return buffer.getvalue()
+
+    # Unbalanced markup must not raise, and must not be interpreted.
+    assert render("[/red]oops") == "✗ Tool not found: [/red]oops\n"
+    # Balanced markup must not be interpreted either — the name is shown as-is.
+    assert render("[bold]x") == "✗ Tool not found: [bold]x\n"
+    # A newline must not forge a second row that carries its own claim.
+    forged = render("a\n✓ 3 subagents finished cleanly")
+    assert forged.count("\n") == 1, f"the name forged an extra row: {forged!r}"
+    assert forged.startswith("✗ ")
+
+
 def test_renderer_tracks_failure() -> None:
     renderer = PrintRenderer(json_mode=False)
     renderer.handle(AgentEndEvent(error="boom"))

--- a/tests/unit/test_exec_mode.py
+++ b/tests/unit/test_exec_mode.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import io
 import json
 import sys
 from collections.abc import Callable, Sequence
@@ -19,6 +20,7 @@ from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
+from rich.console import Console
 
 from local_operator import exec_mode, exec_worker
 from local_operator.exec_mode import ExecArgs, build_worker_argv, slugify
@@ -33,6 +35,7 @@ from local_operator.harness.types import (
     MessageStartEvent,
     MessageUpdateEvent,
     ModelSpec,
+    NoticeEvent,
     TextContent,
     ToolExecutionEndEvent,
     ToolExecutionStartEvent,
@@ -383,6 +386,32 @@ def test_run_exec_prompt_raising_exits_one(fake_factory, capsys) -> None:
     code = exec_mode.run_exec("explode", ExecArgs())
     assert code == 1
     assert "turn blew up" in capsys.readouterr().err
+
+
+def test_an_error_notice_is_marked_by_a_glyph_not_only_by_colour() -> None:
+    """Design round 3, D11. Piped logs and NO_COLOR strip the only signal.
+
+    This renderer writes to a real terminal, but its output is also redirected
+    into logs and read with colour disabled — and there an error notice was
+    byte-identical to an informational one. It matters most for the line that
+    prompted it: an unrunnable tool call used to print `✗ <name> failed`, which
+    DID carry a marker, so moving that diagnostic onto a notice dropped one.
+
+    `info` stays bare on purpose: a marker on every routine line is noise, and
+    it is the one kind with nothing to warn about.
+    """
+    buffer = io.StringIO()
+    console = Console(file=buffer, no_color=True, highlight=False, width=100)
+    renderer = PrintRenderer(json_mode=False, console=console)
+
+    renderer.handle(NoticeEvent(text="Tool not found: reed_file", kind="error"))
+    renderer.handle(NoticeEvent(text="running low on context", kind="warning"))
+    renderer.handle(NoticeEvent(text="compacted", kind="info"))
+
+    lines = buffer.getvalue().splitlines()
+    assert lines[0] == "✗ Tool not found: reed_file"
+    assert lines[1] == "! running low on context"
+    assert lines[2] == "compacted"
 
 
 def test_renderer_tracks_failure() -> None:

--- a/tests/unit/test_exec_mode.py
+++ b/tests/unit/test_exec_mode.py
@@ -414,6 +414,32 @@ def test_an_error_notice_is_marked_by_a_glyph_not_only_by_colour() -> None:
     assert lines[2] == "compacted"
 
 
+def test_a_notice_cannot_smuggle_control_sequences_to_the_terminal() -> None:
+    """Round 7, R7-1. Notice text is no longer only ours.
+
+    The unrunnable-call diagnostic carries a MODEL-CHOSEN tool name, so an
+    erase-display escape inside it reaches a real terminal and clears the
+    operator's screen. The `✗ <name> failed` line this diagnostic replaced was
+    stripped for exactly that reason; moving the message onto a notice moved it
+    off the guard.
+
+    Asserted on the RENDERER rather than the producer, because that is where
+    the guard now lives: the next notice to carry untrusted text should not
+    have to remember to sanitize itself.
+    """
+    buffer = io.StringIO()
+    console = Console(file=buffer, no_color=True, highlight=False, width=100)
+    renderer = PrintRenderer(json_mode=False, console=console)
+
+    renderer.handle(NoticeEvent(text="Tool not found: ru\x1b[2Jn", kind="error"))
+
+    out = buffer.getvalue()
+    assert "\x1b" not in out, f"a control sequence reached the terminal: {out!r}"
+    assert "2J" not in out, f"an erase-display escape survived stripping: {out!r}"
+    # The message itself still arrives, with its severity marker.
+    assert out.startswith("✗ Tool not found: ")
+
+
 def test_renderer_tracks_failure() -> None:
     renderer = PrintRenderer(json_mode=False)
     renderer.handle(AgentEndEvent(error="boom"))

--- a/tests/unit/test_exec_mode.py
+++ b/tests/unit/test_exec_mode.py
@@ -145,7 +145,16 @@ class FakeSession:
     def abort(self, reason: str = "interrupted") -> None:
         pass
 
+    def cancel_subagents(self, reason: str = "interrupted") -> int:
+        """No subagents in this fake; the protocol requires the method."""
+        return 0
+
+    def running_subagents(self) -> int:
+        """No subagents in this fake; the protocol requires the method."""
+        return 0
+
     # events
+
     def subscribe(self, handler: Any) -> Any:
         self.handlers.append(handler)
 

--- a/tests/unit/test_exec_mode.py
+++ b/tests/unit/test_exec_mode.py
@@ -473,6 +473,42 @@ def test_a_notice_cannot_forge_a_row_or_crash_the_renderer() -> None:
     assert forged.startswith("✗ ")
 
 
+def test_no_renderer_branch_interprets_a_tool_name_as_markup() -> None:
+    """Round 14, R14-2. The rule has to hold for every branch, not the newest.
+
+    The tool NAME is model-chosen, and a `[` in it is Rich markup: `[/red]x`
+    raises `MarkupError`, which the session's emit path swallows, so the row
+    vanishes and the operator watches a tool run with no line at all. The
+    notice branch was fixed for D14; the two tool-event branches above it had
+    the same defect (pre-existing on main) and the fix's own comment
+    generalised the rule further than the code did.
+    """
+    name = "[/red]oops"
+
+    def render(event: object) -> str:
+        buffer = io.StringIO()
+        console = Console(file=buffer, no_color=True, highlight=False, width=100)
+        PrintRenderer(json_mode=False, console=console).handle(event)  # type: ignore[arg-type]
+        return buffer.getvalue()
+
+    started = render(
+        ToolExecutionStartEvent(tool_call_id="c1", tool_name=name, args={}, intent="do it")
+    )
+    assert started == "● [/red]oops do it\n"
+
+    result = ToolResult(
+        tool_call_id="c1", tool_name=name, is_error=True, content=[TextContent(text="x")]
+    )
+    ended = render(
+        ToolExecutionEndEvent(tool_call_id="c1", tool_name=name, result=result, is_error=True)
+    )
+    assert ended == "✗ [/red]oops failed\n"
+
+    assert render(NoticeEvent(text=f"Tool not found: {name}", kind="error")) == (
+        "✗ Tool not found: [/red]oops\n"
+    )
+
+
 def test_renderer_tracks_failure() -> None:
     renderer = PrintRenderer(json_mode=False)
     renderer.handle(AgentEndEvent(error="boom"))

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -49,16 +49,25 @@ class _FakeJobs:
 
     Rows are derived from ``running_children`` so a test states the fact it
     cares about ("two children are up") instead of assembling job models.
+
+    ``running_bash_jobs`` does the same for backgrounded shell work, which the
+    stop ladder deliberately SPARES and now names when confirming a stop — so a
+    test needs to be able to say "a build is also running" as plainly.
     """
 
     def __init__(self, session: "FakeSession") -> None:
         self._session = session
 
     def list(self) -> list[Any]:
-        return [
+        rows = [
             SimpleNamespace(id=f"job{i}", status="running", type="task", queued=False)
             for i in range(self._session.running_children)
         ]
+        rows += [
+            SimpleNamespace(id=f"bash{i}", status="running", type="bash", queued=False)
+            for i in range(self._session.running_bash_jobs)
+        ]
+        return rows
 
 
 class FakeSession:
@@ -75,6 +84,10 @@ class FakeSession:
         #: ladder's second press.
         self.subagent_cancels: list[str] = []
         self.running_children = 0
+        #: Backgrounded `bash` jobs, which Esc never stops (`background=true`
+        #: exists so a build outlives the turn). Staged separately from
+        #: `running_children` because the ladder treats them as opposites.
+        self.running_bash_jobs = 0
         #: The job ledger the app counts children in. A real manager's rows are
         #: what `_job_count` reads, so the fake presents the same shape rather
         #: than having the app special-case a test double.

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -44,6 +44,23 @@ from local_operator.tui.widgets.welcome import WelcomeView
 from tests.unit.tui.conftest import caret_cells, chevron_colour, composer_cells
 
 
+class _FakeJobs:
+    """The slice of ``AsyncJobManager`` the app reads: ``list()`` of rows.
+
+    Rows are derived from ``running_children`` so a test states the fact it
+    cares about ("two children are up") instead of assembling job models.
+    """
+
+    def __init__(self, session: "FakeSession") -> None:
+        self._session = session
+
+    def list(self) -> list[Any]:
+        return [
+            SimpleNamespace(id=f"job{i}", status="running", type="task", queued=False)
+            for i in range(self._session.running_children)
+        ]
+
+
 class FakeSession:
     """Records prompts/aborts; satisfies SessionProtocol."""
 
@@ -53,6 +70,15 @@ class FakeSession:
     def __init__(self) -> None:
         self.prompts: list[str] = []
         self.aborts: list[str] = []
+        #: Reasons passed to `cancel_subagents`, and how many children the next
+        #: call should report stopping. Staged by tests that exercise the Esc
+        #: ladder's second press.
+        self.subagent_cancels: list[str] = []
+        self.running_children = 0
+        #: The job ledger the app counts children in. A real manager's rows are
+        #: what `_job_count` reads, so the fake presents the same shape rather
+        #: than having the app special-case a test double.
+        self.jobs = _FakeJobs(self)
         self.completions: list[tuple[str, str]] = []
         self.asides: list[list[Any]] = []
         self.adopted: list[list[Any]] = []
@@ -138,6 +164,22 @@ class FakeSession:
 
     def abort(self, reason: str = "interrupted") -> None:
         self.aborts.append(reason)
+
+    def running_subagents(self) -> int:
+        """The count the stop ladder offers. Staged by tests via
+        ``running_children``, mirroring the real session's single predicate."""
+        return self.running_children
+
+    def cancel_subagents(self, reason: str = "interrupted") -> int:
+        """Record the wider stop and report how many children it stopped.
+
+        Reports the SAME number ``running_subagents`` would, which is the
+        invariant the real session guarantees by sharing one predicate.
+        """
+        self.subagent_cancels.append(reason)
+        stopped = self.running_children
+        self.running_children = 0
+        return stopped
 
     def subscribe(self, handler: Any) -> Any:
         self._handlers.append(handler)

--- a/tests/unit/tui/test_ask_settle.py
+++ b/tests/unit/tui/test_ask_settle.py
@@ -16,6 +16,7 @@ touches nothing the user opened over it.
 from __future__ import annotations
 
 import asyncio
+import time
 
 import pytest
 from textual.app import ComposeResult
@@ -244,3 +245,40 @@ async def test_escape_answers_the_prompt_the_user_is_looking_at() -> None:
             await asked
         except (asyncio.CancelledError, Exception):
             pass
+
+
+@pytest.mark.asyncio
+async def test_escape_skips_a_live_question_rather_than_escalating_the_stop() -> None:
+    """The two Escape meanings must not collide.
+
+    The stop ladder's second press cancels every subagent, and an `ask` picker
+    can be on screen while that offer is armed — a delegated child is exactly
+    the kind of work that raises a question. Escape has to keep meaning "skip
+    this question" there, which is what the card's own footer advertises;
+    escalating instead would destroy delegated work from a keypress the user
+    read as answering the agent.
+
+    The ordering in `action_stop` is what guarantees it, so this pins the
+    behaviour rather than the branch: with the offer armed AND a question up,
+    one press settles the question and cancels nothing.
+    """
+    session = FakeSession()
+    session.running_children = 2
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(90, 30)) as pilot:
+        await pilot.pause()
+        # Arm the ladder exactly as a first Esc during a turn would.
+        app._stop_offered_at = time.monotonic()
+        asked = asyncio.create_task(app.request_user_choice([_question()]))
+        await pilot.pause()
+        await pilot.pause()
+
+        await pilot.press("escape")
+        await pilot.pause()
+
+        assert await asyncio.wait_for(asked, 2) is None, "the question was not skipped"
+        assert (
+            session.subagent_cancels == []
+        ), "Escape on a live question escalated the stop and killed the subagents"
+        # The offer is untouched, so the user can still take it deliberately.
+        assert app._stop_offered_at is not None

--- a/tests/unit/tui/test_band_panels.py
+++ b/tests/unit/tui/test_band_panels.py
@@ -91,6 +91,14 @@ class FakeSession:
     def abort(self, reason: str = "interrupted") -> None:
         self.aborts.append(reason)
 
+    def cancel_subagents(self, reason: str = "interrupted") -> int:
+        """No subagents in this fake; the protocol requires the method."""
+        return 0
+
+    def running_subagents(self) -> int:
+        """No subagents in this fake; the protocol requires the method."""
+        return 0
+
     def subscribe(self, handler: Any) -> Any:
         self._handlers.append(handler)
 

--- a/tests/unit/tui/test_boot_layout.py
+++ b/tests/unit/tui/test_boot_layout.py
@@ -157,6 +157,14 @@ class FakeSession:
     def abort(self, reason: str = "interrupted") -> None:
         pass
 
+    def cancel_subagents(self, reason: str = "interrupted") -> int:
+        """No subagents in this fake; the protocol requires the method."""
+        return 0
+
+    def running_subagents(self) -> int:
+        """No subagents in this fake; the protocol requires the method."""
+        return 0
+
     def subscribe(self, handler: Any) -> Any:
         return lambda: None
 

--- a/tests/unit/tui/test_events.py
+++ b/tests/unit/tui/test_events.py
@@ -142,6 +142,14 @@ class FakeSession:
     def abort(self, reason: str = "interrupted") -> None:
         pass
 
+    def cancel_subagents(self, reason: str = "interrupted") -> int:
+        """No subagents in this fake; the protocol requires the method."""
+        return 0
+
+    def running_subagents(self) -> int:
+        """No subagents in this fake; the protocol requires the method."""
+        return 0
+
     def subscribe(self, handler: Any) -> Any:
         self._handlers.append(handler)
 

--- a/tests/unit/tui/test_snapshot.py
+++ b/tests/unit/tui/test_snapshot.py
@@ -135,6 +135,14 @@ class FakeSession:
     def abort(self, reason: str = "interrupted") -> None:
         self.aborts.append(reason)
 
+    def cancel_subagents(self, reason: str = "interrupted") -> int:
+        """No subagents in this fake; the protocol requires the method."""
+        return 0
+
+    def running_subagents(self) -> int:
+        """No subagents in this fake; the protocol requires the method."""
+        return 0
+
     def subscribe(self, handler: Any) -> Any:
         self._handlers.append(handler)
 

--- a/tests/unit/tui/test_steering_approval.py
+++ b/tests/unit/tui/test_steering_approval.py
@@ -26,6 +26,7 @@ from typing import Any, cast
 import pytest
 from rich.cells import cell_len
 from textual.binding import Binding
+from textual.document._document import Selection
 
 from local_operator.harness.types import (
     ImageContent,
@@ -2874,3 +2875,41 @@ async def test_the_expired_row_recounts_rather_than_restating_a_stale_number() -
         assert not any(
             "still running" in row for row in painted
         ), "the expired row asserted running subagents that had already finished"
+
+
+@pytest.mark.asyncio
+async def test_a_highlighted_composer_keeps_ctrl_c_as_the_interrupt() -> None:
+    """The draft rung must not capture a copy gesture.
+
+    A user who has just highlighted text in the composer is mid-copy, not
+    scrapping a draft — and a highlighted composer always has text in it, so
+    without this the draft rung would take every such press. Two costs if it
+    did: Ctrl+C stops being the interrupt in the widget that is focused in
+    essentially every frame, and clearing the composer destroys the very text
+    the user was reaching for.
+
+    The composer's own copy is hung off the mouse release for the same reason.
+    """
+    session = SteerableSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(pilot, app)
+        session.streaming = True
+        editor = app.query_one(Editor)
+        editor.focus()
+        editor.text = "summarise the ingest path please"
+        await pilot.pause()
+
+        # Highlight part of the draft, exactly as a drag would leave it.
+        editor.selection = Selection((0, 0), (0, 19))
+        await pilot.pause()
+        assert editor.selected_text, "the highlight must be live for this to mean anything"
+
+        await pilot.press("ctrl+c")
+        await pilot.pause(0.1)
+
+        assert session.aborts == [
+            "interrupted"
+        ], "Ctrl+C under a live highlight was captured by the draft rung"
+        # And the text the user was copying is still there.
+        assert editor.text == "summarise the ingest path please"

--- a/tests/unit/tui/test_steering_approval.py
+++ b/tests/unit/tui/test_steering_approval.py
@@ -2920,3 +2920,53 @@ async def test_a_stale_highlight_does_not_divert_ctrl_c_from_the_draft() -> None
         await pilot.press("ctrl+c")
         await pilot.pause(0.1)
         assert app.is_running, "a second reflexive tap exited the app"
+
+
+@pytest.mark.asyncio
+async def test_moving_the_caret_after_a_copy_gives_ctrl_c_back_to_the_draft() -> None:
+    """D20, design review round 6. The deferral must retire when the copy does.
+
+    `_copied` alone retires only on an EDIT, so clicking elsewhere or pressing
+    an arrow left it set with nothing on screen: the user saw a plain draft,
+    got the interrupt instead, and the second reflexive tap quit with the draft
+    lost. That is the D17 damage again, reached by swapping one invisible
+    long-lived flag for another.
+
+    The guard is therefore `_copied` AND a live highlight. The pair is
+    self-retiring and, more to the point, VISIBLE — the key means "interrupt"
+    exactly while the highlight the copy took is on screen, which is the same
+    window in which the user perceives a copy at all.
+    """
+    session = SteerableSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(pilot, app)
+        session.streaming = True
+        editor = app.query_one(Editor)
+        editor.focus()
+        editor.text = "a half-typed prompt I do not want to lose"
+        await pilot.pause()
+
+        # Stand in for a completed drag-copy: the flag is set and the highlight
+        # it took is still on screen.
+        editor.selection = Selection((0, 0), (0, 10))
+        editor._copied = True
+        await pilot.pause()
+
+        # Moving the caret collapses the highlight — the copy is over, and the
+        # user can see that it is.
+        await pilot.press("right")
+        await pilot.pause()
+        assert not editor.selected_text, "the highlight should be gone"
+        assert editor._copied, "this test is only meaningful while _copied is still set"
+
+        await pilot.press("ctrl+c")
+        await pilot.pause(0.1)
+
+        assert session.aborts == [], "a retired copy still diverted the key"
+        assert editor.text == "", "the draft was not cleared"
+        assert "a half-typed prompt I do not want to lose" in editor.prompt_history()
+
+        await pilot.press("ctrl+c")
+        await pilot.pause(0.1)
+        assert app.is_running, "the second tap quit with the draft lost"

--- a/tests/unit/tui/test_steering_approval.py
+++ b/tests/unit/tui/test_steering_approval.py
@@ -2958,11 +2958,13 @@ async def test_moving_the_caret_after_a_copy_gives_ctrl_c_back_to_the_draft() ->
         await pilot.press("right")
         await pilot.pause()
         assert not editor.selected_text, "the highlight should be gone"
-        # `_copied` is retired by the selection watcher the moment the highlight
-        # it took stops being the one on screen, which is the root-cause fix for
-        # this family of bugs. The assertion that matters is the BEHAVIOUR
-        # below, not which flag carries it.
-        assert not editor._copied, "the copy claim should retire with its highlight"
+        # The GESTURE claim retires with the highlight it took; the RECEIPT
+        # flag does not, because the toast it drives is still true (the text
+        # really is on the clipboard). Asserting both is what keeps the two
+        # lifetimes from being fused again — doing so cost a stale receipt once
+        # already (R18-1).
+        assert not editor._copy_gesture, "the gesture claim should retire with its highlight"
+        assert editor._copied, "the receipt is still true and must not be retired here"
 
         await pilot.press("ctrl+c")
         await pilot.pause(0.1)

--- a/tests/unit/tui/test_steering_approval.py
+++ b/tests/unit/tui/test_steering_approval.py
@@ -67,6 +67,7 @@ from local_operator.tui.widgets.tool_card import ToolCard
 from local_operator.tui.widgets.transcript import (
     NoticeBlock,
     TranscriptView,
+    UserBlock,
     WorkingBlock,
 )
 
@@ -2787,3 +2788,89 @@ async def test_the_late_row_promises_the_number_of_presses_it_actually_costs() -
         assert session.subagent_cancels == [
             "interrupted"
         ], "the row promised one more press and one more press did not escalate"
+
+
+@pytest.mark.asyncio
+async def test_a_buried_ladder_row_moves_to_where_the_user_is_looking() -> None:
+    """Review round 3, R3-2. Restating in place must not repaint off-screen.
+
+    `_stop_notice` outlives the turn that created it, so a later press can find
+    it far up in scrollback. D5's unconditional in-place restate repainted it
+    there and left the visible frame unchanged — the silent no-op D1 was filed
+    for, reintroduced on a different axis. When the row is no longer the
+    transcript's tail it is dropped and re-appended, which keeps both the
+    replace-don't-stack promise and the guarantee that a press is visible.
+    """
+    session = SteerableSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(pilot, app)
+        session.streaming = True
+        session.running_children = 2
+
+        await pilot.press("escape")
+        await pilot.pause(0.1)
+        first = app._stop_notice
+        assert first is not None
+
+        # The conversation carries on until the row is genuinely off screen —
+        # asserted, not assumed, since a short transcript would not scroll and
+        # the test would then be exercising the visible path by accident.
+        for turn in range(30):
+            app._append_block(UserBlock(f"another question {turn}"))
+            prose = AssistantBlock()
+            prose.update_text(f"another answer {turn} " + "padding " * 20)
+            app._append_block(prose)
+        await pilot.pause()
+        await pilot.pause()
+        assert not app._is_on_screen(first), "the row never scrolled out of sight"
+
+        # A later press must produce a row the user can actually see.
+        session.streaming = True
+        await pilot.press("escape")
+        await pilot.pause(0.1)
+        # The append scrolls the transcript; let the layout settle before
+        # asking where the row landed.
+        for _ in range(5):
+            await pilot.pause()
+
+        blocks = app._transcript_view().blocks()
+        assert blocks[-1] is app._stop_notice, "the ladder row did not move to the tail"
+        assert first not in blocks, "the buried row was left behind as a duplicate"
+        # And the new row is where the user is actually looking, which is the
+        # whole point: a press that repaints only off-screen rows is a press
+        # the user cannot tell from a dropped keystroke.
+        moved = app._stop_notice
+        assert moved is not None
+        assert app._is_on_screen(moved), "the moved row is still not visible"
+
+
+@pytest.mark.asyncio
+async def test_the_expired_row_recounts_rather_than_restating_a_stale_number() -> None:
+    """Review round 3, R3-3. The surviving row is present tense, so it must be
+    presently true.
+
+    The expiry used to restate the count captured when the offer was ARMED, in
+    the calm receipt weight — so children that finished during the 4s window
+    left the transcript asserting "2 subagents still running" as settled fact.
+    Better than leaving an amber offer up forever, but one step short.
+    """
+    session = SteerableSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(pilot, app)
+        session.streaming = True
+        session.running_children = 2
+
+        await pilot.press("escape")
+        await pilot.pause(0.1)
+        assert any("2 subagents still running" in row for row in rows(app))
+
+        # They finish on their own inside the window.
+        session.running_children = 0
+        await pilot.pause(DOUBLE_STOP_WINDOW_S + 0.5)
+
+        painted = rows(app)
+        assert not any(
+            "still running" in row for row in painted
+        ), "the expired row asserted running subagents that had already finished"

--- a/tests/unit/tui/test_steering_approval.py
+++ b/tests/unit/tui/test_steering_approval.py
@@ -35,7 +35,11 @@ from local_operator.harness.types import (
 )
 from local_operator.paths import CONFIG_DIR_ENV
 from local_operator.resume import TRANSCRIPT_NAME
-from local_operator.tui.app import DOUBLE_INTERRUPT_WINDOW_S, OperatorApp
+from local_operator.tui.app import (
+    DOUBLE_INTERRUPT_WINDOW_S,
+    DOUBLE_STOP_WINDOW_S,
+    OperatorApp,
+)
 from local_operator.tui.events import (
     AssistantDelta,
     AssistantMessageEnd,
@@ -2156,3 +2160,313 @@ async def test_nothing_takes_the_keyboard_from_someone_mid_sentence() -> None:
                     await future
                 except (asyncio.CancelledError, Exception):
                     pass
+
+
+# ---------------------------------------------------------------------------
+# The Esc ladder: stop the turn, then (on a second press) the subagents
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_esc_stops_the_turn_and_offers_to_stop_the_subagents() -> None:
+    """One press stops the parent and SAYS that children are still running.
+
+    The offer is the load-bearing half. A stop that silently left three agents
+    burning tokens is the defect this ladder exists to fix, and a user has no
+    way to discover the wider stop unless the first press names it.
+    """
+    session = SteerableSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(pilot, app)
+        session.streaming = True
+        session.running_children = 2
+
+        await pilot.press("escape")
+        await pilot.pause(0.1)
+
+        assert session.aborts == ["interrupted"]
+        # The children are NOT stopped by the first press.
+        assert session.subagent_cancels == []
+        assert any("2 subagents still running" in row for row in rows(app))
+        assert any("esc again to stop them" in row for row in rows(app))
+
+
+@pytest.mark.asyncio
+async def test_a_second_esc_stops_the_subagents_and_confirms_it() -> None:
+    """The escalation press cancels the children and reports the count."""
+    session = SteerableSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(pilot, app)
+        session.streaming = True
+        session.running_children = 2
+
+        await pilot.press("escape")
+        await pilot.pause(0.1)
+        await pilot.press("escape")
+        await pilot.pause(0.1)
+
+        assert session.subagent_cancels == ["interrupted"]
+        assert any("stopped 2 subagents" in row for row in rows(app))
+        # One line, not two: the stale "still running" row would read as current.
+        assert not any("still running" in row for row in rows(app))
+
+
+@pytest.mark.asyncio
+async def test_a_slow_second_esc_does_not_stop_the_subagents() -> None:
+    """The offer expires, so a much later Esc is a fresh first press.
+
+    Without the window, an Esc pressed minutes after an unrelated stop would
+    silently kill every child — the expensive, unrecoverable action arriving
+    with no warning attached to the keystroke that triggered it.
+    """
+    session = SteerableSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(pilot, app)
+        session.streaming = True
+        session.running_children = 1
+
+        await pilot.press("escape")
+        await pilot.pause(0.1)
+        # Age the offer past its window without waiting for it.
+        assert app._stop_offered_at is not None, "the first press must make the offer"
+        app._stop_offered_at -= DOUBLE_STOP_WINDOW_S + 1
+        await pilot.press("escape")
+        await pilot.pause(0.1)
+
+        assert session.subagent_cancels == [], "an expired offer must not escalate"
+
+
+@pytest.mark.asyncio
+async def test_esc_with_no_children_says_nothing_about_subagents() -> None:
+    """The common case stays silent: no ladder, no line, no second rung."""
+    session = SteerableSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(pilot, app)
+        session.streaming = True
+
+        await pilot.press("escape")
+        await pilot.pause(0.1)
+
+        assert session.aborts == ["interrupted"]
+        assert not any("subagent" in row for row in rows(app))
+        assert app._stop_offered_at is None
+
+
+@pytest.mark.asyncio
+async def test_esc_stops_subagents_even_when_the_parent_turn_has_ended() -> None:
+    """Children outlive the turn that launched them, so Esc must still reach
+    them when the parent is already idle — that is the exact state a user is
+    in when they notice work still running and press Esc."""
+    session = SteerableSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(pilot, app)
+        session.streaming = False  # the parent finished; children did not
+        session.running_children = 3
+
+        await pilot.press("escape")
+        await pilot.pause(0.1)
+        assert any("3 subagents still running" in row for row in rows(app))
+
+        await pilot.press("escape")
+        await pilot.pause(0.1)
+        assert session.subagent_cancels == ["interrupted"]
+        assert any("stopped 3 subagents" in row for row in rows(app))
+
+
+@pytest.mark.asyncio
+async def test_esc_with_nothing_running_still_never_clears_the_composer() -> None:
+    """The rule the ladder must not break: Esc is not a way to lose a draft."""
+    session = SteerableSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(pilot, app)
+        editor = app.query_one(Editor)
+        editor.load_text("a half-typed prompt")
+
+        await pilot.press("escape")
+        await pilot.pause(0.1)
+
+        assert editor.text == "a half-typed prompt"
+        assert session.aborts == []
+
+
+# ---------------------------------------------------------------------------
+# The Ctrl+C ladder: a draft is cleared before the exit ladder starts
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ctrl_c_clears_a_draft_before_arming_the_exit_ladder() -> None:
+    """Ctrl+C on a half-typed prompt means "scrap that", not "start exiting".
+
+    This also removes the ladder's sharpest edge: the quitting press used to be
+    two taps away while the user was typing, so a reflexive double-tap at the
+    composer could close the app with a drafted prompt on screen.
+    """
+    session = SteerableSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(pilot, app)
+        editor = app.query_one(Editor)
+        editor.load_text("draft to be scrapped")
+
+        await pilot.press("ctrl+c")
+        await pilot.pause(0.1)
+
+        assert editor.text == ""
+        assert not any("ctrl+c again to exit" in row for row in rows(app))
+        # The ladder was NOT armed: the press was spent on the composer.
+        assert app._last_interrupt_at == 0.0
+        assert app.is_running
+        # And the text is recoverable rather than destroyed.
+        assert "draft to be scrapped" in editor.prompt_history()
+
+
+@pytest.mark.asyncio
+async def test_two_ctrl_c_presses_from_a_draft_do_not_exit() -> None:
+    """The first press clears; the SECOND is a first press for the ladder."""
+    session = SteerableSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(pilot, app)
+        app.query_one(Editor).load_text("draft")
+
+        await pilot.press("ctrl+c")
+        await pilot.pause(0.1)
+        await pilot.press("ctrl+c")
+        await pilot.pause(0.1)
+
+        assert app.is_running, "a double-tap from a draft must never quit"
+        assert any("ctrl+c again to exit" in row for row in rows(app))
+
+
+@pytest.mark.asyncio
+async def test_ctrl_c_on_an_empty_composer_keeps_the_exit_ladder() -> None:
+    """The existing gesture is unchanged when there is no draft to clear."""
+    session = SteerableSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(pilot, app)
+        session.streaming = True
+
+        await pilot.press("ctrl+c")
+        await pilot.pause(0.1)
+        assert session.aborts == ["interrupted"]
+        assert any("ctrl+c again to exit" in row for row in rows(app))
+
+        await pilot.press("ctrl+c")
+        await pilot.pause(0.3)
+        assert not app.is_running
+
+
+@pytest.mark.asyncio
+async def test_whitespace_only_draft_is_not_treated_as_a_draft() -> None:
+    """Spaces and newlines are not something a user asked to keep, so the key
+    keeps its interrupt meaning rather than being silently swallowed."""
+    session = SteerableSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(pilot, app)
+        session.streaming = True
+        app.query_one(Editor).load_text("   \n  ")
+
+        await pilot.press("ctrl+c")
+        await pilot.pause(0.1)
+
+        assert session.aborts == ["interrupted"]
+        assert any("ctrl+c again to exit" in row for row in rows(app))
+
+
+@pytest.mark.asyncio
+async def test_clearing_the_transcript_disarms_the_stop_offer() -> None:
+    """`/clear` removes the offer's line, so the offer must go with it.
+
+    Two failures at once otherwise: `_replace_stop_notice` would try to remove
+    a block the transcript no longer holds, and an escalation would stay armed
+    whose terms the user can no longer read.
+    """
+    session = SteerableSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(pilot, app)
+        session.streaming = True
+        session.running_children = 2
+
+        await pilot.press("escape")
+        await pilot.pause(0.1)
+        assert app._stop_offered_at is not None
+
+        app.action_clear_transcript()
+        await pilot.pause(0.1)
+        assert app._stop_offered_at is None
+        assert app._stop_notice is None
+
+        # And the next Esc is a FIRST press, not an escalation.
+        await pilot.press("escape")
+        await pilot.pause(0.1)
+        assert session.subagent_cancels == []
+
+
+@pytest.mark.asyncio
+async def test_a_stop_offer_does_not_survive_into_a_new_session() -> None:
+    """The sharpest cross-session leak in this family: an armed escalation.
+
+    Carried across a session swap, an Esc pressed just after `/new` would take
+    up an offer made about the OLD conversation's children and cancel the NEW
+    session's subagents — destroying work on the strength of a count the user
+    was shown for a different conversation.
+    """
+    session = SteerableSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(pilot, app)
+        session.streaming = True
+        session.running_children = 2
+
+        await pilot.press("escape")
+        await pilot.pause(0.1)
+        assert app._stop_offered_at is not None, "the offer must be armed first"
+
+        await app._reload_session()
+        await pilot.pause(0.1)
+
+        assert app._stop_offered_at is None
+        assert app._stop_notice is None
+
+
+@pytest.mark.asyncio
+async def test_ctrl_c_never_files_an_aside_question_in_prompt_history() -> None:
+    """Review round 1, M2. The aside's "off the record" is a contract.
+
+    The card prints "off the record — nothing here joins the chat", and
+    `set_records_history(False)` is how that is enforced. `remember_draft`
+    bypassed the flag, so Ctrl+C filed a question the user deliberately kept
+    out of the conversation into the recallable history — one `up` and one
+    Enter from being sent to the agent as a real turn.
+
+    The press closes the card instead, which is the path that already means
+    "done with this aside" and hands back the borrowed main-chat draft.
+    """
+    session = SteerableSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(pilot, app)
+        editor = app.query_one(Editor)
+        app._open_aside()
+        await pilot.pause(0.1)
+        editor.load_text("is my salary competitive?")
+        await pilot.pause(0.1)
+        assert editor._records_history is False, "the aside must suppress recording"
+
+        await pilot.press("ctrl+c")
+        await pilot.pause(0.15)
+
+        assert not any(
+            "salary" in entry for entry in editor.prompt_history()
+        ), "the off-the-record question reached the recallable history"
+        assert app.is_running

--- a/tests/unit/tui/test_steering_approval.py
+++ b/tests/unit/tui/test_steering_approval.py
@@ -73,6 +73,7 @@ from local_operator.tui.widgets.transcript import (
 )
 
 from .test_app_pilot import FakeSession, _factory
+from .test_transcript_selection import _cell, _composer_drag
 
 
 class SteerableSession(FakeSession):
@@ -2946,12 +2947,18 @@ async def test_moving_the_caret_after_a_copy_gives_ctrl_c_back_to_the_draft() ->
         editor.focus()
         editor.text = "a half-typed prompt I do not want to lose"
         await pilot.pause()
-
-        # Stand in for a completed drag-copy: the flag is set and the highlight
-        # it took is still on screen.
-        editor.selection = Selection((0, 0), (0, 10))
-        editor._copied = True
         await pilot.pause()
+
+        # A REAL drag-copy, driven through the widget's own mouse path rather
+        # than by hand-setting flags. Round 19 (MAJOR-1) caught the hand-set
+        # stand-in going vacuous when `copy_in_flight` moved from `_copied` to
+        # `_copy_gesture`: the stand-in never armed the deferral, so the test
+        # verified that a caret move retires something already retired. Driving
+        # the real gesture ties this guard to whatever predicate the widget
+        # actually arms, so a future re-pointing cannot silently disarm it.
+        await _composer_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 10))
+        assert editor.copy_in_flight, "the drag must arm the deferral for this test to bite"
+        assert editor.selected_text, "the copy's own highlight must be on screen"
 
         # Moving the caret collapses the highlight — the copy is over, and the
         # user can see that it is.

--- a/tests/unit/tui/test_steering_approval.py
+++ b/tests/unit/tui/test_steering_approval.py
@@ -18,6 +18,7 @@ routes messages internally.
 from __future__ import annotations
 
 import asyncio
+import time
 from collections.abc import Awaitable, Callable, Sequence
 from pathlib import Path
 from typing import Any, cast
@@ -2469,4 +2470,243 @@ async def test_ctrl_c_never_files_an_aside_question_in_prompt_history() -> None:
         assert not any(
             "salary" in entry for entry in editor.prompt_history()
         ), "the off-the-record question reached the recallable history"
+        assert app.is_running
+
+
+# ---------------------------------------------------------------------------
+# Design review round 1: what the ladder SAYS when its own state has moved on.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_late_second_esc_is_acknowledged_rather_than_silently_ignored() -> None:
+    """A press that misses the window must not repaint an identical row.
+
+    Past DOUBLE_STOP_WINDOW_S the press falls through to the ordinary stop,
+    which re-arms the offer. Reprinting the same string there made the press
+    indistinguishable from a dropped keystroke — the rendered frame was byte
+    for byte the same — on the very key this change exists to stop making
+    silent promises (D1). The re-armed offer now states the constraint that
+    defeated the press, so the user learns why nothing was stopped.
+    """
+    session = SteerableSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(pilot, app)
+        session.streaming = True
+        session.running_children = 2
+
+        await pilot.press("escape")
+        await pilot.pause(0.1)
+        assert any("esc again to stop them" in row for row in rows(app))
+
+        # The window lapses without a second press.
+        app._stop_offered_at = time.monotonic() - (DOUBLE_STOP_WINDOW_S + 1)
+        await pilot.press("escape")
+        await pilot.pause(0.1)
+
+        # Nothing was stopped — that part is by design — but the row CHANGED,
+        # so the press is visibly acknowledged.
+        assert session.subagent_cancels == []
+        assert any(
+            "press esc twice within" in row for row in rows(app)
+        ), "the late press repainted an identical row and read as a dropped key"
+
+
+@pytest.mark.asyncio
+async def test_children_finishing_between_presses_is_not_reported_as_a_denial() -> None:
+    """ "no subagents were running" must not contradict the offer (D2).
+
+    `cancel_subagents` recounts at press time, so children that settle inside
+    the window return zero. Printing a flat denial there replaces a row that
+    just said "2 subagents still running" and reads as "the first message was
+    wrong" — re-raising the credibility problem this change exists to fix,
+    when what actually happened is better news than the offer implied.
+    """
+    session = SteerableSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(pilot, app)
+        session.streaming = True
+        session.running_children = 2
+
+        await pilot.press("escape")
+        await pilot.pause(0.1)
+
+        # They finish on their own before the user's second press lands.
+        session.running_children = 0
+        await pilot.press("escape")
+        await pilot.pause(0.1)
+
+        painted = rows(app)
+        assert any(
+            "finished before the stop landed" in row for row in painted
+        ), "the confirmation did not explain that the children had finished"
+        assert not any(
+            "no subagents were running" in row for row in painted
+        ), "the confirmation flatly denied the offer the user had just read"
+
+
+@pytest.mark.asyncio
+async def test_a_stop_that_spares_background_jobs_says_so() -> None:
+    """Escalating reads as "stop all of it", and `bash` jobs deliberately
+    survive it (D3). The one moment that is worth a word is the confirmation,
+    and only when such a job actually exists."""
+    session = SteerableSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(pilot, app)
+        session.streaming = True
+        session.running_children = 1
+        session.running_bash_jobs = 1
+
+        await pilot.press("escape")
+        await pilot.pause(0.1)
+        app._stop_offered_at = time.monotonic()
+        await pilot.press("escape")
+        await pilot.pause(0.1)
+
+        painted = rows(app)
+        assert any("stopped 1 subagent" in row for row in painted)
+        assert any(
+            "background job" in row and "jobs cancel" in row for row in painted
+        ), "the spared background job was not named"
+
+
+@pytest.mark.asyncio
+async def test_the_confirmation_stays_quiet_when_nothing_was_spared() -> None:
+    """The `bash` clause is conditional: unconditional, it would be noise on
+    every stop (D3)."""
+    session = SteerableSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(pilot, app)
+        session.streaming = True
+        session.running_children = 1
+        session.running_bash_jobs = 0
+
+        await pilot.press("escape")
+        await pilot.pause(0.1)
+        app._stop_offered_at = time.monotonic()
+        await pilot.press("escape")
+        await pilot.pause(0.1)
+
+        assert not any("background job" in row for row in rows(app))
+
+
+@pytest.mark.asyncio
+async def test_the_offer_retires_its_promise_when_the_window_closes() -> None:
+    """An instruction that no key will honour must not stand (D4).
+
+    Nothing cleared the row, so a transcript kept a warning-amber
+    "esc again to stop them" for the rest of the session, scrolling up through
+    the history with no visible expiry. The FACT survives — the children really
+    are still running — only the promise goes, and it drops out of the warning
+    weight because it is no longer something to act on within a window.
+    """
+    session = SteerableSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(pilot, app)
+        session.streaming = True
+        session.running_children = 2
+
+        await pilot.press("escape")
+        await pilot.pause(0.1)
+        assert any("esc again to stop them" in row for row in rows(app))
+
+        # Wait out the real window rather than reaching into the timer.
+        await pilot.pause(DOUBLE_STOP_WINDOW_S + 0.5)
+
+        painted = rows(app)
+        assert not any(
+            "esc again to stop them" in row for row in painted
+        ), "the expired offer went on advertising an escalation no key honours"
+        assert any(
+            "2 subagents still running" in row for row in painted
+        ), "the surviving fact was dropped along with the promise"
+
+
+@pytest.mark.asyncio
+async def test_taking_the_offer_is_not_undone_by_the_expiry_timer() -> None:
+    """The timer is keyed on the stamp it was armed with, so it can never
+    retire an offer that was already taken, nor a newer one armed since."""
+    session = SteerableSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(pilot, app)
+        session.streaming = True
+        session.running_children = 2
+
+        await pilot.press("escape")
+        await pilot.pause(0.1)
+        app._stop_offered_at = time.monotonic()
+        await pilot.press("escape")
+        await pilot.pause(0.1)
+        assert session.subagent_cancels == ["interrupted"]
+
+        # The first press's timer fires somewhere in here and must do nothing.
+        await pilot.pause(DOUBLE_STOP_WINDOW_S + 0.5)
+
+        assert any(
+            "stopped 2 subagents" in row for row in rows(app)
+        ), "the expiry timer overwrote the confirmation of a stop that happened"
+
+
+@pytest.mark.asyncio
+async def test_the_ladder_row_keeps_its_place_in_the_transcript() -> None:
+    """Replacing the row must not move it (D5).
+
+    `_replace_stop_notice` used to remove and re-append, so the row jumped to
+    the transcript end and landed BELOW notices that had arrived after it —
+    a row the user had already read reordering itself past later ones. The
+    replacement now restates in place, which keeps both the replace-don't-stack
+    decision and a chronological transcript.
+    """
+    session = SteerableSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(pilot, app)
+        session.streaming = True
+        session.running_children = 2
+
+        await pilot.press("escape")
+        await pilot.pause(0.1)
+        # A notice arrives after the offer, as the aborted turn's own does.
+        app._append_block(NoticeBlock("interrupted", "info"))
+        await pilot.pause()
+
+        app._stop_offered_at = time.monotonic()
+        await pilot.press("escape")
+        await pilot.pause(0.1)
+
+        painted = [row for row in rows(app) if row.strip()]
+        ladder = next(i for i, row in enumerate(painted) if "stopped 2 subagents" in row)
+        later = next(i for i, row in enumerate(painted) if "interrupted" in row)
+        assert ladder < later, "the restated ladder row jumped below a later notice"
+
+
+@pytest.mark.asyncio
+async def test_ctrl_c_says_where_the_draft_went() -> None:
+    """Filing the draft into history is the point of this rung, but all the
+    user sees is their sentence vanishing — and recoverability nobody can
+    discover gets retyped instead of recalled (D6)."""
+    session = SteerableSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(pilot, app)
+        editor = app.query_one(Editor)
+        editor.focus()
+        editor.text = "a half-typed prompt I do not want to lose"
+        await pilot.pause()
+
+        await pilot.press("ctrl+c")
+        await pilot.pause(0.1)
+
+        painted = rows(app)
+        assert any(
+            "draft cleared" in row and "up to recover" in row for row in painted
+        ), "the draft vanished with nothing to say it was recoverable"
+        # And the exit ladder is still NOT armed by this press.
+        assert not any("ctrl+c again" in row for row in painted)
         assert app.is_running

--- a/tests/unit/tui/test_steering_approval.py
+++ b/tests/unit/tui/test_steering_approval.py
@@ -2878,17 +2878,18 @@ async def test_the_expired_row_recounts_rather_than_restating_a_stale_number() -
 
 
 @pytest.mark.asyncio
-async def test_a_highlighted_composer_keeps_ctrl_c_as_the_interrupt() -> None:
-    """The draft rung must not capture a copy gesture.
+async def test_a_stale_highlight_does_not_divert_ctrl_c_from_the_draft() -> None:
+    """D17, design round 5. Gate on the GESTURE, not on the selection.
 
-    A user who has just highlighted text in the composer is mid-copy, not
-    scrapping a draft — and a highlighted composer always has text in it, so
-    without this the draft rung would take every such press. Two costs if it
-    did: Ctrl+C stops being the interrupt in the widget that is focused in
-    essentially every frame, and clearing the composer destroys the very text
-    the user was reaching for.
+    A selection is state that persists until the caret moves, so "the composer
+    has a highlight" stays true long after any copy ended. Gating on it meant a
+    composer holding a stale range took the interrupt, ARMED the exit ladder,
+    and a second reflexive tap quit the app with the draft never filed — the
+    exact hazard this rung was added to remove, reintroduced by its own guard.
 
-    The composer's own copy is hung off the mouse release for the same reason.
+    A real drag-copy is covered from the other side by
+    `test_a_composer_drag_still_leaves_ctrl_c_as_the_interrupt` in
+    `test_transcript_selection.py`, which this must not break.
     """
     session = SteerableSession()
     app = OperatorApp(lambda: _factory(session))
@@ -2897,19 +2898,25 @@ async def test_a_highlighted_composer_keeps_ctrl_c_as_the_interrupt() -> None:
         session.streaming = True
         editor = app.query_one(Editor)
         editor.focus()
-        editor.text = "summarise the ingest path please"
+        editor.text = "a half-typed prompt I do not want to lose"
         await pilot.pause()
 
-        # Highlight part of the draft, exactly as a drag would leave it.
-        editor.selection = Selection((0, 0), (0, 19))
+        # A highlight with no gesture in flight: the caret simply sits inside a
+        # range the user selected earlier.
+        editor.selection = Selection((0, 0), (0, 10))
         await pilot.pause()
-        assert editor.selected_text, "the highlight must be live for this to mean anything"
+        assert editor.selected_text, "the stale highlight must be live to mean anything"
+        assert not getattr(editor, "_selecting", False), "no drag should be in flight"
 
         await pilot.press("ctrl+c")
         await pilot.pause(0.1)
 
-        assert session.aborts == [
-            "interrupted"
-        ], "Ctrl+C under a live highlight was captured by the draft rung"
-        # And the text the user was copying is still there.
-        assert editor.text == "summarise the ingest path please"
+        # The draft rung takes it: filed, not aborted, ladder NOT armed.
+        assert session.aborts == [], "a stale highlight diverted the key to the interrupt"
+        assert editor.text == "", "the draft was not cleared"
+        assert "a half-typed prompt I do not want to lose" in editor.prompt_history()
+
+        # And the second press must not quit, which is the damage D17 named.
+        await pilot.press("ctrl+c")
+        await pilot.pause(0.1)
+        assert app.is_running, "a second reflexive tap exited the app"

--- a/tests/unit/tui/test_steering_approval.py
+++ b/tests/unit/tui/test_steering_approval.py
@@ -2710,3 +2710,44 @@ async def test_ctrl_c_says_where_the_draft_went() -> None:
         # And the exit ladder is still NOT armed by this press.
         assert not any("ctrl+c again" in row for row in painted)
         assert app.is_running
+
+
+@pytest.mark.asyncio
+async def test_an_armed_offer_never_outranks_a_waiting_approval() -> None:
+    """A permission gate takes Escape ahead of the escalation (R1).
+
+    Round 1's F5 was the ask picker outranking an approval; the escalation
+    branch was a second door to the same inversion. With the offer armed and
+    an `rm -rf /` approval on screen, Escape has to answer the PROMPT — the
+    thing the engine is blocked on and the most recently raised surface — not
+    silently destroy every delegated child on a press the user could
+    reasonably have aimed at the approval in front of them.
+
+    The offer survives unspent, so the next press still escalates.
+    """
+    session = SteerableSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        ask = await _booted_gate(pilot, session)
+        session.streaming = True
+        session.running_children = 2
+
+        pending = asyncio.ensure_future(ask("bash", "run: rm -rf /"))
+        for _ in range(100):
+            if isinstance(app.screen.focused, ApprovalPrompt):
+                break
+            await pilot.pause(0.02)
+        assert app._live_prompt() is app._approval, "the approval is not the live prompt"
+
+        # Arm the ladder exactly as a first Esc during the turn would.
+        app._stop_offered_at = time.monotonic()
+        app._stop_offer_count = 2
+
+        await pilot.press("escape")
+        await pilot.pause(0.2)
+
+        assert (
+            session.subagent_cancels == []
+        ), "Escape escalated past a waiting approval and killed the subagents"
+        assert await asyncio.wait_for(pending, 2) is False, "the approval was not denied"
+        pending.cancel()

--- a/tests/unit/tui/test_steering_approval.py
+++ b/tests/unit/tui/test_steering_approval.py
@@ -2958,7 +2958,11 @@ async def test_moving_the_caret_after_a_copy_gives_ctrl_c_back_to_the_draft() ->
         await pilot.press("right")
         await pilot.pause()
         assert not editor.selected_text, "the highlight should be gone"
-        assert editor._copied, "this test is only meaningful while _copied is still set"
+        # `_copied` is retired by the selection watcher the moment the highlight
+        # it took stops being the one on screen, which is the root-cause fix for
+        # this family of bugs. The assertion that matters is the BEHAVIOUR
+        # below, not which flag carries it.
+        assert not editor._copied, "the copy claim should retire with its highlight"
 
         await pilot.press("ctrl+c")
         await pilot.pause(0.1)

--- a/tests/unit/tui/test_steering_approval.py
+++ b/tests/unit/tui/test_steering_approval.py
@@ -2509,7 +2509,7 @@ async def test_a_late_second_esc_is_acknowledged_rather_than_silently_ignored() 
         # so the press is visibly acknowledged.
         assert session.subagent_cancels == []
         assert any(
-            "press esc twice within" in row for row in rows(app)
+            "too slow; esc again within" in row for row in rows(app)
         ), "the late press repainted an identical row and read as a dropped key"
 
 
@@ -2705,7 +2705,7 @@ async def test_ctrl_c_says_where_the_draft_went() -> None:
 
         painted = rows(app)
         assert any(
-            "draft cleared" in row and "up to recover" in row for row in painted
+            "draft cleared" in row and "↑ to recover" in row for row in painted
         ), "the draft vanished with nothing to say it was recoverable"
         # And the exit ladder is still NOT armed by this press.
         assert not any("ctrl+c again" in row for row in painted)
@@ -2751,3 +2751,39 @@ async def test_an_armed_offer_never_outranks_a_waiting_approval() -> None:
         ), "Escape escalated past a waiting approval and killed the subagents"
         assert await asyncio.wait_for(pending, 2) is False, "the approval was not denied"
         pending.cancel()
+
+
+@pytest.mark.asyncio
+async def test_the_late_row_promises_the_number_of_presses_it_actually_costs() -> None:
+    """The re-armed offer must not overstate the cost by one (D9).
+
+    The late press itself re-arms the ladder, so by the time its row is painted
+    the offer is live and the very NEXT single press escalates. Saying "press
+    esc twice" there described the ladder in general rather than the state the
+    user is actually in — harmless to obey, but wrong on the one key this
+    change exists to make honest.
+    """
+    session = SteerableSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(pilot, app)
+        session.streaming = True
+        session.running_children = 2
+
+        await pilot.press("escape")
+        await pilot.pause(0.1)
+
+        # The window lapses, so this press cannot escalate — it re-arms.
+        app._stop_offered_at = time.monotonic() - (DOUBLE_STOP_WINDOW_S + 1)
+        await pilot.press("escape")
+        await pilot.pause(0.1)
+        assert session.subagent_cancels == []
+        assert any("esc again within" in row for row in rows(app))
+
+        # ONE further press, exactly as the row now promises.
+        await pilot.press("escape")
+        await pilot.pause(0.1)
+
+        assert session.subagent_cancels == [
+            "interrupted"
+        ], "the row promised one more press and one more press did not escalate"

--- a/tests/unit/tui/test_transcript_selection.py
+++ b/tests/unit/tui/test_transcript_selection.py
@@ -1853,3 +1853,67 @@ async def test_a_new_selection_after_a_copy_does_not_rearm_the_interrupt() -> No
         await pilot.press("ctrl+c")
         await pilot.pause()
         assert app.is_running, "the second tap quit with the draft unfiled"
+
+
+@pytest.mark.asyncio
+async def test_a_blurred_composer_still_paints_the_copy_it_is_deferring_to() -> None:
+    """D25, design review round 8. "On screen" must not quietly become "focused".
+
+    Ctrl+C hands the key to a copy while the highlight that copy took is still
+    VISIBLE, and the user learns that rule from the pixels. Blur is the one
+    place where "on screen" and "focused" come apart: the composer can lose
+    focus with its selection still painted, and the deferral correctly follows
+    the paint rather than the focus.
+
+    That makes the promise true today by a property nothing pins — a future
+    change to blurred-selection styling would silently turn this into the fifth
+    lost draft in this rung's history. This asserts the paint, so such a change
+    fails here loudly instead.
+    """
+    session = FakeSession()
+    app = _pilot_app(session)
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        editor = await _composer(app, pilot, "summarise the ingest path please")
+        await _composer_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 20))
+        assert editor._copied, "the drag should have copied"
+
+        def selection_is_painted() -> bool:
+            """Is the composer's selection tint anywhere on its row?
+
+            Text alone would not catch a regression here — a composer that
+            stopped HIGHLIGHTING its selection still paints the same
+            characters, so the STYLE is the whole subject. The tint is read
+            from the live paint while focused rather than hard-coded, so a
+            theme change cannot turn this into a false alarm.
+            """
+            row = editor.region.y
+            strip = app.screen._compositor.render_strips()[row]
+            return tint in {
+                str(segment.style.bgcolor)
+                for segment in strip
+                if segment.style is not None and segment.style.bgcolor is not None
+            }
+
+        row = editor.region.y
+        focused_strip = app.screen._compositor.render_strips()[row]
+        tints = [
+            str(segment.style.bgcolor)
+            for segment in focused_strip
+            if segment.style is not None and segment.style.bgcolor is not None
+        ]
+        assert tints, "the focused composer painted no selection tint at all"
+        tint = tints[0]
+
+        # Blur the composer WITHOUT touching the selection.
+        app.set_focus(None)
+        await pilot.pause()
+        assert not editor.has_focus, "the composer should be blurred"
+        assert editor.selected_text, "blur must not clear the selection itself"
+
+        # The highlight the deferral promises the user is still on screen, so
+        # the rule the comment states still describes what they can see.
+        assert selection_is_painted(), (
+            "a blurred composer stopped painting the copy's highlight, so the "
+            "Ctrl+C deferral now rests on state the user cannot see"
+        )

--- a/tests/unit/tui/test_transcript_selection.py
+++ b/tests/unit/tui/test_transcript_selection.py
@@ -1806,3 +1806,47 @@ async def test_a_receipt_promoted_from_the_hold_can_still_be_retired() -> None:
 
         assert toast.message == ""
         assert toast.display is False
+
+
+@pytest.mark.asyncio
+async def test_a_new_selection_after_a_copy_does_not_rearm_the_interrupt() -> None:
+    """D22, design review round 7. The deferral belongs to ONE highlight.
+
+    Ctrl+C hands the key to an in-flight copy, and the composer's copy lands on
+    mouse release — so the deferral has to outlive the release by exactly as
+    long as the copy's own highlight is on screen. Testing "`_copied` and *a*
+    selection" was one predicate too weak: after the copied range was collapsed
+    by a caret move, an unrelated shift+arrow selection re-armed the deferral,
+    so the first press aborted instead of clearing and the second QUIT with the
+    draft unfiled. Two pixel-identical frames carried opposite meanings.
+
+    Driven with a real drag, so `_copied` is set by the widget's own
+    `_copy_drag` rather than by the test.
+    """
+    session = FakeSession()
+    app = _pilot_app(session)
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        editor = await _composer(app, pilot, "summarise the ingest path please")
+        await _composer_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 20))
+        assert editor._copied, "the drag should have copied"
+
+        # The caret moves, collapsing the copied range...
+        await pilot.press("right")
+        await pilot.pause()
+        # ...and the user makes a NEW, unrelated selection with the keyboard.
+        await pilot.press("shift+end")
+        await pilot.pause()
+        assert editor.selected_text, "the new selection must be live to mean anything"
+        assert editor._copied, "this is only meaningful while _copied is still set"
+
+        session.aborts.clear()
+        await pilot.press("ctrl+c")
+        await pilot.pause()
+
+        assert session.aborts == [], "an unrelated selection re-armed the copy deferral"
+        assert editor.text == "", "the draft was not cleared"
+
+        await pilot.press("ctrl+c")
+        await pilot.pause()
+        assert app.is_running, "the second tap quit with the draft unfiled"

--- a/tests/unit/tui/test_transcript_selection.py
+++ b/tests/unit/tui/test_transcript_selection.py
@@ -1829,7 +1829,7 @@ async def test_a_new_selection_after_a_copy_does_not_rearm_the_interrupt() -> No
         await pilot.pause()
         editor = await _composer(app, pilot, "summarise the ingest path please")
         await _composer_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 20))
-        assert editor._copied, "the drag should have copied"
+        assert editor._copy_gesture, "the drag should have started a copy gesture"
 
         # The caret moves, collapsing the copied range...
         await pilot.press("right")
@@ -1838,10 +1838,12 @@ async def test_a_new_selection_after_a_copy_does_not_rearm_the_interrupt() -> No
         await pilot.press("shift+end")
         await pilot.pause()
         assert editor.selected_text, "the new selection must be live to mean anything"
-        # The watcher retired the copy claim when the caret moved off the range
-        # it took; the unrelated selection cannot resurrect it. Asserted because
-        # three previous attempts died on `_copied` outliving its own highlight.
-        assert not editor._copied, "an unrelated selection kept the copy claim alive"
+        # The watcher retired the GESTURE claim when the caret moved off the
+        # range it took, and an unrelated selection cannot resurrect it. The
+        # receipt flag is deliberately untouched: the clipboard still holds what
+        # it took, so the toast is still true (R18-1).
+        assert not editor._copy_gesture, "an unrelated selection kept the gesture claim alive"
+        assert editor._copied, "the receipt was destroyed along with the gesture"
 
         session.aborts.clear()
         await pilot.press("ctrl+c")
@@ -1876,7 +1878,7 @@ async def test_a_blurred_composer_still_paints_the_copy_it_is_deferring_to() -> 
         await pilot.pause()
         editor = await _composer(app, pilot, "summarise the ingest path please")
         await _composer_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 20))
-        assert editor._copied, "the drag should have copied"
+        assert editor._copy_gesture, "the drag should have started a copy gesture"
 
         def selection_is_painted() -> bool:
             """Is the composer's selection tint anywhere on its row?
@@ -1917,3 +1919,49 @@ async def test_a_blurred_composer_still_paints_the_copy_it_is_deferring_to() -> 
             "a blurred composer stopped painting the copy's highlight, so the "
             "Ctrl+C deferral now rests on state the user cannot see"
         )
+
+
+@pytest.mark.asyncio
+async def test_a_receipt_retires_even_when_the_caret_moved_before_the_edit() -> None:
+    """R18-1, agent review round 18. Two claims, two lifetimes, one flag each.
+
+    The copy receipt is edit-scoped: it asserts something about text the user
+    can still see, so the first edit to that text withdraws it (design round 1,
+    D3). The Ctrl+C deferral is gesture-scoped: it ends when the highlight the
+    copy took stops being the highlight on screen.
+
+    Pointing the single `_copied` flag at the gesture lifetime gave the right
+    answer to the second question and destroyed the first — a caret move
+    retired the receipt's flag, so a later edit had nothing left to withdraw and
+    the toast sat there claiming a copy of characters that no longer existed.
+
+    Every other D3 test edits immediately after the drag with the highlight
+    still up, which is the one path a selection watcher leaves alone. This is
+    the path that was broken: caret move FIRST, edit second.
+    """
+    session = FakeSession()
+    app = _pilot_app(session)
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        editor = await _composer(app, pilot, "summarise the ingest path please")
+        await _composer_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 20))
+        assert editor._copied, "the drag should have posted a receipt"
+
+        # The caret moves off the copied range, retiring the GESTURE claim only.
+        await pilot.press("right")
+        await pilot.pause()
+        assert not editor._copy_gesture, "the gesture claim should have retired"
+        assert editor._copied, "the receipt is still true and must survive a caret move"
+
+        # NOW the user edits the copied characters away.
+        await pilot.press("backspace")
+        await pilot.pause()
+
+        assert not editor._copied, (
+            "the receipt outlived the text it describes: a caret move before the "
+            "edit left nothing for the edit to withdraw"
+        )
+        rows = [strip.text for strip in app.screen._compositor.render_strips()]
+        assert not any(
+            "copied" in row.lower() for row in rows
+        ), f"a stale copy receipt is still painted: {[r for r in rows if 'copied' in r.lower()]}"

--- a/tests/unit/tui/test_transcript_selection.py
+++ b/tests/unit/tui/test_transcript_selection.py
@@ -1838,7 +1838,10 @@ async def test_a_new_selection_after_a_copy_does_not_rearm_the_interrupt() -> No
         await pilot.press("shift+end")
         await pilot.pause()
         assert editor.selected_text, "the new selection must be live to mean anything"
-        assert editor._copied, "this is only meaningful while _copied is still set"
+        # The watcher retired the copy claim when the caret moved off the range
+        # it took; the unrelated selection cannot resurrect it. Asserted because
+        # three previous attempts died on `_copied` outliving its own highlight.
+        assert not editor._copied, "an unrelated selection kept the copy claim alive"
 
         session.aborts.clear()
         await pilot.press("ctrl+c")

--- a/tests/unit/tui/test_welcome.py
+++ b/tests/unit/tui/test_welcome.py
@@ -534,6 +534,14 @@ class FakeSession:
     def abort(self, reason: str = "interrupted") -> None:
         self.aborts.append(reason)
 
+    def cancel_subagents(self, reason: str = "interrupted") -> int:
+        """No subagents in this fake; the protocol requires the method."""
+        return 0
+
+    def running_subagents(self) -> int:
+        """No subagents in this fake; the protocol requires the method."""
+        return 0
+
     def subscribe(self, handler: Any) -> Any:
         self._handlers.append(handler)
         return lambda: None


### PR DESCRIPTION
# PR Description

## Change classification

**C2 — standard / pre-authorized.** Correctness fix to the abort path, plus one
new keyboard rung. No new dependency, no config, no transcript format change,
no wire-format change. Clean rollback (`git revert`). No RFC requested.

## The bug

> "pressing esc doesn't immediately halt all activity on the session"

Esc stopped the turn *on paper* and left the work running. `Session.abort` set
the flag and the UI said "interrupted", but three separate paths never read it,
so the model kept streaming, the tools kept running, and the subagents kept
spending. The stop was an announcement, not an action.

Reproduced before any change (script inlined at the bottom):

```console
########## BEFORE (origin/main) ##########
non-interruptible tool, immediate mode:
  turn ended 2.61s AFTER the abort
  slow: RAN TO COMPLETION after 3.00s        <-- ignored the abort entirely

interruptible tool, no steering poll:
  turn ended 2.60s AFTER the abort
  slow: RAN TO COMPLETION after 3.00s

GAP: model stream
  turn ended 2.70s AFTER the abort
  stream: PRODUCED NEXT TOKEN after 3.00s    <-- waited the model out

GAP: background subagent jobs
  Session.abort touches self.jobs? False
  subagent: STILL RUNNING, finished after 3.00s
```

The 2.6s is an artifact of the 3s fixture, not a bound. The real wait is
"however long the slowest thing in flight takes" — a `read` over a large tree,
an MCP call, a quiet model, a 40-minute delegated child.

## Four defects, each fixed at its source

**1. Non-interruptible tools ignored the abort.** `interruptible` means
"steering may redirect this" — a redirect a tool is entitled to decline. The
abort path reused that same flag as "the user may stop this", which is not a
permission any tool should get to refuse. A batch of `read`/`edit`/`write`/MCP
calls therefore ignored Esc completely. A batch-wide abort watcher now cancels
every runner regardless of the flag; steering keeps its narrower meaning.

**2. A stalled model stream was waited out.** A provider stream sits in a socket
read between tokens and nothing there consults the flag, so the abort took
effect only when the *next* token arrived — seconds on a model composing a long
reasoning block, the read timeout on a wedged connection. The stream is now
drained by a pump task that the abort cancels, and the cancellation landing
inside the read is what releases the HTTP response.

**3. The loop continued after an aborted batch.** Even with the tools cancelled,
the loop fed their results back and made *another* model call — spending a
request, and the reply to it, on a turn the user had already stopped.

**4. Esc could not stop a subagent at all.** `Session.abort` only ever touched
the parent's turn signal and never `self.jobs`, so children carried on calling
the provider after the turn that launched them had ended. No key stopped them;
this was the most expensive gap of the four and the one the report is really
about.

## The subagent decision: second press, not first

Stopping children is deliberately **not** folded into the first press. A
delegated child can be minutes into useful work, and the key people hit by
reflex to quiet the foreground should not destroy it. So:

- **Esc #1** stops the parent turn and *says* how many children are still
  running. The line is load-bearing: without it a stop silently leaves work
  running, which is the original bug wearing a hat.
- **Esc #2** (within 4s) stops the children too.

Backgrounded `bash` jobs are untouched by both, because `background=true` exists
precisely so a build or a deploy outlives the turn that started it. `jobs cancel`
still stops those, and session teardown still cancels everything.

## Ctrl+C: a rung below the exit ladder

Also requested: with a draft in the composer, the first Ctrl+C now clears the
draft and consumes the press *without arming the exit ladder*. Previously the
quitting press was two taps away while typing, so a reflexive double-tap at the
composer could close the app with a drafted prompt on screen. The draft goes to
prompt history, so `up` brings it straight back — it is not destroyed.
Whitespace-only text is not treated as a draft, so the key keeps its interrupt
meaning there.

## The subtle part: the batch must still come back paired

Every tool call has to return a `tool_result` or the next request carries a
`tool_use` with nothing answering it and the provider rejects the entire
conversation. Cancelling runners mid-flight puts pressure on exactly that
invariant, in a way worth calling out for review:

- The drain now terminates on the **runner tasks settling**, not on counting one
  receipt per task. `ensure_future` only *schedules* a runner, so a cancel
  landing in the same event-loop turn — which is what the abort watcher does —
  means the body never runs and parks no receipt. A counting drain would then
  wait forever for a receipt nobody will send. A closer posts one sentinel after
  awaiting every task; the queue is FIFO, so events still drain in order.
- Any slot whose runner never got to park a result is **backfilled** with a
  synthetic `aborted` result, so a cancel that races a runner's first line still
  cannot break the wire.
- Cleanup on abort is **bounded** (`ABORT_DRAIN_TIMEOUT_S = 2.0`). A cancelled
  tool still gets to unwind — `bash` kills its process group, `eval` tears down
  its worker — but a process refusing to die must not hold the turn open.

## Why a pump and not the obvious race

The natural implementation of "cut a stalled stream" is to race each pull
against the signal. Measured, that is a real regression: two tasks and an
`asyncio.wait` per token.

```console
$ # racing every pull, 4000-delta response
plain :     4.1 ms
raced :  1571.8 ms          <-- +1.5s of stutter on the stream this fix
added :  1567.7 ms              exists to make more responsive

$ # the pump that shipped, same response
plain :    13.6 ms
pumped:    33.6 ms  (4000 events, all delivered=True)
added :    20.0 ms
```

One task for the whole stream instead of one per token: **78x cheaper**, and the
abort still lands immediately because the cancellation goes into the socket read
rather than being polled between events.

# Testing evidence

## A. Before / after on the reproduction

Re-measured on the **rebased head** (`88b61c2`) against a pristine `origin/main`
worktree, with the same harness driving `AgentLoop.run` under the config the
real `Session` uses (`interrupt_mode="immediate"`). Both columns come from the
same script and the same machine, so they are comparable.

```console
########## BEFORE (origin/main f87f778) ##########
non-interruptible tool:
  turn ended 2.60s AFTER the abort
  slow tool: RAN TO COMPLETION after 3.01s        <-- ignored the abort entirely
  model calls made: 2                              <-- and then spent another request

interruptible tool:
  turn ended 0.10s AFTER the abort
  slow tool: CANCELLED after 0.50s
  model calls made: 2

parallel batch of 3 non-interruptible tools:
  turn ended 2.60s AFTER the abort
  slow tool: RAN TO COMPLETION after 3.00s
  model calls made: 2

GAP: stalled model stream (no tools):
  turn ended 2.60s AFTER the abort
  stream produced its next token: True             <-- waited the model out

########## AFTER (this branch, 88b61c2) ##########
non-interruptible tool:
  turn ended 0.00s AFTER the abort
  slow tool: CANCELLED after 0.40s
  model calls made: 1

interruptible tool:
  turn ended 0.00s AFTER the abort
  slow tool: CANCELLED after 0.40s
  model calls made: 1

parallel batch of 3 non-interruptible tools:
  turn ended 0.00s AFTER the abort
  slow tool: CANCELLED after 0.40s
  model calls made: 1

GAP: stalled model stream (no tools):
  turn ended 0.00s AFTER the abort
  stream produced its next token: False
```

2.60s -> 0.00s on every path. Three things changed, not one: the turn no longer
*waits*, the tool reports `CANCELLED` rather than `RAN TO COMPLETION` so the
work has actually stopped, and the follow-up model call is not made at all
(2 requests -> 1), so a stopped turn no longer spends another request and pays
for its reply.

The 2.60s is an artifact of the 3s fixture, not a bound — the real wait is
"however long the slowest thing in flight takes".

> **A trap worth recording for whoever runs this next.** The worktree's `.venv`
> is an editable install whose finder maps `local_operator` to the MAIN checkout,
> not to the worktree. A standalone script run with `.venv/bin/python` therefore
> imports the wrong tree and silently measures `main` while appearing to measure
> the branch — the first run of this harness produced a perfect "no change"
> result for exactly that reason. Run standalone scripts as
> `PYTHONPATH=$PWD .venv/bin/python ...` from the worktree root. `pytest` is
> unaffected, since rootdir goes on `sys.path` first.

## B. A REAL provider, a REAL tool (this is the one that matters)

The unit tests use scripted streams; the whole bug was that the real thing kept
running. So: a genuine `Session` from `create_session`, a genuine Opus turn, a
genuine 45-second `bash` call, stopped by exactly the call the Esc key makes.

```console
$ .venv/bin/python /tmp/esc_live.py
model: anthropic/claude-opus-5
events seen: ['agent_start', 'turn_start', 'message_start', 'tool_call_compose',
              'message_end', 'tool_execution_start']
aborting now (this is what Esc calls)...

RESULT: turn ended 0.00s after the abort (the tool still had ~43s to run)
timed out: False
is_streaming after abort: False

PASS: a real provider turn with a real 45s tool stopped immediately.
```

## C. The child process is dead, not orphaned

Cancelling the `await` is not the same as killing the process. Checked with
`ps`, against a real model-issued `bash` call:

```console
$ .venv/bin/python /tmp/esc_live2.py
(a) is the aborted tool's PROCESS actually killed?
  processes while running: 1
    44545 /bin/sh -c for i in $(seq 1 120); do echo "esc_live_marker_98213 step $i"; sleep 1; done
  processes after abort:   0
  PASS: the process group was killed, nothing orphaned.
```

## D. The subagent ladder, on a real session

```console
(b) a REAL subagent: survives Esc #1, dies on Esc #2
  after Esc #1 -> subagent: running, bash: running
  after Esc #2 -> stopped=1, subagent: cancelled, bash: running
  background bash finished as: completed / 'build survived'
  PASS: children stop on the second press; background bash is untouched.
```

Both halves of the contract: the child dies on the second press, and the
backgrounded `bash` job survives *both* presses and runs to completion.

## E. A normal turn is unaffected

The regression risk of rewriting the stream path is the happy path. Real
provider, real tool, real streaming:

```console
$ .venv/bin/python /tmp/esc_live3.py
turn completed in 3.6s
streamed deltas: 2
final text: 'hello-from-a-normal-turn'

PASS: normal turn streams and completes exactly as before.
```

Plus a unit test asserting a provider failure still surfaces as an error through
the pump (`aborted is False`, error text preserved) — a dead provider must not
be silently reported as a clean empty turn.

## F. The UI, looked at rather than asserted

Frames exported from the real `OperatorApp` (which loads `local_operator.tcss`),
driven through both ladders.

**First Esc — the offer, in warning amber (`!` glyph, top of transcript):**

```
 ! 2 subagents still running — esc again to stop them

 ❯ Message Local Operator…
 ◆ test/model  ›  ⌂ ~/worktrees/lo-esc-cancel
```

**Second Esc — the stale line is replaced, not stacked** (a "still running" row
left above "stopped them" would read as the current state):

```
 · stopped 2 subagents

 ❯ Message Local Operator…
 ◆ test/model  ›  ⌂ ~/worktrees/lo-esc-cancel
```

**Ctrl+C with a draft** — the composer goes from

```
 ❯ a half-typed prompt I do not want to lose
```

to

```
 ❯ Message Local Operator…
```

with **no** exit hint shown and the ladder not armed. The welcome block and the
input card do not shift between the two frames.

SVG frames were exported with `app.save_screenshot` from the real app and
rendered for inspection. This is now reproducible rather than hand-driven:
`scripts/stop_ladder_shot.py` (added in `88b61c2`) exports all six states —
`running`, `offer`, `stopped`, `nochildren`, `draft`, `cleared` — and each was
re-captured and **looked at** on the rebased head, not merely asserted on.

`nochildren` earns its place: a stop with nothing delegated must not mention
subagents at all, and an absence is precisely what a text assertion is worst at
catching and a frame is best at.

Verified from the same run:

```console
first esc  -> aborts: ['interrupted'] | child cancels: []
second esc -> child cancels: ['interrupted']
ctrl+c on draft -> text: '' | history: ['a half-typed prompt I do not want to lose'] | running: True
second ctrl+c -> aborts: ['interrupted'] | running: True
```

## G. Gates

Re-run in full on the rebased head (`88b61c2`):

```console
$ env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit -q
6 failed, 4747 passed, 7 skipped, 315 warnings in 645.83s (0:10:45)

$ .venv/bin/python -m flake8 .
(clean)

$ uvx --from black==26.1.0 black --check local_operator tests
369 files would be left unchanged.

$ uvx isort --check-only --profile black local_operator tests
(clean)

$ .venv/bin/python -m pyright --pythonpath .venv/bin/python .
0 errors, 0 warnings, 0 informations
```

**All six failures are pre-existing on `origin/main`**, verified by running them
on a pristine worktree detached at `f87f778` with no changes:

```console
$ cd /tmp/lo-escbase   # detached at origin/main
$ env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit/tui/test_ask_picker.py -q
5 failed, 45 passed        # the same five footer assertions

$ .venv/bin/python -m pytest tests/unit/tools/test_eval_tool.py::test_background_streams_output_while_it_runs -q
1 failed                   # AssertionError: no streamed output observed while the job ran
```

Five are footer assertions in `tests/unit/tui/test_ask_picker.py` (the painted
footer reads `◆ test/model › ⌂ <cwd>` instead of the advertised keys) and one
is the timing-sensitive `eval` background-streaming test. Both sets fail
identically with and without this branch. Pyright was confirmed clean on that
same pristine worktree first, so the protocol errors this branch initially
produced were genuinely mine (a new `SessionProtocol` method) and are fixed in
all six test fakes.

New tests: 8 in `test_loop.py` (both `interruptible` values parameterised,
parallel batches, stalled stream, untouched stream, provider failure,
pre-aborted signal, slow unwind), 5 in `test_session.py` (children stopped,
bash spared, first press narrow, zero-count, offered count == stopped count),
and the ladder tests in `test_steering_approval.py` (both ladders, window
expiry, draft recovery, offer disarmed by `/clear` and by a session swap).

## H. The rebase onto current `main`, and the second Escape meaning it created

This branch was rebased onto `f87f778`, which brought in main's
*ask-picker-in-composer* change. That change gives the `ask` card its own
Escape meaning (`esc skip`), and this PR gives Escape an escalation meaning
(second press stops the subagents) — so for the first time both can be live at
once, and a delegated child is exactly the kind of work that raises a question.

`action_stop` orders the picker-settle branch **above** the escalation branch:
answering a question the agent asked is not an abort, and escalating there
would destroy minutes of delegated work from a keypress whose own footer
advertises it as `skip`. That ordering was previously guaranteed only by the
source order of two branches; `2961000` pins the behaviour with a test that
arms the offer AND puts a question up, then asserts one press settles the
question and cancels no children.

```console
$ env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest \
    tests/unit/tui/test_ask_settle.py tests/unit/tui/test_steering_approval.py -q
106 passed in 91.93s
```

Conflict state after the rebase: `gh pr view 159` reports `mergeable=MERGEABLE`
at `88b61c2` (it was `CONFLICTING` before).

## Not in scope

Cancelling backgrounded `bash` jobs from Esc — deliberately excluded above, and
`jobs cancel` already covers it. Persisting the stop across a resume.

## Reproduction script

<details><summary>the before/after harness used at the top</summary>

It drives `AgentLoop.run` directly with a tool that records whether it was
cancelled or ran to completion, aborts mid-run, and measures the gap between the
abort and the turn ending. It is deliberately NOT committed — it is a
measurement scaffold, and the behaviour it measures is pinned by the tests in
`tests/unit/harness/test_loop.py` instead.

The UI frames, by contrast, ARE reproducible from the tree:
`scripts/stop_ladder_shot.py` exports each ladder state from the real
`OperatorApp` (the one that loads `local_operator.tcss`):

```sh
env -u NO_COLOR TERM=xterm-256color .venv/bin/python \
    scripts/stop_ladder_shot.py OUT.svg <running|offer|stopped|nochildren|draft|cleared>
```

</details>

