### PR TITLE
fix(providers): keep an uncapped xai unified-billing account in the usage view

### DIFF
--- a/local_operator/providers/usage.py
+++ b/local_operator/providers/usage.py
@@ -1588,12 +1588,38 @@ def _xai_weekly_limits(config: dict[str, Any]) -> list[UsageLimit]:
 
 
 def _xai_monthly_limits(config: dict[str, Any]) -> list[UsageLimit]:
-    """The unified-billing monthly included quota."""
+    """The unified-billing monthly quota — capped, or bare spend when uncapped.
+
+    Some unified-billing accounts are billed by their subscription plan rather
+    than metered against a numeric allowance: the bare billing URL answers
+    ``monthlyLimit: {"val": 0}`` while still counting ``used`` up (verified
+    against production 2026-08-18 — ``used: {"val": 443}`` on a live SuperGrok
+    account). Requiring a positive cap dropped the only number such an account
+    reports, every other row was already empty for it, and the whole report
+    collapsed to None — so the provider vanished from the usage view,
+    indistinguishable from a missing credential.
+
+    A used-only row keeps the account visible and honest: no cap means no
+    fraction, so it renders as an unmeasurable row (dotted bar, bare number)
+    rather than inventing a denominator, and :func:`usage_health` keeps
+    treating the account as "unknown" instead of guessing at depletion.
+    """
     limit = _xai_amount(config.get("monthlyLimit"))
     used = _xai_amount(config.get("used"))
-    if limit is None or limit <= 0 or used is None:
+    if used is None:
         return []
     resets_ms = _parse_iso_ms(config.get("billingPeriodEnd"))
+    if limit is None or limit <= 0:
+        return [
+            UsageLimit(
+                id="xai:usage:1mo",
+                label="Monthly usage",
+                amount=UsageAmount(used=used, unit="unknown"),
+                window="1 month",
+                resets_at_ms=resets_ms,
+                shared=True,
+            )
+        ]
     return [
         UsageLimit(
             id="xai:included:1mo",
@@ -1665,7 +1691,31 @@ async def fetch_xai_oauth(client: httpx.AsyncClient, access_token: str) -> Usage
     # on-demand cap when an account reports weekly and monthly at once.
     seen: set[str] = set()
     deduped = [limit for limit in limits if not (limit.id in seen or seen.add(limit.id))]
-    return UsageReport(provider="xai", limits=deduped) if deduped else None
+    if not deduped:
+        if config is None:
+            # Nothing ANSWERED — transport failure or a dead token. None here
+            # lets the caller fall through to other routes and, failing those,
+            # report "no usage data", which is the truthful message.
+            return None
+        # The endpoint answered, but the shape carried nothing renderable
+        # (e.g. a unified-billing config with neither ``used`` nor a cap).
+        # Returning None here is what made an ANSWERING account disappear from
+        # the panel entirely; an empty report keeps the provider block on
+        # screen ("no windows reported") with a note saying why, which is the
+        # difference between "your login is broken" and "xAI has nothing to
+        # meter for this plan".
+        note = (
+            "unified billing — no metered windows reported"
+            if config.get("isUnifiedBillingUser") is True
+            else "no measurable windows reported"
+        )
+        return UsageReport(provider="xai", limits=[], notes=note)
+    notes = None
+    if unified and all(limit.amount.fraction() is None for limit in deduped):
+        # Every surviving row is unmeasurable (the uncapped-spend shape): say
+        # why the bars are dotted, or the row reads like a rendering defect.
+        notes = "unified billing — spend is reported without a metered cap"
+    return UsageReport(provider="xai", limits=deduped, notes=notes)
 
 
 def _num(value: Any, default: float | None = None) -> float | None:

--- a/local_operator/providers/usage.py
+++ b/local_operator/providers/usage.py
@@ -1687,6 +1687,16 @@ async def fetch_xai_oauth(client: httpx.AsyncClient, access_token: str) -> Usage
         if on_demand is not None:
             limits.append(on_demand)
 
+    # Recompute the unified flag from the *effective* config once both URLs have
+    # had their chance. The pre-fetch value above only gates whether the monthly
+    # URL is probed; when the credits URL 401s but the bare monthly URL answers
+    # for an uncapped unified account, that config carries isUnifiedBillingUser
+    # too, and without this the explanatory note would be dropped — an
+    # unmeasurable bar with no reason reads exactly like the rendering defect
+    # this code warns against. Deriving it here keeps both note branches below
+    # on the same live signal.
+    unified = config is not None and config.get("isUnifiedBillingUser") is True
+
     # Ids are unique by construction, but both shapes can carry the same
     # on-demand cap when an account reports weekly and monthly at once.
     seen: set[str] = set()
@@ -1706,7 +1716,7 @@ async def fetch_xai_oauth(client: httpx.AsyncClient, access_token: str) -> Usage
         # meter for this plan".
         note = (
             "unified billing — no metered windows reported"
-            if config.get("isUnifiedBillingUser") is True
+            if unified
             else "no measurable windows reported"
         )
         return UsageReport(provider="xai", limits=[], notes=note)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.24.3"
+version = "0.24.4"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/providers/test_usage.py
+++ b/tests/unit/providers/test_usage.py
@@ -1261,6 +1261,34 @@ async def test_xai_uncapped_unified_account_still_reports_its_spend() -> None:
 
 
 @pytest.mark.asyncio
+async def test_xai_uncapped_note_survives_a_credits_url_failure() -> None:
+    """Partial failure: the credits URL 401s but the bare monthly URL answers.
+
+    The bare body carries ``isUnifiedBillingUser`` too, so the unified signal
+    must be derived from the *effective* config after both URLs are tried. A
+    version that read the flag only from the credits config left this row
+    unmeasurable with ``notes=None`` — a dotted bar with no reason, exactly the
+    rendering-defect outcome the note exists to prevent."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if "format=credits" in str(request.url):
+            return httpx.Response(401, json={})
+        # The bare monthly body must self-identify as unified for the note to
+        # fire, mirroring what production returns on this URL.
+        body = {"config": {**XAI_UNIFIED_MONTHLY_BODY["config"], "isUnifiedBillingUser": True}}
+        return httpx.Response(200, json=body)
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    async with client:
+        report = await fetch_usage(client, "xai", access_token="tok")
+    assert report is not None
+    row = next(limit for limit in report.limits if limit.id == "xai:usage:1mo")
+    assert row.amount.used == pytest.approx(443.0)
+    assert row.amount.fraction() is None
+    assert report.notes == "unified billing — spend is reported without a metered cap"
+
+
+@pytest.mark.asyncio
 async def test_xai_answered_but_empty_shape_reports_a_note_not_none() -> None:
     """An endpoint that ANSWERS with nothing renderable is still an account.
 

--- a/tests/unit/providers/test_usage.py
+++ b/tests/unit/providers/test_usage.py
@@ -1200,6 +1200,97 @@ async def test_xai_asks_once_when_the_weekly_shape_answers() -> None:
     assert len(urls) == 1, urls
 
 
+#: Verbatim production bodies captured 2026-08-18 from a live SuperGrok account
+#: on unified billing whose plan is NOT metered against a numeric cap: the
+#: credits URL answers with no ``creditUsagePercent`` at all, and the bare URL
+#: reports ``monthlyLimit: 0`` while ``used`` keeps counting. Every window
+#: parser rejected both shapes, the report collapsed to None, and xai was the
+#: one logged-in provider missing from the usage view — the regression these
+#: fixtures pin.
+XAI_UNIFIED_CREDITS_BODY = {
+    "config": {
+        "currentPeriod": {
+            "type": "USAGE_PERIOD_TYPE_WEEKLY",
+            "start": "2026-08-16T10:03:37.905824+00:00",
+            "end": "2026-08-23T10:03:37.905824+00:00",
+        },
+        "onDemandCap": {"val": 0},
+        "onDemandUsed": {"val": 0},
+        "isUnifiedBillingUser": True,
+        "prepaidBalance": {"val": 0},
+        "billingPeriodStart": "2026-08-16T10:03:37.905824+00:00",
+        "billingPeriodEnd": "2026-08-23T10:03:37.905824+00:00",
+    }
+}
+XAI_UNIFIED_MONTHLY_BODY = {
+    "config": {
+        "monthlyLimit": {"val": 0},
+        "used": {"val": 443},
+        "onDemandCap": {"val": 0},
+        "billingPeriodStart": "2026-08-01T00:00:00+00:00",
+        "billingPeriodEnd": "2026-09-01T00:00:00+00:00",
+    }
+}
+
+
+@pytest.mark.asyncio
+async def test_xai_uncapped_unified_account_still_reports_its_spend() -> None:
+    """The regression: an answering account vanished from the panel.
+
+    A unified-billing plan with no metered cap answers ``monthlyLimit: 0`` with
+    a live ``used`` counter. Requiring a positive cap dropped the row, nothing
+    else survived, and ``fetch_xai_oauth`` returned None — which the panel
+    cannot tell apart from a missing credential."""
+    bodies = {"credits": XAI_UNIFIED_CREDITS_BODY, "bare": XAI_UNIFIED_MONTHLY_BODY}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        key = "credits" if "format=credits" in str(request.url) else "bare"
+        return httpx.Response(200, json=bodies[key])
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    async with client:
+        report = await fetch_usage(client, "xai", access_token="tok")
+    assert report is not None
+    row = next(limit for limit in report.limits if limit.id == "xai:usage:1mo")
+    assert row.amount.used == pytest.approx(443.0)
+    # No cap means no denominator: the row must stay unmeasurable rather than
+    # invent a fraction, so quota health keeps answering "unknown".
+    assert row.amount.fraction() is None
+    assert row.shared is True
+    assert report.notes is not None and "unified billing" in report.notes
+
+
+@pytest.mark.asyncio
+async def test_xai_answered_but_empty_shape_reports_a_note_not_none() -> None:
+    """An endpoint that ANSWERS with nothing renderable is still an account.
+
+    Only a transport failure or dead token may collapse to None; a well-formed
+    config with no numbers keeps the provider block on screen with a note, so
+    the user reads "nothing to meter" instead of suspecting their login."""
+    empty = {"config": {"isUnifiedBillingUser": True}}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=empty)
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    async with client:
+        report = await fetch_usage(client, "xai", access_token="tok")
+    assert report is not None
+    assert report.limits == []
+    assert report.notes == "unified billing — no metered windows reported"
+
+
+@pytest.mark.asyncio
+async def test_xai_transport_failure_still_returns_none() -> None:
+    """The None path must survive the empty-report change: a 401 on both URLs
+    is a credential problem, and reporting it as an empty account block would
+    hide exactly the failure the user needs to act on."""
+    client = _client_for({}, status=401)
+    async with client:
+        report = await fetch_usage(client, "xai", access_token="dead")
+    assert report is None
+
+
 @pytest.mark.asyncio
 async def test_oauth_provider_without_token_returns_none() -> None:
     # OAuth-only provider with no access token -> None (no report).


### PR DESCRIPTION
# PR Description

## Change classification

**C2 — standard / pre-authorized.** Correctness fix in one provider's usage fetcher plus a truthful empty-state on the same code path. No new surface, no config, no credential handling change. Clean rollback (`git revert`).

## The bug

The `/usage` view showed every logged-in provider except **xai** — despite a live, unexpired xai OAuth credential in the auth store, `usage_supported("xai") == True`, `can_report_usage("xai") == True`, and the account appearing in `usage_reportable_providers()`. The provider block simply never rendered, which is indistinguishable at the panel from "no credential".

Reproduced against production before the fix (real token, real endpoint):

```console
$ .venv/bin/python /tmp/xai_usage_probe.py
usage_supported(xai): True
usage_kinds(xai): (True, False)
can_report_usage(xai): True
reportable: ['anthropic', 'kimi', 'openai', 'openai-device', 'xai', 'xai-oauth']
oauth accesses: [('oauth', True, '3b90…7a05')]
reports: []          <-- the fetcher returns None on a 200
```

## Root cause

xAI's billing endpoint answers **both** URLs with HTTP 200 for this account, but a unified-billing plan that is not metered against a numeric cap reports shapes no window parser accepted:

```console
GET /v1/billing?format=credits -> 200
{"config":{"currentPeriod":{...},"onDemandCap":{"val":0},"onDemandUsed":{"val":0},
 "isUnifiedBillingUser":true, ...}}          # no creditUsagePercent at all

GET /v1/billing -> 200
{"config":{"monthlyLimit":{"val":0},"used":{"val":443}, ...}}   # cap is 0, spend is live
```

- `_xai_weekly_limits` requires `creditUsagePercent` — absent → `[]`
- `_xai_monthly_limits` requires `monthlyLimit > 0` → `[]` (dropping the one number the account does report: `used: 443`)
- `_xai_on_demand` requires `onDemandCap > 0` → `None`
- `fetch_xai_oauth` then returns `None` for zero limits, and the provider vanishes from the panel

## The fix

`local_operator/providers/usage.py`, two changes on the same path:

1. **`_xai_monthly_limits` reports a used-only row when the cap is zero/absent** (`xai:usage:1mo`, label "Monthly usage"). No denominator is invented: the amount carries only `used`, so `fraction()` stays `None`, the row renders as unmeasurable (dotted bar, bare number, `○` mark), and `usage_health` keeps answering `unknown` instead of guessing at depletion. The capped shape (`monthlyLimit > 0`) is untouched.
2. **An endpoint that ANSWERS with nothing renderable returns an empty report with a note, not `None`.** Only a transport failure or dead token may collapse to `None` (that path is preserved and tested) — a well-formed config with no numbers now keeps the provider block on screen ("no windows reported" + a note naming why), which is the difference between "your login is broken" and "xAI has nothing to meter for this plan". When the only surviving rows are unmeasurable, the report carries the note `unified billing — spend is reported without a metered cap` so the dotted bar doesn't read as a rendering defect.

Tests pin **verbatim production bodies** (captured 2026-08-18) for both URLs, plus the answered-but-empty and transport-failure paths.

## Testing evidence

### Live validation (production endpoint, real credential, fixed code)

```console
$ .venv/bin/python /tmp/xai_fix_live.py
provider: xai | identity: damianvtran@gmail.com | notes: unified billing — spend is reported without a metered cap
   xai:usage:1mo Monthly usage used= 443.0 limit= None fraction= None resets_ms= 1788220800000
  health: QuotaHealth(state='unknown', remaining_fraction=None, reset_after_ms=None, scope='unknown')
```

### Rendered frames (real `OperatorApp`, stylesheet loaded, production bodies via MockTransport)

| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/damianvtran/local-operator/assets/pr-xai-usage/before.png) | ![after](https://raw.githubusercontent.com/damianvtran/local-operator/assets/pr-xai-usage/after.png) |

Before: xai absent entirely (`2 windows`). After: the xai block renders with identity, the explanatory note, and an unmeasurable "Monthly usage 443" row with its reset countdown (`3 windows · 1 not reported`). The footer's "not reported" phrasing and the dotted bar come from the existing unmeasurable-row path — no renderer changes were needed.

Panel text (from `render_lines_for_test()` on the after build):

```text
xai  damianvtran@gmail.com
  unified billing — spend is reported without a metered cap

○ Monthly usage  ························  443  resets in 12d21h
```

### Suites and gates

```console
$ .venv/bin/python -m pytest tests/unit -q --ignore=tests/unit/tui
3064 passed, 3 skipped in 167.48s
$ env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit/tui -q
1664 passed, 4 skipped in 615.35s
$ flake8 / black --check / isort --check / pyright  -> all clean (0 errors)
```

### Not covered

The legacy SuperGrok weekly shape and the capped monthly shape are exercised only by their existing fixtures — I hold no account on those plans, and this change does not touch their parsing branches.
