### PR TITLE
fix(tui): let the ask card spend the column the composer gave it

### DIFF
--- a/local_operator/tui/local_operator.tcss
+++ b/local_operator/tui/local_operator.tcss
@@ -1301,9 +1301,13 @@ SessionPickerScreen .session-picker {
  * and is load-bearing: an auto-width card sizes to its widest LINE, so the
  * question's own wrapping decided how wide the panel was and the card visibly
  * changed width as the user moved between questions of a multi-question ask.
- * Full-width in the dock, the panel is stable and the card's own width budget
- * (`AskPickerScreen._card_width`) governs the TEXT, which is what should be
- * measured against the terminal. */
+ * Full-width in the dock, the panel is stable — and this rule is now the ONLY
+ * statement of how wide the question is. `AskPickerScreen._card_width` reads
+ * this column back rather than budgeting its own against the terminal: it used
+ * to cap the text at 74 cells, a modal-era figure that survived the move into
+ * the dock, so the ink stopped a third of the way short of the panel's own fill
+ * on a wide terminal while the composer directly beneath it ran the full width.
+ * One owner for the width, and it is this line. */
 AskPickerScreen {
     width: 1fr;
     height: auto;

--- a/local_operator/tui/widgets/ask_picker.py
+++ b/local_operator/tui/widgets/ask_picker.py
@@ -61,16 +61,6 @@ from local_operator.tui import theme as theme_mod
 from local_operator.tui.widgets.tool_card import truncate_cells
 from local_operator.tui.widgets.transcript import wrap_cells
 
-#: Width the card takes when the terminal allows it, and the floor it prefers.
-#: Both are CELL counts of the card's content, inside its padding, and are
-#: resolved against the screen every paint (see :meth:`AskPickerScreen._card_width`).
-ASK_MAX_WIDTH = 74
-ASK_MIN_WIDTH = 30
-
-#: Cells left between the card and the terminal edges, on top of the card's own
-#: padding, so it reads as floating rather than bolted to the side.
-ASK_WIDTH_MARGIN = 6
-
 #: Cells of the card's own padding on EACH side, mirroring the horizontal half
 #: of ``padding: 1 1`` in the stylesheet. One cell rather than the modal's two:
 #: docked, this is the same rail every other panel in the dock uses (the
@@ -757,12 +747,14 @@ class AskPickerScreen(Container):
         Three guards, all load-bearing, because a false positive here answers
         the agent's question on the user's behalf:
 
-        - the point must be inside the BODY's region. The card is full-width in
-          the dock while its TEXT is not, so a click in the empty columns beside
-          a row still lands on this widget with a ``y`` that looks valid; and
-          the padding rows above and below the body do the same with an ``x``
-          that does. Region containment is what separates the card's ink from
-          the container it is painted in;
+        - the point must be inside the BODY's region. The body now spans the
+          card's full column, so the columns either side of a row are the card's
+          one-cell padding rather than the wide empty band they were while the
+          text was capped — but the guard is unchanged and still load-bearing:
+          the padding ROWS above and below the body carry no row at all, and a
+          click on one arrives with an ``x`` that looks perfectly valid. Region
+          containment is what separates the card's ink from the container it is
+          painted in, in both axes;
         - the line must map to a row in ``_line_rows``, which is recorded while
           painting, so the header, the blank spacers and the footer resolve to
           nothing rather than to whichever row the arithmetic lands on;
@@ -910,24 +902,40 @@ class AskPickerScreen(Container):
         return reserved if seen else _DOCK_ROWS_FALLBACK
 
     def _card_width(self) -> int:
-        """Content cells the card may use, measured against the terminal.
+        """Content cells the card may use: the COLUMN the dock laid it out in.
 
-        The preferred floor applies only while it FITS: a minimum width is a
-        preference and the terminal is not, so on a very narrow screen the card
-        gives up its breathing margin and then the floor rather than overflowing.
+        This is ``self.size.width`` and not a budget re-derived from the screen,
+        which is the opposite of what :meth:`_screen_size` does for ROWS — and
+        the asymmetry is the point. Height here is content-driven (``height:
+        auto``), so measuring it against the card's own box is measuring its own
+        shadow. Width is not: the stylesheet pins the card at ``width: 1fr``, so
+        its content box is IMPOSED by the dock and reading it back asks the
+        layout engine what column this panel occupies rather than guessing.
 
-        ``ASK_PADDING_CELLS`` must stay equal to the horizontal half of this
-        card's ``padding`` in the stylesheet. They are two statements of one
-        measurement, and when they disagree the card either wastes cells it was
-        given or lays out lines wider than the panel can draw — which the panel
-        resolves by clipping, silently.
+        What it replaces was a modal-era cap — 74 cells, less a floating margin,
+        measured against the terminal — and it survived the move into the dock
+        as a number nothing re-derived. The slab had been full-width since that
+        move, so the two disagreed and the gap grew with the terminal: measured
+        with a question and four options up, the card's text stopped at 74 cells
+        inside a 116-cell panel at 120 columns and inside a 156-cell panel at
+        160, leaving a third of the card as blank fill and every row — the rule
+        under the title, the selected row's tint, the footer — ending short of a
+        composer that ran the full width directly beneath it. A floating modal's
+        margin holds it off the terminal EDGE; docked, there is no edge there to
+        hold off, only the panel the card is part of.
+
+        Padding is not subtracted: Textual is border-box, so ``size`` is already
+        the box inside this widget's ``padding``. ``ASK_PADDING_CELLS`` is still
+        the stylesheet's mirror, and it is what the pre-layout fallback below
+        spends — the one path that has no laid-out width to read, because
+        ``compose`` paints once before the card has been placed. That frame is
+        replaced by ``on_resize`` the moment it has.
         """
+        mine = self.size.width if self.is_mounted else 0
+        if mine:
+            return max(1, mine)
         width, _ = self._screen_size()
-        padding = ASK_PADDING_CELLS * 2
-        room = width - ASK_WIDTH_MARGIN - padding
-        if room < ASK_MIN_WIDTH:
-            return max(1, width - padding)
-        return min(ASK_MAX_WIDTH, room)
+        return max(1, width - ASK_PADDING_CELLS * 2)
 
     def _question_lines(self, width: int) -> list[str]:
         """The question, wrapped. Never truncated: it is what is being asked.

--- a/local_operator/tui/widgets/ask_picker.py
+++ b/local_operator/tui/widgets/ask_picker.py
@@ -779,8 +779,9 @@ class AskPickerScreen(Container):
     def _screen_size(self) -> tuple[int, int]:
         """The SCREEN's content box, which is what the card budgets its ROWS against.
 
-        Rows, and — only before the card has been placed — the fallback width in
-        :meth:`_card_width`. The laid-out width does NOT come from here: it is
+        Rows, and — only while :meth:`_card_width` has no laid-out column to
+        read (before the card is placed, or while it is hidden) — the fallback
+        width. The laid-out width does NOT come from here: it is
         imposed by the stylesheet's ``width: 1fr`` and read back off the card's
         own box. See :meth:`_card_width` for why the two axes differ.
 
@@ -931,10 +932,19 @@ class AskPickerScreen(Container):
 
         Padding is not subtracted: Textual is border-box, so ``size`` is already
         the box inside this widget's ``padding``. ``ASK_PADDING_CELLS`` is still
-        the stylesheet's mirror, and it is what the pre-layout fallback below
-        spends — the one path that has no laid-out width to read, because
-        ``compose`` paints once before the card has been placed. That frame is
-        replaced by ``on_resize`` the moment it has.
+        the stylesheet's mirror, and it is what the fallback below spends on the
+        two paths that have no laid-out width to read:
+
+        - before the card has been PLACED, because ``compose`` paints once on
+          the way in; and
+        - while it is HIDDEN, because a card that found no drawable line sets
+          ``display = False`` (see :meth:`_repaint`) and an undisplayed widget
+          reports a zero-width box. A terminal that shrinks past the card and
+          then grows back re-measures through here (agent review round 2, F6).
+
+        Both frames are replaced by ``on_resize`` as soon as there is a real
+        column to read — measured, the fallback returns the same number the
+        layout then assigns, because ``#prompt-host`` adds no horizontal padding.
         """
         mine = self.size.width if self.is_mounted else 0
         if mine:

--- a/local_operator/tui/widgets/ask_picker.py
+++ b/local_operator/tui/widgets/ask_picker.py
@@ -777,7 +777,12 @@ class AskPickerScreen(Container):
 
     # -- geometry ------------------------------------------------------------
     def _screen_size(self) -> tuple[int, int]:
-        """The box the card budgets itself against: the SCREEN's content box.
+        """The SCREEN's content box, which is what the card budgets its ROWS against.
+
+        Rows, and — only before the card has been placed — the fallback width in
+        :meth:`_card_width`. The laid-out width does NOT come from here: it is
+        imposed by the stylesheet's ``width: 1fr`` and read back off the card's
+        own box. See :meth:`_card_width` for why the two axes differ.
 
         Deliberately not ``self.size``, which is the inverse of what the modal
         version did and is forced by the move into the dock. A docked container
@@ -1341,8 +1346,13 @@ class AskPickerScreen(Container):
         self.call_after_refresh(self._repaint)
 
     def on_resize(self, event) -> None:  # type: ignore[no-untyped-def]
-        """Re-measure: the width, the page size and the descriptions all come
-        from the screen."""
+        """Re-measure: every quantity the card lays out against has just moved.
+
+        The width comes from the COLUMN the dock assigned this card
+        (:meth:`_card_width`); the row budget, the page size and whether
+        descriptions are affordable come from the screen (:meth:`_screen_size`).
+        Two different sources, and this is the event that invalidates both.
+        """
         self._move_to(self.state.selected)
 
     def remeasure(self) -> None:

--- a/local_operator/tui/widgets/ask_picker.py
+++ b/local_operator/tui/widgets/ask_picker.py
@@ -946,7 +946,7 @@ class AskPickerScreen(Container):
         by DIFFERENT events, and the difference is the whole reason
         :meth:`remeasure` exists: a placed card gets ``on_resize``, while a
         hidden one is not laid out and therefore receives no ``Resize`` at all —
-        the app drives it from outside instead (round 2, F7). Measured, the
+        the app drives it from outside instead (round 3, F7). Measured, the
         fallback returns the same number the layout then assigns, because
         ``#prompt-host`` adds no horizontal padding.
         """

--- a/local_operator/tui/widgets/ask_picker.py
+++ b/local_operator/tui/widgets/ask_picker.py
@@ -942,9 +942,13 @@ class AskPickerScreen(Container):
           reports a zero-width box. A terminal that shrinks past the card and
           then grows back re-measures through here (agent review round 2, F6).
 
-        Both frames are replaced by ``on_resize`` as soon as there is a real
-        column to read — measured, the fallback returns the same number the
-        layout then assigns, because ``#prompt-host`` adds no horizontal padding.
+        Both frames are replaced as soon as there is a real column to read, but
+        by DIFFERENT events, and the difference is the whole reason
+        :meth:`remeasure` exists: a placed card gets ``on_resize``, while a
+        hidden one is not laid out and therefore receives no ``Resize`` at all —
+        the app drives it from outside instead (round 2, F7). Measured, the
+        fallback returns the same number the layout then assigns, because
+        ``#prompt-host`` adds no horizontal padding.
         """
         mine = self.size.width if self.is_mounted else 0
         if mine:

--- a/tests/unit/tui/test_ask_picker.py
+++ b/tests/unit/tui/test_ask_picker.py
@@ -27,8 +27,6 @@ from textual.containers import Container
 from local_operator.harness.types import AskOption, AskQuestion
 from local_operator.tui import theme as theme_mod
 from local_operator.tui.widgets.ask_picker import (
-    ASK_MAX_WIDTH,
-    ASK_PADDING_CELLS,
     MIN_TRANSCRIPT_ROWS,
     OTHER_LABEL,
     PROMPT_HEIGHT_SHARE,
@@ -406,13 +404,40 @@ async def test_no_row_overflows_the_card_at_any_width() -> None:
         async with app.run_test(size=(width, 30)) as pilot:
             screen = await app.open_picker()
             await pilot.pause()
-            # Derived from the card's own padding rather than written as a
-            # literal: the two are one measurement, and a hardcoded `width - 4`
-            # silently described the old modal's `padding: 1 2` after the
-            # docked card moved to the dock's one-cell rail.
-            budget = min(ASK_MAX_WIDTH, max(1, width - ASK_PADDING_CELLS * 2))
+            # The card's OWN content box, read back from the layout rather than
+            # re-derived here. The card budgets its text against the column the
+            # dock gave it, so a test that recomputed that column from the
+            # terminal width would be a second opinion about the one number the
+            # widget is not free to be wrong about — and it would agree with a
+            # card that had gone back to capping itself, which is the regression
+            # this file now has to catch.
+            budget = screen.size.width
             for line in screen.render_lines_for_test():
                 assert cell_len(line) <= budget, (width, line)
+
+
+@pytest.mark.asyncio
+async def test_the_card_spends_the_whole_column_the_dock_gave_it() -> None:
+    """The card is laid out at the composer's width, so its ROWS have to reach
+    that width too.
+
+    The defect this pins is the one a clip test cannot see: every row fitted,
+    and the card still stopped 42 cells short of its own panel at 160 columns,
+    because a modal-era cap (74 cells less a floating margin) survived the move
+    into the dock. Under-spending the column is as wrong as overflowing it — the
+    rule under the title, the selected row's tint and the footer all ended in
+    the middle of a panel whose fill ran to the composer's full width.
+    """
+    for width in (80, 100, 120, 160, 200):
+        app = _AskHost([_question()])
+        async with app.run_test(size=(width, 30)) as pilot:
+            screen = await app.open_picker()
+            await pilot.pause()
+            column = screen.size.width
+            # The selected row is painted in its own ground for its full width
+            # (`_fit_row`), so it is the row that states the card's real reach.
+            rows = [line for line in screen.render_lines_for_test() if line.strip()]
+            assert max(cell_len(line) for line in rows) == column, (width, column)
 
 
 @pytest.mark.asyncio
@@ -927,8 +952,18 @@ async def test_the_footer_gives_up_words_before_it_gives_up_keys() -> None:
         assert screen.render_lines_for_test()[-1].strip() == "↑↓ · 1-9 · enter · esc"
 
     # Narrower than four keys: hints go in the same order, escape route last.
+    #
+    # 16 rather than the 18 this rung used to need, and the two cells are the
+    # point rather than a tolerance: the card spends the column it was given
+    # instead of a budget derived from the terminal, so every rung of this
+    # ladder now engages two cells LATER — the card reaches this one only when
+    # it is genuinely that narrow. The ORDER is what this test pins and it is
+    # unchanged; the widths are a consequence of the card's reach, which is why
+    # they move when its reach is corrected. This host has no stylesheet
+    # (`_AskHost` declares no `CSS_PATH`), so its card is the full terminal
+    # width; under the real sheet the same rung lands at 18 columns, measured.
     app = _AskHost([question])
-    async with app.run_test(size=(18, 24)) as pilot:
+    async with app.run_test(size=(16, 24)) as pilot:
         screen = await app.open_picker()
         await pilot.pause()
         footer = screen.render_lines_for_test()[-1].strip()
@@ -1810,3 +1845,38 @@ async def test_a_live_question_does_not_break_slash_completion() -> None:
             await asked
         except (asyncio.CancelledError, Exception):
             pass
+
+
+@pytest.mark.asyncio
+async def test_the_card_reaches_the_composer_at_every_width() -> None:
+    """Under the REAL stylesheet, the question's rows span the composer's column.
+
+    The regression: the card kept a modal-era text budget (74 cells, less a
+    margin held off the terminal edge) after it moved from a floating modal into
+    the dock, where the panel is `width: 1fr`. Nothing re-derived the cap, so
+    the wider the terminal the worse the disagreement — at 160 columns the ink
+    stopped at 74 cells inside a 156-cell panel, and the title's rule, the
+    selected row's tint and the footer all ended mid-slab while the composer
+    directly beneath ran the full width.
+
+    Asserted against `#input-shell` rather than against the terminal, because
+    "extends with the composer" is the actual contract: the two are stacked
+    surfaces of one dock, and the composer's own width already accounts for the
+    screen inset and the shell's padding. A test written against the terminal
+    width would have to restate that arithmetic and would then pass while the
+    two surfaces disagreed.
+    """
+    for size in ((60, 24), (80, 30), (100, 30), (120, 30), (160, 40), (200, 50)):
+        app, card = await _real_app_card(size, [_long_question()])
+        async with app.run_test(size=size) as pilot:
+            await _show(app, pilot, card)
+            composer = app.screen.query_one("#input-shell")
+            # The card's content box is the composer's: same column, same edges.
+            assert card.size.width == composer.size.width, (size, card.size.width)
+            # And the card SPENDS it. The selected row is drawn in its own
+            # ground for the full width (`_fit_row`), so the widest painted row
+            # is the card's real reach — the number the cap used to hold at 74.
+            rows = [row for row in card.render_lines_for_test() if row.strip()]
+            assert max(cell_len(row) for row in rows) == card.size.width, size
+            # Reaching further must not have cost the screen its geometry.
+            assert not app.screen.show_vertical_scrollbar, size

--- a/tests/unit/tui/test_ask_picker.py
+++ b/tests/unit/tui/test_ask_picker.py
@@ -405,12 +405,17 @@ async def test_no_row_overflows_the_card_at_any_width() -> None:
             screen = await app.open_picker()
             await pilot.pause()
             # The card's OWN content box, read back from the layout rather than
-            # re-derived here. The card budgets its text against the column the
-            # dock gave it, so a test that recomputed that column from the
-            # terminal width would be a second opinion about the one number the
-            # widget is not free to be wrong about — and it would agree with a
-            # card that had gone back to capping itself, which is the regression
-            # this file now has to catch.
+            # re-derived here: recomputing the column from the terminal width
+            # would be a second opinion about the one number the widget is not
+            # free to be wrong about.
+            #
+            # This assertion guards OVERFLOW ONLY, which is all its name claims.
+            # Measured (agent review round 1, F4): forcing `_card_width` to
+            # over-return by 10 fails it, while UNDER-returning by 10 passes it
+            # silently — a card that went back to capping its text would satisfy
+            # every line here. `test_the_card_spends_the_whole_column_the_dock_
+            # gave_it` is the guard for that half, and it is the one verified to
+            # fail against the old 74-cell cap.
             budget = screen.size.width
             for line in screen.render_lines_for_test():
                 assert cell_len(line) <= budget, (width, line)


### PR DESCRIPTION
# PR Description

## Change classification

**C1 — low risk.** One TUI geometry method and its stylesheet comment: the ask card reads back the column the layout already gave it instead of re-deriving a narrower one. No new surface, no config, no transcript format change, no engine change. Clean rollback (`git revert`).

## The bug

Reported from a live session: the `ask` picker "looks weird — it doesn't extend across with the composer."

The picker moved out of a `ModalScreen` and into the input dock in #138, where the stylesheet lays it out at `width: 1fr` — the composer's own column. Its **text budget did not make the trip**. `_card_width` went on computing a modal-era cap:

```python
ASK_MAX_WIDTH = 74
ASK_WIDTH_MARGIN = 6   # "cells left between the card and the terminal edges"
...
room = width - ASK_WIDTH_MARGIN - padding
return min(ASK_MAX_WIDTH, room)
```

Both numbers describe a card **floating over the terminal**, held off its edges. Docked, there is no terminal edge there to hold off — only the panel the card is part of, whose fill runs the full width of the composer directly beneath it.

So the slab and the ink disagreed, and because the cap is absolute while the panel is proportional, **the gap grows with the terminal**. Measured on unmodified `main`, with a question and four options up:

| terminal | composer (`#input-shell`) | card slab | **widest painted row** |
|---:|---:|---:|---:|
| 60 | 56 | 56 | 50 |
| 80 | 76 | 76 | 70 |
| 100 | 96 | 96 | **74** |
| 120 | 116 | 116 | **74** |
| 160 | 156 | 156 | **74** |
| 200 | 196 | 196 | **74** |

From 100 columns up the text is pinned at 74 cells no matter how wide the panel gets. At 160 that is a third of the card left as blank fill, with the rule under the title, the selected row's tint and the footer all ending mid-slab.

Worth being precise about what was wrong: **nothing overflowed and nothing was clipped**, which is why the existing suite was green. The card was *under-spending* a column it had already been given — a defect only a rendered frame or a geometry probe can see.

## The fix

`_card_width` reads back the column the layout engine assigned:

```python
mine = self.size.width if self.is_mounted else 0
if mine:
    return max(1, mine)
width, _ = self._screen_size()          # pre-layout only
return max(1, width - ASK_PADDING_CELLS * 2)
```

The cap is **deleted rather than raised** — a bigger magic number would have been the same bug further out. `ASK_MAX_WIDTH`, `ASK_MIN_WIDTH` and `ASK_WIDTH_MARGIN` are gone with it, so the stylesheet's `width: 1fr` is now the single owner of how wide the question is.

**Width and height are deliberately asymmetric now,** and this is the one point worth a reviewer's attention. `_screen_size` exists because the card must *not* measure its own height (`height: auto` means `self.size.height` is whatever it asked for last paint — measuring its own shadow, and it could never shrink). Width is the opposite: it is *imposed* from outside by `width: 1fr`, so reading it back asks the layout engine a question rather than guessing the answer. The docstring states both halves so the next reader does not "fix" the asymmetry.

Padding is not subtracted — Textual is border-box, so `size` is already the box inside the widget's padding. `ASK_PADDING_CELLS` survives as the stylesheet's mirror and is spent only on the pre-layout fallback (`compose` paints once before placement; `on_resize` replaces that frame immediately).

Two comments whose stated reasoning the change invalidated were corrected rather than left to rot: the `_index_at` click guard (which justified itself by "the card is full-width while its TEXT is not" — no longer true, though the guard is still needed for the padding *rows*), and the `AskPickerScreen` block in `local_operator.tcss`.

## Validation

Per AGENTS.md "Visual validation": before/after frames, backed by the geometry numbers.

### 1. Rendered frames — before / after

Captured with the repo's own `scripts/ask_shot.py` over a seeded conversation, rendered as SVG and **viewed** (not just diffed), at 100, 120 and 160 columns. Since a frame cannot be pasted into this description from the CLI, the same evidence is given below as the compositor's own painted rows with their cell widths — which is what the frames show, in numbers.

**Before** (`origin/main`, unmodified), at 160 columns:

```console
$ .venv/bin/python /tmp/askrows.py 160
terminal=160  composer=156  card=156
card rows, as painted (width in cells | text):
    29 | the agent needs your decision
    74 | ──────────────────────────────────────────────────────────────────────
    50 | Which rollout should the stale-row migration take?
    74 |   1. Drop the rows
    74 |      nothing reads the column any more
    74 | ❯ 2. Backfill from the audit log
    74 |      recommended · slower, keeps history
    74 |   3. Dual-write for a week
    74 |      safest, needs a follow-up MR
    74 |   4. Leave them and add a filter
    74 |      cheapest, hides the problem
    74 |   5. Other (type your own)
    74 |      an answer that is not on the list — type it here
    44 | ↑↓ move · 1-9 jump · enter answer · esc skip
```

The card is 156 cells wide and its rule is **74** — visibly a half-drawn card, which is exactly what was reported.

**After** (this branch), same terminal, same question:

```console
$ .venv/bin/python /tmp/askrows.py 160
terminal=160  composer=156  card=156
card rows, as painted (width in cells | text):
    29 | the agent needs your decision
   156 | ──────────────────────────────────────────────────────────────────────
    50 | Which rollout should the stale-row migration take?
   156 |   1. Drop the rows
   156 |      nothing reads the column any more
   156 | ❯ 2. Backfill from the audit log
   156 |      recommended · slower, keeps history
   156 |   3. Dual-write for a week
   156 |      safest, needs a follow-up MR
   156 |   4. Leave them and add a filter
   156 |      cheapest, hides the problem
   156 |   5. Other (type your own)
   156 |      an answer that is not on the list — type it here
    44 | ↑↓ move · 1-9 jump · enter answer · esc skip
```

Every full-width row — the title's rule, each option, each description, the selected row's tinted ground — now reaches 156, flush with the composer beneath. The two rows that are *not* full width are correct: the header text and the footer hints are naturally short strings, not fills.

### 2. The states a single frame misses

Driven and viewed at 160x40: multi-select checkboxes, the free-text `Other:` row with its caret mid-type, and a long question that no longer wraps early — all spending the full column. At 60x24 the honest degradation is intact: descriptions shed, the window line (`showing 2—2 of 4`) appears, and the footer keeps its keys.

### 3. Geometry after the fix

Same probe, same sizes:

| terminal | composer | card | widest row | scrollbar | virtual/size |
|---:|---:|---:|---:|:--:|:--:|
| 60 | 56 | 56 | **56** | False | 22/22 |
| 80 | 76 | 76 | **76** | False | 28/28 |
| 100 | 96 | 96 | **96** | False | 28/28 |
| 120 | 116 | 116 | **116** | False | 28/28 |
| 160 | 156 | 156 | **156** | False | 38/38 |
| 200 | 196 | 196 | **196** | False | 48/48 |

Card content box equals `#input-shell`'s at every width, and the card spends all of it. `virtual_size == size` throughout with no scrollbar — the condition AGENTS.md calls always a bug on this app.

### 4. No reflow, and resize tracks in both directions

Twelve consecutive frames after mount at 160x40: card width and widest row are `156/156` on **every** frame including the first — correct at first paint, no settling motion.

Live resizes on a card that is already up:

```
resized 100: card= 96 shell= 96 longest_row= 96 scrollbar=False virt/size=28/28
resized  60: card= 56 shell= 56 longest_row= 56 scrollbar=False virt/size=22/22
resized 200: card=196 shell=196 longest_row=196 scrollbar=False virt/size=48/48
resized  80: card= 76 shell= 76 longest_row= 76 scrollbar=False virt/size=28/28
```

Shrink and grow both track, including 60 → 200 which the old cap could never follow.

### 5. The footer ladder: order preserved, rungs shift

The shed ladder is width-driven, so correcting the card's reach moves where each rung engages. Real app, under the stylesheet:

```
  18: card= 14 'enter · esc'
  20: card= 16 '↑↓ · enter · esc'
  24: card= 20 '1-9 · enter · esc'
  26: card= 22 '↑↓ · 1-9 · enter · esc'
  32: card= 28 '↑↓ · 1-9 · enter · esc skip'
  40: card= 36 '↑↓ · 1-9 · enter answer · esc skip'
  50: card= 46 '↑↓ move · 1-9 jump · enter answer · esc skip'
```

The **order** is unchanged (words before keys, `skip` last of the words, escape route last of all) — each rung simply engages ~2 cells later because the card no longer discards cells it owns. One assertion in `test_the_footer_gives_up_words_before_it_gives_up_keys` moved 18 → 16 for that reason, with the reason recorded in the test.

### 6. Regression coverage, verified to actually catch it

Two new tests:

- `test_the_card_spends_the_whole_column_the_dock_gave_it` — bare host, several widths.
- `test_the_card_reaches_the_composer_at_every_width` — the **real** `OperatorApp` with the stylesheet applied, asserting against `#input-shell` rather than the terminal, because "extends with the composer" is the actual contract.

Both were confirmed to **fail against the old `_card_width`** and pass against the new one:

```console
$ # with _card_width reverted to the 74-cell cap
FAILED test_the_card_reaches_the_composer_at_every_width - AssertionError: (60, 24)
assert 50 == 56
FAILED test_the_card_spends_the_whole_column_the_dock_gave_it
2 failed, 50 deselected
```

`test_no_row_overflows_the_card_at_any_width` now derives its budget from the card's own content box instead of recomputing it from the terminal — a test that re-derives the number under test would agree with a card that had gone back to capping itself.

### 7. Gates

```console
$ .venv/bin/python -m pytest tests/unit/tui -q
1665 passed, 4 skipped in 522.58s

$ .venv/bin/python -m pytest tests/unit -q --ignore=tests/unit/tui \
    --deselect tests/unit/tools/test_eval_tool.py::test_background_streams_output_while_it_runs
3060 passed, 3 skipped, 1 deselected in 108.55s

$ .venv/bin/python -m flake8 .                                    # clean
$ uvx --from black==26.1.0 black --check local_operator tests      # 369 files unchanged
$ uvx isort --check-only --profile black local_operator tests      # clean
$ .venv/bin/python -m pyright --pythonpath .venv/bin/python .       # 0 errors, 0 warnings
```

**One pre-existing failure, unrelated and not introduced here:** `tests/unit/tools/test_eval_tool.py::test_background_streams_output_while_it_runs`. Confirmed failing identically on a clean detached worktree of `origin/main` (f87f778) with no edits, so it is deselected above rather than hidden.

### Boot layout — the one claim in this description that was wrong

This section originally read "checked, not applicable", reasoning that the splash retires on the first appended block, strictly before any tool can raise a question, so a prompt is never up while the boot layout clamps the composer.

**Agent review round 1 (F3) refuted that,** and the correction is kept here rather than quietly edited away. Pressing <kbd>Ctrl</kbd>+<kbd>L</kbd> calls `_set_welcome_visible(True)` with a live prompt still mounted, which restores the boot layout. Measured at 160 columns on this branch:

```
before ^L: boot=False card=156 shell=156
after  ^L: boot=True boot-card=True card=156 shell=98 widest_ink=156 OVERHANG=58
```

The composer clamps to a centred 98-cell card; `#prompt-host` and the card do not, so the question overhangs the input by 58 cells.

**This is pre-existing and not introduced here.** `AskPickerScreen` has been `width: 1fr` since #138, so the *slab* has overhung in this state all along. The same probe on clean `origin/main` (f87f778):

```
after  ^L: boot=True boot-card=True card=156 shell=98 widest_ink=74 OVERHANG=-24
```

Identical 156-cell slab against a 98-cell shell — the old 74-cell cap merely kept the *ink* inside 98 and hid the mismatch. Removing that cap (the fix) makes an existing #138 layout bug visible. Both review rounds judged it out of scope for this PR; filed as **#168** with both measurements and two candidate fixes.

My error was reasoning from one path instead of enumerating the callers of `_set_welcome_visible(True)`.

## Risk

Low, and reversible. The change is confined to one method's return value; every other consumer of `_card_width` (wrapping, the row/description renderers, the footer ladder, the windowing line) is a pure function of the width it is handed and was already exercised across 24–200 columns by the existing suite. Worst realistic regression is cosmetic at some width, which the frames and the width table cover.

