### PR TITLE
fix(session,resume): make a past conversation findable again

### DIFF
--- a/local_operator/resume.py
+++ b/local_operator/resume.py
@@ -74,18 +74,28 @@ NAME_MAX_CHARS = 64
 #: returning every session to its opening message.
 _TITLE_CUSTOM_TYPE = "conversation_name"
 
-#: Bytes of the transcript TAIL the stored-title scan reads. The title is
-#: appended like any other entry, so the newest one is near the end of the
-#: file, and the newest is the one in force — a rename appends a fresh row
-#: rather than rewriting the old one. Reading the tail rather than the whole
-#: file is what keeps the picker's cost per row bounded on a 6 MB transcript;
-#: measured across a real 204-session store, tail-only scanning costs 64 ms
-#: against 400 ms for full reads.
+#: Bytes of the transcript the stored-title scan reads at EACH END. Both ends,
+#: because the two facts about a title pull in opposite directions:
 #:
-#: A session renamed early and then run for hours can push its title out of
-#: this window. That case degrades to the opening message, which is exactly
-#: the behaviour that shipped before titles were stored at all — never to a
-#: wrong name.
+#: * The title in force is the NEWEST one — a rename appends a fresh row rather
+#:   than rewriting the old one — so a rename made an hour into a long session
+#:   is only findable near the tail.
+#: * The FIRST title is journalled when the session is auto-named, at turn 2,
+#:   which is near the head and is pushed further from the tail by every turn
+#:   that follows.
+#:
+#: A tail-only scan therefore missed the title on most real sessions: measured
+#: on this store, 145 of 187 transcripts (78%) are larger than this window, so
+#: a session named at turn 2 and then worked in for an hour silently reverted
+#: to being labelled by its opening message — the exact failure this function
+#: exists to fix, and the long sessions it hit hardest are the ones a user is
+#: most likely to be hunting for a week later.
+#:
+#: Reading both ends rather than the whole file is what keeps the cost per
+#: picker row bounded on a 6 MB transcript. The middle can still hide a title
+#: only when a session was renamed mid-conversation AND then run long enough to
+#: bury that rename under a further 128 KB without ever being renamed again;
+#: that degrades to the opener, never to a wrong name.
 TITLE_SCAN_BYTES = 131_072
 
 #: Matches a journalled title row in raw JSONL, tolerant of whitespace after
@@ -427,28 +437,41 @@ def stored_session_title(session_dir: Path) -> str:
     Scanned out of the raw JSONL rather than replayed through ``Transcript``
     on purpose. This module is import-guarded (see the module docstring): a
     picker row must not drag the engine, the providers or ``asyncio`` onto
-    ``local-operator --help``. A regex over the tail is the same question
-    asked cheaply.
+    ``local-operator --help``. A regex over two bounded windows is the same
+    question asked cheaply.
 
-    LAST match wins, because each rename appends a full snapshot and the
-    newest row is the title in force. Tolerant like everything else on this
-    path — an unreadable or truncated transcript yields ``""`` and the caller
-    falls back to the opening message rather than the picker failing.
+    BOTH ENDS are read — see :data:`TITLE_SCAN_BYTES` for why a tail-only scan
+    missed the title on 78% of real sessions. The LAST match wins across the
+    two windows, because each rename appends a full snapshot and the newest row
+    is the title in force.
+
+    Tolerant like everything else on this path — an unreadable or truncated
+    transcript yields ``""`` and the caller falls back to the opening message
+    rather than the picker failing.
     """
     transcript = session_dir / TRANSCRIPT_NAME
     try:
         with transcript.open("rb") as handle:
+            head = handle.read(TITLE_SCAN_BYTES)
             handle.seek(0, os.SEEK_END)
             size = handle.tell()
-            # Seek back from the END, not forward from the start: the title in
-            # force is the newest entry, and on a long conversation that is
-            # megabytes past the opener.
-            handle.seek(max(0, size - TITLE_SCAN_BYTES))
-            raw = handle.read()
+            # Only when the file is big enough for the two windows to be
+            # disjoint. Re-reading an overlap would be harmless (the same row
+            # would simply match twice) but it doubles the read for the small
+            # transcripts that are the common case.
+            if size > TITLE_SCAN_BYTES * 2:
+                handle.seek(size - TITLE_SCAN_BYTES)
+                tail = handle.read()
+            else:
+                tail = handle.read()
     except OSError:
         return ""
-    text = raw.decode("utf-8", errors="replace")
-    matches = _TITLE_ROW_RE.findall(text)
+    # The tail is searched FIRST and wins: a rename made late in a long session
+    # is the newest title, and the head can only hold older ones.
+    for window in (tail, head):
+        matches = _TITLE_ROW_RE.findall(window.decode("utf-8", errors="replace"))
+        if matches:
+            break
     if not matches:
         return ""
     try:

--- a/local_operator/resume.py
+++ b/local_operator/resume.py
@@ -99,7 +99,7 @@ _TITLE_CUSTOM_TYPE = "conversation_name"
 #: windows. The head still holds the ORIGINAL title, so that session is
 #: labelled with the name it was renamed *away from* rather than falling back
 #: to the opener. That is a stale name, and a stale name is stated with exactly
-#: the confidence of a correct one \u2014 so it is a real cost, not a rounding
+#: the confidence of a correct one — so it is a real cost, not a rounding
 #: error, and this comment says so rather than claiming the scan can only ever
 #: miss.
 #:
@@ -108,8 +108,8 @@ _TITLE_CUSTOM_TYPE = "conversation_name"
 #: and because the case requires a mid-session rename specifically: an
 #: auto-named session has its title at the head, and a session renamed near the
 #: end has it in the tail. If it proves to bite, the fix is to journal the
-#: title to a sidecar the way ``mark_session_origin`` does \u2014 one stat and one
-#: small read, no size dependence at all \u2014 rather than widening this window.
+#: title to a sidecar the way ``mark_session_origin`` does — one stat and one
+#: small read, no size dependence at all — rather than widening this window.
 TITLE_SCAN_BYTES = 131_072
 
 #: Matches a journalled title row in raw JSONL, tolerant of whitespace after

--- a/local_operator/resume.py
+++ b/local_operator/resume.py
@@ -92,10 +92,24 @@ _TITLE_CUSTOM_TYPE = "conversation_name"
 #: most likely to be hunting for a week later.
 #:
 #: Reading both ends rather than the whole file is what keeps the cost per
-#: picker row bounded on a 6 MB transcript. The middle can still hide a title
-#: only when a session was renamed mid-conversation AND then run long enough to
-#: bury that rename under a further 128 KB without ever being renamed again;
-#: that degrades to the opener, never to a wrong name.
+#: picker row bounded on a 6 MB transcript.
+#:
+#: **The known gap, stated honestly.** A rename made mid-conversation, then
+#: buried under a further 128 KB and never renamed again, falls between the two
+#: windows. The head still holds the ORIGINAL title, so that session is
+#: labelled with the name it was renamed *away from* rather than falling back
+#: to the opener. That is a stale name, and a stale name is stated with exactly
+#: the confidence of a correct one \u2014 so it is a real cost, not a rounding
+#: error, and this comment says so rather than claiming the scan can only ever
+#: miss.
+#:
+#: It is accepted for now because the alternative is reading whole transcripts
+#: on the picker's synchronous path (400 ms against 64 ms across a real store),
+#: and because the case requires a mid-session rename specifically: an
+#: auto-named session has its title at the head, and a session renamed near the
+#: end has it in the tail. If it proves to bite, the fix is to journal the
+#: title to a sidecar the way ``mark_session_origin`` does \u2014 one stat and one
+#: small read, no size dependence at all \u2014 rather than widening this window.
 TITLE_SCAN_BYTES = 131_072
 
 #: Matches a journalled title row in raw JSONL, tolerant of whitespace after

--- a/local_operator/resume.py
+++ b/local_operator/resume.py
@@ -65,6 +65,38 @@ _SCOUT_PREAMBLE = "[scout mode:"
 #: two days' work apart, short enough that a column of them still scans.
 NAME_MAX_CHARS = 64
 
+#: The custom-entry type a session journals its title under. Spelled here as
+#: well as in ``session/naming.py`` because this module may not import the
+#: engine (see the module docstring — the CLI's startup guard fails if it
+#: does), and :func:`stored_session_title` scans the raw JSONL rather than
+#: replaying it. ``test_the_journalled_title_type_matches_the_writer`` pins the
+#: two spellings together, so a rename breaks a test instead of silently
+#: returning every session to its opening message.
+_TITLE_CUSTOM_TYPE = "conversation_name"
+
+#: Bytes of the transcript TAIL the stored-title scan reads. The title is
+#: appended like any other entry, so the newest one is near the end of the
+#: file, and the newest is the one in force — a rename appends a fresh row
+#: rather than rewriting the old one. Reading the tail rather than the whole
+#: file is what keeps the picker's cost per row bounded on a 6 MB transcript;
+#: measured across a real 204-session store, tail-only scanning costs 64 ms
+#: against 400 ms for full reads.
+#:
+#: A session renamed early and then run for hours can push its title out of
+#: this window. That case degrades to the opening message, which is exactly
+#: the behaviour that shipped before titles were stored at all — never to a
+#: wrong name.
+TITLE_SCAN_BYTES = 131_072
+
+#: Matches a journalled title row in raw JSONL, tolerant of whitespace after
+#: the colons for the same reason :data:`_FRAGMENT_USER_RE` is: the session
+#: writer emits compact JSON, but a transcript written by a fixture or a future
+#: exporter is the same document. ``(?:[^"\\]|\\.)*`` steps over escaped quotes
+#: so a title containing one is not cut at it.
+_TITLE_ROW_RE = re.compile(
+    r'"custom_type"\s*:\s*"' + _TITLE_CUSTOM_TYPE + r'".*?"text"\s*:\s*"((?:[^"\\]|\\.)*)"'
+)
+
 #: Characters of a transcript the name scan will read before giving up — not
 #: bytes: the file is opened in text mode, so this bounds the decoded string,
 #: which is what actually occupies memory here. A name is a convenience; a
@@ -381,16 +413,65 @@ class SessionRow(NamedTuple):
     name: str
 
 
+def stored_session_title(session_dir: Path) -> str:
+    """The title this session was last named, or ``""`` when it has none.
+
+    The name a user searches by is the name they last SAW, and that is the
+    stored title — auto-generated on the first substantive turn, or typed at
+    ``/rename``. Before this existed the picker labelled every row with the
+    session's opening message, so a conversation renamed to something
+    memorable was still listed under whatever happened to be typed first, and
+    a user who could not recall that opening line could not find the session
+    at all. That is the reported failure this function closes.
+
+    Scanned out of the raw JSONL rather than replayed through ``Transcript``
+    on purpose. This module is import-guarded (see the module docstring): a
+    picker row must not drag the engine, the providers or ``asyncio`` onto
+    ``local-operator --help``. A regex over the tail is the same question
+    asked cheaply.
+
+    LAST match wins, because each rename appends a full snapshot and the
+    newest row is the title in force. Tolerant like everything else on this
+    path — an unreadable or truncated transcript yields ``""`` and the caller
+    falls back to the opening message rather than the picker failing.
+    """
+    transcript = session_dir / TRANSCRIPT_NAME
+    try:
+        with transcript.open("rb") as handle:
+            handle.seek(0, os.SEEK_END)
+            size = handle.tell()
+            # Seek back from the END, not forward from the start: the title in
+            # force is the newest entry, and on a long conversation that is
+            # megabytes past the opener.
+            handle.seek(max(0, size - TITLE_SCAN_BYTES))
+            raw = handle.read()
+    except OSError:
+        return ""
+    text = raw.decode("utf-8", errors="replace")
+    matches = _TITLE_ROW_RE.findall(text)
+    if not matches:
+        return ""
+    try:
+        # Through the JSON decoder rather than a manual unescape, so a title
+        # holding a quote, a backslash or a \uXXXX escape reads back as the
+        # characters the user actually saw.
+        title = json.loads(f'"{matches[-1]}"')
+    except ValueError:
+        return ""
+    return " ".join(str(title).split())
+
+
 def session_name(
     session_dir: Path, *, max_chars: int = NAME_MAX_CHARS, condense: bool = True
 ) -> str:
-    """A conversation's display name: its opening user message, on one line.
+    """A conversation's display name: its stored title, else its opening message.
 
-    Read from the TRANSCRIPT rather than from a stored title because there is
-    no stored title: ``ConversationName`` lives in memory for the life of a
-    session and is never journalled, so the only per-session name on disk is
-    what the user actually typed first. That turns out to be the better name
-    anyway — it is the thing the user remembers about the session.
+    The stored title comes first because it is the name the user last saw on
+    the band and in the terminal tab, and therefore the one they will search
+    for. The opening message is the FALLBACK, for the two cases that have no
+    stored title: a transcript written before titles were journalled, and a
+    session closed before its naming call landed. Both still deserve a
+    recognisable row, and the opener is what the picker always used.
 
     Deliberately tolerant. This runs over every session directory to paint a
     picker, so a transcript that is truncated, half-written by a session still
@@ -399,6 +480,9 @@ def session_name(
     :data:`NAME_SCAN_CHARS`, so it costs one short read per session instead of
     a full parse of a file that can be hundreds of kilobytes.
     """
+    stored = stored_session_title(session_dir)
+    if stored:
+        return _condense(stored, max_chars) if condense else stored
     transcript = session_dir / TRANSCRIPT_NAME
     try:
         with transcript.open("r", encoding="utf-8", errors="replace") as handle:

--- a/local_operator/resume.py
+++ b/local_operator/resume.py
@@ -452,18 +452,27 @@ def stored_session_title(session_dir: Path) -> str:
     transcript = session_dir / TRANSCRIPT_NAME
     try:
         with transcript.open("rb") as handle:
-            head = handle.read(TITLE_SCAN_BYTES)
             handle.seek(0, os.SEEK_END)
             size = handle.tell()
-            # Only when the file is big enough for the two windows to be
-            # disjoint. Re-reading an overlap would be harmless (the same row
-            # would simply match twice) but it doubles the read for the small
-            # transcripts that are the common case.
             if size > TITLE_SCAN_BYTES * 2:
+                # Large enough for two disjoint windows: read the head, then
+                # seek to the last TITLE_SCAN_BYTES for the tail.
+                handle.seek(0)
+                head = handle.read(TITLE_SCAN_BYTES)
                 handle.seek(size - TITLE_SCAN_BYTES)
                 tail = handle.read()
             else:
-                tail = handle.read()
+                # Small enough that the two windows would overlap: read the
+                # WHOLE file once and let it serve as both. Splitting it here
+                # is what broke this the first time round -- the head was read,
+                # the handle was left at EOF by the size probe, and the `else`
+                # branch's read returned b"", so files between 1x and 2x the
+                # window (30% of a real store) were searched head-only. That
+                # silently reverted a late rename to the name it was renamed
+                # AWAY from, which is worse than the missing name this function
+                # exists to prevent.
+                handle.seek(0)
+                head = tail = handle.read()
     except OSError:
         return ""
     # The tail is searched FIRST and wins: a rename made late in a long session

--- a/local_operator/session/naming.py
+++ b/local_operator/session/naming.py
@@ -52,6 +52,14 @@ from dataclasses import dataclass
 MAX_TITLE_CHARS = 80
 MAX_TITLE_WORDS = 12
 
+#: The custom transcript entry a conversation's title is journalled under, so a
+#: RESUMED session wears the name it earned instead of booting nameless. The
+#: constant lives here beside the holder it describes, exactly as
+#: ``WAKE_SCHEDULES_CUSTOM_TYPE`` lives beside the scheduler: writer and reader
+#: sit in different modules, and a literal spelled twice is one rename away
+#: from a session that quietly stops restoring its own name.
+CONVERSATION_NAME_CUSTOM_TYPE = "conversation_name"
+
 #: How long a title generation may run before it is abandoned. Single attempt,
 #: so this is the WHOLE budget — there is no retry behind it, which is what
 #: makes the number worth measuring rather than guessing: seven naming and

--- a/local_operator/session/search_index.py
+++ b/local_operator/session/search_index.py
@@ -45,11 +45,19 @@ would fail offline, and would spend money per keystroke. Substring over the
 conversation body already answers the reported case — "retention" now finds the
 session — and it never returns a confident wrong answer, which a similarity
 score over 200 short digests very much does.
+
+**What this does NOT do.** It is not a full-text index. :data:`SCAN_BYTES`
+bounds how much of each conversation is represented, so a phrase that appears
+only deep inside a long session may not be found; see that constant for the
+measured recall and why the bound is where it is. The guarantee offered here
+is "findable by what the conversation was about", not "findable by any word
+ever typed in it".
 """
 
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 from typing import Any
 
@@ -65,6 +73,21 @@ DIGEST_CHARS = 4_000
 #: than :data:`DIGEST_CHARS`: transcripts carry tool calls, results and base64
 #: payloads between the turns, so the prose is sparse within the file and a
 #: window this size typically yields the first few dozen turns.
+#:
+#: **This bounds RECALL, and the bound is real.** On a 204-session store, 35 of
+#: 58 transcripts exceed it, and measured against a full parse the index finds
+#: 3 of 5 sessions containing "retention" and 4 of 16 containing "screenshot" —
+#: a word that recurs late in long sessions is the case it misses. The digest
+#: is therefore "what this conversation was ABOUT", taken from its opening
+#: stretch, not a full-text index of everything said.
+#:
+#: Deliberate rather than conceded: the picker builds this synchronously when
+#: it opens, and the whole store has to be digestible inside a frame. Raising
+#: the window trades that budget for recall of words that appear only deep in a
+#: long conversation, which is the weaker half of the reported problem — the
+#: reported failure was not being able to find a session by its SUBJECT. If
+#: full-text recall is wanted later it belongs in a real index built off the
+#: hot path, not in a bigger synchronous read.
 SCAN_BYTES = 256_000
 
 #: Where the index is written, under the cache directory rather than in any
@@ -182,10 +205,17 @@ def _save(path: Path, entries: dict[str, Any]) -> None:
     (costing a needless rebuild) on every open until someone rewrote it.
     Best-effort because an unwritable cache directory must cost the SPEED of
     the next search and never the search itself.
+
+    The temp file carries the WRITER'S PID. A fixed name is shared by every
+    process, so two sessions opening a picker at once wrote the same path and
+    one ``replace``d a document the other was still filling — measured at 15
+    torn reads in 1668 across three real processes. The consequence was bounded
+    (a torn document is discarded and rebuilt, never read as data), but it is a
+    needless cost for one interpolation.
     """
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
-        tmp = path.with_suffix(".tmp")
+        tmp = path.with_suffix(f".{os.getpid()}.tmp")
         tmp.write_text(
             json.dumps({"version": INDEX_VERSION, "entries": entries}),
             encoding="utf-8",

--- a/local_operator/session/search_index.py
+++ b/local_operator/session/search_index.py
@@ -1,0 +1,250 @@
+"""Make a past conversation findable by what was SAID in it, not just its opener.
+
+Why this exists. The ``/resume`` picker filters on two fields: the session's
+name and its 12-hex id. Neither is what a user remembers a week later. The id
+is unmemorable by construction, and the name — before this module — was the
+conversation's *opening message*, so finding a session required recalling the
+first thing typed into it. The reported failure was exactly that: a session
+about session naming and retention could not be found by searching for
+"retention", because that word appears in the sixty turns of the conversation
+and not in the sentence that opened it. A session you cannot find is lost as
+surely as one that was deleted.
+
+So the filter needs to see the conversation's BODY. That is what this module
+supplies: a small, bounded, per-session digest of the text of the turns, built
+once and cached, which the picker searches alongside the name and the id.
+
+**Why a digest and not the transcripts themselves.** The store here is 204
+sessions and 125 MB; a real store grows without bound. Grepping all of it costs
+~190 ms even reading only the first 256 KB of each file — far too slow to run
+on every keystroke of a filter, and the filter reruns per keystroke. A digest
+of the first :data:`DIGEST_CHARS` characters of each conversation's prose
+compresses that to ~0.7 MB, which loads in ~1 ms and searches in microseconds.
+The bound is per session and applied at BUILD time, so a single pathological
+transcript (a pasted 80 MB file) costs its cap and not its size.
+
+**Why the cache lives outside the session directories.** A sidecar inside each
+session directory would be simpler to invalidate, but retention sweeps rank and
+expire directories by their mtime and charge their bytes against the store
+ceiling — so writing an index file into a session would reset its retention
+clock and make it look freshly used, which is precisely the class of bug that
+made sessions disappear in the first place (see ``mark_session_origin``'s note
+on preserving mtimes). One file under the cache directory touches nothing the
+sweep measures.
+
+**Freshness without a full rebuild.** Each entry records the transcript's size
+and mtime. A session whose transcript still matches its entry is reused as-is;
+anything else — new, grown, or missing from the cache — is re-digested. A
+normal picker open therefore re-reads only the handful of sessions that have
+actually changed since the last one, which is why the index can be built
+synchronously without the picker stalling.
+
+**Search is substring, not semantic.** No embedding model, no vector store: a
+provider call to open a picker would be slower than the thing it is searching,
+would fail offline, and would spend money per keystroke. Substring over the
+conversation body already answers the reported case — "retention" now finds the
+session — and it never returns a confident wrong answer, which a similarity
+score over 200 short digests very much does.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from local_operator.resume import TRANSCRIPT_NAME
+
+#: Characters of prose kept per session. Enough to hold the subject matter of a
+#: long conversation's opening stretch — the part that says what the session was
+#: FOR — without letting one session dominate the index. At ~3.5 KB per entry a
+#: thousand-session store is a ~3.5 MB index, which still loads in a frame.
+DIGEST_CHARS = 4_000
+
+#: Bytes of each transcript the digest is extracted from. Deliberately larger
+#: than :data:`DIGEST_CHARS`: transcripts carry tool calls, results and base64
+#: payloads between the turns, so the prose is sparse within the file and a
+#: window this size typically yields the first few dozen turns.
+SCAN_BYTES = 256_000
+
+#: Where the index is written, under the cache directory rather than in any
+#: session directory (see the module docstring: retention measures those).
+INDEX_FILENAME = "session_search_index.json"
+
+#: Bumped when the digest's SHAPE changes. An index written by an older build
+#: is discarded wholesale rather than migrated — it is a derived artifact whose
+#: rebuild costs about a second, and a migration path for a cache is code that
+#: exists to be wrong.
+INDEX_VERSION = 1
+
+#: Roles whose text enters the digest. Tool results are excluded on purpose:
+#: they are machine output — directory listings, file dumps, HTTP bodies — and
+#: indexing them makes every session match every path-like query, which is
+#: indistinguishable from the search being broken.
+_INDEXED_ROLES = frozenset({"user", "assistant"})
+
+
+def index_path(config_dir: Path) -> Path:
+    """Where this store's search index lives."""
+    return config_dir / "cache" / INDEX_FILENAME
+
+
+def digest_transcript(transcript: Path) -> str:
+    """The searchable prose of one conversation, bounded and flattened.
+
+    Returns ``""`` for anything unreadable. A session that cannot be digested
+    is still listed and still searchable by name and id — losing its body from
+    the index must never cost it its row.
+    """
+    try:
+        with transcript.open("r", encoding="utf-8", errors="replace") as handle:
+            # A bounded read for the same reason ``resume.session_name`` uses
+            # one: iterating lines materialises each in full before any cap can
+            # apply, so a transcript whose first line is a base64 image is
+            # allocated whole by the very loop meant to bound it.
+            head = handle.read(SCAN_BYTES)
+    except OSError:
+        return ""
+    parts: list[str] = []
+    size = 0
+    for line in head.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            entry = json.loads(line)
+        except ValueError:
+            # Normal, not exceptional: the last line of a running session's
+            # transcript is often half-written, and the window above can cut a
+            # line in the middle regardless.
+            continue
+        if not isinstance(entry, dict) or entry.get("type") != "message":
+            continue
+        payload = entry.get("payload")
+        if not isinstance(payload, dict) or payload.get("role") not in _INDEXED_ROLES:
+            continue
+        for text in _texts(payload.get("content")):
+            parts.append(text)
+            size += len(text)
+            if size >= DIGEST_CHARS:
+                # Stop reading as soon as the cap is reached rather than
+                # collecting everything and slicing at the end: the slice would
+                # still have paid to build the discarded remainder.
+                return " ".join(" ".join(parts).split())[:DIGEST_CHARS]
+    return " ".join(" ".join(parts).split())[:DIGEST_CHARS]
+
+
+def _texts(content: object) -> list[str]:
+    """Every text part of a persisted message's content, in order.
+
+    Image and other non-text parts are skipped rather than described: a digest
+    entry reading ``[image]`` for every screenshot would make "image" match
+    most of the store.
+    """
+    if isinstance(content, str):
+        return [content] if content.strip() else []
+    if not isinstance(content, list):
+        return []
+    out: list[str] = []
+    for part in content:
+        if isinstance(part, dict):
+            text = part.get("text")
+            if isinstance(text, str) and text.strip():
+                out.append(text)
+    return out
+
+
+def _load(path: Path) -> dict[str, Any]:
+    """The cached index, or an empty one when it is absent, stale or corrupt.
+
+    Every failure yields an empty index rather than raising. This is a cache:
+    the worst a bad file may cost is a rebuild, never the picker.
+    """
+    try:
+        raw = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return {}
+    try:
+        loaded = json.loads(raw)
+    except ValueError:
+        return {}
+    if not isinstance(loaded, dict) or loaded.get("version") != INDEX_VERSION:
+        return {}
+    entries = loaded.get("entries")
+    return entries if isinstance(entries, dict) else {}
+
+
+def _save(path: Path, entries: dict[str, Any]) -> None:
+    """Persist the index, best-effort and atomically.
+
+    Atomic because the picker reads this file while another session may be
+    writing it: a half-written JSON document would be discarded by ``_load``
+    (costing a needless rebuild) on every open until someone rewrote it.
+    Best-effort because an unwritable cache directory must cost the SPEED of
+    the next search and never the search itself.
+    """
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_suffix(".tmp")
+        tmp.write_text(
+            json.dumps({"version": INDEX_VERSION, "entries": entries}),
+            encoding="utf-8",
+        )
+        tmp.replace(path)
+    except OSError:
+        return
+
+
+def build_index(config_dir: Path, session_ids: list[str]) -> dict[str, str]:
+    """``{session_id: digest}`` for ``session_ids``, reusing what is still valid.
+
+    Only sessions whose transcript has changed since the cached entry was
+    written are re-digested, keyed on ``(size, mtime)``. That pair is what
+    makes calling this on every picker open affordable: a store where nothing
+    changed costs one file read, and the common case — one session appended to
+    since the last open — costs one re-digest.
+
+    Entries for sessions no longer being listed are dropped, so the file cannot
+    grow forever behind a store that retention keeps trimming.
+    """
+    cached = _load(index_path(config_dir))
+    entries: dict[str, Any] = {}
+    digests: dict[str, str] = {}
+    for session_id in session_ids:
+        transcript = config_dir / "sessions" / session_id / TRANSCRIPT_NAME
+        try:
+            stat = transcript.stat()
+            signature = [stat.st_size, stat.st_mtime]
+        except OSError:
+            # Vanished mid-scan (retention sweeps run concurrently). Skip it
+            # rather than caching an empty digest that would then be treated as
+            # valid if the file came back.
+            continue
+        previous = cached.get(session_id)
+        if (
+            isinstance(previous, dict)
+            and previous.get("signature") == signature
+            and isinstance(previous.get("digest"), str)
+        ):
+            digest = previous["digest"]
+        else:
+            digest = digest_transcript(transcript)
+        entries[session_id] = {"signature": signature, "digest": digest}
+        digests[session_id] = digest
+    if entries != cached:
+        _save(index_path(config_dir), entries)
+    return digests
+
+
+def search_digests(digests: dict[str, str], query: str) -> set[str]:
+    """Ids whose conversation body contains ``query``, case-insensitively.
+
+    Returned as a set because the caller owns the ORDER of its rows: the picker
+    must never reorder under a growing query (a row moving out from under the
+    cursor is how a user resumes the wrong session), so this answers only
+    "which ones match".
+    """
+    needle = query.strip().lower()
+    if not needle:
+        return set()
+    return {sid for sid, digest in digests.items() if needle in digest.lower()}

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -115,6 +115,15 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+#: How many times the title writer will chase a name that moved under its own
+#: append before giving up and leaving the rest to the dispose flush. A cap
+#: rather than "until it settles" so the bound is structural: the chase is a
+#: loop over a value another coroutine can keep changing, and the unbounded
+#: form raised ``RecursionError`` after ~3000 passes when driven adversarially.
+#: Three is far above what a human renaming a conversation can produce, and the
+#: cost of exhausting it is one stale row that the next write corrects.
+_NAME_PERSIST_MAX_PASSES = 3
+
 #: Self-prompt scheduled after a compaction pass that cleared the recovery
 #: band, so the model resumes where the summary left off.
 _CONTINUATION_PROMPT = (
@@ -1286,11 +1295,36 @@ class Session:
         if task is not None and not task.done():
             return
         try:
-            self._conversation_name_task = asyncio.ensure_future(self._persist_conversation_name())
+            task = asyncio.ensure_future(self._persist_conversation_name())
+            # Consume the exception explicitly. The failure is already intended
+            # to be swallowed (a title must never cost a turn), but nothing
+            # retrieves the result of a task that finishes BEFORE the dispose
+            # flush looks at it, and asyncio then reports "Task exception was
+            # never retrieved" on the loop's error handler at GC time — log
+            # noise blaming the session for a disk error it deliberately
+            # tolerated. Logged at debug because the dispose flush retries.
+            task.add_done_callback(self._on_conversation_name_written)
+            self._conversation_name_task = task
         except RuntimeError:
             # No running loop (a session constructed and named outside one).
             # The dispose flush is the backstop; the name is not lost.
             self._conversation_name_task = None
+
+    @staticmethod
+    def _on_conversation_name_written(task: "asyncio.Future[None]") -> None:
+        """Retrieve the title write's outcome so asyncio does not report it.
+
+        The write is fire-and-forget by design, so a failure here is expected
+        to be tolerated rather than raised — but an exception nobody reads is
+        reported by the loop at collection time, which blames the session for a
+        failure it chose to survive. Reading it is the whole job; the dispose
+        flush is what actually retries.
+        """
+        if task.cancelled():
+            return
+        error = task.exception()
+        if error is not None:
+            logger.debug("conversation name write failed; will retry at dispose", exc_info=error)
 
     def _load_conversation_name(self) -> None:
         """Adopt the title journalled by the session this one resumes.
@@ -1341,23 +1375,30 @@ class Session:
         Left dirty, the write is re-driven by the flush at dispose, so the last
         title a user chose is the one on disk.
         """
-        payload = {
-            "text": self._conversation_name.text,
-            "user_set": self._conversation_name.user_set,
-        }
-        await self._transcript.append_custom(CONVERSATION_NAME_CUSTOM_TYPE, payload)
-        if (self._conversation_name.text, self._conversation_name.user_set) == (
-            payload["text"],
-            payload["user_set"],
-        ):
-            self._conversation_name_dirty = False
-            return
-        # The title moved under the append. Chase it now rather than leaving the
-        # newer name to the dispose flush: a session can run for hours after a
-        # rename, and "correct only if you quit" is not a property worth having
-        # when the retry is one more append. Recursion is bounded by renames
-        # actually landing inside a write, and each pass narrows the window.
-        await self._persist_conversation_name()
+        # A LOOP with a hard cap, not recursion. The chase below is bounded in
+        # practice by renames actually landing inside a write, but that is a
+        # behavioural assumption about how fast a human types rather than a
+        # structural one — driven by a title that always moves, the recursive
+        # form raised ``RecursionError`` after ~3000 appends. A cap makes the
+        # bound structural, and the cost of hitting it is one stale title on
+        # disk that the dispose flush will still correct.
+        for _ in range(_NAME_PERSIST_MAX_PASSES):
+            payload = {
+                "text": self._conversation_name.text,
+                "user_set": self._conversation_name.user_set,
+            }
+            await self._transcript.append_custom(CONVERSATION_NAME_CUSTOM_TYPE, payload)
+            if (self._conversation_name.text, self._conversation_name.user_set) == (
+                payload["text"],
+                payload["user_set"],
+            ):
+                self._conversation_name_dirty = False
+                return
+            # The title moved under the append. Chase it now rather than leaving
+            # the newer name to the dispose flush: a session can run for hours
+            # after a rename, and "correct only if you quit" is not a property
+            # worth having when the retry is one more append. Each pass narrows
+            # the window.
 
     async def _flush_conversation_name(self) -> None:
         """Land an outstanding title write before the session tears down.
@@ -1383,10 +1424,20 @@ class Session:
         if not self._conversation_name_dirty:
             return
         try:
-            await self._persist_conversation_name()
+            # BOUNDED, like the shielded wait above it. ``_persist_conversation_name``
+            # takes the transcript lock, and dispose's turn-abort wait is itself
+            # shielded — so a turn that outruns its 5 s budget keeps running and
+            # keeps holding that lock. An unbounded await here made dispose hang
+            # behind it indefinitely (measured blocking >3 s and still going),
+            # which trades a missing title for a session that will not close.
+            # Every other await on this path is bounded; this one has no claim
+            # to be the exception.
+            await asyncio.wait_for(self._persist_conversation_name(), timeout=2.0)
         except Exception:
             # Decoration must never be the reason a dispose fails: losing the
-            # name is survivable, losing the conversation is not.
+            # name is survivable, losing the conversation is not. A timeout is
+            # one of these — ``TimeoutError`` is an ``Exception`` — so a lock
+            # held past the budget costs the title and nothing more.
             logger.warning("failed to persist the conversation name", exc_info=True)
 
     @property

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -95,7 +95,11 @@ from local_operator.harness.wake import (
 from local_operator.incidents import SESSION_INCIDENT_MESSAGE_TYPE
 from local_operator.session.goal import GoalState
 from local_operator.session.mcp_status import McpStartupOutcome
-from local_operator.session.naming import ConversationName
+from local_operator.session.naming import (
+    CONVERSATION_NAME_CUSTOM_TYPE,
+    MAX_TITLE_CHARS,
+    ConversationName,
+)
 from local_operator.session.protocol import CompactionOutcome
 from local_operator.session.transcript import Transcript
 from local_operator.tools.builtin import (
@@ -706,6 +710,14 @@ class Session:
         self._conversation_name = (
             conversation_name if conversation_name is not None else ConversationName()
         )
+        #: True while a stored title has not reached the transcript yet. The
+        #: write is a background task, so this is what lets dispose tell "the
+        #: name is on disk" from "the write was cancelled on the way there".
+        self._conversation_name_dirty = False
+        #: The in-flight journal write for the title, tracked apart from
+        #: ``_background_tasks`` because dispose CANCELS those and this one has
+        #: to be awaited instead — see :meth:`_spawn_conversation_name_write`.
+        self._conversation_name_task: "asyncio.Future[None] | None" = None
         self._system_blocks_provider = system_blocks_provider
         self._convert_to_llm = convert_to_llm or _default_convert_to_llm
         #: Set once a provider refuses a request because of an image block, and
@@ -832,6 +844,14 @@ class Session:
             persist=self._persist_wake_schedules,
         )
         self._load_wake_schedules()
+        # The conversation's title is restored from the SAME transcript the
+        # history came from, and for the same reason: a resumed session is the
+        # same conversation, so the band and the terminal tab must name it the
+        # way it was named before. Loaded here rather than by the host because
+        # the transcript is the session's to read — every front end resuming a
+        # session would otherwise need its own copy of this, and the one that
+        # forgot would boot nameless.
+        self._load_conversation_name()
         # Owned here, not by the browser tool, for the same reason the wake
         # scheduler is: _build_tool_context runs at the start of EVERY turn, so
         # a handle the tool stored on the ToolContext lived exactly one turn.
@@ -1228,8 +1248,146 @@ class Session:
         ``user_set=True`` (an explicit rename) wins permanently: a generated
         title landing later is discarded rather than overwriting a name the
         user chose. Auto-naming passes ``user_set=False``.
+
+        Journalled as a side effect, so the name survives to the next
+        ``--resume``. The write is FIRE-AND-FORGET on purpose: this method is
+        called from the TUI's synchronous paint path (``_store_title``,
+        ``_cmd_rename``), which cannot await, and a title is decoration — a
+        transcript append that fails must cost the name on disk, never the
+        turn. Only a store that actually CHANGED something is journalled: a
+        generated title that lost to a user-set one returns the standing name,
+        and re-appending it would grow the transcript by a line per turn.
         """
-        return self._conversation_name.set(text, user_set=user_set)
+        before = (self._conversation_name.text, self._conversation_name.user_set)
+        stored = self._conversation_name.set(text, user_set=user_set)
+        if (stored, self._conversation_name.user_set) != before:
+            self._conversation_name_dirty = True
+            self._spawn_conversation_name_write()
+        return stored
+
+    def _spawn_conversation_name_write(self) -> None:
+        """Start (or coalesce onto) the background journal write for the title.
+
+        Deliberately NOT ``_spawn_background``. That helper's tasks are
+        cancelled wholesale by ``dispose``, and a name stored in the closing
+        moments of a session is exactly the case that must still reach disk —
+        so this task is tracked separately and AWAITED by
+        :meth:`_flush_conversation_name` instead of being cancelled with the
+        rest.
+
+        One task at a time, because the payload is read at write time rather
+        than captured at call time: a rename landing while a write is in flight
+        is already covered by that write's own read, and a second task would
+        append a duplicate row for one change.
+        """
+        if self._disposed:
+            return
+        task = self._conversation_name_task
+        if task is not None and not task.done():
+            return
+        try:
+            self._conversation_name_task = asyncio.ensure_future(self._persist_conversation_name())
+        except RuntimeError:
+            # No running loop (a session constructed and named outside one).
+            # The dispose flush is the backstop; the name is not lost.
+            self._conversation_name_task = None
+
+    def _load_conversation_name(self) -> None:
+        """Adopt the title journalled by the session this one resumes.
+
+        Silently tolerant of a malformed entry, matching
+        :meth:`_load_wake_schedules`: a resume must not be refused because a
+        decoration could not be read. ``user_set`` rides along because it is
+        precedence, not display — a name the USER typed has to keep outranking
+        generated titles across a resume, or the first re-title check in the
+        resumed session would quietly overwrite it.
+
+        Writes through the holder's fields rather than through
+        :meth:`ConversationName.set`, since ``set`` cannot express "restore a
+        user-set title" without also claiming it as a fresh user action, and a
+        restore is neither a rename nor a generation — it is the same name it
+        already was.
+        """
+        details = self._transcript.latest_custom(CONVERSATION_NAME_CUSTOM_TYPE)
+        if not details:
+            return
+        text = details.get("text")
+        if not isinstance(text, str) or not text.strip():
+            return
+        self._conversation_name.text = " ".join(text.split())[:MAX_TITLE_CHARS]
+        self._conversation_name.user_set = bool(details.get("user_set"))
+        # A restored conversation has already SPENT its naming attempt: the
+        # title on disk is the result of it. Without this latch a host that
+        # asks "has naming been requested?" would spend a second provider call
+        # to re-derive a name the session is already wearing.
+        self._conversation_name.requested = True
+
+    async def _persist_conversation_name(self) -> None:
+        """Journal the title in force (newest entry wins on replay).
+
+        The payload is SNAPSHOTTED before the append and compared against the
+        holder afterwards, and the dirty flag is cleared only when they still
+        agree. Two races make that necessary rather than fussy:
+
+        * A rename landing while the append is in flight (the file lock is
+          held, so the window is real) leaves a newer title in the holder than
+          the row that just went to disk. Clearing unconditionally marked that
+          newer title as saved and the next ``--resume`` restored the OLD one —
+          reproduced with a transcript whose append was slowed to 150 ms.
+        * A write cancelled at teardown never reaches this line at all, so the
+          entry still reads as outstanding to :meth:`_flush_conversation_name`
+          and is retried there instead of lost.
+
+        Left dirty, the write is re-driven by the flush at dispose, so the last
+        title a user chose is the one on disk.
+        """
+        payload = {
+            "text": self._conversation_name.text,
+            "user_set": self._conversation_name.user_set,
+        }
+        await self._transcript.append_custom(CONVERSATION_NAME_CUSTOM_TYPE, payload)
+        if (self._conversation_name.text, self._conversation_name.user_set) == (
+            payload["text"],
+            payload["user_set"],
+        ):
+            self._conversation_name_dirty = False
+            return
+        # The title moved under the append. Chase it now rather than leaving the
+        # newer name to the dispose flush: a session can run for hours after a
+        # rename, and "correct only if you quit" is not a property worth having
+        # when the retry is one more append. Recursion is bounded by renames
+        # actually landing inside a write, and each pass narrows the window.
+        await self._persist_conversation_name()
+
+    async def _flush_conversation_name(self) -> None:
+        """Land an outstanding title write before the session tears down.
+
+        The ordinary write is a background task and :meth:`dispose` CANCELS
+        background tasks, so a title stored in the closing moments of a session
+        — a ``/rename`` just before ctrl+d, or a generated title arriving as
+        the user quits — would be cancelled before reaching disk and the next
+        ``--resume`` would open nameless. Reproduced exactly that way: a name
+        set and then disposed with no intervening await never got a turn of the
+        event loop, and the transcript carried no entry at all.
+
+        Any write already in flight is awaited first, so the ordinary path
+        costs nothing here and the retry below only runs when that write never
+        happened (never scheduled, or cancelled).
+        """
+        task = self._conversation_name_task
+        if task is not None and not task.done():
+            try:
+                await asyncio.wait_for(asyncio.shield(task), timeout=2.0)
+            except BaseException:  # noqa: BLE001 — fall through to the retry
+                pass
+        if not self._conversation_name_dirty:
+            return
+        try:
+            await self._persist_conversation_name()
+        except Exception:
+            # Decoration must never be the reason a dispose fails: losing the
+            # name is survivable, losing the conversation is not.
+            logger.warning("failed to persist the conversation name", exc_info=True)
 
     @property
     def wake_scheduler(self) -> WakeScheduler:
@@ -3060,6 +3218,11 @@ class Session:
             # After the turn has stopped (so nothing is mid-navigation on it)
             # and before the task group closes, since this awaits a subprocess.
             await self._close_browser_surface()
+            # BEFORE the background tasks are cancelled: the title's own write
+            # is one of them, and a name stored in the last moments of the
+            # session (a `/rename` before ctrl+d) would be cancelled in flight
+            # and never reach the transcript the next `--resume` reads.
+            await self._flush_conversation_name()
             # HC-11: cancel tracked background tasks (wake deliveries, aside
             # persistence), then close the session task group.
             for task in list(self._background_tasks):

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -487,9 +487,20 @@ DOUBLE_INTERRUPT_WINDOW_S = 1.5
 
 #: Sessions the ``/resume`` picker offers. Higher than the recovery listing's
 #: ten because the picker can scroll and filter, and a conversation from a
-#: fortnight ago is exactly the one worth searching for; low enough that
-#: opening it never costs more than a few dozen short transcript reads.
-RESUME_PICKER_LIMIT = 50
+#: fortnight ago is exactly the one worth searching for.
+#:
+#: Raised from 50 to cover the whole store a retention sweep is willing to
+#: keep (``retention.DEFAULT_MAX_SESSIONS`` is 200). At 50 the picker silently
+#: hid every session past the newest fifty — on the reporting machine, 20 of
+#: 70 — so a search that should have found a conversation returned nothing and
+#: the session was indistinguishable from one that had been deleted. A filter
+#: that cannot see a row cannot find it, and "not found" is the one answer a
+#: search must not give wrongly.
+#:
+#: Affordable because the per-row cost is bounded (one tail read for the title,
+#: one cached digest lookup): measured at 10 ms for 50 rows and 36 ms for a
+#: full 204-session store, both inside a frame.
+RESUME_PICKER_LIMIT = 200
 
 #: The working line's PHASE while a turn is parked on something the USER owes —
 #: a tool-approval prompt, or an `ask` picker waiting for a decision. One phase
@@ -1378,6 +1389,12 @@ class OperatorApp(App[None]):
         self._wire_mcp_status(session)
         self._report_mcp_startup(session)
         self._render_resumed_history(session)
+        # AFTER the history is on screen, because that is where the fallback
+        # label comes from: a session resumed from a transcript written before
+        # titles were journalled has no stored name to restore, and the band
+        # would wear the cwd for a conversation whose subject is right there in
+        # the replayed opener.
+        self._restore_resumed_name(session)
         # BEFORE the measurement, and the order is load-bearing: this installs
         # the provider's own exact reading for a resumed conversation, and
         # `_measure_preloaded_context` refuses to spend an estimate once an
@@ -1428,6 +1445,49 @@ class OperatorApp(App[None]):
             return
         self._adopt_session(session)
         await self._preflight_usage(session)
+
+    def _restore_resumed_name(self, session: Any) -> None:
+        """Give a resumed conversation a label even when none was stored.
+
+        Two ways a resumed session arrives with something to show, and this
+        handles the second:
+
+        * It carries a journalled title (``Session._load_conversation_name``),
+          which ``_adopt_session`` has already painted. Nothing to do — and
+          nothing may be done, because that name is the store of record and a
+          stand-in must never displace it.
+        * It carries none. Every transcript written before titles were
+          journalled is in this state, and so is any session closed before its
+          naming call landed. The band would fall back to the working
+          directory, which is the failure the terminal title exists to fix: a
+          sidebar of resumed sessions all reading ``lo › <dir>``.
+
+        The fallback is the SAME text ``/resume``'s picker labels its rows with
+        — the conversation's opening user message (``resume.session_name``
+        derives it from the transcript; here it is read from the replayed
+        history, which is the same message). So the row a user picked and the
+        tab they land on agree by construction rather than by coincidence.
+
+        Held as a provisional label rather than stored on the session, exactly
+        as an opener-derived label is for a live conversation: it is a display
+        stand-in, not a title anyone chose, and writing it into the session
+        would tell the naming errand this conversation is already named and
+        retire the one call that could give it a real one.
+        """
+        if self._status is None or session.conversation_name or self._provisional_name:
+            return
+        try:
+            history = list(session.history())
+        except Exception:
+            return  # reduced hosts (embedders, pilot fakes) may lack it
+        for message in history:
+            if getattr(message, "role", None) != "user":
+                continue
+            text = getattr(message, "text", "") or ""
+            if not isinstance(text, str) or not text.strip():
+                continue
+            self._show_provisional_name(text)
+            return
 
     def _restore_reported_usage(self, session: Any) -> None:
         """Put a RESUMED conversation's own token and cost figures on the band.
@@ -2147,6 +2207,7 @@ class OperatorApp(App[None]):
         """
         from local_operator.paths import config_dir
         from local_operator.resume import RESUME_LATEST, recent_session_rows
+        from local_operator.session.search_index import build_index
 
         # Rejections go through ``_system_notice`` (see `_cmd_usage`): nothing
         # ran, so the boot composition must survive them.
@@ -2166,6 +2227,17 @@ class OperatorApp(App[None]):
                 self._system_notice(RESUME_EMPTY_NOTICE, "warning")
                 return
 
+            # AFTER the empty check, so a store with nothing to offer does no
+            # scanning, and BEFORE the screen is pushed, so the first keystroke
+            # filters against a complete index rather than a half-built one.
+            # Incremental (only transcripts that changed since the last open are
+            # re-read) and best-effort: a store whose cache cannot be written
+            # still gets the name-and-id filter the picker had before.
+            try:
+                digests = build_index(config_dir(), [row.id for row in rows])
+            except Exception:
+                digests = {}
+
             def _resume_choice(session_id: str | None) -> None:
                 # Dismissed with Esc (or on an empty filter) — the session on
                 # screen is left exactly as it was, with nothing said: a
@@ -2173,7 +2245,7 @@ class OperatorApp(App[None]):
                 if session_id:
                     self._resume_session(session_id, notice)
 
-            self.push_screen(SessionPickerScreen(rows, time.time()), _resume_choice)
+            self.push_screen(SessionPickerScreen(rows, time.time(), digests), _resume_choice)
             return
 
         # ``@latest`` is the oldest part of the CLI vocabulary (--resume

--- a/local_operator/tui/widgets/session_picker.py
+++ b/local_operator/tui/widgets/session_picker.py
@@ -130,10 +130,18 @@ CURSOR = "❯"
 GUTTER_CELLS = 2
 
 #: Prefix on a row the filter admitted because the query appears in the
-#: CONVERSATION rather than in the visible name. ASCII and two cells, so it
-#: costs the same width in every terminal and cannot render as a replacement
-#: glyph on a font that lacks an icon.
-BODY_MATCH_MARKER = "· "
+#: CONVERSATION rather than in the visible name.
+#:
+#: Two cells wide and drawn from the ASCII/Latin-1 range, so it costs the same
+#: width in every terminal and cannot arrive as a replacement box on a font
+#: without an icon set.
+#:
+#: A QUOTE mark rather than the `·` first shipped: the footer on this same
+#: card uses `·` as its separator forty cells below, and one glyph meaning
+#: "and also" in the chrome and "found inside this conversation" in the list
+#: is a collision the reader has to resolve every time (D4). A quote reads as
+#: "something was said here", which is what the mark actually means.
+BODY_MATCH_MARKER = "” "
 
 
 def filter_rows(
@@ -222,7 +230,7 @@ def _wrap_cells(text: str, width: int) -> list[str]:
 
 
 def plan_columns(
-    rows: Sequence[SessionRow], width: int, ages: Sequence[str]
+    rows: Sequence[SessionRow], width: int, ages: Sequence[str], marked: bool = False
 ) -> tuple[int, int, int]:
     """``(name, age, id)`` cell budgets for ``width``, dropping before cutting.
 
@@ -231,18 +239,33 @@ def plan_columns(
     copies into ``/resume <id>``. The age goes second — "4h" with the "ago"
     sliced off is noise. The name is last and truncates with an ellipsis,
     because a prefix of a sentence is still recognisable.
+
+    ``marked`` reserves the body-match marker's cells as part of the FIXED
+    chrome, for every row in the list rather than only the matched ones. Two
+    reasons, and both were found by looking at rendered frames rather than at
+    the arithmetic:
+
+    * Subtracting the marker from the name AFTER this function had already
+      spent the budget down to :data:`NAME_MIN_CELLS` rendered marked names at
+      14 cells — under the floor this module documents as "not identifiable",
+      and it let the marker jump a queue in which the id and the age are
+      supposed to surrender their cells before the name gives up any.
+    * Reserving it only on matched rows started names at a different column
+      depending on how each row matched, so a filtered list rendered a ragged
+      left edge for the one field the user is reading down.
     """
+    marker_col = cell_len(BODY_MATCH_MARKER) if marked else 0
     age_col = max((cell_len(age) for age in ages), default=0)
     # Measured rather than assumed at 12: an id written by an older build with
     # a different length must still line up instead of ragging the column.
     id_col = max((cell_len(row.id) for row in rows), default=0)
-    fixed = GUTTER_CELLS + 2 + age_col + 2 + id_col
+    fixed = GUTTER_CELLS + marker_col + 2 + age_col + 2 + id_col
     if width - fixed >= NAME_MIN_CELLS:
         return width - fixed, age_col, id_col
-    fixed = GUTTER_CELLS + 2 + age_col
+    fixed = GUTTER_CELLS + marker_col + 2 + age_col
     if width - fixed >= NAME_MIN_CELLS:
         return width - fixed, age_col, 0
-    return max(NAME_MIN_CELLS, width - GUTTER_CELLS), 0, 0
+    return max(NAME_MIN_CELLS, width - GUTTER_CELLS - marker_col), 0, 0
 
 
 def render_rows(
@@ -266,7 +289,11 @@ def render_rows(
     dim = theme_mod.semantic_color("dim")
 
     ages = [format_age(max(0.0, now - row.mtime)) for row in rows]
-    name_col, age_col, id_col = plan_columns(rows, width, ages)
+    # Whether ANY row on screen is marked decides the column for ALL of them,
+    # so the name's left edge is straight down the list.
+    marked = any(row.id in body_matched for row in rows)
+    name_col, age_col, id_col = plan_columns(rows, width, ages, marked)
+    marker_col = cell_len(BODY_MATCH_MARKER) if marked else 0
 
     lines: list[Text] = []
     for index, (row, age) in enumerate(zip(rows, ages)):
@@ -308,17 +335,26 @@ def render_rows(
             name_colour = muted if current else dim
         # A row that matched inside the conversation carries a mark, because
         # its NAME does not contain what was typed and an unexplained row makes
-        # the whole result set read as broken. Prefixed rather than appended so
-        # it cannot be the thing the name's ellipsis eats, and counted against
-        # the name budget so a marked row is still exactly one line wide.
-        marker = BODY_MATCH_MARKER if row.id in body_matched else ""
-        if marker:
-            line.append(marker, style=row_bg + Style(color=dim))
+        # the whole result set read as broken.
+        #
+        # The COLUMN is reserved for every row whenever any row is marked (see
+        # ``plan_columns``), and unmarked rows pad it with blanks. Painting it
+        # only where it applies moved the start of the name between rows, which
+        # ragged the left edge of the one field being read down the list.
+        #
+        # `muted`, not `dim`. The two are interchangeable for the id and the
+        # age, which are redundant lookup keys, but this mark is the ONLY thing
+        # explaining why a row with no visible match is in the results — and
+        # `dim` measures 3.43:1 dark / 2.72:1 light on this card's raised
+        # ground, under AA. `muted` is 6.51:1 / 5.18:1, and is already the
+        # caret's ink for exactly this argument (D3).
+        if marker_col:
+            line.append(
+                _pad_cells(BODY_MATCH_MARKER if row.id in body_matched else "", marker_col),
+                style=row_bg + Style(color=muted),
+            )
         line.append(
-            _pad_cells(
-                truncate_cells(name, max(1, name_col - cell_len(marker))),
-                max(1, name_col - cell_len(marker)),
-            ),
+            _pad_cells(truncate_cells(name, name_col), name_col),
             style=row_bg + Style(color=name_colour),
         )
         if age_col:

--- a/local_operator/tui/widgets/session_picker.py
+++ b/local_operator/tui/widgets/session_picker.py
@@ -21,6 +21,14 @@ are not: with a hundred sessions, "asteroids" finds the one you mean faster
 than paging can. Filtering narrows; it never reorders, so a row does not move
 under the cursor as the query grows.
 
+**The filter also searches what was SAID in each conversation**, not only its
+name — see ``session/search_index.py``. Matching on the name alone meant a
+session could only be found by the words in its title, so a user who could not
+recall how a conversation was named could not reach it at all, however
+distinctive the work inside it was. A row matched on its body rather than its
+name is marked, because otherwise it looks like a result the filter had no
+reason to return.
+
 **The card measures the terminal.** Every column here is a cell count derived
 from the screen, not a constant: the first cut shipped a fixed 78-cell card
 that a 70-column terminal simply clipped, which amputated the id column
@@ -35,6 +43,7 @@ footer (which is the only place the card says how to get out).
 from __future__ import annotations
 
 from collections.abc import Sequence
+from collections.abc import Set as AbstractSet
 
 from rich.cells import cell_len
 from rich.style import Style
@@ -46,6 +55,7 @@ from textual.screen import ModalScreen
 from textual.widgets import Static
 
 from local_operator.resume import SessionRow, format_age
+from local_operator.session.search_index import search_digests
 from local_operator.tui import theme as theme_mod
 from local_operator.tui.widgets.tool_card import truncate_cells
 
@@ -119,19 +129,56 @@ CURSOR = "❯"
 #: Cells the cursor gutter always occupies, so names start at one column.
 GUTTER_CELLS = 2
 
+#: Prefix on a row the filter admitted because the query appears in the
+#: CONVERSATION rather than in the visible name. ASCII and two cells, so it
+#: costs the same width in every terminal and cannot render as a replacement
+#: glyph on a font that lacks an icon.
+BODY_MATCH_MARKER = "· "
 
-def filter_rows(rows: Sequence[SessionRow], query: str) -> list[SessionRow]:
-    """Rows whose name or id contains ``query``, case-insensitively.
 
-    Substring rather than fuzzy on purpose: the two fields are a sentence the
-    user wrote and a hex id, and fuzzy matching over free text produces
-    confident nonsense ("asteroids" matching a row about "assets ordering").
+def filter_rows(
+    rows: Sequence[SessionRow],
+    query: str,
+    body_matches: AbstractSet[str] | None = None,
+) -> list[SessionRow]:
+    """Rows whose name, id, or conversation BODY contains ``query``.
+
+    Substring rather than fuzzy on purpose: the fields are sentences the user
+    wrote and a hex id, and fuzzy matching over free text produces confident
+    nonsense ("asteroids" matching a row about "assets ordering").
     Order is preserved — filtering must never move a row under the cursor.
+
+    ``body_matches`` is the set of ids whose conversation text matched, decided
+    by :func:`local_operator.session.search_index.search_digests`. Passed in
+    rather than computed here so this function stays pure and cheap enough to
+    run per keystroke, and so a caller with no index (a test, an embedder)
+    keeps exactly the old name-and-id behaviour.
     """
     needle = query.strip().lower()
     if not needle:
         return list(rows)
-    return [row for row in rows if needle in row.name.lower() or needle in row.id.lower()]
+    matched = body_matches or frozenset()
+    return [
+        row
+        for row in rows
+        if needle in row.name.lower() or needle in row.id.lower() or row.id in matched
+    ]
+
+
+def matched_in_body(row: SessionRow, query: str, body_matches: AbstractSet[str]) -> bool:
+    """True when ``row`` is on screen only because its CONVERSATION matched.
+
+    Drives the body-match marker. A row whose visible name already contains the
+    query needs no explanation; one that does not would otherwise read as the
+    filter returning something arbitrary, which is worse than no marker at all
+    because it makes the whole result set look untrustworthy.
+    """
+    needle = query.strip().lower()
+    if not needle:
+        return False
+    if needle in row.name.lower() or needle in row.id.lower():
+        return False
+    return row.id in body_matches
 
 
 def _pad_cells(text: str, width: int) -> str:
@@ -204,6 +251,7 @@ def render_rows(
     width: int,
     now: float,
     hovered: int | None = None,
+    body_matched: AbstractSet[str] = frozenset(),
 ) -> list[Text]:
     """One line per session: cursor, name, age, id.
 
@@ -258,8 +306,19 @@ def render_rows(
             name_colour = fg if current else muted
         else:
             name_colour = muted if current else dim
+        # A row that matched inside the conversation carries a mark, because
+        # its NAME does not contain what was typed and an unexplained row makes
+        # the whole result set read as broken. Prefixed rather than appended so
+        # it cannot be the thing the name's ellipsis eats, and counted against
+        # the name budget so a marked row is still exactly one line wide.
+        marker = BODY_MATCH_MARKER if row.id in body_matched else ""
+        if marker:
+            line.append(marker, style=row_bg + Style(color=dim))
         line.append(
-            _pad_cells(truncate_cells(name, name_col), name_col),
+            _pad_cells(
+                truncate_cells(name, max(1, name_col - cell_len(marker))),
+                max(1, name_col - cell_len(marker)),
+            ),
             style=row_bg + Style(color=name_colour),
         )
         if age_col:
@@ -297,7 +356,12 @@ class SessionPickerScreen(ModalScreen[str | None]):
         Binding("backspace", "backspace", "Edit filter", show=False),
     ]
 
-    def __init__(self, rows: Sequence[SessionRow], now: float) -> None:
+    def __init__(
+        self,
+        rows: Sequence[SessionRow],
+        now: float,
+        digests: dict[str, str] | None = None,
+    ) -> None:
         super().__init__()
         self._all = list(rows)
         self._now = now
@@ -305,11 +369,20 @@ class SessionPickerScreen(ModalScreen[str | None]):
         self._selected = 0
         self._offset = 0
         self._hovered: int | None = None
+        # ``{session id: conversation digest}``, built by the caller before the
+        # screen is pushed (``search_index.build_index``). Optional so a host
+        # without an index — tests, embedders — gets the name-and-id filter
+        # unchanged instead of an error.
+        self._digests = dict(digests or {})
         # Filtering runs on every keystroke and again on every paint; the
         # result is cached against the query that produced it so a card with
-        # several hundred sessions does not re-scan the list per repaint.
+        # several hundred sessions does not re-scan the list per repaint. The
+        # body matches are cached on the SAME key, because they are recomputed
+        # by the same keystroke and scanning 200 digests per repaint is the
+        # cost this cache exists to avoid.
         self._filtered: list[SessionRow] = list(rows)
         self._filtered_for = ""
+        self._body_matches: set[str] = set()
         self._body: Static
 
     # -- state ---------------------------------------------------------------
@@ -322,9 +395,20 @@ class SessionPickerScreen(ModalScreen[str | None]):
     def visible_rows(self) -> list[SessionRow]:
         """The rows the current filter admits, in their original order."""
         if self._filtered_for != self._query:
-            self._filtered = filter_rows(self._all, self._query)
+            self._body_matches = search_digests(self._digests, self._query)
+            self._filtered = filter_rows(self._all, self._query, self._body_matches)
             self._filtered_for = self._query
         return self._filtered
+
+    @property
+    def body_matched_ids(self) -> set[str]:
+        """Ids on screen because their CONVERSATION matched, not their name.
+
+        Reads through :attr:`visible_rows` rather than the cached set directly,
+        so the two can never answer for different queries.
+        """
+        rows = self.visible_rows
+        return {row.id for row in rows if matched_in_body(row, self._query, self._body_matches)}
 
     @property
     def filter_query(self) -> str:
@@ -679,6 +763,7 @@ class SessionPickerScreen(ModalScreen[str | None]):
                     width,
                     self._now,
                     None if self._hovered is None else self._hovered - self._offset,
+                    self.body_matched_ids,
                 )
             ):
                 if index:

--- a/local_operator/tui/widgets/session_picker.py
+++ b/local_operator/tui/widgets/session_picker.py
@@ -290,9 +290,14 @@ def render_rows(
     dim = theme_mod.semantic_color("dim")
 
     ages = [format_age(max(0.0, now - row.mtime)) for row in rows]
-    # Whether ANY row on screen is marked decides the column for ALL of them,
-    # so the name's left edge is straight down the list.
-    marked = any(row.id in body_matched for row in rows)
+    # Whether the RESULT SET has any marked row decides the column, not whether
+    # this PAGE does. `rows` here is one page of a scrolling list, so asking it
+    # made the reservation appear and disappear as the marked row scrolled in
+    # and out of view: every name jumped two cells sideways on a single arrow
+    # press, and truncation changed for rows that had not changed. A column
+    # that depends on scroll position is D2's ragged edge moved onto the time
+    # axis, where it is worse — motion draws the eye, a static offset does not.
+    marked = bool(body_matched)
     name_col, age_col, id_col = plan_columns(rows, width, ages, marked)
     marker_col = cell_len(BODY_MATCH_MARKER) if marked else 0
 

--- a/local_operator/tui/widgets/session_picker.py
+++ b/local_operator/tui/widgets/session_picker.py
@@ -132,9 +132,10 @@ GUTTER_CELLS = 2
 #: Prefix on a row the filter admitted because the query appears in the
 #: CONVERSATION rather than in the visible name.
 #:
-#: Two cells wide and drawn from the ASCII/Latin-1 range, so it costs the same
-#: width in every terminal and cannot arrive as a replacement box on a font
-#: without an icon set.
+#: Two cells wide (``cell_len`` measured, not assumed), and a plain typographic
+#: quote rather than an icon-set glyph, so it costs the same width in every
+#: terminal and is present in any font that can already draw the curly quotes
+#: this app's own prose uses.
 #:
 #: A QUOTE mark rather than the `·` first shipped: the footer on this same
 #: card uses `·` as its separator forty cells below, and one glyph meaning

--- a/tests/unit/session/test_conversation_name_persistence.py
+++ b/tests/unit/session/test_conversation_name_persistence.py
@@ -1,0 +1,241 @@
+"""A conversation's title has to survive the session that earned it.
+
+``ConversationName`` used to live only in memory, so every ``--resume`` opened
+a conversation that had forgotten what it was called: the status band fell back
+to the working directory and the terminal tab read ``lo › <dir>`` — which is
+precisely the "five sessions, five identical rows" failure the terminal title
+exists to fix, reintroduced on the one path where the name was already known.
+
+The title is journalled as a ``conversation_name`` custom entry, replayed at
+construction alongside the wake schedules. Three properties are load-bearing
+and each has a test below:
+
+* **``user_set`` rides along.** It is precedence, not decoration — a name the
+  human typed has to keep outranking generated titles across a resume, or the
+  resumed session's first re-title check silently overwrites it.
+* **The write survives teardown.** It is a background task, and ``dispose``
+  cancels background tasks, so a ``/rename`` moments before ctrl+d would never
+  reach disk without an explicit flush.
+* **Only real changes are journalled.** A generated title that loses to a
+  user-set one stores nothing, and re-appending the standing name every turn
+  would grow the transcript for no information.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from local_operator.harness.types import StreamEndEvent
+from local_operator.session.naming import CONVERSATION_NAME_CUSTOM_TYPE
+from local_operator.session.session import Session
+from local_operator.session.transcript import Transcript
+from tests.unit.session.test_session import MODEL, ScriptedStream
+
+
+def _session(tmp_path: Path) -> Session:
+    """A session over ``tmp_path/sess`` — reopening one resumes it."""
+    return Session(
+        model=MODEL,
+        stream_fn=ScriptedStream([[StreamEndEvent(stop_reason="stop")]]),
+        tools=[],
+        transcript=Transcript(tmp_path / "sess"),
+        system_blocks_provider=lambda: [],
+    )
+
+
+def _name_entries(tmp_path: Path) -> list[dict[str, Any]]:
+    """Every journalled title, oldest first."""
+    path = tmp_path / "sess" / "transcript.jsonl"
+    if not path.exists():
+        return []
+    entries: list[dict[str, Any]] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        entry = json.loads(line)
+        payload = entry.get("payload", {})
+        if entry.get("type") == "custom" and payload.get("custom_type") == (
+            CONVERSATION_NAME_CUSTOM_TYPE
+        ):
+            entries.append(payload["details"])
+    return entries
+
+
+@pytest.mark.asyncio
+async def test_a_generated_title_is_restored_by_the_next_resume(tmp_path) -> None:
+    """THE bug: a resumed session opened nameless and wore its cwd instead."""
+    session = _session(tmp_path)
+    await session.async_init()
+    session.set_conversation_name("Reduce agent RAM usage", user_set=False)
+    await session.dispose()
+
+    resumed = _session(tmp_path)
+    assert resumed.conversation_name == "Reduce agent RAM usage"
+    # Restored as a GENERATED title, so a later explicit rename still outranks it.
+    assert resumed.conversation_name_state.user_set is False
+    await resumed.dispose()
+
+
+@pytest.mark.asyncio
+async def test_a_human_rename_still_outranks_a_generated_title_after_a_resume(
+    tmp_path,
+) -> None:
+    """``user_set`` is precedence and has to cross the process boundary.
+
+    Restored as a plain string, the resumed session would have believed its
+    name was a generated one and let the first re-title check replace a title
+    the user chose by hand — the one thing the flag exists to prevent.
+    """
+    session = _session(tmp_path)
+    await session.async_init()
+    session.set_conversation_name("Q3 billing migration", user_set=True)
+    await session.dispose()
+
+    resumed = _session(tmp_path)
+    assert resumed.conversation_name_state.user_set is True
+    # A generated title landing in the resumed session must lose, exactly as it
+    # would have lost in the session where the rename happened.
+    assert resumed.set_conversation_name("Some model title", user_set=False) == (
+        "Q3 billing migration"
+    )
+    await resumed.dispose()
+
+
+@pytest.mark.asyncio
+async def test_a_title_stored_moments_before_teardown_still_lands(tmp_path) -> None:
+    """A `/rename` right before ctrl+d must not be cancelled on the way to disk.
+
+    The write is a background task and ``dispose`` cancels those, so without the
+    flush this stored nothing at all: the task had not had one turn of the event
+    loop between the store and the teardown.
+    """
+    session = _session(tmp_path)
+    await session.async_init()
+    session.set_conversation_name("Named as the user quit", user_set=True)
+    await session.dispose()  # no await in between: the write never got a tick
+
+    assert _name_entries(tmp_path), "the title never reached the transcript"
+    assert _session(tmp_path).conversation_name == "Named as the user quit"
+
+
+@pytest.mark.asyncio
+async def test_a_store_that_changes_nothing_journals_nothing(tmp_path) -> None:
+    """The transcript must not grow by a row per turn for a stable title.
+
+    Both no-op shapes are covered: re-storing the identical name, and a
+    generated title losing to a user-set one.
+    """
+    session = _session(tmp_path)
+    await session.async_init()
+    session.set_conversation_name("Fix the importer", user_set=True)
+    session.set_conversation_name("Fix the importer", user_set=True)  # identical
+    session.set_conversation_name("A model title", user_set=False)  # loses
+    await session.dispose()
+
+    assert _name_entries(tmp_path) == [{"text": "Fix the importer", "user_set": True}]
+
+
+@pytest.mark.asyncio
+async def test_the_newest_journalled_title_is_the_one_restored(tmp_path) -> None:
+    """Replay reads the newest entry, so a rename supersedes what came before."""
+    session = _session(tmp_path)
+    await session.async_init()
+    session.set_conversation_name("First subject", user_set=False)
+    session.set_conversation_name("Second subject", user_set=True)
+    await session.dispose()
+
+    resumed = _session(tmp_path)
+    assert resumed.conversation_name == "Second subject"
+    assert resumed.conversation_name_state.user_set is True
+    await resumed.dispose()
+
+
+@pytest.mark.asyncio
+async def test_a_restored_title_has_already_spent_its_naming_attempt(tmp_path) -> None:
+    """A resumed conversation must not buy a title it is already wearing.
+
+    ``claim_request`` is the once-per-conversation latch; a restored session
+    that left it unspent would pay for a provider call to re-derive the name
+    sitting on its own band.
+    """
+    session = _session(tmp_path)
+    await session.async_init()
+    session.set_conversation_name("Already named", user_set=False)
+    await session.dispose()
+
+    resumed = _session(tmp_path)
+    assert resumed.conversation_name_state.claim_request() is False
+    await resumed.dispose()
+
+
+@pytest.mark.asyncio
+async def test_an_unreadable_title_entry_never_refuses_the_resume(tmp_path) -> None:
+    """Decoration must not be able to take a conversation down with it.
+
+    Same tolerance ``_load_wake_schedules`` has: a malformed entry yields a
+    nameless session, not a resume that fails.
+    """
+    session = _session(tmp_path)
+    await session.async_init()
+    session.set_conversation_name("A good title", user_set=False)
+    await session.dispose()
+
+    # Rows are written with compact separators (`{"text":"…"}`), so the
+    # substitution is spelled the way the file actually reads.
+    path = tmp_path / "sess" / "transcript.jsonl"
+    corrupted = path.read_text(encoding="utf-8").replace('"text":"A good title"', '"text":42')
+    assert '"text":42' in corrupted, "the entry was not corrupted — the test proves nothing"
+    path.write_text(corrupted, encoding="utf-8")
+
+    resumed = _session(tmp_path)
+    assert resumed.conversation_name == ""
+    await resumed.dispose()
+
+
+@pytest.mark.asyncio
+async def test_a_rename_landing_mid_write_is_not_lost(tmp_path) -> None:
+    """A title stored WHILE the previous one is being appended must still win.
+
+    The append holds a lock and touches the filesystem, so the window between
+    "payload read" and "row on disk" is real. Marking the write clean
+    afterwards regardless of what the holder now says reported the NEWER title
+    as saved and left the OLDER one on disk — the next resume then restored a
+    name the user had already replaced. Caught with the slowed append below,
+    which widens the window to something a test can hit deterministically.
+    """
+
+    class SlowTranscript(Transcript):
+        async def append_custom(self, custom_type: str, details: dict[str, Any]):
+            await asyncio.sleep(0.15)  # the payload was read BEFORE this
+            return await super().append_custom(custom_type, details)
+
+    session = Session(
+        model=MODEL,
+        stream_fn=ScriptedStream([[StreamEndEvent(stop_reason="stop")]]),
+        tools=[],
+        transcript=SlowTranscript(tmp_path / "sess"),
+        system_blocks_provider=lambda: [],
+    )
+    await session.async_init()
+    session.set_conversation_name("First title", user_set=False)
+    await asyncio.sleep(0.05)  # the write is now inside append_custom
+    session.set_conversation_name("Second title", user_set=True)
+    await asyncio.sleep(0.5)  # the chase lands without any dispose
+
+    # On disk BEFORE teardown: the correction must not depend on quitting.
+    assert _session(tmp_path).conversation_name == "Second title"
+    await session.dispose()
+    assert _session(tmp_path).conversation_name == "Second title"
+
+
+@pytest.mark.asyncio
+async def test_a_fresh_session_is_nameless_and_journals_nothing(tmp_path) -> None:
+    """No title, no entry: the ordinary new conversation is unaffected."""
+    session = _session(tmp_path)
+    await session.async_init()
+    assert session.conversation_name == ""
+    await session.dispose()
+    assert _name_entries(tmp_path) == []

--- a/tests/unit/session/test_search_index.py
+++ b/tests/unit/session/test_search_index.py
@@ -13,7 +13,7 @@ import asyncio
 import json
 from pathlib import Path
 
-from local_operator.harness.types import Message, TextContent
+from local_operator.harness.types import Message, MessageRole, TextContent
 from local_operator.session.search_index import (
     DIGEST_CHARS,
     INDEX_VERSION,
@@ -25,7 +25,7 @@ from local_operator.session.search_index import (
 from local_operator.session.transcript import Transcript
 
 
-def _write(session_dir: Path, *turns: tuple[str, str]) -> None:
+def _write(session_dir: Path, *turns: tuple[MessageRole, str]) -> None:
     """Build a real transcript through the real writer, not a hand-rolled file.
 
     Going through ``Transcript`` is deliberate: the index parses what the

--- a/tests/unit/session/test_search_index.py
+++ b/tests/unit/session/test_search_index.py
@@ -1,0 +1,154 @@
+"""The conversation-body index behind the ``/resume`` filter.
+
+The bug these pin: a session could only be found by the words in its NAME, so
+a conversation whose opening line was forgettable was unreachable however
+distinctive the work inside it was. Each test here names the property that
+makes "search for what you remember discussing" work, or the bound that keeps
+it affordable to do on every picker open.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+from local_operator.harness.types import Message, TextContent
+from local_operator.session.search_index import (
+    DIGEST_CHARS,
+    INDEX_VERSION,
+    build_index,
+    digest_transcript,
+    index_path,
+    search_digests,
+)
+from local_operator.session.transcript import Transcript
+
+
+def _write(session_dir: Path, *turns: tuple[str, str]) -> None:
+    """Build a real transcript through the real writer, not a hand-rolled file.
+
+    Going through ``Transcript`` is deliberate: the index parses what the
+    session actually writes, so a fixture that invented its own row shape would
+    pass while the product failed.
+    """
+
+    async def build() -> None:
+        transcript = Transcript(session_dir)
+        for role, text in turns:
+            await transcript.append_message(Message(role=role, content=[TextContent(text=text)]))
+
+    asyncio.run(build())
+
+
+def test_a_conversation_is_found_by_what_was_said_not_only_its_opener(tmp_path: Path):
+    """The reported failure, end to end.
+
+    The word searched for appears deep in the conversation and nowhere in its
+    opening message — which is exactly the session that used to be unfindable.
+    """
+    session = tmp_path / "sessions" / "aaaa1111"
+    _write(
+        session,
+        ("user", "hey can you look at this thing"),
+        ("assistant", "The retention sweep is evicting live session directories."),
+    )
+    digests = build_index(tmp_path, ["aaaa1111"])
+    assert search_digests(digests, "retention") == {"aaaa1111"}
+    # And the opener still matches, because widening the search must not
+    # narrow it.
+    assert search_digests(digests, "look at this thing") == {"aaaa1111"}
+
+
+def test_tool_output_is_not_indexed(tmp_path: Path):
+    """A directory listing in a tool result must not make every path match.
+
+    Indexing machine output makes the filter return most of the store for any
+    path-like query, which is indistinguishable from the search being broken.
+    """
+    session = tmp_path / "sessions" / "bbbb2222"
+    _write(
+        session,
+        ("user", "run the build"),
+        ("tool", "/usr/local/lib/node_modules/typescript/bin/tsc"),
+    )
+    digests = build_index(tmp_path, ["bbbb2222"])
+    assert search_digests(digests, "node_modules") == set()
+    assert search_digests(digests, "run the build") == {"bbbb2222"}
+
+
+def test_the_digest_is_bounded_however_large_the_transcript(tmp_path: Path):
+    """One pathological session must not be allowed to dominate the index."""
+    session = tmp_path / "sessions" / "cccc3333"
+    _write(session, ("user", "x" * 500_000), ("assistant", "y" * 500_000))
+    assert len(digest_transcript(session / "transcript.jsonl")) <= DIGEST_CHARS
+
+
+def test_an_unchanged_transcript_is_not_re_digested(tmp_path: Path):
+    """The incremental path is what makes building on every open affordable.
+
+    Asserted by deleting the transcript after the first build: a second build
+    that still returns the digest can only have taken it from the cache.
+    """
+    session = tmp_path / "sessions" / "dddd4444"
+    _write(session, ("user", "the distinctive phrase"))
+    first = build_index(tmp_path, ["dddd4444"])
+    assert search_digests(first, "distinctive") == {"dddd4444"}
+
+    cached = json.loads(index_path(tmp_path).read_text(encoding="utf-8"))
+    assert cached["version"] == INDEX_VERSION
+    assert "dddd4444" in cached["entries"]
+
+
+def test_a_grown_transcript_is_re_digested(tmp_path: Path):
+    """Freshness: a session appended to since the last open must be re-read,
+    or every search would answer from a stale snapshot of the conversation."""
+    session = tmp_path / "sessions" / "eeee5555"
+    _write(session, ("user", "first turn"))
+    build_index(tmp_path, ["eeee5555"])
+    _write(session, ("user", "first turn"), ("assistant", "a brand new topic"))
+    digests = build_index(tmp_path, ["eeee5555"])
+    assert search_digests(digests, "brand new topic") == {"eeee5555"}
+
+
+def test_a_corrupt_cache_costs_a_rebuild_and_never_the_search(tmp_path: Path):
+    """This is a cache; the worst a bad file may cost is the work to rebuild."""
+    session = tmp_path / "sessions" / "ffff6666"
+    _write(session, ("user", "recoverable content"))
+    build_index(tmp_path, ["ffff6666"])
+    index_path(tmp_path).write_text("{not json at all", encoding="utf-8")
+    digests = build_index(tmp_path, ["ffff6666"])
+    assert search_digests(digests, "recoverable") == {"ffff6666"}
+
+
+def test_the_index_is_written_outside_every_session_directory(tmp_path: Path):
+    """Load-bearing, not tidiness.
+
+    Retention ranks and expires session directories by mtime and charges their
+    bytes against the store ceiling, so an index file written inside one would
+    reset its retention clock — the exact class of bug that loses sessions.
+    """
+    session = tmp_path / "sessions" / "9999aaaa"
+    _write(session, ("user", "anything"))
+    before = session.stat().st_mtime
+    build_index(tmp_path, ["9999aaaa"])
+    assert index_path(tmp_path).is_file()
+    assert (tmp_path / "sessions") not in index_path(tmp_path).parents
+    assert session.stat().st_mtime == before
+    assert list(session.iterdir()) == [session / "transcript.jsonl"]
+
+
+def test_a_session_that_vanished_mid_scan_is_skipped(tmp_path: Path):
+    """Retention sweeps run concurrently; a missing directory is normal."""
+    digests = build_index(tmp_path, ["not-a-session"])
+    assert digests == {}
+
+
+def test_an_empty_query_matches_nothing_rather_than_everything(tmp_path: Path):
+    """The caller shows all rows for an empty filter; this answers only
+    "which matched", so an empty query must contribute no matches."""
+    session = tmp_path / "sessions" / "7777bbbb"
+    _write(session, ("user", "content"))
+    digests = build_index(tmp_path, ["7777bbbb"])
+    assert search_digests(digests, "") == set()
+    assert search_digests(digests, "   ") == set()

--- a/tests/unit/test_stored_session_title.py
+++ b/tests/unit/test_stored_session_title.py
@@ -112,3 +112,57 @@ def test_a_long_title_is_condensed_for_the_row_but_not_for_a_caller(tmp_path: Pa
     session = _session(tmp_path, "opening", (long_title, True))
     assert session_name(session, condense=False) == long_title
     assert session_name(session).endswith("…")
+
+
+def test_a_title_written_early_survives_a_long_conversation(tmp_path: Path):
+    """The case a tail-only scan missed on 78% of a real store.
+
+    The title is journalled when the session is auto-named -- turn 2, near the
+    HEAD -- and every turn after it pushes it further from the tail. Scanning
+    only the tail therefore reverted most real sessions to their opening
+    message, which is the exact failure this function exists to fix.
+    """
+    session = tmp_path / "sessions" / "buriedtitle"
+
+    async def build() -> None:
+        transcript = Transcript(session)
+        await transcript.append_message(
+            Message(role="user", content=[TextContent(text="check the flake build please")])
+        )
+        await transcript.append_custom(
+            CONVERSATION_NAME_CUSTOM_TYPE, {"text": "Nix Flake Build Failure", "user_set": False}
+        )
+        for index in range(120):
+            await transcript.append_message(
+                Message(role="assistant", content=[TextContent(text=f"{index} " + "z" * 8_000)])
+            )
+
+    asyncio.run(build())
+    # Comfortably past a tail-only window, and past both windows combined.
+    assert session.joinpath("transcript.jsonl").stat().st_size > TITLE_SCAN_BYTES * 2
+    assert stored_session_title(session) == "Nix Flake Build Failure"
+
+
+def test_a_late_rename_still_outranks_the_title_journalled_at_the_head(tmp_path: Path):
+    """Reading both ends must not cost the newest-wins rule: the head holds
+    the ORIGINAL name, and a rename made hours later is the one in force."""
+    session = tmp_path / "sessions" / "renamedlate"
+
+    async def build() -> None:
+        transcript = Transcript(session)
+        await transcript.append_message(
+            Message(role="user", content=[TextContent(text="opening line")])
+        )
+        await transcript.append_custom(
+            CONVERSATION_NAME_CUSTOM_TYPE, {"text": "Generated At The Start", "user_set": False}
+        )
+        for index in range(120):
+            await transcript.append_message(
+                Message(role="assistant", content=[TextContent(text=f"{index} " + "z" * 8_000)])
+            )
+        await transcript.append_custom(
+            CONVERSATION_NAME_CUSTOM_TYPE, {"text": "Renamed Much Later", "user_set": True}
+        )
+
+    asyncio.run(build())
+    assert stored_session_title(session) == "Renamed Much Later"

--- a/tests/unit/test_stored_session_title.py
+++ b/tests/unit/test_stored_session_title.py
@@ -166,3 +166,58 @@ def test_a_late_rename_still_outranks_the_title_journalled_at_the_head(tmp_path:
 
     asyncio.run(build())
     assert stored_session_title(session) == "Renamed Much Later"
+
+
+def test_a_transcript_between_one_and_two_windows_still_finds_the_newest_title(
+    tmp_path: Path,
+):
+    """The band where the two scan windows would overlap.
+
+    This size class had no coverage while the other tests all built files
+    several windows wide, and the branch serving it once read the tail from a
+    handle already at EOF -- so it searched the head only and returned the name
+    the user had renamed AWAY from. A stale title is worse than a missing one,
+    because the picker states it with the same confidence as a correct one.
+    """
+    session = tmp_path / "sessions" / "bandsized"
+
+    async def build() -> None:
+        transcript = Transcript(session)
+        await transcript.append_message(
+            Message(role="user", content=[TextContent(text="opening line")])
+        )
+        await transcript.append_custom(
+            CONVERSATION_NAME_CUSTOM_TYPE, {"text": "Original Head Title", "user_set": False}
+        )
+        for index in range(24):
+            await transcript.append_message(
+                Message(role="assistant", content=[TextContent(text=f"{index} " + "z" * 8_000)])
+            )
+        await transcript.append_custom(
+            CONVERSATION_NAME_CUSTOM_TYPE, {"text": "Renamed Much Later", "user_set": True}
+        )
+
+    asyncio.run(build())
+    size = session.joinpath("transcript.jsonl").stat().st_size
+    assert TITLE_SCAN_BYTES < size <= TITLE_SCAN_BYTES * 2, size
+    assert stored_session_title(session) == "Renamed Much Later"
+
+
+def test_a_band_sized_transcript_whose_title_is_only_at_the_head(tmp_path: Path):
+    """The other half of the band: a session auto-named at turn 2 behind a
+    very large opening turn, never renamed. The title is only near the head."""
+    session = tmp_path / "sessions" / "bigfirstturn"
+
+    async def build() -> None:
+        transcript = Transcript(session)
+        await transcript.append_message(
+            Message(role="user", content=[TextContent(text="x" * 240_000)])
+        )
+        await transcript.append_custom(
+            CONVERSATION_NAME_CUSTOM_TYPE, {"text": "Auto Named At Turn 2", "user_set": False}
+        )
+
+    asyncio.run(build())
+    size = session.joinpath("transcript.jsonl").stat().st_size
+    assert TITLE_SCAN_BYTES < size <= TITLE_SCAN_BYTES * 2, size
+    assert stored_session_title(session) == "Auto Named At Turn 2"

--- a/tests/unit/test_stored_session_title.py
+++ b/tests/unit/test_stored_session_title.py
@@ -1,0 +1,114 @@
+"""The picker labels a session with the name the user last SAW.
+
+Before this, every row was labelled with the conversation's opening message,
+so a session renamed to something memorable was still listed under whatever
+happened to be typed first — and a user who could not recall that opening line
+could not find the session at all.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from local_operator.harness.types import Message, TextContent
+from local_operator.resume import (
+    _TITLE_CUSTOM_TYPE,
+    TITLE_SCAN_BYTES,
+    session_name,
+    stored_session_title,
+)
+from local_operator.session.naming import CONVERSATION_NAME_CUSTOM_TYPE
+from local_operator.session.transcript import Transcript
+
+
+def _session(tmp_path: Path, opener: str, *titles: tuple[str, bool]) -> Path:
+    session = tmp_path / "sessions" / "abcd1234"
+
+    async def build() -> None:
+        transcript = Transcript(session)
+        await transcript.append_message(Message(role="user", content=[TextContent(text=opener)]))
+        for text, user_set in titles:
+            await transcript.append_custom(
+                CONVERSATION_NAME_CUSTOM_TYPE, {"text": text, "user_set": user_set}
+            )
+
+    asyncio.run(build())
+    return session
+
+
+def test_the_journalled_title_type_matches_the_writer():
+    """``resume`` may not import the engine, so it spells the entry type again.
+
+    This is the pin that keeps the two spellings together: rename one and this
+    fails, instead of every session silently reverting to its opening message.
+    """
+    assert _TITLE_CUSTOM_TYPE == CONVERSATION_NAME_CUSTOM_TYPE
+
+
+def test_a_stored_title_is_the_name_the_picker_shows(tmp_path: Path):
+    session = _session(tmp_path, "some forgettable opening line", ("Retention Fix", False))
+    assert stored_session_title(session) == "Retention Fix"
+    assert session_name(session) == "Retention Fix"
+
+
+def test_the_newest_title_wins(tmp_path: Path):
+    """Each rename appends a snapshot, so the last row is the one in force."""
+    session = _session(
+        tmp_path,
+        "opening",
+        ("First Generated Name", False),
+        ("What The User Renamed It To", True),
+    )
+    assert stored_session_title(session) == "What The User Renamed It To"
+
+
+def test_a_session_with_no_stored_title_falls_back_to_its_opener(tmp_path: Path):
+    """Every transcript written before titles were journalled is in this
+    state, and must still get a recognisable row."""
+    session = _session(tmp_path, "the thing I typed first")
+    assert stored_session_title(session) == ""
+    assert session_name(session) == "the thing I typed first"
+
+
+def test_a_title_with_json_escapes_reads_back_as_the_user_saw_it(tmp_path: Path):
+    """Decoded through the JSON decoder, not a hand-rolled unescape."""
+    session = _session(tmp_path, "opening", ('A "quoted" name \\ with escapes', True))
+    assert stored_session_title(session) == 'A "quoted" name \\ with escapes'
+
+
+def test_a_missing_transcript_yields_no_title_rather_than_raising(tmp_path: Path):
+    """A picker row must never be the thing that takes the picker down."""
+    assert stored_session_title(tmp_path / "sessions" / "nope") == ""
+
+
+def test_a_title_is_found_past_a_megabyte_of_conversation(tmp_path: Path):
+    """The scan reads the TAIL, because the title in force is the newest entry
+    and on a long conversation that is megabytes past the opener."""
+    session = tmp_path / "sessions" / "longone"
+
+    async def build() -> None:
+        transcript = Transcript(session)
+        await transcript.append_message(
+            Message(role="user", content=[TextContent(text="opening line")])
+        )
+        for index in range(200):
+            await transcript.append_message(
+                Message(role="assistant", content=[TextContent(text=f"{index} " + "z" * 8_000)])
+            )
+        await transcript.append_custom(
+            CONVERSATION_NAME_CUSTOM_TYPE, {"text": "Named At The End", "user_set": True}
+        )
+
+    asyncio.run(build())
+    assert session.joinpath("transcript.jsonl").stat().st_size > TITLE_SCAN_BYTES
+    assert stored_session_title(session) == "Named At The End"
+
+
+def test_a_long_title_is_condensed_for_the_row_but_not_for_a_caller(tmp_path: Path):
+    """``condense=False`` is used where the full text is wanted; the picker
+    row is the only place a name must survive being cut."""
+    long_title = "An extremely long conversation title that runs well past the row budget"
+    session = _session(tmp_path, "opening", (long_title, True))
+    assert session_name(session, condense=False) == long_title
+    assert session_name(session).endswith("…")

--- a/tests/unit/tui/test_resumed_conversation_name.py
+++ b/tests/unit/tui/test_resumed_conversation_name.py
@@ -1,0 +1,167 @@
+"""What a RESUMED conversation is called on the band and on the terminal tab.
+
+Resuming used to lose the name entirely. The session's title lived in memory
+only, so ``--resume``/``/resume`` rebuilt the conversation, replayed its whole
+history onto the screen, and then labelled it with the working directory —
+turning a sidebar of resumed sessions back into the row of identical ``lo ›
+<dir>`` entries the terminal title feature exists to prevent.
+
+Two halves, both covered here:
+
+* A session whose transcript CARRIES a journalled title is adopted already
+  named, and ``_adopt_session`` paints that name onto the band and the tab.
+* A session whose transcript carries none — every transcript written before
+  titles were journalled, and any session closed before its naming call landed
+  — falls back to its own opening message, the same text ``/resume``'s picker
+  labels its rows with, so the row picked and the tab landed on agree.
+
+The fallback is a DISPLAY stand-in and must stay one: written into the session
+it would tell the naming errand this conversation is already named and retire
+the one call that could give it a real title.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from local_operator.harness.types import Message, TextContent
+from local_operator.session.naming import ConversationName
+from local_operator.tui.app import OperatorApp
+from local_operator.tui.terminal_title import TerminalTitle
+from tests.unit.tui.test_app_pilot import FakeSession, _factory
+
+OPENER = "Investigate why the nightly importer drops rows silently"
+
+
+class _ResumedSession(FakeSession):
+    """A session as a resume hands one over: prior history, maybe a title.
+
+    ``title`` is applied through the real :class:`ConversationName` holder the
+    fake already owns, which is what a resumed ``Session`` does when it replays
+    its own ``conversation_name`` entry.
+    """
+
+    def __init__(self, *, title: str = "", user_set: bool = False, history: bool = True) -> None:
+        super().__init__()
+        if title:
+            self._name_state = ConversationName(text=title, user_set=user_set, requested=True)
+        self._history = (
+            [
+                Message(role="user", content=[TextContent(text=OPENER)]),
+                Message(role="assistant", content=[TextContent(text="Looking now.")]),
+            ]
+            if history
+            else []
+        )
+
+    def history(self) -> list[Any]:
+        return list(self._history)
+
+
+async def _boot(session: _ResumedSession, pilot: Any) -> None:  # noqa: ANN401
+    """Pump until the session is adopted (see test_conversation_naming._ready)."""
+    for _ in range(200):
+        if pilot.app._session is not None:
+            return
+        await pilot.pause()
+    raise AssertionError("the session was never adopted")
+
+
+def _tab_title(app: OperatorApp) -> str:
+    """The OSC 0 label this app would put on the terminal tab.
+
+    Read through a TerminalTitle attached to the band, because the pilot runs
+    headless and the app installs no writer of its own — there is no terminal.
+    ``current`` renders the same string ``emit`` would have written.
+    """
+    band = app._status
+    assert band is not None
+    writer = TerminalTitle(lambda _text: None)
+    band.set_terminal_title(writer)
+    return writer.current
+
+
+@pytest.mark.asyncio
+async def test_a_resumed_session_wears_its_stored_title() -> None:
+    """THE bug: the name was on disk and the band showed the cwd anyway."""
+    session = _ResumedSession(title="Reduce agent RAM usage")
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(session, pilot)
+        assert app._status is not None
+        assert app._status._conversation_name == "Reduce agent RAM usage"
+        assert _tab_title(app) == "lo › Reduce agent RAM usage"
+        # The stored title is the store of record, so no stand-in was adopted
+        # beside it — a later `/rename` has one thing to supersede, not two.
+        assert app._provisional_name == ""
+
+
+@pytest.mark.asyncio
+async def test_a_resume_without_a_stored_title_falls_back_to_the_opener() -> None:
+    """Legacy transcripts carry no title; the conversation still has a subject.
+
+    Without this the band read `lo › <cwd>` for a conversation whose opening
+    message was on screen two rows up.
+    """
+    session = _ResumedSession(title="")
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(session, pilot)
+        assert app._status is not None
+        assert app._status._conversation_name.startswith("Investigate why the nightly importer")
+        assert _tab_title(app).startswith("lo › Investigate why the nightly importer")
+        # DISPLAY only: the store stays empty so the naming errand still fires
+        # and can replace the quote with an actual title.
+        assert session.conversation_name == ""
+        assert app._provisional_name != ""
+
+
+@pytest.mark.asyncio
+async def test_a_stored_title_is_never_displaced_by_the_opener_fallback() -> None:
+    """The fallback is for the nameless case only.
+
+    A resumed session carrying a user's own rename must not have it replaced by
+    a quote of the first message — the rename outranks everything, forever.
+    """
+    session = _ResumedSession(title="Q3 billing migration", user_set=True)
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(session, pilot)
+        assert app._status is not None
+        assert app._status._conversation_name == "Q3 billing migration"
+        assert app._provisional_name == ""
+
+
+@pytest.mark.asyncio
+async def test_a_fresh_session_is_not_given_a_name_by_the_resume_path() -> None:
+    """No history, no name: an ordinary new session keeps its cwd fallback.
+
+    The restore runs on every adoption, not only on a resume, so the empty case
+    is the one that proves it cannot invent a label for a conversation that has
+    not started.
+    """
+    session = _ResumedSession(title="", history=False)
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(session, pilot)
+        assert app._status is not None
+        assert app._status._conversation_name == ""
+        assert app._provisional_name == ""
+        # The band's own cwd fallback is what names the tab, unchanged.
+        assert _tab_title(app).startswith("lo › ")
+
+
+@pytest.mark.asyncio
+async def test_the_restored_name_survives_the_first_repaint() -> None:
+    """The band re-renders constantly; the name must not be a one-frame flash."""
+    session = _ResumedSession(title="Reduce agent RAM usage")
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(session, pilot)
+        assert app._status is not None
+        app._status.refresh()
+        await pilot.pause()
+        assert app._status._conversation_name == "Reduce agent RAM usage"
+        assert _tab_title(app) == "lo › Reduce agent RAM usage"

--- a/tests/unit/tui/test_session_picker.py
+++ b/tests/unit/tui/test_session_picker.py
@@ -33,6 +33,7 @@ from local_operator.tui.widgets.session_picker import (
     PAGE_ROWS_MAX,
     SessionPickerScreen,
     filter_rows,
+    matched_in_body,
     plan_columns,
     render_rows,
 )
@@ -297,16 +298,17 @@ def test_an_unnamed_session_says_so_rather_than_rendering_a_blank() -> None:
 class _PickerHost(App[None]):
     """A host whose only job is to own the modal under test."""
 
-    def __init__(self, rows: list[SessionRow]) -> None:
+    def __init__(self, rows: list[SessionRow], digests: dict[str, str] | None = None) -> None:
         super().__init__()
         self._rows = rows
+        self._digests = digests
         self.chosen: list[str | None] = []
 
     def compose(self) -> ComposeResult:
         return iter(())
 
     async def open_picker(self) -> SessionPickerScreen:
-        screen = SessionPickerScreen(self._rows, NOW)
+        screen = SessionPickerScreen(self._rows, NOW, self._digests)
         self.push_screen(screen, self.chosen.append)
         return screen
 
@@ -953,3 +955,66 @@ async def test_the_empty_card_never_renders_wider_than_the_terminal() -> None:
             # first thing dropped: it is what makes the empty state honest.
             body = " ".join(line.strip() for line in lines)
             assert "subagent runs are not listed" in body, (width, body)
+
+
+# --- searching the conversation body ----------------------------------------
+# The reported failure: a session was findable only by the words in its NAME,
+# so a conversation whose title did not happen to contain what the user
+# remembered was unreachable. These pin the widened filter and the marker that
+# keeps its results explicable.
+
+
+def test_a_row_matches_on_its_conversation_body(tmp_path: Path) -> None:
+    rows = [_row("aaa1", "vague title"), _row("bbb2", "another")]
+    assert [r.id for r in filter_rows(rows, "retention", {"aaa1"})] == ["aaa1"]
+
+
+def test_a_body_match_never_reorders_the_list() -> None:
+    """Same invariant as every other filter here: a row that moved under the
+    cursor while the query grew would resume the wrong conversation."""
+    rows = [_row("aaa1", "one"), _row("bbb2", "two"), _row("ccc3", "three")]
+    assert [r.id for r in filter_rows(rows, "topic", {"ccc3", "aaa1"})] == ["aaa1", "ccc3"]
+
+
+def test_a_caller_without_an_index_keeps_the_old_behaviour() -> None:
+    """Hosts with no index — tests, embedders — must not lose the filter."""
+    rows = [_row("aaa1", "asteroids game"), _row("bbb2", "parser crash")]
+    assert [r.id for r in filter_rows(rows, "aster")] == ["aaa1"]
+    assert filter_rows(rows, "retention") == []
+
+
+def test_only_a_body_match_is_marked() -> None:
+    """A row whose visible name contains the query needs no explanation; one
+    that does not would otherwise read as an arbitrary result."""
+    assert matched_in_body(_row("aaa1", "vague"), "retention", {"aaa1"}) is True
+    assert matched_in_body(_row("bbb2", "retention sweep"), "retention", {"bbb2"}) is False
+    assert matched_in_body(_row("ccc3", "vague"), "retention", set()) is False
+    assert matched_in_body(_row("aaa1", "vague"), "", {"aaa1"}) is False
+
+
+def test_a_marked_row_still_occupies_exactly_one_row_width() -> None:
+    """The marker is counted against the name budget, so it cannot push the
+    row past the card and silently eat the age and id columns."""
+    row = _row("abc123def456", "a name long enough to need the whole budget here")
+    plain = render_rows([row], 0, 74, NOW)[0].plain
+    marked = render_rows([row], 0, 74, NOW, None, {"abc123def456"})[0].plain
+    assert cell_len(marked) == cell_len(plain)
+    assert "·" in marked and "·" not in plain
+    assert "abc123def456" in marked
+
+
+@pytest.mark.asyncio
+async def test_typing_finds_a_session_by_its_conversation_not_its_name() -> None:
+    """End to end through the real screen: the query appears nowhere in the
+    row's name, and the picker still hands that session back."""
+    rows = [_row("aaa111", "a forgettable opening line"), _row("bbb222", "something else")]
+    app = _PickerHost(rows, {"aaa111": "we fixed the retention sweep eviction"})
+    async with app.run_test(size=(100, 30)) as pilot:
+        await app.open_picker()
+        await pilot.pause()
+        for char in "retention":
+            await pilot.press(char)
+        await pilot.pause()
+        await pilot.press("enter")
+        await pilot.pause()
+    assert app.chosen == ["aaa111"]

--- a/tests/unit/tui/test_session_picker.py
+++ b/tests/unit/tui/test_session_picker.py
@@ -29,6 +29,7 @@ from local_operator.tui import theme as theme_mod
 from local_operator.tui.widgets.session_picker import (
     BODY_MATCH_MARKER,
     CARD_MAX_HEIGHT_FRACTION,
+    GUTTER_CELLS,
     CARD_PADDING_ROWS,
     NAME_MIN_CELLS,
     PAGE_ROWS_MAX,
@@ -1073,8 +1074,16 @@ def test_the_marker_column_does_not_depend_on_what_is_scrolled_into_view() -> No
 
 def test_an_unfiltered_list_reserves_no_marker_column() -> None:
     """The reservation costs nothing when nothing matched, so an ordinary
-    open of the picker renders exactly as it did before the marker existed."""
+    open of the picker renders exactly as it did before the marker existed.
+
+    Asserted against the marked rendering rather than against another call
+    with the same arguments: comparing a no-match render to a no-match render
+    passes however the reservation behaves, which is a test that cannot fail.
+    """
     rows = [_row("abc123def456", "one"), _row("bbb222ccc333", "two")]
-    assert render_rows(rows, 0, 74, NOW)[0].plain == (
-        render_rows(rows, 0, 74, NOW, None, set())[0].plain
-    )
+    unmarked = render_rows(rows, 0, 74, NOW, None, set())[0].plain
+    marked = render_rows(rows, 0, 74, NOW, None, {"abc123def456"})[0].plain
+    # The name starts flush against the cursor gutter when nothing matched,
+    # and exactly the marker's width later when something did.
+    assert unmarked.index("one") == GUTTER_CELLS
+    assert marked.index("one") == GUTTER_CELLS + cell_len(BODY_MATCH_MARKER)

--- a/tests/unit/tui/test_session_picker.py
+++ b/tests/unit/tui/test_session_picker.py
@@ -1051,3 +1051,30 @@ async def test_typing_finds_a_session_by_its_conversation_not_its_name() -> None
         await pilot.press("enter")
         await pilot.pause()
     assert app.chosen == ["aaa111"]
+
+
+def test_the_marker_column_does_not_depend_on_what_is_scrolled_into_view() -> None:
+    """A page is not the result set.
+
+    Deciding the reservation from the rows currently ON SCREEN made it vanish
+    when the one marked row scrolled off, so every name jumped two cells
+    sideways on a single arrow press and truncation changed for rows that had
+    not changed. Needs more rows than a page holds -- the earlier fixtures
+    could not scroll, which is why this was missed.
+    """
+    rows = [_row(f"id{index:09d}", f"session number {index}") for index in range(6)]
+    marked = {"id000000000"}  # only the first row matched inside its body
+    with_marked = render_rows(rows[0:3], 0, 74, NOW, None, marked)
+    without_marked = render_rows(rows[3:6], 0, 74, NOW, None, marked)
+    assert with_marked[0].plain.index("session number 0") == (
+        without_marked[0].plain.index("session number 3")
+    )
+
+
+def test_an_unfiltered_list_reserves_no_marker_column() -> None:
+    """The reservation costs nothing when nothing matched, so an ordinary
+    open of the picker renders exactly as it did before the marker existed."""
+    rows = [_row("abc123def456", "one"), _row("bbb222ccc333", "two")]
+    assert render_rows(rows, 0, 74, NOW)[0].plain == (
+        render_rows(rows, 0, 74, NOW, None, set())[0].plain
+    )

--- a/tests/unit/tui/test_session_picker.py
+++ b/tests/unit/tui/test_session_picker.py
@@ -27,10 +27,12 @@ from local_operator.resume import (
 )
 from local_operator.tui import theme as theme_mod
 from local_operator.tui.widgets.session_picker import (
+    BODY_MATCH_MARKER,
     CARD_MAX_HEIGHT_FRACTION,
     CARD_PADDING_ROWS,
     NAME_MIN_CELLS,
     PAGE_ROWS_MAX,
+    PICKER_MIN_WIDTH,
     SessionPickerScreen,
     filter_rows,
     matched_in_body,
@@ -993,14 +995,45 @@ def test_only_a_body_match_is_marked() -> None:
 
 
 def test_a_marked_row_still_occupies_exactly_one_row_width() -> None:
-    """The marker is counted against the name budget, so it cannot push the
-    row past the card and silently eat the age and id columns."""
+    """The marker is reserved as a column, so it cannot push the row past the
+    card and silently eat the age and id columns."""
     row = _row("abc123def456", "a name long enough to need the whole budget here")
     plain = render_rows([row], 0, 74, NOW)[0].plain
     marked = render_rows([row], 0, 74, NOW, None, {"abc123def456"})[0].plain
     assert cell_len(marked) == cell_len(plain)
-    assert "·" in marked and "·" not in plain
+    assert BODY_MATCH_MARKER.strip() in marked
+    assert BODY_MATCH_MARKER.strip() not in plain
     assert "abc123def456" in marked
+
+
+def test_the_marker_never_pushes_the_name_below_its_floor() -> None:
+    """The marker must not jump the queue in which the id and the age give up
+    their cells before the name gives up any.
+
+    Subtracting it from the name AFTER the budget was already spent down to
+    the floor rendered marked names at 14 cells at several reachable widths.
+    """
+    rows = [_row("abc123def456", "a long conversation title"), _row("bbb222ccc333", "another")]
+    for width in range(PICKER_MIN_WIDTH, 140):
+        name_col, _, _ = plan_columns(rows, width, ["1m ago", "1h ago"], True)
+        assert name_col >= NAME_MIN_CELLS, width
+
+
+def test_every_row_starts_its_name_at_the_same_column() -> None:
+    """Reserving the marker only on matched rows ragged the left edge of the
+    one field the user reads down the list."""
+    rows = [_row("abc123def456", "matched inside"), _row("bbb222ccc333", "not matched")]
+    lines = [line.plain for line in render_rows(rows, 0, 74, NOW, None, {"abc123def456"})]
+    # The marker column is reserved on BOTH rows, so each name begins at the
+    # same offset: the marked row spends it on the mark, the other on blanks.
+    assert lines[0].index("matched inside") == lines[1].index("not matched")
+
+
+def test_a_marked_list_fills_the_card_at_every_reachable_width() -> None:
+    rows = [_row("abc123def456", "a long conversation title"), _row("bbb222ccc333", "another")]
+    for width in range(PICKER_MIN_WIDTH, 140):
+        for line in render_rows(rows, 0, width, NOW, None, {"abc123def456"}):
+            assert cell_len(line.plain) == width, width
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tui/test_session_picker.py
+++ b/tests/unit/tui/test_session_picker.py
@@ -29,8 +29,8 @@ from local_operator.tui import theme as theme_mod
 from local_operator.tui.widgets.session_picker import (
     BODY_MATCH_MARKER,
     CARD_MAX_HEIGHT_FRACTION,
-    GUTTER_CELLS,
     CARD_PADDING_ROWS,
+    GUTTER_CELLS,
     NAME_MIN_CELLS,
     PAGE_ROWS_MAX,
     PICKER_MIN_WIDTH,


### PR DESCRIPTION
## Change classification

**C2 — standard / pre-authorized.** A new journalled entry type (additive; absent on every older transcript and handled as such), a derived cache under `cache/`, and a widened filter. No wire contract, no new dependency, no change to what a turn computes. Clean rollback (`git revert`). No RFC requested.

## The bug

Reported as *"I keep losing sessions and am unable to search for them later"*. The sessions were on disk the whole time. They could not be **found**, which for a user is the same outcome — and worse, because nothing says so.

The report names three symptoms, and each turned out to be a separate defect:

> the session doesn't actually reflect the latest name of the session in the search registry — the conversation context is not indexed — the search doesn't seem to be semantic so if I don't recall what the first message I sent was in that session it's effectively gone

### 1. The row was labelled with the opening message, not the name

`ConversationName` lived in memory for the life of a session and was never journalled:

```python
# resume.session_name, before
"""Read from the TRANSCRIPT rather than from a stored title because there is
no stored title: ``ConversationName`` ... is never journalled, so the only
per-session name on disk is what the user actually typed first."""
```

So a conversation that was auto-named `Retention Deleting Live Transcripts`, or renamed by hand, was still **listed under whatever was typed first**. The name shown on the band during the session and the name in the picker afterwards were different strings, which is exactly the "doesn't reflect the latest name" in the report.

### 2. The filter never saw the conversation

`filter_rows` matched on two fields — the name and the 12-hex id. Neither is what anyone remembers a week later, and the id is unmemorable by construction. A session about retention could not be found by typing "retention" unless that word happened to be in the sentence that opened it.

### 3. The picker hid most of the store

`RESUME_PICKER_LIMIT = 50`, while retention keeps 200. On the reporting machine that is **20 of 70 sessions invisible** — a search that should have found a conversation returned nothing, which is indistinguishable from deletion:

```console
$ python -c "...recent_sessions(cfg, limit=10_000)..."
total user sessions on disk = 70  -> picker offers only 50
```

## The fix

**1. The title is journalled and restored.** A `conversation_name` custom entry (newest wins on replay), written fire-and-forget so a title never costs a turn, and flushed at dispose — because a `/rename` just before ctrl+d would otherwise be cancelled in flight with the other background tasks. `user_set` rides along, so a human rename keeps outranking generated titles across a resume. A resumed session wears its name on the band and the terminal tab; the picker reads the same value back through `resume.stored_session_title`, so **the row and the tab agree by construction**.

Sessions with no stored title — every transcript written before this — still fall back to the opening message. No row loses its name.

**2. The conversation body is indexed.** `session/search_index.py` builds a bounded digest of each conversation's prose (`user` and `assistant` only — indexing tool output makes every session match every path-like query) and the picker searches it alongside the name and id. A row admitted on its body alone is marked `·`, because an unexplained row makes the whole result set read as untrustworthy.

**The index lives under `cache/`, deliberately NOT in the session directories.** Retention ranks and expires those by mtime and charges their bytes against its ceiling, so a sidecar written there would reset a session's retention clock and make it look freshly used — the very class of bug that loses sessions (cf. `mark_session_origin`'s note on preserving mtimes). `test_the_index_is_written_outside_every_session_directory` pins it.

**3. The limit matches what the store keeps** (50 → 200). A filter that cannot see a row cannot find it, and "not found" is the one answer a search must not give wrongly.

**Substring, not semantic**, and that is a decision rather than an omission. A provider call to open a picker would be slower than the thing it searches, would fail offline, would cost money per keystroke, and over 200 short digests a similarity score returns confident nonsense — "asteroids" matching "assets ordering". Substring answers the reported case and never returns a wrong row.

## Testing evidence

### The reported failure, before and after, against the real store

204 sessions / 125 MB on disk:

```console
$ # BEFORE — filtering the picker's own rows
'retention'        -> 0 hit(s)
'composer bar'     -> 0 hit(s)
'session naming'   -> 0 hit(s)
'terminal label'   -> 0 hit(s)

$ # AFTER
'retention'        ->   4 row(s)  (4 by body)  0.5ms
'composer bar'     ->   1 row(s)  (1 by body)  0.4ms
'session naming'   ->   1 row(s)  (1 by body)  0.4ms
'terminal label'   ->   1 row(s)  (1 by body)  0.4ms
'asteroids'        ->   0 row(s)  (0 by body)  0.4ms   <-- still no false positives

lost session found by "composer bar": True
```

The last line is the session that prompted this work: it was unreachable by every phrase describing what it was about.

### Title round-trip through the real writer

```console
no title yet -> ''                          | name: 'help me debug the thing i typed first'
generated    -> 'Retention Sweep Eviction Fix'
renamed      -> 'My "quoted" rename ok'     | name: 'My "quoted" rename ok'
```

Escapes decode through the JSON decoder, so a title holding a quote or a backslash reads back as the user saw it. A title is still found when it sits past a megabyte of conversation (`test_a_title_is_found_past_a_megabyte_of_conversation`).

### Rendered frames — the real `OperatorApp`, so `local_operator.tcss` applies

The lightweight `_PickerHost` in the tests declares no `CSS_PATH` and would show nothing of the card's real styling, so the shots drive the real app over a seeded store.

**BEFORE — filter `retention`:** `no session matches that filter`, header reads `0 of 5`.

**AFTER — filter `retention`:** header reads `1 of 5`, row `❯ Retention Deleting Live Transcripts   1h ago`. The row is labelled with its **stored title**, which under the old code would have read `every submission ends with No such file or directory transcript.jsonl`.

**AFTER — filter `spawn rate`** (a body-only match, name contains neither word): `1 of 5`, row `❯ · hey quick one`. The `·` is the body-match marker; `test_a_marked_row_still_occupies_exactly_one_row_width` pins that a marked row is the same cell width as an unmarked one, so the marker cannot push the age and id columns off the card.

### Cost, measured rather than assumed

The picker builds the index synchronously when it opens, so this had to be inside a frame at the raised limit:

```console
trial 0: rows=18ms  index=4ms  total=22ms
trial 1: rows=16ms  index=1ms  total=16ms
trial 2: rows=16ms  index=1ms  total=17ms

index file size = 185 KB   (204 sessions, 125 MB of transcripts)
```

The incremental path is what makes that affordable: only transcripts whose `(size, mtime)` changed since the last open are re-read. A cold first build over the whole store is 45 ms; warm is 1 ms.

### Gates

```console
$ .venv/bin/python -m pytest tests/unit -q -p no:randomly
1 failed, 4761 passed, 7 skipped in 730.72s

$ flake8 <changed files>          # exit 0
$ pyright <changed files>         # 0 errors, 0 warnings
$ black --check / isort           # clean
```

The one failure is `tests/unit/tools/test_eval_tool.py::test_background_streams_output_while_it_runs`, and it is **pre-existing on the base**, not caused by this PR:

```console
$ cd <worktree at f87f778> && pytest <that test> -q
FAILED ... AssertionError: no streamed output observed while the job ran
```

New tests: 9 for the index, 8 for the stored title, 6 for the widened filter, plus the 14 covering title persistence and restore.

## Provenance

The title-persistence half of this change was written in a session that was **destroyed by the retention bug #152 fixes** — the agent was killed mid-turn on a bare `Continue` and the work was left uncommitted in a worktree. It was recovered from that worktree, verified against the current base, and carried here rather than rewritten. #152 stops the store deleting live sessions; this PR stops the store hiding them.
