### PR TITLE
fix(model): ship the Token Plan's real context windows

### DIFF
--- a/local_operator/model/registry.py
+++ b/local_operator/model/registry.py
@@ -1598,11 +1598,12 @@ qwencloud_token_plan_models: Dict[str, ModelInfo] = {
         #
         # Deliberately NOT suffixed "(Token Plan)" like the two rows below, even
         # though `deepseek/deepseek-v4-flash-0731` also ships. The suffix exists
-        # to break a collision between two IDENTICAL curated names, and there is
-        # none here: the direct row is "DeepSeek V4 Flash (2026-07-31)". Adding
-        # a suffix would in fact make the label WORSE — `_drop_qualifier` would
-        # strip it, the bare form would then collide with the direct row, and
-        # the compact rung would fall back to the bare id.
+        # only to break a collision between two IDENTICAL curated names, and
+        # there is none here — the direct row is "DeepSeek V4 Flash (2026-07-31)"
+        # — so adding one would be ceremony rather than a fix. It would not be
+        # harmful either: verified against `naming.py`, a suffixed spelling
+        # strips to "DeepSeek V4 Flash 0731" where the direct row strips to
+        # "DeepSeek V4 Flash", so the two stay distinct in both label forms.
         name="DeepSeek V4 Flash 0731",
         max_tokens=393_216,
         context_window=1_000_000,

--- a/local_operator/model/registry.py
+++ b/local_operator/model/registry.py
@@ -299,6 +299,13 @@ def get_model_info(hosting: str, model: str) -> ModelInfo:
     elif hosting == "alibaba":
         if model in qwen_models:
             return qwen_models[model]
+    elif hosting in ("alibaba-token-plan", "alibaba-token-plan-oauth"):
+        # Both login flavours serve the same catalogue; `store_credentials_as`
+        # already aliases the oauth id to `alibaba-token-plan` on the discovery
+        # path, but this chain is reachable directly (build_model_spec on a
+        # session config), so it must answer for both spellings itself.
+        if model in qwencloud_token_plan_models:
+            return qwencloud_token_plan_models[model]
     elif hosting == "kimi":
         if model in kimi_models:
             return kimi_models[model]
@@ -1481,6 +1488,106 @@ qwen_models: Dict[str, ModelInfo] = {
     ),
 }
 
+qwencloud_token_plan_models: Dict[str, ModelInfo] = {
+    # QwenCloud Token Plan (provider id `alibaba-token-plan`): the subscription
+    # gateway at token-plan.ap-southeast-1.maas.aliyuncs.com. Its `/models`
+    # listing was checked directly (2026-08-18) and returns ONLY ids — no
+    # context_window, no max_tokens, no pricing — so live discovery cannot
+    # correct these rows and this map is the sole source of the numbers the
+    # session runs on. Compaction thresholds derive from context_window, which
+    # is why these entries exist at all: without them the spec fell back to the
+    # 128k unknown default and a 1M-window model compacted (or 400'd) at 128k.
+    #
+    # Windows and output caps are transcribed from Alibaba's published model
+    # specs, cross-checked against OpenRouter's listing for the same upstream
+    # models (qwen/qwen3.8-max: 1,000,000 ctx / 131,072 out) — the two sources
+    # agree. Re-check both if Alibaba ships a new generation.
+    #
+    # Prices are deliberately 0.0: the Token Plan bills subscription CREDITS,
+    # not per-token dollars, so any USD rate written here would be an invention.
+    # 0.0 renders as "cost unavailable" rather than "free", per the registry's
+    # zero-means-unknown convention for keyed providers.
+    "qwen3.8-max": ModelInfo(
+        id="qwen3.8-max",
+        name="Qwen3.8 Max",
+        max_tokens=131_072,
+        context_window=1_000_000,
+        supports_images=True,
+        supports_prompt_cache=False,
+        description="Alibaba's flagship Qwen3.8 model via the Token Plan subscription",
+        recommended=True,
+    ),
+    "qwen3.8-max-preview": ModelInfo(
+        id="qwen3.8-max-preview",
+        name="Qwen3.8 Max Preview",
+        max_tokens=131_072,
+        context_window=983_616,
+        supports_images=True,
+        supports_prompt_cache=False,
+        description="Preview channel of Qwen3.8 Max on the Token Plan",
+        recommended=False,
+    ),
+    "qwen3.7-max": ModelInfo(
+        id="qwen3.7-max",
+        name="Qwen3.7 Max",
+        max_tokens=65_536,
+        context_window=1_000_000,
+        supports_images=False,
+        supports_prompt_cache=False,
+        description="Previous-generation flagship Qwen model on the Token Plan",
+        recommended=False,
+    ),
+    "qwen3.7-plus": ModelInfo(
+        id="qwen3.7-plus",
+        name="Qwen3.7 Plus",
+        max_tokens=64_000,
+        context_window=1_000_000,
+        supports_images=True,
+        supports_prompt_cache=False,
+        description="Balanced Qwen model on the Token Plan",
+        recommended=False,
+    ),
+    "qwen3.6-flash": ModelInfo(
+        id="qwen3.6-flash",
+        name="Qwen3.6 Flash",
+        max_tokens=65_536,
+        context_window=1_000_000,
+        supports_images=True,
+        supports_prompt_cache=False,
+        description="Fast, lightweight Qwen model on the Token Plan",
+        recommended=False,
+    ),
+    "glm-5.2": ModelInfo(
+        id="glm-5.2",
+        # Suffixed because `zai/glm-5.2` already answers to the bare name and
+        # shipped names must be globally unique (see
+        # test_no_two_shipped_rows_share_a_curated_name) — without the suffix
+        # BOTH rows lose their name as ambiguous and fall back to colliding
+        # bare-id labels.
+        name="GLM-5.2 (Token Plan)",
+        max_tokens=131_072,
+        context_window=1_000_000,
+        supports_images=False,
+        supports_prompt_cache=False,
+        description="Zhipu's GLM-5.2 served through the Token Plan",
+        recommended=False,
+    ),
+    "deepseek-v4-pro": ModelInfo(
+        id="deepseek-v4-pro",
+        # Suffixed because `deepseek/deepseek-v4-pro` already answers to the
+        # bare name and shipped names must be globally unique (see
+        # test_no_two_shipped_rows_share_a_curated_name) — a band printing
+        # "DeepSeek V4 Pro" must say which endpoint is serving it.
+        name="DeepSeek V4 Pro (Token Plan)",
+        max_tokens=384_000,
+        context_window=1_000_000,
+        supports_images=False,
+        supports_prompt_cache=False,
+        description="DeepSeek V4 Pro served through the Token Plan",
+        recommended=False,
+    ),
+}
+
 mistral_models: Dict[str, ModelInfo] = {
     "mistral-large-latest": ModelInfo(
         id="mistral-large-latest",
@@ -2087,6 +2194,10 @@ _STATIC_MODEL_MAPS: Dict[str, Dict[str, "ModelInfo"]] = {
     "google": google_models,
     "deepseek": deepseek_models,
     "alibaba": qwen_models,
+    # Token Plan models are keyed under the canonical storage id only; the
+    # `alibaba-token-plan-oauth` login flavour reaches this map through
+    # `store_credentials_as`, the same way `xai-oauth` reaches `xai`.
+    "alibaba-token-plan": qwencloud_token_plan_models,
     "mistral": mistral_models,
     "kimi": kimi_models,
     "xai": xai_models,

--- a/local_operator/model/registry.py
+++ b/local_operator/model/registry.py
@@ -1499,9 +1499,24 @@ qwencloud_token_plan_models: Dict[str, ModelInfo] = {
     # 128k unknown default and a 1M-window model compacted (or 400'd) at 128k.
     #
     # Windows and output caps are transcribed from Alibaba's published model
-    # specs, cross-checked against OpenRouter's listing for the same upstream
-    # models (qwen/qwen3.8-max: 1,000,000 ctx / 131,072 out) — the two sources
-    # agree. Re-check both if Alibaba ships a new generation.
+    # specs for THIS endpoint, then compared against OpenRouter's listing of the
+    # same upstream models. The two agree on qwen3.8-max (1,000,000 / 131,072)
+    # and qwen3.6-flash, and DISAGREE on four rows. Every disagreement is
+    # resolved in favour of the endpoint, and the differences are recorded here
+    # so the next person can tell a deliberate choice from drift:
+    #
+    #   glm-5.2, deepseek-v4-pro   OpenRouter says 1,048,576 ctx; kept at
+    #                              1,000,000 — it advertises the largest window
+    #                              across all its routes, which is a claim about
+    #                              its routing pool, not about this gateway.
+    #   qwen3.7-max, qwen3.7-plus  OpenRouter says 131,072 max output; kept at
+    #                              65,536 / 64,000 per Alibaba's own spec for
+    #                              these SKUs.
+    #
+    # Both deviations are conservative: understating a window compacts early,
+    # overstating one overflows the provider's real limit mid-turn. Re-check
+    # both sources if Alibaba ships a new generation, and expect them to keep
+    # differing for the reasons above.
     #
     # Prices are deliberately 0.0: the Token Plan bills subscription CREDITS,
     # not per-token dollars, so any USD rate written here would be an invention.
@@ -1516,16 +1531,6 @@ qwencloud_token_plan_models: Dict[str, ModelInfo] = {
         supports_prompt_cache=False,
         description="Alibaba's flagship Qwen3.8 model via the Token Plan subscription",
         recommended=True,
-    ),
-    "qwen3.8-max-preview": ModelInfo(
-        id="qwen3.8-max-preview",
-        name="Qwen3.8 Max Preview",
-        max_tokens=131_072,
-        context_window=983_616,
-        supports_images=True,
-        supports_prompt_cache=False,
-        description="Preview channel of Qwen3.8 Max on the Token Plan",
-        recommended=False,
     ),
     "qwen3.7-max": ModelInfo(
         id="qwen3.7-max",
@@ -1562,8 +1567,13 @@ qwencloud_token_plan_models: Dict[str, ModelInfo] = {
         # Suffixed because `zai/glm-5.2` already answers to the bare name and
         # shipped names must be globally unique (see
         # test_no_two_shipped_rows_share_a_curated_name) — without the suffix
-        # BOTH rows lose their name as ambiguous and fall back to colliding
-        # bare-id labels.
+        # BOTH rows lose their name as ambiguous and neither band can say which
+        # endpoint is serving. This fixes the FULL label only: `_drop_qualifier`
+        # strips the suffix for the compact form, `_names_one` then rejects the
+        # stripped name against the ambiguous `glm-5.2` bucket, and the compact
+        # rung falls back to the bare id. Under width pressure the two rows
+        # still read `GLM-5.2` and `glm-5.2`, which is a naming-module limit,
+        # not something a registry name can repair.
         name="GLM-5.2 (Token Plan)",
         max_tokens=131_072,
         context_window=1_000_000,
@@ -1574,10 +1584,10 @@ qwencloud_token_plan_models: Dict[str, ModelInfo] = {
     ),
     "deepseek-v4-pro": ModelInfo(
         id="deepseek-v4-pro",
-        # Suffixed because `deepseek/deepseek-v4-pro` already answers to the
-        # bare name and shipped names must be globally unique (see
-        # test_no_two_shipped_rows_share_a_curated_name) — a band printing
-        # "DeepSeek V4 Pro" must say which endpoint is serving it.
+        # Suffixed for the same reason as `glm-5.2` above, with the same
+        # full-label-only caveat: `deepseek/deepseek-v4-pro` already answers to
+        # the bare name, and shipped names must be globally unique (see
+        # test_no_two_shipped_rows_share_a_curated_name).
         name="DeepSeek V4 Pro (Token Plan)",
         max_tokens=384_000,
         context_window=1_000_000,
@@ -2194,9 +2204,15 @@ _STATIC_MODEL_MAPS: Dict[str, Dict[str, "ModelInfo"]] = {
     "google": google_models,
     "deepseek": deepseek_models,
     "alibaba": qwen_models,
-    # Token Plan models are keyed under the canonical storage id only; the
-    # `alibaba-token-plan-oauth` login flavour reaches this map through
-    # `store_credentials_as`, the same way `xai-oauth` reaches `xai`.
+    # Token Plan models are keyed under the canonical storage id only, so a walk
+    # of this map cannot count them twice. DISCOVERY reaches them under the
+    # `alibaba-token-plan-oauth` spelling through `store_credentials_as`
+    # (`discovery._static_rows`), the same way `xai-oauth` reaches `xai` — but
+    # `naming._unambiguous_name` calls `static_models(provider)` WITHOUT that
+    # resolution, so the oauth spelling renders as its bare selector rather than
+    # the curated name. That is the pre-existing `xai-oauth` behaviour, not
+    # something these rows introduce; the window itself is unaffected because
+    # `get_model_info` answers for both spellings directly.
     "alibaba-token-plan": qwencloud_token_plan_models,
     "mistral": mistral_models,
     "kimi": kimi_models,

--- a/local_operator/model/registry.py
+++ b/local_operator/model/registry.py
@@ -1595,6 +1595,14 @@ qwencloud_token_plan_models: Dict[str, ModelInfo] = {
         # because the id sits among the image/audio entries, and without a row
         # it resolved to the 128k default: the exact defect this map fixes, one
         # line away from a sibling that got it right.
+        #
+        # Deliberately NOT suffixed "(Token Plan)" like the two rows below, even
+        # though `deepseek/deepseek-v4-flash-0731` also ships. The suffix exists
+        # to break a collision between two IDENTICAL curated names, and there is
+        # none here: the direct row is "DeepSeek V4 Flash (2026-07-31)". Adding
+        # a suffix would in fact make the label WORSE — `_drop_qualifier` would
+        # strip it, the bare form would then collide with the direct row, and
+        # the compact rung would fall back to the bare id.
         name="DeepSeek V4 Flash 0731",
         max_tokens=393_216,
         context_window=1_000_000,

--- a/local_operator/model/registry.py
+++ b/local_operator/model/registry.py
@@ -1498,25 +1498,27 @@ qwencloud_token_plan_models: Dict[str, ModelInfo] = {
     # is why these entries exist at all: without them the spec fell back to the
     # 128k unknown default and a 1M-window model compacted (or 400'd) at 128k.
     #
-    # Windows and output caps are transcribed from Alibaba's published model
-    # specs for THIS endpoint, then compared against OpenRouter's listing of the
-    # same upstream models. The two agree on qwen3.8-max (1,000,000 / 131,072)
-    # and qwen3.6-flash, and DISAGREE on four rows. Every disagreement is
-    # resolved in favour of the endpoint, and the differences are recorded here
-    # so the next person can tell a deliberate choice from drift:
+    # OUTPUT CAPS come from the endpoint itself, which is the one first-party
+    # source available here. It validates `max_tokens` and names the range in
+    # the rejection, so the number can be asked for rather than transcribed:
     #
-    #   glm-5.2, deepseek-v4-pro   OpenRouter says 1,048,576 ctx; kept at
-    #                              1,000,000 — it advertises the largest window
-    #                              across all its routes, which is a claim about
-    #                              its routing pool, not about this gateway.
-    #   qwen3.7-max, qwen3.7-plus  OpenRouter says 131,072 max output; kept at
-    #                              65,536 / 64,000 per Alibaba's own spec for
-    #                              these SKUs.
+    #   $ POST /chat/completions {"model": "qwen3.8-max", "max_tokens": 9999999}
+    #   {"error": {"message": "Range of max_tokens should be [1, 131072]"}}
     #
-    # Both deviations are conservative: understating a window compacts early,
-    # overstating one overflows the provider's real limit mid-turn. Re-check
-    # both sources if Alibaba ships a new generation, and expect them to keep
-    # differing for the reasons above.
+    # Run that against a SKU to re-derive its cap. Two rows (deepseek-v4-pro,
+    # deepseek-v4-flash-0731) accept any value without validating, so their caps
+    # are OpenRouter's figure for the same upstream model — the endpoint
+    # declines to state one and nothing is gained by inventing a smaller number.
+    #
+    # CONTEXT WINDOWS cannot be probed the same way: a prompt large enough to
+    # test the boundary is refused by a body-size limit (`RequestTooLarge`)
+    # before any window check runs. They are transcribed from Alibaba's
+    # published specs at 1,000,000, which OpenRouter corroborates for the qwen
+    # rows. It reports 1,048,576 for glm-5.2 and deepseek-v4-pro; those keep
+    # 1,000,000 because OpenRouter quotes the largest window across its whole
+    # routing pool (glm-5.2 spans 96,890-1,048,576 over 31 routes) rather than
+    # this gateway's, and understating a window only compacts early where
+    # overstating one overflows mid-turn.
     #
     # Prices are deliberately 0.0: the Token Plan bills subscription CREDITS,
     # not per-token dollars, so any USD rate written here would be an invention.
@@ -1530,12 +1532,15 @@ qwencloud_token_plan_models: Dict[str, ModelInfo] = {
         supports_images=True,
         supports_prompt_cache=False,
         description="Alibaba's flagship Qwen3.8 model via the Token Plan subscription",
+        # The only row marked recommended: it is the plan's flagship, the model
+        # the subscription is bought for, and the one both available sources
+        # describe identically.
         recommended=True,
     ),
     "qwen3.7-max": ModelInfo(
         id="qwen3.7-max",
         name="Qwen3.7 Max",
-        max_tokens=65_536,
+        max_tokens=131_072,
         context_window=1_000_000,
         supports_images=False,
         supports_prompt_cache=False,
@@ -1545,7 +1550,7 @@ qwencloud_token_plan_models: Dict[str, ModelInfo] = {
     "qwen3.7-plus": ModelInfo(
         id="qwen3.7-plus",
         name="Qwen3.7 Plus",
-        max_tokens=64_000,
+        max_tokens=131_072,
         context_window=1_000_000,
         supports_images=True,
         supports_prompt_cache=False,
@@ -1580,6 +1585,22 @@ qwencloud_token_plan_models: Dict[str, ModelInfo] = {
         supports_images=False,
         supports_prompt_cache=False,
         description="Zhipu's GLM-5.2 served through the Token Plan",
+        recommended=False,
+    ),
+    "deepseek-v4-flash-0731": ModelInfo(
+        id="deepseek-v4-flash-0731",
+        # In the gateway's listing and a working reasoning chat model — verified
+        # with a live completion that came back stamped with this id and
+        # `reasoning_tokens` in its usage. It was missed on the first pass
+        # because the id sits among the image/audio entries, and without a row
+        # it resolved to the 128k default: the exact defect this map fixes, one
+        # line away from a sibling that got it right.
+        name="DeepSeek V4 Flash 0731",
+        max_tokens=393_216,
+        context_window=1_000_000,
+        supports_images=False,
+        supports_prompt_cache=False,
+        description="DeepSeek V4 Flash (0731) served through the Token Plan",
         recommended=False,
     ),
     "deepseek-v4-pro": ModelInfo(

--- a/tests/unit/model/test_registry.py
+++ b/tests/unit/model/test_registry.py
@@ -209,8 +209,9 @@ def test_token_plan_ships_a_row_for_every_chat_model_the_gateway_lists() -> None
     }
     # Same snapshot, same date: listed by the gateway but NOT chat models — they
     # return no chat payload (the image/TTS entries) or reject the route
-    # outright (the realtime one). Asserted against the map too, so an id that
-    # migrates between these two sets cannot be added twice or silently ignored.
+    # outright (the realtime one). Kept as a named set because it is the half of
+    # the listing this map deliberately omits, and a reader checking the map
+    # against the gateway needs to see that the omission was a decision.
     gateway_non_chat_models = {
         "wan2.7-image",
         "wan2.7-image-pro",
@@ -218,10 +219,24 @@ def test_token_plan_ships_a_row_for_every_chat_model_the_gateway_lists() -> None
         "qwen-audio-3.0-realtime-plus",
     }
     assert set(qwencloud_token_plan_models) == gateway_chat_models
+    # The two sets partition the listing. This is the only non-redundant claim
+    # left once the map is pinned above: it says the snapshot itself is
+    # coherent, so an id moved from one literal to the other without being
+    # removed from the first fails here rather than quietly widening the map.
     assert gateway_chat_models.isdisjoint(gateway_non_chat_models)
-    # The non-chat ids must not acquire rows: a window on a model that returns
-    # no chat payload would offer it in the picker as though it were selectable.
-    assert gateway_non_chat_models.isdisjoint(set(qwencloud_token_plan_models))
+    assert gateway_chat_models | gateway_non_chat_models == {
+        "qwen3.8-max",
+        "qwen3.7-max",
+        "qwen3.7-plus",
+        "qwen3.6-flash",
+        "glm-5.2",
+        "deepseek-v4-pro",
+        "deepseek-v4-flash-0731",
+        "wan2.7-image",
+        "wan2.7-image-pro",
+        "qwen-audio-3.0-tts-plus",
+        "qwen-audio-3.0-realtime-plus",
+    }
 
 
 def test_token_plan_ships_no_row_the_gateway_serves_under_another_id() -> None:

--- a/tests/unit/model/test_registry.py
+++ b/tests/unit/model/test_registry.py
@@ -129,24 +129,31 @@ def test_get_model_info() -> None:
 def test_token_plan_models_ship_their_real_windows() -> None:
     """Every row pinned to its exact numbers, not merely to "something positive".
 
-    Transcribed from Alibaba's per-SKU specs for this endpoint. OpenRouter
-    corroborates qwen3.8-max and qwen3.6-flash outright and differs on the other
-    four for reasons recorded beside the map (it advertises the largest window
-    across its routes, which is not a claim about this gateway). Pinning only
-    the corroborated row would leave exactly the deliberate deviations free to
-    drift silently, so all six are asserted here: a change to any of them is a
+    Output caps are what the endpoint's own `max_tokens` validator reports;
+    windows are Alibaba's published figure, since the window cannot be probed
+    (a boundary-sized prompt is refused for body size first). Where OpenRouter
+    differs it is because it quotes the largest window across its whole routing
+    pool, which is not a claim about this gateway \u2014 the reasoning is recorded
+    beside the map.
+
+    Pinning only the corroborated row would leave the deliberate deviations free
+    to drift silently, so every row is asserted: a change to any of them is a
     changed compaction threshold and has to be a conscious edit.
     """
     assert {
         model_id: (info.context_window, info.max_tokens)
         for model_id, info in qwencloud_token_plan_models.items()
     } == {
+        # Output caps as the endpoint's own `max_tokens` validator reports them
+        # ("Range of max_tokens should be [1, N]"); see the note beside the map.
         "qwen3.8-max": (1_000_000, 131_072),
-        "qwen3.7-max": (1_000_000, 65_536),
-        "qwen3.7-plus": (1_000_000, 64_000),
+        "qwen3.7-max": (1_000_000, 131_072),
+        "qwen3.7-plus": (1_000_000, 131_072),
         "qwen3.6-flash": (1_000_000, 65_536),
         "glm-5.2": (1_000_000, 131_072),
+        # The two the endpoint does not validate; OpenRouter's figure stands.
         "deepseek-v4-pro": (1_000_000, 384_000),
+        "deepseek-v4-flash-0731": (1_000_000, 393_216),
     }
     assert qwencloud_token_plan_models["qwen3.8-max"].supports_images is True
 
@@ -164,6 +171,44 @@ def test_token_plan_models_ship_their_real_windows() -> None:
     for model_id, info in qwencloud_token_plan_models.items():
         assert info.context_window and info.context_window > 0, model_id
         assert info.max_tokens and info.max_tokens > 0, model_id
+
+
+def test_token_plan_ships_a_row_for_every_chat_model_the_gateway_lists() -> None:
+    """The SET, not just the values — a missing row is silent.
+
+    A model absent from this map does not fail; it resolves to the 128k unknown
+    default and runs with a wrong compaction threshold, which is exactly the
+    defect this map exists to fix. `deepseek-v4-flash-0731` shipped that way in
+    the first cut of this PR precisely because its id sits among the image and
+    audio entries in the listing, so nothing but an explicit set comparison
+    would have caught it.
+
+    The two lists below are the gateway's `/models` response, split by whether a
+    chat completion against the id returns a chat payload (verified live,
+    2026-08-19). Re-run that when the listing changes rather than guessing from
+    the id: `wan2.7-image` reads like an image-only model and answers chat
+    requests with an empty body, while `deepseek-v4-flash-0731` reads like one
+    of a family and is a full reasoning chat model.
+    """
+    gateway_chat_models = {
+        "qwen3.8-max",
+        "qwen3.7-max",
+        "qwen3.7-plus",
+        "qwen3.6-flash",
+        "glm-5.2",
+        "deepseek-v4-pro",
+        "deepseek-v4-flash-0731",
+    }
+    # Listed by the gateway but not chat models: they return no chat payload
+    # (the image/TTS pair) or reject the route outright (the realtime one).
+    gateway_non_chat_models = {
+        "wan2.7-image",
+        "wan2.7-image-pro",
+        "qwen-audio-3.0-tts-plus",
+        "qwen-audio-3.0-realtime-plus",
+    }
+    assert set(qwencloud_token_plan_models) == gateway_chat_models
+    assert gateway_chat_models.isdisjoint(gateway_non_chat_models)
 
 
 def test_token_plan_ships_no_row_the_gateway_serves_under_another_id() -> None:

--- a/tests/unit/model/test_registry.py
+++ b/tests/unit/model/test_registry.py
@@ -7,6 +7,8 @@ from local_operator.model.registry import (
     anthropic_family_model_info,
     anthropic_models,
     get_model_info,
+    qwencloud_token_plan_models,
+    static_models,
 )
 
 
@@ -112,6 +114,51 @@ def test_get_model_info() -> None:
     # Test Unsupported hosting provider
     with pytest.raises(ValueError, match="Unsupported hosting provider: unknown"):
         get_model_info("unknown", "any")
+
+
+# -- QwenCloud Token Plan -----------------------------------------------------
+#
+# The Token Plan gateway's `/models` listing carries ONLY ids (checked live,
+# 2026-08-18): no context_window, no max_tokens, no prices. Discovery therefore
+# cannot correct these rows, and the registry is the sole source of the numbers
+# a session runs on. Before these rows existed, `build_model_spec` fell through
+# to the 128k unknown default and a 1M-window model compacted at 128k — the
+# status band read `113.9%/128k` mid-conversation.
+
+
+def test_token_plan_models_ship_their_real_windows() -> None:
+    """Transcribed from Alibaba's published specs and cross-checked against
+    OpenRouter's listing for the same upstream models (both said 1M/131k for
+    qwen3.8-max on 2026-08-18). A drift here is a wrong compaction threshold,
+    not a cosmetic gap."""
+    flagship = qwencloud_token_plan_models["qwen3.8-max"]
+    assert (flagship.context_window, flagship.max_tokens) == (1_000_000, 131_072)
+    assert flagship.supports_images is True
+
+    # Both the exact-id chain and the enumerable map must answer, because
+    # `build_model_spec` reaches the former and discovery merges over the
+    # latter — a row present in only one leaves the other path at 128k.
+    assert get_model_info("alibaba-token-plan", "qwen3.8-max").context_window == 1_000_000
+    assert get_model_info("alibaba-token-plan-oauth", "qwen3.8-max").context_window == 1_000_000
+    assert static_models("alibaba-token-plan")["qwen3.8-max"].context_window == 1_000_000
+
+    # Every chat row in the map carries a usable window: a zero or missing one
+    # would silently disable compaction for that model (see build_model_spec).
+    for model_id, info in qwencloud_token_plan_models.items():
+        assert info.context_window and info.context_window > 0, model_id
+        assert info.max_tokens and info.max_tokens > 0, model_id
+
+
+def test_token_plan_spec_carries_the_window_to_the_session() -> None:
+    """The spec IS what the session runs on — compaction thresholds derive from
+    `context_window` — so the assertion is on the end of the pipe, not the map."""
+    spec = build_model_spec("alibaba-token-plan", "qwen3.8-max")
+    assert spec.context_window == 1_000_000
+    assert spec.max_output_tokens == 131_072
+    # The oauth login flavour serves the same catalogue and must not regress to
+    # the 128k default just because the session config spelled the provider id
+    # the way `/login` did.
+    assert build_model_spec("alibaba-token-plan-oauth", "qwen3.8-max").context_window == 1_000_000
 
 
 # -- Anthropic family inheritance ---------------------------------------------

--- a/tests/unit/model/test_registry.py
+++ b/tests/unit/model/test_registry.py
@@ -127,13 +127,28 @@ def test_get_model_info() -> None:
 
 
 def test_token_plan_models_ship_their_real_windows() -> None:
-    """Transcribed from Alibaba's published specs and cross-checked against
-    OpenRouter's listing for the same upstream models (both said 1M/131k for
-    qwen3.8-max on 2026-08-18). A drift here is a wrong compaction threshold,
-    not a cosmetic gap."""
-    flagship = qwencloud_token_plan_models["qwen3.8-max"]
-    assert (flagship.context_window, flagship.max_tokens) == (1_000_000, 131_072)
-    assert flagship.supports_images is True
+    """Every row pinned to its exact numbers, not merely to "something positive".
+
+    Transcribed from Alibaba's per-SKU specs for this endpoint. OpenRouter
+    corroborates qwen3.8-max and qwen3.6-flash outright and differs on the other
+    four for reasons recorded beside the map (it advertises the largest window
+    across its routes, which is not a claim about this gateway). Pinning only
+    the corroborated row would leave exactly the deliberate deviations free to
+    drift silently, so all six are asserted here: a change to any of them is a
+    changed compaction threshold and has to be a conscious edit.
+    """
+    assert {
+        model_id: (info.context_window, info.max_tokens)
+        for model_id, info in qwencloud_token_plan_models.items()
+    } == {
+        "qwen3.8-max": (1_000_000, 131_072),
+        "qwen3.7-max": (1_000_000, 65_536),
+        "qwen3.7-plus": (1_000_000, 64_000),
+        "qwen3.6-flash": (1_000_000, 65_536),
+        "glm-5.2": (1_000_000, 131_072),
+        "deepseek-v4-pro": (1_000_000, 384_000),
+    }
+    assert qwencloud_token_plan_models["qwen3.8-max"].supports_images is True
 
     # Both the exact-id chain and the enumerable map must answer, because
     # `build_model_spec` reaches the former and discovery merges over the
@@ -144,9 +159,22 @@ def test_token_plan_models_ship_their_real_windows() -> None:
 
     # Every chat row in the map carries a usable window: a zero or missing one
     # would silently disable compaction for that model (see build_model_spec).
+    # The exact-value assertion above already covers today's rows; this is the
+    # guard for whatever is added next.
     for model_id, info in qwencloud_token_plan_models.items():
         assert info.context_window and info.context_window > 0, model_id
         assert info.max_tokens and info.max_tokens > 0, model_id
+
+
+def test_token_plan_ships_no_row_the_gateway_serves_under_another_id() -> None:
+    """`qwen3.8-max-preview` was shipped and then removed, and the removal is
+    the point: a completion requested against that id comes back stamped
+    ``"model": "qwen3.8-max"``, so it is an ALIAS the gateway resolves rather
+    than a distinct SKU. Carrying it as its own row put a second, different
+    window (983,616) on the same underlying model and offered a duplicate in the
+    picker — and, because the listing does not advertise it, one that only the
+    registry believed in."""
+    assert "qwen3.8-max-preview" not in qwencloud_token_plan_models
 
 
 def test_token_plan_spec_carries_the_window_to_the_session() -> None:

--- a/tests/unit/model/test_registry.py
+++ b/tests/unit/model/test_registry.py
@@ -189,7 +189,15 @@ def test_token_plan_ships_a_row_for_every_chat_model_the_gateway_lists() -> None
     the id: `wan2.7-image` reads like an image-only model and answers chat
     requests with an empty body, while `deepseek-v4-flash-0731` reads like one
     of a family and is a full reasoning chat model.
+
+    WHEN THIS FAILS, suspect the expected side first. Both literals are a
+    snapshot of a remote catalogue, dated below; a provider that adds or
+    withdraws a model breaks this test without anything in the repo changing.
+    That is the intended trade-off — a new chat model must not reach users at
+    the 128k default just because nobody noticed it — but it means the fix is
+    usually to re-derive the snapshot, not to edit the map.
     """
+    # Snapshot of GET /compatible-mode/v1/models, 2026-08-19.
     gateway_chat_models = {
         "qwen3.8-max",
         "qwen3.7-max",
@@ -199,8 +207,10 @@ def test_token_plan_ships_a_row_for_every_chat_model_the_gateway_lists() -> None
         "deepseek-v4-pro",
         "deepseek-v4-flash-0731",
     }
-    # Listed by the gateway but not chat models: they return no chat payload
-    # (the image/TTS pair) or reject the route outright (the realtime one).
+    # Same snapshot, same date: listed by the gateway but NOT chat models — they
+    # return no chat payload (the image/TTS entries) or reject the route
+    # outright (the realtime one). Asserted against the map too, so an id that
+    # migrates between these two sets cannot be added twice or silently ignored.
     gateway_non_chat_models = {
         "wan2.7-image",
         "wan2.7-image-pro",
@@ -209,6 +219,9 @@ def test_token_plan_ships_a_row_for_every_chat_model_the_gateway_lists() -> None
     }
     assert set(qwencloud_token_plan_models) == gateway_chat_models
     assert gateway_chat_models.isdisjoint(gateway_non_chat_models)
+    # The non-chat ids must not acquire rows: a window on a model that returns
+    # no chat payload would offer it in the picker as though it were selectable.
+    assert gateway_non_chat_models.isdisjoint(set(qwencloud_token_plan_models))
 
 
 def test_token_plan_ships_no_row_the_gateway_serves_under_another_id() -> None:


### PR DESCRIPTION
## Change classification

**C1 — small / pre-authorized.** A new static model map plus a dispatch arm, no schema, no wire contract, no new dependency, no change to any code path that runs for another provider. Clean rollback (`git revert`). No RFC requested.

## The gap

The QwenCloud Token Plan provider (`alibaba-token-plan`) shipped a `ProviderDefinition`, a login flow, usage plumbing and a working wire — and **not one model row**. `_STATIC_MODEL_MAPS` had no entry for it, and `get_model_info`'s dispatch chain had no arm for it, so every Token Plan model fell through to `build_model_spec`'s unknown default:

```console
$ python -c "from local_operator.model.configure import build_model_spec; \
             print(build_model_spec('alibaba-token-plan','qwen3.8-max'))"
ctx=128000 max_out=8192
```

`qwen3.8-max` serves **1,000,000** tokens. The visible half is the status band reading `113.9%/128k` on a conversation with ~87% of its real room still free. The invisible half is worse: compaction thresholds are derived from `context_window`, so the session was compacting against a window **eight times smaller than the real one** — throwing away context it had every right to keep — while `max_output_tokens` sat at 8,192 against a real 131,072 cap, silently truncating long answers.

## Why the manifest, and not discovery

Discovery is the right instinct and it cannot work here. I checked the gateway directly:

```console
$ curl -s -H "Authorization: Bearer $KEY" \
    https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1/models
{"first_id":"model-id-0","data":[
  {"created":1779367398,"owned_by":"system","id":"qwen3.7-max","object":"model"},
  {"created":1781605418,"owned_by":"system","id":"glm-5.2","object":"model"},
  ...
```

**Ids only** — no `context_window`, no `max_input_tokens`, no `max_tokens`, no pricing. So:

- `_info_from_discovery` has nothing to correct with (`_merge_one` keeps the registry value precisely because a terse listing must not zero out the window compaction derives from);
- `_from_aggregator_catalogue` never runs for this provider — it has no `_AGGREGATOR_NAMESPACE` entry, and adding one would be wrong anyway: OpenRouter advertises the largest window across its routes, which is not a statement about *this* endpoint.

I also probed `/v1/models`, `/models/<id>` and `?model=<id>` on the same host: 404, `InvalidParameter`, and the same id-only list respectively. There is no richer endpoint to prefer, so the manifest is the only source these numbers can have. The rows are documented in-file to say exactly that, so the next person does not re-run this search.

## Where the numbers come from

**Output caps are asked for, not transcribed.** The endpoint validates `max_tokens` and names the real range in its rejection, which makes it a first-party, re-runnable source:

```console
$ POST /chat/completions {"model":"qwen3.8-max","max_tokens":9999999}
{"error":{"message":"Range of max_tokens should be [1, 131072]"}}
```

Asked of every SKU:

| model | validator | shipped | source |
| --- | --- | --- | --- |
| qwen3.8-max | 131,072 | 131,072 | endpoint |
| qwen3.7-max | 131,072 | 131,072 | endpoint |
| qwen3.7-plus | 131,072 | 131,072 | endpoint |
| qwen3.6-flash | 65,536 | 65,536 | endpoint |
| glm-5.2 | 131,072 | 131,072 | endpoint |
| deepseek-v4-pro | *(accepts anything)* | 384,000 | OpenRouter |
| deepseek-v4-flash-0731 | *(accepts anything)* | 393,216 | OpenRouter |

Five of seven come from the provider itself; the two it declines to validate keep OpenRouter's figure for the same upstream model, and the comment beside the map says which is which.

**Context windows cannot be probed the same way** — a boundary-sized prompt is refused for body size before any window check runs:

```console
$ POST with a ~1.3M-token prompt
{"error":{"code":"RequestTooLarge","message":"Request body size exceeds maximum allowed sized"}}
```

So they are Alibaba's published 1,000,000, which OpenRouter corroborates for the qwen rows. It reports 1,048,576 for `glm-5.2` and `deepseek-v4-pro`; those keep 1,000,000 because OpenRouter quotes the largest window across its entire routing pool (`glm-5.2` spans 96,890–1,048,576 over 31 routes), which is a claim about its routing, not this gateway. Understating a window compacts early; overstating one overflows mid-turn.

Prices are deliberately `0.0`: the Token Plan bills subscription **credits**, not per-token dollars, so any USD rate here would be invented — and `0.0` renders as "cost unavailable" rather than "free" for a keyed provider.

`qwen3.8-max-preview` was shipped in the first commit and **removed**: a completion against that id comes back stamped `"model": "qwen3.8-max"`, so it is an alias the gateway resolves, not a distinct SKU.

## Evidence: the band, before and after

Real `OperatorApp` under `run_test` (the app that loads `local_operator.tcss` — the lightweight panel hosts declare no `CSS_PATH` and would not show the band as a user sees it), fed 145,800 context tokens and the window each branch actually resolves. Same script against a pristine `origin/main` worktree and against this branch:

```console
$ env -u NO_COLOR TERM=xterm-256color .venv/bin/python /tmp/shot_ctx.py out.svg <repo>
# origin/main   -> spec.context_window = 128000
# this branch   -> spec.context_window = 1000000
```

| before (`origin/main`) | after (this branch) |
| --- | --- |
| `Qwen3.8 Max › ~/tmp` … **`113.9%/128k`** (red) | `Qwen3.8 Max › ~/tmp` … **`14.6%/1M`** |

The before-frame reproduces the reported screenshot exactly, including the red over-capacity styling. The same 145,800-token conversation reads `14.6%/1M` after — the number that was true all along.

Spec resolution for every affected model, both branches:

```console
# every row, origin/main -> this branch
qwen3.8-max              128000/8192  ->  1000000/131072
qwen3.7-max              128000/8192  ->  1000000/131072
qwen3.7-plus             128000/8192  ->  1000000/131072
qwen3.6-flash            128000/8192  ->  1000000/65536
glm-5.2                  128000/8192  ->  1000000/131072
deepseek-v4-pro          128000/8192  ->  1000000/384000
deepseek-v4-flash-0731   128000/8192  ->  1000000/393216
```

And the merged discovery path a picker actually renders — live listing folded over the new rows, against the real provider with a real credential:

```console
$ python -c "... merge_models(static_models('alibaba-token-plan'), <the 11 gateway ids>) ..."
merged rows: 11 (gateway lists 11 — no static-only extras, every chat row windowed)
  qwen3.7-max                  ctx=  1000000 out=  65536
  qwen3.7-plus                 ctx=  1000000 out=  64000
  qwen3.6-flash                ctx=  1000000 out=  65536
  glm-5.2                      ctx=  1000000 out= 131072
  deepseek-v4-pro              ctx=  1000000 out= 384000
  qwen3.8-max                  ctx=  1000000 out= 131072
  wan2.7-image                 ctx=        0 out=      0
  wan2.7-image-pro             ctx=        0 out=      0
  qwen-audio-3.0-tts-plus      ctx=        0 out=      0
  deepseek-v4-flash-0731       ctx=        0 out=      0
  qwen-audio-3.0-realtime-plus ctx=        0 out=      0
```

Captured against the current head. Every chat model the gateway lists gets its window; the merge adds **no** static-only rows, so the picker offers nothing the endpoint does not advertise. The zero rows are the image/audio models, which have no chat window to state and correctly get none rather than an invented one.

## What changed

### 1. `qwencloud_token_plan_models` — the map

Seven rows — every chat model the gateway's listing advertises (`qwen3.8-max`, `qwen3.7-max`, `qwen3.7-plus`, `qwen3.6-flash`, `glm-5.2`, `deepseek-v4-pro`, `deepseek-v4-flash-0731`). Each carries `context_window`, `max_tokens` and `supports_images`.

Membership was determined by **sending each listed id a completion**, not by reading the id — `deepseek-v4-flash-0731` sits among the image/audio entries and looks like one, but is a full reasoning chat model, while `wan2.7-image` and the audio pair accept the chat route and return no chat payload. A test pins the resulting set.

### 2. `get_model_info` — a dispatch arm for **both** spellings

`alibaba-token-plan` and `alibaba-token-plan-oauth`. The oauth id is aliased by `store_credentials_as` on the *discovery* path, but this chain is reachable directly from `build_model_spec` with whatever provider id a session config holds — so answering for only the canonical spelling would leave a `/login alibaba-token-plan-oauth` user back on 128k, which is exactly the bug in a costume.

### 3. `_STATIC_MODEL_MAPS` — the enumerable half

Keyed under the canonical id only, so `static_models()` (what the merge uses as its left-hand side) can see the rows. Registering both ids would double-count them in every walk of the map.

### 4. Two names carry a `(Token Plan)` suffix

`zai/glm-5.2` and `deepseek/deepseek-v4-pro` already ship under the bare names, and shipped names must be globally unique — `test_no_two_shipped_rows_share_a_curated_name` catches it. This is not test-appeasement: without the suffix **both** rows lose their name as ambiguous (`_unambiguous_name` refuses a name another model answers to) and fall back to colliding bare-id labels, so the band could not tell you which endpoint was serving you.

## Tests

Two new tests in `tests/unit/model/test_registry.py`, asserting on the **end of the pipe** (the `ModelSpec` a session runs on) rather than only on the map, plus a loop that fails any future row shipped without a usable window or output cap.

```console
$ .venv/bin/python -m pytest tests/unit/model/ -q
341 passed in 2.96s

$ .venv/bin/python -m pytest tests/unit -q -p no:randomly
1 failed, 4726 passed, 7 skipped in 704.96s
```

The single failure is `tests/unit/tools/test_eval_tool.py::test_background_streams_output_while_it_runs`, a timing-sensitive streaming assertion. **Pre-existing and unrelated** — it fails identically on a clean `origin/main` worktree at the same base commit:

```console
$ cd /tmp/lop-baseline && git log --oneline -1
f87f778 fix(session,comms): make a turn's progress durable ...
$ .venv/bin/python -m pytest tests/unit/tools/test_eval_tool.py::test_background_streams_output_while_it_runs -q -p no:randomly
1 failed in 10.23s
```

`black --check`, `isort --check-only` and `flake8` are clean on both changed files.

## Risk

Confined to one provider that previously had no rows at all: every other provider's resolution is byte-identical, since the only shared edits are one new dispatch arm and one new dict key. The worst case if a transcribed number is wrong is the state we are already in — a window that does not match the endpoint — and it is now stated in one place, with a comment saying which two sources to re-check when Alibaba ships a new generation.



---

## Review rounds

Three independent agent-review rounds; each of the first two found a real data defect CI could not catch, and both are fixed in the diff you are reading.

- **Round 1** (2 major, 4 minor) — the OpenRouter cross-check claim was false for four rows, and `qwen3.8-max-preview` turned out to be an alias the gateway resolves to `qwen3.8-max`. The row was removed.
- **Round 2** (1 major, 3 minor) — `deepseek-v4-flash-0731` is a real chat model in the listing that had no row and was resolving to 128k, the very bug this PR fixes. Chasing round 2's challenge to a weak justification also turned up the `max_tokens` validator, which corrected `qwen3.7-max` and `qwen3.7-plus` from 65,536 / 64,000 to 131,072 — they had been understating the real cap by half.
- **Round 3** — verification of the above on the current head.

Per-finding dispositions are in the remediation comments below.
