### PR TITLE
fix(session,harness): apply a model switch to the running turn's next call

### DIFF
--- a/local_operator/harness/loop.py
+++ b/local_operator/harness/loop.py
@@ -410,8 +410,8 @@ class AgentLoop:
         except Exception:  # host accessor bug — never fatal to a running turn
             logger.exception("get_model resolver failed; using the run's model")
             return config.model
-        # A resolver returning None is the same "host has nothing better to
-        # say" case as having no resolver at all.
+        # A resolver returning None is the declared "host has nothing better to
+        # say" case (see the field), handled the same as having no resolver.
         return live if live is not None else config.model
 
     async def _model_turn(

--- a/local_operator/harness/loop.py
+++ b/local_operator/harness/loop.py
@@ -56,6 +56,7 @@ from local_operator.harness.types import (
     MessageEndEvent,
     MessageStartEvent,
     MessageUpdateEvent,
+    ModelSpec,
     NoticeEvent,
     RenderedStreamError,
     StaleAside,
@@ -381,6 +382,38 @@ class AgentLoop:
     # Model streaming
     # ------------------------------------------------------------------
 
+    @staticmethod
+    def _current_model(config: LoopConfig) -> "ModelSpec":
+        """The spec to call RIGHT NOW, re-read at every provider call.
+
+        ``config.model`` is bound once when the host builds the config, so on
+        its own it pins a whole run — model, tools, model, tools — to whichever
+        model the run started on. A user switching model mid-turn is switching
+        precisely because the running model is doing badly, and their switch
+        used to reach nothing until the turn ended. ``get_model`` is the host's
+        answer to "which model now", asked once per call.
+
+        Falls back to the snapshot when the host supplies no resolver (every
+        embedder and test double that builds a ``LoopConfig`` by hand), which
+        is what keeps this backwards compatible.
+
+        A resolver that RAISES falls back too, rather than killing the run. The
+        host is reading its own state, so a failure here is a host bug, and the
+        useful behaviour is to keep the turn alive on the model it already had
+        instead of losing the work in flight to a bad accessor.
+        """
+        resolver = config.get_model
+        if resolver is None:
+            return config.model
+        try:
+            live = resolver()
+        except Exception:  # host accessor bug — never fatal to a running turn
+            logger.exception("get_model resolver failed; using the run's model")
+            return config.model
+        # A resolver returning None is the same "host has nothing better to
+        # say" case as having no resolver at all.
+        return live if live is not None else config.model
+
     async def _model_turn(
         self,
         context: LoopContext,
@@ -388,7 +421,11 @@ class AgentLoop:
         signal: AbortSignal | None,
     ) -> AsyncIterator[AgentEvent | _ModelTurnResult]:
         """One provider call: build the request, stream it, assemble the
-        assistant message, emitting message_start/update/end events."""
+        assistant message, emitting message_start/update/end events.
+
+        The model is resolved HERE, per call, not once per run — see
+        :meth:`_current_model`.
+        """
         shaped = list(context.messages)
         if config.transform_context is not None:
             outcome = config.transform_context(shaped)
@@ -399,7 +436,10 @@ class AgentLoop:
         if inspect.isawaitable(converted):
             converted = await converted
         request = ChatRequest(
-            model=config.model,
+            # Resolved after `transform_context`/`convert_to_llm`, which can
+            # await: the spec is read as late as possible so a switch made
+            # while this call was being prepared still catches it.
+            model=self._current_model(config),
             system_blocks=list(context.system_blocks),
             messages=list(converted),
             tools=list(context.tools),

--- a/local_operator/harness/types.py
+++ b/local_operator/harness/types.py
@@ -1033,7 +1033,13 @@ class LoopConfig(BaseModel):
     # in-flight request keeps the spec it was issued with, so a switch cannot
     # tear down a stream that is already producing tokens or split one response
     # across two models.
-    get_model: Callable[[], "ModelSpec"] | None = Field(default=None, exclude=True)
+    #
+    # ``ModelSpec | None`` in the return, and the None is part of the contract
+    # rather than defensive slack: it lets a host say "nothing better than the
+    # snapshot right now" (still starting, spec briefly unavailable) without
+    # having to invent a spec, and the loop treats it exactly like having no
+    # resolver at all.
+    get_model: Callable[[], "ModelSpec | None"] | None = Field(default=None, exclude=True)
 
     # Required: render transcript messages (incl. custom entries) into the
     # LLM-visible list sent to the provider.

--- a/local_operator/harness/types.py
+++ b/local_operator/harness/types.py
@@ -1007,8 +1007,33 @@ class LoopConfig(BaseModel):
 
     model_config = ConfigDict(arbitrary_types_allowed=True, extra="forbid")
 
-    # The model to call (see providers registry).
+    # The model to call (see providers registry). A SNAPSHOT: hosts that can
+    # change the model while a run is in flight supply ``get_model`` as well,
+    # and this stays the value the run started on.
     model: "ModelSpec"
+
+    # The model to call NOW, re-read immediately before every provider call.
+    #
+    # A run is not one provider call, it is a chain of them: model, tools,
+    # model, tools. ``model`` above is bound once when the host builds this
+    # config, so a switch made while a turn is running — the TUI's ``/model``
+    # and the picker, which a user reaches precisely BECAUSE the current model
+    # is doing badly — could not reach any call in that turn, however many
+    # remained. It landed on the session, the status band repainted, and the
+    # agent went on calling the old model until the user's next message, which
+    # reads as the switch having been ignored.
+    #
+    # A callback rather than a mutable field because the model lives on the
+    # host (``Session._model``) and this config is a per-run value object: the
+    # host would otherwise have to hold a reference to the config of whatever
+    # run happens to be live and write through it. The loop asks instead, so
+    # the session stays the single owner of which model is current.
+    #
+    # The boundary is deliberately BETWEEN calls, never inside one. An
+    # in-flight request keeps the spec it was issued with, so a switch cannot
+    # tear down a stream that is already producing tokens or split one response
+    # across two models.
+    get_model: Callable[[], "ModelSpec"] | None = Field(default=None, exclude=True)
 
     # Required: render transcript messages (incl. custom entries) into the
     # LLM-visible list sent to the provider.

--- a/local_operator/model/configure.py
+++ b/local_operator/model/configure.py
@@ -1576,12 +1576,12 @@ class SessionStreamFn:
         """The frozen auto-effort as a rung ``model`` actually accepts.
 
         The level chosen at the message boundary is a rung on the ladder of the
-        model in force AT THAT MOMENT, and ladders differ between models. When
-        the model changes mid-message the same coarse judgement (the classifier's
-        lo/med/hi tier) is re-fitted to the new ladder rather than the old level
-        being carried across — carrying it either sends a rung the new model
-        rejects (an HTTP 400 that reads as the switch having broken the session)
-        or silently re-tiers the request.
+        model in force AT THAT MOMENT, and ladders differ between models. A level
+        the current model accepts is passed through unchanged; one it does not is
+        replaced by re-fitting the same coarse judgement (the classifier's
+        lo/med/hi tier) to this model's ladder. What is never done is sending the
+        stored level blind, which is an HTTP 400 that reads as the switch having
+        broken the session.
 
         Re-fitting rather than re-classifying is the point (review F2). The
         classifier reads the newest ``role="user"`` message, and mid-turn that is

--- a/local_operator/model/configure.py
+++ b/local_operator/model/configure.py
@@ -1517,6 +1517,31 @@ class SessionStreamFn:
         self._message_boundary_pending = True
         self._message_effort = None
 
+    def on_model_changed(self, model: ModelSpec) -> None:
+        """The session switched model mid-message; drop what was frozen for the old one.
+
+        Two pieces of state are deliberately frozen for the duration of one
+        user message, and both are frozen AGAINST A PARTICULAR MODEL:
+
+        * ``_message_effort`` — the auto-classified reasoning level, mapped onto
+          the old model's effort ladder. Ladders differ between models, so
+          carrying the level across a switch either sends a rung the new model
+          rejects (an HTTP 400 that reads as a broken switch) or silently
+          re-tiers the request. It is re-classified for the new model instead.
+        * the quota preflight's cooldown memo — keyed on the selector, so a
+          switch already invalidates the route via ``_primary_selector``. The
+          check timestamp is cleared here too so the new model is actually
+          preflighted rather than skipped by the old one's 60s TTL.
+
+        Only called when the provider/model pair genuinely changed — ``/effort``
+        and per-request sampling overrides write the spec constantly and must
+        not each pay for a re-classification (see ``Session.set_model``).
+        """
+        del model  # the next request carries it; this is a cache invalidation
+        self._message_boundary_pending = True
+        self._message_effort = None
+        self._usage_checked_at = 0.0
+
     async def _notice(self, text: str, kind: str = "warning") -> None:
         if self._notice_handler is None:
             return

--- a/local_operator/model/configure.py
+++ b/local_operator/model/configure.py
@@ -1493,6 +1493,11 @@ class SessionStreamFn:
         # tool calls would bust the provider cache and make one task reason at
         # several depths.
         self._message_effort: str | None = None
+        # The coarse tier (lo/med/hi) the level above was mapped from, kept so a
+        # mid-message model switch can re-fit the SAME judgement onto the new
+        # model's ladder instead of re-reading the conversation — see
+        # ``on_model_changed``.
+        self._message_tier: str | None = None
         self._primary_selector: str | None = None
         self._usage_checked_selector: str | None = None
         self._usage_checked_at = 0.0
@@ -1516,31 +1521,65 @@ class SessionStreamFn:
         """Mark the next model call as a user-message boundary."""
         self._message_boundary_pending = True
         self._message_effort = None
+        self._message_tier = None
 
     def on_model_changed(self, model: ModelSpec) -> None:
-        """The session switched model mid-message; drop what was frozen for the old one.
+        """The session switched model mid-message; re-fit the frozen effort to it.
 
-        Two pieces of state are deliberately frozen for the duration of one
-        user message, and both are frozen AGAINST A PARTICULAR MODEL:
+        The auto-classified reasoning level is frozen for the duration of one
+        user message so a tool loop reasons at one depth. It is a rung on THAT
+        MODEL's ladder, though, and ladders differ: carrying ``xhigh`` onto a
+        model that stops at ``high`` is an HTTP 400 on the next call, which
+        reads as the switch having broken the session.
 
-        * ``_message_effort`` — the auto-classified reasoning level, mapped onto
-          the old model's effort ladder. Ladders differ between models, so
-          carrying the level across a switch either sends a rung the new model
-          rejects (an HTTP 400 that reads as a broken switch) or silently
-          re-tiers the request. It is re-classified for the new model instead.
-        * the quota preflight's cooldown memo — keyed on the selector, so a
-          switch already invalidates the route via ``_primary_selector``. The
-          check timestamp is cleared here too so the new model is actually
-          preflighted rather than skipped by the old one's 60s TTL.
+        So the TIER is re-mapped onto the new ladder rather than the level being
+        carried, and rather than the message being re-classified from scratch.
+        Re-classifying was the obvious move and it is wrong (review F2): the
+        classifier reads the newest ``role="user"`` message, and mid-turn that
+        is very often not the user's prompt — steering, wake, hub, job-result
+        and todo-reminder asides all render as user turns
+        (``session._default_convert_to_llm``). Switching model after a "hurry
+        up" nudge therefore re-classified the NUDGE: a task the user opened at
+        ``high`` silently continued at ``low``, and an ``auto effort:`` notice
+        was emitted for text they never submitted as a prompt.
+
+        Re-mapping keeps the user's actual prompt as the thing that decided the
+        depth, which is what freezing was for in the first place.
+
+        ``_message_boundary_pending`` is deliberately NOT re-armed, for the same
+        reason: the boundary belongs to the user's message, and the switch did
+        not start a new one.
 
         Only called when the provider/model pair genuinely changed — ``/effort``
         and per-request sampling overrides write the spec constantly and must
-        not each pay for a re-classification (see ``Session.set_model``).
+        not each pay for this (see ``Session.set_model``).
+
+        Must stay SYNCHRONOUS: ``Session.set_model`` is a sync method and
+        discards a returned awaitable, which is the right contract for what is
+        only a cache re-fit.
+
+        Nothing is done for the quota preflight here: it is keyed on the
+        selector and ``preflight_usage`` already clears its route and its check
+        timestamp whenever the selector changes — which is the only condition
+        under which this hook fires (review F1).
         """
-        del model  # the next request carries it; this is a cache invalidation
-        self._message_boundary_pending = True
-        self._message_effort = None
-        self._usage_checked_at = 0.0
+        if self._message_tier is None:
+            # No classification in force (auto-effort off, or no boundary spent
+            # yet): nothing was frozen, so there is nothing to re-fit.
+            return
+        from local_operator.model.effort_classifier import map_tier_to_effort
+
+        cfg = self._settings.get("effort", {}) if isinstance(self._settings, Mapping) else {}
+        allow_max = (
+            bool(cfg.get("allowMax", cfg.get("allow_max", False)))
+            if isinstance(cfg, Mapping)
+            else False
+        )
+        self._message_effort = map_tier_to_effort(
+            self._message_tier,
+            model.reasoning_efforts,
+            allow_max=allow_max,
+        )
 
     async def _notice(self, text: str, kind: str = "warning") -> None:
         if self._notice_handler is None:
@@ -1810,6 +1849,9 @@ class SessionStreamFn:
                 request.model.reasoning_efforts,
                 self._settings,
             )
+            # Remembered so a mid-message model switch can re-map this same
+            # judgement onto a different ladder (``on_model_changed``).
+            self._message_tier = classification.tier if classification is not None else None
             if classification is not None and self._message_effort is not None:
                 await self._notice(
                     f"auto effort: {self._message_effort} ({classification.tier}, "

--- a/local_operator/model/configure.py
+++ b/local_operator/model/configure.py
@@ -1496,8 +1496,13 @@ class SessionStreamFn:
         # The coarse tier (lo/med/hi) the level above was mapped from, kept so a
         # mid-message model switch can re-fit the SAME judgement onto the new
         # model's ladder instead of re-reading the conversation — see
-        # ``on_model_changed``.
+        # ``_effort_for``.
         self._message_tier: str | None = None
+        # A mid-message model switch owes the NEW model a quota check, and this
+        # is deliberately not ``_message_boundary_pending``: that flag also gates
+        # effort classification, and re-arming it to buy a quota check re-grades
+        # the turn from an aside (see ``on_model_changed``).
+        self._quota_recheck_pending = False
         self._primary_selector: str | None = None
         self._usage_checked_selector: str | None = None
         self._usage_checked_at = 0.0
@@ -1520,35 +1525,12 @@ class SessionStreamFn:
     def begin_message(self) -> None:
         """Mark the next model call as a user-message boundary."""
         self._message_boundary_pending = True
+        self._quota_recheck_pending = False
         self._message_effort = None
         self._message_tier = None
 
     def on_model_changed(self, model: ModelSpec) -> None:
-        """The session switched model mid-message; re-fit the frozen effort to it.
-
-        The auto-classified reasoning level is frozen for the duration of one
-        user message so a tool loop reasons at one depth. It is a rung on THAT
-        MODEL's ladder, though, and ladders differ: carrying ``xhigh`` onto a
-        model that stops at ``high`` is an HTTP 400 on the next call, which
-        reads as the switch having broken the session.
-
-        So the TIER is re-mapped onto the new ladder rather than the level being
-        carried, and rather than the message being re-classified from scratch.
-        Re-classifying was the obvious move and it is wrong (review F2): the
-        classifier reads the newest ``role="user"`` message, and mid-turn that
-        is very often not the user's prompt — steering, wake, hub, job-result
-        and todo-reminder asides all render as user turns
-        (``session._default_convert_to_llm``). Switching model after a "hurry
-        up" nudge therefore re-classified the NUDGE: a task the user opened at
-        ``high`` silently continued at ``low``, and an ``auto effort:`` notice
-        was emitted for text they never submitted as a prompt.
-
-        Re-mapping keeps the user's actual prompt as the thing that decided the
-        depth, which is what freezing was for in the first place.
-
-        ``_message_boundary_pending`` is deliberately NOT re-armed, for the same
-        reason: the boundary belongs to the user's message, and the switch did
-        not start a new one.
+        """The session switched model mid-message; re-open the new model's quota check.
 
         Only called when the provider/model pair genuinely changed — ``/effort``
         and per-request sampling overrides write the spec constantly and must
@@ -1556,17 +1538,59 @@ class SessionStreamFn:
 
         Must stay SYNCHRONOUS: ``Session.set_model`` is a sync method and
         discards a returned awaitable, which is the right contract for what is
-        only a cache re-fit.
+        only a cache invalidation.
 
-        Nothing is done for the quota preflight here: it is keyed on the
-        selector and ``preflight_usage`` already clears its route and its check
-        timestamp whenever the selector changes — which is the only condition
-        under which this hook fires (review F1).
+        The EFFORT is deliberately not touched here. It is re-fitted at apply
+        time against the request's own spec (:meth:`_effort_for`), because the
+        model handed to this hook is not guaranteed to be the model the next
+        request actually carries — the loop's resolver can fall back — and
+        fitting to one while applying to the other is how the two drift
+        (review F9).
         """
+        del model  # see above: effort is fitted to the request's own spec
+        # ONLY the quota gate, and it is its OWN flag on purpose.
+        # ``_message_boundary_pending`` also gates effort CLASSIFICATION, so
+        # re-arming that to get a quota check would re-grade the turn from
+        # whatever aside happens to be the newest user-role message — the exact
+        # defect review F2 found.
+        #
+        # Without a flag of its own the new provider went unchecked for the rest
+        # of the turn (review F7): ``preflight_usage``'s body sits behind the
+        # boundary token, which the turn's FIRST call already spent, so clearing
+        # the memo behind that gate achieved nothing.
+        self._quota_recheck_pending = True
+
+    def _effort_for(self, model: ModelSpec) -> str | None:
+        """The frozen auto-effort as a rung ``model`` actually accepts.
+
+        The level chosen at the message boundary is a rung on the ladder of the
+        model in force AT THAT MOMENT, and ladders differ between models. When
+        the model changes mid-message the same coarse judgement (the classifier's
+        lo/med/hi tier) is re-fitted to the new ladder rather than the old level
+        being carried across — carrying it either sends a rung the new model
+        rejects (an HTTP 400 that reads as the switch having broken the session)
+        or silently re-tiers the request.
+
+        Re-fitting rather than re-classifying is the point (review F2). The
+        classifier reads the newest ``role="user"`` message, and mid-turn that is
+        very often not the user's prompt: steering, wake, hub, job-result and
+        todo-reminder asides all render as user turns. Re-classifying on a switch
+        therefore graded the aside — a task opened at ``high`` continued at
+        ``low`` after a "hurry up" nudge. The user's own prompt stays the thing
+        that decided the depth, which is what freezing was for.
+
+        Called per request rather than on the switch itself so the fit is always
+        against the spec being sent (review F9).
+        """
+        if self._message_effort is None:
+            return None
+        if self._message_effort in model.reasoning_efforts:
+            return self._message_effort
         if self._message_tier is None:
-            # No classification in force (auto-effort off, or no boundary spent
-            # yet): nothing was frozen, so there is nothing to re-fit.
-            return
+            # A level with no tier behind it cannot be re-fitted, and it is not
+            # on this model's ladder: dropping it costs one call's depth, where
+            # sending it costs the call.
+            return None
         from local_operator.model.effort_classifier import map_tier_to_effort
 
         cfg = self._settings.get("effort", {}) if isinstance(self._settings, Mapping) else {}
@@ -1575,11 +1599,7 @@ class SessionStreamFn:
             if isinstance(cfg, Mapping)
             else False
         )
-        self._message_effort = map_tier_to_effort(
-            self._message_tier,
-            model.reasoning_efforts,
-            allow_max=allow_max,
-        )
+        return map_tier_to_effort(self._message_tier, model.reasoning_efforts, allow_max=allow_max)
 
     async def _notice(self, text: str, kind: str = "warning") -> None:
         if self._notice_handler is None:
@@ -1664,9 +1684,16 @@ class SessionStreamFn:
             self._primary_selector = selector
             self._route_state.clear()
             self._usage_checked_at = 0.0
-        if not self._message_boundary_pending:
+        # EITHER gate opens the check: the user-message boundary (the ordinary
+        # once-per-message case) or a mid-message model switch, which brings a
+        # provider this turn has never checked. The switch needs its own token
+        # because the boundary one was already spent by the turn's first call —
+        # without it the new provider went unchecked for the rest of the turn
+        # (review F7).
+        if not self._message_boundary_pending and not self._quota_recheck_pending:
             return
         self._message_boundary_pending = False
+        self._quota_recheck_pending = False
 
         now = time.monotonic()
         if (
@@ -1849,8 +1876,8 @@ class SessionStreamFn:
                 request.model.reasoning_efforts,
                 self._settings,
             )
-            # Remembered so a mid-message model switch can re-map this same
-            # judgement onto a different ladder (``on_model_changed``).
+            # Remembered so a mid-message model switch can re-fit this same
+            # judgement onto a different ladder (``_effort_for``).
             self._message_tier = classification.tier if classification is not None else None
             if classification is not None and self._message_effort is not None:
                 await self._notice(
@@ -1858,13 +1885,15 @@ class SessionStreamFn:
                     f"score {classification.score:.1f})",
                     "info",
                 )
-        if self._message_effort is not None:
+        # Fitted to THIS request's spec, every call. The frozen level belongs to
+        # the model it was classified against, and mid-turn the model can change
+        # under it — by the user's switch, or by the loop's resolver falling back
+        # to the run's snapshot. Applying the stored level blind would send a rung
+        # the current model may not have (review F9).
+        effort = self._effort_for(request.model)
+        if effort is not None:
             request = request.model_copy(
-                update={
-                    "model": request.model.model_copy(
-                        update={"reasoning_effort": self._message_effort}
-                    )
-                }
+                update={"model": request.model.model_copy(update={"reasoning_effort": effort})}
             )
 
         if self._session_id and request.prompt_cache_key is None:

--- a/local_operator/model/configure.py
+++ b/local_operator/model/configure.py
@@ -1502,7 +1502,10 @@ class SessionStreamFn:
         # is deliberately not ``_message_boundary_pending``: that flag also gates
         # effort classification, and re-arming it to buy a quota check re-grades
         # the turn from an aside (see ``on_model_changed``).
-        self._quota_recheck_pending = False
+        #
+        # It holds the SELECTOR rather than a bare bool so only the model the
+        # switch was made to can spend it — see ``preflight_usage`` (review F10).
+        self._quota_recheck_for: str | None = None
         self._primary_selector: str | None = None
         self._usage_checked_selector: str | None = None
         self._usage_checked_at = 0.0
@@ -1525,7 +1528,9 @@ class SessionStreamFn:
     def begin_message(self) -> None:
         """Mark the next model call as a user-message boundary."""
         self._message_boundary_pending = True
-        self._quota_recheck_pending = False
+        # A switch nobody spent a check on does not carry into the next message:
+        # this boundary re-checks whatever model it opens on anyway.
+        self._quota_recheck_for = None
         self._message_effort = None
         self._message_tier = None
 
@@ -1547,18 +1552,25 @@ class SessionStreamFn:
         fitting to one while applying to the other is how the two drift
         (review F9).
         """
-        del model  # see above: effort is fitted to the request's own spec
-        # ONLY the quota gate, and it is its OWN flag on purpose.
+        # ONLY the quota gate, and it is its OWN token on purpose.
         # ``_message_boundary_pending`` also gates effort CLASSIFICATION, so
         # re-arming that to get a quota check would re-grade the turn from
         # whatever aside happens to be the newest user-role message — the exact
         # defect review F2 found.
         #
-        # Without a flag of its own the new provider went unchecked for the rest
-        # of the turn (review F7): ``preflight_usage``'s body sits behind the
-        # boundary token, which the turn's FIRST call already spent, so clearing
-        # the memo behind that gate achieved nothing.
-        self._quota_recheck_pending = True
+        # Without a token of its own the new provider went unchecked for the
+        # rest of the turn (review F7): ``preflight_usage``'s body sits behind
+        # the boundary token, which the turn's FIRST call already spent, so
+        # clearing the memo behind that gate achieved nothing.
+        #
+        # The token names the SELECTOR it was armed for, because a bare bool is
+        # spent by whichever request reaches the preflight first — and that is
+        # not necessarily a request on the new model. A call built just before
+        # the switch can still be in flight (the loop resolves the spec two
+        # yields before it calls the stream, and its resolver may fall back to
+        # the run's snapshot), so a bool let a stale call consume the check the
+        # new provider was owed, reproducing F7 on a narrower path (review F10).
+        self._quota_recheck_for = f"{model.provider}/{model.model_id}"
 
     def _effort_for(self, model: ModelSpec) -> str | None:
         """The frozen auto-effort as a rung ``model`` actually accepts.
@@ -1581,6 +1593,14 @@ class SessionStreamFn:
 
         Called per request rather than on the switch itself so the fit is always
         against the spec being sent (review F9).
+
+        A level the new model ALREADY accepts is kept as-is rather than re-fitted
+        (review F11). So a ``med`` prompt frozen as ``low`` on a two-rung ladder
+        stays ``low`` on a three-rung one, where re-fitting would say ``medium``.
+        That is deliberate: this function exists to keep requests legal, and
+        silently deepening a level the user has been shown — and is being billed
+        for — because the ladder got finer is a bigger surprise than a level that
+        holds steady across a switch.
         """
         if self._message_effort is None:
             return None
@@ -1690,10 +1710,17 @@ class SessionStreamFn:
         # because the boundary one was already spent by the turn's first call —
         # without it the new provider went unchecked for the rest of the turn
         # (review F7).
-        if not self._message_boundary_pending and not self._quota_recheck_pending:
+        #
+        # The switch token is honoured only for the selector it was armed for,
+        # and is consumed only by that same selector, so a request still
+        # carrying the pre-switch spec can neither open the gate nor spend the
+        # check the new model is owed (review F10).
+        recheck_due = self._quota_recheck_for == selector
+        if not self._message_boundary_pending and not recheck_due:
             return
         self._message_boundary_pending = False
-        self._quota_recheck_pending = False
+        if recheck_due:
+            self._quota_recheck_for = None
 
         now = time.monotonic()
         if (

--- a/local_operator/session/protocol.py
+++ b/local_operator/session/protocol.py
@@ -88,12 +88,20 @@ class SessionProtocol(Protocol):
         ...
 
     def set_model(self, model: ModelSpec) -> None:
-        """Swap the model spec; takes effect from the next turn onward.
+        """Swap the model spec; in force from the very next provider call.
 
         The TUI's ``/model <provider>/<id>`` path calls this after building a
-        new spec — the loop reads the spec fresh on every turn, so no session
-        teardown is required. Also changes compaction thresholds for the new
-        context window.
+        new spec, so no session teardown is required. Also changes compaction
+        thresholds for the new context window.
+
+        Not "from the next turn": an implementation is expected to reach the
+        RUNNING turn too. A turn is a chain of provider calls with tool batches
+        between them, and a user switching model mid-turn is doing it because
+        the running model is doing badly, so the switch lands at the next call
+        boundary. Whatever is already in flight finishes on the spec it was
+        issued with \u2014 a switch must never split one response across two models.
+        :class:`~local_operator.session.session.Session` implements this by
+        handing the loop a ``LoopConfig.get_model`` resolver.
         """
         ...
 

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -1209,8 +1209,10 @@ class Session:
 
         Tells the stream fn the model changed, so state frozen per user message
         against the OLD model — the auto-effort level, the quota preflight's
-        route — is re-derived for the new one rather than carried across a
-        switch it was never computed for.
+        route — is re-fitted to the new one rather than carried across a switch
+        it was never computed for. That hook must be SYNCHRONOUS: this method is
+        sync and would discard a returned coroutine, which is the right contract
+        for what is only a cache re-fit.
         """
         previous = self._model
         self._model = model
@@ -1218,7 +1220,14 @@ class Session:
             # Same model, different knobs (effort, sampling): nothing routing
             # or quota related has moved, so leave the frozen per-message state
             # alone. `/effort` and the server's option overrides take this path
-            # on every call and must not each cost a re-classification.
+            # on every call and must not each cost a re-fit.
+            #
+            # `base_url` is deliberately NOT part of the key. It is derived from
+            # the provider definition rather than chosen per call, so it cannot
+            # vary independently of the pair above; and the state this guards is
+            # itself selector-keyed (`SessionStreamFn._primary_selector`), so a
+            # third component here would invalidate more often than the thing
+            # being invalidated can actually change.
             return
         notify = getattr(self._stream_fn, "on_model_changed", None)
         if callable(notify):

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -1187,15 +1187,42 @@ class Session:
         return result
 
     def set_model(self, model: ModelSpec) -> None:
-        """Swap the model spec mid-session.
+        """Swap the model spec, in force from the very next provider call.
 
-        The loop reads ``config.model`` fresh on every turn, so the new spec
-        takes effect from the next turn onward. Hosts use this for per-request
-        overrides that are not part of the agent record — the FastAPI server
-        applies ``ChatRequest.options`` (temperature / top_p) this way, since
-        sampling rides on the spec (see ``model/configure.build_model_spec``).
+        Not "from the next turn": the running turn picks it up too. A turn is a
+        chain of provider calls with tool batches between them, and the loop
+        re-reads this spec at each of them (``LoopConfig.get_model``), so a
+        switch made while the agent is working lands at the next call boundary.
+        Anything already in flight finishes on the spec it was issued with — the
+        switch never splits one response across two models.
+
+        That boundary is the whole point of the feature. A user reaches for
+        ``/model`` mid-turn BECAUSE the running model is doing badly, and the
+        old "next turn" behaviour meant the switch was invisible for the rest of
+        a long tool-using turn: the band said the new model, every remaining
+        call went to the old one.
+
+        Also used for per-request overrides that are not part of the agent
+        record — the FastAPI server applies ``ChatRequest.options``
+        (temperature / top_p) this way, since sampling rides on the spec (see
+        ``model/configure.build_model_spec``).
+
+        Tells the stream fn the model changed, so state frozen per user message
+        against the OLD model — the auto-effort level, the quota preflight's
+        route — is re-derived for the new one rather than carried across a
+        switch it was never computed for.
         """
+        previous = self._model
         self._model = model
+        if (previous.provider, previous.model_id) == (model.provider, model.model_id):
+            # Same model, different knobs (effort, sampling): nothing routing
+            # or quota related has moved, so leave the frozen per-message state
+            # alone. `/effort` and the server's option overrides take this path
+            # on every call and must not each cost a re-classification.
+            return
+        notify = getattr(self._stream_fn, "on_model_changed", None)
+        if callable(notify):
+            notify(model)
 
     @property
     def goal(self) -> str:
@@ -1659,6 +1686,10 @@ class Session:
 
             config = LoopConfig(
                 model=self._model,
+                # Re-read per provider call, so a ``set_model`` landing while
+                # this turn is running reaches its NEXT call instead of
+                # waiting for the turn to end (see ``set_model``).
+                get_model=lambda: self._model,
                 convert_to_llm=self._render_history,
                 stream_fn=self._stream_fn,
                 get_steering_messages=self._drain_steering,

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -5714,7 +5714,13 @@ class OperatorApp(App[None]):
         # session layer already declines to re-derive anything for a same-model
         # write; this is the UI half of that rule.
         if session.is_streaming and old_label != session.model_label:
-            notice(MODEL_SWITCH_MID_TURN_NOTICE, "note")
+            # ``info``, matching the receipt it qualifies, NOT ``note`` (design
+            # review D3). Both rows answer one action, and at ``note`` the
+            # subordinate half measured 8.62:1 against the receipt's 4.55:1 —
+            # 1.9x the contrast of its own subject, so the eye landed on the
+            # qualifier first. A continuation reads as a continuation only if it
+            # is not louder than the sentence it continues.
+            notice(MODEL_SWITCH_MID_TURN_NOTICE, "info")
         if warning:
             notice(warning, "warning")
 
@@ -5750,8 +5756,9 @@ class OperatorApp(App[None]):
         """Put ``level`` on the session's spec and repaint the band.
 
         Through ``set_model`` because the spec IS the request: the loop rereads
-        ``config.model`` every turn, so the level takes effect on the next one
-        and every wire client reads it from the same field. Remembered on the
+        the session's spec at every provider call, so the level takes effect on
+        the next one — within the running turn, not just the next turn — and
+        every wire client reads it from the same field. Remembered on the
         app as well, because a session can be REPLACED under a running app —
         ``/new``, ``/reload`` and ``/resume`` all rebuild one — and a setting
         that silently reverted on a reload would be a band asserting a level

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -240,6 +240,19 @@ RESTORED_COST_PREFIX = "≥"
 #: made the reader translate. All four now describe what the user observes.
 QUEUED_STEER_NOTICE = "queued — sends when this step finishes"
 SENT_STEER_NOTICE = "sent — the agent has it now"
+#: Printed under a ``/model`` switch made WHILE a turn is running, and only
+#: then. The request already streaming cannot be re-targeted, so for a few
+#: seconds the band names the new model while the old one is visibly still
+#: working — which reads as the switch having been ignored, the complaint the
+#: mid-turn switch was built to answer.
+#:
+#: Its own row rather than a third clause on the receipt: that line is already
+#: two clauses and a hint, and measured at the widths this app supports,
+#: folding the timing into its scope parenthetical pushed it from two wrapped
+#: lines to three — the run-on the receipt's own comment exists to prevent.
+#: Same "step" noun as the steering pair above, for the same reason: one word
+#: for one observable boundary.
+MODEL_SWITCH_MID_TURN_NOTICE = "applies from the next step — this one finishes on the old model"
 #: The turn ended without ever reaching a boundary to drain at — interrupted,
 #: failed, or simply answered with no further tool calls. ONE string for all
 #: three, because they are one fact from the user's side: the message is waiting
@@ -5681,6 +5694,13 @@ class OperatorApp(App[None]):
                 f"model: {old_label} → {session.model_label} "
                 f"(this session){suffix} — {PERSIST_HINT}"
             )
+            # MID-TURN is the one moment "starting when" is a live question, and
+            # the next receipt cannot answer it because the answer is visible
+            # before then: the agent goes on working on the old model until the
+            # step in flight ends. On its own row and only while streaming — see
+            # MODEL_SWITCH_MID_TURN_NOTICE for why it is not a third clause.
+            if session.is_streaming:
+                notice(MODEL_SWITCH_MID_TURN_NOTICE, "note")
         if warning:
             notice(warning, "warning")
 

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -5694,13 +5694,27 @@ class OperatorApp(App[None]):
                 f"model: {old_label} → {session.model_label} "
                 f"(this session){suffix} — {PERSIST_HINT}"
             )
-            # MID-TURN is the one moment "starting when" is a live question, and
-            # the next receipt cannot answer it because the answer is visible
-            # before then: the agent goes on working on the old model until the
-            # step in flight ends. On its own row and only while streaming — see
-            # MODEL_SWITCH_MID_TURN_NOTICE for why it is not a third clause.
-            if session.is_streaming:
-                notice(MODEL_SWITCH_MID_TURN_NOTICE, "note")
+        # MID-TURN is the one moment "starting when" is a live question, and the
+        # next receipt cannot answer it because the answer is visible before
+        # then: the agent goes on working on the old model until the step in
+        # flight ends. On its own row — see MODEL_SWITCH_MID_TURN_NOTICE for why
+        # it is not a third clause on the receipt.
+        #
+        # OUTSIDE the branches above, and that placement is the fix for a real
+        # defect (design review D1): ``/model default <p>/<id>`` performs the
+        # SAME live switch, and while it was nested in the else-branch that
+        # spelling printed only "used from the next launch" — a receipt that
+        # contradicted the band beside it, which had already repainted to the
+        # new model. Every spelling that switches the session owes the same
+        # answer to "starting when".
+        #
+        # ``old_label != session.model_label`` because re-selecting the model
+        # already in force is a no-op, and promising that "this one finishes on
+        # the old model" describes a handover that will not happen (D4). The
+        # session layer already declines to re-derive anything for a same-model
+        # write; this is the UI half of that rule.
+        if session.is_streaming and old_label != session.model_label:
+            notice(MODEL_SWITCH_MID_TURN_NOTICE, "note")
         if warning:
             notice(warning, "warning")
 

--- a/tests/unit/harness/test_loop.py
+++ b/tests/unit/harness/test_loop.py
@@ -910,3 +910,104 @@ async def test_a_late_call_id_does_not_change_the_compose_key():
         if isinstance(event, ToolCallComposeEvent)
     ]
     assert len({event.tool_call_id for event in composes}) == 1
+
+
+class TestTheModelIsReadAtEveryCall:
+    """A model switched mid-run reaches the run's NEXT provider call.
+
+    A run is a chain of provider calls with tool batches between them, and
+    ``LoopConfig.model`` is bound once when the host builds the config. On its
+    own that pinned every call of a run to the model it started on, so a user
+    switching model while the agent worked saw the switch ignored until their
+    next message. ``get_model`` is asked once per call instead.
+    """
+
+    @staticmethod
+    def _two_call_stream() -> ScriptedStream:
+        return ScriptedStream(
+            [
+                [
+                    tool_call_delta(0, id="c1", name="echo", args="{}"),
+                    StreamEndEvent(stop_reason="toolUse"),
+                ],
+                [StreamTextDelta(delta="done"), StreamEndEvent(stop_reason="stop")],
+            ]
+        )
+
+    @staticmethod
+    def _labels(stream: ScriptedStream) -> list[str]:
+        return [f"{r.model.provider}/{r.model.model_id}" for r in stream.requests]
+
+    @pytest.mark.asyncio
+    async def test_a_switch_between_calls_lands_on_the_next_one(self):
+        """The point of the feature: the second call of the SAME run switches."""
+        new = ModelSpec(provider="test", model_id="new")
+        current = [MODEL]
+        stream = self._two_call_stream()
+
+        async def execute(tool_call_id, args, signal, on_update, context):
+            # The user runs /model while this tool is in flight.
+            current[0] = new
+            return ToolResult(
+                tool_call_id=tool_call_id, tool_name="echo", content=[TextContent(text="ok")]
+            )
+
+        tool = AgentTool(name="echo", parameters={"type": "object"}, execute=execute)
+        context = LoopContext(system_blocks=["sys"], tools=[tool])
+        config = make_config(stream, get_model=lambda: current[0])
+
+        async for _ in AgentLoop().run([Message.user("go")], context, config, None):
+            pass
+
+        assert self._labels(stream) == ["test/m", "test/new"]
+
+    @pytest.mark.asyncio
+    async def test_a_config_without_a_resolver_still_runs(self):
+        """Every embedder and test double builds a LoopConfig with no ``get_model``."""
+        stream = self._two_call_stream()
+        executed: list[str] = []
+        context = LoopContext(system_blocks=["sys"], tools=[echo_tool(executed)])
+
+        async for _ in AgentLoop().run([Message.user("go")], context, make_config(stream), None):
+            pass
+
+        assert self._labels(stream) == ["test/m", "test/m"]
+
+    @pytest.mark.asyncio
+    async def test_a_broken_resolver_does_not_lose_the_turn(self, caplog):
+        """A host accessor that raises is a host bug, not a reason to bin the work.
+
+        Discriminating: it asserts the run COMPLETED on the snapshot model, so a
+        resolver that raised into the loop would fail this rather than be
+        silently tolerated by a test that only checked the label.
+        """
+        stream = self._two_call_stream()
+        executed: list[str] = []
+        context = LoopContext(system_blocks=["sys"], tools=[echo_tool(executed)])
+
+        def broken() -> ModelSpec:
+            raise RuntimeError("host accessor exploded")
+
+        config = make_config(stream, get_model=broken)
+        ends = []
+        with caplog.at_level(logging.ERROR):
+            async for event in AgentLoop().run([Message.user("go")], context, config, None):
+                if isinstance(event, AgentEndEvent):
+                    ends.append(event)
+
+        assert self._labels(stream) == ["test/m", "test/m"]
+        assert ends and ends[-1].error is None and not ends[-1].aborted
+        assert "host accessor exploded" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_a_resolver_returning_none_falls_back_to_the_snapshot(self):
+        """``None`` means "nothing better to say", not "call a model of None"."""
+        stream = self._two_call_stream()
+        executed: list[str] = []
+        context = LoopContext(system_blocks=["sys"], tools=[echo_tool(executed)])
+        config = make_config(stream, get_model=lambda: None)
+
+        async for _ in AgentLoop().run([Message.user("go")], context, config, None):
+            pass
+
+        assert self._labels(stream) == ["test/m", "test/m"]

--- a/tests/unit/model/test_effort_classifier.py
+++ b/tests/unit/model/test_effort_classifier.py
@@ -499,17 +499,25 @@ async def test_a_stale_call_cannot_spend_the_new_models_quota_check() -> None:
         def is_blocked(self, *args, **kwargs):
             return False
 
-    stream = SessionStreamFn(cast(Any, FakeAuth()), {}, "session-x")
-    opened: list[str] = []
-    real_preflight = stream.preflight_usage
+    stream = SessionStreamFn(cast(Any, FakeAuth()), {"retry": {"usageAwareFallback": True}}, "s")
+    # Observe the CREDENTIAL LOOKUP the check body performs, never the flags the
+    # gate itself reads: a probe computed from that state passes even when the
+    # whole gate is deleted, which is the flaw review F12 found in the first
+    # version of this test.
+    checked: list[str] = []
 
-    async def spy(model: ModelSpec) -> None:
-        was_open = stream._message_boundary_pending or stream._quota_recheck_for is not None
-        await real_preflight(model)
-        if was_open:
-            opened.append(model.provider)
+    class WatchedAuth:
+        async def get_oauth_access(self, provider, *args, **kwargs):
+            checked.append(provider)
+            return None
 
-    stream.preflight_usage = spy  # type: ignore[method-assign]
+        def list_credentials(self, *args, **kwargs):
+            return []
+
+        def is_blocked(self, *args, **kwargs):
+            return False
+
+    stream._auth_store = cast(Any, WatchedAuth())
     first = ModelSpec(provider="pa", model_id="m")
     second = ModelSpec(provider="pb", model_id="m")
 
@@ -521,7 +529,7 @@ async def test_a_stale_call_cannot_spend_the_new_models_quota_check() -> None:
     # ...and must not have eaten the check the switched-to model is owed.
     await stream.preflight_usage(second)
 
-    assert "pb" in opened, opened
+    assert checked == ["pa", "pb"], checked
     await stream.close()
 
 

--- a/tests/unit/model/test_effort_classifier.py
+++ b/tests/unit/model/test_effort_classifier.py
@@ -388,7 +388,7 @@ async def test_the_effort_is_fitted_to_the_spec_actually_being_sent(monkeypatch)
 
     async def _preflight(model) -> None:
         stream._message_boundary_pending = False
-        stream._quota_recheck_pending = False
+        stream._quota_recheck_for = None
 
     monkeypatch.setattr(stream, "preflight_usage", _preflight)
     wide = ModelSpec(
@@ -448,7 +448,7 @@ async def test_a_switch_never_applies_an_effort_the_user_was_not_shown(monkeypat
 
     async def _preflight(model) -> None:
         stream._message_boundary_pending = False
-        stream._quota_recheck_pending = False
+        stream._quota_recheck_for = None
 
     monkeypatch.setattr(stream, "preflight_usage", _preflight)
     ladderless = ModelSpec(provider="test", model_id="plain", reasoning_efforts=())
@@ -474,6 +474,54 @@ async def test_a_switch_never_applies_an_effort_the_user_was_not_shown(monkeypat
     ]
     assert captured[-1].model.reasoning_effort is None, captured[-1].model.reasoning_effort
     assert not any("auto effort" in text for text in notices), notices
+    await stream.close()
+
+
+@pytest.mark.asyncio
+async def test_a_stale_call_cannot_spend_the_new_models_quota_check() -> None:
+    """The recheck token names its selector, so only that model can spend it (review F10).
+
+    A request built just BEFORE the switch can still reach the preflight after
+    it: the loop resolves the spec two yields before it calls the stream, and
+    its resolver can fall back to the run's snapshot. With a bare boolean token
+    that stale call consumed the check the new provider was owed, reproducing
+    F7's symptom on a narrower path.
+    """
+    from local_operator.model.configure import SessionStreamFn
+
+    class FakeAuth:
+        async def get_oauth_access(self, *args, **kwargs):
+            return None
+
+        def list_credentials(self, *args, **kwargs):
+            return []
+
+        def is_blocked(self, *args, **kwargs):
+            return False
+
+    stream = SessionStreamFn(cast(Any, FakeAuth()), {}, "session-x")
+    opened: list[str] = []
+    real_preflight = stream.preflight_usage
+
+    async def spy(model: ModelSpec) -> None:
+        was_open = stream._message_boundary_pending or stream._quota_recheck_for is not None
+        await real_preflight(model)
+        if was_open:
+            opened.append(model.provider)
+
+    stream.preflight_usage = spy  # type: ignore[method-assign]
+    first = ModelSpec(provider="pa", model_id="m")
+    second = ModelSpec(provider="pb", model_id="m")
+
+    stream.begin_message()
+    await stream.preflight_usage(first)
+    stream.on_model_changed(second)
+    # A call still carrying the PRE-SWITCH spec lands first...
+    await stream.preflight_usage(first)
+    # ...and must not have eaten the check the switched-to model is owed.
+    await stream.preflight_usage(second)
+
+    assert "pb" in opened, opened
     await stream.close()
 
 

--- a/tests/unit/model/test_effort_classifier.py
+++ b/tests/unit/model/test_effort_classifier.py
@@ -186,8 +186,103 @@ async def test_a_mid_message_model_switch_reclassifies_effort(monkeypatch) -> No
 
 
 @pytest.mark.asyncio
-async def test_a_model_switch_reopens_the_quota_preflight(monkeypatch) -> None:
-    """The preflight's 60s memo is per selector; a switch must not be skipped by it."""
+async def test_the_preflight_itself_reopens_on_a_switch(monkeypatch) -> None:
+    """The quota memo is reopened by `preflight_usage`, not by the hook (review F1).
+
+    The hook used to zero `_usage_checked_at` as well, with a comment claiming
+    the old model's 60s TTL would otherwise skip the new model's check. It could
+    not: the TTL is gated on the selector matching, and `preflight_usage` clears
+    both the route and the timestamp on any selector change — which is the only
+    condition under which the hook fires at all. This pins the real mechanism so
+    the redundant line is not reintroduced.
+    """
+    from local_operator.model.configure import SessionStreamFn
+    from local_operator.providers.failover import FallbackTarget
+
+    class FakeAuth:
+        async def get_oauth_access(self, *args, **kwargs):
+            return None
+
+    stream = SessionStreamFn(cast(Any, FakeAuth()), {}, "session-x")
+    first = ModelSpec(provider="test", model_id="first")
+    await stream.preflight_usage(first)
+    assert stream._usage_checked_at != 0.0
+    assert stream._primary_selector == "test/first"
+
+    # Switching selector is what reopens the check, with no help from the hook:
+    # the timestamp is zeroed and the route dropped the moment the selector
+    # differs, BEFORE the TTL comparison is ever reached.
+    stream._route_state.active = FallbackTarget("test/fallback", None)
+    await stream.preflight_usage(ModelSpec(provider="test", model_id="second"))
+    assert stream._primary_selector == "test/second"
+    assert stream._route_state.active is None
+    await stream.close()
+
+
+@pytest.mark.asyncio
+async def test_a_switch_after_steering_keeps_the_prompts_own_depth(monkeypatch) -> None:
+    """A mid-turn switch must not re-read the conversation to pick effort (review F2).
+
+    The classifier reads the newest ``role="user"`` message, and mid-turn that
+    is very often NOT the user's prompt: steering, wake, hub, job-result and
+    todo-reminder asides all render as user turns. Re-classifying on a switch
+    therefore graded the aside — a task opened at ``high`` silently continued at
+    ``low`` after a "hurry up" nudge, with an ``auto effort:`` notice for text
+    the user never submitted. The remembered TIER is re-mapped instead.
+    """
+    from local_operator.model.configure import SessionStreamFn
+    from local_operator.providers import failover
+
+    captured: list[ChatRequest] = []
+
+    async def fake_stream(request, *args, **kwargs):
+        captured.append(request)
+        yield StreamEndEvent(stop_reason="stop")
+
+    monkeypatch.setattr(failover, "stream_with_failover", fake_stream)
+
+    class FakeAuth:
+        async def get_oauth_access(self, *args, **kwargs):
+            return None
+
+    stream = SessionStreamFn(cast(Any, FakeAuth()), {"effort": {"auto": True}}, "session-x")
+
+    async def _preflight(model) -> None:
+        stream._message_boundary_pending = False
+
+    monkeypatch.setattr(stream, "preflight_usage", _preflight)
+    ladder = ("minimal", "low", "medium", "high", "max")
+    first = ModelSpec(provider="test", model_id="first", reasoning_efforts=ladder)
+    second = ModelSpec(provider="test", model_id="second", reasoning_efforts=ladder)
+
+    heavy = (
+        "Implement, refactor, debug, review, deploy, and release this migration.\n"
+        + "\n".join(f"- acceptance {i}" for i in range(20))
+        + "\n```python\ndef f(): ...\n```"
+    )
+    _ = [
+        event
+        async for event in stream(ChatRequest(model=first, messages=[Message.user(heavy)]), None)
+    ]
+    opened_at = captured[-1].model.reasoning_effort
+    assert opened_at == "high", opened_at
+
+    # Mid-turn: a steering nudge has landed (it renders as a user turn), and the
+    # user switches model.
+    stream.on_model_changed(second)
+    mid_turn = [
+        Message.user(heavy),
+        Message.assistant("working on it"),
+        Message.user("hurry up"),
+    ]
+    _ = [event async for event in stream(ChatRequest(model=second, messages=mid_turn), None)]
+    assert captured[-1].model.reasoning_effort == "high", captured[-1].model.reasoning_effort
+    await stream.close()
+
+
+@pytest.mark.asyncio
+async def test_a_switch_with_auto_effort_off_stays_off(monkeypatch) -> None:
+    """No classification in force means nothing to re-fit, and nothing invented."""
     from local_operator.model.configure import SessionStreamFn
 
     class FakeAuth:
@@ -195,11 +290,10 @@ async def test_a_model_switch_reopens_the_quota_preflight(monkeypatch) -> None:
             return None
 
     stream = SessionStreamFn(cast(Any, FakeAuth()), {}, "session-x")
-    stream._usage_checked_at = 1234.0
-    stream._message_boundary_pending = False
-    stream.on_model_changed(ModelSpec(provider="test", model_id="other"))
-    assert stream._usage_checked_at == 0.0
-    assert stream._message_boundary_pending is True
+    stream.on_model_changed(
+        ModelSpec(provider="test", model_id="other", reasoning_efforts=("low",))
+    )
+    assert stream._message_effort is None
     await stream.close()
 
 

--- a/tests/unit/model/test_effort_classifier.py
+++ b/tests/unit/model/test_effort_classifier.py
@@ -297,5 +297,185 @@ async def test_a_switch_with_auto_effort_off_stays_off(monkeypatch) -> None:
     await stream.close()
 
 
+@pytest.mark.asyncio
+async def test_a_mid_turn_switch_still_quota_checks_the_new_provider(monkeypatch) -> None:
+    """The new provider owes a quota check even though the boundary was spent (review F7).
+
+    ``preflight_usage``'s body sits behind a one-shot token that the turn's FIRST
+    call consumes. A mid-message switch brings a provider this turn has never
+    checked, so it needs a gate of its own — re-arming the message boundary would
+    also re-grade the turn's effort from whatever aside is newest (F2), which is
+    why the two flags are separate.
+    """
+    from local_operator.model.configure import SessionStreamFn
+    from local_operator.providers import failover
+
+    async def fake_stream(request, *args, **kwargs):
+        yield StreamEndEvent(stop_reason="stop")
+
+    monkeypatch.setattr(failover, "stream_with_failover", fake_stream)
+
+    class FakeAuth:
+        async def get_oauth_access(self, *args, **kwargs):
+            return None
+
+    stream = SessionStreamFn(
+        cast(Any, FakeAuth()), {"retry": {"usageAwareFallback": True}}, "session-x"
+    )
+    # Observe the CREDENTIAL LOOKUP the check body performs, not the flag that
+    # gates it: asserting the flag would pass even if the gate never opened.
+    checked: list[str] = []
+
+    class WatchedAuth:
+        """Records which providers the check body actually looked up."""
+
+        async def get_oauth_access(self, provider, *args, **kwargs):
+            checked.append(provider)
+            return None
+
+        def list_credentials(self, *args, **kwargs):
+            return []
+
+        def is_blocked(self, *args, **kwargs):
+            return False
+
+    stream._auth_store = cast(Any, WatchedAuth())
+    first = ModelSpec(provider="pa", model_id="m")
+    second = ModelSpec(provider="pb", model_id="m")
+
+    stream.begin_message()
+    _ = [
+        event
+        async for event in stream(ChatRequest(model=first, messages=[Message.user("go")]), None)
+    ]
+    stream.on_model_changed(second)
+    _ = [
+        event
+        async for event in stream(ChatRequest(model=second, messages=[Message.user("go")]), None)
+    ]
+
+    assert checked == ["pa", "pb"], checked
+    await stream.close()
+
+
+@pytest.mark.asyncio
+async def test_the_effort_is_fitted_to_the_spec_actually_being_sent(monkeypatch) -> None:
+    """Fit at APPLY time, not at switch time (review F9).
+
+    The loop's resolver can fall back to the run's snapshot, so the model handed
+    to ``on_model_changed`` is not guaranteed to be the model the next request
+    carries. Fitting to one and applying to the other sends a rung the request's
+    model may not have — the HTTP 400 this mechanism exists to prevent. Here the
+    switch announces a wide-ladder model but the request that follows carries the
+    narrow one.
+    """
+    from local_operator.model.configure import SessionStreamFn
+    from local_operator.providers import failover
+
+    captured: list[ChatRequest] = []
+
+    async def fake_stream(request, *args, **kwargs):
+        captured.append(request)
+        yield StreamEndEvent(stop_reason="stop")
+
+    monkeypatch.setattr(failover, "stream_with_failover", fake_stream)
+
+    class FakeAuth:
+        async def get_oauth_access(self, *args, **kwargs):
+            return None
+
+    stream = SessionStreamFn(cast(Any, FakeAuth()), {"effort": {"auto": True}}, "session-x")
+
+    async def _preflight(model) -> None:
+        stream._message_boundary_pending = False
+        stream._quota_recheck_pending = False
+
+    monkeypatch.setattr(stream, "preflight_usage", _preflight)
+    wide = ModelSpec(
+        provider="test", model_id="wide", reasoning_efforts=("minimal", "low", "medium", "high")
+    )
+    narrow = ModelSpec(provider="test", model_id="narrow", reasoning_efforts=("medium", "high"))
+
+    _ = [
+        event
+        async for event in stream(
+            ChatRequest(model=wide, messages=[Message.user("show status")]), None
+        )
+    ]
+    assert captured[-1].model.reasoning_effort == "low"
+
+    # The hook is told about `wide` again (a resolver fallback), but the request
+    # that follows carries `narrow`.
+    stream.on_model_changed(wide)
+    _ = [
+        event
+        async for event in stream(
+            ChatRequest(model=narrow, messages=[Message.user("show status")]), None
+        )
+    ]
+    sent = captured[-1].model.reasoning_effort
+    assert sent in narrow.reasoning_efforts, sent
+    await stream.close()
+
+
+@pytest.mark.asyncio
+async def test_a_switch_never_applies_an_effort_the_user_was_not_shown(monkeypatch) -> None:
+    """No silent auto-effort on a ladder-less -> ladder switch (review F8).
+
+    On a model with no ladder the classifier yields a tier but no level, and no
+    ``auto effort:`` notice is printed because there is no level to announce.
+    Switching to a model that HAS a ladder must not quietly turn that unannounced
+    tier into a real rung.
+    """
+    from local_operator.model.configure import SessionStreamFn
+    from local_operator.providers import failover
+
+    captured: list[ChatRequest] = []
+    notices: list[str] = []
+
+    async def fake_stream(request, *args, **kwargs):
+        captured.append(request)
+        yield StreamEndEvent(stop_reason="stop")
+
+    monkeypatch.setattr(failover, "stream_with_failover", fake_stream)
+
+    class FakeAuth:
+        async def get_oauth_access(self, *args, **kwargs):
+            return None
+
+    stream = SessionStreamFn(cast(Any, FakeAuth()), {"effort": {"auto": True}}, "session-x")
+    stream.set_notice_handler(lambda text, kind: notices.append(text))
+
+    async def _preflight(model) -> None:
+        stream._message_boundary_pending = False
+        stream._quota_recheck_pending = False
+
+    monkeypatch.setattr(stream, "preflight_usage", _preflight)
+    ladderless = ModelSpec(provider="test", model_id="plain", reasoning_efforts=())
+    reasoner = ModelSpec(
+        provider="test", model_id="reasoner", reasoning_efforts=("low", "medium", "high")
+    )
+
+    _ = [
+        event
+        async for event in stream(
+            ChatRequest(model=ladderless, messages=[Message.user("show status")]), None
+        )
+    ]
+    assert stream._message_effort is None
+    assert not any("auto effort" in text for text in notices)
+
+    stream.on_model_changed(reasoner)
+    _ = [
+        event
+        async for event in stream(
+            ChatRequest(model=reasoner, messages=[Message.user("show status")]), None
+        )
+    ]
+    assert captured[-1].model.reasoning_effort is None, captured[-1].model.reasoning_effort
+    assert not any("auto effort" in text for text in notices), notices
+    await stream.close()
+
+
 async def _noop() -> None:
     return None

--- a/tests/unit/model/test_effort_classifier.py
+++ b/tests/unit/model/test_effort_classifier.py
@@ -118,5 +118,90 @@ async def test_session_stream_fn_freezes_effort_for_one_tool_loop(monkeypatch) -
     await stream.close()
 
 
+@pytest.mark.asyncio
+async def test_a_mid_message_model_switch_reclassifies_effort(monkeypatch) -> None:
+    """A model switched mid-message must not inherit the old model's rung.
+
+    The auto-effort level is frozen for one user message so a tool loop
+    reasons at one depth, but it is mapped onto a PARTICULAR model's ladder.
+    Carrying it across a switch either sends a rung the new model rejects
+    (an HTTP 400 that reads as a broken switch) or silently re-tiers the
+    request, so ``on_model_changed`` drops the freeze.
+    """
+    from local_operator.model.configure import SessionStreamFn
+    from local_operator.providers import failover
+
+    captured: list[ChatRequest] = []
+
+    async def fake_stream(request, *args, **kwargs):
+        captured.append(request)
+        yield StreamEndEvent(stop_reason="stop")
+
+    monkeypatch.setattr(failover, "stream_with_failover", fake_stream)
+
+    class FakeAuth:
+        async def get_oauth_access(self, *args, **kwargs):
+            return None
+
+    stream = SessionStreamFn(cast(Any, FakeAuth()), {"effort": {"auto": True}}, "session-x")
+
+    async def _preflight(model) -> None:
+        # Faithful to prod: the real `preflight_usage` is what CONSUMES the
+        # message boundary (it clears the flag before its own early returns),
+        # and the freeze under test only exists once the boundary is spent. A
+        # stub that skipped this would leave every call reclassifying, and the
+        # test would pass whether or not the invalidation works.
+        stream._message_boundary_pending = False
+
+    monkeypatch.setattr(stream, "preflight_usage", _preflight)
+    wide = ModelSpec(
+        provider="test",
+        model_id="wide",
+        reasoning_efforts=("minimal", "low", "medium", "high", "max"),
+    )
+    # A DIFFERENT ladder, and deliberately one that does not contain the rung
+    # the first classification picks: this is the 400 the invalidation avoids.
+    narrow = ModelSpec(provider="test", model_id="narrow", reasoning_efforts=("medium", "high"))
+
+    stream.begin_message()
+    _ = [
+        event
+        async for event in stream(
+            ChatRequest(model=wide, messages=[Message.user("show status")]), None
+        )
+    ]
+    assert captured[-1].model.reasoning_effort == "low"
+
+    # The user switches model without sending a new message.
+    stream.on_model_changed(narrow)
+    _ = [
+        event
+        async for event in stream(
+            ChatRequest(model=narrow, messages=[Message.user("show status")]), None
+        )
+    ]
+    landed = captured[-1].model.reasoning_effort
+    assert landed in narrow.reasoning_efforts, landed
+    await stream.close()
+
+
+@pytest.mark.asyncio
+async def test_a_model_switch_reopens_the_quota_preflight(monkeypatch) -> None:
+    """The preflight's 60s memo is per selector; a switch must not be skipped by it."""
+    from local_operator.model.configure import SessionStreamFn
+
+    class FakeAuth:
+        async def get_oauth_access(self, *args, **kwargs):
+            return None
+
+    stream = SessionStreamFn(cast(Any, FakeAuth()), {}, "session-x")
+    stream._usage_checked_at = 1234.0
+    stream._message_boundary_pending = False
+    stream.on_model_changed(ModelSpec(provider="test", model_id="other"))
+    assert stream._usage_checked_at == 0.0
+    assert stream._message_boundary_pending is True
+    await stream.close()
+
+
 async def _noop() -> None:
     return None

--- a/tests/unit/session/test_session.py
+++ b/tests/unit/session/test_session.py
@@ -2300,3 +2300,134 @@ def test_paired_prefix_is_not_defeated_by_a_custom_message_in_the_tail():
         incident,
         incident,
     ]
+
+
+class TestASwitchedModelTakesEffectAtTheNextCall:
+    """``set_model`` reaches the RUNNING turn's next provider call.
+
+    The session's spec used to be snapshotted into ``LoopConfig`` once per
+    turn, so a ``/model`` switch made while the agent was working could not
+    reach any of that turn's remaining calls: the status band repainted, and
+    every remaining call still went to the old model. A user only reaches for
+    ``/model`` mid-turn because the running model is doing badly, so "it
+    applies on your next message" was the wrong boundary.
+    """
+
+    OTHER = ModelSpec(provider="test", model_id="other", context_window=100_000)
+
+    @staticmethod
+    def _labels(stream: ScriptedStream) -> list[str]:
+        return [f"{r.model.provider}/{r.model.model_id}" for r in stream.requests]
+
+    @staticmethod
+    def _tool_then_text() -> ScriptedStream:
+        return ScriptedStream(
+            [
+                [
+                    StreamToolCallDelta(index=0, id="c1", name="echo", argument_delta="{}"),
+                    StreamEndEvent(stop_reason="toolUse"),
+                ],
+                [StreamTextDelta(delta="done"), StreamEndEvent(stop_reason="stop")],
+            ]
+        )
+
+    @pytest.mark.asyncio
+    async def test_a_switch_during_a_tool_reaches_the_next_call(self, tmp_path):
+        holder: dict[str, Session] = {}
+        stream = self._tool_then_text()
+
+        async def execute(tool_call_id, args, signal, on_update, context):
+            holder["session"].set_model(self.OTHER)
+            return ToolResult(
+                tool_call_id=tool_call_id, tool_name="echo", content=[TextContent(text="ok")]
+            )
+
+        tool = AgentTool(name="echo", parameters={"type": "object"}, execute=execute)
+        session = make_session(tmp_path, stream, tools=[tool])
+        holder["session"] = session
+        try:
+            await session.prompt("go")
+        finally:
+            await session.dispose()
+
+        assert self._labels(stream) == ["test/m", "test/other"]
+
+    @pytest.mark.asyncio
+    async def test_a_switch_mid_stream_never_re_targets_the_call_in_flight(self, tmp_path):
+        """The boundary is BETWEEN calls: one response is never split in two.
+
+        Without this, "read the model later" would be free to mean "read it
+        while a stream is already producing tokens", which would attribute a
+        half-finished response to a model that never produced it.
+        """
+        holder: dict[str, Session] = {}
+        seen: list[str] = []
+
+        class SwitchingStream:
+            def __call__(self, request, signal):
+                seen.append(f"{request.model.provider}/{request.model.model_id}")
+
+                async def gen():
+                    yield StreamTextDelta(delta="a")
+                    holder["session"].set_model(TestASwitchedModelTakesEffectAtTheNextCall.OTHER)
+                    yield StreamTextDelta(delta="b")
+                    yield StreamEndEvent(stop_reason="stop")
+
+                return gen()
+
+        session = make_session(tmp_path, SwitchingStream())
+        holder["session"] = session
+        try:
+            await session.prompt("go")
+            assert seen == ["test/m"]
+            # ...and the switch is not lost, it simply lands on the next call.
+            await session.prompt("again")
+        finally:
+            await session.dispose()
+
+        assert seen == ["test/m", "test/other"]
+
+    @pytest.mark.asyncio
+    async def test_a_real_switch_invalidates_state_frozen_for_the_old_model(self, tmp_path):
+        """Auto-effort and the quota memo are frozen per message, per MODEL."""
+        stream = ScriptedStream([[StreamEndEvent(stop_reason="stop")]])
+        changed: list[ModelSpec] = []
+        stream.on_model_changed = changed.append  # type: ignore[attr-defined]
+        session = make_session(tmp_path, stream)
+        try:
+            session.set_model(self.OTHER)
+        finally:
+            await session.dispose()
+
+        assert [f"{m.provider}/{m.model_id}" for m in changed] == ["test/other"]
+
+    @pytest.mark.asyncio
+    async def test_changing_only_the_effort_does_not_invalidate_anything(self, tmp_path):
+        """``/effort`` and the server's sampling overrides write the spec constantly.
+
+        Treating those as a model change would re-classify effort on every one
+        of them — and re-classification is exactly what freezing exists to
+        prevent within a single user message.
+        """
+        stream = ScriptedStream([[StreamEndEvent(stop_reason="stop")]])
+        changed: list[ModelSpec] = []
+        stream.on_model_changed = changed.append  # type: ignore[attr-defined]
+        session = make_session(tmp_path, stream)
+        try:
+            session.set_model(MODEL.model_copy(update={"reasoning_effort": "high"}))
+            session.set_model(MODEL.model_copy(update={"temperature": 0.9}))
+        finally:
+            await session.dispose()
+
+        assert changed == []
+
+    @pytest.mark.asyncio
+    async def test_a_stream_fn_without_the_hook_is_fine(self, tmp_path):
+        """Most stream fns are plain callables; the hook is optional."""
+        stream = ScriptedStream([[StreamEndEvent(stop_reason="stop")]])
+        session = make_session(tmp_path, stream)
+        try:
+            session.set_model(self.OTHER)
+            assert session.model_label == "test/other"
+        finally:
+            await session.dispose()

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -26,6 +26,7 @@ from local_operator.tui import theme as theme_mod
 from local_operator.tui.app import (
     BOOT_LAYOUT_CLASS,
     COMPOSER_FOCUSED_CLASS,
+    MODEL_SWITCH_MID_TURN_NOTICE,
     PERSIST_HINT,
     SLASH_COMMANDS,
     OperatorApp,
@@ -70,6 +71,10 @@ class FakeSession:
         )
         self.preflight_calls = 0
         self.preflight_notice: str | None = None
+        #: Whether a turn is running. Settable because the `/model` receipt now
+        #: reads it: a switch made mid-turn says when it starts applying, and a
+        #: hard-coded False could never exercise that branch.
+        self.streaming = False
         # The REAL holder, not a bare string: `user_set` precedence (a human
         # rename outranks every generated title, forever) is behaviour the TUI
         # relies on, and a fake that reimplements it as a plain assignment
@@ -86,7 +91,7 @@ class FakeSession:
 
     @property
     def is_streaming(self) -> bool:
-        return False
+        return self.streaming
 
     @property
     def model_label(self) -> str:
@@ -3221,6 +3226,55 @@ async def test_every_model_default_surface_says_it_the_same_way() -> None:
     assert _unwrapped("(this session)") in switch_line, switch_line
     assert _unwrapped("from the next turn") not in _unwrapped(receipt), receipt
     assert _unwrapped("anthropic logged in") in _unwrapped(receipt), receipt
+
+
+@pytest.mark.asyncio
+async def test_a_mid_turn_switch_says_when_it_starts_applying() -> None:
+    """Switched while the agent is working, the receipt says WHEN it applies.
+
+    Mid-turn is the one moment "starting when" is a live question: the request
+    already streaming cannot be re-targeted, so for a few seconds the user
+    watches the OLD model keep working after the band has repainted to the new
+    one. Without a word here that reads as the switch having been ignored,
+    which is the complaint this whole change exists to fix.
+    """
+    session = _SwitchableSession()
+    session.streaming = True
+    ctrl = _AccessController(stored=("openrouter", "anthropic"))
+    app = OperatorApp(lambda: _factory(session), provider_controller=ctrl)
+    async with app.run_test(size=(90, 24)) as pilot:
+        await pilot.pause()
+        app._run_slash_command("/model anthropic/claude-opus-5")
+        await pilot.pause()
+        text = _unwrapped(_transcript_text(app))
+
+    assert _unwrapped(MODEL_SWITCH_MID_TURN_NOTICE) in text, text
+    # On its OWN row: the receipt keeps its two-clause budget, which is what
+    # keeps it to two wrapped lines at the widths this app supports. Folding the
+    # timing into the scope parenthetical measured three.
+    assert _unwrapped("(this session)") in text, text
+    assert _unwrapped("/model default") in text, text
+
+
+@pytest.mark.asyncio
+async def test_an_idle_switch_does_not_talk_about_steps() -> None:
+    """Between turns there is no step to wait for, so the timing clause is noise.
+
+    Paired with the test above: together they pin that the clause is
+    CONDITIONAL, not that it was simply added to the string.
+    """
+    session = _SwitchableSession()
+    session.streaming = False
+    ctrl = _AccessController(stored=("openrouter", "anthropic"))
+    app = OperatorApp(lambda: _factory(session), provider_controller=ctrl)
+    async with app.run_test(size=(90, 24)) as pilot:
+        await pilot.pause()
+        app._run_slash_command("/model anthropic/claude-opus-5")
+        await pilot.pause()
+        text = _unwrapped(_transcript_text(app))
+
+    assert _unwrapped("(this session)") in text, text
+    assert _unwrapped(MODEL_SWITCH_MID_TURN_NOTICE) not in text, text
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -3247,6 +3247,7 @@ async def test_a_mid_turn_switch_says_when_it_starts_applying() -> None:
         app._run_slash_command("/model anthropic/claude-opus-5")
         await pilot.pause()
         text = _unwrapped(_transcript_text(app))
+        blocks = list(app.query_one(TranscriptView).blocks())
 
     assert _unwrapped(MODEL_SWITCH_MID_TURN_NOTICE) in text, text
     # On its OWN row: the receipt keeps its two-clause budget, which is what
@@ -3254,6 +3255,20 @@ async def test_a_mid_turn_switch_says_when_it_starts_applying() -> None:
     # timing into the scope parenthetical measured three.
     assert _unwrapped("(this session)") in text, text
     assert _unwrapped("/model default") in text, text
+    # SAME INK as the receipt it qualifies (design review D3). At `note` the
+    # subordinate row measured 8.62:1 against the receipt's 4.55:1 and the eye
+    # landed on the qualifier first; the token is asserted rather than the
+    # colour so this survives a palette change.
+    notices = [b for b in blocks if isinstance(b, NoticeBlock)]
+    qualifier = next(
+        b
+        for b in notices
+        if MODEL_SWITCH_MID_TURN_NOTICE in _renderable_plain(getattr(b, "renderable", ""))
+    )
+    receipt = next(
+        b for b in notices if "\u2192" in _renderable_plain(getattr(b, "renderable", ""))
+    )
+    assert qualifier._token == receipt._token, (qualifier._token, receipt._token)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -3257,6 +3257,59 @@ async def test_a_mid_turn_switch_says_when_it_starts_applying() -> None:
 
 
 @pytest.mark.asyncio
+async def test_model_default_mid_turn_also_says_when_it_applies(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``/model default p/id`` switches the LIVE session too, so it owes the same answer.
+
+    Design review D1: the timing row was nested in the plain-switch branch, so
+    this spelling printed only "used from the next launch" while the status band
+    beside it had already repainted to the new model — a receipt contradicting
+    the band on the same frame, which is the exact class of bug this PR fixes.
+    """
+    import yaml  # noqa: F401  (parity with the sibling default tests)
+
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    (tmp_path / "config.yml").write_text("version: 0.0.0\nvalues:\n  hosting: openrouter\n")
+    session = _SwitchableSession()
+    session.streaming = True
+    ctrl = _AccessController(stored=("openrouter", "anthropic"))
+    app = OperatorApp(lambda: _factory(session), provider_controller=ctrl)
+    async with app.run_test(size=(90, 24)) as pilot:
+        await pilot.pause()
+        app._run_slash_command("/model default anthropic/claude-opus-5")
+        await pilot.pause()
+        text = _unwrapped(_transcript_text(app))
+
+    assert _unwrapped(MODEL_SWITCH_MID_TURN_NOTICE) in text, text
+    # Still the persistence receipt, not the session one: this asserts the row
+    # was ADDED to that branch rather than the branch being changed.
+    assert _unwrapped("used from the next launch") in text, text
+
+
+@pytest.mark.asyncio
+async def test_reselecting_the_model_already_in_force_promises_no_handover() -> None:
+    """A no-op switch must not promise a handover that will never happen (D4).
+
+    "this one finishes on the old model" describes a transition between two
+    models. Re-picking the running model — easy to do from the picker, where the
+    current row is one Enter away — has no old model to finish on.
+    """
+    session = _SwitchableSession()
+    session.streaming = True
+    ctrl = _AccessController(stored=("openrouter", "anthropic"))
+    app = OperatorApp(lambda: _factory(session), provider_controller=ctrl)
+    async with app.run_test(size=(90, 24)) as pilot:
+        await pilot.pause()
+        # Whatever the fake reports as current, selected again.
+        app._run_slash_command(f"/model {session.model_label}")
+        await pilot.pause()
+        text = _unwrapped(_transcript_text(app))
+
+    assert _unwrapped(MODEL_SWITCH_MID_TURN_NOTICE) not in text, text
+
+
+@pytest.mark.asyncio
 async def test_an_idle_switch_does_not_talk_about_steps() -> None:
     """Between turns there is no step to wait for, so the timing clause is noise.
 


### PR DESCRIPTION
# PR Description

## Change classification

**C2 — standard / pre-authorized.** One engine seam (`LoopConfig` gains an optional resolver the loop reads per provider call) plus its session wiring and a conditional TUI receipt row. No config, no transcript format change, no new command. Clean rollback (`git revert`). No RFC requested.

## The bug

Reported from a live session: switching a model does not actually switch it — the new model only starts being used on the **next user message**.

That is exactly what the code did. `Session` snapshotted its spec into `LoopConfig.model` once per turn, and the loop's only read of it was a single line:

```python
# local_operator/harness/loop.py — _model_turn
request = ChatRequest(model=config.model, ...)
```

A turn is not one provider call, it is a chain of them — model, tools, model, tools. So for the whole of a long tool-using turn, **every remaining call went to the old model** while the status band had already repainted to the new one. `Session.set_model`'s own docstring documented this as intended ("takes effect from the next turn onward").

The failure is worst exactly when the feature matters most: a user reaches for `/model` mid-turn *because* the running model is doing badly, and the switch then does nothing for the rest of that turn.

### Reproduced against real providers, before the fix

Real `Session`, real `create_stream_fn` (real auth, real HTTP), a real tool that switches the model while it runs:

```console
$ .venv/bin/python /tmp/live_switch.py     # on origin/main
start model : anthropic/claude-sonnet-5
switch to   : xai/grok-3

  -> provider call #1: anthropic/claude-sonnet-5
  [tool ran] user switches model NOW (mid-turn)
  -> provider call #2: anthropic/claude-sonnet-5      <-- switch ignored

AssertionError: ['anthropic/claude-sonnet-5', 'anthropic/claude-sonnet-5']
```

## The fix

**`LoopConfig.get_model`** — an optional `Callable[[], ModelSpec]` the loop asks **once per provider call**, resolved in `AgentLoop._current_model`. `Session` passes `lambda: self._model`.

A callback rather than a mutable field because the model lives on the host and `LoopConfig` is a per-run value object; the session stays the single owner of which model is current.

Three deliberate properties:

- **The boundary is BETWEEN calls, never inside one.** A request already streaming keeps the spec it was issued with, so a switch cannot re-target a response that is already producing tokens or split one across two models.
- **Backwards compatible.** No resolver ⇒ the old snapshot. Every embedder and test double that builds a `LoopConfig` by hand is unaffected.
- **A raising resolver does not kill the turn.** It logs and falls back to the snapshot: a host accessor bug should not bin work in flight.

**`Session.set_model`** additionally notifies the stream fn when the provider/model pair genuinely changed, because two pieces of state are frozen per user message *against a particular model*:

- **auto-effort** — the classified level is mapped onto the **old model's ladder**. Ladders differ, so carrying a rung across a switch either sends a level the new model rejects (an HTTP 400 that reads as a broken switch) or silently re-tiers the request. Caught by a test: without the invalidation, `low` — absent from the new model's `("medium","high")` ladder — was sent.
- **the quota preflight's 60s memo** — cleared so the new model is actually preflighted rather than skipped by the old one's TTL.

Same-model writes (`/effort`, the server's `ChatRequest.options` sampling overrides) take a cheap early return, so they never pay for a re-classification.

**TUI receipt.** Mid-turn only, `/model` prints one extra `note` row:

```
· applies from the next step — this one finishes on the old model
```

That gap is *visible* — the agent keeps working on the old model until the in-flight step ends — and without a word it reads as the switch having been lost. It is its **own row** rather than a third clause because folding it into the receipt's scope parenthetical measured **three** wrapped lines instead of two at the widths this app supports (the run-on the receipt's existing comment exists to prevent). It reuses the "step" noun the steering receipts already established.

## Validation

### 1. Live end-to-end, real providers, after the fix

Same script, same credentials — the turn now *continues* on the new model, with full context:

```console
$ .venv/bin/python /tmp/live_switch.py
start model : anthropic/claude-sonnet-5
switch to   : xai/grok-3

  -> provider call #1: anthropic/claude-sonnet-5
  [tool ran] user switches model NOW (mid-turn)
  -> provider call #2: xai/grok-3

final answer text: 4417. I am Grok.

provider calls made: ['anthropic/claude-sonnet-5', 'xai/grok-3']
RESULT: the mid-turn switch reached call #2 of the SAME turn.
```

The model **names itself as the new one** and still answers with the code the *previous* model's tool call obtained — so the switch carried the conversation rather than restarting it. Before/after on identical inputs:

| | provider calls in ONE turn |
|---|---|
| before (`origin/main`) | `[anthropic/claude-sonnet-5, anthropic/claude-sonnet-5]` |
| after | `[anthropic/claude-sonnet-5, xai/grok-3]` |

A cross-provider switch (Anthropic → xAI) was chosen deliberately: it exercises different wire clients, different auth, and different effort ladders in one turn.

### 2. In-flight safety, real Session

A switch fired *while tokens are streaming* must not re-target the running call:

```console
calls during streaming switch: ['test/old']
in-flight call kept its own spec: True
all calls: ['test/old', 'test/new']       # lands on the next call, not lost
```

### 3. Rendered frames (user-visible change)

Captured with `app.save_screenshot` from the real `OperatorApp` (loads `local_operator.tcss`), before-frame taken from a clean `origin/main` worktree, then viewed as images.

- **before, mid-turn** — `(this session)`, no timing, 2 wrapped lines.
- **after, mid-turn** — receipt unchanged at **2** lines + the new single-line `note` row.
- **after, idle** — byte-identical to before: no timing row when no turn is running.
- **after, 72 cols** — the narrowest supported width still reads cleanly.

Geometry checked at every width, since a tall overlay costing two cells is a known failure here:

```
(72, 24): virtual=Size(70, 22) actual=Size(70, 22) vscroll=False
(80, 24): virtual=Size(78, 22) actual=Size(78, 22) vscroll=False
(90, 24): virtual=Size(88, 22) actual=Size(88, 22) vscroll=False
(100,30): virtual=Size(98, 28) actual=Size(98, 28) vscroll=False
```

### 4. Tests, and that they discriminate

15 new tests across four layers. Each was **mutation-verified** — the fix was reverted piecemeal and the tests were confirmed to fail:

| mutation | result |
|---|---|
| `model=self._current_model(config)` → `config.model` | 2 loop tests fail |
| drop `get_model=` from `Session`'s `LoopConfig` | session test fails |
| `on_model_changed` body → `return` | both configure tests fail (one catches the real `low`-not-in-ladder bug) |
| drop the same-model early return | "effort change is not a model change" test fails |

Coverage: the switch lands on the next call; a config with **no** resolver still runs; a **raising** resolver completes the turn on the snapshot and logs; a resolver returning `None` falls back; in-flight calls are never re-targeted; effort/sampling writes do not invalidate; a stream fn without the hook is fine; the timing row appears mid-turn and **not** when idle.

One test-fake correction worth noting: `FakeSession.is_streaming` was hard-coded `False`, which could never exercise the new branch — it is now settable, and the idle/mid-turn pair pins that the row is *conditional* rather than merely present.

### 5. Gates

```console
$ .venv/bin/python -m pytest tests/unit -q
4737 passed, 7 skipped, 1 deselected in 688.39s

$ .venv/bin/python -m flake8 .                                   # clean
$ uvx --from black==26.1.0 black --check local_operator tests    # 369 files unchanged
$ uvx isort --check-only --profile black local_operator tests    # clean
$ .venv/bin/python -m pyright --pythonpath .venv/bin/python .    # 0 errors, 0 warnings
```

The one deselected test (`test_eval_tool.py::test_background_streams_output_while_it_runs`) is a pre-existing timing-sensitive failure, confirmed failing on a clean `origin/main` worktree before any change here.

## Risk

Every provider call now resolves the model through one extra callback. The resolver is a lambda reading an attribute, the call sites are per provider request (not per token), and the fallback path is what every non-session host already gets. The blast radius is the model spec used by the next call — a switch that failed to apply is exactly the bug being fixed, and the in-flight guarantee is pinned by test.

## Scope

`Scope: f87f7780d65ec4d7493114504acd76d7e283135e..f9cf706d5f15196e17fe4404f4bf06a1680510eb`
