### PR TITLE
fix(session,tui): restore a resumed conversation's title on both surfaces

### DIFF
--- a/local_operator/resume.py
+++ b/local_operator/resume.py
@@ -386,11 +386,22 @@ def session_name(
 ) -> str:
     """A conversation's display name: its opening user message, on one line.
 
-    Read from the TRANSCRIPT rather than from a stored title because there is
-    no stored title: ``ConversationName`` lives in memory for the life of a
-    session and is never journalled, so the only per-session name on disk is
-    what the user actually typed first. That turns out to be the better name
-    anyway — it is the thing the user remembers about the session.
+    Read from the TRANSCRIPT rather than from the stored title, and that is now
+    a CHOICE rather than the absence of one: sessions journal their title (see
+    ``session.naming.CONVERSATION_NAME_CUSTOM_TYPE``), so a stored name is
+    usually available here.
+
+    The opener is still the better label for this list. The picker names
+    sessions it is not opening, one row each, and the opening message is the
+    thing a user recognises their own work by — it is what they typed, in their
+    words, and it is what they were looking at when they left. A generated title
+    is an interpretation of that message, and a session that never got far
+    enough to be named has one anyway. Keeping one source for every row also
+    keeps the column consistent, where mixing stored titles with openers would
+    make two rows that look alike mean different things.
+
+    Worth revisiting only for an explicit ``/rename``, which is the one case
+    where the user has said in so many words what a session should be called.
 
     Deliberately tolerant. This runs over every session directory to paint a
     picker, so a transcript that is truncated, half-written by a session still

--- a/local_operator/session/naming.py
+++ b/local_operator/session/naming.py
@@ -277,6 +277,34 @@ def parse_title(raw: str) -> str | None:
     return _sentence_case(words)
 
 
+def cut_on_a_word(text: str, max_chars: int) -> str:
+    """``text`` shortened to ``max_chars``, on a word boundary, with an ellipsis.
+
+    The one definition of "shorten a title" in the product, so the band, the
+    terminal tab and the stored name all cut the same string the same way. Three
+    places grew their own version of this and two of them disagreed; a title
+    that reads `…reconcile the ledge` on the tab and `…reconcile the…` on the
+    band is a bug report waiting to be filed.
+
+    The boundary is only taken when it costs less than a third of the budget: a
+    single enormous token (a URL, a base64 blob) is cut mid-token instead,
+    because returning almost nothing for a string that plainly had content is
+    the worse failure. The ellipsis is counted, so the result never exceeds
+    ``max_chars``.
+    """
+    if len(text) <= max_chars:
+        return text
+    cut = text[: max_chars - 1]
+    spaced = cut.rsplit(" ", 1)[0]
+    if len(spaced) >= (max_chars - 1) * 2 // 3:
+        cut = spaced
+    return cut.rstrip(" " + _TRAILING_PUNCTUATION) + "…"
+
+
+#: Module-private alias, so the store below reads as one operation.
+_cut_on_a_word = cut_on_a_word
+
+
 def _sentence_case(words: list[str]) -> str:
     """Capitalise the first word, leave every other word's casing alone.
 
@@ -480,8 +508,21 @@ class ConversationName:
 
         Returns what is stored afterwards (which may be the previous value
         when a generated title lost to a user-set one).
+
+        An over-long title is cut on a WORD boundary with an ellipsis rather
+        than sliced mid-word. Only ``/rename`` can reach this — a model's
+        over-long answer is REJECTED by :func:`parse_title` rather than
+        truncated — and a name the user typed is worth keeping legible: sliced,
+        an 88-character rename ended `…and reconcile the ledge` on both the band
+        and the terminal tab, which reads as a string that ran out of buffer.
+
+        The cut lives HERE rather than in either display surface because this is
+        where the length is actually decided: ``MAX_TITLE_CHARS`` and the tab's
+        ``MAX_LABEL_CHARS`` are both 80, so a tab-side cut could never fire for a
+        conversation name — every title reaching it had already been sliced by
+        this line (design review round 2, D6).
         """
-        cleaned = " ".join((text or "").split())[:MAX_TITLE_CHARS]
+        cleaned = _cut_on_a_word(" ".join((text or "").split()), MAX_TITLE_CHARS)
         if not user_set and self.user_set:
             return self.text
         self.text = cleaned

--- a/local_operator/session/naming.py
+++ b/local_operator/session/naming.py
@@ -52,6 +52,14 @@ from dataclasses import dataclass
 MAX_TITLE_CHARS = 80
 MAX_TITLE_WORDS = 12
 
+#: The custom transcript entry a conversation's title is journalled under, so a
+#: RESUMED session wears the name it earned instead of booting nameless. The
+#: constant lives here beside the holder it describes, exactly as
+#: ``WAKE_SCHEDULES_CUSTOM_TYPE`` lives beside the scheduler: writer and reader
+#: sit in different modules, and a literal spelled twice is one rename away
+#: from a session that quietly stops restoring its own name.
+CONVERSATION_NAME_CUSTOM_TYPE = "conversation_name"
+
 #: How long a title generation may run before it is abandoned. Single attempt,
 #: so this is the WHOLE budget — there is no retry behind it, which is what
 #: makes the number worth measuring rather than guessing: seven naming and

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -1428,11 +1428,22 @@ class Session:
             #
             # "In flight or on disk" is the right claim for this field anyway:
             # its only reader asks whether the title in the holder is already
-            # being written, and an append that is under way answers yes. A
-            # write that dies mid-append leaves the flag dirty, which is what
-            # the flush's retry is for.
+            # being written, and an append that is under way answers yes.
+            #
+            # ROLLED BACK when the append raises, and that is not bookkeeping
+            # tidiness: a failed append is neither in flight nor on disk, so
+            # leaving the claim standing made the dispose flush skip the retry
+            # and the title was LOST outright. It needs a TRANSIENT failure to
+            # bite — first append fails, a later one would have succeeded —
+            # which is why the always-failing test could not see it (review
+            # round 3, F12).
+            previous = self._conversation_name_journalled
             self._conversation_name_journalled = (payload["text"], payload["user_set"])
-            await self._transcript.append_custom(CONVERSATION_NAME_CUSTOM_TYPE, payload)
+            try:
+                await self._transcript.append_custom(CONVERSATION_NAME_CUSTOM_TYPE, payload)
+            except BaseException:
+                self._conversation_name_journalled = previous
+                raise
             if (self._conversation_name.text, self._conversation_name.user_set) == (
                 payload["text"],
                 payload["user_set"],
@@ -1467,19 +1478,29 @@ class Session:
         row (review round 1, F5; the guard's ordering, review round 2, F9).
 
         The retry is itself bounded, and that is the second half of F9. The
-        timeout above bounds only the WAIT: falling through to an unbounded
+        timeout used to bound only the WAIT: falling through to an unbounded
         ``_persist_conversation_name`` put the full write back in front of
         teardown, so a wedged filesystem hung dispose forever — on ctrl+d, for
-        decoration. Both halves are now bounded by the same budget, and a title
-        that cannot be written inside it is dropped with a warning rather than
-        holding the session open. The transcript is append-only and the name is
-        the least important thing in it; a resume that opens nameless is a far
-        better outcome than a session that will not close.
+        decoration. Both halves now share ONE ``_NAME_FLUSH_TIMEOUT_S`` deadline,
+        so that is the whole cost of this method rather than the cost of each
+        half, and a title that cannot be written inside it is dropped rather
+        than holding the session open. The transcript is append-only and the
+        name is the least important thing in it; a resume that opens nameless is
+        a far better outcome than a session that will not close.
         """
+        # ONE deadline shared by both halves rather than one each. Charged
+        # separately they ran in sequence, so teardown could take twice what the
+        # constant advertises — measured at 10.0 s on a wedged transcript with a
+        # moved title, while the constant documents itself as the pause a user
+        # sits through once (review round 3, F14).
+        deadline = time.monotonic() + _NAME_FLUSH_TIMEOUT_S
+
         task = self._conversation_name_task
         if task is not None and not task.done():
             try:
-                await asyncio.wait_for(asyncio.shield(task), timeout=_NAME_FLUSH_TIMEOUT_S)
+                await asyncio.wait_for(
+                    asyncio.shield(task), timeout=max(0.0, deadline - time.monotonic())
+                )
             except BaseException:  # noqa: BLE001 — fall through to the retry
                 pass
         if not self._conversation_name_dirty:
@@ -1492,10 +1513,23 @@ class Session:
             # only because that write has not reached its own clear yet.
             return
         try:
-            await asyncio.wait_for(self._persist_conversation_name(), timeout=_NAME_FLUSH_TIMEOUT_S)
+            await asyncio.wait_for(
+                self._persist_conversation_name(),
+                timeout=max(0.0, deadline - time.monotonic()),
+            )
         except asyncio.TimeoutError:
+            # Says what is TRUE — teardown stopped waiting — rather than "gave
+            # up journalling the conversation name", which claimed a loss this
+            # code cannot establish. The shielded write survives dispose and its
+            # chase loop re-appends a title that moved, so the row often lands
+            # moments after this line; the old wording reported those as dropped
+            # names (round 3, F13). Whether a write that is merely slow will
+            # finish or is wedged forever is not knowable here, so the message
+            # states the fact it has and names the consequence as conditional.
             logger.warning(
-                "gave up journalling the conversation name after %.1fs", _NAME_FLUSH_TIMEOUT_S
+                "stopped waiting for the conversation name to be journalled after %.1fs; "
+                "if the write does not finish, the next resume opens unnamed",
+                _NAME_FLUSH_TIMEOUT_S,
             )
         except Exception:
             # Decoration must never be the reason a dispose fails: losing the

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -127,6 +127,21 @@ _CONTINUATION_PROMPT = (
 #: recovery band must not re-prompt forever.
 _MAX_CONTINUATIONS = 8
 
+#: How many times the title journal will chase a name that moved WHILE it was
+#: being written (see :meth:`Session._persist_conversation_name`). A cap rather
+#: than a convergence argument: the window is the append's own duration, which
+#: is constant, so a writer that renames on every append never converges — as
+#: recursion it reached 2 987 frames and 522 KB of rows. Three is generous for
+#: the real case (a `/rename` landing inside one append), and whatever is still
+#: unwritten afterwards is left for the dispose flush rather than spun on.
+_NAME_CHASE_ATTEMPTS = 3
+
+#: How long ``dispose`` waits for an in-flight title write before giving up on
+#: it. Bounded because teardown must not hang on a wedged filesystem, and short
+#: because the title is decoration; the write is shielded, so it continues on
+#: its own and the wait only stops BLOCKING on it.
+_NAME_FLUSH_TIMEOUT_S = 2.0
+
 #: The builtin tools whose createIf gate reads a field only a SESSION can fill
 #: (``subagent_launcher``, ``jobs``, ``wake_scheduler``, ``subagent_comms``, the
 #: ask hook). Named here rather than inline in
@@ -718,6 +733,11 @@ class Session:
         #: ``_background_tasks`` because dispose CANCELS those and this one has
         #: to be awaited instead — see :meth:`_spawn_conversation_name_write`.
         self._conversation_name_task: "asyncio.Future[None] | None" = None
+        #: ``(text, user_set)`` of the newest row actually WRITTEN. Lets the
+        #: dispose flush tell a title that never reached disk from one whose
+        #: slow write simply has not cleared the dirty flag yet, which is the
+        #: difference between a needed retry and a duplicate row.
+        self._conversation_name_journalled: tuple[str, bool] | None = None
         self._system_blocks_provider = system_blocks_provider
         self._convert_to_llm = convert_to_llm or _default_convert_to_llm
         #: Set once a provider refuses a request because of an image block, and
@@ -1281,16 +1301,49 @@ class Session:
         append a duplicate row for one change.
         """
         if self._disposed:
+            # Nothing will flush this: dispose is idempotent and has already
+            # run its flush. Say so rather than dropping the name silently —
+            # the holder keeps the new title, so the band and the on-disk row
+            # disagree until the process ends, and that is worth being able to
+            # find in a log (review round 1, F6).
+            logger.debug(
+                "conversation name %r stored after dispose; not journalled",
+                self._conversation_name.text,
+            )
             return
         task = self._conversation_name_task
         if task is not None and not task.done():
             return
         try:
-            self._conversation_name_task = asyncio.ensure_future(self._persist_conversation_name())
+            self._conversation_name_task = asyncio.ensure_future(
+                self._guarded_conversation_name_write()
+            )
         except RuntimeError:
-            # No running loop (a session constructed and named outside one).
-            # The dispose flush is the backstop; the name is not lost.
+            # No running loop at all. `ensure_future` does NOT raise merely
+            # because a session was constructed outside one — it returns a task
+            # bound to an unrun loop, which later dies as "Task was destroyed
+            # but it is pending!" and is covered by the dispose flush. This
+            # catch is for the case where no loop can be resolved at all, so
+            # the name simply waits for the flush (review round 1, F8).
             self._conversation_name_task = None
+
+    async def _guarded_conversation_name_write(self) -> None:
+        """Journal the title, logging any failure instead of raising.
+
+        The same guard ``_spawn_background`` puts on every other
+        fire-and-forget in this class, and for the same reason: this task is
+        deliberately NOT routed through that helper (dispose must await it, not
+        cancel it), so without its own wrapper the exception was never
+        retrieved and asyncio printed a traceback into the user's terminal when
+        the volume was full or read-only. A title is decoration; it must never
+        cost the user a traceback, let alone a turn (review round 1, F2).
+        """
+        try:
+            await self._persist_conversation_name()
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.warning("failed to journal the conversation name", exc_info=True)
 
     def _load_conversation_name(self) -> None:
         """Adopt the title journalled by the session this one resumes.
@@ -1340,24 +1393,37 @@ class Session:
 
         Left dirty, the write is re-driven by the flush at dispose, so the last
         title a user chose is the one on disk.
+
+        The chase is a bounded LOOP, not recursion. It was recursion, on the
+        argument that it was bounded by renames actually landing inside a
+        write — which is a property of user behaviour, not of the code. A
+        transcript that moves the holder during every append never converges:
+        2 987 frames, 2 986 rows and 522 KB before ``RecursionError``. Neither
+        half of that is acceptable for decoration, so the stack hazard is gone
+        and the growth is capped: after ``_NAME_CHASE_ATTEMPTS`` the newest
+        title is left dirty for the dispose flush, which is exactly the
+        fallback that already exists for a cancelled write (review round 1,
+        F3).
         """
-        payload = {
-            "text": self._conversation_name.text,
-            "user_set": self._conversation_name.user_set,
-        }
-        await self._transcript.append_custom(CONVERSATION_NAME_CUSTOM_TYPE, payload)
-        if (self._conversation_name.text, self._conversation_name.user_set) == (
-            payload["text"],
-            payload["user_set"],
-        ):
-            self._conversation_name_dirty = False
-            return
-        # The title moved under the append. Chase it now rather than leaving the
-        # newer name to the dispose flush: a session can run for hours after a
-        # rename, and "correct only if you quit" is not a property worth having
-        # when the retry is one more append. Recursion is bounded by renames
-        # actually landing inside a write, and each pass narrows the window.
-        await self._persist_conversation_name()
+        for _ in range(_NAME_CHASE_ATTEMPTS):
+            payload = {
+                "text": self._conversation_name.text,
+                "user_set": self._conversation_name.user_set,
+            }
+            await self._transcript.append_custom(CONVERSATION_NAME_CUSTOM_TYPE, payload)
+            # What is now ON DISK, recorded before the comparison below so the
+            # dispose flush can tell "the flag is stale" from "the title moved".
+            self._conversation_name_journalled = (payload["text"], payload["user_set"])
+            if (self._conversation_name.text, self._conversation_name.user_set) == (
+                payload["text"],
+                payload["user_set"],
+            ):
+                self._conversation_name_dirty = False
+                return
+            # The title moved under the append. Chase it now rather than
+            # leaving the newer name to the dispose flush: a session can run
+            # for hours after a rename, and "correct only if you quit" is not a
+            # property worth having when the retry is one more append.
 
     async def _flush_conversation_name(self) -> None:
         """Land an outstanding title write before the session tears down.
@@ -1373,14 +1439,30 @@ class Session:
         Any write already in flight is awaited first, so the ordinary path
         costs nothing here and the retry below only runs when that write never
         happened (never scheduled, or cancelled).
+
+        The wait is SHIELDED — the write must not be cancelled by the timeout,
+        or the flush would be racing the thing it is trying to complete — and
+        the retry is gated on the payload actually differing rather than on the
+        dirty flag alone. A slow append still holds the flag while it runs, so
+        gating on the flag re-appended a byte-identical row and dispose took the
+        write's full duration anyway (measured: a 3 s append gave a 5 s dispose
+        and two identical rows). Now a write that is merely slow is waited for
+        once and never duplicated (review round 1, F5).
         """
         task = self._conversation_name_task
         if task is not None and not task.done():
             try:
-                await asyncio.wait_for(asyncio.shield(task), timeout=2.0)
+                await asyncio.wait_for(asyncio.shield(task), timeout=_NAME_FLUSH_TIMEOUT_S)
             except BaseException:  # noqa: BLE001 — fall through to the retry
                 pass
         if not self._conversation_name_dirty:
+            return
+        if self._conversation_name_journalled == (
+            self._conversation_name.text,
+            self._conversation_name.user_set,
+        ):
+            # A slow write already put THIS title on disk; the flag is still set
+            # only because that write has not reached its own clear yet.
             return
         try:
             await self._persist_conversation_name()

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -136,11 +136,19 @@ _MAX_CONTINUATIONS = 8
 #: unwritten afterwards is left for the dispose flush rather than spun on.
 _NAME_CHASE_ATTEMPTS = 3
 
-#: How long ``dispose`` waits for an in-flight title write before giving up on
-#: it. Bounded because teardown must not hang on a wedged filesystem, and short
-#: because the title is decoration; the write is shielded, so it continues on
-#: its own and the wait only stops BLOCKING on it.
-_NAME_FLUSH_TIMEOUT_S = 2.0
+#: Budget for landing the title at teardown — applied to the wait for an
+#: in-flight write AND to the retry behind it, so neither half can hold dispose
+#: open on its own.
+#:
+#: Bounded at all because teardown must not hang on a wedged filesystem: an
+#: unbounded retry meant a ctrl+d never returned, for decoration. Not TIGHT,
+#: because the other failure is losing the name: an append is sub-millisecond
+#: on a local disk, so anything in seconds is already pathological (a stalled
+#: network mount, a volume under extreme load) — and in that state a user is
+#: better served by a few seconds of teardown than by a resume that opens
+#: nameless. Five seconds is comfortably above any real append and still a
+#: bound a person will sit through once.
+_NAME_FLUSH_TIMEOUT_S = 5.0
 
 #: The builtin tools whose createIf gate reads a field only a SESSION can fill
 #: (``subagent_launcher``, ``jobs``, ``wake_scheduler``, ``subagent_comms``, the
@@ -1410,10 +1418,21 @@ class Session:
                 "text": self._conversation_name.text,
                 "user_set": self._conversation_name.user_set,
             }
-            await self._transcript.append_custom(CONVERSATION_NAME_CUSTOM_TYPE, payload)
-            # What is now ON DISK, recorded before the comparison below so the
-            # dispose flush can tell "the flag is stale" from "the title moved".
+            # Recorded BEFORE the append, not after, and the ordering is the
+            # whole point: the dispose flush reads this while the append is
+            # still in flight (that is precisely when it gives up waiting), so
+            # a value assigned afterwards is still `None` at the moment it is
+            # consulted and the flush writes the same row a second time.
+            # Measured at exactly the flush timeout — a 2.1 s append gave two
+            # identical rows, a 1.9 s append gave one (review round 2, F9).
+            #
+            # "In flight or on disk" is the right claim for this field anyway:
+            # its only reader asks whether the title in the holder is already
+            # being written, and an append that is under way answers yes. A
+            # write that dies mid-append leaves the flag dirty, which is what
+            # the flush's retry is for.
             self._conversation_name_journalled = (payload["text"], payload["user_set"])
+            await self._transcript.append_custom(CONVERSATION_NAME_CUSTOM_TYPE, payload)
             if (self._conversation_name.text, self._conversation_name.user_set) == (
                 payload["text"],
                 payload["user_set"],
@@ -1442,12 +1461,20 @@ class Session:
 
         The wait is SHIELDED — the write must not be cancelled by the timeout,
         or the flush would be racing the thing it is trying to complete — and
-        the retry is gated on the payload actually differing rather than on the
-        dirty flag alone. A slow append still holds the flag while it runs, so
-        gating on the flag re-appended a byte-identical row and dispose took the
-        write's full duration anyway (measured: a 3 s append gave a 5 s dispose
-        and two identical rows). Now a write that is merely slow is waited for
-        once and never duplicated (review round 1, F5).
+        the retry is gated on the title already being IN FLIGHT OR ON DISK
+        rather than on the dirty flag alone. A slow append holds that flag for
+        its whole duration, so gating on the flag re-appended a byte-identical
+        row (review round 1, F5; the guard's ordering, review round 2, F9).
+
+        The retry is itself bounded, and that is the second half of F9. The
+        timeout above bounds only the WAIT: falling through to an unbounded
+        ``_persist_conversation_name`` put the full write back in front of
+        teardown, so a wedged filesystem hung dispose forever — on ctrl+d, for
+        decoration. Both halves are now bounded by the same budget, and a title
+        that cannot be written inside it is dropped with a warning rather than
+        holding the session open. The transcript is append-only and the name is
+        the least important thing in it; a resume that opens nameless is a far
+        better outcome than a session that will not close.
         """
         task = self._conversation_name_task
         if task is not None and not task.done():
@@ -1461,11 +1488,15 @@ class Session:
             self._conversation_name.text,
             self._conversation_name.user_set,
         ):
-            # A slow write already put THIS title on disk; the flag is still set
+            # This title is already in flight or on disk; the flag is still set
             # only because that write has not reached its own clear yet.
             return
         try:
-            await self._persist_conversation_name()
+            await asyncio.wait_for(self._persist_conversation_name(), timeout=_NAME_FLUSH_TIMEOUT_S)
+        except asyncio.TimeoutError:
+            logger.warning(
+                "gave up journalling the conversation name after %.1fs", _NAME_FLUSH_TIMEOUT_S
+            )
         except Exception:
             # Decoration must never be the reason a dispose fails: losing the
             # name is survivable, losing the conversation is not.

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -95,7 +95,11 @@ from local_operator.harness.wake import (
 from local_operator.incidents import SESSION_INCIDENT_MESSAGE_TYPE
 from local_operator.session.goal import GoalState
 from local_operator.session.mcp_status import McpStartupOutcome
-from local_operator.session.naming import ConversationName
+from local_operator.session.naming import (
+    CONVERSATION_NAME_CUSTOM_TYPE,
+    MAX_TITLE_CHARS,
+    ConversationName,
+)
 from local_operator.session.protocol import CompactionOutcome
 from local_operator.session.transcript import Transcript
 from local_operator.tools.builtin import (
@@ -706,6 +710,14 @@ class Session:
         self._conversation_name = (
             conversation_name if conversation_name is not None else ConversationName()
         )
+        #: True while a stored title has not reached the transcript yet. The
+        #: write is a background task, so this is what lets dispose tell "the
+        #: name is on disk" from "the write was cancelled on the way there".
+        self._conversation_name_dirty = False
+        #: The in-flight journal write for the title, tracked apart from
+        #: ``_background_tasks`` because dispose CANCELS those and this one has
+        #: to be awaited instead — see :meth:`_spawn_conversation_name_write`.
+        self._conversation_name_task: "asyncio.Future[None] | None" = None
         self._system_blocks_provider = system_blocks_provider
         self._convert_to_llm = convert_to_llm or _default_convert_to_llm
         #: Set once a provider refuses a request because of an image block, and
@@ -832,6 +844,14 @@ class Session:
             persist=self._persist_wake_schedules,
         )
         self._load_wake_schedules()
+        # The conversation's title is restored from the SAME transcript the
+        # history came from, and for the same reason: a resumed session is the
+        # same conversation, so the band and the terminal tab must name it the
+        # way it was named before. Loaded here rather than by the host because
+        # the transcript is the session's to read — every front end resuming a
+        # session would otherwise need its own copy of this, and the one that
+        # forgot would boot nameless.
+        self._load_conversation_name()
         # Owned here, not by the browser tool, for the same reason the wake
         # scheduler is: _build_tool_context runs at the start of EVERY turn, so
         # a handle the tool stored on the ToolContext lived exactly one turn.
@@ -1228,8 +1248,146 @@ class Session:
         ``user_set=True`` (an explicit rename) wins permanently: a generated
         title landing later is discarded rather than overwriting a name the
         user chose. Auto-naming passes ``user_set=False``.
+
+        Journalled as a side effect, so the name survives to the next
+        ``--resume``. The write is FIRE-AND-FORGET on purpose: this method is
+        called from the TUI's synchronous paint path (``_store_title``,
+        ``_cmd_rename``), which cannot await, and a title is decoration — a
+        transcript append that fails must cost the name on disk, never the
+        turn. Only a store that actually CHANGED something is journalled: a
+        generated title that lost to a user-set one returns the standing name,
+        and re-appending it would grow the transcript by a line per turn.
         """
-        return self._conversation_name.set(text, user_set=user_set)
+        before = (self._conversation_name.text, self._conversation_name.user_set)
+        stored = self._conversation_name.set(text, user_set=user_set)
+        if (stored, self._conversation_name.user_set) != before:
+            self._conversation_name_dirty = True
+            self._spawn_conversation_name_write()
+        return stored
+
+    def _spawn_conversation_name_write(self) -> None:
+        """Start (or coalesce onto) the background journal write for the title.
+
+        Deliberately NOT ``_spawn_background``. That helper's tasks are
+        cancelled wholesale by ``dispose``, and a name stored in the closing
+        moments of a session is exactly the case that must still reach disk —
+        so this task is tracked separately and AWAITED by
+        :meth:`_flush_conversation_name` instead of being cancelled with the
+        rest.
+
+        One task at a time, because the payload is read at write time rather
+        than captured at call time: a rename landing while a write is in flight
+        is already covered by that write's own read, and a second task would
+        append a duplicate row for one change.
+        """
+        if self._disposed:
+            return
+        task = self._conversation_name_task
+        if task is not None and not task.done():
+            return
+        try:
+            self._conversation_name_task = asyncio.ensure_future(self._persist_conversation_name())
+        except RuntimeError:
+            # No running loop (a session constructed and named outside one).
+            # The dispose flush is the backstop; the name is not lost.
+            self._conversation_name_task = None
+
+    def _load_conversation_name(self) -> None:
+        """Adopt the title journalled by the session this one resumes.
+
+        Silently tolerant of a malformed entry, matching
+        :meth:`_load_wake_schedules`: a resume must not be refused because a
+        decoration could not be read. ``user_set`` rides along because it is
+        precedence, not display — a name the USER typed has to keep outranking
+        generated titles across a resume, or the first re-title check in the
+        resumed session would quietly overwrite it.
+
+        Writes through the holder's fields rather than through
+        :meth:`ConversationName.set`, since ``set`` cannot express "restore a
+        user-set title" without also claiming it as a fresh user action, and a
+        restore is neither a rename nor a generation — it is the same name it
+        already was.
+        """
+        details = self._transcript.latest_custom(CONVERSATION_NAME_CUSTOM_TYPE)
+        if not details:
+            return
+        text = details.get("text")
+        if not isinstance(text, str) or not text.strip():
+            return
+        self._conversation_name.text = " ".join(text.split())[:MAX_TITLE_CHARS]
+        self._conversation_name.user_set = bool(details.get("user_set"))
+        # A restored conversation has already SPENT its naming attempt: the
+        # title on disk is the result of it. Without this latch a host that
+        # asks "has naming been requested?" would spend a second provider call
+        # to re-derive a name the session is already wearing.
+        self._conversation_name.requested = True
+
+    async def _persist_conversation_name(self) -> None:
+        """Journal the title in force (newest entry wins on replay).
+
+        The payload is SNAPSHOTTED before the append and compared against the
+        holder afterwards, and the dirty flag is cleared only when they still
+        agree. Two races make that necessary rather than fussy:
+
+        * A rename landing while the append is in flight (the file lock is
+          held, so the window is real) leaves a newer title in the holder than
+          the row that just went to disk. Clearing unconditionally marked that
+          newer title as saved and the next ``--resume`` restored the OLD one —
+          reproduced with a transcript whose append was slowed to 150 ms.
+        * A write cancelled at teardown never reaches this line at all, so the
+          entry still reads as outstanding to :meth:`_flush_conversation_name`
+          and is retried there instead of lost.
+
+        Left dirty, the write is re-driven by the flush at dispose, so the last
+        title a user chose is the one on disk.
+        """
+        payload = {
+            "text": self._conversation_name.text,
+            "user_set": self._conversation_name.user_set,
+        }
+        await self._transcript.append_custom(CONVERSATION_NAME_CUSTOM_TYPE, payload)
+        if (self._conversation_name.text, self._conversation_name.user_set) == (
+            payload["text"],
+            payload["user_set"],
+        ):
+            self._conversation_name_dirty = False
+            return
+        # The title moved under the append. Chase it now rather than leaving the
+        # newer name to the dispose flush: a session can run for hours after a
+        # rename, and "correct only if you quit" is not a property worth having
+        # when the retry is one more append. Recursion is bounded by renames
+        # actually landing inside a write, and each pass narrows the window.
+        await self._persist_conversation_name()
+
+    async def _flush_conversation_name(self) -> None:
+        """Land an outstanding title write before the session tears down.
+
+        The ordinary write is a background task and :meth:`dispose` CANCELS
+        background tasks, so a title stored in the closing moments of a session
+        — a ``/rename`` just before ctrl+d, or a generated title arriving as
+        the user quits — would be cancelled before reaching disk and the next
+        ``--resume`` would open nameless. Reproduced exactly that way: a name
+        set and then disposed with no intervening await never got a turn of the
+        event loop, and the transcript carried no entry at all.
+
+        Any write already in flight is awaited first, so the ordinary path
+        costs nothing here and the retry below only runs when that write never
+        happened (never scheduled, or cancelled).
+        """
+        task = self._conversation_name_task
+        if task is not None and not task.done():
+            try:
+                await asyncio.wait_for(asyncio.shield(task), timeout=2.0)
+            except BaseException:  # noqa: BLE001 — fall through to the retry
+                pass
+        if not self._conversation_name_dirty:
+            return
+        try:
+            await self._persist_conversation_name()
+        except Exception:
+            # Decoration must never be the reason a dispose fails: losing the
+            # name is survivable, losing the conversation is not.
+            logger.warning("failed to persist the conversation name", exc_info=True)
 
     @property
     def wake_scheduler(self) -> WakeScheduler:
@@ -3060,6 +3218,11 @@ class Session:
             # After the turn has stopped (so nothing is mid-navigation on it)
             # and before the task group closes, since this awaits a subprocess.
             await self._close_browser_surface()
+            # BEFORE the background tasks are cancelled: the title's own write
+            # is one of them, and a name stored in the last moments of the
+            # session (a `/rename` before ctrl+d) would be cancelled in flight
+            # and never reach the transcript the next `--resume` reads.
+            await self._flush_conversation_name()
             # HC-11: cancel tracked background tasks (wake deliveries, aside
             # persistence), then close the session task group.
             for task in list(self._background_tasks):

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -1378,6 +1378,12 @@ class OperatorApp(App[None]):
         self._wire_mcp_status(session)
         self._report_mcp_startup(session)
         self._render_resumed_history(session)
+        # AFTER the history is on screen, because that is where the fallback
+        # label comes from: a session resumed from a transcript written before
+        # titles were journalled has no stored name to restore, and the band
+        # would wear the cwd for a conversation whose subject is right there in
+        # the replayed opener.
+        self._restore_resumed_name(session)
         # BEFORE the measurement, and the order is load-bearing: this installs
         # the provider's own exact reading for a resumed conversation, and
         # `_measure_preloaded_context` refuses to spend an estimate once an
@@ -1428,6 +1434,49 @@ class OperatorApp(App[None]):
             return
         self._adopt_session(session)
         await self._preflight_usage(session)
+
+    def _restore_resumed_name(self, session: Any) -> None:
+        """Give a resumed conversation a label even when none was stored.
+
+        Two ways a resumed session arrives with something to show, and this
+        handles the second:
+
+        * It carries a journalled title (``Session._load_conversation_name``),
+          which ``_adopt_session`` has already painted. Nothing to do — and
+          nothing may be done, because that name is the store of record and a
+          stand-in must never displace it.
+        * It carries none. Every transcript written before titles were
+          journalled is in this state, and so is any session closed before its
+          naming call landed. The band would fall back to the working
+          directory, which is the failure the terminal title exists to fix: a
+          sidebar of resumed sessions all reading ``lo › <dir>``.
+
+        The fallback is the SAME text ``/resume``'s picker labels its rows with
+        — the conversation's opening user message (``resume.session_name``
+        derives it from the transcript; here it is read from the replayed
+        history, which is the same message). So the row a user picked and the
+        tab they land on agree by construction rather than by coincidence.
+
+        Held as a provisional label rather than stored on the session, exactly
+        as an opener-derived label is for a live conversation: it is a display
+        stand-in, not a title anyone chose, and writing it into the session
+        would tell the naming errand this conversation is already named and
+        retire the one call that could give it a real one.
+        """
+        if self._status is None or session.conversation_name or self._provisional_name:
+            return
+        try:
+            history = list(session.history())
+        except Exception:
+            return  # reduced hosts (embedders, pilot fakes) may lack it
+        for message in history:
+            if getattr(message, "role", None) != "user":
+                continue
+            text = getattr(message, "text", "") or ""
+            if not isinstance(text, str) or not text.strip():
+                continue
+            self._show_provisional_name(text)
+            return
 
     def _restore_reported_usage(self, session: Any) -> None:
         """Put a RESUMED conversation's own token and cost figures on the band.

--- a/local_operator/tui/terminal_title.py
+++ b/local_operator/tui/terminal_title.py
@@ -42,6 +42,7 @@ import re
 from pathlib import Path
 from typing import Callable, Literal
 
+from local_operator.session.naming import cut_on_a_word
 from local_operator.tui.settings import settings_get
 
 #: Environment kill switch, mirroring ``shimmer``/``nerd_icons``. Wanted by
@@ -132,27 +133,25 @@ def sanitize_label(value: str | None) -> str:
     Returns ``""`` for anything that sanitises away to nothing, which callers
     read as "no label" rather than as an empty title.
 
-    Over-long labels are cut on a WORD boundary with an ellipsis, matching what
-    the status band does to the same string (``status_line.truncate_name``) and
-    what the excerpt was cut on in the first place
-    (``naming.provisional_title``). A bare slice ended the tab mid-word — `…and
-    reconcile the ledge` — which reads as a string that ran out of buffer rather
-    than as a name that was shortened, and the tab is where truncation bites
-    hardest because most terminals then shorten the label AGAIN to fit the tab
-    strip. The boundary is only taken when it costs less than a third of the
-    cap, so a single enormous token is still cut rather than dropped to nothing
-    (design review D3).
+    Over-long labels are cut on a WORD boundary with an ellipsis, through the
+    same helper the stored title uses (``naming.cut_on_a_word``), so the tab and
+    the band shorten a name identically. A bare slice ended the tab mid-word —
+    `…and reconcile the ledge` — which reads as a string that ran out of buffer
+    rather than as a name that was shortened, and the tab is where truncation
+    bites hardest because most terminals shorten the label AGAIN to fit the tab
+    strip (design review D3).
+
+    For a CONVERSATION NAME this is now a backstop rather than the working cut:
+    ``MAX_TITLE_CHARS`` and ``MAX_LABEL_CHARS`` are both 80, so a title arrives
+    already shortened by the store (D6). It still does real work for the callers
+    with no cap of their own — ``cwd_label`` on a deep path, and a subagent
+    label — which is why the cut lives on both sides rather than being deleted
+    here.
     """
     if not value:
         return ""
     cleaned = " ".join(_CONTROL_CHARS.sub(" ", value).split())
-    if len(cleaned) <= MAX_LABEL_CHARS:
-        return cleaned
-    cut = cleaned[: MAX_LABEL_CHARS - 1]
-    spaced = cut.rsplit(" ", 1)[0]
-    if len(spaced) >= (MAX_LABEL_CHARS - 1) * 2 // 3:
-        cut = spaced
-    return cut.rstrip(" ,.;:") + "…"
+    return cut_on_a_word(cleaned, MAX_LABEL_CHARS)
 
 
 def cwd_label(cwd: str | None) -> str:

--- a/local_operator/tui/terminal_title.py
+++ b/local_operator/tui/terminal_title.py
@@ -131,11 +131,28 @@ def sanitize_label(value: str | None) -> str:
 
     Returns ``""`` for anything that sanitises away to nothing, which callers
     read as "no label" rather than as an empty title.
+
+    Over-long labels are cut on a WORD boundary with an ellipsis, matching what
+    the status band does to the same string (``status_line.truncate_name``) and
+    what the excerpt was cut on in the first place
+    (``naming.provisional_title``). A bare slice ended the tab mid-word — `…and
+    reconcile the ledge` — which reads as a string that ran out of buffer rather
+    than as a name that was shortened, and the tab is where truncation bites
+    hardest because most terminals then shorten the label AGAIN to fit the tab
+    strip. The boundary is only taken when it costs less than a third of the
+    cap, so a single enormous token is still cut rather than dropped to nothing
+    (design review D3).
     """
     if not value:
         return ""
     cleaned = " ".join(_CONTROL_CHARS.sub(" ", value).split())
-    return cleaned[:MAX_LABEL_CHARS]
+    if len(cleaned) <= MAX_LABEL_CHARS:
+        return cleaned
+    cut = cleaned[: MAX_LABEL_CHARS - 1]
+    spaced = cut.rsplit(" ", 1)[0]
+    if len(spaced) >= (MAX_LABEL_CHARS - 1) * 2 // 3:
+        cut = spaced
+    return cut.rstrip(" ,.;:") + "…"
 
 
 def cwd_label(cwd: str | None) -> str:

--- a/local_operator/tui/widgets/status_line.py
+++ b/local_operator/tui/widgets/status_line.py
@@ -958,9 +958,12 @@ class StatusLine:
         # no longer is: `OperatorApp._show_provisional_name` paints an excerpt of
         # the opener in the SAME frame as the submit, with no provider call at
         # all. What still reaches the directory is a conversation nobody has
-        # prompted yet — boot, `/new`, or a resume, since `ConversationName` is
-        # never journalled — and one whose opener had no topic to quote ("hi",
-        # "thanks"), which `naming.is_low_signal` refuses to label. A sidebar row
+        # prompted yet — boot or `/new`; a RESUME no longer lands here, since
+        # the title is journalled and restored (`session.naming`) and a
+        # transcript predating that entry is labelled from its replayed opener
+        # by `OperatorApp._restore_resumed_name` — and one whose opener had no
+        # topic to quote ("hi", "thanks"), which `naming.is_low_signal` refuses
+        # to label. A sidebar row
         # reading `lo ›` five times over is the exact failure this feature exists
         # to fix, and the directory is what the user opened the session for.
         title.set_label(label or cwd_label(self._cwd))

--- a/local_operator/tui/widgets/status_line.py
+++ b/local_operator/tui/widgets/status_line.py
@@ -889,6 +889,12 @@ class StatusLine:
         #: attaches one, which keeps the band usable by the lightweight test
         #: hosts that have no terminal to write to.
         self._title: TerminalTitle | None = None
+        #: Cells of the trailing name's reserved box that the current title does
+        #: not fill. Paid out immediately before the seam that introduces the
+        #: title (see :meth:`_right_text`), which is what keeps the row flush to
+        #: the band's right edge without orphaning the chevron or letting the
+        #: title's length move any column to its left.
+        self._name_slack: int = 0
 
     def set_terminal_title(self, title: TerminalTitle | None) -> None:
         """Attach (or detach) the window-title writer and paint it once.
@@ -1510,6 +1516,9 @@ class StatusLine:
         caution), and the least volatile fields stay neutral. Green is not used
         at all — it belongs to the running indicator.
         """
+        # Reset per render: the reserve's unused cells are a property of THIS
+        # row, and a stale value would pay slack the current title does not have.
+        self._name_slack = 0
         parts: list[tuple[str, str, Style]] = []
         if self._subagent is not None and self._subagent.label:
             # Never dropped: it is what says whose numbers follow it, and a
@@ -1650,34 +1659,43 @@ class StatusLine:
             # of the user's opener, so it has no natural bound, and the band is a
             # fixed two-row box.
             #
-            # PADDED to its box, and RIGHT-aligned in it. The box is the
-            # reserved width, so the padding is what holds every sibling's
-            # column still while a model rewrites the string in it — that half
-            # is the reserve's whole purpose and is unchanged.
+            # The box's UNUSED cells are emitted as their own segment, BEFORE
+            # the seam, rather than as padding on either side of the title.
             #
-            # The alignment inside the box decides where the box's UNUSED cells
-            # sit, and they have to sit somewhere: the fit was decided against
-            # the full box, so those cells are already spoken for and cannot be
-            # given back to the layout without moving every column left of the
-            # name. `rjust` puts them before the title, which makes the title's
-            # last cell the band's right edge at every length.
+            # The reserve itself is unchanged and is still the point: the fit
+            # was decided against the full box, so those cells are spoken for
+            # and cannot be handed back to the layout without moving every
+            # column left of the name. What varies is only where they are
+            # painted, and both obvious answers put them somewhere a reader
+            # notices:
             #
-            # `ljust` put them after it instead, and `_compose` then stripped
-            # them — so the painted row simply ended early: flush for a long
-            # title and up to 35 cells short for a brief one, which reads as a
-            # rendering fault rather than as a band with less to say. (They are
-            # ordinary styled cells, so anything READING the row carried them
-            # too: the SVG export wrote all 35.)
+            # * `ljust` trailed them after the title. `_compose` stripped them,
+            #   so the painted row ended early — flush at the band's edge for a
+            #   long title and up to 35 cells short for a brief one, which reads
+            #   as a rendering fault. (They are ordinary styled cells, so
+            #   anything READING the row carried them too: the SVG export wrote
+            #   all 35.)
+            # * `rjust` moved them between the seam and the title, which fixed
+            #   the edge and orphaned the `‹`: every other seam on the row is
+            #   tight against what it introduces, so a lone chevron with 36
+            #   blanks after it reads as a missing segment (design review D1).
             #
-            # The cost is that the title's FIRST cell moves with its length.
-            # That is the right way round — the reserve exists to stop the
-            # SIBLINGS drifting (the `!` alarm holds its column at every width),
-            # and the alternative, measuring the group by its ink, moves the
-            # alarm itself, which is the defect the box was introduced to fix.
+            # Emitting them ahead of the seam keeps the seam glued to the title
+            # it introduces AND puts the title's last cell on the band's right
+            # edge, while the columns left of the name still cannot see the
+            # title's length. A blank segment renders as blanks either way; the
+            # only thing being chosen here is which side of the chevron the
+            # slack falls on.
+            # Carried on the SEAM's left so no extra separator is emitted: the
+            # blanks ride in front of the ` ‹ ` that introduces the title, which
+            # is one segment, not two.
+            self._name_slack = name_cells - cell_len(
+                truncate_name(self._conversation_name, name_cells)
+            )
             parts.append(
                 (
                     "",
-                    truncate_name(self._conversation_name, name_cells).rjust(name_cells),
+                    truncate_name(self._conversation_name, name_cells),
                     Style(color=theme_mod.semantic_color("muted")),
                 )
             )
@@ -1685,6 +1703,13 @@ class StatusLine:
         right = Text()
         for index, (icon, text, style) in enumerate(parts):
             if index:
+                # The name's unused reserve is paid out HERE, immediately before
+                # the seam that introduces the title, so the chevron stays tight
+                # against the text it points at (design review D1) while the
+                # cells themselves still sit inside the right group and cannot
+                # move any column to its left.
+                if index == len(parts) - 1 and self._name_slack:
+                    right.append(" " * self._name_slack, style=dim)
                 right.append(f" {_SEP_RIGHT} ", style=seam)
             if icon:
                 right.append(f"{icon} ", style=dim)

--- a/local_operator/tui/widgets/status_line.py
+++ b/local_operator/tui/widgets/status_line.py
@@ -1650,17 +1650,34 @@ class StatusLine:
             # of the user's opener, so it has no natural bound, and the band is a
             # fixed two-row box.
             #
-            # PADDED to its box, and left-aligned in it. The box is the reserved
-            # width, so the padding is what holds every sibling's column still
-            # while a model rewrites the string in it; left-aligned because the
-            # eye reads a title from its first cell, and a fixed first cell is
-            # exactly what a string that changes on its own needs. The leftover
-            # lands at the band's right edge, which is the one place on this row
-            # where nothing else was ever going to be.
+            # PADDED to its box, and RIGHT-aligned in it. The box is the
+            # reserved width, so the padding is what holds every sibling's
+            # column still while a model rewrites the string in it — that half
+            # is the reserve's whole purpose and is unchanged.
+            #
+            # The alignment inside the box decides where the box's UNUSED cells
+            # sit, and they have to sit somewhere: the fit was decided against
+            # the full box, so those cells are already spoken for and cannot be
+            # given back to the layout without moving every column left of the
+            # name. `rjust` puts them before the title, which makes the title's
+            # last cell the band's right edge at every length.
+            #
+            # `ljust` put them after it instead, and `_compose` then stripped
+            # them — so the painted row simply ended early: flush for a long
+            # title and up to 35 cells short for a brief one, which reads as a
+            # rendering fault rather than as a band with less to say. (They are
+            # ordinary styled cells, so anything READING the row carried them
+            # too: the SVG export wrote all 35.)
+            #
+            # The cost is that the title's FIRST cell moves with its length.
+            # That is the right way round — the reserve exists to stop the
+            # SIBLINGS drifting (the `!` alarm holds its column at every width),
+            # and the alternative, measuring the group by its ink, moves the
+            # alarm itself, which is the defect the box was introduced to fix.
             parts.append(
                 (
                     "",
-                    truncate_name(self._conversation_name, name_cells).ljust(name_cells),
+                    truncate_name(self._conversation_name, name_cells).rjust(name_cells),
                     Style(color=theme_mod.semantic_color("muted")),
                 )
             )
@@ -1687,31 +1704,22 @@ class StatusLine:
         arithmetic is the same at every title length and a short title leaves its
         leftover at the band's edge rather than shunting the group right.
 
-        That leftover is then CUT from the painted row, and the order of those
-        two steps is the whole point — it is NOT the same thing as aligning the
-        group by its ink. The gap above is still computed from the PADDED box, so
-        every column up to and including the name's first cell remains a function
-        of the row's geometry alone and nothing to the LEFT of the name can see
-        this cut. Aligning by ink instead was tried and reintroduces the exact
-        defect the reserve exists for: the alarm glyph goes back to moving with
-        the title, measured at 120/150/160 columns across the four titles in
-        ``_NAMES`` as columns 91/90/85/108, 121/120/115/138 and 122/117/125/148.
-        Here the only cells removed are the run of blanks BETWEEN the name's last
-        inked cell and the band's right edge, and nothing is ever painted there:
-        the name is the row's last segment by construction.
+        The box's unused cells are spent INSIDE the name segment, which
+        right-aligns itself in them (see :meth:`_right_text`), so the row's last
+        inked cell is the band's right edge at every title length and there is
+        nothing here to trim.
 
-        Worth removing because those blanks are not nothing. They are ordinary
-        cells carrying the band's own style, so anything that READS the row
-        rather than looking at it carries them: the SVG export writes 35 trailing
-        spaces after a `short` title at a 160-column terminal (0 after the cut),
-        and a reflow or a copy would take them the same way. A row whose right
-        edge is flush for a long title and 35 cells short for a brief one reads
-        as a rendering fault rather than as a band with less to say.
+        This method used to `rstrip` a LEFT-aligned name's trailing padding,
+        which produced a row that ended early — flush for a long title and up to
+        35 cells short for a brief one. Moving the padding to the other side of
+        the title fixes that at the source: the cells still exist, so the fit
+        arithmetic and every column left of the name are untouched, but they are
+        no longer at the edge where their absence was visible.
 
-        ``rstrip`` mutates, so it is applied to the freshly built row and never
-        to ``right``: trimming the caller's group in place would leave the fit
-        arithmetic in :meth:`_walk` measuring a different string than the box it
-        reserved, which is the bug this method exists to avoid.
+        Aligning the group by its INK rather than its box is the other way to
+        reach the edge, and the one this must not do: measured across four
+        titles it walks the `!` alarm from column 74 to 91/111/151 at 100/120/160
+        cells, which is exactly the drift the reserve was introduced to stop.
         """
         if not right.plain:
             return left
@@ -1720,7 +1728,6 @@ class StatusLine:
         row.append_text(left)
         row.append(" " * gap, style=dim)
         row.append_text(right)
-        row.rstrip()
         return row
 
     def render_text(self, width: int) -> Text:

--- a/tests/unit/session/test_conversation_name_persistence.py
+++ b/tests/unit/session/test_conversation_name_persistence.py
@@ -1,0 +1,241 @@
+"""A conversation's title has to survive the session that earned it.
+
+``ConversationName`` used to live only in memory, so every ``--resume`` opened
+a conversation that had forgotten what it was called: the status band fell back
+to the working directory and the terminal tab read ``lo › <dir>`` — which is
+precisely the "five sessions, five identical rows" failure the terminal title
+exists to fix, reintroduced on the one path where the name was already known.
+
+The title is journalled as a ``conversation_name`` custom entry, replayed at
+construction alongside the wake schedules. Three properties are load-bearing
+and each has a test below:
+
+* **``user_set`` rides along.** It is precedence, not decoration — a name the
+  human typed has to keep outranking generated titles across a resume, or the
+  resumed session's first re-title check silently overwrites it.
+* **The write survives teardown.** It is a background task, and ``dispose``
+  cancels background tasks, so a ``/rename`` moments before ctrl+d would never
+  reach disk without an explicit flush.
+* **Only real changes are journalled.** A generated title that loses to a
+  user-set one stores nothing, and re-appending the standing name every turn
+  would grow the transcript for no information.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from local_operator.harness.types import StreamEndEvent
+from local_operator.session.naming import CONVERSATION_NAME_CUSTOM_TYPE
+from local_operator.session.session import Session
+from local_operator.session.transcript import Transcript
+from tests.unit.session.test_session import MODEL, ScriptedStream
+
+
+def _session(tmp_path: Path) -> Session:
+    """A session over ``tmp_path/sess`` — reopening one resumes it."""
+    return Session(
+        model=MODEL,
+        stream_fn=ScriptedStream([[StreamEndEvent(stop_reason="stop")]]),
+        tools=[],
+        transcript=Transcript(tmp_path / "sess"),
+        system_blocks_provider=lambda: [],
+    )
+
+
+def _name_entries(tmp_path: Path) -> list[dict[str, Any]]:
+    """Every journalled title, oldest first."""
+    path = tmp_path / "sess" / "transcript.jsonl"
+    if not path.exists():
+        return []
+    entries: list[dict[str, Any]] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        entry = json.loads(line)
+        payload = entry.get("payload", {})
+        if entry.get("type") == "custom" and payload.get("custom_type") == (
+            CONVERSATION_NAME_CUSTOM_TYPE
+        ):
+            entries.append(payload["details"])
+    return entries
+
+
+@pytest.mark.asyncio
+async def test_a_generated_title_is_restored_by_the_next_resume(tmp_path) -> None:
+    """THE bug: a resumed session opened nameless and wore its cwd instead."""
+    session = _session(tmp_path)
+    await session.async_init()
+    session.set_conversation_name("Reduce agent RAM usage", user_set=False)
+    await session.dispose()
+
+    resumed = _session(tmp_path)
+    assert resumed.conversation_name == "Reduce agent RAM usage"
+    # Restored as a GENERATED title, so a later explicit rename still outranks it.
+    assert resumed.conversation_name_state.user_set is False
+    await resumed.dispose()
+
+
+@pytest.mark.asyncio
+async def test_a_human_rename_still_outranks_a_generated_title_after_a_resume(
+    tmp_path,
+) -> None:
+    """``user_set`` is precedence and has to cross the process boundary.
+
+    Restored as a plain string, the resumed session would have believed its
+    name was a generated one and let the first re-title check replace a title
+    the user chose by hand — the one thing the flag exists to prevent.
+    """
+    session = _session(tmp_path)
+    await session.async_init()
+    session.set_conversation_name("Q3 billing migration", user_set=True)
+    await session.dispose()
+
+    resumed = _session(tmp_path)
+    assert resumed.conversation_name_state.user_set is True
+    # A generated title landing in the resumed session must lose, exactly as it
+    # would have lost in the session where the rename happened.
+    assert resumed.set_conversation_name("Some model title", user_set=False) == (
+        "Q3 billing migration"
+    )
+    await resumed.dispose()
+
+
+@pytest.mark.asyncio
+async def test_a_title_stored_moments_before_teardown_still_lands(tmp_path) -> None:
+    """A `/rename` right before ctrl+d must not be cancelled on the way to disk.
+
+    The write is a background task and ``dispose`` cancels those, so without the
+    flush this stored nothing at all: the task had not had one turn of the event
+    loop between the store and the teardown.
+    """
+    session = _session(tmp_path)
+    await session.async_init()
+    session.set_conversation_name("Named as the user quit", user_set=True)
+    await session.dispose()  # no await in between: the write never got a tick
+
+    assert _name_entries(tmp_path), "the title never reached the transcript"
+    assert _session(tmp_path).conversation_name == "Named as the user quit"
+
+
+@pytest.mark.asyncio
+async def test_a_store_that_changes_nothing_journals_nothing(tmp_path) -> None:
+    """The transcript must not grow by a row per turn for a stable title.
+
+    Both no-op shapes are covered: re-storing the identical name, and a
+    generated title losing to a user-set one.
+    """
+    session = _session(tmp_path)
+    await session.async_init()
+    session.set_conversation_name("Fix the importer", user_set=True)
+    session.set_conversation_name("Fix the importer", user_set=True)  # identical
+    session.set_conversation_name("A model title", user_set=False)  # loses
+    await session.dispose()
+
+    assert _name_entries(tmp_path) == [{"text": "Fix the importer", "user_set": True}]
+
+
+@pytest.mark.asyncio
+async def test_the_newest_journalled_title_is_the_one_restored(tmp_path) -> None:
+    """Replay reads the newest entry, so a rename supersedes what came before."""
+    session = _session(tmp_path)
+    await session.async_init()
+    session.set_conversation_name("First subject", user_set=False)
+    session.set_conversation_name("Second subject", user_set=True)
+    await session.dispose()
+
+    resumed = _session(tmp_path)
+    assert resumed.conversation_name == "Second subject"
+    assert resumed.conversation_name_state.user_set is True
+    await resumed.dispose()
+
+
+@pytest.mark.asyncio
+async def test_a_restored_title_has_already_spent_its_naming_attempt(tmp_path) -> None:
+    """A resumed conversation must not buy a title it is already wearing.
+
+    ``claim_request`` is the once-per-conversation latch; a restored session
+    that left it unspent would pay for a provider call to re-derive the name
+    sitting on its own band.
+    """
+    session = _session(tmp_path)
+    await session.async_init()
+    session.set_conversation_name("Already named", user_set=False)
+    await session.dispose()
+
+    resumed = _session(tmp_path)
+    assert resumed.conversation_name_state.claim_request() is False
+    await resumed.dispose()
+
+
+@pytest.mark.asyncio
+async def test_an_unreadable_title_entry_never_refuses_the_resume(tmp_path) -> None:
+    """Decoration must not be able to take a conversation down with it.
+
+    Same tolerance ``_load_wake_schedules`` has: a malformed entry yields a
+    nameless session, not a resume that fails.
+    """
+    session = _session(tmp_path)
+    await session.async_init()
+    session.set_conversation_name("A good title", user_set=False)
+    await session.dispose()
+
+    # Rows are written with compact separators (`{"text":"…"}`), so the
+    # substitution is spelled the way the file actually reads.
+    path = tmp_path / "sess" / "transcript.jsonl"
+    corrupted = path.read_text(encoding="utf-8").replace('"text":"A good title"', '"text":42')
+    assert '"text":42' in corrupted, "the entry was not corrupted — the test proves nothing"
+    path.write_text(corrupted, encoding="utf-8")
+
+    resumed = _session(tmp_path)
+    assert resumed.conversation_name == ""
+    await resumed.dispose()
+
+
+@pytest.mark.asyncio
+async def test_a_rename_landing_mid_write_is_not_lost(tmp_path) -> None:
+    """A title stored WHILE the previous one is being appended must still win.
+
+    The append holds a lock and touches the filesystem, so the window between
+    "payload read" and "row on disk" is real. Marking the write clean
+    afterwards regardless of what the holder now says reported the NEWER title
+    as saved and left the OLDER one on disk — the next resume then restored a
+    name the user had already replaced. Caught with the slowed append below,
+    which widens the window to something a test can hit deterministically.
+    """
+
+    class SlowTranscript(Transcript):
+        async def append_custom(self, custom_type: str, details: dict[str, Any]):
+            await asyncio.sleep(0.15)  # the payload was read BEFORE this
+            return await super().append_custom(custom_type, details)
+
+    session = Session(
+        model=MODEL,
+        stream_fn=ScriptedStream([[StreamEndEvent(stop_reason="stop")]]),
+        tools=[],
+        transcript=SlowTranscript(tmp_path / "sess"),
+        system_blocks_provider=lambda: [],
+    )
+    await session.async_init()
+    session.set_conversation_name("First title", user_set=False)
+    await asyncio.sleep(0.05)  # the write is now inside append_custom
+    session.set_conversation_name("Second title", user_set=True)
+    await asyncio.sleep(0.5)  # the chase lands without any dispose
+
+    # On disk BEFORE teardown: the correction must not depend on quitting.
+    assert _session(tmp_path).conversation_name == "Second title"
+    await session.dispose()
+    assert _session(tmp_path).conversation_name == "Second title"
+
+
+@pytest.mark.asyncio
+async def test_a_fresh_session_is_nameless_and_journals_nothing(tmp_path) -> None:
+    """No title, no entry: the ordinary new conversation is unaffected."""
+    session = _session(tmp_path)
+    await session.async_init()
+    assert session.conversation_name == ""
+    await session.dispose()
+    assert _name_entries(tmp_path) == []

--- a/tests/unit/session/test_conversation_name_persistence.py
+++ b/tests/unit/session/test_conversation_name_persistence.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import time
 from pathlib import Path
 from typing import Any
 
@@ -382,6 +383,137 @@ async def test_a_wedged_write_cannot_hang_dispose(tmp_path, monkeypatch) -> None
     # two budgets rather than never. Generous ceiling: the assertion is
     # "bounded", not a stopwatch on the scheduler.
     await asyncio.wait_for(session.dispose(), timeout=5.0)
+
+
+@pytest.mark.asyncio
+async def test_a_transient_write_failure_still_lands_the_title(tmp_path) -> None:
+    """A hiccup must cost a retry, not the name.
+
+    ``_conversation_name_journalled`` is claimed BEFORE the append so the flush
+    can recognise a write in flight (F9). Left standing when that append
+    RAISES, the claim is false — the title is neither in flight nor on disk —
+    and the flush skipped the very retry that exists to rescue it, losing the
+    name outright.
+
+    The always-failing test above cannot catch this: with every append doomed,
+    the retry fails too and "no row on disk" holds either way. It takes a
+    TRANSIENT failure — first append fails, the next would succeed — which is
+    an ENOSPC/EIO/lock blip rather than a broken disk (review round 3, F12).
+    """
+    calls = {"n": 0}
+
+    class FlakyTranscript(Transcript):
+        async def append_custom(self, custom_type: str, details: dict[str, Any]):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise OSError("transient hiccup")
+            return await super().append_custom(custom_type, details)
+
+    session = Session(
+        model=MODEL,
+        stream_fn=ScriptedStream([[StreamEndEvent(stop_reason="stop")]]),
+        tools=[],
+        transcript=FlakyTranscript(tmp_path / "sess"),
+        system_blocks_provider=lambda: [],
+    )
+    await session.async_init()
+    session.set_conversation_name("Survives a hiccup", user_set=True)
+    await asyncio.sleep(0.05)
+    await session.dispose()
+
+    assert calls["n"] >= 2, "the failed write was never retried"
+    assert _session(tmp_path).conversation_name == "Survives a hiccup"
+
+
+@pytest.mark.asyncio
+async def test_teardown_costs_one_budget_not_two(tmp_path, monkeypatch, caplog) -> None:
+    """The flush's whole cost is ``_NAME_FLUSH_TIMEOUT_S``, once.
+
+    The wait and the retry used to charge a full budget each and ran in
+    sequence, so a wedged volume plus a title that moved under the write made
+    teardown twice what the constant advertises (measured at 10 s). They now
+    share one deadline (review round 3, F14).
+
+    The warning is asserted too, so that bounding the wait stays visible in a
+    log rather than becoming a silent drop.
+    """
+    monkeypatch.setattr(session_mod, "_NAME_FLUSH_TIMEOUT_S", 0.4)
+
+    class WedgedTranscript(Transcript):
+        async def append_custom(self, custom_type: str, details: dict[str, Any]):
+            await asyncio.sleep(3600)
+            raise AssertionError("unreachable: the sleep outlives the test")
+
+    session = Session(
+        model=MODEL,
+        stream_fn=ScriptedStream([[StreamEndEvent(stop_reason="stop")]]),
+        tools=[],
+        transcript=WedgedTranscript(tmp_path / "sess"),
+        system_blocks_provider=lambda: [],
+    )
+    await session.async_init()
+    session.set_conversation_name("Title A", user_set=False)
+    await asyncio.sleep(0.05)
+    # Moves the title under the in-flight write, which is what sends the flush
+    # through BOTH halves — the case that used to cost two budgets.
+    session.set_conversation_name("Title B", user_set=True)
+
+    with caplog.at_level("WARNING"):
+        started = time.monotonic()
+        await session.dispose()
+        elapsed = time.monotonic() - started
+
+    # One budget plus scheduling slack, nowhere near two.
+    assert elapsed < 0.4 * 1.8, f"teardown took {elapsed:.2f}s, more than one budget"
+    assert any("stopped waiting for the conversation name" in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_the_timeout_warning_claims_only_what_it_knows(tmp_path, monkeypatch, caplog) -> None:
+    """The log line must not report a loss that has not happened.
+
+    A timed-out retry says nothing about the title's fate: the shielded write it
+    gave up waiting for survives dispose, and its own chase loop re-appends a
+    title that moved — so the row frequently lands moments later. "Gave up
+    journalling the conversation name" reported those as dropped names, and a
+    warning that cries wolf is worth less than none (review round 3, F13).
+
+    Whether a slow write will finish or is wedged forever is not knowable at
+    this point, so the message states the fact it has — teardown stopped
+    waiting — and names the consequence conditionally. This pins that wording
+    against a case where the title DOES land.
+    """
+    monkeypatch.setattr(session_mod, "_NAME_FLUSH_TIMEOUT_S", 0.4)
+
+    class SlowTranscript(Transcript):
+        async def append_custom(self, custom_type: str, details: dict[str, Any]):
+            await asyncio.sleep(1.0)  # outlives the flush, but does finish
+            return await super().append_custom(custom_type, details)
+
+    session = Session(
+        model=MODEL,
+        stream_fn=ScriptedStream([[StreamEndEvent(stop_reason="stop")]]),
+        tools=[],
+        transcript=SlowTranscript(tmp_path / "sess"),
+        system_blocks_provider=lambda: [],
+    )
+    await session.async_init()
+    session.set_conversation_name("Title A", user_set=False)
+    await asyncio.sleep(0.05)
+    session.set_conversation_name("Title B", user_set=True)  # moves under the write
+
+    with caplog.at_level("WARNING"):
+        await session.dispose()
+        await asyncio.sleep(2.5)  # let the shielded write and its chase land
+
+    # The title reached disk despite the flush giving up on it...
+    assert _session(tmp_path).conversation_name == "Title B"
+    # ...so nothing may claim it was lost or dropped.
+    for record in caplog.records:
+        assert "gave up journalling" not in record.message
+        assert "stopped waiting" not in record.message or "if the write does not finish" in (
+            record.message
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/session/test_conversation_name_persistence.py
+++ b/tests/unit/session/test_conversation_name_persistence.py
@@ -32,7 +32,7 @@ import pytest
 
 from local_operator.harness.types import StreamEndEvent
 from local_operator.session.naming import CONVERSATION_NAME_CUSTOM_TYPE
-from local_operator.session.session import Session
+from local_operator.session.session import _NAME_CHASE_ATTEMPTS, Session
 from local_operator.session.transcript import Transcript
 from tests.unit.session.test_session import MODEL, ScriptedStream
 
@@ -229,6 +229,103 @@ async def test_a_rename_landing_mid_write_is_not_lost(tmp_path) -> None:
     assert _session(tmp_path).conversation_name == "Second title"
     await session.dispose()
     assert _session(tmp_path).conversation_name == "Second title"
+
+
+@pytest.mark.asyncio
+async def test_a_failing_journal_write_is_logged_not_raised(tmp_path, caplog) -> None:
+    """A full or read-only volume must not print a traceback for decoration.
+
+    The write is deliberately NOT routed through ``_spawn_background`` (dispose
+    has to await it, not cancel it), so it needs that helper's guard of its own.
+    Without it the exception was never retrieved and asyncio wrote
+    ``Task exception was never retrieved`` into the user's terminal — for a
+    title (review round 1, F2).
+    """
+
+    class FailingTranscript(Transcript):
+        async def append_custom(self, custom_type: str, details: dict[str, Any]):
+            raise OSError("disk full")
+
+    session = Session(
+        model=MODEL,
+        stream_fn=ScriptedStream([[StreamEndEvent(stop_reason="stop")]]),
+        tools=[],
+        transcript=FailingTranscript(tmp_path / "sess"),
+        system_blocks_provider=lambda: [],
+    )
+    await session.async_init()
+    with caplog.at_level("WARNING"):
+        session.set_conversation_name("A title nobody can store", user_set=True)
+        await asyncio.sleep(0.05)
+        # The session survives, and dispose does too — a decoration failure may
+        # not take teardown down with it.
+        await session.dispose()
+
+    assert any("conversation name" in record.message for record in caplog.records)
+    assert session.conversation_name == "A title nobody can store"
+
+
+@pytest.mark.asyncio
+async def test_a_title_that_keeps_moving_cannot_spin_the_journal(tmp_path) -> None:
+    """The chase is CAPPED, not merely "bounded by user behaviour".
+
+    A writer that renames during every append never converges, and as recursion
+    that was 2 987 frames, 2 986 rows and 522 KB before ``RecursionError``. The
+    loop stops after ``_NAME_CHASE_ATTEMPTS`` and leaves the rest to the dispose
+    flush (review round 1, F3).
+    """
+    renames = iter(range(1, 10_000))
+
+    class MovingTranscript(Transcript):
+        async def append_custom(self, custom_type: str, details: dict[str, Any]):
+            result = await super().append_custom(custom_type, details)
+            # Move the holder under the write, every single time.
+            session._conversation_name.text = f"Moving title {next(renames)}"
+            return result
+
+    session = Session(
+        model=MODEL,
+        stream_fn=ScriptedStream([[StreamEndEvent(stop_reason="stop")]]),
+        tools=[],
+        transcript=MovingTranscript(tmp_path / "sess"),
+        system_blocks_provider=lambda: [],
+    )
+    await session.async_init()
+    session.set_conversation_name("First", user_set=True)
+    await asyncio.sleep(0.1)
+    await session.dispose()
+
+    # Capped rather than unbounded: a handful of rows, not thousands.
+    rows = _name_entries(tmp_path)
+    assert len(rows) <= _NAME_CHASE_ATTEMPTS * 2 + 2, f"the chase spun: {len(rows)} rows"
+
+
+@pytest.mark.asyncio
+async def test_a_slow_write_is_not_duplicated_by_the_dispose_flush(tmp_path) -> None:
+    """Dispose must not re-append a row a slow write already put on disk.
+
+    The flush waits on the in-flight write and then retried whenever the dirty
+    flag was still set — which a slow append holds for its whole duration, so
+    the identical payload was written twice (review round 1, F5).
+    """
+
+    class SlowTranscript(Transcript):
+        async def append_custom(self, custom_type: str, details: dict[str, Any]):
+            await asyncio.sleep(0.3)
+            return await super().append_custom(custom_type, details)
+
+    session = Session(
+        model=MODEL,
+        stream_fn=ScriptedStream([[StreamEndEvent(stop_reason="stop")]]),
+        tools=[],
+        transcript=SlowTranscript(tmp_path / "sess"),
+        system_blocks_provider=lambda: [],
+    )
+    await session.async_init()
+    session.set_conversation_name("Slow write", user_set=True)
+    await session.dispose()
+
+    assert _name_entries(tmp_path) == [{"text": "Slow write", "user_set": True}]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/session/test_conversation_name_persistence.py
+++ b/tests/unit/session/test_conversation_name_persistence.py
@@ -31,6 +31,7 @@ from typing import Any
 import pytest
 
 from local_operator.harness.types import StreamEndEvent
+from local_operator.session import session as session_mod
 from local_operator.session.naming import CONVERSATION_NAME_CUSTOM_TYPE
 from local_operator.session.session import _NAME_CHASE_ATTEMPTS, Session
 from local_operator.session.transcript import Transcript
@@ -256,12 +257,23 @@ async def test_a_failing_journal_write_is_logged_not_raised(tmp_path, caplog) ->
     await session.async_init()
     with caplog.at_level("WARNING"):
         session.set_conversation_name("A title nobody can store", user_set=True)
+        # The BACKGROUND task fails here, before any dispose runs. Asserting
+        # after dispose instead is what made the first version of this test
+        # vacuous: the flush's own error path logs a near-identical line, so
+        # the assertion passed against the unguarded code while asyncio still
+        # printed the traceback (review round 2, F11).
         await asyncio.sleep(0.05)
-        # The session survives, and dispose does too — a decoration failure may
-        # not take teardown down with it.
+        background_logs = [r for r in caplog.records if "conversation name" in r.message]
+        assert background_logs, "the background write's failure was not logged"
+        # And the task really did finish, so nothing is left holding an
+        # unretrieved exception for the GC to complain about.
+        task = session._conversation_name_task
+        assert task is not None and task.done()
+        assert task.exception() is None, "the failure escaped the guard"
+
+        # Teardown still succeeds — a decoration failure may not take it down.
         await session.dispose()
 
-    assert any("conversation name" in record.message for record in caplog.records)
     assert session.conversation_name == "A title nobody can store"
 
 
@@ -301,17 +313,28 @@ async def test_a_title_that_keeps_moving_cannot_spin_the_journal(tmp_path) -> No
 
 
 @pytest.mark.asyncio
-async def test_a_slow_write_is_not_duplicated_by_the_dispose_flush(tmp_path) -> None:
+async def test_a_slow_write_is_not_duplicated_by_the_dispose_flush(tmp_path, monkeypatch) -> None:
     """Dispose must not re-append a row a slow write already put on disk.
 
     The flush waits on the in-flight write and then retried whenever the dirty
     flag was still set — which a slow append holds for its whole duration, so
     the identical payload was written twice (review round 1, F5).
+
+    The append must outlast ``_NAME_FLUSH_TIMEOUT_S``, or the flush's wait
+    simply completes and the ordinary "not dirty" return does the work — the
+    branch under test is never entered and the test passes against the broken
+    code. The first version of this test slept 0.3 s against a 2 s timeout and
+    did exactly that (review round 2, F10), so the delay is derived from the
+    timeout rather than hard-coded, and the timeout itself is monkeypatched
+    down so the test does not pay for it in wall clock.
     """
+    monkeypatch.setattr(session_mod, "_NAME_FLUSH_TIMEOUT_S", 0.2)
 
     class SlowTranscript(Transcript):
         async def append_custom(self, custom_type: str, details: dict[str, Any]):
-            await asyncio.sleep(0.3)
+            # Comfortably PAST the flush's patience, so the shield-wait times
+            # out with the write still in flight — the state F9 was about.
+            await asyncio.sleep(0.5)
             return await super().append_custom(custom_type, details)
 
     session = Session(
@@ -324,8 +347,41 @@ async def test_a_slow_write_is_not_duplicated_by_the_dispose_flush(tmp_path) -> 
     await session.async_init()
     session.set_conversation_name("Slow write", user_set=True)
     await session.dispose()
+    # The shielded write outlives dispose by design; give it a moment to land.
+    await asyncio.sleep(0.5)
 
     assert _name_entries(tmp_path) == [{"text": "Slow write", "user_set": True}]
+
+
+@pytest.mark.asyncio
+async def test_a_wedged_write_cannot_hang_dispose(tmp_path, monkeypatch) -> None:
+    """ctrl+d must return even when the volume never answers.
+
+    The flush's timeout used to bound only the WAIT for an in-flight write; the
+    retry it fell through to was an unbounded await on the same wedged append,
+    and ``dispose`` awaits the flush directly — so a hung filesystem hung the
+    app on exit, for decoration (review round 2, F9).
+    """
+    monkeypatch.setattr(session_mod, "_NAME_FLUSH_TIMEOUT_S", 0.2)
+
+    class WedgedTranscript(Transcript):
+        async def append_custom(self, custom_type: str, details: dict[str, Any]):
+            await asyncio.sleep(3600)  # never answers
+            raise AssertionError("unreachable: the sleep outlives the test")
+
+    session = Session(
+        model=MODEL,
+        stream_fn=ScriptedStream([[StreamEndEvent(stop_reason="stop")]]),
+        tools=[],
+        transcript=WedgedTranscript(tmp_path / "sess"),
+        system_blocks_provider=lambda: [],
+    )
+    await session.async_init()
+    session.set_conversation_name("Never lands", user_set=True)
+    # The bound applies to the wait AND the retry, so dispose returns in about
+    # two budgets rather than never. Generous ceiling: the assertion is
+    # "bounded", not a stopwatch on the scheduler.
+    await asyncio.wait_for(session.dispose(), timeout=5.0)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tui/test_resumed_conversation_name.py
+++ b/tests/unit/tui/test_resumed_conversation_name.py
@@ -1,0 +1,167 @@
+"""What a RESUMED conversation is called on the band and on the terminal tab.
+
+Resuming used to lose the name entirely. The session's title lived in memory
+only, so ``--resume``/``/resume`` rebuilt the conversation, replayed its whole
+history onto the screen, and then labelled it with the working directory —
+turning a sidebar of resumed sessions back into the row of identical ``lo ›
+<dir>`` entries the terminal title feature exists to prevent.
+
+Two halves, both covered here:
+
+* A session whose transcript CARRIES a journalled title is adopted already
+  named, and ``_adopt_session`` paints that name onto the band and the tab.
+* A session whose transcript carries none — every transcript written before
+  titles were journalled, and any session closed before its naming call landed
+  — falls back to its own opening message, the same text ``/resume``'s picker
+  labels its rows with, so the row picked and the tab landed on agree.
+
+The fallback is a DISPLAY stand-in and must stay one: written into the session
+it would tell the naming errand this conversation is already named and retire
+the one call that could give it a real title.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from local_operator.harness.types import Message, TextContent
+from local_operator.session.naming import ConversationName
+from local_operator.tui.app import OperatorApp
+from local_operator.tui.terminal_title import TerminalTitle
+from tests.unit.tui.test_app_pilot import FakeSession, _factory
+
+OPENER = "Investigate why the nightly importer drops rows silently"
+
+
+class _ResumedSession(FakeSession):
+    """A session as a resume hands one over: prior history, maybe a title.
+
+    ``title`` is applied through the real :class:`ConversationName` holder the
+    fake already owns, which is what a resumed ``Session`` does when it replays
+    its own ``conversation_name`` entry.
+    """
+
+    def __init__(self, *, title: str = "", user_set: bool = False, history: bool = True) -> None:
+        super().__init__()
+        if title:
+            self._name_state = ConversationName(text=title, user_set=user_set, requested=True)
+        self._history = (
+            [
+                Message(role="user", content=[TextContent(text=OPENER)]),
+                Message(role="assistant", content=[TextContent(text="Looking now.")]),
+            ]
+            if history
+            else []
+        )
+
+    def history(self) -> list[Any]:
+        return list(self._history)
+
+
+async def _boot(session: _ResumedSession, pilot: Any) -> None:  # noqa: ANN401
+    """Pump until the session is adopted (see test_conversation_naming._ready)."""
+    for _ in range(200):
+        if pilot.app._session is not None:
+            return
+        await pilot.pause()
+    raise AssertionError("the session was never adopted")
+
+
+def _tab_title(app: OperatorApp) -> str:
+    """The OSC 0 label this app would put on the terminal tab.
+
+    Read through a TerminalTitle attached to the band, because the pilot runs
+    headless and the app installs no writer of its own — there is no terminal.
+    ``current`` renders the same string ``emit`` would have written.
+    """
+    band = app._status
+    assert band is not None
+    writer = TerminalTitle(lambda _text: None)
+    band.set_terminal_title(writer)
+    return writer.current
+
+
+@pytest.mark.asyncio
+async def test_a_resumed_session_wears_its_stored_title() -> None:
+    """THE bug: the name was on disk and the band showed the cwd anyway."""
+    session = _ResumedSession(title="Reduce agent RAM usage")
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(session, pilot)
+        assert app._status is not None
+        assert app._status._conversation_name == "Reduce agent RAM usage"
+        assert _tab_title(app) == "lo › Reduce agent RAM usage"
+        # The stored title is the store of record, so no stand-in was adopted
+        # beside it — a later `/rename` has one thing to supersede, not two.
+        assert app._provisional_name == ""
+
+
+@pytest.mark.asyncio
+async def test_a_resume_without_a_stored_title_falls_back_to_the_opener() -> None:
+    """Legacy transcripts carry no title; the conversation still has a subject.
+
+    Without this the band read `lo › <cwd>` for a conversation whose opening
+    message was on screen two rows up.
+    """
+    session = _ResumedSession(title="")
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(session, pilot)
+        assert app._status is not None
+        assert app._status._conversation_name.startswith("Investigate why the nightly importer")
+        assert _tab_title(app).startswith("lo › Investigate why the nightly importer")
+        # DISPLAY only: the store stays empty so the naming errand still fires
+        # and can replace the quote with an actual title.
+        assert session.conversation_name == ""
+        assert app._provisional_name != ""
+
+
+@pytest.mark.asyncio
+async def test_a_stored_title_is_never_displaced_by_the_opener_fallback() -> None:
+    """The fallback is for the nameless case only.
+
+    A resumed session carrying a user's own rename must not have it replaced by
+    a quote of the first message — the rename outranks everything, forever.
+    """
+    session = _ResumedSession(title="Q3 billing migration", user_set=True)
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(session, pilot)
+        assert app._status is not None
+        assert app._status._conversation_name == "Q3 billing migration"
+        assert app._provisional_name == ""
+
+
+@pytest.mark.asyncio
+async def test_a_fresh_session_is_not_given_a_name_by_the_resume_path() -> None:
+    """No history, no name: an ordinary new session keeps its cwd fallback.
+
+    The restore runs on every adoption, not only on a resume, so the empty case
+    is the one that proves it cannot invent a label for a conversation that has
+    not started.
+    """
+    session = _ResumedSession(title="", history=False)
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(session, pilot)
+        assert app._status is not None
+        assert app._status._conversation_name == ""
+        assert app._provisional_name == ""
+        # The band's own cwd fallback is what names the tab, unchanged.
+        assert _tab_title(app).startswith("lo › ")
+
+
+@pytest.mark.asyncio
+async def test_the_restored_name_survives_the_first_repaint() -> None:
+    """The band re-renders constantly; the name must not be a one-frame flash."""
+    session = _ResumedSession(title="Reduce agent RAM usage")
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(session, pilot)
+        assert app._status is not None
+        app._status.refresh()
+        await pilot.pause()
+        assert app._status._conversation_name == "Reduce agent RAM usage"
+        assert _tab_title(app) == "lo › Reduce agent RAM usage"

--- a/tests/unit/tui/test_status_line.py
+++ b/tests/unit/tui/test_status_line.py
@@ -29,6 +29,7 @@ from local_operator.tui.widgets.status_line import (
     _DROP_LADDER_QUIET,
     _DROP_LADDER_QUIET_ESTIMATE,
     _MIN_GROUP_GAP,
+    _SEP_RIGHT,
     _SPINNER_FRAMES,
     _UNBOUNDED_RUNGS,
     ICON_AGENTS,
@@ -1043,8 +1044,11 @@ def test_the_alarm_sits_beside_the_name_rather_than_replacing_it() -> None:
     assert row.endswith("Add todo guardrails")
     assert "auto-approve" not in row, "the alarm's prose was crowding out the name"
     assert "always" not in row
-    # The glyph, immediately before the name and after its seam.
-    assert row.endswith("! ‹ Add todo guardrails")
+    # The glyph, immediately before the name's BOX and after its seam. The title
+    # is right-aligned in that box, so at a width this generous the reserve's
+    # unused cells sit between the seam and the title — the alarm is still the
+    # last thing before the name segment, which is what this pins.
+    assert re.search(r"! ‹ +Add todo guardrails$", row)
 
 
 def test_an_unnamed_session_leaves_the_trailing_slot_to_whatever_is_left() -> None:
@@ -1171,18 +1175,21 @@ def _name_box(row: str, name: str, width: int) -> int:
 
     The box is what the layout is built on, and it is not the same number as the
     ink in it: a word-boundary cut can leave `Bulk export the…` in an 18-cell box.
-    Located from the name's own opening characters, which land on the box's first
-    cell because the name is left-aligned in it.
 
-    Measured to ``width`` rather than to ``len(row)``, and that is the difference
-    between the box and the ink now that ``_compose`` stops painting the box's
-    trailing blanks. The reserve still runs to the band's right edge — the row is
-    laid out to exactly ``width`` and only then trimmed — so the edge, not the
-    last inked cell, is where the box ends. Reading ``len(row)`` here would make
-    this helper return the INK and quietly turn every caller into a test of the
-    string's length instead of the layout's reserve.
+    Located from the SEAM that precedes the segment, not from the name's own
+    characters. The name is right-aligned in its box, so the unused cells are a
+    run of blanks BEFORE the title and the title's first cell moves with its
+    length — which is precisely what this helper must not measure. The seam is
+    the box's left edge and the band's right edge is its right one, so the span
+    between them is the reserve at every title length.
+
+    Measured to ``width`` rather than to ``len(row)`` for the same reason: the
+    row is laid out to exactly ``width``, so the edge is where the box ends, and
+    reading the string's length would quietly turn every caller into a test of
+    the ink instead of the layout's reserve.
     """
-    return width - row.rindex(name[:4])
+    seam = f" {_SEP_RIGHT} "
+    return width - (row.rindex(seam) + len(seam))
 
 
 def test_naming_a_session_never_costs_a_segment_for_nothing(monkeypatch) -> None:
@@ -1294,9 +1301,17 @@ def test_the_name_takes_every_cell_the_row_can_spare(monkeypatch) -> None:
         row = status.render_text(width).plain
         box = len(row) - row.index("! ‹ ") - len("! ‹ ")
         boxes.append(box)
-        # Whatever is spare is IN the name's box, so the hole between the groups
+        # Whatever is spare is IN the name's box, so the hole BETWEEN THE GROUPS
         # is the seam's own width until the box is full.
-        longest_gap = max((len(run) for run in re.findall(r" {2,}", row.rstrip())), default=0)
+        #
+        # Measured up to the name's box rather than across the whole row. The
+        # title is right-aligned in its box, so a word-boundary cut leaves its
+        # unused cells immediately before the title — a run this regex sees and
+        # which is not a layout gap at all but the reserve doing its job. The
+        # property under test is that the LAYOUT does not idle while the name is
+        # still hungry, and the layout is everything left of that box.
+        head = row[: len(row) - box]
+        longest_gap = max((len(run) for run in re.findall(r" {2,}", head)), default=0)
         assert (
             box >= NAME_CELLS or longest_gap <= _MIN_GROUP_GAP
         ), f"width={width}: {longest_gap} cells idle beside a {box}-cell name"
@@ -1308,47 +1323,37 @@ def test_the_name_takes_every_cell_the_row_can_spare(monkeypatch) -> None:
 
 
 def test_a_brief_title_leaves_no_dead_run_at_the_bands_right_edge(monkeypatch) -> None:
-    """The name's box is RESERVED, but its unused tail is not PAINTED.
+    """The name's box is RESERVED, and its unused cells sit BEFORE the title.
 
     The reserve is what holds every sibling's column still while a model rewrites
-    the title (D2), so it stays — but it used to be painted out to the band's
-    right edge as well, which left a brief title trailed by a long run of blank
-    cells that no segment would ever occupy.
+    the title (D2), so it stays. Where its unused cells are painted is the part
+    this pins, and both wrong answers were shipped before the right one:
 
-    The run's SIZE is not a constant. Two earlier versions of this docstring
-    implied otherwise, and the second was written to fix the first — which is
-    the more useful half of the story, because a correction carries more
-    authority than an original and nobody re-checks a sentence whose commit
-    message says it is the fix.
+    * Left-aligned, they trailed the title. ``_compose`` then stripped them and
+      the painted row ended early — flush at the band's edge for a long title
+      and up to 35 cells short for a brief one, which reads as a rendering
+      fault rather than as a band with less to say. (They are ordinary styled
+      cells, so anything READING the row carried them too: the app's own SVG
+      export wrote all 35.)
+    * Measuring the group by its ink instead reaches the edge and moves the `!`
+      alarm with the title's length — the exact drift the reserve exists to
+      stop, so it is not an option.
 
-    The first version said the run was "identical at every width". The second
-    retracted that and then quoted a second illustrative triple, which reproduces
-    only under a band shape it did not name: the width-100 figure moves with the
-    cwd's length and with whether the alarm is armed, so the same measurement
-    yields a different first entry on a shorter path or a disarmed gate. A
-    figure quoted without the conditions that produce it is the same unenforced
-    universal in a narrower costume.
+    Right-aligned, the cells are still reserved and still charged to the fit —
+    nothing left of the name can tell the difference — but they land between the
+    seam and the title, so the row's last inked cell is the band's right edge at
+    every title length.
 
-    So no illustrative numbers are quoted here at all. What identifies the
-    padding is the RELATIONSHIP, which needs none: the run is exactly the box
-    minus the ink, so it grows as the box grows and vanishes when the title
-    fills it — while a layout gap would not track the title's length. The box is
-    itself elastic and only reaches the full ``NAME_CELLS`` once the row can
-    spare it, which is why any single measurement of the run is a fact about one
-    band shape rather than about the defect.
+    No illustrative numbers are quoted here, because the run's SIZE is not a
+    constant: it is exactly the box minus the ink, so it grows as the box grows
+    and vanishes when the title fills it, and the box is itself elastic. Two
+    earlier versions of this docstring quoted figures that reproduced only under
+    a band shape they did not name.
 
-    That relationship is what this test pins, by asserting the row ends on the
-    title's last inked cell at every width rather than by asserting any
-    particular number of dead cells.
-
-    Those cells are ordinary styled cells, so everything that reads the row
-    rather than looking at it carried them — the app's own SVG export wrote 35
-    trailing spaces after `short` at a 160-column terminal.
-
-    The two halves are asserted together on purpose. Trimming the tail is only
+    The two halves are asserted together on purpose. A flush edge is only
     correct while the reserve behind it is untouched, so this pins that the row
-    ends on the title's last inked character AND that the box measured to the
-    band's edge is unchanged by how long the title is.
+    runs to the band's full width AND that the box measured to that edge is
+    unchanged by how long the title is.
     """
     monkeypatch.setenv("HOME", "/Users/tester")
     for label, state in _LADDER_STATES.items():
@@ -1364,6 +1369,13 @@ def test_a_brief_title_leaves_no_dead_run_at_the_bands_right_edge(monkeypatch) -
                 assert (
                     row == row.rstrip()
                 ), f"{where}: {len(row) - len(row.rstrip())} dead cells at the band's edge"
+                # THE regression this test is named for: the row has to reach
+                # the band's right edge, not merely end on a non-blank cell. A
+                # `rstrip`ped row satisfies the assertion above while being 35
+                # cells short of the edge, which is what shipped.
+                assert (
+                    cell_len(row) == width
+                ), f"{where}: the row stops {width - cell_len(row)} cells short of the edge"
                 # The ink really is the title's, not a coincidence of truncation.
                 assert row.endswith(truncate_name(name, _name_box(row, name, width))), where
                 boxes.add(_name_box(row, name, width))

--- a/tests/unit/tui/test_status_line.py
+++ b/tests/unit/tui/test_status_line.py
@@ -1419,6 +1419,38 @@ def test_the_titles_seam_stays_tight_against_the_title(monkeypatch) -> None:
                 assert tail and not tail.startswith(" "), f"{where}: the seam was orphaned"
 
 
+def test_a_double_width_title_never_overflows_the_band(monkeypatch) -> None:
+    """The band is ONE row, in cells — including for CJK and Hangul titles.
+
+    The reserve is measured in cells and the row's gap is computed with
+    ``cell_len``, so any padding of the name has to be counted the same way.
+    Padding it with ``str.rjust`` counts CHARACTERS instead, and a title of
+    double-width glyphs then emits a row wider than the band: 592 rows over
+    their width across the ladder variants, worst case 11 cells. Rich drops the
+    over-wide segment rather than clipping it, so the effect was a CJK-named
+    conversation resuming with no name on the band at all — this feature's own
+    failure, reintroduced for non-Latin titles (review round 1, F1).
+    """
+    monkeypatch.setenv("HOME", "/Users/tester")
+    titles = (
+        "修复恢复时的会话标题",
+        "セッションのタイトルを復元する",
+        "세션 제목 복원하기",
+        "修复登录重定向循环的问题并添加测试用例以防止回归",
+    )
+    for label, state in _LADDER_STATES.items():
+        for alarm in (True, False):
+            status = _swept_band(state, alarm=alarm)
+            for name in titles:
+                status.update(conversation_name=name)
+                for width in range(60, 181):
+                    row = status.render_text(width).plain
+                    assert cell_len(row) <= width, (
+                        f"{label} alarm={alarm} width={width} name={name!r}: "
+                        f"the row is {cell_len(row)} cells wide"
+                    )
+
+
 def test_the_bands_cut_lands_on_a_word_like_the_excerpt_it_was_handed() -> None:
     """``provisional_title`` cuts on a word boundary on purpose — "so it reads as
     a quotation rather than as a string that ran out of buffer" — and the band

--- a/tests/unit/tui/test_status_line.py
+++ b/tests/unit/tui/test_status_line.py
@@ -1044,11 +1044,11 @@ def test_the_alarm_sits_beside_the_name_rather_than_replacing_it() -> None:
     assert row.endswith("Add todo guardrails")
     assert "auto-approve" not in row, "the alarm's prose was crowding out the name"
     assert "always" not in row
-    # The glyph, immediately before the name's BOX and after its seam. The title
-    # is right-aligned in that box, so at a width this generous the reserve's
-    # unused cells sit between the seam and the title — the alarm is still the
-    # last thing before the name segment, which is what this pins.
-    assert re.search(r"! ‹ +Add todo guardrails$", row)
+    # The glyph, immediately before the name's BOX, whose unused cells sit
+    # between the alarm and the seam that introduces the title. The alarm is
+    # still the last INK before the name segment, which is what this pins; the
+    # seam stays tight against the title it points at.
+    assert re.search(r"! +‹ Add todo guardrails$", row)
 
 
 def test_an_unnamed_session_leaves_the_trailing_slot_to_whatever_is_left() -> None:
@@ -1176,12 +1176,12 @@ def _name_box(row: str, name: str, width: int) -> int:
     The box is what the layout is built on, and it is not the same number as the
     ink in it: a word-boundary cut can leave `Bulk export the…` in an 18-cell box.
 
-    Located from the SEAM that precedes the segment, not from the name's own
-    characters. The name is right-aligned in its box, so the unused cells are a
-    run of blanks BEFORE the title and the title's first cell moves with its
-    length — which is precisely what this helper must not measure. The seam is
-    the box's left edge and the band's right edge is its right one, so the span
-    between them is the reserve at every title length.
+    Located from the box's own left edge, which is where its UNUSED cells start
+    — not from the name's first character. The reserve's leftover is painted
+    just before the seam that introduces the title, so the title's first cell
+    moves with its length and measuring from it would return the ink instead of
+    the box. Everything from the end of the previous segment's ink to the band's
+    right edge is the reserve, seam included.
 
     Measured to ``width`` rather than to ``len(row)`` for the same reason: the
     row is laid out to exactly ``width``, so the edge is where the box ends, and
@@ -1189,7 +1189,10 @@ def _name_box(row: str, name: str, width: int) -> int:
     the ink instead of the layout's reserve.
     """
     seam = f" {_SEP_RIGHT} "
-    return width - (row.rindex(seam) + len(seam))
+    # The last seam is the title's. Walk left over the blanks in front of it to
+    # reach the box's first cell; the segment before them ends on real ink.
+    start = len(row[: row.rindex(seam)].rstrip())
+    return width - start - len(seam)
 
 
 def test_naming_a_session_never_costs_a_segment_for_nothing(monkeypatch) -> None:
@@ -1299,7 +1302,10 @@ def test_the_name_takes_every_cell_the_row_can_spare(monkeypatch) -> None:
     boxes = []
     for width in range(100, 181):
         row = status.render_text(width).plain
-        box = len(row) - row.index("! ‹ ") - len("! ‹ ")
+        # From the alarm's ink to the band's edge, blanks and seam included:
+        # the reserve's unused cells sit between the two, so a literal `! ‹ `
+        # is no longer contiguous.
+        box = len(row) - row.index("!") - len("! ‹ ")
         boxes.append(box)
         # Whatever is spare is IN the name's box, so the hole BETWEEN THE GROUPS
         # is the seam's own width until the box is full.
@@ -1382,6 +1388,35 @@ def test_a_brief_title_leaves_no_dead_run_at_the_bands_right_edge(monkeypatch) -
             # ...and the reserve behind that trimmed tail did not move with the
             # title's length, which is the property the padding used to provide.
             assert len(boxes) <= 1, f"{label} width={width}: the box moved with the title {boxes}"
+
+
+def test_the_titles_seam_stays_tight_against_the_title(monkeypatch) -> None:
+    """The `‹` introduces the name and has to touch it (design review D1).
+
+    The reserve's unused cells have to be painted somewhere, and the two obvious
+    places are both wrong. After the title, the row ends early (the defect above
+    this one). Between the seam and the title, the row is flush but the chevron
+    is orphaned: every other seam on the band is tight against what it
+    introduces, so a lone `‹` trailed by a run of blanks reads as a segment that
+    failed to render rather than as spacing.
+
+    So the cells go BEFORE the seam, and this pins that — at every width and for
+    titles short enough to leave a large leftover, which is where an orphan
+    would be most visible.
+    """
+    monkeypatch.setenv("HOME", "/Users/tester")
+    for label, state in _LADDER_STATES.items():
+        status = _swept_band(state, alarm=True)
+        for width in (100, 120, 160):
+            for name in ("a", "short", "Bulk export the invoice columns"):
+                status.update(conversation_name=name)
+                row = status.render_text(width).plain
+                if not status.is_showing("name"):
+                    continue
+                where = f"{label} width={width} name={name!r}"
+                seam = f" {_SEP_RIGHT} "
+                tail = row[row.rindex(seam) + len(seam) :]
+                assert tail and not tail.startswith(" "), f"{where}: the seam was orphaned"
 
 
 def test_the_bands_cut_lands_on_a_word_like_the_excerpt_it_was_handed() -> None:

--- a/tests/unit/tui/test_terminal_title.py
+++ b/tests/unit/tui/test_terminal_title.py
@@ -125,7 +125,32 @@ def test_a_label_that_sanitizes_away_reads_as_no_label() -> None:
 
 
 def test_the_label_is_capped() -> None:
+    # One enormous token has no boundary to cut on, so it is cut mid-token
+    # rather than dropped — a tab reading `lo ›` says less than a cut string.
+    # The ellipsis rides in the last cell, so the cap still holds exactly.
     assert len(sanitize_label("x" * 500)) == MAX_LABEL_CHARS
+
+
+def test_an_over_long_label_is_cut_on_a_word_with_an_ellipsis() -> None:
+    """The tab agrees with the band about how a long name is shortened.
+
+    A bare slice ended the tab mid-word (`…and reconcile the ledge`), which
+    reads as a string that ran out of buffer rather than as a name that was
+    shortened — and the tab is where it bites hardest, since most terminals
+    shorten the label again to fit the tab strip. Both the band
+    (``status_line.truncate_name``) and the excerpt this string came from
+    (``naming.provisional_title``) cut on a word, so this is parity rather than
+    a new rule (design review D3).
+    """
+    label = sanitize_label(
+        "Investigate why the nightly importer drops rows silently "
+        "and reconcile the ledger totals"
+    )
+    assert len(label) <= MAX_LABEL_CHARS
+    assert label.endswith("…")
+    assert label == "Investigate why the nightly importer drops rows silently and reconcile the…"
+    # A name that already fits is returned untouched — no stray ellipsis.
+    assert sanitize_label("Reduce agent RAM usage") == "Reduce agent RAM usage"
 
 
 def test_cwd_stands_in_for_a_conversation_that_has_no_name_yet() -> None:

--- a/tests/unit/tui/test_terminal_title.py
+++ b/tests/unit/tui/test_terminal_title.py
@@ -21,6 +21,7 @@ from typing import cast
 
 from textual.widgets import Static
 
+from local_operator.session.naming import ConversationName
 from local_operator.tui.terminal_title import (
     BRAND,
     MAX_LABEL_CHARS,
@@ -151,6 +152,27 @@ def test_an_over_long_label_is_cut_on_a_word_with_an_ellipsis() -> None:
     assert label == "Investigate why the nightly importer drops rows silently and reconcile the…"
     # A name that already fits is returned untouched — no stray ellipsis.
     assert sanitize_label("Reduce agent RAM usage") == "Reduce agent RAM usage"
+
+
+def test_a_renamed_conversation_reaches_the_tab_cut_on_a_word() -> None:
+    """The cut has to happen where the LENGTH is decided, not on the tab.
+
+    ``MAX_TITLE_CHARS`` and ``MAX_LABEL_CHARS`` are both 80, so a title arrives
+    at ``sanitize_label`` already sliced by the store and the tab-side word cut
+    could never fire for a conversation name — the OSC still ended mid-word
+    (`…and reconcile the ledge`) with the tab-side fix in place. Shortening in
+    ``ConversationName.set`` is what actually reaches the surface, and this
+    drives the real path to prove it (design review round 2, D6).
+    """
+    name = ConversationName()
+    stored = name.set(
+        "Investigate why the nightly importer drops rows silently "
+        "and reconcile the ledger totals",
+        user_set=True,
+    )
+    assert stored.endswith("…"), "the stored title was sliced mid-word"
+    assert not stored.endswith("ledge…"), "cut mid-word rather than on a boundary"
+    assert build_title(sanitize_label(stored), "idle").endswith("and reconcile the…")
 
 
 def test_cwd_stands_in_for_a_conversation_that_has_no_name_yet() -> None:


### PR DESCRIPTION
# PR Description

## Change classification

**C2 — standard / pre-authorized.** Correctness fix on the resume path plus a layout fix in the status band. One new custom transcript entry (`conversation_name`), which is additive and ignored by replay into LLM context; older transcripts load unchanged and newer ones are readable by older builds. Clean rollback (`git revert`). No RFC requested.

## The bug

Resuming a session lost its name. `ConversationName` lived in memory for the life of a process and was never journalled, so `--resume` / `/resume` rebuilt the conversation, replayed its entire history onto the screen, and then labelled it with the **working directory** — turning a sidebar of resumed sessions back into the row of identical `lo › <dir>` rows the terminal-title feature exists to prevent.

The name was known. Nothing carried it across the process boundary:

```console
$ # a real Session, over a real Transcript, closed and reopened
live session name:    'Reduce agent RAM usage'
resumed session name: ''
```

The comment in `resume.py` stated the constraint plainly and it was accurate — *"there is no stored title: `ConversationName` lives in memory for the life of a session and is never journalled"*.

**Before.** A resumed conversation, its band, and the OSC 0 string it puts on the tab:

```console
$ # the band and the tab of a session resumed from a transcript with history
OSC: \x1b]0;lo › lo-title\x07          # the DIRECTORY, not the conversation
band name segment: ''                  # the name segment is empty
```

## The fix

### 1. The session journals and restores its own title

A `conversation_name` custom entry, replayed at construction beside the wake schedules — so the object that reads the history also reads its own name. Three details are load-bearing:

- **`user_set` rides along**, because it is *precedence*, not decoration. Restored as a bare string, a resumed session would believe a name the user typed by hand was a generated one and let the first re-title check silently overwrite it.
- **The restore spends the naming latch** (`requested`), so a session already wearing a title does not buy a provider call to re-derive a name that is already on its band.
- **The write survives teardown.** It is a background task and `dispose` cancels those, so a `/rename` moments before ctrl+d never reached disk. The write is tracked apart from `_background_tasks` so `dispose` *awaits* it instead of cancelling it.

A store that changes nothing journals nothing — an unchanged name, or a generated title losing to a user-set one — so a stable title costs no row per turn.

### 2. A rename landing mid-write is chased, not dropped

Found while probing my own change: the append holds a lock and touches the filesystem, so the window between "payload read" and "row on disk" is real. Clearing the dirty flag unconditionally afterwards reported the *newer* title as saved and left the *older* one on disk. The payload is now snapshotted before the append and compared after; a title that moved under the write is re-appended immediately rather than waiting for dispose.

### 3. The host covers transcripts that predate the entry

Every transcript written before this entry existed carries no title, and so does any session closed before its naming call landed. `_restore_resumed_name` labels a nameless resumed conversation from its **own opening message** — the same text `/resume`'s picker labels its rows with, so the row a user picked and the tab they land on agree by construction rather than by coincidence.

It is held as a **display stand-in** and never written into the session: every gate in the naming errand reads that string to mean "already named", so storing it would retire the one call that could give the conversation a real title.

### 4. The band's trailing gap (reported separately on this branch)

The same work made a second defect visible. The name's 40-cell box is *reserved* so the `!` alarm and its siblings keep a stable column — but a short title's unused cells were painted **after** it and then stripped, so the row simply ended early: flush at the right edge for a long title and up to 35 cells short for a brief one, which reads as a rendering fault rather than as a band with less to say.

Right-aligning the title inside its box moves those cells **before** it. The reserve, the fit arithmetic, and every column left of the name are untouched.

## Validation

### 1. The reported behaviour, end to end through the real resume path

A real `Session` over a real `Transcript`, resolved through `resume.resume_dir` the way the CLI does — not a fake:

```console
=== 1. a live session names itself and is closed ===
   live name        : 'Reduce agent RAM usage'

=== 2. what actually reached the transcript on disk ===
   entry            : custom {"custom_type": "conversation_name",
                              "details": {"text": "Reduce agent RAM usage", "user_set": false}}

=== 3. --resume @latest resolves this session ===
   resolved dir     : a1b2c3d4e5f6 (expected a1b2c3d4e5f6)

=== 4. the resumed session wears the name ===
   resumed name     : 'Reduce agent RAM usage'
   user_set         : False
   naming attempt   : spent
   terminal tab     : 'lo › Reduce agent RAM usage'

=== 5. a rename in the resumed session persists again ===
   third session    : 'Q3 billing migration' user_set: True
   generated loses  : 'Q3 billing migration'   <-- precedence held across TWO boundaries

ALL END-TO-END ASSERTIONS PASSED
```

### 2. Both resume paths, rendered and looked at

**After — a stored title.** The band and the tab both carry it:

```console
OSC: \x1b]0;lo › Reduce agent RAM usage\x07
band name segment: 'Reduce agent RAM usage'
```

**After — a legacy transcript with no stored title.** Named from its replayed opener, with the store left empty so the naming errand can still upgrade it:

```console
OSC: \x1b]0;lo › Investigate why the nightly importer drops rows…\x07
stored name (must stay empty): ''
```

Both were captured as rendered SVG stills from the real `OperatorApp` (which loads the stylesheet) and looked at, per the repo's visual-validation recipe. Consecutive frames are byte-identical (`cmp` on two stills captured a `pilot.pause()` apart), so nothing reflows after paint. Geometry is clean — `virtual_size == size` at `Size(98, 28)`, no scrollbar, band `Size(95, 1)` inside its declared `height: 2`.

### 3. The band reaches the right edge, and the alarm does not move

Measured across four titles at three widths. `short_by` is cells between the last inked cell and the band's edge; `!col` is the alarm's column:

| | `short_by` before | `short_by` after | `!col` before | `!col` after |
|---|---|---|---|---|
| 100 cols | `[17, 0, 4, 0]` | `[0, 0, 0, 0]` | `74` | `74` |
| 120 cols | `[35, 18, 13, 2]` | `[0, 0, 0, 0]` | `76` | `76` |
| 160 cols | `[35, 18, 13, 2]` | `[0, 0, 0, 0]` | `116` | `116` |

The rejected alternative is recorded because it is the obvious one: measuring the right group by its **ink** also reaches the edge, and walks the alarm from column 74 to **91 / 111 / 151** — precisely the drift the reserve was introduced to stop.

The rendered rows, at 120 columns — the pipes are the band's edges:

```text
BEFORE                                                                     ends at
|◆ anthropic/claude-opus-4 › ⌂ /Users/damian/local-operator    ▦ 18.2%/1M ‹ ◈ $14.12 ‹ ! ‹ Fix session title on resume|   117/120
|◆ anthropic/claude-opus-4 › ⌂ /Users/damian/local-operator    ▦ 18.2%/1M ‹ ◈ $14.12 ‹ ! ‹ Reduce agent RAM usage|        112/120

AFTER
|◆ anthropic/claude-opus-4 › ⌂ /Users/damian/local-operator    ▦ 18.2%/1M ‹ ◈ $14.12 ‹ ! ‹    Fix session title on resume|  120/120
|◆ anthropic/claude-opus-4 › ⌂ /Users/damian/local-operator    ▦ 18.2%/1M ‹ ◈ $14.12 ‹ ! ‹         Reduce agent RAM usage|  120/120
```

### 4. Regression tests, confirmed to fail without the fix

14 new tests. Checked out against unmodified `main` at the same base commit, **7 of 8** session tests and **1 of 5** TUI tests fail (the other TUI four assert invariants that already held):

```console
$ # on origin/main, with the new tests copied in
7 failed, 1 passed      tests/unit/session/test_conversation_name_persistence.py
1 failed, 4 passed      tests/unit/tui/test_resumed_conversation_name.py

AssertionError: assert '' == 'Reduce agent RAM usage'
AssertionError: assert '' == 'Second subject'
```

The band's flush-edge assertion was verified the same way — reverting just `rjust` → `ljust` and restoring the `rstrip`:

```console
AssertionError: healthy-mcp/exact width=100 name='a':
  the row stops 20 cells short of the edge
```

The mid-write race has its own test, using a transcript whose append is slowed to 150 ms so the window is deterministic rather than a coin flip.

### 5. Gates

```console
$ .venv/bin/python -m pytest tests/unit -q
4738 passed, 7 skipped, 1 deselected in 644.39s

$ .venv/bin/python -m flake8 .                                   # clean
$ uvx --from black==26.1.0 black --check local_operator tests    # 371 files unchanged
$ uvx isort --check-only --profile black local_operator tests    # clean
$ .venv/bin/python -m pyright --pythonpath .venv/bin/python .     # 0 errors, 0 warnings
```

The one deselected test is `tests/unit/tools/test_eval_tool.py::test_background_streams_output_while_it_runs`, which **fails identically on unmodified `origin/main` at the same commit** (`f87f778`) and is unrelated to this change.

## Scope note

The transcript is append-only and this entry is additive: replay ignores custom entries for LLM context, so an older build reads a newer transcript without noticing the row, and this build reads an older transcript by falling back to the opener. No migration.

`resume.session_name` — the `/resume` picker's row label — is deliberately left reading the transcript's first user message rather than this entry. The picker labels sessions it is not resuming, and a stored title is a fact about a conversation the picker may never open; keeping one source for the row labels avoids two answers to "what is this session called" in one list. Worth revisiting separately if the picker should prefer a user's explicit rename.
