### PR TITLE
fix(tui): make a drag over the composer copy what it highlighted

### DIFF
--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -30,6 +30,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, NamedTuple, Protocol, cast
 
+from rich.cells import cell_len
 from rich.console import Group
 from rich.style import Style
 from rich.terminal_theme import TerminalTheme
@@ -131,6 +132,7 @@ from local_operator.tui.widgets.editor import (
     Attachment,
     Editor,
     EditorCopied,
+    EditorCopyStale,
     EditorQuit,
     EditorSubmitted,
     InterruptRequested,
@@ -2424,6 +2426,26 @@ class OperatorApp(App[None]):
         """
         self._put_on_clipboard(message.text)
 
+    def on_editor_copy_stale(self, message: EditorCopyStale) -> None:
+        """The text a copy receipt describes was edited away — drop the card.
+
+        Select-to-overwrite is the commonest edit in an input: drag a word, type
+        the replacement. The drag copies (that is this PR's whole point), and
+        the receipt then sat there for the rest of its five seconds asserting a
+        copy of characters the user had already replaced (design round 1, D3).
+
+        Only the CLAIM is withdrawn. The clipboard keeps what it took — the
+        copy really happened, and a paste a minute later must still produce it.
+
+        Guarded on the card actually being a copy receipt: an MCP failure that
+        arrived after the copy is not this message's business, and dismissing
+        it because the user carried on typing would be the eviction bug
+        (D2) with extra steps.
+        """
+        toast = self.query_one(Toast)
+        if toast.message.startswith("copied "):
+            toast.dismiss_toast()
+
     def _put_on_clipboard(self, text: str | None) -> None:
         """The one clipboard write, with the receipt that makes it visible.
 
@@ -2436,12 +2458,48 @@ class OperatorApp(App[None]):
         Empty is not an event: ``None`` (nothing selected) and ``""`` (a
         selection nothing would give up) are both "no copy happened", and a
         toast for either would be the same lie the silent copy was.
+
+        **The unit follows the SHAPE of what was taken**, because "line" is a
+        claim the frame can contradict:
+
+        * A selection carrying no newline is reported in CHARACTERS. Saying
+          ``copied 1 line`` there asserted a whole line the user had not taken
+          (they dragged three words out of one), and in the composer it also
+          contradicted the screen: a long draft soft-wraps, so one document
+          line is painted as three highlighted rows and the receipt said
+          ``1 line`` while the user was looking at three (design round 1,
+          D1/D5). A character count is true of both the clipboard and the
+          frame, and it is the number that actually distinguishes "I got the
+          word" from "I got the word and a trailing space".
+        * A selection that spans lines is reported in LINES, which is the
+          useful magnitude there and keeps the transcript's familiar receipt
+          for the multi-paragraph copy it was written for.
+
+        The count is ``splitlines()``, not ``count("\\n") + 1``: the latter
+        reads a trailing newline as a whole further line, so selecting exactly
+        one line and its break — "select this line", a natural composer drag —
+        was reported as ``copied 2 lines`` (review round 1, F3). It is the count
+        the tests already cross-checked against, so the two now agree for every
+        selection rather than only for those ending mid-line.
+
+        The receipt is deliberately a COURTESY (see ``Toast.show``): the user
+        performed this action and can see its result, so it must not evict an
+        actionable failure notice they have not read (design round 1, D2).
         """
         if not text:
             return
         self.copy_to_clipboard(text)
-        lines = text.count("\n") + 1
-        self.query_one(Toast).show(f"copied {lines} line{'' if lines == 1 else 's'}")
+        lines = len(text.splitlines())
+        if lines <= 1:
+            # `cell_len` rather than `len`: the receipt counts what the user
+            # highlighted on screen, and a CJK glyph or an emoji is one
+            # character that occupies two cells. Neither number is wrong in
+            # general; this is the one the frame can be checked against.
+            count = cell_len(text)
+            message = f"copied {count} character{'' if count == 1 else 's'}"
+        else:
+            message = f"copied {lines} lines"
+        self.query_one(Toast).show(message, yield_to_actionable=True)
 
     # -- resize (TUI-017 / D5) ----------------------------------------------
     def on_resize(self, event) -> None:  # type: ignore[no-untyped-def]

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -2432,9 +2432,17 @@ class OperatorApp(App[None]):
         goes through the same clipboard write and must NOT be retired when the
         user turns to the composer and starts typing their next prompt (review
         round 2, F5; design round 2, D8).
+
+        The generation is read BEFORE the write and only adopted if it moved.
+        ``Toast.show`` declines the slot while an actionable notice is up, and
+        an unconditional read then pointed this at the FAILURE's card — so the
+        next keystroke dismissed the very notice the deference existed to
+        protect (review round 3). No card raised, nothing to withdraw.
         """
+        toast = self.query_one(Toast)
+        before = toast.generation
         self._put_on_clipboard(message.text)
-        self._copy_receipt = self.query_one(Toast).generation
+        self._copy_receipt = toast.generation if toast.generation != before else None
 
     def on_editor_copy_stale(self, message: EditorCopyStale) -> None:
         """The text a copy receipt describes was edited away — drop the card.

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -2466,9 +2466,18 @@ class OperatorApp(App[None]):
         """
         receipt = self._copy_receipt
         self._copy_receipt = None
-        if receipt is None:
-            return
         toast = self.query_one(Toast)
+        if receipt is None:
+            # No card of ours is SHOWING — but one may be waiting. A copy made
+            # while an actionable notice held the slot is held back rather than
+            # dropped (D9), and the edit that falsifies it can easily land in
+            # that window: the notice runs for ten seconds and the user is
+            # typing (design round 4, D14). Withdrawing it before it is ever
+            # painted is the same rule as below, applied one moment earlier —
+            # otherwise the claim escapes the staleness check entirely and
+            # appears, already false, when the slot frees.
+            toast.drop_deferred()
+            return
         # The GENERATION, not the wording: two copies can produce the same
         # string, and what must be true is that the card on screen is still the
         # one this editor's copy put there. Any later `show` — another copy, an

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -663,6 +663,15 @@ class _ProviderRows(NamedTuple):
     problem: str
 
 
+#: Tag for the toast the COMPOSER's copy raises, so a later edit can withdraw
+#: that card and no other. One `Toast` slot serves every caller, and a receipt
+#: may be showing OR held behind an actionable notice — the showing case is
+#: named by `Toast.generation`, and this names the held one. A bare sentinel
+#: rather than a widget reference: the identity is all that is compared, and
+#: holding a widget in app state is a lifetime problem for no benefit.
+COMPOSER_COPY = object()
+
+
 class Chrome(Static):
     """A frame element the app draws for itself, and never lets a copy pick up.
 
@@ -975,10 +984,6 @@ class OperatorApp(App[None]):
         #: The two together are the FIFO the engine drains: these rows were
         #: queued first, so they settle first (see `on_steering_delivered`).
         self._deferred_steer_notices: list[NoticeBlock] = []
-        #: The `Toast.generation` of the card the composer's last copy raised,
-        #: or None once it has been withdrawn or superseded. Editing the copied
-        #: text retires THAT card and no other — see `on_editor_copy_stale`.
-        self._copy_receipt: int | None = None
         #: What the CURRENT turn has already been billed for, per model call, by
         #: `on_context_usage_reported`. `on_turn_ended` prices the same turn as a
         #: whole and is the authoritative figure, so it adds only the difference
@@ -2427,22 +2432,25 @@ class OperatorApp(App[None]):
         indistinguishable from a copy out of the transcript, or the receipt
         becomes evidence about which widget you dragged over.
 
-        Only THIS path records the receipt for later withdrawal: the composer's
-        copy is the one an edit to the composer can falsify. A transcript copy
-        goes through the same clipboard write and must NOT be retired when the
-        user turns to the composer and starts typing their next prompt (review
-        round 2, F5; design round 2, D8).
+        Only THIS path tags the card for later withdrawal: the composer's copy
+        is the one an edit to the composer can falsify. A transcript copy goes
+        through the same clipboard write and must NOT be retired when the user
+        turns to the composer and starts typing their next prompt (review round
+        2, F5; design round 2, D8).
 
-        The generation is read BEFORE the write and only adopted if it moved.
-        ``Toast.show`` declines the slot while an actionable notice is up, and
-        an unconditional read then pointed this at the FAILURE's card — so the
-        next keystroke dismissed the very notice the deference existed to
-        protect (review round 3). No card raised, nothing to withdraw.
+        The tag is all the bookkeeping there is. An earlier version recorded
+        ``Toast.generation`` here instead, which named only a card that had
+        actually been PAINTED — so a receipt held behind an actionable notice
+        was untracked while held (design round 4, D14), and untouchable once
+        the slot freed and promoted it. Ownership rides the card through both
+        states, so the two cases collapse into one (review round 4).
         """
-        toast = self.query_one(Toast)
-        before = toast.generation
-        self._put_on_clipboard(message.text)
-        self._copy_receipt = toast.generation if toast.generation != before else None
+        # `COMPOSER_COPY` tags the card as this gesture's, so that a later edit
+        # can withdraw it whether it went up or was held behind an actionable
+        # notice — and can withdraw ONLY it. The tag rides the Toast rather than
+        # being tracked here, which is what makes the two states one case
+        # (review round 4, F14).
+        self._put_on_clipboard(message.text, owner=COMPOSER_COPY)
 
     def on_editor_copy_stale(self, message: EditorCopyStale) -> None:
         """The text a copy receipt describes was edited away — drop the card.
@@ -2455,37 +2463,26 @@ class OperatorApp(App[None]):
         Only the CLAIM is withdrawn. The clipboard keeps what it took — the
         copy really happened, and a paste a minute later must still produce it.
 
-        Retires THE CARD THIS EDITOR'S COPY RAISED, by identity, and nothing
-        else. The first version asked whether the message started with
-        ``copied ``, which cannot tell one receipt from another: a transcript
-        copy raises a ``copied …`` card too, so typing the next prompt dismissed
-        a receipt for text the composer never touched — D3 inverted, withdrawing
-        a claim that was still true (review round 2, F5; design round 2, D8).
-        Comparing the object also drops the string coupling between this method
-        and the two f-strings that build the message (F8).
-        """
-        receipt = self._copy_receipt
-        self._copy_receipt = None
-        toast = self.query_one(Toast)
-        if receipt is None:
-            # No card of ours is SHOWING — but one may be waiting. A copy made
-            # while an actionable notice held the slot is held back rather than
-            # dropped (D9), and the edit that falsifies it can easily land in
-            # that window: the notice runs for ten seconds and the user is
-            # typing (design round 4, D14). Withdrawing it before it is ever
-            # painted is the same rule as below, applied one moment earlier —
-            # otherwise the claim escapes the staleness check entirely and
-            # appears, already false, when the slot frees.
-            toast.drop_deferred()
-            return
-        # The GENERATION, not the wording: two copies can produce the same
-        # string, and what must be true is that the card on screen is still the
-        # one this editor's copy put there. Any later `show` — another copy, an
-        # MCP failure — moves the counter and this stands down.
-        if toast.generation == receipt:
-            toast.dismiss_toast()
+        Retires THE CARD THIS EDITOR'S COPY RAISED, by owner, and nothing else.
+        Three ways that has gone wrong, all now answered by the one call:
 
-    def _put_on_clipboard(self, text: str | None) -> None:
+        * Matching on the message text could not tell one receipt from another,
+          so typing the next prompt withdrew the TRANSCRIPT's copy receipt —
+          D3 inverted, withdrawing a claim that was still true (review round 2,
+          F5; design round 2, D8).
+        * A receipt held behind an actionable notice (D9) escaped the check
+          entirely and appeared, already false, when the slot freed (design
+          round 4, D14).
+        * Withdrawing whatever was held, unqualified, discarded a transcript
+          copy's held receipt on a composer keystroke (review round 4, F14).
+
+        ``Toast.withdraw`` covers a card in either state and refuses one that
+        belongs to anybody else, so this handler no longer has to know which
+        state its receipt reached.
+        """
+        self.query_one(Toast).withdraw(COMPOSER_COPY)
+
+    def _put_on_clipboard(self, text: str | None, owner: object | None = None) -> None:
         """The one clipboard write, with the receipt that makes it visible.
 
         Shared by the transcript's ``TextSelected`` and the composer's
@@ -2544,12 +2541,7 @@ class OperatorApp(App[None]):
             message = f"copied {count} character{'' if count == 1 else 's'}"
         else:
             message = f"copied {lines} lines"
-        self.query_one(Toast).show(message, yield_to_actionable=True)
-        # Any card raised here supersedes a composer receipt this app was
-        # holding: whatever is on screen now is not the one that copy put there,
-        # so there is nothing left for a later edit to withdraw. (The composer's
-        # own path re-arms it immediately afterwards.)
-        self._copy_receipt = None
+        self.query_one(Toast).show(message, yield_to_actionable=True, owner=owner)
 
     # -- resize (TUI-017 / D5) ----------------------------------------------
     def on_resize(self, event) -> None:  # type: ignore[no-untyped-def]

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -30,7 +30,6 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, NamedTuple, Protocol, cast
 
-from rich.cells import cell_len
 from rich.console import Group
 from rich.style import Style
 from rich.terminal_theme import TerminalTheme
@@ -976,6 +975,10 @@ class OperatorApp(App[None]):
         #: The two together are the FIFO the engine drains: these rows were
         #: queued first, so they settle first (see `on_steering_delivered`).
         self._deferred_steer_notices: list[NoticeBlock] = []
+        #: The `Toast.generation` of the card the composer's last copy raised,
+        #: or None once it has been withdrawn or superseded. Editing the copied
+        #: text retires THAT card and no other — see `on_editor_copy_stale`.
+        self._copy_receipt: int | None = None
         #: What the CURRENT turn has already been billed for, per model call, by
         #: `on_context_usage_reported`. `on_turn_ended` prices the same turn as a
         #: whole and is the authoritative figure, so it adds only the difference
@@ -2423,8 +2426,15 @@ class OperatorApp(App[None]):
         share one clipboard write and one toast: a copy out of the input must be
         indistinguishable from a copy out of the transcript, or the receipt
         becomes evidence about which widget you dragged over.
+
+        Only THIS path records the receipt for later withdrawal: the composer's
+        copy is the one an edit to the composer can falsify. A transcript copy
+        goes through the same clipboard write and must NOT be retired when the
+        user turns to the composer and starts typing their next prompt (review
+        round 2, F5; design round 2, D8).
         """
         self._put_on_clipboard(message.text)
+        self._copy_receipt = self.query_one(Toast).generation
 
     def on_editor_copy_stale(self, message: EditorCopyStale) -> None:
         """The text a copy receipt describes was edited away — drop the card.
@@ -2437,13 +2447,25 @@ class OperatorApp(App[None]):
         Only the CLAIM is withdrawn. The clipboard keeps what it took — the
         copy really happened, and a paste a minute later must still produce it.
 
-        Guarded on the card actually being a copy receipt: an MCP failure that
-        arrived after the copy is not this message's business, and dismissing
-        it because the user carried on typing would be the eviction bug
-        (D2) with extra steps.
+        Retires THE CARD THIS EDITOR'S COPY RAISED, by identity, and nothing
+        else. The first version asked whether the message started with
+        ``copied ``, which cannot tell one receipt from another: a transcript
+        copy raises a ``copied …`` card too, so typing the next prompt dismissed
+        a receipt for text the composer never touched — D3 inverted, withdrawing
+        a claim that was still true (review round 2, F5; design round 2, D8).
+        Comparing the object also drops the string coupling between this method
+        and the two f-strings that build the message (F8).
         """
+        receipt = self._copy_receipt
+        self._copy_receipt = None
+        if receipt is None:
+            return
         toast = self.query_one(Toast)
-        if toast.message.startswith("copied "):
+        # The GENERATION, not the wording: two copies can produce the same
+        # string, and what must be true is that the card on screen is still the
+        # one this editor's copy put there. Any later `show` — another copy, an
+        # MCP failure — moves the counter and this stands down.
+        if toast.generation == receipt:
             toast.dismiss_toast()
 
     def _put_on_clipboard(self, text: str | None) -> None:
@@ -2491,15 +2513,26 @@ class OperatorApp(App[None]):
         self.copy_to_clipboard(text)
         lines = len(text.splitlines())
         if lines <= 1:
-            # `cell_len` rather than `len`: the receipt counts what the user
-            # highlighted on screen, and a CJK glyph or an emoji is one
-            # character that occupies two cells. Neither number is wrong in
-            # general; this is the one the frame can be checked against.
-            count = cell_len(text)
+            # `len` rather than `cell_len`, i.e. the word means what it says.
+            # Cells were tried first, on the theory that the receipt should
+            # count what is painted \u2014 but cell width matches the frame only for
+            # the cases where it already matches `len`. An emoji is ONE glyph
+            # the user highlighted and `cell_len` calls it two; a tab is scored
+            # 0 while the editor paints it expanded to `indent_width`, so cells
+            # matched neither the document nor the screen (review round 2, F6).
+            # A newline scores 0 too, which made "select this line and its
+            # break" announce `copied 0 characters` for a real clipboard write
+            # \u2014 a receipt that reads as a failure (design round 2, D10).
+            count = len(text)
             message = f"copied {count} character{'' if count == 1 else 's'}"
         else:
             message = f"copied {lines} lines"
         self.query_one(Toast).show(message, yield_to_actionable=True)
+        # Any card raised here supersedes a composer receipt this app was
+        # holding: whatever is on screen now is not the one that copy put there,
+        # so there is nothing left for a later edit to withdraw. (The composer's
+        # own path re-arms it immediately afterwards.)
+        self._copy_receipt = None
 
     # -- resize (TUI-017 / D5) ----------------------------------------------
     def on_resize(self, event) -> None:  # type: ignore[no-untyped-def]

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -130,6 +130,7 @@ from local_operator.tui.widgets.editor import (
     ArgumentQueryOpened,
     Attachment,
     Editor,
+    EditorCopied,
     EditorQuit,
     EditorSubmitted,
     InterruptRequested,
@@ -2406,7 +2407,36 @@ class OperatorApp(App[None]):
         ``None`` for no selection at all, ``""`` for a selection over widgets
         that every one of them declined.
         """
-        text = self.screen.get_selected_text()
+        self._put_on_clipboard(self.screen.get_selected_text())
+
+    def on_editor_copied(self, message: EditorCopied) -> None:
+        """A drag over the COMPOSER copies too, and says so identically.
+
+        The composer is invisible to ``Screen.selections`` — ``TextArea`` clears
+        the screen selection on every caret move, and the mouse-down that starts
+        the drag is a caret move — so :meth:`on_text_selected` sees nothing to
+        copy and the highlight the user is looking at goes nowhere. The widget
+        therefore reports its own release (``Editor._copy_drag``), and it lands
+        HERE rather than writing the clipboard itself so that both gestures
+        share one clipboard write and one toast: a copy out of the input must be
+        indistinguishable from a copy out of the transcript, or the receipt
+        becomes evidence about which widget you dragged over.
+        """
+        self._put_on_clipboard(message.text)
+
+    def _put_on_clipboard(self, text: str | None) -> None:
+        """The one clipboard write, with the receipt that makes it visible.
+
+        Shared by the transcript's ``TextSelected`` and the composer's
+        :class:`EditorCopied` so the two gestures cannot drift apart in what
+        they write or what they claim. The write is OSC 52
+        (``App.copy_to_clipboard``), which is what carries a copy back to the
+        real clipboard over ssh and inside a multiplexer.
+
+        Empty is not an event: ``None`` (nothing selected) and ``""`` (a
+        selection nothing would give up) are both "no copy happened", and a
+        toast for either would be the same lie the silent copy was.
+        """
         if not text:
             return
         self.copy_to_clipboard(text)

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -665,10 +665,11 @@ class _ProviderRows(NamedTuple):
 
 #: Tag for the toast the COMPOSER's copy raises, so a later edit can withdraw
 #: that card and no other. One `Toast` slot serves every caller, and a receipt
-#: may be showing OR held behind an actionable notice — the showing case is
-#: named by `Toast.generation`, and this names the held one. A bare sentinel
-#: rather than a widget reference: the identity is all that is compared, and
-#: holding a widget in app state is a lifetime problem for no benefit.
+#: may be SHOWING or HELD behind an actionable notice; the tag rides the card
+#: through both, which is what lets `Toast.withdraw` treat them as one case
+#: (see `on_editor_copied`). A bare sentinel rather than a widget reference:
+#: identity is all that is compared, and holding a widget in app state is a
+#: lifetime problem for no benefit.
 COMPOSER_COPY = object()
 
 

--- a/local_operator/tui/widgets/editor.py
+++ b/local_operator/tui/widgets/editor.py
@@ -18,6 +18,10 @@ Key interception happens in :meth:`_on_key`, which runs BEFORE TextArea's
 document-insert path, so a handled key never reaches the buffer. Unhandled
 keys fall through to the stock editor behavior.
 
+Releasing a drag over the composer COPIES the highlighted text, the same rule
+the transcript follows and for the same reason — neither Ctrl+C nor cmd+C is
+available to bind here. See :meth:`Editor._copy_drag`.
+
 The caret is SOLID and never blinks, and on an EMPTY composer it gets a cell of
 its own to the left of the placeholder rather than inverting the placeholder's
 first letter; see ``cursor_blink`` in :meth:`__init__` and :meth:`render_line`.
@@ -343,6 +347,28 @@ class EditorSubmitted(Message):
         #: widget sees an empty map and silently drops the images (review round
         #: 19). Restores need the numbers, which the ordered list has lost.
         self.attachments = dict(attachments or {})
+
+
+class EditorCopied(Message):
+    """Posted when a drag over the composer finishes on a real selection.
+
+    Carries the text rather than leaving the app to re-read the widget: the
+    selection is live state, and by the time a message is delivered a later
+    keystroke may already have moved the caret — which, through
+    ``TextArea._watch_selection``, is exactly the thing that collapses it. The
+    same "ride the message" rule as :class:`EditorSubmitted`'s attachments.
+
+    Separate from ``TextSelected`` (the transcript's copy trigger) because the
+    composer never reaches ``Screen.selections`` at all; see
+    :meth:`Editor._copy_drag` for why. The app answers both with one
+    clipboard write and one toast, so the two gestures stay one behaviour.
+    """
+
+    def __init__(self, text: str) -> None:
+        super().__init__()
+        #: The document text the drag covered, as ``TextArea.selected_text``
+        #: reports it at release.
+        self.text = text
 
 
 class InterruptRequested(Message):
@@ -1404,17 +1430,73 @@ class Editor(TextArea):
         Runs BEFORE ``TextArea._on_mouse_up`` (Editor is first on the MRO), so
         the base class still finalises ``_selecting`` and releases the mouse
         afterwards; it never touches the selection, so nothing overwrites this.
+
+        The release is also where a drag over the composer becomes a COPY, for
+        the same reason it is in the transcript — see :meth:`_copy_drag` and
+        ``OperatorApp.on_text_selected``.
         """
         pressed = self._pressed_marker
         self._pressed_marker = None
-        if pressed is None:
+        # A press that became a drag keeps the range ``_on_mouse_move`` built:
+        # that range is the user's, not ours.
+        if pressed is not None and self.selection.start == self.selection.end:
+            row, start, end = pressed
+            self.selection = Selection((row, start), (row, end))
+            # Not a copy. This selection is the app's own doing — the user
+            # clicked one marker, which means "act on this chip" (the gesture
+            # exists so backspace can delete it whole), not "take a copy of
+            # it". Copying here would put text on the clipboard and raise a
+            # receipt for it on a CLICK, which is precisely the noise
+            # :meth:`_copy_drag` avoids by ignoring collapsed selections.
             return
-        if self.selection.start != self.selection.end:
-            # The press became a drag — ``_on_mouse_move`` has been extending a
-            # range the whole time, and that range is the user's, not ours.
+        self._copy_drag()
+
+    def _copy_drag(self) -> None:
+        """Put a composer drag on the clipboard, exactly as the transcript does.
+
+        Reported from the field: text highlighted in the composer "doesn't copy
+        properly" — the drag paints a highlight and the clipboard keeps whatever
+        it held before. Both halves of the app's copy story miss this widget:
+
+        * **The release does not reach the app.** ``OperatorApp.on_text_selected``
+          copies ``Screen.get_selected_text()``, but a ``TextArea`` never
+          contributes to a screen selection. ``TextArea._watch_selection`` calls
+          ``app.clear_selection()`` on every caret move, and the mouse-down that
+          begins a composer drag moves the caret — so ``Screen.selections`` is
+          wiped on the first event of the gesture and stays empty for the rest
+          of it. Measured before this fix: after a drag over the composer,
+          ``editor.selected_text`` was ``'summarise the inges'`` while
+          ``screen.get_selected_text()`` was ``None`` and the clipboard was ``''``.
+          The base class also captures the mouse on press, so ``Screen``'s own
+          select machinery is bypassed and ``_select_state`` never leaves ``None``.
+
+        * **No key can rescue it.** ``TextArea`` binds ``ctrl+c,super+c`` to
+          ``action_copy``, and neither key arrives: cmd+C is eaten by the
+          terminal (Ghostty binds ``super+c=copy_to_clipboard:mixed`` without
+          ``performable:``), and Ctrl+C is consumed by :meth:`_on_key` as this
+          app's interrupt before any binding runs. That is deliberate — the
+          interrupt cannot become conditional on a live highlight — so the
+          composer is left with a highlight and no way to spend it.
+
+        The fix is the rule the transcript already states: **the release IS the
+        copy**. The gesture carries itself, the user gets the same toast, and no
+        key changes meaning.
+
+        Only a real range copies. A plain click leaves ``start == end`` and is
+        not a copy — nor is the marker click above, which the caller returns on
+        before reaching here because that selection is the app's, made so
+        backspace can delete the chip whole.
+
+        ``selected_text`` is the DOCUMENT's text, which is the right claim for
+        an input: what a user copies out of a field is what they typed and can
+        paste back, so an attachment marker copies as the ``[Image #1, …]`` text
+        that cites it — the same characters :meth:`_submit` would send, and the
+        ones that re-cite the image if pasted into another draft.
+        """
+        text = self.selected_text
+        if not text:
             return
-        row, start, end = pressed
-        self.selection = Selection((row, start), (row, end))
+        self.post_message(EditorCopied(text))
 
     # -- paste ----------------------------------------------------------------
     async def _on_paste(self, event: events.Paste) -> None:

--- a/local_operator/tui/widgets/editor.py
+++ b/local_operator/tui/widgets/editor.py
@@ -584,11 +584,13 @@ class Editor(TextArea):
         #: that begins inside a marker has to stay a drag. See
         #: :meth:`_on_mouse_up`.
         self._pressed_marker: tuple[int, int, int] | None = None
-        #: The text of the copy this widget most recently announced, held only
-        #: until the buffer is edited. It is the SUBJECT of the receipt on
-        #: screen: once the user types over what they highlighted, the card is
-        #: making a claim about characters that are gone. See :meth:`edit`.
-        self._copied_text: str | None = None
+        #: Whether this widget has announced a copy that the buffer has not yet
+        #: been edited past. The receipt on screen is a claim about text the
+        #: user can see, so the first edit after a copy withdraws it. A flag and
+        #: not the text itself: nothing reads the content, and holding the
+        #: user's copied draft on the widget buys nothing (review round 2, F9).
+        #: See :meth:`edit` and :meth:`load_text`.
+        self._copied = False
         self.set_commands(commands or [])
 
     def render_line(self, y: int) -> Strip:
@@ -1541,7 +1543,7 @@ class Editor(TextArea):
         text = self.selected_text
         if not text:
             return
-        self._copied_text = text
+        self._copied = True
         self.post_message(EditorCopied(text))
 
     # -- paste ----------------------------------------------------------------
@@ -1738,10 +1740,10 @@ class Editor(TextArea):
         # five seconds (design round 1, D3). The clipboard keeps what it took
         # — that is what a copy IS, and silently un-copying would be worse —
         # but the CLAIM is retired the moment its subject is edited away.
-        stale_receipt = self._copied_text is not None
+        stale_receipt = self._copied
         result = super().edit(edit)
         if stale_receipt:
-            self._copied_text = None
+            self._copied = False
             self.post_message(EditorCopyStale())
         self._sync_picker()
         if touched:
@@ -1797,6 +1799,20 @@ class Editor(TextArea):
         return touched
 
     def load_text(self, text: str) -> None:
+        """Whole-buffer replacement — the OTHER mutation funnel.
+
+        ``edit()`` does not run for this path (Textual's ``text`` setter calls
+        ``load_text`` directly), so the copy receipt has to be stood down here
+        too. Without it the flag survived every submit, ``/clear``, history
+        step and ``begin_model_query``, and the next keystroke — whenever it
+        came — withdrew whatever receipt happened to be on screen by then
+        (review round 2, F5).
+
+        No ``EditorCopyStale`` is posted: replacing the buffer is not the user
+        editing the text their receipt describes, and the card, if it is still
+        up, is about a copy that remains perfectly true.
+        """
+        self._copied = False
         super().load_text(text)
         self._sync_picker()
 

--- a/local_operator/tui/widgets/editor.py
+++ b/local_operator/tui/widgets/editor.py
@@ -349,6 +349,21 @@ class EditorSubmitted(Message):
         self.attachments = dict(attachments or {})
 
 
+class EditorCopyStale(Message):
+    """Posted when the buffer is edited after a copy receipt was raised.
+
+    The receipt is a claim about text the user can see. Editing that text makes
+    the claim false while it is still on screen, so the app drops the card —
+    the clipboard is untouched, only the assertion about it is withdrawn.
+
+    Carries nothing: "what I said a moment ago no longer holds" needs no
+    payload, and the app decides whether a card of its own is still showing.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+
+
 class EditorCopied(Message):
     """Posted when a drag over the composer finishes on a real selection.
 
@@ -569,6 +584,11 @@ class Editor(TextArea):
         #: that begins inside a marker has to stay a drag. See
         #: :meth:`_on_mouse_up`.
         self._pressed_marker: tuple[int, int, int] | None = None
+        #: The text of the copy this widget most recently announced, held only
+        #: until the buffer is edited. It is the SUBJECT of the receipt on
+        #: screen: once the user types over what they highlighted, the card is
+        #: making a claim about characters that are gone. See :meth:`edit`.
+        self._copied_text: str | None = None
         self.set_commands(commands or [])
 
     def render_line(self, y: int) -> Strip:
@@ -1491,11 +1511,37 @@ class Editor(TextArea):
         an input: what a user copies out of a field is what they typed and can
         paste back, so an attachment marker copies as the ``[Image #1, …]`` text
         that cites it — the same characters :meth:`_submit` would send, and the
-        ones that re-cite the image if pasted into another draft.
+        ones that re-cite the image if pasted into another draft. In a read-only
+        composer (subagent view) that text is the app's rather than the user's,
+        and it copies too: what the field shows is what a drag over it takes.
+
+        Only THIS widget's own drag copies, which ``_selecting`` is the record
+        of — ``TextArea._on_mouse_down`` sets it and ``TextArea._on_mouse_up``
+        clears it, and this runs in between (review round 1, F1/F2). Without
+        that gate every mouse-up delivered here copies, and two of them are not
+        copy gestures at all:
+
+        * A drag that STARTS in the transcript and is released over the composer
+          — the ordinary way to select to the end of the answer, since the
+          composer is docked below it. ``TextArea`` leaves a selection live
+          after its own drag, so the composer still holds the last range the
+          user highlighted in it, and re-copying that range overwrites the
+          transcript copy the same release just made. Measured: the user dragged
+          the agent's answer and got their own draft, with a toast confirming
+          it.
+        * A bare mouse-up over a selection made with shift+arrows, which no
+          mouse gesture asked to copy.
+
+        A guard phrased as "did the PRESS land in this widget" would fix the
+        first and miss the second; ``_selecting`` answers the question that
+        actually matters, which is whether this widget is mid-drag.
         """
+        if not self._selecting:
+            return
         text = self.selected_text
         if not text:
             return
+        self._copied_text = text
         self.post_message(EditorCopied(text))
 
     # -- paste ----------------------------------------------------------------
@@ -1685,7 +1731,18 @@ class Editor(TextArea):
         # touched. Both halves are measured BEFORE the edit, because afterwards
         # the range is gone and the citation positions have moved.
         touched = self._attachments_touched_by(edit)
+        # Select-to-overwrite is the commonest edit in any input, and after this
+        # widget started copying on release it also became a clipboard write:
+        # the user drags a word to replace it, types, and a receipt asserting a
+        # copy of characters that no longer exist sits on screen for another
+        # five seconds (design round 1, D3). The clipboard keeps what it took
+        # — that is what a copy IS, and silently un-copying would be worse —
+        # but the CLAIM is retired the moment its subject is edited away.
+        stale_receipt = self._copied_text is not None
         result = super().edit(edit)
+        if stale_receipt:
+            self._copied_text = None
+            self.post_message(EditorCopyStale())
         self._sync_picker()
         if touched:
             self._release_uncited(touched)

--- a/local_operator/tui/widgets/toast.py
+++ b/local_operator/tui/widgets/toast.py
@@ -195,6 +195,10 @@ class Toast(Static):
         #: to a receipt for something they just did. Guards the slot; see
         #: :meth:`show`.
         self._actionable = False
+        #: A courtesy notice that arrived while an actionable one held the slot,
+        #: as ``(text, duration_ms)``. Shown when the slot frees; see
+        #: :meth:`show` and :meth:`dismiss_toast`.
+        self._deferred: tuple[str | Text, int] | None = None
         #: Bumped by every :meth:`show`. Lets a caller name the card IT raised
         #: and act on it only while that card is still the one on screen — a
         #: message string cannot do this, because two notices can word
@@ -264,7 +268,16 @@ class Toast(Static):
         chance to be seen.
         """
         if yield_to_actionable and self._actionable:
+            # Held, not dropped. A deferred receipt is still an acknowledgement
+            # the user is owed: the copy really happened, and without this the
+            # gesture goes entirely unacknowledged — the failure is dismissed
+            # and nothing ever says the text was taken (design round 2, D9).
+            # Only the LATEST is kept: an older receipt is superseded news, and
+            # a queue of them would march the card down the screen, which is
+            # the stacking this widget exists to avoid.
+            self._deferred = (text, duration_ms)
             return
+        self._deferred = None
         self._stop_timer()
         self._generation += 1
         #: Only an actionable notice claims the slot against a courtesy one.
@@ -298,6 +311,15 @@ class Toast(Static):
         self._message = ""
         self._actionable = False
         self.update("")
+        # The slot is free, so a receipt that deferred to this card gets its
+        # turn — the acknowledgement is late rather than lost. Read and cleared
+        # before the call because `show` writes the field itself, and the
+        # actionable hold is already released above, so this one cannot defer
+        # again and recurse.
+        deferred, self._deferred = self._deferred, None
+        if deferred is not None:
+            text, duration_ms = deferred
+            self.show(text, duration_ms=duration_ms)
 
     def on_unmount(self) -> None:
         """Teardown must not leave a live timer behind (see the module note)."""

--- a/local_operator/tui/widgets/toast.py
+++ b/local_operator/tui/widgets/toast.py
@@ -321,9 +321,18 @@ class Toast(Static):
 
         **The hold is dropped FIRST.** ``dismiss_toast`` promotes whatever is
         held, so dismissing first would raise the very card being withdrawn and
-        then find the hold already consumed. Reachable whenever one owner has a
-        card showing and another held, which is the shipped
-        failure-notice-plus-copy state (review round 5, F15).
+        then find the hold already consumed.
+
+        This bites only when ONE owner has a card showing and another of its
+        own held, which today cannot happen: holding requires the showing card
+        to be actionable, and the only owned card the app raises is a copy
+        receipt at ``TOAST_DEFAULT_MS``. So the order is defensive, not a live
+        fix — it is the right order the moment any owner raises an actionable
+        card, and the test that pins it constructs that state directly rather
+        than waiting for a caller to make it reachable (review round 5, F15;
+        corrected in round 6, F19 — the earlier note claimed the shipped
+        failure-plus-copy state, where the owners differ and the swap is in
+        fact harmless).
         """
         if owner is None:
             raise ValueError("withdraw() needs an owner; None is every unowned card")

--- a/local_operator/tui/widgets/toast.py
+++ b/local_operator/tui/widgets/toast.py
@@ -294,6 +294,20 @@ class Toast(Static):
         self._refit()
         self._timer = self.set_timer(duration_ms / 1000, self.dismiss_toast)
 
+    def drop_deferred(self) -> None:
+        """Forget a held card that has stopped being worth showing.
+
+        The counterpart to the hold in :meth:`show`: a deferred notice is news
+        waiting for a slot, and news can go stale before it gets one. The copy
+        receipt does exactly that \u2014 the text it describes can be typed over
+        while an MCP failure is still holding the slot \u2014 and a card that is
+        already false when it is painted is worse than one that never appears.
+
+        Idempotent, and silent when nothing is held: a caller withdrawing a
+        claim should not have to know whether it was ever queued.
+        """
+        self._deferred = None
+
     def dismiss_toast(self) -> None:
         """Hide the card and drop its timer (idempotent).
 

--- a/local_operator/tui/widgets/toast.py
+++ b/local_operator/tui/widgets/toast.py
@@ -195,6 +195,11 @@ class Toast(Static):
         #: to a receipt for something they just did. Guards the slot; see
         #: :meth:`show`.
         self._actionable = False
+        #: Bumped by every :meth:`show`. Lets a caller name the card IT raised
+        #: and act on it only while that card is still the one on screen — a
+        #: message string cannot do this, because two notices can word
+        #: themselves identically. See :attr:`generation`.
+        self._generation = 0
         # The plain text currently showing. Kept alongside the renderable
         # because Textual's content accessor is a version-specific internal, and
         # "what is this toast saying" is a question both the tests and a future
@@ -212,6 +217,22 @@ class Toast(Static):
     def message(self) -> str:
         """What the card is saying right now; empty once dismissed."""
         return self._message
+
+    @property
+    def generation(self) -> int:
+        """Which card is showing, as a value a caller can hold on to.
+
+        A caller that raises a notice and may later want to withdraw it keeps
+        this and compares before dismissing, so it can only ever retire its own
+        card: any intervening ``show`` moves the counter. The alternative —
+        matching on the message text — cannot tell two identically worded
+        notices apart, which is how a composer edit came to dismiss the
+        transcript's copy receipt (review round 2, F5).
+
+        ``0`` while nothing has ever been shown, and unchanged by a ``show``
+        that declined the slot.
+        """
+        return self._generation
 
     @property
     def content_cells(self) -> int:
@@ -245,6 +266,7 @@ class Toast(Static):
         if yield_to_actionable and self._actionable:
             return
         self._stop_timer()
+        self._generation += 1
         #: Only an actionable notice claims the slot against a courtesy one.
         #: Set from the DURATION rather than a severity name, for the same
         #: reason the durations are: `TOAST_FAILURE_MS` is the app's one marker

--- a/local_operator/tui/widgets/toast.py
+++ b/local_operator/tui/widgets/toast.py
@@ -314,8 +314,19 @@ class Toast(Static):
 
         Ownership is the whole check. The slot is shared, so an unqualified
         withdrawal lets evidence about one gesture discard another's notice
-        (review round 4, F14).
+        (review round 4, F14). ``None`` is not an owner: it is the tag every
+        card that named no owner carries, so accepting it here would retire an
+        unread MCP failure on a one-word mistake that typechecks and passes the
+        suite — D2 restored for the third time (review round 5, F17).
+
+        **The hold is dropped FIRST.** ``dismiss_toast`` promotes whatever is
+        held, so dismissing first would raise the very card being withdrawn and
+        then find the hold already consumed. Reachable whenever one owner has a
+        card showing and another held, which is the shipped
+        failure-notice-plus-copy state (review round 5, F15).
         """
+        if owner is None:
+            raise ValueError("withdraw() needs an owner; None is every unowned card")
         self.drop_deferred(owner)
         if self.display and self._owner is owner:
             self.dismiss_toast()
@@ -337,7 +348,11 @@ class Toast(Static):
 
         Idempotent, and silent when nothing of theirs is held: a caller
         withdrawing a claim should not have to know whether it was ever queued.
+
+        ``None`` is refused for the same reason :meth:`withdraw` refuses it.
         """
+        if owner is None:
+            raise ValueError("drop_deferred() needs an owner; None is every unowned card")
         if self._deferred is not None and self._deferred[2] is owner:
             self._deferred = None
 
@@ -357,6 +372,10 @@ class Toast(Static):
         self.display = False
         self._message = ""
         self._actionable = False
+        # Hygiene, not logic: the only reader of `_owner` is gated on
+        # `display`, which is now False, and a promotion overwrites it a moment
+        # later anyway. Cleared so a hidden card does not sit there claiming an
+        # owner — no test can distinguish it, and it should stay.
         self._owner = None
         self.update("")
         # The slot is free, so a receipt that deferred to this card gets its

--- a/local_operator/tui/widgets/toast.py
+++ b/local_operator/tui/widgets/toast.py
@@ -191,6 +191,10 @@ class Toast(Static):
         # reserve a row of the transcript it overlays.
         self.display = False
         self._timer = None
+        #: Whether what is showing is a notice the user must ACT on, as opposed
+        #: to a receipt for something they just did. Guards the slot; see
+        #: :meth:`show`.
+        self._actionable = False
         # The plain text currently showing. Kept alongside the renderable
         # because Textual's content accessor is a version-specific internal, and
         # "what is this toast saying" is a question both the tests and a future
@@ -214,14 +218,38 @@ class Toast(Static):
         """Cells available to TEXT inside the card at the current width."""
         return max(1, toast_max_width(self.app.size.width) - TOAST_PADDING_CELLS)
 
-    def show(self, text: str | Text, *, duration_ms: int = TOAST_DEFAULT_MS) -> None:
+    def show(
+        self,
+        text: str | Text,
+        *,
+        duration_ms: int = TOAST_DEFAULT_MS,
+        yield_to_actionable: bool = False,
+    ) -> None:
         """Replace whatever is showing, and re-arm the dismissal timer.
 
         Replacement is the point: the previous timer is stopped before the new
         one is set, so a second toast can never dismiss the first one's
         successor early.
+
+        ``yield_to_actionable`` marks a caller as a COURTESY receipt — news the
+        user already knows, because they are the one who just did the thing.
+        Such a card stands down while an actionable notice is up rather than
+        taking the slot. The single slot was sized for startup-scale events;
+        once a routine gesture can write it (the copy receipt), an MCP failure
+        naming a server and an error the user has not read yet could be evicted
+        by a drag in the composer — and startup is exactly when someone is
+        typing their first prompt (design round 1, D2). The gesture's own
+        feedback is the highlight and the clipboard; the failure has no second
+        chance to be seen.
         """
+        if yield_to_actionable and self._actionable:
+            return
         self._stop_timer()
+        #: Only an actionable notice claims the slot against a courtesy one.
+        #: Set from the DURATION rather than a severity name, for the same
+        #: reason the durations are: `TOAST_FAILURE_MS` is the app's one marker
+        #: for "the user has to act on this".
+        self._actionable = duration_ms >= TOAST_FAILURE_MS
         self._message = text.plain if isinstance(text, Text) else text
         self.update(text)
         # `dismiss_toast` resets the inline pointer before hiding; a reused
@@ -246,6 +274,7 @@ class Toast(Static):
         self.styles.pointer = "default"
         self.display = False
         self._message = ""
+        self._actionable = False
         self.update("")
 
     def on_unmount(self) -> None:

--- a/local_operator/tui/widgets/toast.py
+++ b/local_operator/tui/widgets/toast.py
@@ -196,9 +196,14 @@ class Toast(Static):
         #: :meth:`show`.
         self._actionable = False
         #: A courtesy notice that arrived while an actionable one held the slot,
-        #: as ``(text, duration_ms)``. Shown when the slot frees; see
-        #: :meth:`show` and :meth:`dismiss_toast`.
-        self._deferred: tuple[str | Text, int] | None = None
+        #: as ``(text, duration_ms, owner)``. Shown when the slot frees; see
+        #: :meth:`show` and :meth:`dismiss_toast`. The owner is an opaque tag
+        #: supplied by the caller so a withdrawal can name its OWN held card
+        #: (:meth:`withdraw`) — one slot serves every caller, and evidence
+        #: about one gesture must not discard another's notice.
+        self._deferred: tuple[str | Text, int, object | None] | None = None
+        #: Who raised the card currently showing (see :meth:`show`), or None.
+        self._owner: object | None = None
         #: Bumped by every :meth:`show`. Lets a caller name the card IT raised
         #: and act on it only while that card is still the one on screen — a
         #: message string cannot do this, because two notices can word
@@ -249,6 +254,7 @@ class Toast(Static):
         *,
         duration_ms: int = TOAST_DEFAULT_MS,
         yield_to_actionable: bool = False,
+        owner: object | None = None,
     ) -> None:
         """Replace whatever is showing, and re-arm the dismissal timer.
 
@@ -275,11 +281,14 @@ class Toast(Static):
             # Only the LATEST is kept: an older receipt is superseded news, and
             # a queue of them would march the card down the screen, which is
             # the stacking this widget exists to avoid.
-            self._deferred = (text, duration_ms)
+            self._deferred = (text, duration_ms, owner)
             return
         self._deferred = None
         self._stop_timer()
         self._generation += 1
+        #: Who raised the card now showing, for the same reason the deferred
+        #: tuple carries one: a caller may only withdraw its own.
+        self._owner = owner
         #: Only an actionable notice claims the slot against a courtesy one.
         #: Set from the DURATION rather than a severity name, for the same
         #: reason the durations are: `TOAST_FAILURE_MS` is the app's one marker
@@ -294,8 +303,25 @@ class Toast(Static):
         self._refit()
         self._timer = self.set_timer(duration_ms / 1000, self.dismiss_toast)
 
-    def drop_deferred(self) -> None:
-        """Forget a held card that has stopped being worth showing.
+    def withdraw(self, owner: object) -> None:
+        """Retire ``owner``'s card, whether it is SHOWING or still held.
+
+        One entry point for both, because a caller withdrawing a claim should
+        not have to know which state its card reached — and getting that wrong
+        is a real bug rather than an inelegance: a receipt that was deferred
+        and then promoted when the slot freed became unretirable, so an edit
+        could no longer falsify it (review round 4).
+
+        Ownership is the whole check. The slot is shared, so an unqualified
+        withdrawal lets evidence about one gesture discard another's notice
+        (review round 4, F14).
+        """
+        self.drop_deferred(owner)
+        if self.display and self._owner is owner:
+            self.dismiss_toast()
+
+    def drop_deferred(self, owner: object) -> None:
+        """Forget a held card of ``owner``'s that stopped being worth showing.
 
         The counterpart to the hold in :meth:`show`: a deferred notice is news
         waiting for a slot, and news can go stale before it gets one. The copy
@@ -303,10 +329,17 @@ class Toast(Static):
         while an MCP failure is still holding the slot \u2014 and a card that is
         already false when it is painted is worse than one that never appears.
 
-        Idempotent, and silent when nothing is held: a caller withdrawing a
-        claim should not have to know whether it was ever queued.
+        Withdraws only what ``owner`` put there. The slot is shared, so an
+        unqualified drop let evidence about ONE gesture discard another's held
+        card: a composer edit threw away a transcript copy's receipt, which was
+        still perfectly true (review round 4, F14). Same rule, and the same
+        failure, as the showing card's generation check.
+
+        Idempotent, and silent when nothing of theirs is held: a caller
+        withdrawing a claim should not have to know whether it was ever queued.
         """
-        self._deferred = None
+        if self._deferred is not None and self._deferred[2] is owner:
+            self._deferred = None
 
     def dismiss_toast(self) -> None:
         """Hide the card and drop its timer (idempotent).
@@ -324,6 +357,7 @@ class Toast(Static):
         self.display = False
         self._message = ""
         self._actionable = False
+        self._owner = None
         self.update("")
         # The slot is free, so a receipt that deferred to this card gets its
         # turn — the acknowledgement is late rather than lost. Read and cleared
@@ -332,8 +366,8 @@ class Toast(Static):
         # again and recurse.
         deferred, self._deferred = self._deferred, None
         if deferred is not None:
-            text, duration_ms = deferred
-            self.show(text, duration_ms=duration_ms)
+            text, duration_ms, owner = deferred
+            self.show(text, duration_ms=duration_ms, owner=owner)
 
     def on_unmount(self) -> None:
         """Teardown must not leave a live timer behind (see the module note)."""

--- a/tests/unit/tui/test_toast.py
+++ b/tests/unit/tui/test_toast.py
@@ -674,8 +674,13 @@ async def test_withdrawing_drops_the_hold_before_dismissing_the_card() -> None:
 
     `dismiss_toast` PROMOTES whatever is held. So if `withdraw` dismissed
     first, it would raise the very card it is withdrawing and then find the
-    hold already consumed — leaving the claim on screen. Reachable whenever one
-    owner holds both cards (review round 5, F15).
+    hold already consumed — leaving the claim on screen (review round 5, F15).
+
+    The state is constructed directly because no caller reaches it yet: holding
+    requires the showing card to be actionable, and the only owned card the app
+    raises is a copy receipt at `TOAST_DEFAULT_MS`. That is the point — the
+    order is correct defensively, and this pins it before the first owner that
+    would make the hazard live (round 6, F19).
 
     Swapping the two statements leaves every other test in the suite passing,
     which is exactly why this one exists.

--- a/tests/unit/tui/test_toast.py
+++ b/tests/unit/tui/test_toast.py
@@ -449,7 +449,121 @@ async def test_the_generation_names_the_card_that_is_showing() -> None:
         assert toast.generation == held
 
         # Unchanged by dismissal, so a held value can never come to match a
-        # later card by accident.
+        # later card by accident. Dismissed twice: the first frees the slot and
+        # lets the deferred receipt take its turn (which is a new card, and so
+        # a new generation), the second retires that.
         toast.dismiss_toast()
         await pilot.pause()
-        assert toast.generation == held
+        assert toast.message == "copied 9 characters"
+        after_deferred = toast.generation
+        assert after_deferred == held + 1
+        toast.dismiss_toast()
+        await pilot.pause()
+        assert toast.generation == after_deferred
+
+
+@pytest.mark.asyncio
+async def test_a_deferred_courtesy_card_gets_its_turn_when_the_slot_frees() -> None:
+    """Held, not dropped: the acknowledgement is late rather than lost.
+
+    Deferring fixed the eviction, but it left the copy with no feedback at all
+    — the failure was dismissed and nothing ever said the text had been taken
+    (design round 2, D9). The user had dragged, seen nothing, and the notice
+    they were reading disappeared.
+    """
+    async with ToastApp().run_test(size=(80, 24)) as pilot:
+        toast = pilot.app.query_one(Toast)
+        toast.show("⊙ MCP failed: github", duration_ms=TOAST_FAILURE_MS)
+        await pilot.pause()
+
+        toast.show("copied 9 characters", yield_to_actionable=True)
+        await pilot.pause()
+        assert toast.message == "⊙ MCP failed: github"
+
+        toast.dismiss_toast()
+        await pilot.pause()
+
+        assert toast.message == "copied 9 characters"
+        assert toast.display
+
+
+@pytest.mark.asyncio
+async def test_only_the_latest_deferred_card_is_kept() -> None:
+    """Superseded news is not owed a turn.
+
+    Three drags behind one failure notice must not march three cards down the
+    screen afterwards — that is the stacking the single slot exists to prevent.
+    """
+    async with ToastApp().run_test(size=(80, 24)) as pilot:
+        toast = pilot.app.query_one(Toast)
+        toast.show("⊙ MCP failed: github", duration_ms=TOAST_FAILURE_MS)
+        await pilot.pause()
+        for message in ("copied 3 characters", "copied 5 characters", "copied 9 characters"):
+            toast.show(message, yield_to_actionable=True)
+            await pilot.pause()
+
+        toast.dismiss_toast()
+        await pilot.pause()
+        assert toast.message == "copied 9 characters"
+
+        # ...and exactly one card is owed. The next dismissal ends it rather
+        # than uncovering another receipt.
+        toast.dismiss_toast()
+        await pilot.pause()
+        assert toast.message == ""
+        assert toast.display is False
+
+
+@pytest.mark.asyncio
+async def test_a_deferred_card_does_not_defer_to_itself() -> None:
+    """The hold is released before the deferred card is shown.
+
+    Dismissal clears `_actionable` first, so the card taking its turn cannot
+    find the slot still held and re-defer — which would either lose it after
+    all or, worse, recurse.
+    """
+    async with ToastApp().run_test(size=(80, 24)) as pilot:
+        toast = pilot.app.query_one(Toast)
+        toast.show("⊙ MCP failed: github", duration_ms=TOAST_FAILURE_MS)
+        await pilot.pause()
+        toast.show("copied 9 characters", yield_to_actionable=True)
+        await pilot.pause()
+
+        toast.dismiss_toast()
+        await pilot.pause()
+
+        assert toast.message == "copied 9 characters"
+        assert toast._deferred is None
+        # A courtesy card is not itself actionable, so the slot is takeable.
+        toast.show("copied 4 characters", yield_to_actionable=True)
+        await pilot.pause()
+        assert toast.message == "copied 4 characters"
+
+
+@pytest.mark.asyncio
+async def test_a_card_that_actually_showed_clears_the_deferred_one() -> None:
+    """A receipt that got its own turn is not also owed a later one.
+
+    Without clearing the hold on an accepted `show`, a copy deferred behind a
+    failure would resurface after some unrelated notice minutes later — a
+    receipt for a copy the user made long ago, arriving with no gesture behind
+    it.
+    """
+    async with ToastApp().run_test(size=(80, 24)) as pilot:
+        toast = pilot.app.query_one(Toast)
+        toast.show("⊙ MCP failed: github", duration_ms=TOAST_FAILURE_MS)
+        await pilot.pause()
+        toast.show("copied 9 characters", yield_to_actionable=True)
+        await pilot.pause()
+        assert toast._deferred is not None
+
+        # The failure is replaced by an ordinary notice rather than dismissed,
+        # so the slot never passes through `dismiss_toast`.
+        toast.show("⊙ MCP ready: 2 servers", duration_ms=TOAST_DEFAULT_MS)
+        await pilot.pause()
+        assert toast._deferred is None
+
+        toast.dismiss_toast()
+        await pilot.pause()
+        assert toast.message == ""
+        assert toast.display is False

--- a/tests/unit/tui/test_toast.py
+++ b/tests/unit/tui/test_toast.py
@@ -341,3 +341,115 @@ async def test_a_click_dismisses_the_card_early() -> None:
         assert toast.display is False
         assert toast._timer is None
         assert toast.message == ""
+
+
+# -- the slot's two guards ----------------------------------------------------
+#
+# Both exist because a routine editing gesture (a drag over the composer)
+# became able to write this card. A copy receipt is a COURTESY — the user did
+# the thing and can see the result — while an MCP failure names a server and an
+# error they have not read yet. So a courtesy card declines the slot rather
+# than taking it, and `generation` lets a caller withdraw its own card later
+# without being able to touch anyone else's.
+
+
+@pytest.mark.asyncio
+async def test_a_courtesy_card_declines_a_slot_an_actionable_notice_holds() -> None:
+    """The failure the user must act on outranks the receipt for what they did."""
+    async with ToastApp().run_test(size=(80, 24)) as pilot:
+        toast = pilot.app.query_one(Toast)
+        toast.show("⊙ MCP failed: github", duration_ms=TOAST_FAILURE_MS)
+        await pilot.pause()
+
+        toast.show("copied 9 characters", yield_to_actionable=True)
+        await pilot.pause()
+
+        assert toast.message == "⊙ MCP failed: github"
+
+
+@pytest.mark.asyncio
+async def test_a_courtesy_card_takes_a_slot_an_ordinary_notice_holds() -> None:
+    """The deference is to ACTIONABILITY, not to whatever happens to be showing.
+
+    Without this the test above would also pass if a courtesy card had simply
+    stopped being able to show at all.
+    """
+    async with ToastApp().run_test(size=(80, 24)) as pilot:
+        toast = pilot.app.query_one(Toast)
+        toast.show("⊙ MCP ready: 2 servers", duration_ms=TOAST_DEFAULT_MS)
+        await pilot.pause()
+
+        toast.show("copied 9 characters", yield_to_actionable=True)
+        await pilot.pause()
+
+        assert toast.message == "copied 9 characters"
+
+
+@pytest.mark.asyncio
+async def test_an_actionable_notice_is_never_refused_the_slot() -> None:
+    """`yield_to_actionable` is opt-in; a failure always gets through."""
+    async with ToastApp().run_test(size=(80, 24)) as pilot:
+        toast = pilot.app.query_one(Toast)
+        toast.show("⊙ MCP failed: github", duration_ms=TOAST_FAILURE_MS)
+        await pilot.pause()
+
+        toast.show("⊙ MCP failed: gitlab", duration_ms=TOAST_FAILURE_MS)
+        await pilot.pause()
+
+        assert toast.message == "⊙ MCP failed: gitlab"
+
+
+@pytest.mark.asyncio
+async def test_dismissing_clears_the_actionable_hold() -> None:
+    """A failure that has been read must not lock the slot for the session."""
+    async with ToastApp().run_test(size=(80, 24)) as pilot:
+        toast = pilot.app.query_one(Toast)
+        toast.show("⊙ MCP failed: github", duration_ms=TOAST_FAILURE_MS)
+        await pilot.pause()
+        toast.dismiss_toast()
+        await pilot.pause()
+
+        toast.show("copied 9 characters", yield_to_actionable=True)
+        await pilot.pause()
+
+        assert toast.message == "copied 9 characters"
+
+
+@pytest.mark.asyncio
+async def test_the_generation_names_the_card_that_is_showing() -> None:
+    """Each clause of `generation`'s contract, separately.
+
+    It is load-bearing for the copy receipt: the app holds the generation of
+    the card its own copy raised and dismisses only while that is still what is
+    on screen. Every clause below is independently falsifiable, and the third
+    is the one a real bug turned on — a copy made while a failure was up
+    adopted the FAILURE's generation and withdrew it on the next keystroke.
+    """
+    async with ToastApp().run_test(size=(80, 24)) as pilot:
+        toast = pilot.app.query_one(Toast)
+        # 0 before anything has ever been shown.
+        assert toast.generation == 0
+
+        # +1 per ACCEPTED show.
+        toast.show("first", duration_ms=TOAST_DEFAULT_MS)
+        await pilot.pause()
+        first = toast.generation
+        assert first == 1
+        toast.show("second", duration_ms=TOAST_DEFAULT_MS)
+        await pilot.pause()
+        assert toast.generation == 2
+
+        # UNCHANGED by a show that declined the slot: no card was raised, so
+        # there is nothing for a caller to name.
+        toast.show("⊙ MCP failed: github", duration_ms=TOAST_FAILURE_MS)
+        await pilot.pause()
+        held = toast.generation
+        toast.show("copied 9 characters", yield_to_actionable=True)
+        await pilot.pause()
+        assert toast.generation == held
+
+        # Unchanged by dismissal, so a held value can never come to match a
+        # later card by accident.
+        toast.dismiss_toast()
+        await pilot.pause()
+        assert toast.generation == held

--- a/tests/unit/tui/test_toast.py
+++ b/tests/unit/tui/test_toast.py
@@ -567,3 +567,162 @@ async def test_a_card_that_actually_showed_clears_the_deferred_one() -> None:
         await pilot.pause()
         assert toast.message == ""
         assert toast.display is False
+
+
+# -- withdrawal, by owner -----------------------------------------------------
+#
+# The slot is shared, so "retire my card" has to mean *mine*. Four bugs in this
+# PR (F5, D8, D14, F14) were all one signal reaching a card it did not own,
+# patched at four different layers; `withdraw(owner)` asks the question once.
+# These pin it at the widget, where the ownership actually lives — the
+# end-to-end tests in `test_transcript_selection.py` only ever exercise two
+# owners, so the cases that make ownership MEAN something are unpinned there
+# (review round 5, F16).
+
+#: Two distinct callers, as the app's own sentinels are.
+OWNER_A = object()
+OWNER_B = object()
+
+
+@pytest.mark.asyncio
+async def test_withdrawing_retires_a_showing_card_of_your_own() -> None:
+    async with ToastApp().run_test(size=(80, 24)) as pilot:
+        toast = pilot.app.query_one(Toast)
+        toast.show("mine", owner=OWNER_A)
+        await pilot.pause()
+
+        toast.withdraw(OWNER_A)
+        await pilot.pause()
+
+        assert toast.message == ""
+        assert toast.display is False
+
+
+@pytest.mark.asyncio
+async def test_withdrawing_leaves_someone_else_s_showing_card_alone() -> None:
+    async with ToastApp().run_test(size=(80, 24)) as pilot:
+        toast = pilot.app.query_one(Toast)
+        toast.show("theirs", owner=OWNER_B)
+        await pilot.pause()
+
+        toast.withdraw(OWNER_A)
+        await pilot.pause()
+
+        assert toast.message == "theirs"
+        assert toast.display
+
+
+@pytest.mark.asyncio
+async def test_withdrawing_leaves_someone_else_s_held_card_alone() -> None:
+    """...and it still gets its turn when the slot frees."""
+    async with ToastApp().run_test(size=(80, 24)) as pilot:
+        toast = pilot.app.query_one(Toast)
+        toast.show("⊙ MCP failed: github", duration_ms=TOAST_FAILURE_MS)
+        await pilot.pause()
+        toast.show("theirs", yield_to_actionable=True, owner=OWNER_B)
+        await pilot.pause()
+
+        toast.withdraw(OWNER_A)
+        await pilot.pause()
+        toast.dismiss_toast()
+        await pilot.pause()
+
+        assert toast.message == "theirs"
+
+
+@pytest.mark.asyncio
+async def test_withdrawing_drops_the_hold_without_touching_the_card_above_it() -> None:
+    """One owner showing, another held — the shipped failure-plus-copy state."""
+    async with ToastApp().run_test(size=(80, 24)) as pilot:
+        toast = pilot.app.query_one(Toast)
+        toast.show("⊙ MCP failed: github", duration_ms=TOAST_FAILURE_MS, owner=OWNER_B)
+        await pilot.pause()
+        toast.show("mine", yield_to_actionable=True, owner=OWNER_A)
+        await pilot.pause()
+
+        toast.withdraw(OWNER_A)
+        await pilot.pause()
+        assert toast.message == "⊙ MCP failed: github"
+
+        # The slot frees to nothing: the held card was withdrawn, not promoted.
+        toast.dismiss_toast()
+        await pilot.pause()
+        assert toast.message == ""
+        assert toast.display is False
+
+
+@pytest.mark.asyncio
+async def test_withdrawing_the_card_above_promotes_the_hold_beneath_it() -> None:
+    """The same state, withdrawn from the other side."""
+    async with ToastApp().run_test(size=(80, 24)) as pilot:
+        toast = pilot.app.query_one(Toast)
+        toast.show("⊙ MCP failed: github", duration_ms=TOAST_FAILURE_MS, owner=OWNER_B)
+        await pilot.pause()
+        toast.show("mine", yield_to_actionable=True, owner=OWNER_A)
+        await pilot.pause()
+
+        toast.withdraw(OWNER_B)
+        await pilot.pause()
+
+        assert toast.message == "mine"
+        assert toast.display
+
+
+@pytest.mark.asyncio
+async def test_withdrawing_drops_the_hold_before_dismissing_the_card() -> None:
+    """The order inside `withdraw` is load-bearing, in a reachable state.
+
+    `dismiss_toast` PROMOTES whatever is held. So if `withdraw` dismissed
+    first, it would raise the very card it is withdrawing and then find the
+    hold already consumed — leaving the claim on screen. Reachable whenever one
+    owner holds both cards (review round 5, F15).
+
+    Swapping the two statements leaves every other test in the suite passing,
+    which is exactly why this one exists.
+    """
+    async with ToastApp().run_test(size=(80, 24)) as pilot:
+        toast = pilot.app.query_one(Toast)
+        toast.show("mine, actionable", duration_ms=TOAST_FAILURE_MS, owner=OWNER_A)
+        await pilot.pause()
+        toast.show("mine, held", yield_to_actionable=True, owner=OWNER_A)
+        await pilot.pause()
+
+        toast.withdraw(OWNER_A)
+        await pilot.pause()
+
+        assert toast.message == ""
+        assert toast.display is False
+        assert toast._deferred is None
+
+
+@pytest.mark.asyncio
+async def test_withdrawing_nothing_is_silent() -> None:
+    async with ToastApp().run_test(size=(80, 24)) as pilot:
+        toast = pilot.app.query_one(Toast)
+
+        toast.withdraw(OWNER_A)
+        await pilot.pause()
+
+        assert toast.message == ""
+        assert toast.display is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("method", ["withdraw", "drop_deferred"])
+async def test_none_is_not_an_owner(method: str) -> None:
+    """`None` tags every card that named no owner, so it cannot address one.
+
+    Nothing calls it that way today, but it is a one-word mistake that
+    typechecks (`object` includes `None`) and would silently retire an unread
+    MCP failure — D2 for the third time (review round 5, F17).
+    """
+    async with ToastApp().run_test(size=(80, 24)) as pilot:
+        toast = pilot.app.query_one(Toast)
+        toast.show("⊙ MCP failed: github", duration_ms=TOAST_FAILURE_MS)
+        await pilot.pause()
+
+        with pytest.raises(ValueError):
+            getattr(toast, method)(None)
+
+        assert toast.message == "⊙ MCP failed: github"
+        assert toast.display

--- a/tests/unit/tui/test_transcript_selection.py
+++ b/tests/unit/tui/test_transcript_selection.py
@@ -1378,7 +1378,9 @@ async def test_one_line_and_its_break_is_not_reported_as_two_lines() -> None:
 
         assert app._clipboard == "first line here\n"
         assert toast.message != "copied 2 lines"
-        assert toast.message == "copied 15 characters"
+        # 16, not 15: the break is a character the clipboard carries. Cell-width
+        # counting scored it 0 and reported 15 (design round 2, D10).
+        assert toast.message == "copied 16 characters"
 
 
 @pytest.mark.asyncio
@@ -1479,3 +1481,154 @@ async def test_typing_does_not_dismiss_a_notice_that_is_not_a_copy_receipt() -> 
         await pilot.pause()
 
         assert toast.message.startswith("mcp: failed")
+
+
+# -- whose receipt is it? (review round 2 F5/F9, design round 2 D8) -----------
+#
+# The D3 retirement first asked whether the card's message started with
+# `copied `, which cannot tell one receipt from another — a transcript copy
+# raises a `copied …` card too. So turning to the composer and typing the next
+# prompt withdrew a claim that was still perfectly true. The app now remembers
+# the `Toast.generation` of the card the COMPOSER's copy raised, and retires
+# that card and no other.
+
+
+@pytest.mark.asyncio
+async def test_typing_does_not_retire_the_transcript_s_copy_receipt() -> None:
+    """A transcript copy is not falsified by typing in the composer.
+
+    Copy an answer, turn to the composer to write the follow-up, and the
+    receipt for the answer must survive the first keystroke: nothing about that
+    copy went stale, and the composer never touched the text it describes.
+    """
+    app = _pilot_app()
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        block = await _seeded(app, pilot)
+        editor = await _composer(app, pilot, "summarise the ingest path please")
+        toast = app.query_one(Toast)
+
+        # A composer copy FIRST, so the editor is armed exactly as it would be
+        # in use — this is the state that made the old prefix check misfire.
+        await _composer_drag(app, pilot, _cell(editor, 0, 14), _cell(editor, 0, 20))
+        assert toast.message == "copied 6 characters"
+
+        await _drag(app, pilot, (block.region.x, block.region.y), (79, 23))
+        transcript_receipt = toast.message
+        assert transcript_receipt == "copied 3 lines"
+
+        editor.focus()
+        await pilot.press("h")
+        await pilot.pause()
+
+        assert toast.message == transcript_receipt
+        assert toast.display
+
+
+@pytest.mark.asyncio
+async def test_replacing_the_buffer_disarms_the_receipt() -> None:
+    """`load_text` is the other mutation funnel, and it must stand the flag down.
+
+    Textual's ``text`` setter calls ``load_text`` directly, so ``edit()`` never
+    runs for a submit, a `/clear`, a history step or `begin_model_query`. The
+    flag survived all of them, and the next keystroke — whenever it came, and
+    whatever was on screen by then — withdrew that card (review round 2, F5).
+    """
+    app = _pilot_app()
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        editor = await _composer(app, pilot, "summarise the ingest path please")
+        toast = app.query_one(Toast)
+
+        await _composer_drag(app, pilot, _cell(editor, 0, 14), _cell(editor, 0, 20))
+        assert editor._copied, "the copy must arm the flag for this to mean anything"
+
+        editor.clear_content()
+        await pilot.pause()
+        assert not editor._copied
+
+        # A card raised after the buffer was replaced is not this copy's, so
+        # typing must leave it alone.
+        toast.show("mcp: 2 connected (14 tools)")
+        await pilot.pause()
+        await pilot.press("h")
+        await pilot.pause()
+
+        assert toast.message == "mcp: 2 connected (14 tools)"
+
+
+# -- what the number counts (review round 2 F6/F7, design round 2 D10) --------
+
+
+@pytest.mark.asyncio
+async def test_a_line_and_its_break_is_not_reported_as_zero_characters() -> None:
+    """`cell_len` scores a newline 0, so a real copy announced nothing.
+
+    "Select this line" puts a trailing break on the clipboard, which
+    `splitlines()` still counts as one line — so it takes the character branch,
+    and under cell-width counting the receipt read `copied 0 characters` for a
+    genuine clipboard write (design round 2, D10). A receipt that says 0 reads
+    as a failure.
+    """
+    app = _pilot_app()
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        editor = await _composer(app, pilot, "first line here\nsecond line here")
+        toast = app.query_one(Toast)
+
+        await _composer_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 1, 0))
+
+        assert app._clipboard == "first line here\n"
+        assert toast.message == "copied 16 characters"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("draft", "columns", "expected"),
+    [
+        ("👍 ok", 2, "copied 1 character"),
+        ("日本語 text", 3, "copied 1 character"),
+    ],
+)
+async def test_a_wide_glyph_counts_as_the_one_character_it_is(
+    draft: str, columns: int, expected: str
+) -> None:
+    """The word `characters` has to mean characters.
+
+    Cells were tried first, on the theory that the receipt should count what is
+    painted. But an emoji is ONE glyph the user highlighted and `cell_len` calls
+    it two, and a tab is scored 0 while the editor paints it expanded — so cell
+    width matched the frame only where it already matched `len` (review round 2,
+    F6). The reason given for the count now has a test that decides it.
+    """
+    app = _pilot_app()
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        editor = await _composer(app, pilot, draft)
+        toast = app.query_one(Toast)
+
+        await _composer_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, columns))
+
+        assert toast.message == expected
+
+
+@pytest.mark.asyncio
+async def test_a_sub_line_transcript_copy_is_counted_in_characters_too() -> None:
+    """The receipt is shared, so the transcript's wording changed as well.
+
+    Deliberate and consistent with the composer — the unit follows the shape of
+    the selection wherever it was made — but it was changed behaviour with no
+    test asserting it (review round 2, F7).
+    """
+    app = _pilot_app()
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        block = await _seeded(app, pilot)
+        toast = app.query_one(Toast)
+
+        await _drag(
+            app, pilot, (block.region.x, block.region.y), (block.region.x + 13, block.region.y)
+        )
+
+        assert "\n" not in app._clipboard
+        assert toast.message == f"copied {len(app._clipboard)} characters"

--- a/tests/unit/tui/test_transcript_selection.py
+++ b/tests/unit/tui/test_transcript_selection.py
@@ -72,7 +72,7 @@ from local_operator.tui.glyphs import tool_icon
 from local_operator.tui.markdown_theme import install_markdown_theme
 from local_operator.tui.widgets.assistant import AssistantBlock, flatten
 from local_operator.tui.widgets.editor import Editor
-from local_operator.tui.widgets.toast import Toast
+from local_operator.tui.widgets.toast import TOAST_FAILURE_MS, Toast
 from local_operator.tui.widgets.tool_card import OUTPUT_INDENT, ToolCard
 from local_operator.tui.widgets.transcript import (
     NoticeBlock,
@@ -1184,3 +1184,298 @@ async def test_a_composer_drag_still_leaves_ctrl_c_as_the_interrupt() -> None:
         await pilot.pause()
 
         assert session.aborts == ["interrupted"]
+
+
+# -- what a release does NOT copy (review round 1, F1/F2) ---------------------
+#
+# `Editor._on_mouse_up` fires for every mouse-up routed to the composer, not
+# only for drags the composer began — and `TextArea` leaves its selection live
+# after a drag, so the widget is holding a stale range most of the time. The
+# first version of this fix copied on all of them, which meant a transcript
+# copy was overwritten by the composer's old highlight a moment after being
+# made. `_copy_drag` gates on `_selecting`, which is true only between
+# `TextArea`'s own mouse-down and mouse-up.
+
+
+@pytest.mark.asyncio
+async def test_a_transcript_drag_released_over_the_composer_keeps_the_transcript_copy() -> None:
+    """Overshooting a transcript drag into the composer must not clobber it.
+
+    This is the ordinary way to select to the end of an answer — the composer
+    is docked directly below the transcript, and the existing transcript tests
+    deliberately drag to `(79, 23)` for the same reason. Measured before the
+    `_selecting` gate: the user dragged the agent's answer and got their own
+    draft on the clipboard, with a toast confirming the wrong copy.
+
+    Both handlers run for this one release (`TextSelected` from the screen and,
+    before the gate, `EditorCopied` from the widget), and the composer's
+    message is delivered second — so it always won.
+    """
+    app = _pilot_app()
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        block = await _seeded(app, pilot)
+        editor = await _composer(app, pilot, "my private draft")
+
+        # A real composer drag first, so the editor is holding a live selection
+        # exactly as it would be in use.
+        await _composer_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 16))
+        assert app._clipboard == "my private draft"
+        assert editor.selected_text == "my private draft"
+
+        # Now drag the ANSWER and release over the composer.
+        app.screen._forward_event(_mouse(app, events.MouseDown, block.region.x, block.region.y))
+        await pilot.pause()
+        app.screen._forward_event(_mouse(app, events.MouseMove, 70, block.region.y + 2))
+        await pilot.pause()
+        app.screen._forward_event(_mouse(app, events.MouseMove, *_cell(editor, 0, 5)))
+        await pilot.pause()
+        app.screen._forward_event(_mouse(app, events.MouseUp, *_cell(editor, 0, 5)))
+        await pilot.pause()
+        await pilot.pause()
+
+        assert app._clipboard == app.screen.get_selected_text()
+        assert "my private draft" not in app._clipboard
+
+
+@pytest.mark.asyncio
+async def test_a_bare_mouse_up_does_not_copy_a_keyboard_selection() -> None:
+    """A mouse-up with no drag behind it is not a copy gesture.
+
+    Selecting with shift+arrows and then clicking elsewhere would otherwise
+    write the clipboard and announce it, having been asked for neither. Kept
+    separate from the test above because a guard phrased as "did the PRESS land
+    in this widget" would fix that one and leave this one.
+    """
+    app = _pilot_app()
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        editor = await _composer(app, pilot, "my private draft")
+        app._clipboard = "SOMETHING THE USER PUT THERE"
+        toast = app.query_one(Toast)
+
+        await pilot.press("home", *["shift+right"] * 10)
+        await pilot.pause()
+        assert editor.selected_text == "my private", "the keyboard selection must exist"
+
+        app.screen._forward_event(_mouse(app, events.MouseUp, *_cell(editor, 0, 2)))
+        await pilot.pause()
+        await pilot.pause()
+
+        assert app._clipboard == "SOMETHING THE USER PUT THERE"
+        assert toast.message == ""
+
+
+@pytest.mark.asyncio
+async def test_the_read_only_composer_still_copies_what_it_shows() -> None:
+    """Subagent mode is read-only, and a drag over it is still a copy.
+
+    The text there is the app's rather than the user's, which is exactly why
+    someone would want to lift it out. Pinned because `_copy_drag`'s reason for
+    copying the document text is phrased in terms of what the user typed, and
+    the read-only case must not be read as an oversight.
+    """
+    app = _pilot_app()
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        editor = await _composer(app, pilot, "someone else wrote this")
+        editor.read_only = True
+        await pilot.pause()
+        app._clipboard = ""
+
+        await _composer_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 7))
+
+        assert app._clipboard == "someone"
+        assert editor.text == "someone else wrote this"
+
+
+# -- what the receipt CLAIMS (review round 1 F3, design round 1 D1/D2/D3/D5) --
+
+
+@pytest.mark.asyncio
+async def test_a_sub_line_copy_is_counted_in_characters() -> None:
+    """ "1 line" was a claim the frame contradicted.
+
+    Two ways at once: the user dragged three words out of a line, and in the
+    composer a long draft SOFT-WRAPS, so one document line is painted as three
+    highlighted rows. The receipt said `1 line` while the user looked at three
+    rows of highlight — and the count is the only information the card carries.
+    """
+    app = _pilot_app()
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        editor = await _composer(app, pilot, "summarise the ingest path please")
+        toast = app.query_one(Toast)
+
+        await _composer_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 9))
+
+        assert app._clipboard == "summarise"
+        assert toast.message == "copied 9 characters"
+
+
+@pytest.mark.asyncio
+async def test_a_wrapped_selection_is_not_reported_as_one_line() -> None:
+    """The composer's common case: a draft too long for one row.
+
+    The regression this pins is specifically the DISAGREEMENT between the
+    receipt and the frame, so it asserts the widget really is painting more
+    rows than the document has lines.
+    """
+    long_draft = (
+        "please summarise the ingest path and then explain how the dedupe stage "
+        "interacts with the watermark, including the retry semantics and what "
+        "happens on a partial failure"
+    )
+    app = _pilot_app()
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        editor = await _composer(app, pilot, long_draft)
+        toast = app.query_one(Toast)
+        assert editor.region.height > 1, "the draft must actually wrap for this to mean anything"
+
+        await _composer_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 2, 60))
+
+        assert "\n" not in app._clipboard
+        assert "line" not in toast.message
+        assert toast.message == f"copied {len(app._clipboard)} characters"
+
+
+@pytest.mark.asyncio
+async def test_a_multi_line_copy_is_still_counted_in_lines() -> None:
+    """Spanning lines keeps the transcript's familiar receipt.
+
+    The unit follows the shape of the selection: lines are the useful magnitude
+    once there is more than one, and this is the wording the transcript copy
+    has always used for a multi-paragraph take.
+    """
+    app = _pilot_app()
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        editor = await _composer(app, pilot, "first line here\nsecond line here")
+        toast = app.query_one(Toast)
+
+        await _composer_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 1, 11))
+
+        assert app._clipboard == "first line here\nsecond line"
+        assert toast.message == "copied 2 lines"
+
+
+@pytest.mark.asyncio
+async def test_one_line_and_its_break_is_not_reported_as_two_lines() -> None:
+    """`count("\\n") + 1` read a trailing newline as a whole further line.
+
+    "Select this line" — drag from the start of one row to the start of the
+    next — is a natural gesture in a multi-line draft, and it reported
+    `copied 2 lines` for one line of text (review round 1, F3).
+    """
+    app = _pilot_app()
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        editor = await _composer(app, pilot, "first line here\nsecond line here")
+        toast = app.query_one(Toast)
+
+        await _composer_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 1, 0))
+
+        assert app._clipboard == "first line here\n"
+        assert toast.message != "copied 2 lines"
+        assert toast.message == "copied 15 characters"
+
+
+@pytest.mark.asyncio
+async def test_a_copy_receipt_does_not_evict_an_actionable_notice() -> None:
+    """A courtesy card must not take the slot from a failure the user must read.
+
+    The single toast slot was sized for startup-scale events. Once a routine
+    editing gesture can write it, an MCP failure — the 10 s variant, naming a
+    server and an error — was displaced by a drag in the composer, and startup
+    is exactly when someone is typing their first prompt (design round 1, D2).
+
+    The copy itself still happens: it is the CLAIM that stands down, not the
+    clipboard write.
+    """
+    app = _pilot_app()
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        editor = await _composer(app, pilot, "summarise the ingest path please")
+        toast = app.query_one(Toast)
+        toast.show("mcp: failed: github — command not found: gh", duration_ms=TOAST_FAILURE_MS)
+        await pilot.pause()
+        app._clipboard = ""
+
+        await _composer_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 9))
+
+        assert toast.message.startswith("mcp: failed")
+        assert app._clipboard == "summarise"
+
+
+@pytest.mark.asyncio
+async def test_a_copy_receipt_still_replaces_an_ordinary_one() -> None:
+    """Only ACTIONABLE notices hold the slot; the deference is not blanket.
+
+    Without this the previous test would also pass if the copy receipt had
+    simply stopped showing at all.
+    """
+    app = _pilot_app()
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        editor = await _composer(app, pilot, "summarise the ingest path please")
+        toast = app.query_one(Toast)
+        toast.show("mcp: 2 connected (14 tools)")
+        await pilot.pause()
+
+        await _composer_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 9))
+
+        assert toast.message == "copied 9 characters"
+
+
+@pytest.mark.asyncio
+async def test_typing_over_a_copied_selection_retires_the_receipt() -> None:
+    """Select-to-overwrite: the commonest edit in any input.
+
+    Drag a word, type the replacement, and the receipt sat there for the rest
+    of its five seconds asserting a copy of characters that no longer existed
+    in the field (design round 1, D3).
+
+    The CLIPBOARD is deliberately untouched — the copy really happened, and a
+    paste a minute later must still produce it. Only the claim is withdrawn.
+    """
+    app = _pilot_app()
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        editor = await _composer(app, pilot, "summarise the ingest path please")
+        toast = app.query_one(Toast)
+
+        await _composer_drag(app, pilot, _cell(editor, 0, 14), _cell(editor, 0, 20))
+        assert app._clipboard == "ingest"
+        assert toast.message == "copied 6 characters"
+
+        await pilot.press("d", "e", "d", "u", "p", "e")
+        await pilot.pause()
+
+        assert toast.message == ""
+        assert app._clipboard == "ingest"
+        assert editor.text == "summarise the dedupe path please"
+
+
+@pytest.mark.asyncio
+async def test_typing_does_not_dismiss_a_notice_that_is_not_a_copy_receipt() -> None:
+    """The retirement is scoped to the card the copy raised.
+
+    An MCP failure that arrived after the copy is not the editor's business,
+    and dismissing it because the user carried on typing would be the eviction
+    bug (D2) reintroduced from the other side.
+    """
+    app = _pilot_app()
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        editor = await _composer(app, pilot, "summarise the ingest path please")
+        toast = app.query_one(Toast)
+
+        await _composer_drag(app, pilot, _cell(editor, 0, 14), _cell(editor, 0, 20))
+        toast.show("mcp: failed: github — command not found: gh", duration_ms=TOAST_FAILURE_MS)
+        await pilot.pause()
+
+        await pilot.press("d", "e", "d", "u", "p", "e")
+        await pilot.pause()
+
+        assert toast.message.startswith("mcp: failed")

--- a/tests/unit/tui/test_transcript_selection.py
+++ b/tests/unit/tui/test_transcript_selection.py
@@ -1409,6 +1409,17 @@ async def test_a_copy_receipt_does_not_evict_an_actionable_notice() -> None:
         assert toast.message.startswith("mcp: failed")
         assert app._clipboard == "summarise"
 
+        # ...and it is still there a keystroke later. The deference is only
+        # half the protection: the copy raised no card, so it must also not
+        # come to OWN the card it deferred to and withdraw it on the next edit
+        # (review round 3, F10/F11). This test builds the state that bug needs,
+        # so it is the one that should catch it.
+        await pilot.press("x")
+        await pilot.pause()
+
+        assert toast.message.startswith("mcp: failed")
+        assert toast.display
+
 
 @pytest.mark.asyncio
 async def test_a_copy_receipt_still_replaces_an_ordinary_one() -> None:

--- a/tests/unit/tui/test_transcript_selection.py
+++ b/tests/unit/tui/test_transcript_selection.py
@@ -920,3 +920,267 @@ async def test_the_highlight_outlives_the_copy() -> None:
         block = await _seeded(app, pilot)
         await _drag(app, pilot, (block.region.x, block.region.y), (79, 23))
         assert block in app.screen.selections
+
+
+# -- the composer ------------------------------------------------------------
+#
+# Reported from the field after the transcript copy shipped: text highlighted
+# in the COMPOSER "doesn't copy properly". Both halves of the copy story above
+# miss a `TextArea`, and neither is obvious from the transcript's code:
+#
+# * `TextArea._watch_selection` calls `app.clear_selection()` on EVERY caret
+#   move, and the mouse-down that begins a composer drag is a caret move. So
+#   `Screen.selections` is emptied on the first event of the gesture and is
+#   still empty at release — measured before the fix: `editor.selected_text`
+#   was `'summarise the inges'` while `screen.get_selected_text()` was `None`.
+#   `TextArea` also captures the mouse on press, so `Screen._select_state`
+#   never leaves `None` and the screen never sees a selection to begin with.
+# * `TextArea`'s own `ctrl+c,super+c` -> `action_copy` binding cannot save it:
+#   cmd+C is eaten by the terminal (the same Ghostty binding the transcript
+#   docstrings name) and Ctrl+C is consumed by `Editor._on_key` as this app's
+#   interrupt before any binding runs.
+#
+# So the composer reports its own release (`Editor._copy_drag` ->
+# `EditorCopied`) and the app answers it through the same clipboard write and
+# the same toast as the transcript.
+
+
+async def _composer_drag(
+    app: OperatorApp,
+    pilot: Any,
+    start: tuple[int, int],
+    end: tuple[int, int],
+) -> None:
+    """A drag over the composer, as `Screen._forward_event` receives it.
+
+    Separate from `_drag` only in that it does not assert a screen selection
+    afterwards: over a `TextArea` there is never going to be one, which is the
+    whole reason this path exists.
+    """
+    app.screen._forward_event(_mouse(app, events.MouseDown, *start))
+    await pilot.pause()
+    if start != end:
+        app.screen._forward_event(_mouse(app, events.MouseMove, *end))
+        await pilot.pause()
+    app.screen._forward_event(_mouse(app, events.MouseUp, *end))
+    await pilot.pause()
+    await pilot.pause()
+
+
+async def _composer(app: OperatorApp, pilot: Any, text: str) -> Editor:
+    """The composer holding `text`, settled and focused.
+
+    Settling matters for the same reason it does in `_seeded`: the editor's
+    region is read to aim the drag, and a region read before the first layout
+    aims at the wrong row.
+    """
+    editor = app.query_one(Editor)
+    editor.focus()
+    editor.load_text(text)
+    await pilot.pause()
+    await pilot.pause()
+    return editor
+
+
+def _cell(editor: Editor, row: int, column: int) -> tuple[int, int]:
+    """Screen coordinates of one document cell.
+
+    Computed from the widget's own gutter rather than written as
+    `region.x + column`: the composer inherits `padding: 0 1` (see the
+    stylesheet's note on the flush card-on-composer seam), so the naive form
+    aims one column left and every assertion below would be off by a character
+    — which is a test that passes while describing the wrong gesture.
+    """
+    return (
+        editor.region.x + editor.gutter.left + column,
+        editor.region.y + editor.gutter.top + row,
+    )
+
+
+@pytest.mark.asyncio
+async def test_releasing_a_composer_drag_copies_what_was_highlighted() -> None:
+    """The acceptance case: highlight your own draft, let go, it is copied.
+
+    Measured before the fix, this same gesture left `_clipboard` untouched
+    while the highlight sat on screen — the reported bug, in one assertion.
+    """
+    app = _pilot_app()
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        editor = await _composer(app, pilot, "summarise the ingest path please")
+        app._clipboard = ""
+
+        await _composer_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 20))
+
+        assert editor.selected_text == "summarise the ingest"
+        # The clipboard IS the highlight — the property the transcript's
+        # `get_selection` gets from sharing one computation, and which this
+        # path has to get by taking the widget's own selected text.
+        assert app._clipboard == editor.selected_text
+        # ...and the screen still has no selection of its own, so this could
+        # only have come from the editor. If this ever starts passing through
+        # `Screen.selections`, the mechanism changed and these tests are stale.
+        assert not app.screen.selections
+
+
+@pytest.mark.asyncio
+async def test_a_composer_copy_says_so_in_the_same_words() -> None:
+    """One receipt for both gestures, or the toast becomes a tell.
+
+    A copy out of the input has to be indistinguishable from a copy out of the
+    transcript; a different wording (or a silent composer copy) would make the
+    user reason about which widget they dragged over.
+    """
+    app = _pilot_app()
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        editor = await _composer(app, pilot, "first line here\nsecond line here")
+        toast = app.query_one(Toast)
+        assert toast.message == ""
+
+        # Ends inside the second row, so the copy is a partial line — the
+        # count in the toast is rows spanned, not lines completed.
+        await _composer_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 1, 11))
+
+        assert app._clipboard == "first line here\nsecond line"
+        assert toast.message == "copied 2 lines"
+        # Recomputed from the clipboard rather than restated, exactly as the
+        # transcript's test does: the card cannot drift from what was taken.
+        assert toast.message == f"copied {len(app._clipboard.splitlines())} lines"
+
+
+@pytest.mark.asyncio
+async def test_a_click_in_the_composer_copies_nothing() -> None:
+    """Placing the caret is not a copy, and must not announce one.
+
+    The common gesture in this widget by far. A click leaves `start == end`,
+    and a toast on every caret placement would be noise on top of a clipboard
+    the user did not ask to change.
+    """
+    app = _pilot_app()
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        editor = await _composer(app, pilot, "summarise the ingest path please")
+        app._clipboard = "SOMETHING THE USER PUT THERE"
+        toast = app.query_one(Toast)
+
+        await _composer_drag(app, pilot, _cell(editor, 0, 5), _cell(editor, 0, 5))
+
+        assert app._clipboard == "SOMETHING THE USER PUT THERE"
+        assert toast.message == ""
+
+
+@pytest.mark.asyncio
+async def test_a_drag_over_an_empty_composer_copies_nothing() -> None:
+    """The placeholder is not the user's text.
+
+    An empty composer still paints `Message Local Operator…`, and dragging
+    across it selects nothing — `selected_text` is `""`. Copying the invitation
+    would put words on the clipboard that the user never wrote.
+    """
+    app = _pilot_app()
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        editor = await _composer(app, pilot, "")
+        app._clipboard = "SOMETHING THE USER PUT THERE"
+        toast = app.query_one(Toast)
+
+        await _composer_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 15))
+
+        assert editor.selected_text == ""
+        assert app._clipboard == "SOMETHING THE USER PUT THERE"
+        assert toast.message == ""
+
+
+@pytest.mark.asyncio
+async def test_clicking_an_attachment_marker_selects_it_without_copying() -> None:
+    """The chip gesture keeps its meaning: select to delete, not to copy.
+
+    `Editor._on_mouse_up` selects a whole marker on a click inside one so that
+    backspace removes it atomically. That selection is the APP's, not a range
+    the user dragged, so it must not reach the clipboard — otherwise reaching
+    for the delete gesture silently replaces whatever the user had copied, and
+    raises a receipt claiming they asked for it.
+    """
+    app = _pilot_app()
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        editor = await _composer(app, pilot, "[Image #1, 100x100] describe this")
+        app._clipboard = "SOMETHING THE USER PUT THERE"
+        toast = app.query_one(Toast)
+
+        await _composer_drag(app, pilot, _cell(editor, 0, 3), _cell(editor, 0, 3))
+
+        assert app._clipboard == "SOMETHING THE USER PUT THERE"
+        assert toast.message == ""
+
+
+@pytest.mark.asyncio
+async def test_a_composer_drag_copies_a_marker_as_the_text_that_cites_it() -> None:
+    """Dragging ACROSS a marker copies the citation, not a decoration of it.
+
+    A marker is painted as a chip but it is document text — the same characters
+    `_submit` sends and `resolve_markers` reads. Copying what is on the row
+    means the paste re-cites the image in another draft, which is the only
+    behaviour that makes a copied prompt reusable.
+    """
+    app = _pilot_app()
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        editor = await _composer(app, pilot, "[Image #1, 100x100] describe this")
+        app._clipboard = ""
+
+        # `len("[Image #1, 100x100]")` exactly: the drag ends ON the cell
+        # after the closing bracket, and the selection end is exclusive, so
+        # this is the marker and not one character of the prose after it.
+        await _composer_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 19))
+
+        assert app._clipboard == "[Image #1, 100x100]"
+
+
+@pytest.mark.asyncio
+async def test_a_composer_drag_leaves_the_draft_alone() -> None:
+    """Copying is not cutting, and the caret gesture still ends where it did.
+
+    Worth pinning because the copy is bolted onto the mouse-up that `TextArea`
+    also uses to finalise its selection: a copy path that touched the document,
+    or that collapsed the selection it had just taken, would corrupt a draft
+    mid-sentence.
+    """
+    app = _pilot_app()
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        editor = await _composer(app, pilot, "summarise the ingest path please")
+
+        await _composer_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 20))
+
+        assert editor.text == "summarise the ingest path please"
+        # The highlight outlives the copy here for the same reason it does in
+        # the transcript: it is the only record of what was taken.
+        assert editor.selected_text == "summarise the ingest"
+
+
+@pytest.mark.asyncio
+async def test_a_composer_drag_still_leaves_ctrl_c_as_the_interrupt() -> None:
+    """The copy must not buy itself a key, least of all this one.
+
+    The transcript's copy was deliberately hung off the release so that Ctrl+C
+    could stay the interrupt and the first rung of the exit ladder. The
+    composer's copy is hung off the release for the same reason, and this is
+    the assertion that keeps a future "just bind ctrl+c in the editor" from
+    quietly reintroducing the swallowed-abort bug in the one widget that is
+    focused in essentially every frame.
+    """
+    session = FakeSession()
+    app = _pilot_app(session)
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        editor = await _composer(app, pilot, "summarise the ingest path please")
+        await _composer_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 20))
+        assert editor.selected_text, "the highlight must be live for this to mean anything"
+
+        session.aborts.clear()
+        await pilot.press("ctrl+c")
+        await pilot.pause()
+
+        assert session.aborts == ["interrupted"]

--- a/tests/unit/tui/test_transcript_selection.py
+++ b/tests/unit/tui/test_transcript_selection.py
@@ -1736,3 +1736,73 @@ async def test_a_held_receipt_still_arrives_when_its_text_survives() -> None:
 
         assert toast.message == "copied 9 characters"
         assert toast.display
+
+
+@pytest.mark.asyncio
+async def test_a_composer_edit_does_not_discard_the_transcript_s_held_receipt() -> None:
+    """The held slot is shared, so a withdrawal has to name its own card.
+
+    `EditorCopyStale` is evidence about the COMPOSER's buffer, and the first
+    version of the D14 withdrawal dropped whatever was held — so typing in the
+    composer threw away a transcript copy's receipt that was still perfectly
+    true (review round 4, F14). The same failure as F5/D8, one layer down: the
+    composer's staleness signal reaching a card it does not own.
+
+    The composer copy at the start is what makes this bite: it arms `_copied`,
+    so the later keystroke actually posts the stale message.
+    """
+    app = _pilot_app()
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        block = await _seeded(app, pilot)
+        editor = await _composer(app, pilot, "draft prompt")
+        toast = app.query_one(Toast)
+
+        await _composer_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 5))
+        assert editor._copied, "the composer's flag must be armed for this to mean anything"
+
+        toast.show("mcp: failed: github — command not found: gh", duration_ms=TOAST_FAILURE_MS)
+        await pilot.pause()
+
+        # A TRANSCRIPT copy, deferred behind the notice.
+        await _drag(app, pilot, (block.region.x, block.region.y), (79, 23))
+        assert toast._deferred is not None
+
+        editor.focus()
+        await pilot.press("x")
+        await pilot.pause()
+        toast.dismiss_toast()
+        await pilot.pause()
+
+        assert toast.message == "copied 3 lines"
+        assert toast.display
+
+
+@pytest.mark.asyncio
+async def test_a_receipt_promoted_from_the_hold_can_still_be_retired() -> None:
+    """A card that waited for the slot is still the composer's card.
+
+    Tracking the receipt by `Toast.generation` named only a card that had been
+    PAINTED, so one that was deferred and then promoted when the slot freed
+    became unretirable — an edit could no longer falsify it. Ownership rides
+    the card through both states, which is what collapses them into one case
+    (review round 4).
+    """
+    app = _pilot_app()
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        editor = await _composer(app, pilot, "summarise the ingest path please")
+        toast = app.query_one(Toast)
+        toast.show("mcp: failed: github — command not found: gh", duration_ms=TOAST_FAILURE_MS)
+        await pilot.pause()
+
+        await _composer_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 9))
+        toast.dismiss_toast()
+        await pilot.pause()
+        assert toast.message == "copied 9 characters", "the held card must have been promoted"
+
+        await pilot.press("z")
+        await pilot.pause()
+
+        assert toast.message == ""
+        assert toast.display is False

--- a/tests/unit/tui/test_transcript_selection.py
+++ b/tests/unit/tui/test_transcript_selection.py
@@ -1632,3 +1632,33 @@ async def test_a_sub_line_transcript_copy_is_counted_in_characters_too() -> None
 
         assert "\n" not in app._clipboard
         assert toast.message == f"copied {len(app._clipboard)} characters"
+
+
+@pytest.mark.asyncio
+async def test_a_declined_receipt_does_not_adopt_the_notice_it_deferred_to() -> None:
+    """A copy that raised NO card has nothing to withdraw later.
+
+    `Toast.show` declines the slot while an actionable notice is up (D2), so a
+    copy made in that window paints nothing. Reading the generation
+    unconditionally then pointed the app at the FAILURE's card, and the next
+    keystroke dismissed the very notice the deference existed to protect
+    (review round 3) — the eviction bug arriving by the back door, one round
+    after it was closed at the front.
+    """
+    app = _pilot_app()
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        editor = await _composer(app, pilot, "summarise the ingest path please")
+        toast = app.query_one(Toast)
+        toast.show("mcp: failed: github — command not found: gh", duration_ms=TOAST_FAILURE_MS)
+        await pilot.pause()
+
+        await _composer_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 9))
+        assert app._clipboard == "summarise", "the copy itself must still happen"
+        assert toast.message.startswith("mcp: failed")
+
+        await pilot.press("x")
+        await pilot.pause()
+
+        assert toast.message.startswith("mcp: failed")
+        assert toast.display

--- a/tests/unit/tui/test_transcript_selection.py
+++ b/tests/unit/tui/test_transcript_selection.py
@@ -1673,3 +1673,66 @@ async def test_a_declined_receipt_does_not_adopt_the_notice_it_deferred_to() -> 
 
         assert toast.message.startswith("mcp: failed")
         assert toast.display
+
+
+@pytest.mark.asyncio
+async def test_a_held_receipt_is_withdrawn_if_its_text_is_edited_away() -> None:
+    """A deferred claim can go stale before it is ever painted.
+
+    Promoting the declined receipt to a card that outlives the gesture (D9) put
+    it outside the reach of the staleness retirement: `Editor._copied` is a
+    one-shot flag consumed by the first edit, and that edit lands while the
+    receipt is still held — with nothing showing to retire, because the copy
+    correctly declined to arm one (D13). The card then appeared, already false,
+    when the slot freed (design round 4, D14).
+
+    The window makes it likely rather than exotic: the notice runs ten seconds
+    and the user is typing into the composer the whole time.
+    """
+    app = _pilot_app()
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        editor = await _composer(app, pilot, "summarise the ingest path please")
+        toast = app.query_one(Toast)
+        toast.show("mcp: failed: github — command not found: gh", duration_ms=TOAST_FAILURE_MS)
+        await pilot.pause()
+
+        await _composer_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 9))
+        assert app._clipboard == "summarise"
+
+        # The user types over what they copied, while the notice still holds
+        # the slot.
+        await pilot.press("z")
+        await pilot.pause()
+
+        toast.dismiss_toast()
+        await pilot.pause()
+
+        assert toast.message == ""
+        assert toast.display is False
+        # The clipboard is untouched, as everywhere else: only the claim goes.
+        assert app._clipboard == "summarise"
+
+
+@pytest.mark.asyncio
+async def test_a_held_receipt_still_arrives_when_its_text_survives() -> None:
+    """The withdrawal is scoped to a claim that became false.
+
+    Without this, D14's fix could pass by dropping every deferred receipt,
+    which would undo D9 — the copy would go unacknowledged again.
+    """
+    app = _pilot_app()
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        editor = await _composer(app, pilot, "summarise the ingest path please")
+        toast = app.query_one(Toast)
+        toast.show("mcp: failed: github — command not found: gh", duration_ms=TOAST_FAILURE_MS)
+        await pilot.pause()
+
+        await _composer_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 9))
+
+        toast.dismiss_toast()
+        await pilot.pause()
+
+        assert toast.message == "copied 9 characters"
+        assert toast.display


### PR DESCRIPTION
# PR Description

## Change classification

**C2 — standard / pre-authorized.** One TUI gesture: the composer's mouse-up now posts a message the app answers with the clipboard write it already performs for the transcript. No new surface, no config, no persisted state, no engine change. Clean rollback (`git revert`).

## The bug

Reported: selecting text in the composer "doesn't copy properly" — the drag paints a highlight and the clipboard keeps whatever it held before.

Both halves of this app's copy story miss the composer, and neither is visible from the transcript's code:

- **The release never reaches the app.** `OperatorApp.on_text_selected` copies `Screen.get_selected_text()`, but a `TextArea` never contributes to a screen selection. `TextArea._watch_selection` calls `app.clear_selection()` on *every* caret move, and the mouse-down that begins a composer drag **is** a caret move — so `Screen.selections` is wiped on the gesture's first event and is still empty at release. `TextArea` also captures the mouse on press, so `Screen._select_state` never leaves `None` and the screen's own select machinery is bypassed entirely.
- **No key can rescue it.** `TextArea` binds `ctrl+c,super+c` → `action_copy` and *neither key arrives*: cmd+C is eaten by the terminal (Ghostty's `super+c=copy_to_clipboard:mixed`, no `performable:` prefix — the same fact the transcript's copy was built around) and Ctrl+C is consumed by `Editor._on_key` as this app's interrupt before any binding runs. That is deliberate and must stay so: the interrupt is the first rung of the exit ladder and cannot become conditional on a live highlight.

Measured on unmodified `origin/main`, driving a real drag over the composer through `Screen._forward_event`:

```console
editor.selection    : Selection(start=(0, 0), end=(0, 19))
editor.selected_text: 'summarise the inges'     <- the highlight the user sees
screen.selections   : {}                        <- nothing for the app to copy
get_selected_text   : None
clipboard           : ''                        <- the bug
toast               : ''
```

The widget knows exactly what was highlighted; nothing asks it.

## The fix

**The release IS the copy** — the rule the transcript already states, applied to the one widget that could not inherit it.

- `Editor._on_mouse_up` → `Editor._copy_drag()` posts `EditorCopied(text)` when the release leaves a real range. The text rides the message rather than being re-read later, because the selection is live state and any later caret move collapses it (`TextArea._watch_selection` again) — the same rule `EditorSubmitted` follows for its attachments.
- `OperatorApp.on_editor_copied` answers it through `_put_on_clipboard`, which is now the **single** clipboard write + toast shared with `on_text_selected`. A copy out of the input is byte-for-byte indistinguishable from a copy out of the transcript, so the receipt never becomes evidence about which widget you dragged over.

### Copy-on-select: an explicit note

This makes selecting text in the composer **write the clipboard**, which is a semantic macOS/Windows users do not expect from an input field. Stated deliberately rather than left implicit (design round 1, D3): X11 users will find it familiar, but that familiarity comes from the PRIMARY selection, which is a *separate* buffer from the one Cmd+V reads — this writes the latter.

It is kept because this app has no other way to copy: Ctrl+C is the interrupt and the first rung of the exit ladder, and cmd+C never arrives (the terminal eats it). Narrowing the gesture would mean the composer keeps the bug this PR exists to fix. The misleading half of the behaviour — a receipt still asserting a copy of text the user has since typed over — is fixed separately (D3 below).

### What does *not* copy, and why

| gesture | behaviour | why |
|---|---|---|
| a release whose press was **elsewhere** | no copy | `TextArea` leaves its selection live after a drag, so the composer usually holds a stale range; copying it would clobber the transcript copy the same release just made (review round 1, F1) |
| a bare mouse-up over a shift+arrow selection | no copy | no mouse gesture asked for it (review round 1, F2) |
| plain click (caret placement) | no copy, no toast | `start == end`; by far the most common gesture in this widget, and a toast per caret placement would be noise on top of a clipboard the user did not ask to change |
| drag over the **empty** composer | no copy, no toast | the placeholder is not the user's text — `selected_text` is `""` |
| click on an attachment marker | selects the chip, **no** copy | that selection is the *app's*, made so backspace deletes the chip whole; copying there would silently replace the user's clipboard and raise a receipt claiming they asked for it |
| drag **across** a marker | copies `[Image #1, 100x100]` | a marker is document text — the same characters `_submit` sends — so a copied prompt re-cites the image when pasted into another draft |

### The receipt

The toast's unit follows the **shape** of the selection, because "line" is a claim the frame can contradict (design round 1, D1/D5; review round 1, F3):

- no newline → `copied N characters`. A long draft soft-wraps, so one document line is painted as three highlighted rows — `copied 1 line` disagreed with what the user was looking at. `cell_len`, so a wide glyph counts as the cells it occupies.
- spans lines → `copied N lines`, via `len(splitlines())` (`count("\n") + 1` called one line plus its break two lines).

It is also a **courtesy** card: it stands down while an actionable notice (a 10s MCP failure) is up rather than evicting it, and it is retired when the user edits the text it describes — the clipboard keeps what it took, only the claim is withdrawn (D2, D3).

## Validation

### 1. The reported gesture, end to end on the real clipboard

Not a mocked clipboard: the OSC 52 escape `App.copy_to_clipboard` emits was replayed to this session's own Ghostty pane (`/dev/ttys010`) and read back with `pbpaste`, after clearing it first.

```console
$ pbcopy < /dev/null; echo "clipboard cleared: [$(pbpaste)]"
clipboard cleared: []

$ .venv/bin/python /tmp/osc52.py /dev/ttys010
app clipboard: 'composer-copy-e2e-1787110884'
target tty   : /dev/ttys010
sentinel     : composer-copy-e2e-1787110884
pbpaste      : 'composer-copy-e2e-1787110884'
MATCH
```

This is what makes the fix real rather than internally consistent: the bytes reached the **system** clipboard, which is where the reporter's paste comes from.

### 2. Before / after on the same gesture

Same script, same drag, `origin/main` vs this branch:

| | before (`main`) | after |
|---|---|---|
| `editor.selected_text` | `'summarise the ingest '` | `'summarise the ingest '` |
| `app._clipboard` | `''` ❌ | `'summarise the ingest '` ✅ |
| toast | `''` | `'copied 1 line'` |

The highlight is identical on both sides — only its *fate* differs.

### 3. Rendered frames

Captured from the real `OperatorApp` via `app.save_screenshot` (so `local_operator.tcss` is applied) and **viewed as images**, per `AGENTS.md` → "Visual validation".

| before — highlight present, no receipt | after — same highlight, receipt raised |
|---|---|
| ![before](https://raw.githubusercontent.com/damianvtran/local-operator/assets/pr-composer-copy/before.png) | ![after](https://raw.githubusercontent.com/damianvtran/local-operator/assets/pr-composer-copy/after-round2.png) |

The composer, the chevron, the status band and the splash are unchanged; the only difference in the frame is the toast. Two consecutive settled frames are **byte-identical**, so nothing reflows after paint.

### 4. Edge cases, driven as real gestures

```console
1 plain click     : clipboard='PREVIOUS' toast=''                       # unchanged
2 multiline       : clipboard='first line here\nsecond lin' toast='copied 2 lines'
3 backwards drag  : clipboard='arise the inges' toast='copied 1 line'   # right-to-left
4 empty composer  : clipboard='PREVIOUS' toast=''                       # placeholder not copied
5 marker click    : clipboard='PREVIOUS' toast=''                       # chip gesture intact
```

Marker click behaviour was also compared against unmodified `origin/main` and is **identical** (`sel=''` on both), so this PR does not change it.

### 5. Regression tests, and proof they discriminate

Twenty tests added to `tests/unit/tui/test_transcript_selection.py`, alongside the transcript copy tests they mirror. The three that assert the *new* behaviour fail on unmodified `origin/main` with this file dropped in:

```console
$ cd /tmp/lo-cc-base   # detached at origin/main, no edits
$ .venv/bin/python -m pytest tests/unit/tui/test_transcript_selection.py -q -k composer
FAILED ...::test_releasing_a_composer_drag_copies_what_was_highlighted   - assert '' == 'summarise the ingest'
FAILED ...::test_a_composer_copy_says_so_in_the_same_words               - assert '' == 'first line here\nsecond line'
FAILED ...::test_a_composer_drag_copies_a_marker_as_the_text_that_cites_it - assert '' == '[Image #1, 100x100]'
3 failed, 4 passed
```

The other five pin what must **not** change: no copy on a click, none on the empty composer, the marker click still only selects, the draft is never mutated, and — the one worth naming — `test_a_composer_drag_still_leaves_ctrl_c_as_the_interrupt`, which stops a future "just bind ctrl+c in the editor" from reintroducing the swallowed-abort bug in the widget that is focused in essentially every frame.

The drags aim via a `_cell()` helper computed from the widget's own `gutter`, not `region.x + n`: the composer inherits `padding: 0 1`, and the naive form aims one column left — a test that passes while describing the wrong gesture.

### 6. Gates

```console
$ .venv/bin/python -m pytest tests/unit/tui/test_transcript_selection.py -q      # 61 passed
$ .venv/bin/python -m pytest tests/unit/tui -q                                   # 1683 passed, 4 skipped
$ .venv/bin/python -m pytest tests/unit -q                     # 4732 passed, 7 skipped, 1 failed
$ .venv/bin/python -m flake8 .                                 # clean
$ uvx --from black==26.1.0 black --check local_operator tests   # clean
$ uvx isort --check-only --profile black local_operator tests   # clean
$ .venv/bin/python -m pyright --pythonpath .venv/bin/python .   # 0 errors, 0 warnings, 0 informations
```

The one failure is **pre-existing and unrelated**: `tests/unit/tools/test_eval_tool.py::test_background_streams_output_while_it_runs`, a timing-sensitive streaming test. Confirmed failing identically on a pristine `origin/main` worktree (`git reset --hard`, no edits):

```console
$ cd /tmp/lo-cc-base && git log --oneline -1
f87f778 fix(session,comms): make a turn's progress durable...
$ .venv/bin/python -m pytest tests/unit/tools/test_eval_tool.py::test_background_streams_output_while_it_runs -q
1 failed
```

### 7. Review rounds

Both round-1 reviews requested changes and both are remediated in `c7f8f04`:

- **Agent review** found a **blocker** (F1) my own tests could not catch, because every one of them pressed and released inside the composer: a transcript drag released over the composer re-copied the stale draft over the answer. Fixed with a `_selecting` gate, plus F2 (bare mouse-up copying a keyboard selection), F3 (line count) and F4 (the missing tests).
- **Design review** found the receipt was lying in this widget's normal case (D1/D5, soft-wrapped draft), that a copy receipt could evict a 10s MCP failure notice (D2), and that it outlived its subject on select-to-overwrite (D3). All fixed. D4 (keyboard selections still have no copy path) is deferred to #169, D6 acknowledged, D7 rejected with reasoning.

Every fix in the remediation round is mutation-checked — reverting any one of the six fails a test, and no others:

| mutation | tests that fail |
|---|---|
| drop the `_selecting` gate | 2 |
| `len(splitlines())` → `count("\n") + 1` | 1 |
| always report lines, never characters | 5 |
| drop the courtesy-toast deference | 1 |
| drop the stale-receipt retirement | 1 |
| retire *any* toast on edit instead of only the receipt | 1 |

## Rollout / rollback

Pure TUI change, no persisted state and no migration: `git revert` restores the previous behaviour exactly.
