### PR TITLE
fix(tui,session): sit the band's title flush right, and stop losing a slow one

### DIFF
--- a/local_operator/session/naming.py
+++ b/local_operator/session/naming.py
@@ -277,6 +277,34 @@ def parse_title(raw: str) -> str | None:
     return _sentence_case(words)
 
 
+def cut_on_a_word(text: str, max_chars: int) -> str:
+    """``text`` shortened to ``max_chars``, on a word boundary, with an ellipsis.
+
+    The one definition of "shorten a title" in the product, so the band, the
+    terminal tab and the stored name all cut the same string the same way. Three
+    places grew their own version of this and two of them disagreed; a title
+    that reads `…reconcile the ledge` on the tab and `…reconcile the…` on the
+    band is a bug report waiting to be filed.
+
+    The boundary is only taken when it costs less than a third of the budget: a
+    single enormous token (a URL, a base64 blob) is cut mid-token instead,
+    because returning almost nothing for a string that plainly had content is
+    the worse failure. The ellipsis is counted, so the result never exceeds
+    ``max_chars``.
+    """
+    if len(text) <= max_chars:
+        return text
+    cut = text[: max_chars - 1]
+    spaced = cut.rsplit(" ", 1)[0]
+    if len(spaced) >= (max_chars - 1) * 2 // 3:
+        cut = spaced
+    return cut.rstrip(" " + _TRAILING_PUNCTUATION) + "…"
+
+
+#: Module-private alias, so the store below reads as one operation.
+_cut_on_a_word = cut_on_a_word
+
+
 def _sentence_case(words: list[str]) -> str:
     """Capitalise the first word, leave every other word's casing alone.
 
@@ -480,8 +508,21 @@ class ConversationName:
 
         Returns what is stored afterwards (which may be the previous value
         when a generated title lost to a user-set one).
+
+        An over-long title is cut on a WORD boundary with an ellipsis rather
+        than sliced mid-word. Only ``/rename`` can reach this — a model's
+        over-long answer is REJECTED by :func:`parse_title` rather than
+        truncated — and a name the user typed is worth keeping legible: sliced,
+        an 88-character rename ended `…and reconcile the ledge` on both the band
+        and the terminal tab, which reads as a string that ran out of buffer.
+
+        The cut lives HERE rather than in either display surface because this is
+        where the length is actually decided: ``MAX_TITLE_CHARS`` and the tab's
+        ``MAX_LABEL_CHARS`` are both 80, so a tab-side cut could never fire for a
+        conversation name — every title reaching it had already been sliced by
+        this line (design review round 2, D6).
         """
-        cleaned = " ".join((text or "").split())[:MAX_TITLE_CHARS]
+        cleaned = _cut_on_a_word(" ".join((text or "").split()), MAX_TITLE_CHARS)
         if not user_set and self.user_set:
             return self.text
         self.text = cleaned

--- a/local_operator/session/naming.py
+++ b/local_operator/session/naming.py
@@ -301,10 +301,6 @@ def cut_on_a_word(text: str, max_chars: int) -> str:
     return cut.rstrip(" " + _TRAILING_PUNCTUATION) + "…"
 
 
-#: Module-private alias, so the store below reads as one operation.
-_cut_on_a_word = cut_on_a_word
-
-
 def _sentence_case(words: list[str]) -> str:
     """Capitalise the first word, leave every other word's casing alone.
 
@@ -522,7 +518,7 @@ class ConversationName:
         conversation name — every title reaching it had already been sliced by
         this line (design review round 2, D6).
         """
-        cleaned = _cut_on_a_word(" ".join((text or "").split()), MAX_TITLE_CHARS)
+        cleaned = cut_on_a_word(" ".join((text or "").split()), MAX_TITLE_CHARS)
         if not user_set and self.user_set:
             return self.text
         self.text = cleaned

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -125,6 +125,19 @@ logger = logging.getLogger(__name__)
 #: cost of exhausting it is one stale row that the next write corrects.
 _NAME_PERSIST_MAX_PASSES = 3
 
+#: Total budget for landing the title at teardown, shared by the wait for an
+#: in-flight write and the retry behind it (see
+#: :meth:`Session._flush_conversation_name`) so the two cannot add up.
+#:
+#: Bounded at all because teardown must not hang on a wedged filesystem or
+#: behind a transcript lock a long turn still holds. Not TIGHT, because the
+#: bound decides whether a slow-but-real write is LOST: an append is
+#: sub-millisecond on a local disk, so seconds already mean a stalled mount, and
+#: a 4.9 s append lost its title under two 2 s budgets that a single 5 s budget
+#: keeps. Five seconds is comfortably above any real append and still a pause a
+#: person will sit through once on ctrl+d.
+_NAME_FLUSH_TIMEOUT_S = 5.0
+
 #: Self-prompt scheduled after a compaction pass that cleared the recovery
 #: band, so the model resumes where the summary left off.
 _CONTINUATION_PROMPT = (
@@ -1506,11 +1519,25 @@ class Session:
         Any write already in flight is awaited first, so the ordinary path
         costs nothing here and the retry below only runs when that write never
         happened (never scheduled, or cancelled).
+
+        Both halves share ONE deadline, and it is the whole cost of this method
+        rather than the cost of each half. Charged separately they ran in
+        sequence, so teardown could take twice the advertised bound; and because
+        the bound decides whether a slow-but-real write is LOST rather than
+        merely un-waited-for, two tight budgets were also the wrong shape — a
+        4.9 s append lost its title where a single 5 s budget keeps it. An
+        append is sub-millisecond on a local disk, so seconds already mean a
+        stalled mount, and in that state a user is better served by a few
+        seconds of teardown than by a resume that opens unnamed.
         """
+        deadline = time.monotonic() + _NAME_FLUSH_TIMEOUT_S
+
         task = self._conversation_name_task
         if task is not None and not task.done():
             try:
-                await asyncio.wait_for(asyncio.shield(task), timeout=2.0)
+                await asyncio.wait_for(
+                    asyncio.shield(task), timeout=max(0.0, deadline - time.monotonic())
+                )
             except BaseException:  # noqa: BLE001 — fall through to the retry
                 pass
         if not self._conversation_name_dirty:
@@ -1523,8 +1550,12 @@ class Session:
             # behind it indefinitely (measured blocking >3 s and still going),
             # which trades a missing title for a session that will not close.
             # Every other await on this path is bounded; this one has no claim
-            # to be the exception.
-            await asyncio.wait_for(self._persist_conversation_name(), timeout=2.0)
+            # to be the exception. What remains of the shared deadline is the
+            # budget, so the two waits cannot add up.
+            await asyncio.wait_for(
+                self._persist_conversation_name(),
+                timeout=max(0.0, deadline - time.monotonic()),
+            )
         except Exception:
             # Decoration must never be the reason a dispose fails: losing the
             # name is survivable, losing the conversation is not. A timeout is

--- a/local_operator/tui/terminal_title.py
+++ b/local_operator/tui/terminal_title.py
@@ -42,6 +42,7 @@ import re
 from pathlib import Path
 from typing import Callable, Literal
 
+from local_operator.session.naming import cut_on_a_word
 from local_operator.tui.settings import settings_get
 
 #: Environment kill switch, mirroring ``shimmer``/``nerd_icons``. Wanted by
@@ -131,11 +132,26 @@ def sanitize_label(value: str | None) -> str:
 
     Returns ``""`` for anything that sanitises away to nothing, which callers
     read as "no label" rather than as an empty title.
+
+    Over-long labels are cut on a WORD boundary with an ellipsis, through the
+    same helper the stored title uses (``naming.cut_on_a_word``), so the tab and
+    the band shorten a name identically. A bare slice ended the tab mid-word —
+    `…and reconcile the ledge` — which reads as a string that ran out of buffer
+    rather than as a name that was shortened, and the tab is where truncation
+    bites hardest because most terminals shorten the label AGAIN to fit the tab
+    strip (design review D3).
+
+    For a CONVERSATION NAME this is now a backstop rather than the working cut:
+    ``MAX_TITLE_CHARS`` and ``MAX_LABEL_CHARS`` are both 80, so a title arrives
+    already shortened by the store (D6). It still does real work for the callers
+    with no cap of their own — ``cwd_label`` on a deep path, and a subagent
+    label — which is why the cut lives on both sides rather than being deleted
+    here.
     """
     if not value:
         return ""
     cleaned = " ".join(_CONTROL_CHARS.sub(" ", value).split())
-    return cleaned[:MAX_LABEL_CHARS]
+    return cut_on_a_word(cleaned, MAX_LABEL_CHARS)
 
 
 def cwd_label(cwd: str | None) -> str:

--- a/local_operator/tui/widgets/status_line.py
+++ b/local_operator/tui/widgets/status_line.py
@@ -1506,9 +1506,14 @@ class StatusLine:
         """agents ‹ jobs ‹ context ‹ cost ‹ duration ‹ [!] ‹ name.
 
         ``name_cells`` is the box :meth:`_walk` reserved for the trailing name —
-        zero when the ladder dropped it. The name is PADDED to that box rather
-        than measured, which is what pins every other segment's column; see
-        :data:`NAME_CELLS`.
+        zero when the ladder dropped it. The row always SPENDS that whole box,
+        whatever the title's own width, which is what pins every other segment's
+        column; see :data:`NAME_CELLS`. The title itself is emitted UNPADDED and
+        the remainder (:attr:`_name_slack`) is paid out as blanks just before
+        the seam that introduces it, so the box is filled without the title
+        having to be the thing that fills it — which is what lets the row reach
+        the band's right edge at every title length while the columns to the
+        left of the name stay put.
 
         Colour groups by KIND rather than giving every field its own hue, which
         would be a rainbow: counters share `label`, the two numbers an operator
@@ -1733,22 +1738,24 @@ class StatusLine:
         that exactly fitted its frame `_MIN_GROUP_GAP` cells past it, on trailing
         blanks that aligned nothing.
 
-        The right group is aligned by its BOX, not by its ink: the name arrives
-        padded to the cells :meth:`_walk` reserved (:data:`NAME_CELLS`), so this
-        arithmetic is the same at every title length and a short title leaves its
-        leftover at the band's edge rather than shunting the group right.
+        The right group is aligned by its BOX, not by its ink: the group always
+        spends the cells :meth:`_walk` reserved for the name
+        (:data:`NAME_CELLS`), so this arithmetic is the same at every title
+        length and a short title cannot shunt the group right.
 
-        The box's unused cells are spent INSIDE the name segment, which
-        right-aligns itself in them (see :meth:`_right_text`), so the row's last
-        inked cell is the band's right edge at every title length and there is
-        nothing here to trim.
+        The box's unused cells are spent inside the right group by
+        :meth:`_right_text`, as a run of blanks immediately BEFORE the seam that
+        introduces the title — so the row's last inked cell is the band's right
+        edge at every title length and there is nothing here to trim.
 
-        This method used to `rstrip` a LEFT-aligned name's trailing padding,
+        This method used to `rstrip` a left-aligned name's trailing padding,
         which produced a row that ended early — flush for a long title and up to
-        35 cells short for a brief one. Moving the padding to the other side of
-        the title fixes that at the source: the cells still exist, so the fit
-        arithmetic and every column left of the name are untouched, but they are
-        no longer at the edge where their absence was visible.
+        35 cells short for a brief one. Moving those cells ahead of the title
+        fixes that at the source: they still exist, so the fit arithmetic and
+        every column left of the name are untouched, but they are no longer at
+        the edge where their absence was visible. Putting them between the seam
+        and the title instead reaches the edge too and orphans the chevron by up
+        to 39 cells, which reads as a segment that failed to render.
 
         Aligning the group by its INK rather than its box is the other way to
         reach the edge, and the one this must not do: measured across four

--- a/local_operator/tui/widgets/status_line.py
+++ b/local_operator/tui/widgets/status_line.py
@@ -889,6 +889,12 @@ class StatusLine:
         #: attaches one, which keeps the band usable by the lightweight test
         #: hosts that have no terminal to write to.
         self._title: TerminalTitle | None = None
+        #: Cells of the trailing name's reserved box that the current title does
+        #: not fill. Paid out immediately before the seam that introduces the
+        #: title (see :meth:`_right_text`), which is what keeps the row flush to
+        #: the band's right edge without orphaning the chevron or letting the
+        #: title's length move any column to its left.
+        self._name_slack: int = 0
 
     def set_terminal_title(self, title: TerminalTitle | None) -> None:
         """Attach (or detach) the window-title writer and paint it once.
@@ -1510,6 +1516,9 @@ class StatusLine:
         caution), and the least volatile fields stay neutral. Green is not used
         at all — it belongs to the running indicator.
         """
+        # Reset per render: the reserve's unused cells are a property of THIS
+        # row, and a stale value would pay slack the current title does not have.
+        self._name_slack = 0
         parts: list[tuple[str, str, Style]] = []
         if self._subagent is not None and self._subagent.label:
             # Never dropped: it is what says whose numbers follow it, and a
@@ -1650,17 +1659,43 @@ class StatusLine:
             # of the user's opener, so it has no natural bound, and the band is a
             # fixed two-row box.
             #
-            # PADDED to its box, and left-aligned in it. The box is the reserved
-            # width, so the padding is what holds every sibling's column still
-            # while a model rewrites the string in it; left-aligned because the
-            # eye reads a title from its first cell, and a fixed first cell is
-            # exactly what a string that changes on its own needs. The leftover
-            # lands at the band's right edge, which is the one place on this row
-            # where nothing else was ever going to be.
+            # The box's UNUSED cells are emitted as their own segment, BEFORE
+            # the seam, rather than as padding on either side of the title.
+            #
+            # The reserve itself is unchanged and is still the point: the fit
+            # was decided against the full box, so those cells are spoken for
+            # and cannot be handed back to the layout without moving every
+            # column left of the name. What varies is only where they are
+            # painted, and both obvious answers put them somewhere a reader
+            # notices:
+            #
+            # * `ljust` trailed them after the title. `_compose` stripped them,
+            #   so the painted row ended early — flush at the band's edge for a
+            #   long title and up to 35 cells short for a brief one, which reads
+            #   as a rendering fault. (They are ordinary styled cells, so
+            #   anything READING the row carried them too: the SVG export wrote
+            #   all 35.)
+            # * `rjust` moved them between the seam and the title, which fixed
+            #   the edge and orphaned the `‹`: every other seam on the row is
+            #   tight against what it introduces, so a lone chevron with 36
+            #   blanks after it reads as a missing segment (design review D1).
+            #
+            # Emitting them ahead of the seam keeps the seam glued to the title
+            # it introduces AND puts the title's last cell on the band's right
+            # edge, while the columns left of the name still cannot see the
+            # title's length. A blank segment renders as blanks either way; the
+            # only thing being chosen here is which side of the chevron the
+            # slack falls on.
+            # Carried on the SEAM's left so no extra separator is emitted: the
+            # blanks ride in front of the ` ‹ ` that introduces the title, which
+            # is one segment, not two.
+            self._name_slack = name_cells - cell_len(
+                truncate_name(self._conversation_name, name_cells)
+            )
             parts.append(
                 (
                     "",
-                    truncate_name(self._conversation_name, name_cells).ljust(name_cells),
+                    truncate_name(self._conversation_name, name_cells),
                     Style(color=theme_mod.semantic_color("muted")),
                 )
             )
@@ -1668,6 +1703,13 @@ class StatusLine:
         right = Text()
         for index, (icon, text, style) in enumerate(parts):
             if index:
+                # The name's unused reserve is paid out HERE, immediately before
+                # the seam that introduces the title, so the chevron stays tight
+                # against the text it points at (design review D1) while the
+                # cells themselves still sit inside the right group and cannot
+                # move any column to its left.
+                if index == len(parts) - 1 and self._name_slack:
+                    right.append(" " * self._name_slack, style=dim)
                 right.append(f" {_SEP_RIGHT} ", style=seam)
             if icon:
                 right.append(f"{icon} ", style=dim)
@@ -1687,31 +1729,22 @@ class StatusLine:
         arithmetic is the same at every title length and a short title leaves its
         leftover at the band's edge rather than shunting the group right.
 
-        That leftover is then CUT from the painted row, and the order of those
-        two steps is the whole point — it is NOT the same thing as aligning the
-        group by its ink. The gap above is still computed from the PADDED box, so
-        every column up to and including the name's first cell remains a function
-        of the row's geometry alone and nothing to the LEFT of the name can see
-        this cut. Aligning by ink instead was tried and reintroduces the exact
-        defect the reserve exists for: the alarm glyph goes back to moving with
-        the title, measured at 120/150/160 columns across the four titles in
-        ``_NAMES`` as columns 91/90/85/108, 121/120/115/138 and 122/117/125/148.
-        Here the only cells removed are the run of blanks BETWEEN the name's last
-        inked cell and the band's right edge, and nothing is ever painted there:
-        the name is the row's last segment by construction.
+        The box's unused cells are spent INSIDE the name segment, which
+        right-aligns itself in them (see :meth:`_right_text`), so the row's last
+        inked cell is the band's right edge at every title length and there is
+        nothing here to trim.
 
-        Worth removing because those blanks are not nothing. They are ordinary
-        cells carrying the band's own style, so anything that READS the row
-        rather than looking at it carries them: the SVG export writes 35 trailing
-        spaces after a `short` title at a 160-column terminal (0 after the cut),
-        and a reflow or a copy would take them the same way. A row whose right
-        edge is flush for a long title and 35 cells short for a brief one reads
-        as a rendering fault rather than as a band with less to say.
+        This method used to `rstrip` a LEFT-aligned name's trailing padding,
+        which produced a row that ended early — flush for a long title and up to
+        35 cells short for a brief one. Moving the padding to the other side of
+        the title fixes that at the source: the cells still exist, so the fit
+        arithmetic and every column left of the name are untouched, but they are
+        no longer at the edge where their absence was visible.
 
-        ``rstrip`` mutates, so it is applied to the freshly built row and never
-        to ``right``: trimming the caller's group in place would leave the fit
-        arithmetic in :meth:`_walk` measuring a different string than the box it
-        reserved, which is the bug this method exists to avoid.
+        Aligning the group by its INK rather than its box is the other way to
+        reach the edge, and the one this must not do: measured across four
+        titles it walks the `!` alarm from column 74 to 91/111/151 at 100/120/160
+        cells, which is exactly the drift the reserve was introduced to stop.
         """
         if not right.plain:
             return left
@@ -1720,7 +1753,6 @@ class StatusLine:
         row.append_text(left)
         row.append(" " * gap, style=dim)
         row.append_text(right)
-        row.rstrip()
         return row
 
     def render_text(self, width: int) -> Text:

--- a/local_operator/tui/widgets/status_line.py
+++ b/local_operator/tui/widgets/status_line.py
@@ -1701,15 +1701,24 @@ class StatusLine:
             )
 
         right = Text()
+        last = len(parts) - 1
         for index, (icon, text, style) in enumerate(parts):
+            # The name's unused reserve is paid out HERE, immediately before the
+            # seam that introduces the title, so the chevron stays tight against
+            # the text it points at (design review D1) while the cells still sit
+            # inside the right group and cannot move any column to their left.
+            #
+            # OUTSIDE the `if index:` seam guard, because the name is not always
+            # preceded by a sibling: a freshly-opened session has no counters, no
+            # context reading, no cost and no duration, so the title is the whole
+            # right group and lands at index 0. Emitting the slack only alongside
+            # a seam silently skipped it there, and the group then aligned by its
+            # INK — the alternative this design explicitly rejects. Measured at
+            # 100 cells, the title's first column walked 95 -> 78 -> 73 -> 63 as
+            # the title grew, on the very first band a user sees (review F1).
+            if index == last and self._name_slack:
+                right.append(" " * self._name_slack, style=dim)
             if index:
-                # The name's unused reserve is paid out HERE, immediately before
-                # the seam that introduces the title, so the chevron stays tight
-                # against the text it points at (design review D1) while the
-                # cells themselves still sit inside the right group and cannot
-                # move any column to its left.
-                if index == len(parts) - 1 and self._name_slack:
-                    right.append(" " * self._name_slack, style=dim)
                 right.append(f" {_SEP_RIGHT} ", style=seam)
             if icon:
                 right.append(f"{icon} ", style=dim)

--- a/tests/unit/session/test_conversation_name_persistence.py
+++ b/tests/unit/session/test_conversation_name_persistence.py
@@ -25,12 +25,14 @@ from __future__ import annotations
 
 import asyncio
 import json
+import time
 from pathlib import Path
 from typing import Any
 
 import pytest
 
 from local_operator.harness.types import StreamEndEvent
+from local_operator.session import session as session_mod
 from local_operator.session.naming import CONVERSATION_NAME_CUSTOM_TYPE
 from local_operator.session.session import Session
 from local_operator.session.transcript import Transcript
@@ -229,6 +231,83 @@ async def test_a_rename_landing_mid_write_is_not_lost(tmp_path) -> None:
     assert _session(tmp_path).conversation_name == "Second title"
     await session.dispose()
     assert _session(tmp_path).conversation_name == "Second title"
+
+
+@pytest.mark.asyncio
+async def test_teardown_costs_one_budget_not_two(tmp_path, monkeypatch, caplog) -> None:
+    """The flush's whole cost is ``_NAME_FLUSH_TIMEOUT_S``, once.
+
+    The wait and the retry used to charge a full budget each and ran in
+    sequence, so a wedged volume plus a title that moved under the write made
+    teardown twice what the constant advertises (measured at 10 s). They now
+    share one deadline (review round 3, F14).
+
+    The warning is asserted too, so that bounding the wait stays visible in a
+    log rather than becoming a silent drop.
+    """
+    monkeypatch.setattr(session_mod, "_NAME_FLUSH_TIMEOUT_S", 0.4)
+
+    class WedgedTranscript(Transcript):
+        async def append_custom(self, custom_type: str, details: dict[str, Any]):
+            await asyncio.sleep(3600)
+            raise AssertionError("unreachable: the sleep outlives the test")
+
+    session = Session(
+        model=MODEL,
+        stream_fn=ScriptedStream([[StreamEndEvent(stop_reason="stop")]]),
+        tools=[],
+        transcript=WedgedTranscript(tmp_path / "sess"),
+        system_blocks_provider=lambda: [],
+    )
+    await session.async_init()
+    session.set_conversation_name("Title A", user_set=False)
+    await asyncio.sleep(0.05)
+    # Moves the title under the in-flight write, which is what sends the flush
+    # through BOTH halves — the case that used to cost two budgets.
+    session.set_conversation_name("Title B", user_set=True)
+
+    with caplog.at_level("WARNING"):
+        started = time.monotonic()
+        await session.dispose()
+        elapsed = time.monotonic() - started
+
+    # One budget plus scheduling slack, nowhere near two.
+    assert elapsed < 0.4 * 1.8, f"teardown took {elapsed:.2f}s, more than one budget"
+    assert any("conversation name" in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_a_slow_but_real_write_keeps_its_title(tmp_path, monkeypatch) -> None:
+    """The budget must not drop a write that was going to finish.
+
+    The wait and the retry used to charge a full budget EACH and run in
+    sequence, so teardown could take twice the advertised bound — and because
+    the bound is what decides whether a slow-but-real write is lost rather than
+    merely un-awaited, two tight budgets also threw away titles: an append just
+    under the sum was cut off by the first half. One shared deadline keeps any
+    append inside the budget and still bounds teardown.
+    """
+    monkeypatch.setattr(session_mod, "_NAME_FLUSH_TIMEOUT_S", 0.6)
+
+    class SlowTranscript(Transcript):
+        async def append_custom(self, custom_type: str, details: dict[str, Any]):
+            # Inside the shared budget, but past what either half would have
+            # allowed on its own.
+            await asyncio.sleep(0.45)
+            return await super().append_custom(custom_type, details)
+
+    session = Session(
+        model=MODEL,
+        stream_fn=ScriptedStream([[StreamEndEvent(stop_reason="stop")]]),
+        tools=[],
+        transcript=SlowTranscript(tmp_path / "sess"),
+        system_blocks_provider=lambda: [],
+    )
+    await session.async_init()
+    session.set_conversation_name("Slow but real", user_set=True)
+    await session.dispose()
+
+    assert _session(tmp_path).conversation_name == "Slow but real"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/session/test_conversation_name_persistence.py
+++ b/tests/unit/session/test_conversation_name_persistence.py
@@ -287,13 +287,18 @@ async def test_a_slow_but_real_write_keeps_its_title(tmp_path, monkeypatch) -> N
     under the sum was cut off by the first half. One shared deadline keeps any
     append inside the budget and still bounds teardown.
     """
-    monkeypatch.setattr(session_mod, "_NAME_FLUSH_TIMEOUT_S", 0.6)
+    # NOT monkeypatched. The defect was a hard-coded per-half budget, so a test
+    # that patches the shared constant proves nothing about it: the patched name
+    # simply is not read by the broken code, and the test passes either way
+    # (review round 1, F4). The delay is therefore expressed against the REAL
+    # `_NAME_FLUSH_TIMEOUT_S` and placed where the two shapes disagree — past
+    # what a single half used to allow, comfortably inside the shared budget.
+    delay = session_mod._NAME_FLUSH_TIMEOUT_S * 0.6
+    assert delay > 2.0, "the delay must exceed the old per-half budget to discriminate"
 
     class SlowTranscript(Transcript):
         async def append_custom(self, custom_type: str, details: dict[str, Any]):
-            # Inside the shared budget, but past what either half would have
-            # allowed on its own.
-            await asyncio.sleep(0.45)
+            await asyncio.sleep(delay)
             return await super().append_custom(custom_type, details)
 
     session = Session(

--- a/tests/unit/tui/test_status_line.py
+++ b/tests/unit/tui/test_status_line.py
@@ -1379,6 +1379,15 @@ def test_a_brief_title_leaves_no_dead_run_at_the_bands_right_edge(monkeypatch) -
                 assert (
                     row == row.rstrip()
                 ), f"{where}: {len(row) - len(row.rstrip())} dead cells at the band's edge"
+                # THE property, and the one the assertion above cannot carry:
+                # the row must REACH the band's right edge, not merely end on a
+                # non-blank cell. A row whose trailing padding has been stripped
+                # satisfies `row == row.rstrip()` trivially while stopping up to
+                # 35 cells short — which is exactly what shipped, and why this
+                # test passed against the code it was written to pin (F2).
+                assert (
+                    cell_len(row) == width
+                ), f"{where}: the row stops {width - cell_len(row)} cells short of the edge"
                 # The ink really is the title's, not a coincidence of truncation.
                 assert row.endswith(truncate_name(name, _name_box(row, name, width))), where
                 boxes.add(_name_box(row, name, width))
@@ -1414,6 +1423,16 @@ def test_the_titles_seam_stays_tight_against_the_title(monkeypatch) -> None:
                 seam = f" {_SEP_RIGHT} "
                 tail = row[row.rindex(seam) + len(seam) :]
                 assert tail and not tail.startswith(" "), f"{where}: the seam was orphaned"
+                # Both halves together, because either alone is satisfied by a
+                # shape this test exists to reject: `ljust` + `rstrip` also
+                # leaves the seam tight (it just ends the row early), and
+                # `rjust` also reaches the edge (it just orphans the seam). Only
+                # asserting the pair pins the one arrangement that does both,
+                # and without this the test passed against the code it replaced
+                # (F2).
+                assert (
+                    cell_len(row) == width
+                ), f"{where}: the seam is tight but the row stops short of the edge"
 
 
 def test_a_double_width_title_never_overflows_the_band(monkeypatch) -> None:
@@ -1446,6 +1465,55 @@ def test_a_double_width_title_never_overflows_the_band(monkeypatch) -> None:
                         f"{label} alarm={alarm} width={width} name={name!r}: "
                         f"the row is {cell_len(row)} cells wide"
                     )
+                    if not status.is_showing("name"):
+                        # No name means no reserved box to fill, so the row is
+                        # whatever the surviving segments are — only the
+                        # overflow half of the contract applies here.
+                        continue
+                    # EQUAL, not merely `<=`. Both halves of the cell/character
+                    # mismatch are failures and only one of them is an overflow:
+                    # padding a double-width title by CHARACTERS overshoots the
+                    # box, and a row that then strips the excess lands SHORT of
+                    # the edge instead of over it (268 short rows measured that
+                    # way). Asserting the row is exactly its width catches the
+                    # mismatch in whichever direction it manifests — `<=` alone
+                    # passed against the very code this pins (F2).
+                    assert cell_len(row) == width, (
+                        f"{label} alarm={alarm} width={width} name={name!r}: "
+                        f"the row is {cell_len(row)} cells wide, not {width}"
+                    )
+
+
+def test_the_reserve_is_paid_even_when_the_name_is_the_only_segment(monkeypatch) -> None:
+    """The name is not always preceded by a sibling, and the slack must still land.
+
+    A freshly-opened session has no counters, no context reading, no cost and no
+    duration — ``format_jobs(0)``, ``format_agents(0)`` and
+    ``format_context_usage(0, …)`` all return "" and the duration is suppressed
+    at zero — so the title is the WHOLE right group and lands at index 0 of the
+    join loop. Emitting the reserve's slack only alongside a seam skipped it in
+    exactly that shape, and the group then aligned by its INK: the row stopped
+    short of the band's edge and the title's first column walked with its own
+    length, on the very first band a user sees (review round 1, F1).
+
+    This is the sparse band on purpose. Every other band test populates the row.
+    """
+    monkeypatch.setenv("HOME", "/Users/tester")
+    for width in (80, 100, 120, 160):
+        for name in ("a", "Short", "Reduce agent RAM usage", "A much longer title than that"):
+            dock = _dock(width)
+            status = StatusLine(dock)
+            status.update(
+                model_label="anthropic/claude-opus-4",
+                cwd="/Users/tester/work/local-operator",
+                conversation_name=name,
+            )
+            row = status.render_text(width).plain
+            if not status.is_showing("name"):
+                continue
+            assert (
+                cell_len(row) == width
+            ), f"width={width} name={name!r}: the row stops {width - cell_len(row)} cells short"
 
 
 def test_the_bands_cut_lands_on_a_word_like_the_excerpt_it_was_handed() -> None:

--- a/tests/unit/tui/test_status_line.py
+++ b/tests/unit/tui/test_status_line.py
@@ -29,6 +29,7 @@ from local_operator.tui.widgets.status_line import (
     _DROP_LADDER_QUIET,
     _DROP_LADDER_QUIET_ESTIMATE,
     _MIN_GROUP_GAP,
+    _SEP_RIGHT,
     _SPINNER_FRAMES,
     _UNBOUNDED_RUNGS,
     ICON_AGENTS,
@@ -1044,7 +1045,7 @@ def test_the_alarm_sits_beside_the_name_rather_than_replacing_it() -> None:
     assert "auto-approve" not in row, "the alarm's prose was crowding out the name"
     assert "always" not in row
     # The glyph, immediately before the name and after its seam.
-    assert row.endswith("! ‹ Add todo guardrails")
+    assert re.search(r"! +‹ Add todo guardrails$", row)
 
 
 def test_an_unnamed_session_leaves_the_trailing_slot_to_whatever_is_left() -> None:
@@ -1171,18 +1172,24 @@ def _name_box(row: str, name: str, width: int) -> int:
 
     The box is what the layout is built on, and it is not the same number as the
     ink in it: a word-boundary cut can leave `Bulk export the…` in an 18-cell box.
-    Located from the name's own opening characters, which land on the box's first
-    cell because the name is left-aligned in it.
 
-    Measured to ``width`` rather than to ``len(row)``, and that is the difference
-    between the box and the ink now that ``_compose`` stops painting the box's
-    trailing blanks. The reserve still runs to the band's right edge — the row is
-    laid out to exactly ``width`` and only then trimmed — so the edge, not the
-    last inked cell, is where the box ends. Reading ``len(row)`` here would make
-    this helper return the INK and quietly turn every caller into a test of the
-    string's length instead of the layout's reserve.
+    Located from the box's own left edge, which is where its UNUSED cells start
+    — not from the name's first character. The reserve's leftover is painted
+    just before the seam that introduces the title, so the title's first cell
+    moves with its length and measuring from it would return the ink instead of
+    the box. Everything from the end of the previous segment's ink to the band's
+    right edge is the reserve, seam included.
+
+    Measured to ``width`` rather than to ``len(row)`` for the same reason: the
+    row is laid out to exactly ``width``, so the edge is where the box ends, and
+    reading the string's length would quietly turn every caller into a test of
+    the ink instead of the layout's reserve.
     """
-    return width - row.rindex(name[:4])
+    seam = f" {_SEP_RIGHT} "
+    # The last seam is the title's. Walk left over the blanks in front of it to
+    # reach the box's first cell; the segment before them ends on real ink.
+    start = len(row[: row.rindex(seam)].rstrip())
+    return width - start - len(seam)
 
 
 def test_naming_a_session_never_costs_a_segment_for_nothing(monkeypatch) -> None:
@@ -1292,11 +1299,19 @@ def test_the_name_takes_every_cell_the_row_can_spare(monkeypatch) -> None:
     boxes = []
     for width in range(100, 181):
         row = status.render_text(width).plain
-        box = len(row) - row.index("! ‹ ") - len("! ‹ ")
+        box = len(row) - row.index("!") - len("! ‹ ")
         boxes.append(box)
-        # Whatever is spare is IN the name's box, so the hole between the groups
+        # Whatever is spare is IN the name's box, so the hole BETWEEN THE GROUPS
         # is the seam's own width until the box is full.
-        longest_gap = max((len(run) for run in re.findall(r" {2,}", row.rstrip())), default=0)
+        #
+        # Measured up to the name's box rather than across the whole row. The
+        # title is right-aligned in its box, so a word-boundary cut leaves its
+        # unused cells immediately before the title — a run this regex sees and
+        # which is not a layout gap at all but the reserve doing its job. The
+        # property under test is that the LAYOUT does not idle while the name is
+        # still hungry, and the layout is everything left of that box.
+        head = row[: len(row) - box]
+        longest_gap = max((len(run) for run in re.findall(r" {2,}", head)), default=0)
         assert (
             box >= NAME_CELLS or longest_gap <= _MIN_GROUP_GAP
         ), f"width={width}: {longest_gap} cells idle beside a {box}-cell name"
@@ -1370,6 +1385,67 @@ def test_a_brief_title_leaves_no_dead_run_at_the_bands_right_edge(monkeypatch) -
             # ...and the reserve behind that trimmed tail did not move with the
             # title's length, which is the property the padding used to provide.
             assert len(boxes) <= 1, f"{label} width={width}: the box moved with the title {boxes}"
+
+
+def test_the_titles_seam_stays_tight_against_the_title(monkeypatch) -> None:
+    """The `‹` introduces the name and has to touch it (design review D1).
+
+    The reserve's unused cells have to be painted somewhere, and the two obvious
+    places are both wrong. After the title, the row ends early (the defect above
+    this one). Between the seam and the title, the row is flush but the chevron
+    is orphaned: every other seam on the band is tight against what it
+    introduces, so a lone `‹` trailed by a run of blanks reads as a segment that
+    failed to render rather than as spacing.
+
+    So the cells go BEFORE the seam, and this pins that — at every width and for
+    titles short enough to leave a large leftover, which is where an orphan
+    would be most visible.
+    """
+    monkeypatch.setenv("HOME", "/Users/tester")
+    for label, state in _LADDER_STATES.items():
+        status = _swept_band(state, alarm=True)
+        for width in (100, 120, 160):
+            for name in ("a", "short", "Bulk export the invoice columns"):
+                status.update(conversation_name=name)
+                row = status.render_text(width).plain
+                if not status.is_showing("name"):
+                    continue
+                where = f"{label} width={width} name={name!r}"
+                seam = f" {_SEP_RIGHT} "
+                tail = row[row.rindex(seam) + len(seam) :]
+                assert tail and not tail.startswith(" "), f"{where}: the seam was orphaned"
+
+
+def test_a_double_width_title_never_overflows_the_band(monkeypatch) -> None:
+    """The band is ONE row, in cells — including for CJK and Hangul titles.
+
+    The reserve is measured in cells and the row's gap is computed with
+    ``cell_len``, so any padding of the name has to be counted the same way.
+    Padding it with ``str.rjust`` counts CHARACTERS instead, and a title of
+    double-width glyphs then emits a row wider than the band: 592 rows over
+    their width across the ladder variants, worst case 11 cells. Rich drops the
+    over-wide segment rather than clipping it, so the effect was a CJK-named
+    conversation resuming with no name on the band at all — this feature's own
+    failure, reintroduced for non-Latin titles (review round 1, F1).
+    """
+    monkeypatch.setenv("HOME", "/Users/tester")
+    titles = (
+        "修复恢复时的会话标题",
+        "セッションのタイトルを復元する",
+        "세션 제목 복원하기",
+        "修复登录重定向循环的问题并添加测试用例以防止回归",
+    )
+    for label, state in _LADDER_STATES.items():
+        for alarm in (True, False):
+            status = _swept_band(state, alarm=alarm)
+            for name in titles:
+                status.update(conversation_name=name)
+                for width in range(60, 181):
+                    row = status.render_text(width).plain
+                    assert cell_len(row) <= width, (
+                        f"{label} alarm={alarm} width={width} name={name!r}: "
+                        f"the row is {cell_len(row)} cells wide"
+                    )
 
 
 def test_the_bands_cut_lands_on_a_word_like_the_excerpt_it_was_handed() -> None:

--- a/tests/unit/tui/test_terminal_title.py
+++ b/tests/unit/tui/test_terminal_title.py
@@ -21,6 +21,7 @@ from typing import cast
 
 from textual.widgets import Static
 
+from local_operator.session.naming import ConversationName
 from local_operator.tui.terminal_title import (
     BRAND,
     MAX_LABEL_CHARS,
@@ -125,7 +126,31 @@ def test_a_label_that_sanitizes_away_reads_as_no_label() -> None:
 
 
 def test_the_label_is_capped() -> None:
+    # One enormous token has no boundary to cut on, so it is cut mid-token
+    # rather than dropped — a tab reading `lo ›` says less than a cut string.
+    # The ellipsis rides in the last cell, so the cap still holds exactly.
     assert len(sanitize_label("x" * 500)) == MAX_LABEL_CHARS
+
+
+def test_a_renamed_conversation_reaches_the_tab_cut_on_a_word() -> None:
+    """The cut has to happen where the LENGTH is decided, not on the tab.
+
+    ``MAX_TITLE_CHARS`` and ``MAX_LABEL_CHARS`` are both 80, so a title arrives
+    at ``sanitize_label`` already sliced by the store and the tab-side word cut
+    could never fire for a conversation name — the OSC still ended mid-word
+    (`…and reconcile the ledge`) with the tab-side fix in place. Shortening in
+    ``ConversationName.set`` is what actually reaches the surface, and this
+    drives the real path to prove it (design review round 2, D6).
+    """
+    name = ConversationName()
+    stored = name.set(
+        "Investigate why the nightly importer drops rows silently "
+        "and reconcile the ledger totals",
+        user_set=True,
+    )
+    assert stored.endswith("…"), "the stored title was sliced mid-word"
+    assert not stored.endswith("ledge…"), "cut mid-word rather than on a boundary"
+    assert build_title(sanitize_label(stored), "idle").endswith("and reconcile the…")
 
 
 def test_cwd_stands_in_for_a_conversation_that_has_no_name_yet() -> None:


### PR DESCRIPTION
# PR Description

## Change classification

**C2 — standard / pre-authorized.** Correctness and layout fixes on the status band, the terminal tab label, and the title journal's teardown budget. No new surface, no config, no transcript format change. Clean rollback (`git revert`). No RFC requested.

Follow-up to #163, which landed conversation-title persistence. These are defects in that feature's **surface**, found by reviewing what a user sees rather than what the plumbing does. The persistence machinery itself is untouched.

## 1. The band's title never reached the right edge

Reported directly: a short title leaves a visible gap between itself and the band's right edge, while a long one sits flush.

The trailing name is given a reserved 40-cell box so the `!` alarm and its siblings keep a stable column. That part is right and stays. But the box's unused cells were painted **after** the title and then stripped, so the painted row simply ended early:

```text
BEFORE (main @ 90d1f5a)                                                            ends at
|◆ anthropic/claude-opus-4 › ⌂ /Users/damian/local-operator    ▦ 18.2%/1M ‹ ◈ $14.12 ‹ ! ‹ Fix session title on resume|   107/120
|◆ anthropic/claude-opus-4 › ⌂ /Users/damian/local-operator    ▦ 18.2%/1M ‹ ◈ $14.12 ‹ ! ‹ Reduce agent RAM usage|        102/120

AFTER
|◆ anthropic/claude-opus-4 › ⌂ /Users/damian/local-operator    ▦ 18.2%/1M ‹ ◈ $14.12 ‹ !              ‹ Fix session title on resume|  120/120
|◆ anthropic/claude-opus-4 › ⌂ /Users/damian/local-operator    ▦ 18.2%/1M ‹ ◈ $14.12 ‹ !                   ‹ Reduce agent RAM usage|  120/120
```

Up to **35 cells short** for a brief title. They are ordinary styled cells, so anything that *reads* the row carried them too — the app's own SVG export wrote all 35.

The slack now rides immediately **before** the seam that introduces the title. Same cells, same reserve, same fit arithmetic; only which side of the chevron they fall on changes. Three properties then hold together:

| | before | after |
|---|---|---|
| row reaches the band's edge | 107/120, 102/120 | **120/120 at every title length** |
| `!` alarm column (100/120/160 cols) | 74 / 76 / 116 | **74 / 76 / 116 — unchanged** |
| `‹` adjacent to its title | yes | **yes** |

Two weaker shapes were tried and rejected, and both are recorded in the code so the next reader does not repeat them:

- **Padding after the title** is the original bug.
- **`rjust`** reaches the edge but orphans the chevron by up to 39 blank cells, which reads as a segment that failed to render rather than as spacing.
- **Measuring the right group by its ink** also reaches the edge and walks the alarm from column 74 to 91/111/151 — precisely the drift the reserve was built to stop.

## 2. A double-width title made the name vanish

The reserve is measured in **cells** and `_compose` computes its gap with `cell_len`, but the padding counted **characters**. For CJK/Hangul titles the two disagreed and the row was emitted wider than the band:

```console
$ # four CJK/Hangul titles x four ladder variants x alarm on/off x widths 60-180
main @ 90d1f5a:  OVER: w=93 cells=94  name='修复恢复时的会话标题'
                 rows exceeding their width: 95
after:           rows exceeding their width: 0
```

Rich **drops** an over-wide segment rather than clipping it, so a CJK-named conversation resumed onto a band showing no name at all — the exact failure #163 exists to fix, reintroduced for non-Latin titles. Computing the slack with `cell_len` removes the mismatch by construction.

## 3. A long name was cut mid-word on both surfaces

```console
before  stored: 'Investigate why the nightly importer drops rows silently and reconcile the ledge'
        tab   : 'lo › …and reconcile the ledge'
after   stored: 'Investigate why the nightly importer drops rows silently and reconcile the…'
        tab   : 'lo › Investigate why the nightly importer drops rows silently and reconcile the…'
```

`ConversationName.set` sliced at 80 characters. Fixing it in `sanitize_label` alone cannot work — `MAX_TITLE_CHARS` and `MAX_LABEL_CHARS` are both 80, so every title arrives at the tab already sliced — so the cut moves to where the length is actually decided, and the store, the band and the tab now share one `naming.cut_on_a_word` helper.

Only `/rename` can reach this: a model's over-long answer is *rejected* by `parse_title` rather than truncated, and that rule is untouched. A single enormous token (a URL, a base64 blob) is still cut mid-token, because a bare `lo ›` says less than a cut string.

## 4. A slow title write lost its title, and teardown cost two budgets

The dispose flush charged a full 2 s to the wait for an in-flight write **and** another to the retry behind it, in sequence. Two consequences: teardown could take twice the documented bound, and an append landing between one budget and two was cut off by the first half and dropped.

Both halves now share one 5 s deadline, so the constant states the real worst case and any append inside it keeps its title:

```console
                  main @ 90d1f5a          after
append=1.9s       dispose=1.9s rows=1     dispose=1.9s rows=1
append=2.1s       dispose=4.0s rows=1     dispose=2.1s rows=1
append=3.0s       dispose=4.0s rows=1     dispose=3.0s rows=1
append=4.9s       dispose=4.0s rows=0     dispose=4.9s rows=1   <== title was LOST, now kept
append=6.0s       dispose=4.0s rows=0     dispose=5.0s rows=0   <== bounded, warned
```

5 s rather than a tighter number because the bound now decides whether a slow-but-real write is **lost** rather than merely un-awaited. An append is sub-millisecond on a local disk, so seconds already mean a stalled mount — and in that state a user is better served by a few seconds of teardown than by a resume that opens unnamed.

## Validation

### Regression tests, confirmed to fail without each fix

```console
$ # band, with the padding moved back after the title
FAILED test_a_brief_title_leaves_no_dead_run_at_the_bands_right_edge
       the row stops 20 cells short of the edge

$ # band, with rjust restored
FAILED test_the_titles_seam_stays_tight_against_the_title  — the seam was orphaned
FAILED test_a_double_width_title_never_overflows_the_band
       width=106 name='修复恢复时的会话标题': the row is 107 cells wide

$ # store, with the word cut reverted
FAILED test_a_renamed_conversation_reaches_the_tab_cut_on_a_word
       the stored title was sliced mid-word

$ # flush, with a full budget per half
FAILED test_teardown_costs_one_budget_not_two — teardown took 0.80s, more than one budget
```

### Gates

```console
$ .venv/bin/python -m pytest tests/unit -q
4968 passed, 7 skipped, 1 deselected in 821.12s

$ .venv/bin/python -m flake8 .                                   # clean
$ uvx --from black==26.1.0 black --check local_operator tests    # 375 files unchanged
$ uvx isort --check-only --profile black local_operator tests    # clean
$ .venv/bin/python -m pyright --pythonpath .venv/bin/python .     # 0 errors, 0 warnings
```

The one deselected test (`tests/unit/tools/test_eval_tool.py::test_background_streams_output_while_it_runs`) **fails identically on unmodified `origin/main`** and is unrelated to this change.

### Visual

Frames captured from the real `OperatorApp` (which loads the stylesheet — the lightweight test hosts do not) at 80/120/160 columns, short/medium/long/CJK titles, and looked at. Consecutive frames are byte-identical, so nothing reflows after paint.

## Provenance

The band and robustness fixes were developed and reviewed on #166 across four agent-review rounds and two design-review rounds while #163 was in flight; #163 then landed the persistence half independently. This PR is that branch rebased onto the new `main` with the already-merged work dropped, so the diff is only what `main` still lacks. #166 is closed in favour of this.
