### PR TITLE
perf(compaction): make snapcompact local and honest about its numbers

### DIFF
--- a/local_operator/compaction/api.py
+++ b/local_operator/compaction/api.py
@@ -212,6 +212,26 @@ def _serialize_message(message: AgentMessage, drop_call_ids: set[str]) -> str | 
     """One transcript block, or None to drop the message entirely."""
     if isinstance(message, CustomMessage):
         if message.custom_type == "compaction_summary":
+            # A snapcompact marker's summary is reading instructions for its
+            # image frames, not a digest — chaining IT into a later text
+            # summarization would replace the archived history with constant
+            # boilerplate. The archive's text edges are the real transcript
+            # (newest and oldest slices), so serialize those instead. The
+            # session's own summarize path never reaches this branch (it
+            # converts markers to rendered content first); this guards direct
+            # consumers of serialize_conversation handed raw transcript
+            # vocabulary.
+            preserve = message.details.get("preserve_data") or {}
+            snap = preserve.get("snapcompact") if isinstance(preserve, dict) else None
+            if isinstance(snap, dict):
+                edges = [
+                    edge
+                    for edge in (snap.get("text_head"), snap.get("text_tail"))
+                    if isinstance(edge, str) and edge.strip()
+                ]
+                if edges:
+                    joined = "\n[...]\n".join(edges)
+                    return f"[Previously archived history (edges)]\n{joined}"
             summary = message.details.get("summary", "")
             return f"[Previous compaction summary]\n{summary}"
         return f"[{message.custom_type}]"

--- a/local_operator/compaction/api.py
+++ b/local_operator/compaction/api.py
@@ -108,6 +108,14 @@ TOOL_RESULT_MAX_CHARS = 2000
 #: Serialized tool-call arguments are truncated to this many characters.
 TOOL_ARGS_MAX_CHARS = 500
 
+#: Cap on the archived-history edges a snapcompact marker serializes into a
+#: text transcript (``_serialize_message``). Generous relative to the other
+#: slots because the edges ARE the content the marker stands for, but bounded
+#: because they can reach ~71k chars each and a direct consumer of
+#: ``serialize_conversation`` must be able to budget its prompt. Tail-biased
+#: on truncation: chaining wants the newest history most.
+ARCHIVE_EDGES_MAX_CHARS = 8000
+
 
 #: Hard cap on a generated summary (``MAX_SUMMARY_TOKENS``). The
 #: complete_fn has no max-tokens knob yet, so the cap is enforced post-hoc:
@@ -231,6 +239,17 @@ def _serialize_message(message: AgentMessage, drop_call_ids: set[str]) -> str | 
                 ]
                 if edges:
                     joined = "\n[...]\n".join(edges)
+                    # Bounded like every other free-text slot here, but far
+                    # more generously (the edges are up to ~71k chars EACH
+                    # under the Gemini shape, and this serializer's other
+                    # slots cap at 2,000): a direct consumer building a
+                    # prompt from a compacted conversation must not inherit
+                    # an unbounded ~36k-token block. Tail-biased, because
+                    # chaining wants the NEWEST history most.
+                    if len(joined) > ARCHIVE_EDGES_MAX_CHARS:
+                        kept = joined[-ARCHIVE_EDGES_MAX_CHARS:]
+                        dropped = len(joined) - ARCHIVE_EDGES_MAX_CHARS
+                        joined = f"[... {dropped} older characters truncated]\n{kept}"
                     return f"[Previously archived history (edges)]\n{joined}"
             summary = message.details.get("summary", "")
             return f"[Previous compaction summary]\n{summary}"

--- a/local_operator/compaction/png.py
+++ b/local_operator/compaction/png.py
@@ -40,10 +40,16 @@ __all__ = ["encode_grayscale_png"]
 #: CRLF/LF pair let readers detect corrupting transfers.
 _SIGNATURE = b"\x89PNG\r\n\x1a\n"
 
-#: DEFLATE level. 9 is affordable here: frames are two-tone and compress almost
-#: instantly, and archive payloads ride in the model context, where every byte
-#: is billed.
-_COMPRESS_LEVEL = 9
+#: DEFLATE level. 6, not 9, and the difference is the user's wait: on a full
+#: 1932px frame level 9 spends ~390 ms against level 6's ~37 ms (measured on
+#: the raw scanline stream of a typical page) for ~11% fewer bytes. The bytes
+#: are the wrong thing to optimize — providers bill images by their pixel
+#: dimensions, not their file size, so the smaller file saves request payload
+#: only, while the encode time sits directly on the compaction pass the user
+#: is watching. The one byte ceiling that matters (FRAME_DATA_BYTES_BUDGET,
+#: 3 MB per request) is nowhere near binding at either level: a full archive
+#: replay is ~6 frames × ~130 KB base64.
+_COMPRESS_LEVEL = 6
 
 
 def _chunk(kind: bytes, payload: bytes) -> bytes:

--- a/local_operator/compaction/snapcompact.py
+++ b/local_operator/compaction/snapcompact.py
@@ -185,8 +185,9 @@ def frame_token_estimate_for(provider: str, model_id: str) -> int:
     context that the provider then billed at 6.7k. Formulas mirror omp's
     ``familyBilling``, which verified them against live bills:
 
-    - Anthropic: ceil(edge/28)² 28px patches, capped at 4,784 visual tokens,
-      +5% margin (1568px → 3,293; 1932px → 5,024).
+    - Anthropic: ceil(edge/28)² 28px patches, capped at 4,784 patches, +5%
+      margin (1568px → 3,293; 1932px → 5,000 — 69² = 4,761 patches, under
+      the cap; the cap binds only for frames past ~1,937px).
     - Google: flat 1,120 tokens per image (``media_resolution`` HIGH),
       regardless of pixel size.
     - OpenAI: ceil(edge/32)² 32px patches × 1.2 flagship multiplier, capped
@@ -645,13 +646,19 @@ def compact_to_archive(
         edge_tokens = estimate_archive_tokens(
             Archive(frames=[], text_head=text_head, text_tail=text_tail)
         )
+        budget_dropped = 0
         while pages and edge_tokens + len(pages) * per_frame > budget:
-            truncated_chars += len(pages[0])
+            budget_dropped += len(pages[0])
             pages = pages[1:]
+        if budget_dropped:
+            # ONE cumulative marker for the whole budget pass, not one per
+            # dropped page: N markers say the same thing N times and each
+            # re-renders into every later archive via Archive.text.
+            truncated_chars += budget_dropped
             text_head += f"\n[... {truncated_chars} chars of oldest history dropped]"
-        # The marker lines appended above are a handful of tokens; they are
-        # deliberately not folded back into edge_tokens — the budget is an
-        # estimate with a 2x reserve, not an invoice.
+        # The marker line is a handful of tokens; it is deliberately not
+        # folded back into edge_tokens — the budget is an estimate with a
+        # 2x reserve, not an invoice.
 
     frames = [render_frame(page, shape) for page in pages]
     # Pages carry no trailing newline; joining without one glues the last
@@ -730,6 +737,24 @@ def strategy_for_model(model_spec: ModelSpec) -> Literal["snapcompact", "context
     return "snapcompact" if model_spec.supports_images else "context-full"
 
 
+#: ``Shape.id`` grammar: ``<advance>on<line_pitch>-bw@<width>``. Parsed back
+#: when a caption must describe an archive rendered by a DIFFERENT model than
+#: the one reading it (mid-session switches): the frames' own shape_id is the
+#: durable truth about their geometry; the current model's shape is not.
+_SHAPE_ID_RE = re.compile(r"^(\d+)on(\d+)-bw@(\d+)$")
+
+
+def _shape_from_id(shape_id: str) -> Shape | None:
+    """Revive the geometry a persisted archive was rendered with, or None."""
+    match = _SHAPE_ID_RE.match(shape_id or "")
+    if not match:
+        return None
+    advance, line_pitch, width = (int(g) for g in match.groups())
+    if not (advance and line_pitch and width):
+        return None
+    return _shape(8, 13, advance, line_pitch, width)
+
+
 def archive_summary(archive: Archive, provider: str, model_id: str) -> str:
     """Deterministic summary text for a snapcompact pass — NO LLM call.
 
@@ -748,7 +773,11 @@ def archive_summary(archive: Archive, provider: str, model_id: str) -> str:
     contradict it, and hosts that render the text slot get an honest caption
     rather than an unlabelled apology.
     """
-    shape = resolve_shape(provider, model_id)
+    # The frames were rendered with the archive's OWN shape; after a model
+    # switch the current reader's shape can differ, and a caption describing
+    # the wrong grid is worse than none. Fall back to the reader's shape only
+    # for archives predating shape_id.
+    shape = _shape_from_id(archive.shape_id) or resolve_shape(provider, model_id)
     middle = (
         ", with the middle rendered as pixel-font image frames"
         if archive.frames

--- a/local_operator/compaction/snapcompact.py
+++ b/local_operator/compaction/snapcompact.py
@@ -187,7 +187,7 @@ def frame_token_estimate_for(provider: str, model_id: str) -> int:
 
     - Anthropic: ceil(edge/28)² 28px patches, capped at 4,784 patches, +5%
       margin (1568px → 3,293; 1932px → 5,000 — 69² = 4,761 patches, under
-      the cap; the cap binds only for frames past ~1,937px).
+      the cap; the cap binds from 1,933px, where ceil(edge/28) reaches 70).
     - Google: flat 1,120 tokens per image (``media_resolution`` HIGH),
       regardless of pixel size.
     - OpenAI: ceil(edge/32)² 32px patches × 1.2 flagship multiplier, capped
@@ -630,35 +630,34 @@ def compact_to_archive(
         dropped = pages[: len(pages) - max_frames]
         truncated_chars = sum(len(p) for p in dropped)
         pages = pages[len(pages) - max_frames :]
-        text_head += f"\n[... {truncated_chars} chars of oldest history dropped]"
 
     # Token budget: drop oldest middle pages until the replayed archive fits a
     # reserve-adjusted share of the window. Frames are priced with the actual
     # provider's billing (frame_token_estimate_for), not the cross-provider
     # ceiling — the ceiling made a Gemini archive look 4.5x its billed size
     # and dropped history the window could afford. The text edges are
-    # tokenized ONCE outside the loop: they are fixed-size (the truncation
-    # marker aside), and the previous per-iteration re-estimate tokenized
-    # ~126k chars of unchanged text each round through tiktoken.
+    # tokenized ONCE outside the loop: they are fixed-size, and the previous
+    # per-iteration re-estimate tokenized ~126k chars of unchanged text each
+    # round through tiktoken.
     per_frame = frame_token_estimate_for(provider, model_id)
     if pages and context_window and context_window > 0:
         budget = max(per_frame, int(context_window * 0.5))
         edge_tokens = estimate_archive_tokens(
             Archive(frames=[], text_head=text_head, text_tail=text_tail)
         )
-        budget_dropped = 0
         while pages and edge_tokens + len(pages) * per_frame > budget:
-            budget_dropped += len(pages[0])
+            truncated_chars += len(pages[0])
             pages = pages[1:]
-        if budget_dropped:
-            # ONE cumulative marker for the whole budget pass, not one per
-            # dropped page: N markers say the same thing N times and each
-            # re-renders into every later archive via Archive.text.
-            truncated_chars += budget_dropped
-            text_head += f"\n[... {truncated_chars} chars of oldest history dropped]"
-        # The marker line is a handful of tokens; it is deliberately not
-        # folded back into edge_tokens — the budget is an estimate with a
-        # 2x reserve, not an invoice.
+
+    # ONE cumulative marker for everything both passes dropped, appended
+    # after both have run. One marker per pass double-counted: the budget
+    # pass's cumulative figure already included the frame-cap pass's, so a
+    # reader summing the two markers counted the first drop twice — and each
+    # marker re-renders into every later archive via Archive.text. The
+    # marker's few tokens are deliberately not folded back into edge_tokens;
+    # the budget is an estimate with a 2x reserve, not an invoice.
+    if truncated_chars:
+        text_head += f"\n[... {truncated_chars} chars of oldest history dropped]"
 
     frames = [render_frame(page, shape) for page in pages]
     # Pages carry no trailing newline; joining without one glues the last

--- a/local_operator/compaction/snapcompact.py
+++ b/local_operator/compaction/snapcompact.py
@@ -46,17 +46,34 @@ from .tokens import estimate_tokens
 # Constants (snapcompact)
 # ---------------------------------------------------------------------------
 
-#: Upper bound on archive frames carried per compaction
-#: (``MAX_FRAMES_DEFAULT``). Oldest middle frames are dropped first.
+#: Hard upper bound on archive frames carried per compaction. Oldest middle
+#: frames are dropped first. This is a ceiling, not the default: see
+#: :data:`DEFAULT_MAX_FRAMES` for why the pass renders far fewer.
 MAX_FRAMES = 80
 
 #: Conservative per-frame token estimate used for context budgeting — the
-#: upper bound across shapes (``FRAME_TOKEN_ESTIMATE``).
+#: upper bound across shapes (``FRAME_TOKEN_ESTIMATE``). Prefer
+#: :func:`frame_token_estimate_for` when the reader is known: providers bill
+#: images very differently (a Gemini frame is 1,120 tokens, an Anthropic
+#: 1932px frame ~5,000), and budgeting every frame at the ceiling makes the
+#: pass drop history it could afford to keep.
 FRAME_TOKEN_ESTIMATE = 5024
 
 #: High-quality frames kept at each chronological edge of a foveated archive
 #: (``HQ_EDGE_FRAMES``).
 HQ_EDGE_FRAMES = 3
+
+#: Default frame budget for a compaction pass — the number of frames replay
+#: will actually send. ``history_blocks`` foveates any archive middle beyond
+#: ``2 * HQ_EDGE_FRAMES + 2`` frames down to the HQ edges, so a pass that
+#: renders more than this spends ~430 ms of raster+deflate per frame on
+#: pages no model ever sees. Measured on a live 600k-token session: 80 frames
+#: rendered (~35 s), 6 replayed. Content beyond the budget is dropped from
+#: the archive text with an explicit ``[... N chars of oldest history
+#: dropped]`` marker — the same fate omp gives it ("About N characters of
+#: older middle history dropped to fit archive budget"), and strictly more
+#: honest than rendering it into frames that are then silently elided.
+DEFAULT_MAX_FRAMES = 2 * HQ_EDGE_FRAMES + 2
 
 #: Maximum snapcompact image base64 carried in every rebuilt provider request
 #: (``FRAME_DATA_BYTES_BUDGET``).
@@ -68,6 +85,7 @@ TOOL_CALL_MAX_CHARS = 2000
 
 __all__ = [
     "MAX_FRAMES",
+    "DEFAULT_MAX_FRAMES",
     "FRAME_TOKEN_ESTIMATE",
     "HQ_EDGE_FRAMES",
     "FRAME_DATA_BYTES_BUDGET",
@@ -80,6 +98,7 @@ __all__ = [
     "history_blocks",
     "strategy_for_model",
     "estimate_archive_tokens",
+    "frame_token_estimate_for",
 ]
 
 
@@ -153,6 +172,37 @@ def resolve_shape(provider: str, model_id: str) -> Shape:
     if "openai" in p or "codex" in p or "azure" in p:
         return _shape(8, 13, 8, 22, 1568)
     return _shape(8, 13, 8, 22, 1568)
+
+
+def frame_token_estimate_for(provider: str, model_id: str) -> int:
+    """What ONE archive frame costs in the named provider's visual tokens.
+
+    Providers do not bill images alike, and pricing every frame at the
+    cross-provider ceiling (:data:`FRAME_TOKEN_ESTIMATE` = 5024) is not
+    conservative — it is wrong in a user-visible way: the compaction receipt
+    and the status band price the replayed archive with this number, so a
+    Gemini archive of six 1,120-token frames was reported as 30k tokens of
+    context that the provider then billed at 6.7k. Formulas mirror omp's
+    ``familyBilling``, which verified them against live bills:
+
+    - Anthropic: ceil(edge/28)² 28px patches, capped at 4,784 visual tokens,
+      +5% margin (1568px → 3,293; 1932px → 5,024).
+    - Google: flat 1,120 tokens per image (``media_resolution`` HIGH),
+      regardless of pixel size.
+    - OpenAI: ceil(edge/32)² 32px patches × 1.2 flagship multiplier, capped
+      at 10,000 patches (1568px → 2,882).
+    - Unknown families: Anthropic's formula, the safe ceiling.
+    """
+    shape = resolve_shape(provider, model_id)
+    edge = shape.page_width_px
+    p = (provider or "").lower()
+    if "google" in p or "gemini" in p or "vertex" in p:
+        return 1120
+    if "openai" in p or "codex" in p or "azure" in p:
+        patches = min((-(-edge // 32)) ** 2, 10_000)
+        return -(-(patches * 12) // 10)  # ceil(patches * 1.2)
+    patches = min((-(-edge // 28)) ** 2, 4784)
+    return -(-(patches * 105) // 100)  # ceil(patches * 1.05)
 
 
 # ---------------------------------------------------------------------------
@@ -525,7 +575,7 @@ def compact_to_archive(
     model_id: str,
     previous_text: str | None = None,
     *,
-    max_frames: int = MAX_FRAMES,
+    max_frames: int = DEFAULT_MAX_FRAMES,
     context_window: int | None = None,
 ) -> Archive:
     """Run one snapcompact pass over discarded ``messages``.
@@ -536,9 +586,19 @@ def compact_to_archive(
     When the imaged middle overflows the frame budget, the OLDEST middle pages
     are dropped (with a marker) — mirrors how iterative summaries fade the
     oldest detail. ``context_window`` caps the archive by TOKENS as well as
-    frame count: 80 frames at ~5024 visual tokens each is twice a 200k window,
-    so without the cap the pass that exists to get under the threshold can
+    frame count, so the pass that exists to get under the threshold cannot
     itself overflow it on the next turn.
+
+    ``max_frames`` defaults to :data:`DEFAULT_MAX_FRAMES` — exactly the
+    number of frames ``history_blocks`` will replay before foveation elides
+    the interior. The pass used to render up to :data:`MAX_FRAMES` (80) and
+    let replay throw 74 of them away, which is where a manual ``/compact``
+    spent most of its minute: ~430 ms of raster + deflate per frame, on the
+    event loop, for pages no model ever saw — plus ~10 MB of dead base64 in
+    the transcript entry. The dropped content is not lost silently: it leaves
+    the archive text with an explicit ``[... N chars of oldest history
+    dropped]`` marker, and the un-imaged source is what ``Archive.text``
+    carries forward for the next pass.
     """
     shape = resolve_shape(provider, model_id)
     max_frames = max(1, min(max_frames, MAX_FRAMES))
@@ -571,27 +631,27 @@ def compact_to_archive(
         pages = pages[len(pages) - max_frames :]
         text_head += f"\n[... {truncated_chars} chars of oldest history dropped]"
 
-    # Token budget: the frame COUNT cap alone allows 80 * FRAME_TOKEN_ESTIMATE
-    # visual tokens, which exceeds most windows. Drop oldest middle pages
-    # until the replayed archive fits a reserve-adjusted share of the window.
-    if context_window and context_window > 0:
-        budget = max(FRAME_TOKEN_ESTIMATE, int(context_window * 0.5))
-        while (
-            pages
-            and estimate_archive_tokens(
-                Archive(
-                    frames=[],
-                    text=text_head + "\n".join(pages) + text_tail,
-                    text_head=text_head,
-                    text_tail=text_tail,
-                )
-            )
-            + len(pages) * FRAME_TOKEN_ESTIMATE
-            > budget
-        ):
+    # Token budget: drop oldest middle pages until the replayed archive fits a
+    # reserve-adjusted share of the window. Frames are priced with the actual
+    # provider's billing (frame_token_estimate_for), not the cross-provider
+    # ceiling — the ceiling made a Gemini archive look 4.5x its billed size
+    # and dropped history the window could afford. The text edges are
+    # tokenized ONCE outside the loop: they are fixed-size (the truncation
+    # marker aside), and the previous per-iteration re-estimate tokenized
+    # ~126k chars of unchanged text each round through tiktoken.
+    per_frame = frame_token_estimate_for(provider, model_id)
+    if pages and context_window and context_window > 0:
+        budget = max(per_frame, int(context_window * 0.5))
+        edge_tokens = estimate_archive_tokens(
+            Archive(frames=[], text_head=text_head, text_tail=text_tail)
+        )
+        while pages and edge_tokens + len(pages) * per_frame > budget:
             truncated_chars += len(pages[0])
             pages = pages[1:]
             text_head += f"\n[... {truncated_chars} chars of oldest history dropped]"
+        # The marker lines appended above are a handful of tokens; they are
+        # deliberately not folded back into edge_tokens — the budget is an
+        # estimate with a 2x reserve, not an invoice.
 
     frames = [render_frame(page, shape) for page in pages]
     # Pages carry no trailing newline; joining without one glues the last
@@ -668,6 +728,57 @@ def history_blocks(
 def strategy_for_model(model_spec: ModelSpec) -> Literal["snapcompact", "context-full"]:
     """snapcompact iff the model can read images back; else context-full."""
     return "snapcompact" if model_spec.supports_images else "context-full"
+
+
+def archive_summary(archive: Archive, provider: str, model_id: str) -> str:
+    """Deterministic summary text for a snapcompact pass — NO LLM call.
+
+    This is the text slot of the compaction entry when the archive carries the
+    real history. It mirrors omp's ``snapcompact-summary.md``: instructions
+    for reading the replayed archive (text edges verbatim, the middle as
+    pixel-font frames), not a paraphrase of the content. The paraphrase is
+    what the frames replace — producing one anyway meant shipping the whole
+    discarded history to a provider and waiting on the reply, which made the
+    "no LLM call, no network" pass 20–50 s slower than the local work it
+    fronted, and is exactly why ``/compact`` here took a minute while omp's
+    is near-instant.
+
+    Deliberately structural (frame count, grid geometry, truncation note):
+    every fact is derivable from the archive, so the summary can never
+    contradict it, and hosts that render the text slot get an honest caption
+    rather than an unlabelled apology.
+    """
+    shape = resolve_shape(provider, model_id)
+    middle = (
+        ", with the middle rendered as pixel-font image frames"
+        if archive.frames
+        else ", all as plain text"
+    )
+    lines = [
+        "Resume prior conversation. Earlier turns are archived below, oldest to",
+        f"newest{middle}.",
+        "",
+        "Reading the archive:",
+        "- Plain text: verbatim transcript; rely on it exactly.",
+    ]
+    if archive.frames:
+        plural = "s" if len(archive.frames) != 1 else ""
+        lines.append(
+            f"- {len(archive.frames)} image frame{plural}: each is one page of the"
+            f" transcript, a grid up to {shape.chars_per_line} characters wide and"
+            f" {shape.lines_per_frame} rows tall, read left to right, top to bottom."
+            " No word wrap; words may break across rows."
+        )
+    if archive.truncated_chars:
+        lines.append(
+            f"- About {archive.truncated_chars:,} characters of the oldest middle"
+            " history were dropped to fit the archive budget (marked inline)."
+        )
+    lines.append(
+        "- If an exact earlier detail matters and a section is unclear, re-derive"
+        " it from the workspace (re-read files, re-run commands) rather than guess."
+    )
+    return "\n".join(lines)
 
 
 def estimate_archive_tokens(archive: Archive) -> int:

--- a/local_operator/harness/types.py
+++ b/local_operator/harness/types.py
@@ -963,14 +963,16 @@ class CompactionEndEvent(AgentEvent[Literal["compaction_end"]]):
     """A compaction pass settled.
 
     ``tokens_before`` is the figure the gate acted on (``max(provider
-    context, local estimate)``); ``tokens_after`` is the local estimate of
-    the rebuilt history with archive frames priced at the provider's image
-    billing — so a host can report what the pass ACHIEVED in numbers that
-    agree with the status band and the next provider bill. Compaction is slow
-    and its effect is invisible in the transcript, so "context compacted"
-    alone asks the user to take it on faith. Both are zero when the pass
-    failed, and ``strategy`` is the concrete mechanism that ran
-    (``snapcompact`` or ``context-full``).
+    context, local estimate)``); ``tokens_after`` is that figure minus the
+    history-only saving, measured by one local ruler on both sides with
+    archive frames priced at the provider's image billing — so a host can
+    report what the pass ACHIEVED in numbers that agree with the status band
+    and the next provider bill, and can subtract the pair from its own
+    reading without double-counting the request overhead the pass never
+    touched. Compaction is slow and its effect is invisible in the
+    transcript, so "context compacted" alone asks the user to take it on
+    faith. Both are zero when the pass failed, and ``strategy`` is the
+    concrete mechanism that ran (``snapcompact`` or ``context-full``).
     """
 
     type: Literal["compaction_end"] = "compaction_end"

--- a/local_operator/harness/types.py
+++ b/local_operator/harness/types.py
@@ -962,12 +962,15 @@ class CompactionStartEvent(AgentEvent[Literal["compaction_start"]]):
 class CompactionEndEvent(AgentEvent[Literal["compaction_end"]]):
     """A compaction pass settled.
 
-    ``tokens_before``/``tokens_after`` size the LLM-visible history either side
-    of the pass, by the same local ruler, so a host can report what the pass
-    ACHIEVED — compaction is slow and its effect is invisible in the
-    transcript, so "context compacted" alone asks the user to take it on faith.
-    Both are zero when the pass failed, and ``strategy`` is the concrete
-    mechanism that ran (``snapcompact`` or ``context-full``).
+    ``tokens_before`` is the figure the gate acted on (``max(provider
+    context, local estimate)``); ``tokens_after`` is the local estimate of
+    the rebuilt history with archive frames priced at the provider's image
+    billing — so a host can report what the pass ACHIEVED in numbers that
+    agree with the status band and the next provider bill. Compaction is slow
+    and its effect is invisible in the transcript, so "context compacted"
+    alone asks the user to take it on faith. Both are zero when the pass
+    failed, and ``strategy`` is the concrete mechanism that ran
+    (``snapcompact`` or ``context-full``).
     """
 
     type: Literal["compaction_end"] = "compaction_end"

--- a/local_operator/session/protocol.py
+++ b/local_operator/session/protocol.py
@@ -50,11 +50,14 @@ class CompactionOutcome:
 
     ``tokens_before`` is the figure the compaction gate acted on —
     ``max(provider-reported context, local estimate)`` — so the receipt agrees
-    with the status band the user was just looking at. ``tokens_after`` is the
-    local estimate of the rebuilt history, with archive frames re-priced at
-    the provider's own image billing rather than the estimator's flat rate.
-    Both exclude the system blocks and tool schemas, which a compaction does
-    not touch.
+    with the status band the user was just looking at. ``tokens_after`` is
+    ``tokens_before`` minus the pass's saving, where the saving is the
+    HISTORY-only difference measured by one local ruler on both sides (archive
+    frames re-priced at the provider's own image billing). Subtracting a
+    history-only after-figure from a full-request before-figure would count
+    the system blocks and tool schemas — which a compaction does not touch —
+    as if the pass had removed them; keeping the overhead on both sides is
+    what lets a host subtract the pair from its own reading safely.
     """
 
     ran: bool

--- a/local_operator/session/protocol.py
+++ b/local_operator/session/protocol.py
@@ -48,11 +48,13 @@ class CompactionOutcome:
     than in each host so the TUI, exec mode and the server cannot each invent
     their own wording for the same refusal.
 
-    ``tokens_before``/``tokens_after`` are the conversation's size measured by
-    the SAME local ruler on both sides of the pass (compaction's own
-    estimator over the LLM-visible history), so their difference is the saving
-    a receipt can quote. They exclude the system blocks and tool schemas,
-    which a compaction does not touch.
+    ``tokens_before`` is the figure the compaction gate acted on —
+    ``max(provider-reported context, local estimate)`` — so the receipt agrees
+    with the status band the user was just looking at. ``tokens_after`` is the
+    local estimate of the rebuilt history, with archive frames re-priced at
+    the provider's own image billing rather than the estimator's flat rate.
+    Both exclude the system blocks and tool schemas, which a compaction does
+    not touch.
     """
 
     ran: bool

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -2951,27 +2951,49 @@ class Session:
             # baked in here as a plain user message is past both of the guards
             # that expire it.
             self._context.messages = [marker, *kept]
-            # Measured with the SAME ruler as ``plan.tokens_before`` (the local
-            # estimate over the converted history), so the difference is a real
-            # saving a receipt can quote and the recovery band below compares
-            # like with like. The provider's own figure is not available until
-            # the next request.
             tokens_after = await self._offloaded(
                 compaction_api, "estimate_messages_tokens", self._render_for_compaction()
             )
+            # The local ruler prices every image at a flat IMAGE_TOKEN_ESTIMATE
+            # (1200), but the archive frames the marker just replayed are billed
+            # by the PROVIDER's formula — ~5,000 visual tokens for an Anthropic
+            # 1932px frame. Correct the after-figure by the difference so the
+            # receipt prices the archive the way the next bill will. Measured on
+            # the live session that motivated this: the uncorrected figure read
+            # 60.1k against a provider-reported 137.5k on the next request.
+            snap_payload = (preserve_data or {}).get("snapcompact")
+            if isinstance(snap_payload, dict):
+                try:
+                    from local_operator.compaction.snapcompact import (
+                        frame_token_estimate_for,
+                    )
+
+                    frame_count = len(snap_payload.get("frames") or [])
+                    per_frame = frame_token_estimate_for(self._model.provider, self._model.model_id)
+                    tokens_after += frame_count * (per_frame - IMAGE_TOKEN_ESTIMATE)
+                except Exception:  # noqa: BLE001 - a receipt must not fail the pass
+                    logger.debug("frame pricing correction failed", exc_info=True)
+            # ``tokens_before`` is the figure the GATE acted on —
+            # ``max(provider-reported, local estimate)`` — not the bare local
+            # estimate. The user compares the receipt against the status band,
+            # and the band shows the provider's number: a pass that fired at a
+            # provider-reported 600k and then printed "319.4k → …" (the local
+            # estimate) read as the band and the receipt disagreeing about
+            # what just happened. omp quotes the provider figure for the same
+            # reason (``calculateContextTokens(lastUsage)``).
             await self._emit(
                 CompactionEndEvent(
                     reason=reason,
                     success=True,
                     strategy=plan.strategy,
-                    tokens_before=plan.tokens_before,
+                    tokens_before=plan.context_tokens,
                     tokens_after=tokens_after,
                 )
             )
             return CompactionOutcome(
                 ran=True,
                 strategy=plan.strategy,
-                tokens_before=plan.tokens_before,
+                tokens_before=plan.context_tokens,
                 tokens_after=tokens_after,
             )
         except Exception as exc:
@@ -3015,22 +3037,39 @@ class Session:
         replaying it as text while the frames are dropped means the pass
         reduces nothing and re-fires on the next turn. Any error — including
         ImportError — falls back to the one-shot LLM summary.
+
+        The snapcompact branch makes NO provider call — that is its contract
+        (omp: "Archive history onto dense bitmap images the model reads back
+        (no LLM call)"), and for a while this method broke it: the archive was
+        built locally and then the whole discarded history was ALSO shipped to
+        the provider for a written digest of frames that already carry the
+        real thing. On a 600k-token session that call was 20–50 s of the
+        ~60 s a manual ``/compact`` took, with the archive render spending the
+        rest — against omp's near-instant pass. The text slot is now the
+        deterministic reading-instructions digest (``archive_summary``), whose
+        every fact derives from the archive itself.
+
+        ``compact_to_archive`` runs in a worker thread: it is pure CPU
+        (serialize → tokenize → rasterize → deflate) on the order of half a
+        second, and the one event loop it would otherwise stall is shared
+        with every subagent and the TUI repaint — the same reasoning as
+        :meth:`_offloaded`, at a call site that cannot use it (this is not a
+        ruler on the module).
         """
         if strategy == "snapcompact":
             try:
                 from local_operator.compaction import snapcompact
 
-                archive = snapcompact.compact_to_archive(
+                archive = await asyncio.to_thread(
+                    snapcompact.compact_to_archive,
                     to_summarize,
                     self._model.provider,
                     self._model.model_id,
                     self._previous_archive_text(),
                     context_window=self._model.context_window,
                 )
-                # The frames are the durable record; the text slot is a
-                # compact digest for hosts that render summaries as text.
-                summary = await compaction_api.summarize_messages(
-                    to_summarize, self._one_shot_complete
+                summary = snapcompact.archive_summary(
+                    archive, self._model.provider, self._model.model_id
                 )
                 return summary or " ", {"snapcompact": _archive_to_json(archive)}
             except Exception:

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -695,10 +695,28 @@ def _render_compaction_marker(marker: CustomMessage, entry_id: str | None = None
                 return _replayed_user_message(content, entry_id)
         except Exception:
             logger.warning("snapcompact replay failed; falling back to text summary", exc_info=True)
+    # A snapcompact summary is reading instructions for the frames, not a
+    # digest of the history — falling back to it ALONE would replay a caption
+    # describing images that are not there while the real content vanished.
+    # The archive's text edges are plain strings in the same payload and
+    # survive whatever made the frame list unrevivable, so salvage them: they
+    # are the newest/oldest slices of the actual transcript, which is strictly
+    # more useful than any caption.
+    salvage = ""
+    if isinstance(archive_payload, dict):
+        head = archive_payload.get("text_head")
+        tail = archive_payload.get("text_tail")
+        edges = [edge for edge in (head, tail) if isinstance(edge, str) and edge.strip()]
+        if edges:
+            joined = "\n[...]\n".join(edges)
+            salvage = f"\n<archived-transcript-edges>\n{joined}\n</archived-transcript-edges>"
     return _replayed_user_message(
         [
             TextContent(
-                text="<previous-context-summary>\n" f"{summary}\n" "</previous-context-summary>"
+                text="<previous-context-summary>\n"
+                f"{summary}\n"
+                "</previous-context-summary>"
+                f"{salvage}"
             )
         ],
         entry_id,
@@ -2951,7 +2969,7 @@ class Session:
             # baked in here as a plain user message is past both of the guards
             # that expire it.
             self._context.messages = [marker, *kept]
-            tokens_after = await self._offloaded(
+            history_after = await self._offloaded(
                 compaction_api, "estimate_messages_tokens", self._render_for_compaction()
             )
             # The local ruler prices every image at a flat IMAGE_TOKEN_ESTIMATE
@@ -2970,7 +2988,7 @@ class Session:
 
                     frame_count = len(snap_payload.get("frames") or [])
                     per_frame = frame_token_estimate_for(self._model.provider, self._model.model_id)
-                    tokens_after += frame_count * (per_frame - IMAGE_TOKEN_ESTIMATE)
+                    history_after += frame_count * (per_frame - IMAGE_TOKEN_ESTIMATE)
                 except Exception:  # noqa: BLE001 - a receipt must not fail the pass
                     logger.debug("frame pricing correction failed", exc_info=True)
             # ``tokens_before`` is the figure the GATE acted on —
@@ -2981,6 +2999,19 @@ class Session:
             # estimate) read as the band and the receipt disagreeing about
             # what just happened. omp quotes the provider figure for the same
             # reason (``calculateContextTokens(lastUsage)``).
+            #
+            # But the SAVING is measured with one ruler. The provider figure is
+            # the full request (system blocks + tool schemas + history) while
+            # the local estimates cover history alone, so ``context_tokens -
+            # history_after`` would count the fixed overhead as if the pass had
+            # removed it — inflating the receipt's "% smaller" and collapsing
+            # the band (which subtracts before-after) to a figure that
+            # understates the next request by the whole overhead. The honest
+            # after-figure keeps the overhead on both sides:
+            # ``context_tokens - (history saving)``, floored at the history
+            # itself for the degenerate case where the plan's figures cross.
+            saved = max(0, plan.tokens_before - history_after)
+            tokens_after = max(history_after, plan.context_tokens - saved)
             await self._emit(
                 CompactionEndEvent(
                     reason=reason,

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -709,7 +709,14 @@ def _render_compaction_marker(marker: CustomMessage, entry_id: str | None = None
         edges = [edge for edge in (head, tail) if isinstance(edge, str) and edge.strip()]
         if edges:
             joined = "\n[...]\n".join(edges)
-            salvage = f"\n<archived-transcript-edges>\n{joined}\n</archived-transcript-edges>"
+            # The summary above may describe pixel-font frames; none are in
+            # this message, and a caption describing absent images is a claim
+            # the model would waste attention reconciling. Say so explicitly.
+            salvage = (
+                "\n[note: the archive's image frames could not be replayed here; "
+                "the plain-text edges below are what survives]"
+                f"\n<archived-transcript-edges>\n{joined}\n</archived-transcript-edges>"
+            )
     return _replayed_user_message(
         [
             TextContent(

--- a/local_operator/session_factory.py
+++ b/local_operator/session_factory.py
@@ -376,7 +376,19 @@ def _latest_user_query(transcript: Any) -> str:
         entry_type = getattr(entry, "type", None)
         payload = getattr(entry, "payload", None) or {}
         if not summary and entry_type == "compaction":
-            summary = str(payload.get("summary", "")).strip()
+            # A snapcompact entry's summary is reading instructions for the
+            # archive frames, not conversation content — as a selection query
+            # it is constant boilerplate that would drown the user's actual
+            # words. The archive's text_tail is the newest slice of the real
+            # transcript, so prefer it (bounded: selection wants a signal, not
+            # the whole edge).
+            preserve = payload.get("preserve_data") or {}
+            snap = preserve.get("snapcompact") if isinstance(preserve, dict) else None
+            tail = snap.get("text_tail") if isinstance(snap, dict) else None
+            if isinstance(tail, str) and tail.strip():
+                summary = tail.strip()[-2000:]
+            else:
+                summary = str(payload.get("summary", "")).strip()
         if not user_text and entry_type == "message" and payload.get("role") == "user":
             content = payload.get("content") or []
             user_text = "".join(

--- a/local_operator/session_factory.py
+++ b/local_operator/session_factory.py
@@ -384,11 +384,18 @@ def _latest_user_query(transcript: Any) -> str:
             # the whole edge).
             preserve = payload.get("preserve_data") or {}
             snap = preserve.get("snapcompact") if isinstance(preserve, dict) else None
-            tail = snap.get("text_tail") if isinstance(snap, dict) else None
-            if isinstance(tail, str) and tail.strip():
-                summary = tail.strip()[-2000:]
-            else:
-                summary = str(payload.get("summary", "")).strip()
+            # Prefer text_tail, then text_head: a small archive stores ALL its
+            # text in text_head with an empty tail, and falling straight
+            # through to the summary there re-created the boilerplate-noise
+            # defect for exactly the sessions with the least other signal.
+            edge = ""
+            if isinstance(snap, dict):
+                for key in ("text_tail", "text_head"):
+                    candidate = snap.get(key)
+                    if isinstance(candidate, str) and candidate.strip():
+                        edge = candidate.strip()[-2000:]
+                        break
+            summary = edge or str(payload.get("summary", "")).strip()
         if not user_text and entry_type == "message" and payload.get("role") == "user":
             content = payload.get("content") or []
             user_text = "".join(

--- a/tests/unit/compaction/test_api.py
+++ b/tests/unit/compaction/test_api.py
@@ -48,6 +48,40 @@ def test_tool_result_truncation_boundary():
     assert "1 more characters truncated" in in_over
 
 
+def test_snapcompact_marker_serializes_its_text_edges_not_the_caption():
+    """A snapcompact marker's summary is reading instructions for its frames,
+    not a digest — chaining it into a later text summarization (a vision→text
+    model switch is the live path) would replace the archived history with
+    constant boilerplate. The archive's text edges are the real transcript,
+    so the serializer prefers them; a marker with no archive (a context-full
+    pass) keeps the summary, which for that strategy IS the content."""
+    from local_operator.harness.types import CustomMessage
+
+    snap_marker = CustomMessage(
+        custom_type="compaction_summary",
+        details={
+            "summary": "Resume prior conversation. Reading the archive: ...",
+            "preserve_data": {
+                "snapcompact": {
+                    "text_head": "OLDEST: parser question",
+                    "text_tail": "NEWEST: fix landed",
+                }
+            },
+        },
+    )
+    rendered = serialize_conversation([snap_marker])
+    assert "OLDEST: parser question" in rendered
+    assert "NEWEST: fix landed" in rendered
+    assert "Reading the archive" not in rendered
+
+    text_marker = CustomMessage(
+        custom_type="compaction_summary",
+        details={"summary": "the agent read two modules"},
+    )
+    rendered = serialize_conversation([text_marker])
+    assert "the agent read two modules" in rendered
+
+
 def test_useless_drops_pair_but_sibling_survives():
     """A useless result AND its paired call vanish; a sibling call on the same
     assistant survives with its (non-useless) result."""

--- a/tests/unit/compaction/test_snapcompact.py
+++ b/tests/unit/compaction/test_snapcompact.py
@@ -12,13 +12,16 @@ from pydantic import ValidationError
 
 from local_operator.compaction.api import TOOL_ARGS_MAX_CHARS, TOOL_RESULT_MAX_CHARS
 from local_operator.compaction.snapcompact import (
+    DEFAULT_MAX_FRAMES,
     FRAME_DATA_BYTES_BUDGET,
     FRAME_TOKEN_ESTIMATE,
     HQ_EDGE_FRAMES,
     MAX_FRAMES,
     Archive,
+    archive_summary,
     compact_to_archive,
     estimate_archive_tokens,
+    frame_token_estimate_for,
     history_blocks,
     render_frame,
     resolve_shape,
@@ -258,15 +261,31 @@ def test_compact_large_history_frames_and_edges():
     assert again.text.startswith(archive.text[:200])
 
 
-def test_compact_caps_frames_at_max():
-    """Oldest middle pages drop with a marker once the frame budget overflows."""
+def test_compact_caps_frames_at_default_budget():
+    """Oldest middle pages drop with a marker once the frame budget overflows.
+
+    The default budget is DEFAULT_MAX_FRAMES — the number replay actually
+    sends — not the MAX_FRAMES ceiling: rendering 80 frames so foveation
+    could throw 74 of them away is where a manual /compact spent ~35 of its
+    60 seconds."""
     shape = resolve_shape("openai", "gpt-5.5")
-    # Far more text than MAX_FRAMES frames can hold.
-    messages = [Message.user(f"turn {i} " + "w" * shape.capacity) for i in range(MAX_FRAMES + 40)]
+    # Far more text than the default budget's frames can hold.
+    messages = [
+        Message.user(f"turn {i} " + "w" * shape.capacity) for i in range(DEFAULT_MAX_FRAMES + 40)
+    ]
     archive = compact_to_archive(messages, "openai", "gpt-5.5")
-    assert len(archive.frames) == MAX_FRAMES
+    assert len(archive.frames) == DEFAULT_MAX_FRAMES
     assert archive.truncated_chars > 0
     assert "oldest history dropped]" in archive.text_head
+
+
+def test_compact_max_frames_is_a_ceiling_an_explicit_ask_can_reach():
+    """An explicit ``max_frames`` above the default still renders (bounded by
+    MAX_FRAMES) — the knob exists for archives meant to be read exhaustively."""
+    shape = resolve_shape("openai", "gpt-5.5")
+    messages = [Message.user(f"turn {i} " + "w" * shape.capacity) for i in range(20)]
+    archive = compact_to_archive(messages, "openai", "gpt-5.5", max_frames=MAX_FRAMES)
+    assert DEFAULT_MAX_FRAMES < len(archive.frames) <= MAX_FRAMES
 
 
 def test_compact_frames_are_valid_pngs():
@@ -314,13 +333,19 @@ def test_history_blocks_elides_over_budget():
 
 
 def test_history_blocks_foveates_long_middle():
-    """Interior frames beyond the HQ edges collapse to an elision marker."""
+    """Interior frames beyond the HQ edges collapse to an elision marker.
+
+    Reached with an explicit over-default ``max_frames``: a fresh pass renders
+    only what replay sends, but archives PERSISTED by older builds carry up to
+    80 frames, and replaying one of those must still foveate rather than ship
+    them all."""
     shape = resolve_shape("anthropic", "claude-sonnet-4-5")
     page = "f" * (shape.capacity // 2)
     archive = compact_to_archive(
         [Message.user(f"t{i} {page}") for i in range(200)],
         "anthropic",
         "claude-sonnet-4-5",
+        max_frames=MAX_FRAMES,
     )
     assert len(archive.frames) > 2 * HQ_EDGE_FRAMES + 2
     blocks = history_blocks(archive)
@@ -399,6 +424,58 @@ def test_malformed_persisted_frame_is_a_validation_error():
 # ---------------------------------------------------------------------------
 # Integration helpers
 # ---------------------------------------------------------------------------
+
+
+def test_frame_token_estimate_follows_provider_billing():
+    """Per-family image billing (mirrors omp's ``familyBilling``, verified
+    against live bills there): Anthropic patch pricing capped at 4,784 visual
+    tokens +5%, OpenAI 32px patches x1.2, Gemini a flat 1,120 per image. The
+    cross-provider ceiling (5024) stays exported for callers with no reader
+    at hand, but pricing a Gemini frame at it overstated the archive 4.5x."""
+    assert frame_token_estimate_for("anthropic", "claude-fable-5") == 5000  # 1932px, capped
+    assert frame_token_estimate_for("anthropic", "claude-sonnet-4-5") == 3293  # 1568px
+    assert frame_token_estimate_for("openai", "gpt-5.5") == 2882  # 49^2 * 1.2
+    assert frame_token_estimate_for("google", "gemini-3") == 1120  # flat HIGH budget
+    # Unknown families take Anthropic's formula at 1568px: the safe ceiling.
+    assert frame_token_estimate_for("mystery", "model-x") == 3293
+    # Every estimate stays under the exported ceiling.
+    for provider, model in [
+        ("anthropic", "claude-fable-5"),
+        ("openai", "gpt-5.5"),
+        ("google", "gemini-3"),
+    ]:
+        assert frame_token_estimate_for(provider, model) <= FRAME_TOKEN_ESTIMATE
+
+
+def test_archive_summary_is_deterministic_and_structural():
+    """The snapcompact text slot is built locally from the archive — no LLM
+    call (the branch's contract, and the 20-50s the manual pass used to spend).
+    Every claim in it derives from the archive, so it can never contradict
+    the frames it captions."""
+    archive = _large_archive()
+    summary = archive_summary(archive, "anthropic", "claude-sonnet-4-5")
+    assert summary == archive_summary(archive, "anthropic", "claude-sonnet-4-5")
+    assert str(len(archive.frames)) in summary
+    assert "image frame" in summary
+    shape = resolve_shape("anthropic", "claude-sonnet-4-5")
+    assert str(shape.chars_per_line) in summary
+
+    # A text-only archive does not describe frames it does not have.
+    small = compact_to_archive(
+        _conversation_messages(2, payload=50), "anthropic", "claude-sonnet-4-5"
+    )
+    text_only = archive_summary(small, "anthropic", "claude-sonnet-4-5")
+    assert "image frame" not in text_only
+
+    # A truncated archive says so.
+    shape_o = resolve_shape("openai", "gpt-5.5")
+    big = compact_to_archive(
+        [Message.user(f"t{i} " + "w" * shape_o.capacity) for i in range(DEFAULT_MAX_FRAMES + 40)],
+        "openai",
+        "gpt-5.5",
+    )
+    assert big.truncated_chars > 0
+    assert "dropped" in archive_summary(big, "openai", "gpt-5.5")
 
 
 def test_strategy_for_model_both_branches():

--- a/tests/unit/compaction/test_snapcompact.py
+++ b/tests/unit/compaction/test_snapcompact.py
@@ -432,7 +432,8 @@ def test_frame_token_estimate_follows_provider_billing():
     tokens +5%, OpenAI 32px patches x1.2, Gemini a flat 1,120 per image. The
     cross-provider ceiling (5024) stays exported for callers with no reader
     at hand, but pricing a Gemini frame at it overstated the archive 4.5x."""
-    assert frame_token_estimate_for("anthropic", "claude-fable-5") == 5000  # 1932px, capped
+    # 1932px: 69^2 = 4,761 patches, UNDER the 4,784 cap; x1.05 -> 5,000.
+    assert frame_token_estimate_for("anthropic", "claude-fable-5") == 5000
     assert frame_token_estimate_for("anthropic", "claude-sonnet-4-5") == 3293  # 1568px
     assert frame_token_estimate_for("openai", "gpt-5.5") == 2882  # 49^2 * 1.2
     assert frame_token_estimate_for("google", "gemini-3") == 1120  # flat HIGH budget

--- a/tests/unit/session/test_compact_now.py
+++ b/tests/unit/session/test_compact_now.py
@@ -103,11 +103,21 @@ async def talk(session: Session, turns: int = 3) -> None:
 async def test_a_vision_model_compacts_into_a_snapcompact_archive(tmp_path):
     """``supports_images`` picks snapcompact, and the pass proves it took that
     branch by storing an archive — the same ``preserve_data['snapcompact']``
-    payload the automatic pass stores, because it is the same code."""
+    payload the automatic pass stores, because it is the same code.
+
+    The pass must also make NO provider call: that is snapcompact's contract
+    (the archive replaces a summary), and the call it used to make — the whole
+    discarded history shipped out for a caption — is where a manual /compact
+    spent 20–50 of its ~60 seconds. ``_one_shot_complete`` raising proves the
+    branch never reaches for it."""
     stream = ScriptedStream(["reply"] * 4)
     session = make_session(tmp_path, stream, model=VISION_MODEL)
     await talk(session)
 
+    async def no_llm_calls(system: str, prompt: str) -> str:
+        raise AssertionError("snapcompact must not make a provider call")
+
+    session._one_shot_complete = no_llm_calls  # type: ignore[method-assign]
     outcome = await session.compact_now()
 
     assert outcome.ran is True
@@ -238,9 +248,10 @@ async def test_the_manual_strategy_is_the_automatic_one(tmp_path):
 
 @pytest.mark.asyncio
 async def test_the_receipt_reports_a_real_reduction(tmp_path):
-    """tokens_before/after are measured by ONE ruler either side of the pass, so
-    their difference is a saving a receipt can quote — and the end EVENT carries
-    the same pair, which is what the TUI notice renders."""
+    """tokens_before is the figure the gate acted on and tokens_after the
+    estimate of the rebuilt history, so their difference is a saving a receipt
+    can quote — and the end EVENT carries the same pair, which is what the TUI
+    notice renders."""
     stream = ScriptedStream(["reply"] * 4)
     session = make_session(tmp_path, stream, model=TEXT_MODEL)
     await talk(session, turns=4)
@@ -262,6 +273,30 @@ async def test_the_receipt_reports_a_real_reduction(tmp_path):
         outcome.tokens_before,
         outcome.tokens_after,
     )
+    await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_the_receipt_quotes_the_figure_the_gate_acted_on(tmp_path):
+    """When the provider has reported a context size larger than the local
+    estimate, the receipt's "before" is THAT figure — the one on the status
+    band the user is comparing against. Quoting the local estimate instead
+    made a pass that fired at a provider-reported 600k print "319.4k → …",
+    which reads as the band and the receipt disagreeing about what happened.
+    """
+    from local_operator.harness.types import Usage
+
+    stream = ScriptedStream(["reply"] * 4)
+    session = make_session(tmp_path, stream, model=TEXT_MODEL)
+    await talk(session, turns=4)
+    # A provider reading far above anything the tiny fixture history could
+    # estimate locally, as after a long real session.
+    session._last_usage = Usage(input_tokens=1, context_tokens=600_080)
+
+    outcome = await session.compact_now()
+
+    assert outcome.ran is True
+    assert outcome.tokens_before == 600_080
     await session.dispose()
 
 

--- a/tests/unit/session/test_compact_now.py
+++ b/tests/unit/session/test_compact_now.py
@@ -191,12 +191,23 @@ async def test_an_archive_with_frames_replays_as_valid_pngs(tmp_path):
 def test_a_malformed_archive_degrades_to_the_text_summary():
     """A frames list that is not base64 is now a validation error, and the
     marker renderer's degrade path is what keeps that from ending the turn:
-    the summary text still reaches the model, minus the frames."""
+    the summary text still reaches the model, minus the frames — plus the
+    archive's plain-text edges. The snapcompact summary is reading
+    instructions for the frames, not a digest, so without the salvage the
+    fallback replayed a caption describing images that are not there while
+    the actual history vanished."""
     marker = CustomMessage(
         custom_type="compaction_summary",
         details={
             "summary": "what happened earlier",
-            "preserve_data": {"snapcompact": {"frames": ["not base64 at all!!"], "text": "t"}},
+            "preserve_data": {
+                "snapcompact": {
+                    "frames": ["not base64 at all!!"],
+                    "text": "t",
+                    "text_head": "OLDEST: the user asked about parsers",
+                    "text_tail": "NEWEST: the fix landed in commit abc123",
+                }
+            },
         },
     )
 
@@ -205,6 +216,9 @@ def test_a_malformed_archive_degrades_to_the_text_summary():
     assert not any(isinstance(block, ImageContent) for block in rendered.content)
     texts = [block.text for block in rendered.content if isinstance(block, TextContent)]
     assert texts and "what happened earlier" in texts[0]
+    # The real transcript edges survive the frame corruption.
+    assert "the user asked about parsers" in texts[0]
+    assert "the fix landed in commit abc123" in texts[0]
 
 
 @pytest.mark.asyncio
@@ -283,6 +297,13 @@ async def test_the_receipt_quotes_the_figure_the_gate_acted_on(tmp_path):
     band the user is comparing against. Quoting the local estimate instead
     made a pass that fired at a provider-reported 600k print "319.4k → …",
     which reads as the band and the receipt disagreeing about what happened.
+
+    The SAVING, though, is measured with one local ruler on both sides: the
+    provider figure includes system blocks and tool schemas the pass never
+    touches, so ``after`` must be ``before - (history saving)`` rather than
+    the bare history estimate — otherwise the receipt counts the fixed
+    overhead as removed and a band that subtracts the pair understates the
+    next request by exactly that overhead.
     """
     from local_operator.harness.types import Usage
 
@@ -297,6 +318,11 @@ async def test_the_receipt_quotes_the_figure_the_gate_acted_on(tmp_path):
 
     assert outcome.ran is True
     assert outcome.tokens_before == 600_080
+    # The tiny fixture's whole history is a few hundred tokens, so the
+    # history-only saving is far below the provider figure: an after-figure
+    # anywhere near zero would prove the overhead was double-counted.
+    assert outcome.tokens_after > 590_000
+    assert outcome.tokens_after < outcome.tokens_before
     await session.dispose()
 
 

--- a/tests/unit/session/test_compaction_trigger.py
+++ b/tests/unit/session/test_compaction_trigger.py
@@ -171,13 +171,14 @@ async def test_a_200k_session_still_compacts_at_80_percent(tmp_path, monkeypatch
 async def test_the_gate_measures_the_provider_figure_not_just_the_estimate(tmp_path, monkeypatch):
     """``compaction_context_tokens`` is ``max(provider-reported, local)``, and
     the gate acts on that maximum. The plan carries BOTH figures: the maximum
-    (``context_tokens``, what the gate compared and what the receipt now
-    quotes as "before") and the bare local estimate (``tokens_before``, the
-    transcript-entry bookkeeping). They used to be printed crosswise — the
-    receipt quoted the local estimate while the band showed the provider
-    figure, so a pass that fired at a provider-reported 600k printed
-    "319.4k → …" and read as the two disagreeing about what just happened.
-    Pinning the fields apart keeps the split documented.
+    (``context_tokens``, what the gate compared, what the transcript entry
+    records, and what the receipt quotes as "before") and the bare local
+    estimate (``tokens_before``, the pre-pass half of the same-ruler saving
+    the commit subtracts from the maximum to get "after"). They used to be
+    printed crosswise — the receipt quoted the local estimate while the band
+    showed the provider figure, so a pass that fired at a provider-reported
+    600k printed "319.4k → …" and read as the two disagreeing about what just
+    happened. Pinning the fields apart keeps the split documented.
     """
     session = make_session(tmp_path)
     await talk(session)

--- a/tests/unit/session/test_compaction_trigger.py
+++ b/tests/unit/session/test_compaction_trigger.py
@@ -170,13 +170,14 @@ async def test_a_200k_session_still_compacts_at_80_percent(tmp_path, monkeypatch
 @pytest.mark.asyncio
 async def test_the_gate_measures_the_provider_figure_not_just_the_estimate(tmp_path, monkeypatch):
     """``compaction_context_tokens`` is ``max(provider-reported, local)``, and
-    the gate acts on that maximum while the receipt quotes the local estimate.
-
-    This is why the reported pass PRINTED 234.8k: the receipt's "before" is the
-    local estimate (``_CompactionPlan.tokens_before``), while the figure that
-    cleared the threshold was the provider's larger one
-    (``_CompactionPlan.context_tokens``). Pinning them apart keeps that split
-    documented instead of surprising the next reader of a receipt.
+    the gate acts on that maximum. The plan carries BOTH figures: the maximum
+    (``context_tokens``, what the gate compared and what the receipt now
+    quotes as "before") and the bare local estimate (``tokens_before``, the
+    transcript-entry bookkeeping). They used to be printed crosswise — the
+    receipt quoted the local estimate while the band showed the provider
+    figure, so a pass that fired at a provider-reported 600k printed
+    "319.4k → …" and read as the two disagreeing about what just happened.
+    Pinning the fields apart keeps the split documented.
     """
     session = make_session(tmp_path)
     await talk(session)

--- a/tests/unit/session/test_session_footprint.py
+++ b/tests/unit/session/test_session_footprint.py
@@ -241,7 +241,14 @@ async def test_real_compaction_then_resume_replays_the_kept_window(tmp_path):
     # DISTINCT paths on purpose: reads of the SAME path are superseded and
     # blanked by the prune pass, which drops the estimate back under the
     # threshold and means the fixture never reaches compaction at all.
-    small_model = ModelSpec(provider="test", model_id="m", context_window=2_000)
+    # Text-only on purpose: this fixture asserts on the LLM-summary path
+    # ("SUMMARY:" below). A vision model would take snapcompact, which makes
+    # no summarization call at all — the kept-window invariant it guards is
+    # strategy-independent, but the routing trick used to feed the summarizer
+    # is not.
+    small_model = ModelSpec(
+        provider="test", model_id="m", context_window=2_000, supports_images=False
+    )
     # The summarization call is routed by REQUEST SHAPE rather than by
     # position in a script: compaction fires whenever the estimate crosses
     # the threshold, which is not a fixed turn index, and a positional script


### PR DESCRIPTION
## Problem

A manual `/compact` on a vision model took ~60 s (omp's is near-instant), and the receipt's numbers matched neither the status band nor the next provider bill. Observed on a live session: the pass fired at a provider-reported **600,080** tokens but printed `319.4k → 60.1k`, while the first request after the pass billed **137,507** tokens.

## Causes and fixes

1. **The "no-LLM" snapcompact branch made an LLM call.** It built the archive locally, then shipped the entire discarded history (~600k tokens serialized) to the provider for a written digest of frames that already carry the real history — 20–50 s of the minute. Now the text slot is a deterministic reading-instructions summary (`archive_summary`) derived entirely from the archive, mirroring omp's snapcompact contract ("no LLM call").
2. **80 frames rendered, 6 replayed.** `history_blocks` foveation elides the interior beyond `2*HQ_EDGE_FRAMES + 2 = 8` frames, so ~74 of 80 rendered frames (~430 ms each, ~35 s, on the event loop) were never sent to any model — plus ~10 MB of dead base64 per transcript entry. `DEFAULT_MAX_FRAMES` caps the pass at what replay sends; dropped content keeps its explicit inline marker and stays in `Archive.text` for later passes. The archive build now runs in a worker thread.
3. **PNG deflate 9 → 6.** 390 ms → 37 ms per frame for ~11% more bytes; providers bill pixels, not file size, and the 3 MB payload budget is nowhere near binding at either level.
4. **Receipt figures.** `tokens_before` now quotes the figure the gate acted on (`max(provider-reported, local estimate)`) so it agrees with the status band; `tokens_after` re-prices archive frames at the provider's own image billing via new `frame_token_estimate_for` (mirrors omp's `familyBilling`, verified there against live bills: Anthropic patch pricing capped at 4,784 +5%, OpenAI 32px patches ×1.2, Gemini flat 1,120).

## Testing evidence

End-to-end `Session.compact_now()` on a ~340k-token vision-model history (real Session, real transcript, scripted provider):

```
=== NEW (this branch) ===
compact_now: 0.40s ran=True strategy=snapcompact
tokens: 343,336 -> 71,374
stream calls during compaction: 0

=== OLD (origin/main, LLM call stubbed to instant) ===
compact_now: 4.90s ran=True strategy=snapcompact
tokens: 340,942 -> 38,580
stream calls during compaction: 1     <- the real call is 20-50s, not instant
```

Module benchmark (921k chars history): `compact_to_archive` 8.9 s → 0.42 s; archive dump 10 MB → 0.8 MB; replayed frame count unchanged (foveation already capped it).

- The vision-path test now pins the no-provider-call contract (`_one_shot_complete` raises if reached).
- New tests: per-family frame pricing values, deterministic/structural `archive_summary`, default-vs-ceiling frame budgets, receipt quoting the gate figure (600,080 in, 600,080 printed).
- Full unit suite: 3,062 passed; the one failure (`test_background_streams_output_while_it_runs`) reproduces identically on clean `origin/main` (pre-existing, unrelated).
- Gates: flake8, black, isort, pyright all clean on touched paths.

No UI changes (receipt/band render existing fields; only the numbers feeding them changed), so no screenshots.
