### PR TITLE
feat(skills): disclose reference files on a bare skill read

### DIFF
--- a/local_operator/skills/index.py
+++ b/local_operator/skills/index.py
@@ -237,7 +237,9 @@ def render_block(skills: list[Skill]) -> str:
     if user_skills:
         lines = [
             "Skills are specialized knowledge. If one matches your task, you MUST read "
-            "`skill://<name>` before proceeding.",
+            "`skill://<name>` before proceeding. The skill body ends with its "
+            "reference files; read those with `skill://<name>/<path>`, never a "
+            "raw filesystem path.",
             "<skills>",
         ]
         lines.extend(f"- {skill.name}: {skill.description}" for skill in user_skills)

--- a/local_operator/skills/protocol.py
+++ b/local_operator/skills/protocol.py
@@ -57,7 +57,10 @@ def _list_directory(directory: Path) -> str:
     """Render a directory listing: ``name/ (dir)`` for dirs, plain names for
     files, deterministic alphabetical order. Dotfiles are skipped (they are
     unlisted and unreadable by design) and the listing is capped at
-    ``_MAX_LISTING_ENTRIES`` with an overflow marker."""
+    ``_MAX_LISTING_ENTRIES`` with an overflow marker. Names are
+    percent-encoded the same way as the bare-read reference listing, so a
+    name copied from here into a ``skill://<name>/<path>`` URL survives
+    ``urlsplit``/``unquote`` even when it contains ``%``, ``#`` or ``?``."""
     lines: list[str] = []
     try:
         entries = sorted(directory.iterdir(), key=lambda p: (p.name.lower(), p.name))
@@ -69,7 +72,8 @@ def _list_directory(directory: Path) -> str:
             continue
         if shown >= _MAX_LISTING_ENTRIES:
             break
-        lines.append(f"{entry.name}/ (dir)" if entry.is_dir() else entry.name)
+        encoded = quote(entry.name, safe="")
+        lines.append(f"{encoded}/ (dir)" if entry.is_dir() else encoded)
         shown += 1
     hidden = sum(1 for entry in entries if not entry.name.startswith(".")) - shown
     if hidden > 0:
@@ -134,7 +138,9 @@ def _reference_listing(resource: Skill, *, scheme: str) -> str:
     - symlinks (file or directory) are admitted only when their RESOLVED
       target stays inside ``base_dir`` — the same containment check the
       resolver applies on read — and resolved directories are visited at
-      most once so a link cycle cannot grow the walk;
+      most once so a link cycle cannot grow the walk. Deduplication means
+      one ROUTE per directory is listed when an alias and its target both
+      appear; every route stays readable through the resolver either way;
     - names are percent-encoded exactly as ``_resolve_child``'s ``unquote``
       expects, so a filename containing ``%``, ``#`` or ``?`` survives the
       URL round-trip instead of being listed in a form ``urlsplit`` mangles;
@@ -155,6 +161,12 @@ def _reference_listing(resource: Skill, *, scheme: str) -> str:
     except OSError:
         return ""
     body_file = resource.file_path
+    try:
+        # Resolved once so a symlink ALIAS of the body file is excluded too:
+        # the caller just returned that content, whatever name it wears.
+        body_resolved = body_file.resolve()
+    except OSError:
+        body_resolved = body_file
     entries: list[str] = []
     overflow = False
     visited: set[str] = set()
@@ -195,8 +207,14 @@ def _reference_listing(resource: Skill, *, scheme: str) -> str:
             elif child.is_file():
                 if child == body_file:
                     continue
-                if child.is_symlink() and not _contained(child):
-                    continue
+                if child.is_symlink():
+                    if not _contained(child):
+                        continue
+                    try:
+                        if child.resolve() == body_resolved:
+                            continue
+                    except OSError:
+                        continue
                 if len(entries) >= _MAX_REFERENCE_ENTRIES:
                     overflow = True
                     return

--- a/local_operator/skills/protocol.py
+++ b/local_operator/skills/protocol.py
@@ -28,6 +28,16 @@ summarized with a marker rather than streamed into context."""
 
 _TRUNCATION_MARKER = "\n\n[... content truncated at 200KB ...]"
 
+_MAX_REFERENCE_ENTRIES = 100
+"""A bare resource read appends at most this many reference paths. Skills ship
+a handful of reference docs; a runaway directory (a vendored node_modules, a
+data dump) must not turn every skill read into a directory bomb."""
+
+_MAX_REFERENCE_DEPTH = 4
+"""Reference discovery descends at most this many directory levels. Deep
+trees are almost never authored skill references, and the cap bounds the walk
+itself, not just the output."""
+
 
 def _read_text_capped(path: Path) -> str:
     """Read a file as UTF-8 (lossy), truncating at MAX_READ_BYTES.
@@ -99,6 +109,85 @@ def _resolve_child(
     return _read_text_capped(target)
 
 
+def _reference_listing(resource: Skill, *, scheme: str) -> str:
+    """List a resource's reference files as protocol-readable child paths.
+
+    Progressive disclosure has three steps: the prompt carries only names and
+    descriptions, a bare ``skill://<name>`` read returns the body, and the
+    reference files enter context only when individually read. This listing
+    closes the gap between steps two and three: without it the model knows
+    references exist (the body mentions them) but not how to reach them, and
+    the observed failure mode is guessing a RAW filesystem path
+    (``~/.<harness>/skills/<name>/references/x.md``) that is wrong on any
+    machine whose skills live under a different root. Appending the exact
+    ``<scheme>://<name>/<relpath>`` form makes the protocol read the obvious
+    next move.
+
+    Constraints, matching the resolver's own rules so the listing never
+    advertises a path a follow-up read would then reject:
+
+    - dotfiles and dot-directories are skipped (unlisted and unreadable by
+      design);
+    - the body file itself (``SKILL.md``/``GUIDE.md``) is excluded — the
+      caller just returned it;
+    - symlinked directories are not followed (a link cycle or an escape
+      outside ``base_dir`` must not grow or poison the walk);
+    - output is deterministic (sorted relative paths) and bounded by
+      :data:`_MAX_REFERENCE_ENTRIES` and :data:`_MAX_REFERENCE_DEPTH`, with
+      an explicit overflow marker instead of silent truncation.
+
+    Returns an empty string when the resource has no reference files, so a
+    body-only skill read stays byte-identical to the pre-listing behaviour.
+    """
+    base = resource.base_dir
+    body_file = resource.file_path
+    entries: list[str] = []
+    overflow = False
+
+    def _walk(directory: Path, depth: int) -> None:
+        nonlocal overflow
+        if depth > _MAX_REFERENCE_DEPTH or overflow:
+            return
+        try:
+            children = sorted(directory.iterdir(), key=lambda p: (p.name.lower(), p.name))
+        except OSError:
+            return
+        for child in children:
+            if overflow:
+                return
+            if child.name.startswith("."):
+                continue
+            if child.is_dir():
+                if child.is_symlink():
+                    continue
+                _walk(child, depth + 1)
+            elif child.is_file():
+                if child == body_file:
+                    continue
+                if len(entries) >= _MAX_REFERENCE_ENTRIES:
+                    overflow = True
+                    return
+                entries.append(child.relative_to(base).as_posix())
+
+    _walk(base, 1)
+    if not entries:
+        return ""
+
+    lines = [
+        "",
+        "---",
+        f"Reference files (read with `{scheme}://{resource.name}/<path>` — "
+        "never a raw filesystem path):",
+    ]
+    lines.extend(sorted(entries))
+    if overflow:
+        lines.append(
+            f"[... more files not shown; list a directory with "
+            f"`{scheme}://{resource.name}/<dir>` ...]"
+        )
+    return "\n".join(lines)
+
+
 def resolve_resource_url(
     url: str,
     resources: Mapping[str, Skill],
@@ -129,7 +218,9 @@ def resolve_resource_url(
 
     path = parts.path
     if not path or not path.strip("/"):
-        return _read_text_capped(resource.file_path)
+        body = _read_text_capped(resource.file_path)
+        listing = _reference_listing(resource, scheme=scheme)
+        return body + "\n" + listing if listing else body
     return _resolve_child(resource, path, scheme=scheme, label=label)
 
 

--- a/local_operator/skills/protocol.py
+++ b/local_operator/skills/protocol.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from pathlib import Path
-from urllib.parse import unquote, urlsplit
+from urllib.parse import quote, unquote, urlsplit
 
 from local_operator.skills.discovery import Skill
 
@@ -123,31 +123,62 @@ def _reference_listing(resource: Skill, *, scheme: str) -> str:
     ``<scheme>://<name>/<relpath>`` form makes the protocol read the obvious
     next move.
 
-    Constraints, matching the resolver's own rules so the listing never
-    advertises a path a follow-up read would then reject:
+    Constraints, matching the resolver's own rules (``_resolve_child``) so
+    the listing never advertises a path a follow-up read would then reject,
+    and never hides one it would accept:
 
     - dotfiles and dot-directories are skipped (unlisted and unreadable by
       design);
     - the body file itself (``SKILL.md``/``GUIDE.md``) is excluded — the
       caller just returned it;
-    - symlinked directories are not followed (a link cycle or an escape
-      outside ``base_dir`` must not grow or poison the walk);
+    - symlinks (file or directory) are admitted only when their RESOLVED
+      target stays inside ``base_dir`` — the same containment check the
+      resolver applies on read — and resolved directories are visited at
+      most once so a link cycle cannot grow the walk;
+    - names are percent-encoded exactly as ``_resolve_child``'s ``unquote``
+      expects, so a filename containing ``%``, ``#`` or ``?`` survives the
+      URL round-trip instead of being listed in a form ``urlsplit`` mangles;
     - output is deterministic (sorted relative paths) and bounded by
-      :data:`_MAX_REFERENCE_ENTRIES` and :data:`_MAX_REFERENCE_DEPTH`, with
-      an explicit overflow marker instead of silent truncation.
+      :data:`_MAX_REFERENCE_ENTRIES` (explicit overflow marker) and
+      :data:`_MAX_REFERENCE_DEPTH` (deeper files are silently omitted — a
+      directory read of their parent still finds them, and a marker per
+      pruned subtree would cost more than it informs). An unreadable
+      subdirectory is likewise skipped without a marker, mirroring the
+      resolver's own degradation.
 
     Returns an empty string when the resource has no reference files, so a
     body-only skill read stays byte-identical to the pre-listing behaviour.
     """
     base = resource.base_dir
+    try:
+        base_resolved = base.resolve()
+    except OSError:
+        return ""
     body_file = resource.file_path
     entries: list[str] = []
     overflow = False
+    visited: set[str] = set()
+
+    def _contained(child: Path) -> bool:
+        """True when the child's resolved target stays inside base_dir — the
+        same check ``_resolve_child`` applies, so listing and read agree on
+        every symlink."""
+        try:
+            return child.resolve().is_relative_to(base_resolved)
+        except OSError:
+            return False
 
     def _walk(directory: Path, depth: int) -> None:
         nonlocal overflow
         if depth > _MAX_REFERENCE_DEPTH or overflow:
             return
+        try:
+            key = str(directory.resolve())
+        except OSError:
+            return
+        if key in visited:
+            return
+        visited.add(key)
         try:
             children = sorted(directory.iterdir(), key=lambda p: (p.name.lower(), p.name))
         except OSError:
@@ -158,16 +189,18 @@ def _reference_listing(resource: Skill, *, scheme: str) -> str:
             if child.name.startswith("."):
                 continue
             if child.is_dir():
-                if child.is_symlink():
+                if child.is_symlink() and not _contained(child):
                     continue
                 _walk(child, depth + 1)
             elif child.is_file():
                 if child == body_file:
                     continue
+                if child.is_symlink() and not _contained(child):
+                    continue
                 if len(entries) >= _MAX_REFERENCE_ENTRIES:
                     overflow = True
                     return
-                entries.append(child.relative_to(base).as_posix())
+                entries.append(quote(child.relative_to(base).as_posix(), safe="/"))
 
     _walk(base, 1)
     if not entries:

--- a/local_operator/tools/builtin.py
+++ b/local_operator/tools/builtin.py
@@ -1642,9 +1642,11 @@ class ReadParams(BaseModel):
     path: str = Field(
         description=(
             "File path (absolute or relative to the working directory), or an "
-            "internal URL: skill://<name>, or spill://<id> to expand an output "
-            "that was truncated (append '?q=<regex>' to search inside it "
-            "instead of paging through it)."
+            "internal URL: skill://<name> (its reference files via "
+            "skill://<name>/<relpath>, listed at the end of the skill body — "
+            "never via a raw filesystem path), or spill://<id> to expand an "
+            "output that was truncated (append '?q=<regex>' to search inside "
+            "it instead of paging through it)."
         )
     )
     range: str | None = Field(

--- a/tests/unit/skills/test_index.py
+++ b/tests/unit/skills/test_index.py
@@ -248,7 +248,9 @@ class TestRenderBlock:
         ]
         assert render_block(skills) == (
             "Skills are specialized knowledge. If one matches your task, you MUST read "
-            "`skill://<name>` before proceeding.\n"
+            "`skill://<name>` before proceeding. The skill body ends with its "
+            "reference files; read those with `skill://<name>/<path>`, never a "
+            "raw filesystem path.\n"
             "<skills>\n"
             "- alpha: first skill\n"
             "- beta: second skill\n"

--- a/tests/unit/skills/test_protocol.py
+++ b/tests/unit/skills/test_protocol.py
@@ -412,6 +412,31 @@ class TestReferenceListing:
         assert resolve_skill_url("skill://alpha/notes%20%231.md", skills) == "hash"
         assert resolve_skill_url("skill://alpha/100%25.md", skills) == "percent"
 
+    def test_directory_listing_names_round_trip(self, skills: dict[str, Skill]) -> None:
+        # R2-2: the child-path DIRECTORY listing is where the overflow marker
+        # sends the model, so its names must survive the same URL round-trip
+        # as the bare-read listing — a raw '#' name copied from it would be
+        # cut at the fragment and fail to resolve.
+        refs = skills["alpha"].base_dir / "references"
+        refs.mkdir()
+        (refs / "notes #1.md").write_text("hash", encoding="utf-8")
+        listing = resolve_skill_url("skill://alpha/references", skills)
+        assert listing is not None
+        assert "notes%20%231.md" in listing
+        assert resolve_skill_url("skill://alpha/references/notes%20%231.md", skills) == "hash"
+
+    def test_symlink_alias_of_body_file_not_listed(self, tmp_path: Path) -> None:
+        # R2-3: a symlink whose resolved target IS the body file re-offers
+        # content the caller just returned; exclude it like the body file
+        # itself (resolved-target equality, not path equality).
+        skill = _make_skill(tmp_path, "bodylink")
+        (skill.base_dir / "readme.md").symlink_to(skill.file_path)
+        (skill.base_dir / "real-ref.md").write_text("r", encoding="utf-8")
+        content = resolve_skill_url("skill://bodylink", {"bodylink": skill})
+        assert content is not None
+        assert "readme.md" not in content
+        assert "real-ref.md" in content
+
     def test_listing_bounded_with_overflow_marker(self, skills: dict[str, Skill]) -> None:
         base = skills["alpha"].base_dir
         refs = base / "references"

--- a/tests/unit/skills/test_protocol.py
+++ b/tests/unit/skills/test_protocol.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import pytest
 
+from local_operator.skills import protocol
 from local_operator.skills.discovery import Skill
 from local_operator.skills.protocol import MAX_READ_BYTES, resolve_skill_url
 
@@ -271,6 +272,114 @@ class TestTruncation:
         content = resolve_skill_url("skill://alpha/exact.txt", skills)
         assert content is not None
         assert content == "y" * MAX_READ_BYTES
+
+
+class TestReferenceListing:
+    """A bare read discloses the skill's reference files as PROTOCOL paths.
+
+    The gap this closes: after reading `skill://<name>`, a model that saw
+    references mentioned in the body used to guess raw filesystem paths
+    (wrong on any machine with a different skills root). The bare read now
+    ends with the exact `skill://<name>/<relpath>` form for every reference,
+    so the protocol read is the discoverable next step.
+    """
+
+    def test_bare_read_lists_references(self, skills: dict[str, Skill]) -> None:
+        base = skills["alpha"].base_dir
+        refs = base / "references"
+        refs.mkdir()
+        (refs / "admin-api.md").write_text("# Admin API", encoding="utf-8")
+        (base / "NOTES.md").write_text("notes", encoding="utf-8")
+        content = resolve_skill_url("skill://alpha", skills)
+        assert content is not None
+        # Body still present, listing appended after it.
+        assert "# Test skill body" in content
+        assert "skill://alpha/<path>" in content
+        assert "references/admin-api.md" in content
+        assert "NOTES.md" in content
+        assert content.index("# Test skill body") < content.index("references/admin-api.md")
+
+    def test_listed_paths_resolve_via_protocol(self, skills: dict[str, Skill]) -> None:
+        # The listing must never advertise a path the resolver then rejects.
+        base = skills["alpha"].base_dir
+        refs = base / "references"
+        refs.mkdir()
+        (refs / "guide.md").write_text("ref body", encoding="utf-8")
+        content = resolve_skill_url("skill://alpha", skills)
+        assert content is not None and "references/guide.md" in content
+        assert resolve_skill_url("skill://alpha/references/guide.md", skills) == "ref body"
+
+    def test_body_only_skill_is_byte_identical(self, skills: dict[str, Skill]) -> None:
+        # No reference files -> no listing, no trailing separator: the
+        # pre-listing output is preserved byte for byte.
+        body = skills["alpha"].file_path.read_text(encoding="utf-8")
+        assert resolve_skill_url("skill://alpha", skills) == body
+
+    def test_skill_md_itself_not_listed(self, skills: dict[str, Skill]) -> None:
+        base = skills["alpha"].base_dir
+        (base / "extra.md").write_text("x", encoding="utf-8")
+        content = resolve_skill_url("skill://alpha", skills)
+        assert content is not None
+        listing = content.split("---")[-1]
+        assert "SKILL.md" not in listing
+
+    def test_dotfiles_not_listed(self, skills: dict[str, Skill]) -> None:
+        base = skills["alpha"].base_dir
+        (base / ".secret").write_text("hidden", encoding="utf-8")
+        hidden_dir = base / ".git"
+        hidden_dir.mkdir()
+        (hidden_dir / "config").write_text("repo", encoding="utf-8")
+        (base / "visible.md").write_text("v", encoding="utf-8")
+        content = resolve_skill_url("skill://alpha", skills)
+        assert content is not None
+        assert ".secret" not in content
+        assert ".git" not in content
+        assert "visible.md" in content
+
+    def test_symlinked_directory_not_followed(self, tmp_path: Path) -> None:
+        # A symlink pointing outside base_dir must not leak foreign paths
+        # into the listing (the resolver would reject reading them anyway).
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (outside / "leak.md").write_text("leak", encoding="utf-8")
+        skill = _make_skill(tmp_path, "linky")
+        (skill.base_dir / "escape").symlink_to(outside, target_is_directory=True)
+        content = resolve_skill_url("skill://linky", {"linky": skill})
+        assert content is not None
+        assert "leak.md" not in content
+
+    def test_listing_bounded_with_overflow_marker(self, skills: dict[str, Skill]) -> None:
+        base = skills["alpha"].base_dir
+        refs = base / "references"
+        refs.mkdir()
+        for i in range(protocol._MAX_REFERENCE_ENTRIES + 20):
+            (refs / f"ref-{i:04d}.md").write_text("r", encoding="utf-8")
+        content = resolve_skill_url("skill://alpha", skills)
+        assert content is not None
+        listed = [line for line in content.splitlines() if line.startswith("references/ref-")]
+        assert len(listed) == protocol._MAX_REFERENCE_ENTRIES
+        assert "more files not shown" in content
+
+    def test_depth_capped(self, skills: dict[str, Skill]) -> None:
+        base = skills["alpha"].base_dir
+        deep = base / "a" / "b" / "c" / "d"
+        deep.mkdir(parents=True)
+        (base / "a" / "shallow.md").write_text("s", encoding="utf-8")
+        (deep / "too-deep.md").write_text("d", encoding="utf-8")
+        content = resolve_skill_url("skill://alpha", skills)
+        assert content is not None
+        assert "a/shallow.md" in content
+        assert "too-deep.md" not in content
+
+    def test_child_path_reads_unchanged(self, skills: dict[str, Skill]) -> None:
+        # The listing rides only the BARE read; a child read returns the file
+        # alone, and a directory read returns the flat listing as before.
+        base = skills["alpha"].base_dir
+        refs = base / "references"
+        refs.mkdir()
+        (refs / "one.md").write_text("one", encoding="utf-8")
+        assert resolve_skill_url("skill://alpha/references/one.md", skills) == "one"
+        assert resolve_skill_url("skill://alpha/references", skills) == "one.md"
 
 
 if __name__ == "__main__":

--- a/tests/unit/skills/test_protocol.py
+++ b/tests/unit/skills/test_protocol.py
@@ -320,8 +320,11 @@ class TestReferenceListing:
         (base / "extra.md").write_text("x", encoding="utf-8")
         content = resolve_skill_url("skill://alpha", skills)
         assert content is not None
-        listing = content.split("---")[-1]
+        # Anchor on the listing header, not on "---" (frontmatter and
+        # horizontal rules use the same delimiter).
+        listing = content.split("Reference files (read with")[-1]
         assert "SKILL.md" not in listing
+        assert "extra.md" in listing
 
     def test_dotfiles_not_listed(self, skills: dict[str, Skill]) -> None:
         base = skills["alpha"].base_dir
@@ -336,7 +339,7 @@ class TestReferenceListing:
         assert ".git" not in content
         assert "visible.md" in content
 
-    def test_symlinked_directory_not_followed(self, tmp_path: Path) -> None:
+    def test_escaping_symlinked_directory_not_followed(self, tmp_path: Path) -> None:
         # A symlink pointing outside base_dir must not leak foreign paths
         # into the listing (the resolver would reject reading them anyway).
         outside = tmp_path / "outside"
@@ -347,6 +350,67 @@ class TestReferenceListing:
         content = resolve_skill_url("skill://linky", {"linky": skill})
         assert content is not None
         assert "leak.md" not in content
+
+    def test_escaping_symlinked_file_not_listed(self, tmp_path: Path) -> None:
+        # R1-1: a symlinked FILE whose target escapes base_dir passes
+        # is_file() (which follows links) but _resolve_child rejects reading
+        # it — so listing it would advertise a guaranteed failure. The
+        # listing applies the resolver's own containment check instead.
+        outside = tmp_path / "outside-file.md"
+        outside.write_text("secret", encoding="utf-8")
+        skill = _make_skill(tmp_path, "filelink")
+        (skill.base_dir / "escape.md").symlink_to(outside)
+        content = resolve_skill_url("skill://filelink", {"filelink": skill})
+        assert content is not None
+        assert "escape.md" not in content
+
+    def test_internal_symlinks_listed_and_followed(self, tmp_path: Path) -> None:
+        # R1-3: symlinks resolving INSIDE base_dir are readable by the
+        # resolver, so hiding them would be the reverse parity gap. Both a
+        # linked file and a linked directory must appear.
+        skill = _make_skill(tmp_path, "inlink")
+        base = skill.base_dir
+        (base / "real.md").write_text("real", encoding="utf-8")
+        (base / "alias.md").symlink_to(base / "real.md")
+        subdir = base / "docs"
+        subdir.mkdir()
+        (subdir / "inner.md").write_text("inner", encoding="utf-8")
+        (base / "docs-link").symlink_to(subdir, target_is_directory=True)
+        content = resolve_skill_url("skill://inlink", {"inlink": skill})
+        assert content is not None
+        assert "alias.md" in content
+        assert "docs/inner.md" in content
+        assert resolve_skill_url("skill://inlink/alias.md", {"inlink": skill}) == "real"
+
+    def test_symlink_cycle_terminates(self, tmp_path: Path) -> None:
+        # An internal directory link cycle must not hang or duplicate the
+        # walk: resolved directories are visited at most once.
+        skill = _make_skill(tmp_path, "cycle")
+        base = skill.base_dir
+        subdir = base / "docs"
+        subdir.mkdir()
+        (subdir / "page.md").write_text("p", encoding="utf-8")
+        (subdir / "loop").symlink_to(base, target_is_directory=True)
+        content = resolve_skill_url("skill://cycle", {"cycle": skill})
+        assert content is not None
+        assert content.count("docs/page.md") == 1
+
+    def test_special_characters_round_trip(self, skills: dict[str, Skill]) -> None:
+        # R1-2: a filename with '#' or '%' must be listed in a form the URL
+        # parser survives — urlsplit treats a raw '#' as a fragment and
+        # unquote mangles a raw '%'. The listing percent-encodes, and the
+        # encoded path must actually resolve.
+        base = skills["alpha"].base_dir
+        (base / "notes #1.md").write_text("hash", encoding="utf-8")
+        (base / "100%.md").write_text("percent", encoding="utf-8")
+        content = resolve_skill_url("skill://alpha", skills)
+        assert content is not None
+        listing = content.split("Reference files (read with")[-1]
+        listed = [line for line in listing.splitlines() if line.endswith(".md")]
+        assert "notes%20%231.md" in listed
+        assert "100%25.md" in listed
+        assert resolve_skill_url("skill://alpha/notes%20%231.md", skills) == "hash"
+        assert resolve_skill_url("skill://alpha/100%25.md", skills) == "percent"
 
     def test_listing_bounded_with_overflow_marker(self, skills: dict[str, Skill]) -> None:
         base = skills["alpha"].base_dir


### PR DESCRIPTION
# PR Description

## Change classification

**C2 — standard / pre-authorized.** Additive change to the `skill://`/`guide://` resolver: a bare resource read appends a bounded listing of the resource's reference files as protocol paths. Two prompt-text touches (skills block, `read` tool path description) teach the child-path form. No new surface beyond the appended text, no config, clean rollback (`git revert`).

## The bug

Observed in a live session (trace attached to the work request): after `read skill://minerva-admin-apis` succeeded, the very next step was

```
read ~/.omp/skills/minerva-admin-apis/references/admin-api.md
  → Path does not exist: /Users/damian/.omp/skills/m…  ✗
bash ls ~/.omp/skills/minerva-admin-apis/; find ~ -maxdepth 4 -name "admin-api.md" …
  → 6.3s of filesystem sweeping
```

The skill body names its reference docs, but nothing tells the model **how to reach them**: the disclosure ladder went prompt-listing → body → (cliff). So the model guessed a raw filesystem path — and guessed a *different harness's* skills root at that, which is wrong on any machine whose skills live elsewhere (lop discovers skills across `~/.local-operator/skills`, `~/.omp/agent/skills`, `~/.claude/skills`, `~/.codex/skills`, `~/.agents/skills`; the actual root is an implementation detail the model should never need).

The resolver has supported `skill://<name>/<relpath>` all along — the capability existed, the affordance didn't.

## The fix

`_reference_listing` in `local_operator/skills/protocol.py`: a bare read (`skill://<name>` or `guide://<name>`) now returns the body followed by

```
---
Reference files (read with `skill://minerva-admin-apis/<path>` — never a raw filesystem path):
agents/openai.yaml
references/admin-api.md
references/equifax-billing.md
references/launchdarkly.md
references/minerva-api.md
references/nexus.md
```

The listing mirrors the resolver's own containment rules so it never advertises a path a follow-up read would then reject: dotfiles/dot-dirs skipped, the body file (`SKILL.md`/`GUIDE.md`) excluded, symlinked directories not followed (no escape, no cycle), entries capped at 100 and depth at 4 with explicit overflow markers, deterministic sorted order. A resource with no reference files returns the body **byte-identical** to the previous output — which covers every packaged guide today, so guide reads are unchanged in practice.

Prompt-facing text now closes the loop from the other side: the skills block and the `read` tool's `path` description both name the `skill://<name>/<path>` form and forbid raw filesystem paths.

## Testing evidence

**Reproduced the real case.** With the worktree's code, discovery over the real machine roots, reading the exact skill from the trace:

- `resolve_skill_url("skill://minerva-admin-apis", skills)` → body ends with the listing above, including `references/admin-api.md` — the precise file the live session failed to reach.
- `resolve_skill_url("skill://minerva-admin-apis/references/admin-api.md", skills)` → returns the reference body (`# Admin API …`). Every advertised path resolves.

**Negative/containment cases** (unit-tested, all passing):

- dotfiles (`.secret`), dot-dirs (`.git/`) absent from the listing; body file never listed
- symlinked directory pointing outside `base_dir` not followed — foreign filenames never leak into the listing
- 120 reference files → exactly 100 listed + `[... more files not shown; list a directory with `skill://alpha/<dir>` ...]`
- depth-5 file excluded, depth-2 file included
- child reads unchanged: `skill://alpha/references/one.md` returns the file alone; `skill://alpha/references` returns the flat directory listing as before
- body-only skill: bare read byte-identical to pre-change output

**Suites.** `tests/unit/skills` + `tests/unit/guides`: 165 passed. Full `tests/unit` excl. TUI: 3238 passed, 3 skipped, 1 pre-existing flake (`test_eval_tool.py::test_background_streams_output_while_it_runs`) that fails identically on clean `origin/main` at the same base commit (verified in a pristine baseline worktree) — load-sensitive streaming assertion, untouched by this change and already noted in PR #172.

**Gates.** black 26.1.0 and isort clean on the touched files.
