### PR TITLE
feat(tui): expand settled write/edit cards to the diff alone

### DIFF
--- a/local_operator/tui/widgets/tool_card.py
+++ b/local_operator/tui/widgets/tool_card.py
@@ -1548,19 +1548,33 @@ class ToolCard(TranscriptBlock):
         row = self._build_row(width)
         if not self._expanded:
             return row
-        self._append_input_body(row, width)
         # A RUNNING card has no result to show and must not look like one that
         # came back empty. Its own block states the state and carries whatever
         # has streamed, and it takes precedence over the settled blocks, which
         # are empty at this point anyway.
         if self._state == "running":
+            self._append_input_body(row, width)
             self._append_live_body(row, width)
         elif self._diff:
+            # A settled write/edit expands to its DIFF ALONE. The arguments are
+            # the same change stated twice — `old_text`/`new_text` (or the
+            # whole `content`) escaped into flat `\n`-ridden lines above a
+            # unified diff that already shows every one of those bytes with
+            # markers and colour — and the path is on the summary row. Painting
+            # both buried the readable form under the unreadable one; the diff
+            # is the record, so it is the whole expansion. A FAILED edit takes
+            # the plain-output branch below (no diff was produced) and keeps
+            # its argument block: there the args are the only account of what
+            # was attempted, and the error only makes sense next to them.
             self._append_diff_body(row, width)
         elif self.tool_name.lower() == "web_search" and self._output:
+            self._append_input_body(row, width)
             self._append_search_body(row, width)
         elif self._output:
+            self._append_input_body(row, width)
             self._append_output_body(row, width)
+        else:
+            self._append_input_body(row, width)
         return row
 
     def _append_live_body(self, row: Text, width: int) -> None:
@@ -1722,11 +1736,12 @@ class ToolCard(TranscriptBlock):
         """The write/edit expansion: the unified diff, coloured by hunk line.
 
         ``+`` added in the success green, ``-`` removed in danger, ``@@``
-        hunk markers and ``---/+++`` headers muted, context lines dim — the
-        same ink law as the counters in the summary row, so the pill on the
-        one-line summary and the expanded body tell the same story. Only the
-        leading marker character is coloured here; the text rides the card's
-        default so a coloured line never reads as a wall of tint.
+        hunk markers muted, context lines dim — the same ink law as the
+        counters in the summary row, so the pill on the one-line summary and
+        the expanded body tell the same story. Only the leading marker
+        character is coloured here; the text rides the card's default so a
+        coloured line never reads as a wall of tint. The nameless ``---/+++``
+        file headers are filtered out below rather than tinted.
         """
         success = Style(color=theme_mod.semantic_color("success"))
         danger = Style(color=theme_mod.semantic_color("danger"))
@@ -1734,12 +1749,22 @@ class ToolCard(TranscriptBlock):
         dim = Style(color=theme_mod.semantic_color("dim"))
         line_width = max(1, width - 2 - OUTPUT_INDENT)
         indent = " " * OUTPUT_INDENT
-        diff = self._diff or []
+        # The `---`/`+++` file headers are dropped: the tool diffs one file's
+        # before/after in memory, so difflib emits them NAMELESS (`--- ` /
+        # `+++ `) and the path already heads the summary row. Two blank-label
+        # rows above every diff were pure chrome. Bound to exactly the headers
+        # difflib produces — a `-`/`+` content line can never start `--- `/
+        # `+++ ` here because content rows carry a single marker cell.
+        diff = [
+            line
+            for line in (self._diff or [])
+            if not (line.startswith("--- ") or line.startswith("+++ ") or line in ("---", "+++"))
+        ]
         shown = diff[:EXPAND_MAX_LINES]
         for raw in shown:
             line = raw.rstrip()
             prefix = line[:1] if line else ""
-            if line.startswith("---") or line.startswith("+++") or prefix == "@":
+            if prefix == "@":
                 ink = muted
             elif prefix == "+":
                 ink = success

--- a/local_operator/tui/widgets/tool_card.py
+++ b/local_operator/tui/widgets/tool_card.py
@@ -1555,7 +1555,7 @@ class ToolCard(TranscriptBlock):
         if self._state == "running":
             self._append_input_body(row, width)
             self._append_live_body(row, width)
-        elif self._diff:
+        elif self._state == "success" and self._diff:
             # A settled write/edit expands to its DIFF ALONE. The arguments are
             # the same change stated twice — `old_text`/`new_text` (or the
             # whole `content`) escaped into flat `\n`-ridden lines above a
@@ -1752,14 +1752,15 @@ class ToolCard(TranscriptBlock):
         # The `---`/`+++` file headers are dropped: the tool diffs one file's
         # before/after in memory, so difflib emits them NAMELESS (`--- ` /
         # `+++ `) and the path already heads the summary row. Two blank-label
-        # rows above every diff were pure chrome. Bound to exactly the headers
-        # difflib produces — a `-`/`+` content line can never start `--- `/
-        # `+++ ` here because content rows carry a single marker cell.
-        diff = [
-            line
-            for line in (self._diff or [])
-            if not (line.startswith("--- ") or line.startswith("+++ ") or line in ("---", "+++"))
-        ]
+        # rows above every diff were pure chrome. Stripped POSITIONALLY — the
+        # first two lines, and only when they are exactly the nameless header
+        # pair — never by pattern over the body: a removed content line that
+        # itself begins `--` (a SQL/Lua comment, say) renders as `--- …` inside
+        # the body, and a pattern filter would silently delete the very record
+        # this expansion now solely carries (review round 1, F1/D1).
+        diff = list(self._diff or [])
+        if len(diff) >= 2 and diff[0].rstrip() == "---" and diff[1].rstrip() == "+++":
+            diff = diff[2:]
         shown = diff[:EXPAND_MAX_LINES]
         for raw in shown:
             line = raw.rstrip()

--- a/tests/unit/tui/test_tool_card.py
+++ b/tests/unit/tui/test_tool_card.py
@@ -300,9 +300,52 @@ def test_a_settled_edit_expansion_is_the_diff_alone() -> None:
     assert "old_text:" not in content
     assert "new_text:" not in content
     assert "path:" not in content
-    # …and no blank-label file headers.
-    assert "---" not in content
-    assert "+++" not in content
+    # …and no blank-label file header ROWS. Asserted per-line rather than by
+    # substring: a body line may legitimately contain or even start with
+    # `---`/`+++` (see the regression test below), so only the leading pair
+    # difflib emits is what must be gone.
+    lines = content.splitlines()
+    assert not any(line.strip() in ("---", "+++") for line in lines)
+
+
+def test_removed_lines_that_start_with_dashes_survive_the_header_strip() -> None:
+    """The header strip is positional, never a pattern over the diff body.
+
+    Regression for review round 1 F1/D1: a removed content line that itself
+    begins `--` (a SQL/Lua/Haskell comment) renders inside the body as
+    `--- old comment`, and a removed bare `--` renders as exactly `---`. A
+    pattern filter silently deleted both — the summary pill said `-2` while
+    the expansion showed no red line at all, and with the argument echo gone
+    the diff is the SOLE record of the removal.
+    """
+    card = ToolCard("t", "edit", {"path": "query.sql"})
+    card.mark_done(
+        "Edited query.sql: replaced 1 occurrence(s) of old_text.",
+        {
+            "path": "query.sql",
+            "added": 0,
+            "removed": 2,
+            "diff": [
+                "--- ",
+                "+++ ",
+                "@@ -1,4 +1,2 @@",
+                " SELECT 1;",
+                "--- old comment",
+                "---",
+                " SELECT 2;",
+            ],
+        },
+    )
+    card.toggle_expanded()
+    content = card._build_content(80).plain
+    # Both removed lines are painted; only the two leading headers are gone.
+    assert "--- old comment" in content
+    body_lines = [line.strip() for line in content.splitlines()]
+    assert "---" in body_lines  # the removed bare `--` line survives
+    # The nameless header pair itself (rows before the @@ hunk) is absent:
+    # the first diff row painted is the hunk marker.
+    at = next(i for i, line in enumerate(body_lines) if line.startswith("@@"))
+    assert not any(line in ("---", "+++") for line in body_lines[:at])
 
 
 def test_a_running_edit_still_shows_its_arguments() -> None:
@@ -321,17 +364,27 @@ def test_a_running_edit_still_shows_its_arguments() -> None:
 
 
 def test_a_failed_edit_keeps_its_argument_block() -> None:
-    """A failed edit produced no diff; its args are the only record of intent.
+    """A failed edit's args are the only record of intent; diff-only must not apply.
 
     The error ("old_text not found") only makes sense next to the old_text
-    that was searched for, so the diff-only rule must not reach this state.
+    that was searched for. The diff-only branch therefore gates on the
+    SUCCESS state, not on diff presence (review round 1, F2): even if a
+    failing tool ever shipped a diff in its details, the failed card must
+    still paint its arguments and error, not a diff with no account of what
+    was attempted.
     """
     card = ToolCard("t", "edit", {"path": "notes.md", "old_text": "missing", "new_text": "x"})
-    card.mark_failed("old_text not found", "old_text not found (exact and whitespace-tolerant)")
-    assert card._diff is None
+    card.mark_failed(
+        "old_text not found",
+        "old_text not found (exact and whitespace-tolerant)",
+        # A diff in a FAILED result is unreachable from today's tools, but the
+        # branch must be gated by state, not by this payload's presence.
+        {"path": "notes.md", "added": 0, "removed": 0, "diff": ["@@ -1 +1 @@", "-a", "+b"]},
+    )
     card.toggle_expanded()
     content = card._build_content(80).plain
     assert "old_text: missing" in content
+    assert "old_text not found" in content
 
 
 def test_a_tool_without_a_diff_expands_to_its_raw_output() -> None:

--- a/tests/unit/tui/test_tool_card.py
+++ b/tests/unit/tui/test_tool_card.py
@@ -205,8 +205,14 @@ def test_diff_counters_never_break_the_single_row() -> None:
 
 
 def _diff_card() -> ToolCard:
-    """A settled write card carrying a rendered unified diff in details."""
-    card = ToolCard("t", "edit", {"path": "notes.md"})
+    """A settled edit card carrying a rendered unified diff in details.
+
+    The args carry ``old_text``/``new_text`` deliberately: the expansion
+    contract is that these do NOT paint — the diff is the whole body.
+    """
+    card = ToolCard(
+        "t", "edit", {"path": "notes.md", "old_text": "old line", "new_text": "new line"}
+    )
     card.mark_done(
         "Edited notes.md: replaced 1 occurrence(s) of old_text.",
         {
@@ -258,7 +264,6 @@ def test_diff_lines_are_tinted_by_hunk_role() -> None:
     minus_style = _style_at(content, "-old line")
     ctx_style = _style_at(content, " a")
     hunk_style = _style_at(content, "@@ -1,4 +1,4 @@")
-    header_style = _style_at(content, "+++")
 
     # Build the expected triplet from the semantic hex (``#rrggbb``).
     def _expect(semantic: str) -> ColorTriplet:
@@ -269,10 +274,64 @@ def test_diff_lines_are_tinted_by_hunk_role() -> None:
     # the same two tints the summary pill uses for +N/-N.
     assert _triplet(plus_style.color) == _expect("success")
     assert _triplet(minus_style.color) == _expect("danger")
-    # Context rides dim; headers/hunks ride muted — neither success nor danger.
+    # Context rides dim; hunk markers ride muted — neither success nor danger.
     assert ctx_style != plus_style and ctx_style != minus_style
     assert hunk_style != plus_style and hunk_style != minus_style
-    assert header_style != plus_style and header_style != minus_style
+
+
+def test_a_settled_edit_expansion_is_the_diff_alone() -> None:
+    """No argument echo, no ``---/+++`` chrome — just the coloured diff.
+
+    Reported from the field: an expanded edit card led with ``path:`` and a
+    flattened ``edits: [{"old_text": "…\\n…"}]`` wall — the same change the
+    diff below it already showed readably — so the record was buried under
+    its own escape sequences. The settled diff branch now paints ONLY the
+    diff, and drops difflib's nameless file headers (the path is on the
+    summary row).
+    """
+    card = _diff_card()
+    card.toggle_expanded()
+    content = card._build_content(80).plain
+    # The diff itself is intact…
+    assert "+new line" in content
+    assert "-old line" in content
+    assert "@@ -1,4 +1,4 @@" in content
+    # …with no argument block above it…
+    assert "old_text:" not in content
+    assert "new_text:" not in content
+    assert "path:" not in content
+    # …and no blank-label file headers.
+    assert "---" not in content
+    assert "+++" not in content
+
+
+def test_a_running_edit_still_shows_its_arguments() -> None:
+    """Diff-only is a SETTLED-state rule; live cards keep the argument block.
+
+    While the call runs there is no diff yet, so the arguments are the only
+    account of what the tool was asked to do — exactly the frame a user
+    opens to answer "what is it editing?".
+    """
+    card = ToolCard("t", "edit", {"path": "notes.md", "old_text": "a", "new_text": "b"})
+    assert card.can_expand() is True
+    card.toggle_expanded()
+    content = card._build_content(80).plain
+    assert "path: notes.md" in content
+    assert "old_text:" in content
+
+
+def test_a_failed_edit_keeps_its_argument_block() -> None:
+    """A failed edit produced no diff; its args are the only record of intent.
+
+    The error ("old_text not found") only makes sense next to the old_text
+    that was searched for, so the diff-only rule must not reach this state.
+    """
+    card = ToolCard("t", "edit", {"path": "notes.md", "old_text": "missing", "new_text": "x"})
+    card.mark_failed("old_text not found", "old_text not found (exact and whitespace-tolerant)")
+    assert card._diff is None
+    card.toggle_expanded()
+    content = card._build_content(80).plain
+    assert "old_text: missing" in content
 
 
 def test_a_tool_without_a_diff_expands_to_its_raw_output() -> None:


### PR DESCRIPTION
# PR Description

## Change classification

**C2 — standard / pre-authorized.** TUI-only rendering change to the tool card's
expanded view; no schema, transcript-format, or wire change. Clean rollback
(`git revert`). No RFC requested.

## The problem

Expanding a settled `edit` card painted the raw call arguments first — `path:`
plus an `edits: [{"old_text": "…\n…", "new_text": "…\n…"}]` wall with every
newline escaped into `\n` — and only then the unified diff. The argument block
is the same change stated a second time, unreadably: the diff below it already
shows every one of those bytes with `+`/`-` markers and colour, and the path is
already on the summary row. The readable form was buried under the unreadable
one.

## The change

- A **settled** write/edit card with a diff now expands to the diff alone —
  no `path:`/`old_text:`/`new_text:`/`edits:` echo (`_build_content`).
- The nameless `---`/`+++` file headers difflib emits for an in-memory diff are
  dropped from the expansion (`_append_diff_body`). They carry no path (the tool
  diffs one file's before/after strings), so they were two blank-label rows of
  chrome; the summary row names the file.
- Everything else keeps its argument block, because there the args are the only
  account of the call:
  - a **running** edit (no diff exists yet — "what is it editing?" must be
    answerable),
  - a **failed** edit (no diff was produced; "old_text not found" only makes
    sense next to the old_text),
  - every plain-output tool (bash/read/etc.) and web_search, unchanged.

# Testing evidence

## 1. Rendered frames (before / after)

Captured from the real `OperatorApp` via `app.save_screenshot` (stylesheet
applied), rendered to PNG and **viewed as images**, per `AGENTS.md` → "Visual
validation". The seeded card reproduces the reported case: a multi-hunk `edits`
argument with escaped newlines, at 196 columns. Before frame captured at `cf0367d49`; after frame re-captured at
`a30ebaa` (the round-1 remediation head; the positional header strip changes
no pixels in this seeded state, but the frame matches the current code).

**Before** — argument wall + `---`/`+++` chrome above the diff:

![before](https://raw.githubusercontent.com/damianvtran/local-operator/assets/pr-edit-diff-only/before.png)

**After** — the expansion is the diff alone; path and `+110` counter stay on the
summary row:

![after](https://raw.githubusercontent.com/damianvtran/local-operator/assets/pr-edit-diff-only/after.png)

The delta is confined to the expansion body: summary row, counters, and the
collapse hint are unchanged between the frames.

## 2. Tests

New, pinning the behaviour and its boundaries:

- `test_a_settled_edit_expansion_is_the_diff_alone` — diff intact; no
  `old_text:`/`new_text:`/`path:` echo; no `---`/`+++` rows.
- `test_a_running_edit_still_shows_its_arguments` — diff-only is a settled-state
  rule; a live card keeps its argument block.
- `test_a_failed_edit_keeps_its_argument_block` — a failed edit has no diff, so
  its args remain the record of what was attempted.

Updated: `_diff_card` now carries `old_text`/`new_text` args (so the diff-only
assertion has something real to exclude), and the tint test drops its assertion
on the now-filtered `+++` header while keeping the success/danger/muted/dim
checks.

```console
$ pytest tests/unit/tui -q ……………………………… all passed
$ pytest tests/unit -q ………………………………… 3082 passed, 3 skipped, 1 failed
```

The one failure is `tests/unit/tools/test_eval_tool.py::test_background_streams_output_while_it_runs`,
a timing-sensitive eval-kernel test that fails identically on a pristine
`origin/main` worktree (`/tmp/lo-main-now`) — pre-existing, unrelated to this
diff.

`flake8` and `black --check` (the repo's Makefile lint/format tools) are clean
on both changed files.

