### PR TITLE
feat(providers): serve the branded callback page on provider OAuth logins

### DIFF
--- a/local_operator/callback_page.py
+++ b/local_operator/callback_page.py
@@ -1,8 +1,11 @@
-"""The page the browser lands on at the end of an MCP OAuth grant.
+"""The page the browser lands on at the end of an OAuth grant.
 
-This is the only web surface local-operator serves, and it is served at the
-worst possible moment: the user has just handed a third party permission on
-their behalf and is looking for confirmation that the thing they authorized
+Served by both loopback listeners local-operator runs — the MCP authorization
+flow (``local_operator.mcp.auth``) and the provider login flows
+(``local_operator.providers.oauth.callback_server``). It is the only web
+surface local-operator serves, and it is served at the worst possible moment:
+the user has just handed a third party permission on their behalf and is
+looking for confirmation that the thing they authorized
 actually received it. A bare ``<h2>`` on a white page reads like a server
 error even when it says "Authorized", so this page is drawn in the product's
 own design language — the Local Operator marketing site's system
@@ -268,13 +271,19 @@ def render_callback_page(
     *,
     tone: Tone = "neutral",
     server: str | None = None,
+    provider: str | None = None,
     provider_message: str | None = None,
     closable: bool = True,
 ) -> str:
     """The full HTML document for one callback outcome.
 
     ``server`` is the MCP server the grant was for, shown in a labelled trough —
-    omitted rather than faked when the caller does not know it.
+    omitted rather than faked when the caller does not know it. ``provider`` is
+    the same trough for a model-provider login (Anthropic, OpenAI, Z.AI): the
+    name of the party the user just authorized, labelled ``Provider`` so the
+    page says *whose* login finished without pretending an MCP server was
+    involved. The two are mutually exclusive at the call sites (one listener
+    each), but nothing here needs to enforce that.
 
     ``provider_message`` is the third party's own ``error_description``, and it
     gets its own labelled trough rather than being spliced into ``detail``.
@@ -291,6 +300,8 @@ def render_callback_page(
     blocks = ""
     if server:
         blocks += _trough("MCP server", server)
+    if provider:
+        blocks += _trough("Provider", provider)
     # Strip BEFORE the gate. `error_description=%20%20%20` is truthy and
     # reaches here from the wire, and gating on the raw argument then rendering
     # the stripped text produces a labelled empty box — the exact thing the
@@ -327,6 +338,7 @@ def callback_response(
     *,
     tone: Tone = "neutral",
     server: str | None = None,
+    provider: str | None = None,
     provider_message: str | None = None,
     closable: bool = True,
     status: str = "200 OK",
@@ -343,6 +355,7 @@ def callback_response(
         detail,
         tone=tone,
         server=server,
+        provider=provider,
         provider_message=provider_message,
         closable=closable,
     ).encode()

--- a/local_operator/mcp/auth.py
+++ b/local_operator/mcp/auth.py
@@ -36,7 +36,7 @@ from urllib.parse import parse_qs, urlparse
 from pydantic import AnyUrl
 
 from local_operator.ansi import strip_control_sequences
-from local_operator.mcp.callback_page import callback_response
+from local_operator.callback_page import callback_response
 
 if TYPE_CHECKING:
     # The SDK is an optional extra: these names are needed for annotations
@@ -201,7 +201,10 @@ def _resolve_store(store: StructuralAuthStore | None) -> StructuralAuthStore | N
 
         return AuthStore()
     except Exception:  # pragma: no cover - environment dependent
-        logger.debug("providers.auth_store unavailable; MCP OAuth storage disabled", exc_info=True)
+        logger.debug(
+            "providers.auth_store unavailable; MCP OAuth storage disabled",
+            exc_info=True,
+        )
         return None
 
 
@@ -355,7 +358,11 @@ class McpTokenStorage:
 
             return OAuthClientInformationFull.model_validate(info)
         except Exception:
-            logger.debug("Stored MCP client info invalid for %s", self.credential_id, exc_info=True)
+            logger.debug(
+                "Stored MCP client info invalid for %s",
+                self.credential_id,
+                exc_info=True,
+            )
             return None
 
     async def set_client_info(self, client_info: OAuthClientInformationFull) -> None:
@@ -573,7 +580,8 @@ class LoopbackAuthFlow:
         prompt = "Paste the full redirect URL (or 'code state' separated by a space): "
         try:
             raw = await asyncio.wait_for(
-                asyncio.to_thread(lambda: input(prompt).strip()), timeout=PASTE_INPUT_TIMEOUT_S
+                asyncio.to_thread(lambda: input(prompt).strip()),
+                timeout=PASTE_INPUT_TIMEOUT_S,
             )
         except asyncio.TimeoutError as exc:
             # TRANSLATE IT. Since 3.11 `asyncio.TimeoutError` IS `TimeoutError`

--- a/local_operator/providers/oauth/anthropic.py
+++ b/local_operator/providers/oauth/anthropic.py
@@ -79,6 +79,7 @@ class AnthropicOAuthFlow(OAuthCallbackFlow):
                 preferred_port=CALLBACK_PORT,
                 callback_path=CALLBACK_PATH,
                 manual_input_only=manual_input_only,
+                provider_label="Anthropic",
             ),
             callbacks,
             open_browser=open_browser,
@@ -140,7 +141,9 @@ class AnthropicOAuthFlow(OAuthCallbackFlow):
 
 
 async def _fetch_identity(
-    access_token: str, http_client: httpx.AsyncClient | None, model: str = "claude-sonnet-4-5"
+    access_token: str,
+    http_client: httpx.AsyncClient | None,
+    model: str = "claude-sonnet-4-5",
 ) -> dict[str, Any]:
     """Fallback identity source when the token response carries no org info."""
     client = http_client or httpx.AsyncClient(timeout=30.0)

--- a/local_operator/providers/oauth/callback_server.py
+++ b/local_operator/providers/oauth/callback_server.py
@@ -375,8 +375,13 @@ class OAuthCallbackFlow(ABC):
                         await self._respond(writer, 200, body)
                     else:
                         self._finish(code, state)
+                        # "Authorization complete", not "Signed in": this page is
+                        # served on CODE receipt, before the token exchange, and
+                        # its own detail line says the sign-in is still finishing.
+                        # Matches the register of the MCP surface's "Authorized"
+                        # (D1, PR #177 design round 1).
                         body = self._page(
-                            "Signed in",
+                            "Authorization complete",
                             "Local Operator has the authorization code and is "
                             "finishing the sign-in.",
                             tone="success",
@@ -411,6 +416,7 @@ class OAuthCallbackFlow(ABC):
                     "There is no sign-in waiting on this address. Start the "
                     "login again from Local Operator.",
                     closable=False,
+                    show_provider=False,
                 )
                 await self._respond(writer, 404, body)
         else:
@@ -420,6 +426,7 @@ class OAuthCallbackFlow(ABC):
                 "Nothing here",
                 "This address only answers the login redirect.",
                 closable=False,
+                show_provider=False,
             )
             await self._respond(writer, 404, body)
         try:
@@ -436,6 +443,7 @@ class OAuthCallbackFlow(ABC):
         tone: Tone = "neutral",
         provider_message: str | None = None,
         closable: bool = True,
+        show_provider: bool = True,
     ) -> bytes:
         """One outcome of this login, as the shared Local Operator page.
 
@@ -443,13 +451,17 @@ class OAuthCallbackFlow(ABC):
         user who authorizes a provider and an MCP server sees one product on
         both landings instead of a styled card on one and bare ``<h1>`` HTML
         on the other. The provider's display name rides along when the flow
-        knows it.
+        knows it — but only on real outcome pages. ``show_provider=False`` is
+        for the neutral 404s (a speculative favicon fetch, ``/launch`` with
+        nothing pending): a non-event given the outcome grammar of a labelled
+        provider trough would read as if something happened with that provider
+        (F2/D2, PR #177 round 1).
         """
         return render_callback_page(
             title,
             detail,
             tone=tone,
-            provider=self.options.provider_label,
+            provider=self.options.provider_label if show_provider else None,
             provider_message=provider_message,
             closable=closable,
         ).encode()

--- a/local_operator/providers/oauth/callback_server.py
+++ b/local_operator/providers/oauth/callback_server.py
@@ -27,6 +27,7 @@ import webbrowser
 from abc import ABC, abstractmethod
 from typing import Any, Awaitable, Callable, TypeVar
 
+from local_operator.callback_page import Tone, render_callback_page
 from local_operator.harness.types import AbortSignal
 
 DEFAULT_TIMEOUT_SECONDS = 300.0
@@ -214,6 +215,12 @@ class CallbackFlowOptions:
     allow_port_fallback: bool = True
     manual_input_only: bool = False
     timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS
+    #: Display name of the provider being signed into ("Anthropic", "OpenAI"),
+    #: rendered in a labelled trough on the browser landing page so the user
+    #: can see WHOSE login just finished. Optional because the page is honest
+    #: without it — the trough is omitted rather than faked (mirrors how the
+    #: MCP flow treats its server URL).
+    provider_label: str | None = None
 
 
 class OAuthCallbackFlow(ABC):
@@ -329,8 +336,18 @@ class OAuthCallbackFlow(ABC):
             if error:
                 desc = query.get("error_description", "")
                 self._finish_error(f"Authorization failed: {error} {desc}".strip())
-                body = (
-                    b"<html><body><h1>Login failed</h1><p>You may close this tab.</p></body></html>"
+                # The provider's words go in their own labelled trough rather
+                # than into our sentence — same voice boundary the MCP flow
+                # draws, and where a bare `access_denied` reads as data rather
+                # than as broken English. Stripped `desc` falls back to the
+                # error code so a `error_description=%20%20%20` redirect still
+                # names what went wrong.
+                body = self._page(
+                    "Sign-in failed",
+                    "The provider did not grant this sign-in, so nothing was "
+                    "connected. You can start the login again from Local Operator.",
+                    tone="danger",
+                    provider_message=desc.strip() or error,
                 )
                 await self._respond(writer, 200, body)
             else:
@@ -347,11 +364,23 @@ class OAuthCallbackFlow(ABC):
                             "Authorization callback state mismatch — stale tab or forged "
                             "redirect. Restart the login."
                         )
-                        body = b"<html><body><h1>Login failed</h1><p>You may close this tab.</p></body></html>"  # noqa: E501
+                        body = self._page(
+                            "Sign-in failed",
+                            "This redirect did not match the login Local Operator "
+                            "started. It may be a stale tab, or a redirect it "
+                            "never asked for. Nothing was connected. Restart the "
+                            "login from Local Operator.",
+                            tone="danger",
+                        )
                         await self._respond(writer, 200, body)
                     else:
                         self._finish(code, state)
-                        body = b"<html><body><h1>Login complete</h1><p>You may close this tab.</p></body></html>"  # noqa: E501
+                        body = self._page(
+                            "Signed in",
+                            "Local Operator has the authorization code and is "
+                            "finishing the sign-in.",
+                            tone="success",
+                        )
                         await self._respond(writer, 200, body)
                 else:
                     # PR-14: no code AND no error — fail the login promptly
@@ -360,22 +389,70 @@ class OAuthCallbackFlow(ABC):
                         "Authorization callback arrived with neither a code nor an error "
                         "parameter. Restart the login."
                     )
-                    body = b"<html><body><h1>Login failed</h1><p>You may close this tab.</p></body></html>"  # noqa: E501
+                    body = self._page(
+                        "No authorization code",
+                        "The redirect arrived without an authorization code, so "
+                        "there is nothing to hand back. You can start the login "
+                        "again from Local Operator.",
+                        tone="danger",
+                    )
                     await self._respond(writer, 200, body)
         elif path == "/launch" and method == "GET":
             if self._pending_auth_url:
                 await self._respond(
-                    writer, 302, b"", extra_headers=[("Location", self._pending_auth_url)]
+                    writer,
+                    302,
+                    b"",
+                    extra_headers=[("Location", self._pending_auth_url)],
                 )
             else:
-                await self._respond(writer, 404, b"no pending login")
+                body = self._page(
+                    "No login in progress",
+                    "There is no sign-in waiting on this address. Start the "
+                    "login again from Local Operator.",
+                    closable=False,
+                )
+                await self._respond(writer, 404, body)
         else:
-            await self._respond(writer, 404, b"not found")
+            # Browsers ask for /favicon.ico off their own bat; a neutral 404
+            # keeps a speculative fetch from being mistaken for the redirect.
+            body = self._page(
+                "Nothing here",
+                "This address only answers the login redirect.",
+                closable=False,
+            )
+            await self._respond(writer, 404, body)
         try:
             writer.close()
             await writer.wait_closed()
         except Exception:
             pass
+
+    def _page(
+        self,
+        title: str,
+        detail: str,
+        *,
+        tone: Tone = "neutral",
+        provider_message: str | None = None,
+        closable: bool = True,
+    ) -> bytes:
+        """One outcome of this login, as the shared Local Operator page.
+
+        Same document the MCP OAuth listener serves (``callback_page``), so a
+        user who authorizes a provider and an MCP server sees one product on
+        both landings instead of a styled card on one and bare ``<h1>`` HTML
+        on the other. The provider's display name rides along when the flow
+        knows it.
+        """
+        return render_callback_page(
+            title,
+            detail,
+            tone=tone,
+            provider=self.options.provider_label,
+            provider_message=provider_message,
+            closable=closable,
+        ).encode()
 
     async def _respond(
         self,
@@ -389,6 +466,7 @@ class OAuthCallbackFlow(ABC):
             f"HTTP/1.1 {status} {reason}",
             f"Content-Length: {len(body)}",
             "Content-Type: text/html; charset=utf-8",
+            "Cache-Control: no-store",
             "Connection: close",
         ]
         for name, value in extra_headers or []:
@@ -413,7 +491,10 @@ class OAuthCallbackFlow(ABC):
         if self.options.manual_input_only or self._server is None or self._bound_port is None:
             return None
         uri = urllib.parse.urlsplit(self.redirect_uri())
-        if uri.scheme not in ("http", "https") or uri.hostname not in ("localhost", "127.0.0.1"):
+        if uri.scheme not in ("http", "https") or uri.hostname not in (
+            "localhost",
+            "127.0.0.1",
+        ):
             return None
         if self.options.callback_path == "/launch":
             return None
@@ -499,7 +580,8 @@ class OAuthCallbackFlow(ABC):
                     # before, and the callback keeps its chance to win either
                     # way because this loop never blocks it.
                     await report_safely(
-                        self.callbacks.on_warning or self.callbacks.on_progress, str(exc)
+                        self.callbacks.on_warning or self.callbacks.on_progress,
+                        str(exc),
                     )
                     # Ordered after the message so a host that repaints on
                     # rejection does so with the reason already on screen
@@ -545,7 +627,9 @@ class OAuthCallbackFlow(ABC):
 
         try:
             done, _pending = await asyncio.wait(
-                waiters, timeout=self.options.timeout_seconds, return_when=asyncio.FIRST_COMPLETED
+                waiters,
+                timeout=self.options.timeout_seconds,
+                return_when=asyncio.FIRST_COMPLETED,
             )
         finally:
             for task in waiters:

--- a/local_operator/providers/oauth/openai.py
+++ b/local_operator/providers/oauth/openai.py
@@ -94,7 +94,10 @@ def identity_from_id_token(id_token: str) -> dict[str, Any]:
         raise LoginError("OpenAI login returned no account id (chatgpt_account_id claim missing)")
     plan_type = auth.get("chatgpt_plan_type")
     email = profile.get("email") or claims.get("email")
-    identity: dict[str, Any] = {"account_id": str(account_id), "org_id": str(account_id)}
+    identity: dict[str, Any] = {
+        "account_id": str(account_id),
+        "org_id": str(account_id),
+    }
     if plan_type:
         identity["org_name"] = str(plan_type)
     if email:
@@ -154,6 +157,7 @@ class OpenAIOAuthFlow(OAuthCallbackFlow):
                 # Pinned: OpenAI allowlists this exact URI.
                 redirect_uri=REDIRECT_URI,
                 allow_port_fallback=False,
+                provider_label="OpenAI",
             ),
             callbacks,
             open_browser=open_browser,

--- a/local_operator/providers/oauth/zai.py
+++ b/local_operator/providers/oauth/zai.py
@@ -200,7 +200,10 @@ async def mint_zai_api_key(
 
     customer = _unwrap(
         await _get_json(
-            http, f"{BIZ_BASE}/api/biz/customer/getCustomerInfo", auth, "customer lookup"
+            http,
+            f"{BIZ_BASE}/api/biz/customer/getCustomerInfo",
+            auth,
+            "customer lookup",
         ),
         "customer lookup",
     )
@@ -223,7 +226,10 @@ async def mint_zai_api_key(
         (
             k
             for k in _key_array(
-                _unwrap(await _get_json(http, keys_url, auth, "api key list"), "api key list")
+                _unwrap(
+                    await _get_json(http, keys_url, auth, "api key list"),
+                    "api key list",
+                )
             )
             if k.get("name") == KEY_NAME
         ),
@@ -273,6 +279,7 @@ class ZaiOAuthFlow(OAuthCallbackFlow):
                 # fallback port would produce a redirect the IdP refuses.
                 allow_port_fallback=False,
                 manual_input_only=manual_input_only,
+                provider_label="Z.AI",
             ),
             callbacks,
             open_browser=open_browser,
@@ -306,7 +313,12 @@ class ZaiOAuthFlow(OAuthCallbackFlow):
                 TOKEN_URL,
                 # Deliberately NOT an RFC 6749 body: the provider's own client
                 # posts these fields and the endpoint rejects grant_type.
-                {"provider": "zai", "code": code, "redirect_uri": redirect_uri, "state": state},
+                {
+                    "provider": "zai",
+                    "code": code,
+                    "redirect_uri": redirect_uri,
+                    "state": state,
+                },
                 "token exchange",
             )
             data = _unwrap(body, "token exchange")

--- a/tests/unit/providers/test_oauth_flows.py
+++ b/tests/unit/providers/test_oauth_flows.py
@@ -457,6 +457,107 @@ async def test_openai_exchange_omits_state() -> None:
     assert result["org_id"] == "acct-1"
 
 
+async def test_callback_pages_are_the_shared_branded_document() -> None:
+    """The browser lands on the same Local Operator page the MCP flow serves.
+
+    Not a styling snapshot — what is pinned is that every outcome of the
+    loopback listener answers with the shared ``callback_page`` document
+    (identity mark + outcome heading), that the provider's display name rides
+    in its labelled trough, and that a provider error's own words land in the
+    data trough rather than in our sentence. A regression to the old bare
+    ``<h1>Login complete</h1>`` bodies passes every flow-mechanics test in
+    this file, which is exactly why these assertions exist.
+    """
+    pages: dict[str, httpx.Response] = {}
+
+    async def drive_success() -> None:
+        # Any settled outcome stops the server, so the mismatch (which settles
+        # the error future and fails run()) gets its own flow below.
+        flow = _EchoFlow(
+            CallbackFlowOptions(preferred_port=0, provider_label="Anthropic"),
+            LoginCallbacks(),
+        )
+        task = asyncio.create_task(flow.run())
+        for _ in range(400):
+            if flow.bound_port is not None and flow.generated:
+                break
+            await asyncio.sleep(0.01)
+        base = f"http://127.0.0.1:{flow.bound_port}"
+        async with httpx.AsyncClient() as client:
+            # A speculative browser fetch is not an outcome and must not be.
+            pages["favicon"] = await client.get(f"{base}/favicon.ico")
+            # The real redirect completes the flow.
+            pages["success"] = await client.get(
+                f"{base}/callback",
+                params={"code": "c", "state": flow.generated["state"]},
+            )
+        await task
+
+    async def drive_mismatch() -> None:
+        flow = _EchoFlow(CallbackFlowOptions(preferred_port=0), LoginCallbacks())
+        task = asyncio.create_task(flow.run())
+        for _ in range(400):
+            if flow.bound_port is not None and flow.generated:
+                break
+            await asyncio.sleep(0.01)
+        async with httpx.AsyncClient() as client:
+            # A forged/stale redirect: wrong state alongside a real-looking code.
+            pages["mismatch"] = await client.get(
+                f"http://127.0.0.1:{flow.bound_port}/callback",
+                params={"code": "c", "state": "not-the-state"},
+            )
+        with pytest.raises(LoginError, match="state mismatch"):
+            await task
+
+    await asyncio.wait_for(drive_success(), timeout=10)
+    await asyncio.wait_for(drive_mismatch(), timeout=10)
+
+    success = pages["success"].text
+    assert "<h1>Signed in</h1>" in success
+    assert 'class="mark"' in success  # the shared branded document, not bare HTML
+    assert 'class="label">Provider<' in success
+    assert 'class="trough">Anthropic<' in success
+    assert "close this tab" in success
+
+    mismatch = pages["mismatch"].text
+    assert "<h1>Sign-in failed</h1>" in mismatch
+    assert 'class="mark"' in mismatch
+
+    favicon = pages["favicon"]
+    assert favicon.status_code == 404
+    assert "<h1>Nothing here</h1>" in favicon.text
+
+
+async def test_provider_denial_lands_in_the_data_trough() -> None:
+    """`error_description` is the provider's text: labelled trough, escaped,
+    never spliced into the sentence spoken in Local Operator's voice."""
+    flow = _EchoFlow(CallbackFlowOptions(preferred_port=0), LoginCallbacks())
+
+    async def drive() -> httpx.Response:
+        task = asyncio.create_task(flow.run())
+        for _ in range(400):
+            if flow.bound_port is not None and flow.generated:
+                break
+            await asyncio.sleep(0.01)
+        async with httpx.AsyncClient() as client:
+            response = await client.get(
+                f"http://127.0.0.1:{flow.bound_port}/callback",
+                params={
+                    "error": "access_denied",
+                    "error_description": "<b>User denied</b>",
+                },
+            )
+        with pytest.raises(LoginError, match="access_denied"):
+            await task
+        return response
+
+    response = await asyncio.wait_for(drive(), timeout=10)
+    page = response.text
+    assert 'class="label">Provider response<' in page
+    assert "&lt;b&gt;User denied&lt;/b&gt;" in page  # escaped, not injected
+    assert "<b>User denied</b>" not in page
+
+
 async def test_callback_missing_code_fails_promptly() -> None:
     """PR-14: a redirect carrying neither code nor error fails the login
     immediately — no 300 s hang."""
@@ -543,7 +644,9 @@ def test_kimi_common_headers_carry_device_identity() -> None:
     assert headers["X-Msh-Platform"] == "kimi_cli"
 
 
-async def test_kimi_slow_down_updates_poller_interval(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_kimi_slow_down_updates_poller_interval(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """PR-10: a slow_down payload with a larger interval raises the poller's
     interval via the mutable holder."""
     from local_operator.providers.oauth.kimi import (
@@ -677,7 +780,9 @@ async def test_every_paste_key_provider_can_actually_be_logged_into() -> None:
         assert await login(callbacks) == "sk-pasted-key", definition.id
 
 
-def test_cli_hides_an_api_key_and_echoes_an_oauth_code(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_cli_hides_an_api_key_and_echoes_an_oauth_code(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Round 1 F2: an API key must not be echoed into the terminal scrollback.
 
     ``CredentialManager`` and the web-search CLI already read this same class of
@@ -1000,7 +1105,10 @@ async def test_qwencloud_token_plan_login_captures_key_and_device_grant() -> Non
                         "AccessToken": "mgmt-access",
                         "RefreshToken": "mgmt-refresh",
                         "ExpireTime": "2030-01-01T00:00:00Z",
-                        "User": {"AliyunId": "damian-aliyun", "Email": "damian@example.com"},
+                        "User": {
+                            "AliyunId": "damian-aliyun",
+                            "Email": "damian@example.com",
+                        },
                     },
                 },
             },
@@ -1056,7 +1164,8 @@ async def test_qwencloud_token_plan_login_expired_device_code_is_terminal() -> N
     callbacks = LoginCallbacks(on_manual_code_input=lambda: "sk-sp-test")
     with pytest.raises(Exception, match="expired"):
         await login_qwencloud_token_plan(
-            callbacks, http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler))
+            callbacks,
+            http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
         )
 
 
@@ -1337,7 +1446,8 @@ class TestZaiSignInMintsADurableKey:
             spec, http_client=httpx.AsyncClient(transport=httpx.MockTransport(wire))
         )
         request = ChatRequest(
-            model=spec, messages=[Message(role="user", content=[TextContent(text="ping")])]
+            model=spec,
+            messages=[Message(role="user", content=[TextContent(text="ping")])],
         )
         events = [
             event
@@ -1386,7 +1496,10 @@ class TestPastedCallbackParsing:
             _parse_pasted_callback,
         )
 
-        assert _parse_pasted_callback("https://example.com/cb?code=c1#state=s9") == ("c1", "s9")
+        assert _parse_pasted_callback("https://example.com/cb?code=c1#state=s9") == (
+            "c1",
+            "s9",
+        )
 
     def test_percent_encoding_is_decoded(self) -> None:
         from local_operator.providers.oauth.callback_server import (
@@ -1545,7 +1658,7 @@ class TestABadPasteDoesNotEndTheLogin:
             loop = asyncio.get_running_loop()
             flow = self._flow("http://localhost:54548/cb?error=access_denied", [])
             flow.callbacks = cs.LoginCallbacks(
-                on_manual_code_input=lambda: "http://localhost:54548/cb?error=access_denied",
+                on_manual_code_input=lambda: ("http://localhost:54548/cb?error=access_denied"),
                 **{hook: _boom},
             )
             flow._captured = loop.create_future()

--- a/tests/unit/providers/test_oauth_flows.py
+++ b/tests/unit/providers/test_oauth_flows.py
@@ -460,13 +460,17 @@ async def test_openai_exchange_omits_state() -> None:
 async def test_callback_pages_are_the_shared_branded_document() -> None:
     """The browser lands on the same Local Operator page the MCP flow serves.
 
-    Not a styling snapshot — what is pinned is that every outcome of the
-    loopback listener answers with the shared ``callback_page`` document
-    (identity mark + outcome heading), that the provider's display name rides
-    in its labelled trough, and that a provider error's own words land in the
-    data trough rather than in our sentence. A regression to the old bare
-    ``<h1>Login complete</h1>`` bodies passes every flow-mechanics test in
-    this file, which is exactly why these assertions exist.
+    Not a styling snapshot — what is pinned is that the listener's outcomes
+    answer with the shared ``callback_page`` document (identity mark + outcome
+    heading) and that the provider's display name rides in its labelled trough
+    on real outcomes only. This test covers success, state mismatch, code-less
+    redirect, and the favicon 404; the provider-denial trough is pinned in
+    ``test_provider_denial_lands_in_the_data_trough`` and the ``/launch``
+    no-pending 404 in
+    ``test_launch_with_no_pending_login_serves_the_branded_404``. A regression
+    to the old bare ``<h1>Login complete</h1>`` bodies passes every
+    flow-mechanics test in this file, which is exactly why these assertions
+    exist.
     """
     pages: dict[str, httpx.Response] = {}
 
@@ -486,6 +490,9 @@ async def test_callback_pages_are_the_shared_branded_document() -> None:
         async with httpx.AsyncClient() as client:
             # A speculative browser fetch is not an outcome and must not be.
             pages["favicon"] = await client.get(f"{base}/favicon.ico")
+            # /launch after run() has generated the auth URL redirects; the
+            # no-pending branch needs a flow that has not generated one, which
+            # drive_no_pending below covers.
             # The real redirect completes the flow.
             pages["success"] = await client.get(
                 f"{base}/callback",
@@ -509,11 +516,31 @@ async def test_callback_pages_are_the_shared_branded_document() -> None:
         with pytest.raises(LoginError, match="state mismatch"):
             await task
 
+    async def drive_no_code() -> None:
+        flow = _EchoFlow(
+            CallbackFlowOptions(preferred_port=0, provider_label="Anthropic"),
+            LoginCallbacks(),
+        )
+        task = asyncio.create_task(flow.run())
+        for _ in range(400):
+            if flow.bound_port is not None and flow.generated:
+                break
+            await asyncio.sleep(0.01)
+        async with httpx.AsyncClient() as client:
+            pages["no_code"] = await client.get(
+                f"http://127.0.0.1:{flow.bound_port}/callback", params={}
+            )
+        with pytest.raises(LoginError, match="neither a code nor an error"):
+            await task
+
     await asyncio.wait_for(drive_success(), timeout=10)
     await asyncio.wait_for(drive_mismatch(), timeout=10)
+    await asyncio.wait_for(drive_no_code(), timeout=10)
 
     success = pages["success"].text
-    assert "<h1>Signed in</h1>" in success
+    # "Authorization complete", not "Signed in": served on code receipt,
+    # before the token exchange (D1, PR #177 design round 1).
+    assert "<h1>Authorization complete</h1>" in success
     assert 'class="mark"' in success  # the shared branded document, not bare HTML
     assert 'class="label">Provider<' in success
     assert 'class="trough">Anthropic<' in success
@@ -523,9 +550,41 @@ async def test_callback_pages_are_the_shared_branded_document() -> None:
     assert "<h1>Sign-in failed</h1>" in mismatch
     assert 'class="mark"' in mismatch
 
+    no_code = pages["no_code"].text
+    assert "<h1>No authorization code</h1>" in no_code
+    assert 'class="mark"' in no_code
+
     favicon = pages["favicon"]
     assert favicon.status_code == 404
     assert "<h1>Nothing here</h1>" in favicon.text
+    # A non-event carries no provider trough: a speculative fetch given the
+    # outcome grammar would read as if something happened with that provider
+    # (F2/D2, PR #177 round 1).
+    assert 'class="label">Provider<' not in favicon.text
+
+
+async def test_launch_with_no_pending_login_serves_the_branded_404() -> None:
+    """/launch before an auth URL exists is a dead end, and it must say so in
+    the same branded document as every other page — without the provider
+    trough, because nothing happened with the provider (F1/F2, PR #177).
+
+    The window where the server is up but no auth URL is pending cannot be
+    reached through run() (it generates the URL immediately after binding), so
+    the server is started directly, the way run() starts it.
+    """
+    flow = _EchoFlow(
+        CallbackFlowOptions(preferred_port=0, provider_label="Anthropic"), LoginCallbacks()
+    )
+    await flow._start_server()
+    try:
+        async with httpx.AsyncClient() as client:
+            response = await client.get(f"http://127.0.0.1:{flow.bound_port}/launch")
+        assert response.status_code == 404
+        assert "<h1>No login in progress</h1>" in response.text
+        assert 'class="mark"' in response.text
+        assert 'class="label">Provider<' not in response.text
+    finally:
+        await flow._stop_server()
 
 
 async def test_provider_denial_lands_in_the_data_trough() -> None:

--- a/tests/unit/test_callback_page.py
+++ b/tests/unit/test_callback_page.py
@@ -15,7 +15,7 @@ import re
 
 import pytest
 
-from local_operator.mcp.callback_page import callback_response, render_callback_page
+from local_operator.callback_page import callback_response, render_callback_page
 
 
 class TestZeroNetwork:
@@ -31,7 +31,11 @@ class TestZeroNetwork:
         "kwargs",
         [
             {"tone": "success", "server": "https://srv.example/mcp"},
-            {"tone": "danger", "server": "https://srv.example/mcp", "provider_message": "denied"},
+            {
+                "tone": "danger",
+                "server": "https://srv.example/mcp",
+                "provider_message": "denied",
+            },
             {"tone": "neutral", "closable": False},
             # A caller string that CONTAINS the tokens the assertions look for.
             # It is escaped into a text node and cannot fetch, so the invariant
@@ -109,10 +113,13 @@ class TestVoiceBoundary:
         fold on a page with no navigation. Truncation is visible rather than
         clipped in CSS so the page never hides text without saying so.
         """
-        from local_operator.mcp.callback_page import _MAX_PROVIDER_MESSAGE
+        from local_operator.callback_page import _MAX_PROVIDER_MESSAGE
 
         page = render_callback_page(
-            "Authorization failed", "Detail.", tone="danger", provider_message="x" * 16_000
+            "Authorization failed",
+            "Detail.",
+            tone="danger",
+            provider_message="x" * 16_000,
         )
         rendered = re.search(r'class="trough">(x+…?)<', page)
         assert rendered is not None
@@ -121,7 +128,10 @@ class TestVoiceBoundary:
 
     def test_a_short_provider_message_is_untouched(self) -> None:
         page = render_callback_page(
-            "Authorization failed", "Detail.", tone="danger", provider_message="access_denied"
+            "Authorization failed",
+            "Detail.",
+            tone="danger",
+            provider_message="access_denied",
         )
         assert 'class="trough">access_denied<' in page
         assert "…" not in page
@@ -129,6 +139,17 @@ class TestVoiceBoundary:
     def test_absent_provider_message_renders_no_empty_trough(self) -> None:
         page = render_callback_page("Authorized", "Detail.", tone="success")
         assert "Provider response" not in page
+
+    def test_provider_name_gets_its_own_labelled_trough(self) -> None:
+        """A model-provider login names WHO was signed into, same grammar as
+        the MCP flow's server trough — a labelled trough, not a sentence."""
+        page = render_callback_page("Signed in", "Detail.", tone="success", provider="Anthropic")
+        assert 'class="label">Provider<' in page
+        assert 'class="trough">Anthropic<' in page
+
+    def test_absent_provider_renders_no_trough(self) -> None:
+        page = render_callback_page("Signed in", "Detail.", tone="success")
+        assert 'class="label">Provider<' not in page
 
     @pytest.mark.parametrize("blank", ["", "   ", "\t\n "])
     def test_a_whitespace_only_provider_message_renders_no_trough(self, blank) -> None:
@@ -170,7 +191,8 @@ class TestOutcomeSurvivesWithoutColour:
     """Colour is redundant: the heading and the tab title carry the outcome."""
 
     @pytest.mark.parametrize(
-        "title", ["Authorized", "Authorization failed", "No authorization code", "Nothing here"]
+        "title",
+        ["Authorized", "Authorization failed", "No authorization code", "Nothing here"],
     )
     def test_title_leads_the_document_title(self, title) -> None:
         page = render_callback_page(title, "Detail.")


### PR DESCRIPTION
# PR Description

## Change classification

**C2 — standard / pre-authorized.** User-visible polish of the provider OAuth login landing pages plus a module move (`local_operator/mcp/callback_page.py` → `local_operator/callback_page.py`). No protocol change: the loopback listener's routes, status codes, and flow-settling behaviour are untouched; only the HTML bodies (and one added `Cache-Control: no-store` header) change. Clean rollback via `git revert`.

## The gap

Provider OAuth logins (Anthropic Claude Pro/Max, OpenAI ChatGPT, Z.AI browser sign-in) end with the browser landing on the loopback callback server, which answered with bare unstyled HTML:

```html
<html><body><h1>Login complete</h1><p>You may close this tab.</p></body></html>
```

Meanwhile the MCP OAuth flow already lands users on a designed Local Operator page (`callback_page.py`): warm paper/dark ramp, identity mark, one semantic colour spend, labelled data troughs, zero network. Both listeners serve the same moment — the user just granted a third party access and wants confirmation the software they trust received it — so a bare `<h1>` on one of them reads like a server error.

## The fix

- **Promote `local_operator/mcp/callback_page.py` to `local_operator/callback_page.py`** (git mv; the module had no MCP imports — it was MCP-specific only by location) and repoint the MCP auth listener import. Its test suite moves with it.
- **Add an optional `provider` trough** to the shared page, exactly mirroring the MCP `server` trough grammar: a provider login now names *who* was signed into ("Provider: Anthropic") without pretending an MCP server was involved.
- **Serve the shared page from `OAuthCallbackFlow`** for every outcome:
  - success → "Signed in", success tone
  - provider denial → "Sign-in failed", danger tone, `error_description` in the escaped **Provider response** trough (same voice boundary as MCP: the third party's words are data, never spliced into our sentence; whitespace-only descriptions fall back to the error code)
  - state mismatch (forged/stale redirect) → "Sign-in failed", danger tone
  - redirect with no code → "No authorization code", danger tone
  - `/launch` with no pending login → 404 "No login in progress"
  - anything else (e.g. the browser's speculative `/favicon.ico`) → neutral 404 "Nothing here"
- **`CallbackFlowOptions` grows `provider_label`**, set by the three loopback flows (Anthropic / OpenAI / Z.AI). Optional: the trough is omitted rather than faked when a flow does not set it.
- **`Cache-Control: no-store`** added to provider callback responses, matching the MCP listener.

## Testing evidence

**Real-path exercise.** Ran the real `OAuthCallbackFlow` loopback server (not a stub) via a small harness on fixed ports and drove every outcome with `curl`, one process per outcome since any settled outcome stops the server (the flow's contract):

- Success: `GET /callback?code=demo-code&state=<sent-state>` → `200`, `<h1>Signed in</h1>`, identity mark present, `Provider: Anthropic` trough, `Cache-Control: no-store` in headers; flow returned the exchanged credentials (`FLOW DONE`).
- Denial: `GET /callback?error=access_denied&error_description=User%20declined%20the%20request` → `200`, `<h1>Sign-in failed</h1>`, both `Provider` and `Provider response` troughs; flow raised `LoginError: Authorization failed: access_denied User declined the request`.
- Forged state: `GET /callback?code=evil&state=wrong-state` → `200`, `<h1>Sign-in failed</h1>`; flow raised `LoginError: … state mismatch`.
- No code: `GET /callback` → `200`, `<h1>No authorization code</h1>`; flow raised the PR-14 prompt error (no 300 s hang — behaviour preserved).
- Speculative fetch: `GET /favicon.ico` → `404`, `<h1>Nothing here</h1>`, flow kept waiting (server stayed up for the subsequent callback).
- XSS/voice boundary: `error_description=<b>User denied</b>` renders escaped (`&lt;b&gt;…`) inside the labelled trough; raw markup absent from the document.

**Browser screenshots** (real browser, dark ramp) — before/after and state coverage below.

**Unit suites.** `tests/unit/test_callback_page.py` + `tests/unit/providers/test_oauth_flows.py` + `tests/unit/mcp` + `tests/unit/test_import_graph.py`: 240 passed. New tests pin: the provider trough renders and is omitted when absent; every listener outcome answers with the shared branded document (a regression to the old bare `<h1>` bodies passes every flow-mechanics test, which is exactly why these assertions exist); the denial trough is escaped, never spliced. Full `tests/unit`: 5031 passed, 7 skipped, 1 pre-existing flake (`test_eval_tool.py::test_background_streams_output_while_it_runs`) that fails identically on clean `origin/main` at the same base commit `ade8d81` (verified in a pristine worktree) — load-sensitive streaming assertion already noted on PRs #172/#174, untouched here.

**Gates.** black + isort clean; flake8 clean on `local_operator` and `tests`; pyright (`--pythonpath .venv/bin/python`) 0 errors on all touched files.

## Screenshots

Captured in a real browser (dark ramp). Round-1 remediation frames (success retitled, 404s lost the provider trough) captured at head `0af30bb05b83`; the unchanged states (denial, mismatch, no-code) at `aa110e0735` — their rendered output is byte-identical at the current head except for the round-1 deltas, which are pinned by exact-text assertions in `test_oauth_flows.py`. The before frame renders the exact bytes the old server sent.

| State | Frame |
| --- | --- |
| **Before** — the old page every outcome shared | ![before: bare Login complete page](https://raw.githubusercontent.com/damianvtran/local-operator/assets/pr-provider-oauth-page/before-success.png) |
| **Authorization complete** — success tone, provider trough (`0af30bb05b83`) | ![authorization complete](https://raw.githubusercontent.com/damianvtran/local-operator/assets/pr-provider-oauth-page/authorization-complete.png) |
| **Provider denial** — danger tone, escaped response trough (`aa110e0735`) | ![denial](https://raw.githubusercontent.com/damianvtran/local-operator/assets/pr-provider-oauth-page/denied.png) |
| **Forged/stale state** — danger tone (`aa110e0735`) | ![state mismatch](https://raw.githubusercontent.com/damianvtran/local-operator/assets/pr-provider-oauth-page/state-mismatch.png) |
| **No authorization code** — danger tone (`aa110e0735`) | ![no code](https://raw.githubusercontent.com/damianvtran/local-operator/assets/pr-provider-oauth-page/no-code.png) |
| **Speculative-fetch 404** — neutral, no provider trough (`0af30bb05b83`) | ![404](https://raw.githubusercontent.com/damianvtran/local-operator/assets/pr-provider-oauth-page/not-found-404.png) |
| **/launch, no pending login** — neutral 404 (`0af30bb05b83`) | ![launch 404](https://raw.githubusercontent.com/damianvtran/local-operator/assets/pr-provider-oauth-page/launch-no-pending-404.png) |
