### PR TITLE
fix(providers,model): resolve OAuth login flavours to their stored credential, and stop 400ing Kimi's coding plan

### DIFF
--- a/local_operator/cli.py
+++ b/local_operator/cli.py
@@ -1184,10 +1184,11 @@ def _preflight_api_key(
         import asyncio
 
         from local_operator.providers.auth_store import AuthStore
+        from local_operator.providers.registry import credential_provider_id
 
         auth_store = AuthStore(credential_manager=credential_manager)
         try:
-            storage_provider = definition.store_credentials_as or canonical
+            storage_provider = credential_provider_id(canonical)
             if auth_store.list_credentials(provider=storage_provider):
                 return None
             api_key = asyncio.run(auth_store.get_api_key(canonical))

--- a/local_operator/model/configure.py
+++ b/local_operator/model/configure.py
@@ -214,6 +214,23 @@ _NO_SAMPLING_PARAMS = re.compile(
     r"claude-[a-z]+-(?:[5-9]|\d{2,})(?!\d)" r"|(?:^|[/:-])o[1-9](?:-|$)" r"|gpt-5"
 )
 
+#: Kimi's coding-plan host pins sampling instead of rejecting the keys
+#: outright: ``api.kimi.com/coding/v1/chat/completions`` answers HTTP 400
+#: ``invalid temperature: only 1 is allowed for this model`` for any other
+#: value, and ``invalid top_p: only 0.95 is allowed`` likewise — while
+#: OMITTING both keys succeeds. Verified live against ``k3`` and
+#: ``k2-thinking`` with temperatures 0.2/0.6/1/absent and top_p 0.9/1/absent.
+#:
+#: Scoped to the coding-plan model ids rather than folded into
+#: :data:`_NO_SAMPLING_PARAMS`, because this is NOT a property of a model
+#: family across routes: the mainland ``api.moonshot.cn`` host serves
+#: ``kimi-k2-*``/``moonshot-*`` under the same ``kimi`` provider id and
+#: accepts the pair. The ids below (``k3``, ``k3-256k``, ``kimi-for-coding``,
+#: ``kimi-for-coding-highspeed``) exist only on the coding host, so matching
+#: them is matching the endpoint that pins the values. Anchored at the start:
+#: ``kimi-k2-0711-preview`` must not match on its ``k2`` fragment.
+_KIMI_PINNED_SAMPLING = re.compile(r"^(?:k\d+(?:-|$)|kimi-for-coding)")
+
 #: OpenAI introduced the public Responses route for the GPT-5 generation. The
 #: direct `/v1/models` listing exposes ids but no capability flags, so an
 #: uncurated current snapshot still needs a family rule; older registry rows
@@ -282,6 +299,12 @@ def build_model_spec(hosting: str, model_name: str, info: ModelInfo | None = Non
     # while a provider-keyed rule would keep shipping a value that is provably
     # discarded and would start 400ing the day an aggregator stops normalising.
     supports_sampling_params = _NO_SAMPLING_PARAMS.search(lowered) is None
+    # The kimi coding-plan host pins temperature/top_p to fixed values and
+    # 400s on any other; omitted keys pass. Unlike _NO_SAMPLING_PARAMS this
+    # IS keyed on the provider too, because the same model family accepts the
+    # pair on the mainland host — see _KIMI_PINNED_SAMPLING.
+    if canonical == "kimi" and _KIMI_PINNED_SAMPLING.match(lowered):
+        supports_sampling_params = False
     # Seeded to the model's own documented default, not left unset, so the band
     # states a real level from the first frame. Safe only because the provider
     # says the two are the same request — Anthropic documents `effort: "high"`

--- a/local_operator/model/configure.py
+++ b/local_operator/model/configure.py
@@ -819,10 +819,9 @@ def _oauth_listing_token(provider: str) -> tuple[str, bool, str | None]:
     store = None
     try:
         from local_operator.providers.auth_store import AuthStore
-        from local_operator.providers.registry import get_provider_definition
+        from local_operator.providers.registry import credential_provider_id
 
-        definition = get_provider_definition(provider)
-        storage = (definition.store_credentials_as or provider) if definition else provider
+        storage = credential_provider_id(provider)
         store = AuthStore()
         rows = store.list_credentials(provider=storage)
         for row in reversed(rows):
@@ -1677,10 +1676,9 @@ class SessionStreamFn:
 
     @staticmethod
     def _storage_provider(provider: str) -> str:
-        from local_operator.providers.registry import get_provider_definition
+        from local_operator.providers.registry import credential_provider_id
 
-        definition = get_provider_definition(provider)
-        return definition.store_credentials_as or provider if definition is not None else provider
+        return credential_provider_id(provider)
 
     async def _primary_has_auth(self, model: ModelSpec) -> bool:
         from local_operator.providers.failover import FallbackTarget

--- a/local_operator/model/configure.py
+++ b/local_operator/model/configure.py
@@ -225,9 +225,11 @@ _NO_SAMPLING_PARAMS = re.compile(
 #: :data:`_NO_SAMPLING_PARAMS`, because this is NOT a property of a model
 #: family across routes: the mainland ``api.moonshot.cn`` host serves
 #: ``kimi-k2-*``/``moonshot-*`` under the same ``kimi`` provider id and
-#: accepts the pair. The ids below (``k3``, ``k3-256k``, ``kimi-for-coding``,
-#: ``kimi-for-coding-highspeed``) exist only on the coding host, so matching
-#: them is matching the endpoint that pins the values. Anchored at the start:
+#: accepts the pair. The rule is "any k-numbered coding-host id, now or
+#: later": ``k3``, ``k3-256k``, ``k2-thinking`` (the live probe confirmed it
+#: pins the pair too) and ``kimi-for-coding*`` all exist only on the coding
+#: host, so matching the ``k<digit>``/``kimi-for-coding`` shapes is matching
+#: the endpoint that pins the values. Anchored at the start:
 #: ``kimi-k2-0711-preview`` must not match on its ``k2`` fragment.
 _KIMI_PINNED_SAMPLING = re.compile(r"^(?:k\d+(?:-|$)|kimi-for-coding)")
 

--- a/local_operator/model/discovery.py
+++ b/local_operator/model/discovery.py
@@ -47,6 +47,7 @@ from local_operator.model.registry import ModelInfo, static_models
 from local_operator.providers.registry import (
     PROVIDER_REGISTRY,
     WireFormat,
+    credential_provider_id,
     get_provider_definition,
 )
 
@@ -827,7 +828,7 @@ def _static_rows(provider_id: str) -> dict[str, ModelInfo]:
     definition = get_provider_definition(provider_id)
     if definition is None:
         return {}
-    return static_models(definition.store_credentials_as or definition.id)
+    return static_models(credential_provider_id(definition.id))
 
 
 def fetch_models(
@@ -1248,7 +1249,7 @@ def _available_models(
             "models": [dataclasses.asdict(row) for row in live],
         }
 
-    storage_id = definition.store_credentials_as or definition.id
+    storage_id = credential_provider_id(definition.id)
     # Derived ONCE and reused for both the document name and the pruning
     # decision, so the two cannot disagree about whether this listing is the
     # account's authoritative catalogue.

--- a/local_operator/providers/auth_cli.py
+++ b/local_operator/providers/auth_cli.py
@@ -16,6 +16,7 @@ from local_operator.providers.oauth.callback_server import LoginCallbacks, Login
 from local_operator.providers.registry import (
     PROVIDER_REGISTRY,
     ProviderDefinition,
+    credential_provider_id,
     env_key_name,
     get_provider_definition,
     list_login_providers,
@@ -147,7 +148,7 @@ def run_login(
         print("Login cancelled.")
         return 1
 
-    storage_provider = definition.store_credentials_as or definition.id
+    storage_provider = credential_provider_id(definition.id)
     if isinstance(result, str):
         # Paste-an-API-key login: store as api_key credential with source login.
         if result:
@@ -176,7 +177,7 @@ def run_logout(provider_id: str, auth_store: "AuthStore") -> int:
         print(f"Unknown provider: {provider_id}")
         return 1
     # Log out of both the alias (e.g. xai-oauth) and its storage id (xai).
-    targets = {provider_id, definition.store_credentials_as or provider_id}
+    targets = {provider_id, credential_provider_id(provider_id)}
     removed = 0
     for target in sorted(targets):
         removed += auth_store.delete_credentials_for_provider(target, disabled_cause="logged-out")

--- a/local_operator/providers/auth_store.py
+++ b/local_operator/providers/auth_store.py
@@ -42,8 +42,9 @@ from typing import TYPE_CHECKING, Any, Callable
 
 from local_operator.paths import config_dir
 from local_operator.providers.registry import (
-    ProviderDefinition,
+    GetApiKeyFn,
     RefreshFn,
+    credential_provider_id,
     get_provider_definition,
 )
 
@@ -296,11 +297,56 @@ class AuthStore:
             updated_at=row[7],
         )
 
+    @staticmethod
+    def _oauth_key_fn(provider: str) -> GetApiKeyFn | None:
+        """The extractor that pulls the WIRE token out of an OAuth row.
+
+        Which field is the bearer is a property of the row, and the row belongs
+        to the storage provider — so the storage definition's extractor is the
+        authoritative one, and the flavour's own is preferred only where it has
+        one. QwenCloud is why this cannot just read ``creds["access"]``: its row
+        holds a management token in ``access`` and the ``sk-sp-…`` inference key
+        in ``api_key``, and only ``alibaba-token-plan`` (the STORAGE id) carries
+        the extractor that knows to prefer the latter. Resolving the ``-oauth``
+        flavour by its own definition would authenticate inference with the
+        token the inference endpoint rejects.
+        """
+        definition = get_provider_definition(provider)
+        if definition is not None and definition.get_api_key is not None:
+            return definition.get_api_key
+        storage = get_provider_definition(credential_provider_id(provider))
+        return storage.get_api_key if storage is not None else None
+
+    @staticmethod
+    def _storage_id(provider: str) -> str:
+        """The provider id whose ROWS answer a query about ``provider``.
+
+        Login flavours (``xai-oauth``, ``openai-device``,
+        ``alibaba-token-plan-oauth``) deliberately store their credential under
+        the base provider's name, so every query here — which is exact SQL —
+        has to be asked in terms of the storage id or it matches nothing. Doing
+        it once, at the boundary of the store, is what keeps the translation
+        from having to be remembered at each of the dozen call sites that ask
+        this class about a provider; forgetting it does not fail loudly, it
+        silently reports the provider as having no credential at all.
+
+        Applied to row lookups, blocks and session stickiness alike: an alias
+        and its base are ONE credential, so a backoff earned by a request under
+        one name must be honoured under the other, and a session that stuck to
+        an account must stay on it across both spellings.
+        """
+        return credential_provider_id(provider)
+
     def list_credentials(
         self, provider: str | None = None, include_disabled: bool = False
     ) -> list[StoredCredential]:
-        """Enabled credentials (all providers or one), oldest first."""
+        """Enabled credentials (all providers or one), oldest first.
+
+        ``provider`` is resolved through :meth:`_storage_id`, so asking for a
+        login flavour returns the rows its login actually wrote.
+        """
         if provider is not None:
+            provider = self._storage_id(provider)
             rows = self._conn.execute(
                 "SELECT id, provider, credential_type, data, disabled_cause, identity_key,"
                 " created_at, updated_at FROM auth_credentials WHERE provider = ? ORDER BY id",
@@ -320,8 +366,16 @@ class AuthStore:
         """Insert, or update the row for the same identity (org scope ⇒ rows).
 
         Revives soft-deleted rows for the same identity (re-login).
-        ``store_credentials_as`` aliasing happens at the caller (login path).
+
+        The login path already resolves ``store_credentials_as`` before calling
+        here, so this normalization is usually a no-op. It is applied anyway
+        because the READS now alias unconditionally: a caller that passed a
+        flavour id would otherwise write a row under ``xai-oauth`` that no
+        lookup for either ``xai-oauth`` or ``xai`` would ever return, which is
+        a worse failure than the one being fixed and an invisible one. Writes
+        and reads must agree on where a credential lives.
         """
+        provider = self._storage_id(provider)
         # An EXPLICIT type wins; the structural guess is the fallback for the
         # callers (and stored rows) that never declared one.
         #
@@ -423,8 +477,9 @@ class AuthStore:
         block_scope: str = "",
         block_ms: int = DEFAULT_BLOCK_MS,
     ) -> None:
-        """Record a backoff keyed by ``provider:type``."""
+        """Record a backoff keyed by ``provider:type`` (storage id)."""
         credential = self.get_credential(credential_id)
+        provider = self._storage_id(provider)
         provider_key = f"{provider}:{credential.credential_type if credential else 'api_key'}"
         until = self._now_ms() + max(1000, int(block_ms))
         self._conn.execute(
@@ -439,6 +494,7 @@ class AuthStore:
 
     def is_blocked(self, credential_id: int, provider: str) -> bool:
         credential = self.get_credential(credential_id)
+        provider = self._storage_id(provider)
         provider_key = f"{provider}:{credential.credential_type if credential else 'api_key'}"
         row = self._conn.execute(
             "SELECT blocked_until_ms FROM auth_credential_blocks"
@@ -456,6 +512,15 @@ class AuthStore:
     # -- OAuth refresh -----------------------------------------------------------
 
     def _refresh_fn(self, provider: str) -> RefreshFn | None:
+        """The refresh callable for rows stored under ``provider``.
+
+        Rows live under the STORAGE id, so the definition that owns the refresh
+        is frequently not the one named by that id: a row under ``xai`` may have
+        been written by ``xai-oauth``'s login, and only the flavour carries a
+        ``refresh_token``. Hence the reverse scan — base definition first (a
+        provider that refreshes its own rows), then the flavour that aliases
+        onto it.
+        """
         definition = get_provider_definition(provider)
         if definition is not None and definition.refresh_token is not None:
             return definition.refresh_token
@@ -566,8 +631,12 @@ class AuthStore:
         left an account bottom-of-pool for the life of the process -- the same
         "healthy account effectively out of rotation" outcome this whole change
         exists to prevent, arrived at the slow way.
+
+        Keyed by the STORAGE id, like blocks and stickiness: an alias and its
+        base are one credential pool, so a demotion earned under one spelling
+        must reorder the other's selection too.
         """
-        marks = self._deprioritized.setdefault(provider, {})
+        marks = self._deprioritized.setdefault(self._storage_id(provider), {})
         marks[credential_id] = self._now_ms() + DEPRIORITIZE_TTL_MS
 
     def clear_deprioritized(
@@ -580,6 +649,7 @@ class AuthStore:
         subset of rows: a one-row tier finding its only row demoted must not
         drop the marks belonging to rows in another tier that it never saw.
         """
+        provider = self._storage_id(provider)
         marks = self._deprioritized.get(provider)
         if marks is None:
             return
@@ -599,6 +669,7 @@ class AuthStore:
         consulted here, so a lazy sweep is both sufficient and free of a
         background task that would have to be owned and cancelled.
         """
+        provider = self._storage_id(provider)
         marks = self._deprioritized.get(provider)
         if not marks:
             return set()
@@ -620,6 +691,12 @@ class AuthStore:
     ) -> list[StoredCredential]:
         if not rows:
             return []
+        # Same key as ``_set_sticky`` writes: an alias and its base share one
+        # credential, so they must share one stickiness and one round-robin
+        # cursor, or a session alternating spellings would alternate accounts.
+        # Normalized here, ahead of both the demotion marks and the base order,
+        # so every keyed structure below sees one spelling.
+        provider = self._storage_id(provider)
         ordered = self._base_selection_order(rows, provider, session_id)
         # Demotion is applied LAST, to the finished order.
         #
@@ -671,7 +748,11 @@ class AuthStore:
     def _base_selection_order(
         self, rows: list[StoredCredential], provider: str, session_id: str | None
     ) -> list[StoredCredential]:
-        """Stickiness, then a per-session hash, then round-robin."""
+        """Stickiness, then a per-session hash, then round-robin.
+
+        ``provider`` arrives already normalized by :meth:`_selection_order`,
+        its only caller.
+        """
         if session_id:
             sticky_id = self._sticky.get((provider, session_id))
             sticky = next((r for r in rows if r.id == sticky_id), None)
@@ -689,6 +770,7 @@ class AuthStore:
     def _set_sticky(self, provider: str, session_id: str | None, credential_id: int | None) -> None:
         if not session_id:
             return
+        provider = self._storage_id(provider)
         if credential_id is None:
             self._sticky.pop((provider, session_id), None)
         else:
@@ -855,8 +937,7 @@ class AuthStore:
         """
         if self._runtime_overrides.get(provider) or self._config_overrides.get(provider):
             return []
-        definition: ProviderDefinition | None = get_provider_definition(provider)
-        key_fn = definition.get_api_key if definition else None
+        key_fn = self._oauth_key_fn(provider)
         rows = [r for r in self.list_credentials(provider) if r.credential_type == "oauth"]
         accesses: list[OAuthAccess] = []
         for row in sorted(rows, key=lambda r: r.id):
@@ -915,7 +996,6 @@ class AuthStore:
         account's own bookkeeping, not a decision about where requests go, and
         dropping it would throw away a single-use refresh token.
         """
-        definition: ProviderDefinition | None = get_provider_definition(provider)
 
         def pin(credential_id: int | None) -> None:
             """Write (or, with ``None``, clear) session stickiness — unless this
@@ -944,7 +1024,7 @@ class AuthStore:
                 if not read_only:
                     self.block_credential(row.id, provider)  # try a sibling
                 continue
-            key_fn = definition.get_api_key if definition else None
+            key_fn = self._oauth_key_fn(provider)
             key = key_fn(creds) if key_fn else creds.get("access")
             if key:
                 pin(row.id)
@@ -1024,7 +1104,14 @@ class AuthStore:
         return None, None
 
     def _env_api_key(self, provider: str) -> str | None:
+        # A login flavour declares no env var of its own (there is no
+        # ``XAI_OAUTH_API_KEY``), but it serves the same endpoint as the
+        # provider it stores under, so the base provider's var is the one that
+        # authenticates it. Without this fallback a user with ``XAI_API_KEY``
+        # set could run `xai` and not `xai-oauth`, for one wire and one key.
         definition = get_provider_definition(provider)
+        if definition is None or definition.env_keys is None:
+            definition = get_provider_definition(credential_provider_id(provider))
         if definition is not None and definition.env_keys is not None:
             if callable(definition.env_keys):
                 value = definition.env_keys()
@@ -1078,8 +1165,16 @@ class AuthStore:
         if api_key is not None:
             failing = next((r for r in rows if self._row_matches_key(r, api_key)), None)
         elif session_id:
+            # Stickiness is written under the storage id (`_set_sticky`), so the
+            # lookup must ask with the same spelling or a flavour id would never
+            # find the failing row it is sticky to.
             failing = next(
-                (r for r in rows if r.id == self._sticky.get((provider, session_id))), None
+                (
+                    r
+                    for r in rows
+                    if r.id == self._sticky.get((self._storage_id(provider), session_id))
+                ),
+                None,
             )
         else:
             failing = None

--- a/local_operator/providers/auth_store.py
+++ b/local_operator/providers/auth_store.py
@@ -46,6 +46,7 @@ from local_operator.providers.registry import (
     RefreshFn,
     credential_provider_id,
     get_provider_definition,
+    resolve_env_key,
 )
 
 if TYPE_CHECKING:  # the legacy reader stays an optional, import-guarded tier
@@ -322,8 +323,9 @@ class AuthStore:
         """The provider id whose ROWS answer a query about ``provider``.
 
         Login flavours (``xai-oauth``, ``openai-device``,
-        ``alibaba-token-plan-oauth``) deliberately store their credential under
-        the base provider's name, so every query here — which is exact SQL —
+        ``alibaba-token-plan-oauth``, ``zai-oauth``) deliberately store their
+        credential under the base provider's name, so every query here — which
+        is exact SQL —
         has to be asked in terms of the storage id or it matches nothing. Doing
         it once, at the boundary of the store, is what keeps the translation
         from having to be remembered at each of the dozen call sites that ask
@@ -1104,23 +1106,18 @@ class AuthStore:
         return None, None
 
     def _env_api_key(self, provider: str) -> str | None:
-        # A login flavour declares no env var of its own (there is no
-        # ``XAI_OAUTH_API_KEY``), but it serves the same endpoint as the
-        # provider it stores under, so the base provider's var is the one that
-        # authenticates it. Without this fallback a user with ``XAI_API_KEY``
-        # set could run `xai` and not `xai-oauth`, for one wire and one key.
+        # The env leg is the SAME reader every other surface uses —
+        # ``registry.resolve_env_key`` is alias-aware (a flavour authenticates
+        # with its base provider's var), so the cascade, ``is_usable`` and the
+        # catalogue enrichment cannot disagree about whether an env key runs a
+        # flavour. The store adds only the legacy ``credentials.env`` tier on
+        # top, which predates the store and no other reader sees.
         definition = get_provider_definition(provider)
         if definition is None or definition.env_keys is None:
             definition = get_provider_definition(credential_provider_id(provider))
-        if definition is not None and definition.env_keys is not None:
-            if callable(definition.env_keys):
-                value = definition.env_keys()
-                if value:
-                    return value
-            else:
-                value = os.environ.get(definition.env_keys)
-                if value:
-                    return value
+        value = resolve_env_key(provider)
+        if value:
+            return value
         # Legacy credentials.env tier via CredentialManager (lazy import so a
         # missing legacy module degrades to env-only).
         if self._credential_manager is None:
@@ -1235,7 +1232,14 @@ class AuthStore:
     def _row_matches_key(row: StoredCredential, api_key: str) -> bool:
         if row.credential_type == "api_key":
             return row.data.get("key") == api_key
-        return row.data.get("access") == api_key
+        # Compare against the SAME extractor the cascade used to produce the
+        # wire key, not ``data["access"]`` directly: a QwenCloud row holds a
+        # management token in ``access`` and the ``sk-sp-…`` inference key in
+        # ``api_key``, so the failing bearer failover reports is the extractor's
+        # output and a raw-field compare would find no row — no block, no
+        # demotion, no sticky clear for a credential that just failed.
+        key_fn = AuthStore._oauth_key_fn(row.provider)
+        return (key_fn(row.data) if key_fn else row.data.get("access")) == api_key
 
     def credential_id_for_key(self, provider: str, api_key: str) -> int | None:
         """Reverse lookup used by failover to block the exact bearer."""

--- a/local_operator/providers/auth_store.py
+++ b/local_operator/providers/auth_store.py
@@ -1238,8 +1238,18 @@ class AuthStore:
         # ``api_key``, so the failing bearer failover reports is the extractor's
         # output and a raw-field compare would find no row — no block, no
         # demotion, no sticky clear for a credential that just failed.
+        # A malformed row (neither ``access`` nor ``api_key``) must not raise
+        # here: this runs inside failover's failure path, where an exception
+        # would replace "rotate away from the failing credential" with a crash.
+        # The extractor reads fields directly, so fall back to the raw compare
+        # when it cannot produce a key.
         key_fn = AuthStore._oauth_key_fn(row.provider)
-        return (key_fn(row.data) if key_fn else row.data.get("access")) == api_key
+        if key_fn is not None:
+            try:
+                return key_fn(row.data) == api_key
+            except KeyError:
+                return False
+        return row.data.get("access") == api_key
 
     def credential_id_for_key(self, provider: str, api_key: str) -> int | None:
         """Reverse lookup used by failover to block the exact bearer."""

--- a/local_operator/providers/controller.py
+++ b/local_operator/providers/controller.py
@@ -32,6 +32,7 @@ from local_operator.providers.registry import (
     AGGREGATOR_PROVIDERS,
     PROVIDER_REGISTRY,
     ProviderDefinition,
+    credential_provider_id,
     get_provider_definition,
     list_login_providers,
     resolve_env_key,
@@ -150,8 +151,7 @@ class ProviderController:
 
     def has_any_credential(self, provider: str) -> bool:
         """Whether ``provider`` (or its storage id) has a stored credential."""
-        definition = get_provider_definition(provider)
-        storage = (definition.store_credentials_as or provider) if definition else provider
+        storage = credential_provider_id(provider)
         return any(c.provider == storage for c in self.auth_store.list_credentials(provider=None))
 
     def is_usable(self, provider: str) -> bool:
@@ -192,7 +192,7 @@ class ProviderController:
             return None
         usable: set[str] = set()
         for definition in PROVIDER_REGISTRY:
-            storage = definition.store_credentials_as or definition.id
+            storage = credential_provider_id(definition.id)
             if (
                 definition.allows_missing_api_key  # a local Ollama needs no credential
                 or storage in stored
@@ -360,8 +360,7 @@ class ProviderController:
         seen: set[str] = set()
         ordered: list[str] = []
         for provider in targets:
-            definition = get_provider_definition(provider)
-            storage = (definition.store_credentials_as or provider) if definition else provider
+            storage = credential_provider_id(provider)
             if storage in seen:
                 continue
             seen.add(storage)
@@ -538,8 +537,7 @@ class ProviderController:
         prefix -- the very ids this listing exists to stop presenting as
         current.
         """
-        definition = get_provider_definition(provider)
-        credential_id = (definition.store_credentials_as or provider) if definition else provider
+        credential_id = credential_provider_id(provider)
         access = await self.auth_store.get_oauth_access(credential_id)
         if access is not None and access.kind == "oauth" and access.access_token:
             return access.access_token, True, access.account_id or access.org_id

--- a/local_operator/providers/registry.py
+++ b/local_operator/providers/registry.py
@@ -556,6 +556,29 @@ def list_login_providers() -> list[ProviderDefinition]:
 AGGREGATOR_PROVIDERS = frozenset({"openrouter", "radient"})
 
 
+def credential_provider_id(provider_id: str) -> str:
+    """The provider id a credential for ``provider_id`` is actually STORED under.
+
+    Login flavours do not own their credentials. ``xai-oauth``, ``openai-device``
+    and ``alibaba-token-plan-oauth`` are alternate ways of authenticating
+    ``xai``, ``openai`` and ``alibaba-token-plan``, and their login writes ONE
+    row under the aliased name (``store_credentials_as``) so that logging in
+    either way yields one account rather than two half-configured ones.
+
+    Every credential lookup therefore has to be translated before it reaches a
+    store whose queries are exact (``WHERE provider = ?``). Asking for the
+    literal flavour id matches no row, which does not read as "translate this" —
+    it reads as "this provider has no credential", i.e. the "No API key
+    configured for provider 'xai-oauth'" that an OAuth login is specifically
+    supposed to make impossible.
+
+    Unknown ids and providers that store under their own name pass through, so
+    this is safe to call unconditionally on any provider id.
+    """
+    definition = get_provider_definition(provider_id)
+    return (definition.store_credentials_as or definition.id) if definition else provider_id
+
+
 def resolve_env_key(provider_id: str) -> str | None:
     """Resolve the provider's API key from the environment.
 

--- a/local_operator/providers/registry.py
+++ b/local_operator/providers/registry.py
@@ -559,11 +559,12 @@ AGGREGATOR_PROVIDERS = frozenset({"openrouter", "radient"})
 def credential_provider_id(provider_id: str) -> str:
     """The provider id a credential for ``provider_id`` is actually STORED under.
 
-    Login flavours do not own their credentials. ``xai-oauth``, ``openai-device``
-    and ``alibaba-token-plan-oauth`` are alternate ways of authenticating
-    ``xai``, ``openai`` and ``alibaba-token-plan``, and their login writes ONE
-    row under the aliased name (``store_credentials_as``) so that logging in
-    either way yields one account rather than two half-configured ones.
+    Login flavours do not own their credentials. ``xai-oauth``, ``openai-device``,
+    ``alibaba-token-plan-oauth`` and ``zai-oauth`` are alternate ways of
+    authenticating ``xai``, ``openai``, ``alibaba-token-plan`` and ``zai``, and
+    their login writes ONE row under the aliased name (``store_credentials_as``)
+    so that logging in either way yields one account rather than two
+    half-configured ones.
 
     Every credential lookup therefore has to be translated before it reaches a
     store whose queries are exact (``WHERE provider = ?``). Asking for the
@@ -584,8 +585,17 @@ def resolve_env_key(provider_id: str) -> str | None:
 
     Handles both forms of ``env_keys``: a plain variable name, or a callable
     that picks among several (feature-flag style).
+
+    Alias-aware: a login flavour declares no env var of its own (there is no
+    ``XAI_OAUTH_API_KEY``), but it serves the same endpoint as the provider it
+    stores under, so the base provider's var authenticates it too. This is the
+    ONE env reader the store's ``_env_api_key``, the controller's ``is_usable``
+    and the catalogue enrichment share; a second, literal one is how a flavour
+    resolves at stream time yet reads "needs login" on every status surface.
     """
     definition = get_provider_definition(provider_id)
+    if definition is None or definition.env_keys is None:
+        definition = get_provider_definition(credential_provider_id(provider_id))
     if definition is None or definition.env_keys is None:
         return None
     if callable(definition.env_keys):

--- a/tests/unit/model/test_catalogue.py
+++ b/tests/unit/model/test_catalogue.py
@@ -1289,6 +1289,8 @@ def test_an_unshipped_xai_id_does_not_keep_the_unknown_placeholder_name(monkeypa
         # be caught by the k3 arm's "k<digit>" shape.
         ("kimi", "k3", False),
         ("kimi", "k3-256k", False),
+        # Live-probed alongside k3: pins the pair the same way.
+        ("kimi", "k2-thinking", False),
         ("kimi", "kimi-for-coding", False),
         ("kimi", "kimi-for-coding-highspeed", False),
         ("kimi", "kimi-k2-0711-preview", True),

--- a/tests/unit/model/test_catalogue.py
+++ b/tests/unit/model/test_catalogue.py
@@ -1279,6 +1279,23 @@ def test_an_unshipped_xai_id_does_not_keep_the_unknown_placeholder_name(monkeypa
         # silently dropping a working setting is worse than the 400 it avoids.
         ("google", "gemini-2.5-flash-thinking", True),
         ("deepseek", "deepseek-reasoner", True),
+        # Kimi's coding-plan host (api.kimi.com/coding/v1) pins the pair
+        # instead of rejecting the keys: HTTP 400 "invalid temperature: only 1
+        # is allowed for this model" / "invalid top_p: only 0.95 is allowed",
+        # while omitting both succeeds. Verified live against k3 and
+        # k2-thinking on chat/completions. Scoped to the coding-plan ids —
+        # the mainland moonshot host accepts the pair on its own models, so
+        # kimi-k2-0711-preview must keep its sampling settings and must not
+        # be caught by the k3 arm's "k<digit>" shape.
+        ("kimi", "k3", False),
+        ("kimi", "k3-256k", False),
+        ("kimi", "kimi-for-coding", False),
+        ("kimi", "kimi-for-coding-highspeed", False),
+        ("kimi", "kimi-k2-0711-preview", True),
+        ("kimi", "moonshot-v1-128k", True),
+        # The id shape is kimi's, not the world's: a k-something on another
+        # provider keeps its parameters.
+        ("openrouter", "moonshotai/kimi-k2", True),
     ],
 )
 def test_the_spec_knows_which_models_reject_sampling_parameters(

--- a/tests/unit/providers/test_auth_store.py
+++ b/tests/unit/providers/test_auth_store.py
@@ -257,6 +257,26 @@ async def test_rotate_sibling_finds_a_token_plan_row_by_its_wire_key(
     assert store.is_blocked(row.id, "alibaba-token-plan-oauth") is True
 
 
+async def test_rotate_sibling_survives_a_malformed_oauth_row(store: AuthStore) -> None:
+    """A hand-written row with neither ``access`` nor ``api_key`` must not turn
+    the failure path into a crash: the extractor raises KeyError on it, and
+    ``_row_matches_key`` has to swallow that and report "no match" so failover
+    still rotates. The healthy sibling must still be found and served."""
+    bad = store.upsert_credential("alibaba-token-plan", {"type": "oauth"})
+    failing = store.upsert_credential("alibaba-token-plan", {"key": "k-good", "type": "api_key"})
+    sibling = store.upsert_credential("alibaba-token-plan", {"key": "k-other", "type": "api_key"})
+    from local_operator.providers.failover import ProviderError
+
+    error = ProviderError(401, "invalid api key", auth_error=True)
+    # The bad row is walked FIRST and must read as "not the failing key", not
+    # raise; the real failing row is blocked and the sibling reported.
+    assert store.rotate_sibling("alibaba-token-plan", None, error, api_key="k-good") is True
+    assert store.is_blocked(failing.id, "alibaba-token-plan") is True
+    assert store.is_blocked(bad.id, "alibaba-token-plan") is False
+    assert await store.get_api_key("alibaba-token-plan") == "k-other"
+    _ = sibling
+
+
 async def test_invalidated_token_soft_deletes_row(store: AuthStore) -> None:
     """Only TRUE invalidation signals soft-delete (PR-03): an explicit
     revocation marker, never a generic expired/unauthorized 401."""

--- a/tests/unit/providers/test_auth_store.py
+++ b/tests/unit/providers/test_auth_store.py
@@ -227,6 +227,36 @@ async def test_rotate_sibling_usage_limit_preserves_sticky(store: AuthStore) -> 
     assert sticky is not None
 
 
+async def test_rotate_sibling_finds_a_token_plan_row_by_its_wire_key(
+    store: AuthStore,
+) -> None:
+    """The failing bearer is the EXTRACTOR's output, not ``data["access"]``.
+
+    A QwenCloud row holds the management token in ``access`` and the ``sk-sp-…``
+    inference key in ``api_key``; the cascade authenticates with the latter, so
+    the key failover reports on failure is the latter. Matching the raw field
+    found no row and the failing credential was never blocked, demoted or
+    unstuck — the failover layer could not rotate away from it."""
+    row = store.upsert_credential(
+        "alibaba-token-plan",
+        {"type": "oauth", "access": "mgmt-token", "api_key": "sk-sp-wire"},
+    )
+    from local_operator.providers.failover import ProviderError
+
+    error = ProviderError(401, "invalid api key", auth_error=True)
+    # The management token is NOT the wire key: reporting it rotates nothing —
+    # no row matches, so the lone row is still its own untried sibling (True)
+    # and nothing is blocked.
+    assert store.rotate_sibling("alibaba-token-plan", None, error, api_key="mgmt-token") is True
+    assert store.is_blocked(row.id, "alibaba-token-plan") is False
+    # Asked under the flavour id, with the WIRE key the request actually
+    # carried: the row is found and blocked, and no sibling remains (False).
+    assert (
+        store.rotate_sibling("alibaba-token-plan-oauth", None, error, api_key="sk-sp-wire") is False
+    )
+    assert store.is_blocked(row.id, "alibaba-token-plan-oauth") is True
+
+
 async def test_invalidated_token_soft_deletes_row(store: AuthStore) -> None:
     """Only TRUE invalidation signals soft-delete (PR-03): an explicit
     revocation marker, never a generic expired/unauthorized 401."""
@@ -1096,6 +1126,8 @@ class TestLoginFlavourAliases:
             ("xai-oauth", "xai"),
             ("openai-device", "openai"),
             ("alibaba-token-plan-oauth", "alibaba-token-plan"),
+            # The flavour the bug was actually reported for.
+            ("zai-oauth", "zai"),
         ):
             store.upsert_credential(storage, _oauth(access=f"{storage}-access"))
             assert await store.get_api_key(flavour) == f"{storage}-access"

--- a/tests/unit/providers/test_auth_store.py
+++ b/tests/unit/providers/test_auth_store.py
@@ -1067,3 +1067,103 @@ class TestADemotionSurvivesAMixedPool:
 
         assert await store.get_api_key("anthropic") is None
         assert await store.get_api_key("anthropic", read_only=True) is None
+
+
+class TestLoginFlavourAliases:
+    """A login flavour and its base provider are ONE credential.
+
+    ``xai-oauth``, ``openai-device`` and ``alibaba-token-plan-oauth`` write their
+    row under another provider's name (``store_credentials_as``), and the store's
+    SQL is exact. Before this, every lookup for the flavour id matched no row and
+    the cascade reported "No API key configured for provider 'xai-oauth'" at the
+    end of a successful OAuth login -- the one failure an OAuth login exists to
+    prevent, and one that told the user to go get an API key they should not need.
+    """
+
+    async def test_oauth_login_flavour_resolves_the_row_its_login_wrote(
+        self, store: AuthStore
+    ) -> None:
+        """The reported bug: log in with `/login xai-oauth`, then stream on it."""
+        store.upsert_credential("xai", _oauth(access="xai-access"))
+        assert await store.get_api_key("xai-oauth") == "xai-access"
+        access = await store.get_oauth_access("xai-oauth")
+        assert access is not None and access.kind == "oauth"
+        assert access.access_token == "xai-access"
+
+    async def test_every_registry_alias_resolves_not_just_xai(self, store: AuthStore) -> None:
+        """Fixed for the property, not for the one provider that was reported."""
+        for flavour, storage in (
+            ("xai-oauth", "xai"),
+            ("openai-device", "openai"),
+            ("alibaba-token-plan-oauth", "alibaba-token-plan"),
+        ):
+            store.upsert_credential(storage, _oauth(access=f"{storage}-access"))
+            assert await store.get_api_key(flavour) == f"{storage}-access"
+
+    async def test_the_alias_and_its_base_share_one_backoff(self, store: AuthStore) -> None:
+        """One credential ⇒ one block: a 429 earned as `xai` is not evaded by
+        asking again as `xai-oauth`, which would spend a rate-limited account
+        twice and re-trip the limit."""
+        row = store.upsert_credential("xai", _oauth(access="xai-access"))
+        store.block_credential(row.id, "xai")
+        assert store.is_blocked(row.id, "xai-oauth") is True
+
+    async def test_the_alias_and_its_base_share_one_sticky_account(self, store: AuthStore) -> None:
+        """Stickiness pins an ACCOUNT, so it cannot depend on the spelling used.
+
+        Two DISTINCT identities: rows sharing one identity key collapse into a
+        single row on upsert, and with only one row to choose from every
+        selection path returns the same token whether stickiness was honoured or
+        not -- a test that cannot fail. ``session-1`` also hashes to index 0, so
+        the unsticky fallback would return the FIRST row, making the assertion
+        below sensitive to the pin rather than to luck.
+        """
+        store.upsert_credential(
+            "xai", {**_oauth(refresh="r1", access="a1"), "account_id": "acct-a"}
+        )
+        second = store.upsert_credential(
+            "xai", {**_oauth(refresh="r2", access="a2"), "account_id": "acct-b"}
+        )
+        store._set_sticky("xai-oauth", "session-1", second.id)
+        assert await store.get_api_key("xai", "session-1") == "a2"
+
+    async def test_the_base_providers_env_key_authenticates_the_flavour(
+        self, store: AuthStore, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """There is no XAI_OAUTH_API_KEY: same wire, same endpoint, same key."""
+        monkeypatch.setenv("XAI_API_KEY", "env-xai")
+        assert await store.get_api_key("xai-oauth") == "env-xai"
+
+    async def test_token_plan_flavour_gets_the_inference_key_not_the_mgmt_token(
+        self, store: AuthStore
+    ) -> None:
+        """QwenCloud's row holds two tokens and only the STORAGE definition knows
+        which one the inference endpoint accepts; resolving the flavour by its own
+        definition would authenticate with the token that endpoint rejects."""
+        store.upsert_credential(
+            "alibaba-token-plan",
+            {**_oauth(access="mgmt-token"), "api_key": "sk-sp-inference"},
+        )
+        assert await store.get_api_key("alibaba-token-plan-oauth") == "sk-sp-inference"
+
+    async def test_logout_still_removes_the_row_through_either_name(self, store: AuthStore) -> None:
+        """list_credentials now aliases, so the logout path must not double-count
+        or miss the row it is asked to delete."""
+        store.upsert_credential("xai", _oauth())
+        assert store.delete_credentials_for_provider("xai-oauth") == 1
+        assert await store.get_api_key("xai-oauth") is None
+
+    async def test_a_row_written_under_the_flavour_id_is_still_findable(
+        self, store: AuthStore
+    ) -> None:
+        """Writes alias too, so no caller can strand a credential.
+
+        The reads above resolve to the storage id; if a write did not, a
+        credential saved under ``xai-oauth`` would live at an id no lookup
+        visits -- invisible to the cascade, to `/logout` and to the usage view
+        at once.
+        """
+        row = store.upsert_credential("xai-oauth", _oauth(access="flavour-write"))
+        assert row.provider == "xai"
+        assert await store.get_api_key("xai") == "flavour-write"
+        assert await store.get_api_key("xai-oauth") == "flavour-write"

--- a/tests/unit/providers/test_controller.py
+++ b/tests/unit/providers/test_controller.py
@@ -327,11 +327,31 @@ def test_an_api_key_cannot_reach_an_oauth_only_usage_endpoint(controller, monkey
     for provider in ("anthropic", "openai", "openai-device", "xai"):
         assert controller.is_usable(provider), f"{provider}: the key does run the model"
         assert not controller.can_report_usage(provider), f"{provider}: but not the quota"
-    # `xai-oauth` has no env var of its own and nothing stored under `xai`, so it
-    # never even reaches the finer check — it is unusable outright.
-    assert not controller.is_usable("xai-oauth")
+    # `xai-oauth` has no env var of its own, but its base's DOES authenticate it
+    # (same wire, same endpoint), so the stream-time cascade runs it and
+    # `is_usable` must agree — the status surfaces used to say "needs login"
+    # for a provider whose very next request succeeds. The finer usage check
+    # still excludes it: an API key cannot read the OAuth-only quota endpoint.
+    assert controller.is_usable("xai-oauth")
     assert not controller.can_report_usage("xai-oauth")
     assert controller.usage_reportable_providers() == []
+
+
+def test_is_usable_agrees_with_the_cascade_on_env_keyed_flavours(controller, monkeypatch) -> None:
+    """`is_usable` and the stream-time cascade are one question, one reader.
+
+    With only the base provider's var set, `get_api_key(flavour)` resolves the
+    env key, so every status surface built on `is_usable` (`/usage`'s warning,
+    the welcome screen, the provider row) must say usable too — and must keep
+    saying unusable when NO var is set, or the welcome screen would promise a
+    login that the cascade then fails."""
+    for name in _USAGE_ENV_VARS:
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv("XAI_API_KEY", "xai-test")
+    assert controller.is_usable("xai")
+    assert controller.is_usable("xai-oauth")
+    monkeypatch.delenv("XAI_API_KEY")
+    assert not controller.is_usable("xai-oauth")
 
 
 def test_an_env_api_key_does_reach_an_api_key_usage_endpoint(controller, monkeypatch) -> None:


### PR DESCRIPTION
# PR Description

## Change classification

**C2 — standard / pre-authorized.** Two credential-resolution bug fixes, no schema change, no migration, clean rollback (`git revert` of two commits). No RFC requested.

## What this fixes

Two first-turn failures immediately after a successful login, one per commit:

1. **`zai-oauth` / `xai-oauth`:** `/login zai-oauth` completes, stores its credential, and the very next request fails with `No API key configured for provider 'zai-oauth'` — telling a user who just authenticated with OAuth to go get an API key they should not need. Same for `xai-oauth` (4 occurrences in session transcripts, plus the reported `zai-oauth` one).
2. **Kimi coding plan (`kimi/k3`):** the first turn after a Kimi OAuth login fails with `invalid request (HTTP 400): invalid temperature: only 1 is allowed for this model`.

## Commit 1 — resolve OAuth login flavours to the credential their login wrote

`zai-oauth` is a login *flavour* of `zai` and declares `store_credentials_as="zai"`, so its login writes ONE row under `zai` — deliberately, so logging in either way yields one account rather than two half-configured ones. But `AuthStore`'s SQL is exact (`WHERE provider = ?`), and every lookup arrived holding the literal flavour id. Zero rows does not read as "translate this id"; it reads as "this provider has no credential", so the cascade fell through OAuth, through the login-key tier, through env (there is no `ZAI_OAUTH_API_KEY`) and reported the provider as unconfigured.

Fixed at the store boundary rather than at the call sites: `AuthStore` normalizes the provider id once, on the way in, via `registry.credential_provider_id`. Row lookups, blocks, stickiness, demotions and writes all go through it, so an alias and its base behave as the one credential they are. Also folded in, since each was the same latent bug:

- **Blocks, stickiness and demotion marks** were keyed by the literal id, so a 429 earned as `zai` was evadable by asking as `zai-oauth` (spending a rate-limited account twice), and a session could alternate accounts by spelling.
- **The OAuth key extractor** was read off the literal definition; only the storage definition knows which field is the wire bearer (QwenCloud's row carries a management token in `access` and the inference key in `api_key`).
- **The env tier** now falls back to the base provider's variable: same wire, same endpoint, so `XAI_API_KEY` authenticates both spellings.
- **Writes normalize too** — with reads aliasing unconditionally, a write that did not would strand a credential at an id no lookup ever visits.

This is a port of the pre-existing `fix/xai-oauth-alias-credential` branch onto current main, extended to the demotion structures (`_deprioritized`, `rotate_sibling`'s sticky lookup) that main grew after that branch was cut.

## Commit 2 — stop sending pinned sampling params to Kimi's coding-plan models

The coding-plan host (`api.kimi.com/coding/v1/chat/completions`) pins `temperature` to 1 and `top_p` to 0.95 and 400s on any other value — while omitting both keys succeeds — and the wire client sent the spec defaults (0.2/0.9) unconditionally.

Fixed where the capability already lives: `build_model_spec` clears `supports_sampling_params` for the coding-plan model ids (`k3`, `k3-256k`, `kimi-for-coding*`), so every wire client omits the pair the same way it already does for Claude 5 and the o-series. Scoped to provider `kimi` AND the coding-plan id shapes, because this is a property of the host, not the model family: the mainland `api.moonshot.cn` host accepts the pair on its own models, so `kimi-k2-0711-preview` and `moonshot-v1-*` keep their sampling settings.

## Validation

All commands run in the worktree venv against this branch; credentials came from a snapshot of the real auth store and were never printed.

### 1. Alias resolution, before/after, real store

`get_api_key` through the real `AuthStore` against a snapshot of the live credential DB (which holds real `zai`, `xai`, `kimi` OAuth rows):

```console
== BEFORE (origin/main) ==
zai          -> KEY RESOLVED (len=49)
zai-oauth    -> None
xai          -> KEY RESOLVED (len=786)
xai-oauth    -> None
kimi         -> KEY RESOLVED (len=704)
== AFTER (fix) ==
zai          -> KEY RESOLVED (len=49)
zai-oauth    -> KEY RESOLVED (len=49)
xai          -> KEY RESOLVED (len=786)
xai-oauth    -> KEY RESOLVED (len=786)
kimi         -> KEY RESOLVED (len=704)
```

### 2. Live end-to-end: `zai-oauth` streams against the real Z.AI coding host

Real `AuthStore` → real `client_for_spec` wire client → live `api.z.ai/api/coding/paas/v4`, asking as the flavour id that used to fail:

```console
get_oauth_access('zai') -> record
get_oauth_access('zai-oauth') -> record
get_oauth_access('xai-oauth') -> record
text: 'OK'
end: stop
```

### 3. Kimi pinning, reproduced live and A/B'd through the real client

Probed `api.kimi.com/coding/v1/chat/completions` directly (curl, token from the store, never echoed):

```console
k3 temp=0.2  -> HTTP 400 : invalid temperature: only 1 is allowed for this model
k3 temp=0.6  -> HTTP 400 : invalid temperature: only 1 is allowed for this model
k3 temp=1    -> HTTP 200 : ok
k3 temp=none -> HTTP 200 : ok
k3 top_p=0.9 -> HTTP 400 : invalid top_p: only 0.95 is allowed for this model
k3 top_p=1   -> HTTP 400 : invalid top_p: only 0.95 is allowed for this model
```

(k2-thinking behaves identically; the Anthropic-style `/messages` route on the same host accepts any value, so this is specifically the chat/completions path this client uses.)

Then the same live k3 call through the real `client_for_spec` path, with main's spec vs the fixed one:

```console
BEFORE (sends temperature=0.2/top_p=0.9): ProviderError: invalid request (HTTP 400): invalid temperature: only 1 is allowed for this model
AFTER  (omits the pair)                 : StreamTextDelta 'OK' … StreamEndEvent stop_reason='stop'
```

The BEFORE line is byte-identical to the user-reported error.

### 4. Gates

```console
$ .venv/bin/python -m pytest tests/unit -q         # 5043 passed, 7 skipped
$ .venv/bin/python -m flake8 local_operator tests  # clean
$ .venv/bin/black --check local_operator tests     # 375 files unchanged
$ .venv/bin/isort --check-only local_operator tests# clean
$ .venv/bin/pyright <changed files>                # identical to origin/main baseline
```

The cherry-picked commit carries its original 8 regression tests (each verified to fail without the fix on its original branch); commit 2 adds 7 parametrized cases pinning the kimi/moonshot split, including the guard that `kimi-k2-0711-preview` must NOT match the `k3` arm.
