### PR TITLE
fix(harness): keep an eager-attached child when the launch is recorded

### DIFF
--- a/local_operator/harness/comms.py
+++ b/local_operator/harness/comms.py
@@ -252,7 +252,32 @@ class SubagentComms:
         Called by :func:`~local_operator.harness.subagent.run_subagent` the
         moment the job id exists, so a parent can address a child that is
         still parked behind the capacity gate.
+
+        MERGES into an existing record instead of replacing it, and the
+        difference is load-bearing under an eager task factory. Textual
+        installs ``asyncio.eager_task_factory`` on the TUI's loop
+        (``textual/app.py``), which makes ``ensure_future`` execute a new
+        coroutine synchronously up to its first true suspension — so the
+        subagent runner registered inside ``jobs_manager.register`` can build
+        its child session and call :meth:`attach` BEFORE ``register`` returns
+        to ``run_subagent``, which only then calls this method. Replacing the
+        record here discarded that attach: the fresh record had no ``child``,
+        no ``session_dir`` and no reply watcher, so every later ``send``/
+        ``steer``/``ask`` buffered into ``pending`` on a record whose flush
+        (attach) had already happened and would never happen again. Live
+        effect, observed 2026-08-19: a healthy reviewer subagent worked for
+        41 minutes while two ``hub ask`` status checks silently never reached
+        it, it was cancelled as wedged, and the roster reported every settled
+        child as "never started, so it has no transcript" — which also made
+        ``resume`` refuse them.
         """
+        existing = self._records.get(job_id)
+        if existing is not None:
+            # attach() ran first (eager task factory) and its record carries
+            # the live child, the flushed asides and the reply watcher; the
+            # only fact this call adds is the label run_subagent chose.
+            existing.label = label
+            return
         self._records[job_id] = _ChildRecord(job_id=job_id, label=label)
         self._evict_overflow()
 

--- a/tests/unit/harness/test_comms.py
+++ b/tests/unit/harness/test_comms.py
@@ -256,6 +256,58 @@ def test_send_to_an_unstarted_child_buffers_until_it_attaches():
     assert "skip the migration" in hub_aside(aside).details["text"]
 
 
+def test_record_launch_after_attach_keeps_the_attached_child():
+    """attach() can run BEFORE record_launch(): under Textual's eager task
+    factory the runner registered by ``jobs_manager.register`` executes
+    synchronously up to its first suspension, so it may build its child and
+    call attach() before ``register`` returns and ``run_subagent`` records
+    the launch. record_launch() must merge into that record, not replace it —
+    replacing it discards the live child, the reply watcher and the session
+    directory, and every later send/steer/ask then buffers into ``pending``
+    on a record whose flush (attach) already happened. Observed live: a
+    healthy reviewer ran 41 minutes while two ``hub ask`` status checks never
+    reached it, and the roster reported the settled child as "never started".
+    """
+    jobs = FakeJobs()
+    comms = SubagentComms(FakeParent(jobs))  # type: ignore[arg-type]
+    jobs.add("job-1")
+    child = FakeChild()
+    session_dir = tmp_dir() / "child-session"
+    comms.attach("job-1", child, session_dir)  # eager runner attaches first
+    comms.record_launch("job-1", "reviewer")  # then registration records
+
+    # The live child survived the late record_launch.
+    delivery = comms.send("job-1", "scope is only the diff")
+    assert delivery.outcome == "injected"
+    [aside] = child.materialize()
+    assert "scope is only the diff" in hub_aside(aside).details["text"]
+
+    # The roster keeps the transcript directory, so a settled child stays
+    # resumable instead of reading "never started, so it has no transcript".
+    [row] = [info for info in comms.roster() if info.job_id == "job-1"]
+    assert row.label == "reviewer"
+    assert row.session_id == session_dir.name
+
+
+def test_record_launch_replacement_is_still_the_normal_path():
+    """The merge must not change the ordinary ordering: a child that has not
+    attached yet gets its launch record, and a buffered note still flushes at
+    the later attach."""
+    jobs = FakeJobs()
+    comms = SubagentComms(FakeParent(jobs))  # type: ignore[arg-type]
+    jobs.add("job-1")
+    comms.record_launch("job-1", "parser")
+    comms.record_launch("job-1", "parser")  # a duplicate launch is a no-op
+
+    delivery = comms.send("job-1", "note")
+    assert delivery.outcome == "queued"
+
+    child = FakeChild()
+    comms.attach("job-1", child, tmp_dir())
+    [aside] = child.materialize()
+    assert "note" in hub_aside(aside).details["text"]
+
+
 @pytest.mark.asyncio
 async def test_a_starting_child_is_not_reported_as_parked_behind_the_gate():
     """Two states reach the no-live-child branch and an operator acts on them

--- a/tests/unit/session/test_launch_subagent.py
+++ b/tests/unit/session/test_launch_subagent.py
@@ -881,3 +881,126 @@ async def test_a_launched_subagent_stays_out_of_the_resume_picker(tmp_path, monk
     assert session_origin(child_dir) == ORIGIN_SUBAGENT
 
     await parent.dispose()
+
+
+@pytest.mark.asyncio
+async def test_hub_ask_reaches_a_child_under_the_eager_task_factory(tmp_path, monkeypatch):
+    """The observed wedge, end to end. Textual installs
+    ``asyncio.eager_task_factory`` on its loop (``textual/app.py``), which makes
+    ``ensure_future`` execute a new coroutine synchronously up to its first
+    suspension. The subagent runner registered inside ``jobs_manager.register``
+    can therefore build its child and call ``comms.attach`` BEFORE ``register``
+    returns to ``run_subagent`` — which then calls ``record_launch`` on an
+    already-attached record. The pre-fix ``record_launch`` REPLACED that
+    record, discarding the live child, the reply watcher and the session
+    directory: every later ``hub`` send/steer/ask buffered into ``pending`` on
+    a record whose flush (attach) had already happened and would never happen
+    again. Live, a healthy reviewer worked 41 minutes while two ``hub ask``
+    status checks never reached it, it was cancelled as wedged, and the roster
+    reported the settled child as "never started, so it has no transcript".
+
+    This drives the real launch path on an eager loop with a child that stays
+    in a slow tool call (the wedged reviewer's shape), asks it mid-run, and
+    asserts the question reaches the child's next provider request, the
+    child's prose reply resolves the ask, and the roster keeps the transcript.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    loop = asyncio.get_running_loop()
+    old_factory = loop.get_task_factory()
+    loop.set_task_factory(asyncio.eager_task_factory)
+
+    try:
+        from local_operator.harness import subagent as subagent_mod
+        from local_operator.harness.types import AgentTool, TextContent, ToolResult
+
+        slow_runs = [0]
+
+        async def slow_execute(tool_call_id, args, signal=None, on_update=None, context=None):
+            slow_runs[0] += 1
+            await asyncio.sleep(0.4)
+            return ToolResult(
+                tool_call_id=tool_call_id,
+                tool_name="slow",
+                content=[TextContent(text="ok")],
+            )
+
+        slow_tool = AgentTool(
+            name="slow",
+            label="slow",
+            description="slow test tool",
+            parameters={"type": "object", "properties": {}},
+            execute=slow_execute,
+        )
+
+        class SlowToolChildStream:
+            """One slow-tool turn, then a final text turn; records whether a
+            parent message ever reached the child's context."""
+
+            def __init__(self) -> None:
+                self.calls = 0
+                self.parent_message_seen = False
+
+            def __call__(self, request: ChatRequest, signal):
+                self.calls += 1
+                for m in request.messages:
+                    if "parent-message" in m.text:
+                        self.parent_message_seen = True
+                n = self.calls
+
+                async def gen():
+                    if n == 1:
+                        yield StreamToolCallDelta(
+                            index=0, id="tc1", name="slow", argument_delta="{}"
+                        )
+                        yield StreamEndEvent(stop_reason="toolUse")
+                    else:
+                        yield StreamTextDelta(delta="child done, all fine")
+                        yield StreamEndEvent(stop_reason="stop")
+
+                return gen()
+
+        child_stream = SlowToolChildStream()
+        orig_build = subagent_mod._build_child_session
+
+        async def build_with_slow_tool(**kwargs):
+            child = await orig_build(**kwargs)
+            child._tools = [slow_tool]
+            child._context.tools = [slow_tool]
+            child._stream_fn = child_stream
+            return child
+
+        monkeypatch.setattr(subagent_mod, "_build_child_session", build_with_slow_tool)
+
+        parent = make_session(tmp_path, child_stream)
+        job_id = parent._launch_subagent(label="reviewer", prompt="review the diff")
+        comms = parent.subagent_comms
+
+        # The eager runner attached before record_launch ran; the fix must have
+        # merged, so the live child is still addressable right now.
+        record = comms._records[job_id]
+        assert record.child is not None, "attach was clobbered by record_launch"
+        assert record.session_dir is not None
+
+        # The child is parked in its slow tool call; ask it mid-run, exactly
+        # the parent's status-check pattern that used to time out.
+        reply = await comms.ask(job_id, "Status check: where are you?", 10_000)
+        assert reply.timed_out is False
+        assert reply.error is None
+        assert "child done" in (reply.text or "")
+        assert child_stream.parent_message_seen, "the question never reached the child"
+        assert slow_runs[0] == 1
+
+        # The settled child keeps its transcript on the roster, so resume and
+        # the roster's "never started" lie are both gone.
+        def _settled() -> bool:
+            job = parent.jobs.get(job_id)
+            return job is None or job.status != "running"
+
+        await wait_for(_settled)
+        [row] = [info for info in comms.roster() if info.job_id == job_id]
+        assert row.session_id == record.session_dir.name
+        assert "never started" not in (row.detail or "")
+
+        await parent.dispose()
+    finally:
+        loop.set_task_factory(old_factory)


### PR DESCRIPTION
# PR Description

## Change classification

**C2 — standard / pre-authorized.** One method in `harness/comms.py` plus
tests; no schema, transcript-format, or wire change. Clean rollback
(`git revert`). No RFC requested.

## The problem

`hub` messaging (send/steer/ask) and the roster silently stopped working for
every subagent launched from the TUI, while the subagent itself ran fine.

Observed live on 2026-08-19 (session "Fixing Slow Context Compaction
Performance", PR #173 review): a `reviewer` subagent worked continuously for
41 minutes, but two `hub op='ask'` status checks from the parent never reached
it — its transcript contains no `<parent-message>` entry and the child never
saw the questions. The parent read "did not answer within 120000ms; it is
still running and the question is in its context" (a false statement: it was
not), concluded the reviewer was wedged, and cancelled it. The replacement
reviewer exhibited the same silence. Afterwards `hub op='list'` reported every
settled child, including ones that had run to completion with transcripts on
disk, as "never started, so it has no transcript", which also made
`hub op='resume'` refuse them.

Mechanism: Textual installs `asyncio.eager_task_factory` on its loop
(`textual/app.py`), so `ensure_future` executes a new coroutine synchronously
up to its first suspension. `run_subagent` registers the runner via
`jobs_manager.register` (which `ensure_future`s it) and only then calls
`comms.record_launch`. Under the eager factory the runner can build its child
session and call `comms.attach` *inside* `register`, before `record_launch`
runs — and `record_launch` did `self._records[job_id] = _ChildRecord(...)`,
replacing the attached record with a fresh one: no `child`, no `session_dir`,
no reply watcher. Every later `send`/`steer`/`ask` then took the
`record.child is None` path and buffered into `pending` on a record whose
flush (`attach`) had already happened and would never happen again, so the
messages sat there forever. The roster's `record.session_dir is None` branch
produced the "never started" lie.

Why the unit suite never saw it: `tests/unit/harness/test_comms.py` calls
`record_launch` before `attach` (the lazy-factory ordering), and no test ran
the launch path under an eager task factory.

## The change

`record_launch` merges into an existing record (updating only the label)
instead of replacing it. The docstring records the eager-factory ordering and
the live effect, because the invariant "record_launch runs before attach" is
exactly the assumption that broke.

# Testing evidence

## 1. Regression tests, mutation-checked

- `tests/unit/harness/test_comms.py`: `test_record_launch_after_attach_keeps_the_attached_child`
  (attach first, then record_launch; send must inject, roster keeps the
  session dir) and `test_record_launch_replacement_is_still_the_normal_path`
  (the ordinary ordering is unchanged).
- `tests/unit/session/test_launch_subagent.py`:
  `test_hub_ask_reaches_a_child_under_the_eager_task_factory` drives the real
  launch path on `asyncio.eager_task_factory` with a child parked in a slow
  tool call (the wedged reviewer's shape), asks it mid-run, and asserts the
  question reaches the child's next provider request, the child's prose reply
  resolves the ask, and the roster keeps the transcript.

Both fail on the unfixed code with the observed symptoms (verified by
re-running against `origin/main`'s `comms.py`: the unit test fails
`injected != queued`, the integration test fails `attach was clobbered by
record_launch`), and pass with the fix.

## 2. Live reproduction against the installed runtime, before and after

A scripted parent + real `run_subagent` child under the eager task factory,
run against the installed package and against this branch's source:

```
# installed (unfixed): ask at t+3s of a 9s child run
record: child_attached= False  session_dir= None
ask -> timed_out / error after 9.0s; child saw parent message: False
ROSTER probe: status=completed detail='never started, so it has no transcript'

# this branch (fixed), same script:
record: child_attached= True
ask -> text='child done' after 9.0s; child saw parent message: True
ROSTER probe: status=completed detail=None
```

## 3. Gates

- `pytest tests/unit/harness tests/unit/session`: 458 passed.
- flake8, black --check, isort --check-only, pyright on the changed files:
  clean.

#### Follow-up observations

- The `hub op='ask'` timeout receipt ("the question is in its context") is a
  false statement in the buffered-and-never-flushed case; with this fix the
  buffer can no longer be orphaned, but the receipt still cannot distinguish
  "queued for a child that will attach" from "queued and lost". Worth a
  follow-up if a future ordering change reintroduces a gap.
