### PR TITLE
fix(providers): stop blocking reserve-quota accounts until their window resets

### DIFF
--- a/local_operator/model/configure.py
+++ b/local_operator/model/configure.py
@@ -1825,16 +1825,46 @@ class SessionStreamFn:
                 )
                 return
 
-            block_ms = max(
-                60_000,
-                health.reset_after_ms or self.DEFAULT_USAGE_BLOCK_MS,
-            )
+            # How the account is taken out of the running depends on WHAT the
+            # verdict was, and conflating the two is the incident this split
+            # comes from. "Depleted" is a fact about the provider: it will 429
+            # every request until the spent window resets, so a cross-process
+            # SQLite block until that reset merely records reality. "Reserve"
+            # is the opposite of unusable — the account still HAS quota, held
+            # back so it is there when nothing better remains. Writing a block
+            # for it (as this code once did) stood the reserve on its head:
+            # accounts at 90% of a seven-day window were blocked for DAYS, one
+            # by one, until the last live account genuinely depleted and every
+            # session died reporting "all credentials unusable" while three
+            # accounts still held quota.
+            #
+            # So a reserve account is DEPRIORITIZED instead: an in-process,
+            # self-expiring routing preference (see
+            # ``AuthStore.deprioritize_credential``) that steers this walk and
+            # the session's next resolve toward healthier siblings, while the
+            # cascade's ignore-demotions second pass still serves the account
+            # the moment it is the only thing left. The mark is short-lived on
+            # purpose; the preflight re-checks and re-applies it while the
+            # preference still holds.
+            if health.state == "depleted":
+
+                def take_out_of_rotation(credential_id: int) -> None:
+                    self._auth_store.block_credential(
+                        credential_id,
+                        storage,
+                        block_ms=max(60_000, health.reset_after_ms or self.DEFAULT_USAGE_BLOCK_MS),
+                    )
+
+            else:
+
+                def take_out_of_rotation(credential_id: int) -> None:
+                    # Keyed by ``model.provider``, not ``storage``: demotions
+                    # are consulted by ``_resolve`` under the provider name the
+                    # request resolves with.
+                    self._auth_store.deprioritize_credential(model.provider, credential_id)
+
             if siblings:
-                self._auth_store.block_credential(
-                    access.credential_id,
-                    storage,
-                    block_ms=block_ms,
-                )
+                take_out_of_rotation(access.credential_id)
                 await self._notice(
                     f"{model.provider} {condition}{remaining} — trying another "
                     f"{model.provider} account before provider fallback"
@@ -1844,11 +1874,7 @@ class SessionStreamFn:
             assert fallback is not None
             fallback_provider, _model_id = parse_selector(fallback.selector)
             if fallback_provider != model.provider:
-                self._auth_store.block_credential(
-                    access.credential_id,
-                    storage,
-                    block_ms=block_ms,
-                )
+                take_out_of_rotation(access.credential_id)
             await self._route_state.activate(
                 fallback,
                 f"{model.provider} {condition}{remaining}",

--- a/local_operator/providers/failover.py
+++ b/local_operator/providers/failover.py
@@ -1407,6 +1407,17 @@ async def stream_with_failover(
         spec = request.model if target == primary_target else spec_for_target(request.model, target)
         route_key = (selector, target.effort)
         walked.add(route_key)
+        if (
+            looped_back
+            and server_faults_by_target.get(route_key, 0) >= MAX_SERVER_FAULT_REQUESTS_PER_TURN
+        ):
+            # A revisit must not become a top-up: this target already aimed the
+            # turn's whole server-fault allowance at its provider, and the
+            # loop-back exists to catch freed capacity, not to keep spending
+            # against an outage. Checked BEFORE the route-state activation
+            # below, so a target the sweep refuses to ask cannot capture the
+            # session's route pin on its way out (review R1-F1).
+            continue
         client = clients.get(route_key)
         if client is None:
             built = client_for(spec)
@@ -1438,14 +1449,10 @@ async def stream_with_failover(
         # chain. Each provider is a different service having a different day,
         # and the ceiling is about what ONE provider receives. Loaded from the
         # cross-sweep ledger so the loop-back sweep finishes the same ceiling
-        # instead of opening a second one.
+        # instead of opening a second one; a revisited target whose ledger is
+        # already spent was skipped at the top of this walk, before it could
+        # touch the route pin.
         server_fault_requests = server_faults_by_target.get(route_key, 0)
-        if looped_back and server_fault_requests >= MAX_SERVER_FAULT_REQUESTS_PER_TURN:
-            # A revisit must not become a top-up: this target already aimed the
-            # turn's whole server-fault allowance at its provider, and the
-            # loop-back exists to catch freed capacity, not to keep spending
-            # against an outage.
-            continue
         # Attempts this target's FIRST bearer spent before rotation started, so
         # the restore below can hand back the remainder of the user's budget
         # instead of a fresh one.

--- a/local_operator/providers/failover.py
+++ b/local_operator/providers/failover.py
@@ -816,6 +816,13 @@ MAX_SAME_CREDENTIAL_SERVER_RETRIES = 2
 #: behaviour, whatever the pool size.
 MAX_SERVER_FAULT_REQUESTS_PER_TURN = 12
 
+#: Ceiling on the pause before the loop-back sweep re-walks an exhausted
+#: cascade. The sweep honours the shortest wait a provider advertised —
+#: sleeping less would re-ask a question whose answer is already known — but a
+#: long quota reset must not stall the verdict for hours: past this cap the
+#: sweep goes immediately and lets resolution report whatever is still blocked.
+LOOPBACK_MAX_WAIT_MS = 30_000
+
 #: Attempts the FIRST bearer may spend on a server-side fault before the turn
 #: tries another credential. It is deliberately below ``max_retries``: until a
 #: rotation has happened nothing knows whether a sibling exists, and spending
@@ -1328,6 +1335,10 @@ async def stream_with_failover(
             for candidate in expand_fallback_targets(primary_selector, chain):
                 if candidate not in targets:
                     targets.append(candidate)
+    # The list as CONFIGURED, kept before the route-state trim below: the
+    # loop-back sweep at the bottom of the walk re-checks the whole waterfall,
+    # including targets the pin excluded from the first pass.
+    full_targets = list(targets)
     if route_state is not None and route_state.active in targets:
         targets = targets[targets.index(route_state.active) :]
 
@@ -1361,7 +1372,32 @@ async def stream_with_failover(
                 "%s failed: %s", "requested model" if primary else "fallback selector", error
             )
 
-    for target in targets:
+    # One walk down the cascade, then AT MOST one more. The second sweep exists
+    # because "every target failed once" is not the same fact as "every target
+    # is exhausted": by the time the walk reaches the end of the chain, the
+    # failures at the top are minutes old — a 60s credential block written by
+    # another process has expired, a transient outage has passed, a short rate
+    # limit has reset — and targets the route-state pin trimmed off the first
+    # pass were never asked at all this turn. Dying without looking again
+    # reports exhaustion the harness has not actually verified.
+    #
+    # Bounded and discriminating, so the loop-back cannot become a hammer:
+    # exactly one extra sweep per call, revisiting only targets that were never
+    # walked this turn or whose failure was the kind that heals on its own
+    # (quota/timeout/transient — see the `recoverable` marks below). A 400 the
+    # provider meant, or a bearer it rejected past rotation, gets no second ask:
+    # the same bytes would get the same answer.
+    pending = list(targets)
+    walked: set[tuple[str, str | None]] = set()
+    recoverable: set[tuple[str, str | None]] = set()
+    # Server-fault spend per target, carried ACROSS the sweeps: the per-turn
+    # ceiling is about what one provider receives, and a loop-back that reset
+    # the counter would quietly double it.
+    server_faults_by_target: dict[tuple[str, str | None], int] = {}
+    shortest_retry_after_ms: int | None = None
+    looped_back = False
+    while pending:
+        target = pending.pop(0)
         selector = target.selector
         if signal is not None and signal.aborted:
             raise ProviderError(None, signal.reason or "aborted", retryable=False, kind="aborted")
@@ -1370,6 +1406,7 @@ async def stream_with_failover(
         provider, _model_id = parse_selector(selector)
         spec = request.model if target == primary_target else spec_for_target(request.model, target)
         route_key = (selector, target.effort)
+        walked.add(route_key)
         client = clients.get(route_key)
         if client is None:
             built = client_for(spec)
@@ -1399,8 +1436,16 @@ async def stream_with_failover(
         # with no retries -- so a fallback that would have succeeded on its
         # second try never got one, which defeats the entire point of having a
         # chain. Each provider is a different service having a different day,
-        # and the ceiling is about what ONE provider receives.
-        server_fault_requests = 0
+        # and the ceiling is about what ONE provider receives. Loaded from the
+        # cross-sweep ledger so the loop-back sweep finishes the same ceiling
+        # instead of opening a second one.
+        server_fault_requests = server_faults_by_target.get(route_key, 0)
+        if looped_back and server_fault_requests >= MAX_SERVER_FAULT_REQUESTS_PER_TURN:
+            # A revisit must not become a top-up: this target already aimed the
+            # turn's whole server-fault allowance at its provider, and the
+            # loop-back exists to catch freed capacity, not to keep spending
+            # against an outage.
+            continue
         # Attempts this target's FIRST bearer spent before rotation started, so
         # the restore below can hand back the remainder of the user's budget
         # instead of a fresh one.
@@ -1499,10 +1544,15 @@ async def stream_with_failover(
                     # reported frame sent the user off to configure a key they
                     # already had -- the reported `No API key configured for
                     # provider 'openai'` on an account signed in via OAuth.
-                    record(
-                        _no_credential_error(auth, provider),
-                        primary=is_primary,
-                    )
+                    missing = _no_credential_error(auth, provider)
+                    record(missing, primary=is_primary)
+                    if missing.retryable:
+                        # Retryable means blocked-not-absent: backoffs expire on
+                        # their own (and other processes release credentials),
+                        # so the loop-back sweep may find this provider
+                        # serviceable again. A genuinely unconfigured provider
+                        # is not retryable and gets no second visit.
+                        recoverable.add(route_key)
                     break
                 error = None
             retry_same_key = False
@@ -1546,6 +1596,26 @@ async def stream_with_failover(
                 record(exc, primary=is_primary)
                 if is_server_side_failure(exc):
                     server_fault_requests += 1
+                    server_faults_by_target[route_key] = server_fault_requests
+                if (
+                    exc.kind == "quota"
+                    and exc.retry_after_ms
+                    and exc.retry_after_ms <= LOOPBACK_MAX_WAIT_MS
+                ):
+                    # A throttle that clears within the loop-back's wait ceiling
+                    # earns this target a second visit after the walk: the sweep
+                    # sleeps the advertised delay first, so the revisit asks a
+                    # question whose answer can actually have changed. Long
+                    # quota resets are excluded — nothing about them changes in
+                    # the seconds this turn has left — and server-side faults
+                    # are excluded on purpose: their in-place retry budgets
+                    # (`_same_credential_retry_allowed`, the per-target fault
+                    # ceiling) already spent the turn's whole allowance for that
+                    # provider, and a revisit would quietly double it.
+                    recoverable.add(route_key)
+                    shortest_retry_after_ms = min(
+                        shortest_retry_after_ms or exc.retry_after_ms, exc.retry_after_ms
+                    )
                 if not retry.enabled:
                     raise
                 if _same_credential_retry_allowed(
@@ -1596,6 +1666,7 @@ async def stream_with_failover(
                 record(wrapped, primary=is_primary)
                 if is_server_side_failure(wrapped):
                     server_fault_requests += 1
+                    server_faults_by_target[route_key] = server_fault_requests
                 if not retry.enabled:
                     raise wrapped from exc
                 # Same budget rule as the ProviderError arm above, asked the same
@@ -1634,6 +1705,35 @@ async def stream_with_failover(
                 return
 
         # Provider exhausted — walk on to the next fallback selector.
+
+        if pending or looped_back or not retry.enabled:
+            continue
+        # The walk has reached the end of the waterfall. Before declaring the
+        # whole cascade exhausted, sweep it once more from the top: targets the
+        # route-state pin excluded were never asked this turn, and the ones
+        # that failed with a self-healing kind (see `recoverable`) may have
+        # been freed while the rest of the walk was busy failing. Skipping
+        # this check reported "everything is exhausted" on evidence that had
+        # already gone stale — and one expired 60s block is the difference
+        # between a served turn and a dead one.
+        revisit = [
+            candidate
+            for candidate in full_targets
+            if (candidate.selector, candidate.effort) not in walked
+            or (candidate.selector, candidate.effort) in recoverable
+        ]
+        if not revisit:
+            continue
+        looped_back = True
+        # Honour the shortest advertised wait, but never stall an interactive
+        # turn for a long quota reset: past the cap the sweep goes now and lets
+        # resolution report whatever is still blocked.
+        if shortest_retry_after_ms is not None:
+            delay_ms = min(shortest_retry_after_ms, LOOPBACK_MAX_WAIT_MS)
+        else:
+            delay_ms = backoff_delay_ms(retry.base_delay_ms, 1, rng=rng)
+        await _abortable_sleep(delay_ms, signal)
+        pending = revisit
 
     if reported is not None:
         raise reported

--- a/local_operator/providers/usage.py
+++ b/local_operator/providers/usage.py
@@ -353,8 +353,19 @@ def usage_health(
     else:
         state = "healthy"
     binding = [limit for limit, value in measured if value <= threshold]
-    binding_resets = [limit.resets_in_ms(now_ms) for limit in binding]
-    reset_after = max((value for value in binding_resets if value is not None), default=None)
+    # ``reset_after_ms`` answers "when does the condition the STATE names
+    # clear", and the horizon must come from the windows that produced that
+    # state. A depleted verdict feeds a block that lasts this long, so it may
+    # only count fully-spent windows: mixing in a window that is merely in
+    # reserve stretched a three-hour 5h-window block out to that window's
+    # seven-day reset — a days-long outage written against an account that
+    # was usable again the same afternoon.
+    if state == "depleted":
+        horizon = [limit for limit, value in measured if value <= 0]
+    else:
+        horizon = binding
+    horizon_resets = [limit.resets_in_ms(now_ms) for limit in horizon]
+    reset_after = max((value for value in horizon_resets if value is not None), default=None)
     if not binding:
         scope: Literal["account", "model", "unknown"] = "unknown"
     elif all(limit.tier and not limit.shared for limit in binding):

--- a/tests/unit/model/test_configure.py
+++ b/tests/unit/model/test_configure.py
@@ -7,6 +7,7 @@ hits the same endpoints as before through a descriptor table.
 """
 
 import json
+import zlib
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -464,6 +465,142 @@ async def test_usage_reserve_can_reduce_effort_without_blocking_account(tmp_path
 
         assert not store.is_blocked(account.id, "anthropic")
         assert stream._route_state.active == FallbackTarget("anthropic/claude-opus-5", "low")
+    finally:
+        await stream.close()
+        store.close()
+
+
+def _session_hashing_to_first_row(row_count: int) -> str:
+    """A session id whose crc32 lands the selection order on row index 0.
+
+    ``AuthStore._base_selection_order`` rotates the pool by
+    ``crc32(session_id) % len(rows)`` when no sticky credential is set, so a
+    fixed literal makes "which account does the walk meet first" an accident
+    of the string. These tests need the FIRST-INSERTED account visited first
+    for their scenario to exist at all, so the id is derived, not guessed.
+    """
+    candidates = (f"session-{i}" for i in range(64))
+    return next(s for s in candidates if zlib.crc32(s.encode()) % row_count == 0)
+
+
+@pytest.mark.asyncio
+async def test_usage_preflight_demotes_rather_than_blocks_a_reserve_account(tmp_path) -> None:
+    """An account in reserve still has quota, so it must never be written into
+    the cross-process block table.
+
+    The block preflight used to write lasted until the BINDING window's reset
+    — for a seven-day window at 90 % that is a multi-day outage recorded in
+    SQLite against an account that could still serve. Reserve is a routing
+    preference, so it gets the in-process, self-expiring demotion instead."""
+    store = AuthStore(tmp_path / "auth.db")
+    first = store.upsert_credential("anthropic", _oauth("oauth-a", "account-a"))
+    second = store.upsert_credential("anthropic", _oauth("oauth-b", "account-b"))
+    session = _session_hashing_to_first_row(2)
+    stream = create_stream_fn(
+        store,
+        {"retry": {"usageAwareFallback": True, "usageReservePercent": 10}},
+        session_id=session,
+    )
+    model = ModelSpec(provider="anthropic", model_id="claude-opus-5")
+
+    async def usage_for_access(_client, _provider, *, access_token=None, **_kwargs):
+        return _anthropic_usage(95.0 if access_token == "oauth-a" else 25.0)
+
+    try:
+        with patch("local_operator.providers.usage.fetch_usage", side_effect=usage_for_access):
+            await stream.preflight_usage(model)
+
+        assert not store.is_blocked(first.id, "anthropic")
+        assert not store.is_blocked(second.id, "anthropic")
+        # The preference still holds: the healthy sibling serves next.
+        selected = await store.get_oauth_access("anthropic", session)
+        assert selected is not None and selected.credential_id == second.id
+    finally:
+        await stream.close()
+        store.close()
+
+
+@pytest.mark.asyncio
+async def test_reserve_account_still_serves_after_the_healthy_sibling_depletes(tmp_path) -> None:
+    """The incident this change fixes, replayed end to end.
+
+    One account sits in reserve (95 % of a window used), the other is healthy.
+    Preflight steers to the healthy account; later that account genuinely
+    exhausts and the 429 path blocks it for its advertised reset. The reserve
+    account is now the only thing left — and it MUST serve. When preflight
+    recorded reserve as a SQLite block, this exact sequence left the provider
+    with four configured credentials and zero usable ones, and every live
+    session died with "all credentials not usable" while quota remained."""
+    from local_operator.providers.failover import ProviderError
+
+    store = AuthStore(tmp_path / "auth.db")
+    reserve = store.upsert_credential("anthropic", _oauth("oauth-a", "account-a"))
+    healthy = store.upsert_credential("anthropic", _oauth("oauth-b", "account-b"))
+    session = _session_hashing_to_first_row(2)
+    stream = create_stream_fn(
+        store,
+        {"retry": {"usageAwareFallback": True, "usageReservePercent": 10}},
+        session_id=session,
+    )
+    model = ModelSpec(provider="anthropic", model_id="claude-opus-5")
+
+    async def usage_for_access(_client, _provider, *, access_token=None, **_kwargs):
+        return _anthropic_usage(95.0 if access_token == "oauth-a" else 25.0)
+
+    try:
+        with patch("local_operator.providers.usage.fetch_usage", side_effect=usage_for_access):
+            await stream.preflight_usage(model)
+        # The healthy account served and is sticky; now it runs out for real.
+        store.rotate_sibling(
+            "anthropic",
+            session,
+            ProviderError(429, "rate limited", retryable=True, retry_after_ms=3 * 3_600_000),
+        )
+        assert store.is_blocked(healthy.id, "anthropic")
+
+        survivor = await store.get_oauth_access("anthropic", session)
+        assert survivor is not None and survivor.credential_id == reserve.id
+    finally:
+        await stream.close()
+        store.close()
+
+
+@pytest.mark.asyncio
+async def test_reserve_account_is_not_blocked_when_falling_back_cross_provider(tmp_path) -> None:
+    """The no-siblings branch takes the same depleted/reserve split.
+
+    A lone reserve account with a cross-provider fallback used to be blocked
+    until its window reset before the session moved to the fallback. The block
+    is cross-process, so it also stranded every OTHER session — including ones
+    whose fallback chains could not rescue them."""
+    store = AuthStore(tmp_path / "auth.db")
+    account = store.upsert_credential("anthropic", _oauth("oauth-a", "account-a"))
+    store.upsert_credential("openai", {"key": "sk-openai", "source": "login"})
+    stream = create_stream_fn(
+        store,
+        {
+            "retry": {
+                "usageAwareFallback": True,
+                "usageReservePercent": 10,
+                "fallbackChains": {"default": ["openai/gpt-5.3-codex"]},
+            }
+        },
+        session_id="session-a",
+    )
+    model = ModelSpec(provider="anthropic", model_id="claude-opus-5")
+
+    try:
+        with patch(
+            "local_operator.providers.usage.fetch_usage",
+            side_effect=lambda *_args, **_kwargs: _anthropic_usage(95.0),
+        ):
+            await stream.preflight_usage(model)
+
+        assert not store.is_blocked(account.id, "anthropic")
+        assert stream._route_state.active == FallbackTarget("openai/gpt-5.3-codex")
+        # Another session (or process) with no fallback still reaches the account.
+        access = await store.get_oauth_access("anthropic", "some-other-session")
+        assert access is not None and access.credential_id == account.id
     finally:
         await stream.close()
         store.close()

--- a/tests/unit/providers/test_auth_store.py
+++ b/tests/unit/providers/test_auth_store.py
@@ -198,6 +198,24 @@ async def test_blocking_backoff(store: AuthStore) -> None:
     assert await store.get_api_key("openai") == "k1"
 
 
+async def test_a_blocked_row_returns_to_service_when_its_window_passes(
+    store: AuthStore, monkeypatch: Any
+) -> None:
+    """Expiry by TIME, not by an explicit clear. Every other test unblocks via
+    ``clear_blocks``, which leaves the actual recovery path — the comparison
+    against ``blocked_until_ms`` — unpinned; a regression that wrote
+    far-future blocks (the reserve-blocking incident) would have looked
+    exactly like this test never existing."""
+    clock = {"now": 1_000_000}
+    monkeypatch.setattr(AuthStore, "_now_ms", staticmethod(lambda: clock["now"]))
+    row = store.upsert_credential("openai", {"key": "k1", "type": "api_key"})
+    store.block_credential(row.id, "openai", block_ms=60_000)
+    assert await store.get_api_key("openai") is None
+    clock["now"] += 60_001
+    assert not store.is_blocked(row.id, "openai")
+    assert await store.get_api_key("openai") == "k1"
+
+
 async def test_rotate_sibling_blocks_failing_and_reports_remaining(store: AuthStore) -> None:
     store.upsert_credential("openai", {"key": "k1", "type": "api_key"})
     row2 = store.upsert_credential("openai", {"key": "k2", "type": "api_key"})

--- a/tests/unit/providers/test_failover.py
+++ b/tests/unit/providers/test_failover.py
@@ -734,7 +734,13 @@ async def test_short_rate_limit_retries_twice_per_credential(monkeypatch) -> Non
             pass
 
     assert attempts == ["k1", "k1", "k1", "k2", "k2", "k2"]
-    assert len(sleeps) == 4
+    # Four in-place retry sleeps, plus ONE loop-back pause: a short throttle
+    # arms the end-of-cascade sweep, which sleeps the advertised delay and
+    # re-resolves — finding nothing (both keys rotated out), hence no seventh
+    # attempt. The attempts list above is the budget contract; the fifth sleep
+    # is the sweep's, not a fifth retry.
+    assert len(sleeps) == 5
+    assert sleeps[-1] == 5
 
 
 async def test_403_rotates_once_per_credential_no_double_rotation() -> None:
@@ -2570,3 +2576,472 @@ class TestARestoredBudgetIsTheConfiguredOne:
         )
 
         assert await self._requests_for(store, max_retries) == max_retries + 1
+
+
+class TestRotationPermutations:
+    """The credential shapes users actually hold, each driven END TO END
+    through ``stream_with_failover`` on a real ``AuthStore``.
+
+    Rotation policy and cascade tiers each had unit coverage, but the
+    incident that motivated this class was a composition failure: every
+    session died reporting four credentials unusable while three still held
+    quota. So each permutation here asserts the thing a user cares about —
+    after the failure, SOMEBODY serves — not the mechanism that got there.
+    """
+
+    @staticmethod
+    def _no_sleep():
+        async def no_sleep(delay_ms: int, signal: Any) -> None:
+            return None
+
+        return no_sleep
+
+    async def test_oauth_429_rotates_to_the_sibling_account(self, tmp_path: Any) -> None:
+        """OAuth → OAuth inside one provider: the first account's 429 blocks it
+        for the advertised reset and the sibling serves the SAME request."""
+        store = AuthStore(db_path=tmp_path / "auth.db")
+        store.upsert_credential(
+            "anthropic",
+            # Distinct emails: OAuth rows without an identity field dedupe to
+            # one per-provider row (see `_identity_key_for`), silently turning
+            # a two-account pool into a single account.
+            {
+                "type": "oauth",
+                "access": "acct-a",
+                "refresh": "r",
+                "expires": None,
+                "email": "a@example.com",
+            },
+        )
+        store.upsert_credential(
+            "anthropic",
+            {
+                "type": "oauth",
+                "access": "acct-b",
+                "refresh": "r",
+                "expires": None,
+                "email": "b@example.com",
+            },
+        )
+        served: list[str | None] = []
+
+        def first_account_exhausted(
+            request: ChatRequest, api_key: str | None, oauth_access: Any = None
+        ) -> AsyncIterator[Any]:
+            if api_key == "acct-a":
+                raise ProviderError(
+                    429, "quota reset pending", retryable=True, retry_after_ms=3 * 3_600_000
+                )
+            served.append(api_key)
+            return _clean_stream()
+
+        async def client_for(spec: ModelSpec) -> Any:
+            return _FnClient(first_account_exhausted)
+
+        original = failover_module._abortable_sleep
+        failover_module._abortable_sleep = self._no_sleep()  # type: ignore[assignment]
+        try:
+            async for _ in stream_with_failover(
+                _request("anthropic", "claude-opus-5"),
+                store,
+                {"retry": {"enabled": True}},
+                client_for,
+                session_id="s0",
+            ):
+                pass
+        finally:
+            failover_module._abortable_sleep = original  # type: ignore[assignment]
+
+        assert served == ["acct-b"]
+        rows = {r.data["access"]: r for r in store.list_credentials("anthropic")}
+        assert store.is_blocked(rows["acct-a"].id, "anthropic")
+        assert not store.is_blocked(rows["acct-b"].id, "anthropic")
+
+    async def test_a_429d_oauth_row_falls_through_to_an_api_key_row(self, tmp_path: Any) -> None:
+        """OAuth → API key inside one provider. ``rotate_sibling`` only counts
+        same-type siblings, so the cross-type hop happens in the cascade: the
+        blocked OAuth tier empties and tier 6 hands over the stored key. This
+        is the whole request surviving that hop, not the tier unit test."""
+        store = AuthStore(db_path=tmp_path / "auth.db")
+        store.upsert_credential(
+            "anthropic",
+            {"type": "oauth", "access": "oauth-token", "refresh": "r", "expires": None},
+        )
+        store.upsert_credential("anthropic", {"type": "api_key", "key": "sk-stored"})
+        served: list[str | None] = []
+
+        def oauth_exhausted(
+            request: ChatRequest, api_key: str | None, oauth_access: Any = None
+        ) -> AsyncIterator[Any]:
+            if api_key == "oauth-token":
+                raise ProviderError(
+                    429, "quota reset pending", retryable=True, retry_after_ms=3 * 3_600_000
+                )
+            served.append(api_key)
+            return _clean_stream()
+
+        async def client_for(spec: ModelSpec) -> Any:
+            return _FnClient(oauth_exhausted)
+
+        original = failover_module._abortable_sleep
+        failover_module._abortable_sleep = self._no_sleep()  # type: ignore[assignment]
+        try:
+            async for _ in stream_with_failover(
+                _request("anthropic", "claude-opus-5"),
+                store,
+                {"retry": {"enabled": True}},
+                client_for,
+                session_id="s0",
+            ):
+                pass
+        finally:
+            failover_module._abortable_sleep = original  # type: ignore[assignment]
+
+        assert served == ["sk-stored"]
+
+    async def test_a_multi_key_pool_walks_every_key_until_one_serves(self, tmp_path: Any) -> None:
+        """API key → API key → API key: the token-plan shape (several pasted
+        keys under one provider). Two keys 429; the third serves."""
+        store = AuthStore(db_path=tmp_path / "auth.db")
+        for i in range(3):
+            store.upsert_credential(
+                "alibaba-token-plan", {"type": "api_key", "key": f"plan-key-{i}"}
+            )
+        served: list[str | None] = []
+        rejected: list[str | None] = []
+
+        def two_exhausted(
+            request: ChatRequest, api_key: str | None, oauth_access: Any = None
+        ) -> AsyncIterator[Any]:
+            # Order-independent on purpose: which key the walk meets first is a
+            # session-hash accident, so the first two DISTINCT keys are the
+            # exhausted ones and whichever remains serves.
+            if len(rejected) < 2:
+                rejected.append(api_key)
+                raise ProviderError(
+                    429, "quota reset pending", retryable=True, retry_after_ms=3 * 3_600_000
+                )
+            served.append(api_key)
+            return _clean_stream()
+
+        async def client_for(spec: ModelSpec) -> Any:
+            return _FnClient(two_exhausted)
+
+        original = failover_module._abortable_sleep
+        failover_module._abortable_sleep = self._no_sleep()  # type: ignore[assignment]
+        try:
+            async for _ in stream_with_failover(
+                _request("alibaba-token-plan", "qwen3-max"),
+                store,
+                {"retry": {"enabled": True}},
+                client_for,
+                session_id="s0",
+            ):
+                pass
+        finally:
+            failover_module._abortable_sleep = original  # type: ignore[assignment]
+
+        assert len(rejected) == 2 and len(set(rejected)) == 2
+        assert len(served) == 1
+        assert {*rejected, *served} == {"plan-key-0", "plan-key-1", "plan-key-2"}
+
+    async def test_cross_provider_fallback_resolves_an_api_key_provider(
+        self, tmp_path: Any
+    ) -> None:
+        """OAuth primary exhausted → chain hops providers → the fallback's
+        LOGIN API key resolves through the real cascade and serves."""
+        store = AuthStore(db_path=tmp_path / "auth.db")
+        store.upsert_credential(
+            "anthropic",
+            {"type": "oauth", "access": "acct-a", "refresh": "r", "expires": None},
+        )
+        store.upsert_credential(
+            "openai", {"type": "api_key", "key": "sk-openai", "source": "login"}
+        )
+        served: list[tuple[str, str | None]] = []
+
+        def primary_exhausted(
+            request: ChatRequest, api_key: str | None, oauth_access: Any = None
+        ) -> AsyncIterator[Any]:
+            if request.model.provider == "anthropic":
+                raise ProviderError(
+                    429, "quota reset pending", retryable=True, retry_after_ms=3 * 3_600_000
+                )
+            served.append((request.model.provider, api_key))
+            return _clean_stream()
+
+        async def client_for(spec: ModelSpec) -> Any:
+            return _FnClient(primary_exhausted)
+
+        original = failover_module._abortable_sleep
+        failover_module._abortable_sleep = self._no_sleep()  # type: ignore[assignment]
+        try:
+            async for _ in stream_with_failover(
+                _request("anthropic", "claude-opus-5"),
+                store,
+                {
+                    "retry": {
+                        "enabled": True,
+                        "fallbackChains": {"default": ["openai/gpt-5.4"]},
+                    }
+                },
+                client_for,
+                session_id="s0",
+            ):
+                pass
+        finally:
+            failover_module._abortable_sleep = original  # type: ignore[assignment]
+
+        assert served == [("openai", "sk-openai")]
+
+
+class TestTheLoopBackSweep:
+    """An exhausted walk gets ONE more look at the waterfall before the verdict.
+
+    "Every target failed once" is stale evidence by the time the walk ends:
+    blocks written by other processes expire, short throttles clear, and
+    targets the route-state pin trimmed off were never asked at all. The sweep
+    is bounded (one revisit per call) and discriminating (never-walked targets,
+    short-throttle quota failures, and blocked-not-absent credential pools —
+    never server faults, whose budgets were already spent in place).
+    """
+
+    async def test_the_sweep_revisits_targets_the_route_pin_excluded(self) -> None:
+        """The 'sample upwards' case: pinned to the last fallback, which dies —
+        the sweep walks back up and the recovered primary serves the turn."""
+        served: list[str] = []
+        sleeps: list[int] = []
+
+        def fallback_dead_primary_alive(
+            request: ChatRequest, api_key: str | None, oauth_access: Any = None
+        ) -> AsyncIterator[Any]:
+            if request.model.provider == "openai":
+                raise ProviderError(400, "schema rejected", retryable=False, kind="request")
+            served.append(request.model.provider)
+            return _clean_stream()
+
+        async def record_sleep(delay_ms: int, signal: Any) -> None:
+            sleeps.append(delay_ms)
+
+        async def client_for(spec: ModelSpec) -> Any:
+            return _FnClient(fallback_dead_primary_alive)
+
+        route_state = FailoverRouteState()
+        fallback = FallbackTarget("openai/gpt-5.4")
+        await route_state.activate(fallback, "provider failure", cooldown_ms=600_000)
+
+        original = failover_module._abortable_sleep
+        failover_module._abortable_sleep = record_sleep  # type: ignore[assignment]
+        try:
+            async for _ in stream_with_failover(
+                _request("anthropic", "claude-opus-5"),
+                FakeAuth({"anthropic": ["acct"], "openai": ["sk"]}),
+                {
+                    "retry": {
+                        "enabled": True,
+                        "baseDelayMs": 1,
+                        "fallbackChains": {"default": ["openai/gpt-5.4"]},
+                    }
+                },
+                client_for,
+                session_id="s0",
+                route_state=route_state,
+            ):
+                pass
+        finally:
+            failover_module._abortable_sleep = original  # type: ignore[assignment]
+
+        # The pinned walk asked only openai; the sweep asked the primary.
+        assert served == ["anthropic"]
+
+    async def test_a_short_throttle_is_swept_once_and_can_serve(self) -> None:
+        """A bearer with no store row (env-var shaped) 429s through its budget;
+        the sweep waits the advertised delay and the SAME bearer serves."""
+        attempts: list[str | None] = []
+        sleeps: list[int] = []
+
+        class EnvAuth:
+            """get_api_key-only store: one bearer, nothing to block."""
+
+            async def get_api_key(
+                self, provider: str, session_id: str | None = None, **kwargs: Any
+            ) -> str | None:
+                return "env-key"
+
+            def rotate_sibling(
+                self, provider: str, session_id: str | None, error: Any, api_key: str | None = None
+            ) -> bool:
+                return False
+
+        def throttled_then_clear(
+            request: ChatRequest, api_key: str | None, oauth_access: Any = None
+        ) -> AsyncIterator[Any]:
+            attempts.append(api_key)
+            if len(attempts) < 4:
+                raise ProviderError(429, "brief throttle", retryable=True, retry_after_ms=5)
+            return _clean_stream()
+
+        async def record_sleep(delay_ms: int, signal: Any) -> None:
+            sleeps.append(delay_ms)
+
+        async def client_for(spec: ModelSpec) -> Any:
+            return _FnClient(throttled_then_clear)
+
+        original = failover_module._abortable_sleep
+        failover_module._abortable_sleep = record_sleep  # type: ignore[assignment]
+        try:
+            async for _ in stream_with_failover(
+                _request(),
+                EnvAuth(),
+                {"retry": {"enabled": True, "baseDelayMs": 1, "fallbackChains": {}}},
+                client_for,
+                session_id="s0",
+            ):
+                pass
+        finally:
+            failover_module._abortable_sleep = original  # type: ignore[assignment]
+
+        # Three in-place attempts (initial + the short-throttle pair), then the
+        # sweep's fourth after sleeping the advertised 5 ms.
+        assert attempts == ["env-key"] * 4
+        assert sleeps[-1] == 5
+
+    async def test_the_sweep_runs_at_most_once(self) -> None:
+        """A throttle that never clears gets exactly one revisit — the sweep
+        must not turn the walk into a spin."""
+        attempts: list[str | None] = []
+
+        class EnvAuth:
+            async def get_api_key(
+                self, provider: str, session_id: str | None = None, **kwargs: Any
+            ) -> str | None:
+                return "env-key"
+
+            def rotate_sibling(
+                self, provider: str, session_id: str | None, error: Any, api_key: str | None = None
+            ) -> bool:
+                return False
+
+        def always_throttled(
+            request: ChatRequest, api_key: str | None, oauth_access: Any = None
+        ) -> AsyncIterator[Any]:
+            attempts.append(api_key)
+            raise ProviderError(429, "brief throttle", retryable=True, retry_after_ms=5)
+
+        async def no_sleep(delay_ms: int, signal: Any) -> None:
+            return None
+
+        async def client_for(spec: ModelSpec) -> Any:
+            return _FnClient(always_throttled)
+
+        original = failover_module._abortable_sleep
+        failover_module._abortable_sleep = no_sleep  # type: ignore[assignment]
+        try:
+            with pytest.raises(ProviderError) as excinfo:
+                async for _ in stream_with_failover(
+                    _request(),
+                    EnvAuth(),
+                    {"retry": {"enabled": True, "baseDelayMs": 1, "fallbackChains": {}}},
+                    client_for,
+                    session_id="s0",
+                ):
+                    pass
+        finally:
+            failover_module._abortable_sleep = original  # type: ignore[assignment]
+
+        assert excinfo.value.status == 429
+        # Three attempts per walk, exactly two walks.
+        assert attempts == ["env-key"] * 6
+
+    async def test_a_block_expiring_mid_walk_is_caught_by_the_sweep(
+        self, tmp_path: Any, monkeypatch: Any
+    ) -> None:
+        """The incident, inverted: every credential blocked at resolve time is
+        a RETRYABLE verdict, so the sweep re-resolves — and a block that
+        expired while the walk was busy failing puts the account back in
+        service instead of the turn dying on stale evidence."""
+        clock = {"now": 1_000_000}
+        monkeypatch.setattr(AuthStore, "_now_ms", staticmethod(lambda: clock["now"]))
+        store = AuthStore(db_path=tmp_path / "auth.db")
+        row = store.upsert_credential(
+            "anthropic",
+            {"type": "oauth", "access": "acct-a", "refresh": "r", "expires": None},
+        )
+        store.block_credential(row.id, "anthropic", block_ms=2_000)
+        served: list[str | None] = []
+
+        def serves(
+            request: ChatRequest, api_key: str | None, oauth_access: Any = None
+        ) -> AsyncIterator[Any]:
+            served.append(api_key)
+            return _clean_stream()
+
+        async def sleep_advances_clock(delay_ms: int, signal: Any) -> None:
+            clock["now"] += 5_000
+
+        async def client_for(spec: ModelSpec) -> Any:
+            return _FnClient(serves)
+
+        original = failover_module._abortable_sleep
+        failover_module._abortable_sleep = sleep_advances_clock  # type: ignore[assignment]
+        try:
+            async for _ in stream_with_failover(
+                _request("anthropic", "claude-opus-5"),
+                store,
+                {"retry": {"enabled": True, "baseDelayMs": 1}},
+                client_for,
+                session_id="s0",
+            ):
+                pass
+        finally:
+            failover_module._abortable_sleep = original  # type: ignore[assignment]
+
+        assert served == ["acct-a"]
+
+    async def test_a_still_blocked_pool_keeps_the_quota_verdict(self, tmp_path: Any) -> None:
+        """When the sweep finds the pool still blocked, the verdict is the
+        retryable quota error naming the blocked credentials — never the
+        'No API key configured' misdiagnosis."""
+        store = AuthStore(db_path=tmp_path / "auth.db")
+        for access, email in (("acct-a", "a@example.com"), ("acct-b", "b@example.com")):
+            row = store.upsert_credential(
+                "anthropic",
+                {
+                    "type": "oauth",
+                    "access": access,
+                    "refresh": "r",
+                    "expires": None,
+                    "email": email,
+                },
+            )
+            store.block_credential(row.id, "anthropic", block_ms=3_600_000)
+
+        def never_reached(
+            request: ChatRequest, api_key: str | None, oauth_access: Any = None
+        ) -> AsyncIterator[Any]:
+            raise AssertionError("no bearer should resolve")
+
+        async def no_sleep(delay_ms: int, signal: Any) -> None:
+            return None
+
+        async def client_for(spec: ModelSpec) -> Any:
+            return _FnClient(never_reached)
+
+        original = failover_module._abortable_sleep
+        failover_module._abortable_sleep = no_sleep  # type: ignore[assignment]
+        try:
+            with pytest.raises(ProviderError) as excinfo:
+                async for _ in stream_with_failover(
+                    _request("anthropic", "claude-opus-5"),
+                    store,
+                    {"retry": {"enabled": True, "baseDelayMs": 1}},
+                    client_for,
+                    session_id="s0",
+                ):
+                    pass
+        finally:
+            failover_module._abortable_sleep = original  # type: ignore[assignment]
+
+        assert excinfo.value.kind == "quota"
+        assert excinfo.value.retryable
+        assert "not usable right now" in excinfo.value.message

--- a/tests/unit/providers/test_usage.py
+++ b/tests/unit/providers/test_usage.py
@@ -121,6 +121,39 @@ def test_usage_health_shared_window_reaches_reserve() -> None:
     assert health.reset_after_ms == 10_000
 
 
+def test_usage_health_depleted_reset_ignores_windows_merely_in_reserve() -> None:
+    """The depleted horizon counts only fully-spent windows.
+
+    ``reset_after_ms`` on a depleted verdict feeds a credential block of that
+    length, so it must answer "when is the SPENT window back". Computing it
+    over every binding window let a seven-day window sitting at 91 % stretch a
+    two-hour 5h-window block out to five days — a days-long outage written
+    against an account that was usable again the same afternoon."""
+    report = UsageReport(
+        provider="anthropic",
+        limits=[
+            UsageLimit(
+                id="anthropic:5h",
+                label="5 hour",
+                amount=UsageAmount(used_fraction=1.0),
+                shared=True,
+                resets_at_ms=2 * 3_600_000,
+            ),
+            UsageLimit(
+                id="anthropic:7d",
+                label="7 day",
+                amount=UsageAmount(used_fraction=0.91),
+                shared=True,
+                resets_at_ms=5 * 86_400_000,
+            ),
+        ],
+    )
+    health = usage_health(report, "claude-opus-5", reserve_percent=10, now_ms=0)
+    assert health.state == "depleted"
+    assert health.scope == "account"
+    assert health.reset_after_ms == 2 * 3_600_000
+
+
 def test_usage_health_ignores_unrelated_model_tier() -> None:
     report = UsageReport(
         provider="anthropic",


### PR DESCRIPTION
# PR Description

## Change classification

**C2 — standard / pre-authorized.** Provider-routing behaviour change confined to
`preflight_usage`, `usage_health`, and `stream_with_failover`; no schema,
transcript-format, or wire change. Clean rollback (`git revert`). No RFC
requested.

## The incident

Every live session died at once with:

```
✕ rate limit or quota exceeded: All 4 OAuth sign-in credentials for provider
  'anthropic' are not usable right now (rate limited, a token refresh failed,
  or the stored credential could not be read). ...
```

while the usage panel showed three of the four accounts with quota remaining
(5h windows at 0%, 0%, 92%; 7-day windows at 90%). The shared `auth.db` block
table told the story:

| cred | account state at block time | blocked for |
|---|---|---|
| 1 | 5h window at 100% (genuinely depleted) | 3.4 h — correct, the 429 path |
| 6 | 5h window at **92%** | ~2 h |
| 7 | 7d window at **90%** | **~1.9 days** |
| 4 | 7d window at **90%** | **~4.9 days** |

## The root cause

`preflight_usage` treated **reserve** (remaining ≤ `usageReservePercent`, i.e.
"still has quota, hold it back") the same as **depleted**: it wrote a
cross-process SQLite block lasting until the binding window's reset —
`usage_health.reset_after_ms`, which for a 7-day window at 90% is multi-day.
Reserve accounts entered that state one by one over hours; each still had an
unblocked sibling at check time, so each got days-blocked. When the last live
account genuinely hit 100%, its (correct) 429 block emptied the pool and every
session — current and future, in every process — died on a pool that was 75%
usable. The reserve concept was standing on its head: the quota held back for
emergencies was exactly the quota made unreachable in one.

A second bug compounded it: `reset_after_ms` was computed over **every binding
window**, so an account whose 5h window was spent (resets in 2h) but whose 7d
window sat at 91% got blocked until the **7-day** reset.

## The change

- **`preflight_usage`** (`model/configure.py`): a *depleted* account keeps the
  block-until-reset (the provider would 429 it anyway). A *reserve* account is
  **deprioritized** instead — the in-process, self-expiring routing preference
  (`AuthStore.deprioritize_credential`) that steers this walk and the session's
  next resolve toward healthier siblings, while the cascade's
  `ignore_demotions` second pass still serves the account the moment it is the
  only thing left. Reserve can no longer strand other sessions or processes.
- **`usage_health`** (`providers/usage.py`): on a depleted verdict,
  `reset_after_ms` now counts only **fully-spent** windows; merely-in-reserve
  windows no longer stretch the horizon.
- **`stream_with_failover`** (`providers/failover.py`): an exhausted walk gets
  **one loop-back sweep** of the full waterfall before the verdict. It
  revisits: targets the route-state pin excluded from the first pass (never
  asked this turn — the "sample upwards" case), quota failures whose advertised
  wait fits under `LOOPBACK_MAX_WAIT_MS` (sleeps that long first, so the answer
  can have changed), and blocked-not-absent credential pools (blocks expire on
  their own, and other processes release credentials mid-walk). Server-side
  faults never arm the sweep — their in-place retry budgets already spent the
  turn's allowance — and the per-target server-fault ledger carries across
  sweeps so the ceiling cannot double. Bounded: at most one revisit per call.

## Failover permutation coverage

A coverage audit found the composition paths untested (rotation policy had
unit coverage with fakes; cascade tiers had store-level coverage; almost
nothing drove a real `AuthStore` through `stream_with_failover`). New
end-to-end tests, each on a real store:

- OAuth → OAuth 429 rotation inside one provider (sibling serves; failed
  account blocked for its advertised reset).
- OAuth → API-key tier fall-through inside one provider (`rotate_sibling`
  only counts same-type siblings; the hop happens in the cascade — pinned as
  a whole-request survival, not a tier unit test).
- Multi-API-key pool (token-plan shape, 3 keys): walks every key until one
  serves.
- Cross-provider chain to an API-key provider (fallback's login key resolves
  through the real cascade).
- Time-based block expiry (`is_blocked` vs `blocked_until_ms`) — previously
  every test unblocked via explicit `clear_blocks`.
- Loop-back sweep: pin-excluded primary served on the sweep; short throttle
  swept once and served; sweep runs at most once; block expiring mid-walk
  caught by the sweep; still-blocked pool keeps the retryable quota verdict.

# Testing evidence

## 1. Incident replay, OLD (installed main) vs NEW (this branch)

Deterministic two-account scenario (account A at 92% of a 7-day window,
account B healthy, then B genuinely exhausts via the 429 path):

```
=== OLD (installed main) ===
[OLD] after preflight: account-A blocked in SQLite = True
[OLD]   block lasts another 120.0 hours
[OLD] account-B now 429-blocked = True
[OLD] can the session still resolve a bearer? NO - ALL SESSIONS DEAD
=== NEW (worktree fix) ===
[NEW] after preflight: account-A blocked in SQLite = False
[NEW] account-B now 429-blocked = True
[NEW] can the session still resolve a bearer? YES via account-A (reserve)
```

## 2. Live-DB confirmation of the diagnosis

Against a copy of the production `auth.db` taken during the incident,
`get_oauth_access("anthropic", ...)` returns `None` and
`_no_credential_error` renders the exact frame from the report:
`All 4 OAuth sign-in credentials for provider 'anthropic' are not usable right
now (...)`.

## 3. Suites and gates

- `tests/unit/providers` + `tests/unit/model`: **856 passed** (includes 3 new
  preflight regression tests, 9 new failover permutation/sweep tests, 1 new
  auth-store expiry test, 1 new usage_health horizon test).
- Full unit suite: 5060 passed, 1 failed —
  `test_background_streams_output_while_it_runs`, which **fails identically on
  a clean `origin/main` worktree** (timing-sensitive, unrelated; verified
  before touching anything).
- `flake8`, `black --check`, `isort --check-only`, `pyright`: all clean.

## 4. Runtime path

No UI change (a TUI notice string is reused verbatim); no design round needed.
This is a routing-policy change exercised end-to-end through
`stream_with_failover` + `AuthStore` on real SQLite in the tests above and in
the replay script.
