### PR TITLE
fix(harness): accept string forms of hub 'to' that models emit

### DIFF
--- a/local_operator/tools/builtin.py
+++ b/local_operator/tools/builtin.py
@@ -60,7 +60,14 @@ from pathlib import Path
 from typing import Any, Literal, cast
 from urllib.parse import urlsplit
 
-from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    ValidationError,
+    field_validator,
+    model_validator,
+)
 
 from local_operator.harness.approval import ask_approval
 from local_operator.harness.types import (
@@ -5959,6 +5966,43 @@ def build_jobs_tool(context: ToolContext) -> AgentTool | None:
 # four ops it cannot use and invite it to try them.
 
 
+def _coerce_hub_to(value: Any) -> Any:
+    """Accept the string shapes models emit for ``to`` instead of an array.
+
+    Observed live (2026-08-19, session "Fix analytics widget spacing and
+    alignment"): a parent model retried ``op='ask'`` five times against a
+    running reviewer and never once emitted a real array — ``"<id>"`` (a bare
+    id), ``'["<id>"]'`` (the array JSON-serialized into a string, the form the
+    TUI then prints so it *looks* like a list), and even ``'[<id>]'`` without
+    quotes. Each failed ``to: Input should be a valid list`` and the turn
+    burned on retries while the child kept working unheard. The schema below
+    must stay a plain array — an ``anyOf`` union of two real types is the one
+    construct the provider matrix rejects — so the leniency lives here, in a
+    before-validator: parse a JSON array, fall back to a bracket-stripped
+    split, fall back to the bare string as a single target. Anything that is
+    not one of those shapes passes through untouched and fails validation
+    with the normal message.
+    """
+    if not isinstance(value, str):
+        return value
+    text = value.strip()
+    if text.startswith("["):
+        try:
+            parsed = json.loads(text)
+        except ValueError:
+            # '[<id>]' with unquoted items is not JSON; the bracket-stripped
+            # split below recovers it.
+            parsed = None
+        if isinstance(parsed, list):
+            return [item if isinstance(item, str) else str(item) for item in parsed]
+        inner = text[1:]
+        if inner.endswith("]"):
+            inner = inner[:-1]
+        items = [item.strip().strip("'\"") for item in inner.split(",")]
+        return [item for item in items if item]
+    return [text] if text else value
+
+
 class HubParams(BaseModel):
     """Parent-side hub arguments."""
 
@@ -5995,6 +6039,15 @@ class HubParams(BaseModel):
             "op='list', which addresses nobody."
         ),
     )
+
+    # Models that serialize the array themselves send ``to`` as a string (a
+    # bare id, or the JSON of the list); see ``_coerce_hub_to`` for the live
+    # observation. Coercing here keeps the retry loop from burning the turn.
+    @field_validator("to", mode="before")
+    @classmethod
+    def _coerce_to(cls, value: Any) -> Any:
+        return _coerce_hub_to(value)
+
     message: str | None = Field(
         default=None,
         description=(

--- a/local_operator/tools/builtin.py
+++ b/local_operator/tools/builtin.py
@@ -5982,6 +5982,16 @@ def _coerce_hub_to(value: Any) -> Any:
     split, fall back to the bare string as a single target. Anything that is
     not one of those shapes passes through untouched and fails validation
     with the normal message.
+
+    The bracket-stripped split — also taken when a leading-``[`` value is not
+    valid JSON, e.g. ``'[job-1'`` — splits on commas, so a comma-bearing label
+    sent in the unquoted form splits into fragments; the JSON form is the only
+    shape that carries commas safely. That is an accepted leniency tradeoff on
+    a path that previously hard-failed: the fragments fail resolution instead
+    of the call failing validation, and the observed live shapes never carried
+    commas. Non-string items inside a parsed JSON array are dropped, so
+    ``'[null]'`` coerces to ``[]`` and fails with the normal "needs a 'to'
+    target" message rather than a fabricated ``"None"`` target name.
     """
     if not isinstance(value, str):
         return value
@@ -5994,7 +6004,7 @@ def _coerce_hub_to(value: Any) -> Any:
             # split below recovers it.
             parsed = None
         if isinstance(parsed, list):
-            return [item if isinstance(item, str) else str(item) for item in parsed]
+            return [item for item in parsed if isinstance(item, str)]
         inner = text[1:]
         if inner.endswith("]"):
             inner = inner[:-1]

--- a/tests/unit/harness/test_comms.py
+++ b/tests/unit/harness/test_comms.py
@@ -993,6 +993,44 @@ async def test_the_tool_refuses_to_ask_several_children_at_once():
 
 
 @pytest.mark.asyncio
+async def test_the_tool_accepts_the_string_forms_models_send_for_to():
+    """Observed live (2026-08-19): a parent model retried ``op='ask'`` against
+    a running reviewer and never once emitted a real array — a bare id, the
+    JSON of the list as a string (which the TUI then prints so it *looks*
+    like a list), and the bracketed id without quotes. Every attempt failed
+    ``to: Input should be a valid list`` while the child worked unheard. The
+    before-validator coerces those shapes; a real array is untouched."""
+    comms, _jobs, child, _parent = wire()
+    context = ToolContext(cwd=".", subagent_comms=comms)
+
+    for to_value in ('["job-1"]', "[job-1]", "job-1"):
+        result = await execute_hub(
+            "call-1", {"op": "send", "to": to_value, "message": "hi"}, None, None, context
+        )
+        assert not result.is_error, to_value
+        assert child.asides, to_value
+        child.asides.clear()
+
+    listed = await execute_hub("call-2", {"op": "list"}, None, None, context)
+    assert not listed.is_error
+
+    bad = await execute_hub(
+        "call-3", {"op": "send", "to": 42, "message": "hi"}, None, None, context
+    )
+    assert bad.is_error and "valid list" in body(bad)
+
+
+def test_the_hub_schema_still_advertises_a_nullable_array_not_a_union():
+    """The coercion lives in a validator because a ``str | list[str]`` schema
+    would render a non-nullable ``anyOf`` — the one construct the provider
+    matrix rejects for every request in the session. Pin the nullable-array
+    shape the comment on ``HubParams.to`` promises."""
+    tool = hub_tool(job_id=None, comms=wire()[0])
+    kinds = [entry.get("type") for entry in tool.parameters["properties"]["to"]["anyOf"]]
+    assert kinds == ["array", "null"]
+
+
+@pytest.mark.asyncio
 async def test_the_tool_requires_a_body_for_everything_but_cancel():
     comms, _jobs, _child, _parent = wire()
     context = ToolContext(cwd=".", subagent_comms=comms)

--- a/tests/unit/harness/test_comms.py
+++ b/tests/unit/harness/test_comms.py
@@ -1014,10 +1014,18 @@ async def test_the_tool_accepts_the_string_forms_models_send_for_to():
     listed = await execute_hub("call-2", {"op": "list"}, None, None, context)
     assert not listed.is_error
 
-    bad = await execute_hub(
-        "call-3", {"op": "send", "to": 42, "message": "hi"}, None, None, context
+    for bad_to in (42, ""):
+        bad = await execute_hub(
+            "call-3", {"op": "send", "to": bad_to, "message": "hi"}, None, None, context
+        )
+        assert bad.is_error and "valid list" in body(bad), bad_to
+
+    # '[null]' drops its non-string item and fails as a missing target, not
+    # as a fabricated "None" target name.
+    nulls = await execute_hub(
+        "call-4", {"op": "send", "to": "[null]", "message": "hi"}, None, None, context
     )
-    assert bad.is_error and "valid list" in body(bad)
+    assert nulls.is_error and "needs a 'to' target" in body(nulls)
 
 
 def test_the_hub_schema_still_advertises_a_nullable_array_not_a_union():


### PR DESCRIPTION
# PR Description

## Change classification

**C2 — standard / pre-authorized.** One before-validator on `HubParams.to`
plus a coercion helper and tests; no schema-shape, transcript-format, or wire
change (the rendered JSON schema is byte-identical). Clean rollback
(`git revert`). No RFC requested.

## The problem

`hub` calls from a parent model fail validation and burn the turn on retries
whenever the model serializes the `to` array itself, which happens in the
wild: observed live on 2026-08-19 (session "Fix analytics widget spacing and
alignment"), a parent retried `op='ask'` five times against a running
`reviewer` subagent and **never once emitted a real array**. The transcript
shows the progression:

```json
{"op": "ask", "to": "8ef061647935", ...}                    // bare id string
{"op": "ask", "to": "[\"8ef061647935\"]", ...}              // JSON of the list, as a string
{"op": "ask", "to": "[8ef061647935]", ...}                  // brackets, unquoted id
{"op": "ask", "to": "[\"code-review-1277\"]", ...}          // JSON of the list, label form
```

Every one returned `invalid arguments: - to: Input should be a valid list`.
The second form is especially nasty in the TUI: the card prints the string
verbatim, so the expanded row shows `to: ["code-review-1277"]` and reads as a
valid list — the failure looks like a harness bug while the argument on the
wire is a string. Meanwhile the child kept working unheard and the parent
concluded messaging was broken.

Why the schema cannot simply accept both types: `str | list[str]` renders a
non-nullable `anyOf`, and this module's schemas reach Gemini verbatim as
`function_declarations` — a construct one provider rejects fails *every*
request in the session, not just the hub call. The existing comment on
`HubParams.to` records exactly this constraint, so the leniency lives in a
validator instead of the schema.

## The change

- **`_coerce_hub_to`** (`tools/builtin.py`): a before-validator on `to` that
  accepts the string shapes models actually emit — parse a leading-`[` value
  as a JSON array; if that fails (the unquoted form is not JSON), strip the
  brackets and split on commas; otherwise treat the bare string as a single
  target. Non-strings, empty strings, and `None` pass through untouched, so
  genuinely wrong input still fails with the normal `invalid arguments`
  voice, and `op='list'` (no `to`) is unaffected.
- The rendered schema is unchanged: still the nullable-array `anyOf`
  (`[array, null]`), the same shape `message` has always had.
- Tests in `tests/unit/harness/test_comms.py`: the three observed string
  shapes deliver to the child through `execute_hub`; `to=42` and `to=""`
  still fail validation; and a schema pin asserting `to` advertises
  `["array", "null"]` and not a union of two real types.

## Testing evidence

### 1. Live reproduction (before the fix)

The session transcript `~/.local-operator/sessions/cd338b844a54/transcript.jsonl`
carries the exact failing calls quoted above, each answered by
`invalid arguments:\n- to: Input should be a valid list` — five consecutive
retries, none of which reached the child.

### 2. Regression tests, driven through the real tool entrypoint

```
$ .venv/bin/python -m pytest tests/unit/harness/test_comms.py -q
============================== 83 passed in 15.97s ==============================
```

including `test_the_tool_accepts_the_string_forms_models_send_for_to` (the
three live shapes deliver an aside to the child; int and empty string are
still rejected) and `test_the_hub_schema_still_advertises_a_nullable_array_not_a_union`.

### 3. Full suite and gates

```
$ .venv/bin/python -m pytest tests/unit -q
===== 1 failed, 3106 passed, 3 skipped in 184.28s =====
```

The one failure, `tests/unit/tools/test_eval_tool.py::test_background_streams_output_while_it_runs`,
fails identically on a clean `origin/main` worktree (verified: same assertion
on the unmodified tree) — a pre-existing environmental flake in background
kernel streaming, unrelated to this change.

```
$ .venv/bin/python -m flake8 local_operator/tools/builtin.py tests/unit/harness/test_comms.py   # clean
$ uvx --from black==26.1.0 black --check ...   # 2 files would be left unchanged
$ uvx isort --check-only --profile black ...   # clean
$ .venv/bin/python -m pyright --pythonpath .venv/bin/python ...
0 errors, 0 warnings, 0 informations
```

### 4. Behavioural spot-check of the coercion

```python
>>> _coerce_hub_to('["code-review-1277"]')   # JSON-of-list string
['code-review-1277']
>>> _coerce_hub_to('[8ef061647935]')         # unquoted brackets
['8ef061647935']
>>> _coerce_hub_to('8ef061647935')           # bare id
['8ef061647935']
>>> _coerce_hub_to(['a', 'b']), _coerce_hub_to(None)   # passthrough
(['a', 'b'], None)
```

## Impact

- No breaking changes; no dependency updates; no performance or security
  implications (the validator only reshapes the `to` argument before the
  existing resolution path).
- Models that already send a real array see no difference.

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my changes work as intended.
- [x] All new and existing tests pass (one pre-existing flake, documented above).
- [x] I have run formatting (black/isort), linting (flake8), and type checks (pyright), and they pass.
- [x] I have updated the documentation when required (comments carry the why and the live observation).
- [x] Security considerations are addressed (no new execution surface; input still validated).
- [x] I have linked all related issues.
