### PR TITLE
feat(tui): /theme command with live preview and 32 curated themes

### DIFF
--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -127,6 +127,7 @@ from local_operator.tui.widgets.editor import (
     ASIDE_PLACEHOLDER,
     DEFAULT_PLACEHOLDER,
     READ_ONLY_PLACEHOLDER,
+    ArgumentHighlightChanged,
     ArgumentQueryOpened,
     Attachment,
     Editor,
@@ -372,6 +373,20 @@ SLASH_COMMANDS: list[SlashCommand] = [
         # still prints the ladder with the current one marked. The list is what
         # the printed ladder could never be — the rungs are OFFERED rather than
         # transcribed by hand from a line of prose.
+        arguments=ArgumentMode.OPTIONAL,
+    ),
+    # NOT an echo, same rule as `/approvals`: the argument is a setting, and
+    # the receipt names the theme that ended up in force — strictly more than
+    # the typed word, which may have been an abbreviation the matcher resolved.
+    SlashCommand(
+        "theme",
+        # Terse like `/model`'s: the description column wraps past ~55 cells.
+        # "live preview" is the half the list cannot teach on its own — a user
+        # has to know arrowing is safe before they will browse with it.
+        "Switch color theme; arrows preview live",
+        aliases=("themes",),
+        # OPTIONAL: a bare `/theme` reports the active theme, and the space
+        # offers every registered ramp with the current one marked.
         arguments=ArgumentMode.OPTIONAL,
     ),
     # The listing is the receipt.
@@ -854,7 +869,15 @@ class OperatorApp(App[None]):
         resume_factory: Callable[[str | None], Awaitable[SessionProtocol]] | None = None,
     ) -> None:
         super().__init__()
-        theme_mod.set_theme(theme_name)  # dark is the product's island night
+        # Dark is the product's island night and the fallback: `theme_name`
+        # arrives from config.yml, and a saved name a build no longer ships
+        # (downgrade, hand-edited config) must not keep the app from booting.
+        # `set_theme` deliberately raises for CODE handing it a bad name; a
+        # CONFIG value is user data, and user data degrades gracefully.
+        try:
+            theme_mod.set_theme(theme_name)
+        except KeyError:
+            theme_mod.set_theme(theme_mod.DEFAULT_THEME)
         self._session_factory = session_factory
         # ``/resume <id>`` rebinds the session factory to a resume-specific one
         # (the CLI wires it to ``create_session`` with ``args.resume`` mutated)
@@ -870,6 +893,14 @@ class OperatorApp(App[None]):
         # commands; ``None`` degrades /provider /usage /model-switch to
         # pointer notices when it is absent.
         self._providers = provider_controller
+        #: The real theme while a ``/theme`` list preview repaints the screen
+        #: in a candidate ramp; ``None`` when no preview is standing. Stashed
+        #: on the first highlight and spent on close-or-commit, so however the
+        #: list ends the screen is never left wearing a theme nobody chose.
+        self._theme_before_preview: str | None = None
+        #: Whether a markdown ramp is on the console's theme stack, so a theme
+        #: switch pops the previous one instead of stacking forever.
+        self._markdown_theme_pushed = False
         self._session: SessionProtocol | None = None
         self._controller: EventController | None = None
         self._status: StatusLine | None = None
@@ -1313,6 +1344,7 @@ class OperatorApp(App[None]):
         install_markdown_theme()
         try:
             self.console.push_theme(brand_markdown_theme())  # D1 markdown ramp
+            self._markdown_theme_pushed = True
         except Exception:
             pass  # headless consoles without a pushable theme keep defaults
         self.ansi_theme_dark = _brand_terminal_theme()
@@ -6056,6 +6088,8 @@ class OperatorApp(App[None]):
             self._cmd_model(arg, notice)
         elif command == "/effort":
             self._cmd_effort(arg, notice)
+        elif command == "/theme":
+            self._cmd_theme(arg, notice)
         elif command == "/provider":
             self._cmd_providers(notice)
         elif command == "/search":
@@ -6584,6 +6618,205 @@ class OperatorApp(App[None]):
         # `notice`, not `_system_notice`: this one CHANGED something, so it is a
         # receipt for an action rather than an answer about the app's settings.
         notice(f"reasoning effort: {current or 'provider default'} → {wanted} (this session)")
+
+    # -- theme --------------------------------------------------------------
+    def _cmd_theme(self, arg: str, notice: NoticeFn) -> None:
+        """``/theme`` — name the active theme; ``/theme <name>`` — switch to it.
+
+        A switch PERSISTS (``tui.theme`` in config.yml) without a ``default``
+        word, which is where this parts company with ``/model``. A theme is a
+        standing preference by nature — nobody wants their colors reverting at
+        the next launch — and unlike a model it has no cost dimension, so the
+        one-word form does the thing every user means. The receipt says so,
+        because a persisted setting whose persistence is silent looks
+        session-scoped and sends users hunting for a config key.
+
+        A bare ``/theme`` answers with the current theme and points at the
+        space, mirroring ``/approvals``: the LIST (with live preview) is the
+        real browsing surface, and a printed catalogue of thirty names would
+        be the one presentation that cannot show what any of them look like.
+        """
+        wanted = arg.strip().lower()
+        current = theme_mod.current_theme()
+        if not wanted:
+            label = theme_mod.theme_spec(current).label
+            self._system_notice(
+                f"theme: {label} ({current}) — /theme <name> switches; "
+                "space opens the list, arrows preview live"
+            )
+            return
+        try:
+            spec = theme_mod.theme_spec(wanted)
+        except KeyError:
+            self._system_notice(
+                f"unknown theme {wanted!r} — type /theme and space to browse the list",
+                "warning",
+            )
+            return
+        # A no-op switch still ends a live preview: the preview repainted the
+        # screen in the candidate ramp, so "already dark" must put DARK back
+        # rather than leaving the preview's colors standing with a receipt
+        # claiming nothing changed.
+        if spec.name == current and self._theme_before_preview is None:
+            self._system_notice(f"theme: already {spec.label}")
+            return
+        self._theme_before_preview = None
+        self._apply_theme(spec.name)
+        persisted = self._persist_theme(spec.name)
+        if spec.name == current:
+            self._system_notice(f"theme: already {spec.label}")
+        elif persisted is None:
+            notice(f"theme: {current} → {spec.name} (saved as your default)")
+        else:
+            # Switched but not saved: the screen is honest about both halves.
+            notice(f"theme switched, but could not save default: {persisted}", "warning")
+
+    def _persist_theme(self, name: str) -> str | None:
+        """Write ``tui.theme`` to config.yml; the error text on failure.
+
+        The same nested ``tui`` mapping the CLI reads at boot
+        (``tui_config.get("theme", ...)``), merged rather than replaced so a
+        future sibling key survives the write.
+        """
+        try:
+            from local_operator.config import ConfigManager
+            from local_operator.paths import config_dir
+
+            manager = ConfigManager(config_dir())
+            tui_config = manager.get_config_value("tui", None)
+            merged = dict(tui_config) if isinstance(tui_config, dict) else {}
+            merged["theme"] = name
+            manager.set_config_value("tui", merged)
+            return None
+        except Exception as error:  # noqa: BLE001 — reported to the user verbatim
+            return str(error)
+
+    def _apply_theme(self, name: str) -> None:
+        """Switch every rendering surface to ``name``, live.
+
+        One orchestrator, because the theme is spread across four systems that
+        do not watch each other and each has to be told in its own language:
+
+        * the TCSS variables — ``refresh_css`` re-asks ``get_css_variables``
+          and reflows every widget's styles;
+        * the rich console theme — markdown element styles are pushed once at
+          mount, so a switch pushes the new ramp's table on top;
+        * the ANSI terminal theme — ``_brand_terminal_theme`` bakes hexes;
+        * every widget that resolved ``semantic_color`` at build time — the
+          epoch bump plus :meth:`_repaint_themed_widgets` below.
+
+        Bump-then-repaint order matters: caches key on the epoch, so painting
+        first would faithfully reproduce the OLD colors out of every cache.
+        """
+        theme_mod.set_theme(name)
+        try:
+            # Pop the ramp the mount (or the previous switch) pushed before
+            # pushing this one: a preview arrows through dozens of themes, and
+            # push-without-pop grows the console's theme stack by one entry
+            # per row visited for the life of the process.
+            if self._markdown_theme_pushed:
+                self.console.pop_theme()
+            self.console.push_theme(brand_markdown_theme())
+            self._markdown_theme_pushed = True
+        except Exception:
+            pass  # headless consoles without a pushable theme keep defaults
+        self.ansi_theme_dark = _brand_terminal_theme()
+        self.refresh_css(animate=False)
+        self._repaint_themed_widgets()
+
+    def _repaint_themed_widgets(self) -> None:
+        """Re-ink content that resolved its colors at BUILD time.
+
+        The stylesheet pass handles everything painted through TCSS variables,
+        but most transcript content is rich ``Text`` carrying ``Style`` objects
+        resolved from ``semantic_color`` when the block was built — a finalized
+        notice keeps its old ink forever unless rebuilt. Each branch below uses
+        the widget's own existing re-build seam (the same ones ``on_resize``
+        uses), so no block gains a second way to render:
+
+        * every ``TranscriptBlock`` gets :meth:`TranscriptBlock.retheme` —
+          notices, prompts, assistant messages and tool cards each rebuild
+          through their own existing seam; blocks holding pre-rendered
+          content (``RichBlock``) inherit the no-op and keep their ink as
+          history, which is accepted: those listings are receipts of what
+          was shown, and new content takes the new ramp immediately;
+        * the status band re-renders now rather than on its next tick, so an
+          idle band does not keep stale ink until the next turn;
+        * the welcome view re-renders from its reactive state.
+        """
+        from local_operator.tui.widgets.transcript import TranscriptBlock
+
+        for block in self.query(TranscriptBlock):
+            try:
+                block.retheme()
+            except Exception:
+                # One stubborn block must not stop the sweep: the rest of the
+                # screen still deserves the new ramp, and the straggler catches
+                # up on its own next real resize.
+                continue
+        if self._status is not None:
+            try:
+                self._status.refresh()
+            except Exception:
+                pass
+        try:
+            self.query_one(WelcomeView).refresh()
+        except Exception:
+            pass
+
+    def _theme_choices(self) -> list[ArgumentChoice]:
+        """One row per registered theme, the active one marked.
+
+        ``detail`` carries the ACTIVE marker only. The row's description is
+        the one-liner from the spec; the colors themselves are previewed live
+        on the whole screen as the highlight moves, which says more than any
+        swatch a text row could carry.
+        """
+        current = theme_mod.current_theme()
+        return [
+            ArgumentChoice(
+                spec.name,
+                spec.description,
+                detail="← current" if spec.name == current else "",
+            )
+            for spec in (theme_mod.theme_spec(name) for name in theme_mod.available_themes())
+        ]
+
+    def on_argument_highlight_changed(self, message: ArgumentHighlightChanged) -> None:
+        """Live-preview the highlighted theme; restore when the list closes.
+
+        The whole screen IS the swatch: as the user arrows or hovers through
+        ``/theme``'s rows the app paints itself in the candidate ramp, and the
+        first highlight stashes the real theme so Esc, deleting the word, or
+        submitting some other command all land back where the user started.
+        Only ``/theme`` previews — every other argument list reports ``None``
+        command matches and falls through to the restore branch, which is a
+        no-op unless a preview is actually standing.
+        """
+        message.stop()
+        # The editor reports the TYPED word, so the alias resolves here — the
+        # same one-resolver rule `_run_slash_command` documents: `/themes`
+        # must preview exactly as `/theme` does.
+        entry = slash_command_for(f"/{message.command}") if message.command else None
+        resolved = entry.name if entry is not None else message.command
+        if resolved == "theme" and message.name is not None:
+            candidate = message.name.lower()
+            try:
+                theme_mod.theme_spec(candidate)
+            except KeyError:
+                return  # a row that is not a theme name cannot be tried on
+            if self._theme_before_preview is None:
+                self._theme_before_preview = theme_mod.current_theme()
+            if candidate != theme_mod.current_theme():
+                self._apply_theme(candidate)
+            return
+        # List closed or moved off the rows: put the real theme back. `/theme
+        # <name>` clears the stash BEFORE applying, so a submit is not undone.
+        restore = self._theme_before_preview
+        if restore is not None:
+            self._theme_before_preview = None
+            if restore != theme_mod.current_theme():
+                self._apply_theme(restore)
 
     def action_cycle_effort(self) -> None:
         """``shift+tab`` — step one level up this model's ladder, wrapping.
@@ -7781,6 +8014,10 @@ class OperatorApp(App[None]):
             return
         if message.command == "approvals":
             picker.set_choices(self._approval_choices())
+            picker.set_notice("")
+            return
+        if message.command in ("theme", "themes"):
+            picker.set_choices(self._theme_choices())
             picker.set_notice("")
             return
         if message.command == "effort":
@@ -9708,28 +9945,36 @@ def _hex_to_rgb(value: str) -> tuple[int, int, int]:
 
 
 def _brand_terminal_theme() -> TerminalTheme:
-    """Map the ANSI palette onto the brand ramp (no Monokai in this house)."""
-    tokens = theme_mod.BRAND_TOKENS["dark"]
+    """Map the ANSI palette onto the ACTIVE ramp's semantic tokens.
+
+    Resolved through ``semantic_color`` rather than ``BRAND_TOKENS[\"dark\"]``
+    so a `/theme` switch re-maps ANSI content too — the mapping is rebuilt by
+    ``_apply_theme`` on every switch. (Historical note: the docstring used to
+    say "no Monokai in this house"; Monokai is now a registered guest, but
+    only when asked for by name.)
+    """
+    color = theme_mod.semantic_color
     ansi = [
-        tokens["bg"],
-        tokens["danger"],
-        tokens["accent"],
-        tokens["amber"],
-        tokens["fg"],
-        tokens["muted"],
-        tokens["dim"],
-        tokens["edge"],
+        color("bg"),
+        color("danger"),
+        color("accent"),
+        color("warning"),
+        color("fg"),
+        color("muted"),
+        color("dim"),
+        color("edge"),
     ]
     bright = [
-        tokens["string"],
-        tokens["danger"],
-        tokens["accent"],
-        tokens["amber"],
-        tokens["fg"],
-        tokens["muted"],
-        tokens["dim"],
-        tokens["surface"],
+        color("string"),
+        color("danger"),
+        color("accent"),
+        color("warning"),
+        color("fg"),
+        color("muted"),
+        color("dim"),
+        color("surface"),
     ]
+    tokens = {"bg": color("bg"), "fg": color("fg")}
     return TerminalTheme(
         _hex_to_rgb(tokens["bg"]),
         _hex_to_rgb(tokens["fg"]),

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -6865,13 +6865,14 @@ class OperatorApp(App[None]):
             if restore != theme_mod.current_theme():
                 self._apply_theme(restore)
             elif painted:
-                # The browse ended ON the real theme (arrowed away and back
-                # home). No switch to make, but the previews left offscreen
-                # blocks in a candidate ramp's ink (`preview=True` skips
-                # them), so the settle sweep still runs. `theme_epoch` is
-                # unchanged along this path, which is exactly why the sweep
-                # must be explicit rather than left to epoch-keyed caches. A
-                # list that never painted (opened, closed) skips it entirely.
+                # The browse ended ON the real theme, reached by arrowing
+                # back home — which re-applied it via the preview path, so
+                # `current_theme` is already right but offscreen blocks were
+                # skipped by every one of those bounded sweeps. The explicit
+                # full sweep here is what corrects them; epoch-keyed caches
+                # alone cannot, because a cache is only consulted when its
+                # block repaints, and nothing else repaints an offscreen
+                # block. A list that never painted (opened, closed) skips it.
                 self._repaint_themed_widgets()
 
     def action_cycle_effort(self) -> None:

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -901,6 +901,11 @@ class OperatorApp(App[None]):
         #: Whether a markdown ramp is on the console's theme stack, so a theme
         #: switch pops the previous one instead of stacking forever.
         self._markdown_theme_pushed = False
+        #: True once a preview has actually painted a candidate ramp — i.e.
+        #: offscreen blocks may be wearing skipped ink. It is what lets the
+        #: settle path skip the full sweep for a list that was opened and
+        #: closed without ever moving off the current theme.
+        self._theme_preview_painted = False
         self._session: SessionProtocol | None = None
         self._controller: EventController | None = None
         self._status: StatusLine | None = None
@@ -6661,6 +6666,9 @@ class OperatorApp(App[None]):
             self._system_notice(f"theme: already {spec.label}")
             return
         self._theme_before_preview = None
+        # A commit is a settle: the full sweep below covers whatever the
+        # preview skipped, so the painted flag is spent here too.
+        self._theme_preview_painted = False
         self._apply_theme(spec.name)
         persisted = self._persist_theme(spec.name)
         if spec.name == current:
@@ -6691,7 +6699,7 @@ class OperatorApp(App[None]):
         except Exception as error:  # noqa: BLE001 — reported to the user verbatim
             return str(error)
 
-    def _apply_theme(self, name: str) -> None:
+    def _apply_theme(self, name: str, *, preview: bool = False) -> None:
         """Switch every rendering surface to ``name``, live.
 
         One orchestrator, because the theme is spread across four systems that
@@ -6707,14 +6715,32 @@ class OperatorApp(App[None]):
 
         Bump-then-repaint order matters: caches key on the epoch, so painting
         first would faithfully reproduce the OLD colors out of every cache.
+
+        ``preview=True`` bounds the cost for the browsing path (review round 1,
+        F1). A full switch re-inks EVERY transcript block, which is linear in
+        session length — measured at ~219 ms on a 120-block transcript, ~152 ms
+        of it the sweep — and the preview pays this on every arrow key. A
+        preview therefore re-inks only the blocks whose rows are actually on
+        screen (the only ones a preview can show anybody) and leaves the rest
+        wearing the old ramp; they are corrected by the FULL sweep that runs
+        when the preview settles — every preview ends in a commit
+        (``_cmd_theme``) or a restore (``on_argument_highlight_changed``), and
+        both call this with ``preview=False``. Blocks scrolled INTO view
+        mid-preview still self-correct: their next rebuild (resize, expand)
+        reads the current theme, and the settle sweep is never more than one
+        keystroke away.
         """
         theme_mod.set_theme(name)
         try:
             # Pop the ramp the mount (or the previous switch) pushed before
             # pushing this one: a preview arrows through dozens of themes, and
             # push-without-pop grows the console's theme stack by one entry
-            # per row visited for the life of the process.
+            # per row visited for the life of the process. The flag is cleared
+            # between the two calls so a pop that succeeds followed by a push
+            # that raises cannot leave it claiming a ramp this code never
+            # pushed (F5).
             if self._markdown_theme_pushed:
+                self._markdown_theme_pushed = False
                 self.console.pop_theme()
             self.console.push_theme(brand_markdown_theme())
             self._markdown_theme_pushed = True
@@ -6722,9 +6748,9 @@ class OperatorApp(App[None]):
             pass  # headless consoles without a pushable theme keep defaults
         self.ansi_theme_dark = _brand_terminal_theme()
         self.refresh_css(animate=False)
-        self._repaint_themed_widgets()
+        self._repaint_themed_widgets(visible_only=preview)
 
-    def _repaint_themed_widgets(self) -> None:
+    def _repaint_themed_widgets(self, *, visible_only: bool = False) -> None:
         """Re-ink content that resolved its colors at BUILD time.
 
         The stylesheet pass handles everything painted through TCSS variables,
@@ -6743,10 +6769,19 @@ class OperatorApp(App[None]):
         * the status band re-renders now rather than on its next tick, so an
           idle band does not keep stale ink until the next turn;
         * the welcome view re-renders from its reactive state.
+
+        ``visible_only`` is the preview's cost bound (F1): re-ink only blocks
+        whose rows overlap the transcript viewport — the same predicate the
+        stop notice uses (:meth:`_is_on_screen`) — because a preview can only
+        ever be seen on the rows that are on screen. The settle sweep
+        (``visible_only=False``) still covers everything, so no block keeps
+        preview-skipped ink past the preview's own lifetime.
         """
         from local_operator.tui.widgets.transcript import TranscriptBlock
 
         for block in self.query(TranscriptBlock):
+            if visible_only and not self._is_on_screen(block):
+                continue
             try:
                 block.retheme()
             except Exception:
@@ -6805,18 +6840,39 @@ class OperatorApp(App[None]):
                 theme_mod.theme_spec(candidate)
             except KeyError:
                 return  # a row that is not a theme name cannot be tried on
-            if self._theme_before_preview is None:
-                self._theme_before_preview = theme_mod.current_theme()
+            # Stash only when a preview actually paints (the seeded first
+            # report names the CURRENT theme, which needs no restore and must
+            # not arm one): `current_theme` has not moved yet on the first
+            # differing candidate, so stashing at that moment still records
+            # the user's real theme.
             if candidate != theme_mod.current_theme():
-                self._apply_theme(candidate)
+                if self._theme_before_preview is None:
+                    self._theme_before_preview = theme_mod.current_theme()
+                # `preview=True` bounds the repaint to the visible rows (F1):
+                # this runs per arrow key, and the full-transcript sweep is
+                # deferred to the settle below, which is at most one keystroke
+                # away however the browse ends.
+                self._theme_preview_painted = True
+                self._apply_theme(candidate, preview=True)
             return
         # List closed or moved off the rows: put the real theme back. `/theme
         # <name>` clears the stash BEFORE applying, so a submit is not undone.
         restore = self._theme_before_preview
         if restore is not None:
             self._theme_before_preview = None
+            painted = self._theme_preview_painted
+            self._theme_preview_painted = False
             if restore != theme_mod.current_theme():
                 self._apply_theme(restore)
+            elif painted:
+                # The browse ended ON the real theme (arrowed away and back
+                # home). No switch to make, but the previews left offscreen
+                # blocks in a candidate ramp's ink (`preview=True` skips
+                # them), so the settle sweep still runs. `theme_epoch` is
+                # unchanged along this path, which is exactly why the sweep
+                # must be explicit rather than left to epoch-keyed caches. A
+                # list that never painted (opened, closed) skips it entirely.
+                self._repaint_themed_widgets()
 
     def action_cycle_effort(self) -> None:
         """``shift+tab`` — step one level up this model's ladder, wrapping.
@@ -8017,7 +8073,12 @@ class OperatorApp(App[None]):
             picker.set_notice("")
             return
         if message.command in ("theme", "themes"):
-            picker.set_choices(self._theme_choices())
+            # Seeded on the CURRENT theme's row (F2): the highlight previews
+            # live, so opening the list must not flash the screen to whatever
+            # theme happens to sort first — and a browse naturally starts from
+            # where the user already is, the same landing `/model` gives its
+            # empty query.
+            picker.set_choices(self._theme_choices(), highlight=theme_mod.current_theme())
             picker.set_notice("")
             return
         if message.command == "effort":
@@ -9974,10 +10035,9 @@ def _brand_terminal_theme() -> TerminalTheme:
         color("dim"),
         color("surface"),
     ]
-    tokens = {"bg": color("bg"), "fg": color("fg")}
     return TerminalTheme(
-        _hex_to_rgb(tokens["bg"]),
-        _hex_to_rgb(tokens["fg"]),
+        _hex_to_rgb(color("bg")),
+        _hex_to_rgb(color("fg")),
         [_hex_to_rgb(c) for c in ansi],
         [_hex_to_rgb(c) for c in bright],
     )

--- a/local_operator/tui/palettes/__init__.py
+++ b/local_operator/tui/palettes/__init__.py
@@ -1,0 +1,44 @@
+"""Curated color themes for the Local Operator TUI.
+
+Each submodule holds a family of :class:`~local_operator.tui.theme.ThemeSpec`
+palettes (classic editor schemes, neon/retro, nature-inspired, light ramps).
+They are DATA, deliberately kept out of ``theme.py``: the theme module owns
+the semantic vocabulary and the registry mechanics, and this package owns the
+thirty-odd ramps that speak it. ``theme._registry`` folds these in lazily on
+first lookup, so importing :mod:`local_operator.tui.theme` never pays for the
+palette tables until something actually lists or switches themes.
+
+Every palette must be TOTAL over ``theme.SEMANTIC_TOKENS`` — registration
+rejects a missing or invented token — and must clear the contrast floors
+pinned in ``tests/unit/tui/test_palette_contrast.py``. The floors are derived
+from the brand ramps' own measurements (``fg`` ≥ 7:1 on the ground, ``dim``
+≥ 3:1, state hues ≥ 4:1…), so "readable" is a checked property of every
+theme, not a hope. Authors: run that test, then render the screenshot grid
+(``scripts/theme_preview.py``) and LOOK at the frames before submitting.
+"""
+
+from __future__ import annotations
+
+from local_operator.tui.theme import ThemeSpec
+
+
+def all_palettes() -> list[ThemeSpec]:
+    """Every curated palette, in presentation order (after the brand ramps).
+
+    Order is the picker's row order: classics first because they are the
+    names users arrive knowing, then the neon/retro set, then nature, then
+    the light ramps at the end where a dark-terminal user scrolls past them.
+    """
+    from local_operator.tui.palettes import (  # local: cycle-free at call time
+        classics,
+        lights,
+        nature,
+        neon,
+    )
+
+    return [
+        *classics.PALETTES,
+        *neon.PALETTES,
+        *nature.PALETTES,
+        *lights.PALETTES,
+    ]

--- a/local_operator/tui/palettes/classics.py
+++ b/local_operator/tui/palettes/classics.py
@@ -55,4 +55,368 @@ PALETTES: list[ThemeSpec] = [
             "tint-attach-hi": "#33506b",
         },
     ),
+    # Dracula — draculatheme.com/spec. The published accents are all loud
+    # enough for the state tokens (green 10.4:1, cyan 10.3:1, orange 8.4:1),
+    # so fidelity is easy up top; the work is the TEXT ramp: canonical
+    # comment #6272a4 is only 3.03:1 on the bg, far under the 4.5 muted
+    # floor, so it lands on `faint` (its real role — inert hints) and
+    # muted/dim are solved along the same blue-slate hue. Purple is the
+    # signature (accent), pink takes the violet-ish `label` slot since
+    # purple is spent, and `overlay` is the canonical current-line #44475a.
+    ThemeSpec(
+        name="dracula",
+        label="Dracula",
+        description="Purple-on-slate night with the famous pink and cyan",
+        dark=True,
+        tokens={
+            "bg": "#282a36",
+            "surface": "#2f323f",
+            "raised": "#363948",
+            "overlay": "#44475a",  # canonical "current line"
+            "sunken": "#1e2029",
+            "fg": "#f8f8f2",  # canonical foreground
+            "muted": "#b6bdda",  # solved: comment #6272a4 is 3.03:1 (< 4.5)
+            "dim": "#7b89bd",  # comment hue, lifted to clear 3.4:1
+            "faint": "#6272a4",  # canonical comment — the inert-hint rung
+            "edge": "#3d4152",
+            "edge-hi": "#4d5268",
+            "accent": "#bd93f9",  # canonical purple — THE Dracula color
+            "success": "#50fa7b",
+            "warning": "#ffb86c",
+            "danger": "#ff5555",
+            "string": "#50fa7b",
+            "signal": "#8be9fd",  # canonical cyan
+            "label": "#ff79c6",  # canonical pink; purple is spent on accent
+            "tint-danger": "#3c2632",
+            "tint-select": "#2f2a44",  # purple cast — selection wears the accent hue
+            "tint-select-hi": "#373254",
+            "tint-attach": "#263a4a",
+            "tint-attach-hi": "#345670",
+        },
+    ),
+    # Catppuccin Mocha — catppuccin.com/palette. The pastels are generous
+    # (every state hue clears 7:1 on base), and the palette even supplies
+    # the ground ramp: sunken = canonical mantle, overlay = surface0,
+    # edge-hi = surface1, and the text ladder is canonical text/subtext0/
+    # overlay1/overlay0 verbatim. Mauve is the brand's own signature color;
+    # lavender takes `label`, blue takes `signal`.
+    ThemeSpec(
+        name="catppuccin-mocha",
+        label="Catppuccin Mocha",
+        description="Soothing pastels on a soft charcoal-blue base",
+        dark=True,
+        tokens={
+            "bg": "#1e1e2e",  # canonical base
+            "surface": "#262637",
+            "raised": "#2d2d40",
+            "overlay": "#313244",  # canonical surface0
+            "sunken": "#181825",  # canonical mantle
+            "fg": "#cdd6f4",  # canonical text
+            "muted": "#a6adc8",  # canonical subtext0
+            "dim": "#7f849c",  # canonical overlay1
+            "faint": "#6c7086",  # canonical overlay0
+            "edge": "#363653",
+            "edge-hi": "#45475a",  # canonical surface1
+            "accent": "#cba6f7",  # canonical mauve — Catppuccin's signature
+            "success": "#a6e3a1",  # canonical green
+            "warning": "#fab387",  # canonical peach
+            "danger": "#f38ba8",  # canonical red
+            "string": "#a6e3a1",
+            "signal": "#89b4fa",  # canonical blue
+            "label": "#b4befe",  # canonical lavender
+            "tint-danger": "#332434",
+            "tint-select": "#28283e",
+            "tint-select-hi": "#2e2e49",
+            "tint-attach": "#213048",
+            "tint-attach-hi": "#2d4568",
+        },
+    ),
+    # Catppuccin Latte — the light flavor. Elevation DARKENS upward (paper →
+    # deeper cards), mirroring the brand light ramp's solve; `sunken` is the
+    # canonical mantle, which sits just below the paper. Latte's published
+    # accents are tuned for syntax at large sizes, not one-word UI states,
+    # and several fail the 4:1 state floor on this paper: green #40a02b is
+    # 2.96:1, yellow #df8e1d 2.31:1, lavender #7287fd 2.81:1. Each is
+    # darkened along its own hue until it clears both grounds (green →
+    # #2e7a1e, yellow → #8f6203, lavender → #5265d8). Canonical text
+    # #4c4f69 also thins to 6.64:1 on the first elevation step, under the
+    # 7:1 body floor, so fg deepens slightly to #42455f.
+    ThemeSpec(
+        name="catppuccin-latte",
+        label="Catppuccin Latte",
+        description="The Catppuccin pastels poured over warm morning paper",
+        dark=False,
+        tokens={
+            "bg": "#eff1f5",  # canonical base
+            "surface": "#e8eaf0",
+            "raised": "#dfe2ea",
+            "overlay": "#d3d7e3",
+            "sunken": "#e6e9ef",  # canonical mantle — the band below the paper
+            "fg": "#42455f",  # canonical text #4c4f69: 6.64:1 on surface (< 7)
+            "muted": "#5c5f77",  # canonical subtext1
+            "dim": "#787c92",
+            "faint": "#9ca0b0",  # canonical overlay0
+            "edge": "#dcdfe8",
+            "edge-hi": "#bcc0cc",  # canonical surface1
+            "accent": "#8839ef",  # canonical mauve
+            "success": "#2e7a1e",  # canonical green #40a02b: 2.96:1 (< 4)
+            "warning": "#8f6203",  # canonical yellow #df8e1d: 2.31:1 (< 4)
+            "danger": "#d20f39",  # canonical red — clears at 4.80:1
+            "string": "#2e7a1e",
+            "signal": "#1e66f5",  # canonical blue
+            "label": "#5265d8",  # canonical lavender #7287fd: 2.81:1 (< 4)
+            "tint-danger": "#f6dfe1",
+            "tint-select": "#e4ecf9",
+            "tint-select-hi": "#d5e2f6",
+            "tint-attach": "#e3ecfb",
+            "tint-attach-hi": "#c8daf6",
+        },
+    ),
+    # Tokyo Night — github.com/tokyo-night. The published night variant
+    # supplies most of the ramp verbatim: bg_dark #16161e is `sunken`,
+    # fg_gutter #3b4261 is `edge-hi`, comment #565f89 (2.76:1) is `faint`,
+    # and the state row is the canonical red/yellow/green/blue/magenta.
+    # Blue is the theme's identity, so it takes accent; cyan #7dcfff is the
+    # link/file `signal`. `dim` is canonical dark5 #737aa2, which clears
+    # the floor here (3.78:1 on surface) though not on storm's ground.
+    ThemeSpec(
+        name="tokyo-night",
+        label="Tokyo Night",
+        description="Neon-lit indigo night, the VS Code favourite",
+        dark=True,
+        tokens={
+            "bg": "#1a1b26",  # canonical bg
+            "surface": "#20222f",
+            "raised": "#262939",
+            "overlay": "#2f334d",
+            "sunken": "#16161e",  # canonical bg_dark
+            "fg": "#c0caf5",  # canonical fg
+            "muted": "#a9b1d6",  # canonical fg_dark
+            "dim": "#737aa2",  # canonical dark5
+            "faint": "#565f89",  # canonical comment
+            "edge": "#2c3045",
+            "edge-hi": "#3b4261",  # canonical fg_gutter
+            "accent": "#7aa2f7",  # canonical blue — the theme's identity
+            "success": "#9ece6a",  # canonical green
+            "warning": "#e0af68",  # canonical yellow
+            "danger": "#f7768e",  # canonical red
+            "string": "#9ece6a",
+            "signal": "#7dcfff",  # canonical cyan
+            "label": "#bb9af7",  # canonical magenta
+            "tint-danger": "#2f222f",
+            "tint-select": "#1f2837",  # blue cast — selection wears the accent
+            "tint-select-hi": "#253044",
+            "tint-attach": "#1d2f42",
+            "tint-attach-hi": "#2c4a67",
+        },
+    ),
+    # Tokyo Night Storm — the same city, one shade before dark: canonical
+    # storm bg #24283b with the identical accent row (the variants share
+    # their hues by design). The lighter ground costs contrast everywhere,
+    # so the text ladder re-solves: dark5 #737aa2 drops to 3.34:1 on the
+    # surface step (< 3.4) and lifts to #7e86b0; comment #565f89 still
+    # reads as `faint`. Tints are brighter than night's to stay visible
+    # casts against the lighter ground.
+    ThemeSpec(
+        name="tokyo-night-storm",
+        label="Tokyo Night Storm",
+        description="Tokyo Night's softer storm-blue ground",
+        dark=True,
+        tokens={
+            "bg": "#24283b",  # canonical storm bg
+            "surface": "#2b3048",
+            "raised": "#333955",
+            "overlay": "#3d4466",
+            "sunken": "#1d2032",
+            "fg": "#c0caf5",  # canonical fg
+            "muted": "#a9b1d6",  # canonical fg_dark
+            "dim": "#7e86b0",  # canonical dark5 #737aa2: 3.34:1 on surface (< 3.4)
+            "faint": "#565f89",  # canonical comment
+            "edge": "#363c58",
+            "edge-hi": "#454c70",
+            "accent": "#7aa2f7",
+            "success": "#9ece6a",
+            "warning": "#e0af68",
+            "danger": "#f7768e",
+            "string": "#9ece6a",
+            "signal": "#7dcfff",
+            "label": "#bb9af7",
+            "tint-danger": "#3a2c3d",
+            "tint-select": "#283349",
+            "tint-select-hi": "#2e3c55",
+            "tint-attach": "#263a52",
+            "tint-attach-hi": "#365478",
+        },
+    ),
+    # Gruvbox (dark, medium) — github.com/morhetz/gruvbox. Ground and text
+    # ladders are canonical throughout: bg0 #282828, bg0_h #1d2021 as
+    # `sunken`, bg1/bg2 as edge/edge-hi, fg1/fg3/gray/bg3+ as the text
+    # rungs. Yellow is gruvbox's face (the logo, the cursor line numbers),
+    # so it takes accent and bright orange takes warning — they sit far
+    # enough apart (8.7:1 vs 5.8:1, yellow vs orange hue) to never merge.
+    # Bright red #fb4934 measures 3.97:1 on the surface step — a hair under
+    # the 4:1 state floor — so danger is #fb4f3e, the same red warmed one
+    # step (4.42:1 bg, 4.09:1 surface), still unmistakably gruvbox red.
+    ThemeSpec(
+        name="gruvbox",
+        label="Gruvbox",
+        description="Retro groove — warm bread-crust browns and hard yellows",
+        dark=True,
+        tokens={
+            "bg": "#282828",  # canonical bg0
+            "surface": "#302d2c",
+            "raised": "#3c3836",  # canonical bg1
+            "overlay": "#46403d",
+            "sunken": "#1d2021",  # canonical bg0_h (hard contrast bg)
+            "fg": "#ebdbb2",  # canonical fg1
+            "muted": "#bdae93",  # canonical fg3
+            "dim": "#928374",  # canonical gray
+            "faint": "#665c54",  # canonical bg3
+            "edge": "#3c3836",  # canonical bg1
+            "edge-hi": "#504945",  # canonical bg2
+            "accent": "#fabd2f",  # canonical bright yellow — the gruvbox face
+            "success": "#b8bb26",  # canonical bright green
+            "warning": "#fe8019",  # canonical bright orange
+            # Canonical bright red #fb4934 is 3.97:1 on the surface step,
+            # just under the 4:1 floor; warmed one step to keep the hue.
+            "danger": "#fb4f3e",
+            "string": "#b8bb26",
+            "signal": "#83a598",  # canonical bright blue
+            "label": "#d3869b",  # canonical bright purple
+            "tint-danger": "#3b2723",
+            "tint-select": "#32321c",  # olive cast — gruvbox green is yellow-green
+            "tint-select-hi": "#3b3b21",
+            "tint-attach": "#28353a",
+            "tint-attach-hi": "#3a5158",
+        },
+    ),
+    # Nord — nordtheme.com. Polar Night supplies the ground (nord0 base,
+    # nord1/nord2 as raised/overlay, nord3 as edge-hi) and Frost supplies
+    # the cool accents (nord8 cyan-ice as THE accent, nord9 as signal).
+    # Nord's one real casualty is Aurora red: nord11 #bf616a is 3.05:1 on
+    # nord0 — Nord was designed for syntax, not one-word states — so danger
+    # lifts along the same desaturated rose to #e0838e (4.64:1/4.30:1).
+    # `muted` is a half-step below Snow Storm's nord4 (9.25:1) so the
+    # secondary rung stays clearly secondary to fg (10.84:1).
+    ThemeSpec(
+        name="nord",
+        label="Nord",
+        description="Arctic bluish calm — frost accents on polar night",
+        dark=True,
+        tokens={
+            "bg": "#2e3440",  # canonical nord0
+            "surface": "#333947",
+            "raised": "#3b4252",  # canonical nord1
+            "overlay": "#434c5e",  # canonical nord2
+            "sunken": "#272c36",
+            "fg": "#eceff4",  # canonical nord6
+            "muted": "#c8cfdd",  # nord4 #d8dee9 is 9.25:1 — too close to fg's rung
+            "dim": "#8b96ab",
+            "faint": "#616e88",
+            "edge": "#3b4252",  # canonical nord1
+            "edge-hi": "#4c566a",  # canonical nord3
+            "accent": "#88c0d0",  # canonical nord8 — Nord's primary frost
+            "success": "#a3be8c",  # canonical nord14
+            "warning": "#ebcb8b",  # canonical nord13
+            # Canonical nord11 #bf616a measures 3.05:1 on nord0 (< 4);
+            # lifted along the same muted rose.
+            "danger": "#e0838e",
+            "string": "#a3be8c",
+            "signal": "#81a1c1",  # canonical nord9
+            "label": "#b48ead",  # canonical nord15
+            "tint-danger": "#3d323c",
+            "tint-select": "#2e3d40",  # frost-teal cast
+            "tint-select-hi": "#354a4e",
+            "tint-attach": "#2b3b4e",
+            "tint-attach-hi": "#3d5673",
+        },
+    ),
+    # One Dark — Atom's default (atom/one-dark-syntax). The accent row is
+    # canonical: blue #61afef (Atom's identity hue) as accent, cyan as
+    # signal, purple as label, and the red/green/yellow triple verbatim.
+    # The text ladder needs the solve: canonical fg #abb2bf is 6.57:1 on
+    # the bg — under the 7:1 body floor — so fg lifts along the same cool
+    # gray to #bec4d0, and muted/dim step down from it; canonical comment
+    # #5c6370 (2.32:1) is exactly the `faint` rung.
+    ThemeSpec(
+        name="one-dark",
+        label="One Dark",
+        description="Atom's cool gray-blue standard, steady and unflashy",
+        dark=True,
+        tokens={
+            "bg": "#282c34",  # canonical bg
+            "surface": "#2d3139",
+            "raised": "#333842",
+            "overlay": "#3b414d",
+            "sunken": "#21252b",
+            # Canonical fg #abb2bf is 6.57:1 on bg (< 7); lifted on-hue.
+            "fg": "#bec4d0",
+            "muted": "#9aa2b0",
+            "dim": "#7d8695",
+            "faint": "#5c6370",  # canonical comment
+            "edge": "#3a3f4b",
+            "edge-hi": "#4b5263",  # canonical visual/gutter gray
+            "accent": "#61afef",  # canonical blue — Atom's identity
+            "success": "#98c379",  # canonical green
+            "warning": "#e5c07b",  # canonical yellow
+            "danger": "#e06c75",  # canonical red
+            "string": "#98c379",
+            "signal": "#56b6c2",  # canonical cyan
+            "label": "#c678dd",  # canonical purple
+            "tint-danger": "#362a31",
+            "tint-select": "#28333c",  # blue cast
+            "tint-select-hi": "#2e3c47",
+            "tint-attach": "#263647",
+            "tint-attach-hi": "#375069",
+        },
+    ),
+    # Solarized Dark — ethanschoonover.com/solarized. Solarized's precise
+    # CIELAB symmetry predates UI-state contrast floors, and it shows: on
+    # base03 the canonical red #dc322f is 3.25:1, orange #cb4b16 3.26:1,
+    # magenta 3.30:1, violet 3.43:1, and blue #268bd2 drops to 3.79:1 on
+    # the surface step. The passing hues stay canonical (yellow, green,
+    # cyan — cyan is THE solarized accent); the failing ones lift along
+    # their own hue by the minimum that clears both grounds: red →
+    # #ea5b52, blue → #3a9ae0, violet → #8489d4. The text ladder keeps
+    # base0 #839496 as `muted` a hair brightened (#87999b, base0 is
+    # 4.41:1 on surface) and base01 as `faint`; body fg is base1 pushed
+    # one step (canonical #93a1a1 is 5.61:1, under the 7:1 floor).
+    ThemeSpec(
+        name="solarized-dark",
+        label="Solarized Dark",
+        description="The deep teal lab classic, sixteen colors of discipline",
+        dark=True,
+        tokens={
+            "bg": "#002b36",  # canonical base03
+            "surface": "#00313d",
+            "raised": "#073642",  # canonical base02
+            "overlay": "#0e3d4a",
+            "sunken": "#00252e",
+            # Canonical base1 #93a1a1 is 5.61:1 on base03 (< 7); lifted on-hue.
+            "fg": "#b1bcbc",
+            # Canonical base0 #839496 is 4.41:1 on the surface step (< 4.5).
+            "muted": "#87999b",
+            "dim": "#69838c",
+            "faint": "#586e75",  # canonical base01
+            "edge": "#0b3844",
+            "edge-hi": "#16454f",
+            "accent": "#2aa198",  # canonical cyan — solarized's signature
+            "success": "#859900",  # canonical green
+            "warning": "#b58900",  # canonical yellow
+            # Canonical red #dc322f is 3.25:1 on base03 (< 4); lifted on-hue.
+            "danger": "#ea5b52",
+            "string": "#859900",
+            # Canonical blue #268bd2 is 3.79:1 on the surface step (< 4).
+            "signal": "#3a9ae0",
+            # Canonical violet #6c71c4 is 3.43:1 on base03 (< 4).
+            "label": "#8489d4",
+            # A maroon-leaning cast: on solarized's cool teal ground, a
+            # neutral-red mix reads as plain gray, so the red channel leads.
+            "tint-danger": "#3a2c32",
+            "tint-select": "#0a3538",  # cyan cast
+            "tint-select-hi": "#0f4044",
+            "tint-attach": "#0b3547",
+            "tint-attach-hi": "#134e64",
+        },
+    ),
 ]

--- a/local_operator/tui/palettes/classics.py
+++ b/local_operator/tui/palettes/classics.py
@@ -1,0 +1,58 @@
+"""Classic editor color schemes, mapped onto the Local Operator token set.
+
+These are the names users arrive already knowing — Monokai, Dracula,
+Catppuccin, Tokyo Night, Gruvbox, Nord, Solarized, One Dark — so fidelity to
+the published palettes matters more here than in the invented families: the
+hues people recognise (Dracula's purple, Monokai's pink) must land on the
+tokens where they are most visible (``danger``, ``label``, ``accent``), while
+the GROUND ramp (bg → surface → raised → overlay, with ``sunken`` below) is
+solved per theme because none of the source palettes define five elevation
+steps. Elevation steps follow the brand ramp's own proportions: each step is
+a just-visible lift (~1.1–1.3:1 against the last), never a slab.
+
+Every palette must clear the contrast floors in
+``tests/unit/tui/test_palette_contrast.py``; run that file after any tweak,
+then render ``scripts/theme_preview.py`` and look at the frames.
+"""
+
+from __future__ import annotations
+
+from local_operator.tui.theme import ThemeSpec
+
+PALETTES: list[ThemeSpec] = [
+    ThemeSpec(
+        name="monokai",
+        label="Monokai",
+        description="The classic warm-charcoal editor scheme",
+        dark=True,
+        tokens={
+            "bg": "#272822",
+            "surface": "#30312a",
+            "raised": "#383931",
+            "overlay": "#40413a",
+            "sunken": "#1d1e19",
+            "fg": "#f8f8f2",
+            "muted": "#c8c8c0",
+            "dim": "#90918b",
+            "faint": "#5a5b55",
+            "edge": "#48493f",
+            "edge-hi": "#5c5d50",
+            "accent": "#a6e22e",
+            "success": "#a6e22e",
+            "warning": "#fd971f",
+            # Monokai Pro's red rather than classic #f92672: the classic pink
+            # measures 3.47:1 on this surface — under the 4:1 state floor —
+            # and the Pro revision solved exactly this legibility problem
+            # while keeping the hue recognisably "Monokai pink".
+            "danger": "#ff6188",
+            "signal": "#66d9ef",
+            "label": "#ae81ff",
+            "string": "#a6e22e",
+            "tint-danger": "#3a2429",
+            "tint-select": "#2c3624",
+            "tint-select-hi": "#333f2a",
+            "tint-attach": "#263644",
+            "tint-attach-hi": "#33506b",
+        },
+    ),
+]

--- a/local_operator/tui/palettes/classics.py
+++ b/local_operator/tui/palettes/classics.py
@@ -37,8 +37,14 @@ PALETTES: list[ThemeSpec] = [
             "faint": "#5a5b55",
             "edge": "#48493f",
             "edge-hi": "#5c5d50",
+            # The signature Monokai green is spent on ACCENT alone (review
+            # round 1, D2): with success and string on the same hex, a link,
+            # a ✓ and a quoted literal were one indistinguishable ink.
+            # Success takes a calmer leaf green (7.4:1 on bg) and string takes
+            # canonical Monokai's own string yellow #e6db74 — which is what
+            # the source palette actually paints literals with.
             "accent": "#a6e22e",
-            "success": "#a6e22e",
+            "success": "#98c379",
             "warning": "#fd971f",
             # Monokai Pro's red rather than classic #f92672: the classic pink
             # measures 3.47:1 on this surface — under the 4:1 state floor —
@@ -47,7 +53,7 @@ PALETTES: list[ThemeSpec] = [
             "danger": "#ff6188",
             "signal": "#66d9ef",
             "label": "#ae81ff",
-            "string": "#a6e22e",
+            "string": "#e6db74",  # canonical Monokai string yellow (see accent note)
             "tint-danger": "#3a2429",
             "tint-select": "#2c3624",
             "tint-select-hi": "#333f2a",
@@ -182,7 +188,7 @@ PALETTES: list[ThemeSpec] = [
     ThemeSpec(
         name="tokyo-night",
         label="Tokyo Night",
-        description="Neon-lit indigo night, the VS Code favourite",
+        description="Neon-lit indigo night, the VS Code favorite",
         dark=True,
         tokens={
             "bg": "#1a1b26",  # canonical bg
@@ -260,7 +266,7 @@ PALETTES: list[ThemeSpec] = [
     ThemeSpec(
         name="gruvbox",
         label="Gruvbox",
-        description="Retro groove — warm bread-crust browns and hard yellows",
+        description="Retro groove, warm bread-crust browns and hard yellows",
         dark=True,
         tokens={
             "bg": "#282828",  # canonical bg0
@@ -301,7 +307,7 @@ PALETTES: list[ThemeSpec] = [
     ThemeSpec(
         name="nord",
         label="Nord",
-        description="Arctic bluish calm — frost accents on polar night",
+        description="Arctic bluish calm, frost accents on polar night",
         dark=True,
         tokens={
             "bg": "#2e3440",  # canonical nord0
@@ -384,7 +390,7 @@ PALETTES: list[ThemeSpec] = [
     ThemeSpec(
         name="solarized-dark",
         label="Solarized Dark",
-        description="The deep teal lab classic, sixteen colors of discipline",
+        description="The deep teal lab classic, 16-color discipline",
         dark=True,
         tokens={
             "bg": "#002b36",  # canonical base03
@@ -412,7 +418,11 @@ PALETTES: list[ThemeSpec] = [
             "label": "#8489d4",
             # A maroon-leaning cast: on solarized's cool teal ground, a
             # neutral-red mix reads as plain gray, so the red channel leads.
-            "tint-danger": "#3a2c32",
+            # Darker than the first solve (#3a2c32, where the lifted red read
+            # 3.86:1 — under the 4.0 state floor; review round 1, D1). Sunk
+            # toward base03 with the maroon lead kept so the band still says
+            # "failed" rather than reading as a neutral elevation step.
+            "tint-danger": "#2a2028",
             "tint-select": "#0a3538",  # cyan cast
             "tint-select-hi": "#0f4044",
             "tint-attach": "#0b3547",

--- a/local_operator/tui/palettes/lights.py
+++ b/local_operator/tui/palettes/lights.py
@@ -1,0 +1,19 @@
+"""Light themes beyond the brand paper ramp.
+
+Light ramps invert every decision the dark ones make: elevation lifts
+TOWARD white instead of away from black, state hues need to be darker
+rather than brighter to hold contrast, and the tint grounds (``tint-*``)
+sit just below the paper rather than just above the night. The brand
+``light`` ramp in ``theme.py`` is the reference solve — mirror its
+relationships, not its hexes.
+
+Every palette must clear ``tests/unit/tui/test_palette_contrast.py``
+(``dark=False`` flips the polarity checks) and be inspected as rendered
+frames via ``scripts/theme_preview.py``.
+"""
+
+from __future__ import annotations
+
+from local_operator.tui.theme import ThemeSpec
+
+PALETTES: list[ThemeSpec] = []

--- a/local_operator/tui/palettes/lights.py
+++ b/local_operator/tui/palettes/lights.py
@@ -72,7 +72,11 @@ PALETTES: list[ThemeSpec] = [
             "danger": "#dc322f",  # red, CANONICAL — it already clears 4:1
             "signal": "#0e8074",  # cyan, darkened from canonical #2aa198 (2.93:1)
             "label": "#5f64bb",  # violet, darkened from canonical #6c71c4 (3.57:1 surf)
-            "tint-danger": "#f6e0d2",  # warm wash toward red on base3
+            # Lighter than the first solve (#f6e0d2, where canonical red read
+            # 3.64:1 — under the 4.0 state floor on the one band that always
+            # carries it; review round 1, D1). Pulled toward base3 so the wash
+            # stays warm while the red clears 4.1:1.
+            "tint-danger": "#fcefe6",
             "tint-select": "#eaefd2",  # green-leaning cast (selection = the green family)
             "tint-select-hi": "#e0e7c2",
             "tint-attach": "#e4ecec",  # cool cyan cast — signal is the file hue
@@ -127,7 +131,7 @@ PALETTES: list[ThemeSpec] = [
     ThemeSpec(
         name="paper",
         label="Paper",
-        description="Warm cream and brown ink — an open book in good light",
+        description="Warm cream and brown ink, an open book in good light",
         dark=False,
         tokens={
             "bg": "#f9f3e6",
@@ -206,7 +210,7 @@ PALETTES: list[ThemeSpec] = [
     ThemeSpec(
         name="high-contrast-light",
         label="High Contrast Light",
-        description="Ink on near-white, every state 6:1+ — built for legibility",
+        description="Ink on near-white, every state 6:1+, built for legibility",
         dark=False,
         tokens={
             "bg": "#fcfcfc",

--- a/local_operator/tui/palettes/lights.py
+++ b/local_operator/tui/palettes/lights.py
@@ -7,6 +7,23 @@ sit just below the paper rather than just above the night. The brand
 ``light`` ramp in ``theme.py`` is the reference solve — mirror its
 relationships, not its hexes.
 
+Family-wide solves this file repeats per theme:
+
+- The elevation ladder darkens upward (bg > surface > raised > overlay in
+  luminance) in the brand light ramp's proportions — each step a
+  just-visible ~1.06–1.14:1 lift, never a slab — and ``sunken`` stays at
+  or just below the paper (light polarity has no deep well to sink into;
+  the brand ramp's own sunken is only 1.20:1 off the paper).
+- State hues must be DARK: a hue that clears 4:1 on a near-black ground
+  arrives at ~2–3:1 on paper, so every state here is re-solved downward
+  until it measures >= 4:1 on BOTH grounds while staying recognisably
+  itself (red, amber, green, blue, violet stay five distinct hues).
+- ``fg`` is a near-neutral ink tinted toward the paper's temperature
+  (warm ink on cream, cool ink on linen); saturation lives in the state
+  hues and the tints, never in body text.
+- Tints sit just below the paper's luminance (< 2.2:1 vs bg) so a state
+  ground reads as a wash on the page, not a highlighter stripe.
+
 Every palette must clear ``tests/unit/tui/test_palette_contrast.py``
 (``dark=False`` flips the polarity checks) and be inspected as rendered
 frames via ``scripts/theme_preview.py``.
@@ -16,4 +33,244 @@ from __future__ import annotations
 
 from local_operator.tui.theme import ThemeSpec
 
-PALETTES: list[ThemeSpec] = []
+PALETTES: list[ThemeSpec] = [
+    # Solarized Light — Ethan Schoonover's published values wherever they
+    # clear the floors. The grounds ARE canonical: bg=base3, raised=base2,
+    # fg=base02, muted=base01, dim=base00, faint=base1; surface/overlay are
+    # interpolated between base3 and base2 (Solarized defines only two
+    # ground steps, this UI needs five). The accent CONTENT hues are where
+    # Solarized famously trades contrast for calm, so several miss the 4:1
+    # state floor on base3 and are darkened minimally along their own hue:
+    #   - blue    #268bd2 measures 3.41:1 -> #1c6ea4 (same hue, darker)
+    #   - green   #859900 measures 2.97:1 -> #657600
+    #   - yellow  #b58900 measures 2.98:1 -> #8a6800
+    #   - cyan    #2aa198 measures 2.93:1 -> #0e8074
+    #   - violet  #6c71c4 measures 3.57:1 on surface -> #5f64bb
+    # red #dc322f is canonical (4.29:1/4.06:1 — the only content hue
+    # Schoonover pushed dark enough), which is exactly why danger keeps it.
+    ThemeSpec(
+        name="solarized-light",
+        label="Solarized Light",
+        description="Schoonover's sunlit base3 paper, the classic 16-color science",
+        dark=False,
+        tokens={
+            "bg": "#fdf6e3",  # base3, canonical
+            "surface": "#f6f0dd",  # base3->base2 midpoint (Solarized has no step here)
+            "raised": "#eee8d5",  # base2, canonical
+            "overlay": "#e2dbc1",  # one just-visible step past base2
+            "sunken": "#f5eed9",  # a hair below base3 — light polarity has no well
+            "fg": "#073642",  # base02, canonical (12.05:1)
+            "muted": "#586e75",  # base01, canonical
+            "dim": "#657b83",  # base00, canonical (4.13:1 — Solarized's own body color)
+            "faint": "#93a1a1",  # base1, canonical
+            "edge": "#e6dfc8",
+            "edge-hi": "#d5cdae",
+            "accent": "#1c6ea4",  # blue, darkened from canonical #268bd2 (3.41:1)
+            "success": "#657600",  # green, darkened from canonical #859900 (2.97:1)
+            "string": "#657600",
+            "warning": "#8a6800",  # yellow, darkened from canonical #b58900 (2.98:1)
+            "danger": "#dc322f",  # red, CANONICAL — it already clears 4:1
+            "signal": "#0e8074",  # cyan, darkened from canonical #2aa198 (2.93:1)
+            "label": "#5f64bb",  # violet, darkened from canonical #6c71c4 (3.57:1 surf)
+            "tint-danger": "#f6e0d2",  # warm wash toward red on base3
+            "tint-select": "#eaefd2",  # green-leaning cast (selection = the green family)
+            "tint-select-hi": "#e0e7c2",
+            "tint-attach": "#e4ecec",  # cool cyan cast — signal is the file hue
+            "tint-attach-hi": "#cfe0e6",
+        },
+    ),
+    # GitHub Light — Primer's published light scale, used verbatim: every
+    # hex below is a Primer token (canvas, canvas-subtle, fg-default,
+    # fg-muted, border-default, the fg-role state colors, and the
+    # attention/danger/accent subtle backgrounds as tints). GitHub solved
+    # 4.5:1 on white for all of these, so nothing needed darkening — the
+    # only editorial choice is signal=#0550ae (Primer blue-7, the syntax
+    # constant blue) so links/files stay GitHub-blue without collapsing
+    # into the #0969da accent that carries focus.
+    ThemeSpec(
+        name="github-light",
+        label="GitHub Light",
+        description="Clean Primer white with GitHub's own state colors",
+        dark=False,
+        tokens={
+            "bg": "#ffffff",  # canvas.default
+            "surface": "#f6f8fa",  # canvas.subtle
+            "raised": "#eaeef2",  # neutral.subtle step
+            "overlay": "#dde2e8",
+            "sunken": "#f0f3f7",
+            "fg": "#1f2328",  # fg.default
+            "muted": "#59626c",  # fg.muted, nudged for the 4.5 floor on surface
+            "dim": "#6e7781",  # fg.subtle
+            "faint": "#a8b1bb",
+            "edge": "#d8dee4",  # border.default territory
+            "edge-hi": "#c2cad3",
+            "accent": "#0969da",  # accent.fg — THE GitHub blue
+            "success": "#1a7f37",  # success.fg (open-PR green)
+            "string": "#0a3069",  # Primer syntax string dark-blue
+            "warning": "#9a6700",  # attention.fg
+            "danger": "#cf222e",  # danger.fg
+            "signal": "#0550ae",  # blue-7: links/files stay blue, distinct from accent
+            "label": "#8250df",  # done.fg (the merged-PR purple)
+            "tint-danger": "#ffebe9",  # danger.subtle
+            "tint-select": "#ddf4ff",  # accent.subtle — GitHub selects in blue
+            "tint-select-hi": "#c6e6f8",
+            "tint-attach": "#eef2f8",
+            "tint-attach-hi": "#d8e4f5",
+        },
+    ),
+    # Paper — warm cream, book-page feel. Deliberately WARMER and softer
+    # than the built-in brand "light" (#f7f4ee): the ground is a true cream
+    # (#f9f3e6, yellower and a touch brighter), the ink is a warm
+    # brown-black rather than the brand's cool-neutral, and the states are
+    # bookish — sepia accent, olive string, brick danger — like a printed
+    # page with editorial ink annotations rather than a UI.
+    ThemeSpec(
+        name="paper",
+        label="Paper",
+        description="Warm cream and brown ink — an open book in good light",
+        dark=False,
+        tokens={
+            "bg": "#f9f3e6",
+            "surface": "#f1ead9",
+            "raised": "#e7dfc9",
+            "overlay": "#dbd1b8",
+            "sunken": "#efe8d6",
+            "fg": "#332b20",  # warm brown-black ink, 12.6:1
+            "muted": "#5f574a",
+            "dim": "#7f7666",
+            "faint": "#b2a78f",
+            "edge": "#e2d9c2",
+            "edge-hi": "#cdc1a2",
+            # Sepia/rust accent: the one signature is the color of an
+            # editor's pen on a manuscript, not a screen blue.
+            "accent": "#8a4b2a",
+            "success": "#4a7a2e",  # leaf green, dark enough for cream
+            "string": "#5d7030",  # olive — reads "quoted text" without neon
+            "warning": "#8f6410",
+            "danger": "#b03d2e",  # brick red, clearly apart from the sepia accent
+            "signal": "#2e6d9e",  # the page's one cool hue: links/files
+            "label": "#7d5799",
+            "tint-danger": "#f3ddcd",
+            "tint-select": "#ece9ca",  # dry-grass cast toward the olive family
+            "tint-select-hi": "#e2dfba",
+            "tint-attach": "#e7ebe2",  # cool-leaning wash for the signal hue
+            "tint-attach-hi": "#d3decf",
+        },
+    ),
+    # Linen — cool off-white with muted pastel-derived states. Where paper
+    # is warm and bookish, linen is gray-green fabric: every state hue is
+    # deliberately DESATURATED (dusty teal, moss, clay, slate, dusty
+    # violet) so the whole surface reads soft even when it is reporting an
+    # error. The floor still binds — "muted" here means low chroma, not
+    # low contrast — so each hue is darkened until it clears 4:1.
+    ThemeSpec(
+        name="linen",
+        label="Linen",
+        description="Cool off-white weave, states in soft dusty pastels",
+        dark=False,
+        tokens={
+            "bg": "#f4f4f1",
+            "surface": "#eaebe7",
+            "raised": "#dfe1dc",
+            "overlay": "#d2d5cf",
+            "sunken": "#eceded",
+            "fg": "#2b2e2c",  # cool near-neutral ink
+            "muted": "#575d59",
+            "dim": "#767d78",
+            "faint": "#a9b0aa",
+            "edge": "#dcdeda",
+            "edge-hi": "#c5c9c3",
+            "accent": "#377568",  # dusty teal — quiet, but unmistakably the signature
+            "success": "#4d7a55",  # moss
+            "string": "#5c7561",  # gray-green, one step off success
+            "warning": "#8a6a2f",  # clay amber
+            "danger": "#a2544e",  # dusty brick — soft, still clearly "red"
+            "signal": "#54708f",  # slate blue, kept apart from the teal accent
+            "label": "#7a648f",  # dusty violet
+            "tint-danger": "#f0e1de",
+            "tint-select": "#e4e9e2",
+            "tint-select-hi": "#d9e1d8",
+            "tint-attach": "#e5e9ec",
+            "tint-attach-hi": "#d3dce4",
+        },
+    ),
+    # High Contrast Light — the accessibility ramp. Near-white ground,
+    # true ink-black body text (19.3:1), and states saturated AND dark so
+    # every one of them clears 6:1 on both grounds (well past the 4:1
+    # floor — this theme's contract is headroom, not minimum compliance).
+    # The grounds are pure neutrals: on a hue-less page the state colors
+    # carry ALL the meaning, so the five hues are pushed maximally apart
+    # (pure blue accent, pure green, pure red, brown-amber, deep violet).
+    # Tints are the loudest in the file (up to ~1.3:1) because faint
+    # washes are exactly what low-vision users lose first.
+    ThemeSpec(
+        name="high-contrast-light",
+        label="High Contrast Light",
+        description="Ink on near-white, every state 6:1+ — built for legibility",
+        dark=False,
+        tokens={
+            "bg": "#fcfcfc",
+            "surface": "#f1f1f1",
+            "raised": "#e5e5e5",
+            "overlay": "#d8d8d8",
+            "sunken": "#f4f4f4",
+            "fg": "#0a0a0a",  # ink black, 19.3:1
+            "muted": "#3d3d3d",  # 10.6:1 — "secondary" still reads like text
+            "dim": "#595959",  # 6.8:1, double the dim floor
+            "faint": "#8f8f8f",
+            "edge": "#c8c8c8",  # borders visibly darker than any elevation step
+            "edge-hi": "#a8a8a8",
+            "accent": "#0b47c2",  # saturated royal blue, 7.6:1
+            "success": "#0a6b26",  # deep pure green, 6.5:1
+            "string": "#123f83",  # navy — code strings stay prose-dark
+            "warning": "#7a4d00",  # brown-amber: yellow can't reach 6:1, brown can
+            "danger": "#c40016",  # saturated pure red, 6.1:1
+            "signal": "#005a9e",  # distinct darker azure for links/files
+            "label": "#6a1f9e",  # deep violet, 8.9:1
+            "tint-danger": "#fcd9d9",
+            "tint-select": "#d6e6fb",  # blue selection — matches the accent's meaning
+            "tint-select-hi": "#bcd7f7",
+            "tint-attach": "#e3edf9",
+            "tint-attach-hi": "#c9def5",
+        },
+    ),
+    # Mint Light — white with a fresh green signature. The trap in an
+    # all-green identity is accent/success/string collapsing into one hue,
+    # so the greens are split by darkness and temperature: accent is the
+    # brightest, freshest mint (#0c824e), success a clearly darker pine
+    # (#1d6a3e, 1.36:1 apart from accent), string a warmer grass green —
+    # "live", "succeeded", and "quoted" stay three readable things.
+    # Grounds carry a barely-there green cast so the page itself feels
+    # mint without tinting the text.
+    ThemeSpec(
+        name="mint-light",
+        label="Mint Light",
+        description="Crisp white with a cool fresh-mint green accent",
+        dark=False,
+        tokens={
+            "bg": "#fbfdfb",
+            "surface": "#eef6ef",
+            "raised": "#e0eee2",
+            "overlay": "#d0e4d4",
+            "sunken": "#f1f7f2",
+            "fg": "#1c2b21",  # near-neutral ink with a green whisper
+            "muted": "#4c5f52",
+            "dim": "#6b7f71",
+            "faint": "#a3b5a8",
+            "edge": "#d9e7dc",
+            "edge-hi": "#bcd4c2",
+            "accent": "#0c824e",  # fresh mint — the signature
+            "success": "#1d6a3e",  # pine, darker so ✓ never impersonates focus
+            "string": "#2e6e2b",  # grass, warmer than both
+            "warning": "#8c6410",
+            "danger": "#c2413b",
+            "signal": "#2470a8",  # cool blue counterweight for links/files
+            "label": "#77579e",
+            "tint-danger": "#f9e4e0",
+            "tint-select": "#dcf2e2",  # mint wash — selection wears the accent hue
+            "tint-select-hi": "#c8e9d2",
+            "tint-attach": "#e6f0f7",
+            "tint-attach-hi": "#d0e2f2",
+        },
+    ),
+]

--- a/local_operator/tui/palettes/nature.py
+++ b/local_operator/tui/palettes/nature.py
@@ -1,0 +1,17 @@
+"""Nature-inspired themes: sage (Zelda beige/sage-green), forest, ocean…
+
+The family's shared idea is a GROUND with an identity — warm beige, deep
+sea, pine shadow — with states kept legible against it. Warm grounds
+(sage, desert, autumn) have to re-solve ``danger`` and ``warning`` rather
+than copy a cool theme's values: a red that clears 4:1 on a blue-black can
+drop under the floor on beige.
+
+Every palette must clear ``tests/unit/tui/test_palette_contrast.py`` and be
+inspected as rendered frames via ``scripts/theme_preview.py``.
+"""
+
+from __future__ import annotations
+
+from local_operator.tui.theme import ThemeSpec
+
+PALETTES: list[ThemeSpec] = []

--- a/local_operator/tui/palettes/nature.py
+++ b/local_operator/tui/palettes/nature.py
@@ -39,7 +39,7 @@ PALETTES: list[ThemeSpec] = [
     ThemeSpec(
         name="sage",
         label="Sage",
-        description="Parchment dark and sage green — a quiet Hyrule field at dusk",
+        description="Parchment dark and sage green, a quiet Hyrule field at dusk",
         dark=True,
         tokens={
             "bg": "#211b10",
@@ -54,7 +54,10 @@ PALETTES: list[ThemeSpec] = [
             "edge": "#43392a",
             "edge-hi": "#554936",
             "accent": "#a3c47f",  # sage green — soft, gray-leaning, the one signature
-            "success": "#94c479",
+            # A step greener and deeper than the accent (review round 1, D2:
+            # the first solve sat 21 RGB units away, close enough that a ✓ and
+            # the caret read as one hue). 7.4:1 on bg, 70 units off the accent.
+            "success": "#7fb968",
             "string": "#94c479",
             # Warm-ground re-solve: a cool theme's #e06c75-class red measures
             # ~3.5:1 on this beige; lifted to salmon to clear 4:1 both grounds.
@@ -254,30 +257,37 @@ PALETTES: list[ThemeSpec] = [
         label="Arctic",
         description="Blue-white on slate, lit by an aurora green",
         dark=True,
+        # Re-grounded in review round 1 (D3): the first solve's near-black slate
+        # sat 7 RGB units from ocean's ground, so two themes sold as different
+        # vibes were pixel-duplicates in a 34-row picker. The slate now sits a
+        # step lighter and bluer (bg 41 units from ocean's), which is also what
+        # the description promises — blue-white ON slate, not on deep sea. The
+        # aurora stays the accent alone (D2): success takes the kelp green so a
+        # ✓ and the caret stop sharing one hue.
         tokens={
-            "bg": "#131a22",
-            "surface": "#1b242e",
-            "raised": "#232e39",
-            "overlay": "#2b3844",
-            "sunken": "#0d1219",
+            "bg": "#1a2431",
+            "surface": "#232e3d",
+            "raised": "#2c3949",
+            "overlay": "#354455",
+            "sunken": "#121a25",
             "fg": "#e3ecf4",
             "muted": "#a9bcca",
             "dim": "#77909f",
             "faint": "#425666",
-            "edge": "#2a3d4d",
-            "edge-hi": "#374f62",
-            "accent": "#68e0a3",  # aurora
-            "success": "#68e0a3",
+            "edge": "#31435a",
+            "edge-hi": "#405671",
+            "accent": "#68e0a3",  # aurora — the one saturated thing in the ice
+            "success": "#6cc99b",
             "string": "#87ceab",
             "warning": "#dcb45e",
             "danger": "#ee8b8e",
             "signal": "#7fbde8",
             "label": "#b0a3e6",
-            "tint-danger": "#291f28",
-            "tint-select": "#152b28",  # aurora cast
-            "tint-select-hi": "#1a3531",
-            "tint-attach": "#1b2c40",
-            "tint-attach-hi": "#2b4560",
+            "tint-danger": "#32262e",
+            "tint-select": "#1c332f",  # aurora cast
+            "tint-select-hi": "#223d38",
+            "tint-attach": "#22344c",
+            "tint-attach-hi": "#334e6c",
         },
     ),
     # Rosewood — dark rosewood ground, dried-rose DANGER, brass warning (as

--- a/local_operator/tui/palettes/nature.py
+++ b/local_operator/tui/palettes/nature.py
@@ -2,9 +2,26 @@
 
 The family's shared idea is a GROUND with an identity — warm beige, deep
 sea, pine shadow — with states kept legible against it. Warm grounds
-(sage, desert, autumn) have to re-solve ``danger`` and ``warning`` rather
-than copy a cool theme's values: a red that clears 4:1 on a blue-black can
-drop under the floor on beige.
+(sage, desert, autumn, rosewood) have to re-solve ``danger`` and
+``warning`` rather than copy a cool theme's values: a red that clears 4:1
+on a blue-black can drop under the floor on beige, because the warm ground
+already carries much of the red/yellow luminance a state hue relies on for
+separation. Every warm theme here therefore lifts its reds toward salmon
+and its ambers toward gold until they measure >= 4:1 on BOTH grounds,
+while staying recognisably "red" and "amber" next to each other.
+
+Design constraints the whole family obeys:
+
+- The ground ramp (sunken < bg < surface < raised < overlay) is solved per
+  theme in the brand dark ramp's proportions — each lift a just-visible
+  ~1.1x step, never a slab — because no nature reference defines five
+  elevation steps.
+- ``fg`` is always a near-neutral tinted toward the ground's hue (warm
+  bone on beige, sea-mist on blue): the vibe lives in accent/signal/label/
+  string and the tints, never in body text.
+- ``tint-select`` leans toward the theme's accent hue at roughly the
+  ground's luminance; ``tint-attach`` stays a cool cast everywhere because
+  ``signal`` is the family-wide file/reference hue and must read on it.
 
 Every palette must clear ``tests/unit/tui/test_palette_contrast.py`` and be
 inspected as rendered frames via ``scripts/theme_preview.py``.
@@ -14,4 +31,289 @@ from __future__ import annotations
 
 from local_operator.tui.theme import ThemeSpec
 
-PALETTES: list[ThemeSpec] = []
+PALETTES: list[ThemeSpec] = [
+    # Sage — the requested Zelda theme: parchment-dark ground (a warm dark
+    # beige-brown, deliberately NOT gray), sage-green accent, warm korok
+    # tones in the tints. The selection tint is a mossy olive cast rather
+    # than the brand's cool green so the highlight feels grown, not lit.
+    ThemeSpec(
+        name="sage",
+        label="Sage",
+        description="Parchment dark and sage green — a quiet Hyrule field at dusk",
+        dark=True,
+        tokens={
+            "bg": "#211b10",
+            "surface": "#2b2418",
+            "raised": "#342c1f",
+            "overlay": "#3d3426",
+            "sunken": "#18130b",
+            "fg": "#ece5d2",  # warm bone, near-neutral
+            "muted": "#bcb39d",
+            "dim": "#8b8471",
+            "faint": "#544d3c",
+            "edge": "#43392a",
+            "edge-hi": "#554936",
+            "accent": "#a3c47f",  # sage green — soft, gray-leaning, the one signature
+            "success": "#94c479",
+            "string": "#94c479",
+            # Warm-ground re-solve: a cool theme's #e06c75-class red measures
+            # ~3.5:1 on this beige; lifted to salmon to clear 4:1 both grounds.
+            "warning": "#e0ac4e",
+            "danger": "#f08c78",
+            "signal": "#7db8d8",
+            "label": "#c39ede",
+            "tint-danger": "#33201a",
+            "tint-select": "#252b18",  # korok-moss cast
+            "tint-select-hi": "#2c331e",
+            "tint-attach": "#25343e",
+            "tint-attach-hi": "#365064",
+        },
+    ),
+    # Forest — deep pine shadow with a moss accent. The greens are split by
+    # temperature so they never collapse: accent is yellow-moss, success is
+    # cooler leaf-green, string sits between; signal is a stream-blue kept
+    # clearly apart from all three.
+    ThemeSpec(
+        name="forest",
+        label="Forest",
+        description="Deep pine shadow, moss-green light through the canopy",
+        dark=True,
+        tokens={
+            "bg": "#0f1a13",
+            "surface": "#17231b",
+            "raised": "#1f2c23",
+            "overlay": "#27352b",
+            "sunken": "#0a120d",
+            "fg": "#dde8dd",
+            "muted": "#a8bba9",
+            "dim": "#788d7b",
+            "faint": "#465547",
+            "edge": "#2c3d31",
+            "edge-hi": "#3a4e3f",
+            "accent": "#8fbf68",  # moss
+            "success": "#7cc487",
+            "string": "#9dc47c",
+            "warning": "#d8ae52",
+            "danger": "#e58579",
+            "signal": "#6fb3c9",
+            "label": "#b195d6",
+            "tint-danger": "#28211c",
+            "tint-select": "#1a2a1a",
+            "tint-select-hi": "#213321",
+            "tint-attach": "#1c2e38",
+            "tint-attach-hi": "#2c4a58",
+        },
+    ),
+    # Ocean — deep-sea blue-green ground, pale foam accent. Accent is the
+    # brightest, whitest green in the family (sea foam), while success stays
+    # a kelp green so "live/focused" and "succeeded" read as two things.
+    ThemeSpec(
+        name="ocean",
+        label="Ocean",
+        description="Deep-sea blue-green with a pale sea-foam accent",
+        dark=True,
+        tokens={
+            "bg": "#0c1a20",
+            "surface": "#132630",
+            "raised": "#1b2e39",
+            "overlay": "#233742",
+            "sunken": "#081218",
+            "fg": "#dcebee",
+            "muted": "#a4bec5",
+            "dim": "#71919a",
+            "faint": "#3e565f",
+            "edge": "#254049",
+            "edge-hi": "#31525d",
+            "accent": "#84e0cf",  # foam
+            "success": "#6cc99b",  # kelp
+            "string": "#7fcbb0",
+            "warning": "#d9b45c",
+            "danger": "#ef8b85",
+            "signal": "#72b6e4",
+            "label": "#ab9ce0",
+            "tint-danger": "#26212a",
+            "tint-select": "#12302c",  # teal cast, not the brand's leaf green
+            "tint-select-hi": "#173a35",
+            "tint-attach": "#1a2c42",
+            "tint-attach-hi": "#294663",
+        },
+    ),
+    # Desert — warm dark sand with terracotta and cactus. The ground sits a
+    # step LIGHTER and yellower than sage's parchment (bg #271e12 vs sage's
+    # #211b10) so the two warm-beige themes stay distinguishable side by
+    # side: sage is dusk parchment, desert is sunlit sand after dark.
+    # Accent (terracotta) and warning (amber) share warmth, so warning is
+    # pushed yellow and danger toward a clear coral-red to keep the three
+    # warm states distinct at a glance. Warm-ground rule: danger/warning
+    # solved here, not copied.
+    ThemeSpec(
+        name="desert",
+        label="Desert",
+        description="Warm dark sand, terracotta glow, a stripe of cactus green",
+        dark=True,
+        tokens={
+            "bg": "#271e12",
+            "surface": "#31271a",
+            "raised": "#3a2f21",
+            "overlay": "#433728",
+            "sunken": "#1d160c",
+            "fg": "#f0e6d5",
+            "muted": "#c4b5a0",
+            "dim": "#93866f",
+            "faint": "#5b503e",
+            "edge": "#4a3c2a",
+            "edge-hi": "#5d4c36",
+            "accent": "#e59d6a",  # terracotta
+            "success": "#9ac275",  # cactus
+            "string": "#adc275",
+            "warning": "#e2b148",
+            "danger": "#f58384",  # coral-red, lifted for the warm ground
+            "signal": "#84bad8",
+            "label": "#cb9edc",
+            "tint-danger": "#3b2419",
+            "tint-select": "#2f2e18",  # dry-grass cast
+            "tint-select-hi": "#37371e",
+            "tint-attach": "#2c3843",
+            "tint-attach-hi": "#405466",
+        },
+    ),
+    # Autumn — dark oak ground, maple red and amber leaves. Three warm
+    # states again: accent is maple-orange, warning a yellower harvest
+    # amber, danger a lifted maple red (a cool theme's crimson would sit
+    # near 3.5:1 on oak). Success is a drying leaf-green, not spring green.
+    ThemeSpec(
+        name="autumn",
+        label="Autumn",
+        description="Dark oak under maple red and harvest amber",
+        dark=True,
+        tokens={
+            "bg": "#1d1510",
+            "surface": "#271e17",
+            "raised": "#30261e",
+            "overlay": "#392e25",
+            "sunken": "#140e09",
+            "fg": "#eddfd0",
+            "muted": "#c0ac97",
+            "dim": "#8e7d6a",
+            "faint": "#55483a",
+            "edge": "#42332a",
+            "edge-hi": "#544236",
+            "accent": "#e08d4f",  # maple orange
+            "success": "#a2b96a",  # drying leaf
+            "string": "#b3b96a",
+            "warning": "#ddab35",
+            "danger": "#f37f6f",  # maple red, warm-ground lifted
+            "signal": "#7fb0d3",
+            "label": "#c599d6",
+            "tint-danger": "#331b14",
+            "tint-select": "#292312",  # fallen-leaf cast
+            "tint-select-hi": "#312b17",
+            "tint-attach": "#233140",
+            "tint-attach-hi": "#354c61",
+        },
+    ),
+    # Lavender — dusk purple-gray ground, lavender accent. Label (violet
+    # meta) lives one hue step pinker than the accent so the two purples
+    # never merge; danger leans rose to stay off the label's lane too.
+    ThemeSpec(
+        name="lavender",
+        label="Lavender",
+        description="Purple-gray dusk with a soft lavender glow",
+        dark=True,
+        tokens={
+            "bg": "#191623",
+            "surface": "#211e2e",
+            "raised": "#2a2638",
+            "overlay": "#332e42",
+            "sunken": "#110f19",
+            "fg": "#e6e2f0",
+            "muted": "#b3adc6",
+            "dim": "#837c9a",
+            "faint": "#4c4762",
+            "edge": "#363050",
+            "edge-hi": "#453e64",
+            "accent": "#b9a3e8",  # lavender
+            "success": "#7fc98f",
+            "string": "#98c887",
+            "warning": "#dcae54",
+            "danger": "#ef8595",  # rose-red, apart from both purples
+            "signal": "#7db2e2",
+            "label": "#cf94d8",  # pinker violet than accent
+            "tint-danger": "#2b1a26",
+            "tint-select": "#1f2333",  # deeper dusk-blue cast
+            "tint-select-hi": "#262b40",
+            "tint-attach": "#1c2740",
+            "tint-attach-hi": "#2c405f",
+        },
+    ),
+    # Arctic — blue-white on slate with an aurora-green accent. The accent
+    # is the one saturated thing in an otherwise icy ramp; the selection
+    # tint carries a faint aurora cast so highlighting feels like the sky.
+    ThemeSpec(
+        name="arctic",
+        label="Arctic",
+        description="Blue-white on slate, lit by an aurora green",
+        dark=True,
+        tokens={
+            "bg": "#131a22",
+            "surface": "#1b242e",
+            "raised": "#232e39",
+            "overlay": "#2b3844",
+            "sunken": "#0d1219",
+            "fg": "#e3ecf4",
+            "muted": "#a9bcca",
+            "dim": "#77909f",
+            "faint": "#425666",
+            "edge": "#2a3d4d",
+            "edge-hi": "#374f62",
+            "accent": "#68e0a3",  # aurora
+            "success": "#68e0a3",
+            "string": "#87ceab",
+            "warning": "#dcb45e",
+            "danger": "#ee8b8e",
+            "signal": "#7fbde8",
+            "label": "#b0a3e6",
+            "tint-danger": "#291f28",
+            "tint-select": "#152b28",  # aurora cast
+            "tint-select-hi": "#1a3531",
+            "tint-attach": "#1b2c40",
+            "tint-attach-hi": "#2b4560",
+        },
+    ),
+    # Rosewood — dark rosewood ground, dried-rose DANGER, brass warning (as
+    # briefed: the rose hue is the failure color here, so accent takes a
+    # fresh rose-pink clearly apart from danger's dusty salmon, and warning
+    # is brass rather than gold to stay off the wood's own warmth. Another
+    # warm ground: both re-solved to >= 4:1 on bg and surface.
+    ThemeSpec(
+        name="rosewood",
+        label="Rosewood",
+        description="Dark rosewood, dried-rose reds, a glint of brass",
+        dark=True,
+        tokens={
+            "bg": "#201314",
+            "surface": "#2a1c1d",
+            "raised": "#332425",
+            "overlay": "#3c2c2d",
+            "sunken": "#170c0d",
+            "fg": "#eee0dc",
+            "muted": "#c2aba6",
+            "dim": "#907c78",
+            "faint": "#584745",
+            "edge": "#453130",
+            "edge-hi": "#57403e",
+            "accent": "#e895b5",  # fresh rose blossom
+            "success": "#94bd80",
+            "string": "#a8bd80",
+            "warning": "#d8ab58",  # brass
+            "danger": "#ea8378",  # dried rose — dusty salmon-red
+            "signal": "#82b1d4",
+            "label": "#c99bd2",
+            "tint-danger": "#371c1c",
+            "tint-select": "#2b2318",  # warm heartwood cast
+            "tint-select-hi": "#332b1e",
+            "tint-attach": "#263140",
+            "tint-attach-hi": "#394c61",
+        },
+    ),
+]

--- a/local_operator/tui/palettes/neon.py
+++ b/local_operator/tui/palettes/neon.py
@@ -1,0 +1,20 @@
+"""Neon / retro-futurist themes: synthwave, matrix, tron, and kin.
+
+The design constraint that separates this family from the classics: the
+VIBE is carried by the accent, signal and label hues plus the tinted
+grounds — never by pushing the body ink to a saturated hue. ``fg`` stays a
+near-neutral (a cold white, a pale green-white) so hours of prose reading
+do not fatigue; the matrix theme in particular keeps its phosphor green for
+the accent and states while the text sits at a desaturated green-white,
+because a full screen of #00ff00 body text is the definition of "hard on
+the eyes".
+
+Every palette must clear ``tests/unit/tui/test_palette_contrast.py`` and be
+inspected as rendered frames via ``scripts/theme_preview.py``.
+"""
+
+from __future__ import annotations
+
+from local_operator.tui.theme import ThemeSpec
+
+PALETTES: list[ThemeSpec] = []

--- a/local_operator/tui/palettes/neon.py
+++ b/local_operator/tui/palettes/neon.py
@@ -9,6 +9,14 @@ the accent and states while the text sits at a desaturated green-white,
 because a full screen of #00ff00 body text is the definition of "hard on
 the eyes".
 
+Grounds do the other half of the work. Each theme's bg carries a CAST
+(purple-navy, green-black, blue-black, violet-black...) so the vibe is
+present even in an empty pane, but the five elevation steps mirror the
+brand dark ramp's proportions — each lift ~1.05–1.13:1 against the last,
+a just-visible rise, never a slab. None of the source aesthetics define
+five ground steps, so every ramp here is solved per theme by scaling the
+signature ground's luminance along the brand ramp's curve.
+
 Every palette must clear ``tests/unit/tui/test_palette_contrast.py`` and be
 inspected as rendered frames via ``scripts/theme_preview.py``.
 """
@@ -17,4 +25,304 @@ from __future__ import annotations
 
 from local_operator.tui.theme import ThemeSpec
 
-PALETTES: list[ThemeSpec] = []
+PALETTES: list[ThemeSpec] = [
+    # Synthwave '84 (Robb Owen's VS Code theme). Unusually for a neon
+    # palette, every canonical hue clears the 4:1 state floor on the
+    # canonical ground (#262335) — even the hot red #fe4450 (4.84:1) — so
+    # this theme is pure fidelity: pink, cyan, yellow, red, green and the
+    # comment-violet are all published values. `dim` is the canonical
+    # comment color #848bbd (4.66:1 on bg), which is exactly the job
+    # comments do in the source theme.
+    ThemeSpec(
+        name="synthwave",
+        label="Synthwave '84",
+        description="Hot pink and cyan on a deep purple-navy night drive",
+        dark=True,
+        tokens={
+            "bg": "#262335",
+            "surface": "#2d2a41",
+            "raised": "#35314c",
+            "overlay": "#3d3958",
+            "sunken": "#1e1b2a",
+            "fg": "#f2eff8",
+            "muted": "#bcb3d4",
+            "dim": "#848bbd",
+            "faint": "#575071",
+            "edge": "#443f5e",
+            "edge-hi": "#544e72",
+            "accent": "#ff7edb",
+            "success": "#72f1b8",
+            "warning": "#fede5d",
+            "danger": "#fe4450",
+            "signal": "#36f9f6",
+            "label": "#b893ce",
+            "string": "#72f1b8",
+            "tint-danger": "#3f2138",
+            "tint-select": "#352a55",
+            "tint-select-hi": "#3e3264",
+            "tint-attach": "#22334f",
+            "tint-attach-hi": "#2f476b",
+        },
+    ),
+    # Digital rain. The ground is a near-black with a green cast (never
+    # neutral black — the cast IS the CRT), and the whole ramp stays in
+    # hue. Raw phosphor #00ff00 clears every floor but is deliberately
+    # NOT used anywhere: accent is a tamed phosphor #22e06a and body text
+    # a desaturated green-white, per the family constraint above. The
+    # off-hue states (amber warning, red danger, cyan signal, violet
+    # label) are desaturation-matched so they read as glitches in the
+    # rain rather than visitors from another theme.
+    ThemeSpec(
+        name="matrix",
+        label="Matrix",
+        description="Phosphor green rain on a near-black terminal screen",
+        dark=True,
+        tokens={
+            "bg": "#050d07",
+            "surface": "#0b160e",
+            "raised": "#122016",
+            "overlay": "#1a2b1e",
+            "sunken": "#020703",
+            "fg": "#d4e6d6",
+            "muted": "#99bd9f",
+            "dim": "#639c70",
+            "faint": "#2f5238",
+            "edge": "#1d3524",
+            "edge-hi": "#2a4a33",
+            "accent": "#22e06a",
+            "success": "#3ecf74",
+            "warning": "#d8c24a",
+            "danger": "#ff6b5e",
+            "signal": "#3fd0c9",
+            "label": "#a08fe0",
+            "string": "#57d98a",
+            "tint-danger": "#231311",
+            "tint-select": "#0e2417",
+            "tint-select-hi": "#132e1e",
+            "tint-attach": "#0d2426",
+            "tint-attach-hi": "#133638",
+        },
+    ),
+    # The Grid. Blue-black ground, electric cyan for the light-cycle
+    # lines (accent + edges lean cyan-blue), and danger is ORANGE, not
+    # red — the Rinzler suit is the franchise's own error color. Warning
+    # therefore shifts to a yellow-gold so the two warm states cannot
+    # collapse; success is a sea-glass teal-green that stays cool enough
+    # to belong on the Grid.
+    ThemeSpec(
+        name="tron",
+        label="Tron",
+        description="Electric cyan circuitry on the Grid's blue-black",
+        dark=True,
+        tokens={
+            "bg": "#060b12",
+            "surface": "#0c1420",
+            "raised": "#131e2d",
+            "overlay": "#1a283a",
+            "sunken": "#03060b",
+            "fg": "#d8e6f2",
+            "muted": "#9fb8cc",
+            "dim": "#6a89a3",
+            "faint": "#33485c",
+            "edge": "#1e3245",
+            "edge-hi": "#2a4660",
+            "accent": "#00d8ff",
+            "success": "#3fe0b0",
+            "warning": "#e8c14a",
+            "danger": "#ff7a2f",
+            "signal": "#7ab8ff",
+            "label": "#a496ff",
+            "string": "#3fe0b0",
+            "tint-danger": "#2a1a0d",
+            "tint-select": "#0d2430",
+            "tint-select-hi": "#122f3e",
+            "tint-attach": "#132339",
+            "tint-attach-hi": "#1c3453",
+        },
+    ),
+    # Night City. The 2077 marketing trio lands intact: construction
+    # yellow #fcee0a as THE accent, glare cyan #00f0f0-family as signal,
+    # and the logo red #ff003c as danger (4.95:1 on this violet-black —
+    # legal, and its scarlet punch is the point). Selection tints are
+    # YELLOW-cast rather than the usual green/blue, because in this theme
+    # yellow is the brand's "pay attention" color.
+    ThemeSpec(
+        name="cyberpunk",
+        label="Cyberpunk",
+        description="Construction yellow and glare cyan over violet-black Night City",
+        dark=True,
+        tokens={
+            "bg": "#0e0a16",
+            "surface": "#16101f",
+            "raised": "#1e172a",
+            "overlay": "#271e36",
+            "sunken": "#080510",
+            "fg": "#eae5f2",
+            "muted": "#b3a8c6",
+            "dim": "#82749c",
+            "faint": "#4a4060",
+            "edge": "#2e2340",
+            "edge-hi": "#3d2f54",
+            "accent": "#fcee0a",
+            "success": "#3fe07a",
+            "warning": "#ff9e3d",
+            "danger": "#ff003c",
+            "signal": "#00f0ff",
+            "label": "#b98aff",
+            "string": "#3fe07a",
+            "tint-danger": "#2c1420",
+            "tint-select": "#28230e",
+            "tint-select-hi": "#332c12",
+            "tint-attach": "#122733",
+            "tint-attach-hi": "#1a3a4c",
+        },
+    ),
+    # Mall-at-closing-time pastels. Same purple ground family as
+    # synthwave but every state hue is pulled toward chalk — dusty pink
+    # accent, sun-bleached teal signal, sherbet amber — so the theme
+    # reads soft-focus where synthwave reads laser-sharp. The pastels
+    # start bright enough that no floor forces a deviation; the restraint
+    # is the aesthetic.
+    ThemeSpec(
+        name="vaporwave",
+        label="Vaporwave",
+        description="Dusty pink and faded teal pastels on deep mall-purple",
+        dark=True,
+        tokens={
+            "bg": "#1f1730",
+            "surface": "#271e3b",
+            "raised": "#2f2547",
+            "overlay": "#382d54",
+            "sunken": "#181128",
+            "fg": "#ede8f2",
+            "muted": "#c0b2d4",
+            "dim": "#9184ae",
+            "faint": "#5a4e74",
+            "edge": "#3c3158",
+            "edge-hi": "#4c3f6c",
+            "accent": "#f7a8d8",
+            "success": "#8fe6c0",
+            "warning": "#f0cd8a",
+            "danger": "#f2808a",
+            "signal": "#7fd8d4",
+            "label": "#c5a3f0",
+            "string": "#8fe6c0",
+            "tint-danger": "#3a2138",
+            "tint-select": "#232a48",
+            "tint-select-hi": "#2a3358",
+            "tint-attach": "#1c2f44",
+            "tint-attach-hi": "#28425e",
+        },
+    ),
+    # Sunset-grid racing. The canonical Outrun quad lands intact on the
+    # midnight-blue ground: magenta #ff2975 as accent (5.19:1 — clears
+    # the floor with room), grid cyan #2de2e6 as signal, sun yellow
+    # #f9c80e as warning, and the sunset orange #ff6c11 as danger — this
+    # palette has no red, and orange-as-danger keeps the sunset story
+    # while staying far from the magenta accent. Selection tints are
+    # indigo (the grid at dusk), not green.
+    ThemeSpec(
+        name="outrun",
+        label="Outrun",
+        description="Sunset magenta and grid cyan racing over midnight blue",
+        dark=True,
+        tokens={
+            "bg": "#0d1029",
+            "surface": "#141834",
+            "raised": "#1b2040",
+            "overlay": "#23294e",
+            "sunken": "#080a1e",
+            "fg": "#e6e6f2",
+            "muted": "#adafd0",
+            "dim": "#7c7fa8",
+            "faint": "#454870",
+            "edge": "#262c56",
+            "edge-hi": "#343b6e",
+            "accent": "#ff2975",
+            "success": "#3fe0a0",
+            "warning": "#f9c80e",
+            "danger": "#ff6c11",
+            "signal": "#2de2e6",
+            "label": "#a48fff",
+            "string": "#3fe0a0",
+            "tint-danger": "#301526",
+            "tint-select": "#1c1444",
+            "tint-select-hi": "#241a54",
+            "tint-attach": "#102a3e",
+            "tint-attach-hi": "#183d58",
+        },
+    ),
+    # Neon through rain. The one theme in this family where the neon is
+    # REFLECTED, not direct: a slightly cool charcoal ground and every
+    # sign hue knocked back to wet-pavement saturation — dim cyan accent,
+    # rose danger, sodium amber. Deliberately the quietest member; it
+    # should feel like the city at 3am, two blocks from the signs.
+    ThemeSpec(
+        name="neon-noir",
+        label="Neon Noir",
+        description="Rain-dimmed cyan and magenta signs over 3am charcoal",
+        dark=True,
+        tokens={
+            "bg": "#15171c",
+            "surface": "#1c1f26",
+            "raised": "#242830",
+            "overlay": "#2c313b",
+            "sunken": "#101216",
+            "fg": "#dcdfe4",
+            "muted": "#a6acb8",
+            "dim": "#767e8c",
+            "faint": "#454b56",
+            "edge": "#2b303a",
+            "edge-hi": "#3a414e",
+            "accent": "#5fc4d4",
+            "success": "#6cc49a",
+            "warning": "#cfae62",
+            "danger": "#e07a8a",
+            "signal": "#7aa8d8",
+            "label": "#b48ec6",
+            "string": "#6cc49a",
+            "tint-danger": "#2a1c22",
+            "tint-select": "#1a262c",
+            "tint-select-hi": "#203038",
+            "tint-attach": "#1a2634",
+            "tint-attach-hi": "#243648",
+        },
+    ),
+    # CRT cabinet. Near-neutral black glass (the one ground here with no
+    # strong cast — arcade CRTs were glass-grey when off) and candy
+    # primaries for the states: marquee yellow accent, 1-up green,
+    # bonus-round orange, hit-flash red, ice-level blue, power-up violet.
+    # Each state is its own primary so nothing can collapse; the fg is a
+    # warm bone white like a lit dot-matrix score.
+    ThemeSpec(
+        name="arcade",
+        label="Arcade",
+        description="Candy RGB game states glowing on black CRT glass",
+        dark=True,
+        tokens={
+            "bg": "#0a0a0c",
+            "surface": "#141417",
+            "raised": "#1d1d21",
+            "overlay": "#26262c",
+            "sunken": "#050506",
+            "fg": "#e8e8e4",
+            "muted": "#b0b0ac",
+            "dim": "#7c7c7a",
+            "faint": "#44444a",
+            "edge": "#2a2a30",
+            "edge-hi": "#3a3a42",
+            "accent": "#ffd23f",
+            "success": "#45e055",
+            "warning": "#ff9430",
+            "danger": "#ff5252",
+            "signal": "#52b4ff",
+            "label": "#c792ff",
+            "string": "#45e055",
+            "tint-danger": "#26100f",
+            "tint-select": "#0e2213",
+            "tint-select-hi": "#132d1a",
+            "tint-attach": "#0e2030",
+            "tint-attach-hi": "#153048",
+        },
+    ),
+]

--- a/local_operator/tui/theme.py
+++ b/local_operator/tui/theme.py
@@ -14,6 +14,9 @@ theme can be invalidated in one shot (a ``getThemeEpoch``-style pattern).
 
 from __future__ import annotations
 
+import re
+from dataclasses import dataclass, field
+
 from rich.style import Style
 
 #: Brand token ramps, keyed by theme name. Hex values are exact brand kit
@@ -165,6 +168,117 @@ _SEMANTIC_ALIASES: dict[str, dict[str, str]] = {
 
 DEFAULT_THEME = "dark"
 
+#: The canonical semantic token set — the ONE vocabulary every widget, the
+#: TCSS, and the markdown/syntax ramps speak. A theme is precisely a total
+#: function from this set to hexes: `register_theme` rejects a palette that
+#: misses a token (a partial theme would fail at render time, on whichever
+#: widget happened to ask first) or invents one (a token nothing reads is a
+#: palette author's typo, not an extension point).
+SEMANTIC_TOKENS: tuple[str, ...] = tuple(_SEMANTIC_ALIASES["dark"])
+
+#: Palette hexes must be exactly ``#rrggbb``. Short forms and named colors are
+#: rejected at registration: the TCSS variable block and the terminal-theme
+#: mapping both slice these strings positionally.
+_HEX_RE = re.compile(r"#[0-9a-fA-F]{6}")
+
+
+@dataclass(frozen=True)
+class ThemeSpec:
+    """One selectable theme: identity, one-line pitch, and its full ramp.
+
+    ``tokens`` maps every name in :data:`SEMANTIC_TOKENS` to a hex. ``dark``
+    drives the pieces that need a boolean polarity rather than a palette —
+    the ANSI terminal-theme mapping and Textual's own dark/light styling.
+    ``description`` is the picker row's one-liner, so it is written for a
+    user choosing between thirty rows, not for a changelog.
+    """
+
+    name: str
+    label: str
+    description: str
+    dark: bool = True
+    tokens: dict[str, str] = field(default_factory=dict)
+
+
+def _builtin_spec(name: str, label: str, description: str, dark: bool) -> ThemeSpec:
+    """Wrap a :data:`BRAND_TOKENS` ramp in the registry's spec shape.
+
+    The two brand ramps keep their raw-token + alias form because the raw
+    names (``amber``, ``paper``, ``ink``) are pinned by tests and still
+    emitted as TCSS variables; everything else registers semantic-only.
+    """
+    tokens = {
+        semantic: BRAND_TOKENS[name][raw] for semantic, raw in _SEMANTIC_ALIASES[name].items()
+    }
+    return ThemeSpec(name=name, label=label, description=description, dark=dark, tokens=tokens)
+
+
+#: Every registered theme, keyed by name. Seeded with the two brand ramps;
+#: the curated palettes in :mod:`local_operator.tui.palettes` add themselves
+#: on first use (see :func:`_registry` — the import is lazy to keep this
+#: module importable from the palettes package without a cycle).
+_THEMES: dict[str, ThemeSpec] = {
+    "dark": _builtin_spec(
+        "dark", "Operator Dark", "The island night — the Local Operator default", dark=True
+    ),
+    "light": _builtin_spec("light", "Operator Light", "Warm paper, brand ink", dark=False),
+}
+
+_palettes_loaded = False
+
+
+def _registry() -> dict[str, ThemeSpec]:
+    """The theme registry with the curated palettes folded in (lazy, once).
+
+    Lazy because :mod:`local_operator.tui.palettes` imports THIS module for
+    :class:`ThemeSpec`; importing it at module top would be a cycle. The
+    palettes never override the two brand ramps — ``register_theme`` refuses
+    duplicates, so a palette shadowing ``dark`` is a loud error, not a silent
+    rebrand.
+    """
+    global _palettes_loaded
+    if not _palettes_loaded:
+        _palettes_loaded = True
+        from local_operator.tui import palettes
+
+        for spec in palettes.all_palettes():
+            register_theme(spec)
+    return _THEMES
+
+
+def register_theme(spec: ThemeSpec) -> None:
+    """Add ``spec`` to the registry, validating it is total and new.
+
+    A theme is data, so every mistake a palette author can make is caught
+    HERE, at registration, rather than at render time in whichever widget
+    first asks for the missing token.
+    """
+    if spec.name in _THEMES:
+        raise ValueError(f"theme {spec.name!r} is already registered")
+    missing = [token for token in SEMANTIC_TOKENS if token not in spec.tokens]
+    if missing:
+        raise ValueError(f"theme {spec.name!r} is missing tokens: {', '.join(missing)}")
+    unknown = [token for token in spec.tokens if token not in SEMANTIC_TOKENS]
+    if unknown:
+        raise ValueError(f"theme {spec.name!r} has unknown tokens: {', '.join(unknown)}")
+    malformed = [
+        f"{token}={value!r}" for token, value in spec.tokens.items() if not _HEX_RE.fullmatch(value)
+    ]
+    if malformed:
+        raise ValueError(f"theme {spec.name!r} has malformed hexes: {', '.join(malformed)}")
+    _THEMES[spec.name] = spec
+
+
+def theme_spec(name: str | None = None) -> ThemeSpec:
+    """The :class:`ThemeSpec` for ``name`` (default: the active theme)."""
+    registry = _registry()
+    key = name or _current_theme
+    try:
+        return registry[key]
+    except KeyError:
+        raise KeyError(f"unknown theme: {key!r} (have {', '.join(registry)})") from None
+
+
 _current_theme: str = DEFAULT_THEME
 #: Bumped on every theme switch; render caches compare against this to know
 #: when their cached rows/styles are stale.
@@ -172,8 +286,8 @@ _theme_epoch: int = 0
 
 
 def available_themes() -> list[str]:
-    """Names of the built-in theme ramps."""
-    return list(BRAND_TOKENS)
+    """Names of every registered theme, brand ramps first, then curated."""
+    return list(_registry())
 
 
 def current_theme() -> str:
@@ -194,29 +308,34 @@ def set_theme(name: str) -> int:
     Returns the new epoch.
     """
     global _current_theme, _theme_epoch
-    if name not in BRAND_TOKENS:
-        raise KeyError(f"unknown theme: {name!r} (have {', '.join(BRAND_TOKENS)})")
+    registry = _registry()
+    if name not in registry:
+        raise KeyError(f"unknown theme: {name!r} (have {', '.join(registry)})")
     _current_theme = name
     _theme_epoch += 1
     return _theme_epoch
 
 
 def get_tokens(theme: str | None = None) -> dict[str, str]:
-    """Raw brand tokens for ``theme`` (defaults to the current theme)."""
+    """Raw tokens for ``theme`` (defaults to the current theme).
+
+    For the two brand ramps this is the raw :data:`BRAND_TOKENS` vocabulary
+    (``amber``, ``paper``…), preserved because tests and the TCSS variable
+    block pin it; every curated theme answers with its semantic tokens,
+    which ARE its only vocabulary.
+    """
     name = theme or _current_theme
-    try:
+    if name in BRAND_TOKENS:
         return dict(BRAND_TOKENS[name])
-    except KeyError:
-        raise KeyError(f"unknown theme: {name!r} (have {', '.join(BRAND_TOKENS)})") from None
+    return dict(theme_spec(name).tokens)
 
 
 def semantic_color(semantic: str, theme: str | None = None) -> str:
     """Resolve a semantic name (``bg``, ``accent``, ...) to a hex for a ramp."""
-    name = theme or _current_theme
-    aliases = _SEMANTIC_ALIASES[name]
-    if semantic not in aliases:
-        raise KeyError(f"unknown semantic color {semantic!r} for theme {name!r}")
-    return BRAND_TOKENS[name][aliases[semantic]]
+    spec = theme_spec(theme)
+    if semantic not in spec.tokens:
+        raise KeyError(f"unknown semantic color {semantic!r} for theme {spec.name!r}")
+    return spec.tokens[semantic]
 
 
 def tcss_variable_map(theme: str | None = None) -> dict[str, str]:
@@ -229,7 +348,7 @@ def tcss_variable_map(theme: str | None = None) -> dict[str, str]:
     variables: dict[str, str] = {}
     for token, hex_value in get_tokens(name).items():
         variables[f"lo-{token}"] = hex_value
-    for semantic in _SEMANTIC_ALIASES[name]:
+    for semantic in SEMANTIC_TOKENS:
         variables[f"lo-{semantic}"] = semantic_color(semantic, name)
     return variables
 

--- a/local_operator/tui/theme.py
+++ b/local_operator/tui/theme.py
@@ -187,10 +187,14 @@ class ThemeSpec:
     """One selectable theme: identity, one-line pitch, and its full ramp.
 
     ``tokens`` maps every name in :data:`SEMANTIC_TOKENS` to a hex. ``dark``
-    drives the pieces that need a boolean polarity rather than a palette —
-    the ANSI terminal-theme mapping and Textual's own dark/light styling.
-    ``description`` is the picker row's one-liner, so it is written for a
-    user choosing between thirty rows, not for a changelog.
+    declares the ramp's POLARITY — whether elevation lightens (dark ground)
+    or darkens (paper ground) as it rises. Its consumer today is the palette
+    contrast gate, which checks the elevation ladder in the declared
+    direction; nothing at runtime branches on it (the ANSI mapping is built
+    from the active ramp's tokens whatever the polarity, and Textual's own
+    dark/light flag is left alone). ``description`` is the picker row's
+    one-liner, so it is written for a user choosing between thirty rows,
+    not for a changelog.
     """
 
     name: str
@@ -219,7 +223,7 @@ def _builtin_spec(name: str, label: str, description: str, dark: bool) -> ThemeS
 #: module importable from the palettes package without a cycle).
 _THEMES: dict[str, ThemeSpec] = {
     "dark": _builtin_spec(
-        "dark", "Operator Dark", "The island night — the Local Operator default", dark=True
+        "dark", "Operator Dark", "The island night, the Local Operator default", dark=True
     ),
     "light": _builtin_spec("light", "Operator Light", "Warm paper, brand ink", dark=False),
 }
@@ -238,11 +242,22 @@ def _registry() -> dict[str, ThemeSpec]:
     """
     global _palettes_loaded
     if not _palettes_loaded:
-        _palettes_loaded = True
         from local_operator.tui import palettes
 
+        # Latched only AFTER the fold completes (review round 1, F3): set
+        # before it, a partial registration failure would serve a silently
+        # truncated registry to every later caller — themes vanishing with no
+        # error, and a saved name in the missing tail reading as user error.
+        # The identity skip below is what makes the retry safe: the palette
+        # lists are module-level constants, so a second pass sees the SAME
+        # spec objects it already folded and skips them, reaching — and
+        # re-raising from — the palette that actually failed. Identity, not
+        # name: a name-based skip would also silence a genuine cross-family
+        # name collision, which must keep raising.
         for spec in palettes.all_palettes():
-            register_theme(spec)
+            if _THEMES.get(spec.name) is not spec:
+                register_theme(spec)
+        _palettes_loaded = True
     return _THEMES
 
 

--- a/local_operator/tui/widgets/assistant.py
+++ b/local_operator/tui/widgets/assistant.py
@@ -531,6 +531,28 @@ class AssistantBlock(TranscriptBlock):
             return Text("")
         return flatten(Markdown(self._full_text), self._flat_width(), self._flat_console())
 
+    def retheme(self) -> None:
+        """Re-flatten in the new ramp, dropping every theme-baked cache.
+
+        The flatten renders through the app console, whose markdown theme the
+        switch has already re-pushed — but the frozen prefix is cached as
+        FLATTENED TEXT with the old ramp's styles baked into every span, so
+        the caches go first (the same invalidation ``update_text`` performs
+        when it notices an epoch change) and the rebuild re-lexes from source.
+        """
+        if not self._full_text:
+            return
+        self._frozen_rendered = None
+        self._frozen_flat = None
+        self._frozen_epoch = theme_mod.get_theme_epoch()
+        was_finalized = self._finalized
+        self._finalized = False
+        try:
+            rows = self._flat_whole() if was_finalized else self._flat_rows(self._flat_width())
+            self._apply_rows(rows)
+        finally:
+            self._finalized = was_finalized
+
     def settled_rows(self) -> int:
         """Rows provably stable now: the frozen prefix's render while live."""
         if self._finalized:

--- a/local_operator/tui/widgets/command_picker.py
+++ b/local_operator/tui/widgets/command_picker.py
@@ -334,9 +334,23 @@ class CommandPicker(Static):
     never touches the buffer.
     """
 
-    def __init__(self, on_choose: Callable[[str], None]) -> None:
+    def __init__(
+        self,
+        on_choose: Callable[[str], None],
+        on_highlight: Callable[[str | None], None] | None = None,
+    ) -> None:
         super().__init__()
         self._on_choose = on_choose
+        #: Observer for the row the user is CONSIDERING — the hover target when
+        #: the mouse is over a row, else the keyboard highlight — called with
+        #: ``None`` when an argument list stops showing rows. It exists for
+        #: live preview (``/theme``): the preview has to track what the eye is
+        #: on, which is not always what Enter would choose. Only ARGUMENT rows
+        #: report; a command-word list has nothing to preview.
+        self._on_highlight = on_highlight
+        #: Last name reported to ``_on_highlight``, so the observer hears each
+        #: change once — mouse-move events arrive per cell, not per row.
+        self._reported_highlight: str | None = None
         self._commands: list[SlashCommand] = []
         self._choices: list[ArgumentChoice] = []
         self._mode = PickerMode.COMMAND
@@ -541,6 +555,7 @@ class CommandPicker(Static):
         self.display = True
         self._scroll_to_selection()
         self._repaint()
+        self._report_highlight()
 
     def move(self, delta: int) -> None:
         """Move the highlight by ``delta`` rows, wrapping at both ends."""
@@ -554,6 +569,7 @@ class CommandPicker(Static):
         self._chosen_by_hand = True
         self._scroll_to_selection()
         self._repaint()
+        self._report_highlight()
 
     def scroll_rows(self, delta: int) -> None:
         """Move the highlight by ``delta`` rows for a WHEEL notch, clamped.
@@ -575,6 +591,7 @@ class CommandPicker(Static):
         self._chosen_by_hand = True
         self._scroll_to_selection()
         self._repaint()
+        self._report_highlight()
 
     def dismiss(self) -> None:
         """Hide the picker for the CURRENT word without touching the text."""
@@ -621,6 +638,7 @@ class CommandPicker(Static):
         if index != self._hovered:
             self._hovered = index
             self._repaint()
+            self._report_highlight()
         # The hand pointer only over a ROW: the picker's padding and notice
         # rows are not click targets, and a static `pointer` rule on the
         # widget would promise the click the empty rows cannot keep. Setting
@@ -633,6 +651,7 @@ class CommandPicker(Static):
         if self._hovered is not None:
             self._hovered = None
             self._repaint()
+            self._report_highlight()
         self.styles.pointer = "default"
 
     def on_resize(self, event: events.Resize) -> None:
@@ -1014,6 +1033,26 @@ class CommandPicker(Static):
             return None
         return index
 
+    def _report_highlight(self) -> None:
+        """Tell the observer which ARGUMENT row the user's eye is on now.
+
+        The reported row is the HOVER target when the pointer is over one,
+        else the keyboard highlight — the same precedence the row grounds
+        paint, so what previews is always the row that reads as active.
+        De-duplicated on the name: a mouse crossing five cells of one row and
+        a repaint that reproduced the same set both say nothing new.
+        """
+        if self._on_highlight is None:
+            return
+        name: str | None = None
+        if self._mode is PickerMode.ARGUMENT and self._matches:
+            index = self._hovered if self._hovered is not None else self._selected
+            if 0 <= index < len(self._matches):
+                name = self._matches[index][0]
+        if name != self._reported_highlight:
+            self._reported_highlight = name
+            self._on_highlight(name)
+
     def _reset_rows(self) -> None:
         """Drop every row and the state that pointed into them, but not the
         notice: a list can be showing its informational row with no rows at all."""
@@ -1033,3 +1072,4 @@ class CommandPicker(Static):
         # submission all arrive here, and each one is the user done with it.
         self._notice = ""
         self.display = False
+        self._report_highlight()

--- a/local_operator/tui/widgets/command_picker.py
+++ b/local_operator/tui/widgets/command_picker.py
@@ -351,6 +351,9 @@ class CommandPicker(Static):
         #: Last name reported to ``_on_highlight``, so the observer hears each
         #: change once — mouse-move events arrive per cell, not per row.
         self._reported_highlight: str | None = None
+        #: True only while ``set_choices`` seeds a highlight: the interim
+        #: row-0 state must not reach the observer (see ``set_choices``).
+        self._suppress_report = False
         self._commands: list[SlashCommand] = []
         self._choices: list[ArgumentChoice] = []
         self._mode = PickerMode.COMMAND
@@ -377,18 +380,43 @@ class CommandPicker(Static):
         """Replace the offered command registry."""
         self._commands = list(commands)
 
-    def set_choices(self, choices: list[ArgumentChoice]) -> None:
+    def set_choices(self, choices: list[ArgumentChoice], highlight: str | None = None) -> None:
         """Replace the values offered for the current command's ARGUMENT.
 
         Re-derives the visible rows immediately, because the app fills these in
         answer to a posted message — one message-loop tick after the keystroke
         that opened the list. Without the resync the picker would sit closed on
         the empty set it was opened with until the user typed another character.
+
+        ``highlight`` seeds the selection onto the named row when the list
+        opens bare (empty query, nothing chosen by hand). It exists for lists
+        where the highlight has a SIDE EFFECT: ``/theme`` previews the
+        highlighted row live, so a list that opened on row 0 flashed every
+        non-default user to the default theme before they touched a key
+        (review round 1, F2). Seeding the row where the user already IS makes
+        the first report a no-op — and is where a browse should start anyway.
         """
         self._choices = list(choices)
         if self._mode is PickerMode.ARGUMENT:
             matches = argument_suggestions(self._query, self._choices)
-            self._apply(PickerMode.ARGUMENT, self._query, matches)
+            seeding = highlight is not None and not self._query and not self._chosen_by_hand
+            if seeding:
+                # Silence `_apply`'s own report: it fires for row 0 before the
+                # seed lands, and for a previewing list that one report IS the
+                # flash — the observer would try row 0 on and take it off
+                # again one message later.
+                self._suppress_report = True
+            try:
+                self._apply(PickerMode.ARGUMENT, self._query, matches)
+            finally:
+                self._suppress_report = False
+            if seeding:
+                names = [name for name, _ in self._matches]
+                if highlight in names and names.index(highlight) != self._selected:
+                    self._selected = names.index(highlight)
+                    self._scroll_to_selection()
+                    self._repaint()
+                self._report_highlight()
 
     def set_notice(self, text: str) -> None:
         """Say why an ARGUMENT list is empty, IN THE LIST'S OWN PLACE.
@@ -1042,7 +1070,7 @@ class CommandPicker(Static):
         De-duplicated on the name: a mouse crossing five cells of one row and
         a repaint that reproduced the same set both say nothing new.
         """
-        if self._on_highlight is None:
+        if self._on_highlight is None or self._suppress_report:
             return
         name: str | None = None
         if self._mode is PickerMode.ARGUMENT and self._matches:

--- a/local_operator/tui/widgets/editor.py
+++ b/local_operator/tui/widgets/editor.py
@@ -443,6 +443,24 @@ class ArgumentQueryOpened(Message):
         self.command = command
 
 
+class ArgumentHighlightChanged(Message):
+    """Posted when the row the user's eye is on in an ARGUMENT list changes.
+
+    Carries the command word and the highlighted value name (``None`` when the
+    list closed or emptied). The one consumer is live preview: ``/theme``
+    applies the highlighted theme as the user arrows or hovers through the
+    rows, and restores the real one when the list goes away. Every other
+    command ignores it — previewing is an explicit opt-in on the app side,
+    because most argument rows (a credential to remove, a provider to log
+    into) have no meaningful "try it on" semantics.
+    """
+
+    def __init__(self, command: str, name: str | None) -> None:
+        super().__init__()
+        self.command = command
+        self.name = name
+
+
 #: The composer's resting prose. Named rather than inlined because the app
 #: swaps it for :data:`READ_ONLY_PLACEHOLDER` while the full-page subagent
 #: view is open and has to be able to put this one back.
@@ -501,7 +519,7 @@ class Editor(TextArea):
         # Built BEFORE super().__init__: TextArea's constructor loads its
         # initial document, which funnels through load_text() and therefore
         # through _sync_picker().
-        self._picker = CommandPicker(self._apply_command)
+        self._picker = CommandPicker(self._apply_command, self._on_picker_highlight)
         self._model_picker = ModelPicker(self._apply_model)
         # Which list-taking command the argument list is currently open for, or
         # None when the buffer is not in one. This is the transition edge the
@@ -1960,6 +1978,17 @@ class Editor(TextArea):
             # Transition only. Posting per keystroke would re-fetch every provider
             # for each character the user types into the query.
             self.post_message(ModelQueryOpened())
+
+    def _on_picker_highlight(self, name: str | None) -> None:
+        """Relay the picker's highlight to the app (see ArgumentHighlightChanged).
+
+        The picker reports a display NAME with no idea which command's list it
+        is; the buffer knows, and this widget owns the buffer, so the pairing
+        happens here. A ``None`` command (the word was deleted under the open
+        list) is reported as a close — the preview must not outlive its list.
+        """
+        command = self._argument_command
+        self.post_message(ArgumentHighlightChanged(command or "", name if command else None))
 
     def _command_word(self) -> str | None:
         """The lower-cased command word on the buffer's first non-blank line."""

--- a/local_operator/tui/widgets/tool_card.py
+++ b/local_operator/tui/widgets/tool_card.py
@@ -1447,6 +1447,10 @@ class ToolCard(TranscriptBlock):
             return
         self._refresh_row()
 
+    def retheme(self) -> None:
+        """Re-fit the row: `_build_content` resolves every ink at build time."""
+        self._refresh_row()
+
     # -- text selection (TUI-021) -------------------------------------------
     #: The icon field on the summary row: the per-tool glyph and its separator,
     #: which every rung of :meth:`_build_row` writes as ``icon + " "`` and every

--- a/local_operator/tui/widgets/transcript.py
+++ b/local_operator/tui/widgets/transcript.py
@@ -328,6 +328,25 @@ class TranscriptBlock(Static):
         """Freeze the block; the container never re-renders it afterwards."""
         self._finalized = True
 
+    def retheme(self) -> None:
+        """Rebuild this block's content in the CURRENT theme's ink.
+
+        Blocks resolve ``semantic_color`` when content is built, so a theme
+        switch leaves every settled block wearing the old ramp until it is
+        rebuilt. Each subclass whose content is a pure function of its state
+        overrides this with its own existing rebuild seam (the same one its
+        ``on_resize`` uses); the base is a no-op because the base class cannot
+        know how to rebuild content it was handed pre-rendered
+        (:class:`RichBlock`), and repainting nothing is the honest fallback —
+        such blocks keep their ink as history.
+
+        This deliberately does NOT bypass finalization by itself: overriders
+        use the same finalized-guard dance their resize handlers do, so the
+        FINALIZED-BLOCK protocol keeps exactly two sanctioned re-entry points
+        (width changed, theme changed), both producing the same rows for the
+        same state.
+        """
+
     def is_finalized(self) -> bool:
         """True when the block is immutable (FINALIZED-BLOCK protocol)."""
         return self._finalized
@@ -646,6 +665,15 @@ class UserBlock(TranscriptBlock):
             self._receipt_row = None
         return rows
 
+    def retheme(self) -> None:
+        """Re-ink rule, prose and receipt from the current ramp."""
+        was_finalized = self._finalized
+        self._finalized = False
+        try:
+            self.set_content(self._build(), layout=False)
+        finally:
+            self._finalized = was_finalized
+
     def _build(self) -> RenderableType:
         """The prompt, every row prefixed by the gutter rule.
 
@@ -813,6 +841,15 @@ class NoticeBlock(TranscriptBlock):
         parent = self.parent
         if isinstance(parent, TranscriptView):
             parent.refresh_gap_around(self)
+
+    def retheme(self) -> None:
+        """Re-ink glyph and text: the notice's whole render is `_token`'s hue."""
+        was_finalized = self._finalized
+        self._finalized = False
+        try:
+            self.set_content(self._build(), layout=False)
+        finally:
+            self._finalized = was_finalized
 
     def _build(self) -> RenderableType:
         """Glyph + text on the spine, WRAPPED with a hanging indent.

--- a/scripts/theme_preview.py
+++ b/scripts/theme_preview.py
@@ -1,0 +1,117 @@
+"""Render one SVG frame per theme, with representative transcript content.
+
+The palette gate (``tests/unit/tui/test_palette_contrast.py``) proves the
+numbers; this proves the LOOK. It drives the real ``OperatorApp`` (the one
+that loads ``local_operator.tcss``) through ``run_test``, fills the screen
+with the content mix a real session shows — user prompt, assistant markdown
+with a code fence, tool rows in all three outcomes, a notice, the status
+band — switches the theme live through the same ``_apply_theme`` path the
+``/theme`` command uses, and saves a frame per theme.
+
+Usage::
+
+    env -u NO_COLOR TERM=xterm-256color .venv/bin/python scripts/theme_preview.py OUTDIR [theme ...]
+
+With no theme arguments it renders every registered theme. SVGs land in
+OUTDIR as ``<theme>.svg``; convert or open them and LOOK — the gate cannot
+see a hue clash, only a ratio.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+# The pilot needs a colour terminal and stilled animation for stable frames.
+os.environ.setdefault("LOCAL_OPERATOR_NO_SHIMMER", "1")
+os.environ.pop("NO_COLOR", None)
+
+from local_operator.tui import theme as theme_mod  # noqa: E402
+from local_operator.tui.app import OperatorApp  # noqa: E402
+from local_operator.tui.widgets.assistant import AssistantBlock  # noqa: E402
+from local_operator.tui.widgets.tool_card import ToolCard  # noqa: E402
+from local_operator.tui.widgets.transcript import (  # noqa: E402
+    NoticeBlock,
+    UserBlock,
+)
+from tests.unit.tui.test_app_pilot import FakeSession, _factory  # noqa: E402
+
+#: Markdown exercising the inks a theme must keep distinct: prose, bold,
+#: inline code (signal), a fenced block (syntax ramp), a list, a link.
+_ASSISTANT_MD = """\
+Here's the plan — I checked the **routing table** and `config.yml` first.
+
+```python
+def relight(theme: str) -> int:
+    # comments sit at dim; strings at the literal hue
+    return apply(theme, mode="live")
+```
+
+1. Switch the ramp atomically
+2. Re-ink every settled block
+3. [Persist the choice](https://example.com) to config
+"""
+
+
+def _populate(app: OperatorApp) -> None:
+    """One screen of representative content, appended through the real seams."""
+    app._append_block(
+        UserBlock(
+            "Switch my theme and show me every kind of row.\n\n"
+            "Second paragraph, for the gutter rule."
+        )
+    )
+    assistant = AssistantBlock()
+    assistant.update_text(_ASSISTANT_MD)
+    assistant.finalize_text()
+    app._append_block(assistant)
+
+    done = ToolCard("call-1", "bash", {"command": "pytest -q tests/unit"})
+    app._append_block(done)
+    done.mark_done("2701 passed in 204s")
+
+    failed = ToolCard("call-2", "read", {"path": "/tmp/missing.txt"})
+    app._append_block(failed)
+    failed.mark_failed("no such file: /tmp/missing.txt")
+
+    running = ToolCard("call-3", "edit", {"path": "app.py"})
+    app._append_block(running)
+
+    app._append_block(NoticeBlock("theme: dark → monokai (saved as your default)", "note"))
+    app._append_block(NoticeBlock("credential store unreachable — retrying", "warning"))
+
+
+async def _render(names: list[str], outdir: Path) -> None:
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(110, 34)) as pilot:
+        await pilot.pause()
+        _populate(app)
+        await pilot.pause()
+        for name in names:
+            app._apply_theme(name)
+            await pilot.pause()
+            await pilot.pause()
+            target = outdir / f"{name}.svg"
+            app.save_screenshot(str(target))
+            print(f"wrote {target}")
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        raise SystemExit(__doc__)
+    outdir = Path(sys.argv[1])
+    outdir.mkdir(parents=True, exist_ok=True)
+    names = sys.argv[2:] or theme_mod.available_themes()
+    unknown = [name for name in names if name not in theme_mod.available_themes()]
+    if unknown:
+        raise SystemExit(f"unknown themes: {', '.join(unknown)}")
+    asyncio.run(_render(names, outdir))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/theme_preview.py
+++ b/scripts/theme_preview.py
@@ -35,10 +35,7 @@ from local_operator.tui import theme as theme_mod  # noqa: E402
 from local_operator.tui.app import OperatorApp  # noqa: E402
 from local_operator.tui.widgets.assistant import AssistantBlock  # noqa: E402
 from local_operator.tui.widgets.tool_card import ToolCard  # noqa: E402
-from local_operator.tui.widgets.transcript import (  # noqa: E402
-    NoticeBlock,
-    UserBlock,
-)
+from local_operator.tui.widgets.transcript import NoticeBlock, UserBlock  # noqa: E402
 from tests.unit.tui.test_app_pilot import FakeSession, _factory  # noqa: E402
 
 #: Markdown exercising the inks a theme must keep distinct: prose, bold,

--- a/tests/unit/tui/test_approvals_ux.py
+++ b/tests/unit/tui/test_approvals_ux.py
@@ -485,6 +485,9 @@ def test_the_registry_states_which_commands_offer_values() -> None:
     }
     assert modes == {
         "effort": ArgumentMode.OPTIONAL,
+        # OPTIONAL like `/effort`: bare `/theme` answers with the active theme,
+        # and the space opens the ramp list with live preview.
+        "theme": ArgumentMode.OPTIONAL,
         "approvals": ArgumentMode.OPTIONAL,
         "login": ArgumentMode.REQUIRED,
         "logout": ArgumentMode.REQUIRED,

--- a/tests/unit/tui/test_palette_contrast.py
+++ b/tests/unit/tui/test_palette_contrast.py
@@ -1,0 +1,156 @@
+"""Contrast floors every registered theme must clear — the palette gate.
+
+"Readable" is a checked property here, not a review comment. The floors are
+calibrated from the BRAND ramps' own measured values (the dark ramp's ``dim``
+is 4.55:1 on the ground, the light ramp's is 3.77:1; every state hue clears
+4.3:1 on both), with enough headroom under each brand value that the brand
+ramps themselves pass their own gate. A curated palette that fails here is
+returned to its author with the exact token and ratio — the failure message
+is the review.
+
+The floors, and why each exists:
+
+- ``fg`` >= 7:1 on ``bg`` and ``surface``: body prose is read for hours;
+  both brand ramps sit near 14:1 and WCAG AAA is 7:1.
+- ``muted`` >= 4.5:1: secondary text is still text (WCAG AA).
+- ``dim`` >= 3.4:1: micro-labels and separators — the light brand ramp's
+  3.77:1 is the reference, 3.4 leaves solve room without dipping to
+  imperceptible.
+- state hues (``accent success warning danger signal label string``)
+  >= 4.0:1 on ``bg`` AND ``surface``: they carry meaning in one word
+  (a red ✗, a green ✓) and both brand ramps clear 4.3:1 everywhere.
+- ``faint`` BELOW ``dim``: it is the "inert hint" rung; a faint brighter
+  than dim inverts the ramp's whole hierarchy.
+- elevation is monotonic in the theme's polarity: each step of
+  bg → surface → raised → overlay moves AWAY from the polarity's floor
+  (lighter on dark themes, darker on light ones) and ``sunken`` moves the
+  other way. A theme whose "raised" is darker than its ground paints
+  depth upside down.
+- tints stay near the ground (< 2.2:1 vs ``bg``): a tint is a cast, not a
+  slab — the brand ramps' loudest tint is 1.6:1.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from local_operator.tui import theme
+
+
+def _linear(channel: int) -> float:
+    scaled = channel / 255
+    return scaled / 12.92 if scaled <= 0.04045 else ((scaled + 0.055) / 1.055) ** 2.4
+
+
+def _luminance(hex_color: str) -> float:
+    value = hex_color.lstrip("#")
+    red, green, blue = (int(value[index : index + 2], 16) for index in (0, 2, 4))
+    return 0.2126 * _linear(red) + 0.7152 * _linear(green) + 0.0722 * _linear(blue)
+
+
+def contrast(color_a: str, color_b: str) -> float:
+    lum_a, lum_b = _luminance(color_a), _luminance(color_b)
+    high, low = max(lum_a, lum_b), min(lum_a, lum_b)
+    return (high + 0.05) / (low + 0.05)
+
+
+#: Foreground floors: token -> minimum ratio, checked against BOTH ``bg``
+#: and ``surface`` (text renders on both grounds).
+_FG_FLOORS: dict[str, float] = {
+    "fg": 7.0,
+    "muted": 4.5,
+    "dim": 3.4,
+    "accent": 4.0,
+    "success": 4.0,
+    "warning": 4.0,
+    "danger": 4.0,
+    "signal": 4.0,
+    "label": 4.0,
+    "string": 4.0,
+}
+
+#: A tint is a cast at roughly the ground's luminance, never a slab.
+_TINT_CEILING = 2.2
+
+_ALL_THEMES = theme.available_themes()
+
+
+@pytest.mark.parametrize("name", _ALL_THEMES)
+def test_theme_is_total(name: str) -> None:
+    spec = theme.theme_spec(name)
+    assert set(spec.tokens) == set(theme.SEMANTIC_TOKENS)
+    assert spec.label, f"{name} has no picker label"
+    assert spec.description, f"{name} has no picker description"
+
+
+@pytest.mark.parametrize("name", _ALL_THEMES)
+def test_foreground_contrast_floors(name: str) -> None:
+    spec = theme.theme_spec(name)
+    tokens = spec.tokens
+    failures: list[str] = []
+    for token, floor in _FG_FLOORS.items():
+        for ground in ("bg", "surface"):
+            ratio = contrast(tokens[token], tokens[ground])
+            if ratio < floor:
+                failures.append(
+                    f"{token} {tokens[token]} on {ground} {tokens[ground]}: "
+                    f"{ratio:.2f} < {floor}"
+                )
+    assert not failures, f"{name}: " + "; ".join(failures)
+
+
+@pytest.mark.parametrize("name", _ALL_THEMES)
+def test_faint_sits_below_dim(name: str) -> None:
+    tokens = theme.theme_spec(name).tokens
+    assert contrast(tokens["faint"], tokens["bg"]) < contrast(tokens["dim"], tokens["bg"]), (
+        f"{name}: faint ({tokens['faint']}) reads louder than dim ({tokens['dim']}) — "
+        "the hint rung outranks the label rung"
+    )
+
+
+@pytest.mark.parametrize("name", _ALL_THEMES)
+def test_elevation_is_monotonic(name: str) -> None:
+    spec = theme.theme_spec(name)
+    tokens = spec.tokens
+    ladder = [_luminance(tokens[step]) for step in ("bg", "surface", "raised", "overlay")]
+    if spec.dark:
+        assert ladder == sorted(ladder), f"{name}: dark elevation must lighten upward: {ladder}"
+        assert _luminance(tokens["sunken"]) <= ladder[0], f"{name}: sunken must sit below bg"
+    else:
+        assert ladder == sorted(
+            ladder, reverse=True
+        ), f"{name}: light elevation must darken upward: {ladder}"
+        assert (
+            _luminance(tokens["sunken"]) <= _luminance(tokens["bg"])
+            or contrast(tokens["sunken"], tokens["bg"]) < 1.35
+        ), f"{name}: light sunken should stay near or below the paper"
+
+
+@pytest.mark.parametrize("name", _ALL_THEMES)
+def test_tints_are_casts_not_slabs(name: str) -> None:
+    tokens = theme.theme_spec(name).tokens
+    failures: list[str] = []
+    for token in ("tint-danger", "tint-select", "tint-select-hi"):
+        ratio = contrast(tokens[token], tokens["bg"])
+        if ratio > _TINT_CEILING:
+            failures.append(f"{token} {tokens[token]} vs bg: {ratio:.2f} > {_TINT_CEILING}")
+    assert not failures, f"{name}: " + "; ".join(failures)
+
+
+@pytest.mark.parametrize("name", _ALL_THEMES)
+def test_select_tint_survives_hover(name: str) -> None:
+    """Hover on the selected row must read as MORE, not the same.
+
+    The brand ramp's D8 lesson: tint-select-hi exists because hover has to be
+    additive. Equal hexes silently erase hover feedback for mouse users.
+    """
+    tokens = theme.theme_spec(name).tokens
+    assert (
+        tokens["tint-select"] != tokens["tint-select-hi"]
+    ), f"{name}: tint-select-hi equals tint-select — hover on the selected row is invisible"
+
+
+def test_default_theme_is_operator_dark() -> None:
+    """The product default stays the island night, whatever gets registered."""
+    assert theme.DEFAULT_THEME == "dark"
+    assert theme.available_themes()[0] == "dark"

--- a/tests/unit/tui/test_palette_contrast.py
+++ b/tests/unit/tui/test_palette_contrast.py
@@ -100,6 +100,25 @@ def test_foreground_contrast_floors(name: str) -> None:
 
 
 @pytest.mark.parametrize("name", _ALL_THEMES)
+def test_danger_reads_on_its_own_tint(name: str) -> None:
+    """The failed tool row pairs ``danger`` ink WITH the ``tint-danger`` band.
+
+    Review round 1 (D1) caught the gap: the state floors above check ``bg``
+    and ``surface``, but the one place danger ink always renders is the failed
+    row's own tinted ground (``tool_card.py`` paints the error reason in
+    ``danger`` on ``tint-danger``), and two palettes cleared every other floor
+    while dipping to 3.6–3.9:1 on exactly that pairing. Same 4.0 floor as the
+    other state checks.
+    """
+    tokens = theme.theme_spec(name).tokens
+    ratio = contrast(tokens["danger"], tokens["tint-danger"])
+    assert ratio >= 4.0, (
+        f"{name}: danger {tokens['danger']} on tint-danger {tokens['tint-danger']}: "
+        f"{ratio:.2f} < 4.0 — the failed row's error text is illegible on its own band"
+    )
+
+
+@pytest.mark.parametrize("name", _ALL_THEMES)
 def test_faint_sits_below_dim(name: str) -> None:
     tokens = theme.theme_spec(name).tokens
     assert contrast(tokens["faint"], tokens["bg"]) < contrast(tokens["dim"], tokens["bg"]), (

--- a/tests/unit/tui/test_slash_echo.py
+++ b/tests/unit/tui/test_slash_echo.py
@@ -49,6 +49,9 @@ ECHO_POLICY = {
     # A setting, not words the model is told: the receipt names the level that
     # is now in force and the band carries it from then on.
     "effort": False,
+    # A setting, not words the model is told: the receipt names the theme now
+    # in force, and the screen itself is wearing the change.
+    "theme": False,
     "provider": False,
     "search": False,
     "accounts": False,

--- a/tests/unit/tui/test_theme_command.py
+++ b/tests/unit/tui/test_theme_command.py
@@ -1,0 +1,201 @@
+"""``/theme``: the switch, the persistence, and the live preview's lifecycle.
+
+The preview is the part with real failure modes, so the tests here are about
+its LIFETIME: a highlight applies the candidate theme to the whole screen, a
+dismissal (Esc, deleting the word, an empty match set) restores the theme the
+user actually has, and a commit clears the stash BEFORE applying so the
+restore branch cannot undo what was just chosen. Every test restores the
+module-level theme singleton, because ``theme_mod`` is process state shared
+with every other test in the run.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from local_operator.paths import CONFIG_DIR_ENV
+from local_operator.tui import theme as theme_mod
+from local_operator.tui.app import OperatorApp
+from local_operator.tui.widgets.editor import Editor
+from local_operator.tui.widgets.transcript import NoticeBlock
+from tests.unit.tui.test_app_pilot import FakeSession, _factory
+
+
+@pytest.fixture()
+def config_dir(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    """Point the config at a temp dir — a committed switch WRITES one."""
+    monkeypatch.setenv(CONFIG_DIR_ENV, str(tmp_path))
+    return tmp_path
+
+
+@pytest.fixture(autouse=True)
+def _restore_theme():
+    """The theme module is a process singleton; put dark back afterwards."""
+    original = theme_mod.current_theme()
+    yield
+    theme_mod.set_theme(original)
+
+
+async def _boot(pilot, app: OperatorApp) -> None:
+    for _ in range(40):
+        await pilot.pause()
+        if app._session is not None:
+            return
+
+
+async def _type(pilot, app: OperatorApp, text: str) -> None:
+    app.query_one(Editor).text = text
+    await pilot.pause()
+    await pilot.pause()
+
+
+def _notices(app: OperatorApp) -> list[str]:
+    return [getattr(block, "_text", "") for block in app.query(NoticeBlock)]
+
+
+@pytest.mark.asyncio
+async def test_bare_theme_names_the_active_theme(config_dir: Path) -> None:
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(110, 34)) as pilot:
+        await _boot(pilot, app)
+        app._run_slash_command("/theme")
+        await pilot.pause()
+        texts = _notices(app)
+        assert any("Operator Dark" in text and "dark" in text for text in texts), texts
+
+
+@pytest.mark.asyncio
+async def test_switch_applies_persists_and_receipts(config_dir: Path) -> None:
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(110, 34)) as pilot:
+        await _boot(pilot, app)
+        app._run_slash_command("/theme monokai")
+        await pilot.pause()
+        assert theme_mod.current_theme() == "monokai"
+        # The receipt names both ends of the change and says it was saved.
+        assert any("dark → monokai" in text for text in _notices(app))
+        saved = yaml.safe_load((config_dir / "config.yml").read_text(encoding="utf-8"))
+        assert saved["values"]["tui"]["theme"] == "monokai"
+
+
+@pytest.mark.asyncio
+async def test_unknown_theme_is_refused_and_nothing_moves(config_dir: Path) -> None:
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(110, 34)) as pilot:
+        await _boot(pilot, app)
+        app._run_slash_command("/theme neon-nonexistent")
+        await pilot.pause()
+        assert theme_mod.current_theme() == "dark"
+        assert not (config_dir / "config.yml").exists()
+        assert any("unknown theme" in text for text in _notices(app))
+
+
+@pytest.mark.asyncio
+async def test_arrowing_previews_and_esc_restores(config_dir: Path) -> None:
+    """The whole screen is the swatch, and Esc hands the real theme back."""
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(110, 34)) as pilot:
+        await _boot(pilot, app)
+        editor = app.query_one(Editor)
+        editor.focus()
+        await _type(pilot, app, "/theme ")
+        picker = editor.picker
+        assert picker.is_open()
+        await pilot.press("down")
+        await pilot.pause()
+        await pilot.pause()
+        previewed = theme_mod.current_theme()
+        assert previewed != "dark", "arrowing to another row must apply its theme"
+        assert app._theme_before_preview == "dark"
+        await pilot.press("escape")
+        await pilot.pause()
+        await pilot.pause()
+        assert theme_mod.current_theme() == "dark"
+        assert app._theme_before_preview is None
+        # Browsing must never write: preview is try-on, not commitment.
+        assert not (config_dir / "config.yml").exists()
+
+
+@pytest.mark.asyncio
+async def test_deleting_the_word_restores_too(config_dir: Path) -> None:
+    """The buffer is the authority: no list, no preview."""
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(110, 34)) as pilot:
+        await _boot(pilot, app)
+        editor = app.query_one(Editor)
+        editor.focus()
+        await _type(pilot, app, "/theme ")
+        await pilot.press("down")
+        await pilot.pause()
+        assert theme_mod.current_theme() != "dark"
+        await _type(pilot, app, "")
+        await pilot.pause()
+        assert theme_mod.current_theme() == "dark"
+        assert app._theme_before_preview is None
+
+
+@pytest.mark.asyncio
+async def test_committing_a_previewed_theme_survives_the_list_closing(config_dir: Path) -> None:
+    """Enter on a previewed row keeps it: the restore must not undo the choice.
+
+    The ordering under test: `_cmd_theme` clears the stash BEFORE applying, so
+    the close-of-list restore that follows submission finds no stash and the
+    committed theme stands.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(110, 34)) as pilot:
+        await _boot(pilot, app)
+        editor = app.query_one(Editor)
+        editor.focus()
+        await _type(pilot, app, "/theme ")
+        picker = editor.picker
+        names = [name for name, _ in picker.suggestions()]
+        target = names.index("monokai")
+        for _ in range(target):
+            await pilot.press("down")
+            await pilot.pause()
+        assert picker.highlighted_name() == "monokai"
+        await pilot.press("enter")
+        await pilot.pause()
+        await pilot.pause()
+        assert theme_mod.current_theme() == "monokai"
+        assert app._theme_before_preview is None
+        saved = yaml.safe_load((config_dir / "config.yml").read_text(encoding="utf-8"))
+        assert saved["values"]["tui"]["theme"] == "monokai"
+
+
+@pytest.mark.asyncio
+async def test_switch_reinks_settled_blocks(config_dir: Path) -> None:
+    """A finalized notice must wear the NEW ramp after a switch (retheme seam)."""
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(110, 34)) as pilot:
+        await _boot(pilot, app)
+        block = NoticeBlock("a settled receipt", "warning")
+        app._append_block(block)
+        await pilot.pause()
+        before = theme_mod.semantic_color("warning")
+        app._run_slash_command("/theme monokai")
+        await pilot.pause()
+        await pilot.pause()
+        after = theme_mod.semantic_color("warning")
+        assert before != after, "monokai's warning must differ for this test to see the re-ink"
+        rendered = block.renderable
+        spans = getattr(rendered, "spans", [])
+        colors = {
+            str(span.style.color.name)
+            for span in spans
+            if getattr(span.style, "color", None) is not None
+        }
+        assert any(
+            after in color for color in colors
+        ), f"finalized notice still wears the old ramp: {colors} (wanted {after})"
+
+
+def test_boot_with_unknown_saved_theme_falls_back_to_dark() -> None:
+    """A stale config.yml name must not keep the app from booting."""
+    app = OperatorApp(lambda: _factory(FakeSession()), theme_name="theme-that-was-removed")
+    assert theme_mod.current_theme() == "dark"
+    assert app is not None

--- a/tests/unit/tui/test_theme_command.py
+++ b/tests/unit/tui/test_theme_command.py
@@ -265,13 +265,22 @@ async def test_preview_defers_offscreen_reink_to_the_settle(config_dir: Path) ->
             previewed_warning in color for color in _colors(blocks[-1])
         ), "onscreen block should carry the previewed ramp"
 
-        # Settle (Esc restores dark): the skipped block is swept back too.
-        await pilot.press("escape")
+        # Settle by COMMITTING a third theme rather than Esc-ing back to dark
+        # (review round 2, F7): the probe block wears dark's ink throughout
+        # the preview, so a restore-to-dark settle would pass even with the
+        # settle sweep deleted. Committing to a ramp the probe has never worn
+        # is the assertion that actually binds — the offscreen block can only
+        # carry that ink if the full sweep ran.
+        editor.text = "/theme monokai"
+        await pilot.pause()
+        await pilot.press("enter")
         await pilot.pause()
         await pilot.pause()
-        assert theme_mod.current_theme() == "dark"
+        assert theme_mod.current_theme() == "monokai"
+        monokai_warning = theme_mod.semantic_color("warning")
+        assert monokai_warning not in (dark_warning, previewed_warning)
         assert any(
-            dark_warning in color for color in _colors(offscreen)
+            monokai_warning in color for color in _colors(offscreen)
         ), "the settle sweep must cover what the preview skipped"
 
 

--- a/tests/unit/tui/test_theme_command.py
+++ b/tests/unit/tui/test_theme_command.py
@@ -194,6 +194,87 @@ async def test_switch_reinks_settled_blocks(config_dir: Path) -> None:
         ), f"finalized notice still wears the old ramp: {colors} (wanted {after})"
 
 
+@pytest.mark.asyncio
+async def test_opening_the_list_does_not_flash_the_theme(config_dir: Path) -> None:
+    """`/theme ` opens ON the current theme's row, previewing nothing (F2).
+
+    The highlight previews live, so a list that opened on row 0 flashed every
+    non-default user to whatever theme sorts first before they touched a key.
+    The list must open with the highlight seeded on the active theme and the
+    screen unmoved.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()), theme_name="monokai")
+    async with app.run_test(size=(110, 34)) as pilot:
+        await _boot(pilot, app)
+        editor = app.query_one(Editor)
+        editor.focus()
+        await _type(pilot, app, "/theme ")
+        await pilot.pause()
+        assert theme_mod.current_theme() == "monokai", "opening the list must not switch themes"
+        assert app._theme_before_preview is None, "no preview is standing before any movement"
+        picker = editor.picker
+        assert picker.highlighted_name() == "monokai", "the browse starts where the user is"
+
+
+@pytest.mark.asyncio
+async def test_preview_defers_offscreen_reink_to_the_settle(config_dir: Path) -> None:
+    """A preview re-inks visible rows only; the settle sweep covers the rest (F1).
+
+    The preview pays its cost per arrow key, so it is bounded to the viewport;
+    whatever it skipped is corrected when the browse ends, however it ends.
+    This pins the settle-on-restore path: blocks scrolled far offscreen wear
+    the old ramp mid-preview and the current ramp once the list closes.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(110, 20)) as pilot:
+        await _boot(pilot, app)
+        # Enough notices that the first is far above the fold.
+        blocks = [NoticeBlock(f"receipt {index}", "warning") for index in range(40)]
+        for block in blocks:
+            app._append_block(block)
+        await pilot.pause()
+        offscreen = blocks[0]
+        assert not app._is_on_screen(offscreen), "the probe block must be scrolled out"
+        dark_warning = theme_mod.semantic_color("warning")
+
+        editor = app.query_one(Editor)
+        editor.focus()
+        await _type(pilot, app, "/theme ")
+        await pilot.press("down")
+        await pilot.pause()
+        await pilot.pause()
+        previewed = theme_mod.current_theme()
+        assert previewed != "dark"
+        previewed_warning = theme_mod.semantic_color("warning")
+        assert previewed_warning != dark_warning, "pick a probe token the ramps disagree on"
+
+        def _colors(block: NoticeBlock) -> set[str]:
+            spans = getattr(block.renderable, "spans", [])
+            return {
+                str(span.style.color.name)
+                for span in spans
+                if getattr(span.style, "color", None) is not None
+            }
+
+        # Mid-preview: the offscreen block still wears dark's ink (skipped),
+        # while an onscreen one wears the preview's.
+        assert any(
+            dark_warning in color for color in _colors(offscreen)
+        ), "offscreen block should be skipped by the preview sweep"
+        assert any(
+            previewed_warning in color for color in _colors(blocks[-1])
+        ), "onscreen block should carry the previewed ramp"
+
+        # Settle (Esc restores dark): the skipped block is swept back too.
+        await pilot.press("escape")
+        await pilot.pause()
+        await pilot.pause()
+        assert theme_mod.current_theme() == "dark"
+        assert any(
+            dark_warning in color for color in _colors(offscreen)
+        ), "the settle sweep must cover what the preview skipped"
+
+
 def test_boot_with_unknown_saved_theme_falls_back_to_dark() -> None:
     """A stale config.yml name must not keep the app from booting."""
     app = OperatorApp(lambda: _factory(FakeSession()), theme_name="theme-that-was-removed")


### PR DESCRIPTION
# PR Description

## Change classification

**C2 — standard / pre-authorized.** A new `/theme` slash command with live preview, a validating theme registry, and 32 curated palettes on top of the two brand ramps. The default theme is unchanged (`dark`, the island night) and nothing switches unless the user asks; clean rollback via `git revert`.

## The gap

The TUI shipped with exactly two ramps (`dark`, `light`) selectable only by hand-editing `tui.theme` in `config.yml` before launch. There was no way to see a theme before committing to it, no vocabulary for adding one safely (a palette missing a token failed at render time, on whichever widget asked first), and several surfaces resolved colors at build time — so even a successful switch left settled transcript blocks wearing the old ramp.

## The fix

**Centralized theming first** (the refactor the feature sits on):

- `theme.py` becomes a validating registry. `ThemeSpec(name, label, description, dark, tokens)` must be **total** over the canonical `SEMANTIC_TOKENS` vocabulary — registration rejects missing tokens, invented tokens, malformed hexes, and duplicate names, so every palette mistake fails loudly at registration rather than at render time. The two brand ramps keep their pinned raw vocabulary (`amber`, `paper`, `ink`) and exact hexes — `tests/unit/tui/test_theme.py` passes with zero edits.
- Curated palettes live in `local_operator/tui/palettes/` (classics / neon / nature / lights), folded into the registry lazily so importing `theme.py` never pays for the tables.
- `_apply_theme` orchestrates a **live** switch across all four rendering systems: TCSS variables (`refresh_css`), the rich markdown/syntax console theme (pop-then-push, so previews can't grow the theme stack), the ANSI terminal-theme mapping (now resolved from the active ramp, not hardcoded to brand dark), and a `retheme()` seam on every transcript block that re-inks build-time-resolved styles through each widget's existing rebuild path (the same seams `on_resize` uses — no second way to render).

**Then `/theme`** (alias `/themes`):

- Bare `/theme` names the active theme; `/theme <name>` switches, **persists** to `tui.theme` (merged into the existing mapping), and receipts `theme: dark → monokai (saved as your default)`. Unknown names are refused with a pointer at the list; a saved name a build no longer ships falls back to `dark` at boot instead of failing.
- `/theme ` (with a space) opens the argument list seeded on the current theme's row: **the highlighted row is previewed live on the whole screen** as you arrow or hover through it. The first differing highlight stashes the real theme; Esc, deleting the word, or an empty match set restores it; Enter commits (the stash is cleared before applying, so the list-close restore cannot undo the choice). Browsing never writes to disk, and opening the list changes nothing until you move.
- The preview plumbing is a small observer on `CommandPicker` (hover-then-keyboard precedence, de-duplicated) relayed through a new `ArgumentHighlightChanged` message; only `/theme` opts in — other argument lists (a credential to remove) have no "try it on" semantics.

**32 curated themes**, split among four curator subagents and validated two ways each:

- classics: monokai, dracula, catppuccin-mocha, catppuccin-latte, tokyo-night, tokyo-night-storm, gruvbox, nord, one-dark, solarized-dark
- neon/retro: synthwave, matrix, tron, cyberpunk, vaporwave, outrun, neon-noir, arcade
- nature: sage (Zelda beige/sage-green), forest, ocean, desert, autumn, lavender, arctic, rosewood
- light: solarized-light, github-light, paper, linen, high-contrast-light, mint-light

Craft rules enforced in the files: published hexes wherever they clear the floors, with every deviation commented naming the canonical value, the measured ratio, and the substitute (e.g. Monokai's classic `#f92672` pink is 3.47:1 on its own surface — the file carries Monokai Pro's `#ff6188` and says why). Body ink is always near-neutral; the vibe lives in accent/signal/label and the tinted grounds — matrix keeps its phosphor green for states while prose sits at a desaturated green-white, per the "matrix vibes, easy on the eyes" brief.

**"Readable" is a checked property, not a review comment**: `tests/unit/tui/test_palette_contrast.py` pins WCAG-derived floors calibrated from the brand ramps' own measurements (fg ≥ 7:1 on both grounds, muted ≥ 4.5, dim ≥ 3.4, all seven state hues ≥ 4:1, faint below dim, elevation monotonic in the theme's polarity, tints < 2.2:1). 239 parameterized gate tests across the 34 themes, including a `danger`-on-`tint-danger` ≥ 4:1 floor added in review round 1 (the failed tool row pairs those two).

## Testing evidence

**Real-path exercise** (pilot against the real `OperatorApp`, the one that loads the stylesheet):

- Typed `/theme ` → list opens with all 34 rows, current theme marked `← current`, highlight seeded on it (no flash).
- Arrowed down → screen repainted in the highlighted theme, stash recorded (`after down: highlighted: light theme: light stash: dark`).
- Esc → theme restored (`after esc: theme: dark stash: None`), **no config written**.
- Reopened, arrowed to monokai, Enter → committed (`after enter: theme: monokai stash: None`), receipt in transcript (`theme: dark → monokai (saved as your default)`), and `config.yml` holds `tui: {theme: monokai}` (verified by reading the file back).
- Invalid input: `/theme neon-nonexistent` → refused with `unknown theme … type /theme and space to browse`, theme unmoved, nothing written. Boot with a stale saved name falls back to `dark` (pinned in a test).
- Re-ink: a **finalized** warning notice appended before the switch carries the new ramp's warning hex in its spans after `/theme monokai` (pinned in `test_switch_reinks_settled_blocks`).

**Preview performance** (review round 1, F1): a preview re-inks only viewport-visible blocks; the full sweep runs when the browse settles (commit/restore). Measured: 120-block transcript 219 ms → 23.7 ms per switch, 360-block 172 ms → 42.9 ms, residual being Textual's `refresh_css` (constant in transcript length).

**Visual validation.** `scripts/theme_preview.py` (in this PR) drives the real app, fills it with representative content — multi-paragraph user prompt, assistant markdown with a code fence, tool rows in ✓/✗/running states, note + warning notices, the status band — switches themes through the same `_apply_theme` path the command uses, and exports one SVG per theme. All **34 frames rendered and visually reviewed**, twice: once by the curator subagents (who iterated on what looked wrong, not just what failed the gate) and once re-shot at the remediation head for the design round's verification.

**Unit suites.** Full `tests/unit`: 5241 passed, 7 skipped at the pre-review head; full `tests/unit/tui` re-run green after the review remediations (2027 passed, 4 skipped at `871c36b`); CI runs the whole suite on the merge head (`2682dbe`: 3.12 and 3.13 both green). The `/theme` lifecycle suite is 10 tests (preview/restore/commit/persist/re-ink, plus the round-1 regressions: no flash on open, offscreen re-ink deferred to the settle — the latter mutation-verified). The two pinned policy tables (`ECHO_POLICY`, the argument-mode table) each gained their `/theme` row with the reasoning comment the tables require.

**Gates.** black + isort clean (CI's isort 5.13.2 included); flake8 clean; pyright 0 errors, 0 warnings.

## Review rounds

Code: rounds 1–4 recorded on this PR, final approval at head `2682dbe`. Design: rounds 1–2, approval at `871c36b` with freshness notes confirming the later deltas (comment rewrite, test hardening, import reformat) are non-visual. All findings dispositioned in the matching remediation comments.

## Screenshots

All frames captured at `871c36b` (the round-1 remediation head; later commits change no rendered output — see the freshness notes). Full grid: all 34 themes on the same representative screen.

![contact sheet](https://raw.githubusercontent.com/damianvtran/local-operator/assets/pr-tui-themes/contact-sheet.png)

| Theme | Frame |
| --- | --- |
| **dark** — the unchanged default (before = after for existing users) | ![dark](https://raw.githubusercontent.com/damianvtran/local-operator/assets/pr-tui-themes/dark.png) |
| **Live preview mid-browse** — arrowed onto a row, whole screen wearing it (captured pre-remediation at `1d65e6a`; the preview mechanics it evidences are unchanged) | ![preview](https://raw.githubusercontent.com/damianvtran/local-operator/assets/pr-tui-themes/preview-mid.png) |
| monokai | ![monokai](https://raw.githubusercontent.com/damianvtran/local-operator/assets/pr-tui-themes/monokai.png) |
| dracula | ![dracula](https://raw.githubusercontent.com/damianvtran/local-operator/assets/pr-tui-themes/dracula.png) |
| catppuccin-mocha | ![catppuccin-mocha](https://raw.githubusercontent.com/damianvtran/local-operator/assets/pr-tui-themes/catppuccin-mocha.png) |
| tokyo-night | ![tokyo-night](https://raw.githubusercontent.com/damianvtran/local-operator/assets/pr-tui-themes/tokyo-night.png) |
| gruvbox | ![gruvbox](https://raw.githubusercontent.com/damianvtran/local-operator/assets/pr-tui-themes/gruvbox.png) |
| nord | ![nord](https://raw.githubusercontent.com/damianvtran/local-operator/assets/pr-tui-themes/nord.png) |
| synthwave | ![synthwave](https://raw.githubusercontent.com/damianvtran/local-operator/assets/pr-tui-themes/synthwave.png) |
| matrix | ![matrix](https://raw.githubusercontent.com/damianvtran/local-operator/assets/pr-tui-themes/matrix.png) |
| tron | ![tron](https://raw.githubusercontent.com/damianvtran/local-operator/assets/pr-tui-themes/tron.png) |
| sage | ![sage](https://raw.githubusercontent.com/damianvtran/local-operator/assets/pr-tui-themes/sage.png) |
| solarized-dark (D1 re-solve) | ![solarized-dark](https://raw.githubusercontent.com/damianvtran/local-operator/assets/pr-tui-themes/solarized-dark.png) |
| arctic (D3 re-ground) | ![arctic](https://raw.githubusercontent.com/damianvtran/local-operator/assets/pr-tui-themes/arctic.png) |
| catppuccin-latte (light) | ![catppuccin-latte](https://raw.githubusercontent.com/damianvtran/local-operator/assets/pr-tui-themes/catppuccin-latte.png) |
| github-light | ![github-light](https://raw.githubusercontent.com/damianvtran/local-operator/assets/pr-tui-themes/github-light.png) |
| solarized-light (D1 re-solve) | ![solarized-light](https://raw.githubusercontent.com/damianvtran/local-operator/assets/pr-tui-themes/solarized-light.png) |
