### PR TITLE
perf(providers,tui): make /usage answer from a shared cache instead of live fetches

### DIFF
--- a/local_operator/cli.py
+++ b/local_operator/cli.py
@@ -1776,6 +1776,10 @@ def main() -> int:
                     )
             finally:
                 try:
+                    tui_controller.close()
+                except Exception:  # noqa: BLE001 — closing on teardown, never fatal
+                    pass
+                try:
                     tui_auth_store.close()
                 except Exception:  # noqa: BLE001 — closing on teardown, never fatal
                     pass

--- a/local_operator/providers/auth_store.py
+++ b/local_operator/providers/auth_store.py
@@ -272,6 +272,23 @@ class AuthStore:
         else:
             self._config_overrides.pop(provider, None)
 
+    def override_keys(self, provider: str) -> list[str]:
+        """The override-tier secrets (runtime, then config) for ``provider``.
+
+        Public accessor for callers that need to know WHICH secrets the
+        cascade's tiers 1/2 would resolve without re-implementing the lookup —
+        the usage cache folds these into its account fingerprint so two
+        sessions on different override keys never share a cache row. Reading
+        the private maps from outside worked but pinned this module's field
+        names: a rename here would have silently reverted that fingerprint.
+        """
+        keys: list[str] = []
+        for tier in (self._runtime_overrides, self._config_overrides):
+            secret = tier.get(provider)
+            if secret:
+                keys.append(secret)
+        return keys
+
     def set_fallback_resolver(
         self, provider: str, resolver: Callable[[str], str | None] | None
     ) -> None:

--- a/local_operator/providers/controller.py
+++ b/local_operator/providers/controller.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import asyncio
 import dataclasses
+import random
 import time
 from typing import TYPE_CHECKING, Any, Callable, Protocol
 
@@ -43,6 +44,13 @@ from local_operator.providers.usage import (
     usage_kinds,
     usage_supported,
 )
+from local_operator.providers.usage_cache import (
+    USAGE_REPORT_TTL_MS,
+    UsageCacheStore,
+    fingerprint_accounts,
+    fingerprint_secret,
+    provider_cache_key,
+)
 
 if TYPE_CHECKING:  # auth_store stays off this module's runtime import graph
     from local_operator.credentials import CredentialManager
@@ -50,6 +58,18 @@ if TYPE_CHECKING:  # auth_store stays off this module's runtime import graph
     from local_operator.providers.oauth.callback_server import LoginCallbacks
 
 LoginCallbackFactory = Callable[[ProviderDefinition], "LoginCallbacks"]
+
+
+class _UsageFetchError(Exception):
+    """Every fetch attempt for a provider failed.
+
+    Distinct from a legitimately EMPTY result: a provider whose endpoint
+    answered "no quota" (an empty plan, a key with no balance endpoint) must be
+    negative-cached so the warmer does not re-hit it every tick, while a
+    provider whose endpoint is DOWN must keep serving its last good value and
+    retry on the next cool-down. Raising is how the two are told apart at the
+    cache-settling layer.
+    """
 
 
 @dataclasses.dataclass(frozen=True)
@@ -117,6 +137,7 @@ class ProviderController:
         credential_manager: "CredentialManager | None" = None,
         *,
         login_callbacks: LoginCallbackFactory | None = None,
+        usage_cache: UsageCacheStore | None = None,
     ) -> None:
         self.auth_store = auth_store
         self.credential_manager = credential_manager
@@ -124,6 +145,12 @@ class ProviderController:
         # used by default; an embedding host (e.g. a Textual app) injects
         # callbacks that yield the terminal before the flow runs.
         self._login_callbacks = login_callbacks
+        # Shared on-disk usage cache (see providers.usage_cache). Built lazily
+        # so a host that never asks for usage pays nothing, and injectable so
+        # tests can aim it at a temp file. Deliberately SHARED across every
+        # lop session on this machine: several terminals run at once, and one
+        # process's refresh is every process's answer.
+        self._usage_cache = usage_cache
 
     def set_login_callbacks(self, factory: "LoginCallbackFactory | None") -> None:
         """Install host-specific login callbacks after construction.
@@ -299,11 +326,32 @@ class ProviderController:
         return f"Removed {removed} credential(s) for '{provider_id}'."
 
     # -- usage -------------------------------------------------------------
-    async def fetch_usage(self, provider_ids: list[str] | None = None) -> list[UsageReport]:
+    async def fetch_usage(
+        self,
+        provider_ids: list[str] | None = None,
+        *,
+        force_refresh: bool = False,
+    ) -> list[UsageReport]:
         """Fetch normalized usage reports for the requested (or all
         report-able) providers. Never raises: a provider with no reachable
         credential or endpoint is simply absent from the result, and one
-        malformed provider never aborts the others."""
+        malformed provider never aborts the others.
+
+        Two accelerators sit in front of the network (see
+        :mod:`local_operator.providers.usage_cache`):
+
+        - A **shared on-disk cache** keyed per provider + account set, so a
+          fresh entry answers with no network at all — and because it is shared
+          across every lop session on this machine, one session's refresh is
+          every session's answer.
+        - **Parallel fan-out** across providers. The old loop awaited each
+          provider in turn, so the panel waited for the SUM of the round trips;
+          now it waits for the slowest one.
+
+        ``force_refresh`` bypasses the fresh-cache check (the panel's ``r``)
+        but still writes its result back, so the next read — in this session or
+        any other — is instant.
+        """
         targets = provider_ids or []
         if not targets:
             # The SAME predicate `/provider` and `/usage <provider>` use. An env key
@@ -314,14 +362,236 @@ class ProviderController:
         # De-duplicate aliases that share a storage id (openai vs
         # openai-device; xai vs xai-oauth) so one request/one report per row.
         targets = self._dedupe_targets(targets)
+        if not targets:
+            return []
         reports: list[UsageReport] = []
         async with httpx.AsyncClient() as client:
-            for provider in targets:
-                try:
-                    reports.extend(await self._fetch_provider(client, provider))
-                except Exception:  # noqa: BLE001 — isolate one broken provider
-                    continue
+            results = await asyncio.gather(
+                *(
+                    self._fetch_provider_cached(client, provider, force_refresh)
+                    for provider in targets
+                ),
+                return_exceptions=True,
+            )
+        for result in results:
+            # Isolate one broken provider: an exception here drops that row
+            # rather than aborting the whole report (the old per-provider try).
+            if isinstance(result, BaseException):
+                continue
+            reports.extend(result)
         return reports
+
+    # -- usage cache plumbing ------------------------------------------------
+
+    def close(self) -> None:
+        """Release the shared usage cache handle (idempotent, never raises)."""
+        if self._usage_cache is not None:
+            try:
+                self._usage_cache.close()
+            except Exception:  # noqa: BLE001 — teardown, never fatal
+                pass
+            self._usage_cache = None
+
+    def usage_cache_age_ms(self, provider: str) -> int | None:
+        """Milliseconds since the cached usage row for ``provider`` was fetched.
+
+        ``None`` when there is no cached row for the provider's CURRENT account
+        set (never fetched, or the account set changed since). This is the
+        question the TUI's background warmer asks before deciding whether to
+        spend a refresh: a warm row means `/usage` will answer from disk, so
+        the warmer only fires when the row is missing or going stale.
+
+        Synchronous and cheap (one indexed SQLite read), safe to call from an
+        interval callback.
+        """
+        cache = self._usage_cache_store()
+        if cache is None:
+            return None
+        key = self._usage_cache_key(provider)
+        fetched_at = cache.fetched_at_ms(key)
+        if fetched_at is None or fetched_at <= 0:
+            return None
+        now_ms = int(time.time() * 1000)
+        return max(0, now_ms - fetched_at)
+
+    def cached_usage_reports(self, provider: str | None = None) -> list[UsageReport]:
+        """The cached usage reports for ``provider`` (or all providers), any age.
+
+        The panel's instant-open half: when a row exists, `/usage` can paint it
+        immediately (its age stated in the title) while the fetch worker runs in
+        the background to confirm or replace it. Reads the shared cache only —
+        never crosses the network — so it is safe to call synchronously on the
+        keystroke that opens the panel.
+        """
+        cache = self._usage_cache_store()
+        if cache is None:
+            return []
+        targets = (
+            [provider] if provider else self._dedupe_targets(self.usage_reportable_providers())
+        )
+        reports: list[UsageReport] = []
+        for target in targets:
+            key = self._usage_cache_key(target)
+            try:
+                cached = cache.get(key, include_expired=True)
+            except Exception:  # noqa: BLE001 — a bad read is an empty open
+                cached = None
+            if cached:
+                reports.extend(cached)
+        return reports
+
+    def _usage_cache_store(self) -> UsageCacheStore | None:
+        """The shared usage cache, built lazily on first use.
+
+        Lazy so a host that never asks for usage pays nothing. Injectable via
+        the constructor so tests can aim it at a temp file instead of the real
+        ``~/.local-operator/usage_cache.db``.
+        """
+        if self._usage_cache is None:
+            try:
+                self._usage_cache = UsageCacheStore()
+            except Exception:  # noqa: BLE001 — no cache = live fetch, never fatal
+                return None
+        return self._usage_cache
+
+    def _storage_id(self, provider: str) -> str:
+        """The credential storage id for ``provider`` (aliases collapse).
+
+        ``openai-device`` logs in under ``openai``, ``xai-oauth`` under ``xai``;
+        the registry's ``store_credentials_as`` says so. Cache keys must follow
+        the SAME aliasing or the two spellings of one account would hold two
+        rows — one of them permanently stale.
+        """
+        definition = get_provider_definition(provider)
+        return (definition.store_credentials_as or provider) if definition else provider
+
+    def _usage_cache_key(self, provider: str) -> str:
+        """The shared-cache key for ``provider``'s current account set."""
+        return provider_cache_key(self._storage_id(provider), self._account_fingerprint(provider))
+
+    def _account_fingerprint(self, provider: str) -> str:
+        """A synchronous fingerprint of WHICH accounts ``provider`` would fetch.
+
+        Built from the stored credential rows (identity keys for OAuth, a hash
+        for API keys) plus any env key — no OAuth refresh, no network. Folding
+        the account set into the cache key is what makes login/logout
+        self-invalidating: the moment the set changes, the key changes and the
+        stale row stops matching. See :mod:`usage_cache` for why the key names
+        the account rather than the (rotating) access token.
+        """
+        storage = self._storage_id(provider)
+        parts: list[str] = []
+        try:
+            rows = self.auth_store.list_credentials(storage)
+        except Exception:  # noqa: BLE001 — an unreadable store fingerprints empty
+            rows = []
+        for row in rows:
+            if getattr(row, "credential_type", None) == "oauth":
+                identity = getattr(row, "identity_key", None)
+                parts.append(identity or f"cred:{getattr(row, 'id', 0)}")
+            else:
+                data = getattr(row, "data", None) or {}
+                key = data.get("key") if isinstance(data, dict) else None
+                if key:
+                    parts.append(fingerprint_secret(str(key)))
+        try:
+            env_key = resolve_env_key(storage)
+        except Exception:  # noqa: BLE001
+            env_key = None
+        if env_key:
+            parts.append(fingerprint_secret(env_key))
+        return fingerprint_accounts(parts)
+
+    @staticmethod
+    def _jittered_ttl_ms() -> int:
+        """Base TTL spread ±25%, so several accounts/providers do not all expire
+        into the same refresh window (the per-IP burst that earns a 429)."""
+        jitter = USAGE_REPORT_TTL_MS * (random.random() * 0.5 - 0.25)
+        return int(USAGE_REPORT_TTL_MS + jitter)
+
+    async def _fetch_provider_cached(
+        self,
+        client: httpx.AsyncClient,
+        provider: str,
+        force_refresh: bool,
+    ) -> list[UsageReport]:
+        """One provider's reports, cache-first.
+
+        Fast path: a fresh cache entry returns with no network at all. The
+        slow path delegates to :meth:`_refresh_provider_usage`, where the
+        cross-process lease ensures only one session on the machine actually
+        crosses the network for a stale row — every other session serves the
+        stale value while that one refreshes. That lease is the coordination;
+        no in-process future map is needed on top of it.
+        """
+        cache = self._usage_cache_store()
+        key = ""
+        if cache is not None:
+            key = self._usage_cache_key(provider)
+            if not force_refresh:
+                fresh = cache.get(key)
+                if fresh is not None:
+                    return fresh
+        return await self._refresh_provider_usage(client, provider, key, cache, force_refresh)
+
+    async def _refresh_provider_usage(
+        self,
+        client: httpx.AsyncClient,
+        provider: str,
+        key: str,
+        cache: UsageCacheStore | None,
+        force_refresh: bool,
+    ) -> list[UsageReport]:
+        """Actually cross the network for ``provider``, then settle the cache.
+
+        Cross-process coordination lives here: when the cached row is stale,
+        ONE session wins a lease and refreshes while the others serve the stale
+        row rather than joining a synchronized fan-out (Anthropic/OpenAI
+        rate-limit the usage endpoint per source IP). On failure the last good
+        value is served with a short cool-down, so a blip never blanks the
+        report.
+        """
+        stale: list[UsageReport] | None = None
+        lease_held = False
+        if cache is not None and key:
+            stale = cache.get(key, include_expired=True)
+            # The lease only has something to protect when a stale value exists:
+            # the loser serves it while the winner refreshes. With nothing on
+            # hand every session must fetch anyway (the pre-cache behaviour).
+            if not force_refresh and stale is not None and not cache.try_lease(key):
+                # A peer session owns this refresh; its result lands in the same
+                # shared row. Serve what we have instead of doubling the fan-out.
+                return stale
+            lease_held = stale is not None
+        try:
+            try:
+                reports = await self._fetch_provider(client, provider)
+            except _UsageFetchError:
+                # Every attempt failed: keep the last good value servable through
+                # a short cool-down rather than blanking the report.
+                reports = []
+                if cache is not None and key and stale is not None:
+                    cache.write_failure(key, provider)
+            else:
+                if cache is not None and key:
+                    now_ms = int(time.time() * 1000)
+                    # Cache the answer whether or not it has rows: a provider that
+                    # legitimately reports no quota (an empty plan) is negative-
+                    # cached so the warmer does not re-hit its endpoint every
+                    # tick. The empty list round-trips through the same row.
+                    cache.set(
+                        key, provider, reports, expires_at_ms=now_ms + self._jittered_ttl_ms()
+                    )
+        finally:
+            if lease_held and cache is not None and key:
+                cache.release_lease(key)
+        if reports:
+            return reports
+        if stale is not None:
+            # A forced refresh that failed still shows the last good numbers
+            # (their age is stated in the panel) rather than an empty card.
+            return stale
+        return []
 
     async def _fetch_provider(self, client: httpx.AsyncClient, provider: str) -> list[UsageReport]:
         """Every account's usage for one provider — not just the cascade's pick.
@@ -340,20 +610,45 @@ class ProviderController:
         if not usage_supported(provider):
             return []
         reports: list[UsageReport] = []
+        # Whether ANY fetch attempt ran against a real credential and completed
+        # without raising. That is the line between a legitimately EMPTY answer
+        # (negative-cache it) and a DOWN endpoint (keep the last good value and
+        # retry): a provider whose endpoint answered "no quota" must not be
+        # re-hit every warmer tick, while one whose every attempt raised must.
+        any_completed = False
         for access in await self.auth_store.list_oauth_accesses(provider):
             try:
                 report = await self._fetch_one(client, provider, access=access)
             except Exception:  # noqa: BLE001 — one bad account, not the provider
                 continue
+            any_completed = True
             if report is not None:
                 reports.append(report)
         if reports:
             return reports
+        # The API-key route only counts as "completed" when there WAS a key to
+        # try: `_fetch_one` returns None for "no credential at all", which is
+        # nothing fetched, not an empty answer. Without this guard a provider
+        # whose OAuth accounts all failed to fetch would be negative-cached as
+        # "no quota" instead of served its last good value.
         try:
-            report = await self._fetch_one(client, provider, access=None)
+            api_key = await self.auth_store.get_api_key(provider)
         except Exception:  # noqa: BLE001
-            return []
-        return [report] if report is not None else []
+            api_key = None
+        if api_key:
+            try:
+                report = await self._fetch_one(client, provider, access=None)
+            except Exception:  # noqa: BLE001
+                report = None
+            else:
+                any_completed = True
+            if report is not None:
+                return [report]
+        if not any_completed:
+            # Every attempt raised (or there was nothing to attempt): a failure,
+            # not an empty answer.
+            raise _UsageFetchError(provider)
+        return []
 
     def _dedupe_targets(self, targets: list[str]) -> list[str]:
         """Keep one id per storage row so alias providers don't double-fetch."""

--- a/local_operator/providers/controller.py
+++ b/local_operator/providers/controller.py
@@ -59,6 +59,17 @@ if TYPE_CHECKING:  # auth_store stays off this module's runtime import graph
 
 LoginCallbackFactory = Callable[[ProviderDefinition], "LoginCallbacks"]
 
+#: How long an empty refresh keeps deferring to old data before it is believed.
+#: The empty-over-data heuristic reads a blank answer over non-empty history as
+#: an outage — but a provider that GENUINELY went quota-less (plan lapsed,
+#: account emptied) would otherwise be re-fetched on every cool-down forever,
+#: because each ``write_failure`` keeps the old row alive. Once the last real
+#: data is this old, consecutive empty answers are accepted as the truth and
+#: negative-cached at full TTL. Half an hour: long enough to ride out any
+#: plausible rate-limit window, short enough that a lapsed plan stops burning
+#: a request per warm tick the same day.
+EMPTY_OVER_DATA_ACCEPT_MS = 30 * 60_000
+
 
 @dataclasses.dataclass(frozen=True)
 class CatalogueEntry:
@@ -473,14 +484,18 @@ class ProviderController:
         # the fetch — `get_api_key` resolves them ahead of every stored row —
         # so they belong in the fingerprint too, or two sessions running on
         # different override keys would share one cache row and read each
-        # other's numbers. Reached via getattr because the narrow store
-        # protocol does not require these maps; a store without them simply
-        # has no overrides to name.
-        for tier in ("_runtime_overrides", "_config_overrides"):
-            overrides = getattr(self.auth_store, tier, None)
-            secret = overrides.get(provider) if isinstance(overrides, dict) else None
-            if secret:
-                parts.append(fingerprint_secret(str(secret)))
+        # other's numbers. `override_keys` is AuthStore's public accessor for
+        # exactly this question; guarded because the narrow store protocol
+        # does not require it, and a store without it has no overrides to name.
+        override_keys = getattr(self.auth_store, "override_keys", None)
+        if callable(override_keys):
+            try:
+                secrets = override_keys(provider)
+            except Exception:  # noqa: BLE001 — overrides are optional context
+                secrets = ()
+            if isinstance(secrets, (list, tuple)):
+                for secret in secrets:
+                    parts.append(fingerprint_secret(str(secret)))
         try:
             rows = self.auth_store.list_credentials(storage)
         except Exception:  # noqa: BLE001 — an unreadable store fingerprints empty
@@ -567,6 +582,9 @@ class ProviderController:
         """
         stale: list[UsageReport] | None = None
         lease_held = False
+        #: The empty answer was BELIEVED (no history, or history too old), so
+        #: the stale row must not be served over it — see the acceptance branch.
+        accepted_empty = False
         if cache is not None and key:
             stale = cache.get(key, include_expired=True)
             # The lease only has something to protect when a stale value exists:
@@ -597,22 +615,37 @@ class ProviderController:
                 elif stale:
                     # Truthiness, not `is not None`: only a NON-EMPTY history
                     # marks this empty answer as a probable outage. Keep the
-                    # last good value servable through a short cool-down.
-                    cache.write_failure(key, provider)
+                    # last good value servable through a short cool-down —
+                    # unless the data is old enough that the "outage" reading
+                    # has expired (EMPTY_OVER_DATA_ACCEPT_MS), in which case
+                    # the empty answer is accepted and negative-cached so a
+                    # genuinely quota-less provider stops being re-fetched on
+                    # every cool-down forever.
+                    now_ms = int(time.time() * 1000)
+                    newest = max((int(r.fetched_at or 0) for r in stale), default=0)
+                    if newest and now_ms - newest > EMPTY_OVER_DATA_ACCEPT_MS:
+                        cache.set(key, provider, [], expires_at_ms=now_ms + self._jittered_ttl_ms())
+                        accepted_empty = True
+                    else:
+                        cache.write_failure(key, provider)
                 else:
                     # No history of data (or an empty one): negative-cache so
                     # the warmer stops re-hitting an endpoint that reports
                     # nothing. `r` (force_refresh) still bypasses this row.
                     now_ms = int(time.time() * 1000)
                     cache.set(key, provider, [], expires_at_ms=now_ms + self._jittered_ttl_ms())
+                    accepted_empty = True
         finally:
             if lease_held and cache is not None and key:
                 cache.release_lease(key)
         if reports:
             return reports
-        if stale is not None:
+        if stale is not None and not accepted_empty:
             # A forced refresh that failed still shows the last good numbers
-            # (their age is stated in the panel) rather than an empty card.
+            # (their age is stated in the panel) rather than an empty card. An
+            # ACCEPTED empty answer is not papered over with old data, though —
+            # the cache just recorded "this provider reports nothing" and the
+            # caller should say the same.
             return stale
         return []
 

--- a/local_operator/providers/controller.py
+++ b/local_operator/providers/controller.py
@@ -60,18 +60,6 @@ if TYPE_CHECKING:  # auth_store stays off this module's runtime import graph
 LoginCallbackFactory = Callable[[ProviderDefinition], "LoginCallbacks"]
 
 
-class _UsageFetchError(Exception):
-    """Every fetch attempt for a provider failed.
-
-    Distinct from a legitimately EMPTY result: a provider whose endpoint
-    answered "no quota" (an empty plan, a key with no balance endpoint) must be
-    negative-cached so the warmer does not re-hit it every tick, while a
-    provider whose endpoint is DOWN must keep serving its last good value and
-    retry on the next cool-down. Raising is how the two are told apart at the
-    cache-settling layer.
-    """
-
-
 @dataclasses.dataclass(frozen=True)
 class CatalogueEntry:
     """One offerable model, provider-qualified, with the provider's auth state.
@@ -481,6 +469,18 @@ class ProviderController:
         """
         storage = self._storage_id(provider)
         parts: list[str] = []
+        # Cascade tiers 1/2 (runtime `--api-key`, models.yml pointer) can WIN
+        # the fetch — `get_api_key` resolves them ahead of every stored row —
+        # so they belong in the fingerprint too, or two sessions running on
+        # different override keys would share one cache row and read each
+        # other's numbers. Reached via getattr because the narrow store
+        # protocol does not require these maps; a store without them simply
+        # has no overrides to name.
+        for tier in ("_runtime_overrides", "_config_overrides"):
+            overrides = getattr(self.auth_store, tier, None)
+            secret = overrides.get(provider) if isinstance(overrides, dict) else None
+            if secret:
+                parts.append(fingerprint_secret(str(secret)))
         try:
             rows = self.auth_store.list_credentials(storage)
         except Exception:  # noqa: BLE001 — an unreadable store fingerprints empty
@@ -550,6 +550,20 @@ class ProviderController:
         rate-limit the usage endpoint per source IP). On failure the last good
         value is served with a short cool-down, so a blip never blanks the
         report.
+
+        **An empty result never overwrites non-empty last-good data.** The
+        fetchers signal transport/HTTP failure by returning ``None`` —
+        ``_get_json`` swallows ``httpx.HTTPError``, non-200s (including 429)
+        and bad JSON — so by the time a result reaches this function, "the
+        endpoint is down" and "the account has no quota to report" are the
+        same empty list. The one disambiguating fact on hand is history: a
+        provider that HAD data a moment ago and reports none now is far more
+        likely rate-limited than suddenly quota-less, so the empty answer is
+        treated as a failure (last-good kept servable under a short cool-down,
+        retried on the next poll). A provider with no history of data — or
+        whose last answer was also empty — negative-caches the empty list at
+        the full TTL, which is what stops the warmer from re-hitting endpoints
+        that legitimately report nothing.
         """
         stale: list[UsageReport] | None = None
         lease_held = False
@@ -558,30 +572,39 @@ class ProviderController:
             # The lease only has something to protect when a stale value exists:
             # the loser serves it while the winner refreshes. With nothing on
             # hand every session must fetch anyway (the pre-cache behaviour).
-            if not force_refresh and stale is not None and not cache.try_lease(key):
-                # A peer session owns this refresh; its result lands in the same
-                # shared row. Serve what we have instead of doubling the fan-out.
-                return stale
-            lease_held = stale is not None
+            if not force_refresh and stale is not None:
+                if not cache.try_lease(key):
+                    # A peer session owns this refresh; its result lands in the
+                    # same shared row. Serve what we have instead of doubling
+                    # the fan-out.
+                    return stale
+                # Held ONLY when try_lease actually granted it: the force path
+                # never takes the lease, and releasing one it does not hold
+                # would free a concurrent warmer's lease (holder identity is
+                # per-process, not per-coroutine).
+                lease_held = True
         try:
             try:
                 reports = await self._fetch_provider(client, provider)
-            except _UsageFetchError:
-                # Every attempt failed: keep the last good value servable through
-                # a short cool-down rather than blanking the report.
+            except Exception:  # noqa: BLE001 — isolate a broken provider
                 reports = []
-                if cache is not None and key and stale is not None:
-                    cache.write_failure(key, provider)
-            else:
-                if cache is not None and key:
+            if cache is not None and key:
+                if reports:
                     now_ms = int(time.time() * 1000)
-                    # Cache the answer whether or not it has rows: a provider that
-                    # legitimately reports no quota (an empty plan) is negative-
-                    # cached so the warmer does not re-hit its endpoint every
-                    # tick. The empty list round-trips through the same row.
                     cache.set(
                         key, provider, reports, expires_at_ms=now_ms + self._jittered_ttl_ms()
                     )
+                elif stale:
+                    # Truthiness, not `is not None`: only a NON-EMPTY history
+                    # marks this empty answer as a probable outage. Keep the
+                    # last good value servable through a short cool-down.
+                    cache.write_failure(key, provider)
+                else:
+                    # No history of data (or an empty one): negative-cache so
+                    # the warmer stops re-hitting an endpoint that reports
+                    # nothing. `r` (force_refresh) still bypasses this row.
+                    now_ms = int(time.time() * 1000)
+                    cache.set(key, provider, [], expires_at_ms=now_ms + self._jittered_ttl_ms())
         finally:
             if lease_held and cache is not None and key:
                 cache.release_lease(key)
@@ -610,45 +633,20 @@ class ProviderController:
         if not usage_supported(provider):
             return []
         reports: list[UsageReport] = []
-        # Whether ANY fetch attempt ran against a real credential and completed
-        # without raising. That is the line between a legitimately EMPTY answer
-        # (negative-cache it) and a DOWN endpoint (keep the last good value and
-        # retry): a provider whose endpoint answered "no quota" must not be
-        # re-hit every warmer tick, while one whose every attempt raised must.
-        any_completed = False
         for access in await self.auth_store.list_oauth_accesses(provider):
             try:
                 report = await self._fetch_one(client, provider, access=access)
             except Exception:  # noqa: BLE001 — one bad account, not the provider
                 continue
-            any_completed = True
             if report is not None:
                 reports.append(report)
         if reports:
             return reports
-        # The API-key route only counts as "completed" when there WAS a key to
-        # try: `_fetch_one` returns None for "no credential at all", which is
-        # nothing fetched, not an empty answer. Without this guard a provider
-        # whose OAuth accounts all failed to fetch would be negative-cached as
-        # "no quota" instead of served its last good value.
         try:
-            api_key = await self.auth_store.get_api_key(provider)
+            report = await self._fetch_one(client, provider, access=None)
         except Exception:  # noqa: BLE001
-            api_key = None
-        if api_key:
-            try:
-                report = await self._fetch_one(client, provider, access=None)
-            except Exception:  # noqa: BLE001
-                report = None
-            else:
-                any_completed = True
-            if report is not None:
-                return [report]
-        if not any_completed:
-            # Every attempt raised (or there was nothing to attempt): a failure,
-            # not an empty answer.
-            raise _UsageFetchError(provider)
-        return []
+            return []
+        return [report] if report is not None else []
 
     def _dedupe_targets(self, targets: list[str]) -> list[str]:
         """Keep one id per storage row so alias providers don't double-fetch."""

--- a/local_operator/providers/usage_cache.py
+++ b/local_operator/providers/usage_cache.py
@@ -406,23 +406,27 @@ class UsageCacheStore:
         now = self._now_ms()
         expires = now + ttl_ms
         try:
-            with conn:  # a transaction so check-and-take is atomic
-                row = conn.execute(
-                    "SELECT expires_at_ms FROM usage_fetch_leases WHERE key = ?", (key,)
-                ).fetchone()
-                if row is not None and int(row[0]) > now:
-                    return False
-                conn.execute(
+            # ONE atomic statement, judged by rowcount. A SELECT-then-INSERT
+            # pair is not atomic here even inside `with conn:` — Python's
+            # sqlite3 defers BEGIN until the first write, so two processes can
+            # both read "no live lease" and both take it, precisely at the
+            # synchronized-expiry moment the lease guards. The conditional
+            # upsert moves the check into the same write: the UPDATE arm only
+            # fires when the standing lease has expired, so exactly one
+            # process's statement reports a changed row.
+            with conn:
+                cursor = conn.execute(
                     """
                     INSERT INTO usage_fetch_leases (key, holder, expires_at_ms)
                     VALUES (?, ?, ?)
                     ON CONFLICT(key) DO UPDATE SET
                       holder = excluded.holder,
                       expires_at_ms = excluded.expires_at_ms
+                    WHERE usage_fetch_leases.expires_at_ms <= ?
                     """,
-                    (key, self._holder, expires),
+                    (key, self._holder, expires, now),
                 )
-            return True
+            return cursor.rowcount > 0
         except Exception:  # noqa: BLE001 — coordination failure = go fetch
             logger.debug("usage cache: lease failed", exc_info=True)
             return True

--- a/local_operator/providers/usage_cache.py
+++ b/local_operator/providers/usage_cache.py
@@ -378,13 +378,25 @@ class UsageCacheStore:
         return last_good
 
     def _cleanup(self, conn: sqlite3.Connection, now_ms: int) -> None:
-        """Drop rows whose retention has passed. Cheap: one indexed scan."""
+        """Drop rows whose retention has passed. Cheap: one indexed scan.
+
+        ``with conn:`` is load-bearing, not style. Python's sqlite3 opens an
+        implicit transaction on the first write and leaves it OPEN until
+        something commits — so bare DELETEs here held the WAL write lock from
+        one refresh to the next, and every OTHER session's cache call blocked
+        for the full 5 s busy timeout and then failed: leases collapsed to
+        "everyone fetches" and writes were silently lost, each stall freezing
+        that session's whole TUI (these calls are synchronous inside async
+        workers). The context manager commits on exit, releasing the lock the
+        moment the pruning is done.
+        """
         try:
-            conn.execute(
-                "DELETE FROM usage_reports WHERE expires_at_ms < ?",
-                (now_ms - USAGE_LAST_GOOD_RETENTION_MS,),
-            )
-            conn.execute("DELETE FROM usage_fetch_leases WHERE expires_at_ms < ?", (now_ms,))
+            with conn:
+                conn.execute(
+                    "DELETE FROM usage_reports WHERE expires_at_ms < ?",
+                    (now_ms - USAGE_LAST_GOOD_RETENTION_MS,),
+                )
+                conn.execute("DELETE FROM usage_fetch_leases WHERE expires_at_ms < ?", (now_ms,))
         except Exception:  # noqa: BLE001
             pass
 

--- a/local_operator/providers/usage_cache.py
+++ b/local_operator/providers/usage_cache.py
@@ -60,11 +60,7 @@ from pathlib import Path
 from typing import Any
 
 from local_operator.paths import config_dir
-from local_operator.providers.usage import (
-    UsageAmount,
-    UsageLimit,
-    UsageReport,
-)
+from local_operator.providers.usage import UsageAmount, UsageLimit, UsageReport
 
 logger = logging.getLogger("local_operator.providers.usage_cache")
 

--- a/local_operator/providers/usage_cache.py
+++ b/local_operator/providers/usage_cache.py
@@ -1,0 +1,448 @@
+"""Shared on-disk cache for provider usage reports.
+
+``/usage`` used to cross the network once per logged-in provider, every time,
+sequentially — four logged-in providers meant four serial round trips before
+the panel had anything to show. The quota data itself moves slowly (rolling
+windows that reset hours apart), so the answer is a cache with a TTL measured
+in minutes, not seconds.
+
+The cache lives in ``~/.local-operator/usage_cache.db`` (0600, WAL, busy
+timeout — the same discipline as ``auth.db``) rather than in process memory
+because a user typically runs SEVERAL lop sessions at once (one per cmux
+workspace). An in-process cache would make every session pay the full fetch
+cost; a shared one means the first session to refresh populates the answer for
+all of them, and a lease table ensures that when several sessions notice an
+expired entry at the same moment, only ONE of them actually hits the provider.
+The others serve the last good value, which is exactly as fresh — it is the
+same row.
+
+Semantics (modelled on omp's ``AuthStorage`` usage cache, which solved the
+same problem for the same providers):
+
+- **Fresh entry** (``expires_at`` in the future): served as-is, no network.
+- **Expired entry**: one process wins the lease and fetches; everyone else
+  serves the stale row rather than joining a synchronized fan-out. Anthropic
+  and OpenAI rate-limit their usage endpoints per source IP regardless of
+  account, so N sessions refreshing in lockstep is how a quota screen earns a
+  429 of its own.
+- **Fetch failure**: the winner writes the last good value back with a short
+  cool-down instead of dropping the provider from the report. A transient
+  network blip must not make an account's quota unreadable.
+- **TTL jitter**: each entry's lifetime is spread ±25% around the base TTL so
+  several accounts on one provider do not all expire into the same refresh
+  window (the same per-IP burst, one cycle later).
+
+Cache keys are ``provider:<account fingerprint>``: the fingerprint summarises
+WHICH accounts the provider was fetched for (the identity keys of the stored
+credential rows, plus any env key), and is computed synchronously from the
+credential store — no OAuth refresh, no network. Folding the account set into
+the key makes login/logout self-invalidating, and keying on the account rather
+than the access token matters because OAuth tokens rotate on every refresh:
+a key that named the token would expire exactly as often as the token rotates,
+which is to say, constantly. Usage is per account, not per token.
+
+Everything here degrades silently: a cache that cannot be read or written
+falls back to the uncached behaviour (fetch live, show live). The cache is an
+accelerator, never a dependency.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import sqlite3
+import time
+import uuid
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+from local_operator.paths import config_dir
+from local_operator.providers.usage import (
+    UsageAmount,
+    UsageLimit,
+    UsageReport,
+)
+
+logger = logging.getLogger("local_operator.providers.usage_cache")
+
+#: Base time-to-live for a successful report. Five minutes matches omp: long
+#: enough that back-to-back ``/usage`` calls and every concurrent session read
+#: the same row, short enough that a rolling window's approach to its cap is
+#: still visible while it matters. Jittered ±25% per entry (see module doc).
+USAGE_REPORT_TTL_MS = 5 * 60_000
+
+#: Cool-down written after a fetch failure, over the LAST GOOD value. The
+#: failure is remembered briefly so a dead endpoint is not re-probed on every
+#: keystroke, while the numbers themselves stay readable.
+USAGE_FAILURE_BACKOFF_MS = 10_000
+
+#: How long a last-good row survives past its expiry, for stale serving and
+#: failure fallback. One day: longer than any rolling window the fetchers
+#: report, so a row old enough to be interesting is also old enough to be
+#: wrong, and the disk stays bounded.
+USAGE_LAST_GOOD_RETENTION_MS = 24 * 60 * 60_000
+
+#: Cross-process fetch lease lifetime. A refresh for these endpoints takes at
+#: most ~10 s (the fetchers' own timeout); a lease comfortably longer than
+#: that covers a slow response without stranding the row when a process dies
+#: mid-fetch (it expires, and the next session fetches).
+USAGE_FETCH_LEASE_MS = 30_000
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS usage_reports (
+  key TEXT PRIMARY KEY,
+  provider TEXT NOT NULL,
+  payload TEXT NOT NULL,
+  fetched_at_ms INTEGER NOT NULL,
+  expires_at_ms INTEGER NOT NULL,
+  updated_at_ms INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_usage_reports_provider ON usage_reports(provider);
+
+CREATE TABLE IF NOT EXISTS usage_fetch_leases (
+  key TEXT PRIMARY KEY,
+  holder TEXT NOT NULL,
+  expires_at_ms INTEGER NOT NULL
+);
+"""
+
+
+def default_cache_path() -> Path:
+    return config_dir() / "usage_cache.db"
+
+
+# ---------------------------------------------------------------------------
+# Wire format: UsageReport <-> JSON-safe dict
+# ---------------------------------------------------------------------------
+
+
+def report_to_dict(report: UsageReport) -> dict[str, Any]:
+    """Serialize a report to a JSON-safe dict.
+
+    The report shape is plain dataclasses of scalars, so ``asdict`` is the
+    whole job; the explicit function exists so the cache's wire format has ONE
+    named definition to version if the shape ever grows.
+    """
+    return asdict(report)
+
+
+def report_from_dict(data: Any) -> UsageReport | None:
+    """Rebuild a report from a cached dict, or None when it no longer parses.
+
+    Defensive on purpose: the cache outlives the process that wrote it, and a
+    schema change between versions must read as a cache MISS — never an
+    exception on the ``/usage`` path.
+    """
+    if not isinstance(data, dict):
+        return None
+    try:
+        limits = [
+            UsageLimit(
+                id=str(limit["id"]),
+                label=str(limit["label"]),
+                amount=UsageAmount(**limit["amount"]),
+                window=str(limit.get("window", "")),
+                status=limit.get("status"),
+                resets_at=limit.get("resets_at"),
+                resets_at_ms=limit.get("resets_at_ms"),
+                tier=str(limit.get("tier", "")),
+                shared=bool(limit.get("shared", False)),
+            )
+            for limit in data.get("limits", [])
+        ]
+        return UsageReport(
+            provider=str(data["provider"]),
+            fetched_at=int(data.get("fetched_at", 0)),
+            limits=limits,
+            notes=data.get("notes"),
+            identity=data.get("identity"),
+        )
+    except Exception:  # noqa: BLE001 — a bad row is a miss, not a failure
+        logger.debug("usage cache: unparseable report row dropped", exc_info=True)
+        return None
+
+
+def provider_cache_key(provider: str, account_fingerprint: str) -> str:
+    """The cache key for one provider's full usage report set.
+
+    ``account_fingerprint`` summarises WHICH accounts the row was fetched for
+    (the sorted identity keys of the stored credentials, or a hash of the API
+    key on the key route). Folding the account set into the key is what makes
+    login/logout self-invalidating: the moment the set of logged-in accounts
+    changes, the fingerprint changes, the old row stops matching, and the next
+    read fetches fresh instead of rendering an account the user no longer owns
+    (or hiding one they just added).
+    """
+    return f"{provider}:{account_fingerprint}"
+
+
+def fingerprint_accounts(identities: list[str]) -> str:
+    """A stable fingerprint for a set of account identities.
+
+    Sorted so enumeration order (row id, round-robin) never changes the key —
+    the same accounts must hit the same row no matter which session asks.
+    """
+    if not identities:
+        return "none"
+    joined = "\n".join(sorted(identities))
+    return hashlib.sha256(joined.encode("utf-8", "replace")).hexdigest()[:16]
+
+
+def fingerprint_secret(secret: str) -> str:
+    """Fingerprint for the API-key route: a hash of the key, never the key.
+
+    The key bytes must not sit in the row's primary key (or the WAL) any
+    longer than they must; a digest identifies the account just as well for
+    cache-hit purposes.
+    """
+    return "key:" + hashlib.sha256(secret.encode("utf-8", "replace")).hexdigest()[:16]
+
+
+class UsageCacheStore:
+    """SQLite-backed shared usage cache; every method is exception-safe."""
+
+    def __init__(self, db_path: str | Path | None = None) -> None:
+        self._db_path = Path(db_path) if db_path is not None else default_cache_path()
+        #: Identity of this process in lease rows, so a release only frees a
+        #: lease THIS process took.
+        self._holder = f"{os.getpid()}:{uuid.uuid4().hex[:8]}"
+        self._conn: sqlite3.Connection | None = None
+
+    # -- connection ----------------------------------------------------------
+    def _connect(self) -> sqlite3.Connection | None:
+        """Open (once) and return the connection, or None when unavailable.
+
+        A cache that cannot open is a permanent miss, not an error: the caller
+        fetches live. The alternative — raising — would make a read-only home
+        directory or a locked file take ``/usage`` down entirely.
+        """
+        if self._conn is not None:
+            return self._conn
+        try:
+            self._db_path.parent.mkdir(parents=True, exist_ok=True)
+            # Create the file 0600 BEFORE sqlite opens it (same rule as
+            # auth.db): quota rows carry account identity, and the
+            # connect-then-chmod pattern leaves a readable window.
+            if not self._db_path.exists():
+                fd = os.open(self._db_path, os.O_CREAT | os.O_WRONLY, 0o600)
+                os.close(fd)
+            conn = sqlite3.connect(str(self._db_path), timeout=5.0)
+            conn.execute("PRAGMA journal_mode=WAL")
+            conn.execute("PRAGMA synchronous=NORMAL")
+            conn.execute("PRAGMA busy_timeout=5000")
+            conn.executescript(_SCHEMA)
+            conn.commit()
+            for path in (
+                self._db_path,
+                self._db_path.with_suffix(self._db_path.suffix + "-wal"),
+                self._db_path.with_suffix(self._db_path.suffix + "-shm"),
+            ):
+                try:
+                    os.chmod(path, 0o600)
+                except OSError:
+                    pass
+            self._conn = conn
+            return conn
+        except Exception:  # noqa: BLE001 — cache unavailable = cache miss
+            logger.debug("usage cache: cannot open %s", self._db_path, exc_info=True)
+            return None
+
+    def close(self) -> None:
+        if self._conn is not None:
+            self._conn.close()
+            self._conn = None
+
+    @staticmethod
+    def _now_ms() -> int:
+        return int(time.time() * 1000)
+
+    # -- reads ---------------------------------------------------------------
+    def get(self, key: str, *, include_expired: bool = False) -> list[UsageReport] | None:
+        """The cached report list for ``key``, or None when absent/expired/bad.
+
+        With ``include_expired`` this is the stale-serving half of the design:
+        a row past its TTL is still the freshest answer on hand while a refresh
+        is in flight elsewhere or has failed.
+        """
+        conn = self._connect()
+        if conn is None:
+            return None
+        try:
+            row = conn.execute(
+                "SELECT payload, expires_at_ms FROM usage_reports WHERE key = ?", (key,)
+            ).fetchone()
+        except Exception:  # noqa: BLE001
+            logger.debug("usage cache: read failed", exc_info=True)
+            return None
+        if row is None:
+            return None
+        payload, expires_at_ms = row
+        if not include_expired and int(expires_at_ms) <= self._now_ms():
+            return None
+        try:
+            data = json.loads(payload)
+        except Exception:  # noqa: BLE001
+            return None
+        if not isinstance(data, list):
+            return None
+        reports = [report_from_dict(item) for item in data]
+        reports = [report for report in reports if report is not None]
+        return reports
+
+    def expiry_ms(self, key: str) -> int | None:
+        """When the cached row for ``key`` expires, or None when absent."""
+        conn = self._connect()
+        if conn is None:
+            return None
+        try:
+            row = conn.execute(
+                "SELECT expires_at_ms FROM usage_reports WHERE key = ?", (key,)
+            ).fetchone()
+        except Exception:  # noqa: BLE001
+            return None
+        return int(row[0]) if row is not None else None
+
+    def fetched_at_ms(self, key: str) -> int | None:
+        """When the cached row for ``key`` was fetched, or None when absent.
+
+        Unlike :meth:`get`, this answers for EMPTY rows too (a provider that
+        legitimately reports no quota): the warmer asks "how old is the answer",
+        and "no quota, checked a minute ago" IS an answer.
+        """
+        conn = self._connect()
+        if conn is None:
+            return None
+        try:
+            row = conn.execute(
+                "SELECT fetched_at_ms FROM usage_reports WHERE key = ?", (key,)
+            ).fetchone()
+        except Exception:  # noqa: BLE001
+            return None
+        return int(row[0]) if row is not None else None
+
+    # -- writes ----------------------------------------------------------------
+    def set(
+        self,
+        key: str,
+        provider: str,
+        reports: list[UsageReport],
+        *,
+        expires_at_ms: int,
+    ) -> None:
+        """Write one provider's report list, then opportunistically prune."""
+        conn = self._connect()
+        if conn is None:
+            return
+        try:
+            payload = json.dumps([report_to_dict(report) for report in reports])
+            now = self._now_ms()
+            fetched_at = max((report.fetched_at for report in reports), default=now)
+            conn.execute(
+                """
+                INSERT INTO usage_reports (
+                  key, provider, payload, fetched_at_ms, expires_at_ms, updated_at_ms
+                )
+                VALUES (?, ?, ?, ?, ?, ?)
+                ON CONFLICT(key) DO UPDATE SET
+                  provider = excluded.provider,
+                  payload = excluded.payload,
+                  fetched_at_ms = excluded.fetched_at_ms,
+                  expires_at_ms = excluded.expires_at_ms,
+                  updated_at_ms = excluded.updated_at_ms
+                """,
+                (key, provider, payload, fetched_at, expires_at_ms, now),
+            )
+            conn.commit()
+            self._cleanup(conn, now)
+        except Exception:  # noqa: BLE001 — a failed write is a future miss
+            logger.debug("usage cache: write failed", exc_info=True)
+
+    def write_failure(self, key: str, provider: str) -> list[UsageReport] | None:
+        """Record a failed fetch; return the last good reports if any exist.
+
+        The cool-down row keeps the failure warm briefly (no re-probe per
+        keystroke) while the stale values stay servable — the caller renders
+        the returned reports exactly as if they had been fetched.
+        """
+        last_good = self.get(key, include_expired=True)
+        if last_good is not None:
+            self.set(
+                key,
+                provider,
+                last_good,
+                expires_at_ms=self._now_ms() + USAGE_FAILURE_BACKOFF_MS,
+            )
+        return last_good
+
+    def _cleanup(self, conn: sqlite3.Connection, now_ms: int) -> None:
+        """Drop rows whose retention has passed. Cheap: one indexed scan."""
+        try:
+            conn.execute(
+                "DELETE FROM usage_reports WHERE expires_at_ms < ?",
+                (now_ms - USAGE_LAST_GOOD_RETENTION_MS,),
+            )
+            conn.execute("DELETE FROM usage_fetch_leases WHERE expires_at_ms < ?", (now_ms,))
+        except Exception:  # noqa: BLE001
+            pass
+
+    # -- leases ----------------------------------------------------------------
+    def try_lease(self, key: str, ttl_ms: int = USAGE_FETCH_LEASE_MS) -> bool:
+        """Take the fetch lease for ``key`` if it is free (or expired).
+
+        True means THIS process is the one that should fetch. False means a
+        peer session already owns the refresh; the caller serves its stale row
+        instead of joining the fan-out. The lease expires on its own, so a
+        process that dies mid-fetch cannot strand the row forever.
+        """
+        conn = self._connect()
+        if conn is None:
+            # No shared coordination available: every process fetches. That is
+            # the pre-cache behaviour, and correctness does not depend on the
+            # lease — only efficiency does.
+            return True
+        now = self._now_ms()
+        expires = now + ttl_ms
+        try:
+            with conn:  # a transaction so check-and-take is atomic
+                row = conn.execute(
+                    "SELECT expires_at_ms FROM usage_fetch_leases WHERE key = ?", (key,)
+                ).fetchone()
+                if row is not None and int(row[0]) > now:
+                    return False
+                conn.execute(
+                    """
+                    INSERT INTO usage_fetch_leases (key, holder, expires_at_ms)
+                    VALUES (?, ?, ?)
+                    ON CONFLICT(key) DO UPDATE SET
+                      holder = excluded.holder,
+                      expires_at_ms = excluded.expires_at_ms
+                    """,
+                    (key, self._holder, expires),
+                )
+            return True
+        except Exception:  # noqa: BLE001 — coordination failure = go fetch
+            logger.debug("usage cache: lease failed", exc_info=True)
+            return True
+
+    def release_lease(self, key: str) -> None:
+        """Free the lease if this process holds it (a fetch finished).
+
+        Released rather than left to expire so the NEXT session to notice the
+        stale row a moment later can refresh immediately instead of waiting out
+        the lease TTL. Only the holder releases: freeing a peer's lease would
+        re-open the very fan-out the lease prevents.
+        """
+        conn = self._connect()
+        if conn is None:
+            return
+        try:
+            with conn:
+                conn.execute(
+                    "DELETE FROM usage_fetch_leases WHERE key = ? AND holder = ?",
+                    (key, self._holder),
+                )
+        except Exception:  # noqa: BLE001
+            logger.debug("usage cache: lease release failed", exc_info=True)

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -486,9 +486,12 @@ JOB_POLL_INTERVAL_S = 1.0
 USAGE_WARM_INTERVAL_S = 60.0
 
 #: Refresh threshold for the warmer: a row younger than this is left alone.
-#: One TTL interval below the cache TTL, so the warmer fires roughly once per
-#: TTL window rather than racing the expiry.
-USAGE_WARM_STALE_AFTER_S = 240.0
+#: Must sit BELOW the cache TTL's jitter floor (5 min ±25% ⇒ 225 s minimum)
+#: minus one warm interval, or a short-drawn row expires in the gap between
+#: "the warmer judged it fresh" and the next tick — making the next `/usage`
+#: pay the live fetch the warmer exists to prevent. 150 s keeps a full tick of
+#: headroom under the worst draw while still refreshing only ~twice per TTL.
+USAGE_WARM_STALE_AFTER_S = 150.0
 
 #: Minimum seconds between two re-title CHECKS on one conversation. The check
 #: is a provider call (the model, not a keyword rule, judges whether the
@@ -7357,7 +7360,7 @@ class OperatorApp(App[None]):
             except Exception:  # noqa: BLE001 — a cache read failure is a cold open
                 cached = []
             if cached:
-                panel.show_cached(cached, now_ms=self._usage_data_age_ms(cached))
+                panel.show_cached(cached, now_ms=self._usage_data_fetched_ms(cached))
         # A second command replaces the first request. Without exclusivity a slow
         # response can overwrite the newer provider's report.
         self.run_worker(
@@ -7422,10 +7425,10 @@ class OperatorApp(App[None]):
             # from the shared cache may be minutes old, and "just now" would
             # overstate a number the user is deciding on. `r` forces a live
             # fetch when fresher numbers are wanted.
-            panel.show_reports(reports, now_ms=self._usage_data_age_ms(reports))
+            panel.show_reports(reports, now_ms=self._usage_data_fetched_ms(reports))
 
     @staticmethod
-    def _usage_data_age_ms(reports: list[Any]) -> float:
+    def _usage_data_fetched_ms(reports: list[Any]) -> float:
         """The oldest report's ``fetched_at`` as an epoch-ms clock reading.
 
         The panel's title renders ``now - fetched_ms`` as the age, so handing
@@ -7436,8 +7439,6 @@ class OperatorApp(App[None]):
         stamps = [int(getattr(report, "fetched_at", 0) or 0) for report in reports]
         stamps = [stamp for stamp in stamps if stamp > 0]
         if not stamps:
-            import time
-
             return time.time() * 1000
         return float(min(stamps))
 
@@ -7512,7 +7513,18 @@ class OperatorApp(App[None]):
         if panel is None:
             return
         target = panel.target
+        # Keep the numbers ON SCREEN while the forced fetch runs: `start_fetch`
+        # clears them for the cold open, but a refresh has live rows the user
+        # is reading, and blanking them to "fetching…" would make `r` worse
+        # than the cached open it sits next to.
+        shown = panel.reports
+        shown_ms = panel.fetched_ms
         generation = panel.start_fetch(target)
+        if shown:
+            panel.show_cached(
+                shown,
+                now_ms=shown_ms if shown_ms is not None else self._usage_data_fetched_ms(shown),
+            )
         self.run_worker(
             self._fetch_usage_worker(target or None, generation, force_refresh=True),
             thread=False,

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -476,6 +476,20 @@ LOOP_PROMPT = (
 #: when the count actually CHANGES.
 JOB_POLL_INTERVAL_S = 1.0
 
+#: How often the background usage warmer checks whether the active provider's
+#: quota row is going stale. The warmer only REFRESHES when the shared cache row
+#: is older than the TTL minus one interval, so in steady state it costs one
+#: network round per provider per TTL — and because the cache is shared across
+#: every lop session on this machine, one session's warm keeps every session's
+#: `/usage` instant. The panel's own fetch reads the same cache, so a warm row
+#: means `/usage` answers with no network at all.
+USAGE_WARM_INTERVAL_S = 60.0
+
+#: Refresh threshold for the warmer: a row younger than this is left alone.
+#: One TTL interval below the cache TTL, so the warmer fires roughly once per
+#: TTL window rather than racing the expiry.
+USAGE_WARM_STALE_AFTER_S = 240.0
+
 #: Minimum seconds between two re-title CHECKS on one conversation. The check
 #: is a provider call (the model, not a keyword rule, judges whether the
 #: subject moved — see :meth:`OperatorApp._maybe_retitle_conversation`), so
@@ -1353,6 +1367,9 @@ class OperatorApp(App[None]):
         editor.focus()
         # The count has no event to hang off (see JOB_POLL_INTERVAL_S).
         self.set_interval(JOB_POLL_INTERVAL_S, self._poll_subagents)
+        # Keep the active provider's quota warm in the shared cache so `/usage`
+        # answers from disk (see USAGE_WARM_INTERVAL_S).
+        self.set_interval(USAGE_WARM_INTERVAL_S, self._warm_usage_background)
 
         # Await the session in a worker so the app paints first.
         self.run_worker(self._boot_session(), thread=False, group="session")
@@ -1498,6 +1515,11 @@ class OperatorApp(App[None]):
             return
         self._adopt_session(session)
         await self._preflight_usage(session)
+        # Warm the active provider's quota row in the shared cache so the first
+        # `/usage` after launch answers from disk. No-op when another session
+        # already holds a fresh row (the age gate), so a fleet of terminals does
+        # not each pay a startup fetch.
+        self._warm_usage_background()
 
     def _restore_resumed_name(self, session: Any) -> None:
         """Give a resumed conversation a label even when none was stored.
@@ -6298,6 +6320,10 @@ class OperatorApp(App[None]):
         # A different model may well have a dial, so the per-model refusal latch
         # goes with the old one.
         self._effort_refusal_shown = None
+        # The active provider just changed; warm its quota row so a `/usage`
+        # right after the switch answers from disk too. The age gate makes this
+        # a no-op when the row is already warm.
+        self._warm_usage_background()
         persist_result: str | None = None
         saved_to = ""
         if persist_default:
@@ -7303,11 +7329,17 @@ class OperatorApp(App[None]):
         self._open_usage_panel(target)
 
     def _open_usage_panel(self, target: str) -> None:
-        """Show the panel in its loading state and start the fetch.
+        """Show the panel and start the fetch.
 
         The panel opens BEFORE the request. The fetch crosses the network once
         per logged-in provider, and a command whose only immediate effect was a
         transcript notice read as a command that had not run.
+
+        When the shared cache already holds a row for the target, the reports
+        paint IMMEDIATELY (their age stated in the title, a ``refreshing…``
+        mark while the fetch confirms them) — that is the fast path `/usage`
+        exists for. With nothing cached the panel shows its loading state and
+        the fetch is the whole answer.
         """
         panel = self._usage_panel()
         if panel is None:
@@ -7316,6 +7348,16 @@ class OperatorApp(App[None]):
         self._usage_focus_restore = self.focused
         generation = panel.start_fetch(target)
         panel.focus()
+        # Instant paint from the shared cache, when a row exists. Synchronous
+        # and network-free, so it is safe on the keystroke; the fetch below
+        # then confirms or replaces what is on screen.
+        if self._providers is not None:
+            try:
+                cached = self._providers.cached_usage_reports(target or None)
+            except Exception:  # noqa: BLE001 — a cache read failure is a cold open
+                cached = []
+            if cached:
+                panel.show_cached(cached, now_ms=self._usage_data_age_ms(cached))
         # A second command replaces the first request. Without exclusivity a slow
         # response can overwrite the newer provider's report.
         self.run_worker(
@@ -7332,32 +7374,137 @@ class OperatorApp(App[None]):
         except Exception:  # noqa: BLE001 — the panel is optional chrome
             return None
 
-    async def _fetch_usage_worker(self, provider: str | None, generation: int) -> None:
+    async def _fetch_usage_worker(
+        self, provider: str | None, generation: int, force_refresh: bool = False
+    ) -> None:
         """Fetch usage and paint only if this request still owns the panel.
 
         A failure is reported INSIDE the panel rather than as a transcript
         notice: the panel is what has focus and what carries the key that
         retries, so sending the error anywhere else asks the user to look away
         from the surface holding the fix.
+
+        ``force_refresh`` is the panel's ``r``: bypass the fresh-cache check so
+        an explicit refresh always crosses the network. The bare command and the
+        warmer read the shared cache first, which is how `/usage` answers
+        instantly when a row is warm.
         """
         panel = self._usage_panel()
         try:
             assert self._providers is not None
-            reports = await self._providers.fetch_usage([provider] if provider else None)
+            reports = await self._providers.fetch_usage(
+                [provider] if provider else None, force_refresh=force_refresh
+            )
         except Exception as error:
             if panel is None:
                 self._append_block(NoticeBlock(f"usage fetch failed: {error}", "error"))
             elif panel.accepts_request(generation):
-                panel.show_error(f"usage fetch failed: {error}")
+                # Cached reports already on screen survive a failed refresh:
+                # the numbers stay, the `refreshing…` mark goes, and the age in
+                # the title already states how stale they are. Blanking them for
+                # a network blip would lose the very answer the cache holds.
+                if panel.has_reports:
+                    panel.settle_refresh()
+                else:
+                    panel.show_error(f"usage fetch failed: {error}")
             return
         if panel is None:
             self._append_block(NoticeBlock("usage panel unavailable", "warning"))
             return
         if panel.accepts_request(generation):
-            panel.show_reports(reports)
+            if not reports and panel.has_reports:
+                # An empty result with cached rows on screen means the refresh
+                # found nothing new (or failed and served stale): keep what is
+                # painted rather than wipe it for an empty fetch.
+                panel.settle_refresh()
+                return
+            # The age shown is the DATA's age, not the fetch's: a row served
+            # from the shared cache may be minutes old, and "just now" would
+            # overstate a number the user is deciding on. `r` forces a live
+            # fetch when fresher numbers are wanted.
+            panel.show_reports(reports, now_ms=self._usage_data_age_ms(reports))
+
+    @staticmethod
+    def _usage_data_age_ms(reports: list[Any]) -> float:
+        """The oldest report's ``fetched_at`` as an epoch-ms clock reading.
+
+        The panel's title renders ``now - fetched_ms`` as the age, so handing
+        it the OLDEST report's fetch time states how stale the stalest number
+        on screen is. Falls back to the wall clock (age ≈ 0) when no report
+        carries a usable timestamp.
+        """
+        stamps = [int(getattr(report, "fetched_at", 0) or 0) for report in reports]
+        stamps = [stamp for stamp in stamps if stamp > 0]
+        if not stamps:
+            import time
+
+            return time.time() * 1000
+        return float(min(stamps))
+
+    def _warm_usage_background(self) -> None:
+        """Keep the active provider's quota row warm so `/usage` answers from disk.
+
+        Interval callback (see :data:`USAGE_WARM_INTERVAL_S`). Reads the shared
+        cache's age for the provider this session is actually running on, and
+        only when that row is missing or going stale does it kick a background
+        refresh — so in steady state it costs one network round per provider per
+        TTL, never a fetch per interval.
+
+        The refresh goes through the SAME cached fetch path the panel uses, which
+        is what makes this cheap across many concurrent sessions: the cross-process
+        lease in :mod:`usage_cache` ensures only one session on the machine
+        actually crosses the network for a stale row, and every other session's
+        warmer reads the freshly-written shared cache and does nothing. Warming
+        the active provider (rather than every reportable one) is deliberate —
+        it is the account a turn could run out of, and the one a user is most
+        likely to ask about; bare `/usage` still fetches any cold provider in
+        parallel on demand.
+
+        Never raises into the event loop: a quota warm-up is an optimisation,
+        and a failure must read as "the next `/usage` fetches live", not as a
+        crash.
+        """
+        if self._providers is None:
+            return
+        provider = getattr(_model_spec(self._session), "provider", None)
+        if not provider:
+            return
+        try:
+            if not self._providers.can_report_usage(provider):
+                return
+            age_ms = self._providers.usage_cache_age_ms(provider)
+        except Exception:  # noqa: BLE001 — a warm-up must never take the app down
+            return
+        if age_ms is not None and age_ms <= USAGE_WARM_STALE_AFTER_S * 1000:
+            return  # still fresh: nothing to do this tick
+        self.run_worker(
+            self._warm_usage_worker(provider),
+            thread=False,
+            group="usage-warm",
+            exclusive=True,
+        )
+
+    async def _warm_usage_worker(self, provider: str) -> None:
+        """Background refresh for one provider; never paints the panel.
+
+        Deliberately NOT the panel's ``group="usage"`` worker: a warm-up must
+        neither cancel an in-flight panel fetch nor be cancelled by one, and it
+        has no surface to update — its only output is the shared cache row the
+        next `/usage` reads.
+        """
+        try:
+            assert self._providers is not None
+            await self._providers.fetch_usage([provider])
+        except Exception:  # noqa: BLE001 — warm-up failure is a future live fetch
+            pass
 
     def on_usage_refresh_requested(self, message: UsageRefreshRequested) -> None:
-        """``r`` in the panel — re-run the same fetch behind the same view."""
+        """``r`` in the panel — re-run the same fetch behind the same view.
+
+        Forced: ``r`` is the user saying the numbers on screen are not fresh
+        enough, so it bypasses the cache rather than risk handing back the
+        same row.
+        """
         message.stop()
         if self._providers is None:
             return
@@ -7367,7 +7514,7 @@ class OperatorApp(App[None]):
         target = panel.target
         generation = panel.start_fetch(target)
         self.run_worker(
-            self._fetch_usage_worker(target or None, generation),
+            self._fetch_usage_worker(target or None, generation, force_refresh=True),
             thread=False,
             group="usage",
             exclusive=True,

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -7407,7 +7407,7 @@ class OperatorApp(App[None]):
                 # the title already states how stale they are. Blanking them for
                 # a network blip would lose the very answer the cache holds.
                 if panel.has_reports:
-                    panel.settle_refresh()
+                    panel.settle_refresh(failed=True)
                 else:
                     panel.show_error(f"usage fetch failed: {error}")
             return
@@ -7417,9 +7417,10 @@ class OperatorApp(App[None]):
         if panel.accepts_request(generation):
             if not reports and panel.has_reports:
                 # An empty result with cached rows on screen means the refresh
-                # found nothing new (or failed and served stale): keep what is
-                # painted rather than wipe it for an empty fetch.
-                panel.settle_refresh()
+                # came back with nothing while the user is looking at numbers:
+                # keep what is painted, and say the refresh failed — the mark
+                # silently vanishing is not an answer to a key they pressed.
+                panel.settle_refresh(failed=True)
                 return
             # The age shown is the DATA's age, not the fetch's: a row served
             # from the shared cache may be minutes old, and "just now" would
@@ -7519,12 +7520,19 @@ class OperatorApp(App[None]):
         # than the cached open it sits next to.
         shown = panel.reports
         shown_ms = panel.fetched_ms
+        # BEFORE start_fetch: its repaint clamps the offset against the one-row
+        # loading body, so reading it afterwards always yields 0.
+        shown_offset = panel.view_offset
         generation = panel.start_fetch(target)
         if shown:
             panel.show_cached(
                 shown,
                 now_ms=shown_ms if shown_ms is not None else self._usage_data_fetched_ms(shown),
+                keep_offset=True,
             )
+            # `start_fetch` reset the offset; put the reader back where they
+            # were — a refresh must not lose their place in a long report.
+            panel.set_view_offset(shown_offset)
         self.run_worker(
             self._fetch_usage_worker(target or None, generation, force_refresh=True),
             thread=False,

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -7415,17 +7415,14 @@ class OperatorApp(App[None]):
             self._append_block(NoticeBlock("usage panel unavailable", "warning"))
             return
         if panel.accepts_request(generation):
-            if not reports and panel.has_reports:
-                # An empty result with cached rows on screen means the refresh
-                # came back with nothing while the user is looking at numbers:
-                # keep what is painted, and say the refresh failed — the mark
-                # silently vanishing is not an answer to a key they pressed.
-                panel.settle_refresh(failed=True)
-                return
-            # The age shown is the DATA's age, not the fetch's: a row served
-            # from the shared cache may be minutes old, and "just now" would
-            # overstate a number the user is deciding on. `r` forces a live
-            # fetch when fresher numbers are wanted.
+            # Paint whatever the controller returned. After the empty-over-data
+            # acceptance window, `[]` is a REAL answer ("this provider reports
+            # nothing") and must replace the stale numbers the cache just
+            # stopped serving — treating it as a failed refresh would undo that
+            # settlement and keep showing data the cache no longer stands
+            # behind. A true outage already comes back as the last-good list
+            # (not `[]`), so the exception branch above is the only path that
+            # should pin the failed-refresh note.
             panel.show_reports(reports, now_ms=self._usage_data_fetched_ms(reports))
 
     @staticmethod

--- a/local_operator/tui/widgets/usage_panel.py
+++ b/local_operator/tui/widgets/usage_panel.py
@@ -519,6 +519,9 @@ class UsagePanel(Static):
         #: rather than "fetching…": the numbers the user came for are present,
         #: and the fetch only confirms or replaces them.
         self._refreshing = False
+        #: The last refresh over these reports came back empty-handed; a note
+        #: under the title says so (see :meth:`settle_refresh`).
+        self._refresh_failed = False
         self._error = ""
         self._target = ""
         self._fetched_ms: float | None = None
@@ -545,6 +548,7 @@ class UsagePanel(Static):
         self._request_generation += 1
         self._loading = True
         self._refreshing = False
+        self._refresh_failed = False
         self._error = ""
         self._target = target
         # Clear any previous reports so a cold open reads "fetching…" rather
@@ -556,20 +560,29 @@ class UsagePanel(Static):
         self._repaint()
         return self._request_generation
 
-    def show_cached(self, reports, *, now_ms: float) -> None:  # noqa: ANN001
+    def show_cached(
+        self, reports, *, now_ms: float, keep_offset: bool = False
+    ) -> None:  # noqa: ANN001
         """Paint cached reports immediately while the fetch runs behind them.
 
         The panel opened with a row already in the shared cache: showing
         "fetching…" would hide an answer that is on hand, so the reports render
         at once with their true age in the title and a ``refreshing…`` mark, and
         the fetch's result replaces them when it lands.
+
+        ``keep_offset`` is the ``r`` path's flag: a refresh re-shows the rows
+        the user is already READING, and snapping their scroll position to the
+        top would lose their place in a long report for no reason. A fresh open
+        starts at the top as before.
         """
         self._reports = list(reports)
         self._loading = False
         self._refreshing = True
+        self._refresh_failed = False
         self._error = ""
         self._fetched_ms = now_ms
-        self._offset = 0
+        if not keep_offset:
+            self._offset = 0
         self.display = True
         self._repaint()
 
@@ -578,6 +591,7 @@ class UsagePanel(Static):
         self._reports = list(reports)
         self._loading = False
         self._refreshing = False
+        self._refresh_failed = False
         self._error = ""
         self._fetched_ms = self._now() if now_ms is None else now_ms
         self._offset = 0
@@ -588,19 +602,23 @@ class UsagePanel(Static):
         """A failed fetch stays IN the panel, next to the key that retries it."""
         self._loading = False
         self._refreshing = False
+        self._refresh_failed = False
         self._error = message
         self.display = True
         self._repaint()
 
-    def settle_refresh(self) -> None:
+    def settle_refresh(self, *, failed: bool = False) -> None:
         """A background refresh ended with the cached reports still on screen.
 
         The fetch path serves stale data on failure rather than blanking the
-        panel, so the only visible change is the ``refreshing…`` mark going
-        away: the numbers stay, and their age in the title already says how
-        stale they are.
+        panel, so the numbers stay and their age in the title already says how
+        stale they are. ``failed`` additionally pins a one-row note under the
+        title: without it the only signal that an EXPLICIT ``r`` came back
+        empty-handed was the ``refreshing…`` mark silently disappearing —
+        honest, but illegible as an answer to a key the user just pressed.
         """
         self._refreshing = False
+        self._refresh_failed = failed
         self._repaint()
 
     def accepts_request(self, generation: int) -> bool:
@@ -652,6 +670,16 @@ class UsagePanel(Static):
     @property
     def view_offset(self) -> int:
         return self._offset
+
+    def set_view_offset(self, offset: int) -> None:
+        """Restore a scroll position (clamped by the next repaint).
+
+        Exists for the ``r`` path, which re-shows the standing reports after
+        ``start_fetch`` reset the offset: the reader's place in a long report
+        survives the refresh instead of snapping to the top.
+        """
+        self._offset = max(0, int(offset))
+        self._repaint()
 
     def set_clock(self, now_ms: float) -> None:
         """Pin the clock (tests; the panel otherwise reads the wall clock)."""
@@ -742,7 +770,12 @@ class UsagePanel(Static):
         """
         rows = self._rows_above_dock()
         gutter = PANEL_PADDING_ROWS if rows >= SQUEEZE_ROWS else 0
-        return rows, gutter, max(1, rows - PANEL_HEIGHT_MARGIN - CHROME_ROWS - gutter)
+        # The failed-refresh note is a CONDITIONAL chrome row (see
+        # `_compose_rows`): when it is pinned it must come out of the body
+        # budget like the title and rule do, or a full-height card grows one
+        # row past the dock exactly when the note appears.
+        note = 1 if (self._refresh_failed and self._reports) else 0
+        return rows, gutter, max(1, rows - PANEL_HEIGHT_MARGIN - CHROME_ROWS - gutter - note)
 
     def sync_layout(self, *, force: bool = False) -> None:
         """Repaint when the screen or live dock changed around an open card.
@@ -808,14 +841,25 @@ class UsagePanel(Static):
     def _title_row(self) -> Text:
         muted = Style(color=theme_mod.semantic_color("muted"))
         dim = Style(color=theme_mod.semantic_color("dim"))
+        faint = Style(color=theme_mod.semantic_color("faint"))
         row = Text()
         row.append("Usage", style=Style(color=theme_mod.semantic_color("fg")))
         if self._target:
             row.append(f"  {self._target}", style=muted)
         if self._fetched_ms is not None and not self._loading and not self._error:
+            # A `·` between the age and the refreshing mark so "2m ago" and
+            # "refreshing…" read as two facts rather than one running phrase.
             row.append(f"  {format_age(self._now() - self._fetched_ms)}", style=dim)
         if self._refreshing and not self._error:
-            row.append("  refreshing…", style=dim)
+            row.append("  · ", style=faint)
+            row.append("refreshing…", style=dim)
+        # Truncated like every other composed row. The title grew suffixes
+        # (target, age, refreshing) that can outrun a 32-cell card, and an
+        # untruncated Text WRAPS — an extra visual row `_repaint`'s pinned
+        # height never counted, which clipped the footer (and its `r refresh`
+        # receipt) off the bottom exactly in the stale/narrow state where the
+        # refresh key matters most.
+        row.truncate(max(1, self._content_width()), overflow="ellipsis")
         return row
 
     def _hint_row(self, scrolled: bool) -> Text:
@@ -886,7 +930,19 @@ class UsagePanel(Static):
         faint = Style(color=theme_mod.semantic_color("faint"))
         dim = Style(color=theme_mod.semantic_color("dim"))
         rule = Text("─" * self._content_width(), style=faint)
-        rows = [self._title_row(), rule, *window]
+        rows = [self._title_row(), rule]
+        if self._refresh_failed and self._reports:
+            # One dim row, pinned with the chrome rather than scrolled with the
+            # body: it annotates the WHOLE report ("these numbers are what you
+            # already had"), and it must stay visible next to the age it
+            # qualifies while the user scrolls looking for fresher rows.
+            note = Text(
+                "refresh failed — showing last known numbers",
+                style=Style(color=theme_mod.semantic_color("warning")),
+            )
+            note.truncate(max(1, self._content_width()), overflow="ellipsis")
+            rows.append(note)
+        rows.extend(window)
         # Quiet ground between the report and the card's bottom meta, in BOTH
         # states. Without it the tally and the key hints sit flush against the
         # last meter and read as one more data row rather than as chrome.

--- a/local_operator/tui/widgets/usage_panel.py
+++ b/local_operator/tui/widgets/usage_panel.py
@@ -514,6 +514,11 @@ class UsagePanel(Static):
         self._reports: list[Any] = []
         self._offset = 0
         self._loading = False
+        #: A background refresh is running while cached reports are already on
+        #: screen. The body renders the reports (their age stated in the title)
+        #: rather than "fetching…": the numbers the user came for are present,
+        #: and the fetch only confirms or replaces them.
+        self._refreshing = False
         self._error = ""
         self._target = ""
         self._fetched_ms: float | None = None
@@ -539,16 +544,40 @@ class UsagePanel(Static):
         """
         self._request_generation += 1
         self._loading = True
+        self._refreshing = False
         self._error = ""
         self._target = target
+        # Clear any previous reports so a cold open reads "fetching…" rather
+        # than the last session's numbers; the cached-first path repopulates
+        # this immediately via `show_cached` when a row is on hand.
+        self._reports = []
+        self._fetched_ms = None
         self.display = True
         self._repaint()
         return self._request_generation
+
+    def show_cached(self, reports, *, now_ms: float) -> None:  # noqa: ANN001
+        """Paint cached reports immediately while the fetch runs behind them.
+
+        The panel opened with a row already in the shared cache: showing
+        "fetching…" would hide an answer that is on hand, so the reports render
+        at once with their true age in the title and a ``refreshing…`` mark, and
+        the fetch's result replaces them when it lands.
+        """
+        self._reports = list(reports)
+        self._loading = False
+        self._refreshing = True
+        self._error = ""
+        self._fetched_ms = now_ms
+        self._offset = 0
+        self.display = True
+        self._repaint()
 
     def show_reports(self, reports, *, now_ms: float | None = None) -> None:  # noqa: ANN001
         """Install a finished fetch and paint it."""
         self._reports = list(reports)
         self._loading = False
+        self._refreshing = False
         self._error = ""
         self._fetched_ms = self._now() if now_ms is None else now_ms
         self._offset = 0
@@ -558,8 +587,20 @@ class UsagePanel(Static):
     def show_error(self, message: str) -> None:
         """A failed fetch stays IN the panel, next to the key that retries it."""
         self._loading = False
+        self._refreshing = False
         self._error = message
         self.display = True
+        self._repaint()
+
+    def settle_refresh(self) -> None:
+        """A background refresh ended with the cached reports still on screen.
+
+        The fetch path serves stale data on failure rather than blanking the
+        panel, so the only visible change is the ``refreshing…`` mark going
+        away: the numbers stay, and their age in the title already says how
+        stale they are.
+        """
+        self._refreshing = False
         self._repaint()
 
     def accepts_request(self, generation: int) -> bool:
@@ -570,6 +611,7 @@ class UsagePanel(Static):
         """Hide the panel and forget the scroll position."""
         self._request_generation += 1
         self._loading = False
+        self._refreshing = False
         self._offset = 0
         self.display = False
 
@@ -590,6 +632,11 @@ class UsagePanel(Static):
     @property
     def reports(self) -> list[Any]:
         return list(self._reports)
+
+    @property
+    def has_reports(self) -> bool:
+        """Whether any reports (live or cached) are on screen."""
+        return bool(self._reports)
 
     @property
     def view_offset(self) -> int:
@@ -734,7 +781,7 @@ class UsagePanel(Static):
                 [Text(truncate_cells(self._error, width), style=danger)],
                 frozenset({1}),
             )
-        if self._loading:
+        if self._loading and not self._reports:
             return UsageBody([Text("fetching…", style=dim)], frozenset({1}))
         if not self._reports:
             # Two failures look identical in an empty panel and only one is
@@ -756,6 +803,8 @@ class UsagePanel(Static):
             row.append(f"  {self._target}", style=muted)
         if self._fetched_ms is not None and not self._loading and not self._error:
             row.append(f"  {format_age(self._now() - self._fetched_ms)}", style=dim)
+        if self._refreshing and not self._error:
+            row.append("  refreshing…", style=dim)
         return row
 
     def _hint_row(self, scrolled: bool) -> Text:

--- a/local_operator/tui/widgets/usage_panel.py
+++ b/local_operator/tui/widgets/usage_panel.py
@@ -639,6 +639,17 @@ class UsagePanel(Static):
         return bool(self._reports)
 
     @property
+    def fetched_ms(self) -> float | None:
+        """The epoch-ms clock reading the title's age is measured from.
+
+        Exposed so the app's ``r`` handler can re-show the standing reports
+        with their ORIGINAL age while the forced fetch runs — re-deriving it
+        from the reports would silently reset the age of rows that carry no
+        ``fetched_at`` of their own.
+        """
+        return self._fetched_ms
+
+    @property
     def view_offset(self) -> int:
         return self._offset
 

--- a/tests/unit/providers/test_controller.py
+++ b/tests/unit/providers/test_controller.py
@@ -8,6 +8,7 @@ httpx transport.
 from __future__ import annotations
 
 import types
+from collections.abc import Iterator
 from typing import Any
 
 import httpx
@@ -16,6 +17,7 @@ import pytest
 from local_operator.harness.types import ModelSpec
 from local_operator.providers.controller import ProviderController
 from local_operator.providers.usage import UsageReport
+from local_operator.providers.usage_cache import UsageCacheStore
 
 
 class FakeAuthStore:
@@ -71,8 +73,17 @@ def store() -> FakeAuthStore:
 
 
 @pytest.fixture
-def controller(store):
-    return ProviderController(store, login_callbacks=None)
+def usage_cache(tmp_path) -> Iterator[UsageCacheStore]:
+    # Aim the shared cache at a temp file so controller tests never touch (or
+    # are polluted by) the real ~/.local-operator/usage_cache.db.
+    cache = UsageCacheStore(tmp_path / "usage_cache.db")
+    yield cache
+    cache.close()
+
+
+@pytest.fixture
+def controller(store, usage_cache):
+    return ProviderController(store, login_callbacks=None, usage_cache=usage_cache)
 
 
 def test_login_provider_listing(controller) -> None:
@@ -541,3 +552,146 @@ def test_a_catalogue_survives_a_store_that_cannot_be_read(controller, store) -> 
     entries = controller.static_catalogue()
     assert entries
     assert all(entry.connected for entry in entries)
+
+
+class TestUsageCache:
+    """`/usage` answers from the shared cache, not the network, whenever a row
+    is warm. The cache is what makes the command instant across every lop
+    session on the machine, so these pin the fetch path to it."""
+
+    @staticmethod
+    def _account(email: str, account_id: str):
+        return types.SimpleNamespace(
+            access_token=f"tok-{account_id}",
+            credential_id=0,
+            account_id=account_id,
+            email=email,
+            org_id=None,
+            api_endpoint=None,
+            kind="oauth",
+            raw=None,
+        )
+
+    @pytest.mark.asyncio
+    async def test_a_warm_row_is_served_without_crossing_the_network(
+        self, controller, store, monkeypatch
+    ) -> None:
+        store.oauth_accounts["anthropic"] = [self._account("me@example.com", "acct-1")]
+        calls = 0
+
+        async def fake_fetch(
+            client, provider, *, api_key, access_token, account_id, oauth_creds=None
+        ):
+            nonlocal calls
+            calls += 1
+            return UsageReport(provider=provider, limits=[])
+
+        monkeypatch.setattr("local_operator.providers.controller.fetch_usage", fake_fetch)
+
+        first = await controller.fetch_usage(["anthropic"])
+        second = await controller.fetch_usage(["anthropic"])
+
+        assert len(first) == 1 and len(second) == 1
+        # The second read hit the cache: exactly one network round total.
+        assert calls == 1
+
+    @pytest.mark.asyncio
+    async def test_force_refresh_bypasses_the_warm_row(
+        self, controller, store, monkeypatch
+    ) -> None:
+        store.oauth_accounts["anthropic"] = [self._account("me@example.com", "acct-1")]
+        calls = 0
+
+        async def fake_fetch(
+            client, provider, *, api_key, access_token, account_id, oauth_creds=None
+        ):
+            nonlocal calls
+            calls += 1
+            return UsageReport(provider=provider, limits=[])
+
+        monkeypatch.setattr("local_operator.providers.controller.fetch_usage", fake_fetch)
+
+        await controller.fetch_usage(["anthropic"])
+        await controller.fetch_usage(["anthropic"], force_refresh=True)
+
+        # `r` in the panel must actually re-fetch, not hand back the cache.
+        assert calls == 2
+
+    @pytest.mark.asyncio
+    async def test_login_invalidates_the_cached_row(self, controller, store, monkeypatch) -> None:
+        """The account set is folded into the cache key, so adding an account
+        stops the old row from matching and forces a fresh fetch.
+
+        The fingerprint is a synchronous projection of the STORED credential
+        rows (the same source `list_oauth_accesses` reads in the real store),
+        so the test populates `rows` as well as the fake's `oauth_accounts`.
+        """
+        store.upsert_credential(
+            "anthropic", {"refresh": "r1", "access": "a1", "email": "me@example.com"}
+        )
+        store.oauth_accounts["anthropic"] = [self._account("me@example.com", "acct-1")]
+        calls = 0
+
+        async def fake_fetch(
+            client, provider, *, api_key, access_token, account_id, oauth_creds=None
+        ):
+            nonlocal calls
+            calls += 1
+            return UsageReport(provider=provider, limits=[])
+
+        monkeypatch.setattr("local_operator.providers.controller.fetch_usage", fake_fetch)
+
+        await controller.fetch_usage(["anthropic"])
+        # A second account logs in: the fingerprint changes, the cached row no
+        # longer matches, and the fetch runs again.
+        store.upsert_credential(
+            "anthropic", {"refresh": "r2", "access": "a2", "email": "other@example.com"}
+        )
+        store.oauth_accounts["anthropic"].append(self._account("other@example.com", "acct-2"))
+        await controller.fetch_usage(["anthropic"])
+        # The second fetch re-ran for BOTH accounts (the row no longer matched),
+        # so the total is 1 + 2, not a cache hit.
+        assert calls == 3
+
+    @pytest.mark.asyncio
+    async def test_a_failed_refresh_serves_the_last_good_value(
+        self, controller, store, monkeypatch
+    ) -> None:
+        store.oauth_accounts["anthropic"] = [self._account("me@example.com", "acct-1")]
+        fail = False
+
+        async def fake_fetch(
+            client, provider, *, api_key, access_token, account_id, oauth_creds=None
+        ):
+            if fail:
+                raise RuntimeError("quota endpoint exploded")
+            return UsageReport(provider=provider, limits=[])
+
+        monkeypatch.setattr("local_operator.providers.controller.fetch_usage", fake_fetch)
+
+        warm = await controller.fetch_usage(["anthropic"])
+        assert len(warm) == 1
+
+        # Expire the row (a RECENT past expiry — an ancient one is pruned by the
+        # retention cleanup on the next write), then fail the refresh: the stale
+        # value must survive.
+        key = controller._usage_cache_key("anthropic")
+        cache = controller._usage_cache_store()
+        assert cache is not None
+        stale = cache.get(key, include_expired=True)
+        assert stale is not None
+        import time as _time
+
+        cache.set(key, "anthropic", stale, expires_at_ms=int(_time.time() * 1000) - 1000)
+
+        fail = True
+        recovered = await controller.fetch_usage(["anthropic"])
+        assert len(recovered) == 1, "a blip must not blank the report"
+
+    @pytest.mark.asyncio
+    async def test_alias_providers_share_one_cache_row(
+        self, controller, store, monkeypatch
+    ) -> None:
+        """`openai-device` logs in under `openai`; both spellings must read the
+        same cache row rather than hold one permanently-stale copy each."""
+        assert controller._usage_cache_key("openai") == controller._usage_cache_key("openai-device")

--- a/tests/unit/providers/test_controller.py
+++ b/tests/unit/providers/test_controller.py
@@ -730,3 +730,44 @@ class TestUsageCache:
         """`openai-device` logs in under `openai`; both spellings must read the
         same cache row rather than hold one permanently-stale copy each."""
         assert controller._usage_cache_key("openai") == controller._usage_cache_key("openai-device")
+
+    @pytest.mark.asyncio
+    async def test_old_enough_data_lets_an_empty_answer_be_believed(
+        self, controller, store, monkeypatch
+    ) -> None:
+        """A provider that GENUINELY went quota-less must eventually settle.
+
+        The empty-over-data heuristic reads a blank answer over recent data as
+        an outage — but each write_failure kept the old row alive, so a lapsed
+        plan was re-fetched on every cool-down forever. Once the last real data
+        is older than EMPTY_OVER_DATA_ACCEPT_MS, the empty answer is accepted
+        and negative-cached at full TTL.
+        """
+        import time as _time
+
+        from local_operator.providers.controller import EMPTY_OVER_DATA_ACCEPT_MS
+
+        store.oauth_accounts["anthropic"] = [self._account("me@example.com", "acct-1")]
+
+        async def fake_fetch(
+            client, provider, *, api_key, access_token, account_id, oauth_creds=None
+        ):
+            return None  # blank answer, endpoint reachable
+
+        monkeypatch.setattr("local_operator.providers.controller.fetch_usage", fake_fetch)
+
+        # Plant a last-good row whose data is OLDER than the acceptance window,
+        # already expired so the refresh path runs.
+        key = controller._usage_cache_key("anthropic")
+        cache = controller._usage_cache_store()
+        assert cache is not None
+        now_ms = int(_time.time() * 1000)
+        old = UsageReport(provider="anthropic", limits=[])
+        old.fetched_at = now_ms - EMPTY_OVER_DATA_ACCEPT_MS - 60_000
+        old.identity = "me@example.com"
+        cache.set(key, "anthropic", [old], expires_at_ms=now_ms - 1000)
+
+        # The empty answer is BELIEVED: no stale serve, and the row is now a
+        # full-TTL negative entry (fresh, empty).
+        assert await controller.fetch_usage(["anthropic"]) == []
+        assert cache.get(key) == []

--- a/tests/unit/providers/test_controller.py
+++ b/tests/unit/providers/test_controller.py
@@ -657,6 +657,14 @@ class TestUsageCache:
     async def test_a_failed_refresh_serves_the_last_good_value(
         self, controller, store, monkeypatch
     ) -> None:
+        """A DOWN endpoint must not blank (or negative-cache over) real data.
+
+        HONEST failure mode: the real fetchers never raise — `_get_json`
+        swallows transport errors, non-200s and bad JSON and returns None — so
+        an outage reaches the cache layer as an EMPTY result. The disambiguator
+        is history: a provider that had data a moment ago and reports none now
+        keeps its last good value under a short cool-down.
+        """
         store.oauth_accounts["anthropic"] = [self._account("me@example.com", "acct-1")]
         fail = False
 
@@ -664,7 +672,7 @@ class TestUsageCache:
             client, provider, *, api_key, access_token, account_id, oauth_creds=None
         ):
             if fail:
-                raise RuntimeError("quota endpoint exploded")
+                return None  # what a 429/outage actually looks like to callers
             return UsageReport(provider=provider, limits=[])
 
         monkeypatch.setattr("local_operator.providers.controller.fetch_usage", fake_fetch)
@@ -687,6 +695,33 @@ class TestUsageCache:
         fail = True
         recovered = await controller.fetch_usage(["anthropic"])
         assert len(recovered) == 1, "a blip must not blank the report"
+        # And the shared row still holds the data for every OTHER session.
+        assert cache.get(key, include_expired=True), "last-good row was overwritten"
+
+    @pytest.mark.asyncio
+    async def test_a_provider_with_no_data_history_is_negative_cached(
+        self, controller, store, monkeypatch
+    ) -> None:
+        """A provider that reports nothing (and never has) is cached as empty,
+        so the warmer stops re-hitting an endpoint with nothing to say."""
+        store.oauth_accounts["xai"] = [self._account("me@example.com", "acct-1")]
+        calls = 0
+
+        async def fake_fetch(
+            client, provider, *, api_key, access_token, account_id, oauth_creds=None
+        ):
+            nonlocal calls
+            calls += 1
+            return None  # endpoint answers, but there is no quota to report
+
+        monkeypatch.setattr("local_operator.providers.controller.fetch_usage", fake_fetch)
+
+        assert await controller.fetch_usage(["xai"]) == []
+        assert await controller.fetch_usage(["xai"]) == []
+        # The empty answer was cached: exactly one network round total.
+        assert calls == 1
+        # And the row is visible to the warmer's age probe.
+        assert controller.usage_cache_age_ms("xai") is not None
 
     @pytest.mark.asyncio
     async def test_alias_providers_share_one_cache_row(

--- a/tests/unit/providers/test_usage_cache.py
+++ b/tests/unit/providers/test_usage_cache.py
@@ -203,3 +203,28 @@ def test_retention_prunes_only_rows_past_the_last_good_window(cache) -> None:
     )
     assert cache.get(key, include_expired=True) is None
     assert cache.get("anthropic:other") is not None
+
+
+def test_a_write_leaves_no_open_transaction_behind(cache) -> None:
+    """`set()`'s pruning DELETEs must commit. sqlite3 opens an implicit
+    transaction on the first write and leaves it OPEN until something commits;
+    the bare cleanup DELETEs held the WAL write lock from one refresh to the
+    next, so every other session's cache call blocked for the full 5s busy
+    timeout and then failed — leases collapsed and writes were silently lost,
+    each stall freezing that session's whole TUI."""
+    cache.set("k", "p", [_report()], expires_at_ms=int(time.time() * 1000) + 60_000)
+    assert cache._connect() is not None
+    assert not cache._conn.in_transaction, "cleanup left the write lock held"
+
+    # And the practical consequence: a SECOND connection's lease and write are
+    # immediate, not a 5-second busy-timeout stall.
+    other = UsageCacheStore(cache._db_path)
+    try:
+        start = time.perf_counter()
+        assert other.try_lease("k2") is True
+        other.set("k3", "p", [_report()], expires_at_ms=int(time.time() * 1000) + 60_000)
+        elapsed = time.perf_counter() - start
+        assert elapsed < 1.0, f"peer session blocked {elapsed:.1f}s on the cache"
+        assert other.get("k3") is not None, "peer write was silently lost"
+    finally:
+        other.close()

--- a/tests/unit/providers/test_usage_cache.py
+++ b/tests/unit/providers/test_usage_cache.py
@@ -1,0 +1,205 @@
+"""The shared usage cache — TTL, stale serving, leases, and the wire format.
+
+The cache is what makes `/usage` instant across every lop session on the
+machine, so its contract is tested directly against a temp file: a fresh row
+answers, an expired row does not (but stays servable), a lease serializes
+refreshes, and a failure keeps the last good value readable.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from local_operator.providers.usage import UsageAmount, UsageLimit, UsageReport
+from local_operator.providers.usage_cache import (
+    USAGE_FAILURE_BACKOFF_MS,
+    USAGE_LAST_GOOD_RETENTION_MS,
+    UsageCacheStore,
+    fingerprint_accounts,
+    fingerprint_secret,
+    provider_cache_key,
+    report_from_dict,
+    report_to_dict,
+)
+
+
+def _report(provider: str = "anthropic", percent: float = 42.0) -> UsageReport:
+    return UsageReport(
+        provider=provider,
+        fetched_at=int(time.time() * 1000),
+        limits=[
+            UsageLimit(
+                id=f"{provider}:5h",
+                label="5 hour",
+                amount=UsageAmount(
+                    used=percent, limit=100.0, used_fraction=percent / 100, unit="percent"
+                ),
+                window="5 hour",
+                shared=True,
+            )
+        ],
+        identity="me@example.com",
+    )
+
+
+@pytest.fixture
+def cache(tmp_path):
+    store = UsageCacheStore(tmp_path / "usage_cache.db")
+    yield store
+    store.close()
+
+
+# -- wire format --------------------------------------------------------------
+def test_report_round_trips_through_the_wire_format() -> None:
+    report = _report()
+    restored = report_from_dict(report_to_dict(report))
+    assert restored is not None
+    assert restored.provider == report.provider
+    assert restored.fetched_at == report.fetched_at
+    assert restored.identity == report.identity
+    assert len(restored.limits) == 1
+    limit = restored.limits[0]
+    assert limit.id == "anthropic:5h"
+    assert limit.amount.used_fraction == pytest.approx(0.42)
+    assert limit.shared is True
+
+
+def test_report_from_dict_rejects_garbage_as_a_miss() -> None:
+    # A schema change or a corrupt row must read as a cache MISS, never an
+    # exception on the /usage path.
+    assert report_from_dict(None) is None
+    assert report_from_dict({"no": "provider"}) is None
+    assert report_from_dict({"provider": "x", "limits": [{"id": "a"}]}) is None
+
+
+# -- keys ---------------------------------------------------------------------
+def test_cache_key_names_provider_and_account_set() -> None:
+    fp = fingerprint_accounts(["a@x.com", "b@x.com"])
+    assert provider_cache_key("anthropic", fp) == f"anthropic:{fp}"
+
+
+def test_fingerprint_is_order_independent() -> None:
+    # Enumeration order (row id, round-robin) must not change the key.
+    assert fingerprint_accounts(["a", "b"]) == fingerprint_accounts(["b", "a"])
+    assert fingerprint_accounts([]) == "none"
+
+
+def test_secret_fingerprint_never_contains_the_secret() -> None:
+    fp = fingerprint_secret("sk-or-very-secret")
+    assert "sk-or-very-secret" not in fp
+    assert fingerprint_secret("sk-or-very-secret") == fp  # stable
+
+
+# -- TTL and stale serving ----------------------------------------------------
+def test_a_fresh_row_is_served_and_an_expired_one_is_not(cache) -> None:
+    key = "anthropic:test"
+    cache.set(key, "anthropic", [_report()], expires_at_ms=int(time.time() * 1000) + 60_000)
+    assert cache.get(key) is not None
+
+    cache.set(key, "anthropic", [_report()], expires_at_ms=int(time.time() * 1000) - 1)
+    assert cache.get(key) is None
+    # ...but stays servable as the stale fallback.
+    assert cache.get(key, include_expired=True) is not None
+
+
+def test_expiry_ms_reports_the_rows_ttl(cache) -> None:
+    key = "anthropic:test"
+    assert cache.expiry_ms(key) is None
+    expires = int(time.time() * 1000) + 60_000
+    cache.set(key, "anthropic", [_report()], expires_at_ms=expires)
+    assert cache.expiry_ms(key) == expires
+
+
+def test_multiple_reports_round_trip_as_one_row(cache) -> None:
+    # A provider with two accounts stores BOTH reports under one key.
+    key = "anthropic:two"
+    reports = [_report(percent=10.0), _report(percent=90.0)]
+    cache.set(key, "anthropic", reports, expires_at_ms=int(time.time() * 1000) + 60_000)
+    restored = cache.get(key)
+    assert restored is not None
+    assert len(restored) == 2
+    assert restored[0].limits[0].amount.used == 10.0
+    assert restored[1].limits[0].amount.used == 90.0
+
+
+# -- failure fallback ----------------------------------------------------------
+def test_write_failure_keeps_the_last_good_value_readable(cache) -> None:
+    key = "anthropic:test"
+    cache.set(key, "anthropic", [_report()], expires_at_ms=int(time.time() * 1000) + 60_000)
+    # Expire it, then record a failure: the stale value must come back with a
+    # short cool-down so a blip does not blank the report.
+    cache.set(key, "anthropic", [_report()], expires_at_ms=int(time.time() * 1000) - 1)
+    last_good = cache.write_failure(key, "anthropic")
+    assert last_good is not None
+    # Fresh again (within the backoff window).
+    assert cache.get(key) is not None
+    assert cache.expiry_ms(key) is not None
+    assert cache.expiry_ms(key) <= int(time.time() * 1000) + USAGE_FAILURE_BACKOFF_MS + 5
+
+
+def test_write_failure_with_no_history_returns_none(cache) -> None:
+    assert cache.write_failure("anthropic:never", "anthropic") is None
+
+
+# -- leases ---------------------------------------------------------------------
+def test_the_fetch_lease_serializes_concurrent_refreshers(cache) -> None:
+    key = "anthropic:test"
+    assert cache.try_lease(key) is True
+    # A second refresher in the same window loses the lease.
+    other = UsageCacheStore(cache._db_path)
+    try:
+        assert other.try_lease(key) is False
+    finally:
+        other.close()
+    # Releasing hands it back.
+    cache.release_lease(key)
+    assert other.try_lease(key) is True
+
+
+def test_an_expired_lease_can_be_retaken(cache) -> None:
+    key = "anthropic:test"
+    assert cache.try_lease(key, ttl_ms=1) is True
+    time.sleep(0.01)
+    other = UsageCacheStore(cache._db_path)
+    try:
+        assert other.try_lease(key) is True
+    finally:
+        other.close()
+
+
+def test_only_the_holder_releases_a_lease(cache, tmp_path) -> None:
+    key = "anthropic:test"
+    assert cache.try_lease(key) is True
+    other = UsageCacheStore(cache._db_path)
+    try:
+        # The non-holder's release must not free the holder's lease.
+        other.release_lease(key)
+        assert other.try_lease(key) is False
+    finally:
+        other.close()
+
+
+# -- degradation ----------------------------------------------------------------
+def test_an_unopenable_cache_is_a_miss_not_an_error(tmp_path) -> None:
+    # Point at a path that cannot be a database (a directory). Every operation
+    # degrades to the uncached behaviour instead of raising.
+    store = UsageCacheStore(tmp_path / "a_directory")
+    (tmp_path / "a_directory").mkdir(exist_ok=True)
+    assert store.get("k") is None
+    store.set("k", "anthropic", [_report()], expires_at_ms=int(time.time() * 1000) + 1000)
+    assert store.try_lease("k") is True  # no coordination, fetch anyway
+    store.close()
+
+
+def test_retention_prunes_only_rows_past_the_last_good_window(cache) -> None:
+    key = "anthropic:old"
+    # A row expired longer than the retention bound is dropped on the next write.
+    ancient = int(time.time() * 1000) - USAGE_LAST_GOOD_RETENTION_MS - 60_000
+    cache.set(key, "anthropic", [_report()], expires_at_ms=ancient)
+    cache.set(
+        "anthropic:other", "anthropic", [_report()], expires_at_ms=int(time.time() * 1000) + 60_000
+    )
+    assert cache.get(key, include_expired=True) is None
+    assert cache.get("anthropic:other") is not None

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -1429,6 +1429,31 @@ async def test_usage_opens_instantly_from_the_cache_when_a_row_is_warm() -> None
 
 
 @pytest.mark.asyncio
+async def test_an_empty_successful_fetch_replaces_cached_numbers() -> None:
+    """`[]` from the controller is a REAL answer after the empty-over-data
+    acceptance window ("this provider reports nothing"). Treating it as a
+    failed refresh would keep the stale numbers the cache just stopped serving
+    and pin a "refresh failed" note on the wrong arm."""
+    from local_operator.tui.widgets.usage_panel import UsagePanel
+
+    session = FakeSession()
+    ctrl = FakeProviderController()
+    ctrl.cached_reports = _usage_reports(used=5.0)
+    ctrl.usage_reports = []  # the fetch's answer: nothing to report
+    app = OperatorApp(lambda: _factory(session), provider_controller=ctrl)
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        await _run_usage_command(pilot, app)
+        panel = app.query_one(UsagePanel)
+        for _ in range(6):
+            await pilot.pause()
+        text = "\n".join(panel.render_lines_for_test())
+    assert "refresh failed" not in text
+    assert "Credits" not in text  # the stale numbers were replaced
+    assert "no usage" in text
+
+
+@pytest.mark.asyncio
 async def test_the_background_warmer_only_fetches_when_the_row_is_stale() -> None:
     """The warmer is an optimisation, not a fetch-per-interval: it must skip the
     network when the shared cache already holds a fresh row for the active

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -1047,6 +1047,12 @@ class FakeProviderController:
         self.usage_error: Exception | None = None
         self.logins: list[str] = []
         self.logouts: list[str] = []
+        #: Staged cache rows for the instant-open path. Empty by default so
+        #: existing tests exercise the cold (fetching…) open.
+        self.cached_reports: list[Any] = []
+        #: Age in ms of the staged cache row, or None when there is none.
+        #: The warmer reads this to decide whether to fetch.
+        self.usage_cache_age: int | None = None
 
     def login_providers(self) -> list[Any]:
         return [

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -1109,6 +1109,10 @@ class FakeProviderController:
         # can reach it"; `/provider` renders this one, not the wider list.
         return [p for p in self.usage_enabled_providers() if self.has_any_credential(p)]
 
+    def can_report_usage(self, provider):
+        # The warmer's gate: "has an endpoint AND a credential to reach it".
+        return provider in self.usage_reportable_providers()
+
     def resolve_model(self, provider, model_id):
         return FakeModel(provider, model_id)
 
@@ -1126,11 +1130,21 @@ class FakeProviderController:
         self.logouts.append(provider)
         return f"removed {provider}"
 
-    async def fetch_usage(self, provider_ids=None):
+    async def fetch_usage(self, provider_ids=None, *, force_refresh: bool = False):
         self.usage_calls.append(provider_ids)
         if self.usage_error is not None:
             raise self.usage_error
         return self.usage_reports
+
+    def cached_usage_reports(self, provider=None):
+        # The shared-cache fast path. Empty by default so the existing pilot
+        # tests exercise the cold (fetching…) open; a test that wants the
+        # instant-paint path stages rows here.
+        return list(getattr(self, "cached_reports", []))
+
+    def usage_cache_age_ms(self, provider):
+        # Settable so a test can simulate a warm row (0) or a cold one (None).
+        return getattr(self, "usage_cache_age", None)
 
 
 class _FakeDef:
@@ -1341,7 +1355,7 @@ class _ControlledUsageController(FakeProviderController):
         self.first_started = asyncio.Event()
         self.first_cancelled = False
 
-    async def fetch_usage(self, provider_ids=None):
+    async def fetch_usage(self, provider_ids=None, *, force_refresh: bool = False):
         self.usage_calls.append(provider_ids)
         if len(self.usage_calls) == 1:
             self.first_started.set()
@@ -1387,6 +1401,66 @@ async def test_usage_command_opens_the_panel_with_the_report() -> None:
         assert app.focused is panel
     assert "openrouter" in text
     assert "Credits" in text
+
+
+@pytest.mark.asyncio
+async def test_usage_opens_instantly_from_the_cache_when_a_row_is_warm() -> None:
+    """The whole point of the shared cache: when a row is on hand, `/usage`
+    paints it immediately (with its age) rather than showing "fetching…" and
+    making the user wait for a network round they did not need."""
+    from local_operator.tui.widgets.usage_panel import UsagePanel
+
+    session = FakeSession()
+    ctrl = FakeProviderController()
+    ctrl.usage_reports = _usage_reports()
+    # Stage a warm cache row: the panel must paint THIS before the fetch lands.
+    ctrl.cached_reports = _usage_reports(used=5.0)
+    app = OperatorApp(lambda: _factory(session), provider_controller=ctrl)
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        await _run_usage_command(pilot, app)
+        panel = app.query_one(UsagePanel)
+        assert panel.is_open
+        text = "\n".join(panel.render_lines_for_test())
+    # The cached row painted immediately: no "fetching…", the report is there.
+    assert "fetching…" not in text
+    assert "openrouter" in text
+    assert "Credits" in text
+
+
+@pytest.mark.asyncio
+async def test_the_background_warmer_only_fetches_when_the_row_is_stale() -> None:
+    """The warmer is an optimisation, not a fetch-per-interval: it must skip the
+    network when the shared cache already holds a fresh row for the active
+    provider, and only fire when that row is missing or going stale."""
+
+    class _SessionWithModel(FakeSession):
+        @property
+        def model(self):
+            return FakeModel("openrouter", "deepseek/deepseek-chat")
+
+    session = _SessionWithModel()
+    ctrl = FakeProviderController()
+    ctrl.usage_reports = _usage_reports()
+    app = OperatorApp(lambda: _factory(session), provider_controller=ctrl)
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        # No cached row yet (the fake's `usage_cache_age_ms` returns None), so
+        # the warmer must fire a background fetch for the active provider.
+        before = len(ctrl.usage_calls)
+        app._warm_usage_background()
+        for _ in range(4):
+            await pilot.pause()
+        assert len(ctrl.usage_calls) == before + 1
+        assert ctrl.usage_calls[-1] == ["openrouter"]
+
+        # Now the row is warm: a second warm tick must NOT fetch again.
+        ctrl.usage_cache_age = 0  # pretend the row is fresh
+        before = len(ctrl.usage_calls)
+        app._warm_usage_background()
+        for _ in range(4):
+            await pilot.pause()
+        assert len(ctrl.usage_calls) == before
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tui/test_usage_panel.py
+++ b/tests/unit/tui/test_usage_panel.py
@@ -859,3 +859,42 @@ async def test_a_cold_open_still_says_fetching() -> None:
     async with _panel_app() as panel:
         panel.start_fetch("")
         assert "fetching…" in "\n".join(panel.render_lines_for_test())
+
+
+@pytest.mark.asyncio
+async def test_a_failed_refresh_says_so_instead_of_just_dropping_the_mark() -> None:
+    """`r` came back empty-handed: the numbers stay, and a pinned note says the
+    refresh failed — the mark silently vanishing is not an answer to a key the
+    user just pressed."""
+    import time as _time
+
+    async with _panel_app() as panel:
+        panel.start_fetch("")
+        panel.show_cached(
+            [_report(_percent("a:5h", "5 hour", 5.0, shared=True))],
+            now_ms=_time.time() * 1000,
+        )
+        panel.settle_refresh(failed=True)
+        text = "\n".join(panel.render_lines_for_test())
+        assert "refresh failed — showing last known numbers" in text
+        assert "refreshing…" not in text
+        assert "5 hour" in text  # the numbers survived
+
+
+@pytest.mark.asyncio
+async def test_the_title_row_truncates_instead_of_wrapping() -> None:
+    """The title gained suffixes (target, age, refreshing…) that can outrun a
+    narrow card. An untruncated Text WRAPS — an extra visual row the pinned
+    height never counted, which clipped the footer (and its `r refresh`
+    receipt) off the card exactly in the stale/narrow state where the refresh
+    key matters most."""
+    import time as _time
+
+    async with _panel_app(size=(36, 24)) as panel:
+        panel.start_fetch("openrouter")
+        panel.show_cached(
+            [_report(_percent("a:5h", "5 hour", 5.0, shared=True), provider="openrouter")],
+            now_ms=_time.time() * 1000 - 12 * 3600_000,  # "12h ago"
+        )
+        title = panel._compose_rows()[0]
+        assert cell_len(title.plain) <= panel.panel_width(), title.plain

--- a/tests/unit/tui/test_usage_panel.py
+++ b/tests/unit/tui/test_usage_panel.py
@@ -792,3 +792,70 @@ async def test_a_scrolled_footer_keeps_the_affordance_over_the_tally() -> None:
     assert "esc close" in footer, footer
     # The tally is what yields, not the way out.
     assert "windows" not in footer, footer
+
+
+# -- cached-first open --------------------------------------------------------
+@pytest.mark.asyncio
+async def test_show_cached_paints_the_reports_with_their_age_and_a_refreshing_mark() -> None:
+    """When the shared cache already holds a row, `/usage` must not say
+    "fetching…" and hide an answer that is on hand — it paints the reports at
+    once, states their age, and marks that a refresh is running behind them."""
+    import time as _time
+
+    async with _panel_app() as panel:
+        panel.start_fetch("")
+        fetched_ms = _time.time() * 1000 - 120_000  # 2 minutes old
+        panel.show_cached(
+            [_report(_percent("a:5h", "5 hour", 5.0, shared=True))], now_ms=fetched_ms
+        )
+        text = "\n".join(panel.render_lines_for_test())
+        assert "fetching…" not in text
+        assert "refreshing…" in text
+        assert "2m ago" in text
+        assert "anthropic" in text
+
+
+@pytest.mark.asyncio
+async def test_show_reports_clears_the_refreshing_mark() -> None:
+    """The fetch's result replaces the cached view; the `refreshing…` mark goes."""
+    import time as _time
+
+    async with _panel_app() as panel:
+        panel.start_fetch("")
+        panel.show_cached(
+            [_report(_percent("a:5h", "5 hour", 5.0, shared=True))],
+            now_ms=_time.time() * 1000,
+        )
+        panel.show_reports([_report(_percent("a:5h", "5 hour", 50.0, shared=True))])
+        text = "\n".join(panel.render_lines_for_test())
+        assert "refreshing…" not in text
+        assert "50%" in text
+
+
+@pytest.mark.asyncio
+async def test_settle_refresh_keeps_the_cached_numbers_when_the_fetch_fails() -> None:
+    """A failed refresh must not blank the panel: the cached numbers stay, the
+    `refreshing…` mark goes, and the age in the title already says how stale
+    they are."""
+    import time as _time
+
+    async with _panel_app() as panel:
+        panel.start_fetch("")
+        panel.show_cached(
+            [_report(_percent("a:5h", "5 hour", 5.0, shared=True))],
+            now_ms=_time.time() * 1000,
+        )
+        panel.settle_refresh()
+        text = "\n".join(panel.render_lines_for_test())
+        assert "refreshing…" not in text
+        assert "anthropic" in text
+        assert "5%" in text
+
+
+@pytest.mark.asyncio
+async def test_a_cold_open_still_says_fetching() -> None:
+    """With nothing cached the panel shows its loading state — the cached-first
+    path must not accidentally render an empty report set."""
+    async with _panel_app() as panel:
+        panel.start_fetch("")
+        assert "fetching…" in "\n".join(panel.render_lines_for_test())


### PR DESCRIPTION
# PR Description

## Change classification

**C2 — standard.** Performance/UX change to the `/usage` quota surface; no
schema, transcript-format, or wire change. Clean rollback (`git revert`).

## The problem

`/usage` fetched every logged-in provider's quota **sequentially** on every
open, so the command waited for the SUM of the round trips — ~3.2s with four
providers — and every concurrent lop session paid that cost again. The panel
also showed `fetching…` the whole time even when the numbers were already on
hand, and the title age said "just now" for data that could be minutes old.

`omp` solves this with a per-credential usage cache (5-min jittered TTL,
stale-on-failure, single-flight). This ports that idea to lop, adapted to the
fact that a user runs SEVERAL lop sessions at once: the cache lives in a shared
SQLite file so one session's refresh is every session's answer.

## The change

- **`providers/usage_cache.py` (new)** — shared SQLite cache
  (`~/.local-operator/usage_cache.db`, 0600/WAL) keyed per provider +
  account-set fingerprint, with: 5-min jittered TTL (±25%, so accounts don't
  all expire into one refresh window and trip per-IP 429s); a cross-process
  fetch **lease** so only ONE session refreshes a stale row while the rest
  serve it; stale-on-failure fallback (a blip never blanks the report);
  negative caching for providers that legitimately report no quota (so the
  warmer doesn't re-hit them every tick); 24h last-good retention + pruning.
  Login/logout self-invalidates because the account set is folded into the key.
  Every method degrades to "cache miss, fetch live" on any I/O error.
- **`controller.fetch_usage`** — cache-first reads, **parallel** fan-out across
  providers (`asyncio.gather`), and `force_refresh` for the panel's `r`.
- **`tui`** — `/usage` paints cached reports **instantly** (age stated in the
  title, `refreshing…` mark) while the fetch confirms/replaces them; a
  background warmer (60s tick, gated on row age) keeps the active provider's
  row fresh so the command is ready when typed; `r` forces a live fetch; the
  panel age now states the DATA's age, not the fetch's.

## Testing evidence

### 1. Real-network timing (against the real `~/.local-operator/auth.db`)

```
reportable: anthropic(4 accounts), kimi, openai, openrouter, xai, zai, alibaba
COLD (fresh cache, parallel):  1.5s   (old sequential: 3.2s — 2.1x)
WARM (cache hit):              7.9ms  (~400x)
instant-open (cached paint):   2.2ms
SECOND session WARM:           8.3ms  (shared row, no re-fetch)
```

### 2. Visual validation (before/after SVG stills, real OperatorApp + CSS)

- before: panel shows `fetching…` for the full network round.
- after (live): identical frame, no regression.
- after (cached): reports painted instantly with `2m ago` + `refreshing…`.

### 3. Suites and gates

- New: `tests/unit/providers/test_usage_cache.py` (15), controller cache tests
  (5), panel cached-first tests (4), pilot instant-open + warmer tests (2).
- `tests/unit/providers` + `tests/unit/model`: 862 passed.
- Full unit suite: 5076 passed (one flaky ask-picker timing failure on a first
  run passed clean on immediate re-run; unrelated to this change).
- `flake8`, `black --check`, `isort --check-only`, `pyright`: all clean.

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my changes work as intended.
- [x] All new and existing tests pass.
- [x] I have run formatting (black/isort), linting (flake8), and type checks (pyright), and they pass.
- [x] Security considerations are addressed (cache file 0600; API keys hashed, never stored in keys/WAL).
