### PR TITLE
feat(tui): render images inline in the transcript

### DIFF
--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -1776,7 +1776,7 @@ class OperatorApp(App[None]):
                     ]
                     if text or replay_images:
                         self._append_block(UserBlock(text, len(replay_images)))
-                        self._append_image_blocks(replay_images)
+                        self._append_image_blocks(replay_images, marker_text=text)
                         appended = True
                     continue
                 if role != "assistant":
@@ -4940,8 +4940,9 @@ class OperatorApp(App[None]):
         # is the difference between "1 image attached" and knowing you pasted
         # the right screenshot. Markers stay in the prompt text (they are what
         # the user typed around); the images render in citation order, the
-        # same order `resolve_markers` sent them in.
-        self._append_image_blocks(images)
+        # same order `resolve_markers` sent them in, labeled by the text's own
+        # marker numbers.
+        self._append_image_blocks(images, marker_text=text)
         if self._session is None:
             self._append_block(NoticeBlock("session is still starting…", "warning"))
             return
@@ -6007,7 +6008,9 @@ class OperatorApp(App[None]):
         if not ends_empty_state:
             self._sync_boot_layout()
 
-    def _append_image_blocks(self, images: list[ImageContent]) -> None:
+    def _append_image_blocks(
+        self, images: list[ImageContent], *, marker_text: str | None = None
+    ) -> None:
         """Mount one :class:`ImageBlock` per image, in order.
 
         The single entry point for putting pictures on the transcript — the
@@ -6018,15 +6021,30 @@ class OperatorApp(App[None]):
         receipt), but a failure CONSTRUCTING one must not take down the
         message dispatch that carried a perfectly good tool result.
 
-        Labels are positional (``#1``, ``#2``) and only when the batch has
-        more than one image: a receipt for a batch of one names nothing the
-        row above it has not already said, while `image '#2' unavailable`
-        tells the reader WHICH of several pictures is gone — the number is
-        the same one the prompt's ``[Image #N]`` markers use (review round
-        1, F4).
+        Labels name WHICH of several images a receipt is about, and only
+        when the batch has more than one — a receipt for a batch of one
+        names nothing the row above it has not already said (review round
+        1, F4). Where ``marker_text`` is given (the prompt paths), the
+        numbers are read from the text's own ``[Image #N]`` citations, in
+        citation order — the same walk ``resolve_markers`` built ``images``
+        from — because marker numbers are not positional: delete #1 and
+        paste again and the draft reads ``[Image #2] [Image #3]``, so a
+        positional ``#1`` would name a marker the prompt does not contain
+        (review round 2, F9). Tool results have no markers and fall back to
+        positions.
         """
+        indices: list[int] = []
+        if marker_text:
+            from local_operator.tui.widgets.editor import IMAGE_MARKER
+
+            indices = [int(match.group(1)) for match in IMAGE_MARKER.finditer(marker_text)]
         for index, image in enumerate(images):
-            label = f"#{index + 1}" if len(images) > 1 else ""
+            if len(images) <= 1:
+                label = ""
+            elif index < len(indices):
+                label = f"#{indices[index]}"
+            else:
+                label = f"#{index + 1}"
             try:
                 block = ImageBlock(image.data or None, image.mime_type, label=label)
             except Exception:

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -80,6 +80,7 @@ from local_operator.logger import current_log_file
 from local_operator.model.effort import default_effort, next_effort
 from local_operator.session import naming
 from local_operator.session.protocol import SessionProtocol
+from local_operator.tui import images as images_mod
 from local_operator.tui import theme as theme_mod
 from local_operator.tui.autocomplete import ArgumentChoice, ArgumentMode, SlashCommand
 from local_operator.tui.costs import job_cost, turn_cost
@@ -139,6 +140,7 @@ from local_operator.tui.widgets.editor import (
     StopRequested,
     resolve_markers,
 )
+from local_operator.tui.widgets.image_block import ImageBlock
 from local_operator.tui.widgets.model_picker import ModelRow
 from local_operator.tui.widgets.session_picker import (
     RESUME_EMPTY_NOTICE,
@@ -1335,6 +1337,14 @@ class OperatorApp(App[None]):
         # is unnamed. Attaching first would leave a bare `lo ›` on screen for
         # as long as the boot takes.
         self._start_terminal_title()
+        # Inline images write kitty graphics APCs through the same driver door
+        # (`tui/images.py` docs the interleaving hazard). Installed with the
+        # same gate as the title: no driver or headless means no terminal to
+        # transmit to, and ImageBlock then falls back to half-cells or text on
+        # its own — the writer's absence is a mode signal, never an error.
+        driver = self._driver
+        if driver is not None and not self.is_headless:
+            images_mod.set_escape_writer(driver.write)
         # Same driver, same gating, one line later: the notifier is the title's
         # out-of-app counterpart (state vs edge — see `tui/notify.py`), and both
         # want the terminal available and the app non-headless.
@@ -1754,8 +1764,19 @@ class OperatorApp(App[None]):
                 text = getattr(message, "text", "") or ""
                 text = text.strip() if isinstance(text, str) else ""
                 if role == "user":
-                    if text:
-                        self._append_block(UserBlock(text))
+                    # The images ride the persisted message as base64 content
+                    # blocks — the same bytes the model saw — so a resumed
+                    # prompt replays WITH its pictures, not just the receipt
+                    # count. This is the resume half of the promise the live
+                    # path makes in `_submit_prompt`.
+                    replay_images = [
+                        block
+                        for block in (getattr(message, "content", None) or [])
+                        if isinstance(block, ImageContent)
+                    ]
+                    if text or replay_images:
+                        self._append_block(UserBlock(text, len(replay_images)))
+                        self._append_image_blocks(replay_images)
                         appended = True
                     continue
                 if role != "assistant":
@@ -1820,6 +1841,16 @@ class OperatorApp(App[None]):
             )
         else:
             card.restore(state="success", result_text=result_text, details=details)
+        # Same rule as `on_tool_ended`: a result carrying image blocks shows
+        # them under the settled card, so a resumed session's screenshots are
+        # back on screen exactly where the live session showed them.
+        self._append_image_blocks(
+            [
+                block
+                for block in (getattr(result, "content", None) or [])
+                if isinstance(block, ImageContent)
+            ]
+        )
 
     def _on_boot_failed(self, error: Exception) -> None:
         """Report a session that never constructed, WITHOUT retiring the splash.
@@ -4885,6 +4916,10 @@ class OperatorApp(App[None]):
         # session teardown would otherwise leave the user's shell wearing this
         # session's title.
         self._stop_terminal_title()
+        # The escape writer goes with the driver it wraps. ImageBlock unmounts
+        # delete their terminal-side images through it a moment before this
+        # runs (children unmount first), so clearing here strands nothing.
+        images_mod.set_escape_writer(None)
         if self._status is not None:
             self._status.dispose()
         if self._controller is not None:
@@ -4900,6 +4935,13 @@ class OperatorApp(App[None]):
     ) -> None:
         images = images or []
         self._append_block(UserBlock(text, len(images)))
+        # The pictures themselves, under the prompt that cites them. The
+        # receipt row above says the bytes went; these show WHICH bytes, which
+        # is the difference between "1 image attached" and knowing you pasted
+        # the right screenshot. Markers stay in the prompt text (they are what
+        # the user typed around); the images render in citation order, the
+        # same order `resolve_markers` sent them in.
+        self._append_image_blocks(images)
         if self._session is None:
             self._append_block(NoticeBlock("session is still starting…", "warning"))
             return
@@ -5964,6 +6006,25 @@ class OperatorApp(App[None]):
             transcript.append_block(block)
         if not ends_empty_state:
             self._sync_boot_layout()
+
+    def _append_image_blocks(self, images: list[ImageContent]) -> None:
+        """Mount one :class:`ImageBlock` per image, in order.
+
+        The single entry point for putting pictures on the transcript — the
+        prompt path, the tool-result path, and the resume replay all route
+        here so a rendering decision (caps, protocol, the unavailable
+        receipt) is made in exactly one place. Guarded per block: a block
+        whose bytes will not decode still mounts (as its unavailable
+        receipt), but a failure CONSTRUCTING one must not take down the
+        message dispatch that carried a perfectly good tool result.
+        """
+        for image in images:
+            try:
+                block = ImageBlock(image.data or None, image.mime_type)
+            except Exception:
+                logger.debug("image block construction failed", exc_info=True)
+                continue
+            self._append_block(block)
 
     # -- slash commands -----------------------------------------------------
     def _notice(self, body: str, kind: NoticeKind = "info") -> None:
@@ -9142,6 +9203,13 @@ class OperatorApp(App[None]):
             card.mark_failed(_first_line(result_text), result_text, details)
         else:
             card.mark_done(result_text, details)
+        # A result that carries image blocks (a `read` of a PNG, a browser
+        # screenshot) shows them under the card, so the user watches the same
+        # pixels the model is about to reason over. After the card settles, so
+        # the picture lands beneath its own caption row rather than above it.
+        self._append_image_blocks(
+            [block for block in event.result.content if isinstance(block, ImageContent)]
+        )
 
     def on_notice_posted(self, message: NoticePosted) -> None:
         self._append_block(NoticeBlock(message.text, message.kind))

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -6017,10 +6017,18 @@ class OperatorApp(App[None]):
         whose bytes will not decode still mounts (as its unavailable
         receipt), but a failure CONSTRUCTING one must not take down the
         message dispatch that carried a perfectly good tool result.
+
+        Labels are positional (``#1``, ``#2``) and only when the batch has
+        more than one image: a receipt for a batch of one names nothing the
+        row above it has not already said, while `image '#2' unavailable`
+        tells the reader WHICH of several pictures is gone — the number is
+        the same one the prompt's ``[Image #N]`` markers use (review round
+        1, F4).
         """
-        for image in images:
+        for index, image in enumerate(images):
+            label = f"#{index + 1}" if len(images) > 1 else ""
             try:
-                block = ImageBlock(image.data or None, image.mime_type)
+                block = ImageBlock(image.data or None, image.mime_type, label=label)
             except Exception:
                 logger.debug("image block construction failed", exc_info=True)
                 continue

--- a/local_operator/tui/images.py
+++ b/local_operator/tui/images.py
@@ -1,0 +1,703 @@
+"""Inline image rendering for the transcript: protocol detection, fit
+arithmetic, kitty graphics encoding, and the half-cell fallback.
+
+The TUI shows images three ways, best available first:
+
+- **Kitty graphics via Unicode placeholders** (``U=1`` + U+10EEEE cells).
+  The image bytes are transmitted to the terminal ONCE (APC ``a=t``), a
+  virtual placement names a cell grid for them (``a=p,U=1``), and the grid
+  is then drawn as ordinary text: each cell is the placeholder character
+  plus row/column combining diacritics, with the image id carried in the
+  foreground colour. Because the cells are text, Textual's compositor can
+  scroll, clip and repaint them like any other content — which is the whole
+  reason this mode works inside a compositing TUI at all. A direct
+  cursor-positioned placement (``a=p`` without ``U=1``) or a raw Sixel/iTerm2
+  blob would be painted once and then shredded by the next compositor frame,
+  so those protocols are deliberately not offered.
+- **Half-cell pixels**: the image is downscaled with Pillow and painted as
+  ``▀`` characters, foreground = top pixel, background = bottom pixel. Pure
+  text and colours, so it works in every terminal, over SSH, inside tmux,
+  and in the SVG screenshots the test harness exports.
+- **A one-line text receipt** naming the format and dimensions, for
+  ``display.images = false`` or a terminal where even half-cells would be
+  noise (``TERM=dumb``).
+
+Protocol references: kitty ``docs/graphics-protocol.rst`` ("Unicode
+placeholders"), and omp's ``packages/tui/src/kitty-graphics.ts``, whose
+placeholder strategy this module mirrors. The performance posture is
+deliberately stricter than omp's: pixels cross the wire exactly once per
+image (downscaled to the placement grid, so a 4 MB screenshot transmits a
+few tens of KB), a resize re-places the existing terminal-side image without
+retransmitting, and everything after the transmit is plain text repaints.
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+import struct
+import sys
+from collections import OrderedDict
+from typing import Callable
+
+from local_operator.tui.settings import settings_get
+
+__all__ = [
+    "CellSize",
+    "ImageMode",
+    "MAX_LIVE_KITTY_IMAGES",
+    "cell_size",
+    "detect_mode",
+    "encode_delete",
+    "encode_placement",
+    "encode_transmit",
+    "fit_cells",
+    "next_image_id",
+    "placeholder_grid",
+    "register_live",
+    "release_live",
+    "reset_for_tests",
+    "set_escape_writer",
+    "write_escape",
+]
+
+#: Environment kill switch / override. ``kitty``/``halfcell``/``text`` force a
+#: mode; ``off`` is accepted as an alias for ``text`` (the receipt line is the
+#: floor — silently showing nothing would hide that an image arrived at all).
+_ENV_MODE = "LOCAL_OPERATOR_IMAGES"
+
+#: How many kitty images stay live in the terminal's own store at once.
+#:
+#: Kitty-protocol terminals keep every transmitted image in a per-terminal
+#: store; text clears (``CSI 2J``) do not remove them, so an unbounded session
+#: that reads many screenshots piles up store memory for images long scrolled
+#: away. omp bounds this at 8 and demotes older images to their text fallback;
+#: the budget here does the same but demotes to HALF-CELLS, so an evicted
+#: image stays a picture in scrollback — it just stops costing terminal store.
+MAX_LIVE_KITTY_IMAGES = 8
+
+#: Grid caps. ``MAX_ROWS`` is the consistent-size rule: every image lands at
+#: the same height ceiling so a transcript of mixed screenshots reads as a
+#: ledger rather than a scrapbook, with width following each image's own
+#: aspect ratio under ``MAX_COLS``. Small images stay small (no upscaling).
+MAX_ROWS = 12
+MAX_COLS = 72
+
+#: Kitty Unicode placeholder base character (U+10EEEE, Plane 16 PUA).
+PLACEHOLDER = "\U0010eeee"
+
+#: Row/column combining diacritics naming a placeholder cell's coordinates.
+#: Index ``i`` -> codepoint, from kitty ``gen/rowcolumn-diacritics.txt``
+#: (Unicode 6.0.0 NSM set, combining class 230, no decomposition). 297
+#: entries, so one image can address a 297x297 cell grid — far past the caps
+#: above. The same table omp and textual-image carry.
+ROWCOLUMN_DIACRITICS: tuple[int, ...] = (
+    0x0305,
+    0x030D,
+    0x030E,
+    0x0310,
+    0x0312,
+    0x033D,
+    0x033E,
+    0x033F,
+    0x0346,
+    0x034A,
+    0x034B,
+    0x034C,
+    0x0350,
+    0x0351,
+    0x0352,
+    0x0357,
+    0x035B,
+    0x0363,
+    0x0364,
+    0x0365,
+    0x0366,
+    0x0367,
+    0x0368,
+    0x0369,
+    0x036A,
+    0x036B,
+    0x036C,
+    0x036D,
+    0x036E,
+    0x036F,
+    0x0483,
+    0x0484,
+    0x0485,
+    0x0486,
+    0x0487,
+    0x0592,
+    0x0593,
+    0x0594,
+    0x0595,
+    0x0597,
+    0x0598,
+    0x0599,
+    0x059C,
+    0x059D,
+    0x059E,
+    0x059F,
+    0x05A0,
+    0x05A1,
+    0x05A8,
+    0x05A9,
+    0x05AB,
+    0x05AC,
+    0x05AF,
+    0x05C4,
+    0x0610,
+    0x0611,
+    0x0612,
+    0x0613,
+    0x0614,
+    0x0615,
+    0x0616,
+    0x0617,
+    0x0657,
+    0x0658,
+    0x0659,
+    0x065A,
+    0x065B,
+    0x065D,
+    0x065E,
+    0x06D6,
+    0x06D7,
+    0x06D8,
+    0x06D9,
+    0x06DA,
+    0x06DB,
+    0x06DC,
+    0x06DF,
+    0x06E0,
+    0x06E1,
+    0x06E2,
+    0x06E4,
+    0x06E7,
+    0x06E8,
+    0x06EB,
+    0x06EC,
+    0x0730,
+    0x0732,
+    0x0733,
+    0x0735,
+    0x0736,
+    0x073A,
+    0x073D,
+    0x073F,
+    0x0740,
+    0x0741,
+    0x0743,
+    0x0745,
+    0x0747,
+    0x0749,
+    0x074A,
+    0x07EB,
+    0x07EC,
+    0x07ED,
+    0x07EE,
+    0x07EF,
+    0x07F0,
+    0x07F1,
+    0x07F3,
+    0x0816,
+    0x0817,
+    0x0818,
+    0x0819,
+    0x081B,
+    0x081C,
+    0x081D,
+    0x081E,
+    0x081F,
+    0x0820,
+    0x0821,
+    0x0822,
+    0x0823,
+    0x0825,
+    0x0826,
+    0x0827,
+    0x0829,
+    0x082A,
+    0x082B,
+    0x082C,
+    0x082D,
+    0x0951,
+    0x0953,
+    0x0954,
+    0x0F82,
+    0x0F83,
+    0x0F86,
+    0x0F87,
+    0x135D,
+    0x135E,
+    0x135F,
+    0x17DD,
+    0x193A,
+    0x1A17,
+    0x1A75,
+    0x1A76,
+    0x1A77,
+    0x1A78,
+    0x1A79,
+    0x1A7A,
+    0x1A7B,
+    0x1A7C,
+    0x1B6B,
+    0x1B6D,
+    0x1B6E,
+    0x1B6F,
+    0x1B70,
+    0x1B71,
+    0x1B72,
+    0x1B73,
+    0x1CD0,
+    0x1CD1,
+    0x1CD2,
+    0x1CDA,
+    0x1CDB,
+    0x1CE0,
+    0x1DC0,
+    0x1DC1,
+    0x1DC3,
+    0x1DC4,
+    0x1DC5,
+    0x1DC6,
+    0x1DC7,
+    0x1DC8,
+    0x1DC9,
+    0x1DCB,
+    0x1DCC,
+    0x1DD1,
+    0x1DD2,
+    0x1DD3,
+    0x1DD4,
+    0x1DD5,
+    0x1DD6,
+    0x1DD7,
+    0x1DD8,
+    0x1DD9,
+    0x1DDA,
+    0x1DDB,
+    0x1DDC,
+    0x1DDD,
+    0x1DDE,
+    0x1DDF,
+    0x1DE0,
+    0x1DE1,
+    0x1DE2,
+    0x1DE3,
+    0x1DE4,
+    0x1DE5,
+    0x1DE6,
+    0x1DFE,
+    0x20D0,
+    0x20D1,
+    0x20D4,
+    0x20D5,
+    0x20D6,
+    0x20D7,
+    0x20DB,
+    0x20DC,
+    0x20E1,
+    0x20E7,
+    0x20E9,
+    0x20F0,
+    0x2CEF,
+    0x2CF0,
+    0x2CF1,
+    0x2DE0,
+    0x2DE1,
+    0x2DE2,
+    0x2DE3,
+    0x2DE4,
+    0x2DE5,
+    0x2DE6,
+    0x2DE7,
+    0x2DE8,
+    0x2DE9,
+    0x2DEA,
+    0x2DEB,
+    0x2DEC,
+    0x2DED,
+    0x2DEE,
+    0x2DEF,
+    0x2DF0,
+    0x2DF1,
+    0x2DF2,
+    0x2DF3,
+    0x2DF4,
+    0x2DF5,
+    0x2DF6,
+    0x2DF7,
+    0x2DF8,
+    0x2DF9,
+    0x2DFA,
+    0x2DFB,
+    0x2DFC,
+    0x2DFD,
+    0x2DFE,
+    0x2DFF,
+    0xA66F,
+    0xA67C,
+    0xA67D,
+    0xA6F0,
+    0xA6F1,
+    0xA8E0,
+    0xA8E1,
+    0xA8E2,
+    0xA8E3,
+    0xA8E4,
+    0xA8E5,
+    0xA8E6,
+    0xA8E7,
+    0xA8E8,
+    0xA8E9,
+    0xA8EA,
+    0xA8EB,
+    0xA8EC,
+    0xA8ED,
+    0xA8EE,
+    0xA8EF,
+    0xA8F0,
+    0xA8F1,
+    0xAAB0,
+    0xAAB2,
+    0xAAB3,
+    0xAAB7,
+    0xAAB8,
+    0xAABE,
+    0xAABF,
+    0xAAC1,
+    0xFE20,
+    0xFE21,
+    0xFE22,
+    0xFE23,
+    0xFE24,
+    0xFE25,
+    0xFE26,
+    0x10A0F,
+    0x10A38,
+    0x1D185,
+    0x1D186,
+    0x1D187,
+    0x1D188,
+    0x1D189,
+    0x1D1AA,
+    0x1D1AB,
+    0x1D1AC,
+    0x1D1AD,
+    0x1D242,
+    0x1D243,
+    0x1D244,
+)
+
+_APC_START = "\x1b_G"
+_APC_END = "\x1b\\"
+
+#: Base64 payload chunk size for transmits, per the kitty spec's 4096 limit.
+_CHUNK = 4096
+
+
+# ---------------------------------------------------------------------------
+# Mode detection and cell geometry
+# ---------------------------------------------------------------------------
+
+ImageMode = str  # "kitty" | "halfcell" | "text"
+
+#: Memoized answers. Detection reads the environment and (for cell size) an
+#: ioctl; both are stable for the life of the process, and re-running them
+#: per block would put an ioctl on every image append.
+_mode_cache: ImageMode | None = None
+_cell_cache: "CellSize | None" = None
+
+
+class CellSize:
+    """One terminal cell's pixel footprint, from ``TIOCGWINSZ``.
+
+    The window-size ioctl carries the window's pixel dimensions alongside its
+    cell dimensions on terminals that report them (ghostty and kitty do), and
+    it is a pure kernel read: unlike the escape-based cell-size queries omp
+    and textual-image use, it needs no terminal response, so it stays safe to
+    call while Textual owns stdin. Terminals that report zero pixels fall
+    back to 8x16 — the classic bitmap-font cell, and the same default
+    textual-image lands on.
+    """
+
+    __slots__ = ("width", "height")
+
+    def __init__(self, width: int, height: int) -> None:
+        self.width = width
+        self.height = height
+
+
+def cell_size() -> CellSize:
+    """The terminal's cell pixel size, queried once and memoized."""
+    global _cell_cache
+    if _cell_cache is None:
+        _cell_cache = _query_cell_size()
+    return _cell_cache
+
+
+def _query_cell_size() -> CellSize:
+    try:
+        import fcntl
+        import termios
+
+        stdout = sys.__stdout__
+        if stdout is None:
+            raise OSError("no stdout")
+        packed = fcntl.ioctl(stdout.fileno(), termios.TIOCGWINSZ, struct.pack("HHHH", 0, 0, 0, 0))
+        rows, cols, xpixel, ypixel = struct.unpack("HHHH", packed)
+        if rows > 0 and cols > 0 and xpixel > 0 and ypixel > 0:
+            return CellSize(max(1, xpixel // cols), max(1, ypixel // rows))
+    except Exception:
+        pass
+    return CellSize(8, 16)
+
+
+def detect_mode() -> ImageMode:
+    """Which rendering mode this terminal gets, best first, memoized.
+
+    Kitty graphics are claimed only where Unicode placeholders are KNOWN to
+    render: kitty itself (``TERM=xterm-kitty`` / ``KITTY_WINDOW_ID``) and
+    ghostty (which is also what cmux embeds). WezTerm and Konsole advertise
+    the kitty protocol but do not render placeholder cells (the same finding
+    textual-image documents), so they take half-cells. A multiplexer between
+    us and the terminal (tmux/screen) would need APC passthrough wrapping and
+    pane-scroll bookkeeping this deliberately does not attempt — omp gates
+    the same way — so it also takes half-cells, which are plain text and
+    survive anything. ``TERM=dumb`` gets the receipt line.
+    """
+    global _mode_cache
+    if _mode_cache is None:
+        _mode_cache = _detect_mode()
+    return _mode_cache
+
+
+def _detect_mode() -> ImageMode:
+    import os
+
+    forced = (os.environ.get(_ENV_MODE) or "").strip().lower()
+    if forced in ("kitty", "halfcell", "text"):
+        return forced
+    if forced == "off":
+        return "text"
+    if not settings_get("display.images", True):
+        return "text"
+    term = os.environ.get("TERM", "")
+    if term == "dumb" or not term:
+        return "text"
+    if os.environ.get("TMUX") or term.startswith(("screen", "tmux")):
+        return "halfcell"
+    term_program = (os.environ.get("TERM_PROGRAM") or "").lower()
+    if term == "xterm-kitty" or os.environ.get("KITTY_WINDOW_ID") or term_program == "ghostty":
+        return "kitty"
+    return "halfcell"
+
+
+def reset_for_tests() -> None:
+    """Drop every module-level memo and registry (test isolation hook)."""
+    global _mode_cache, _cell_cache, _writer
+    _mode_cache = None
+    _cell_cache = None
+    _writer = None
+    _live.clear()
+
+
+# ---------------------------------------------------------------------------
+# Fit arithmetic
+# ---------------------------------------------------------------------------
+
+
+def fit_cells(
+    px_width: int,
+    px_height: int,
+    max_cols: int,
+    max_rows: int,
+    cell: CellSize | None = None,
+) -> tuple[int, int]:
+    """The ``(cols, rows)`` cell grid ``px_width`` x ``px_height`` fits into.
+
+    Aspect ratio is preserved in PIXELS, not cells: a cell is roughly twice
+    as tall as it is wide, so the ratio must be computed against the cell's
+    real pixel footprint or every image renders half its true height. The
+    scale never exceeds 1.0 — an icon smaller than the grid stays icon-sized
+    rather than being blown up into mush — and both axes are clamped to at
+    least one cell so a 1px-tall tracking pixel still occupies a row instead
+    of producing a zero-height widget.
+    """
+    cell = cell or cell_size()
+    if px_width <= 0 or px_height <= 0:
+        return (1, 1)
+    max_cols = max(1, max_cols)
+    max_rows = max(1, max_rows)
+    scale = min(
+        (max_cols * cell.width) / px_width,
+        (max_rows * cell.height) / px_height,
+        1.0,
+    )
+    cols = max(1, round((px_width * scale) / cell.width))
+    rows = max(1, round((px_height * scale) / cell.height))
+    return (min(cols, max_cols), min(rows, max_rows))
+
+
+# ---------------------------------------------------------------------------
+# Kitty escape encoding (pure string builders — writing is the caller's job)
+# ---------------------------------------------------------------------------
+
+#: Process-global image id allocator. Kitty image ids live in the terminal's
+#: OWN registry, which outlives this process and is shared with every other
+#: program that ever transmitted an image to the same terminal — so ids start
+#: from a random seed (omp does the same) to avoid stomping a neighbour's
+#: placements, and stay within 24 bits so the id round-trips through the
+#: placeholder cell's RGB foreground colour without needing the fourth-byte
+#: diacritic.
+_next_id: int | None = None
+
+
+def next_image_id() -> int:
+    """A fresh 24-bit kitty image id, randomly seeded per process."""
+    global _next_id
+    if _next_id is None:
+        import random
+
+        _next_id = random.randint(1, 0xFFFFFF)
+    _next_id = (_next_id % 0xFFFFFF) + 1
+    return _next_id
+
+
+def encode_transmit(image_id: int, png_base64: str) -> str:
+    """The chunked APC transmit sequence for ``png_base64`` as ``image_id``.
+
+    ``f=100`` declares PNG data (the one compressed format the protocol
+    takes; callers convert other formats first), ``q=2`` suppresses the
+    terminal's acknowledgement — Textual owns stdin, so a response would land
+    in its key parser as garbage input.
+    """
+    parts: list[str] = []
+    offset = 0
+    first = True
+    total = len(png_base64)
+    while offset < total or first:
+        chunk = png_base64[offset : offset + _CHUNK]
+        offset += _CHUNK
+        more = 1 if offset < total else 0
+        if first:
+            parts.append(f"{_APC_START}a=t,i={image_id},f=100,q=2,m={more};{chunk}{_APC_END}")
+            first = False
+        else:
+            parts.append(f"{_APC_START}m={more};{chunk}{_APC_END}")
+    return "".join(parts)
+
+
+def encode_placement(image_id: int, cols: int, rows: int) -> str:
+    """The virtual-placement APC: ``image_id`` scaled onto a cols x rows grid.
+
+    ``U=1`` makes it a Unicode-placeholder placement (displayed wherever the
+    placeholder cells land, not at the cursor). A fixed ``p=1`` placement id
+    means re-sending this for the same image REPLACES the placement instead
+    of stacking a second one — which is what makes a resize re-place without
+    retransmitting or leaking placements.
+    """
+    return f"{_APC_START}a=p,i={image_id},p=1,U=1,c={cols},r={rows},q=2{_APC_END}"
+
+
+def encode_delete(image_id: int) -> str:
+    """Delete ``image_id`` and its placements from the terminal's store."""
+    return f"{_APC_START}a=d,d=I,i={image_id},q=2{_APC_END}"
+
+
+def placeholder_grid(rows: int, cols: int) -> list[str]:
+    """The placeholder text rows for a ``rows`` x ``cols`` placement.
+
+    Each cell is U+10EEEE plus a row diacritic plus a column diacritic; the
+    terminal maps the cell to the placement's sub-rectangle from those two
+    marks and the image id in the cell's foreground colour. Grids are capped
+    far below the diacritic table's 297 entries, so indexing cannot overrun.
+    """
+    return [
+        "".join(
+            PLACEHOLDER + chr(ROWCOLUMN_DIACRITICS[row]) + chr(ROWCOLUMN_DIACRITICS[col])
+            for col in range(cols)
+        )
+        for row in range(rows)
+    ]
+
+
+def encode_png_base64(data: bytes) -> str:
+    """``data`` (already PNG bytes) as the base64 payload string."""
+    return base64.b64encode(data).decode("ascii")
+
+
+def to_png(pil_image: "object") -> bytes:
+    """Encode a PIL image to PNG bytes (the transmit wire format)."""
+    buffer = io.BytesIO()
+    pil_image.save(buffer, format="PNG")  # type: ignore[attr-defined]
+    return buffer.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# Escape writer and the live-image budget
+# ---------------------------------------------------------------------------
+
+#: Where APC escapes go. Textual serialises every byte it paints through a
+#: writer thread, so a second writer (``sys.stdout``) would interleave an APC
+#: into the middle of a frame and corrupt it. The app installs
+#: ``driver.write`` here — the same door it hands ``TerminalTitle`` and the
+#: notifier, for the same reason. ``None`` (headless, tests, exec mode) makes
+#: every write a no-op: the placeholder cells still render, they just have no
+#: image behind them, which is invisible because headless frames go nowhere.
+_writer: Callable[[str], None] | None = None
+
+#: Live kitty images, oldest first: image id -> demote callback. The values
+#: are callbacks rather than widget references so this module never holds a
+#: widget alive past its unmount.
+_live: "OrderedDict[int, Callable[[], None]]" = OrderedDict()
+
+
+def set_escape_writer(writer: Callable[[str], None] | None) -> None:
+    """Install (or clear) the sink APC escapes are written through."""
+    global _writer
+    _writer = writer
+
+
+def write_escape(sequence: str) -> bool:
+    """Write ``sequence`` to the terminal; ``False`` when there is no sink."""
+    if _writer is None:
+        return False
+    try:
+        _writer(sequence)
+        return True
+    except Exception:
+        return False
+
+
+def register_live(image_id: int, demote: Callable[[], None]) -> None:
+    """Admit ``image_id`` to the live-image budget, evicting past the cap.
+
+    Eviction deletes the OLDEST image from the terminal store and calls its
+    ``demote`` callback, which repaints that block as half-cells. The evicted
+    image therefore stays visible in scrollback as pixels-in-text; only the
+    terminal-side store entry is reclaimed. Callbacks run on the UI thread
+    (registration only ever happens from widget mount/render paths).
+    """
+    _live[image_id] = demote
+    _live.move_to_end(image_id)
+    while len(_live) > MAX_LIVE_KITTY_IMAGES:
+        old_id, old_demote = _live.popitem(last=False)
+        write_escape(encode_delete(old_id))
+        try:
+            old_demote()
+        except Exception:
+            pass  # a demotion repaint must never take the app down
+
+
+def release_live(image_id: int) -> None:
+    """Remove ``image_id`` from the budget and the terminal store.
+
+    Called on widget unmount — ``/clear``, transcript teardown, app exit —
+    so the terminal's image registry is left exactly as this process found
+    it. Safe to call for ids that were never registered or already evicted.
+    """
+    if _live.pop(image_id, None) is not None:
+        write_escape(encode_delete(image_id))

--- a/local_operator/tui/images.py
+++ b/local_operator/tui/images.py
@@ -38,7 +38,7 @@ import io
 import struct
 import sys
 from collections import OrderedDict
-from typing import Callable
+from typing import Callable, Literal
 
 from local_operator.tui.settings import settings_get
 
@@ -402,7 +402,7 @@ _CHUNK = 4096
 # Mode detection and cell geometry
 # ---------------------------------------------------------------------------
 
-ImageMode = str  # "kitty" | "halfcell" | "text"
+ImageMode = Literal["kitty", "halfcell", "text"]
 
 #: Memoized answers. Detection reads the environment and (for cell size) an
 #: ioctl; both are stable for the life of the process, and re-running them
@@ -479,8 +479,15 @@ def _detect_mode() -> ImageMode:
 
     forced = (os.environ.get(_ENV_MODE) or "").strip().lower()
     if forced in ("kitty", "halfcell", "text"):
-        return forced
+        return forced  # type: ignore[return-value]  # narrowed by the check
     if forced == "off":
+        return "text"
+    # NO_COLOR strips foreground colors from Textual's output — and the kitty
+    # placeholder grid carries the image id IN the foreground color, so under
+    # NO_COLOR it would render as bare U+10EEEE tofu; half-cells degrade to
+    # monochrome soup the same way. The honest mode there is the receipt.
+    # (review round 1, F2)
+    if os.environ.get("NO_COLOR"):
         return "text"
     if not settings_get("display.images", True):
         return "text"
@@ -497,10 +504,11 @@ def _detect_mode() -> ImageMode:
 
 def reset_for_tests() -> None:
     """Drop every module-level memo and registry (test isolation hook)."""
-    global _mode_cache, _cell_cache, _writer
+    global _mode_cache, _cell_cache, _writer, _next_id
     _mode_cache = None
     _cell_cache = None
     _writer = None
+    _next_id = None
     _live.clear()
 
 

--- a/local_operator/tui/settings.py
+++ b/local_operator/tui/settings.py
@@ -22,6 +22,12 @@ _DEFAULTS: dict[str, Any] = {
     # the sequence entirely, and the title is saved on start and restored on
     # exit, so the worst case for an unsupported terminal is no change at all.
     "display.terminal_title": True,
+    # Inline images on the transcript (tool-result screenshots, pasted
+    # attachments — `tui/images.py`). Defaults ON: the supported terminals
+    # degrade to half-cell pixels or a one-line receipt on their own, so OFF
+    # exists for the user who wants a text-only ledger, not for compatibility.
+    # The env override is `LOCAL_OPERATOR_IMAGES` (kitty|halfcell|text|off).
+    "display.images": True,
     # Desktop notifications for the two moments a user who is looking elsewhere
     # needs to know about: the parent agent finished, or it is waiting on them
     # (`tui/notify.py`). Defaults ON, and only ever fires while the terminal is

--- a/local_operator/tui/widgets/image_block.py
+++ b/local_operator/tui/widgets/image_block.py
@@ -52,6 +52,12 @@ _HALF = "▀"
 #: Glyph leading the unavailable receipt. WGL4-safe (no Nerd Font needed).
 _UNAVAILABLE_GLYPH = "▨"
 
+#: Glyph leading the HEALTHY text-mode receipt — the prompt's own attachment
+#: row already uses ``↑`` for "attached", so the receipt speaks the same
+#: grammar and a glyph scan can tell fine-but-not-shown from broken (design
+#: round 1, D3). ``▨`` stays exclusively the unavailable mark.
+_ATTACHED_GLYPH = "↑"
+
 
 def _decode(data_b64: str, mime_type: str) -> "PILImage | None":
     """Decode base64 image bytes to a PIL image, or ``None``.
@@ -227,6 +233,14 @@ class ImageBlock(TranscriptBlock):
             images_mod.register_live(image_id, self._demote_to_halfcell)
         if self._placed != (cols, rows):
             if not images_mod.write_escape(images_mod.encode_placement(self._kitty_id, cols, rows)):
+                # The transmit landed but the placement could not be written:
+                # without this release the terminal would keep an image that
+                # will never be placed, parked in one of the 8 budget slots
+                # until unmount (review round 1, F1). Reclaim it and let the
+                # caller demote.
+                images_mod.release_live(self._kitty_id)
+                self._kitty_id = None
+                self._placed = None
                 return None
             self._placed = (cols, rows)
         grid = images_mod.placeholder_grid(rows, cols)
@@ -244,16 +258,37 @@ class ImageBlock(TranscriptBlock):
         return text
 
     def _transmit_frame(self) -> "PILImage":
-        """The pixels sent to the terminal.
+        """The pixels sent to the terminal, LETTERBOXED to the cap grid.
 
         `_shrink` already sized the retained copy to the CAP grid rather than
         the current one, so a later resize to a wider terminal re-places
         against pixels that were never smaller than any placement can be —
         placements only ever downscale, which is what keeps one transmit
         sharp at every width without ever retransmitting.
+
+        The letterbox exists because a kitty placement STRETCHES the image to
+        fill its ``c=`` x ``r=`` cell rectangle, and the rectangle's aspect
+        only approximates the image's (cells are integers). For a 12-row
+        screenshot the rounding error is invisible; for a 2-row icon it was a
+        measured 25% vertical stretch (design round 1, D2). Padding the frame
+        to exactly the grid rectangle's pixel aspect with TRANSPARENT bars
+        makes the stretch-to-fill aspect-true — the bars render as the
+        terminal's own background.
         """
         assert self._pil is not None
-        return self._pil
+        from PIL import Image as PIL_Image
+
+        cell = images_mod.cell_size()
+        cols, rows = images_mod.fit_cells(
+            self._px_width, self._px_height, images_mod.MAX_COLS, images_mod.MAX_ROWS
+        )
+        box = (cols * cell.width, rows * cell.height)
+        frame = self._pil if self._pil.mode == "RGBA" else self._pil.convert("RGBA")
+        if (frame.width, frame.height) == box:
+            return frame
+        canvas = PIL_Image.new("RGBA", box, (0, 0, 0, 0))
+        canvas.paste(frame, ((box[0] - frame.width) // 2, (box[1] - frame.height) // 2))
+        return canvas
 
     def _build_halfcell(self, cols: int, rows: int) -> Text:
         """The image as ``▀`` cells: top pixel in fg ink, bottom in bg.
@@ -268,11 +303,29 @@ class ImageBlock(TranscriptBlock):
             return self._halfcell_cache[1]
         from PIL import Image as PIL_Image
 
-        frame = self._pil.convert("RGBA").resize((cols, rows * 2), PIL_Image.Resampling.LANCZOS)
+        # LETTERBOX, never stretch-to-fill (design round 1, D2): the grid's
+        # display aspect only approximates the image's, and at small grids the
+        # rounding error is gross. The image is scaled to the largest
+        # half-cell-pixel rectangle that fits INSIDE the grid at its true
+        # display aspect (a half-cell pixel measures cell.width x
+        # cell.height/2 real pixels), then centered; the bars are theme
+        # background, i.e. invisible.
+        cell = images_mod.cell_size()
+        grid_w, grid_h = cols, rows * 2
+        # Clamped at 1.0: grid quantization can hand a tiny image a grid a
+        # shade larger than its pixels, and filling it would upscale.
+        scale = min(
+            (cols * cell.width) / max(1, self._px_width),
+            (rows * cell.height) / max(1, self._px_height),
+            1.0,
+        )
+        inner_w = min(grid_w, max(1, round(self._px_width * scale / cell.width)))
+        inner_h = min(grid_h, max(1, round(2 * self._px_height * scale / cell.height)))
+        frame = self._pil.convert("RGBA").resize((inner_w, inner_h), PIL_Image.Resampling.LANCZOS)
         background = theme_mod.semantic_color("bg").lstrip("#")
         bg_rgb = tuple(int(background[i : i + 2], 16) for i in (0, 2, 4))
-        canvas = PIL_Image.new("RGBA", frame.size, (*bg_rgb, 255))
-        canvas.alpha_composite(frame)
+        canvas = PIL_Image.new("RGBA", (grid_w, grid_h), (*bg_rgb, 255))
+        canvas.alpha_composite(frame, ((grid_w - inner_w) // 2, (grid_h - inner_h) // 2))
         pixels = canvas.load()
         assert pixels is not None
         indent = " " * SPINE_INDENT
@@ -307,21 +360,42 @@ class ImageBlock(TranscriptBlock):
         self.styles.height = 1
         detail = f"{self._px_width}x{self._px_height}"
         if self._label:
-            detail = f"{self._label}, {detail}"
-        return self._receipt_row(f"image attached ({detail})")
+            detail = f"'{self._label}', {detail}"
+        return self._receipt_row(f"image attached ({detail})", glyph=_ATTACHED_GLYPH)
 
     def _build_unavailable(self) -> Text:
         """The missing-image receipt: what was here, and why it is not."""
         self.styles.height = 1
         reason = self._unavailable or "unavailable"
-        name = f" {self._label}" if self._label else ""
+        # Quoted: an unquoted filename spliced into the sentence reads as a
+        # typo (`image dashboard.png unavailable`) — design round 1, D4.
+        name = f" '{self._label}'" if self._label else ""
         return self._receipt_row(f"image{name} unavailable — {reason}")
 
-    def _receipt_row(self, message: str) -> Text:
+    def _receipt_row(self, message: str, glyph: str = _UNAVAILABLE_GLYPH) -> Text:
+        """One receipt row, truncated to the block's width with a real ``…``.
+
+        Truncated HERE, in the string, not via ``Text(no_wrap=True,
+        overflow="ellipsis")``: ``set_content`` promotes a ``Text`` through
+        ``Content.from_rich_text``, which drops both flags — so the flagged
+        version WRAPPED in measurement (2 rows at 44 columns) while
+        ``styles.height = 1`` clipped the second row invisibly, losing the
+        reason mid-phrase and opening a phantom spacing gap from the 2-row
+        measurement (design round 1, D1). A pre-truncated string measures one
+        row at every width, so the frame and the measurement cannot disagree.
+        """
+        from rich.cells import cell_len
+
         style = Style(color=theme_mod.semantic_color("muted"))
-        text = Text(no_wrap=True, overflow="ellipsis")
+        lead = f"{glyph} "
+        room = max(8, (self.size.width or 80) - SPINE_INDENT - cell_len(lead))
+        if cell_len(message) > room:
+            from rich.cells import set_cell_size
+
+            message = set_cell_size(message, room - 1) + "…"
+        text = Text(no_wrap=True)
         text.append(" " * SPINE_INDENT, style=style)
-        text.append(f"{_UNAVAILABLE_GLYPH} ", style=style)
+        text.append(lead, style=style)
         text.append(message, style=style)
         return text
 
@@ -341,9 +415,12 @@ class ImageBlock(TranscriptBlock):
         self._repaint()
 
     def on_resize(self, event: object) -> None:
-        """Re-fit at the new width; a changed grid is a height change."""
-        if self._pil is None:
-            return
+        """Re-fit at the new width; a changed grid is a height change.
+
+        Receipts repaint too: their truncation point is a function of the
+        width (see :meth:`_receipt_row`), so a receipt built at 100 columns
+        and left alone would clip rather than ellipsize at 44.
+        """
         self._repaint()
         parent = self.parent
         refresh = getattr(parent, "refresh_gap_around", None)

--- a/local_operator/tui/widgets/image_block.py
+++ b/local_operator/tui/widgets/image_block.py
@@ -164,6 +164,10 @@ class ImageBlock(TranscriptBlock):
         #: grid the current placement was made for (re-place only on change).
         self._kitty_id: int | None = None
         self._placed: tuple[int, int] | None = None
+        #: Pixel aspect of the letterboxed frame actually transmitted — what
+        #: :meth:`_build_kitty` compares a new grid against to decide between
+        #: a free re-place and a retransmit (review round 2, F8).
+        self._transmit_aspect: float | None = None
         #: The mode this block actually painted with. Resolved at first paint
         #: (not construction) so the escape writer installed at app mount is
         #: visible; pinned afterwards except for demotion.
@@ -224,12 +228,29 @@ class ImageBlock(TranscriptBlock):
         so they cannot interleave with a frame Textual is writing.
         """
         assert self._pil is not None
+        cell = images_mod.cell_size()
+        box_aspect = (cols * cell.width) / max(1, rows * cell.height)
+        if self._kitty_id is not None and self._placed != (cols, rows):
+            # The transmitted frame was letterboxed for the aspect of the grid
+            # it was transmitted for. A resize that lands on a grid of the
+            # SAME aspect (the common case: width changes rarely move the
+            # fit's shape) just re-places; one whose aspect materially moved
+            # would stretch the old bars into the picture (review round 2,
+            # F8), so the image is retransmitted padded for the new grid.
+            # Bounded: only an actual grid-aspect change pays it, and the
+            # pixels come from the retained capped copy — tens of KB.
+            if abs(box_aspect - (self._transmit_aspect or box_aspect)) > 0.01:
+                images_mod.release_live(self._kitty_id)
+                self._kitty_id = None
+                self._placed = None
         if self._kitty_id is None:
             image_id = images_mod.next_image_id()
-            payload = images_mod.encode_png_base64(images_mod.to_png(self._transmit_frame()))
+            frame = self._transmit_frame(cols, rows)
+            payload = images_mod.encode_png_base64(images_mod.to_png(frame))
             if not images_mod.write_escape(images_mod.encode_transmit(image_id, payload)):
                 return None
             self._kitty_id = image_id
+            self._transmit_aspect = frame.width / max(1, frame.height)
             images_mod.register_live(image_id, self._demote_to_halfcell)
         if self._placed != (cols, rows):
             if not images_mod.write_escape(images_mod.encode_placement(self._kitty_id, cols, rows)):
@@ -241,6 +262,7 @@ class ImageBlock(TranscriptBlock):
                 images_mod.release_live(self._kitty_id)
                 self._kitty_id = None
                 self._placed = None
+                self._transmit_aspect = None
                 return None
             self._placed = (cols, rows)
         grid = images_mod.placeholder_grid(rows, cols)
@@ -257,14 +279,8 @@ class ImageBlock(TranscriptBlock):
             text.append(row, style=style)
         return text
 
-    def _transmit_frame(self) -> "PILImage":
-        """The pixels sent to the terminal, LETTERBOXED to the cap grid.
-
-        `_shrink` already sized the retained copy to the CAP grid rather than
-        the current one, so a later resize to a wider terminal re-places
-        against pixels that were never smaller than any placement can be —
-        placements only ever downscale, which is what keeps one transmit
-        sharp at every width without ever retransmitting.
+    def _transmit_frame(self, cols: int, rows: int) -> "PILImage":
+        """The pixels sent to the terminal, letterboxed to the PLACEMENT grid.
 
         The letterbox exists because a kitty placement STRETCHES the image to
         fill its ``c=`` x ``r=`` cell rectangle, and the rectangle's aspect
@@ -274,16 +290,30 @@ class ImageBlock(TranscriptBlock):
         to exactly the grid rectangle's pixel aspect with TRANSPARENT bars
         makes the stretch-to-fill aspect-true — the bars render as the
         terminal's own background.
+
+        Padded for the grid the placement will actually use, NOT the cap
+        grid: padding for the cap while placing into the current-width grid
+        compounds the two rectangles' aspect errors — measured 22% off for a
+        wide image in a 44-column terminal (review round 2, F8). The pixels
+        INSIDE the bars still come from the retained cap-sized copy, scaled
+        down to fit the grid box at their true aspect, so nothing upscales.
+        A later resize whose grid keeps this aspect re-places for free;
+        :meth:`_build_kitty` retransmits when the aspect itself moves.
         """
         assert self._pil is not None
         from PIL import Image as PIL_Image
 
         cell = images_mod.cell_size()
-        cols, rows = images_mod.fit_cells(
-            self._px_width, self._px_height, images_mod.MAX_COLS, images_mod.MAX_ROWS
-        )
-        box = (cols * cell.width, rows * cell.height)
+        box = (max(1, cols * cell.width), max(1, rows * cell.height))
         frame = self._pil if self._pil.mode == "RGBA" else self._pil.convert("RGBA")
+        # Scale the retained pixels down to fit inside the box at their true
+        # aspect (never up — the retained copy is already cap-bounded).
+        scale = min(box[0] / frame.width, box[1] / frame.height, 1.0)
+        if scale < 1.0:
+            frame = frame.resize(
+                (max(1, round(frame.width * scale)), max(1, round(frame.height * scale))),
+                PIL_Image.Resampling.LANCZOS,
+            )
         if (frame.width, frame.height) == box:
             return frame
         canvas = PIL_Image.new("RGBA", box, (0, 0, 0, 0))
@@ -433,6 +463,7 @@ class ImageBlock(TranscriptBlock):
             images_mod.release_live(self._kitty_id)
             self._kitty_id = None
             self._placed = None
+            self._transmit_aspect = None
 
     def _demote_to_halfcell(self) -> None:
         """Budget eviction: keep the picture, drop the terminal store entry.
@@ -444,6 +475,7 @@ class ImageBlock(TranscriptBlock):
         """
         self._kitty_id = None
         self._placed = None
+        self._transmit_aspect = None
         self._mode = "halfcell"
         self._repaint()
 

--- a/local_operator/tui/widgets/image_block.py
+++ b/local_operator/tui/widgets/image_block.py
@@ -1,0 +1,379 @@
+"""One inline image in the transcript, as a first-class block.
+
+The transcript already carries the model's READING of an image — the tool
+card's caption line, the prompt's ``[Image #N]`` marker — but not the image
+itself, so a session that navigates by screenshots (UI work, chart reviews,
+"look at this error") was a ledger of descriptions of pictures nobody could
+see. This block puts the picture in the flow, sized consistently, in the
+original aspect ratio, live for the session and equally on ``--resume``
+(images ride the transcript as base64, so a resumed conversation replays
+them from the same bytes the model saw).
+
+Rendering strategy lives in :mod:`local_operator.tui.images` (protocol
+detection, kitty escapes, fit arithmetic); this widget owns the lifecycle:
+
+- decode once (Pillow), remember pixels, drop the base64;
+- on mount, pick the best mode the terminal supports and paint;
+- kitty mode transmits the pixels to the terminal ONCE, downscaled to the
+  largest grid the caps allow, then paints plain placeholder text — resizes
+  re-place (one short escape) and repaint text, never retransmit;
+- a live-image budget caps terminal-side store use; evicted blocks demote
+  to half-cells in place, so scrollback keeps the picture;
+- unmount deletes the terminal-side image, leaving the terminal clean.
+
+The UNAVAILABLE state is deliberate UX, not an error path: an image whose
+bytes are gone (pruned from a resumed transcript, dropped after a provider
+rejection) or undecodable (corrupt data, HEIC without the codec) renders a
+one-row receipt naming what is missing and why, in the notice ink — the
+reader learns an image WAS here, which is the fact the empty space would
+have hidden.
+"""
+
+from __future__ import annotations
+
+import base64
+from typing import TYPE_CHECKING, ClassVar, cast
+
+from rich.style import Style
+from rich.text import Text
+
+from local_operator.tui import images as images_mod
+from local_operator.tui import theme as theme_mod
+from local_operator.tui.widgets.transcript import SPINE_INDENT, TranscriptBlock
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from PIL.Image import Image as PILImage
+
+__all__ = ["ImageBlock"]
+
+#: The half block char half-cell mode paints: fg = top pixel, bg = bottom.
+_HALF = "▀"
+
+#: Glyph leading the unavailable receipt. WGL4-safe (no Nerd Font needed).
+_UNAVAILABLE_GLYPH = "▨"
+
+
+def _decode(data_b64: str, mime_type: str) -> "PILImage | None":
+    """Decode base64 image bytes to a PIL image, or ``None``.
+
+    HEIC/HEIF goes through pillow-heif's opener when the ``images`` extra is
+    installed; its absence is one of the honest "unavailable" reasons rather
+    than a crash. Every failure maps to ``None`` — the caller renders the
+    unavailable receipt, which is this feature's error UX.
+    """
+    try:
+        import io
+
+        from PIL import Image as PIL_Image
+
+        if mime_type in ("image/heic", "image/heif"):
+            try:
+                from pillow_heif import register_heif_opener
+
+                register_heif_opener()
+            except Exception:
+                return None
+        raw = base64.b64decode(data_b64, validate=False)
+        image = PIL_Image.open(io.BytesIO(raw))
+        image.load()
+        return image
+    except Exception:
+        return None
+
+
+def _shrink(image: "PILImage") -> "PILImage":
+    """The retained working copy: capped at the largest renderable grid.
+
+    The cap grid (``MAX_COLS`` x ``MAX_ROWS`` cells at the real cell pixel
+    size) is the most pixels ANY mode can ever paint from this block, so
+    keeping more than that resident buys nothing. Downscaling once here also
+    makes the kitty transmit frame free (it IS this copy) and bounds every
+    half-cell resize to a small source. Converted to RGBA up front so the
+    per-mode paths never re-convert.
+    """
+    cell = images_mod.cell_size()
+    cols, rows = images_mod.fit_cells(
+        image.width, image.height, images_mod.MAX_COLS, images_mod.MAX_ROWS
+    )
+    target = (max(1, cols * cell.width), max(1, rows * cell.height))
+    frame = image if image.mode in ("RGB", "RGBA") else image.convert("RGBA")
+    if frame.width > target[0] or frame.height > target[1]:
+        frame = frame.copy() if frame is image else frame
+        frame.thumbnail(target)
+    return frame
+
+
+def _rgb(pixel: tuple[int, ...]) -> str:
+    """A rich ``rgb(...)`` color string for one decoded pixel."""
+    return f"rgb({pixel[0]},{pixel[1]},{pixel[2]})"
+
+
+class ImageBlock(TranscriptBlock):
+    """One image, indented onto the transcript's text column.
+
+    Sizing is the consistent-ledger rule from :mod:`~local_operator.tui.images`:
+    every image fits a shared height ceiling (:data:`~local_operator.tui.images.MAX_ROWS`)
+    with width following its own aspect ratio, so a column of mixed
+    screenshots scans like rows of a ledger. Small images stay small.
+
+    The block is finalized after every paint (the FINALIZED-BLOCK protocol:
+    committed rows never change under scroll) and does the same temporary
+    unfreeze dance ``NoticeBlock.restate`` documents for the three legitimate
+    repaints: a width change, a kitty→half-cell demotion, and the first paint
+    after mount replaces the pre-mount estimate.
+    """
+
+    #: Images are their own spacing kind: a change of subject against both the
+    #: prompt above and the prose below, so the adaptive rule brackets them.
+    SPACING_KIND: ClassVar[str] = "image"
+
+    def __init__(
+        self, data_b64: str | None, mime_type: str = "image/png", *, label: str = ""
+    ) -> None:
+        super().__init__()
+        self.add_class("image-block")
+        #: Short human name for the unavailable receipt (marker text or file
+        #: name). Never rendered while the image itself is on screen — the
+        #: caption already lives on the tool card or in the prompt text.
+        self._label = label
+        decoded = _decode(data_b64, mime_type) if data_b64 else None
+        #: Original pixel dimensions, for aspect-ratio fits and the receipt.
+        #: Kept as numbers because the pixels themselves are NOT kept at full
+        #: size: a session that reads a dozen screenshots would otherwise hold
+        #: a dozen multi-megabyte RGBA buffers in the widget tree for its
+        #: whole life (the same hazard `UserBlock` documents for base64).
+        #: `_shrink` caps the retained copy at the largest grid any render
+        #: mode can use, so every later paint has full resolution FOR ITS
+        #: GRID while the resident cost stays a few hundred KB per image.
+        self._px_width = decoded.width if decoded is not None else 0
+        self._px_height = decoded.height if decoded is not None else 0
+        self._pil: "PILImage | None" = _shrink(decoded) if decoded is not None else None
+        #: Why there is no picture, shown by the receipt. ``None`` = healthy.
+        self._unavailable: str | None = None
+        if self._pil is None:
+            self._unavailable = (
+                "no longer in the transcript" if not data_b64 else "could not be decoded"
+            )
+        #: Kitty state: the terminal-side image id once transmitted, and the
+        #: grid the current placement was made for (re-place only on change).
+        self._kitty_id: int | None = None
+        self._placed: tuple[int, int] | None = None
+        #: The mode this block actually painted with. Resolved at first paint
+        #: (not construction) so the escape writer installed at app mount is
+        #: visible; pinned afterwards except for demotion.
+        self._mode: str | None = None
+        #: Memoized half-cell frame, keyed by grid, so scroll repaints and
+        #: no-op resizes never re-run the pixel walk.
+        self._halfcell_cache: tuple[tuple[int, int], Text] | None = None
+        self.set_content(self._build())
+        self.finalize()
+
+    # -- rendering ---------------------------------------------------------
+
+    def _grid(self) -> tuple[int, int]:
+        """The ``(cols, rows)`` this image gets at the current width.
+
+        Fitted against the ORIGINAL pixel dimensions, not the retained
+        (possibly downscaled) copy: the fit's job is the true aspect ratio
+        and the no-upscale rule, both properties of the source image.
+        """
+        width = self.size.width or 80
+        avail = max(8, width - SPINE_INDENT)
+        return images_mod.fit_cells(
+            self._px_width,
+            self._px_height,
+            min(avail, images_mod.MAX_COLS),
+            images_mod.MAX_ROWS,
+        )
+
+    def _build(self) -> Text:
+        if self._pil is None:
+            return self._build_unavailable()
+        cols, rows = self._grid()
+        mode = self._resolve_mode()
+        if mode == "kitty":
+            frame = self._build_kitty(cols, rows)
+            if frame is not None:
+                self.styles.height = rows
+                return frame
+            # The transmit could not be written (no driver yet, or the write
+            # failed): paint half-cells now rather than an empty reservation.
+            self._mode = "halfcell"
+        if self._mode == "halfcell":
+            self.styles.height = rows
+            return self._build_halfcell(cols, rows)
+        return self._build_receipt()
+
+    def _resolve_mode(self) -> str:
+        if self._mode is None:
+            self._mode = images_mod.detect_mode()
+        return self._mode
+
+    def _build_kitty(self, cols: int, rows: int) -> Text | None:
+        """Transmit/place as needed, then the placeholder grid as text.
+
+        Returns ``None`` when the escapes cannot reach the terminal, which
+        tells :meth:`_build` to demote. The escapes go through the app's
+        driver sink (see :func:`~local_operator.tui.images.set_escape_writer`)
+        so they cannot interleave with a frame Textual is writing.
+        """
+        assert self._pil is not None
+        if self._kitty_id is None:
+            image_id = images_mod.next_image_id()
+            payload = images_mod.encode_png_base64(images_mod.to_png(self._transmit_frame()))
+            if not images_mod.write_escape(images_mod.encode_transmit(image_id, payload)):
+                return None
+            self._kitty_id = image_id
+            images_mod.register_live(image_id, self._demote_to_halfcell)
+        if self._placed != (cols, rows):
+            if not images_mod.write_escape(images_mod.encode_placement(self._kitty_id, cols, rows)):
+                return None
+            self._placed = (cols, rows)
+        grid = images_mod.placeholder_grid(rows, cols)
+        image_id = self._kitty_id
+        style = Style(
+            color=f"rgb({(image_id >> 16) & 255},{(image_id >> 8) & 255},{image_id & 255})"
+        )
+        indent = " " * SPINE_INDENT
+        text = Text(no_wrap=True)
+        for index, row in enumerate(grid):
+            if index:
+                text.append("\n")
+            text.append(indent)
+            text.append(row, style=style)
+        return text
+
+    def _transmit_frame(self) -> "PILImage":
+        """The pixels sent to the terminal.
+
+        `_shrink` already sized the retained copy to the CAP grid rather than
+        the current one, so a later resize to a wider terminal re-places
+        against pixels that were never smaller than any placement can be —
+        placements only ever downscale, which is what keeps one transmit
+        sharp at every width without ever retransmitting.
+        """
+        assert self._pil is not None
+        return self._pil
+
+    def _build_halfcell(self, cols: int, rows: int) -> Text:
+        """The image as ``▀`` cells: top pixel in fg ink, bottom in bg.
+
+        Transparent pixels composite over the theme background so a logo on
+        alpha does not paint black squares on paper themes. Consecutive
+        same-colour cells share one styled span — a screenshot is mostly runs,
+        so the segment count stays far under cols x rows.
+        """
+        assert self._pil is not None
+        if self._halfcell_cache is not None and self._halfcell_cache[0] == (cols, rows):
+            return self._halfcell_cache[1]
+        from PIL import Image as PIL_Image
+
+        frame = self._pil.convert("RGBA").resize((cols, rows * 2), PIL_Image.Resampling.LANCZOS)
+        background = theme_mod.semantic_color("bg").lstrip("#")
+        bg_rgb = tuple(int(background[i : i + 2], 16) for i in (0, 2, 4))
+        canvas = PIL_Image.new("RGBA", frame.size, (*bg_rgb, 255))
+        canvas.alpha_composite(frame)
+        pixels = canvas.load()
+        assert pixels is not None
+        indent = " " * SPINE_INDENT
+        text = Text(no_wrap=True)
+        for row in range(rows):
+            if row:
+                text.append("\n")
+            text.append(indent)
+            run_start = 0
+            run_style: str | None = None
+            line: list[tuple[str, str]] = []
+            for col in range(cols):
+                # RGBA canvas => getpixel returns a 4-int tuple; the cast
+                # narrows PIL's float|tuple union for the type checker.
+                top = cast("tuple[int, ...]", pixels[col, row * 2])
+                bottom = cast("tuple[int, ...]", pixels[col, row * 2 + 1])
+                style = f"{_rgb(top)} on {_rgb(bottom)}"
+                if style != run_style:
+                    if run_style is not None:
+                        line.append((_HALF * (col - run_start), run_style))
+                    run_start = col
+                    run_style = style
+            if run_style is not None:
+                line.append((_HALF * (cols - run_start), run_style))
+            for glyphs, style in line:
+                text.append(glyphs, style=style)
+        self._halfcell_cache = ((cols, rows), text)
+        return text
+
+    def _build_receipt(self) -> Text:
+        """Text mode: one dim row acknowledging the image without pixels."""
+        self.styles.height = 1
+        detail = f"{self._px_width}x{self._px_height}"
+        if self._label:
+            detail = f"{self._label}, {detail}"
+        return self._receipt_row(f"image attached ({detail})")
+
+    def _build_unavailable(self) -> Text:
+        """The missing-image receipt: what was here, and why it is not."""
+        self.styles.height = 1
+        reason = self._unavailable or "unavailable"
+        name = f" {self._label}" if self._label else ""
+        return self._receipt_row(f"image{name} unavailable — {reason}")
+
+    def _receipt_row(self, message: str) -> Text:
+        style = Style(color=theme_mod.semantic_color("muted"))
+        text = Text(no_wrap=True, overflow="ellipsis")
+        text.append(" " * SPINE_INDENT, style=style)
+        text.append(f"{_UNAVAILABLE_GLYPH} ", style=style)
+        text.append(message, style=style)
+        return text
+
+    # -- lifecycle ---------------------------------------------------------
+
+    def _repaint(self) -> None:
+        """Rebuild through the finalize dance (see class docstring)."""
+        was_finalized = self._finalized
+        self._finalized = False
+        try:
+            self.set_content(self._build())
+        finally:
+            self._finalized = was_finalized
+
+    def on_mount(self) -> None:
+        """First paint at the real width (construction guessed 80 cols)."""
+        self._repaint()
+
+    def on_resize(self, event: object) -> None:
+        """Re-fit at the new width; a changed grid is a height change."""
+        if self._pil is None:
+            return
+        self._repaint()
+        parent = self.parent
+        refresh = getattr(parent, "refresh_gap_around", None)
+        if callable(refresh):
+            refresh(self)
+
+    def on_unmount(self) -> None:
+        """Return the terminal-side image store entry (``/clear``, exit)."""
+        if self._kitty_id is not None:
+            images_mod.release_live(self._kitty_id)
+            self._kitty_id = None
+            self._placed = None
+
+    def _demote_to_halfcell(self) -> None:
+        """Budget eviction: keep the picture, drop the terminal store entry.
+
+        Called by :func:`~local_operator.tui.images.register_live` when this
+        image is the oldest past the cap. The terminal-side delete already
+        happened; this swaps the placeholder text for half-cell pixels so the
+        block stays a picture in scrollback.
+        """
+        self._kitty_id = None
+        self._placed = None
+        self._mode = "halfcell"
+        self._repaint()
+
+    # -- selection ---------------------------------------------------------
+
+    def copy_row_is_chrome(self, index: int) -> bool:
+        """Every row is furniture: a drag-copy must never paste placeholder
+        codepoints or half-block soup into a document. The image is not text,
+        so the clipboard gets nothing from it."""
+        return True

--- a/tests/unit/tui/test_image_block.py
+++ b/tests/unit/tui/test_image_block.py
@@ -1,0 +1,359 @@
+"""Inline transcript images: fit arithmetic, protocol encoding, the widget's
+three modes, the live-image budget, and the app wiring (prompt, tool result,
+resume replay, missing-image receipt).
+
+The kitty escapes themselves are asserted as STRINGS (the encoders are pure),
+and the end-to-end proof that a real terminal receives them lives in the MR
+evidence (a PTY run against the real driver) — a unit test cannot own a
+terminal. What the tests here pin is everything that decides WHAT is written:
+mode detection, grid fits, transmit-once/replace-on-resize, budget eviction,
+and the unavailable receipt.
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+
+import pytest
+from rich.text import Text
+
+from local_operator.harness.types import ImageContent
+from local_operator.tui import images as images_mod
+from local_operator.tui.images import (
+    MAX_COLS,
+    MAX_ROWS,
+    PLACEHOLDER,
+    CellSize,
+    encode_delete,
+    encode_placement,
+    encode_transmit,
+    fit_cells,
+    placeholder_grid,
+    register_live,
+    release_live,
+    set_escape_writer,
+)
+from local_operator.tui.widgets.image_block import ImageBlock
+
+CELL = CellSize(8, 16)
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    images_mod.reset_for_tests()
+    yield
+    images_mod.reset_for_tests()
+
+
+def _png(width: int, height: int, color=(200, 60, 90)) -> str:
+    from PIL import Image
+
+    buffer = io.BytesIO()
+    Image.new("RGB", (width, height), color).save(buffer, format="PNG")
+    return base64.b64encode(buffer.getvalue()).decode("ascii")
+
+
+def _plain(block: ImageBlock) -> str:
+    """The block's rendered text, TYPE-ASSERTED as the ``Text`` every mode
+    builds (the same narrowing ``test_user_block`` does): a block that starts
+    returning something else should fail here and say so."""
+    renderable = block.renderable
+    assert isinstance(renderable, Text)
+    return renderable.plain
+
+
+# ---------------------------------------------------------------------------
+# fit_cells: aspect ratio in pixels, caps, no upscaling
+# ---------------------------------------------------------------------------
+
+
+def test_fit_preserves_aspect_ratio_in_pixels() -> None:
+    # 1600x1000 at 8x16 cells: height caps at 12 rows = 192px -> scale .192,
+    # width 307px -> 38 cells. The cell being twice as tall as wide is the
+    # whole reason rows != cols/aspect.
+    cols, rows = fit_cells(1600, 1000, 72, 12, CELL)
+    assert rows == 12
+    assert cols == 38
+
+
+def test_fit_small_image_never_upscales() -> None:
+    cols, rows = fit_cells(48, 24, 72, 12, CELL)
+    # 48px wide is 6 cells; 24px tall is 1.5 -> 2 rows. No inflation to caps.
+    assert cols == 6
+    assert rows == 2
+
+
+def test_fit_degenerate_dimensions_take_one_cell() -> None:
+    assert fit_cells(0, 0, 72, 12, CELL) == (1, 1)
+    assert fit_cells(10000, 1, 72, 12, CELL)[1] >= 1
+
+
+def test_fit_narrow_terminal_clamps_width() -> None:
+    cols, rows = fit_cells(1600, 1000, 20, 12, CELL)
+    assert cols <= 20
+    # Width became the binding constraint, so the height drops with it.
+    assert rows < 12
+
+
+# ---------------------------------------------------------------------------
+# Escape encoders (pure string builders)
+# ---------------------------------------------------------------------------
+
+
+def test_transmit_is_chunked_and_pinned_to_png() -> None:
+    payload = "A" * 9000  # forces three 4096 chunks
+    sequence = encode_transmit(7, payload)
+    assert sequence.startswith("\x1b_Ga=t,i=7,f=100,q=2,m=1;")
+    assert sequence.count("\x1b_G") == 3
+    assert sequence.count("m=1") == 2  # all but the last chunk continue
+    assert "m=0;" in sequence  # the final chunk closes the stream
+    # The full payload survives the chunking byte for byte.
+    assert sequence.count("A") == 9000
+
+
+def test_placement_replaces_via_fixed_placement_id() -> None:
+    sequence = encode_placement(7, cols=38, rows=12)
+    assert "a=p" in sequence and "U=1" in sequence
+    assert "p=1" in sequence  # same id => re-place, never stack
+    assert "c=38" in sequence and "r=12" in sequence
+
+
+def test_delete_targets_the_image_id() -> None:
+    assert "a=d,d=I,i=9" in encode_delete(9)
+
+
+def test_placeholder_grid_shape_and_codepoints() -> None:
+    grid = placeholder_grid(rows=2, cols=3)
+    assert len(grid) == 2
+    for row in grid:
+        assert row.count(PLACEHOLDER) == 3
+        # placeholder + row diacritic + column diacritic per cell
+        assert len(row) == 9
+
+
+# ---------------------------------------------------------------------------
+# Live-image budget
+# ---------------------------------------------------------------------------
+
+
+def test_budget_evicts_oldest_and_demotes() -> None:
+    written: list[str] = []
+    set_escape_writer(written.append)
+    demoted: list[int] = []
+    for image_id in range(1, images_mod.MAX_LIVE_KITTY_IMAGES + 2):
+        register_live(image_id, lambda i=image_id: demoted.append(i))
+    assert demoted == [1]  # oldest only
+    assert any("a=d,d=I,i=1," in seq for seq in written)  # store reclaimed
+
+
+def test_release_is_idempotent_and_deletes_once() -> None:
+    written: list[str] = []
+    set_escape_writer(written.append)
+    register_live(5, lambda: None)
+    release_live(5)
+    release_live(5)
+    assert sum("a=d,d=I,i=5," in seq for seq in written) == 1
+
+
+# ---------------------------------------------------------------------------
+# ImageBlock modes (forced via the env override the module documents)
+# ---------------------------------------------------------------------------
+
+
+def test_halfcell_paints_pixels_as_half_blocks(monkeypatch) -> None:
+    monkeypatch.setenv("LOCAL_OPERATOR_IMAGES", "halfcell")
+    block = ImageBlock(_png(160, 100))
+    text = _plain(block)
+    assert "▀" in text
+    # Every row leads with the spine indent, like every other block.
+    for row in text.split("\n"):
+        assert row.startswith("  ")
+
+
+def test_text_mode_is_a_receipt_with_dimensions(monkeypatch) -> None:
+    monkeypatch.setenv("LOCAL_OPERATOR_IMAGES", "text")
+    block = ImageBlock(_png(160, 100))
+    assert "image attached (160x100)" in _plain(block)
+
+
+def test_kitty_mode_transmits_once_and_replaces_on_resize(monkeypatch) -> None:
+    monkeypatch.setenv("LOCAL_OPERATOR_IMAGES", "kitty")
+    written: list[str] = []
+    set_escape_writer(written.append)
+    block = ImageBlock(_png(1600, 1000))
+    transmits = sum("a=t,i=" in seq for seq in written)
+    placements = sum("a=p,i=" in seq for seq in written)
+    assert transmits == 1 and placements == 1
+    assert PLACEHOLDER in _plain(block)
+    # A repaint at the same grid re-sends nothing.
+    block._repaint()
+    assert sum("a=t,i=" in seq for seq in written) == 1
+    assert sum("a=p,i=" in seq for seq in written) == 1
+
+
+def test_kitty_without_writer_falls_back_to_halfcell(monkeypatch) -> None:
+    monkeypatch.setenv("LOCAL_OPERATOR_IMAGES", "kitty")
+    set_escape_writer(None)  # headless: no driver installed
+    block = ImageBlock(_png(160, 100))
+    assert "▀" in _plain(block)
+    assert PLACEHOLDER not in _plain(block)
+
+
+def test_kitty_demotion_keeps_the_picture(monkeypatch) -> None:
+    monkeypatch.setenv("LOCAL_OPERATOR_IMAGES", "kitty")
+    written: list[str] = []
+    set_escape_writer(written.append)
+    block = ImageBlock(_png(160, 100))
+    assert PLACEHOLDER in _plain(block)
+    block._demote_to_halfcell()
+    assert "▀" in _plain(block)
+    assert PLACEHOLDER not in _plain(block)
+
+
+def test_unavailable_receipt_for_missing_bytes(monkeypatch) -> None:
+    monkeypatch.setenv("LOCAL_OPERATOR_IMAGES", "halfcell")
+    block = ImageBlock(None)
+    plain = _plain(block)
+    assert "unavailable" in plain and "no longer in the transcript" in plain
+
+
+def test_unavailable_receipt_for_corrupt_bytes(monkeypatch) -> None:
+    monkeypatch.setenv("LOCAL_OPERATOR_IMAGES", "halfcell")
+    corrupt = base64.b64encode(b"not an image").decode("ascii")
+    block = ImageBlock(corrupt)
+    assert "could not be decoded" in _plain(block)
+
+
+def test_selection_treats_every_row_as_chrome(monkeypatch) -> None:
+    monkeypatch.setenv("LOCAL_OPERATOR_IMAGES", "halfcell")
+    block = ImageBlock(_png(160, 100))
+    assert block.copy_row_is_chrome(0)
+    assert block.copy_row_is_chrome(3)
+
+
+def test_retained_copy_is_capped(monkeypatch) -> None:
+    monkeypatch.setenv("LOCAL_OPERATOR_IMAGES", "halfcell")
+    block = ImageBlock(_png(3200, 2000))
+    # Original dimensions are remembered for the fit and the receipt…
+    assert (block._px_width, block._px_height) == (3200, 2000)
+    # …but the resident pixels are bounded by the cap grid's pixel size.
+    cell = images_mod.cell_size()
+    assert block._pil is not None
+    assert block._pil.width <= MAX_COLS * cell.width
+    assert block._pil.height <= MAX_ROWS * cell.height
+
+
+# ---------------------------------------------------------------------------
+# App wiring: prompt path, tool-result path, resume replay
+# ---------------------------------------------------------------------------
+
+
+async def _pilot_app():
+    from local_operator.tui.app import OperatorApp
+    from tests.unit.tui.test_app_pilot import FakeSession, _factory
+
+    session = FakeSession()
+    return OperatorApp(lambda: _factory(session)), session
+
+
+@pytest.mark.asyncio
+async def test_prompt_images_render_under_the_user_block(monkeypatch) -> None:
+    monkeypatch.setenv("LOCAL_OPERATOR_IMAGES", "halfcell")
+    app, _ = await _pilot_app()
+    async with app.run_test(size=(100, 40)) as pilot:
+        await pilot.pause()
+        image = ImageContent(data=_png(160, 100), mime_type="image/png")
+        app._submit_prompt("look [Image #1]", [image])
+        await pilot.pause()
+        blocks = list(app.query(ImageBlock))
+        assert len(blocks) == 1
+        assert "▀" in _plain(blocks[0])
+
+
+@pytest.mark.asyncio
+async def test_tool_result_images_render_after_the_card(monkeypatch) -> None:
+    monkeypatch.setenv("LOCAL_OPERATOR_IMAGES", "halfcell")
+    from local_operator.harness.types import (
+        TextContent,
+        ToolExecutionEndEvent,
+        ToolExecutionStartEvent,
+        ToolResult,
+    )
+    from local_operator.tui.events import ToolEnded, ToolStarted
+
+    app, _ = await _pilot_app()
+    async with app.run_test(size=(100, 40)) as pilot:
+        await pilot.pause()
+        start = ToolExecutionStartEvent(tool_call_id="c1", tool_name="read", args={})
+        app.on_tool_started(ToolStarted(start))
+        await pilot.pause()
+        result = ToolResult(
+            tool_call_id="c1",
+            tool_name="read",
+            content=[
+                TextContent(text="Image shot.png (image/png, 160x100)"),
+                ImageContent(data=_png(160, 100), mime_type="image/png"),
+            ],
+        )
+        end = ToolExecutionEndEvent(tool_call_id="c1", tool_name="read", result=result)
+        app.on_tool_ended(ToolEnded(end))
+        await pilot.pause()
+        assert len(list(app.query(ImageBlock))) == 1
+
+
+@pytest.mark.asyncio
+async def test_resume_replays_prompt_and_tool_images(monkeypatch) -> None:
+    monkeypatch.setenv("LOCAL_OPERATOR_IMAGES", "halfcell")
+    from local_operator.harness.types import Message, ToolCall
+
+    app, session = await _pilot_app()
+    image_b64 = _png(160, 100)
+    call = ToolCall(id="c9", name="read", arguments={"path": "shot.png"})
+    session._history = [
+        Message(
+            role="user",
+            content=[
+                # `Message.user` stores text + image blocks exactly like this.
+                *_user_content("check this [Image #1]", image_b64),
+            ],
+        ),
+        Message(role="assistant", content=[], tool_calls=[call]),
+        Message(
+            role="tool",
+            tool_call_id="c9",
+            content=[ImageContent(data=image_b64, mime_type="image/png")],
+        ),
+    ]
+    async with app.run_test(size=(100, 50)) as pilot:
+        await pilot.pause()
+        blocks = list(app.query(ImageBlock))
+        # One from the user prompt replay, one from the tool-result replay.
+        assert len(blocks) == 2
+        for block in blocks:
+            assert "▀" in _plain(block)
+
+
+def _user_content(text: str, image_b64: str):
+    from local_operator.harness.types import TextContent
+
+    return [
+        TextContent(text=text),
+        ImageContent(data=image_b64, mime_type="image/png"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_resume_replays_missing_image_as_receipt(monkeypatch) -> None:
+    monkeypatch.setenv("LOCAL_OPERATOR_IMAGES", "halfcell")
+    from local_operator.harness.types import Message
+
+    app, session = await _pilot_app()
+    session._history = [
+        Message(role="user", content=_user_content("gone [Image #1]", "")),
+    ]
+    async with app.run_test(size=(100, 40)) as pilot:
+        await pilot.pause()
+        blocks = list(app.query(ImageBlock))
+        assert len(blocks) == 1
+        assert "unavailable" in _plain(blocks[0])

--- a/tests/unit/tui/test_image_block.py
+++ b/tests/unit/tui/test_image_block.py
@@ -190,13 +190,50 @@ def test_kitty_mode_transmits_once_and_replaces_on_resize(monkeypatch) -> None:
     block._repaint()
     assert sum("a=t,i=" in seq for seq in written) == 1
     assert sum("a=p,i=" in seq for seq in written) == 1
-    # A repaint at a CHANGED grid re-places — one short escape — and still
-    # never retransmits the pixels (review round 1, F6: the `_placed !=
-    # (cols, rows)` branch was untested).
-    block._placed = (10, 4)  # simulate a stale placement from another width
+    # A repaint at a CHANGED grid of the SAME aspect re-places — one short
+    # escape — without retransmitting (review round 1, F6). The stale grid
+    # here keeps the real grid's aspect so only the placement is stale.
+    real = block._placed
+    assert real is not None
+    block._placed = (real[0] // 2, real[1] // 2)  # same aspect, wrong size
     block._repaint()
     assert sum("a=t,i=" in seq for seq in written) == 1
     assert sum("a=p,i=" in seq for seq in written) == 2
+
+
+def test_kitty_retransmits_when_the_grid_aspect_moves(monkeypatch) -> None:
+    """A placement grid whose ASPECT differs from the transmitted frame's
+    letterbox would stretch the old bars into the picture — measured 22%
+    aspect error for a wide image in a 44-column terminal (round 2, F8).
+    The block must retransmit padded for the new grid, and release the old
+    terminal-store image."""
+    monkeypatch.setenv("LOCAL_OPERATOR_IMAGES", "kitty")
+    written: list[str] = []
+    set_escape_writer(written.append)
+    block = ImageBlock(_png(3200, 400))  # 8:1, the shape that exposed F8
+    first_id = block._kitty_id
+    assert sum("a=t,i=" in seq for seq in written) == 1
+    # Simulate the fit at a much narrower terminal: half the columns, same
+    # rows — a materially different grid aspect.
+    placed = block._placed
+    assert placed is not None
+    monkeypatch.setattr(block, "_grid", lambda: (placed[0] // 2, placed[1]))
+    block._repaint()
+    assert sum("a=t,i=" in seq for seq in written) == 2  # retransmitted
+    assert any(f"a=d,d=I,i={first_id}," in seq for seq in written)  # old freed
+    assert block._kitty_id != first_id
+
+
+def test_transmit_frame_matches_the_placement_grid_aspect(monkeypatch) -> None:
+    """The letterboxed frame's pixel box must equal the placement grid's
+    pixel rectangle — the property whose violation was F8."""
+    monkeypatch.setenv("LOCAL_OPERATOR_IMAGES", "kitty")
+    set_escape_writer(lambda s: None)
+    block = ImageBlock(_png(3200, 400))
+    cell = images_mod.cell_size()
+    for cols, rows in ((20, 12), (38, 12), (6, 2)):
+        frame = block._transmit_frame(cols, rows)
+        assert (frame.width, frame.height) == (cols * cell.width, rows * cell.height)
 
 
 def test_kitty_without_writer_falls_back_to_halfcell(monkeypatch) -> None:
@@ -232,7 +269,7 @@ def test_kitty_placement_failure_releases_the_store_entry(monkeypatch) -> None:
     set_escape_writer(writer)
     block = ImageBlock(_png(160, 100))
     # Demoted to half-cells, id cleared, and the transmitted image deleted.
-    assert "◀".replace("◀", "▀") in _plain(block)
+    assert "▀" in _plain(block)
     assert block._kitty_id is None
     assert any("a=d,d=I" in seq for seq in written)
 
@@ -360,6 +397,27 @@ async def test_prompt_images_render_under_the_user_block(monkeypatch) -> None:
         blocks = list(app.query(ImageBlock))
         assert len(blocks) == 1
         assert "▀" in _plain(blocks[0])
+
+
+@pytest.mark.asyncio
+async def test_prompt_labels_follow_marker_numbers_not_positions(monkeypatch) -> None:
+    """Marker numbers are max-derived, not positional: delete #1 and paste
+    twice and the prompt reads [Image #2] [Image #3]. Receipts must name the
+    text's own numbers (round 2, F9)."""
+    monkeypatch.setenv("LOCAL_OPERATOR_IMAGES", "halfcell")
+    app, _ = await _pilot_app()
+    async with app.run_test(size=(100, 40)) as pilot:
+        await pilot.pause()
+        missing = ImageContent(data="", mime_type="image/png")
+        corrupt = ImageContent(
+            data=base64.b64encode(b"junk").decode("ascii"), mime_type="image/png"
+        )
+        app._submit_prompt("renumbered [Image #2] [Image #3]", [missing, corrupt])
+        await pilot.pause()
+        blocks = list(app.query(ImageBlock))
+        assert len(blocks) == 2
+        assert "'#2'" in _plain(blocks[0])
+        assert "'#3'" in _plain(blocks[1])
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tui/test_image_block.py
+++ b/tests/unit/tui/test_image_block.py
@@ -190,6 +190,13 @@ def test_kitty_mode_transmits_once_and_replaces_on_resize(monkeypatch) -> None:
     block._repaint()
     assert sum("a=t,i=" in seq for seq in written) == 1
     assert sum("a=p,i=" in seq for seq in written) == 1
+    # A repaint at a CHANGED grid re-places — one short escape — and still
+    # never retransmits the pixels (review round 1, F6: the `_placed !=
+    # (cols, rows)` branch was untested).
+    block._placed = (10, 4)  # simulate a stale placement from another width
+    block._repaint()
+    assert sum("a=t,i=" in seq for seq in written) == 1
+    assert sum("a=p,i=" in seq for seq in written) == 2
 
 
 def test_kitty_without_writer_falls_back_to_halfcell(monkeypatch) -> None:
@@ -209,6 +216,90 @@ def test_kitty_demotion_keeps_the_picture(monkeypatch) -> None:
     block._demote_to_halfcell()
     assert "▀" in _plain(block)
     assert PLACEHOLDER not in _plain(block)
+
+
+def test_kitty_placement_failure_releases_the_store_entry(monkeypatch) -> None:
+    """A transmit that lands whose placement cannot be written must not
+    strand the image in the terminal store or a budget slot (F1)."""
+    monkeypatch.setenv("LOCAL_OPERATOR_IMAGES", "kitty")
+    written: list[str] = []
+
+    def writer(sequence: str) -> None:
+        if "a=p," in sequence:
+            raise OSError("driver gone")
+        written.append(sequence)
+
+    set_escape_writer(writer)
+    block = ImageBlock(_png(160, 100))
+    # Demoted to half-cells, id cleared, and the transmitted image deleted.
+    assert "◀".replace("◀", "▀") in _plain(block)
+    assert block._kitty_id is None
+    assert any("a=d,d=I" in seq for seq in written)
+
+
+def test_no_color_forces_text_mode(monkeypatch) -> None:
+    """NO_COLOR strips the fg color that carries the kitty image id, so the
+    honest mode is the receipt (F2)."""
+    monkeypatch.delenv("LOCAL_OPERATOR_IMAGES", raising=False)
+    monkeypatch.setenv("NO_COLOR", "1")
+    monkeypatch.setenv("TERM", "xterm-kitty")
+    images_mod.reset_for_tests()
+    assert images_mod.detect_mode() == "text"
+
+
+def test_receipt_truncates_to_one_row_with_ellipsis(monkeypatch) -> None:
+    """Receipts must be one row at ANY width, ellipsized in the string
+    itself: Content.from_rich_text drops Text's overflow flags, so a
+    wrapped receipt measures two rows while painting one (D1)."""
+    monkeypatch.setenv("LOCAL_OPERATOR_IMAGES", "halfcell")
+    block = ImageBlock(None)
+    row = block._receipt_row("image unavailable — no longer in the transcript")
+    # At the default 80-col guess the full reason fits.
+    assert "transcript" in row.plain
+    # Narrow: the row ends in an ellipsis and never carries a newline.
+    # `size` is a live property over the content region, so the narrow
+    # width is injected by patching it on the class (monkeypatch restores).
+    from textual.geometry import Size
+
+    narrow = ImageBlock(None)
+    monkeypatch.setattr(ImageBlock, "size", property(lambda self: Size(44, 1)))
+    clipped = narrow._receipt_row("image unavailable — no longer in the transcript")
+    assert "\n" not in clipped.plain
+    assert clipped.plain.rstrip().endswith("…")
+
+
+def test_halfcell_letterboxes_small_images(monkeypatch) -> None:
+    """A 2:1 icon must paint a 2:1 footprint, not stretch to fill its grid
+    (D2). Asserted from the PAINTED spans: a solid red 48x24 source in a
+    6x2-cell grid (6x4 half-rows) must leave at least one half-row as pure
+    theme background — the letterbox bar. The old stretch-to-fill code
+    painted red into every half-row, so this fails on it by construction.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_IMAGES", "halfcell")
+    from local_operator.tui import theme as theme_mod
+
+    block = ImageBlock(_png(48, 24, color=(255, 0, 0)))
+    cols, rows = block._grid()
+    assert (cols, rows) == (6, 2)  # the fit at 8x16 cells
+    frame = block._build_halfcell(cols, rows)
+    background = theme_mod.semantic_color("bg").lstrip("#")
+    bg = f"rgb({int(background[0:2], 16)},{int(background[2:4], 16)},{int(background[4:6], 16)})"
+    # Walk the styled segments: each carries "<top> on <bottom>". 48x24 at
+    # 8x16 cells occupies 3 of the grid's 4 half-rows, so SOME cell must
+    # pair red pixels with a background half — the bar's edge. Stretch-to-
+    # fill paints red into all 4 half-rows and has no such pair.
+    pairs: list[tuple[str, str]] = []
+    for span in frame.spans:
+        style = str(span.style)
+        if " on " not in style:
+            continue
+        top, _, bottom = style.partition(" on ")
+        pairs.append((top.strip(), bottom.strip()))
+    assert pairs, "no styled half-cell spans painted"
+    assert any("255,0,0" in top for top, _ in pairs), "icon pixels missing"
+    assert any(
+        "255,0,0" in top and bottom == bg for top, bottom in pairs
+    ), "no letterbox bar: the icon was stretched to fill its grid"
 
 
 def test_unavailable_receipt_for_missing_bytes(monkeypatch) -> None:


### PR DESCRIPTION
# PR Description

## Change classification

**C2 — standard / pre-authorized.** New TUI capability: images render inline in the transcript (tool-result screenshots, pasted prompt attachments, and both again on `--resume`). Additive — no provider, session, or persistence contract changes; the transcript block protocol gains one new block type. Clean rollback via `git revert`; runtime kill switches exist (`display.images: false`, `LOCAL_OPERATOR_IMAGES=off`).

## The gap

The transcript carried only *descriptions* of images: a `read` of a PNG showed the caption line, a pasted screenshot showed `↑ 1 image attached`, and a resumed session showed bare `[Image #N]` markers. A session that navigates by visuals — UI reviews, chart reading, "look at this error" — gave the user no way to see what the agent was looking at, live or after resume. omp renders images inline (kitty graphics + budgeted fallbacks); this brings the same capability to Local Operator's Textual TUI with a stricter performance posture.

## The design

**`local_operator/tui/images.py`** — protocol layer, no widget knowledge:

- **Mode detection** (memoized): kitty Unicode placeholders on kitty/ghostty (the terminals known to render `U=1` + U+10EEEE placeholder cells — cmux embeds ghostty); **half-cell pixels** (`▀` fg/bg pairs, pure text) everywhere else including tmux/screen and terminals that advertise kitty but don't render placeholders (WezTerm/Konsole, the same finding textual-image documents); a **one-line receipt** for `TERM=dumb` or `display.images: false`. Env override `LOCAL_OPERATOR_IMAGES=kitty|halfcell|text|off`.
- **Why placeholders, not direct placement/Sixel/iTerm2:** placeholder cells are ordinary text, so Textual's compositor scrolls/clips/repaints them like any content. A cursor-positioned placement or raw Sixel blob is shredded by the next compositor frame.
- **Fit arithmetic** in *pixels* (a cell is ~2× taller than wide): every image fits a shared 12-row height ceiling with width following its own aspect ratio under a 72-col cap — mixed screenshots read as a consistent ledger; small images never upscale.
- **Escapes go through `driver.write`** — the same serialization door `TerminalTitle` uses — so an APC can never interleave into a frame Textual is writing. Cell pixel size comes from the `TIOCGWINSZ` ioctl (a kernel read; no escape-response query can run while Textual owns stdin).
- **Live-image budget (8, mirroring omp):** kitty terminals keep transmitted images in a per-terminal store that text clears don't touch. Past the cap the oldest image is deleted from the store and its block **demotes to half-cells in place** — scrollback keeps the picture (omp demotes to text; this keeps pixels).

**`widgets/image_block.py`** — the transcript block:

- Decodes once; retains a working copy capped at the largest renderable grid (~a few hundred KB) instead of the full-size RGBA buffer; original dimensions kept as numbers for the fit and receipts.
- **Transmit once, ever**: pixels cross the wire one time per image, downscaled to the cap grid. Resize re-places (one ~40-byte escape) and repaints text — never retransmits. Half-cell frames are memoized per grid.
- Unmount (`/clear`, session swap, exit) deletes the terminal-side image; verified under a real PTY (below).
- **Unavailable UX**: missing bytes (pruned/dropped from a resumed transcript) or undecodable bytes render a one-row receipt — `▨ image unavailable — no longer in the transcript` / `— could not be decoded` — so the reader learns an image *was* here rather than seeing nothing.
- Drag-copy treats every row as chrome: the clipboard never receives placeholder codepoints or half-block soup.

**`app.py`** — one shared mount helper (`_append_image_blocks`) feeds three paths: live prompt submit/steer (images render under the `UserBlock` receipt), `tool_execution_end` (under the settled card), and resume replay of both user and tool messages. Persistence needed no change: images already ride the transcript as base64 — the same bytes the model saw replay on resume.

## Testing evidence

**Real kitty path under a PTY** (the real Textual driver, not headless): forked the real `OperatorApp` under `pty.fork()` with `TERM_PROGRAM=ghostty`, submitted a prompt with a 1600×1000 PNG, drained the terminal side:

```
bytes captured: 69297
transmit APC (a=t,f=100): True
virtual placement (a=p,U=1): True
placeholder cells (U+10EEEE): True
cleanup delete on exit (a=d,d=I): True
```

One transmit, one placement, placeholder text painted, store cleaned on exit — the full lifecycle against a real driver.

**Rendered frames** (real `OperatorApp` + real stylesheet via `run_test` + `save_screenshot`, per the repo's visual-validation recipe). All captured at `211d155` except the before frame, captured from `origin/main` (`e28104b`) in a pristine worktree whose provenance was asserted in-cell (`local_operator.__file__` under the before tree; `tui/images.py` absent — the branch-unique needle):

| State | Frame |
| --- | --- |
| **Before (main)** — resumed session: markers only, no images, no receipts | ![before](https://raw.githubusercontent.com/damianvtran/local-operator/assets/pr-tui-inline-images/before-resume.png) |
| **After — resume replay**: prompt image, tool-result image under its card, pruned-image receipt | ![after resume](https://raw.githubusercontent.com/damianvtran/local-operator/assets/pr-tui-inline-images/after-resume.png) |
| **After — live prompts** (half-cell mode): wide 1600×1000 at the 12-row ceiling, small 48×24 stays small, both unavailable receipts | ![after halfcell](https://raw.githubusercontent.com/damianvtran/local-operator/assets/pr-tui-inline-images/after-halfcell.png) |
| **After — kitty mode, headless**: no driver ⇒ silent demotion to half-cells (the fallback path) | ![after kitty headless](https://raw.githubusercontent.com/damianvtran/local-operator/assets/pr-tui-inline-images/after-kitty-headless.png) |

Frames show: consistent height ceiling across a wide and a tall image, true aspect ratios (1600×1000 → 38×12 cells; 300×900 → 4×12), no-upscale for the 48×24 icon, spine indent alignment, and both unavailable receipts.

**Unit tests** — 23 new in `tests/unit/tui/test_image_block.py`: fit arithmetic (pixel-true aspect, caps, no-upscale, degenerate inputs), escape encoders (chunking at 4096, fixed placement id, delete targeting), budget eviction + demote + idempotent release, all three widget modes, transmit-once/no-retransmit-on-repaint, headless fallback, unavailable receipts (missing and corrupt), selection-as-chrome, resident-memory cap, and the three app paths (prompt, tool end, resume replay incl. missing-image receipt) through the pilot harness.

**Suites**: TUI `1801 passed, 4 skipped`; non-TUI `3321 passed, 3 skipped` (one earlier run showed 14 OAuth failures — that run raced the rebase under an editable install; clean re-run green).

**Gates**: flake8 clean; black/isort clean; pyright 0 errors (matches main's baseline).

## Rollout notes

- Default on; `display.images: false` in config or `LOCAL_OPERATOR_IMAGES=off` turns it off; `=halfcell` forces the portable mode on a terminal with a broken kitty implementation.
- Sixel/iTerm2 protocols deliberately unsupported (composited TUI incompatibility, documented in `images.py`); those terminals get half-cells, which every colour terminal renders.
