### PR TITLE
fix(tui): ink the session name unpadded so siblings sit flush against it

### DIFF
--- a/local_operator/tui/widgets/status_line.py
+++ b/local_operator/tui/widgets/status_line.py
@@ -116,24 +116,25 @@ ICON_MCP = "⊙"
 #: warning glyph so it reads the same as a warning notice in the transcript.
 ICON_APPROVALS = "!"
 
-#: The name's cell BUDGET: the widest box the trailing segment may take, and
-#: the narrowest it is worth showing at. Everything between is available — the
-#: segment is elastic, and which width it gets is decided by :meth:`_walk` from
-#: the row's geometry ALONE, never from the length of the string in it.
+#: The name's cell BUDGET: the most the trailing segment may take, and the
+#: narrowest it is worth showing at when the row is too tight for all of it.
+#: The budget is a CAP, not a reservation: the segment spends only the cells
+#: its truncated text actually inks, so the rest of the right group sits flush
+#: against the title instead of across a run of reserved blanks.
 #:
-#: That last clause is the whole design of this segment, and it is worth stating
-#: plainly because the obvious implementation gets it wrong. The name is
-#: model-authored and it CHANGES UNDER THE READER: an opener excerpt lands on
+#: That is a deliberate reversal of this segment's earlier design, and the
+#: trade is worth stating plainly because both sides of it are real. The name
+#: is model-authored and CHANGES UNDER THE READER: an opener excerpt lands on
 #: submit, the generated title replaces it ~1.5 s later, and a re-title can
-#: land at any time after that (see ``local_operator.session.naming``). Size the
-#: box to the string and every one of those arrivals re-flows the row —
-#: measured at a fixed 150 columns, the alarm glyph sat at column 144, then 101,
-#: 102, 110 across four consecutive frames, two of those moves with no user
-#: input at all, and a ONE-cell difference in title length flipped the whole
-#: 13-cell `◍ 2 agents` segment in and out. Size the box to the geometry and the
-#: name is the only thing on the band that a title can change: the box is
-#: reserved, the name is left-aligned in it, and the leftover cells sit at the
-#: band's own edge where nothing else lives.
+#: land at any time after that (see ``local_operator.session.naming``). Sizing
+#: to the string means each of those arrivals re-flows the right group — the
+#: alarm and the figures shift left or right with the title's length. The
+#: previous design reserved the full box against exactly that drift, and what
+#: it bought column stability with was a HOLE: every title shorter than the
+#: box left a run of blanks between the alarm and the `‹` seam (up to 39 cells
+#: for a one-word title), which read as a rendering fault on every frame,
+#: all session long. A reflow happens twice in a session's first two seconds
+#: and then rarely; the hole was permanent. The operator chose the reflow.
 #:
 #: 40 for the cap: it fits every title the naming caps allow (``MAX_TITLE_CHARS``
 #: is 80, but a 3-7 word answer lands well inside 40) and leaves the identity
@@ -172,10 +173,10 @@ _MIN_GROUP_GAP = 4
 #:
 #: The ladder DROPS, SHORTENS, and — for the name only — FLEXES. The name is
 #: still on it twice, but the first entry is no longer a step from one fixed
-#: width to another: ``flex-name`` is where the segment stops being a rigid box
-#: of :data:`NAME_CELLS` and becomes elastic down to its floor, taking back
-#: whatever the row needs and giving back whatever it does not. What remains
-#: below is its DROP — the point where even the floor has stopped fitting.
+#: width to another: ``flex-name`` is where the segment's cap drops from
+#: :data:`NAME_CELLS` to its floor and becomes elastic, taking back whatever
+#: the row needs and giving back whatever it does not. What remains below is
+#: its DROP — the point where even the floor has stopped fitting.
 #:
 #: The ordering principle: shed what the user already knows or can re-derive,
 #: and protect what predicts their next decision. In order —
@@ -221,19 +222,18 @@ _DROP_LADDER: tuple[str, ...] = (
     # visible in the transcript as a tool card, while a subagent is not.
     "jobs",
     "subagents",
-    # The name stops being a rigid box here and becomes elastic: from this rung
-    # down it is measured at its FLOOR and handed back whatever the fitting row
-    # left over, so its width runs continuously from 18 cells to 40 instead of
-    # jumping between two values. This rung replaced a `shorten-name` that halved
-    # it outright, and the halving is what made the segment idle: across 30-180
-    # columns the name rendered at only 0, 18 or 40 cells, so a 130-column
-    # terminal showed an 18-cell stub beside an 18-cell hole with 32 cells
-    # available, and the excerpt-to-title moment this feature exists for read as
+    # The name's cap drops from :data:`NAME_CELLS` to its floor here, and the
+    # fitting row hands back whatever it can spare, so the visible width runs
+    # continuously from 18 cells to 40 instead of jumping between two values.
+    # This rung replaced a `shorten-name` that halved it outright, and the
+    # halving is what made the segment idle: across 30-180 columns the name
+    # rendered at only 0, 18 or 40 cells, so a 130-column terminal showed an
+    # 18-cell stub beside an 18-cell hole with 32 cells available, and the
+    # excerpt-to-title moment this feature exists for read as
     # `The /resume picke…` → `Fix unnamed sessi…` at every width under 138.
     #
-    # The flex is measured from the geometry, never from the string: a title is
-    # model-authored and lands while the user is reading, so a box sized to it
-    # would re-flow the row on its own. See :data:`NAME_CELLS`.
+    # The cap bounds the segment; the segment's painted width is its INK. See
+    # :data:`NAME_CELLS` for the trade that decision carries.
     "flex-name",
     # Shorten before dropping: a basename still answers "where am I" and a bare
     # model id still answers "who is replying".
@@ -889,12 +889,6 @@ class StatusLine:
         #: attaches one, which keeps the band usable by the lightweight test
         #: hosts that have no terminal to write to.
         self._title: TerminalTitle | None = None
-        #: Cells of the trailing name's reserved box that the current title does
-        #: not fill. Paid out immediately before the seam that introduces the
-        #: title (see :meth:`_right_text`), which is what keeps the row flush to
-        #: the band's right edge without orphaning the chevron or letting the
-        #: title's length move any column to its left.
-        self._name_slack: int = 0
 
     def set_terminal_title(self, title: TerminalTitle | None) -> None:
         """Attach (or detach) the window-title writer and paint it once.
@@ -1307,9 +1301,9 @@ class StatusLine:
         entirely, and the wider-surviving of the two rows wins.
 
         The comparison is by segments SURVIVING rather than by cells painted,
-        because the padded name box makes "cells" the wrong measure — a row can
-        paint more cells and say less. The restart wins nearly always (a walk with
-        21 fewer cells to place fits no later than one with them), and it is
+        because a wider row is not a more informative one — a row can paint
+        more cells and say less. The restart wins nearly always (a walk with
+        fewer cells to place fits no later than one with them), and it is
         compared rather than assumed so the rule stays true if a future rung
         changes what a concession costs.
         """
@@ -1348,17 +1342,15 @@ class StatusLine:
         measuring segments independently and getting the separator arithmetic
         subtly wrong.
 
-        The name is measured at its RESERVE — the full :data:`NAME_CELLS` until
-        the ``flex-name`` rung fires, its floor after — and then grown into
-        whatever the fitting rung left over, capped. Three properties come out of
-        that, and all three are the point:
-
-        * The reserve is a function of the row's geometry and never of the name's
-          text, so a title arriving or being rewritten cannot move a sibling.
-        * A long title never sheds a neighbour that a short one would have kept,
-          because the fit test measured the box either way.
-        * The leftover goes to the one segment that can use it rather than into
-          the hole between the groups.
+        The name is offered a CAP — the full :data:`NAME_CELLS` until the
+        ``flex-name`` rung fires, its floor after — and then the cap is grown
+        into whatever the fitting rung left over, bounded by the full cap. The
+        row spends only the cells the truncated title actually inks: the fit
+        test below measures the built text, so a short title fits rungs a
+        reserved box would have failed, and its siblings sit flush against the
+        seam instead of across a run of reserved blanks. The trade — a title
+        arriving or being rewritten now re-flows the right group — is priced in
+        :data:`NAME_CELLS`'s own comment.
         """
         dropped: set[str] = {"name"} if forgo_name else set()
         short: set[str] = set()
@@ -1369,13 +1361,13 @@ class StatusLine:
             elif step is not None:
                 target = step.partition("shorten-")[2]
                 (short if target else dropped).add(target or step)
-            reserve = (
+            cap = (
                 0
                 if "name" in dropped or not self._conversation_name
                 else NAME_CELLS_FLOOR if flexed else NAME_CELLS
             )
             left = self._left_text(dropped, short, dim, muted, seam, accent)
-            right = self._right_text(dropped, short, reserve, dim, seam)
+            right = self._right_text(dropped, short, cap, dim, seam)
             # The fit test reserves the group gap rather than asking whether the
             # composed row happens to fit. `_compose` pads with `max(1, …)`, so a
             # row could "fit" with the two groups ONE cell apart — tighter than
@@ -1392,10 +1384,20 @@ class StatusLine:
             slack = width - cell_len(left.plain) - cell_len(right.plain) - gap
             if slack < 0:
                 continue
-            if reserve and slack and reserve < NAME_CELLS:
-                right = self._right_text(
-                    dropped, short, min(NAME_CELLS, reserve + slack), dim, seam
-                )
+            if cap and slack and cap < NAME_CELLS:
+                # Regrow the cap into the leftover so the flexed name takes
+                # every cell the row can spare, up to the full cap. Grown from
+                # the title's measured INK, never from the cap itself: a
+                # word-boundary cut can ink well under the cap, and crediting
+                # the cap hands those saved cells out twice — measured on an
+                # 80-cell row, a 29-cell title inked 14 at an 18-cell cap, and
+                # `cap + slack` regrew to the full 29, four cells past the
+                # band's edge. From the ink, the rebuilt title adds at most
+                # `slack` cells to the measured row, so it fits by
+                # construction.
+                ink = cell_len(truncate_name(self._conversation_name, cap))
+                cap = min(NAME_CELLS, ink + slack)
+                right = self._right_text(dropped, short, cap, dim, seam)
             return frozenset(dropped), left, right
         return None
 
@@ -1505,15 +1507,13 @@ class StatusLine:
     ) -> Text:
         """agents ‹ jobs ‹ context ‹ cost ‹ duration ‹ [!] ‹ name.
 
-        ``name_cells`` is the box :meth:`_walk` reserved for the trailing name —
-        zero when the ladder dropped it. The row always SPENDS that whole box,
-        whatever the title's own width, which is what pins every other segment's
-        column; see :data:`NAME_CELLS`. The title itself is emitted UNPADDED and
-        the remainder (:attr:`_name_slack`) is paid out as blanks just before
-        the seam that introduces it, so the box is filled without the title
-        having to be the thing that fills it — which is what lets the row reach
-        the band's right edge at every title length while the columns to the
-        left of the name stay put.
+        ``name_cells`` is the CAP :meth:`_walk` granted the trailing name —
+        zero when the ladder dropped it. The title is emitted unpadded and cut
+        to that cap, and the row spends only the cells it inks: no reserve is
+        painted, so the seam and every sibling sit flush against the title's
+        actual width and the group's last inked cell is the band's right edge.
+        The columns to the left therefore move when the title's length changes
+        — the trade :data:`NAME_CELLS`'s comment prices.
 
         Colour groups by KIND rather than giving every field its own hue, which
         would be a rainbow: counters share `label`, the two numbers an operator
@@ -1521,9 +1521,6 @@ class StatusLine:
         caution), and the least volatile fields stay neutral. Green is not used
         at all — it belongs to the running indicator.
         """
-        # Reset per render: the reserve's unused cells are a property of THIS
-        # row, and a stale value would pay slack the current title does not have.
-        self._name_slack = 0
         parts: list[tuple[str, str, Style]] = []
         if self._subagent is not None and self._subagent.label:
             # Never dropped: it is what says whose numbers follow it, and a
@@ -1592,10 +1589,12 @@ class StatusLine:
             # is now spoken for: the session NAME is what an operator reads this
             # corner for, and 20 cells of prose about a mode that has not changed
             # since boot was crowding out the one field that says which
-            # conversation this is. The argument is answered rather than ignored —
-            # the name's box is RESERVED (:data:`NAME_CELLS`), so this glyph has
-            # one column per terminal width and a title landing under it cannot
-            # move it.
+            # conversation this is. The glyph's column now moves with the
+            # title's length — the name is inked unpadded rather than boxed
+            # (see :data:`NAME_CELLS`) — but a re-title is a twice-a-session
+            # event where the old reserved box was a permanent blank run, and
+            # one cell of red is findable at the end of the figures run at any
+            # column.
             #
             # What survives is the alarm itself, because nothing else in the UI
             # carries it for longer than a scroll: `/approvals` answers on
@@ -1664,39 +1663,18 @@ class StatusLine:
             # of the user's opener, so it has no natural bound, and the band is a
             # fixed two-row box.
             #
-            # The box's UNUSED cells are emitted as their own segment, BEFORE
-            # the seam, rather than as padding on either side of the title.
-            #
-            # The reserve itself is unchanged and is still the point: the fit
-            # was decided against the full box, so those cells are spoken for
-            # and cannot be handed back to the layout without moving every
-            # column left of the name. What varies is only where they are
-            # painted, and both obvious answers put them somewhere a reader
-            # notices:
-            #
-            # * `ljust` trailed them after the title. `_compose` stripped them,
-            #   so the painted row ended early — flush at the band's edge for a
-            #   long title and up to 35 cells short for a brief one, which reads
-            #   as a rendering fault. (They are ordinary styled cells, so
-            #   anything READING the row carried them too: the SVG export wrote
-            #   all 35.)
-            # * `rjust` moved them between the seam and the title, which fixed
-            #   the edge and orphaned the `‹`: every other seam on the row is
-            #   tight against what it introduces, so a lone chevron with 36
-            #   blanks after it reads as a missing segment (design review D1).
-            #
-            # Emitting them ahead of the seam keeps the seam glued to the title
-            # it introduces AND puts the title's last cell on the band's right
-            # edge, while the columns left of the name still cannot see the
-            # title's length. A blank segment renders as blanks either way; the
-            # only thing being chosen here is which side of the chevron the
-            # slack falls on.
-            # Carried on the SEAM's left so no extra separator is emitted: the
-            # blanks ride in front of the ` ‹ ` that introduces the title, which
-            # is one segment, not two.
-            self._name_slack = name_cells - cell_len(
-                truncate_name(self._conversation_name, name_cells)
-            )
+            # UNPADDED, on purpose. This segment used to reserve its full cap
+            # and pay the unused cells out as blanks before its seam, so that a
+            # title's length could never move a sibling's column — and every
+            # title shorter than the cap bought that stability with a permanent
+            # run of up to 39 blank cells between the alarm and the `‹`, which
+            # read as a rendering fault (the hole is what the user reported).
+            # The title changes twice in a session's first seconds and rarely
+            # after; the hole was on every frame. So the segment now inks only
+            # what the title measures and the right group re-flows on a
+            # re-title — the reversal is priced in :data:`NAME_CELLS`'s
+            # comment, and the seam stays tight against the title from both
+            # sides by construction.
             parts.append(
                 (
                     "",
@@ -1706,23 +1684,7 @@ class StatusLine:
             )
 
         right = Text()
-        last = len(parts) - 1
         for index, (icon, text, style) in enumerate(parts):
-            # The name's unused reserve is paid out HERE, immediately before the
-            # seam that introduces the title, so the chevron stays tight against
-            # the text it points at (design review D1) while the cells still sit
-            # inside the right group and cannot move any column to their left.
-            #
-            # OUTSIDE the `if index:` seam guard, because the name is not always
-            # preceded by a sibling: a freshly-opened session has no counters, no
-            # context reading, no cost and no duration, so the title is the whole
-            # right group and lands at index 0. Emitting the slack only alongside
-            # a seam silently skipped it there, and the group then aligned by its
-            # INK — the alternative this design explicitly rejects. Measured at
-            # 100 cells, the title's first column walked 95 -> 78 -> 73 -> 63 as
-            # the title grew, on the very first band a user sees (review F1).
-            if index == last and self._name_slack:
-                right.append(" " * self._name_slack, style=dim)
             if index:
                 right.append(f" {_SEP_RIGHT} ", style=seam)
             if icon:
@@ -1738,29 +1700,14 @@ class StatusLine:
         that exactly fitted its frame `_MIN_GROUP_GAP` cells past it, on trailing
         blanks that aligned nothing.
 
-        The right group is aligned by its BOX, not by its ink: the group always
-        spends the cells :meth:`_walk` reserved for the name
-        (:data:`NAME_CELLS`), so this arithmetic is the same at every title
-        length and a short title cannot shunt the group right.
-
-        The box's unused cells are spent inside the right group by
-        :meth:`_right_text`, as a run of blanks immediately BEFORE the seam that
-        introduces the title — so the row's last inked cell is the band's right
-        edge at every title length and there is nothing here to trim.
-
-        This method used to `rstrip` a left-aligned name's trailing padding,
-        which produced a row that ended early — flush for a long title and up to
-        35 cells short for a brief one. Moving those cells ahead of the title
-        fixes that at the source: they still exist, so the fit arithmetic and
-        every column left of the name are untouched, but they are no longer at
-        the edge where their absence was visible. Putting them between the seam
-        and the title instead reaches the edge too and orphans the chevron by up
-        to 39 cells, which reads as a segment that failed to render.
-
-        Aligning the group by its INK rather than its box is the other way to
-        reach the edge, and the one this must not do: measured across four
-        titles it walks the `!` alarm from column 74 to 91/111/151 at 100/120/160
-        cells, which is exactly the drift the reserve was introduced to stop.
+        The right group is aligned by its INK: it spends exactly the cells its
+        segments paint, the trailing name included, so the group's last inked
+        cell is the band's right edge and no blank run ever sits inside it.
+        The filler between the two groups absorbs whatever a short title frees
+        — which is where spare cells belong, in the one gap that separates the
+        groups rather than in a hole between two right-group siblings. The
+        cost is that the group's columns move when the title's length changes;
+        :data:`NAME_CELLS`'s comment prices that trade.
         """
         if not right.plain:
             return left

--- a/local_operator/tui/widgets/status_line.py
+++ b/local_operator/tui/widgets/status_line.py
@@ -128,7 +128,11 @@ ICON_APPROVALS = "!"
 #: submit, the generated title replaces it ~1.5 s later, and a re-title can
 #: land at any time after that (see ``local_operator.session.naming``). Sizing
 #: to the string means each of those arrivals re-flows the right group — the
-#: alarm and the figures shift left or right with the title's length. The
+#: alarm and the figures shift left or right with the title's length, and
+#: because the title's ink participates in the fit test, a re-title can also
+#: change which segments SURVIVE the ladder band-wide (a one-char title at
+#: 100 cells keeps the duration and the full cwd path; a 21-cell title drops
+#: the duration and shortens the cwd to its basename). The
 #: previous design reserved the full box against exactly that drift, and what
 #: it bought column stability with was a HOLE: every title shorter than the
 #: box left a run of blanks between the alarm and the `‹` seam (up to 39 cells
@@ -1512,8 +1516,9 @@ class StatusLine:
         to that cap, and the row spends only the cells it inks: no reserve is
         painted, so the seam and every sibling sit flush against the title's
         actual width and the group's last inked cell is the band's right edge.
-        The columns to the left therefore move when the title's length changes
-        — the trade :data:`NAME_CELLS`'s comment prices.
+        The columns to the left therefore move when the title's length
+        changes, and the fit itself can shed or restore siblings with it —
+        the trade :data:`NAME_CELLS`'s comment prices.
 
         Colour groups by KIND rather than giving every field its own hue, which
         would be a rainbow: counters share `label`, the two numbers an operator

--- a/tests/unit/tui/test_status_line.py
+++ b/tests/unit/tui/test_status_line.py
@@ -1368,6 +1368,13 @@ def test_the_titles_seam_stays_tight_against_the_title(monkeypatch) -> None:
     row early, and `rjust` reached the edge while orphaning the chevron behind
     a run of blanks that read as a segment that failed to render. Asserting
     the pair pins the one arrangement that does both.
+
+    The third assertion is the one that falsifies the RESERVED design itself
+    (review round 1, M1): paying the box's slack out on the seam's LEFT kept
+    the seam tight and the row flush — both checks above passed against the
+    very code this PR removes — while parking the dead run between the alarm
+    and the chevron. So the cells left of the title's seam must end on ink:
+    the seam's own leading space is the only blank allowed to touch them.
     """
     monkeypatch.setenv("HOME", "/Users/tester")
     for label, state in _LADDER_STATES.items():
@@ -1392,6 +1399,18 @@ def test_the_titles_seam_stays_tight_against_the_title(monkeypatch) -> None:
                 assert (
                     cell_len(row) == width
                 ), f"{where}: the seam is tight but the row stops short of the edge"
+                # The discriminating half (M1): everything left of the title's
+                # seam ends on ink. The old reserved box painted its unused
+                # cells exactly here — a blank run between the alarm and the
+                # `‹` — and both assertions above were satisfied by it. The
+                # inter-group filler lives further left and is bounded by the
+                # groups' own separators, so a trailing blank run here can only
+                # be a reintroduced name reserve.
+                head = row[: row.rindex(seam)]
+                assert head == head.rstrip(), (
+                    f"{where}: {len(head) - len(head.rstrip())} dead cells "
+                    f"between the right group and the title's seam"
+                )
 
 
 def test_a_double_width_title_never_overflows_the_band(monkeypatch) -> None:

--- a/tests/unit/tui/test_status_line.py
+++ b/tests/unit/tui/test_status_line.py
@@ -1167,29 +1167,18 @@ def _swept_band(state: _LadderState, *, alarm: bool) -> StatusLine:
     return status
 
 
-def _name_box(row: str, name: str, width: int) -> int:
-    """Cells the trailing name segment RESERVED, its unpainted tail included.
+def _name_ink(row: str, width: int) -> int:
+    """Cells the trailing name segment actually INKS on the row.
 
-    The box is what the layout is built on, and it is not the same number as the
-    ink in it: a word-boundary cut can leave `Bulk export the…` in an 18-cell box.
-
-    Located from the box's own left edge, which is where its UNUSED cells start
-    — not from the name's first character. The reserve's leftover is painted
-    just before the seam that introduces the title, so the title's first cell
-    moves with its length and measuring from it would return the ink instead of
-    the box. Everything from the end of the previous segment's ink to the band's
-    right edge is the reserve, seam included.
-
-    Measured to ``width`` rather than to ``len(row)`` for the same reason: the
-    row is laid out to exactly ``width``, so the edge is where the box ends, and
-    reading the string's length would quietly turn every caller into a test of
-    the ink instead of the layout's reserve.
+    The segment is unpadded — the name spends only the cells its truncated text
+    measures and the inter-group filler absorbs whatever a short title frees —
+    so the ink runs from the cell after the title's own seam to the band's
+    right edge. Measured to ``width`` rather than to ``len(row)`` because the
+    row is laid out to exactly ``width``: the title is the group's last segment
+    and its final cell is the band's edge, so the edge is where the ink ends.
     """
     seam = f" {_SEP_RIGHT} "
-    # The last seam is the title's. Walk left over the blanks in front of it to
-    # reach the box's first cell; the segment before them ends on real ink.
-    start = len(row[: row.rindex(seam)].rstrip())
-    return width - start - len(seam)
+    return width - row.rindex(seam) - len(seam)
 
 
 def test_naming_a_session_never_costs_a_segment_for_nothing(monkeypatch) -> None:
@@ -1227,60 +1216,67 @@ def test_naming_a_session_never_costs_a_segment_for_nothing(monkeypatch) -> None
                     where = f"{label} alarm={alarm} width={width}"
                     lost = set(status._dropped) - bare - {"name"}
                     if status.is_showing("name"):
-                        box = _name_box(row, name, width)
-                        assert (
-                            box >= NAME_CELLS_FLOOR
-                        ), f"{where}: {sorted(lost)} spent for a {box}-cell name"
+                        # The GRANT is what the concessions bought, and the ink
+                        # can legitimately run under it twice over: `Fix boot`
+                        # inks 8 cells inside an 18-cell grant because that is
+                        # the whole title, and a word-boundary cut spends up to
+                        # a third of the cap on reading well (`truncate_name`'s
+                        # bound). So a shown name is the complete title, or at
+                        # least two thirds of a floor's worth of it.
+                        ink = _name_ink(row, width)
+                        assert ink >= NAME_CELLS_FLOOR * 2 // 3 or row.endswith(
+                            name
+                        ), f"{where}: {sorted(lost)} spent for a {ink}-cell name"
                     else:
                         assert (
                             not lost
                         ), f"{where}: the name was dropped and {sorted(lost)} went with it"
 
 
-def test_the_alarms_column_does_not_move_when_the_title_changes(monkeypatch) -> None:
-    """One column per width, whatever the name says — the D2 contract.
+def test_the_layout_is_a_function_of_the_titles_ink_not_its_content(monkeypatch) -> None:
+    """Two titles of equal measure get byte-identical layout — only the text differs.
 
-    The alarm is one cell and it is the band's only standing word that no tool
-    will ask before it runs, so where it sits has to be learnable. Before the
-    name's box was reserved, its column was a function of the model's word count:
-    at a fixed 150 columns the glyph sat at 144, then 101, 102, 110 across four
-    consecutive frames as the excerpt, the title and a re-title landed — two of
-    those moves with no user input at all.
+    The name is inked unpadded now (see :data:`NAME_CELLS` on the reversal), so
+    the row's columns legitimately move with the title's LENGTH — the fixed
+    columns were the old reserved box's purchase, paid for with a permanent
+    blank run this change removes. What must survive the reversal is that the
+    length is all a title can move: the walk measures cells and never reads
+    the string, so a re-title to a same-measure name (the equality this test
+    constructs: same word boundaries, same cell count, so the same cut at
+    every cap) changes not one column, and any two titles differ in layout
+    only as far as their measures differ. A violation would mean the band's
+    layout depends on the title's CONTENT, which is the door back to a row
+    that reshuffles for reasons a reader cannot see.
 
-    Asserted over the whole row rather than just the glyph: everything up to the
-    name's own box has to be identical, or something else moved instead.
-
-    The row's painted LENGTH is deliberately not the assertion. ``_compose`` no
-    longer paints the name box's trailing blanks, so a brief title ends earlier
-    than a long one by design and comparing lengths would pin the ink instead of
-    the layout. What has to hold is that the box each title was given is the same
-    size — asserted below through ``_name_box``, which measures to the band's
-    right edge — and that is the property the length comparison stood in for.
+    The pair share word-boundary structure on purpose — `truncate_name` cuts
+    on words, so equal structure is what makes their ink equal at every cap.
     """
     monkeypatch.setenv("HOME", "/Users/tester")
+    pairs = (
+        ("Fix the login flow", "Add the audit sync"),
+        ("Bulk export the invoice columns", "Auto import the payment receipts"[:31]),
+        ("a", "z"),
+    )
     for label, state in _LADDER_STATES.items():
         status = _swept_band(state, alarm=True)
         for width in range(30, 181):
-            rows = []
-            for name in _NAMES:
-                status.update(conversation_name=name)
-                rows.append(status.render_text(width).plain)
-            first = rows[0]
-            assert len({row.index("!") for row in rows}) == 1, (
-                f"{label} width={width}: the alarm moved with the title "
-                f"({[row.index('!') for row in rows]})"
-            )
-            head = first[: first.index("!") + 1]
-            for row in rows[1:]:
-                assert row.startswith(head), f"{label} width={width}: the row reflowed"
-            # The reserve itself, which is what the old length comparison meant:
-            # every title at this width was handed a box of the same size, so a
-            # title arriving or being rewritten cannot resize the segment under
-            # the reader. Measurable only where the name survived the ladder.
-            boxes = {
-                _name_box(row, name, width) for row, name in zip(rows, _NAMES) if name[:4] in row
-            }
-            assert len(boxes) <= 1, f"{label} width={width}: the name's box changed size {boxes}"
+            for first, second in pairs:
+                status.update(conversation_name=first)
+                row_a = status.render_text(width).plain
+                shown_a = status.is_showing("name")
+                status.update(conversation_name=second)
+                row_b = status.render_text(width).plain
+                shown_b = status.is_showing("name")
+                where = f"{label} width={width} pair=({first!r}, {second!r})"
+                assert shown_a == shown_b, f"{where}: one title survived, the other did not"
+                if not shown_a:
+                    assert row_a == row_b, f"{where}: unnamed rows differ"
+                    continue
+                ink = _name_ink(row_a, width)
+                assert ink == _name_ink(row_b, width), f"{where}: the ink moved"
+                assert (
+                    row_a[: len(row_a) - ink] == row_b[: len(row_b) - ink]
+                ), f"{where}: the layout depends on the title's content"
 
 
 def test_the_name_takes_every_cell_the_row_can_spare(monkeypatch) -> None:
@@ -1294,82 +1290,50 @@ def test_the_name_takes_every_cell_the_row_can_spare(monkeypatch) -> None:
     the seam and the box grows with the terminal.
     """
     monkeypatch.setenv("HOME", "/Users/tester")
+    name = "Add todo guardrails to the operator loop"
     status = _swept_band(_LADDER_STATES["healthy-mcp/exact"], alarm=True)
-    status.update(conversation_name="Add todo guardrails to the operator loop")
-    boxes = []
+    status.update(conversation_name=name)
+    inks = []
     for width in range(100, 181):
         row = status.render_text(width).plain
-        box = len(row) - row.index("!") - len("! ‹ ")
-        boxes.append(box)
-        # Whatever is spare is IN the name's box, so the hole BETWEEN THE GROUPS
-        # is the seam's own width until the box is full.
-        #
-        # Measured up to the name's box rather than across the whole row. The
-        # title is right-aligned in its box, so a word-boundary cut leaves its
-        # unused cells immediately before the title — a run this regex sees and
-        # which is not a layout gap at all but the reserve doing its job. The
-        # property under test is that the LAYOUT does not idle while the name is
-        # still hungry, and the layout is everything left of that box.
-        head = row[: len(row) - box]
+        ink = _name_ink(row, width)
+        inks.append(ink)
+        # While the title is still hungry (cut short), the layout may not idle:
+        # every run wider than the group gap has to be cells the title could
+        # not have used. The name is unpadded and cut on a word boundary, so
+        # the one legitimate excess is the word-cut remainder — the cells
+        # between the cut title's ink and the cap the walk granted it, which
+        # `truncate_name` bounds at a third of the cap. Anything past that is a
+        # hole the old fixed-widths defect would have left.
+        head = row[: len(row) - ink]
         longest_gap = max((len(run) for run in re.findall(r" {2,}", head)), default=0)
         assert (
-            box >= NAME_CELLS or longest_gap <= _MIN_GROUP_GAP
-        ), f"width={width}: {longest_gap} cells idle beside a {box}-cell name"
-    assert min(boxes) >= NAME_CELLS_FLOOR
-    assert max(boxes) == NAME_CELLS
-    # More than the two widths the old constant pair allowed, and monotone in the
-    # terminal's width over the range where the row is otherwise unchanged.
-    assert len(set(boxes)) > 5, f"the name still has only {sorted(set(boxes))} widths"
+            row.endswith(name) or longest_gap <= _MIN_GROUP_GAP + NAME_CELLS // 3
+        ), f"width={width}: {longest_gap} cells idle beside a {ink}-cell name"
+    # The segment is elastic: the ink grows with the terminal, reaching the
+    # whole title (this one measures exactly NAME_CELLS) at the wide end and
+    # never dropping under the floor's word-cut worst case at the narrow end.
+    assert max(inks) == cell_len(name) == NAME_CELLS
+    assert min(inks) >= NAME_CELLS_FLOOR * 2 // 3
+    # More than the two widths the old constant pair allowed.
+    assert len(set(inks)) > 5, f"the name still has only {sorted(set(inks))} widths"
 
 
-def test_a_brief_title_leaves_no_dead_run_at_the_bands_right_edge(monkeypatch) -> None:
-    """The name's box is RESERVED, but its unused tail is not PAINTED.
+def test_the_row_is_flush_to_the_bands_right_edge_at_every_title_length(monkeypatch) -> None:
+    """The title's last inked cell IS the band's right edge — no dead tail.
 
-    The reserve is what holds every sibling's column still while a model rewrites
-    the title (D2), so it stays — but it used to be painted out to the band's
-    right edge as well, which left a brief title trailed by a long run of blank
-    cells that no segment would ever occupy.
-
-    The run's SIZE is not a constant. Two earlier versions of this docstring
-    implied otherwise, and the second was written to fix the first — which is
-    the more useful half of the story, because a correction carries more
-    authority than an original and nobody re-checks a sentence whose commit
-    message says it is the fix.
-
-    The first version said the run was "identical at every width". The second
-    retracted that and then quoted a second illustrative triple, which reproduces
-    only under a band shape it did not name: the width-100 figure moves with the
-    cwd's length and with whether the alarm is armed, so the same measurement
-    yields a different first entry on a shorter path or a disarmed gate. A
-    figure quoted without the conditions that produce it is the same unenforced
-    universal in a narrower costume.
-
-    So no illustrative numbers are quoted here at all. What identifies the
-    padding is the RELATIONSHIP, which needs none: the run is exactly the box
-    minus the ink, so it grows as the box grows and vanishes when the title
-    fills it — while a layout gap would not track the title's length. The box is
-    itself elastic and only reaches the full ``NAME_CELLS`` once the row can
-    spare it, which is why any single measurement of the run is a fact about one
-    band shape rather than about the defect.
-
-    That relationship is what this test pins, by asserting the row ends on the
-    title's last inked cell at every width rather than by asserting any
-    particular number of dead cells.
-
-    Those cells are ordinary styled cells, so everything that reads the row
-    rather than looking at it carried them — the app's own SVG export wrote 35
-    trailing spaces after `short` at a 160-column terminal.
-
-    The two halves are asserted together on purpose. Trimming the tail is only
-    correct while the reserve behind it is untouched, so this pins that the row
-    ends on the title's last inked character AND that the box measured to the
-    band's edge is unchanged by how long the title is.
+    The name is emitted unpadded (see :data:`NAME_CELLS` on the reversal from
+    the reserved box), so this holds by construction rather than by a slack
+    payout: the row's trailing segment is the title's own ink, cut to the cap
+    the walk granted it. Both halves are asserted because either alone passes
+    on a shape this exists to reject — `row == row.rstrip()` is satisfied by a
+    row that stops short of the edge, and `cell_len(row) == width` is satisfied
+    by a row whose last cells are padding blanks.
     """
     monkeypatch.setenv("HOME", "/Users/tester")
     for label, state in _LADDER_STATES.items():
         status = _swept_band(state, alarm=True)
         for width in (100, 120, 160):
-            boxes = set()
             for name in ("a", "short", "Bulk export the invoice columns"):
                 status.update(conversation_name=name)
                 row = status.render_text(width).plain
@@ -1379,36 +1343,31 @@ def test_a_brief_title_leaves_no_dead_run_at_the_bands_right_edge(monkeypatch) -
                 assert (
                     row == row.rstrip()
                 ), f"{where}: {len(row) - len(row.rstrip())} dead cells at the band's edge"
-                # THE property, and the one the assertion above cannot carry:
-                # the row must REACH the band's right edge, not merely end on a
-                # non-blank cell. A row whose trailing padding has been stripped
-                # satisfies `row == row.rstrip()` trivially while stopping up to
-                # 35 cells short — which is exactly what shipped, and why this
-                # test passed against the code it was written to pin (F2).
                 assert (
                     cell_len(row) == width
                 ), f"{where}: the row stops {width - cell_len(row)} cells short of the edge"
-                # The ink really is the title's, not a coincidence of truncation.
-                assert row.endswith(truncate_name(name, _name_box(row, name, width))), where
-                boxes.add(_name_box(row, name, width))
-            # ...and the reserve behind that trimmed tail did not move with the
-            # title's length, which is the property the padding used to provide.
-            assert len(boxes) <= 1, f"{label} width={width}: the box moved with the title {boxes}"
+                # The ink really is the title's, not a coincidence of
+                # truncation. `truncate_name` is not a fixed point — a title
+                # word-cut at a 20-cell cap inks 16 cells, and re-cutting the
+                # original at 16 lands on an earlier word — so the assertion is
+                # on the tail's shape: the whole title, or a prefix of it
+                # ending in the ellipsis.
+                tail = row[len(row) - _name_ink(row, width) :]
+                assert tail == name or (
+                    tail.endswith("…") and name.startswith(tail[:-1].rstrip())
+                ), where
 
 
 def test_the_titles_seam_stays_tight_against_the_title(monkeypatch) -> None:
     """The `‹` introduces the name and has to touch it (design review D1).
 
-    The reserve's unused cells have to be painted somewhere, and the two obvious
-    places are both wrong. After the title, the row ends early (the defect above
-    this one). Between the seam and the title, the row is flush but the chevron
-    is orphaned: every other seam on the band is tight against what it
-    introduces, so a lone `‹` trailed by a run of blanks reads as a segment that
-    failed to render rather than as spacing.
-
-    So the cells go BEFORE the seam, and this pins that — at every width and for
-    titles short enough to leave a large leftover, which is where an orphan
-    would be most visible.
+    Under the unpadded design this holds by construction — the title is the
+    seam's immediate neighbour because nothing is painted between them — but it
+    is pinned anyway, because both historical arrangements of the old reserve
+    broke one half of it: `ljust` + `rstrip` kept the seam tight and ended the
+    row early, and `rjust` reached the edge while orphaning the chevron behind
+    a run of blanks that read as a segment that failed to render. Asserting
+    the pair pins the one arrangement that does both.
     """
     monkeypatch.setenv("HOME", "/Users/tester")
     for label, state in _LADDER_STATES.items():
@@ -1438,14 +1397,14 @@ def test_the_titles_seam_stays_tight_against_the_title(monkeypatch) -> None:
 def test_a_double_width_title_never_overflows_the_band(monkeypatch) -> None:
     """The band is ONE row, in cells — including for CJK and Hangul titles.
 
-    The reserve is measured in cells and the row's gap is computed with
-    ``cell_len``, so any padding of the name has to be counted the same way.
-    Padding it with ``str.rjust`` counts CHARACTERS instead, and a title of
-    double-width glyphs then emits a row wider than the band: 592 rows over
-    their width across the ladder variants, worst case 11 cells. Rich drops the
-    over-wide segment rather than clipping it, so the effect was a CJK-named
-    conversation resuming with no name on the band at all — this feature's own
-    failure, reintroduced for non-Latin titles (review round 1, F1).
+    Every cut and every fit test on this row must count CELLS (``cell_len``),
+    never characters. Counting characters — as a ``str.rjust`` padding of the
+    name once did — emits a row wider than the band for a title of
+    double-width glyphs: 592 rows over their width across the ladder variants,
+    worst case 11 cells. Rich drops the over-wide segment rather than clipping
+    it, so the effect was a CJK-named conversation resuming with no name on
+    the band at all — this feature's own failure, reintroduced for non-Latin
+    titles (review round 1, F1).
     """
     monkeypatch.setenv("HOME", "/Users/tester")
     titles = (
@@ -1484,17 +1443,17 @@ def test_a_double_width_title_never_overflows_the_band(monkeypatch) -> None:
                     )
 
 
-def test_the_reserve_is_paid_even_when_the_name_is_the_only_segment(monkeypatch) -> None:
-    """The name is not always preceded by a sibling, and the slack must still land.
+def test_the_row_is_flush_even_when_the_name_is_the_only_segment(monkeypatch) -> None:
+    """The name is not always preceded by a sibling, and the row must still be flush.
 
     A freshly-opened session has no counters, no context reading, no cost and no
     duration — ``format_jobs(0)``, ``format_agents(0)`` and
     ``format_context_usage(0, …)`` all return "" and the duration is suppressed
     at zero — so the title is the WHOLE right group and lands at index 0 of the
-    join loop. Emitting the reserve's slack only alongside a seam skipped it in
-    exactly that shape, and the group then aligned by its INK: the row stopped
-    short of the band's edge and the title's first column walked with its own
-    length, on the very first band a user sees (review round 1, F1).
+    join loop. The inter-group filler in ``_compose`` is what carries the row
+    to the band's edge here (the unpadded title cannot), so this pins the
+    sparse shape where a filler bug would surface first — the very first band
+    a user sees (review round 1, F1).
 
     This is the sparse band on purpose. Every other band test populates the row.
     """
@@ -1521,10 +1480,10 @@ def test_the_bands_cut_lands_on_a_word_like_the_excerpt_it_was_handed() -> None:
     a quotation rather than as a string that ran out of buffer" — and the band
     used to re-cut the same string mid-word one call later, throwing that away.
 
-    The floor case is the exception the rule needs: at 18 cells a word cut would
-    leave `Add todo…` and nine blank cells, which distinguishes two tiled
-    sessions less well than the mid-word cut does. So the boundary is taken only
-    while it costs less than a third of the box.
+    The floor case is the exception the rule needs: at an 18-cell cap a word cut
+    would leave `Add todo…`, which distinguishes two tiled sessions less well
+    than the mid-word cut does. So the boundary is taken only while it costs
+    less than a third of the cap.
     """
     excerpt = "The /resume picker shows (unnamed session) for image openers"
     assert truncate_name(excerpt, 40) == "The /resume picker shows (unnamed…"


### PR DESCRIPTION
# PR Description

## Change classification

**C2 — standard / pre-authorized.** One widget (`status_line.py`) plus its
tests; no schema, transcript-format, or wire change. Clean rollback
(`git revert`). No RFC requested.

## The problem

The status band reserved a fixed 40-cell box (18 after the `flex-name` rung)
for the trailing session name and paid the box's unused cells out as blanks
immediately before the name's own `‹` seam. Every title shorter than the box
therefore left a permanent dead run between the alarm and the chevron — up to
39 blank cells on every frame, all session long:

```
▦ 19.1%/1M ‹ ◈ ≥$2.39 ‹ ◷ 13s ‹ !      ‹ Style OAuth Provider Redirect Page
                                  ^^^^^^ dead run, painted on every frame
```

The reserve bought column stability — a model re-title could not move a
sibling's column — but the price was inverted: a title changes about twice in
a session's first seconds and rarely after, while the hole was permanent and
read as a rendering fault.

## The fix

The name's width is now derived from the rendered title text instead of a
fixed allocation, and the other segments sit flush against it:

- `_walk` offers the name a **cap** instead of a reserve and fit-tests the row
  against the title's actual ink. The leftover regrows the cap **from the
  measured ink**, never from the cap itself — crediting the cap double-counts
  a word-boundary cut's savings and overflows the band (measured: a 29-cell
  title inked 14 at an 18-cell cap; `cap + slack` regrew to 29, four cells
  past the edge).
- `_right_text` emits the title **unpadded**, so the seam and every sibling
  are flush against the rendered text and the group's last inked cell is the
  band's right edge by construction. The slack-payout mechanism and
  `_name_slack` state are deleted.
- The inter-group filler in `_compose` absorbs whatever a short title frees —
  spare cells land in the one gap that separates the groups rather than
  inside the right group.

The elastic ladder behaviour is unchanged: the cap still runs 40 → 18 through
`flex-name`, the name's drop still restarts the walk, and `truncate_name`
still cuts on word boundaries (bounded at a third of the cap).

## Tests

Tests that pinned the reserved-box contract are rewritten to pin the new one:

- `test_the_row_is_flush_to_the_bands_right_edge_at_every_title_length` — the
  title's last inked cell is the band's edge; the tail is the title or a
  prefix of it ending in the ellipsis.
- `test_the_titles_seam_stays_tight_against_the_title` — no orphaned chevron,
  row flush, both halves asserted together.
- `test_the_layout_is_a_function_of_the_titles_ink_not_its_content` — two
  same-measure titles get byte-identical layout at every width in every
  ladder variant; the walk never reads the string.
- `test_naming_a_session_never_costs_a_segment_for_nothing` — updated floor:
  a shown name is the complete title or at least two-thirds of a floor's
  worth (the word-cut allowance `truncate_name` bounds).
- `test_the_name_takes_every_cell_the_row_can_spare` — measures ink instead
  of the box; elasticity (>5 distinct widths across 100–180 cells) preserved.
- `_name_box` helper (reserve semantics) replaced by `_name_ink`.

## Testing evidence

- `tests/unit/tui/test_status_line.py`: **73 passed**.
- Full TUI suite (`tests/unit/tui`, colour env per AGENTS.md): **1778 passed,
  4 skipped**.
- Gates: `flake8` clean, `black --check` clean, `isort --check-only` clean,
  `pyright` 0 errors on both changed files.
- Rendered-frame validation (per AGENTS.md "Visual validation"): the band was
  driven through `StatusLine.render_text` with a populated band (model,
  effort, cwd, 3 MCP, 19.1%/1M, ≥$2.39, 13s, alarm) at 100/120/160 cells and
  exported to SVG → PNG, before and after.

Geometry behind the frames (after): every row measures exactly its width and
the last seam's tail is the title itself —

```
w=100 'Style OAuth Provider Redirect Page' row_cells=100 flush=YES tail='Style OAuth Provider…'
w=100 'Fix boot'                           row_cells=100 flush=YES tail='Fix boot'
w=100 'a'                                  row_cells=100 flush=YES tail='a'
w=160 'Style OAuth Provider Redirect Page' row_cells=160 flush=YES tail='Style OAuth Provider Redirect Page'
w=160 'Fix boot'                           row_cells=160 flush=YES tail='Fix boot'
w=160 'a'                                  row_cells=160 flush=YES tail='a'
```

### Before (head `9a290d3` base; captured at branch base) — dead run left of the title

160 cells (rows: long title, `Fix boot`, `a`, unnamed):

![before 160](https://raw.githubusercontent.com/damianvtran/local-operator/assets/pr-status-name-flush/before-160.png)

100 cells:

![before 100](https://raw.githubusercontent.com/damianvtran/local-operator/assets/pr-status-name-flush/before-100.png)

### After (captured at `db875f6`) — seam flush against the title, no dead run

160 cells:

![after 160](https://raw.githubusercontent.com/damianvtran/local-operator/assets/pr-status-name-flush/after-160.png)

100 cells:

![after 100](https://raw.githubusercontent.com/damianvtran/local-operator/assets/pr-status-name-flush/after-100.png)

## Trade-off, stated

The right group's columns now move when the title's length changes (the old
reserve's purchase). This is deliberate and priced in `NAME_CELLS`'s comment:
a re-title is a twice-a-session event, the hole was permanent, and the
structural contract that survives is pinned by the layout-is-ink test.

## Rollout

No flags, no migration. Ships with the next `lop-update`.
