### PR TITLE
feat(providers,harness,tui): surface model refusals instead of ending the turn silently

### DIFF
--- a/local_operator/harness/loop.py
+++ b/local_operator/harness/loop.py
@@ -422,8 +422,17 @@ class AgentLoop:
                     context.messages.append(assistant)
                     new_messages.append(assistant)
 
-                    if stop_reason in ("error", "aborted"):
+                    if stop_reason in ("error", "aborted", "refusal"):
                         # Pair every dangling tool call so the wire stays legal.
+                        # "refusal" rides this branch because it is terminal the
+                        # same way an error is: the model declined, so there is
+                        # nothing to feed back for another call — and it must
+                        # NOT fall through to the clean-stop path, where the
+                        # turn ended with an empty frame and no explanation of
+                        # what the provider refused (the silent-refusal bug).
+                        # ``stream_error`` carries the provider's own refusal
+                        # message, which is what lets the user decide whether
+                        # to rephrase or switch models.
                         placeholders = [
                             self._synthetic_result(call, ABORTED_RESULT_TEXT)
                             for call in assistant.tool_calls
@@ -723,6 +732,12 @@ class AgentLoop:
                         usage = event.usage
                     provider_payload = event.provider_payload
                     error = event.error
+                    if stop_reason == "refusal" and not error:
+                        # Belt-and-braces: every wire client composes a refusal
+                        # message, but a bare "refusal" end from a client that
+                        # forgot must still say SOMETHING — a refusal nobody can
+                        # see is the exact bug this stop_reason exists to fix.
+                        error = "model refused the request (no details from provider)"
         except asyncio.CancelledError:
             raise
         except Exception as exc:
@@ -752,6 +767,15 @@ class AgentLoop:
         ]
         assistant.stop_reason = stop_reason
         assistant.usage = usage
+        if stop_reason == "refusal" and error:
+            # The refusal message otherwise lives only in the run's AgentEndEvent
+            # and dies with it: a resumed session replaying this message could
+            # say "the model refused" but not WHAT it said, which is the half of
+            # the diagnosis that decides between rephrasing and switching models.
+            # ``provider_payload`` is the established home for harness bookkeeping
+            # that must survive into the transcript (see ``pruned``/``details``);
+            # wire clients never replay these keys to providers.
+            provider_payload = {**(provider_payload or {}), "refusal": error}
         assistant.provider_payload = provider_payload
         # Token-cache settle gate (review RC-20): the message is finalized
         # (usage/stop_reason set), so any provisional cached estimate must be

--- a/local_operator/harness/types.py
+++ b/local_operator/harness/types.py
@@ -171,7 +171,7 @@ class Message(BaseModel):
     tool_call_id: str | None = None
     tool_name: str | None = None
     is_error: bool = False
-    stop_reason: str | None = None  # stop | length | toolUse | error | aborted
+    stop_reason: str | None = None  # stop | length | toolUse | refusal | error | aborted
     usage: "Usage | None" = None
     # Provider-native replay payload (opaque to the harness). NOTE: the loop
     # stores harness bookkeeping under ``provider_payload["details"]`` (tool
@@ -1305,9 +1305,17 @@ class StreamUsageEvent(BaseModel):
 
 class StreamEndEvent(BaseModel):
     type: Literal["end"] = "end"
-    stop_reason: str  # stop | length | toolUse | error | aborted
+    stop_reason: str  # stop | length | toolUse | refusal | error | aborted
     usage: Usage | None = None
     provider_payload: dict[str, Any] | None = None
+    #: The provider's own words about an abnormal end. For ``refusal`` this is
+    #: the refusal message (or a line naming the provider's terminal marker when
+    #: it sent no prose). Refusals used to be mapped onto ``stop``, which ended
+    #: the turn with a clean frame and NOTHING on screen — the user saw an empty
+    #: turn and could not tell a refusal from a no-op, let alone decide to
+    #: switch models. The wire clients are the only place the provider's actual
+    #: marker (``content_filter``, ``refusal``, ``SAFETY``…) is still visible,
+    #: so they must put it here; downstream only ever sees the normalized stop.
     error: str | None = None
 
 

--- a/local_operator/headless_print.py
+++ b/local_operator/headless_print.py
@@ -241,7 +241,16 @@ class PrintRenderer:
             self.console.print("[dim]compacting context…[/dim]", highlight=False)
         elif isinstance(event, AgentEndEvent):
             if event.error:
-                self.console.print(f"[red]Error: {event.error}[/red]", highlight=False)
+                # ``markup=False`` for the same reason as the notice branch
+                # above: ``error`` now carries model-authored prose (a
+                # provider's refusal message), and adversarial text like
+                # ``[/see policy]`` raised MarkupError inside this subscriber —
+                # BEFORE ``_track_outcome`` ran, so the process printed a
+                # traceback instead of the error line and exited 0. The text is
+                # data, never markup. (Review R1-1.)
+                self.console.print(
+                    f"Error: {event.error}", style="red", highlight=False, markup=False
+                )
             elif event.aborted:
                 self.console.print("[red]aborted[/red]", highlight=False)
 

--- a/local_operator/providers/clients.py
+++ b/local_operator/providers/clients.py
@@ -672,7 +672,7 @@ _FINISH_TO_STOP_REASON = {
 }
 
 
-def _refusal_error(marker: str, refusal_text: str) -> str:
+def _refusal_error(marker: str, refusal_text: str, *, streamed_text: bool = False) -> str:
     """The one visible line a refusal produces, always naming the wire marker.
 
     ``marker`` is the provider's own terminal signal (``finish_reason=
@@ -683,12 +683,20 @@ def _refusal_error(marker: str, refusal_text: str) -> str:
     frequently send NO prose at all — that silent case is the whole reason this
     line exists, so it must read as a diagnosis rather than an empty string.
 
+    ``streamed_text`` is whether the client forwarded any answer prose before
+    the refusal terminal (design review D1): Anthropic and Gemini safety stops
+    often cut a partial answer, and "sent no message" directly under a
+    partially-rendered reply asserts the opposite of what is on screen. The
+    line must describe the frame the user is looking at.
+
     Parentheses, not square brackets: this string reaches ``console.print`` in
     the headless renderer, where ``[marker]`` parses as rich markup and the
     diagnosis silently vanishes from its own error line.
     """
     if refusal_text:
         return f"model refused: {_capped(refusal_text)} ({marker})"
+    if streamed_text:
+        return f"model refused and cut the reply short ({marker})"
     return f"model refused and sent no message ({marker})"
 
 
@@ -1091,9 +1099,14 @@ class OpenAICompatClient:
             stop_reason = "refusal"
         error: str | None = None
         if stop_reason == "refusal":
-            error = _refusal_error(
-                f"finish_reason={finish_reason or 'stop'}", "".join(refusal_parts)
-            )
+            # Name what actually detected the refusal (design review D2): when
+            # the finish reason was an ordinary stop/length and the prose slot
+            # was the signal, a bare "(finish_reason=stop)" argues with the
+            # word "refused" and names a mechanism that did not fire.
+            marker = f"finish_reason={finish_reason or 'stop'}"
+            if finish_reason != "content_filter":
+                marker = f"delta.refusal, {marker}"
+            error = _refusal_error(marker, "".join(refusal_parts))
         yield StreamEndEvent(
             stop_reason=stop_reason,
             usage=usage,
@@ -1217,9 +1230,12 @@ class OpenAICompatClient:
                                 # Refusal prose truncated by the output cap is
                                 # still a refusal; a bare "length" terminal
                                 # dropped the collected prose (review R1-3).
+                                # The refusal slot is named as the detection
+                                # signal (D2): the incomplete reason alone
+                                # describes the truncation, not the refusal.
                                 terminal_stop = "refusal"
                                 terminal_error = _refusal_error(
-                                    f"incomplete_details.reason={reason}",
+                                    f"response.refusal, incomplete_details.reason={reason}",
                                     "".join(refusal_parts),
                                 )
                             else:
@@ -1592,6 +1608,7 @@ class AnthropicClient:
         url = f"{self._base_url}/v1/messages"
         stop_reason = "stop"
         usage = Usage()
+        streamed_text = False
         block_index_to_call: dict[int, tuple[str, str]] = {}
 
         async with self._http.stream(
@@ -1640,6 +1657,7 @@ class AnthropicClient:
                     if delta_type == "text_delta":
                         text = delta.get("text")
                         if text:
+                            streamed_text = True
                             yield StreamTextDelta(delta=text)
                     elif delta_type == "input_json_delta":
                         index = int(event.get("index", 0))
@@ -1671,8 +1689,9 @@ class AnthropicClient:
         if mapped == "refusal":
             # Anthropic sends no refusal prose alongside this stop_reason; any
             # text it did stream has already been forwarded, so the terminal
-            # line only needs to name the mechanism.
-            error = _refusal_error("stop_reason=refusal", "")
+            # line only needs to name the mechanism — and whether it cut a
+            # partially-streamed answer or produced nothing at all (D1).
+            error = _refusal_error("stop_reason=refusal", "", streamed_text=streamed_text)
         yield StreamUsageEvent(usage=usage)
         yield StreamEndEvent(stop_reason=mapped, usage=usage, error=error)
 
@@ -1822,6 +1841,7 @@ class GoogleClient:
         # never seen, while an error line with the verbatim marker stays true.
         refusal_marker: str | None = None
         defect_marker: str | None = None
+        streamed_text = False
         # Gemini returns one complete functionCall per part with no ids and
         # no part indexes, so the harness must mint both. They must be UNIQUE
         # per response: the loop dedups tool calls by id (first-wins), and a
@@ -1846,6 +1866,7 @@ class GoogleClient:
                     for part in (candidate.get("content") or {}).get("parts") or []:
                         text = part.get("text")
                         if text:
+                            streamed_text = True
                             yield StreamTextDelta(delta=text)
                         function_call = part.get("functionCall")
                         if function_call:
@@ -1898,8 +1919,11 @@ class GoogleClient:
         error: str | None = None
         if stop_reason == "refusal":
             # Gemini sends no refusal prose; any text it did stream has been
-            # forwarded already, so the line names the classifier that fired.
-            error = _refusal_error(refusal_marker or "finishReason=OTHER", "")
+            # forwarded already, so the line names the classifier that fired —
+            # and whether it cut a partial answer or produced nothing (D1).
+            error = _refusal_error(
+                refusal_marker or "finishReason=OTHER", "", streamed_text=streamed_text
+            )
         elif stop_reason == "error":
             error = f"model call failed ({defect_marker or 'unknown finishReason'})"
         yield StreamEndEvent(stop_reason=stop_reason, usage=usage, error=error)
@@ -1932,7 +1956,7 @@ class MockClient:
             yield StreamEndEvent(
                 stop_reason="refusal",
                 usage=Usage(input_tokens=10, output_tokens=0),
-                error=_refusal_error("mock refusal", "I can't help with that request."),
+                error=_refusal_error("stop_reason=mock_refusal", "I can't help with that request."),
             )
             return
         wants_tool = any("[tool]" in message.text for message in request.messages)

--- a/local_operator/providers/clients.py
+++ b/local_operator/providers/clients.py
@@ -664,8 +664,32 @@ _FINISH_TO_STOP_REASON = {
     "length": "length",
     "tool_calls": "toolUse",
     "function_call": "toolUse",
-    "content_filter": "stop",
+    # A filtered completion is a REFUSAL, not a clean stop. Mapping it to
+    # "stop" ended the turn with an empty frame and no explanation — the user
+    # saw nothing and could not tell a refusal from a no-op, which matters
+    # because the remedy (rephrase, or switch models) is theirs to choose.
+    "content_filter": "refusal",
 }
+
+
+def _refusal_error(marker: str, refusal_text: str) -> str:
+    """The one visible line a refusal produces, always naming the wire marker.
+
+    ``marker`` is the provider's own terminal signal (``finish_reason=
+    content_filter``, ``stop_reason=refusal``, ``finishReason=SAFETY``…) and is
+    kept in the message even when refusal prose exists: the prose says what the
+    model would not do, the marker says which provider mechanism fired, and
+    deciding whether to rephrase or switch models needs both. Providers
+    frequently send NO prose at all — that silent case is the whole reason this
+    line exists, so it must read as a diagnosis rather than an empty string.
+
+    Parentheses, not square brackets: this string reaches ``console.print`` in
+    the headless renderer, where ``[marker]`` parses as rich markup and the
+    diagnosis silently vanishes from its own error line.
+    """
+    if refusal_text:
+        return f"model refused: {_capped(refusal_text)} ({marker})"
+    return f"model refused and sent no message ({marker})"
 
 
 # ---------------------------------------------------------------------------
@@ -980,6 +1004,11 @@ class OpenAICompatClient:
         finish_reason: str | None = None
         usage: Usage | None = None
         provider_payload: dict[str, Any] | None = None
+        # Refusal prose arrives in its own delta slot (``delta.refusal``), not
+        # ``delta.content``. It is collected rather than yielded as text: it is
+        # not an answer, and forwarding it as prose would leave the transcript
+        # reading as if the model replied normally.
+        refusal_parts: list[str] = []
 
         async with self._http.stream(
             "POST",
@@ -1026,6 +1055,9 @@ class OpenAICompatClient:
                 text = delta.get("content")
                 if text:
                     yield StreamTextDelta(delta=text)
+                refusal = delta.get("refusal")
+                if refusal:
+                    refusal_parts.append(str(refusal))
                 for tool_delta in delta.get("tool_calls") or []:
                     index = int(tool_delta.get("index", 0))
                     function = tool_delta.get("function") or {}
@@ -1046,10 +1078,23 @@ class OpenAICompatClient:
                         "system_fingerprint": chunk.get("system_fingerprint"),
                     }
 
+        stop_reason = _FINISH_TO_STOP_REASON.get(finish_reason or "", finish_reason or "stop")
+        # A refusal delta with a non-filter finish (OpenAI sends
+        # ``finish_reason=stop`` for its own refusals; only third-party filters
+        # send ``content_filter``) is still a refusal: the prose slot is the
+        # authoritative signal that no answer was produced.
+        if refusal_parts and stop_reason == "stop":
+            stop_reason = "refusal"
+        error: str | None = None
+        if stop_reason == "refusal":
+            error = _refusal_error(
+                f"finish_reason={finish_reason or 'stop'}", "".join(refusal_parts)
+            )
         yield StreamEndEvent(
-            stop_reason=_FINISH_TO_STOP_REASON.get(finish_reason or "", finish_reason or "stop"),
+            stop_reason=stop_reason,
             usage=usage,
             provider_payload=provider_payload,
+            error=error,
         )
 
     async def _stream_responses(
@@ -1071,6 +1116,11 @@ class OpenAICompatClient:
         provider_payload: dict[str, Any] | None = None
         tool_call_count = 0
         terminal_stop: str | None = None
+        terminal_error: str | None = None
+        # Refusal prose streams in its own event type (``response.refusal.delta``)
+        # and is collected, not yielded as text: it is not an answer, and the
+        # transcript must not read as if the model replied normally.
+        refusal_parts: list[str] = []
         # Output item/call ids -> normalized tool-call index.
         call_indexes: dict[str, int] = {}
 
@@ -1116,6 +1166,10 @@ class OpenAICompatClient:
                     delta = payload.get("delta")
                     if delta:
                         yield StreamTextDelta(delta=delta)
+                elif event_type == "response.refusal.delta":
+                    delta = payload.get("delta")
+                    if delta:
+                        refusal_parts.append(str(delta))
                 elif event_type in ("response.completed", "response.incomplete"):
                     response_obj = payload.get("response") or {}
                     if response_obj.get("id"):
@@ -1135,7 +1189,18 @@ class OpenAICompatClient:
                         )
                         yield StreamUsageEvent(usage=usage)
                     if event_type == "response.completed":
-                        terminal_stop = "toolUse" if tool_call_count else "stop"
+                        if refusal_parts:
+                            # A completed response whose only output was a
+                            # refusal item: the wire says "completed", the
+                            # content says "no". The content wins — reporting
+                            # "stop" here is the silent-empty-turn bug.
+                            terminal_stop = "refusal"
+                            terminal_error = _refusal_error(
+                                "response.completed with a refusal item",
+                                "".join(refusal_parts),
+                            )
+                        else:
+                            terminal_stop = "toolUse" if tool_call_count else "stop"
                     else:
                         incomplete = response_obj.get("incomplete_details") or {}
                         reason = str(
@@ -1147,6 +1212,16 @@ class OpenAICompatClient:
                             # Length means the loop pairs placeholders and NEVER
                             # executes a partial function call.
                             terminal_stop = "length"
+                        elif reason == "content_filter":
+                            # A filtered response is a refusal, not a transport
+                            # fault: raising ProviderError here sent it into
+                            # failover's retry machinery for a request the
+                            # provider had already declined on content grounds.
+                            terminal_stop = "refusal"
+                            terminal_error = _refusal_error(
+                                "incomplete_details.reason=content_filter",
+                                "".join(refusal_parts),
+                            )
                         else:
                             raise ProviderError(
                                 400,
@@ -1166,6 +1241,7 @@ class OpenAICompatClient:
             stop_reason=terminal_stop,
             usage=usage,
             provider_payload=provider_payload,
+            error=terminal_error,
         )
 
 
@@ -1571,9 +1647,20 @@ class AnthropicClient:
             "max_tokens": "length",
             "tool_use": "toolUse",
             "stop_sequence": "stop",
+            # Anthropic's documented refusal terminal (classifier-stopped
+            # output). It passed through this map UNMAPPED, and downstream —
+            # which only branches on error/aborted/length — treated the unknown
+            # value as a clean stop: an empty turn with no explanation.
+            "refusal": "refusal",
         }.get(stop_reason, stop_reason)
+        error: str | None = None
+        if mapped == "refusal":
+            # Anthropic sends no refusal prose alongside this stop_reason; any
+            # text it did stream has already been forwarded, so the terminal
+            # line only needs to name the mechanism.
+            error = _refusal_error("stop_reason=refusal", "")
         yield StreamUsageEvent(usage=usage)
-        yield StreamEndEvent(stop_reason=mapped, usage=usage)
+        yield StreamEndEvent(stop_reason=mapped, usage=usage, error=error)
 
 
 # ---------------------------------------------------------------------------
@@ -1707,6 +1794,13 @@ class GoogleClient:
             headers["x-goog-api-key"] = api_key
         usage: Usage | None = None
         stop_reason = "stop"
+        # Gemini's non-STOP finish reasons (SAFETY, RECITATION,
+        # PROHIBITED_CONTENT, SPII, BLOCKLIST, IMAGE_SAFETY, OTHER…) are all
+        # refusals of one kind or another. They used to collapse into the
+        # "stop" fallback of the finishReason map below, which is the silent
+        # empty turn this field exists to prevent. The marker is kept verbatim
+        # so the visible line names WHICH classifier fired.
+        refusal_marker: str | None = None
         # Gemini returns one complete functionCall per part with no ids and
         # no part indexes, so the harness must mint both. They must be UNIQUE
         # per response: the loop dedups tool calls by id (first-wins), and a
@@ -1744,9 +1838,17 @@ class GoogleClient:
                             call_index += 1
                     if candidate.get("finishReason"):
                         reason = str(candidate["finishReason"])
-                        stop_reason = {"MAX_TOKENS": "length", "TOOL_USE": "toolUse"}.get(
-                            reason, "stop"
-                        )
+                        normal = {"STOP": "stop", "MAX_TOKENS": "length", "TOOL_USE": "toolUse"}
+                        stop_reason = normal.get(reason, "refusal")
+                        if stop_reason == "refusal":
+                            refusal_marker = f"finishReason={reason}"
+                # A prompt blocked outright never produces a candidate, only
+                # ``promptFeedback.blockReason`` — without this the stream ends
+                # on the "stop" default with nothing on screen.
+                feedback = chunk.get("promptFeedback")
+                if isinstance(feedback, Mapping) and feedback.get("blockReason"):
+                    stop_reason = "refusal"
+                    refusal_marker = f"promptFeedback.blockReason={feedback['blockReason']}"
                 raw_usage = chunk.get("usageMetadata")
                 if raw_usage:
                     usage = Usage(
@@ -1758,7 +1860,12 @@ class GoogleClient:
 
         if usage is not None:
             yield StreamUsageEvent(usage=usage)
-        yield StreamEndEvent(stop_reason=stop_reason, usage=usage)
+        error: str | None = None
+        if stop_reason == "refusal":
+            # Gemini sends no refusal prose; any text it did stream has been
+            # forwarded already, so the line names the classifier that fired.
+            error = _refusal_error(refusal_marker or "finishReason=OTHER", "")
+        yield StreamEndEvent(stop_reason=stop_reason, usage=usage, error=error)
 
 
 # ---------------------------------------------------------------------------
@@ -1771,7 +1878,10 @@ class MockClient:
 
     Emits two text deltas + usage + end; when the last user message contains
     ``[tool]`` it emits one tool call (``echo`` with ``{"text": "hi"}``) and
-    stops with ``toolUse`` instead.
+    stops with ``toolUse`` instead. ``[refuse]`` ends the stream as a refusal
+    with a canned provider message — the only way to exercise the whole
+    refusal path (loop → event → TUI notice → transcript replay) against a
+    real running app without needing a provider to actually decline.
     """
 
     async def stream(
@@ -1780,6 +1890,14 @@ class MockClient:
         api_key: str | None,
         oauth_access: "OAuthAccess | None" = None,
     ) -> AsyncIterator[StreamEvent]:
+        if any("[refuse]" in message.text for message in request.messages):
+            yield StreamUsageEvent(usage=Usage(input_tokens=10, output_tokens=0))
+            yield StreamEndEvent(
+                stop_reason="refusal",
+                usage=Usage(input_tokens=10, output_tokens=0),
+                error=_refusal_error("mock refusal", "I can't help with that request."),
+            )
+            return
         wants_tool = any("[tool]" in message.text for message in request.messages)
         if wants_tool:
             yield StreamToolCallDelta(index=0, id="call_mock_1", name="echo")

--- a/local_operator/providers/clients.py
+++ b/local_operator/providers/clients.py
@@ -1082,8 +1082,12 @@ class OpenAICompatClient:
         # A refusal delta with a non-filter finish (OpenAI sends
         # ``finish_reason=stop`` for its own refusals; only third-party filters
         # send ``content_filter``) is still a refusal: the prose slot is the
-        # authoritative signal that no answer was produced.
-        if refusal_parts and stop_reason == "stop":
+        # authoritative signal that no answer was produced. ``length`` counts
+        # too — refusal prose truncated by the token cap is a refusal whose
+        # message got cut, and ending the turn as a bare "length" dropped the
+        # collected prose entirely (review R1-3). ``toolUse`` is left alone: a
+        # turn that produced executable calls is actionable output.
+        if refusal_parts and stop_reason in ("stop", "length"):
             stop_reason = "refusal"
         error: str | None = None
         if stop_reason == "refusal":
@@ -1209,9 +1213,19 @@ class OpenAICompatClient:
                             else incomplete
                         )
                         if reason in ("max_output_tokens", "max_output_chars"):
-                            # Length means the loop pairs placeholders and NEVER
-                            # executes a partial function call.
-                            terminal_stop = "length"
+                            if refusal_parts:
+                                # Refusal prose truncated by the output cap is
+                                # still a refusal; a bare "length" terminal
+                                # dropped the collected prose (review R1-3).
+                                terminal_stop = "refusal"
+                                terminal_error = _refusal_error(
+                                    f"incomplete_details.reason={reason}",
+                                    "".join(refusal_parts),
+                                )
+                            else:
+                                # Length means the loop pairs placeholders and
+                                # NEVER executes a partial function call.
+                                terminal_stop = "length"
                         elif reason == "content_filter":
                             # A filtered response is a refusal, not a transport
                             # fault: raising ProviderError here sent it into
@@ -1794,13 +1808,20 @@ class GoogleClient:
             headers["x-goog-api-key"] = api_key
         usage: Usage | None = None
         stop_reason = "stop"
-        # Gemini's non-STOP finish reasons (SAFETY, RECITATION,
-        # PROHIBITED_CONTENT, SPII, BLOCKLIST, IMAGE_SAFETY, OTHER…) are all
-        # refusals of one kind or another. They used to collapse into the
-        # "stop" fallback of the finishReason map below, which is the silent
-        # empty turn this field exists to prevent. The marker is kept verbatim
-        # so the visible line names WHICH classifier fired.
+        # Gemini's abnormal finish reasons split into two families, and the
+        # split decides the diagnosis the user reads (review R1-2). Content
+        # classifiers (the allowlist below) are REFUSALS — "rephrase or switch
+        # models" is the right advice. Model/tooling defects
+        # (MALFORMED_FUNCTION_CALL, UNEXPECTED_TOOL_CALL…) are ERRORS — a plain
+        # retry usually works, and calling them refusals steers the user away
+        # from it. Both used to collapse into the "stop" fallback of the
+        # finishReason map below: the silent empty turn this field exists to
+        # prevent. The marker is kept verbatim either way so the visible line
+        # names WHICH terminal fired. Unknown reasons land on the error side:
+        # "the model refused" is a strong claim to make about a marker we have
+        # never seen, while an error line with the verbatim marker stays true.
         refusal_marker: str | None = None
+        defect_marker: str | None = None
         # Gemini returns one complete functionCall per part with no ids and
         # no part indexes, so the harness must mint both. They must be UNIQUE
         # per response: the loop dedups tool calls by id (first-wins), and a
@@ -1839,9 +1860,23 @@ class GoogleClient:
                     if candidate.get("finishReason"):
                         reason = str(candidate["finishReason"])
                         normal = {"STOP": "stop", "MAX_TOKENS": "length", "TOOL_USE": "toolUse"}
-                        stop_reason = normal.get(reason, "refusal")
-                        if stop_reason == "refusal":
+                        refusals = (
+                            "SAFETY",
+                            "RECITATION",
+                            "PROHIBITED_CONTENT",
+                            "SPII",
+                            "BLOCKLIST",
+                            "IMAGE_SAFETY",
+                            "OTHER",
+                        )
+                        if reason in normal:
+                            stop_reason = normal[reason]
+                        elif reason in refusals:
+                            stop_reason = "refusal"
                             refusal_marker = f"finishReason={reason}"
+                        else:
+                            stop_reason = "error"
+                            defect_marker = f"finishReason={reason}"
                 # A prompt blocked outright never produces a candidate, only
                 # ``promptFeedback.blockReason`` — without this the stream ends
                 # on the "stop" default with nothing on screen.
@@ -1865,6 +1900,8 @@ class GoogleClient:
             # Gemini sends no refusal prose; any text it did stream has been
             # forwarded already, so the line names the classifier that fired.
             error = _refusal_error(refusal_marker or "finishReason=OTHER", "")
+        elif stop_reason == "error":
+            error = f"model call failed ({defect_marker or 'unknown finishReason'})"
         yield StreamEndEvent(stop_reason=stop_reason, usage=usage, error=error)
 
 

--- a/local_operator/providers/clients.py
+++ b/local_operator/providers/clients.py
@@ -1017,6 +1017,7 @@ class OpenAICompatClient:
         # not an answer, and forwarding it as prose would leave the transcript
         # reading as if the model replied normally.
         refusal_parts: list[str] = []
+        streamed_text = False
 
         async with self._http.stream(
             "POST",
@@ -1062,6 +1063,7 @@ class OpenAICompatClient:
                 delta = choice.get("delta") or {}
                 text = delta.get("content")
                 if text:
+                    streamed_text = True
                     yield StreamTextDelta(delta=text)
                 refusal = delta.get("refusal")
                 if refusal:
@@ -1106,7 +1108,11 @@ class OpenAICompatClient:
             marker = f"finish_reason={finish_reason or 'stop'}"
             if finish_reason != "content_filter":
                 marker = f"delta.refusal, {marker}"
-            error = _refusal_error(marker, "".join(refusal_parts))
+            # ``streamed_text`` matters on the content_filter path, where a
+            # third-party filter commonly terminates AFTER answer chunks have
+            # rendered and there is no refusal prose: "sent no message" under a
+            # partial reply is the D1 contradiction again (review R3-1).
+            error = _refusal_error(marker, "".join(refusal_parts), streamed_text=streamed_text)
         yield StreamEndEvent(
             stop_reason=stop_reason,
             usage=usage,
@@ -1138,6 +1144,7 @@ class OpenAICompatClient:
         # and is collected, not yielded as text: it is not an answer, and the
         # transcript must not read as if the model replied normally.
         refusal_parts: list[str] = []
+        streamed_text = False
         # Output item/call ids -> normalized tool-call index.
         call_indexes: dict[str, int] = {}
 
@@ -1182,6 +1189,7 @@ class OpenAICompatClient:
                 elif event_type == "response.output_text.delta":
                     delta = payload.get("delta")
                     if delta:
+                        streamed_text = True
                         yield StreamTextDelta(delta=delta)
                 elif event_type == "response.refusal.delta":
                     delta = payload.get("delta")
@@ -1248,9 +1256,14 @@ class OpenAICompatClient:
                             # failover's retry machinery for a request the
                             # provider had already declined on content grounds.
                             terminal_stop = "refusal"
+                            # ``streamed_text`` for the same reason as the
+                            # chat-completions filter terminal: a filter that
+                            # cut a partially-rendered answer must not claim
+                            # "sent no message" under it (review R3-1).
                             terminal_error = _refusal_error(
                                 "incomplete_details.reason=content_filter",
                                 "".join(refusal_parts),
+                                streamed_text=streamed_text,
                             )
                         else:
                             raise ProviderError(

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -1770,14 +1770,27 @@ class OperatorApp(App[None]):
                 for call in tool_calls:
                     self._replay_tool_call(call, results)
                     appended = True
-                if not text and not tool_calls:
+                stop = getattr(message, "stop_reason", None)
+                if stop == "refusal":
+                    # A refused turn replays its refusal even when the model DID
+                    # stream some prose first (Gemini safety stops often cut a
+                    # partial answer): the prose alone reads as a complete,
+                    # oddly short reply, and the user re-reading the session
+                    # needs to know the provider cut it off and why. The message
+                    # itself was stashed on the assistant message by the loop
+                    # precisely so this replay could show it.
+                    payload = getattr(message, "provider_payload", None) or {}
+                    refusal = str(payload.get("refusal") or "") or "model refused the request"
+                    self._append_block(NoticeBlock(refusal, "error"))
+                    appended = True
+                elif not text and not tool_calls:
                     # An assistant message with neither prose nor a call is a
                     # turn that FAILED. Skipping it is what left a resumed
                     # session showing a prompt and nothing after it, with no
                     # hint that the answer had errored rather than never been
                     # asked for.
-                    if getattr(message, "stop_reason", None) in ("error", "aborted"):
-                        reason = "turn failed" if message.stop_reason == "error" else "interrupted"
+                    if stop in ("error", "aborted"):
+                        reason = "turn failed" if stop == "error" else "interrupted"
                         self._append_block(NoticeBlock(reason, "error"))
                         appended = True
         if appended:

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -1780,7 +1780,12 @@ class OperatorApp(App[None]):
                     # itself was stashed on the assistant message by the loop
                     # precisely so this replay could show it.
                     payload = getattr(message, "provider_payload", None) or {}
-                    refusal = str(payload.get("refusal") or "") or "model refused the request"
+                    # The fallback keeps the marker grammar (D3): every other
+                    # refusal line ends in a parenthetical, and a user who has
+                    # learned that shape would read its absence as meaningful.
+                    refusal = str(payload.get("refusal") or "") or (
+                        "model refused the request (no details recorded)"
+                    )
                     self._append_block(NoticeBlock(refusal, "error"))
                     appended = True
                 elif not text and not tool_calls:

--- a/tests/unit/harness/test_loop.py
+++ b/tests/unit/harness/test_loop.py
@@ -1820,3 +1820,108 @@ def test_the_flush_suppression_counts_rather_than_matching():
     assert _consume_claim(claimed, "dup") is False
     # An id nobody claimed is never suppressed.
     assert _consume_claim(Counter(), "other") is False
+
+
+# ---------------------------------------------------------------------------
+# Refusal terminal: the model said no, and the run must end saying WHY
+# ---------------------------------------------------------------------------
+
+
+class TestRefusalEndsTheRunVisibly:
+    """``stop_reason="refusal"`` used to fall through to the clean-stop path:
+    the loop treated it as a finished answer and the frame showed an empty
+    turn. It must end the run the way an error does — dangling calls paired,
+    no further model calls — while carrying the provider's refusal message
+    on the ``agent_end`` so a UI can show it.
+    """
+
+    @pytest.mark.asyncio
+    async def test_refusal_ends_the_run_with_the_providers_message(self) -> None:
+        stream = ScriptedStream(
+            [
+                [
+                    StreamEndEvent(
+                        stop_reason="refusal",
+                        error="model refused: I can't help with that. [finish_reason=stop]",
+                    )
+                ],
+                # A second scripted turn that must NEVER run: a refusal is
+                # terminal, and reaching this script means the loop fed the
+                # refusal back for another call.
+                [StreamTextDelta(delta="unreachable"), StreamEndEvent(stop_reason="stop")],
+            ]
+        )
+        context = LoopContext()
+        loop = AgentLoop()
+
+        events = []
+        async for event in loop.run([Message.user("go")], context, make_config(stream), None):
+            events.append(event)
+
+        assert len(stream.requests) == 1
+        end = events[-1]
+        assert isinstance(end, AgentEndEvent)
+        assert end.aborted is False
+        assert end.error is not None and "I can't help with that." in end.error
+
+    @pytest.mark.asyncio
+    async def test_refusal_pairs_dangling_calls_without_executing(self) -> None:
+        """A stream can be cut by a filter mid-tool-call; the composed call must
+        be paired (the wire stays legal) and must not execute."""
+        executed: list[str] = []
+        stream = ScriptedStream(
+            [
+                [
+                    tool_call_delta(0, id="c1", name="echo", args='{"text":"a"}'),
+                    StreamEndEvent(stop_reason="refusal", error="model refused [marker]"),
+                ]
+            ]
+        )
+        context = LoopContext(tools=[echo_tool(executed)])
+        loop = AgentLoop()
+
+        events = []
+        async for event in loop.run([Message.user("go")], context, make_config(stream), None):
+            events.append(event)
+
+        assert executed == []
+        tool_messages = [m for m in context.messages if isinstance(m, Message) and m.role == "tool"]
+        assert [m.tool_call_id for m in tool_messages] == ["c1"]
+        assert all(m.is_error for m in tool_messages)
+
+    @pytest.mark.asyncio
+    async def test_refusal_message_survives_onto_the_assistant_message(self) -> None:
+        """The agent_end dies with the run; a resumed session replays the
+        transcript's messages, so the refusal text must be stored on the
+        assistant message it explains (under ``provider_payload``, the
+        established home for harness bookkeeping that wire clients never
+        replay)."""
+        stream = ScriptedStream(
+            [[StreamEndEvent(stop_reason="refusal", error="model refused: no. [m]")]]
+        )
+        context = LoopContext()
+        loop = AgentLoop()
+        async for _ in loop.run([Message.user("go")], context, make_config(stream), None):
+            pass
+
+        assistant = next(
+            m for m in context.messages if isinstance(m, Message) and m.role == "assistant"
+        )
+        assert assistant.stop_reason == "refusal"
+        assert (assistant.provider_payload or {}).get("refusal") == "model refused: no. [m]"
+
+    @pytest.mark.asyncio
+    async def test_a_bare_refusal_end_still_says_something(self) -> None:
+        """A wire client that emits ``refusal`` with no message must not
+        reintroduce the silent failure this stop_reason exists to fix."""
+        stream = ScriptedStream([[StreamEndEvent(stop_reason="refusal")]])
+        context = LoopContext()
+        loop = AgentLoop()
+
+        events = []
+        async for event in loop.run([Message.user("go")], context, make_config(stream), None):
+            events.append(event)
+
+        end = events[-1]
+        assert isinstance(end, AgentEndEvent)
+        assert end.error is not None and "refused" in end.error

--- a/tests/unit/providers/test_clients.py
+++ b/tests/unit/providers/test_clients.py
@@ -2093,3 +2093,141 @@ class TestRefusalsAreSurfacedNotSwallowed:
         assert isinstance(end, StreamEndEvent)
         assert end.stop_reason == "refusal"
         assert end.error is not None and "can't help" in end.error
+
+    async def test_chat_completions_refusal_truncated_by_length_still_surfaces(self) -> None:
+        """Refusal prose cut by the token cap ended as a bare ``length`` with
+        the collected prose dropped — the swallowed-refusal shape again
+        (review R1-3)."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                content=_sse(
+                    [
+                        {"choices": [{"delta": {"refusal": "I can't hel"}}]},
+                        {"choices": [{"delta": {}, "finish_reason": "length"}]},
+                    ]
+                ),
+                headers={"content-type": "text/event-stream"},
+            )
+
+        client = OpenAICompatClient(
+            "https://api.test.example/v1",
+            http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+        )
+        events = await _collect(
+            client.stream(ChatRequest(model=_spec(), messages=[Message.user("hi")]), "sk-test")
+        )
+        end = self._end(events)
+        assert end.stop_reason == "refusal"
+        assert end.error is not None and "I can't hel" in end.error
+
+    async def test_responses_refusal_truncated_by_output_cap_still_surfaces(self) -> None:
+        """Same gap on the Responses wire: ``response.incomplete`` with
+        ``reason=max_output_tokens`` after refusal deltas (review R1-3)."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                content=_sse(
+                    [
+                        {"type": "response.refusal.delta", "delta": "I won't"},
+                        {
+                            "type": "response.incomplete",
+                            "response": {
+                                "id": "resp_3",
+                                "incomplete_details": {"reason": "max_output_tokens"},
+                                "usage": {"input_tokens": 5, "output_tokens": 2},
+                            },
+                        },
+                    ]
+                ),
+                headers={"content-type": "text/event-stream"},
+            )
+
+        client = OpenAICompatClient(
+            "https://api.openai.com/v1",
+            http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+            openai_api="responses",
+        )
+        events = await _collect(
+            client.stream(
+                ChatRequest(
+                    model=_spec("openai", "gpt-5.4").model_copy(
+                        update={"supports_responses_api": True}
+                    ),
+                    messages=[Message.user("hi")],
+                ),
+                "sk-test",
+            )
+        )
+        end = self._end(events)
+        assert end.stop_reason == "refusal"
+        assert end.error is not None and "I won't" in end.error
+
+    async def test_responses_plain_length_is_still_length(self) -> None:
+        """The R1-3 fix must not reclassify an ordinary truncation: no refusal
+        deltas means ``max_output_tokens`` stays ``length``."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                content=_sse(
+                    [
+                        {"type": "response.output_text.delta", "delta": "partial answ"},
+                        {
+                            "type": "response.incomplete",
+                            "response": {
+                                "id": "resp_4",
+                                "incomplete_details": {"reason": "max_output_tokens"},
+                                "usage": {"input_tokens": 5, "output_tokens": 2},
+                            },
+                        },
+                    ]
+                ),
+                headers={"content-type": "text/event-stream"},
+            )
+
+        client = OpenAICompatClient(
+            "https://api.openai.com/v1",
+            http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+            openai_api="responses",
+        )
+        events = await _collect(
+            client.stream(
+                ChatRequest(
+                    model=_spec("openai", "gpt-5.4").model_copy(
+                        update={"supports_responses_api": True}
+                    ),
+                    messages=[Message.user("hi")],
+                ),
+                "sk-test",
+            )
+        )
+        end = self._end(events)
+        assert end.stop_reason == "length"
+        assert end.error is None
+
+    @pytest.mark.parametrize("reason", ["MALFORMED_FUNCTION_CALL", "UNEXPECTED_TOOL_CALL"])
+    async def test_google_model_defects_are_errors_not_refusals(self, reason: str) -> None:
+        """Gemini's tooling-defect finishes are not content refusals: calling
+        them refusals steers the user to rephrase/switch when a plain retry
+        usually works (review R1-2). They end as ``error`` naming the marker."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                content=_sse([{"candidates": [{"finishReason": reason}]}]),
+                headers={"content-type": "text/event-stream"},
+            )
+
+        client = GoogleClient(http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler)))
+        events = await _collect(
+            client.stream(
+                ChatRequest(model=_spec("google", "gemini-2.5-pro"), messages=[Message.user("hi")]),
+                "g-key",
+            )
+        )
+        end = self._end(events)
+        assert end.stop_reason == "error"
+        assert end.error is not None and reason in end.error and "refused" not in end.error

--- a/tests/unit/providers/test_clients.py
+++ b/tests/unit/providers/test_clients.py
@@ -2316,3 +2316,80 @@ class TestRefusalsAreSurfacedNotSwallowed:
         )
         end = self._end(events)
         assert end.error is not None and "delta.refusal" in end.error
+
+    async def test_chat_content_filter_after_prose_says_cut_short(self) -> None:
+        """Review R3-1: a third-party filter (Azure-style) commonly terminates
+        with ``content_filter`` AFTER answer chunks rendered and sends no
+        refusal prose — 'sent no message' under that partial reply is the D1
+        contradiction on this wire."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                content=_sse(
+                    [
+                        {"choices": [{"delta": {"content": "The document says"}}]},
+                        {"choices": [{"delta": {}, "finish_reason": "content_filter"}]},
+                    ]
+                ),
+                headers={"content-type": "text/event-stream"},
+            )
+
+        client = OpenAICompatClient(
+            "https://api.test.example/v1",
+            http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+        )
+        events = await _collect(
+            client.stream(ChatRequest(model=_spec(), messages=[Message.user("hi")]), "sk-test")
+        )
+        end = self._end(events)
+        assert end.stop_reason == "refusal"
+        assert end.error is not None
+        assert "cut the reply short" in end.error
+        assert "sent no message" not in end.error
+
+    async def test_responses_content_filter_after_prose_says_cut_short(self) -> None:
+        """Same R3-1 state on the Responses wire: output text streamed, then
+        ``response.incomplete`` with ``reason=content_filter`` and no refusal
+        deltas."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                content=_sse(
+                    [
+                        {"type": "response.output_text.delta", "delta": "The document says"},
+                        {
+                            "type": "response.incomplete",
+                            "response": {
+                                "id": "resp_5",
+                                "incomplete_details": {"reason": "content_filter"},
+                                "usage": {"input_tokens": 5, "output_tokens": 3},
+                            },
+                        },
+                    ]
+                ),
+                headers={"content-type": "text/event-stream"},
+            )
+
+        client = OpenAICompatClient(
+            "https://api.openai.com/v1",
+            http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+            openai_api="responses",
+        )
+        events = await _collect(
+            client.stream(
+                ChatRequest(
+                    model=_spec("openai", "gpt-5.4").model_copy(
+                        update={"supports_responses_api": True}
+                    ),
+                    messages=[Message.user("hi")],
+                ),
+                "sk-test",
+            )
+        )
+        end = self._end(events)
+        assert end.stop_reason == "refusal"
+        assert end.error is not None
+        assert "cut the reply short" in end.error
+        assert "sent no message" not in end.error

--- a/tests/unit/providers/test_clients.py
+++ b/tests/unit/providers/test_clients.py
@@ -2231,3 +2231,88 @@ class TestRefusalsAreSurfacedNotSwallowed:
         end = self._end(events)
         assert end.stop_reason == "error"
         assert end.error is not None and reason in end.error and "refused" not in end.error
+
+    async def test_anthropic_refusal_after_partial_prose_says_cut_short(self) -> None:
+        """Design review D1: 'sent no message' directly under a partially
+        rendered answer asserts the opposite of what is on screen. When text
+        streamed before the refusal terminal, the line says the reply was cut."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            body = _sse(
+                [
+                    {"type": "message_start", "message": {"usage": {"input_tokens": 7}}},
+                    {
+                        "type": "content_block_delta",
+                        "index": 0,
+                        "delta": {"type": "text_delta", "text": "Here is the beginning of"},
+                    },
+                    {"type": "message_delta", "delta": {"stop_reason": "refusal"}, "usage": {}},
+                ]
+            )
+            return httpx.Response(200, content=body, headers={"content-type": "text/event-stream"})
+
+        client = AnthropicClient(
+            http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        )
+        events = await _collect(
+            client.stream(
+                ChatRequest(model=_spec("anthropic", "claude-x"), messages=[Message.user("hi")]),
+                "sk-ant",
+            )
+        )
+        end = self._end(events)
+        assert end.stop_reason == "refusal"
+        assert end.error is not None
+        assert "cut the reply short" in end.error
+        assert "sent no message" not in end.error
+
+    async def test_google_refusal_after_partial_prose_says_cut_short(self) -> None:
+        """Same D1 state on the Gemini wire, where safety stops commonly cut a
+        partial answer."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                content=_sse(
+                    [
+                        {"candidates": [{"content": {"parts": [{"text": "Starting to answ"}]}}]},
+                        {"candidates": [{"finishReason": "SAFETY"}]},
+                    ]
+                ),
+                headers={"content-type": "text/event-stream"},
+            )
+
+        client = GoogleClient(http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler)))
+        events = await _collect(
+            client.stream(
+                ChatRequest(model=_spec("google", "gemini-2.5-pro"), messages=[Message.user("hi")]),
+                "g-key",
+            )
+        )
+        end = self._end(events)
+        assert end.stop_reason == "refusal"
+        assert end.error is not None and "cut the reply short" in end.error
+
+    async def test_prose_slot_refusal_names_the_slot_not_just_the_finish(self) -> None:
+        """Design review D2: '(finish_reason=stop)' beside the word 'refused'
+        names a mechanism that did not fire. When the prose slot detected the
+        refusal, the marker names the slot."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                content=_sse(
+                    [{"choices": [{"delta": {"refusal": "No."}, "finish_reason": "stop"}]}]
+                ),
+                headers={"content-type": "text/event-stream"},
+            )
+
+        client = OpenAICompatClient(
+            "https://api.test.example/v1",
+            http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+        )
+        events = await _collect(
+            client.stream(ChatRequest(model=_spec(), messages=[Message.user("hi")]), "sk-test")
+        )
+        end = self._end(events)
+        assert end.error is not None and "delta.refusal" in end.error

--- a/tests/unit/providers/test_clients.py
+++ b/tests/unit/providers/test_clients.py
@@ -1811,3 +1811,285 @@ def test_non_object_raw_arguments_fall_back_to_parsed_arguments() -> None:
         "arguments"
     ]
     assert json.loads(arguments) == {"a": 1}
+
+
+# ---------------------------------------------------------------------------
+# Refusal surfacing: the provider said no, and the user must see its words
+# ---------------------------------------------------------------------------
+
+
+class TestRefusalsAreSurfacedNotSwallowed:
+    """A provider refusal used to end the turn as a clean ``stop``: nothing on
+    screen, no explanation, indistinguishable from a no-op. Every wire's
+    refusal marker must map to ``stop_reason="refusal"`` with the provider's
+    own message (or a line naming the marker, when the wire sends no prose)
+    in ``StreamEndEvent.error`` — that message is what lets the user decide
+    between rephrasing and switching models.
+    """
+
+    @staticmethod
+    def _end(events: list[Any]) -> StreamEndEvent:
+        end = events[-1]
+        assert isinstance(end, StreamEndEvent)
+        return end
+
+    async def test_chat_completions_content_filter_is_a_refusal(self) -> None:
+        """``finish_reason=content_filter`` (Azure/OpenRouter-style filters)."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                content=_sse([{"choices": [{"delta": {}, "finish_reason": "content_filter"}]}]),
+                headers={"content-type": "text/event-stream"},
+            )
+
+        client = OpenAICompatClient(
+            "https://api.test.example/v1",
+            http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+        )
+        events = await _collect(
+            client.stream(ChatRequest(model=_spec(), messages=[Message.user("hi")]), "sk-test")
+        )
+        end = self._end(events)
+        assert end.stop_reason == "refusal"
+        assert end.error is not None and "content_filter" in end.error
+
+    async def test_chat_completions_refusal_delta_carries_the_providers_words(self) -> None:
+        """OpenAI streams refusal prose in ``delta.refusal`` with
+        ``finish_reason=stop`` — the prose slot, not the finish reason, is the
+        signal, and its text must reach the frame verbatim."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                content=_sse(
+                    [
+                        {"choices": [{"delta": {"refusal": "I can't help "}}]},
+                        {
+                            "choices": [
+                                {"delta": {"refusal": "with that."}, "finish_reason": "stop"}
+                            ]
+                        },
+                    ]
+                ),
+                headers={"content-type": "text/event-stream"},
+            )
+
+        client = OpenAICompatClient(
+            "https://api.test.example/v1",
+            http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+        )
+        events = await _collect(
+            client.stream(ChatRequest(model=_spec(), messages=[Message.user("hi")]), "sk-test")
+        )
+        # Refusal prose is not an answer: it must not have streamed as text.
+        assert not [e for e in events if isinstance(e, StreamTextDelta)]
+        end = self._end(events)
+        assert end.stop_reason == "refusal"
+        assert end.error is not None and "I can't help with that." in end.error
+
+    async def test_responses_content_filter_is_a_refusal_not_a_provider_error(self) -> None:
+        """``response.incomplete`` with ``reason=content_filter`` used to raise
+        ProviderError, sending a content decline into transport-retry
+        machinery. It is a refusal: terminal, visible, not retried."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                content=_sse(
+                    [
+                        {
+                            "type": "response.incomplete",
+                            "response": {
+                                "id": "resp_1",
+                                "incomplete_details": {"reason": "content_filter"},
+                                "usage": {"input_tokens": 5, "output_tokens": 0},
+                            },
+                        }
+                    ]
+                ),
+                headers={"content-type": "text/event-stream"},
+            )
+
+        client = OpenAICompatClient(
+            "https://api.openai.com/v1",
+            http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+            openai_api="responses",
+        )
+        events = await _collect(
+            client.stream(
+                ChatRequest(
+                    model=_spec("openai", "gpt-5.4").model_copy(
+                        update={"supports_responses_api": True}
+                    ),
+                    messages=[Message.user("hi")],
+                ),
+                "sk-test",
+            )
+        )
+        end = self._end(events)
+        assert end.stop_reason == "refusal"
+        assert end.error is not None and "content_filter" in end.error
+
+    async def test_responses_refusal_item_beats_the_completed_terminal(self) -> None:
+        """A ``response.completed`` whose only output was a refusal item says
+        "completed" on the wire and "no" in the content; the content wins."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                content=_sse(
+                    [
+                        {"type": "response.refusal.delta", "delta": "I won't do that."},
+                        {
+                            "type": "response.completed",
+                            "response": {
+                                "id": "resp_2",
+                                "usage": {"input_tokens": 5, "output_tokens": 3},
+                            },
+                        },
+                    ]
+                ),
+                headers={"content-type": "text/event-stream"},
+            )
+
+        client = OpenAICompatClient(
+            "https://api.openai.com/v1",
+            http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+            openai_api="responses",
+        )
+        events = await _collect(
+            client.stream(
+                ChatRequest(
+                    model=_spec("openai", "gpt-5.4").model_copy(
+                        update={"supports_responses_api": True}
+                    ),
+                    messages=[Message.user("hi")],
+                ),
+                "sk-test",
+            )
+        )
+        assert not [e for e in events if isinstance(e, StreamTextDelta)]
+        end = self._end(events)
+        assert end.stop_reason == "refusal"
+        assert end.error is not None and "I won't do that." in end.error
+
+    async def test_anthropic_refusal_stop_reason_is_mapped_and_named(self) -> None:
+        """Anthropic's documented ``stop_reason: refusal`` passed through the
+        terminal map unmapped, and downstream read the unknown value as a
+        clean stop."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            body = _sse(
+                [
+                    {
+                        "type": "message_start",
+                        "message": {"usage": {"input_tokens": 7}},
+                    },
+                    {"type": "message_delta", "delta": {"stop_reason": "refusal"}, "usage": {}},
+                ]
+            )
+            return httpx.Response(200, content=body, headers={"content-type": "text/event-stream"})
+
+        client = AnthropicClient(
+            http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        )
+        events = await _collect(
+            client.stream(
+                ChatRequest(model=_spec("anthropic", "claude-x"), messages=[Message.user("hi")]),
+                "sk-ant",
+            )
+        )
+        end = self._end(events)
+        assert end.stop_reason == "refusal"
+        assert end.error is not None and "stop_reason=refusal" in end.error
+
+    @pytest.mark.parametrize("reason", ["SAFETY", "RECITATION", "PROHIBITED_CONTENT", "OTHER"])
+    async def test_google_safety_finishes_are_refusals(self, reason: str) -> None:
+        """Every non-STOP/MAX_TOKENS/TOOL_USE Gemini finishReason is a refusal,
+        and the visible line names WHICH classifier fired."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                content=_sse([{"candidates": [{"finishReason": reason}]}]),
+                headers={"content-type": "text/event-stream"},
+            )
+
+        client = GoogleClient(http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler)))
+        events = await _collect(
+            client.stream(
+                ChatRequest(model=_spec("google", "gemini-2.5-pro"), messages=[Message.user("hi")]),
+                "g-key",
+            )
+        )
+        end = self._end(events)
+        assert end.stop_reason == "refusal"
+        assert end.error is not None and reason in end.error
+
+    async def test_google_blocked_prompt_is_a_refusal(self) -> None:
+        """A blocked prompt yields NO candidates, only promptFeedback — the
+        exact shape that used to end as the silent ``stop`` default."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                content=_sse([{"promptFeedback": {"blockReason": "SAFETY"}}]),
+                headers={"content-type": "text/event-stream"},
+            )
+
+        client = GoogleClient(http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler)))
+        events = await _collect(
+            client.stream(
+                ChatRequest(model=_spec("google", "gemini-2.5-pro"), messages=[Message.user("hi")]),
+                "g-key",
+            )
+        )
+        end = self._end(events)
+        assert end.stop_reason == "refusal"
+        assert end.error is not None and "blockReason=SAFETY" in end.error
+
+    async def test_google_normal_finishes_are_untouched(self) -> None:
+        """The refusal mapping must not reclassify the three normal finishes."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                content=_sse(
+                    [
+                        {
+                            "candidates": [
+                                {"content": {"parts": [{"text": "hi"}]}, "finishReason": "STOP"}
+                            ]
+                        }
+                    ]
+                ),
+                headers={"content-type": "text/event-stream"},
+            )
+
+        client = GoogleClient(http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler)))
+        events = await _collect(
+            client.stream(
+                ChatRequest(model=_spec("google", "gemini-2.5-pro"), messages=[Message.user("hi")]),
+                "g-key",
+            )
+        )
+        end = self._end(events)
+        assert end.stop_reason == "stop"
+        assert end.error is None
+
+    async def test_mock_refuse_trigger_emits_the_full_shape(self) -> None:
+        """``[refuse]`` exists so the whole path can be exercised against a
+        real running app; it must produce the same event shape a real wire
+        does."""
+        client = MockClient()
+        events = await _collect(
+            client.stream(
+                ChatRequest(model=_spec("test", "m"), messages=[Message.user("[refuse] hi")]),
+                None,
+            )
+        )
+        end = events[-1]
+        assert isinstance(end, StreamEndEvent)
+        assert end.stop_reason == "refusal"
+        assert end.error is not None and "can't help" in end.error

--- a/tests/unit/test_exec_mode.py
+++ b/tests/unit/test_exec_mode.py
@@ -440,6 +440,29 @@ def test_a_notice_cannot_smuggle_control_sequences_to_the_terminal() -> None:
     assert out.startswith("✗ Tool not found: ")
 
 
+def test_a_refusal_with_markup_shaped_prose_still_prints_and_fails(fake_factory, capsys) -> None:
+    """Review R1-1. ``agent_end.error`` now carries MODEL-AUTHORED prose (a
+    provider's refusal message), and rendering it as rich markup meant prose
+    like ``[/see our policy]`` raised MarkupError inside the subscriber —
+    BEFORE the outcome tracker ran, so exec printed a traceback instead of the
+    error line and exited 0: the silent-refusal bug resurfacing on adversarial
+    text. The text is data, never markup.
+    """
+    refusal = "model refused: I can't comply [/see our policy] with that. (finish_reason=stop)"
+    reply = Message(role="assistant", stop_reason="refusal")
+    script: list[AgentEvent] = [
+        AgentStartEvent(),
+        MessageStartEvent(message=reply),
+        MessageEndEvent(message=reply),
+        AgentEndEvent(messages=[reply], error=refusal),
+    ]
+    fake_factory(FakeSession([script]))
+    code = exec_mode.run_exec("refused task", ExecArgs())
+    captured = capsys.readouterr()
+    assert code == 1
+    assert "[/see our policy]" in captured.err
+
+
 def test_a_notice_cannot_forge_a_row_or_crash_the_renderer() -> None:
     """Design round 4, D14/D15. The tool name in a notice is model-chosen.
 

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -3926,6 +3926,58 @@ class TestResumeReplaysTheWholeConversation:
         assert counts["user"] == 2 and counts["notice"] == 1
 
     @pytest.mark.asyncio
+    async def test_a_refused_turn_replays_the_providers_refusal(self) -> None:
+        """A refusal is not a generic "turn failed": the loop stashes the
+        provider's own words on the assistant message so a resumed session can
+        show WHAT was refused — the half of the diagnosis that decides between
+        rephrasing and switching models."""
+        from local_operator.harness.types import Message
+        from local_operator.tui.widgets.transcript import NoticeBlock
+
+        session = _resumed(
+            Message.user("do the thing"),
+            Message(
+                role="assistant",
+                stop_reason="refusal",
+                provider_payload={"refusal": "model refused: I can't help with that. [marker]"},
+            ),
+        )
+        app = OperatorApp(lambda: _factory(session))
+        async with app.run_test(size=(100, 30)) as pilot:
+            assert await _settle(pilot, lambda: _blocks_by_type(app)["notice"] == 1)
+            notice = next(
+                b for b in app.query_one(TranscriptView).blocks() if isinstance(b, NoticeBlock)
+            )
+        assert "I can't help with that." in notice._text
+
+    @pytest.mark.asyncio
+    async def test_a_refused_turn_with_partial_prose_still_shows_the_refusal(self) -> None:
+        """Gemini safety stops often cut a partial answer: the prose alone
+        reads as a complete, oddly short reply, so the refusal notice must
+        appear even when text was streamed."""
+        from local_operator.harness.types import Message
+        from local_operator.harness.types import TextContent as _Text
+
+        session = _resumed(
+            Message.user("do the thing"),
+            Message(
+                role="assistant",
+                content=[_Text(text="Here is the beginning of")],
+                stop_reason="refusal",
+                provider_payload={"refusal": "model refused and sent no message [SAFETY]"},
+            ),
+        )
+        app = OperatorApp(lambda: _factory(session))
+        async with app.run_test(size=(100, 30)) as pilot:
+            assert await _settle(
+                pilot,
+                lambda: _blocks_by_type(app)["notice"] == 1
+                and _blocks_by_type(app)["assistant"] == 1,
+            )
+            counts = _blocks_by_type(app)
+        assert counts["assistant"] == 1 and counts["notice"] == 1
+
+    @pytest.mark.asyncio
     async def test_a_fresh_session_still_replays_nothing(self) -> None:
         """The splash must not be retired by an empty history."""
         app = OperatorApp(lambda: _factory(_resumed()))


### PR DESCRIPTION
# PR Description

## Change classification

**C2 — standard / pre-authorized.** Behavioural fix in the provider wire clients, harness loop, headless renderer, and TUI: model refusals become a first-class terminal (`stop_reason="refusal"`) carrying the provider's own message, instead of collapsing into a clean `stop` that rendered as a silent empty turn. No API/schema contract broken for external callers: `stop_reason` was already a free-form `str` everywhere it flows. Clean rollback via `git revert`.

## The gap

When a provider refuses a request — a content filter, a safety classifier, an explicit refusal — the turn ended looking like this: the prompt, then *nothing*. Every wire client mapped its refusal marker onto `"stop"` (or let it fall through a terminal map unmapped, which downstream read as a clean stop). The user could not tell a refusal from a no-op, and had no way to see the refusal message and decide whether to rephrase or switch models.

Per provider, the swallowed markers were:

- **OpenAI chat completions**: `finish_reason=content_filter` mapped to `"stop"` explicitly; `delta.refusal` prose (which OpenAI sends with `finish_reason=stop`) was dropped entirely.
- **OpenAI Responses**: `response.refusal.delta` events were ignored; `incomplete_details.reason=content_filter` raised a `ProviderError`, sending a content decline into transport-retry/failover machinery.
- **Anthropic**: the documented `stop_reason: "refusal"` terminal passed through the map unmapped and read downstream as a clean stop.
- **Google**: safety-classifier `finishReason`s (`SAFETY`, `RECITATION`, `PROHIBITED_CONTENT`, `SPII`, `BLOCKLIST`, `IMAGE_SAFETY`, `OTHER`) collapsed into the `"stop"` fallback, and a prompt blocked outright (`promptFeedback.blockReason`, no candidates at all) ended on the `"stop"` default.

## The fix

- **Wire clients** normalize every refusal marker to `stop_reason="refusal"` and compose the one visible line in `StreamEndEvent.error`: the provider's own refusal prose where the wire sends it, and a line naming the wire marker where it does not. The line describes the frame it renders under: `model refused: <prose> (<marker>)` with prose, `model refused and cut the reply short (<marker>)` when answer text streamed before the refusal terminal (common for Anthropic/Gemini safety stops and Azure-style filters), and `model refused and sent no message (<marker>)` only when nothing streamed. When the prose slot was the detection signal the marker names it (`delta.refusal, finish_reason=stop`). Refusal prose truncated by the output cap still surfaces (both OpenAI wires). Gemini refusal detection is an allowlist of content classifiers; tooling defects (`MALFORMED_FUNCTION_CALL`, `UNEXPECTED_TOOL_CALL`) and unknown reasons end as `error` naming the marker, since "the model refused" would steer the user away from the plain retry that usually works.
- **Harness loop**: `"refusal"` ends the run through the same branch as `"error"` — dangling tool calls paired so the wire stays legal, no further model calls — with the message on `agent_end.error`, plus a backstop message for a bare `refusal` end. The refusal text is also stashed on the assistant message's `provider_payload` (the established home for harness bookkeeping that wire clients never replay) so it survives into the transcript.
- **Headless renderer**: `agent_end.error` prints with `markup=False` — the field now carries model-authored prose, and markup-shaped text like `[/see our policy]` used to raise `MarkupError` before the outcome tracker ran (traceback instead of the error line, exit 0).
- **TUI**: the live path already renders `agent_end.error` as an error notice, so it lights up for free. The replay path gains a `refusal` branch: a resumed session shows the provider's actual words (fallback `model refused the request (no details recorded)`), including when partial prose streamed before a safety stop.
- **MockClient** gains a `[refuse]` trigger emitting the full refusal shape, so the whole path (client → loop → event → TUI notice → transcript replay) can be exercised against a real running app without needing a provider to actually decline.

## Testing evidence

**Real-path exercise (headless).** Ran the real CLI end to end on the mock provider from an isolated `$HOME`:

```
$ local-operator --hosting test --model m exec "[refuse] please do something"
Error: model refused: I can't help with that request. (stop_reason=mock_refusal)   # stderr
$ echo $?
1
```

`exec --json` shows the full event shape: `message_end`/`turn_end` carry `stop_reason: "refusal"`, and `agent_end` carries the refusal in `error` with `"aborted": false`. The adversarial-markup case (`[/see our policy]` inside refusal prose) was reproduced through the same real exec path after the R1-1 fix: prose printed verbatim on stderr, exit 1.

**Real-path exercise (TUI, rendered frames).** Drove the real `OperatorApp` over a real wired session whose wire client is the tree's own `AnthropicClient` reading a canned SSE stream ending in Anthropic's documented `stop_reason: "refusal"` — the identical scenario run through both trees (`origin/main` @ `e28104b`, and this branch), so the before/after pair isolates exactly this change. Frames below; the design rounds independently re-rendered these states and matched.

**Unit suites.** 22 provider refusal tests (`TestRefusalsAreSurfacedNotSwallowed`: every wire's refusal shapes, truncated-refusal and partial-prose variants, plain-length and normal-finish non-regressions, Gemini defect-vs-refusal split, mock trigger), 4 loop terminal tests (`TestRefusalEndsTheRunVisibly`), 2 TUI replay tests, 1 headless markup-injection reproduction. Full suite at round 0: 5114 passed, 7 skipped, 1 pre-existing flake (`test_eval_tool.py::test_background_streams_output_while_it_runs`) that fails identically on clean `origin/main` at `e28104b` (verified in a pristine worktree) — the load-sensitive streaming assertion already noted on PRs #172/#174/#177, untouched here. Affected suites re-run green at every remediation head (818 passed at `34a1706`); CI runs the full matrix on this head.

**Gates.** black + isort clean; flake8 clean; pyright (`--pythonpath .venv/bin/python`) 0 errors.

## Review rounds

Code review: rounds 1–4 (`### Agent review — round N` comments), terminal at round 4, **Approve** on head `34a1706`. Design review: rounds 1–3 (`### Design review — round N`), terminal at round 3, **Approve** on head `34a1706`. All findings dispositioned in the matching remediation comments.

## Screenshots

Identical Anthropic-refusal scenario through both trees, real `OperatorApp`, 100×30.

| State | Frame |
| --- | --- |
| **Before** (`origin/main` @ `e28104b`) — refusal swallowed: prompt, then nothing | ![before: silent empty turn](https://raw.githubusercontent.com/damianvtran/local-operator/assets/pr-refusal-surfacing/before-silent-empty-turn.png) |
| **After** (head `868e681`; copy unchanged at `34a1706`) — no-prose refusal named | ![after: refusal notice](https://raw.githubusercontent.com/damianvtran/local-operator/assets/pr-refusal-surfacing/after-refusal-notice-868e681.png) |
| **After** (head `868e681`; copy unchanged at `34a1706`) — refusal after partial prose says the reply was cut, not that nothing was sent (design D1) | ![partial prose cut short](https://raw.githubusercontent.com/damianvtran/local-operator/assets/pr-refusal-surfacing/partial-prose-cut-short.png) |
