### PR TITLE
fix(providers): drop empty assistant turns so strict providers stop 400ing

### DIFF
--- a/local_operator/providers/clients.py
+++ b/local_operator/providers/clients.py
@@ -488,6 +488,43 @@ def _replayable_tool_arguments_json(call: ToolCall) -> str:
     return json.dumps(_replayable_tool_arguments(call))
 
 
+def _is_empty_assistant(message: Message) -> bool:
+    """Is ``message`` an assistant turn with nothing on it a provider accepts?
+
+    The harness persists an assistant message for EVERY model turn, including
+    turns that died before producing a single token — an errored stream, an
+    abort during thinking, a rate-limited request (``harness/loop.py`` appends
+    the message and then sets ``stop_reason="error"/"aborted"``). Replayed
+    verbatim, that turn serializes as an assistant message with empty content,
+    and strict OpenAI-compatible providers reject the whole request: Moonshot/
+    Kimi answers HTTP 400 "the message at position N with role 'assistant'
+    must not be empty" (observed live 2026-08-19 switching a session from Qwen,
+    which tolerates the empty turn, to Kimi, which does not). Anthropic
+    likewise 400s on an empty content array.
+
+    So every wire client drops these turns at body-build time — the same
+    boundary where empty TOOL results are already backfilled (see
+    ``EMPTY_TOOL_RESULT_TEXT``). Dropped rather than backfilled because a
+    backfill would put words in the assistant's mouth that it never said, and
+    the turn carries zero information: no text, no images, and — decisive for
+    wire legality — no tool calls, so nothing downstream (a tool message, an
+    Anthropic ``tool_result`` pairing) references it. Fixing the render rather
+    than the transcript also repairs every EXISTING session that already
+    carries such a turn, which is the actual failure mode: the 400 appears
+    hundreds of messages deep, long after the errored turn was written.
+
+    Whitespace-only text counts as empty: it renders to content a strict
+    provider may still reject, and dropping it loses nothing a model could
+    read. Assistant turns with tool calls are NEVER empty in this sense —
+    the calls are the content.
+    """
+    if message.role != "assistant" or message.tool_calls:
+        return False
+    if any(isinstance(block, ImageContent) for block in message.content):
+        return False
+    return not message.text.strip()
+
+
 def _message_to_openai(message: Message) -> dict[str, Any]:
     """Render one harness message into OpenAI chat-completions shape."""
     if message.role == "assistant" and message.tool_calls:
@@ -561,6 +598,10 @@ def _messages_to_openai_responses(messages: Sequence[Message]) -> list[dict[str,
     """Render harness history as Responses input items, including tool turns."""
     items: list[dict[str, Any]] = []
     for message in messages:
+        # Same normalization as chat/completions: an errored/aborted turn's
+        # empty assistant message is dead weight a strict provider rejects.
+        if _is_empty_assistant(message):
+            continue
         if message.role == "assistant" and message.tool_calls:
             if message.text:
                 items.append({"role": "assistant", "content": message.text})
@@ -849,7 +890,10 @@ class OpenAICompatClient:
     def _build_body(self, request: ChatRequest) -> dict[str, Any]:
         messages = [
             *self._system_messages(request),
-            *[_message_to_openai(m) for m in request.messages],
+            # Empty assistant turns (errored/aborted model turns the harness
+            # persists) are dropped, not sent: Moonshot/Kimi 400s on them.
+            # See `_is_empty_assistant`.
+            *[_message_to_openai(m) for m in request.messages if not _is_empty_assistant(m)],
         ]
         if request.model.supports_prompt_cache:
             self._message_cache_markers(messages)
@@ -1521,6 +1565,12 @@ class AnthropicClient:
     def _build_body(self, request: ChatRequest, *, oauth: bool = False) -> dict[str, Any]:
         messages: list[dict[str, Any]] = []
         for message in request.messages:
+            # Anthropic 400s on an assistant message whose content array is
+            # empty, which is exactly what an errored/aborted model turn
+            # replays as. Same drop as the OpenAI paths; see
+            # `_is_empty_assistant`.
+            if _is_empty_assistant(message):
+                continue
             if message.role == "assistant" and message.tool_calls:
                 content = self._message_blocks(message)
                 content.extend(
@@ -1737,6 +1787,13 @@ class GoogleClient:
     def _build_body(self, request: ChatRequest) -> dict[str, Any]:
         contents: list[dict[str, Any]] = []
         for message in request.messages:
+            # The `if parts or ...` guard below already skips an assistant
+            # turn with NO parts, but a whitespace-only text still renders
+            # one. Route through the shared predicate so all three clients
+            # agree on what an empty assistant turn is; see
+            # `_is_empty_assistant`.
+            if _is_empty_assistant(message):
+                continue
             role = "user" if message.role == "user" else "model"
             parts: list[dict[str, Any]] = [{"text": message.text}] if message.text else []
             for block in message.content:

--- a/local_operator/providers/clients.py
+++ b/local_operator/providers/clients.py
@@ -528,7 +528,10 @@ def _is_empty_assistant(message: Message) -> bool:
 def _message_to_openai(message: Message) -> dict[str, Any]:
     """Render one harness message into OpenAI chat-completions shape."""
     if message.role == "assistant" and message.tool_calls:
-        text = message.text
+        # Same whitespace rule as `_is_empty_assistant`: a whitespace-only
+        # text next to tool calls is noise, not content, and shipping it
+        # would make the two paths disagree about what counts as empty.
+        text = message.text if message.text.strip() else ""
         entry: dict[str, Any] = {"role": "assistant"}
         if text:
             entry["content"] = text
@@ -603,7 +606,9 @@ def _messages_to_openai_responses(messages: Sequence[Message]) -> list[dict[str,
         if _is_empty_assistant(message):
             continue
         if message.role == "assistant" and message.tool_calls:
-            if message.text:
+            # Whitespace-only text is dropped for the same reason
+            # `_is_empty_assistant` treats it as empty — see that predicate.
+            if message.text.strip():
                 items.append({"role": "assistant", "content": message.text})
             for call in message.tool_calls:
                 items.append(

--- a/tests/unit/providers/test_clients.py
+++ b/tests/unit/providers/test_clients.py
@@ -2504,3 +2504,22 @@ def test_empty_assistant_with_image_content_is_kept() -> None:
         content=[ImageContent(data="Zm9v", mime_type="image/png")],
     )
     assert not _is_empty_assistant(message)
+
+
+def test_tool_call_turns_do_not_ship_whitespace_only_text() -> None:
+    """F1 (PR #189 review round 1): the predicate treats whitespace as empty,
+    so a tool-call turn must not ship a whitespace-only `content` either —
+    the two paths have to agree about what counts as content."""
+    from local_operator.providers.clients import _messages_to_openai_responses
+
+    message = Message(
+        role="assistant",
+        content=[TextContent(text="  \n")],
+        tool_calls=[ToolCall(id="t9", name="x", arguments={})],
+    )
+    chat = _message_to_openai(message)
+    assert "content" not in chat
+    assert chat["tool_calls"]
+
+    items = _messages_to_openai_responses([message])
+    assert [i.get("type") for i in items] == ["function_call"]

--- a/tests/unit/providers/test_clients.py
+++ b/tests/unit/providers/test_clients.py
@@ -2393,3 +2393,114 @@ class TestRefusalsAreSurfacedNotSwallowed:
         assert end.error is not None
         assert "cut the reply short" in end.error
         assert "sent no message" not in end.error
+# Empty assistant turns (errored/aborted model turns) must not reach the wire
+# ---------------------------------------------------------------------------
+
+
+def _empty_assistant() -> Message:
+    """The message an errored model turn persists: no text, no tool calls.
+
+    `harness/loop.py` appends the assistant message to the context BEFORE the
+    stream finishes; a stream that dies without a single token leaves exactly
+    this shape in the transcript, and every later request replays it.
+    """
+    return Message(role="assistant", content=[], stop_reason="error")
+
+
+def test_openai_chat_drops_empty_assistant_turns() -> None:
+    """Moonshot/Kimi rejects the whole request over ONE empty assistant turn:
+    HTTP 400 "the message at position N with role 'assistant' must not be
+    empty" (observed live, 2026-08-19). The turn carries no information, so it
+    is dropped at body-build time — which also repairs existing transcripts
+    that already contain one."""
+    request = ChatRequest(
+        model=_spec(),
+        messages=[Message.user("hi"), _empty_assistant(), Message.user("continue")],
+    )
+    body = OpenAICompatClient("https://x")._build_body(request)
+    roles = [m["role"] for m in body["messages"]]
+    assert roles == ["user", "user"]
+
+
+def test_openai_chat_drops_whitespace_only_assistant_turns() -> None:
+    """Whitespace renders to content a strict provider may still reject, and
+    a model cannot read anything from it — same drop as truly empty."""
+    request = ChatRequest(
+        model=_spec(),
+        messages=[
+            Message.user("hi"),
+            Message(role="assistant", content=[TextContent(text="  \n")]),
+        ],
+    )
+    body = OpenAICompatClient("https://x")._build_body(request)
+    assert [m["role"] for m in body["messages"]] == ["user"]
+
+
+def test_openai_chat_keeps_assistant_turns_with_tool_calls_or_content() -> None:
+    """The drop must be surgical: a tool-call-only assistant turn is NOT empty
+    (the calls are the content, and a paired tool message references them), and
+    normal text turns pass through untouched."""
+    tool_turn = _assistant_with([ToolCall(id="t1", name="x", arguments={})])
+    request = ChatRequest(
+        model=_spec(),
+        messages=[
+            Message.user("hi"),
+            tool_turn,
+            Message(role="tool", tool_call_id="t1", content=[TextContent(text="done")]),
+            Message.assistant("all set"),
+        ],
+    )
+    body = OpenAICompatClient("https://x")._build_body(request)
+    roles = [m["role"] for m in body["messages"]]
+    assert roles == ["user", "assistant", "tool", "assistant"]
+
+
+def test_openai_responses_drops_empty_assistant_turns() -> None:
+    """Same normalization on the Responses route: an errored turn's empty
+    assistant message must not become an empty output_text item."""
+    from local_operator.providers.clients import _messages_to_openai_responses
+
+    items = _messages_to_openai_responses(
+        [Message.user("hi"), _empty_assistant(), Message.user("continue")]
+    )
+    assert [i.get("role") for i in items] == ["user", "user"]
+
+
+def test_anthropic_drops_empty_assistant_turns() -> None:
+    """Anthropic 400s on an assistant message with an empty content array —
+    the exact serialization of an errored model turn."""
+    request = ChatRequest(
+        model=_spec(provider="anthropic", model_id="claude-sonnet-4-5"),
+        messages=[Message.user("hi"), _empty_assistant(), Message.user("continue")],
+    )
+    body = AnthropicClient()._build_body(request)
+    assert [m["role"] for m in body["messages"]] == ["user", "user"]
+
+
+def test_google_drops_whitespace_only_assistant_turns() -> None:
+    """Google's builder already skipped no-part assistant turns; the shared
+    predicate extends that to whitespace-only text so all three clients agree
+    on what an empty assistant turn is."""
+    request = ChatRequest(
+        model=_spec(provider="google", model_id="gemini-2.0-flash"),
+        messages=[
+            Message.user("hi"),
+            Message(role="assistant", content=[TextContent(text=" ")]),
+            _empty_assistant(),
+        ],
+    )
+    body = GoogleClient()._build_body(request)
+    assert [c["role"] for c in body["contents"]] == ["user"]
+
+
+def test_empty_assistant_with_image_content_is_kept() -> None:
+    """An image block is content even with no text: dropping it would lose
+    information. (No current model emits assistant images, but the predicate
+    must not assume that.)"""
+    from local_operator.providers.clients import _is_empty_assistant
+
+    message = Message(
+        role="assistant",
+        content=[ImageContent(data="Zm9v", mime_type="image/png")],
+    )
+    assert not _is_empty_assistant(message)

--- a/tests/unit/providers/test_clients.py
+++ b/tests/unit/providers/test_clients.py
@@ -2393,6 +2393,8 @@ class TestRefusalsAreSurfacedNotSwallowed:
         assert end.error is not None
         assert "cut the reply short" in end.error
         assert "sent no message" not in end.error
+
+
 # Empty assistant turns (errored/aborted model turns) must not reach the wire
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
# PR Description

## Change classification

**C2 — standard / pre-authorized.** One module (`providers/clients.py`) plus its
tests; no schema, transcript-format, or session-state change. Clean rollback
(`git revert`). No RFC requested.

## The problem

An errored or aborted model turn persists an assistant message with **no text
and no tool calls**: `harness/loop.py` appends the assistant message to the
context before the stream settles, and a stream that dies without producing a
token (rate limit, provider outage, abort during thinking) leaves exactly that
shape in the transcript. Session `3cf26a5be086` is the live specimen — its
second entry is `{"role": "assistant", "stop_reason": "error"}` with empty
content, written when all Anthropic OAuth credentials were rate-limited.

Every later request replays that turn verbatim. Lenient providers (Qwen,
OpenAI) ignore it; strict OpenAI-compatible providers reject the **whole
request**. Switching that session to Kimi produced:

```
× invalid request (HTTP 400): the message at position 538 with role 'assistant' must not be empty
```

The failure appears hundreds of messages after the errored turn was written,
is unrecoverable from inside the session (every retry replays the same
history), and follows the transcript across model switches forever.

## The fix

One shared predicate, `_is_empty_assistant`, applied at body-build time in all
three wire clients (`OpenAICompatClient` chat-completions **and** Responses
route, `AnthropicClient`, `GoogleClient`): an assistant turn with no tool
calls, no image blocks, and no non-whitespace text is dropped from the wire.

- **Dropped, not backfilled** — the empty-tool-result precedent
  (`EMPTY_TOOL_RESULT_TEXT`) backfills because a tool message must pair with
  its call id; an empty assistant turn pairs with nothing and carries zero
  information, and a backfill would fabricate assistant speech.
- **Fixed at the render, not the transcript** — repairs every existing session
  that already carries such a turn, which is the actual failure mode.
- **Surgical** — tool-call-only assistant turns are never "empty" (the calls
  are the content and tool messages reference their ids); image-bearing turns
  are kept; whitespace-only text counts as empty (it renders to content a
  strict provider may still reject, and no model can read anything from it).
- Anthropic benefits identically (it 400s on an empty content array); Google's
  builder already skipped no-part assistant turns, and now agrees with the
  other two clients on whitespace-only text.

## Testing evidence

**Live reproduction and fix against the real Kimi API** (coding-plan OAuth,
`kimi-for-coding`, host `api.kimi.com/coding/v1`), sending a history containing
the exact errored-turn shape — old behaviour reproduced by disabling the
predicate, new behaviour through the shipped code path:

```
[OLD (empty turn sent)] wire roles: ['user', 'assistant', 'user']
[OLD (empty turn sent)] HTTP 400: {"error":{"message":"the message at position 1 with role 'assistant' must not be empty","type":"invalid_request_error"}}
[NEW (empty turn dropped)] wire roles: ['user', 'user']
[NEW (empty turn dropped)] HTTP 200, assistant said: 'ready\n\nWhat would you like me to continue with?'
```

**The originating session's transcript replayed through the fix** — the same
`Transcript.build_llm_history()` → `_default_convert_to_llm` → `_build_body`
path a real request takes:

```
wire roles from repro session: ['user', 'user']
no empty assistant messages on the wire ✓
```

**Unit tests** — 7 new tests pinning: the chat-completions drop, the
whitespace-only drop, the Responses-route drop, the Anthropic drop, the Google
whitespace extension, tool-call turns surviving untouched, and image-bearing
turns surviving untouched.

**Gates on head:**

- `pytest tests/unit` — 5105 passed, 7 skipped, 1 flake
  (`test_oauth_429_rotates_to_the_sibling_account`, a failover
  credential-rotation timing test untouched by this change; its file passes
  147/147 standalone and the test passes 3/3 on rerun).
- `flake8` clean, `black --check` clean, `isort --check-only` clean,
  `pyright` 0 errors on `providers/clients.py`.

## Rollback

`git revert` of the single commit; no data or state migration involved.
