### PR TITLE
feat(providers,session,tui): track the model actually serving through a fallback

### DIFF
--- a/local_operator/harness/subagent.py
+++ b/local_operator/harness/subagent.py
@@ -105,6 +105,7 @@ from local_operator.harness.types import (
     Message,
     MessageEndEvent,
     MessageStartEvent,
+    ModelChangeEvent,
     ModelSpec,
     SubagentEndEvent,
     SubagentProgressEvent,
@@ -289,12 +290,24 @@ def _make_runner(
             if job is not None:
                 # Off the CHILD, not the parent: ``model_spec`` may have put
                 # this child on a different model, which is precisely the fact
-                # a reader of the job row needs.
-                job.model_label = child.model_label
+                # a reader of the job row needs. The EFFECTIVE label (with a
+                # getattr degrade for reduced hosts) because a resumed child
+                # may boot straight onto a restored provider fallback, and the
+                # job row exists to say which model is actually doing the work.
+                job.model_label = str(
+                    getattr(child, "effective_model_label", "") or child.model_label
+                )
                 # From the spec the child was ALREADY built with, so this
                 # costs nothing: no registry resolve, no provider discovery,
                 # and none of it on anyone's render path.
-                job.context_window = child.model.context_window
+                job.context_window = int(
+                    getattr(
+                        getattr(child, "effective_model", None) or child.model,
+                        "context_window",
+                        0,
+                    )
+                    or child.model.context_window
+                )
             if comms is not None:
                 # Before the prompt runs: the parent may already have a
                 # question queued for this child, and attach is what flushes
@@ -544,6 +557,15 @@ def _make_relay(
                 final["text"] = message.text
                 _accumulate_usage(job, message.usage)
                 progress = ACTIVITY_THINKING
+        elif isinstance(event, ModelChangeEvent):
+            # Keep the job row's label truthful about which model is doing the
+            # child's work — the band and the jobs list read it live, and a
+            # child that fell over to another provider mid-run is exactly what
+            # a reader of those surfaces needs to know.
+            if job is not None:
+                job.model_label = f"{event.provider}/{event.model_id}"
+                if event.context_window > 0:
+                    job.context_window = event.context_window
         elif isinstance(event, AgentEndEvent):
             if event.error:
                 final["error"] = event.error

--- a/local_operator/harness/types.py
+++ b/local_operator/harness/types.py
@@ -990,6 +990,36 @@ class RetryStartEvent(AgentEvent[Literal["retry_start"]]):
     fallback_model: str | None = None
 
 
+class ModelChangeEvent(AgentEvent[Literal["model_change"]]):
+    """The model ACTUALLY SERVING requests changed mid-session.
+
+    Emitted when a provider fallback pins a different model (``is_fallback``
+    True), when the primary route recovers and requests return to the selected
+    model (``is_fallback`` False), and when the user switches models. The
+    fallback notice ("provider failure — falling back to …") narrates the
+    moment; this event is what lets a front end keep its MODEL DISPLAY truthful
+    for the rest of the fallback's lifetime — without it the status band keeps
+    asserting the selected model while every request goes elsewhere.
+
+    ``provider``/``model_id`` name the model now in force (the fallback while
+    one is pinned, the selected model otherwise); ``effort`` is the reasoning
+    level that model is actually running at, which matters because a fallback
+    target may clamp the user's chosen level to its own ladder.
+    """
+
+    type: Literal["model_change"] = "model_change"
+    provider: str
+    model_id: str
+    effort: str | None = None
+    reason: str = ""
+    is_fallback: bool = False
+    # The model-in-force's own window, carried so consumers that hold only the
+    # event (a parent relaying a child's stream) can keep their usage
+    # denominators truthful without re-resolving the model themselves. Zero
+    # means the emitter did not know, and readers keep their previous value.
+    context_window: int = 0
+
+
 class RetryEndEvent(AgentEvent[Literal["retry_end"]]):
     type: Literal["retry_end"] = "retry_end"
     success: bool

--- a/local_operator/headless_print.py
+++ b/local_operator/headless_print.py
@@ -34,6 +34,7 @@ from local_operator.harness.types import (
     MessageEndEvent,
     MessageStartEvent,
     MessageUpdateEvent,
+    ModelChangeEvent,
     NoticeEvent,
     RetryStartEvent,
     ToolExecutionEndEvent,
@@ -237,6 +238,16 @@ class PrintRenderer:
             self.console.print(f"{glyph}{text}", style=style, highlight=False, markup=False)
         elif isinstance(event, RetryStartEvent):
             self.console.print(f"[dim]retry {event.attempt}: {event.error}[/dim]", highlight=False)
+        elif isinstance(event, ModelChangeEvent):
+            # The route edge in one line, both directions — the exec-mode
+            # counterpart of the TUI band repaint: a reader of a long headless
+            # run needs to know which model produced the output from here on.
+            selector = f"{event.provider}/{event.model_id}"
+            self.console.print(
+                f"[dim]{'now serving from' if event.is_fallback else 'back on'} "
+                f"{selector}[/dim]",
+                highlight=False,
+            )
         elif isinstance(event, CompactionStartEvent):
             self.console.print("[dim]compacting context…[/dim]", highlight=False)
         elif isinstance(event, AgentEndEvent):

--- a/local_operator/headless_print.py
+++ b/local_operator/headless_print.py
@@ -242,10 +242,11 @@ class PrintRenderer:
             # The route edge in one line, both directions — the exec-mode
             # counterpart of the TUI band repaint: a reader of a long headless
             # run needs to know which model produced the output from here on.
+            # The verbs pair with the failure notice's "falling back to"
+            # (design D2): "serving from" reads as a location, not a route.
             selector = f"{event.provider}/{event.model_id}"
             self.console.print(
-                f"[dim]{'now serving from' if event.is_fallback else 'back on'} "
-                f"{selector}[/dim]",
+                f"[dim]{'fell back to' if event.is_fallback else 'back to'} " f"{selector}[/dim]",
                 highlight=False,
             )
         elif isinstance(event, CompactionStartEvent):

--- a/local_operator/model/configure.py
+++ b/local_operator/model/configure.py
@@ -1511,7 +1511,17 @@ class SessionStreamFn:
         self._session_id = session_id
         self._http = httpx.AsyncClient(timeout=httpx.Timeout(600.0, connect=30.0))
         self._notice_handler: Callable[[str, str], Awaitable[None] | None] | None = None
-        self._route_state = FailoverRouteState(on_change=self._on_route_change)
+        # The session's route bridge: called with the pinned fallback target
+        # (or None on recovery) so the host can keep its model display and its
+        # persisted session state truthful about which model is actually
+        # serving requests. Installed by the owning Session, exactly like the
+        # notice handler above — the stream owns routing, the session owns
+        # ordered event delivery.
+        self._route_handler: Callable[[Any, str], Awaitable[None] | None] | None = None
+        self._route_state = FailoverRouteState(
+            on_change=self._on_route_change,
+            on_settle=self._on_route_settle,
+        )
         self._message_boundary_pending = True
         # Frozen for one user-message tool loop: choosing a new effort between
         # tool calls would bust the provider cache and make one task reason at
@@ -1548,6 +1558,53 @@ class SessionStreamFn:
     ) -> None:
         """Install the owning session's event bridge."""
         self._notice_handler = handler
+
+    def set_route_handler(
+        self, handler: Callable[[Any, str], Awaitable[None] | None] | None
+    ) -> None:
+        """Install the owning session's fallback-route bridge.
+
+        Called with the active ``FallbackTarget`` when a fallback pins, and with
+        ``None`` when the route returns to the primary — both edges, because a
+        model display that only ever learns "fell back" keeps naming the
+        fallback after the primary has recovered.
+        """
+        self._route_handler = handler
+
+    def restore_fallback(self, selector: str, effort: str | None, primary_selector: str) -> None:
+        """Re-pin a fallback route persisted by a previous run of this session.
+
+        A resumed session whose transcript says "requests were being served by
+        the fallback" should keep being served by it rather than re-sending the
+        first prompt to the provider that was failing when the session closed.
+        Pinned WITHOUT a cooldown: the next message boundary's preflight is
+        free to probe the primary immediately, so a recovered provider is
+        picked back up on the first turn rather than after an arbitrary wait.
+
+        ``primary_selector`` is the SELECTED model this pin belongs to, seeded
+        into the preflight's selector memo because that memo starts ``None``:
+        without it the first ``preflight_usage`` call reads the primary as "a
+        different model than last time" and clears the pin it was just handed,
+        making every restore a no-op.
+
+        Set directly rather than through ``activate`` so NEITHER handler fires:
+        the transcript replay already shows the original fallback notice
+        (re-announcing it on every resume reads as a fresh failure that did not
+        happen), and the restoring session sets its own display/persistence
+        state from the same entry it restored this pin from — a settle edge
+        here would only write that entry back to the transcript it came from.
+        """
+        from local_operator.providers.failover import FallbackTarget
+
+        self._route_state.active = FallbackTarget(selector, effort)
+        # The same minimum grace the live driver gives a fresh pin (60s):
+        # without it the TUI's boot-time quota preflight — which runs seconds
+        # after this and probes only that the primary HAS AUTH, not that it
+        # recovered — would clear the pin before the first request proved
+        # anything, turning every restore into an immediate un-restore. After
+        # the grace, the ordinary boundary probe reclaims a recovered primary.
+        self._route_state.primary_retry_at_ms = int(time.time() * 1000) + 60_000
+        self._primary_selector = primary_selector
 
     def begin_message(self) -> None:
         """Mark the next model call as a user-message boundary."""
@@ -1656,6 +1713,20 @@ class SessionStreamFn:
         effort = f" ({target.effort} effort)" if target.effort else ""
         await self._notice(f"{reason} — falling back to {target.selector}{effort}")
 
+    async def _on_route_settle(self, target: Any, reason: str) -> None:
+        """Forward the effective-route edge (fallback pinned / primary back)."""
+        if target is None:
+            # The recovery deserves the same narration the failure got: the
+            # fallback edge printed "falling back to X", and without this line
+            # the model display silently snapping back reads as a glitch, not
+            # a recovery. Info, not warning — it is good news.
+            await self._notice(f"{reason} — back on {self._primary_selector}", "info")
+        if self._route_handler is None:
+            return
+        result = self._route_handler(target, reason)
+        if inspect.isawaitable(result):
+            await result
+
     def _fallback_targets(self, model: ModelSpec) -> list[Any]:
         from local_operator.providers.failover import (
             RetrySettings,
@@ -1759,7 +1830,11 @@ class SessionStreamFn:
             return
         if not retry.usage_aware_fallback:
             if self._route_state.active is not None and await self._primary_has_auth(model):
-                self._route_state.clear()
+                # A real recovery edge, not bookkeeping: a fallback was pinned
+                # and requests are about to return to the primary, so the
+                # host's model display has to hear about it (settled, not
+                # silent — same reasoning as the stream driver's clear).
+                await self._route_state.clear_settled("primary model recovered")
             return
 
         attempted_ids: set[int] = set()
@@ -1802,7 +1877,9 @@ class SessionStreamFn:
                 reserve_percent=retry.usage_reserve_percent,
             )
             if health.state == "healthy":
-                self._route_state.clear()
+                # Settled for the same reason as the auth-only path above: this
+                # clear is the moment a pinned fallback stops serving requests.
+                await self._route_state.clear_settled("primary model recovered")
                 return
             if health.state == "unknown":
                 return

--- a/local_operator/model/configure.py
+++ b/local_operator/model/configure.py
@@ -1719,8 +1719,10 @@ class SessionStreamFn:
             # The recovery deserves the same narration the failure got: the
             # fallback edge printed "falling back to X", and without this line
             # the model display silently snapping back reads as a glitch, not
-            # a recovery. Info, not warning — it is good news.
-            await self._notice(f"{reason} — back on {self._primary_selector}", "info")
+            # a recovery. Info, not warning — it is good news. One clause,
+            # "back to" — the failure edge's "falling back to" and this pair
+            # off the same preposition (design D1).
+            await self._notice(f"back to {self._primary_selector}", "info")
         if self._route_handler is None:
             return
         result = self._route_handler(target, reason)

--- a/local_operator/providers/failover.py
+++ b/local_operator/providers/failover.py
@@ -1045,6 +1045,14 @@ class RetrySettings:
 
 RouteChangeHandler = Callable[[FallbackTarget, str], Awaitable[None] | None]
 
+#: Fired whenever the EFFECTIVE route settles on a different target — with the
+#: fallback target when one is pinned, with ``None`` when requests return to
+#: the primary. Distinct from ``on_change`` (which only narrates activations)
+#: because a front end keeping its model display truthful needs BOTH edges:
+#: without the clear edge the band keeps naming the fallback after the primary
+#: recovered, which is the same lie in the other direction.
+RouteSettleHandler = Callable[[FallbackTarget | None, str], Awaitable[None] | None]
+
 
 @dataclasses.dataclass
 class FailoverRouteState:
@@ -1060,6 +1068,7 @@ class FailoverRouteState:
     active: FallbackTarget | None = None
     on_change: RouteChangeHandler | None = None
     primary_retry_at_ms: int = 0
+    on_settle: RouteSettleHandler | None = None
 
     async def activate(
         self,
@@ -1086,19 +1095,46 @@ class FailoverRouteState:
                 int(time.time() * 1000) + cooldown_ms,
             )
         self.active = target
-        if self.on_change is None:
-            return
-        result = self.on_change(target, reason)
-        if inspect.isawaitable(result):
-            await result
+        if self.on_change is not None:
+            result = self.on_change(target, reason)
+            if inspect.isawaitable(result):
+                await result
+        await self._settle(target, reason)
 
     def primary_retry_due(self, now_ms: int | None = None) -> bool:
         now = int(time.time() * 1000) if now_ms is None else now_ms
         return now >= self.primary_retry_at_ms
 
     def clear(self) -> None:
+        """Return the route to the primary WITHOUT announcing it.
+
+        Kept for the callers that reset routing state as bookkeeping — a
+        ``/model`` switch, a preflight that re-verified auth — where "back on
+        the primary" is not news anyone needs. A recovery worth telling the
+        front end about (the primary actually served a request again) goes
+        through :meth:`clear_settled` instead.
+        """
         self.active = None
         self.primary_retry_at_ms = 0
+
+    async def clear_settled(self, reason: str) -> None:
+        """Return the route to the primary and NOTIFY ``on_settle``.
+
+        Fires only on the transition (a fallback was actually pinned), so the
+        ordinary case — the primary succeeding while it was already the route —
+        stays silent rather than spamming the settle hook once per request.
+        """
+        was_fallback = self.active is not None
+        self.clear()
+        if was_fallback:
+            await self._settle(None, reason)
+
+    async def _settle(self, target: FallbackTarget | None, reason: str) -> None:
+        if self.on_settle is None:
+            return
+        result = self.on_settle(target, reason)
+        if inspect.isawaitable(result):
+            await result
 
 
 def parse_selector(selector: str) -> tuple[str, str]:
@@ -1580,7 +1616,11 @@ async def stream_with_failover(
                     forwarded_any = True
                     yield event
                 if route_state is not None and target == primary_target:
-                    route_state.clear()
+                    # Settled, not silent: while a fallback was pinned the front
+                    # end has been displaying THAT model, so the primary serving
+                    # again is exactly the edge its display needs. A no-op when
+                    # nothing was pinned (see `clear_settled`).
+                    await route_state.clear_settled("primary model recovered")
                 # This credential just served a request, so whatever provider
                 # fault demoted it has passed. Without this the mark outlived
                 # the outage for the life of the process, contradicting the

--- a/local_operator/session/protocol.py
+++ b/local_operator/session/protocol.py
@@ -89,7 +89,23 @@ class SessionProtocol(Protocol):
 
     @property
     def model(self) -> ModelSpec:
-        """The active spec (provider/model_id/base_url/context_window)."""
+        """The SELECTED spec (provider/model_id/base_url/context_window)."""
+        ...
+
+    @property
+    def effective_model(self) -> ModelSpec:
+        """The spec ACTUALLY serving requests.
+
+        Equals ``model`` except while a provider fallback is pinned, when it is
+        the fallback's own spec. Front ends paint their model display from THIS
+        — a display reading ``model`` during a fallback names a model that is
+        not answering.
+        """
+        ...
+
+    @property
+    def effective_model_label(self) -> str:
+        """``provider/model`` of the spec actually serving requests."""
         ...
 
     def set_model(self, model: ModelSpec) -> None:

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -73,6 +73,7 @@ from local_operator.harness.types import (
     ImageContent,
     LoopConfig,
     Message,
+    ModelChangeEvent,
     ModelSpec,
     NoticeEvent,
     StaleAside,
@@ -115,6 +116,16 @@ if TYPE_CHECKING:
     from local_operator.mcp.manager import McpManager
 
 logger = logging.getLogger(__name__)
+
+#: Transcript custom-entry type recording which model is ACTUALLY serving
+#: requests when a provider fallback pins a route away from the selected
+#: model. Written on every route edge (fallback pinned / primary recovered)
+#: and read back at construction, so a resumed session keeps running — and
+#: displaying — the model that was really answering when it closed, instead
+#: of silently re-routing the first prompt to the provider that was failing.
+#: An entry with ``active: None`` records the recovery, which is what lets
+#: ``latest_custom``'s backward scan land on "no fallback pinned" after one.
+ACTIVE_ROUTE_CUSTOM_TYPE = "active_model_route"
 
 #: How many times the title writer will chase a name that moved under its own
 #: append before giving up and leaving the rest to the dispose flush. A cap
@@ -790,6 +801,13 @@ class Session:
             # delivery. Binding the two here lets every front end receive quota
             # and fallback notices without teaching the harness loop providers.
             notice_bridge(self._stream_notice)
+        route_bridge = getattr(self._stream_fn, "set_route_handler", None)
+        if callable(route_bridge):
+            # Same division of labour as the notice bridge, for the ROUTE
+            # itself rather than its narration: the stream reports which model
+            # is actually serving requests, the session persists that fact and
+            # emits the event a front end repaints its model display from.
+            route_bridge(self._on_route_settled)
         self._tools = list(tools)
         self._transcript = transcript
         self._session_id = session_id or transcript.directory.name
@@ -950,6 +968,24 @@ class Session:
         # session would otherwise need its own copy of this, and the one that
         # forgot would boot nameless.
         self._load_conversation_name()
+        # Which model is ACTUALLY serving requests, when that is not the
+        # selected one: the spec of the pinned fallback route, or None while
+        # the primary serves. Owned by the session (not read off the stream
+        # fn) because every reader — the TUI's model display, cost attribution,
+        # persistence — needs it between events, and the stream fn is an
+        # optional capability some hosts construct sessions without.
+        self._active_fallback: ModelSpec | None = None
+        # The pin itself — (selector, the chain entry's own effort or None) —
+        # kept beside the derived spec above because the spec is a SNAPSHOT:
+        # an `/effort` change while a fallback serves has to re-derive the
+        # display spec from the pin, and the derivation's input is the target,
+        # not the previous derivation.
+        self._active_route: tuple[str, str | None] | None = None
+        # AFTER the wake/name restores, same transcript, same reason: a
+        # resumed session must come back on the model that was really
+        # answering when it closed, not silently re-route the first prompt to
+        # the provider that was failing.
+        self._restore_active_route()
         # Owned here, not by the browser tool, for the same reason the wake
         # scheduler is: _build_tool_context runs at the start of EVERY turn, so
         # a handle the tool stored on the ToolContext lived exactly one turn.
@@ -1239,6 +1275,27 @@ class Session:
         """The spec every provider call is built from."""
         return self._model
 
+    @property
+    def active_fallback(self) -> ModelSpec | None:
+        """The pinned fallback's spec while one is serving requests, else None."""
+        return self._active_fallback
+
+    @property
+    def effective_model(self) -> ModelSpec:
+        """The spec ACTUALLY serving requests.
+
+        ``model`` is what the user selected; while a provider fallback is
+        pinned the requests go elsewhere, and a display reading ``model``
+        asserts a model that is not answering. Front ends paint from THIS.
+        """
+        return self._active_fallback if self._active_fallback is not None else self._model
+
+    @property
+    def effective_model_label(self) -> str:
+        """``provider/model`` of the spec actually serving requests."""
+        spec = self.effective_model
+        return f"{spec.provider}/{spec.model_id}"
+
     def history(self) -> list[AgentMessage]:
         """The conversation as replayed into LLM context, in order.
 
@@ -1291,7 +1348,11 @@ class Session:
             "messages": estimate_messages_tokens(
                 self._render_history(list(self._context.messages))
             ),
-            "context_window": int(self._model.context_window),
+            # The EFFECTIVE model's window: the breakdown predicts whether the
+            # NEXT request fits, and while a fallback serves that request goes
+            # to the fallback — measuring it against the selected model's
+            # window misstates the one number the panel exists to report.
+            "context_window": int(self.effective_model.context_window),
             "cache_read": int(
                 self._last_usage.cache_read_tokens if self._last_usage is not None else 0
             ),
@@ -1351,7 +1412,43 @@ class Session:
             # itself selector-keyed (`SessionStreamFn._primary_selector`), so a
             # third component here would invalidate more often than the thing
             # being invalidated can actually change.
+            #
+            # One exception rides this path: while a fallback serves, the
+            # DERIVED display spec carried the previous effort onto the target
+            # (see `spec_for_target` — a chain entry naming no effort inherits
+            # the chosen level), so an `/effort` change has to re-derive it or
+            # the band keeps naming the level the user just moved away from.
+            # Quietly — no event, no persistence: the route did not move, and
+            # the `/effort` receipt plus the host's own repaint already cover
+            # the level change.
+            if self._active_route is not None:
+                refreshed = self._spec_for_route(*self._active_route)
+                if refreshed is not None:
+                    self._active_fallback = refreshed
             return
+        # An explicit switch withdraws the fallback pin's premise: the pin
+        # rescued the PREVIOUS selection, and the stream fn's preflight will
+        # clear its own route state the moment it sees the new selector. The
+        # display state has to move in the same step — a band still naming the
+        # old fallback after `/model` is the same stale frame this state
+        # exists to prevent. Persisted (with the new primary) so a resume does
+        # not restore a pin the user already switched away from.
+        if self._active_fallback is not None:
+            self._active_fallback = None
+            self._active_route = None
+            self._spawn_background(self._persist_active_route(model))
+            self._spawn_background(
+                self._emit(
+                    ModelChangeEvent(
+                        provider=model.provider,
+                        model_id=model.model_id,
+                        effort=model.reasoning_effort,
+                        reason="model switched",
+                        is_fallback=False,
+                        context_window=int(model.context_window),
+                    )
+                )
+            )
         notify = getattr(self._stream_fn, "on_model_changed", None)
         if callable(notify):
             notify(model)
@@ -2008,6 +2105,72 @@ class Session:
     ) -> None:
         """Bridge provider-routing diagnostics onto the session event stream."""
         await self._emit(NoticeEvent(text=text, kind=kind))
+
+    async def _on_route_settled(self, target: Any, reason: str) -> None:
+        """The stream fn's effective route moved; record it and tell the host.
+
+        ``target`` is the pinned ``FallbackTarget`` (selector + optional
+        effort) or ``None`` when requests returned to the selected model. Three
+        jobs, in order: derive the fallback's own spec (metadata belongs to the
+        TARGET model — a display that keeps the primary's context window under
+        a fallback's name misreports both), persist the edge so a resume comes
+        back on the right model, and emit the event the front end repaints its
+        model display from.
+        """
+        if target is None:
+            self._active_fallback = None
+            self._active_route = None
+            await self._persist_active_route(self._model)
+            await self._emit(
+                ModelChangeEvent(
+                    provider=self._model.provider,
+                    model_id=self._model.model_id,
+                    effort=self._model.reasoning_effort,
+                    reason=reason,
+                    is_fallback=False,
+                    context_window=int(self._model.context_window),
+                )
+            )
+            return
+        selector = str(target.selector)
+        target_effort = getattr(target, "effort", None)
+        spec = self._spec_for_route(selector, target_effort)
+        if spec is None:
+            # An unresolvable selector must not take the session down mid-turn;
+            # the fallback still serves, the display just cannot follow it.
+            logger.warning("could not resolve fallback spec for %r", target.selector)
+            return
+        self._active_fallback = spec
+        self._active_route = (selector, target_effort)
+        await self._persist_active_route(self._model)
+        await self._emit(
+            ModelChangeEvent(
+                provider=spec.provider,
+                model_id=spec.model_id,
+                effort=spec.reasoning_effort,
+                reason=reason,
+                is_fallback=True,
+                context_window=int(spec.context_window),
+            )
+        )
+
+    def _spec_for_route(self, selector: str, effort: str | None) -> ModelSpec | None:
+        """The fallback target's own ``ModelSpec``, or None when unresolvable.
+
+        Through :func:`~local_operator.providers.failover.spec_for_target`
+        because that is the SAME derivation the failover driver uses to build
+        the request — deriving the display spec any other way is how the band
+        and the wire end up disagreeing about effort or context window.
+        """
+        try:
+            from local_operator.providers.failover import (
+                FallbackTarget,
+                spec_for_target,
+            )
+
+            return spec_for_target(self._model, FallbackTarget(selector, effort))
+        except Exception:  # noqa: BLE001 — display state is never worth a broken turn
+            return None
 
     async def _emit(self, event: AgentEvent) -> None:
         for handler in list(self._handlers):
@@ -2692,7 +2855,7 @@ class Session:
             from local_operator.compaction import api as compaction_api
 
             if not compaction_api.should_compact(
-                provider_reported, self._model.context_window, settings
+                provider_reported, self.effective_model.context_window, settings
             ):
                 return None
         # Persist what the run has produced SO FAR before planning a cut.
@@ -2758,7 +2921,7 @@ class Session:
         if getattr(planned.settings, "auto_continue", False):
             compaction_api = planned.compaction_api
             threshold = compaction_api.resolve_threshold_tokens(
-                self._model.context_window, planned.settings
+                self.effective_model.context_window, planned.settings
             )
             if outcome.tokens_after <= compaction_api.RECOVERY_BAND * threshold:
                 self._continuation_queue.append(Message.user(_CONTINUATION_PROMPT))
@@ -2943,7 +3106,7 @@ class Session:
             bound = compaction_api.messages_tokens_upper_bound(llm_history)
             if not compaction_api.should_compact(
                 compaction_api.compaction_context_tokens(provider_reported, bound),
-                self._model.context_window,
+                self.effective_model.context_window,
                 settings,
             ):
                 return CompactionOutcome(ran=False, reason="below_threshold")
@@ -2962,7 +3125,7 @@ class Session:
         )
         context_tokens = compaction_api.compaction_context_tokens(provider_reported, local_estimate)
         if respect_threshold and not compaction_api.should_compact(
-            context_tokens, self._model.context_window, settings
+            context_tokens, self.effective_model.context_window, settings
         ):
             return CompactionOutcome(ran=False, reason="below_threshold")
 
@@ -3182,16 +3345,20 @@ class Session:
             try:
                 from local_operator.compaction import snapcompact
 
+                # The EFFECTIVE model throughout: the archive is being sized
+                # and tokenized for the model that will actually receive the
+                # replay, which during a fallback is the fallback.
+                effective = self.effective_model
                 archive = await asyncio.to_thread(
                     snapcompact.compact_to_archive,
                     to_summarize,
-                    self._model.provider,
-                    self._model.model_id,
+                    effective.provider,
+                    effective.model_id,
                     self._previous_archive_text(),
-                    context_window=self._model.context_window,
+                    context_window=effective.context_window,
                 )
                 summary = snapcompact.archive_summary(
-                    archive, self._model.provider, self._model.model_id
+                    archive, effective.provider, effective.model_id
                 )
                 return summary or " ", {"snapcompact": _archive_to_json(archive)}
             except Exception:
@@ -3466,6 +3633,83 @@ class Session:
             WAKE_SCHEDULES_CUSTOM_TYPE,
             {"schedules": [schedule.model_dump() for schedule in schedules]},
         )
+
+    # -- active model route (fallback persistence) ---------------------------
+
+    async def _persist_active_route(self, primary: ModelSpec) -> None:
+        """Record which model is actually serving requests, for resume.
+
+        Written on EVERY edge, including recovery (``active: None``), because
+        ``latest_custom`` reads backwards and stops at the first hit: without
+        the recovery row a session that fell back and recovered would resume
+        pinned to a fallback nothing is wrong with. ``primary`` rides along so
+        the restore can tell a pin that belongs to the CURRENT selected model
+        from one stranded by a later ``/model`` switch.
+        """
+        # The PIN is what persists — the target selector and the chain entry's
+        # own effort (None when the entry named none) — not the derived display
+        # spec: a restore re-derives against whatever the primary's effort is
+        # THEN, exactly as the live failover driver would.
+        route = self._active_route
+        await self._transcript.append_custom(
+            ACTIVE_ROUTE_CUSTOM_TYPE,
+            {
+                "primary": f"{primary.provider}/{primary.model_id}",
+                "active": (None if route is None else {"selector": route[0], "effort": route[1]}),
+            },
+        )
+
+    def _restore_active_route(self) -> None:
+        """Re-adopt the fallback that was serving when this session last ran.
+
+        Guarded three ways, each a real situation rather than paranoia:
+
+        - no entry / ``active: None`` → the session closed on its selected
+          model (or recovered before closing); nothing to restore.
+        - persisted ``primary`` differs from the CURRENT selection → the pin
+          belongs to a model the user has since switched away from (a
+          ``/model default`` change, an agent profile edit, a ``--hosting``
+          flag). The new selection owes the user a fresh start on the model
+          they actually chose, not a detour recorded against the old one.
+        - the fallback selector equals the current selection → the user
+          adopted the fallback as their model; a pin would be a no-op that
+          still repainted the band with a spurious fallback marker.
+
+        Restores quietly (no event, no notice): construction runs before any
+        front end subscribes, so hosts read ``effective_model`` when they build
+        their chrome — the same way they read ``model_label`` — and the replayed
+        transcript already narrates the original failure.
+        """
+        details = self._transcript.latest_custom(ACTIVE_ROUTE_CUSTOM_TYPE)
+        if not details:
+            return
+        active = details.get("active")
+        if not isinstance(active, dict):
+            return
+        selector = str(active.get("selector") or "")
+        if "/" not in selector:
+            return
+        current = f"{self._model.provider}/{self._model.model_id}"
+        persisted_primary = str(details.get("primary") or "")
+        if persisted_primary and persisted_primary != current:
+            return
+        if selector == current:
+            return
+        raw_effort = active.get("effort")
+        effort = str(raw_effort) if isinstance(raw_effort, str) and raw_effort else None
+        spec = self._spec_for_route(selector, effort)
+        if spec is None:
+            logger.warning("dropping unresolvable persisted fallback route: %r", selector)
+            return
+        self._active_fallback = spec
+        self._active_route = (selector, effort)
+        # Re-pin the stream fn's route too, or the restore is display-only and
+        # the first prompt goes back to the provider that was failing. Optional
+        # capability like the notice bridge: hosts that construct sessions with
+        # bare stream functions simply resume on the primary.
+        restore = getattr(self._stream_fn, "restore_fallback", None)
+        if callable(restore):
+            restore(selector, effort, current)
 
     async def set_wake_schedules(self, schedules: list[WakeSchedule]) -> None:
         """Full-list update from the wake tool: persists then re-arms."""

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -91,6 +91,7 @@ from local_operator.tui.events import (
     CompactionEnded,
     CompactionStarted,
     ContextUsageReported,
+    EffectiveModelChanged,
     EventController,
     NoticePosted,
     RetryEnded,
@@ -1502,7 +1503,11 @@ class OperatorApp(App[None]):
         self._controller.subscribe()
         assert self._status is not None
         self._status.update(
-            model_label=session.model_label,
+            # The EFFECTIVE label: a resumed session that was serving from a
+            # provider fallback when it closed boots back onto that fallback
+            # (Session._restore_active_route), and painting the selection here
+            # would open the band on a model that is not answering.
+            model_label=_effective_label(session),
             model_name=_model_name(session),
             effort=_effort_label(session),
             context_window=_context_window(session),
@@ -6509,8 +6514,11 @@ class OperatorApp(App[None]):
             # The window and the effort belong to the SPEC, not the session:
             # a switch that repainted only the label would leave the context
             # percentage measured against the previous model's window.
+            # `_effective_label`, though after an explicit switch it equals
+            # `model_label` — `set_model` clears any pinned fallback — so this
+            # is one vocabulary for every model paint, not a second opinion.
             self._status.update(
-                model_label=session.model_label,
+                model_label=_effective_label(session),
                 model_name=_model_name(session),
                 effort=_effort_label(session),
                 context_window=_context_window(session),
@@ -9472,7 +9480,10 @@ class OperatorApp(App[None]):
         """
         if self._session is None:
             return None
-        return turn_cost(self._session.model_label, usage)
+        # The EFFECTIVE model: while a fallback serves, the tokens were billed
+        # at ITS rates, and pricing them off the selected model is a wrong
+        # number wearing the band's authority.
+        return turn_cost(_effective_label(self._session), usage)
 
     def _harvest_subagent_costs(self) -> None:
         """Record what each child has spent, keyed by job id.
@@ -9970,6 +9981,35 @@ class OperatorApp(App[None]):
         if held or held_images:
             self._start_turn(held, resolve_markers(held, held_images))
 
+    def on_effective_model_changed(self, message: EffectiveModelChanged) -> None:
+        """Repaint the model segment with the model actually serving requests.
+
+        The fallback NOTICE narrates the moment; this keeps the band truthful
+        for the fallback's whole lifetime, in both directions — pinned and
+        recovered. The window and effort ride along because they are properties
+        of the model being displayed: a band naming the fallback while dividing
+        context usage by the primary's window misreports both at once.
+
+        No transcript line of its own: the route-change notice (or the
+        ``/model`` receipt) has already said what happened, and a second line
+        for the same edge is the two-notices-for-one-event defect the
+        compaction handlers document.
+        """
+        if self._status is None:
+            return
+        session = self._session
+        self._status.update(
+            model_label=f"{message.provider}/{message.model_id}",
+            # Re-read through the session helpers rather than trusting the
+            # event alone: they already answer "what name / window does the
+            # EFFECTIVE model have", and the session updated its effective spec
+            # before emitting. A host without the tracking degrades to the
+            # selected model's values, which is then also what the label says.
+            model_name=_model_name(session) if session is not None else "",
+            effort=_effort_label(session) if session is not None else "",
+            context_window=_context_window(session) if session is not None else 0,
+        )
+
     def on_retry_started(self, message: RetryStarted) -> None:
         body = f"retry {message.attempt}: {message.error}"
         if message.fallback_model:
@@ -10079,13 +10119,39 @@ def slot_rows(slot: Any) -> int:
 
 
 def _model_spec(session) -> Any | None:
-    """The session's active ``ModelSpec``, or ``None`` when it has none.
+    """The session's SELECTED ``ModelSpec``, or ``None`` when it has none.
 
     Defensive because the TUI also runs against reduced hosts — embedders
     and the pilot fakes supply a session without the spec accessor — and a
     status segment must degrade to "unknown" rather than take the app down.
+
+    This is the spec the MUTATION paths read (``/effort`` validates against
+    it, ``/model default`` persists it); what the band DISPLAYS is
+    :func:`_effective_spec`, which differs while a provider fallback serves.
     """
     return getattr(session, "model", None)
+
+
+def _effective_spec(session) -> Any | None:
+    """The spec of the model ACTUALLY serving requests, or ``None``.
+
+    Falls back to the selected spec on hosts that predate the fallback
+    tracking (the pilot fakes, embedders): for them the two are the same
+    claim, so degrading is honest rather than approximate.
+    """
+    return getattr(session, "effective_model", None) or getattr(session, "model", None)
+
+
+def _effective_label(session) -> str:
+    """``provider/model`` of the model actually serving requests.
+
+    What every band paint uses for the model segment: while a provider
+    fallback is pinned, painting ``session.model_label`` (the selection)
+    asserts a model that is not answering — the exact stale frame the
+    fallback display work exists to prevent.
+    """
+    label = str(getattr(session, "effective_model_label", "") or "")
+    return label or str(getattr(session, "model_label", "") or "")
 
 
 def _model_name(session) -> str:
@@ -10099,17 +10165,26 @@ def _model_name(session) -> str:
     ``getattr`` for the same reason :func:`_model_spec` uses it: the pilot fakes
     and embedding hosts supply specs of their own shape, and a missing name is a
     segment that falls back to the selector, not a crash.
+
+    Off the EFFECTIVE spec: while a fallback serves, the band's label names the
+    fallback, and a human name resolved from the selected model beside it would
+    caption one model with another's name.
     """
-    return str(getattr(_model_spec(session), "display_name", "") or "")
+    return str(getattr(_effective_spec(session), "display_name", "") or "")
 
 
 def _context_window(session) -> int:
-    """The active model's context window, or 0 when it is unknown.
+    """The context window of the model actually serving, or 0 when unknown.
 
     Zero is meaningful downstream: the usage segment renders ``12.4k/—``
     rather than inventing a denominator to divide by.
+
+    The EFFECTIVE spec, deliberately: the usage percentage predicts when the
+    NEXT request overflows, and the next request goes to the fallback — a
+    denominator borrowed from the selected model misstates exactly the number
+    the segment exists to report.
     """
-    window = getattr(_model_spec(session), "context_window", 0) or 0
+    window = getattr(_effective_spec(session), "context_window", 0) or 0
     return int(window) if window > 0 else 0
 
 
@@ -10193,8 +10268,12 @@ def _effort_label(session) -> str:
 
     Non-reasoning models render nothing, which is what makes the segment's
     presence informative.
+
+    The EFFECTIVE spec, like the label and window: a fallback target may clamp
+    the chosen level to its own ladder (see ``spec_for_target``), and the
+    segment's one job is to name the level in force on the model answering.
     """
-    spec = _model_spec(session)
+    spec = _effective_spec(session)
     if spec is None:
         return ""
     explicit = getattr(spec, "reasoning_effort", None)

--- a/local_operator/tui/events.py
+++ b/local_operator/tui/events.py
@@ -46,6 +46,7 @@ from local_operator.harness.types import (
     MessageEndEvent,
     MessageStartEvent,
     MessageUpdateEvent,
+    ModelChangeEvent,
     NoticeEvent,
     RetryEndEvent,
     RetryStartEvent,
@@ -235,6 +236,33 @@ class RetryStarted(Message):
         self.attempt = attempt
         self.error = error
         self.fallback_model = fallback_model
+
+
+class EffectiveModelChanged(Message):
+    """The model actually serving requests changed (fallback or recovery).
+
+    What the status band repaints its model segment from: ``provider`` and
+    ``model_id`` name the model now answering, ``is_fallback`` says whether it
+    is a fallback detour or the selected model back in force. Carried as data
+    rather than read off the session at handling time because the event
+    crosses the controller's thread boundary — by the time the app thread
+    handles it, the session may already be mid-way through the NEXT edge.
+    """
+
+    def __init__(
+        self,
+        provider: str,
+        model_id: str,
+        effort: str | None,
+        reason: str,
+        is_fallback: bool,
+    ) -> None:
+        super().__init__()
+        self.provider = provider
+        self.model_id = model_id
+        self.effort = effort
+        self.reason = reason
+        self.is_fallback = is_fallback
 
 
 class RetryEnded(Message):
@@ -540,6 +568,20 @@ class EventController:
     def _handle_retry_start(self, event: RetryStartEvent) -> None:
         self._post(RetryStarted(event.attempt, event.error, event.fallback_model))
 
+    def _handle_model_change(self, event: ModelChangeEvent) -> None:
+        # No generation guard: the route edge belongs to the session, not to a
+        # turn, and a fallback pinned by a stale turn's last request is still
+        # the route the next request will take.
+        self._post(
+            EffectiveModelChanged(
+                event.provider,
+                event.model_id,
+                event.effort,
+                event.reason,
+                event.is_fallback,
+            )
+        )
+
     def _handle_retry_end(self, event: RetryEndEvent) -> None:
         self._post(RetryEnded(event.success))
 
@@ -579,6 +621,7 @@ class EventController:
         "compaction_end": _handle_compaction_end,
         "retry_start": _handle_retry_start,
         "retry_end": _handle_retry_end,
+        "model_change": _handle_model_change,
         "subagent_start": _handle_subagent_start,
         "subagent_progress": _handle_subagent_progress,
         "subagent_end": _handle_subagent_end,

--- a/local_operator/tui/widgets/subagent_view.py
+++ b/local_operator/tui/widgets/subagent_view.py
@@ -360,6 +360,17 @@ def fold_trajectory(events: Sequence[Any], *, settled: bool = False) -> list[Sub
             if event.get("fallback_model"):
                 body += f" → falling back to {event.get('fallback_model')}"
             note(index, body, "warning")
+        elif etype == "model_change":
+            # The child's route moved (fallback pinned or primary recovered).
+            # One line either way: the page is a trajectory, and which model
+            # answered from this point on is part of what happened.
+            fell = bool(event.get("is_fallback"))
+            selector = f"{event.get('provider', '')}/{event.get('model_id', '')}"
+            note(
+                index,
+                (f"now serving from {selector}" if fell else f"back on {selector}"),
+                "warning" if fell else "info",
+            )
         elif etype == "agent_end":
             # The child's own failure, in the wording `on_turn_ended` uses for
             # the parent's. Without it a failed subagent's page simply stopped,

--- a/local_operator/tui/widgets/subagent_view.py
+++ b/local_operator/tui/widgets/subagent_view.py
@@ -366,9 +366,10 @@ def fold_trajectory(events: Sequence[Any], *, settled: bool = False) -> list[Sub
             # answered from this point on is part of what happened.
             fell = bool(event.get("is_fallback"))
             selector = f"{event.get('provider', '')}/{event.get('model_id', '')}"
+            # Same verb pairing as the parent's notices (design D2).
             note(
                 index,
-                (f"now serving from {selector}" if fell else f"back on {selector}"),
+                (f"fell back to {selector}" if fell else f"back to {selector}"),
                 "warning" if fell else "info",
             )
         elif etype == "agent_end":

--- a/scripts/fallback_shot.py
+++ b/scripts/fallback_shot.py
@@ -1,0 +1,93 @@
+"""Capture the composer band while a provider fallback serves requests.
+
+    env -u NO_COLOR TERM=xterm-256color .venv/bin/python scripts/fallback_shot.py out.svg after
+    env -u NO_COLOR TERM=xterm-256color .venv/bin/python scripts/fallback_shot.py out.svg before
+
+Drives the REAL ``OperatorApp`` (the one that loads ``local_operator.tcss``)
+with a session whose effective-model surface follows the route edge, posts the
+fallback notice and the ``EffectiveModelChanged`` message the way the live
+event bridge does, and saves the settled frame.
+
+``before`` skips the ``EffectiveModelChanged`` post, which reproduces the
+pre-fix behaviour exactly — the notice printed, the band never moved — so the
+pair shows the delta this feature exists to close: a band still naming the
+selected model while every request goes to the fallback.
+"""
+
+import asyncio
+import sys
+from types import SimpleNamespace
+
+sys.path.insert(0, ".")
+
+from local_operator.tui.app import OperatorApp  # noqa: E402
+from local_operator.tui.events import EffectiveModelChanged, NoticePosted  # noqa: E402
+from tests.unit.tui.test_app_pilot import FakeSession, _factory  # noqa: E402
+
+
+class _FallbackSession(FakeSession):
+    """A session mid-fallback: selection Kimi K3, requests served by GLM 5.3."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        # Declared on the class: the "after" frame assigns it, and pyright
+        # rejects attribute-creation off an assignment.
+        self._eff: object = None
+
+    @property
+    def model_label(self) -> str:
+        return "kimi/kimi-k3"
+
+    @property
+    def model(self):
+        return SimpleNamespace(
+            provider="kimi",
+            model_id="kimi-k3",
+            display_name="Kimi K3",
+            context_window=262_144,
+            reasoning_effort=None,
+            reasoning_efforts=(),
+            reasoning=False,
+        )
+
+    @property
+    def effective_model(self):
+        return getattr(self, "_eff", None) or self.model
+
+    @property
+    def effective_model_label(self):
+        spec = self.effective_model
+        return f"{spec.provider}/{spec.model_id}"
+
+
+async def main() -> None:
+    out, mode = sys.argv[1], sys.argv[2]
+    session = _FallbackSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await pilot.pause()
+        # The user's turn, then the failure narration the stream fn emits.
+        from local_operator.tui.widgets.transcript import UserBlock
+
+        app._append_block(UserBlock("Continue"))
+        app.post_message(NoticePosted("provider failure — falling back to zai/glm-5.3", "warning"))
+        await pilot.pause()
+        if mode == "after":
+            session._eff = SimpleNamespace(
+                provider="zai",
+                model_id="glm-5.3",
+                display_name="GLM 5.3",
+                context_window=1_000_000,
+                reasoning_effort=None,
+                reasoning_efforts=(),
+                reasoning=False,
+            )
+            app.post_message(
+                EffectiveModelChanged("zai", "glm-5.3", None, "provider failure", True)
+            )
+        await pilot.pause()
+        await pilot.pause()
+        app.save_screenshot(out)
+
+
+asyncio.run(main())

--- a/tests/unit/model/test_configure.py
+++ b/tests/unit/model/test_configure.py
@@ -1086,3 +1086,118 @@ class TestAnIsolatedRequestTouchesNoneOfTheSessionsSharedState:
         assert result["message_effort"] is not None
         assert result["preflights"], "no preflight ran on an ordinary request"
         assert result["body"]["prompt_cache_key"] == "session-isolation"
+
+
+class TestRouteSettleBridge:
+    """The stream fn's route bridge: what the session's model display hangs off.
+
+    ``set_route_handler`` receives BOTH edges — the pinned target on a
+    fallback, ``None`` on recovery — because a display that only ever hears
+    "fell back" keeps naming the fallback after the primary recovered.
+    """
+
+    def _stream(self, store, settings=None):
+        return create_stream_fn(
+            store,
+            settings
+            or {
+                "retry": {
+                    "usageAwareFallback": True,
+                    "fallbackChains": {"default": ["openai/gpt-5.3-codex"]},
+                }
+            },
+            session_id="session-route",
+        )
+
+    @pytest.mark.asyncio
+    async def test_fallback_activation_reaches_the_route_handler(self, tmp_path) -> None:
+        store = AuthStore(tmp_path / "auth.db")
+        stream = self._stream(store)
+        edges: list[tuple[Any, str]] = []
+        stream.set_route_handler(lambda target, reason: edges.append((target, reason)))
+        try:
+            await stream._route_state.activate(
+                FallbackTarget("openai/gpt-5.3-codex"), "provider failure"
+            )
+            assert len(edges) == 1
+            target, reason = edges[0]
+            assert target == FallbackTarget("openai/gpt-5.3-codex")
+            assert reason == "provider failure"
+        finally:
+            await stream.close()
+            store.close()
+
+    @pytest.mark.asyncio
+    async def test_preflight_recovery_settles_and_narrates(self, tmp_path) -> None:
+        """The auth-only preflight path clears a pinned route as a SETTLED
+        edge (handler told, notice printed), not as silent bookkeeping —
+        otherwise the display keeps naming a fallback that stopped serving."""
+        store = AuthStore(tmp_path / "auth.db")
+        store.upsert_credential("anthropic", {"key": "sk-ant", "source": "login"})
+        stream = create_stream_fn(
+            store,
+            {"retry": {"usageAwareFallback": False}},
+            session_id="session-route",
+        )
+        edges: list[Any] = []
+        notices: list[str] = []
+        stream.set_route_handler(lambda target, reason: edges.append(target))
+        stream.set_notice_handler(lambda text, kind: notices.append(f"{kind}:{text}"))
+        model = ModelSpec(provider="anthropic", model_id="claude-opus-5")
+        stream._primary_selector = "anthropic/claude-opus-5"
+        stream._route_state.active = FallbackTarget("openai/gpt-5.3-codex")
+        try:
+            await stream.preflight_usage(model)
+            assert edges == [None]
+            assert any("back on anthropic/claude-opus-5" in notice for notice in notices)
+            assert any(notice.startswith("info:") for notice in notices)
+        finally:
+            await stream.close()
+            store.close()
+
+    @pytest.mark.asyncio
+    async def test_restore_fallback_pins_without_announcing(self, tmp_path) -> None:
+        """A resume's re-pin fires NEITHER handler — the transcript replay
+        already narrates the original failure, and the restoring session set
+        its own state from the same entry — but must seed the primary memo and
+        a probe grace, or the next preflight clears the pin it was handed."""
+        store = AuthStore(tmp_path / "auth.db")
+        stream = self._stream(store)
+        edges: list[Any] = []
+        notices: list[str] = []
+        stream.set_route_handler(lambda target, reason: edges.append(target))
+        stream.set_notice_handler(lambda text, kind: notices.append(text))
+        try:
+            stream.restore_fallback("openai/gpt-5.3-codex", None, "anthropic/claude-opus-5")
+            assert stream._route_state.active == FallbackTarget("openai/gpt-5.3-codex")
+            assert stream._primary_selector == "anthropic/claude-opus-5"
+            assert not stream._route_state.primary_retry_due()
+            assert edges == []
+            assert notices == []
+        finally:
+            await stream.close()
+            store.close()
+
+    @pytest.mark.asyncio
+    async def test_restored_pin_survives_the_boot_preflight(self, tmp_path) -> None:
+        """The TUI runs a quota preflight seconds after boot; a restored pin
+        must survive it. The auth-only clear path would otherwise probe only
+        "does the primary HAVE auth" — true throughout an outage — and unpin
+        a fallback the provider is still failing behind."""
+        store = AuthStore(tmp_path / "auth.db")
+        store.upsert_credential("anthropic", {"key": "sk-ant", "source": "login"})
+        stream = create_stream_fn(
+            store,
+            {"retry": {"usageAwareFallback": False}},
+            session_id="session-route",
+        )
+        edges: list[Any] = []
+        stream.set_route_handler(lambda target, reason: edges.append(target))
+        try:
+            stream.restore_fallback("openai/gpt-5.3-codex", None, "anthropic/claude-opus-5")
+            await stream.preflight_usage(ModelSpec(provider="anthropic", model_id="claude-opus-5"))
+            assert stream._route_state.active == FallbackTarget("openai/gpt-5.3-codex")
+            assert edges == []
+        finally:
+            await stream.close()
+            store.close()

--- a/tests/unit/model/test_configure.py
+++ b/tests/unit/model/test_configure.py
@@ -1149,7 +1149,7 @@ class TestRouteSettleBridge:
         try:
             await stream.preflight_usage(model)
             assert edges == [None]
-            assert any("back on anthropic/claude-opus-5" in notice for notice in notices)
+            assert any("back to anthropic/claude-opus-5" in notice for notice in notices)
             assert any(notice.startswith("info:") for notice in notices)
         finally:
             await stream.close()

--- a/tests/unit/providers/test_failover.py
+++ b/tests/unit/providers/test_failover.py
@@ -3045,3 +3045,69 @@ class TestTheLoopBackSweep:
         assert excinfo.value.kind == "quota"
         assert excinfo.value.retryable
         assert "not usable right now" in excinfo.value.message
+
+
+@pytest.mark.asyncio
+async def test_route_edges_reach_the_settle_handler_in_both_directions() -> None:
+    """The settle hook hears the fallback pin AND the recovery.
+
+    The recovery direction is the one a display cannot live without: the
+    driver's success path used to `clear()` silently, so a band that learned
+    "now serving from the fallback" had no edge to learn "back on the
+    primary" from — the same stale frame in the opposite direction.
+    """
+    primary_healthy = False
+
+    async def client_for(spec: ModelSpec) -> Any:
+        if spec.provider == "openai" and not primary_healthy:
+            return ScriptedClient(ProviderError(400, "model unavailable"))
+        return ScriptedClient([StreamEndEvent(stop_reason="stop")])
+
+    settings = {"retry": {"fallbackChains": {"default": ["anthropic/claude-opus-5"]}}}
+    edges: list[Any] = []
+    state = FailoverRouteState(on_settle=lambda target, reason: edges.append(target))
+    auth = FakeAuth({"openai": ["k1"], "anthropic": ["k2"]})
+
+    _ = [
+        event
+        async for event in stream_with_failover(
+            _request(), auth, settings, client_for, route_state=state
+        )
+    ]
+    assert edges == [FallbackTarget("anthropic/claude-opus-5")]
+
+    # The primary recovers; a probe reaching it must settle the route back.
+    primary_healthy = True
+    state.primary_retry_at_ms = 0  # the cooldown has elapsed
+    state.active = None  # preflight's probe path re-opens the primary
+    _ = [
+        event
+        async for event in stream_with_failover(
+            _request(), auth, settings, client_for, route_state=state
+        )
+    ]
+    # No new edge: nothing was pinned when the primary served, so the clear
+    # is a no-op rather than a spurious "back on" for a route never left.
+    assert edges == [FallbackTarget("anthropic/claude-opus-5")]
+
+
+@pytest.mark.asyncio
+async def test_primary_success_with_a_pinned_route_settles_the_recovery() -> None:
+    """`clear_settled` fires exactly on the pinned→primary transition."""
+    edges: list[Any] = []
+    state = FailoverRouteState(on_settle=lambda target, reason: edges.append(target))
+    state.active = FallbackTarget("anthropic/claude-opus-5")
+
+    async def client_for(spec: ModelSpec) -> Any:
+        return ScriptedClient([StreamEndEvent(stop_reason="stop")])
+
+    # The pinned target is not in this request's chain (no chains configured),
+    # so the walk starts at the primary — the "primary probe succeeds" shape.
+    _ = [
+        event
+        async for event in stream_with_failover(
+            _request(), FakeAuth({"openai": ["k1"]}), None, client_for, route_state=state
+        )
+    ]
+    assert edges == [None]
+    assert state.active is None

--- a/tests/unit/session/test_active_route.py
+++ b/tests/unit/session/test_active_route.py
@@ -1,0 +1,342 @@
+"""The effective-model surface: fallback display state, persistence, resume.
+
+A provider fallback re-routes requests away from the SELECTED model, and the
+session is the one place that fact is turned into host-visible state:
+
+- ``effective_model`` / ``effective_model_label`` are what a front end paints
+  its model display from (the composer band in the TUI);
+- every route edge is persisted as an ``active_model_route`` custom entry, so a
+  resumed session comes back on the model that was really answering;
+- a ``ModelChangeEvent`` rides the session stream at each edge so the display
+  updates live rather than at the next boot.
+
+These tests drive the session through the same bridge the real
+``SessionStreamFn`` uses (``set_route_handler``), because the contract under
+test is the session's half: what it does when the stream reports a route edge.
+The stream fn's own half (when it reports one) is covered in
+``tests/unit/model/test_configure.py`` and ``tests/unit/providers/test_failover.py``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from local_operator.harness.types import ModelChangeEvent, ModelSpec, StreamEndEvent
+from local_operator.providers.failover import FallbackTarget
+from local_operator.session.session import ACTIVE_ROUTE_CUSTOM_TYPE, Session
+from local_operator.session.transcript import Transcript
+
+from .test_session import MODEL, ScriptedStream, wait_for
+
+
+class RoutedStream(ScriptedStream):
+    """A stream fn with the route-bridge capability the session binds to."""
+
+    def __init__(self, turns=None) -> None:
+        super().__init__(turns or [[StreamEndEvent(stop_reason="stop")]])
+        # Annotated: pyright infers Optional from a bare ``= None``, and every
+        # test below CALLS the handler — an Optional call error in a suite that
+        # only ever runs with the bridge installed is noise the assert already
+        # answers.
+        self.route_handler: Any = None
+        self.notice_handler: Any = None
+        self.restored: list[tuple[str, str | None, str]] = []
+        self.models_changed: list[ModelSpec] = []
+
+    def set_route_handler(self, handler) -> None:
+        self.route_handler = handler
+
+    def set_notice_handler(self, handler) -> None:
+        self.notice_handler = handler
+
+    def restore_fallback(self, selector: str, effort: str | None, primary: str) -> None:
+        self.restored.append((selector, effort, primary))
+
+    def on_model_changed(self, model: ModelSpec) -> None:
+        self.models_changed.append(model)
+
+
+def _session(tmp_path, stream, **kwargs) -> Session:
+    transcript = Transcript(tmp_path / "sess")
+    return Session(
+        model=kwargs.pop("model", MODEL),
+        stream_fn=stream,
+        tools=[],
+        transcript=transcript,
+        system_blocks_provider=lambda: ["stable", "env"],
+        **kwargs,
+    )
+
+
+def _route_entries(session: Session) -> list[dict[str, Any]]:
+    return [
+        entry.payload["details"]
+        for entry in session._transcript.entries()
+        if entry.type == "custom" and entry.payload.get("custom_type") == ACTIVE_ROUTE_CUSTOM_TYPE
+    ]
+
+
+@pytest.mark.asyncio
+async def test_fallback_edge_updates_effective_model_and_emits(tmp_path):
+    """A pinned fallback becomes the effective model, with its OWN metadata.
+
+    The derived spec must be the target's (context window included), not a
+    relabelled copy of the primary: a display naming the fallback while
+    dividing usage by the primary's window misreports both at once.
+    """
+    stream = RoutedStream()
+    session = _session(tmp_path, stream)
+    events: list[Any] = []
+    session.subscribe(events.append)
+
+    assert session.effective_model_label == session.model_label
+
+    assert stream.route_handler is not None
+    await stream.route_handler(FallbackTarget("zai/glm-5.3", None), "provider failure")
+
+    assert session.effective_model_label == "zai/glm-5.3"
+    assert session.model_label == "test/m", "the SELECTION must not move"
+    # The target's own window, not the primary's 100k.
+    assert session.effective_model.context_window != MODEL.context_window
+
+    changes = [event for event in events if isinstance(event, ModelChangeEvent)]
+    assert len(changes) == 1
+    assert (changes[0].provider, changes[0].model_id) == ("zai", "glm-5.3")
+    assert changes[0].is_fallback is True
+    assert changes[0].context_window == session.effective_model.context_window
+
+
+@pytest.mark.asyncio
+async def test_recovery_edge_returns_display_to_the_selection(tmp_path):
+    stream = RoutedStream()
+    session = _session(tmp_path, stream)
+    events: list[Any] = []
+    session.subscribe(events.append)
+
+    await stream.route_handler(FallbackTarget("zai/glm-5.3", None), "provider failure")
+    await stream.route_handler(None, "primary model recovered")
+
+    assert session.effective_model_label == "test/m"
+    assert session.active_fallback is None
+    changes = [event for event in events if isinstance(event, ModelChangeEvent)]
+    assert [change.is_fallback for change in changes] == [True, False]
+
+
+@pytest.mark.asyncio
+async def test_every_edge_is_persisted_including_recovery(tmp_path):
+    """Recovery writes an ``active: None`` row.
+
+    ``latest_custom`` scans backwards and stops at the first hit, so without
+    the recovery row a session that fell back and recovered would resume
+    pinned to a fallback nothing is wrong with.
+    """
+    stream = RoutedStream()
+    session = _session(tmp_path, stream)
+
+    await stream.route_handler(FallbackTarget("zai/glm-5.3", "high"), "provider failure")
+    await stream.route_handler(None, "primary model recovered")
+
+    entries = _route_entries(session)
+    assert len(entries) == 2
+    assert entries[0]["active"] == {"selector": "zai/glm-5.3", "effort": "high"}
+    assert entries[0]["primary"] == "test/m"
+    assert entries[1]["active"] is None
+
+
+@pytest.mark.asyncio
+async def test_resume_restores_the_pinned_fallback(tmp_path):
+    """A session that closed while a fallback served resumes ON that fallback.
+
+    Both halves matter: the display state (``effective_model``) so the band
+    opens truthful, and the stream re-pin (``restore_fallback``) so the first
+    prompt does not go back to the provider that was failing — a restore
+    without the re-pin is display-only and lies the other way.
+    """
+    first = RoutedStream()
+    _session(tmp_path, first)  # binds the route handler; entries land in tmp_path/sess
+    await first.route_handler(FallbackTarget("zai/glm-5.3", None), "provider failure")
+
+    resumed_stream = RoutedStream()
+    resumed = Session(
+        model=MODEL,
+        stream_fn=resumed_stream,
+        tools=[],
+        transcript=Transcript(tmp_path / "sess"),
+        system_blocks_provider=lambda: ["stable", "env"],
+    )
+
+    assert resumed.effective_model_label == "zai/glm-5.3"
+    assert resumed.model_label == "test/m"
+    assert resumed_stream.restored == [("zai/glm-5.3", None, "test/m")]
+
+
+@pytest.mark.asyncio
+async def test_resume_after_recovery_restores_nothing(tmp_path):
+    first = RoutedStream()
+    _session(tmp_path, first)  # binds the route handler; entries land in tmp_path/sess
+    await first.route_handler(FallbackTarget("zai/glm-5.3", None), "provider failure")
+    await first.route_handler(None, "primary model recovered")
+
+    resumed_stream = RoutedStream()
+    resumed = Session(
+        model=MODEL,
+        stream_fn=resumed_stream,
+        tools=[],
+        transcript=Transcript(tmp_path / "sess"),
+        system_blocks_provider=lambda: ["stable", "env"],
+    )
+
+    assert resumed.effective_model_label == "test/m"
+    assert resumed_stream.restored == []
+
+
+@pytest.mark.asyncio
+async def test_resume_drops_a_pin_recorded_against_another_selection(tmp_path):
+    """A `/model default` change between runs invalidates the persisted pin.
+
+    The pin rescued the OLD selection; the new selection owes the user a fresh
+    start on the model they actually chose, not a detour recorded against a
+    model they moved away from.
+    """
+    first = RoutedStream()
+    _session(tmp_path, first)  # binds the route handler; entries land in tmp_path/sess
+    await first.route_handler(FallbackTarget("zai/glm-5.3", None), "provider failure")
+
+    resumed_stream = RoutedStream()
+    resumed = Session(
+        model=ModelSpec(provider="anthropic", model_id="claude-opus-5", context_window=200_000),
+        stream_fn=resumed_stream,
+        tools=[],
+        transcript=Transcript(tmp_path / "sess"),
+        system_blocks_provider=lambda: ["stable", "env"],
+    )
+
+    assert resumed.effective_model_label == "anthropic/claude-opus-5"
+    assert resumed_stream.restored == []
+
+
+@pytest.mark.asyncio
+async def test_resume_skips_a_pin_naming_the_current_selection(tmp_path):
+    """The user adopting the fallback as their model makes the pin a no-op."""
+    first = RoutedStream()
+    _session(tmp_path, first)  # binds the route handler; entries land in tmp_path/sess
+    await first.route_handler(FallbackTarget("zai/glm-5.3", None), "provider failure")
+
+    resumed_stream = RoutedStream()
+    # Persisted primary was test/m, but the restore's primary-mismatch guard
+    # fires first; craft a same-primary entry whose fallback IS the selection.
+    resumed = Session(
+        model=MODEL,
+        stream_fn=resumed_stream,
+        tools=[],
+        transcript=Transcript(tmp_path / "sess"),
+        system_blocks_provider=lambda: ["stable", "env"],
+    )
+    # Sanity: the ordinary restore happened. Now simulate adopting the
+    # fallback: a new session selecting zai/glm-5.3 against the same entry.
+    adopted_stream = RoutedStream()
+    adopted = Session(
+        model=resumed.effective_model,
+        stream_fn=adopted_stream,
+        tools=[],
+        transcript=Transcript(tmp_path / "sess"),
+        system_blocks_provider=lambda: ["stable", "env"],
+    )
+    # The primary differs from the persisted one, so nothing restores — which
+    # is also the right answer for "selection == fallback": no spurious pin.
+    assert adopted.active_fallback is None
+    assert adopted_stream.restored == []
+
+
+@pytest.mark.asyncio
+async def test_set_model_clears_the_pin_and_announces_the_selection(tmp_path):
+    """An explicit `/model` switch withdraws the fallback pin's premise."""
+    stream = RoutedStream()
+    session = _session(tmp_path, stream)
+    events: list[Any] = []
+    session.subscribe(events.append)
+
+    await stream.route_handler(FallbackTarget("zai/glm-5.3", None), "provider failure")
+    assert session.effective_model_label == "zai/glm-5.3"
+
+    new_model = ModelSpec(provider="anthropic", model_id="claude-opus-5", context_window=200_000)
+    session.set_model(new_model)
+
+    assert session.active_fallback is None
+    assert session.effective_model_label == "anthropic/claude-opus-5"
+    # The clear is persisted (spawned in the background) with the NEW primary,
+    # so a resume does not restore the withdrawn pin.
+    await wait_for(lambda: len(_route_entries(session)) == 2)
+    entries = _route_entries(session)
+    assert entries[1]["active"] is None
+    assert entries[1]["primary"] == "anthropic/claude-opus-5"
+    await wait_for(
+        lambda: any(
+            isinstance(event, ModelChangeEvent) and not event.is_fallback for event in events
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_effort_change_rederives_the_fallback_display_spec(tmp_path):
+    """`/effort` while a fallback serves must move the DISPLAYED effort too.
+
+    ``spec_for_target`` carries the chosen level onto a chain entry that names
+    none, so the derived display spec holds a snapshot of the old level; the
+    same-model branch of ``set_model`` re-derives it from the pin.
+    """
+    stream = RoutedStream()
+    session = _session(
+        tmp_path,
+        stream,
+        model=ModelSpec(
+            provider="test",
+            model_id="m",
+            context_window=100_000,
+            reasoning_efforts=("low", "medium", "high"),
+            reasoning_effort="low",
+        ),
+    )
+    await stream.route_handler(FallbackTarget("openai/gpt-5.2", None), "provider failure")
+    before = session.effective_model.reasoning_effort
+
+    session.set_model(session.model.model_copy(update={"reasoning_effort": "high"}))
+
+    after = session.effective_model.reasoning_effort
+    assert session.effective_model_label == "openai/gpt-5.2"
+    assert before != after
+    assert after == "high"
+    # Quietly: same-model set_model persists no route entry (the route did not
+    # move) and notifies no model change.
+    assert len(_route_entries(session)) == 1
+
+
+@pytest.mark.asyncio
+async def test_unresolvable_persisted_route_is_dropped_not_fatal(tmp_path):
+    first = RoutedStream()
+    session = _session(tmp_path, first)
+    await session._transcript.append_custom(
+        ACTIVE_ROUTE_CUSTOM_TYPE,
+        {"primary": "test/m", "active": {"selector": "not-a-selector", "effort": None}},
+    )
+
+    resumed = Session(
+        model=MODEL,
+        stream_fn=RoutedStream(),
+        tools=[],
+        transcript=Transcript(tmp_path / "sess"),
+        system_blocks_provider=lambda: ["stable", "env"],
+    )
+    assert resumed.active_fallback is None
+    assert resumed.effective_model_label == "test/m"
+
+
+@pytest.mark.asyncio
+async def test_bare_stream_fn_degrades_to_the_selected_model(tmp_path):
+    """Hosts constructing sessions without the route capability keep working."""
+    stream = ScriptedStream([[StreamEndEvent(stop_reason="stop")]])
+    session = _session(tmp_path, stream)
+    assert session.effective_model is session.model
+    assert session.effective_model_label == session.model_label

--- a/tests/unit/test_exec_mode.py
+++ b/tests/unit/test_exec_mode.py
@@ -79,6 +79,15 @@ class FakeSession:
     def model(self) -> ModelSpec:
         return ModelSpec(provider="fake", model_id="fake-model")
 
+    @property
+    def effective_model(self) -> ModelSpec:
+        # The fake never falls back, so selection and effective agree.
+        return self.model
+
+    @property
+    def effective_model_label(self) -> str:
+        return self.model_label
+
     def set_model(self, model: ModelSpec) -> None:
         pass
 

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -140,6 +140,16 @@ class FakeSession:
     def model(self) -> Any:
         return None
 
+    @property
+    def effective_model(self) -> Any:
+        """The fake never falls back, so selection and effective agree —
+        which is also what keeps the protocol's degrade honest."""
+        return self.model
+
+    @property
+    def effective_model_label(self) -> str:
+        return self.model_label
+
     def set_model(self, model: Any) -> None:
         pass
 
@@ -4499,3 +4509,62 @@ async def test_context_command_renders_wire_schema_breakdown() -> None:
         assert "Messages" in listing and "~10.9k" in listing
         assert "Total" in listing and "~20.1k / 200k (10.1%)" in listing
         assert "Last cache read (exact)" in listing and "12.8k" in listing
+
+
+@pytest.mark.asyncio
+async def test_effective_model_change_repaints_the_band() -> None:
+    """A fallback edge repaints the band's model segment with the model
+    actually serving, and the recovery edge paints the selection back.
+
+    The band is the composer's one account of "who is replying"; leaving it
+    on the selected model while every request goes to a fallback is the stale
+    frame this event exists to prevent.
+    """
+    from local_operator.tui.events import EffectiveModelChanged
+
+    class _Effective(FakeSession):
+        """A session whose effective surface follows the edge, the way the
+        real one's does — the handler re-reads name/effort/window through it."""
+
+        def __init__(self) -> None:
+            super().__init__()
+            # Declared on the class so assigning it below is not an implicit
+            # attribute-creation (pyright), and so the property has a stable
+            # value before the first edge arrives.
+            self._eff: Any = None
+
+        @property
+        def effective_model(self):
+            return getattr(self, "_eff", None)
+
+        @property
+        def effective_model_label(self):
+            spec = getattr(self, "_eff", None)
+            return f"{spec.provider}/{spec.model_id}" if spec else "test/model"
+
+    session = _Effective()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await pilot.pause()
+        session._eff = SimpleNamespace(
+            provider="zai",
+            model_id="glm-5.3",
+            display_name="GLM 5.3",
+            context_window=200_000,
+            reasoning_effort=None,
+            reasoning_efforts=(),
+            reasoning=False,
+        )
+        app.post_message(EffectiveModelChanged("zai", "glm-5.3", None, "provider failure", True))
+        await pilot.pause()
+        assert app._status is not None
+        assert app._status._model_label == "zai/glm-5.3"
+        assert app._status._context_window == 200_000
+
+        # Recovery: the selection comes back, with its own metadata.
+        session._eff = None
+        app.post_message(
+            EffectiveModelChanged("test", "model", None, "primary model recovered", False)
+        )
+        await pilot.pause()
+        assert app._status._model_label == "test/model"

--- a/tests/unit/tui/test_band_panels.py
+++ b/tests/unit/tui/test_band_panels.py
@@ -60,6 +60,15 @@ class FakeSession:
     def model(self) -> Any:
         return None
 
+    @property
+    def effective_model(self) -> Any:
+        # The fake never falls back, so selection and effective agree.
+        return self.model
+
+    @property
+    def effective_model_label(self) -> str:
+        return self.model_label
+
     def set_model(self, model: Any) -> None:
         pass
 

--- a/tests/unit/tui/test_boot_layout.py
+++ b/tests/unit/tui/test_boot_layout.py
@@ -101,6 +101,15 @@ class FakeSession:
     def model(self) -> Any:
         return None
 
+    @property
+    def effective_model(self) -> Any:
+        # The fake never falls back, so selection and effective agree.
+        return self.model
+
+    @property
+    def effective_model_label(self) -> str:
+        return self.model_label
+
     def set_model(self, model: Any) -> None:
         pass
 

--- a/tests/unit/tui/test_cost_aggregation.py
+++ b/tests/unit/tui/test_cost_aggregation.py
@@ -76,6 +76,10 @@ class _Session(FakeSession):
     def model_label(self) -> str:
         return self._model_label
 
+    @property
+    def effective_model_label(self) -> str:
+        return self._model_label
+
 
 def _band_cost(app: OperatorApp) -> str:
     """What the status line is currently holding in its cost segment."""

--- a/tests/unit/tui/test_events.py
+++ b/tests/unit/tui/test_events.py
@@ -106,6 +106,14 @@ class FakeSession:
     def model(self) -> Any:
         return None
 
+    @property
+    def effective_model(self) -> Any:
+        return None
+
+    @property
+    def effective_model_label(self) -> str:
+        return "test/model"
+
     def set_model(self, model: Any) -> None:
         pass
 

--- a/tests/unit/tui/test_snapshot.py
+++ b/tests/unit/tui/test_snapshot.py
@@ -102,6 +102,15 @@ class FakeSession:
     def model(self) -> Any:
         return None
 
+    @property
+    def effective_model(self) -> Any:
+        # The fake never falls back, so selection and effective agree.
+        return self.model
+
+    @property
+    def effective_model_label(self) -> str:
+        return self.model_label
+
     def set_model(self, model: Any) -> None:
         pass
 

--- a/tests/unit/tui/test_welcome.py
+++ b/tests/unit/tui/test_welcome.py
@@ -474,6 +474,14 @@ class FakeSession:
     def model(self) -> Any:
         return None
 
+    @property
+    def effective_model(self) -> Any:
+        return self.model
+
+    @property
+    def effective_model_label(self) -> str:
+        return self.model_label
+
     def set_model(self, model: Any) -> None:
         pass
 


### PR DESCRIPTION
# PR Description

## Change classification

**C2 — standard / pre-authorized.** Behavioural feature across the provider failover layer, the session facade, and the TUI: the composer band and the persisted session state now track the model **actually serving requests** through a provider fallback, in both directions (pinned and recovered), instead of asserting the last selected model. No external API/schema contract is broken: `SessionProtocol` gains two read-only properties, and the session transcript gains an append-only custom entry type old builds simply ignore. Clean rollback via `git revert`.

## The gap

When a provider failed and the failover driver pinned a fallback, the transcript got one warning line — `provider failure — falling back to zai/glm-5.3` — and the composer band kept naming the selected model for the rest of the session:

- **The band lied about who was replying.** It paints `session.model_label` (the selection), which a fallback never changes, and no event existed to tell a front end the route had moved — or had moved back.
- **A resume re-routed the first prompt to the provider that was failing.** The pin lived in process memory (`FailoverRouteState`), so closing and resuming a session mid-fallback silently dropped the detour the last run had learned the hard way.
- **Every derived reading was wrong while a fallback served.** Context usage divided by the selected model's window, compaction gated on it, turn cost was priced at its rates, and a resumed subagent's job row reopened on the selection too.

## The fix

**Provider/stream layer** — `FailoverRouteState` gains an `on_settle` hook fired on *both* edges: `activate` (pinned target) and the new `clear_settled` (primary recovered). The driver's primary-success clear and both preflight recovery clears are now settled edges; bookkeeping clears (the selector reset on a `/model` switch) stay silent. `SessionStreamFn` forwards the pair to its owning session through `set_route_handler`, mirroring the notice bridge's ownership split, and `restore_fallback()` re-pins a persisted route — seeding the preflight's primary-selector memo (without which the first boundary check reads the primary as "a different model" and clears the pin it was just handed) and a short 60s probe grace so the TUI's boot-time quota preflight cannot un-pin a restored fallback before the first request proves anything. Recovery is narrated too (`info` line, `back on <selector>`), because a display that snaps back silently reads as a glitch.

**Session layer** — the session owns the derived state: `effective_model`/`effective_model_label` (on `SessionProtocol`) name the fallback's own spec while one is pinned, derived by the same `spec_for_target` the driver builds requests from, so the band and the wire cannot disagree about effort or window. Every edge persists an `active_model_route` custom entry — **including recovery** (`active: None`), because `latest_custom`'s backward scan stops at the first hit and without the recovery row a fall-back-then-recovered session would resume pinned to a detour nothing was wrong with. A `ModelChangeEvent` rides the session stream at each edge carrying the model-in-force's window, so consumers holding only the event (a parent relaying a child's stream) stay truthful without re-resolving.

**Restore is conservative.** A resumed session re-adopts the pin only when it was recorded against the *current* selection: a `/model default` change, an agent-profile edit, or a `--hosting` flag between runs drops it; the user adopting the fallback as their model makes the pin a no-op; an explicit `/model` switch clears the pin and persists the new primary in the same step. Compaction gates and the snapcompact archive now size against the effective model's window — the next request is the one that has to fit — and `/effort` while a fallback serves re-derives the displayed level from the pin (quietly: the route did not move).

**Front ends** — the TUI repaints the band from `ModelChangeEvent` in both directions (model, resolved name, effort, context window), boot and `/model` paints use the effective label, turn cost is priced at the serving model's rates, subagent job rows follow the child's own `model_change` events, the trajectory page notes the edge, and headless print mode gets the same one line. Everything reads the effective surface through `getattr` degrades, so reduced hosts (pilot fakes, embedders) keep working unchanged.

## Testing evidence

**Unit suites.** 24 new tests: session-level (`tests/unit/session/test_active_route.py` — edge updates the effective spec with the target's own window, every edge persists including recovery, resume restores display + route, recovery/cross-selection/adoption cases restore nothing, `/model` clears the pin and persists the new primary, `/effort` mid-fallback re-derives the display spec, malformed entry dropped, bare stream fn degrades), stream-level (`TestRouteSettleBridge` in `test_configure.py` — the settle bridge fires on pin and recovery, restore is silent, **a restored pin survives the boot preflight**), driver-level (`test_failover.py` — the primary-success path settles the recovery edge exactly once; no spurious edge when nothing was pinned), TUI-level (band repaints on the event in both directions).

**Full suite:** 5114 passed, 7 skipped, 1 failure — `test_eval_tool.py::test_background_streams_output_while_it_runs`, the load-sensitive streaming assertion already documented as flaky on PRs #172/#174/#177/#187. Verified failing **identically on clean `origin/main`** (`e22416c`) in a pristine worktree, with no code from this branch involved: the test drives background bash-job output streaming and touches nothing in the failover/session/model-display path.

**Gates.** black + isort clean; flake8 clean; pyright (`--pythonpath .venv/bin/python .`) **0 errors** (baseline `origin/main` also 0 — the two new `SessionProtocol` properties were added to every test fake that asserts protocol conformance).

**Real-path exercise (rendered frames).** Drove the real `OperatorApp` (loads the real stylesheet) at 100×24 over a session mid-fallback — selection `kimi/kimi-k3`, requests served by `zai/glm-5.3` — posting the failure notice and the route edge exactly as the live event bridge does (`scripts/fallback_shot.py`, committed). The `before` frame skips the `EffectiveModelChanged` post, which reproduces the pre-fix behaviour exactly: the notice printed, the band never moved. The pair isolates the delta.

## Screenshots

Real `OperatorApp`, 100×24, head `7bc49c9`. Same transcript state in both frames — the difference is the band.

| State | Frame |
| --- | --- |
| **Before** — notice says `falling back to zai/glm-5.3`; band still says Kimi K3 | ![before](https://raw.githubusercontent.com/damianvtran/local-operator/assets/pr-fallback-model/before-band-stuck-on-selection.png) |
| **After** — band follows the route edge: GLM 5.3, with the fallback's own window behind the usage segment | ![after](https://raw.githubusercontent.com/damianvtran/local-operator/assets/pr-fallback-model/after-band-follows-fallback.png) |

## Non-goals

- The fallback remains session-scoped routing state; nothing about *when* to fall back changed — only who hears about it.
- The `/model` picker's current-row marker and boot-default persistence are unchanged; the new state answers "who is answering", not "what did I pick".
- No changes to credential rotation, quota policy, or chain configuration.
