### PR TITLE
fix(providers): exhaust every account's quota before failing over

### DIFF
--- a/local_operator/model/configure.py
+++ b/local_operator/model/configure.py
@@ -1833,7 +1833,6 @@ class SessionStreamFn:
 
             shared_remaining, tier_binding = shared_tier_saturation(
                 report,
-                model.model_id,
                 reserve_percent=retry.usage_reserve_percent,
             )
             remaining = (
@@ -1875,7 +1874,7 @@ class SessionStreamFn:
         access: Any,
         storage: str,
         health: Any,
-        shared_remaining: float,
+        shared_remaining: float | None,
         tier_binding: bool,
         retry: Any,
     ) -> bool:
@@ -1898,7 +1897,10 @@ class SessionStreamFn:
         from local_operator.providers.failover import parse_selector
 
         threshold = min(100.0, max(0.0, float(retry.usage_reserve_percent))) / 100.0
-        shared_above_reserve = shared_remaining > threshold
+        # ``None`` means no shared window carried a number — indeterminate, not
+        # headroom, so the tier-cap guard stays off and the cautious rotate /
+        # failover path runs.
+        shared_above_reserve = shared_remaining is not None and shared_remaining > threshold
         remaining = (
             ""
             if health.remaining_fraction is None
@@ -2003,7 +2005,7 @@ class SessionStreamFn:
         storage: str,
         rows: list[Any],
         retry: Any,
-    ) -> tuple[Any, float, bool, Any] | None:
+    ) -> tuple[Any, float | None, bool, Any] | None:
         """Re-check every blocked account before a provider failover.
 
         ``get_oauth_access`` returns None the moment all credentials are
@@ -2029,10 +2031,12 @@ class SessionStreamFn:
                 access = await self._auth_store.get_oauth_access(model.provider, self._session_id)
             except Exception:
                 access = None
-            if access is None or access.kind != "oauth":
-                # Not recoverable as an OAuth account (refresh failure, or the
-                # cascade fell through to an API key); stand the backoff back up
-                # and keep looking.
+            if access is None or access.kind != "oauth" or access.credential_id != row.id:
+                # Only a verdict for the exact row just unblocked counts. The
+                # cascade can fall through to a different credential (an API
+                # key, or a sibling that outranked this one), and attributing
+                # that credential's quota to this row would unblock the wrong
+                # account. Stand the backoff back up and keep looking.
                 self._auth_store.block_credential(
                     row.id, storage, block_ms=self.DEFAULT_USAGE_BLOCK_MS
                 )
@@ -2060,7 +2064,6 @@ class SessionStreamFn:
                 continue
             shared_remaining, tier_binding = shared_tier_saturation(
                 report,
-                model.model_id,
                 reserve_percent=retry.usage_reserve_percent,
             )
             if health.state == "healthy":

--- a/local_operator/model/configure.py
+++ b/local_operator/model/configure.py
@@ -1719,7 +1719,7 @@ class SessionStreamFn:
         when a sibling or configured fallback is ready, so preflight can never
         turn usable reserve capacity into a dead end.
         """
-        from local_operator.providers.failover import RetrySettings, parse_selector
+        from local_operator.providers.failover import RetrySettings
 
         selector = f"{model.provider}/{model.model_id}"
 
@@ -1772,6 +1772,26 @@ class SessionStreamFn:
                 storage = self._storage_provider(model.provider)
                 rows = self._auth_store.list_credentials(storage)
                 if rows and all(self._auth_store.is_blocked(row.id, storage) for row in rows):
+                    # Every account is under a block, but "blocked" is only a
+                    # verdict from an earlier probe — quota resets while the
+                    # backoff is still on the clock, and a tier-scoped cap can
+                    # block an account that still serves other models. Fail over
+                    # to another provider only after re-checking the blocks
+                    # themselves: exhaust every login first.
+                    recovered = await self._recover_blocked_accounts(model, storage, rows, retry)
+                    if recovered is not None:
+                        health, shared_remaining, tier_binding, access = recovered
+                        if health.state != "healthy" and await self._apply_account_health(
+                            model,
+                            access,
+                            storage,
+                            health,
+                            shared_remaining,
+                            tier_binding,
+                            retry,
+                        ):
+                            continue
+                        return
                     fallback = await self._first_available_fallback(
                         model,
                         different_provider=True,
@@ -1786,7 +1806,11 @@ class SessionStreamFn:
                 return
             attempted_ids.add(access.credential_id)
 
-            from local_operator.providers.usage import fetch_usage, usage_health
+            from local_operator.providers.usage import (
+                fetch_usage,
+                shared_tier_saturation,
+                usage_health,
+            )
 
             report = await fetch_usage(
                 self._http,
@@ -1807,6 +1831,11 @@ class SessionStreamFn:
             if health.state == "unknown":
                 return
 
+            shared_remaining, tier_binding = shared_tier_saturation(
+                report,
+                model.model_id,
+                reserve_percent=retry.usage_reserve_percent,
+            )
             remaining = (
                 ""
                 if health.remaining_fraction is None
@@ -1828,81 +1857,222 @@ class SessionStreamFn:
                 return
 
             storage = self._storage_provider(model.provider)
-            row = self._auth_store.get_credential(access.credential_id)
-            siblings = [
-                candidate
-                for candidate in self._auth_store.list_credentials(storage)
-                if candidate.id != access.credential_id
-                and (row is None or candidate.credential_type == row.credential_type)
-                and not self._auth_store.is_blocked(candidate.id, storage)
-            ]
-            fallback = await self._first_available_fallback(
+            if await self._apply_account_health(
                 model,
-                # A different effort cannot revive a fully exhausted provider,
-                # but it can preserve reserve quota by reducing token spend.
-                different_provider=health.state == "depleted",
+                access,
+                storage,
+                health,
+                shared_remaining,
+                tier_binding,
+                retry,
+            ):
+                continue
+            return
+
+    async def _apply_account_health(
+        self,
+        model: ModelSpec,
+        access: Any,
+        storage: str,
+        health: Any,
+        shared_remaining: float,
+        tier_binding: bool,
+        retry: Any,
+    ) -> bool:
+        """Act on a low/depleted account-scope verdict.
+
+        Returns True when the caller should re-resolve credentials (a sibling
+        account took over), False when the routing decision is final.
+
+        The binding windows that produced ``health`` can be scoped to a model
+        tier while the shared windows still hold quota (Anthropic's
+        ``7 day (Fable)`` at 100% beside an 11%-free 5-hour window, when the
+        model being routed never draws on Fable). Taking that account out of
+        rotation — and, once every account reports the same shape, failing
+        over to another provider — strands real shared headroom. Rotation is
+        reserved for accounts whose SHARED windows are genuinely binding; a
+        tier-only cap keeps the account in service, and the last account with
+        any shared headroom is always allowed to spend it down to zero before
+        a provider fallback is even considered.
+        """
+        from local_operator.providers.failover import parse_selector
+
+        threshold = min(100.0, max(0.0, float(retry.usage_reserve_percent))) / 100.0
+        shared_above_reserve = shared_remaining > threshold
+        remaining = (
+            ""
+            if health.remaining_fraction is None
+            else f" ({health.remaining_fraction * 100:.0f}% remaining)"
+        )
+        condition = "quota exhausted" if health.state == "depleted" else "quota low"
+
+        row = self._auth_store.get_credential(access.credential_id)
+        siblings = [
+            candidate
+            for candidate in self._auth_store.list_credentials(storage)
+            if candidate.id != access.credential_id
+            and (row is None or candidate.credential_type == row.credential_type)
+            and not self._auth_store.is_blocked(candidate.id, storage)
+        ]
+        fallback = await self._first_available_fallback(
+            model,
+            # A different effort cannot revive a fully exhausted provider,
+            # but it can preserve reserve quota by reducing token spend.
+            different_provider=health.state == "depleted",
+        )
+        if not siblings and fallback is None:
+            await self._notice(
+                f"{model.provider} {condition}{remaining}; no configured fallback is available"
             )
-            if not siblings and fallback is None:
-                await self._notice(
-                    f"{model.provider} {condition}{remaining}; no configured fallback is available"
+            return False
+
+        if tier_binding and shared_above_reserve:
+            # The tight window is a scoped tier cap, not the shared pool, and
+            # the shared windows still hold reserve. The current model does not
+            # draw on that tier, so the account keeps serving: spend the shared
+            # headroom down to zero instead of rotating or failing over on a
+            # cap that does not gate this request.
+            binding = "/".join(health.binding_labels) or "a model-tier window"
+            await self._notice(
+                f"{model.provider} {binding} spent; shared quota remains{remaining} "
+                "— continuing until shared windows are exhausted",
+                "info",
+            )
+            self._route_state.clear()
+            return False
+
+        # How the account is taken out of the running depends on WHAT the
+        # verdict was, and conflating the two is the incident this split
+        # comes from. "Depleted" is a fact about the provider: it will 429
+        # every request until the spent window resets, so a cross-process
+        # SQLite block until that reset merely records reality. "Reserve"
+        # is the opposite of unusable — the account still HAS quota, held
+        # back so it is there when nothing better remains. Writing a block
+        # for it (as this code once did) stood the reserve on its head:
+        # accounts at 90% of a seven-day window were blocked for DAYS, one
+        # by one, until the last live account genuinely depleted and every
+        # session died reporting "all credentials unusable" while three
+        # accounts still held quota.
+        #
+        # So a reserve account is DEPRIORITIZED instead: an in-process,
+        # self-expiring routing preference (see
+        # ``AuthStore.deprioritize_credential``) that steers this walk and
+        # the session's next resolve toward healthier siblings, while the
+        # cascade's ignore-demotions second pass still serves the account
+        # the moment it is the only thing left. The mark is short-lived on
+        # purpose; the preflight re-checks and re-applies it while the
+        # preference still holds.
+        if health.state == "depleted":
+
+            def take_out_of_rotation(credential_id: int) -> None:
+                self._auth_store.block_credential(
+                    credential_id,
+                    storage,
+                    block_ms=max(60_000, health.reset_after_ms or self.DEFAULT_USAGE_BLOCK_MS),
                 )
-                return
 
-            # How the account is taken out of the running depends on WHAT the
-            # verdict was, and conflating the two is the incident this split
-            # comes from. "Depleted" is a fact about the provider: it will 429
-            # every request until the spent window resets, so a cross-process
-            # SQLite block until that reset merely records reality. "Reserve"
-            # is the opposite of unusable — the account still HAS quota, held
-            # back so it is there when nothing better remains. Writing a block
-            # for it (as this code once did) stood the reserve on its head:
-            # accounts at 90% of a seven-day window were blocked for DAYS, one
-            # by one, until the last live account genuinely depleted and every
-            # session died reporting "all credentials unusable" while three
-            # accounts still held quota.
-            #
-            # So a reserve account is DEPRIORITIZED instead: an in-process,
-            # self-expiring routing preference (see
-            # ``AuthStore.deprioritize_credential``) that steers this walk and
-            # the session's next resolve toward healthier siblings, while the
-            # cascade's ignore-demotions second pass still serves the account
-            # the moment it is the only thing left. The mark is short-lived on
-            # purpose; the preflight re-checks and re-applies it while the
-            # preference still holds.
-            if health.state == "depleted":
+        else:
 
-                def take_out_of_rotation(credential_id: int) -> None:
-                    self._auth_store.block_credential(
-                        credential_id,
-                        storage,
-                        block_ms=max(60_000, health.reset_after_ms or self.DEFAULT_USAGE_BLOCK_MS),
-                    )
+            def take_out_of_rotation(credential_id: int) -> None:
+                # Keyed by ``model.provider``, not ``storage``: demotions
+                # are consulted by ``_resolve`` under the provider name the
+                # request resolves with.
+                self._auth_store.deprioritize_credential(model.provider, credential_id)
 
-            else:
+        if siblings:
+            take_out_of_rotation(access.credential_id)
+            await self._notice(
+                f"{model.provider} {condition}{remaining} — trying another "
+                f"{model.provider} account before provider fallback"
+            )
+            return True
 
-                def take_out_of_rotation(credential_id: int) -> None:
-                    # Keyed by ``model.provider``, not ``storage``: demotions
-                    # are consulted by ``_resolve`` under the provider name the
-                    # request resolves with.
-                    self._auth_store.deprioritize_credential(model.provider, credential_id)
+        assert fallback is not None
+        fallback_provider, _model_id = parse_selector(fallback.selector)
+        if fallback_provider != model.provider:
+            take_out_of_rotation(access.credential_id)
+        await self._route_state.activate(
+            fallback,
+            f"{model.provider} {condition}{remaining}",
+        )
+        return False
 
-            if siblings:
-                take_out_of_rotation(access.credential_id)
-                await self._notice(
-                    f"{model.provider} {condition}{remaining} — trying another "
-                    f"{model.provider} account before provider fallback"
+    async def _recover_blocked_accounts(
+        self,
+        model: ModelSpec,
+        storage: str,
+        rows: list[Any],
+        retry: Any,
+    ) -> tuple[Any, float, bool, Any] | None:
+        """Re-check every blocked account before a provider failover.
+
+        ``get_oauth_access`` returns None the moment all credentials are
+        blocked, but a block is a stale verdict the moment a window resets —
+        and preflight takes accounts out of rotation on nothing more than
+        crossing a reserve threshold, so a pool that still has spendable quota
+        can look exactly like a dead one. Each blocked account is probed in
+        turn: its block is lifted, its usage re-fetched, and the first account
+        with a definite answer (healthy, or low in a way that still routes)
+        wins. Unknown/unreachable reports re-impose a short block and move on.
+        ``None`` means every account is genuinely out — only then is a
+        provider fallback honest.
+        """
+        from local_operator.providers.usage import (
+            fetch_usage,
+            shared_tier_saturation,
+            usage_health,
+        )
+
+        for row in rows:
+            self._auth_store.clear_block(row.id, storage)
+            try:
+                access = await self._auth_store.get_oauth_access(model.provider, self._session_id)
+            except Exception:
+                access = None
+            if access is None or access.kind != "oauth":
+                # Not recoverable as an OAuth account (refresh failure, or the
+                # cascade fell through to an API key); stand the backoff back up
+                # and keep looking.
+                self._auth_store.block_credential(
+                    row.id, storage, block_ms=self.DEFAULT_USAGE_BLOCK_MS
                 )
                 continue
-
-            assert fallback is not None
-            fallback_provider, _model_id = parse_selector(fallback.selector)
-            if fallback_provider != model.provider:
-                take_out_of_rotation(access.credential_id)
-            await self._route_state.activate(
-                fallback,
-                f"{model.provider} {condition}{remaining}",
+            report = await fetch_usage(
+                self._http,
+                model.provider,
+                access_token=access.access_token,
+                account_id=access.account_id,
             )
-            return
+            if report is None:
+                self._auth_store.block_credential(
+                    row.id, storage, block_ms=self.DEFAULT_USAGE_BLOCK_MS
+                )
+                continue
+            health = usage_health(
+                report,
+                model.model_id,
+                reserve_percent=retry.usage_reserve_percent,
+            )
+            if health.state == "unknown":
+                self._auth_store.block_credential(
+                    row.id, storage, block_ms=self.DEFAULT_USAGE_BLOCK_MS
+                )
+                continue
+            shared_remaining, tier_binding = shared_tier_saturation(
+                report,
+                model.model_id,
+                reserve_percent=retry.usage_reserve_percent,
+            )
+            if health.state == "healthy":
+                await self._notice(
+                    f"{model.provider} account quota recovered — resuming {model.provider}",
+                    "info",
+                )
+                self._route_state.clear()
+            # Low/depleted but answerable: hand it to the shared policy, which
+            # decides between spending shared headroom, rotating, and blocking.
+            return health, shared_remaining, tier_binding, access
+        return None
 
     async def __call__(
         self, request: ChatRequest, signal: AbortSignal | None

--- a/local_operator/providers/auth_store.py
+++ b/local_operator/providers/auth_store.py
@@ -511,6 +511,23 @@ class AuthStore:
         )
         self._conn.commit()
 
+    def clear_block(self, credential_id: int, provider: str) -> None:
+        """Drop the primary block for ONE credential, leaving other scopes alone.
+
+        ``clear_blocks`` wipes every block the credential carries; usage-aware
+        fallback only ever wants to rescind the quota backoff it placed itself,
+        and must not disturb a block another mechanism (e.g. an auth failure on
+        a different scope) recorded against the same row.
+        """
+        credential = self.get_credential(credential_id)
+        provider_key = f"{provider}:{credential.credential_type if credential else 'api_key'}"
+        self._conn.execute(
+            "DELETE FROM auth_credential_blocks"
+            " WHERE credential_id = ? AND provider_key = ? AND block_scope = ''",
+            (credential_id, provider_key),
+        )
+        self._conn.commit()
+
     # -- OAuth refresh -----------------------------------------------------------
 
     def _refresh_fn(self, provider: str) -> RefreshFn | None:

--- a/local_operator/providers/auth_store.py
+++ b/local_operator/providers/auth_store.py
@@ -520,6 +520,7 @@ class AuthStore:
         a different scope) recorded against the same row.
         """
         credential = self.get_credential(credential_id)
+        provider = self._storage_id(provider)
         provider_key = f"{provider}:{credential.credential_type if credential else 'api_key'}"
         self._conn.execute(
             "DELETE FROM auth_credential_blocks"

--- a/local_operator/providers/usage.py
+++ b/local_operator/providers/usage.py
@@ -303,6 +303,11 @@ class QuotaHealth:
     remaining_fraction: float | None = None
     reset_after_ms: int | None = None
     scope: Literal["account", "model", "unknown"] = "unknown"
+    #: Labels of the windows at or under the reserve threshold (the ones that
+    #: set ``remaining_fraction`` and ``reset_after_ms``). The preflight uses
+    #: these to tell "everything is spent" from "one secondary window is spent"
+    #: without re-deriving the binding set from the raw report.
+    binding_labels: tuple[str, ...] = ()
 
 
 def usage_health(
@@ -377,7 +382,44 @@ def usage_health(
         remaining_fraction=remaining,
         reset_after_ms=reset_after,
         scope=scope,
+        binding_labels=tuple(limit.label for limit in binding),
     )
+
+
+def shared_tier_saturation(
+    report: UsageReport,
+    model_id: str,
+    *,
+    reserve_percent: float = 10.0,
+) -> tuple[float, bool]:
+    """How full the shared windows are, and whether they are the binding limit.
+
+    ``usage_health`` reduces a report to the single tightest window, so a
+    scoped cap that belongs to a model tier the user never runs (Anthropic's
+    ``7 day (Fable)`` against a ``claude-opus`` request) can dominate the
+    verdict and hide real headroom in the shared 5-hour / 7-day windows. This
+    re-reads the report the other way: the min remaining fraction across the
+    SHARED windows alone, and whether at least one scoped (per-tier) window is
+    at or under the reserve threshold. "Account exhausted" is only honest when
+    the shared windows are binding too; a report whose tight window is scoped
+    while the shared windows still hold quota is a tier cap, not an empty
+    account, and rotating or failing over on it strands usable reserve.
+    """
+    threshold = min(100.0, max(0.0, float(reserve_percent))) / 100.0
+    shared: list[float] = []
+    tier_binding = False
+    for limit in report.limits:
+        if limit.id.endswith(":extra"):
+            continue
+        fraction = limit.amount.fraction()
+        if fraction is None:
+            continue
+        remaining = max(0.0, min(1.0, 1.0 - fraction))
+        if limit.shared or not limit.tier:
+            shared.append(remaining)
+        elif remaining <= threshold:
+            tier_binding = True
+    return (min(shared) if shared else 1.0), tier_binding
 
 
 # ---------------------------------------------------------------------------

--- a/local_operator/providers/usage.py
+++ b/local_operator/providers/usage.py
@@ -388,10 +388,9 @@ def usage_health(
 
 def shared_tier_saturation(
     report: UsageReport,
-    model_id: str,
     *,
     reserve_percent: float = 10.0,
-) -> tuple[float, bool]:
+) -> tuple[float | None, bool]:
     """How full the shared windows are, and whether they are the binding limit.
 
     ``usage_health`` reduces a report to the single tightest window, so a
@@ -404,6 +403,10 @@ def shared_tier_saturation(
     the shared windows are binding too; a report whose tight window is scoped
     while the shared windows still hold quota is a tier cap, not an empty
     account, and rotating or failing over on it strands usable reserve.
+
+    The shared fraction is ``None`` when no shared window carries a numeric
+    amount — an INDETERMINATE answer, not "full headroom", so a caller cannot
+    mistake an unparseable report for a licence to spend.
     """
     threshold = min(100.0, max(0.0, float(reserve_percent))) / 100.0
     shared: list[float] = []
@@ -419,7 +422,7 @@ def shared_tier_saturation(
             shared.append(remaining)
         elif remaining <= threshold:
             tier_binding = True
-    return (min(shared) if shared else 1.0), tier_binding
+    return (min(shared) if shared else None), tier_binding
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/model/test_configure.py
+++ b/tests/unit/model/test_configure.py
@@ -341,6 +341,36 @@ def _anthropic_usage(used_percent: float) -> UsageReport:
     )
 
 
+def _anthropic_tier_capped_usage(five_hour_used: float, fable_used: float) -> UsageReport:
+    """Shared 5h headroom beside a fully-spent scoped tier cap.
+
+    This is the shape behind the false "credentials temporarily unavailable":
+    the Fable weekly is at 100% but the shared 5-hour window still serves,
+    and the model being routed (``claude-opus-5``) never draws on Fable."""
+    return UsageReport(
+        provider="anthropic",
+        limits=[
+            UsageLimit(
+                id="anthropic:5h",
+                label="5 hour",
+                amount=UsageAmount(used=five_hour_used, limit=100.0, unit="percent"),
+                window="5h",
+                shared=True,
+                resets_at_ms=10**15,
+            ),
+            UsageLimit(
+                id="anthropic:7d:fable",
+                label="7 day (Fable)",
+                amount=UsageAmount(used=fable_used, limit=100.0, unit="percent"),
+                window="7d",
+                shared=False,
+                tier="fable",
+                resets_at_ms=10**15,
+            ),
+        ],
+    )
+
+
 @pytest.mark.asyncio
 async def test_usage_preflight_rotates_accounts_before_providers(tmp_path) -> None:
     store = AuthStore(tmp_path / "auth.db")
@@ -375,6 +405,88 @@ async def test_usage_preflight_rotates_accounts_before_providers(tmp_path) -> No
         assert selected is not None and selected.credential_id == second.id
         assert stream._route_state.active is None
         assert any("trying another anthropic account" in notice for notice in notices)
+    finally:
+        await stream.close()
+        store.close()
+
+
+@pytest.mark.asyncio
+async def test_tier_scoped_cap_with_shared_headroom_keeps_the_account_serving(tmp_path) -> None:
+    """A spent tier cap is not an exhausted account when shared quota remains.
+
+    The reported incident: every Anthropic account showed a full Fable weekly
+    while the shared 5-hour window still had headroom, and preflight treated
+    the tier cap as account exhaustion — rotating, then failing over to z.ai
+    while usable Anthropic quota sat idle. A tier-scoped binding window that
+    the routed model never draws on must leave the account in service until
+    the SHARED windows are the ones that run out."""
+    store = AuthStore(tmp_path / "auth.db")
+    account = store.upsert_credential("anthropic", _oauth("oauth-a", "account-a"))
+    store.upsert_credential("zai", {"key": "sk-zai", "source": "login"})
+    stream = create_stream_fn(
+        store,
+        {
+            "retry": {
+                "usageAwareFallback": True,
+                "usageReservePercent": 10,
+                "fallbackChains": {"default": ["zai/glm-5.3"]},
+            }
+        },
+        session_id="session-a",
+    )
+    notices: list[str] = []
+    stream.set_notice_handler(lambda text, kind: notices.append(text))
+    model = ModelSpec(provider="anthropic", model_id="claude-opus-5")
+
+    try:
+        with patch(
+            "local_operator.providers.usage.fetch_usage",
+            side_effect=lambda *_args, **_kwargs: _anthropic_tier_capped_usage(89.0, 100.0),
+        ):
+            await stream.preflight_usage(model)
+
+        # The account is neither blocked nor deprioritized, and no failover fires.
+        assert not store.is_blocked(account.id, "anthropic")
+        assert stream._route_state.active is None
+        selected = await store.get_oauth_access("anthropic", "session-a")
+        assert selected is not None and selected.credential_id == account.id
+    finally:
+        await stream.close()
+        store.close()
+
+
+@pytest.mark.asyncio
+async def test_shared_window_exhaustion_still_rotates_even_with_a_tier_cap(tmp_path) -> None:
+    """The tier guard must not mask a genuinely spent shared window.
+
+    When the shared 5-hour window is itself at 100%, the account IS out for
+    this model regardless of what the tier caps say, so the sibling rotation
+    still happens."""
+    store = AuthStore(tmp_path / "auth.db")
+    first = store.upsert_credential("anthropic", _oauth("oauth-a", "account-a"))
+    second = store.upsert_credential("anthropic", _oauth("oauth-b", "account-b"))
+    session = _session_hashing_to_first_row(2)
+    stream = create_stream_fn(
+        store,
+        {"retry": {"usageAwareFallback": True, "usageReservePercent": 10}},
+        session_id=session,
+    )
+    model = ModelSpec(provider="anthropic", model_id="claude-opus-5")
+
+    async def usage_for_access(_client, _provider, *, access_token=None, **_kwargs):
+        # First account: shared window spent. Second: plenty of shared headroom.
+        if access_token == "oauth-a":
+            return _anthropic_tier_capped_usage(100.0, 100.0)
+        return _anthropic_tier_capped_usage(20.0, 100.0)
+
+    try:
+        with patch("local_operator.providers.usage.fetch_usage", side_effect=usage_for_access):
+            await stream.preflight_usage(model)
+
+        assert store.is_blocked(first.id, "anthropic")
+        assert not store.is_blocked(second.id, "anthropic")
+        selected = await store.get_oauth_access("anthropic", session)
+        assert selected is not None and selected.credential_id == second.id
     finally:
         await stream.close()
         store.close()
@@ -634,7 +746,16 @@ async def test_transport_fallback_cooldown_skips_quota_probe(tmp_path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_startup_preflight_warns_when_primary_credentials_are_blocked(tmp_path) -> None:
+async def test_startup_preflight_recovers_a_blocked_account_that_still_has_quota(
+    tmp_path,
+) -> None:
+    """A block is a stale verdict, not ground truth — re-probe before failover.
+
+    The all-blocked branch used to fail over to another provider without ever
+    asking whether the blocked accounts had come back to life. A window reset
+    (or a block written for a tier cap the current model does not draw on)
+    leaves live quota stranded behind the backoff. The blocked account is
+    re-probed, found healthy, unblocked, and kept in service — no failover."""
     store = AuthStore(tmp_path / "auth.db")
     account = store.upsert_credential("anthropic", _oauth("oauth-a", "account-a"))
     store.block_credential(account.id, "anthropic", block_ms=60_000)
@@ -653,13 +774,58 @@ async def test_startup_preflight_warns_when_primary_credentials_are_blocked(tmp_
     stream.set_notice_handler(lambda text, kind: notices.append(text))
 
     try:
-        with patch("local_operator.providers.usage.fetch_usage") as fetch:
+        with patch(
+            "local_operator.providers.usage.fetch_usage",
+            side_effect=lambda *_args, **_kwargs: _anthropic_usage(25.0),
+        ) as fetch:
             await stream.preflight_usage(ModelSpec(provider="anthropic", model_id="claude-opus-5"))
-        fetch.assert_not_called()
+        fetch.assert_called()
+        # The recovered account serves again; no provider failover.
+        assert not store.is_blocked(account.id, "anthropic")
+        assert stream._route_state.active is None
+        assert any("recovered" in notice for notice in notices)
+    finally:
+        await stream.close()
+        store.close()
+
+
+@pytest.mark.asyncio
+async def test_startup_preflight_fails_over_only_when_every_account_is_exhausted(
+    tmp_path,
+) -> None:
+    """The re-probe confirms exhaustion before the provider fallback fires.
+
+    With every account still genuinely at 100%, recovery finds no usable
+    login, the block is stood back up, and only then does the session move to
+    the configured cross-provider fallback."""
+    store = AuthStore(tmp_path / "auth.db")
+    account = store.upsert_credential("anthropic", _oauth("oauth-a", "account-a"))
+    store.block_credential(account.id, "anthropic", block_ms=60_000)
+    store.upsert_credential("openai", {"key": "sk-openai", "source": "login"})
+    stream = create_stream_fn(
+        store,
+        {
+            "retry": {
+                "usageAwareFallback": True,
+                "fallbackChains": {"default": ["openai/gpt-5.3-codex"]},
+            }
+        },
+        session_id="session-a",
+    )
+    notices: list[str] = []
+    stream.set_notice_handler(lambda text, kind: notices.append(text))
+
+    try:
+        with patch(
+            "local_operator.providers.usage.fetch_usage",
+            side_effect=lambda *_args, **_kwargs: _anthropic_usage(100.0),
+        ) as fetch:
+            await stream.preflight_usage(ModelSpec(provider="anthropic", model_id="claude-opus-5"))
+        fetch.assert_called()
+        assert store.is_blocked(account.id, "anthropic")
         assert stream._route_state.active == FallbackTarget("openai/gpt-5.3-codex")
         assert notices == [
-            "anthropic credentials temporarily unavailable — "
-            "falling back to openai/gpt-5.3-codex"
+            "anthropic quota exhausted (0% remaining) — falling back to openai/gpt-5.3-codex"
         ]
     finally:
         await stream.close()


### PR DESCRIPTION
## Problem

The `anthropic credentials temporarily unavailable — falling back to zai/glm-5.3` notice fired while every Anthropic login still held usable quota (shared 5-hour headroom, and weekly windows below 100%). Two defects combined:

1. **The all-blocked branch gave up without checking.** When `get_oauth_access` returns `None` because every credential is blocked, preflight jumped straight to the cross-provider fallback. But a block is a *stale verdict* the moment a window resets — and preflight takes accounts out of rotation merely for crossing a reserve threshold — so a pool that still holds quota looked exactly like a dead one.
2. **A tier-scoped cap could masquerade as account exhaustion.** The binding window that produces a low/depleted verdict can be scoped to a model tier the routed model never draws on (Anthropic's `7 day (Fable)` at 100% beside an 11%-free shared 5-hour window, for `claude-opus-5`). Treating that as account exhaustion rotated/blocked accounts that still had shared headroom.

## Fix

- **Re-probe before failover** (`_recover_blocked_accounts`): when every account is blocked, lift each block in turn, re-fetch usage, and keep the first account with a definite answer in service. Healthy → unblocked and resumed. Low/depleted → handed to the shared policy. Only when *every* login is genuinely exhausted does the cross-provider fallback fire.
- **Shared account-health policy** (`_apply_account_health`): one code path for the live and recovered branches, preserving the existing reserve(deprioritize)/depleted(block) split.
- **Tier-cap guard**: `usage_health` now reports its binding window labels, and a new `shared_tier_saturation` helper separates "shared pool spent" from "one scoped tier spent". A tier-only cap with shared headroom keeps the account serving until the *shared* windows run out.
- **`AuthStore.clear_block`**: lifts a single credential's primary block without disturbing other scopes.

## Testing

- `test_startup_preflight_recovers_a_blocked_account_that_still_has_quota` — a blocked account that re-probes healthy is unblocked and kept; **no** failover.
- `test_startup_preflight_fails_over_only_when_every_account_is_exhausted` — all accounts still at 100% → block re-imposed, failover fires.
- `test_tier_scoped_cap_with_shared_headroom_keeps_the_account_serving` — Fable at 100% + 5h at 89% → account stays in service.
- `test_shared_window_exhaustion_still_rotates_even_with_a_tier_cap` — shared 5h at 100% → sibling rotation still happens.

```
tests/unit/model/test_configure.py tests/unit/providers/test_usage.py tests/unit/providers/test_auth_store.py
210 passed
```

Gates clean: flake8, black, isort, pyright on the changed files.

## Notes

This is the quota half of the reported incident. The composer model label not updating on failover is the pre-existing `fix/composer-fallback-model` work, which I'll bring up to date and land separately on top of this.
