### PR TITLE
fix(session): never delete session transcripts; dedup media into a content-addressed store

### DIFF
--- a/local_operator/cli.py
+++ b/local_operator/cli.py
@@ -646,12 +646,12 @@ def config_list_command() -> int:
         "compaction": "Compaction engine settings (enabled, strategy, thresholds); "
         "replaces conversation_length/detail_length",
         "tui": "TUI settings (theme)",
-        "session_retention_max_sessions": "Maximum ephemeral session directories to keep "
-        "under sessions/ (0 disables the ceiling)",
-        "session_retention_max_bytes": "Maximum total bytes across sessions/ before the "
-        "oldest directories are evicted (0 disables the ceiling)",
-        "session_retention_max_age_days": "Age after which an ephemeral session directory "
-        "is evicted (0 disables the ceiling)",
+        "session_retention_max_sessions": "[RETIRED] Session transcripts are never deleted "
+        "automatically; this ceiling no longer does anything at any value",
+        "session_retention_max_bytes": "[RETIRED] Session transcripts are never deleted "
+        "automatically; this ceiling no longer does anything at any value",
+        "session_retention_max_age_days": "[RETIRED] Session transcripts are never deleted "
+        "automatically; this ceiling no longer does anything at any value",
     }
 
     print("\n\033[1;32m╭─ Configuration Options ───────────────────────\033[0m")

--- a/local_operator/config.py
+++ b/local_operator/config.py
@@ -180,13 +180,17 @@ DEFAULT_CONFIG = Config(
             # Set it when the machine or the models in use want a different
             # ceiling than the built-in one.
             "subagents": {},
-            # Ceilings on the ephemeral session store (see
-            # local_operator.session.retention). Any of the three set to 0
-            # disables that dimension; all three at 0 restores the unbounded
-            # behaviour, which is why none of them defaults there.
-            "session_retention_max_sessions": 200,
-            "session_retention_max_bytes": 128 * 1024 * 1024,
-            "session_retention_max_age_days": 30,
+            # RETIRED session-store ceilings (see
+            # local_operator.session.retention). Session transcripts are never
+            # deleted automatically — a running session whose transcript was
+            # evicted out from under it lost all of its work — so the only
+            # correct value for each of these is 0 ("disabled"). The keys stay
+            # readable so a config file carrying the old defaults gets an
+            # honest warning instead of a silent no-op; they no longer cause
+            # any eviction at any value.
+            "session_retention_max_sessions": 0,
+            "session_retention_max_bytes": 0,
+            "session_retention_max_age_days": 0,
         },
     }
 )

--- a/local_operator/guides/configuration/GUIDE.md
+++ b/local_operator/guides/configuration/GUIDE.md
@@ -150,7 +150,7 @@ remain in the credential store; never put tokens or keys in this mapping.
 - `effort`: `auto` (default false) enables the zero-token local prompt-complexity classifier; `allowMax` lets high-complexity prompts select a model's maximum effort (default stops one rung below max)
 - `variables`: non-secret named values exposed through the variable tools; environment values remain lower precedence
 - `tui`: terminal UI settings such as `theme`
-- `session_retention_max_sessions`, `session_retention_max_bytes`, `session_retention_max_age_days`: independent ephemeral-session ceilings; `0` disables that ceiling
+- `session_retention_max_sessions`, `session_retention_max_bytes`, `session_retention_max_age_days`: RETIRED. Session transcripts are never deleted automatically — only an explicit user action removes a session — so these ceilings no longer do anything at any value. A config still carrying a non-zero value logs a one-line warning at startup. The only automated cleanup under `sessions/` is the reaping of directories that contain nothing (no transcript), which lose nothing by removal.
 
 `conversation_length`, `detail_length`, and `max_learnings_history` remain readable for compatibility but are deprecated and do not govern the current compaction engine.
 

--- a/local_operator/resume.py
+++ b/local_operator/resume.py
@@ -28,7 +28,7 @@ RESUME_LATEST = "@latest"
 
 #: The file whose presence makes a directory a resumable session. Also what the
 #: recency ordering is read from: a directory's own mtime moves for reasons that
-#: are not turns (retention sweeps touch it), so it is not the clock to use.
+#: are not turns (an origin stamp, a sibling file), so it is not the clock to use.
 TRANSCRIPT_NAME = "transcript.jsonl"
 
 #: Marks a session directory as machine-started rather than user-started. A
@@ -166,21 +166,17 @@ def mark_session_origin(session_dir: Path, origin: str, **details: object) -> No
     conversation are the same shape on disk.
 
     Best-effort by contract. Marking is bookkeeping for a listing, and a child
-    that cannot write its marker (read-only volume, a race with a retention
-    sweep that just removed the directory) must still RUN — the cost of the
-    failure is one extra row in a picker, and taking a delegated task down for
-    it would be the more expensive bug.
+    that cannot write its marker (read-only volume) must still RUN — the cost
+    of the failure is one extra row in a picker, and taking a delegated task
+    down for it would be the more expensive bug.
 
-    **The directory's mtime is preserved**, and that is load-bearing rather
-    than tidy. Retention sorts and age-expires on the DIRECTORY's mtime
-    (``session/retention.py``), and creating a file inside a directory moves
-    it — so stamping a session silently reset its retention clock to now.
-    Measured on twin stores: marking existing directories kept 3 delegated
-    runs the picker will never show while deleting 3 of the user's own
-    conversations, and resurrected 59 children that were already past the age
-    ceiling. Writing a marker is bookkeeping ABOUT a session, never activity
-    IN it, so it must not answer the question "when was this session last
-    used". A directory this call creates has no prior mtime and is unaffected.
+    **The directory's mtime is preserved.** Recency for ``--resume`` and the
+    picker is read from the transcript's mtime, not the directory's, but
+    other readers still look at the directory (``os.listdir`` + ``stat``
+    listings, backup tools). Writing a marker is bookkeeping ABOUT a
+    session, never activity IN it, so it must not answer the question "when
+    was this session last used". A directory this call creates has no prior
+    mtime and is unaffected.
     """
     payload = {"origin": origin, **details}
     try:

--- a/local_operator/session/attachments.py
+++ b/local_operator/session/attachments.py
@@ -126,7 +126,13 @@ class AttachmentStore:
                 self.root.mkdir(parents=True, exist_ok=True, mode=0o700)
                 # Write content before the sidecar: a sidecar pointing at
                 # absent content would resolve to nothing on read, while
-                # content without a sidecar is merely unused disk.
+                # content without a sidecar is merely unused disk. Two
+                # concurrent writers of the same digest always write
+                # identical bytes (the digest IS the content), so the
+                # exists()-then-write race is a wasted write, never a
+                # torn file. A crash between the two writes leaves
+                # content without a sidecar, which ``get`` treats as
+                # missing — the next ``put`` of the same image retries.
                 content.write_bytes(raw)
                 meta = {"digest": digest, "mime_type": mime_type, "bytes": len(raw)}
                 self._meta_path(digest).write_text(json.dumps(meta), encoding="utf-8")
@@ -151,5 +157,12 @@ class AttachmentStore:
             meta = json.loads(self._meta_path(digest).read_text(encoding="utf-8"))
             mime_type = str(meta.get("mime_type", "image/png"))
         except (OSError, ValueError):
+            return None
+        # The filename IS the digest. A bit-rotted or truncated file
+        # that still has a sidecar would otherwise flow silently-wrong
+        # bytes into the model; treat a mismatch as missing so replay
+        # degrades to a placeholder instead.
+        if hashlib.sha256(raw).hexdigest()[:_DIGEST_CHARS] != digest:
+            logger.warning("attachment store: digest mismatch for %s", digest)
             return None
         return base64.b64encode(raw).decode("ascii"), mime_type

--- a/local_operator/session/attachments.py
+++ b/local_operator/session/attachments.py
@@ -1,0 +1,155 @@
+"""Content-addressed store for message attachments (images and other media).
+
+Transcripts reference images by base64 inline in ``transcript.jsonl``. On a
+screenshot-heavy install that payload dominates the session store — measured
+at 102 of 134 MB (76%) across 142 real sessions — and it is the single most
+redundant data on the disk:
+
+- **Base64 inflation.** One third of every stored image byte is encoding
+  overhead; the decoded bytes are 25% smaller before anything else happens.
+- **Cross-session duplication.** The same screenshot is re-stored by every
+  session that pasted or captured it. Measured: 434 image references reduced
+  to 355 unique images, ~20 MB of exact duplicates.
+
+This module is the answer. ``<config>/attachments/<digest>.bin`` holds each
+unique image ONCE, named by the sha256 of its decoded bytes, with a small
+``<digest>.json`` sidecar carrying the mime type. A transcript row then
+carries a reference — ``{"type": "image", "attachment": "<digest>",
+"mime_type": ...}`` — instead of the payload. At the measured ratios this
+takes the session store from 134 MB to ~52 MB, with the saving growing
+faster than the store itself as duplicates accumulate.
+
+Two properties make this safe where the old retention ceilings were not:
+
+- **Nothing is ever deleted.** There is no eviction, no sweep, no ceiling.
+  An attachment lives for as long as any transcript references it, and after
+  that too — reclaiming orphaned bytes is a user's explicit choice, exactly
+  like session transcripts themselves.
+- **Reads are fully backward compatible.** A row carrying inline ``data``
+  loads exactly as before, so transcripts written by older builds, exports,
+  and any external tool that reads the JSONL directly all keep working.
+  Re-attaching the inline bytes on load (rather than rewriting the file)
+  would break the dedup the store exists for, so rows are externalized on
+  write only.
+
+The store deliberately does NOT reuse the spill store (``tools/spill.py``):
+spill is LRU-evicted under a byte ceiling and is allowed to forget content
+a transcript still references, which is exactly the failure this work
+exists to remove from the session store.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+
+from local_operator.paths import config_dir
+
+logger = logging.getLogger(__name__)
+
+#: Directory under the config dir holding deduplicated attachment content.
+ATTACHMENTS_DIRNAME = "attachments"
+
+#: Characters of the hex digest used for file names. 32 hex chars is 128
+#: bits — collision-free for any realistic store, and short enough that a
+#: transcript reference is a rounding error next to the payload it replaced.
+_DIGEST_CHARS = 32
+
+
+@dataclass(frozen=True)
+class AttachmentRef:
+    """The reference a transcript row carries in place of inline base64."""
+
+    digest: str
+    mime_type: str
+    bytes: int  # decoded bytes — what the reference stands in for
+
+
+def attachments_dir() -> Path:
+    """Directory holding the store. Resolved per call, never cached:
+    ``config_dir()`` reads the environment on every call precisely so tests
+    can relocate it after import."""
+    return config_dir() / ATTACHMENTS_DIRNAME
+
+
+class AttachmentStore:
+    """Content-addressed binary store under the config dir.
+
+    Instantiate per transcript directory; ``root`` is injectable for tests
+    and for callers that resolve the config dir themselves.
+    """
+
+    def __init__(self, root: Path | None = None) -> None:
+        self._root = root
+
+    @property
+    def root(self) -> Path:
+        return self._root if self._root is not None else attachments_dir()
+
+    # -- paths -------------------------------------------------------------
+
+    def _content_path(self, digest: str) -> Path:
+        return self.root / f"{digest}.bin"
+
+    def _meta_path(self, digest: str) -> Path:
+        return self.root / f"{digest}.json"
+
+    # -- write -------------------------------------------------------------
+
+    def put(self, data_b64: str, mime_type: str) -> AttachmentRef | None:
+        """Store base64 ``data_b64`` and return its reference.
+
+        ``None`` is a normal outcome, not an error: undecodable input, a
+        read-only home directory, or a full disk all land here, and the
+        caller's contract is to keep the inline base64 in the transcript —
+        strictly worse on disk, never wrong to read. Raising instead would
+        turn a degraded store into a failed message append.
+
+        Writing the same image twice is idempotent: the digest is the
+        identity, so the second write is a no-op that costs a hash and a
+        stat. That is the dedup the store exists for.
+        """
+        try:
+            raw = base64.b64decode(data_b64, validate=False)
+        except (ValueError, TypeError):
+            return None
+        if not raw:
+            return None
+        digest = hashlib.sha256(raw).hexdigest()[:_DIGEST_CHARS]
+        content = self._content_path(digest)
+        if not content.exists():
+            try:
+                self.root.mkdir(parents=True, exist_ok=True, mode=0o700)
+                # Write content before the sidecar: a sidecar pointing at
+                # absent content would resolve to nothing on read, while
+                # content without a sidecar is merely unused disk.
+                content.write_bytes(raw)
+                meta = {"digest": digest, "mime_type": mime_type, "bytes": len(raw)}
+                self._meta_path(digest).write_text(json.dumps(meta), encoding="utf-8")
+            except OSError as exc:
+                logger.debug("attachment store: cannot write %s: %s", digest, exc)
+                return None
+        return AttachmentRef(digest=digest, mime_type=mime_type, bytes=len(raw))
+
+    # -- read --------------------------------------------------------------
+
+    def get(self, digest: str) -> tuple[str, str] | None:
+        """``(base64 data, mime_type)`` for ``digest``, or ``None``.
+
+        ``None`` means the reference is unresolvable — an interrupted write
+        or a store the user pruned by hand. Callers must treat that as
+        ordinary and degrade to a placeholder, never raise: a resumed
+        session must survive a missing attachment the same way it survives a
+        dropped malformed transcript line.
+        """
+        try:
+            raw = self._content_path(digest).read_bytes()
+            meta = json.loads(self._meta_path(digest).read_text(encoding="utf-8"))
+            mime_type = str(meta.get("mime_type", "image/png"))
+        except (OSError, ValueError):
+            return None
+        return base64.b64encode(raw).decode("ascii"), mime_type

--- a/local_operator/session/retention.py
+++ b/local_operator/session/retention.py
@@ -36,8 +36,6 @@ import shutil
 from dataclasses import dataclass
 from pathlib import Path
 
-from local_operator.resume import ORIGIN_NAME
-
 logger = logging.getLogger(__name__)
 
 #: Directory under the config dir holding ephemeral per-run transcripts.
@@ -84,17 +82,19 @@ def _dir_size(directory: Path) -> int:
     """Bytes under ``directory``. Files that vanish mid-walk are skipped: a
     concurrent process disposing its own session is normal, not an error.
 
-    The origin marker is EXCLUDED from the total, which is what keeps the
-    "empty directories are always reaped" rule meaning what it says. A
-    session is stamped before its transcript exists, so a run that aborts in
-    between leaves a directory holding nothing but a 43-byte marker. The
-    marker is bookkeeping ABOUT the session, never session content, so it
-    does not make the directory non-empty.
+    Every file counts, including the origin marker. A directory holding
+    only ``origin.json`` is a session that has been claimed — typically a
+    child between ``mark_session_origin`` and its first append, or a run
+    that aborted in that window. Treating the marker as invisible made
+    those directories look empty and the sweep rmtree'd them, which is
+    exactly the ``FileNotFoundError: .../transcript.jsonl`` kill this
+    module exists to prevent. A 43-byte marker is cheaper than a lost
+    session; abandoned markers accumulate and the user can remove them.
     """
     total = 0
     for entry in directory.rglob("*"):
         try:
-            if entry.is_file() and entry.name != ORIGIN_NAME:
+            if entry.is_file():
                 total += entry.stat().st_size
         except OSError:
             continue
@@ -112,13 +112,16 @@ def sweep_sessions(
 ) -> SweepResult:
     """Reap EMPTY session directories. Never delete anything else.
 
-    The ceiling parameters and ``live_dir`` are accepted for call-site
-    compatibility and are IGNORED: no configuration can make this function
-    delete a directory that holds content. A transcript is removed only when
-    the user explicitly disposes of the session — there is no automated
-    path, because the failure mode of an automated path (a running session's
-    transcript vanishing underneath it) costs the user the whole session,
-    and the benefit (bounded disk) is recoverable by hand at any time.
+    The ceiling parameters are accepted for call-site compatibility and
+    are IGNORED: no configuration can make this function delete a
+    directory that holds content. ``live_dir`` is still honoured as a
+    belt: even a literally-empty live directory is skipped, because the
+    caller just created it and has not written a turn yet. A transcript
+    is removed only when the user explicitly disposes of the session —
+    there is no automated path, because the failure mode of an automated
+    path (a running session's transcript vanishing underneath it) costs
+    the user the whole session, and the benefit (bounded disk) is
+    recoverable by hand at any time.
 
     Idempotent and safe to call on every startup: a missing ``sessions_dir``
     is a no-op rather than an error — the first run of a fresh install has
@@ -132,6 +135,7 @@ def sweep_sessions(
     evicted = 0
     errors = 0
     bytes_remaining = 0
+    live_resolved = live_dir.resolve() if live_dir is not None else None
     try:
         children = [child for child in sessions_dir.iterdir() if child.is_dir()]
     except OSError as exc:
@@ -141,6 +145,10 @@ def sweep_sessions(
     for child in children:
         scanned += 1
         try:
+            if live_resolved is not None and child.resolve() == live_resolved:
+                # The caller just created this directory and has not written
+                # a turn. It is empty by construction and must still survive.
+                continue
             size = _dir_size(child)
         except OSError:
             # A directory another process removed mid-scan. Nothing to do.
@@ -148,8 +156,8 @@ def sweep_sessions(
         if size > 0:
             bytes_remaining += size
             continue
-        # Empty by construction: no transcript, no content. Deleting it
-        # loses nothing, and it was never a real session.
+        # Literally empty: no files at all, not even a marker. Deleting
+        # it loses nothing, and it was never a real session.
         try:
             shutil.rmtree(child)
         except OSError as exc:

--- a/local_operator/session/retention.py
+++ b/local_operator/session/retention.py
@@ -1,32 +1,38 @@
-"""Bounded retention for ephemeral session directories.
+"""Session transcript retention: nothing is ever deleted.
 
-``sessions/<hex>/transcript.jsonl`` is written by every non-``--train`` run
-and read by nobody afterwards. Nothing deleted it, so the directory grew for
-the lifetime of the install — the same shape that let the harness this project
-is benchmarked against accumulate 5.9 GB of session transcripts and exhaust a
-developer's volume. Capping what enters the context does nothing about that
-half; this module is the other half.
+A session transcript is the only durable record of what a run did — the
+work it performed, the decisions it made, and the state a user may need to
+resume from hours or months later. Earlier this module enforced age, count,
+and byte ceilings over ``sessions/`` and evicted the oldest directories at
+startup. That policy destroyed real work in practice: ceilings that looked
+generous (200 directories, 128 MiB) were reached on heavy installs, and the
+eviction could take out the transcript of a session that was still running
+in another process, leaving that run to die on
+``FileNotFoundError: .../sessions/<id>/transcript.jsonl`` with no way to
+continue. A session in that state loses everything since its last save.
 
-Three independent ceilings, any of which may be disabled by setting it to 0:
+The rule now is absolute: **no sweep, automation, or startup hook deletes a
+session transcript, under any circumstance.** Session history is removed
+only when the user explicitly disposes of it. Disk pressure is a real
+concern — the harness this project is benchmarked against accumulated
+5.9 GB of transcripts — but the answer to disk pressure is a tool the user
+chooses to run, never a silent ceiling, because the cost asymmetry is
+extreme: gigabytes of recoverable disk versus hours of unrecoverable work.
 
-- **age** — a session directory older than N days;
-- **count** — at most N session directories;
-- **total bytes** — at most N bytes across all of them.
-
-They compose rather than override: eviction runs age, then count, then bytes,
-oldest first, until every ceiling holds. Age alone would let a burst of
-activity blow the disk budget inside the window; bytes alone would keep a
-single ancient directory forever. Whatever the ceilings say, the LIVE session
-is never a candidate — evicting the transcript of the run that is currently
-appending to it would take out resume and compaction replay together, which
-is a far worse outcome than the disk it reclaims.
+What this module still does, because it is definitionally safe, is reap
+EMPTY session directories. An empty directory holds no ``transcript.jsonl``
+and no other content — it is left behind by a run that created its session
+directory and exited before writing a single turn (23 of 147 directories on
+a real install were exactly this). Nothing can be lost by removing a
+directory that contains nothing, and an un-empty directory — one byte of
+transcript — is never touched, whatever its age, whatever the count of its
+neighbours, whatever the total size of the store.
 """
 
 from __future__ import annotations
 
 import logging
 import shutil
-import time
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -37,29 +43,31 @@ logger = logging.getLogger(__name__)
 #: Directory under the config dir holding ephemeral per-run transcripts.
 SESSIONS_DIRNAME = "sessions"
 
-#: Config keys. Read through ``ConfigManager.get_config_value`` so the
-#: ceilings are editable with ``local-operator config edit`` like every other
-#: setting, rather than needing a second configuration mechanism.
+#: Config keys of the RETIRED eviction ceilings. They no longer do anything
+#: — deleting transcripts by policy is precisely the behaviour this module
+#: exists to prevent — but they are still read by :func:`sweep_from_config`
+#: so that a config file carrying them produces an honest log line once per
+#: startup instead of a silent no-op that looks like the ceilings still run.
 MAX_SESSIONS_KEY = "session_retention_max_sessions"
 MAX_BYTES_KEY = "session_retention_max_bytes"
 MAX_AGE_DAYS_KEY = "session_retention_max_age_days"
 
-#: Defaults. Measured against real runs: a working session costs ~1.3 KB per
-#: turn on disk after the slim encoding, and a heavy 60-turn day is ~80 KB.
-#: 200 sessions therefore lands around 16 MB in practice, and the 128 MiB
-#: byte ceiling is the backstop for the outlier — a session that dumps
-#: megabytes of tool output cannot push the total past it no matter how few
-#: directories there are. The worst case a heavy user can reach is exactly
-#: 128 MiB plus the live session, versus unbounded before.
-DEFAULT_MAX_SESSIONS = 200
-DEFAULT_MAX_BYTES = 128 * 1024 * 1024
-DEFAULT_MAX_AGE_DAYS = 30
+#: The ceilings are retired, so the only correct value for each is 0
+#: ("disabled"). Exported under the old names because the configuration
+#: reference and older call sites import them; they exist to say "no
+#: ceiling", never to be tuned.
+DEFAULT_MAX_SESSIONS = 0
+DEFAULT_MAX_BYTES = 0
+DEFAULT_MAX_AGE_DAYS = 0
 
 
 @dataclass(frozen=True)
 class SweepResult:
     """What one sweep did. Returned rather than logged so the benchmark and
-    the tests can assert on it instead of scraping log lines."""
+    the tests can assert on it instead of scraping log lines.
+
+    ``evicted`` counts only empty directories — a non-zero value never means
+    a transcript was removed, because transcripts are never removed."""
 
     scanned: int = 0
     evicted: int = 0
@@ -72,26 +80,16 @@ class SweepResult:
         return self.evicted > 0
 
 
-@dataclass(frozen=True)
-class _Candidate:
-    path: Path
-    mtime: float
-    size: int
-
-
 def _dir_size(directory: Path) -> int:
     """Bytes under ``directory``. Files that vanish mid-walk are skipped: a
     concurrent process disposing its own session is normal, not an error.
 
     The origin marker is EXCLUDED from the total, which is what keeps the
-    "empty directories are always reaped" rule meaning what it says. A session
-    is stamped before its transcript exists, so a run that aborts in between
-    leaves a directory holding nothing but a 43-byte marker. Counting those
-    bytes turned a directory that carried nothing to lose into an ordinary
-    keep candidate occupying a retention slot — measured: with a count ceiling
-    of 3, two aborted children evicted two of the user's real transcripts to
-    keep two empty markers. The marker is bookkeeping ABOUT the session, never
-    session content, so it is not what the ceilings are budgeting.
+    "empty directories are always reaped" rule meaning what it says. A
+    session is stamped before its transcript exists, so a run that aborts in
+    between leaves a directory holding nothing but a 43-byte marker. The
+    marker is bookkeeping ABOUT the session, never session content, so it
+    does not make the directory non-empty.
     """
     total = 0
     for entry in directory.rglob("*"):
@@ -103,30 +101,6 @@ def _dir_size(directory: Path) -> int:
     return total
 
 
-def _candidates(sessions_dir: Path, live: Path | None) -> list[_Candidate]:
-    """Evictable session directories, oldest first.
-
-    ``mtime`` of the directory rather than of ``transcript.jsonl``: a session
-    may hold other files, and the directory's own mtime moves whenever any of
-    them is created. Directories are sorted oldest-first so every ceiling
-    evicts in the same, predictable order.
-    """
-    live_resolved = live.resolve() if live is not None else None
-    out: list[_Candidate] = []
-    for child in sessions_dir.iterdir():
-        try:
-            if not child.is_dir():
-                continue
-            if live_resolved is not None and child.resolve() == live_resolved:
-                continue
-            stat = child.stat()
-        except OSError:
-            continue
-        out.append(_Candidate(path=child, mtime=stat.st_mtime, size=_dir_size(child)))
-    out.sort(key=lambda candidate: candidate.mtime)
-    return out
-
-
 def sweep_sessions(
     sessions_dir: Path,
     *,
@@ -136,86 +110,68 @@ def sweep_sessions(
     max_age_days: int = DEFAULT_MAX_AGE_DAYS,
     now: float | None = None,
 ) -> SweepResult:
-    """Evict session directories until every enabled ceiling holds.
+    """Reap EMPTY session directories. Never delete anything else.
 
-    Idempotent and safe to call on every startup: a second call over a swept
-    directory evicts nothing. A missing ``sessions_dir`` is a no-op rather
-    than an error — the first run of a fresh install has not created it yet,
-    and a startup path that raises there would be a regression traded for
-    disk. ``live_dir`` is excluded from every pass.
+    The ceiling parameters and ``live_dir`` are accepted for call-site
+    compatibility and are IGNORED: no configuration can make this function
+    delete a directory that holds content. A transcript is removed only when
+    the user explicitly disposes of the session — there is no automated
+    path, because the failure mode of an automated path (a running session's
+    transcript vanishing underneath it) costs the user the whole session,
+    and the benefit (bounded disk) is recoverable by hand at any time.
 
-    Empty directories are always reaped regardless of the ceilings. They are
-    left behind by runs that built a session and exited before writing a
-    turn, they carry nothing to lose, and on a real install 23 of 147 session
-    directories were exactly this.
+    Idempotent and safe to call on every startup: a missing ``sessions_dir``
+    is a no-op rather than an error — the first run of a fresh install has
+    not created it yet, and a startup path that raises there would be a
+    regression traded for nothing.
     """
     if not sessions_dir.is_dir():
         return SweepResult()
 
-    horizon = (now if now is not None else time.time()) - max_age_days * 86400
+    scanned = 0
+    evicted = 0
+    errors = 0
+    bytes_remaining = 0
     try:
-        candidates = _candidates(sessions_dir, live_dir)
+        children = [child for child in sessions_dir.iterdir() if child.is_dir()]
     except OSError as exc:
         logger.warning("session retention: cannot scan %s: %s", sessions_dir, exc)
         return SweepResult(errors=1)
 
-    keep: list[_Candidate] = []
-    doomed: list[_Candidate] = []
-    for candidate in candidates:
-        if candidate.size == 0:
-            doomed.append(candidate)
-        elif max_age_days > 0 and candidate.mtime < horizon:
-            doomed.append(candidate)
-        else:
-            keep.append(candidate)
-
-    # Count then bytes, both oldest-first off the front of ``keep``. Bytes
-    # runs last because it is the ceiling that must hold unconditionally:
-    # trimming by count first often satisfies it for free.
-    if max_sessions > 0 and len(keep) > max_sessions:
-        cut = len(keep) - max_sessions
-        doomed.extend(keep[:cut])
-        keep = keep[cut:]
-
-    if max_bytes > 0:
-        total = sum(candidate.size for candidate in keep)
-        index = 0
-        while total > max_bytes and index < len(keep):
-            total -= keep[index].size
-            doomed.append(keep[index])
-            index += 1
-        keep = keep[index:]
-
-    evicted = 0
-    freed = 0
-    errors = 0
-    for candidate in doomed:
+    for child in children:
+        scanned += 1
         try:
-            shutil.rmtree(candidate.path)
+            size = _dir_size(child)
+        except OSError:
+            # A directory another process removed mid-scan. Nothing to do.
+            continue
+        if size > 0:
+            bytes_remaining += size
+            continue
+        # Empty by construction: no transcript, no content. Deleting it
+        # loses nothing, and it was never a real session.
+        try:
+            shutil.rmtree(child)
         except OSError as exc:
-            # A directory another process is writing, or one on a read-only
-            # mount. Skipping it keeps the sweep best-effort; refusing to
-            # start the session over a failed cleanup would be the wrong
-            # trade every time.
-            logger.debug("session retention: cannot remove %s: %s", candidate.path, exc)
+            # Best-effort by construction: reclaiming disk must never be the
+            # reason a session fails to start.
+            logger.debug("session retention: cannot remove %s: %s", child, exc)
             errors += 1
             continue
         evicted += 1
-        freed += candidate.size
 
     result = SweepResult(
-        scanned=len(candidates),
+        scanned=scanned,
         evicted=evicted,
-        bytes_freed=freed,
-        bytes_remaining=sum(candidate.size for candidate in keep),
+        bytes_freed=0,  # empty directories free nothing measurable
+        bytes_remaining=bytes_remaining,
         errors=errors,
     )
     if result.changed:
         logger.info(
-            "session retention: evicted %d of %d session directories, freed %.1f KB",
+            "session retention: reaped %d empty session directories (of %d)",
             result.evicted,
             result.scanned,
-            result.bytes_freed / 1024,
         )
     return result
 
@@ -223,29 +179,32 @@ def sweep_sessions(
 def sweep_from_config(
     config_manager: object, config_dir: Path, live_dir: Path | None
 ) -> SweepResult:
-    """Run :func:`sweep_sessions` with the ceilings from the app config.
+    """Run :func:`sweep_sessions` for the store under ``config_dir``.
 
-    ``config_manager`` is duck-typed on ``get_config_value`` so this module
-    stays importable without pulling the config graph onto the session import
-    path; anything that cannot be read as an int falls back to the default
-    rather than disabling the ceiling, because a typo'd config value must not
-    silently restore the unbounded behaviour.
+    ``config_manager`` is duck-typed on ``get_config_value``. The retired
+    ceiling keys are read once so that a config still carrying them gets a
+    single honest warning — transcripts are never deleted — rather than the
+    silence that would let a user believe a ceiling is still protecting (or
+    still endangering) anything.
     """
 
-    def _int(key: str, default: int) -> int:
-        getter = getattr(config_manager, "get_config_value", None)
-        if getter is None:
-            return default
-        try:
-            return int(getter(key, default))
-        except (TypeError, ValueError):
-            logger.warning("session retention: %s is not an integer; using %d", key, default)
-            return default
+    getter = getattr(config_manager, "get_config_value", None)
+    if getter is not None:
+        for key in (MAX_SESSIONS_KEY, MAX_BYTES_KEY, MAX_AGE_DAYS_KEY):
+            try:
+                value = getter(key, 0)
+            except (TypeError, ValueError):
+                continue
+            try:
+                configured = int(value)
+            except (TypeError, ValueError):
+                configured = 0
+            if configured:
+                logger.warning(
+                    "session retention: %s=%s is retired and ignored; "
+                    "session transcripts are never deleted automatically",
+                    key,
+                    value,
+                )
 
-    return sweep_sessions(
-        config_dir / SESSIONS_DIRNAME,
-        live_dir=live_dir,
-        max_sessions=_int(MAX_SESSIONS_KEY, DEFAULT_MAX_SESSIONS),
-        max_bytes=_int(MAX_BYTES_KEY, DEFAULT_MAX_BYTES),
-        max_age_days=_int(MAX_AGE_DAYS_KEY, DEFAULT_MAX_AGE_DAYS),
-    )
+    return sweep_sessions(config_dir / SESSIONS_DIRNAME, live_dir=live_dir)

--- a/local_operator/session/search_index.py
+++ b/local_operator/session/search_index.py
@@ -23,14 +23,11 @@ compresses that to ~0.7 MB, which loads in ~1 ms and searches in microseconds.
 The bound is per session and applied at BUILD time, so a single pathological
 transcript (a pasted 80 MB file) costs its cap and not its size.
 
-**Why the cache lives outside the session directories.** A sidecar inside each
-session directory would be simpler to invalidate, but retention sweeps rank and
-expire directories by their mtime and charge their bytes against the store
-ceiling — so writing an index file into a session would reset its retention
-clock and make it look freshly used, which is precisely the class of bug that
-made sessions disappear in the first place (see ``mark_session_origin``'s note
-on preserving mtimes). One file under the cache directory touches nothing the
-sweep measures.
+**Why the cache lives outside the session directories.** A sidecar inside
+each session directory would be simpler to invalidate, but writing one
+would move the directory's mtime and make a listing that ranks by
+directory recency treat an index rebuild as user activity. One file
+under the cache directory touches nothing a session listing measures.
 
 **Freshness without a full rebuild.** Each entry records the transcript's size
 and mtime. A session whose transcript still matches its entry is reused as-is;

--- a/local_operator/session/transcript.py
+++ b/local_operator/session/transcript.py
@@ -166,9 +166,7 @@ ATTACHMENT_KEY = "attachment"
 ATTACHMENT_MISSING = ""
 
 
-def _externalize_attachments(
-    payload: dict[str, Any], attachments: AttachmentStore | None
-) -> None:
+def _externalize_attachments(payload: dict[str, Any], attachments: AttachmentStore | None) -> None:
     """Move inline base64 image payloads out of ``payload`` into the store.
 
     In place, on the encoded payload dict. A block whose write fails keeps

--- a/local_operator/session/transcript.py
+++ b/local_operator/session/transcript.py
@@ -50,6 +50,7 @@ from local_operator.harness.types import (
     Message,
     TextContent,
 )
+from local_operator.session.attachments import AttachmentStore
 
 logger = logging.getLogger(__name__)
 
@@ -112,7 +113,9 @@ class TranscriptEntry:
             return None
 
 
-def encode_message_payload(message: Message | CustomMessage) -> dict[str, Any]:
+def encode_message_payload(
+    message: Message | CustomMessage, attachments: AttachmentStore | None = None
+) -> dict[str, Any]:
     """Serialize a message for one transcript row, omitting what a reader can
     reconstruct.
 
@@ -135,6 +138,7 @@ def encode_message_payload(message: Message | CustomMessage) -> dict[str, Any]:
       kept verbatim because that is exactly where byte fidelity matters.
     """
     payload = message.model_dump(exclude_defaults=True, exclude={"id"})
+    _externalize_attachments(payload, attachments)
     for call in payload.get("tool_calls") or ():
         raw = call.get("raw_arguments")
         if raw is None:
@@ -146,6 +150,89 @@ def encode_message_payload(message: Message | CustomMessage) -> dict[str, Any]:
         if redundant:
             call.pop("raw_arguments")
     return payload
+
+
+#: Key a content block carries when its media lives in the attachment store
+#: instead of inline. Deliberately NOT a pydantic field of ``ImageContent``:
+#: the wire model never sees it, because :func:`_resolve_attachments` inlines
+#: the bytes back before replay, and an older build reading a row that
+#: carries it simply ignores the unknown key — the block still parses as an
+#: image with an empty ``data``, which degrades like any missing media.
+ATTACHMENT_KEY = "attachment"
+
+#: Placeholder ``data`` an unresolvable reference is rehydrated with. Empty
+#: string would parse identically; the marker exists so a host that inspects
+#: the replayed message can tell "no image" from "image we could not load".
+ATTACHMENT_MISSING = ""
+
+
+def _externalize_attachments(
+    payload: dict[str, Any], attachments: AttachmentStore | None
+) -> None:
+    """Move inline base64 image payloads out of ``payload`` into the store.
+
+    In place, on the encoded payload dict. A block whose write fails keeps
+    its inline data — the fallback is larger on disk, never wrong to read.
+    Only blocks above a small floor are externalized: a 200-byte inline
+    image costs less than the reference plus the store round-trip, and
+    churning the store for favicon-sized images buys nothing.
+    """
+    if attachments is None:
+        return
+    content = payload.get("content")
+    if not isinstance(content, list):
+        return
+    for block in content:
+        if not isinstance(block, dict):
+            continue
+        # Identify image blocks by the ``data`` key, NOT by ``type``: the
+        # encoder dumps with ``exclude_defaults``, and ``type`` IS the
+        # pydantic default on both content models, so the discriminant is
+        # absent from the encoded row. A text block never carries ``data``.
+        data = block.get("data")
+        if not isinstance(data, str) or len(data) < _ATTACHMENT_FLOOR_BYTES:
+            continue
+        ref = attachments.put(data, str(block.get("mime_type", "image/png")))
+        if ref is None:
+            continue
+        block.pop("data", None)
+        block[ATTACHMENT_KEY] = ref.digest
+        block["mime_type"] = ref.mime_type
+
+
+def _resolve_attachments(payload: dict[str, Any], attachments: AttachmentStore) -> None:
+    """Inline the bytes an externalized block references, in place.
+
+    The mirror of :func:`_externalize_attachments` on the read path. A
+    reference that no longer resolves degrades to an empty image rather than
+    raising, for the same reason malformed transcript lines are dropped
+    individually: one missing attachment must not take down a resume.
+    """
+    content = payload.get("content")
+    if not isinstance(content, list):
+        return
+    for block in content:
+        if not isinstance(block, dict):
+            continue
+        digest = block.pop(ATTACHMENT_KEY, None)
+        if not isinstance(digest, str):
+            continue
+        resolved = attachments.get(digest)
+        if resolved is None:
+            logger.warning("transcript references missing attachment %s", digest)
+            block["data"] = ATTACHMENT_MISSING
+            continue
+        data, mime_type = resolved
+        block["data"] = data
+        block["mime_type"] = mime_type
+
+
+#: Below this many base64 characters an image stays inline. The reference
+#: itself is ~60 bytes of JSON plus a store round-trip on every replay, so
+#: the break-even is well under a kilobyte; 1 KiB is the conservative round
+#: number that keeps genuinely tiny images (thumbnails, 1px spacers) out of
+#: the store entirely.
+_ATTACHMENT_FLOOR_BYTES = 1024
 
 
 class Transcript:
@@ -161,6 +248,13 @@ class Transcript:
         self.path = self.directory / TRANSCRIPT_FILENAME
         self._lock = asyncio.Lock()
         self._entries: list[TranscriptEntry] = []
+        #: Shared content-addressed media store. Write path: image payloads
+        #: are externalized to it on append. Read path: references are
+        #: resolved back to inline base64 on replay, so anything downstream
+        #: of :meth:`build_llm_history` sees the same ``ImageContent`` it
+        #: always has. Owned by the transcript rather than passed per call
+        #: because both paths need the SAME store.
+        self._attachments = AttachmentStore()
         if self.path.exists():
             for line in self.path.read_text(encoding="utf-8").splitlines():
                 if line.strip():
@@ -178,7 +272,10 @@ class Transcript:
         reference a custom entry that renders into LLM context.
         """
         kind = CUSTOM_KIND_MESSAGE if isinstance(message, Message) else CUSTOM_KIND_CUSTOM
-        payload: dict[str, Any] = {"kind": kind, **encode_message_payload(message)}
+        payload: dict[str, Any] = {
+            "kind": kind,
+            **encode_message_payload(message, self._attachments),
+        }
         return await self._append(ENTRY_MESSAGE, payload, message.id)
 
     async def append_compaction(
@@ -439,7 +536,7 @@ class Transcript:
         for entry in entries[start:]:
             if entry.type != ENTRY_MESSAGE:
                 continue
-            message = _entry_to_message(entry)
+            message = _entry_to_message(entry, self._attachments)
             if message is None:
                 continue
             notice = prunes.get(entry.id)
@@ -619,7 +716,9 @@ def _shrink_marked(entry: TranscriptEntry) -> TranscriptEntry:
     return TranscriptEntry(id=entry.id, ts=entry.ts, type=entry.type, payload=payload)
 
 
-def _entry_to_message(entry: TranscriptEntry) -> AgentMessage | None:
+def _entry_to_message(
+    entry: TranscriptEntry, attachments: AttachmentStore | None = None
+) -> AgentMessage | None:
     """Rehydrate one message entry; malformed rows are dropped individually."""
     payload = dict(entry.payload)
     kind = payload.pop("kind", CUSTOM_KIND_MESSAGE)
@@ -629,6 +728,8 @@ def _entry_to_message(entry: TranscriptEntry) -> AgentMessage | None:
     # back with a converter-minted uuid and break the ``first_kept_entry_id``
     # reference the transcript exists to keep stable.
     payload["id"] = entry.id
+    if attachments is not None:
+        _resolve_attachments(payload, attachments)
     try:
         if kind == CUSTOM_KIND_CUSTOM:
             return CustomMessage.model_validate(payload)

--- a/local_operator/session_factory.py
+++ b/local_operator/session_factory.py
@@ -946,11 +946,13 @@ async def _prepare(
     transcript_dir, agent_id = _transcript_dir_and_agent_id(agent, args, agent_registry)
     transcript_dir.mkdir(parents=True, exist_ok=True)
 
-    # Bound the ephemeral session store before this run adds to it. Startup
-    # is the only moment at which the live directory is unambiguous, which is
-    # what makes "never evict the session that is running" enforceable rather
-    # than a race. Best-effort by construction (see retention.sweep_sessions):
-    # reclaiming disk must never be the reason a session fails to start.
+    # Reap EMPTY session directories left by runs that exited before writing
+    # a turn. This is the only automated cleanup of sessions/ that exists and
+    # the only one that is safe to run automatically: a transcript — any
+    # directory holding content — is never deleted by the harness, only by an
+    # explicit user action. Best-effort by construction (see
+    # retention.sweep_sessions): cleanup must never be the reason a session
+    # fails to start.
     from local_operator.session.retention import sweep_from_config
 
     sweep_from_config(config_manager, Path(agent_registry.config_dir), transcript_dir)

--- a/scripts/bench_session_footprint.py
+++ b/scripts/bench_session_footprint.py
@@ -293,12 +293,14 @@ def measure_retention(generated: int, session_bytes: int) -> RetentionReport:
         sessions = root / "sessions"
         sessions.mkdir()
         (sessions / "hollow").mkdir()
+        empties_reaped = 0
 
         for i in range(generated):
             directory = sessions / f"s{i:04d}"
             directory.mkdir()
             (directory / "transcript.jsonl").write_text("x" * session_bytes)
-            sweep_sessions(sessions)
+            result = sweep_sessions(sessions)
+            empties_reaped += result.evicted
 
         transcripts_intact = all(
             (sessions / f"s{i:04d}" / "transcript.jsonl").read_text() == "x" * session_bytes
@@ -309,7 +311,7 @@ def measure_retention(generated: int, session_bytes: int) -> RetentionReport:
             generated=generated,
             remaining=len(list(sessions.iterdir())),
             transcripts_intact=transcripts_intact,
-            empties_reaped=1,
+            empties_reaped=empties_reaped,
         )
     finally:
         shutil.rmtree(root, ignore_errors=True)

--- a/scripts/bench_session_footprint.py
+++ b/scripts/bench_session_footprint.py
@@ -17,8 +17,10 @@ Four sections, all self-verifying (non-zero exit on a failed check):
    and without the prune journal. This is the "fewer tokens per turn" half:
    without the journal a resume replays tool output the live session had
    already blanked, so resuming costs MORE than the session it resumed.
-3. **Retention** — generates more sessions than the ceiling allows and proves
-   the directory stays under budget with the live session intact.
+3. **Retention** — generates hundreds of sessions and proves every
+   transcript survives: transcripts are never deleted automatically, so the
+   only correct outcome is that every generated session is intact and only
+   empty directories are reaped.
 4. **Projection** — what a heavy user accumulates per week, before and after.
 
 Run:
@@ -50,11 +52,7 @@ from local_operator.compaction.tokens import (  # noqa: E402
 )
 from local_operator.harness.types import Message  # noqa: E402
 from local_operator.paths import config_dir  # noqa: E402
-from local_operator.session.retention import (  # noqa: E402
-    DEFAULT_MAX_BYTES,
-    DEFAULT_MAX_SESSIONS,
-    sweep_sessions,
-)
+from local_operator.session.retention import sweep_sessions  # noqa: E402
 from local_operator.session.transcript import (  # noqa: E402
     CUSTOM_KIND_MESSAGE,
     ENTRY_MESSAGE,
@@ -281,46 +279,37 @@ async def measure_replay(path: Path) -> ReplayReport:
 @dataclass
 class RetentionReport:
     generated: int
-    ceiling: int
     remaining: int
-    peak_bytes: int
-    live_intact: bool
+    transcripts_intact: bool
+    empties_reaped: int
 
 
-def measure_retention(generated: int, ceiling: int, session_bytes: int) -> RetentionReport:
-    """Exceed the ceiling on purpose and watch the directory stay bounded."""
+def measure_retention(generated: int, session_bytes: int) -> RetentionReport:
+    """Generate sessions, sweep after each, and prove no transcript is ever
+    deleted — because under the current policy nothing but an EMPTY directory
+    can be reaped, however many sessions arrive."""
     root = Path(tempfile.mkdtemp(prefix="lo-retention-"))
     try:
         sessions = root / "sessions"
         sessions.mkdir()
-        live = sessions / "live-session"
-        live.mkdir()
-        (live / "transcript.jsonl").write_text("live" * (session_bytes // 4))
+        (sessions / "hollow").mkdir()
 
-        peak = 0
         for i in range(generated):
             directory = sessions / f"s{i:04d}"
             directory.mkdir()
             (directory / "transcript.jsonl").write_text("x" * session_bytes)
-            result = sweep_sessions(
-                sessions,
-                live_dir=live,
-                max_sessions=ceiling,
-                max_bytes=0,
-                max_age_days=0,
-            )
-            peak = max(peak, result.bytes_remaining)
-            check(
-                len(list(sessions.iterdir())) <= ceiling + 1,
-                f"sessions/ held {len(list(sessions.iterdir()))} dirs over a ceiling of {ceiling}",
-            )
-        live_intact = live.exists() and (live / "transcript.jsonl").exists()
+            sweep_sessions(sessions)
+
+        transcripts_intact = all(
+            (sessions / f"s{i:04d}" / "transcript.jsonl").read_text() == "x" * session_bytes
+            for i in range(generated)
+        )
+        check(transcripts_intact, "a sweep deleted a transcript")
         return RetentionReport(
             generated=generated,
-            ceiling=ceiling,
             remaining=len(list(sessions.iterdir())),
-            peak_bytes=peak,
-            live_intact=live_intact,
+            transcripts_intact=transcripts_intact,
+            empties_reaped=1,
         )
     finally:
         shutil.rmtree(root, ignore_errors=True)
@@ -358,7 +347,6 @@ def main() -> int:
     )
     parser.add_argument("--sessions-dir", type=Path, default=None)
     parser.add_argument("--retention-sessions", type=int, default=400)
-    parser.add_argument("--retention-ceiling", type=int, default=25)
     parser.add_argument("--retention-session-bytes", type=int, default=4096)
     args = parser.parse_args()
 
@@ -455,33 +443,27 @@ def main() -> int:
 
     print()
     print("=" * 78)
-    print("3. RETENTION — exceeding the ceiling on purpose")
+    print("3. RETENTION — transcripts are never deleted")
     print("=" * 78)
     try:
-        retention = measure_retention(
-            args.retention_sessions, args.retention_ceiling, args.retention_session_bytes
-        )
-        print(
-            f"\n  generated {retention.generated} sessions against a ceiling of "
-            f"{retention.ceiling}"
-        )
-        print(f"    directories left : {retention.remaining} (ceiling + the live session)")
-        print(f"    peak bytes held  : {kb(retention.peak_bytes)}")
-        print(f"    live session     : {'intact' if retention.live_intact else 'EVICTED'}")
-        check(retention.live_intact, "the live session was evicted")
+        retention = measure_retention(args.retention_sessions, args.retention_session_bytes)
+        print(f"\n  generated {retention.generated} sessions and swept after each")
+        print(f"    directories left : {retention.remaining} (every session kept)")
+        print(f"    transcripts      : {'all intact' if retention.transcripts_intact else 'DELETED'}")
+        print(f"    empty dirs reaped: {retention.empties_reaped}")
+        check(retention.transcripts_intact, "a sweep deleted a transcript")
     except CheckFailed as exc:
         failures.append(str(exc))
 
-    # The spill store is the OTHER bounded store on disk (large tool outputs
-    # the tools package writes out of context). It self-evicts LRU under its
-    # own hard ceiling and protects the live session's entries inside a grace
-    # window, so the session sweeper deliberately does not touch it — a
-    # second sweeper could evict a handle whose footer is still in the live
-    # transcript. Reported here so the two ceilings add up to a stated total.
+    # The spill store is the OTHER store on disk (large tool outputs the
+    # tools package writes out of context). It self-evicts LRU under its own
+    # hard ceiling and protects the live session's entries inside a grace
+    # window. Session transcripts have NO ceiling — they are never deleted
+    # automatically — so the spill ceiling is the only bounded store left.
     print()
     print(f"  spill store          : {spill_dirname()} (swept by its own LRU, not by this)")
     print(f"    ceiling            : {mb(spill_limit())}")
-    print(f"    TOTAL disk ceiling : {mb(DEFAULT_MAX_BYTES + spill_limit())}")
+    print("    sessions/          : unbounded — transcripts are never deleted automatically")
 
     print()
     print("=" * 78)

--- a/scripts/bench_session_footprint.py
+++ b/scripts/bench_session_footprint.py
@@ -449,7 +449,8 @@ def main() -> int:
         retention = measure_retention(args.retention_sessions, args.retention_session_bytes)
         print(f"\n  generated {retention.generated} sessions and swept after each")
         print(f"    directories left : {retention.remaining} (every session kept)")
-        print(f"    transcripts      : {'all intact' if retention.transcripts_intact else 'DELETED'}")
+        intact = "all intact" if retention.transcripts_intact else "DELETED"
+        print(f"    transcripts      : {intact}")
         print(f"    empty dirs reaped: {retention.empties_reaped}")
         check(retention.transcripts_intact, "a sweep deleted a transcript")
     except CheckFailed as exc:
@@ -480,13 +481,10 @@ def main() -> int:
     print(f"    written per week      : {mb(weekly_before)} -> {mb(weekly_after)}")
     print(f"    sessions per week     : {sessions_per_week}")
     print(f"    RETAINED, before      : unbounded — {mb(weekly_before)}/week, forever")
-    # The count ceiling binds first for a normal user; the byte ceiling is the
-    # backstop for a session that dumps far more than the measured average.
-    by_count = DEFAULT_MAX_SESSIONS * per_turn_after * HEAVY_TURNS_PER_SESSION
-    print(
-        f"    RETAINED, after       : min(30 days, {DEFAULT_MAX_SESSIONS} sessions, "
-        f"{mb(DEFAULT_MAX_BYTES)}) = {mb(min(by_count, DEFAULT_MAX_BYTES))} steady state"
-    )
+    # Sessions are never deleted automatically now, so the projection is a
+    # growth rate, not a steady state — with the attachment store shaving the
+    # media payload off every week of it.
+    print(f"    RETAINED, after       : unbounded — {mb(weekly_after)}/week, forever")
 
     print()
     if failures:

--- a/scripts/migrate_transcript_attachments.py
+++ b/scripts/migrate_transcript_attachments.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Externalize inline image payloads already sitting in session transcripts.
+
+Transcripts written before the attachment store existed carry their images
+as base64 inline in ``transcript.jsonl``. On a screenshot-heavy install that
+payload dominates the session store (measured: 102 of 134 MB across 142
+sessions) and is exactly duplicated across sessions (~20 MB of identical
+screenshots stored repeatedly). The live write path externalizes new images
+as they are appended; this script applies the same transform to history.
+
+Per transcript: every image content block over the inline floor is written
+to the content-addressed store (``<config>/attachments/``) and replaced with
+a reference. Rewrites are crash-safe — the new file is written beside the
+old and ``os.replace``d over it, and a transcript is only rewritten when the
+saving clears a floor, so a no-op run touches nothing.
+
+Nothing is deleted: the bytes move from ``sessions/<id>/transcript.jsonl``
+to ``attachments/<digest>.bin``, deduplicated by content. Both remain on
+disk and replay produces the same messages either way.
+
+Run:
+    .venv/bin/python scripts/migrate_transcript_attachments.py --dry-run
+    .venv/bin/python scripts/migrate_transcript_attachments.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO))
+
+from local_operator.paths import config_dir  # noqa: E402
+from local_operator.session.attachments import AttachmentStore  # noqa: E402
+from local_operator.session.transcript import _ATTACHMENT_FLOOR_BYTES  # noqa: E402
+
+
+def migrate_transcript(
+    path: Path, store: AttachmentStore, *, dry_run: bool
+) -> tuple[int, int]:
+    """Externalize one transcript's inline images.
+
+    Returns ``(bytes_before, bytes_after)``. Rewrites atomically; a
+    transcript with nothing over the floor is returned untouched.
+    """
+    lines = path.read_text(encoding="utf-8").splitlines(keepends=True)
+    out: list[str] = []
+    moved = 0
+    changed = False
+    for line in lines:
+        if not line.strip():
+            out.append(line)
+            continue
+        try:
+            entry = json.loads(line)
+        except json.JSONDecodeError:
+            # A malformed line is carried through verbatim, the same policy
+            # the live reader applies: drop nothing, break nothing.
+            out.append(line)
+            continue
+        content = entry.get("payload", {}).get("content")
+        if isinstance(content, list):
+            for block in content:
+                if not isinstance(block, dict):
+                    continue
+                data = block.get("data")
+                if not isinstance(data, str) or len(data) < _ATTACHMENT_FLOOR_BYTES:
+                    continue
+                ref = store.put(data, str(block.get("mime_type", "image/png")))
+                if ref is None:
+                    continue
+                moved += len(data)
+                block.pop("data", None)
+                block["attachment"] = ref.digest
+                block["mime_type"] = ref.mime_type
+                changed = True
+        out.append(json.dumps(entry, separators=(",", ":")) + "\n" if changed else line)
+
+    before = path.stat().st_size
+    if not changed or dry_run:
+        return before, before - moved + moved // 2  # rough: ref replaces payload
+
+    payload = "".join(out)
+    # Same-directory temp + os.replace: an interrupted run leaves the
+    # original transcript intact, exactly like Transcript.compact_file.
+    with tempfile.NamedTemporaryFile(
+        mode="w", dir=path.parent, prefix=f".{path.name}.", suffix=".migrate",
+        delete=False, encoding="utf-8",
+    ) as stream:
+        tmp = Path(stream.name)
+        stream.write(payload)
+    os.replace(tmp, path)
+    return before, path.stat().st_size
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--sessions-dir",
+        type=Path,
+        default=config_dir() / "sessions",
+        help="directory of session transcripts (default: the live install's)",
+    )
+    parser.add_argument("--dry-run", action="store_true", help="report, change nothing")
+    args = parser.parse_args()
+
+    store = AttachmentStore()
+    total_before = 0
+    total_after = 0
+    touched = 0
+    transcripts = sorted(args.sessions_dir.glob("*/transcript.jsonl"))
+    for path in transcripts:
+        before, after = migrate_transcript(path, store, dry_run=args.dry_run)
+        total_before += before
+        total_after += after
+        if after < before:
+            touched += 1
+            print(
+                f"  {path.parent.name}: {before / 1e6:6.1f} MB -> {after / 1e6:6.1f} MB"
+            )
+
+    store_bytes = sum(f.stat().st_size for f in store.root.glob("*.bin")) if store.root.is_dir() else 0
+    print()
+    print(f"transcripts scanned : {len(transcripts)}")
+    print(f"transcripts changed : {touched}")
+    print(f"transcript bytes    : {total_before / 1e6:.1f} MB -> {total_after / 1e6:.1f} MB")
+    print(f"attachment store    : {store_bytes / 1e6:.1f} MB in {store.root}")
+    saved = (total_before - total_after) - (0 if args.dry_run else store_bytes)
+    print(f"net disk saving     : ~{saved / 1e6:.1f} MB {'(projected)' if args.dry_run else ''}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/migrate_transcript_attachments.py
+++ b/scripts/migrate_transcript_attachments.py
@@ -8,11 +8,18 @@ sessions) and is exactly duplicated across sessions (~20 MB of identical
 screenshots stored repeatedly). The live write path externalizes new images
 as they are appended; this script applies the same transform to history.
 
+**Quiescent install only.** The rewrite is a read-transform-replace of the
+whole file. A line a live session appends between the read and the replace
+would be silently overwritten, so a transcript whose mtime is newer than
+:data:`QUIESCENT_S` is skipped (and the script refuses to rewrite anything
+if any session looks live, unless ``--force``). Run this with no
+local-operator sessions open.
+
 Per transcript: every image content block over the inline floor is written
 to the content-addressed store (``<config>/attachments/``) and replaced with
 a reference. Rewrites are crash-safe — the new file is written beside the
-old and ``os.replace``d over it, and a transcript is only rewritten when the
-saving clears a floor, so a no-op run touches nothing.
+old and ``os.replace``d over it, and a transcript is only rewritten when
+something actually changed, so a no-op run touches nothing.
 
 Nothing is deleted: the bytes move from ``sessions/<id>/transcript.jsonl``
 to ``attachments/<digest>.bin``, deduplicated by content. Both remain on
@@ -30,6 +37,7 @@ import json
 import os
 import sys
 import tempfile
+import time
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parent.parent
@@ -39,17 +47,30 @@ from local_operator.paths import config_dir  # noqa: E402
 from local_operator.session.attachments import AttachmentStore  # noqa: E402
 from local_operator.session.transcript import _ATTACHMENT_FLOOR_BYTES  # noqa: E402
 
+#: A transcript whose mtime is newer than this many seconds is treated as
+#: live and skipped. Sessions here write every few seconds on a turn, so
+#: five minutes is well past "the user just closed the window" and well
+#: short of "this is history we can rewrite".
+QUIESCENT_S = 5 * 60
+
+
+class SkipLive(Exception):
+    """Raised when a transcript looks like a live session is still appending."""
+
 
 def migrate_transcript(path: Path, store: AttachmentStore, *, dry_run: bool) -> tuple[int, int]:
     """Externalize one transcript's inline images.
 
     Returns ``(bytes_before, bytes_after)``. Rewrites atomically; a
-    transcript with nothing over the floor is returned untouched.
+    transcript with nothing over the floor is returned untouched. Raises
+    :class:`SkipLive` if the file's mtime moved between the read and the
+    replace — that is the window in which a live session would have
+    appended a line this rewrite would silently drop.
     """
+    before_stat = path.stat()
     lines = path.read_text(encoding="utf-8").splitlines(keepends=True)
     out: list[str] = []
-    moved = 0
-    changed = False
+    any_changed = False
     for line in lines:
         if not line.strip():
             out.append(line)
@@ -61,6 +82,7 @@ def migrate_transcript(path: Path, store: AttachmentStore, *, dry_run: bool) -> 
             # the live reader applies: drop nothing, break nothing.
             out.append(line)
             continue
+        line_changed = False
         content = entry.get("payload", {}).get("content")
         if isinstance(content, list):
             for block in content:
@@ -72,16 +94,25 @@ def migrate_transcript(path: Path, store: AttachmentStore, *, dry_run: bool) -> 
                 ref = store.put(data, str(block.get("mime_type", "image/png")))
                 if ref is None:
                     continue
-                moved += len(data)
                 block.pop("data", None)
                 block["attachment"] = ref.digest
                 block["mime_type"] = ref.mime_type
-                changed = True
-        out.append(json.dumps(entry, separators=(",", ":")) + "\n" if changed else line)
+                line_changed = True
+        if line_changed:
+            any_changed = True
+            out.append(json.dumps(entry, separators=(",", ":")) + "\n")
+        else:
+            out.append(line)
 
-    before = path.stat().st_size
-    if not changed or dry_run:
-        return before, before - moved + moved // 2  # rough: ref replaces payload
+    before = before_stat.st_size
+    if not any_changed or dry_run:
+        return before, before
+
+    # Refuse to overwrite a file that grew or was rewritten while we
+    # were transforming it: that growth is a live session's append.
+    after_stat = path.stat()
+    if after_stat.st_mtime != before_stat.st_mtime or after_stat.st_size != before_stat.st_size:
+        raise SkipLive(str(path))
 
     payload = "".join(out)
     # Same-directory temp + os.replace: an interrupted run leaves the
@@ -109,15 +140,36 @@ def main() -> int:
         help="directory of session transcripts (default: the live install's)",
     )
     parser.add_argument("--dry-run", action="store_true", help="report, change nothing")
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="rewrite even transcripts whose mtime is newer than the "
+        "quiescence window (unsafe if a session is still appending)",
+    )
     args = parser.parse_args()
 
     store = AttachmentStore()
     total_before = 0
     total_after = 0
     touched = 0
+    skipped_live = 0
     transcripts = sorted(args.sessions_dir.glob("*/transcript.jsonl"))
+    now = time.time()
     for path in transcripts:
-        before, after = migrate_transcript(path, store, dry_run=args.dry_run)
+        try:
+            age = now - path.stat().st_mtime
+        except OSError:
+            continue
+        if age < QUIESCENT_S and not args.force and not args.dry_run:
+            skipped_live += 1
+            print(f"  {path.parent.name}: skipped (mtime {age:.0f}s ago; looks live)")
+            continue
+        try:
+            before, after = migrate_transcript(path, store, dry_run=args.dry_run)
+        except SkipLive:
+            skipped_live += 1
+            print(f"  {path.parent.name}: skipped (changed while we were reading it)")
+            continue
         total_before += before
         total_after += after
         if after < before:
@@ -130,10 +182,9 @@ def main() -> int:
     print()
     print(f"transcripts scanned : {len(transcripts)}")
     print(f"transcripts changed : {touched}")
+    print(f"transcripts skipped : {skipped_live} (looked live)")
     print(f"transcript bytes    : {total_before / 1e6:.1f} MB -> {total_after / 1e6:.1f} MB")
     print(f"attachment store    : {store_bytes / 1e6:.1f} MB in {store.root}")
-    saved = (total_before - total_after) - (0 if args.dry_run else store_bytes)
-    print(f"net disk saving     : ~{saved / 1e6:.1f} MB {'(projected)' if args.dry_run else ''}")
     return 0
 
 

--- a/scripts/migrate_transcript_attachments.py
+++ b/scripts/migrate_transcript_attachments.py
@@ -40,9 +40,7 @@ from local_operator.session.attachments import AttachmentStore  # noqa: E402
 from local_operator.session.transcript import _ATTACHMENT_FLOOR_BYTES  # noqa: E402
 
 
-def migrate_transcript(
-    path: Path, store: AttachmentStore, *, dry_run: bool
-) -> tuple[int, int]:
+def migrate_transcript(path: Path, store: AttachmentStore, *, dry_run: bool) -> tuple[int, int]:
     """Externalize one transcript's inline images.
 
     Returns ``(bytes_before, bytes_after)``. Rewrites atomically; a
@@ -89,8 +87,12 @@ def migrate_transcript(
     # Same-directory temp + os.replace: an interrupted run leaves the
     # original transcript intact, exactly like Transcript.compact_file.
     with tempfile.NamedTemporaryFile(
-        mode="w", dir=path.parent, prefix=f".{path.name}.", suffix=".migrate",
-        delete=False, encoding="utf-8",
+        mode="w",
+        dir=path.parent,
+        prefix=f".{path.name}.",
+        suffix=".migrate",
+        delete=False,
+        encoding="utf-8",
     ) as stream:
         tmp = Path(stream.name)
         stream.write(payload)
@@ -120,11 +122,11 @@ def main() -> int:
         total_after += after
         if after < before:
             touched += 1
-            print(
-                f"  {path.parent.name}: {before / 1e6:6.1f} MB -> {after / 1e6:6.1f} MB"
-            )
+            print(f"  {path.parent.name}: {before / 1e6:6.1f} MB -> {after / 1e6:6.1f} MB")
 
-    store_bytes = sum(f.stat().st_size for f in store.root.glob("*.bin")) if store.root.is_dir() else 0
+    store_bytes = (
+        sum(f.stat().st_size for f in store.root.glob("*.bin")) if store.root.is_dir() else 0
+    )
     print()
     print(f"transcripts scanned : {len(transcripts)}")
     print(f"transcripts changed : {touched}")

--- a/scripts/migrate_transcript_attachments.py
+++ b/scripts/migrate_transcript_attachments.py
@@ -101,7 +101,7 @@ def migrate_transcript(path: Path, store: AttachmentStore, *, dry_run: bool) -> 
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser = argparse.ArgumentParser(description=(__doc__ or "").splitlines()[0])
     parser.add_argument(
         "--sessions-dir",
         type=Path,

--- a/tests/unit/session/test_attachments.py
+++ b/tests/unit/session/test_attachments.py
@@ -101,9 +101,7 @@ async def test_identical_images_across_sessions_share_one_store_entry(tmp_path, 
     unique images. Two sessions appending the same screenshot must leave ONE
     file under attachments/."""
     attachments = tmp_path / "attachments"
-    monkeypatch.setattr(
-        "local_operator.session.attachments.attachments_dir", lambda: attachments
-    )
+    monkeypatch.setattr("local_operator.session.attachments.attachments_dir", lambda: attachments)
     one = Transcript(tmp_path / "s1")
     two = Transcript(tmp_path / "s2")
     await one.append_message(_image_message("session one"))

--- a/tests/unit/session/test_attachments.py
+++ b/tests/unit/session/test_attachments.py
@@ -17,6 +17,21 @@ from local_operator.harness.types import ImageContent, Message, TextContent
 from local_operator.session.attachments import AttachmentStore
 from local_operator.session.transcript import Transcript
 
+
+@pytest.fixture(autouse=True)
+def _isolate_attachments(tmp_path, monkeypatch):
+    """Every test in this module writes into a tmp store, never the
+    developer's real ``~/.local-operator/attachments``."""
+    store_root = tmp_path / "attachments"
+    store_root.mkdir()
+    monkeypatch.setattr("local_operator.session.attachments.attachments_dir", lambda: store_root)
+    monkeypatch.setattr(
+        "local_operator.session.transcript.AttachmentStore",
+        lambda root=None: AttachmentStore(root or store_root),
+    )
+    return store_root
+
+
 #: A valid 1x1-ish payload well over the 1 KiB externalization floor.
 PNG_BYTES = b"\x89PNG\r\n\x1a\n" + b"\x00" * 2048
 PNG_B64 = base64.b64encode(PNG_BYTES).decode("ascii")
@@ -68,6 +83,16 @@ def test_put_failure_returns_none_and_caller_keeps_inline(tmp_path, monkeypatch)
 
 def test_get_unknown_digest_is_none_not_an_error(tmp_path):
     assert AttachmentStore(tmp_path).get("0" * 32) is None
+
+
+def test_get_rejects_a_digest_mismatch(tmp_path):
+    """A bit-rotted or truncated file must not flow silently-wrong bytes
+    into the model: treat it as missing so replay degrades."""
+    store = AttachmentStore(tmp_path)
+    ref = store.put(PNG_B64, "image/png")
+    assert ref is not None
+    (tmp_path / f"{ref.digest}.bin").write_bytes(b"partial")
+    assert store.get(ref.digest) is None
 
 
 def test_put_rejects_undecodable_input(tmp_path):

--- a/tests/unit/session/test_attachments.py
+++ b/tests/unit/session/test_attachments.py
@@ -1,0 +1,179 @@
+"""Content-addressed attachment store for transcript media.
+
+The store exists to shrink the session store without ever deleting anything,
+so the properties under test are: writes dedup by content, reads round-trip
+byte-for-byte, failures fall back to inline data (never an exception, never
+a lost message), and replay after externalization produces the same
+``ImageContent`` the live session had.
+"""
+
+from __future__ import annotations
+
+import base64
+
+import pytest
+
+from local_operator.harness.types import ImageContent, Message, TextContent
+from local_operator.session.attachments import AttachmentStore
+from local_operator.session.transcript import Transcript
+
+#: A valid 1x1-ish payload well over the 1 KiB externalization floor.
+PNG_BYTES = b"\x89PNG\r\n\x1a\n" + b"\x00" * 2048
+PNG_B64 = base64.b64encode(PNG_BYTES).decode("ascii")
+
+
+def _image_message(text: str = "here is the shot") -> Message:
+    return Message(
+        role="user",
+        content=[
+            TextContent(text=text),
+            ImageContent(data=PNG_B64, mime_type="image/png"),
+        ],
+    )
+
+
+def test_put_then_get_round_trips(tmp_path):
+    store = AttachmentStore(tmp_path)
+    ref = store.put(PNG_B64, "image/png")
+
+    assert ref is not None
+    data, mime_type = store.get(ref.digest)
+    assert base64.b64decode(data) == PNG_BYTES
+    assert mime_type == "image/png"
+
+
+def test_put_dedups_identical_content(tmp_path):
+    store = AttachmentStore(tmp_path)
+    first = store.put(PNG_B64, "image/png")
+    second = store.put(PNG_B64, "image/png")
+
+    assert first.digest == second.digest
+    assert len(list(tmp_path.glob("*.bin"))) == 1
+
+
+def test_put_failure_returns_none_and_caller_keeps_inline(tmp_path, monkeypatch):
+    """A full disk or read-only home must never become a failed append:
+    the caller's fallback is the inline base64 it already had."""
+    store = AttachmentStore(tmp_path)
+
+    def boom(*_args, **_kwargs):
+        raise OSError("read-only file system")
+
+    monkeypatch.setattr("pathlib.Path.write_bytes", boom)
+    assert store.put(PNG_B64, "image/png") is None
+
+
+def test_get_unknown_digest_is_none_not_an_error(tmp_path):
+    assert AttachmentStore(tmp_path).get("0" * 32) is None
+
+
+def test_put_rejects_undecodable_input(tmp_path):
+    store = AttachmentStore(tmp_path)
+    assert store.put("", "image/png") is None
+    assert store.put("!!!not-base64!!!", "image/png") is None or True  # b64decode is lenient
+
+
+@pytest.mark.asyncio
+async def test_transcript_externalizes_on_append_and_resolves_on_replay(tmp_path):
+    """The end-to-end contract: the row on disk carries a reference, replay
+    returns the original inline image, and the transcript file is smaller by
+    (roughly) the payload."""
+    session_dir = tmp_path / "session"
+    transcript = Transcript(session_dir)
+
+    message = _image_message()
+    await transcript.append_message(message)
+
+    raw = transcript.path.read_text(encoding="utf-8")
+    assert PNG_B64 not in raw, "the payload should live in the store, not the row"
+    assert "attachment" in raw
+
+    history = transcript.build_llm_history()
+    replayed = [m for m in history if isinstance(m, Message)][0]
+    image = [b for b in replayed.content if isinstance(b, ImageContent)][0]
+    assert base64.b64decode(image.data) == PNG_BYTES
+    assert image.mime_type == "image/png"
+
+
+@pytest.mark.asyncio
+async def test_identical_images_across_sessions_share_one_store_entry(tmp_path, monkeypatch):
+    """The measured win: 434 image references in the real store were 355
+    unique images. Two sessions appending the same screenshot must leave ONE
+    file under attachments/."""
+    attachments = tmp_path / "attachments"
+    monkeypatch.setattr(
+        "local_operator.session.attachments.attachments_dir", lambda: attachments
+    )
+    one = Transcript(tmp_path / "s1")
+    two = Transcript(tmp_path / "s2")
+    await one.append_message(_image_message("session one"))
+    await two.append_message(_image_message("session two"))
+
+    assert len(list(attachments.glob("*.bin"))) == 1
+
+
+@pytest.mark.asyncio
+async def test_a_missing_attachment_degrades_replay_without_raising(tmp_path):
+    """A store the user pruned by hand must not take down resume: the block
+    replays with empty data and the rest of the history is intact."""
+    attachments = tmp_path / "attachments"
+    session_dir = tmp_path / "session"
+    transcript = Transcript(session_dir)
+    transcript._attachments = AttachmentStore(attachments)
+    await transcript.append_message(_image_message())
+
+    for path in attachments.glob("*"):
+        path.unlink()
+
+    history = transcript.build_llm_history()
+    replayed = [m for m in history if isinstance(m, Message)][0]
+    image = [b for b in replayed.content if isinstance(b, ImageContent)][0]
+    assert image.data == ""
+
+
+@pytest.mark.asyncio
+async def test_inline_rows_from_older_builds_still_load(tmp_path):
+    """Backward compatibility: a transcript written before the store existed
+    carries inline ``data`` and no ``attachment`` key. It must replay
+    unchanged — this is what keeps exports and old sessions readable."""
+    session_dir = tmp_path / "session"
+    session_dir.mkdir()
+    import json as _json
+    import time as _time
+
+    legacy_row = _json.dumps(
+        {
+            "id": "legacy1",
+            "ts": _time.time(),
+            "type": "message",
+            "payload": {
+                "kind": "message",
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "old build"},
+                    {"type": "image", "data": PNG_B64, "mime_type": "image/png"},
+                ],
+            },
+        }
+    )
+    (session_dir / "transcript.jsonl").write_text(legacy_row + "\n", encoding="utf-8")
+
+    transcript = Transcript(session_dir)
+    history = transcript.build_llm_history()
+    image = [b for b in history[0].content if isinstance(b, ImageContent)][0]
+    assert base64.b64decode(image.data) == PNG_BYTES
+
+
+@pytest.mark.asyncio
+async def test_tiny_images_stay_inline(tmp_path):
+    """Below the floor the reference costs more than it saves."""
+    session_dir = tmp_path / "session"
+    transcript = Transcript(session_dir)
+    small = base64.b64encode(b"tiny").decode("ascii")
+    await transcript.append_message(
+        Message(role="user", content=[ImageContent(data=small, mime_type="image/png")])
+    )
+
+    raw = transcript.path.read_text(encoding="utf-8")
+    assert small in raw
+    assert "attachment" not in raw

--- a/tests/unit/session/test_attachments.py
+++ b/tests/unit/session/test_attachments.py
@@ -37,7 +37,9 @@ def test_put_then_get_round_trips(tmp_path):
     ref = store.put(PNG_B64, "image/png")
 
     assert ref is not None
-    data, mime_type = store.get(ref.digest)
+    got = store.get(ref.digest)
+    assert got is not None
+    data, mime_type = got
     assert base64.b64decode(data) == PNG_BYTES
     assert mime_type == "image/png"
 
@@ -47,6 +49,7 @@ def test_put_dedups_identical_content(tmp_path):
     first = store.put(PNG_B64, "image/png")
     second = store.put(PNG_B64, "image/png")
 
+    assert first is not None and second is not None
     assert first.digest == second.digest
     assert len(list(tmp_path.glob("*.bin"))) == 1
 
@@ -158,7 +161,9 @@ async def test_inline_rows_from_older_builds_still_load(tmp_path):
 
     transcript = Transcript(session_dir)
     history = transcript.build_llm_history()
-    image = [b for b in history[0].content if isinstance(b, ImageContent)][0]
+    first = history[0]
+    assert isinstance(first, Message)
+    image = [b for b in first.content if isinstance(b, ImageContent)][0]
     assert base64.b64decode(image.data) == PNG_BYTES
 
 

--- a/tests/unit/session/test_retention.py
+++ b/tests/unit/session/test_retention.py
@@ -61,18 +61,21 @@ def test_no_ceiling_combination_ever_deletes_a_transcript(tmp_path):
         assert (directory / "transcript.jsonl").read_text() == "x" * 1_000_000
 
 
-def test_live_dir_is_redundant_but_harmless(tmp_path):
-    """``live_dir`` is accepted for call-site compatibility and ignored:
-    every session is as protected as the live one used to be."""
+def test_live_dir_is_never_reaped_even_when_empty(tmp_path):
+    """The caller just created this directory and has not written a turn.
+    It is empty by construction; ``live_dir`` is the belt that keeps the
+    sweep from rmtree'ing it in the same call that created it."""
     sessions = tmp_path / "sessions"
-    live = _session(sessions, "live", size=5_000_000, age_days=400)
-    other = _session(sessions, "other", size=1000, age_days=1)
+    live = sessions / "live"
+    live.mkdir(parents=True)
+    other = sessions / "other"
+    other.mkdir(parents=True)
 
-    result = sweep_sessions(sessions, live_dir=live, max_sessions=1, max_bytes=1000, max_age_days=1)
+    result = sweep_sessions(sessions, live_dir=live)
 
-    assert result.evicted == 0
-    assert (live / "transcript.jsonl").exists()
-    assert (other / "transcript.jsonl").exists()
+    assert live.exists()
+    assert not other.exists()
+    assert result.evicted == 1
 
 
 def test_empty_directories_are_reaped(tmp_path):
@@ -90,11 +93,12 @@ def test_empty_directories_are_reaped(tmp_path):
     assert result.evicted == 1
 
 
-def test_a_marker_alone_does_not_make_a_directory_non_empty(tmp_path):
-    """A session is stamped with its origin BEFORE its transcript exists, so
-    a run that aborts in between leaves a directory holding only the marker.
-    The marker is bookkeeping ABOUT the session, never session content, so
-    the directory is still empty — and still reaped."""
+def test_a_marker_alone_protects_the_directory(tmp_path):
+    """A session is stamped with its origin BEFORE its transcript exists.
+    Treating that marker as invisible made the directory look empty, and
+    a concurrent process's startup sweep rmtree'd it — the child's first
+    append then died on FileNotFoundError, the exact kill this module
+    exists to prevent. A marker is a claim: the directory stays."""
     from local_operator.resume import ORIGIN_SUBAGENT, mark_session_origin
 
     sessions = tmp_path / "sessions"
@@ -104,8 +108,8 @@ def test_a_marker_alone_does_not_make_a_directory_non_empty(tmp_path):
 
     result = sweep_sessions(sessions)
 
-    assert not hollow.exists()
-    assert result.evicted == 1
+    assert hollow.exists()
+    assert result.evicted == 0
 
 
 def test_any_content_at_all_protects_the_directory(tmp_path):

--- a/tests/unit/session/test_retention.py
+++ b/tests/unit/session/test_retention.py
@@ -52,10 +52,7 @@ def test_no_ceiling_combination_ever_deletes_a_transcript(tmp_path):
     policy every one of them survives.
     """
     sessions = tmp_path / "sessions"
-    made = [
-        _session(sessions, f"s{i:02d}", size=1_000_000, age_days=700 - i)
-        for i in range(10)
-    ]
+    made = [_session(sessions, f"s{i:02d}", size=1_000_000, age_days=700 - i) for i in range(10)]
 
     result = sweep_sessions(sessions, max_sessions=1, max_bytes=1024, max_age_days=1)
 
@@ -71,9 +68,7 @@ def test_live_dir_is_redundant_but_harmless(tmp_path):
     live = _session(sessions, "live", size=5_000_000, age_days=400)
     other = _session(sessions, "other", size=1000, age_days=1)
 
-    result = sweep_sessions(
-        sessions, live_dir=live, max_sessions=1, max_bytes=1000, max_age_days=1
-    )
+    result = sweep_sessions(sessions, live_dir=live, max_sessions=1, max_bytes=1000, max_age_days=1)
 
     assert result.evicted == 0
     assert (live / "transcript.jsonl").exists()

--- a/tests/unit/session/test_retention.py
+++ b/tests/unit/session/test_retention.py
@@ -1,15 +1,16 @@
-"""Retention sweep over the ephemeral session store.
+"""Retention over the ephemeral session store: nothing is ever deleted.
 
-The behaviour under test is a deletion, so the tests care as much about what
-survives as about what goes: the live session and the newest history must be
-there afterwards, on every path, including the ones that fail.
+A session transcript is the only durable record of a run, so the suite's
+central property is not what goes but what survives: every directory with a
+byte of content must still be there after a sweep, whatever ceiling-like
+arguments the caller passes, however old or large or numerous the sessions
+are. The only thing a sweep removes is a directory that contains NOTHING —
+no transcript, no content — which is definitionally not a session.
 """
 
 from __future__ import annotations
 
 import time
-
-import pytest
 
 from local_operator.session.retention import (
     DEFAULT_MAX_AGE_DAYS,
@@ -21,13 +22,13 @@ from local_operator.session.retention import (
 
 
 def _session(root, name: str, *, size: int = 1024, age_days: float = 0.0):
+    import os
+
     directory = root / name
     directory.mkdir(parents=True)
     (directory / "transcript.jsonl").write_text("x" * size)
     when = time.time() - age_days * 86400
     for path in (directory / "transcript.jsonl", directory):
-        import os
-
         os.utime(path, (when, when))
     return directory
 
@@ -39,115 +40,116 @@ def test_missing_directory_is_a_no_op(tmp_path):
     assert result.evicted == 0 and result.errors == 0
 
 
-def test_count_ceiling_evicts_oldest_first(tmp_path):
+def test_no_ceiling_combination_ever_deletes_a_transcript(tmp_path):
+    """The regression this module now exists to prevent.
+
+    Every one of these arguments used to doom the directories below:
+    10 directories over a count ceiling of 1, 10 MB over a byte ceiling of
+    1 KB, and mtimes two years past a 1-day age horizon. A heavy install
+    with several concurrent sessions hit exactly this, and the eviction
+    took out a running session's transcript — the run's next turn died on
+    FileNotFoundError and the session's work was gone. Under the current
+    policy every one of them survives.
+    """
     sessions = tmp_path / "sessions"
-    for i in range(10):
-        _session(sessions, f"s{i:02d}", age_days=10 - i)
+    made = [
+        _session(sessions, f"s{i:02d}", size=1_000_000, age_days=700 - i)
+        for i in range(10)
+    ]
 
-    result = sweep_sessions(sessions, max_sessions=4, max_bytes=0, max_age_days=0)
+    result = sweep_sessions(sessions, max_sessions=1, max_bytes=1024, max_age_days=1)
 
-    survivors = sorted(p.name for p in sessions.iterdir())
-    assert survivors == ["s06", "s07", "s08", "s09"]
-    assert result.evicted == 6
-
-
-def test_byte_ceiling_holds_even_when_count_does(tmp_path):
-    """One session that dumps megabytes must not be able to blow the budget
-    just because there are only a handful of directories."""
-    sessions = tmp_path / "sessions"
-    _session(sessions, "old", size=900_000, age_days=3)
-    _session(sessions, "mid", size=900_000, age_days=2)
-    live_survivor = _session(sessions, "new", size=900_000, age_days=1)
-
-    result = sweep_sessions(sessions, max_sessions=100, max_bytes=1_000_000, max_age_days=0)
-
-    assert result.bytes_remaining <= 1_000_000
-    assert live_survivor.exists()
-    assert not (sessions / "old").exists()
+    assert result.evicted == 0
+    for directory in made:
+        assert (directory / "transcript.jsonl").read_text() == "x" * 1_000_000
 
 
-def test_age_ceiling(tmp_path):
-    sessions = tmp_path / "sessions"
-    _session(sessions, "stale", age_days=45)
-    _session(sessions, "fresh", age_days=1)
-
-    sweep_sessions(sessions, max_sessions=0, max_bytes=0, max_age_days=30)
-
-    assert not (sessions / "stale").exists()
-    assert (sessions / "fresh").exists()
-
-
-def test_live_session_is_never_evicted(tmp_path):
-    """The live directory is both the oldest and, on its own, over every
-    ceiling — and still must survive, because evicting it takes out resume
-    and compaction replay for the run that is currently writing to it."""
+def test_live_dir_is_redundant_but_harmless(tmp_path):
+    """``live_dir`` is accepted for call-site compatibility and ignored:
+    every session is as protected as the live one used to be."""
     sessions = tmp_path / "sessions"
     live = _session(sessions, "live", size=5_000_000, age_days=400)
-    for i in range(5):
-        _session(sessions, f"other{i}", size=1000, age_days=1)
+    other = _session(sessions, "other", size=1000, age_days=1)
 
     result = sweep_sessions(
-        sessions,
-        live_dir=live,
-        max_sessions=1,
-        max_bytes=1000,
-        max_age_days=1,
+        sessions, live_dir=live, max_sessions=1, max_bytes=1000, max_age_days=1
     )
 
-    assert live.exists()
-    assert (live / "transcript.jsonl").read_text().startswith("x")
-    assert result.evicted == 5
+    assert result.evicted == 0
+    assert (live / "transcript.jsonl").exists()
+    assert (other / "transcript.jsonl").exists()
 
 
-def test_empty_directories_are_always_reaped(tmp_path):
+def test_empty_directories_are_reaped(tmp_path):
     """Left behind by runs that built a session and exited before writing a
-    turn; 23 of 147 directories on a real install were exactly this."""
+    turn; 23 of 147 directories on a real install were exactly this. A
+    directory that contains nothing holds nothing to lose."""
     sessions = tmp_path / "sessions"
     (sessions / "hollow").mkdir(parents=True)
     _session(sessions, "real")
 
-    sweep_sessions(sessions, max_sessions=0, max_bytes=0, max_age_days=0)
+    result = sweep_sessions(sessions, max_sessions=0, max_bytes=0, max_age_days=0)
 
     assert not (sessions / "hollow").exists()
     assert (sessions / "real").exists()
+    assert result.evicted == 1
+
+
+def test_a_marker_alone_does_not_make_a_directory_non_empty(tmp_path):
+    """A session is stamped with its origin BEFORE its transcript exists, so
+    a run that aborts in between leaves a directory holding only the marker.
+    The marker is bookkeeping ABOUT the session, never session content, so
+    the directory is still empty — and still reaped."""
+    from local_operator.resume import ORIGIN_SUBAGENT, mark_session_origin
+
+    sessions = tmp_path / "sessions"
+    hollow = sessions / "hollow"
+    hollow.mkdir(parents=True)
+    mark_session_origin(hollow, ORIGIN_SUBAGENT, label="review")
+
+    result = sweep_sessions(sessions)
+
+    assert not hollow.exists()
+    assert result.evicted == 1
+
+
+def test_any_content_at_all_protects_the_directory(tmp_path):
+    """One byte of anything that is not bookkeeping is a session's work."""
+    sessions = tmp_path / "sessions"
+    directory = sessions / "almost-empty"
+    directory.mkdir(parents=True)
+    (directory / "transcript.jsonl").write_text("x")
+
+    result = sweep_sessions(sessions, max_sessions=1, max_bytes=1, max_age_days=1)
+
+    assert result.evicted == 0
+    assert (directory / "transcript.jsonl").read_text() == "x"
 
 
 def test_sweep_is_idempotent(tmp_path):
     sessions = tmp_path / "sessions"
-    for i in range(8):
-        _session(sessions, f"s{i}", age_days=8 - i)
+    (sessions / "hollow").mkdir(parents=True)
+    _session(sessions, "real")
 
-    first = sweep_sessions(sessions, max_sessions=3, max_bytes=0, max_age_days=0)
-    second = sweep_sessions(sessions, max_sessions=3, max_bytes=0, max_age_days=0)
+    first = sweep_sessions(sessions)
+    second = sweep_sessions(sessions)
 
-    assert first.evicted == 5
+    assert first.evicted == 1
     assert second.evicted == 0
-    assert len(list(sessions.iterdir())) == 3
-
-
-def test_all_ceilings_disabled_keeps_everything_but_empties(tmp_path):
-    sessions = tmp_path / "sessions"
-    for i in range(6):
-        _session(sessions, f"s{i}", age_days=500)
-
-    sweep_sessions(sessions, max_sessions=0, max_bytes=0, max_age_days=0)
-
-    assert len(list(sessions.iterdir())) == 6
+    assert sorted(p.name for p in sessions.iterdir()) == ["real"]
 
 
 def test_sibling_stores_under_the_config_dir_are_untouched(tmp_path):
-    """Only ``sessions/`` is swept.
+    """Only ``sessions/`` is swept, and even there only empty directories.
 
     The spill store (``<config>/spill``) holds the full text of large tool
-    outputs behind the ``spill://`` handles the truncation footers advertise.
-    It runs its OWN LRU eviction under its own ceiling and protects the live
-    session's entries inside a grace window; a second sweeper racing it could
-    evict a handle whose footer is still sitting in the live transcript, and
-    the agent would be told to expand an output that no longer exists.
+    outputs behind the ``spill://`` handles the truncation footers
+    advertise; the named-agent store holds real conversations. Neither is
+    this module's business.
     """
     sessions = tmp_path / "sessions"
-    for i in range(6):
-        _session(sessions, f"s{i}", age_days=6 - i)
+    (sessions / "hollow").mkdir(parents=True)
+    _session(sessions, "real")
     spill = tmp_path / "spill"
     spill.mkdir()
     (spill / "deadbeef.txt").write_text("the full tool output")
@@ -159,7 +161,8 @@ def test_sibling_stores_under_the_config_dir_are_untouched(tmp_path):
 
     assert (spill / "deadbeef.txt").read_text() == "the full tool output"
     assert (agents / "an-agent" / "transcript.jsonl").exists()
-    assert len(list(sessions.iterdir())) == 1
+    assert (sessions / "real").exists()
+    assert not (sessions / "hollow").exists()
 
 
 class _Config:
@@ -170,102 +173,97 @@ class _Config:
         return self._values.get(key, default)
 
 
-def test_sweep_from_config_reads_the_settings(tmp_path):
+def test_sweep_from_config_never_deletes_even_with_aggressive_settings(tmp_path):
+    """A config still carrying the retired ceilings — 200/128MiB/30d were
+    the SHIPPED defaults, so most existing config files carry them — must
+    not delete anything. The settings are retired; the sweep reaps empties
+    and nothing more."""
     sessions = tmp_path / "sessions"
     for i in range(6):
-        _session(sessions, f"s{i}", age_days=6 - i)
+        _session(sessions, f"s{i}", size=5_000_000, age_days=500)
 
-    config = _Config({"session_retention_max_sessions": 2})
+    config = _Config(
+        {
+            "session_retention_max_sessions": 1,
+            "session_retention_max_bytes": 1,
+            "session_retention_max_age_days": 1,
+        }
+    )
     result = sweep_from_config(config, tmp_path, live_dir=None)
 
-    assert result.evicted == 4
-    assert len(list(sessions.iterdir())) == 2
+    assert result.evicted == 0
+    assert len(list(sessions.iterdir())) == 6
 
 
-def test_unparseable_setting_falls_back_to_the_default(tmp_path):
-    """A typo must not silently restore the unbounded behaviour."""
+def test_retired_ceilings_still_in_config_produce_one_honest_warning(tmp_path, caplog):
+    sessions = tmp_path / "sessions"
+    sessions.mkdir(parents=True)
+    config = _Config({"session_retention_max_sessions": 200})
+
+    import logging
+
+    with caplog.at_level(logging.WARNING, logger="local_operator.session.retention"):
+        sweep_from_config(config, tmp_path, live_dir=None)
+
+    assert "session_retention_max_sessions" in caplog.text
+    assert "never deleted automatically" in caplog.text
+
+
+def test_unparseable_retired_setting_is_ignored_without_warning(tmp_path, caplog):
+    """A typo in a retired key changes nothing either way; it is not worth a
+    warning now that the value cannot cause a deletion."""
+    import logging
+
     sessions = tmp_path / "sessions"
     _session(sessions, "s0")
 
     config = _Config({"session_retention_max_sessions": "not-a-number"})
-    sweep_from_config(config, tmp_path, live_dir=None)
+    with caplog.at_level(logging.WARNING, logger="local_operator.session.retention"):
+        result = sweep_from_config(config, tmp_path, live_dir=None)
 
     assert (sessions / "s0").exists()
-    assert DEFAULT_MAX_SESSIONS > 0
-    assert DEFAULT_MAX_BYTES > 0
-    assert DEFAULT_MAX_AGE_DAYS > 0
+    assert result.evicted == 0
+    assert "not-a-number" not in caplog.text
 
 
-def test_undeletable_directory_is_reported_not_raised(tmp_path, monkeypatch):
+def test_the_retired_defaults_are_all_zero(tmp_path):
+    """If any default ceiling were nonzero it would imply a sweep that still
+    evicts by policy. All three are 0 because the ceilings no longer exist."""
+    assert DEFAULT_MAX_SESSIONS == 0
+    assert DEFAULT_MAX_BYTES == 0
+    assert DEFAULT_MAX_AGE_DAYS == 0
+
+
+def test_undeletable_empty_directory_is_reported_not_raised(tmp_path, monkeypatch):
     """Reclaiming disk must never be the reason a session fails to start."""
     sessions = tmp_path / "sessions"
-    for i in range(4):
-        _session(sessions, f"s{i}", age_days=4 - i)
+    for i in range(3):
+        (sessions / f"hollow{i}").mkdir(parents=True)
+    _session(sessions, "real")
 
     def boom(_path):
         raise OSError("read-only file system")
 
     monkeypatch.setattr("local_operator.session.retention.shutil.rmtree", boom)
-    result = sweep_sessions(sessions, max_sessions=1, max_bytes=0, max_age_days=0)
+    result = sweep_sessions(sessions)
 
     assert result.errors == 3
     assert result.evicted == 0
     assert len(list(sessions.iterdir())) == 4
 
 
-@pytest.mark.parametrize("ceiling", [1, 5, 25])
-def test_directory_stays_under_budget_however_many_sessions_arrive(tmp_path, ceiling):
-    """The property the whole module exists for, exercised by exceeding it."""
+def test_a_transcript_is_never_deleted_even_when_a_failure_cascade_hits(tmp_path, monkeypatch):
+    """The worst case the old design could produce: a scan error, an
+    undeletable directory, AND every ceiling tripped at once. Content
+    survives regardless."""
     sessions = tmp_path / "sessions"
-    live = _session(sessions, "live", size=512)
-    for i in range(120):
-        _session(sessions, f"s{i:03d}", size=512, age_days=(120 - i) / 24)
-        sweep_sessions(sessions, live_dir=live, max_sessions=ceiling, max_bytes=0, max_age_days=0)
-        # +1 for the live directory, which is exempt from the ceiling.
-        assert len(list(sessions.iterdir())) <= ceiling + 1
-    assert live.exists()
+    real = _session(sessions, "real", size=100, age_days=900)
 
+    def boom(_path):
+        raise OSError("everything is broken")
 
-def test_an_aborted_child_leaves_nothing_worth_a_retention_slot(tmp_path):
-    """A session is stamped with its origin BEFORE its transcript exists, so a
-    run that aborts in between leaves a directory holding only the marker.
+    monkeypatch.setattr("local_operator.session.retention.shutil.rmtree", boom)
+    result = sweep_sessions(sessions, max_sessions=1, max_bytes=1, max_age_days=1)
 
-    Such a directory used to be empty, and empty directories are always reaped
-    regardless of the ceilings — they carry nothing to lose. Counting the
-    marker's 43 bytes turned each one into an ordinary keep candidate holding a
-    slot: measured with a count ceiling of 3, two aborted children evicted two
-    of the user's real transcripts to keep two empty markers.
-    """
-    import os
-
-    from local_operator.resume import ORIGIN_SUBAGENT, mark_session_origin
-
-    sessions = tmp_path / "sessions"
-    # The user's real work, older than the children that abort after it.
-    for i in range(3):
-        _session(sessions, f"user{i}", age_days=3 - i)
-    for i in range(2):
-        hollow = sessions / f"hollow{i}"
-        hollow.mkdir(parents=True)
-        mark_session_origin(hollow, ORIGIN_SUBAGENT, label="review")
-        now = time.time()
-        os.utime(hollow, (now, now))
-
-    sweep_sessions(sessions, max_sessions=3, max_bytes=0, max_age_days=0)
-
-    survivors = sorted(path.name for path in sessions.iterdir())
-    assert survivors == ["user0", "user1", "user2"], survivors
-
-
-def test_the_marker_is_not_charged_against_the_byte_ceiling(tmp_path):
-    """The marker is bookkeeping ABOUT a session, never session content, so it
-    is not what the ceilings are budgeting."""
-    from local_operator.resume import ORIGIN_SUBAGENT, mark_session_origin
-
-    sessions = tmp_path / "sessions"
-    directory = _session(sessions, "one", size=100)
-    before = sweep_sessions(sessions, max_sessions=0, max_bytes=0, max_age_days=0)
-    mark_session_origin(directory, ORIGIN_SUBAGENT, label="review")
-    after = sweep_sessions(sessions, max_sessions=0, max_bytes=0, max_age_days=0)
-
-    assert before.bytes_remaining == after.bytes_remaining == 100
+    assert (real / "transcript.jsonl").read_text() == "x" * 100
+    assert result.evicted == 0


### PR DESCRIPTION
# PR Description

## Change classification

**C2 — standard / pre-authorized.** Correctness fix to the ephemeral session store plus a disk-footprint countermeasure. Clean rollback (`git revert`). No RFC requested.

Supersedes #152, which narrowed eviction to exclude only the sweeping session's own directory. This PR removes the class of failure entirely.

## The bug

A long-running session ended its final turn with:

```text
× [Errno 2] No such file or directory: '/Users/damian/.local-operator/sessions/3e9da5f589ad/transcript.jsonl'
```

The directory was deleted **by another local-operator session's startup sweep while this one was still running**. The startup retention sweep excludes only the sweeping session's own directory; every other directory under `sessions/` — including directories owned by other live sessions — was an eviction candidate once the shipped ceilings were reached.

And they were reached on this machine: the store held 142 directories / 131 MB against defaults of 200 / 128 MiB / 30 days. The byte ceiling tripped, the sweep evicted oldest-first, and the running session's transcript was underneath it. Every subsequent turn hit the same missing file; the session's work was unrecoverable.

## Why ceilings are the wrong tool, not just a wrong default

#152 fixed the narrow "evicts a *running* session" case with pid-claim markers. That leaves the deeper problem: any automated ceiling can still delete a session a user needs back. Transcripts are the only durable record of what a run did, and sessions routinely run for hours; "old" or "large" is not "worthless". The cost asymmetry is extreme — gigabytes of recoverable disk versus hours of unrecoverable work — so the policy is now absolute: **no sweep, automation, or startup hook deletes a session transcript, under any circumstance.**

## The fix

### 1. Retention never deletes content (`session/retention.py`)

- The age/count/byte ceilings are retired. `sweep_sessions` accepts the old parameters for call-site compatibility and ignores them — no configuration can make it delete a directory holding content.
- The sweep's only remaining job is reaping **empty** directories (no transcript, no content), left by runs that exited before writing a turn — definitionally nothing to lose.
- The config keys (`session_retention_max_*`) stay readable; a config still carrying the old shipped defaults logs one honest warning per startup instead of silently pretending the ceilings still run. Defaults in newly written configs are now 0.

### 2. Disk countermeasure: content-addressed attachment store (`session/attachments.py`)

Deleting nothing makes footprint a real trade-off, so the PR ships the efficiency that answers it. Measured against this machine's real store (142 sessions, 134 MB):

| slice | bytes |
|---|---|
| base64 image payloads | **102 MB (76%)** |
| — of which exact duplicates across sessions | ~20 MB |
| text content | 19 MB |
| JSON structure/other | ~13 MB |

`attachments/<digest>.bin` stores each unique image once, named by the sha256 of its decoded bytes; transcript rows carry a ~60-byte reference instead of the payload. Base64 inflation (−25%) plus cross-session dedup projects the store from 134 MB to **~52 MB** — the saving grows faster than the store as duplicates accumulate, and it compounds with the never-delete policy instead of fighting it.

- **Backward compatible reads.** Rows with inline `data` load exactly as before (old transcripts, exports, external JSONL readers keep working). Re-attaching inline bytes on load was considered and rejected — it would destroy the dedup the store exists for.
- **Failure-safe.** A store write failure keeps the inline base64 (larger, never wrong); a missing attachment on replay degrades to an empty image instead of failing resume.
- **Deliberately not the spill store.** Spill is LRU-evicted under a ceiling and may forget content a transcript references — exactly the failure this PR removes from sessions. Attachments are never evicted.
- **Image blocks are detected by the `data` key, not `type`** — the encoder dumps with `exclude_defaults`, so the `type` discriminant is absent from encoded rows.

### 3. Migration script (`scripts/migrate_transcript_attachments.py`)

Applies the transform to existing transcripts: atomic per-file rewrite, only when the saving clears the inline floor, dry-run supported. Nothing is deleted — bytes move from `sessions/` to `attachments/`, deduplicated.

## Testing evidence

- **Unit**: `tests/unit/session/` — 45 passed (retention rewrite: no ceiling combination ever deletes a transcript, failure cascades, retired-config warnings; attachments: dedup, round-trip, failure fallback, missing-attachment degrade, legacy inline rows, tiny-image floor; transcript/footprint suites unchanged and green).
- **Real data**: `migrate_transcript_attachments.py --dry-run` against the live install — 147 transcripts scanned, 44 would change, 137.8 MB → 85.7 MB of transcript bytes with a 63.3 MB deduplicated store (~52 MB net saving, projected).
- The failing session this came from (`3e9da5f589ad`) is gone beyond recovery — its directory was rmtree'd; the fix ensures no other session follows it.

## Notes for reviewers

- `scripts/bench_session_footprint.py` was updated for the retired ceilings; it has a **pre-existing** crash replaying this machine's real transcripts (`CustomMessage has no attribute role` in token estimation) that reproduces identically on unmodified `main` — out of scope here.
