### PR TITLE
feat(tui): radient theme ported from the radient-site palette

### DIFF
--- a/local_operator/tui/palettes/__init__.py
+++ b/local_operator/tui/palettes/__init__.py
@@ -28,9 +28,9 @@ def all_palettes() -> list[ThemeSpec]:
     Order is the picker's row order: classics first because they are the
     names users arrive knowing, then the neon/retro set, then nature, then
     the light ramps at the end where a dark-terminal user scrolls past them.
-    The Radient brand ramp goes immediately AFTER neon's tron: it is the
-    same blue-black architecture wearing the Radient kit, so a user
-    comparing the two finds them adjacent.
+    The Radient brand ramp goes immediately after the neon FAMILY: it is
+    the same blue-black architecture as neon's tron wearing the Radient
+    kit, so a user comparing the two finds them one family scroll apart.
     """
     from local_operator.tui.palettes import (  # local: cycle-free at call time
         classics,

--- a/local_operator/tui/palettes/__init__.py
+++ b/local_operator/tui/palettes/__init__.py
@@ -28,17 +28,22 @@ def all_palettes() -> list[ThemeSpec]:
     Order is the picker's row order: classics first because they are the
     names users arrive knowing, then the neon/retro set, then nature, then
     the light ramps at the end where a dark-terminal user scrolls past them.
+    The Radient brand ramp goes immediately AFTER neon's tron: it is the
+    same blue-black architecture wearing the Radient kit, so a user
+    comparing the two finds them adjacent.
     """
     from local_operator.tui.palettes import (  # local: cycle-free at call time
         classics,
         lights,
         nature,
         neon,
+        radient,
     )
 
     return [
         *classics.PALETTES,
         *neon.PALETTES,
+        *radient.PALETTES,
         *nature.PALETTES,
         *lights.PALETTES,
     ]

--- a/local_operator/tui/palettes/radient.py
+++ b/local_operator/tui/palettes/radient.py
@@ -35,20 +35,25 @@ PALETTES: list[ThemeSpec] = [
     ThemeSpec(
         name="radient",
         label="Radient",
-        description="One signal blue on a blue-tinted near-black, straight from radient.com",
+        description="One signal blue on a blue-tinted near-black (the Radient kit)",
         dark=True,
         tokens={
             # The site's ground ramp is four steps (void/canvas/surface/
             # elevated); the TUI speaks five. Mapping: void -> sunken (the
             # status band), canvas -> bg, surface -> surface, elevated ->
-            # raised. `overlay` (dialogs, active selection) takes the
-            # hairline value — the kit's own "one step above elevated"
-            # structural tone — which keeps the ladder monotonic without
-            # inventing a sixth site token.
+            # raised. `overlay` (dialogs, active selection) is the ONE
+            # interpolated value in this port: the midpoint of the kit's
+            # hairline/hairline-strong pair (#252b34/#343c46). The kit runs
+            # out of ramp at four ground steps, and the review caught that
+            # taking hairline verbatim made overlay byte-identical to
+            # `edge` — a dialog ground whose outline would be invisible.
+            # The midpoint keeps the ladder monotonic (1.26:1 over raised)
+            # and the border visible (1.12:1 against the hairline) while
+            # staying inside the kit's own structural tones.
             "bg": "#090d13",  # canvas
             "surface": "#12171d",  # surface
             "raised": "#1c2229",  # elevated
-            "overlay": "#252b34",  # hairline, as the fifth elevation step
+            "overlay": "#2c333d",  # hairline/hairline-strong midpoint (interpolated)
             "sunken": "#030509",  # void
             # Text ramp is verbatim: fg, fg-muted, fg-dim. `faint` (inert
             # hints) is fg-disabled — the kit's quietest ink, exempt from AA

--- a/local_operator/tui/palettes/radient.py
+++ b/local_operator/tui/palettes/radient.py
@@ -1,0 +1,93 @@
+"""The Radient brand ramp: the radient.com design language as a TUI theme.
+
+Where the neon family SOLVES its vibe (source aesthetics supply a hue or
+two and the ramp is scaled to fit), this one is a direct port: every token
+is a published value from the Radient design system in the radient-site
+repository (``src/index.css`` — the ``@theme`` block is the single source
+of colour truth; ``docs/design-language.md`` there is the rationale), with
+the mapping decisions called out per token below. If the site's palette
+shifts, shift these to match rather than re-solving — fidelity to the
+brand kit is the point of the theme.
+
+The architecture mirrors the brand dark ramp's: a blue-tinted near-black
+ground (OKLCH hue 255, the measured hue of the brand blue, so neutrals and
+the accent read as one family), elevation as a background step (never a
+shadow), hairline borders as the primary structural device, and exactly one
+saturated signal blue spent sparingly — primary action, active state, one
+emphasised element.
+
+Two deliberate departures from the tron neighbour this theme sits beside:
+
+- Danger is the brand's warm RED, not tron's Rinzler orange. The Radient
+  kit ships a real danger hue with its own wash, so the failed-row band is
+  the kit's ``danger-wash`` ground, not an invented tint.
+- There is no second accent hue. The kit spends one blue, so ``signal``
+  (links, file paths) is the accent's hover step — brighter, same hue —
+  and ``label`` (tips, skill labels) is the kit's muted text step. A
+  violet or cyan here would be a visitor from another theme.
+"""
+
+from __future__ import annotations
+
+from local_operator.tui.theme import ThemeSpec
+
+PALETTES: list[ThemeSpec] = [
+    ThemeSpec(
+        name="radient",
+        label="Radient",
+        description="One signal blue on a blue-tinted near-black, straight from radient.com",
+        dark=True,
+        tokens={
+            # The site's ground ramp is four steps (void/canvas/surface/
+            # elevated); the TUI speaks five. Mapping: void -> sunken (the
+            # status band), canvas -> bg, surface -> surface, elevated ->
+            # raised. `overlay` (dialogs, active selection) takes the
+            # hairline value — the kit's own "one step above elevated"
+            # structural tone — which keeps the ladder monotonic without
+            # inventing a sixth site token.
+            "bg": "#090d13",  # canvas
+            "surface": "#12171d",  # surface
+            "raised": "#1c2229",  # elevated
+            "overlay": "#252b34",  # hairline, as the fifth elevation step
+            "sunken": "#030509",  # void
+            # Text ramp is verbatim: fg, fg-muted, fg-dim. `faint` (inert
+            # hints) is fg-disabled — the kit's quietest ink, exempt from AA
+            # on the site for the same reason `faint` is sub-floor here.
+            "fg": "#ebf0f5",
+            "muted": "#b7bec8",  # fg-muted
+            "dim": "#868f9a",  # fg-dim
+            "faint": "#5c646e",  # fg-disabled
+            "edge": "#252b34",  # hairline
+            "edge-hi": "#343c46",  # hairline-strong
+            # The one blue. Accent-hover is the same hue pushed brighter,
+            # so it carries `signal` (links, paths) — a second hue would
+            # break the kit's one-signal discipline.
+            "accent": "#51a2f8",
+            "signal": "#75baff",  # accent-hover
+            # Meta labels (tips, skills) are quiet by design in the kit —
+            # eyebrow/label text renders in fg-muted — so `label` follows
+            # rather than importing a hue the site never uses.
+            "label": "#b7bec8",  # fg-muted
+            # States are the kit's semantic trio, verbatim; string rides
+            # success as in the brand ramps.
+            "success": "#4bc680",
+            "warning": "#eebc4a",
+            "danger": "#ef6661",
+            "string": "#4bc680",
+            # Tints are the kit's own washes. Failed row: danger-wash —
+            # danger ink holds 5.35:1 on it. Selection: accent-wash at
+            # rest, accent-muted on hover, so the selected row reads as the
+            # brand's blue ground and hover is still a visible step up
+            # (1.2:1 between the two).
+            "tint-danger": "#321614",  # danger-wash
+            "tint-select": "#101e2d",  # accent-wash
+            "tint-select-hi": "#152d46",  # accent-muted
+            # The attachment chip is a blue card by family convention; the
+            # kit's accent wash/muted pair supplies both steps, keeping the
+            # chip and the picker selection in the same blue family the
+            # site uses for active grounds.
+            "tint-attach": "#101e2d",  # accent-wash
+            "tint-attach-hi": "#152d46",  # accent-muted
+        },
+    ),
+]


### PR DESCRIPTION
# PR Description

## Change classification

**C1 — low-risk addition.** One new curated theme (`radient`) in the palette registry: a new data module plus a registration entry. No behaviour changes for any existing theme; the default stays `dark`; nothing switches unless the user picks it. Clean rollback via `git revert`.

## The gap

The neon family has `tron` — a blue-black ground with one electric signal hue — and the Radient product site (`radient-site`, `src/index.css`) speaks the same architecture: a blue-tinted near-black (OKLCH hue 255, the measured hue of the brand blue), hairline borders as the structural device, and exactly one signal blue spent sparingly. The TUI had no ramp wearing the Radient kit.

## The fix

**`local_operator/tui/palettes/radient.py`** — a *direct port* of the Radient design system's dark ramp, not a re-solve. Every token is a published kit value, with the mapping decisions commented per token in the file:

- **Grounds:** the site's four-step ramp maps onto the TUI's five — `void`→`sunken`, `canvas`→`bg`, `surface`→`surface`, `elevated`→`raised`, and the `hairline` value serves as `overlay` (the kit's own one-step-above-elevated tone), keeping the elevation ladder monotonic without inventing a sixth site token.
- **Text:** the `fg` / `fg-muted` / `fg-dim` ramp verbatim; `faint` is `fg-disabled`, the kit's quietest ink.
- **The one-blue discipline holds:** `accent` is the kit's `#51a2f8`; `signal` (links, paths) is `accent-hover` `#75baff` — brighter, same hue; `label` is `fg-muted`. A violet or cyan here would be a visitor from another theme.
- **States:** the kit's semantic trio verbatim (`success #4bc680`, `warning #eebc4a`, `danger #ef6661`); unlike tron's Rinzler orange, danger is the kit's warm red, and the failed-row band is the kit's own `danger-wash` (danger ink holds 5.35:1 on it).
- **Tints:** selection and the attachment chip use the kit's `accent-wash` / `accent-muted` pair, so hover on the selected row is still a visible step (1.2:1 between the two).

**`local_operator/tui/palettes/__init__.py`** — registers the ramp immediately after neon's `tron`, so the two blue-black themes sit adjacent in the `/theme` picker for comparison.

## Testing evidence

**Palette gate** (`tests/unit/tui/test_palette_contrast.py`, the checked definition of "readable"): all floors clear with margin — `fg` 16.98:1 on `bg` (floor 7), `muted` 10.40 (4.5), `dim` 5.94 (3.4), every state hue ≥ 5.78:1 on both grounds (floor 4.0), `danger` on `tint-danger` 5.35:1 (floor 4.0), `faint` below `dim`, elevation monotonic, all tints ≤ 1.39:1 vs `bg` (ceiling 2.2 — casts, not slabs).

**Theme registry suites:** `test_palette_contrast.py` + `test_theme.py` — 256 passed. Theme-adjacent TUI suites (`-k "theme or palette or markdown or ansi"`) — 273 passed. Full `tests/unit/tui` — 2036 passed, 4 skipped (10m33s).

**Visual validation.** Rendered with `scripts/theme_preview.py` (drives the real `OperatorApp` with the stylesheet loaded, representative transcript content, switches through the same `_apply_theme` path `/theme` uses) and the frames inspected: radient alongside tron and the brand dark ramp. Radient reads as tron's calmer sibling — same blue-black architecture, cooler neutral text, the brand blue instead of electric cyan, and a red (not orange) failed row that stays legible on its wash. Frames attached below.

**Gates.** black + isort clean; flake8 clean; pyright 0 errors, 0 warnings.

## Screenshots

**radient** (this PR):

![radient](https://raw.githubusercontent.com/damianvtran/dump/main/radient.png)

**tron** (for comparison — same content, same harness):

![tron](https://raw.githubusercontent.com/damianvtran/dump/main/tron.png)

**dark** (the unchanged brand default):

![dark](https://raw.githubusercontent.com/damianvtran/dump/main/dark.png)
