### PR TITLE
fix(tui): keep the splash up for harness notices

### DIFF
--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -9922,6 +9922,12 @@ class OperatorApp(App[None]):
         rule as the toast slot. The toast is the interruption; the splash
         row is what is still there after the toast dismisses, until a
         real message starts the conversation.
+
+        The toast is a SHORT headline, not the same sentence. Repeating
+        the full line made a two-row card that sat on the mark's crown
+        (design round 1, D1) and read as a label stuck on the logo
+        rather than as a complementary alert (D2). The splash row keeps
+        the reason; the toast only has to say that something happened.
         """
         self._splash_notice = text
         if self._welcome is not None:
@@ -9931,7 +9937,7 @@ class OperatorApp(App[None]):
         except NoMatches:
             return
         duration = TOAST_FAILURE_MS if kind in ("warning", "error") else TOAST_DEFAULT_MS
-        toast.show(text, duration_ms=duration)
+        toast.show(_splash_toast_headline(text), duration_ms=duration)
 
     def _settle_queued_steer_notices_unsent(self) -> None:
         """Retire queued-steer rows the turn that just ended did not deliver.
@@ -10415,6 +10421,33 @@ def _first_line(text: str) -> str:
         if stripped:
             return stripped
     return ""
+
+
+def _splash_toast_headline(text: str) -> str:
+    """The toast half of a splash announcement: a glance, not the reason.
+
+    The splash row already carries the full sentence. Repeating it in the
+    toast made a two-row card that sat on the mark (design round 1, D1)
+    and printed the same 64 characters twice in one viewport (D2). A
+    fallback notice's useful glance is the TARGET — ``Fell back to
+    zai/glm-5.3`` — because that is the model the next prompt will hit.
+    Anything else stays one short clause, never the whole line.
+    """
+    body = " ".join(text.split())
+    if not body:
+        return "Notice"
+    marker = "falling back to "
+    index = body.lower().rfind(marker)
+    if index >= 0:
+        target = body[index + len(marker) :].strip()
+        if target:
+            return f"Fell back to {target}"
+    # One clause, no wrap: the toast sits over the lockup, and a second
+    # row is what buried the mark. 36 cells is comfortably inside the
+    # right-hand gutter of a 80-col boot frame.
+    if len(body) <= 36:
+        return body
+    return body[:35].rstrip() + "…"
 
 
 def _partial_text(partial_result) -> str:

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -6157,18 +6157,19 @@ class OperatorApp(App[None]):
         ``ends_empty_state=False`` appends WITHOUT ending it, because the
         predicate is "the CONVERSATION has started", not "something got drawn". A
         system notice about infrastructure — an MCP server that failed to
-        connect, a quota fallback — is not a user or assistant message, and
-        letting one collapse the boot composition would mean anyone with a
-        single broken server (or a low quota) never saw the centred prompt at
-        all. The notice is still appended and still scrolls back; it simply
-        lands under the splash, exactly as the ``/clear`` receipt does.
+        connect — is not conversation content, and letting one collapse the boot
+        composition would mean anyone with a single broken server never saw the
+        centred prompt at all. The notice is still appended and still scrolls
+        back; it simply lands under the splash, exactly as the ``/clear`` receipt
+        does.
 
-        A :class:`NoticeBlock` never ends the empty state on its own, even
-        when the caller left the default. Session-originated notices used to
-        take the default and retire the splash for an empty message view —
-        the quota-fallback line on a fresh launch. The conversation starts
-        when a user or assistant row lands, not when the harness has
-        something to say.
+        The default stays `True` for every block — a transcript row appended
+        deliberately IS conversation content, including a ``NoticeBlock`` the
+        caller wrote as a receipt. The boot-time exception lives one level up,
+        in :meth:`on_notice_posted`, which is the only path that fires on a
+        launch before anyone has typed; a gate here would swallow that
+        distinction and keep the splash up over a transcript that had
+        genuinely grown (the seam-stability suite pins exactly that).
 
         ``pin_tail=True`` also holds the block at the BOTTOM as later blocks
         arrive — see :meth:`TranscriptView.pin_tail`. Only the working line uses
@@ -6178,10 +6179,6 @@ class OperatorApp(App[None]):
         composition is measured against, so the reserve is recomputed here rather
         than left centred for a region that no longer exists.
         """
-        if isinstance(block, NoticeBlock):
-            # Defence in depth for every notice path, not just the ones that
-            # remembered to pass ``ends_empty_state=False``. See the docstring.
-            ends_empty_state = False
         if ends_empty_state:
             self._set_welcome_visible(False)
         transcript = self._transcript_view()

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -163,7 +163,12 @@ from local_operator.tui.widgets.subagent_panel import (
     job_elapsed,
 )
 from local_operator.tui.widgets.subagent_view import SubagentView, SubagentViewDismissed
-from local_operator.tui.widgets.toast import Toast, format_mcp_startup
+from local_operator.tui.widgets.toast import (
+    TOAST_DEFAULT_MS,
+    TOAST_FAILURE_MS,
+    Toast,
+    format_mcp_startup,
+)
 from local_operator.tui.widgets.todo_panel import TodoPanel
 from local_operator.tui.widgets.tool_card import ToolCard, clean_intent
 from local_operator.tui.widgets.transcript import (
@@ -1011,6 +1016,13 @@ class OperatorApp(App[None]):
         #: `_reload_session` once the answer is settled, which is what still
         #: puts the splash up for a swap onto a genuinely empty session.
         self._welcome_pending = False
+        #: A harness notice held for the splash while the conversation has
+        #: not started — a quota fallback, a provider that is missing. The
+        #: splash is the empty state, and treating one of these as a
+        #: transcript block retired it for an empty message view. Latest
+        #: one only: the splash is one row. Cleared on a session swap
+        #: because it describes the session that just died.
+        self._splash_notice: str | None = None
         # Whatever held focus when the usage panel opened, so closing it returns
         # the user to the composer they were typing in rather than to nothing.
         # The approval card follows the same discipline for the same reason.
@@ -1278,7 +1290,11 @@ class OperatorApp(App[None]):
         # hidden the splash on mount.
         self._transcript = TranscriptView(id="transcript")
         with self._transcript:
-            yield WelcomeView(lambda: session_welcome_info(self._session, self._providers))
+            yield WelcomeView(
+                lambda: session_welcome_info(
+                    self._session, self._providers, notice=self._splash_notice
+                )
+            )
         # The dock band: subagent task list + todo list, sitting between the
         # transcript and the composer. It is a transparent POSITIONER (zero own
         # height when empty) holding one filled body per panel; the two panels
@@ -1542,8 +1558,9 @@ class OperatorApp(App[None]):
         """Warm the provider's quota reading once the app is already painted.
 
         Runs AFTER :meth:`_adopt_session`, which is subscribed and on screen, so
-        quota I/O cannot delay first paint and any warning lands in the
-        transcript. An optional session capability, so lightweight hosts need
+        quota I/O cannot delay first paint and any warning lands as a toast
+        and on the splash — not as a transcript row that would retire the
+        empty state. An optional session capability, so lightweight hosts need
         not fake network preflight; failure must never become another startup
         gate, hence the bare catch.
 
@@ -2245,6 +2262,9 @@ class OperatorApp(App[None]):
         # dead conversation's already-billed calls from its own turn total and
         # under-report that turn by exactly that much.
         self._turn_accrued_cost = 0.0
+        # The splash notice describes the session being replaced. Left
+        # standing, a `/new` would open on the dead session's quota warning.
+        self._splash_notice = None
         # The MCP segment is cleared too: the old session's manager is gone, so
         # a lingering count would describe servers nothing is connected to any
         # more. `_adopt_session` repaints it from the new session's manager.
@@ -6131,17 +6151,24 @@ class OperatorApp(App[None]):
         self, block, *, ends_empty_state: bool = True, pin_tail: bool = False
     ) -> None:
         """Append a block, retiring the welcome view — and the boot layout — on
-        the first one. That is the authoritative "the session has content" edge;
-        both layouts hang off it (see `_set_welcome_visible`).
+        the first conversation message. That is the authoritative "the session
+        has content" edge; both layouts hang off it (see `_set_welcome_visible`).
 
         ``ends_empty_state=False`` appends WITHOUT ending it, because the
         predicate is "the CONVERSATION has started", not "something got drawn". A
         system notice about infrastructure — an MCP server that failed to
-        connect — is not conversation content, and letting one collapse the boot
-        composition would mean anyone with a single broken server never saw the
-        centred prompt at all. The notice is still appended and still scrolls
-        back; it simply lands under the splash, exactly as the ``/clear`` receipt
-        does.
+        connect, a quota fallback — is not a user or assistant message, and
+        letting one collapse the boot composition would mean anyone with a
+        single broken server (or a low quota) never saw the centred prompt at
+        all. The notice is still appended and still scrolls back; it simply
+        lands under the splash, exactly as the ``/clear`` receipt does.
+
+        A :class:`NoticeBlock` never ends the empty state on its own, even
+        when the caller left the default. Session-originated notices used to
+        take the default and retire the splash for an empty message view —
+        the quota-fallback line on a fresh launch. The conversation starts
+        when a user or assistant row lands, not when the harness has
+        something to say.
 
         ``pin_tail=True`` also holds the block at the BOTTOM as later blocks
         arrive — see :meth:`TranscriptView.pin_tail`. Only the working line uses
@@ -6151,6 +6178,10 @@ class OperatorApp(App[None]):
         composition is measured against, so the reserve is recomputed here rather
         than left centred for a region that no longer exists.
         """
+        if isinstance(block, NoticeBlock):
+            # Defence in depth for every notice path, not just the ones that
+            # remembered to pass ``ends_empty_state=False``. See the docstring.
+            ends_empty_state = False
         if ends_empty_state:
             self._set_welcome_visible(False)
         transcript = self._transcript_view()
@@ -9863,7 +9894,44 @@ class OperatorApp(App[None]):
         )
 
     def on_notice_posted(self, message: NoticePosted) -> None:
+        """Surface a session notice without starting the message view.
+
+        A quota fallback, a missing-credential warning — these fire on boot,
+        before anyone has typed. Routing them through the default
+        ``_append_block`` retired the splash for a single yellow line over
+        an empty screen, which is how a launch with a healthy session
+        looked like a conversation that had already started. While the
+        splash is up the notice is a toast (interruption) and a splash
+        row (durable for as long as the empty state lasts). Once a user
+        or assistant message has retired the splash, the same event is
+        just another transcript line.
+        """
+        # `_welcome_pending` is the same fact mid-swap: the replacement is
+        # empty and the splash is about to come back, so a preflight notice
+        # must not land as a transcript row that the splash then sits on.
+        if self._welcome_visible or self._welcome_pending:
+            self._announce_on_splash(message.text, message.kind)
+            return
         self._append_block(NoticeBlock(message.text, message.kind))
+
+    def _announce_on_splash(self, text: str, kind: NoticeKind) -> None:
+        """Hold ``text`` on the splash and raise a toast for it.
+
+        The splash is content-sized and rests on the input card, so a
+        second row of warning is a real cost — latest one only, same
+        rule as the toast slot. The toast is the interruption; the splash
+        row is what is still there after the toast dismisses, until a
+        real message starts the conversation.
+        """
+        self._splash_notice = text
+        if self._welcome is not None:
+            self._welcome.refresh_info()
+        try:
+            toast = self.query_one(Toast)
+        except NoMatches:
+            return
+        duration = TOAST_FAILURE_MS if kind in ("warning", "error") else TOAST_DEFAULT_MS
+        toast.show(text, duration_ms=duration)
 
     def _settle_queued_steer_notices_unsent(self) -> None:
         """Retire queued-steer rows the turn that just ended did not deliver.

--- a/local_operator/tui/widgets/welcome.py
+++ b/local_operator/tui/widgets/welcome.py
@@ -14,6 +14,7 @@ BORDERLESS block resting on the input card:
     openrouter/deepseek/deepseek-chat
            ~/local-operator
       ! not logged in — /login openrouter
+      ! anthropic quota low — falling back to zai/glm-5.3
 
     /         command picker
     /help     all commands
@@ -35,7 +36,8 @@ Five things make this a design decision rather than a splash screen:
   of bright blocks.
 - **It degrades in a fixed order.** Terminals are not a fixed canvas, so the
   view sheds decoration before information: the logo goes first, the hints
-  second, the status rows last, and the credential warning never. See
+  second, the status rows last, and the credential warning never — a
+  harness notice (quota fallback) sheds just before it. See
   :func:`build_welcome_lines`.
 - **One thing glows, and it is the identity.** A slow swell lifts the mark's
   rows a third of a ramp step above their resting ``dim`` and lets them back
@@ -318,12 +320,16 @@ TIP_MIN_WIDTH = max(cell_len(f"{TIP_GLYPH} {tip}") for tip in TIPS)
 WARNING_SHORT = "not logged in"
 
 #: Drop priorities for the status rows. Rows are shed lowest-first when the
-#: terminal is too short for all of them, so the warning — the only row that
-#: changes what the user must DO next — is the last one standing.
+#: terminal is too short for all of them, so the credential warning — the
+#: only row that changes what the user must DO next — is the last one
+#: standing. A harness notice (quota fallback) is the same KIND of row but
+#: not the same urgency: you can still type, just on a different model, so
+#: it sheds one step before the login warning.
 _PRIORITY_VERSION = 0
 _PRIORITY_CWD = 1
 _PRIORITY_MODEL = 2
-_PRIORITY_WARNING = 3
+_PRIORITY_NOTICE = 3
+_PRIORITY_WARNING = 4
 
 
 @dataclass(frozen=True)
@@ -346,6 +352,13 @@ class WelcomeInfo:
     #: the answer is *known* to be "no credential" — see
     #: :func:`session_welcome_info`.
     missing_credential: str | None = None
+    #: A harness notice that arrived while the splash is still the empty
+    #: state — a quota fallback, a provider that is missing. The conversation
+    #: has not started, so this lives ON the splash rather than retiring it
+    #: for an empty message view. Latest one only: the splash is one row, and
+    #: stacking would shove the lockup the way a transcript notice already
+    #: does. ``None`` when nothing has been announced.
+    notice: str | None = None
 
 
 def app_version() -> str:
@@ -361,11 +374,19 @@ def app_version() -> str:
         return ""
 
 
-def session_welcome_info(session: Any | None, providers: Any | None) -> WelcomeInfo:
+def session_welcome_info(
+    session: Any | None,
+    providers: Any | None,
+    *,
+    notice: str | None = None,
+) -> WelcomeInfo:
     """Snapshot the facts the welcome view shows.
 
     Takes the session and provider facade rather than the app so the whole
-    gathering step lives here instead of leaking into ``app.py``.
+    gathering step lives here instead of leaking into ``app.py``. ``notice``
+    is the one fact that is NOT a session property — it is a harness
+    announcement the app is holding while the splash is still up — so it is
+    handed in rather than re-derived.
 
     The credential question is ``is_usable``, not ``has_any_credential``. A key in
     the ENVIRONMENT is what the stream-time cascade resolves, so a session started
@@ -406,6 +427,7 @@ def session_welcome_info(session: Any | None, providers: Any | None) -> WelcomeI
         model_name=name,
         cwd=os.getcwd(),
         missing_credential=missing,
+        notice=notice or None,
     )
 
 
@@ -559,6 +581,17 @@ def _status_rows(info: WelcomeInfo, width: int) -> list[tuple[int, Text]]:
     if info.cwd:
         shown = _fit_tail(_shorten_home(info.cwd), width)
         rows.append((_PRIORITY_CWD, Text(shown, style=dim, no_wrap=True)))
+    if info.notice:
+        # Same glyph and tint as the credential warning: both are "something
+        # about the harness you should know before you type". Truncated from
+        # the RIGHT — the head names the condition (`anthropic quota low`),
+        # the tail names the fallback, and a half-printed selector is still
+        # a selector. The login warning drops its remedy WHOLE because a
+        # half-printed `/logi…` is an instruction nobody can follow; a
+        # notice is a fact, not a command.
+        glyph = NOTICE_GLYPHS["warning"]
+        body = f"{glyph} {info.notice}"
+        rows.append((_PRIORITY_NOTICE, Text(body, style=warn, no_wrap=True)))
     if info.missing_credential:
         # The single most common first-run failure, so it is spelled as the
         # command that fixes it. `!` is the app's warning glyph (D14). When the
@@ -707,10 +740,11 @@ def build_welcome_lines(
         mark = []
 
     status_full = _status_rows(info, width)
-    # Version is the only status row in the visible ladder. Model, cwd and the
-    # credential warning are the facts the app needs to answer "can I start?";
-    # if even those do not fit, their existing priorities shed cwd then model,
-    # leaving the actionable warning last.
+    # Version is the only status row in the visible ladder. Model, cwd, a
+    # harness notice and the credential warning are the facts the app needs
+    # to answer "can I start?"; if even those do not fit, their existing
+    # priorities shed cwd then model then the notice, leaving the
+    # actionable login warning last.
     status_without_version = [row for row in status_full if row[0] != _PRIORITY_VERSION]
     status = list(status_without_version)
     hints = _hint_lines(width)
@@ -1008,9 +1042,19 @@ class WelcomeView(Static):
         self._sync_pulse_timer()
         self._sync_tip_timer()
         if visible:
-            self._poll()
+            self.refresh_info()
         else:
             self._sync_timer()
+
+    def refresh_info(self) -> None:
+        """Re-read the info source and repaint if anything changed.
+
+        Public because the poll timer retires once the model label lands, and
+        a harness notice can arrive after that — a quota fallback on a
+        session that already resolved its model. Without a push the notice
+        would sit in the source unseen until the next ``set_visible``.
+        """
+        self._poll()
 
     def _poll(self) -> None:
         info = self._info_source()

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -39,7 +39,7 @@ from local_operator.tui.widgets.editor import ASIDE_PLACEHOLDER, Editor
 from local_operator.tui.widgets.session_picker import SessionPickerScreen
 from local_operator.tui.widgets.toast import Toast
 from local_operator.tui.widgets.tool_card import ToolCard
-from local_operator.tui.widgets.transcript import NoticeBlock, TranscriptView
+from local_operator.tui.widgets.transcript import NoticeBlock, TranscriptView, UserBlock
 from local_operator.tui.widgets.welcome import WelcomeView
 from tests.unit.tui.conftest import caret_cells, chevron_colour, composer_cells
 
@@ -324,6 +324,13 @@ async def test_boot_typing_sends_prompt() -> None:
 
 @pytest.mark.asyncio
 async def test_boot_renders_non_blocking_quota_warning() -> None:
+    """A quota fallback is harness news, not a conversation.
+
+    Routing it through the default notice path retired the splash for a
+    single yellow line over an empty screen — a launch that looked like
+    a conversation that had already started. The splash stays; the
+    warning is a toast and a splash row.
+    """
     session = FakeSession()
     session.preflight_notice = (
         "anthropic quota exhausted — falling back to openai/gpt-5.3-codex (high effort)"
@@ -331,13 +338,39 @@ async def test_boot_renders_non_blocking_quota_warning() -> None:
     app = OperatorApp(lambda: _factory(session))
 
     async with app.run_test(size=(100, 30)) as pilot:
-        await pilot.pause()
-        await pilot.pause()
+        for _ in range(8):
+            await pilot.pause()
+            if app._splash_notice:
+                break
 
-        text = _transcript_text(app)
-        assert "anthropic quota exhausted" in text
-        assert "falling back to openai/gpt-5.3-codex (high effort)" in text
         assert session.prompts == []
+        welcome = app.query_one(WelcomeView)
+        assert welcome.display is True, "a quota notice must not retire the splash"
+        assert app.screen.has_class(BOOT_LAYOUT_CLASS)
+        assert app.query_one(TranscriptView).blocks() == []
+        assert "anthropic quota exhausted" in (welcome._info.notice or "")
+        assert "falling back to openai/gpt-5.3-codex (high effort)" in (welcome._info.notice or "")
+        toast = app.query_one(Toast)
+        assert toast.display is True
+        assert "anthropic quota exhausted" in toast.message
+
+
+@pytest.mark.asyncio
+async def test_a_notice_after_the_conversation_starts_is_a_transcript_row() -> None:
+    """Once a user message has retired the splash, a later notice is just
+    another line — the toast/splash path is only for the empty state."""
+    session = FakeSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        app._append_block(UserBlock("hello"))
+        await pilot.pause()
+        assert app.query_one(WelcomeView).display is False
+        session.emit(NoticeEvent(text="anthropic quota low — falling back", kind="warning"))
+        await pilot.pause()
+        assert "anthropic quota low" in _transcript_text(app)
+        assert app.query_one(WelcomeView).display is False
+        assert app.query_one(Toast).display is False
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -30,6 +30,7 @@ from local_operator.tui.app import (
     PERSIST_HINT,
     SLASH_COMMANDS,
     OperatorApp,
+    _splash_toast_headline,
 )
 from local_operator.tui.autocomplete import ArgumentChoice
 from local_operator.tui.events import TurnEnded, TurnStarted
@@ -322,6 +323,22 @@ async def test_boot_typing_sends_prompt() -> None:
         assert len(transcript.blocks()) == 1
 
 
+def test_splash_toast_headline_names_the_fallback_target() -> None:
+    """The toast is a glance; the splash row keeps the reason."""
+    assert (
+        _splash_toast_headline("anthropic quota low (8% remaining) — falling back to zai/glm-5.3")
+        == "Fell back to zai/glm-5.3"
+    )
+    assert (
+        _splash_toast_headline(
+            "anthropic quota exhausted — falling back to openai/gpt-5.3-codex (high effort)"
+        )
+        == "Fell back to openai/gpt-5.3-codex (high effort)"
+    )
+    assert _splash_toast_headline("session failed to start") == "session failed to start"
+    assert _splash_toast_headline("") == "Notice"
+
+
 @pytest.mark.asyncio
 async def test_boot_renders_non_blocking_quota_warning() -> None:
     """A quota fallback is harness news, not a conversation.
@@ -352,7 +369,11 @@ async def test_boot_renders_non_blocking_quota_warning() -> None:
         assert "falling back to openai/gpt-5.3-codex (high effort)" in (welcome._info.notice or "")
         toast = app.query_one(Toast)
         assert toast.display is True
-        assert "anthropic quota exhausted" in toast.message
+        # Headline, not the full sentence: the splash row already carries
+        # the reason, and repeating it made a two-row card that sat on
+        # the mark (design round 1, D1/D2).
+        assert toast.message == "Fell back to openai/gpt-5.3-codex (high effort)"
+        assert "quota exhausted" not in toast.message
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tui/test_welcome.py
+++ b/tests/unit/tui/test_welcome.py
@@ -284,6 +284,26 @@ def test_status_rows_shed_lowest_priority_first_and_the_warning_never() -> None:
     assert _warning_body(one)
 
 
+def test_a_harness_notice_sheds_before_the_credential_warning() -> None:
+    """A quota fallback is news; a missing login is an action. When the
+    box can hold only one of them, the action stays."""
+    info = WelcomeInfo(
+        version="0.15.10",
+        model_label="anthropic/claude-opus-5",
+        cwd="/tmp",
+        missing_credential="anthropic",
+        notice="anthropic quota low — falling back to zai/glm-5.3",
+    )
+    one = build_welcome_lines(info, ROOMY_W, 1)
+    assert len(one) == 1
+    assert _warning_body(one)
+    assert "quota low" not in plain(one)
+
+    two = build_welcome_lines(info, ROOMY_W, 2)
+    assert "quota low" in plain(two)
+    assert _warning_body(two)
+
+
 def _warning_body(lines: list[Text]) -> bool:
     return any("not logged in" in line.plain for line in lines)
 
@@ -727,6 +747,18 @@ async def test_no_credential_warning_appears() -> None:
         welcome._poll()  # the factory has resolved by now; force one read
         body = plain(build_welcome_lines(welcome._info, welcome.size.width, welcome.size.height))
         assert "! not logged in — /login openrouter" in body
+
+
+def test_a_harness_notice_is_drawn_on_the_splash() -> None:
+    """A quota fallback is a status row, same glyph as the login warning."""
+    info = WelcomeInfo(
+        version="0.15.10",
+        model_label="anthropic/claude-opus-5",
+        cwd="/tmp",
+        notice="anthropic quota low — falling back to zai/glm-5.3",
+    )
+    body = plain(build_welcome_lines(info, ROOMY_W, ROOMY_H))
+    assert "! anthropic quota low — falling back to zai/glm-5.3" in body
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# PR Description

## Change classification

**C1 — standard/pre-authorized.** A TUI empty-state bug: a boot-time quota fallback was treated as conversation content and retired the splash. No API, persistence, or auth change. Clean rollback via `git revert`.

## Summary of Changes

A launch with a quota-low fallback (e.g. `! anthropic quota low (8% remaining) — falling back to zai/glm-5.3`) switched from the welcome splash to the message view even though nobody had typed anything. The screen was one yellow line over empty space.

The conversation now starts only when a user or assistant message lands. A session notice that arrives while the splash is still up is:

- a short toast headline (the interruption), e.g. `Fell back to zai/glm-5.3`
- a warning row on the splash itself (the full reason, durable after the toast dismisses)

Once a real message retires the splash, later notices stay ordinary transcript rows.

## Related Issue(s)

- None. Reported from a live launch.

## Impact

- No breaking changes.
- No dependency updates.
- No security implications. The notice text is the same string the session already emitted.

## Testing Details

**Reproduction (before).** Drive `OperatorApp` with a `FakeSession` that emits a quota-fallback `NoticeEvent` from `preflight_usage`. After the notice lands:

- splash is gone
- boot layout is gone
- one `NoticeBlock` sits at the top of an otherwise empty transcript

**Same path after.** Splash stays, boot class stays, transcript has zero blocks, toast shows `Fell back to zai/glm-5.3`, splash status row shows the full warning.

**Automated.**

- `test_boot_renders_non_blocking_quota_warning` — splash + short toast + splash row, no transcript block
- `test_a_notice_after_the_conversation_starts_is_a_transcript_row` — once a user message has retired the splash, a later notice is a transcript line and does not toast
- `test_splash_toast_headline_names_the_fallback_target` — toast copy is the target, not the full sentence
- `test_a_harness_notice_is_drawn_on_the_splash` / `test_a_harness_notice_sheds_before_the_credential_warning` — geometry: notice is a status row and sheds before the login warning

**Visual.** Real `OperatorApp` with the stylesheet loaded.

- 100×30: `welcome.display True`, `screen.virtual_size == screen.size` (98×28), no scrollbar, toast 24×1 top-right, zero transcript blocks
- 80×24: toast `Region(x=53, y=1, width=26, height=1)`, welcome `Region(x=2, y=3, width=76, height=12)`, no overlap, no scrollbar

**Gates.** black + isort + flake8 + pyright clean on the changed files.

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my changes work as intended.
- [x] All new and existing tests pass.
- [x] I have run formatting (black/isort), linting (flake8), and type checks (pyright), and they pass.
- [x] I have updated the documentation when required.
- [x] Security considerations are addressed (especially for code execution features).
- [x] I have linked all related issues.

## Screenshots

**Before** (head `85b2cce`, same harness, notice has landed): splash gone, one yellow line over empty space.

![before](https://raw.githubusercontent.com/damianvtran/dump-public/main/splash-notice-before.png)

**After** (this PR, `5b34384`, 100×30): splash stays; short toast top-right; full warning on the splash row; composer still the boot card.

![after](https://raw.githubusercontent.com/damianvtran/dump-public/main/splash-notice-after.png)

**After, 80 columns** (`5b34384`): toast still top-right, off the wordmark.

![after-80](https://raw.githubusercontent.com/damianvtran/dump-public/main/splash-notice-after-80.png)
