### PR TITLE
fix(tools): keep grep's tree walk off the event loop

### DIFF
--- a/local_operator/tools/builtin.py
+++ b/local_operator/tools/builtin.py
@@ -3521,14 +3521,25 @@ async def execute_grep(
         # rg applies --max-filesize silently; recover the count the footer
         # contract promises. The walk+stat pass is the same filesystem load
         # as the scan itself, so it rides a thread raced against abort.
-        skipped_count, aborted = await _run_with_abort(
-            asyncio.to_thread(_count_oversized_files, target),
-            signal,
-            lambda: None,
-        )
-        if aborted:
-            return _error(tool_call_id, "grep", "Search aborted.")
-        files_skipped = skipped_count or 0
+        # Skipped for a single named file: the engine gate above only keeps
+        # rg when that file is already under the cap, so the count is
+        # definitionally zero and a worker-thread hop to confirm it would be
+        # pure overhead on the most common grep shape (review F2).
+        if not target_is_file:
+            skipped_count, aborted = await _run_with_abort(
+                asyncio.to_thread(_count_oversized_files, target),
+                signal,
+                lambda: None,
+            )
+            if aborted:
+                return _error(tool_call_id, "grep", "Search aborted.")
+            # Non-None whenever aborted is False: _run_with_abort returns the
+            # coroutine's result on the non-abort arms, and the counter always
+            # returns an int. The assert states that contract for the type
+            # checker instead of an `or 0` that would silently launder a
+            # future internal failure into a zero (review N1).
+            assert skipped_count is not None
+            files_skipped = skipped_count
     else:
         if signal and signal.aborted:
             return _error(tool_call_id, "grep", "Search aborted.")
@@ -3548,8 +3559,14 @@ async def execute_grep(
             signal,
             lambda: None,
         )
-        if aborted or py_result is None:
+        if aborted:
             return _error(tool_call_id, "grep", "Search aborted.")
+        # Non-None whenever aborted is False (same contract as above): an
+        # exception inside the walk/scan propagates to _guard rather than
+        # returning None, so a None here could only mean a broken
+        # _run_with_abort — assert, never mislabel it "Search aborted."
+        # (review F1).
+        assert py_result is not None
         records, files_searched, files_skipped = py_result
 
     matches = [r for r in records if r[3] == "m"]

--- a/local_operator/tools/builtin.py
+++ b/local_operator/tools/builtin.py
@@ -2915,24 +2915,44 @@ def _walk_entries(root: Path, *, respect_ignore: bool = True) -> list[Path]:
             found = _load_ignore_rules(directory, rel_dir)
             if found:
                 local_rules = rules + [(rel_dir, found)]
+        # os.scandir, not Path.iterdir + per-entry Path.is_symlink/is_dir/
+        # is_file: a DirEntry carries the d_type the kernel already returned
+        # with the directory listing, so the symlink/dir/file classification
+        # below costs zero extra syscalls on the common path where iterdir
+        # paid three stat(2) calls PER ENTRY. On the 60k-entry trees this
+        # walk actually meets (a workspace with vendored checkouts) that is
+        # the difference between a scan and a stall — and this function runs
+        # under a worker thread on behalf of a TUI whose frame budget the
+        # caller is protecting, so raw walk speed is part of the contract.
+        # Sorting by name matches the old sorted(iterdir()) order exactly:
+        # within one directory, Path ordering IS name ordering.
         try:
-            entries = sorted(directory.iterdir())
+            with os.scandir(directory) as scan:
+                entries = sorted(scan, key=lambda e: e.name)
         except OSError:
             return
         for entry in entries:
-            if entry.is_symlink():
-                continue  # never follow links: cycles and out-of-tree escapes
+            try:
+                if entry.is_symlink():
+                    continue  # never follow links: cycles and out-of-tree escapes
+                is_dir = entry.is_dir(follow_symlinks=False)
+                is_file = entry.is_file(follow_symlinks=False)
+            except OSError:
+                # An entry that vanished or cannot be classified mid-walk is
+                # skipped, matching the directory-level OSError handling: a
+                # concurrent delete is normal filesystem life, not an error.
+                continue
             rel = f"{rel_dir}/{entry.name}" if rel_dir else entry.name
-            if entry.is_dir():
+            if is_dir:
                 if entry.name in _GREP_PRUNE_DIRS or entry.name.startswith("."):
                     continue
                 if respect_ignore and _ignored(rel, True, local_rules):
                     continue
-                _walk(entry, rel, local_rules)
-            elif entry.is_file():
+                _walk(Path(entry.path), rel, local_rules)
+            elif is_file:
                 if respect_ignore and _ignored(rel, False, local_rules):
                     continue
-                files.append(entry)
+                files.append(Path(entry.path))
 
     _walk(root, "", [])
     return files
@@ -2941,6 +2961,44 @@ def _walk_entries(root: Path, *, respect_ignore: bool = True) -> list[Path]:
 def _walk_files(root: Path) -> list[Path]:
     """The grep file set: the ignore-aware walk."""
     return _walk_entries(root)
+
+
+def _grep_file_set(target: Path) -> tuple[list[Path], Path]:
+    """``(files, base)`` for one grep target, file or directory.
+
+    Synchronous by design: the walk is tens of thousands of scandir/stat
+    calls on a large tree, so every caller reaches this through
+    ``asyncio.to_thread``. Running it inline in ``execute_grep`` was the
+    freeze reported as "the session hangs on concurrent tool calls": under
+    Textual's eager task factory the runner coroutine executes synchronously
+    up to its first true suspension AT TASK-CREATION TIME, so a batch of
+    greps put every tree walk back-to-back on the render loop before the
+    first frame of the batch could paint (sampled live: 100% of main-thread
+    samples inside os_lstat/os_scandir/os_stat under task_eager_start).
+    """
+    if target.is_file():
+        return [target], target.parent
+    return _walk_files(target), target
+
+
+def _count_oversized_files(target: Path) -> int:
+    """How many files in the grep set exceed ``GREP_FILE_LIMIT_BYTES``.
+
+    The ripgrep engine applies ``--max-filesize`` silently, and the footer
+    contract promises the skipped count either way — this recovers it. It
+    re-walks the tree, which is exactly the filesystem load described on
+    ``_grep_file_set``, so it is synchronous and thread-hosted for the same
+    reason.
+    """
+    files, _base = _grep_file_set(target)
+    skipped = 0
+    for file_path in files:
+        try:
+            if file_path.stat().st_size > GREP_FILE_LIMIT_BYTES:
+                skipped += 1
+        except OSError:
+            continue
+    return skipped
 
 
 class GlobParams(BaseModel):
@@ -3428,15 +3486,26 @@ async def execute_grep(
     files_skipped = 0
     engine_note = ""
 
-    if target.is_file():
-        base = target.parent
-        files: list[Path] = [target]
-    else:
-        base = target
-        files = _walk_files(target)
+    # Engine choice needs only a stat of an explicitly named file, never the
+    # tree walk: the walk is deferred into the worker threads below so the
+    # event loop — which is also the TUI's render loop, and under Textual's
+    # eager task factory executes every runner in a batch synchronously up to
+    # its first true suspension — never pays a directory tree's worth of
+    # scandir/stat calls. Walking here inline was the observed freeze on
+    # concurrent grep/glob batches (main thread pinned in os_lstat/os_scandir
+    # under task_eager_start, one runner at a time, no frame in between).
+    target_is_file = target.is_file()
+    base = target.parent if target_is_file else target
+    use_rg = _use_ripgrep()
+    if use_rg and target_is_file:
+        try:
+            if target.stat().st_size > GREP_FILE_LIMIT_BYTES:
+                use_rg = False
+        except OSError:
+            use_rg = False
 
     scan_result = None
-    if _use_ripgrep() and not (target.is_file() and target.stat().st_size > GREP_FILE_LIMIT_BYTES):
+    if use_rg:
         scan_result = await _ripgrep_scan(
             params.pattern,
             target,
@@ -3450,30 +3519,36 @@ async def execute_grep(
         records, _count = scan_result
         engine_note = " (ripgrep)"
         # rg applies --max-filesize silently; recover the count the footer
-        # contract promises from the already-walked file list so both
-        # engines tell the model the same thing.
-        for f in files:
-            try:
-                if f.stat().st_size > GREP_FILE_LIMIT_BYTES:
-                    files_skipped += 1
-            except OSError:
-                continue
-    else:
-        if signal and signal.aborted:
-            return _error(tool_call_id, "grep", "Search aborted.")
-        # The scan is FILESYSTEM + REGEX work on model-controlled input;
-        # running it on the event loop would pin the CPU on a backtracking
-        # pattern or a large tree and make Ctrl+C unprocessable. It runs in a
-        # worker thread raced against the abort signal, with a wall-clock cap
-        # bounding the pathological-regex case (regexes are not classified).
-        py_result, aborted = await _run_with_abort(
-            asyncio.to_thread(
-                _python_grep_scan, files, base, regex, params.include, params.context_lines
-            ),
+        # contract promises. The walk+stat pass is the same filesystem load
+        # as the scan itself, so it rides a thread raced against abort.
+        skipped_count, aborted = await _run_with_abort(
+            asyncio.to_thread(_count_oversized_files, target),
             signal,
             lambda: None,
         )
         if aborted:
+            return _error(tool_call_id, "grep", "Search aborted.")
+        files_skipped = skipped_count or 0
+    else:
+        if signal and signal.aborted:
+            return _error(tool_call_id, "grep", "Search aborted.")
+
+        # The walk and the scan are FILESYSTEM + REGEX work on
+        # model-controlled input; running either on the event loop would pin
+        # the CPU on a backtracking pattern or a large tree and make Ctrl+C
+        # unprocessable. Both run in one worker-thread hop raced against the
+        # abort signal, with a wall-clock cap bounding the
+        # pathological-regex case (regexes are not classified).
+        def _walk_and_scan() -> tuple[list[tuple[str, int, str, str]], int, int]:
+            files, scan_base = _grep_file_set(target)
+            return _python_grep_scan(files, scan_base, regex, params.include, params.context_lines)
+
+        py_result, aborted = await _run_with_abort(
+            asyncio.to_thread(_walk_and_scan),
+            signal,
+            lambda: None,
+        )
+        if aborted or py_result is None:
             return _error(tool_call_id, "grep", "Search aborted.")
         records, files_searched, files_skipped = py_result
 

--- a/tests/unit/tools/test_loop_liveness.py
+++ b/tests/unit/tools/test_loop_liveness.py
@@ -238,3 +238,89 @@ async def test_oversized_bash_output_keeps_the_loop_live(
         f"the loop thread burned {probe.worst:.3f}s of CPU without yielding while "
         "bash settled — the oversized-output tail is back on the render loop"
     )
+
+
+def _wide_tree(root: Path, *, dirs: int = 40, files_per_dir: int = 50) -> int:
+    """A many-file tree whose walk is thousands of scandir/stat calls.
+
+    2000 files is small enough to build in well under a second and large
+    enough that a walk accidentally back on the loop is visible to the
+    structural spy — which is the half with teeth here, because a tree walk
+    is blocking syscalls, not CPU (see the module docstring on which half
+    owns which shape).
+    """
+    total = 0
+    for d in range(dirs):
+        directory = root / f"pkg_{d:03d}"
+        directory.mkdir()
+        for f in range(files_per_dir):
+            (directory / f"mod_{f:03d}.py").write_text(f"needle_{d}_{f} = {f}\n")
+            total += 1
+    return total
+
+
+@pytest.mark.asyncio
+async def test_concurrent_grep_walks_keep_the_loop_live(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A batch of greps over a wide tree must not walk it on the render loop.
+
+    The regression this pins: ``execute_grep`` walked the target tree inline
+    before hopping to a worker thread, so under Textual's eager task factory
+    (which runs each new task synchronously up to its first true suspension)
+    a batch of grep/glob calls executed every walk back-to-back on the render
+    loop before the batch's first frame could paint. Observed live as a
+    session frozen at "composing…" with the main thread pinned in
+    os_lstat/os_scandir under ``task_eager_start``.
+    """
+    _wide_tree(tmp_path)
+    monkeypatch.setenv("LOCAL_OPERATOR_GREP_ENGINE", "python")
+
+    # The walk (_grep_file_set) and the scan (_python_grep_scan) are the two
+    # filesystem-bound hops of the Python engine; both must run off-loop.
+    spy = OffLoopSpy(monkeypatch, "_grep_file_set", "_python_grep_scan")
+    context = builtin.ToolContext(cwd=str(tmp_path), session_id="liveness")
+    probe = LoopCpuProbe()
+    probe.start()
+    try:
+        results = await asyncio.gather(
+            *(
+                builtin.execute_grep(f"grep-{i}", {"pattern": f"needle_{i}_"}, None, None, context)
+                for i in range(3)
+            )
+        )
+    finally:
+        await probe.stop()
+
+    assert not any(r.is_error for r in results), "greps failed; liveness proved nothing"
+    spy.assert_all_off_loop()
+    assert probe.samples, "heartbeat never woke"
+    assert probe.worst < MAX_LOOP_CPU_S, (
+        f"the loop thread burned {probe.worst:.3f}s of CPU without yielding while "
+        "the greps ran — the tree walk is back on the render loop"
+    )
+
+
+@pytest.mark.asyncio
+async def test_ripgrep_skipped_count_walk_stays_off_loop(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The rg engine's oversized-file recount re-walks the tree — off-loop.
+
+    The ripgrep subprocess never blocked the loop, but the footer's
+    skipped-file count is recovered by a second Python walk+stat pass, and
+    that pass carried the same inline-walk regression as the Python engine.
+    Skipped (not failed) when rg is not installed: the path under test does
+    not exist without it.
+    """
+    if not builtin._use_ripgrep():
+        pytest.skip("ripgrep not on PATH; the rg recount path cannot run")
+    _wide_tree(tmp_path, dirs=10, files_per_dir=20)
+
+    spy = OffLoopSpy(monkeypatch, "_count_oversized_files")
+    context = builtin.ToolContext(cwd=str(tmp_path), session_id="liveness")
+    result = await builtin.execute_grep("grep-rg", {"pattern": "needle_"}, None, None, context)
+
+    assert not result.is_error, result.text
+    assert "(ripgrep)" in result.text, "rg engine did not run; recount path untested"
+    spy.assert_all_off_loop()

--- a/tests/unit/tools/test_loop_liveness.py
+++ b/tests/unit/tools/test_loop_liveness.py
@@ -313,6 +313,10 @@ async def test_ripgrep_skipped_count_walk_stays_off_loop(
     Skipped (not failed) when rg is not installed: the path under test does
     not exist without it.
     """
+    # Pin the engine selector to 'auto' so the skip condition below is purely
+    # about the rg binary, not an ambient LOCAL_OPERATOR_GREP_ENGINE override
+    # (review N2).
+    monkeypatch.delenv("LOCAL_OPERATOR_GREP_ENGINE", raising=False)
     if not builtin._use_ripgrep():
         pytest.skip("ripgrep not on PATH; the rg recount path cannot run")
     _wide_tree(tmp_path, dirs=10, files_per_dir=20)


### PR DESCRIPTION
# PR Description

## Change classification

**C2 — standard / pre-authorized.** Liveness/performance fix inside the builtin `grep` tool plus a syscall-count optimization of the shared tree walker. Clean rollback (`git revert`). No behavioural contract changes: same match output, same gitignore semantics, same sort order.

## The bug

A live session in `~/tmp` froze for 11+ minutes at "composing… 0s" the moment the model issued a concurrent batch (`todo` + `grep` + `grep` + `glob`), with the process burning 60–80% CPU. A 3-second `sample(1)` of the stuck process showed **100% of main-thread samples inside `os_lstat`/`os_scandir`/`os_stat`**, reached via `task_eager_start` → `execute_grep`'s inline tree walk.

The mechanism has three cooperating parts:

1. **`execute_grep` walked the target tree inline, before its first `await`.** `_walk_files(target)` ran directly on the event loop; only the *scan* was threaded.
2. **The walk ran even when ripgrep was the engine.** The rg subprocess never blocks the loop, but the oversized-file recount (`for f in files: f.stat()`) consumed the same inline walk — so having `rg` installed did not avoid the stall.
3. **Textual installs `asyncio.eager_task_factory` on the TUI loop**, so each runner task in a tool batch executes synchronously up to its first true suspension *at task-creation time*. A batch of N greps therefore performed N full tree walks back-to-back on the render loop before the batch's first frame could paint — and on a 63k-entry cwd (`~/tmp` holds cloned repos and build trees; the walk's stat storm is amplified 3× by `Path.iterdir` + per-entry `is_symlink`/`is_dir`/`is_file`), that is seconds of frozen UI per batch, repeated every turn.

The freeze in the report is this shape exactly: the model's turn `Recreating Daily Backup Schedule from…` fanned out `grep`+`grep`+`glob` over `~/tmp`.

## The fix

- **`execute_grep` defers the walk into the same worker-thread hop as the scan** (`_grep_file_set` + `_python_grep_scan` inside one `asyncio.to_thread`, raced against the abort signal). The coroutine's pre-suspension prefix now does no filesystem work beyond a couple of stats on the explicitly named target.
- **The ripgrep recount rides its own `to_thread` hop** (`_count_oversized_files`), also abort-raced, so the rg path no longer pays a loop-hosted Python walk for a footer count.
- **`_walk_entries` switched from `Path.iterdir` to `os.scandir`**, classifying entries from the `DirEntry` type info the kernel already returned with the listing (0 extra syscalls on the common path vs 3 `stat(2)` per entry). Sort order (`sorted by name` ≡ `sorted(iterdir())` within one directory), symlink refusal, prune list, and nested-gitignore semantics all preserved; entries that vanish mid-walk are skipped like the existing directory-level `OSError` handling.

`execute_glob` already ran its walk through `to_thread` and is unchanged.

## Testing evidence

**Reproduction, before → after** (real workload: the frozen session's own cwd `~/tmp`, 5,764 walked files, an event loop with `eager_task_factory` installed exactly as Textual does, and the session's actual batch shape `grep`+`grep`+`glob`; 20 ms heartbeat measuring loop stalls):

```
=== BEFORE (origin/main) ===
batch: 2857 ms total, 3 results, all ok=True
worst loop stall: 450 ms over 117 heartbeats
=== AFTER (fix) ===
batch: 2225 ms total, 3 results, all ok=True
worst loop stall: 19 ms over 107 heartbeats
```

450 ms → 19 ms worst loop stall on the same tree and batch. (The live freeze was minutes, not 450 ms, because every turn re-issued batches over a larger effective tree while three sibling sessions competed for the same cores; the repro pins the mechanism, not the pathology's full magnitude.)

**Regression tests** — two new tests in the existing `test_loop_liveness.py` anti-freeze suite, using its `OffLoopSpy` (structural: the walk observably runs off the loop thread) and `LoopCpuProbe` (temporal: loop-thread CPU per 20 ms heartbeat) harness over a 2,000-file fixture tree:

- `test_concurrent_grep_walks_keep_the_loop_live` — 3 concurrent Python-engine greps; both `_grep_file_set` and `_python_grep_scan` must run off-loop.
- `test_ripgrep_skipped_count_walk_stays_off_loop` — the rg engine's recount path; skips (not passes) when `rg` is absent.

**Mutation-verified**: hoisting the walk back inline (the old shape) fails the new test with `_grep_file_set ran on the event-loop thread 3 of 3 times`; restore verified by md5 against the pre-mutation file.

**Walker equivalence**: old and new `_walk_entries` return the identical 5,764-file set on `~/tmp`; the scandir version is 36% faster (198 ms → 127 ms warm).

**Suites and gates** (all green):

```
tests/unit/tools — 481 passed
flake8 (whole tree) — clean
black 26.1.0 --check (whole tree) — 427 files unchanged
isort 5.13.2 --check — clean
pyright — 0 errors, 0 warnings
```

No UI change → no design round required (TUI liveness is validated by the temporal probe above, which is this repo's prescribed instrument for "does the frame animate" — see `tests/unit/tools/test_loop_liveness.py` module docstring.
EOF
)