### PR TITLE
fix(providers): bench failed fallbacks so message boundaries stop replaying the waterfall

### DIFF
--- a/local_operator/model/configure.py
+++ b/local_operator/model/configure.py
@@ -1762,15 +1762,38 @@ class SessionStreamFn:
         *,
         different_provider: bool = False,
     ) -> Any | None:
+        """The first configured fallback with working auth, bench-aware.
+
+        "First configured" alone is what replayed the waterfall on every
+        message boundary: with the chain's head providers down, each quota
+        preflight re-selected the first entry, re-pinned it, and the stream
+        walk then re-paid one failure notice and one serial timeout per dead
+        target before landing back on the one provider that had actually been
+        serving. Targets the stream driver recently benched (see
+        ``FailoverRouteState.mark_target_failed``) are therefore passed over
+        here, so a session that has settled on a working fallback stays on it.
+
+        The bench is a preference, not a verdict: when EVERY authed candidate
+        is benched, the first of them is returned anyway — returning ``None``
+        would report "no configured fallback" to a user who has several, and
+        the stream walk's own retry machinery is the right place to discover
+        which bench has expired.
+        """
         from local_operator.providers.failover import parse_selector
 
+        first_benched: Any | None = None
         for target in self._fallback_targets(model):
             provider, _model_id = parse_selector(target.selector)
             if different_provider and provider == model.provider:
                 continue
-            if await self._target_has_auth(target):
-                return target
-        return None
+            if not await self._target_has_auth(target):
+                continue
+            if not self._route_state.target_retry_due(target):
+                if first_benched is None:
+                    first_benched = target
+                continue
+            return target
+        return first_benched
 
     @staticmethod
     def _storage_provider(provider: str) -> str:

--- a/local_operator/providers/failover.py
+++ b/local_operator/providers/failover.py
@@ -823,6 +823,24 @@ MAX_SERVER_FAULT_REQUESTS_PER_TURN = 12
 #: sweep goes immediately and lets resolution report whatever is still blocked.
 LOOPBACK_MAX_WAIT_MS = 30_000
 
+#: How long a FALLBACK target that exhausted its provider stays out of
+#: consideration before the cascade asks it again. Without this the chain had
+#: no memory between turns: every message boundary re-selected the FIRST
+#: configured fallback, so a session that had settled on the one provider that
+#: works replayed the whole waterfall — quota notice, then one "provider
+#: failure" per dead target — on every single message, paying the serial
+#: latency each time. Five minutes, not the 60s the primary-probe cooldown
+#: uses: the primary is the model the user chose, so probing it early is worth
+#: a request, while a fallback that hard-failed is just one of several
+#: interchangeable reserves and nothing is lost by leaving it benched for a
+#: few minutes. A longer advertised ``Retry-After`` extends the mark (see the
+#: call site); a shorter one does not shrink it, because the annoyance this
+#: exists to fix is measured in message-boundary intervals, not in seconds.
+#: The mark is advisory, never a dead end: the loop-back sweep still revisits
+#: benched targets before a turn is declared exhausted, and a target that
+#: serves a request sheds its mark immediately.
+FALLBACK_FAILURE_COOLDOWN_MS = 5 * 60 * 1000
+
 #: Attempts the FIRST bearer may spend on a server-side fault before the turn
 #: tries another credential. It is deliberately below ``max_retries``: until a
 #: rotation has happened nothing knows whether a sibling exists, and spending
@@ -1069,6 +1087,20 @@ class FailoverRouteState:
     on_change: RouteChangeHandler | None = None
     primary_retry_at_ms: int = 0
     on_settle: RouteSettleHandler | None = None
+    #: Per-target bench: ``(selector, effort) -> earliest ms it may be asked
+    #: again``. Written when a FALLBACK target exhausts its provider during a
+    #: walk, consulted by the next walk's first pass and by preflight's
+    #: fallback selection, so a session that has settled past a dead target
+    #: does not replay its failure — one notice and one serial timeout per
+    #: message — at every message boundary. Deliberately NOT cleared by
+    #: :meth:`clear`: the bench records facts about the fallback providers
+    #: ("kimi 500'd out 40s ago"), and neither a model switch nor the primary
+    #: recovering changes those facts. Entries expire on their own, and a
+    #: target that serves a request sheds its mark via :meth:`clear_target`.
+    #: The bench is advisory: the stream driver's loop-back sweep re-walks
+    #: benched targets before any turn is declared exhausted, so it can delay
+    #: a target but never remove the last route to a served turn.
+    target_retry_at_ms: dict[tuple[str, str | None], int] = dataclasses.field(default_factory=dict)
 
     async def activate(
         self,
@@ -1104,6 +1136,31 @@ class FailoverRouteState:
     def primary_retry_due(self, now_ms: int | None = None) -> bool:
         now = int(time.time() * 1000) if now_ms is None else now_ms
         return now >= self.primary_retry_at_ms
+
+    def mark_target_failed(
+        self,
+        target: FallbackTarget,
+        *,
+        cooldown_ms: int,
+        now_ms: int | None = None,
+    ) -> None:
+        """Bench ``target`` until ``now + cooldown_ms``.
+
+        ``max()`` against any existing deadline so a fresh short failure
+        cannot shrink a longer advertised quota-reset wait already recorded.
+        """
+        now = int(time.time() * 1000) if now_ms is None else now_ms
+        key = (target.selector, target.effort)
+        self.target_retry_at_ms[key] = max(self.target_retry_at_ms.get(key, 0), now + cooldown_ms)
+
+    def target_retry_due(self, target: FallbackTarget, now_ms: int | None = None) -> bool:
+        """True when ``target`` is not benched (or its bench has expired)."""
+        now = int(time.time() * 1000) if now_ms is None else now_ms
+        return now >= self.target_retry_at_ms.get((target.selector, target.effort), 0)
+
+    def clear_target(self, target: FallbackTarget) -> None:
+        """Drop ``target``'s bench mark — it just served a request."""
+        self.target_retry_at_ms.pop((target.selector, target.effort), None)
 
     def clear(self) -> None:
         """Return the route to the primary WITHOUT announcing it.
@@ -1424,6 +1481,28 @@ async def stream_with_failover(
     # provider meant, or a bearer it rejected past rotation, gets no second ask:
     # the same bytes would get the same answer.
     pending = list(targets)
+    if route_state is not None:
+        # Fallbacks that exhausted their provider within the cooldown window
+        # sit out the first pass — re-paying their failure (one "provider
+        # failure" notice plus a serial timeout per dead target, on every
+        # message boundary) is the waterfall replay this bench exists to stop.
+        # Filtered HERE rather than skipped inside the walk so a benched
+        # target can never be the last pending item and starve the loop-back
+        # sweep below, which is what still owes every filtered target a visit
+        # (they are never added to `walked`): the bench delays a target, it
+        # never removes the last route to a served turn. Two exemptions: the
+        # primary, whose suppression is the route pin plus the preflight's
+        # metered probe and never this bench, and the pinned route itself,
+        # which is the target the session is actually running on — benching
+        # it would orphan the very route the trim above started the walk
+        # from. Either exemption also guarantees the first pass is non-empty.
+        pending = [
+            candidate
+            for candidate in pending
+            if candidate == primary_target
+            or candidate == route_state.active
+            or route_state.target_retry_due(candidate)
+        ]
     walked: set[tuple[str, str | None]] = set()
     recoverable: set[tuple[str, str | None]] = set()
     # Server-fault spend per target, carried ACROSS the sweeps: the per-turn
@@ -1440,8 +1519,8 @@ async def stream_with_failover(
 
         is_primary = selector == primary_selector
         provider, _model_id = parse_selector(selector)
-        spec = request.model if target == primary_target else spec_for_target(request.model, target)
         route_key = (selector, target.effort)
+        spec = request.model if target == primary_target else spec_for_target(request.model, target)
         walked.add(route_key)
         if (
             looped_back
@@ -1497,6 +1576,11 @@ async def stream_with_failover(
         # configured budget has already been handed back once rotation ran out.
         last_access: "OAuthAccess | None" = None
         exhausted_budget_restored = False
+        # The longest reset THIS target's own errors advertised, for sizing its
+        # bench below. Tracked per target rather than read from `reported`,
+        # which keeps the most diagnostic error of the WHOLE walk and would
+        # bench this target for another provider's quota reset.
+        target_retry_after_ms = 0
 
         while state.attempts <= AUTH_RETRY_MAX_ATTEMPTS:
             if signal is not None and signal.aborted:
@@ -1621,6 +1705,11 @@ async def stream_with_failover(
                     # again is exactly the edge its display needs. A no-op when
                     # nothing was pinned (see `clear_settled`).
                     await route_state.clear_settled("primary model recovered")
+                if route_state is not None:
+                    # Serving a request is the affirmative signal that ends a
+                    # bench: whatever exhausted this target's provider has
+                    # passed, so the next walk may ask it again immediately.
+                    route_state.clear_target(target)
                 # This credential just served a request, so whatever provider
                 # fault demoted it has passed. Without this the mark outlived
                 # the outage for the life of the process, contradicting the
@@ -1641,6 +1730,7 @@ async def stream_with_failover(
                 if forwarded_any:
                     raise  # partial output already reached the caller
                 record(exc, primary=is_primary)
+                target_retry_after_ms = max(target_retry_after_ms, exc.retry_after_ms or 0)
                 if is_server_side_failure(exc):
                     server_fault_requests += 1
                     server_faults_by_target[route_key] = server_fault_requests
@@ -1752,6 +1842,21 @@ async def stream_with_failover(
                 return
 
         # Provider exhausted — walk on to the next fallback selector.
+
+        if route_state is not None and target != primary_target:
+            # Bench the exhausted fallback so the next message boundary does
+            # not re-pay this failure. The bench floor is deliberately longer
+            # than any advertised short throttle — the annoyance this fixes is
+            # per-message replay, not per-second pacing — but a LONGER
+            # advertised quota reset extends it, because asking before the
+            # provider's own stated reset is guaranteed waste. The primary is
+            # never benched here: its suppression is the route pin plus
+            # `primary_retry_at_ms`, owned by the preflight, and the user's
+            # chosen model deserves the periodic probe that cooldown meters.
+            route_state.mark_target_failed(
+                target,
+                cooldown_ms=max(FALLBACK_FAILURE_COOLDOWN_MS, target_retry_after_ms),
+            )
 
         if pending or looped_back or not retry.enabled:
             continue

--- a/tests/unit/model/test_configure.py
+++ b/tests/unit/model/test_configure.py
@@ -539,6 +539,90 @@ async def test_usage_preflight_exhausts_accounts_then_uses_provider_fallback(tmp
 
 
 @pytest.mark.asyncio
+async def test_preflight_fallback_selection_skips_benched_targets(tmp_path) -> None:
+    """Quota preflight must not re-pin a fallback the stream driver just
+    watched fail.
+
+    The reported annoyance: with the chain's head fallbacks down, every
+    message boundary re-selected the FIRST configured fallback, re-pinned it,
+    and the stream walk then replayed the whole waterfall — one "provider
+    failure" notice and one serial timeout per dead target — before landing
+    back on the provider that had been serving. A target benched by
+    ``mark_target_failed`` is passed over until its cooldown expires.
+    """
+    store = AuthStore(tmp_path / "auth.db")
+    store.upsert_credential("anthropic", _oauth("oauth-a", "account-a"))
+    store.upsert_credential("zai", {"key": "sk-zai", "source": "login"})
+    store.upsert_credential("openai", {"key": "sk-openai", "source": "login"})
+    stream = create_stream_fn(
+        store,
+        {
+            "retry": {
+                "usageAwareFallback": True,
+                "fallbackChains": {"default": ["zai/glm-5.3", "openai/gpt-5.3-codex"]},
+            }
+        },
+        session_id="session-a",
+    )
+    model = ModelSpec(provider="anthropic", model_id="claude-opus-5")
+
+    try:
+        # The stream driver benched zai after it exhausted its provider.
+        stream._route_state.mark_target_failed(FallbackTarget("zai/glm-5.3"), cooldown_ms=300_000)
+        with patch(
+            "local_operator.providers.usage.fetch_usage",
+            side_effect=lambda *_args, **_kwargs: _anthropic_usage(100.0),
+        ):
+            await stream.preflight_usage(model)
+
+        # Preflight pinned the SECOND fallback, not the benched head.
+        assert stream._route_state.active == FallbackTarget("openai/gpt-5.3-codex")
+    finally:
+        await stream.close()
+        store.close()
+
+
+@pytest.mark.asyncio
+async def test_preflight_fallback_uses_a_benched_target_when_nothing_else_remains(
+    tmp_path,
+) -> None:
+    """An all-benched chain is still a chain — never "no configured fallback".
+
+    The bench is a preference between working candidates. When every authed
+    candidate is benched, the first is returned anyway: reporting a dead end
+    to a user who configured several fallbacks would turn a routing hint into
+    an outage, and the stream walk owns discovering which bench has expired.
+    """
+    store = AuthStore(tmp_path / "auth.db")
+    store.upsert_credential("anthropic", _oauth("oauth-a", "account-a"))
+    store.upsert_credential("zai", {"key": "sk-zai", "source": "login"})
+    stream = create_stream_fn(
+        store,
+        {
+            "retry": {
+                "usageAwareFallback": True,
+                "fallbackChains": {"default": ["zai/glm-5.3"]},
+            }
+        },
+        session_id="session-a",
+    )
+    model = ModelSpec(provider="anthropic", model_id="claude-opus-5")
+
+    try:
+        stream._route_state.mark_target_failed(FallbackTarget("zai/glm-5.3"), cooldown_ms=300_000)
+        with patch(
+            "local_operator.providers.usage.fetch_usage",
+            side_effect=lambda *_args, **_kwargs: _anthropic_usage(100.0),
+        ):
+            await stream.preflight_usage(model)
+
+        assert stream._route_state.active == FallbackTarget("zai/glm-5.3")
+    finally:
+        await stream.close()
+        store.close()
+
+
+@pytest.mark.asyncio
 async def test_usage_reserve_can_reduce_effort_without_blocking_account(tmp_path) -> None:
     store = AuthStore(tmp_path / "auth.db")
     account = store.upsert_credential("anthropic", _oauth("oauth-a", "account-a"))

--- a/tests/unit/providers/test_failover.py
+++ b/tests/unit/providers/test_failover.py
@@ -588,6 +588,164 @@ async def test_the_primary_cooldown_is_a_deadline_not_a_sliding_window(
     assert state.primary_retry_due(now_ms=now_ms + 10_001)
 
 
+async def test_exhausted_fallback_is_benched_for_the_next_walk(monkeypatch) -> None:
+    """Message 2 must not re-pay message 1's failed fallback.
+
+    The reported annoyance: with the chain's head providers down, every user
+    message replayed the whole waterfall — one "provider failure" notice and
+    one serial timeout per dead target — before landing back on the one
+    provider that had been serving all along. A fallback that exhausted its
+    provider is benched for ``FALLBACK_FAILURE_COOLDOWN_MS``, so the next
+    walk goes straight from the failed primary to the working tail.
+    """
+    now_ms = 1_000_000
+    monkeypatch.setattr(
+        failover_module, "time", SimpleNamespace(time=lambda: now_ms / 1000), raising=True
+    )
+    specs_seen: list[str] = []
+
+    async def client_for(spec: ModelSpec) -> Any:
+        specs_seen.append(f"{spec.provider}/{spec.model_id}")
+        if spec.provider in ("openai", "anthropic"):
+            return ScriptedClient(ProviderError(400, "model unavailable"))
+        return ScriptedClient([StreamEndEvent(stop_reason="stop")])
+
+    settings = {
+        "retry": {
+            "baseDelayMs": 1,
+            "fallbackChains": {"default": ["anthropic/claude-x", "groq/llama-x"]},
+        }
+    }
+    state = FailoverRouteState()
+    auth = FakeAuth({"openai": ["k1"], "anthropic": ["k2"], "groq": ["k3"]})
+
+    async def run() -> None:
+        _ = [
+            event
+            async for event in stream_with_failover(
+                _request(), auth, settings, client_for, route_state=state
+            )
+        ]
+
+    await run()
+    assert specs_seen == ["openai/gpt-4o", "anthropic/claude-x", "groq/llama-x"]
+    # The dead fallback is benched; the one that served is not.
+    assert not state.target_retry_due(FallbackTarget("anthropic/claude-x"), now_ms=now_ms)
+    assert state.target_retry_due(FallbackTarget("groq/llama-x"), now_ms=now_ms)
+
+    # A preflight that believed the primary recovered clears the pin — which
+    # must NOT clear the bench, or the next walk replays the waterfall.
+    state.clear()
+    specs_seen.clear()
+    now_ms += 30_000  # well inside the cooldown
+    await run()
+    assert specs_seen == [
+        "openai/gpt-4o",
+        "groq/llama-x",
+    ], "the benched fallback was re-walked inside its cooldown"
+
+    # Past the cooldown the bench expires on its own and the target is asked
+    # again — the bench is a delay, not a removal.
+    state.clear()
+    specs_seen.clear()
+    now_ms += failover_module.FALLBACK_FAILURE_COOLDOWN_MS
+    await run()
+    assert specs_seen == ["openai/gpt-4o", "anthropic/claude-x", "groq/llama-x"]
+
+
+async def test_bench_never_strands_a_turn_when_every_fallback_is_benched(monkeypatch) -> None:
+    """An all-benched chain must still serve via the loop-back sweep.
+
+    The bench is advisory: it shapes the first pass, and the loop-back sweep
+    re-walks whatever the first pass never asked. A turn may be slower here,
+    but it must never die reporting exhaustion while a benched target would
+    have served.
+    """
+    now_ms = 1_000_000
+    monkeypatch.setattr(
+        failover_module, "time", SimpleNamespace(time=lambda: now_ms / 1000), raising=True
+    )
+    specs_seen: list[str] = []
+
+    async def client_for(spec: ModelSpec) -> Any:
+        specs_seen.append(f"{spec.provider}/{spec.model_id}")
+        if spec.provider == "openai":
+            return ScriptedClient(ProviderError(400, "model unavailable"))
+        return ScriptedClient([StreamEndEvent(stop_reason="stop")])
+
+    settings = {"retry": {"baseDelayMs": 1, "fallbackChains": {"default": ["groq/llama-x"]}}}
+    state = FailoverRouteState()
+    state.mark_target_failed(
+        FallbackTarget("groq/llama-x"),
+        cooldown_ms=failover_module.FALLBACK_FAILURE_COOLDOWN_MS,
+        now_ms=now_ms,
+    )
+    got = [
+        event
+        async for event in stream_with_failover(
+            _request(),
+            FakeAuth({"openai": ["k1"], "groq": ["k3"]}),
+            settings,
+            client_for,
+            route_state=state,
+        )
+    ]
+    assert specs_seen == ["openai/gpt-4o", "groq/llama-x"]
+    assert any(isinstance(e, StreamEndEvent) for e in got)
+    # Serving cleared the bench mark.
+    assert state.target_retry_due(FallbackTarget("groq/llama-x"), now_ms=now_ms)
+
+
+async def test_pinned_route_is_exempt_from_its_own_bench(monkeypatch) -> None:
+    """The route the session is running on is never skipped by the bench.
+
+    A pinned fallback that hiccups gets benched like any other; the pin
+    exemption keeps the session's own route in the walk so the trim that
+    starts the walk from the pin cannot produce an empty first pass.
+    """
+    now_ms = 1_000_000
+    monkeypatch.setattr(
+        failover_module, "time", SimpleNamespace(time=lambda: now_ms / 1000), raising=True
+    )
+    specs_seen: list[str] = []
+
+    async def client_for(spec: ModelSpec) -> Any:
+        specs_seen.append(f"{spec.provider}/{spec.model_id}")
+        return ScriptedClient([StreamEndEvent(stop_reason="stop")])
+
+    settings = {"retry": {"baseDelayMs": 1, "fallbackChains": {"default": ["groq/llama-x"]}}}
+    state = FailoverRouteState()
+    target = FallbackTarget("groq/llama-x")
+    await state.activate(target, "provider failure", cooldown_ms=60_000)
+    state.mark_target_failed(
+        target,
+        cooldown_ms=failover_module.FALLBACK_FAILURE_COOLDOWN_MS,
+        now_ms=now_ms,
+    )
+    _ = [
+        event
+        async for event in stream_with_failover(
+            _request(),
+            FakeAuth({"openai": ["k1"], "groq": ["k3"]}),
+            settings,
+            client_for,
+            route_state=state,
+        )
+    ]
+    # The pin trim starts the walk at groq, and the bench must not skip it.
+    assert specs_seen == ["groq/llama-x"]
+
+
+async def test_bench_deadline_extends_but_never_shrinks(monkeypatch) -> None:
+    """A fresh short failure cannot shorten a longer advertised reset."""
+    state = FailoverRouteState()
+    target = FallbackTarget("groq/llama-x")
+    state.mark_target_failed(target, cooldown_ms=600_000, now_ms=1_000_000)
+    state.mark_target_failed(target, cooldown_ms=60_000, now_ms=1_000_000)
+    assert not state.target_retry_due(target, now_ms=1_000_000 + 599_999)
+    assert state.target_retry_due(target, now_ms=1_000_000 + 600_000)
+
+
 async def test_stream_exhaustion_raises_last_error() -> None:
     async def client_for(spec: ModelSpec) -> Any:
         return ScriptedClient(ProviderError(500, "still down", retryable=True))


### PR DESCRIPTION
## Problem

After a failover cascade, every subsequent user message replayed the whole waterfall from the top. With the chain's head providers down (anthropic quota exhausted, zai/kimi 500ing, xai serving), each message boundary produced:

```
! anthropic quota low (8% remaining) — falling back to zai/glm-5.3
! provider failure — falling back to kimi/k3
! provider failure — falling back to alibaba-token-plan/qwen3.8-max
! provider failure — falling back to xai/grok-4.6
```

paying one notice and one serial timeout per dead target on **every message**, even though the session had already discovered which provider works.

Mechanism: the chain had no memory between turns. At each message boundary past the 60s primary-probe cooldown, the quota preflight re-ran, re-selected the **first configured** fallback (`_first_available_fallback` checks only auth, not recent failure), re-pinned it over the serving route, and the stream walk re-paid every dead target between it and the working tail.

## Fix

`FailoverRouteState` now carries a per-target bench (`target_retry_at_ms`): when a **fallback** target exhausts its provider during a walk, it is benched for `FALLBACK_FAILURE_COOLDOWN_MS` (5 minutes, extended to the provider's advertised `Retry-After` when longer). While benched:

- `stream_with_failover` filters the target out of the first pass of the next walk;
- preflight's `_first_available_fallback` passes over it, so the boundary re-pin lands on a working candidate.

The bench is advisory, never a dead end:

- the loop-back sweep still revisits benched targets before any turn is declared exhausted (they are filtered before `walked.add`, so the sweep owes them a visit);
- an all-benched chain still returns its first authed candidate from preflight rather than "no configured fallback";
- the primary is never benched (its suppression stays the route pin + `primary_retry_at_ms`, the metered probe the user's chosen model deserves);
- the pinned route itself is exempt (benching the route the session runs on would orphan the walk's own starting point);
- a target that serves a request sheds its mark immediately — the affirmative signal that the outage passed;
- `clear()` deliberately does **not** clear the bench: the bench records facts about fallback providers, which neither a model switch nor primary recovery changes.

## Change class

C2 — standard/pre-authorized; behaviour fix in the failover router with a bounded blast radius (fallback route selection), no contract changes.

## Testing

**End-to-end repro (real `SessionStreamFn`: usage preflight + `stream_with_failover` + production wire clients over `httpx.MockTransport`; only `fetch_usage` patched).** Cascade: anthropic OAuth quota-exhausted (429 + retry-after), zai/kimi down (500), xai serving. Message 2 sent past the 60s cooldown/TTL, the state every boundary sees during a sustained outage.

Before (`origin/main` @ `ed7d9e0`):

```
message 1 requests: {'zai': 2, 'kimi': 2, 'xai': 1}
    m1: [warning] anthropic quota exhausted (0% remaining) — falling back to zai/glm-5.3
    m1: [warning] provider failure — falling back to kimi/k3
    m1: [warning] provider failure — falling back to xai/grok-4.6
message 2 requests: {'zai': 2, 'kimi': 2, 'xai': 1}     ← full replay
    m2: [warning] anthropic quota exhausted (0% remaining) — falling back to zai/glm-5.3
    m2: [warning] provider failure — falling back to kimi/k3
    m2: [warning] provider failure — falling back to xai/grok-4.6
```

After (this branch):

```
message 1 requests: {'zai': 2, 'kimi': 2, 'xai': 1}     ← discovery walk, unchanged
    m1: (same three notices)
message 2 requests: {'xai': 1}                           ← straight to the serving provider
    m2: (no notices)
```

**Unit tests** (all mutation-checked: disabling `target_retry_due` fails the read-side tests; removing `mark_target_failed` fails the write-side test):

- `test_exhausted_fallback_is_benched_for_the_next_walk` — message 2 skips the benched target inside the cooldown; past the cooldown the bench expires and the target is asked again.
- `test_bench_never_strands_a_turn_when_every_fallback_is_benched` — all-benched chain still serves via the loop-back sweep; serving clears the mark.
- `test_pinned_route_is_exempt_from_its_own_bench` — the pin-trimmed walk still asks the pinned route.
- `test_bench_deadline_extends_but_never_shrinks` — a fresh short failure cannot shorten a longer advertised reset.
- `test_preflight_fallback_selection_skips_benched_targets` — boundary preflight pins the second fallback, not the benched head.
- `test_preflight_fallback_uses_a_benched_target_when_nothing_else_remains` — all-benched preflight still pins rather than reporting "no configured fallback".

**Suites/gates:**

- `tests/unit` minus TUI: 3472 passed, 1 failed — `test_eval_tool.py::test_background_streams_output_while_it_runs`, which fails identically on a clean `origin/main` worktree (pre-existing sandbox-streaming flake, unrelated).
- `tests/unit/tui` (colour env): 2076 passed, 4 skipped.
- flake8, black, isort, pyright: clean repo-wide.
