### PR TITLE
feat(tui): enlarge inline transcript images for legibility

### DIFF
--- a/local_operator/tui/images.py
+++ b/local_operator/tui/images.py
@@ -80,8 +80,14 @@ MAX_LIVE_KITTY_IMAGES = 8
 #: the same height ceiling so a transcript of mixed screenshots reads as a
 #: ledger rather than a scrapbook, with width following each image's own
 #: aspect ratio under ``MAX_COLS``. Small images stay small (no upscaling).
-MAX_ROWS = 12
-MAX_COLS = 72
+#: The ceiling is legibility-driven: a UI screenshot's smallest text has to
+#: survive the downscale to stay readable, and 12 rows turned the browser
+#: tool's 1080p-ish captures into thumbnails where labels were guesswork.
+#: ``MAX_COLS`` stays under a typical full-screen terminal's text column, so
+#: on wide terminals this cap binds and on narrow ones the transcript width
+#: does — the image never grows past what the conversation can show.
+MAX_ROWS = 18
+MAX_COLS = 100
 
 #: Kitty Unicode placeholder base character (U+10EEEE, Plane 16 PUA).
 PLACEHOLDER = "\U0010eeee"


### PR DESCRIPTION
## Problem

Images rendered inline in the transcript (attached to prompts, returned by `read`/browser tools) were capped at a 72×12 cell grid. For a typical 1568×808 browser screenshot the *height* ceiling bound first, so the image actually landed at **47×12 cells** (8×16 fallback cell) — ~24% of native height. UI labels at ~10px source became ~2.4 terminal pixels: "Outstanding", "Potential match", and sidebar items were guesswork.

## Fix

Raise the grid caps in `local_operator/tui/images.py` to 18 rows × 100 columns, with a comment recording why: the ceiling is legibility-driven (a UI screenshot's smallest text has to survive the downscale). `MAX_COLS` stays under a typical full-screen text column so the cap — not the terminal — is what binds on *ultrawide* images; for ordinary ~2:1 screenshots the row ceiling still binds.

The same 1568×808 capture now lands at **70×18 cells** (~36% of native height, 1.5× taller, 2.2× the painted area). `MAX_COLS=100` only engages past ~2.8:1. Everything else about the sizing rules is unchanged:

- **No upscaling** — small images still render at their natural size.
- **Consistent ledger** — all images share one height ceiling; mixed screenshots still scan uniformly.
- **Bounded memory** — `_shrink` derives the retained-copy cap from these constants (worst-case ~900 KB RGBA at 8×16, still bounded).
- **Kitty budget unchanged** — `MAX_LIVE_KITTY_IMAGES = 8`; evicted images demote to half-cells as before.

## Change class

C2 — standard/pre-authorized; a TUI display constant change with a one-file diff and no contract changes.

## Testing

**Unit:** `tests/unit/tui` (the full TUI suite, 2076 passed, 4 skipped), including `test_image_block.py` (111 tests over fit arithmetic, kitty transmit/placement, half-cell painting, budget eviction, resume replay). The fit tests pass explicit grid values and are independent of the constants; `test_retained_copy_is_capped` asserts the resident copy is bounded by the constants themselves.

**Visual (before/after, real `OperatorApp` under `run_test`, half-cell mode, 100×40 terminal, 1568×808 image attached to a prompt — the frame Textual painted, exported via `save_screenshot`):**

Before (`origin/main` @ `ed7d9e0`) — image occupies 47×12 cells:

![before](https://github.com/damianvtran/lo-scratch/releases/download/pr199-frames/img_before.svg.png)

After (this branch) — same image at 70×18 cells, 1.5× taller, same width-binding axis (height):

![after](https://github.com/damianvtran/lo-scratch/releases/download/pr199-frames/img_after.svg.png)

Geometry check (8×16 fallback cell): `fit_cells(1568, 808, 72, 12)` → `(47, 12)`; `fit_cells(1568, 808, 100, 18)` → `(70, 18)`. Aspect 1568:808 ≈ 1.94; 70 cols × 18 rows at a 1:2 cell ≈ 1.94. `MAX_COLS=100` is inert for this aspect (binds past ~2.8:1).
