### PR TITLE
fix(mobile): densify the phone UI to TUI ledger rhythm; restart and pid fixes

### DIFF
--- a/local_operator/mobile/daemon.py
+++ b/local_operator/mobile/daemon.py
@@ -158,7 +158,12 @@ async def _dial(daemon: "MobileDaemon", entry: SessionEntry) -> None:
     frames until the connection dies. One task per session."""
     record = entry.record
     try:
-        reader, writer = await asyncio.open_connection("127.0.0.1", record.control_port)
+        # Match the registrant's 1 MB line limit. The default 64 KB
+        # StreamReader cap is what made a transcript push raise
+        # ValueError and leave the session stuck on "connecting…".
+        reader, writer = await asyncio.open_connection(
+            "127.0.0.1", record.control_port, limit=1 << 20
+        )
     except OSError:
         entry.degraded = True
         entry.next_dial_at = time.monotonic() + REDIAL_BACKOFF_S

--- a/local_operator/mobile/daemon.py
+++ b/local_operator/mobile/daemon.py
@@ -169,7 +169,14 @@ async def _dial(daemon: "MobileDaemon", entry: SessionEntry) -> None:
         writer.write(json.dumps({"key": record.control_key}).encode() + b"\n")
         await writer.drain()
         while True:
-            line = await reader.readline()
+            try:
+                line = await reader.readline()
+            except ValueError:
+                # A frame longer than the stream limit is not a reason to
+                # drop the session — a transcript push can outgrow 64 KB.
+                # Skip the oversized line and keep the connection.
+                logger.warning("mobile daemon: oversized control frame from pid %s", record.pid)
+                continue
             if not line:
                 break
             try:

--- a/local_operator/mobile/daemon.py
+++ b/local_operator/mobile/daemon.py
@@ -240,6 +240,10 @@ def _projection_from_json(data: dict[str, Any], record: SessionRecord) -> Sessio
         if k in known and k not in ("transcript", "todos", "subagents", "pending")
     }
     projection = SessionProjection(**base)
+    # The fold stamps pid=0 (the registrant does not know its own listen
+    # pid until after the record is published). The discovery record is
+    # the source of truth, and the phone keys drafts and commands on it.
+    projection.pid = record.pid
     projection.transcript = build(TranscriptEntry, data.get("transcript", []))
     projection.todos = build(TodoItem, data.get("todos", []))
     projection.subagents = build(SubagentRow, data.get("subagents", []))

--- a/local_operator/mobile/install.py
+++ b/local_operator/mobile/install.py
@@ -71,6 +71,31 @@ def _launchctl(*args: str) -> subprocess.CompletedProcess[str]:
     return subprocess.run(["launchctl", *args], capture_output=True, text=True, timeout=15)
 
 
+def _our_daemon_listening(port: int) -> bool:
+    """True when the process bound to ``port`` is the one this plist starts.
+
+    Health alone cannot answer this: a stale foreground daemon on the same
+    port passes every check while the supervised one fails to bind. Ask
+    launchd which pid it is running, then ask lsof who owns the port.
+    """
+    import re
+
+    printed = _launchctl("print", f"{_domain()}/{LABEL}")
+    if printed.returncode != 0:
+        return False
+    match = re.search(r"pid = (\d+)", printed.stdout)
+    if not match:
+        return False
+    pid = match.group(1)
+    listeners = subprocess.run(
+        ["lsof", "-nP", f"-iTCP:{port}", "-sTCP:LISTEN", "-t"],
+        capture_output=True,
+        text=True,
+        timeout=5,
+    )
+    return pid in listeners.stdout.split()
+
+
 def _domain() -> str:
     import os
 
@@ -138,9 +163,12 @@ def install(port: int = DEFAULT_PORT, *, dry_run: bool = False) -> dict[str, obj
             return {"ok": False, "steps": steps, "error": result.stderr.strip()[:300]}
         steps.append("loaded the LaunchAgent")
 
-        deadline = time.time() + 15
+        # The daemon we just bootstrapped owns the port now; a health check
+        # that passed on a leftover foreground process would lie about the
+        # supervised one. Wait for OUR pid to be the listener before probing.
+        deadline = time.time() + 20
         while time.time() < deadline:
-            if health(port) and gate_closed(port):
+            if _our_daemon_listening(port) and health(port) and gate_closed(port):
                 steps.append("health check passed and the auth gate is closed")
                 # Never return the password: a `--json` dump or an agent
                 # capturing stdout would put it in the transcript.
@@ -171,7 +199,19 @@ def uninstall(*, purge: bool = False, dry_run: bool = False) -> dict[str, object
 
 
 def service_action(action: str) -> dict[str, object]:
-    """start|stop|restart via launchctl kickstart/kill."""
+    """start|stop|restart via launchctl.
+
+    The kickstart family fails with "Could not find service" when the plist
+    exists but the agent was never bootstrapped (or was booted out and not
+    re-loaded). Bootstrap it on demand so the control commands work from
+    whatever state launchd is in, not just the state `install` left behind.
+    """
+    if action in ("start", "restart") and plist_path().exists():
+        printed = _launchctl("print", f"{_domain()}/{LABEL}")
+        if printed.returncode != 0:
+            bootstrap = _launchctl("bootstrap", _domain(), str(plist_path()))
+            if bootstrap.returncode != 0:
+                return {"ok": False, "error": bootstrap.stderr.strip()[:300]}
     if action == "start":
         result = _launchctl("kickstart", f"{_domain()}/{LABEL}")
     elif action == "stop":

--- a/local_operator/mobile/web/pnpm-workspace.yaml
+++ b/local_operator/mobile/web/pnpm-workspace.yaml
@@ -1,2 +1,4 @@
+allowBuilds:
+  esbuild: true
 onlyBuiltDependencies:
   - esbuild

--- a/local_operator/mobile/web/pnpm-workspace.yaml
+++ b/local_operator/mobile/web/pnpm-workspace.yaml
@@ -1,4 +1,4 @@
 allowBuilds:
-  esbuild: set this to true or false
+  esbuild: true
 onlyBuiltDependencies:
   - esbuild

--- a/local_operator/mobile/web/pnpm-workspace.yaml
+++ b/local_operator/mobile/web/pnpm-workspace.yaml
@@ -1,4 +1,4 @@
 allowBuilds:
-  esbuild: true
+  esbuild: set this to true or false
 onlyBuiltDependencies:
   - esbuild

--- a/local_operator/mobile/web/src/components/composer.tsx
+++ b/local_operator/mobile/web/src/components/composer.tsx
@@ -267,7 +267,7 @@ export function Composer({
 				<button
 					type="button"
 					onClick={() => void send("continue", "prompt")}
-					className="flex min-h-11 items-center justify-center rounded-sm border border-hairline bg-surface text-body-sm text-ink-muted active:bg-elevated"
+					className="flex min-h-11 items-center justify-center rounded-sm border border-control bg-surface text-body-sm text-ink active:bg-elevated"
 				>
 					interrupted — tap to resume
 				</button>

--- a/local_operator/mobile/web/src/components/composer.tsx
+++ b/local_operator/mobile/web/src/components/composer.tsx
@@ -28,21 +28,33 @@ function SlashSheet({
 	open,
 	onClose,
 	onPick,
+	query,
 }: {
 	open: boolean;
 	onClose: () => void;
 	/** fill: text to place in the composer; submit: send immediately. */
 	onPick: (fill: string, submit: boolean) => void;
+	/** The token after `/` in the composer — seeds the filter. */
+	query: string;
 }) {
 	const [commands, setCommands] = useState<SlashCommand[]>([]);
-	const [filter, setFilter] = useState("");
+	const [filter, setFilter] = useState(query);
+	const [loaded, setLoaded] = useState(false);
 
 	useEffect(() => {
 		if (!open) return;
+		setFilter(query);
+		setLoaded(false);
 		getCommands()
-			.then((r) => setCommands(r.commands))
-			.catch(() => setCommands([]));
-	}, [open]);
+			.then((r) => {
+				setCommands(r.commands);
+				setLoaded(true);
+			})
+			.catch(() => {
+				setCommands([]);
+				setLoaded(true);
+			});
+	}, [open, query]);
 
 	const filtered = useMemo(() => {
 		const q = filter.trim().toLowerCase();
@@ -92,7 +104,11 @@ function SlashSheet({
 						</span>
 					</button>
 				))}
-				{filtered.length === 0 ? (
+				{!loaded ? (
+					<p className="px-3 py-2 text-body-sm text-ink-dim">
+						loading…
+					</p>
+				) : filtered.length === 0 ? (
 					<p className="px-3 py-2 text-body-sm text-ink-dim">
 						no matching commands
 					</p>
@@ -105,15 +121,17 @@ function SlashSheet({
 function EffortSheet({
 	open,
 	onClose,
+	pid,
 	projection,
 }: {
 	open: boolean;
 	onClose: () => void;
+	pid: number;
 	projection: SessionProjection;
 }) {
 	const set = async (effort: string) => {
 		try {
-			await sendCommand(projection.pid, { op: "set_effort", effort });
+			await sendCommand(pid, { op: "set_effort", effort });
 		} catch {
 			/* The next repaint shows the truth; a failed set leaves it. */
 		}
@@ -151,19 +169,21 @@ function EffortSheet({
 const MAX_TEXTAREA_PX = 6 * 22; /* six lines at body line-height */
 
 export function Composer({
+	pid,
 	projection,
 	onOpenModels,
 	onOpenEffort,
 	effortOpen,
 	onCloseEffort,
 }: {
+	/** Route pid — the discovery record's, not the fold's (which stamps 0). */
+	pid: number;
 	projection: SessionProjection;
 	onOpenModels: () => void;
 	onOpenEffort: () => void;
 	effortOpen: boolean;
 	onCloseEffort: () => void;
 }) {
-	const pid = projection.pid;
 	const [text, setText] = useDraft(pid);
 	const [slashOpen, setSlashOpen] = useState(false);
 	const [sending, setSending] = useState(false);
@@ -334,10 +354,12 @@ export function Composer({
 				open={slashOpen && !disabled}
 				onClose={() => setSlashOpen(false)}
 				onPick={onSlashPick}
+				query={slashQuery(text) ?? ""}
 			/>
 			<EffortSheet
 				open={effortOpen}
 				onClose={onCloseEffort}
+				pid={pid}
 				projection={projection}
 			/>
 		</div>

--- a/local_operator/mobile/web/src/components/composer.tsx
+++ b/local_operator/mobile/web/src/components/composer.tsx
@@ -65,7 +65,7 @@ function SlashSheet({
 					spellCheck={false}
 					autoCapitalize="off"
 					autoCorrect="off"
-					className="mb-1 min-h-11 rounded-sm border border-control bg-surface px-3 text-body text-ink outline-none placeholder:text-ink-dim"
+					className="mb-1 min-h-9 rounded-sm border border-control bg-surface px-3 text-body text-ink outline-none placeholder:text-ink-dim"
 				/>
 				{filtered.map((c) => (
 					<button
@@ -79,7 +79,7 @@ function SlashSheet({
 							}
 							onClose();
 						}}
-						className="flex min-h-11 items-center gap-2 rounded-sm px-3 text-left active:bg-surface"
+						className="flex min-h-8 items-center gap-2 rounded-sm px-2 text-left active:bg-surface"
 					>
 						<span className="shrink-0 font-mono text-mono-sm text-ink">
 							/{c.name}
@@ -127,7 +127,7 @@ function EffortSheet({
 						key={rung}
 						type="button"
 						onClick={() => set(rung)}
-						className="flex min-h-11 items-center gap-3 rounded-sm px-3 text-left active:bg-surface"
+						className="flex min-h-8 items-center gap-2 rounded-sm px-2 text-left active:bg-surface"
 					>
 						<span
 							className={cn(
@@ -242,7 +242,7 @@ export function Composer({
 	};
 
 	return (
-		<div className="flex flex-col gap-2 px-3 pt-2 pb-[max(env(safe-area-inset-bottom),0.75rem)]">
+		<div className="flex flex-col gap-1.5 px-3 pt-1.5 pb-[max(env(safe-area-inset-bottom),0.5rem)]">
 			{showResume && !projection.streaming && !disabled ? (
 				<button
 					type="button"
@@ -256,7 +256,7 @@ export function Composer({
 			{error ? <p className="text-body-sm text-danger">{error}</p> : null}
 
 			<div className="flex items-end gap-2">
-				<div className="flex min-w-0 flex-1 items-end rounded-md border border-control bg-elevated px-3.5 py-2.5">
+				<div className="flex min-w-0 flex-1 items-end rounded-md border border-control bg-elevated px-3 py-2">
 					<textarea
 						ref={textareaRef}
 						value={text}
@@ -305,7 +305,7 @@ export function Composer({
 				</button>
 			</div>
 
-			<div className="flex items-center gap-3 px-1">
+			<div className="flex items-center gap-2 px-0.5">
 				{projection.queued_count > 0 ? (
 					<span className="font-mono text-mono-sm text-ink-dim">
 						{projection.queued_count} queued
@@ -315,7 +315,7 @@ export function Composer({
 				<button
 					type="button"
 					onClick={onOpenModels}
-					className="flex min-h-11 items-center font-mono text-mono-sm text-ink-dim active:text-ink-muted"
+					className="flex min-h-8 items-center font-mono text-mono-sm text-ink-dim active:text-ink-muted"
 				>
 					{projection.model_label || "model"}
 				</button>
@@ -323,7 +323,7 @@ export function Composer({
 					<button
 						type="button"
 						onClick={onOpenEffort}
-						className="flex min-h-11 items-center font-mono text-mono-sm text-ink-dim active:text-ink-muted"
+						className="flex min-h-8 items-center font-mono text-mono-sm text-ink-dim active:text-ink-muted"
 					>
 						{projection.effort || "effort"}
 					</button>

--- a/local_operator/mobile/web/src/components/markdown.tsx
+++ b/local_operator/mobile/web/src/components/markdown.tsx
@@ -201,14 +201,14 @@ const HEADING_CLASSES = [
 export function Markdown({ text }: { text: string }) {
 	const blocks = splitBlocks(text);
 	return (
-		<div className="flex flex-col gap-2">
+		<div className="flex flex-col gap-1.5">
 			{blocks.map((b) => {
 				switch (b.kind) {
 					case "code":
 						return (
 							<pre
 								key={key()}
-								className="lo-scroll overflow-x-auto rounded-sm bg-sunken p-3 font-mono text-mono-sm whitespace-pre"
+								className="lo-scroll overflow-x-auto rounded-sm bg-sunken p-2 font-mono text-mono-sm leading-snug whitespace-pre"
 							>
 								{b.lines.join("\n")}
 							</pre>
@@ -228,7 +228,7 @@ export function Markdown({ text }: { text: string }) {
 						);
 					case "ul":
 						return (
-							<ul key={key()} className="flex list-disc flex-col gap-1 pl-5">
+							<ul key={key()} className="flex list-disc flex-col gap-0.5 pl-5">
 								{b.lines.map((li) => (
 									<li key={key()}>{renderInline(li)}</li>
 								))}
@@ -238,7 +238,7 @@ export function Markdown({ text }: { text: string }) {
 						return (
 							<ol
 								key={key()}
-								className="flex list-decimal flex-col gap-1 pl-5"
+								className="flex list-decimal flex-col gap-0.5 pl-5"
 							>
 								{b.lines.map((li) => (
 									<li key={key()}>{renderInline(li)}</li>

--- a/local_operator/mobile/web/src/components/markdown.tsx
+++ b/local_operator/mobile/web/src/components/markdown.tsx
@@ -42,7 +42,7 @@ function renderInline(text: string): ReactNode[] {
 			out.push(
 				<code
 					key={key()}
-					className="rounded-xs bg-sunken px-1 font-mono text-mono-sm"
+					className="rounded-xs bg-sunken px-0.5 font-mono text-mono-sm"
 				>
 					{code.slice(1, -1)}
 				</code>,

--- a/local_operator/mobile/web/src/components/model-sheet.tsx
+++ b/local_operator/mobile/web/src/components/model-sheet.tsx
@@ -12,10 +12,13 @@ import { Sheet } from "./ui/sheet";
 export function ModelSheet({
 	open,
 	onClose,
+	pid,
 	projection,
 }: {
 	open: boolean;
 	onClose: () => void;
+	/** Route pid — the discovery record's, not the fold's (which stamps 0). */
+	pid: number;
 	projection: SessionProjection;
 }) {
 	const [models, setModels] = useState<ModelEntry[]>([]);
@@ -49,7 +52,7 @@ export function ModelSheet({
 
 	const choose = async (m: ModelEntry) => {
 		try {
-			await sendCommand(projection.pid, {
+			await sendCommand(pid, {
 				op: "set_model",
 				provider: m.provider,
 				model_id: m.model_id,

--- a/local_operator/mobile/web/src/components/model-sheet.tsx
+++ b/local_operator/mobile/web/src/components/model-sheet.tsx
@@ -70,7 +70,7 @@ export function ModelSheet({
 					spellCheck={false}
 					autoCapitalize="off"
 					autoCorrect="off"
-					className="mb-1 min-h-11 rounded-sm border border-control bg-surface px-3 text-body text-ink outline-none placeholder:text-ink-dim"
+					className="mb-1 min-h-9 rounded-sm border border-control bg-surface px-3 text-body text-ink outline-none placeholder:text-ink-dim"
 				/>
 				{error ? (
 					<p className="px-3 py-1 text-body-sm text-danger">
@@ -90,7 +90,7 @@ export function ModelSheet({
 									key={m.selector}
 									type="button"
 									onClick={() => void choose(m)}
-									className="flex min-h-11 items-center gap-3 rounded-sm px-3 text-left active:bg-surface"
+									className="flex min-h-8 items-center gap-2 rounded-sm px-2 text-left active:bg-surface"
 								>
 									<span
 										className={cn(

--- a/local_operator/mobile/web/src/components/pending-card.tsx
+++ b/local_operator/mobile/web/src/components/pending-card.tsx
@@ -58,14 +58,14 @@ export function PendingCard({
 		);
 
 	return (
-		<div className="border-accent bg-accent-wash mx-3 flex flex-col gap-3 rounded-lg border p-3">
-			<div className="flex flex-col gap-1">
+		<div className="border-accent bg-accent-wash mx-2 flex flex-col gap-2 rounded-md border p-2.5">
+			<div className="flex flex-col gap-0.5">
 				<span className="text-meta text-accent">
 					{pending.kind === "approval"
 						? "approval needed"
 						: "question"}
 				</span>
-				<span className="text-heading">{pending.title}</span>
+				<span className="text-body font-medium">{pending.title}</span>
 				{pending.detail ? (
 					<p className="text-body-sm text-ink-muted whitespace-pre-wrap">
 						{pending.detail}

--- a/local_operator/mobile/web/src/components/subagents-panel.tsx
+++ b/local_operator/mobile/web/src/components/subagents-panel.tsx
@@ -54,7 +54,7 @@ export function SubagentsPanel({ subagents }: { subagents: SubagentRow[] }) {
 							key={s.job_id}
 							type="button"
 							onClick={() => setSelected(s)}
-							className="flex min-h-11 w-full flex-col justify-center rounded-sm px-1 text-left active:bg-elevated"
+							className="flex min-h-8 w-full flex-col justify-center rounded-sm px-1 text-left active:bg-elevated"
 						>
 							<span className="flex w-full items-center gap-2">
 								<span

--- a/local_operator/mobile/web/src/components/tool-row.tsx
+++ b/local_operator/mobile/web/src/components/tool-row.tsx
@@ -55,11 +55,18 @@ export function ToolRow({ entry }: { entry: TranscriptEntry }) {
 		entry.error;
 
 	return (
-		<div>
+		<div
+			className={cn(
+				"rounded-sm px-1.5",
+				running && "bg-elevated",
+				entry.tool_state === "failed" && "bg-danger-wash",
+				entry.tool_state === "done" && "bg-surface",
+			)}
+		>
 			<button
 				type="button"
 				onClick={() => hasDetails && setOpen(!open)}
-				className="flex min-h-11 w-full items-center gap-2 text-left select-none"
+				className="flex min-h-8 w-full items-center gap-1.5 text-left select-none"
 			>
 				<span
 					className={cn(
@@ -107,7 +114,7 @@ export function ToolRow({ entry }: { entry: TranscriptEntry }) {
 				) : null}
 			</button>
 			{open && hasDetails ? (
-				<div className="flex flex-col gap-2 pt-1 pb-2 pl-6">
+				<div className="flex flex-col gap-1.5 pb-1 pl-6">
 					{entry.intent ? (
 						<p className="text-body-sm text-ink-muted">
 							{entry.intent}

--- a/local_operator/mobile/web/src/components/transcript.tsx
+++ b/local_operator/mobile/web/src/components/transcript.tsx
@@ -21,7 +21,7 @@ function Entry({ entry }: { entry: TranscriptEntry }) {
 		case "user":
 			return (
 				<div className="flex justify-end">
-					<div className="max-w-[85%] rounded-frame bg-elevated px-3 py-2 text-body whitespace-pre-wrap">
+					<div className="max-w-[85%] rounded-md border border-hairline bg-surface px-3 py-1.5 text-body leading-normal whitespace-pre-wrap">
 						{entry.text}
 					</div>
 				</div>
@@ -29,14 +29,14 @@ function Entry({ entry }: { entry: TranscriptEntry }) {
 		case "steer":
 			return (
 				<div className="flex justify-end">
-					<div className="max-w-[85%] rounded-frame border border-hairline px-3 py-2 text-body-sm text-ink-muted whitespace-pre-wrap">
+					<div className="max-w-[85%] rounded-md border border-hairline px-3 py-1 text-body-sm text-ink-muted whitespace-pre-wrap">
 						{entry.text}
 					</div>
 				</div>
 			);
 		case "assistant":
 			return (
-				<div className="text-body">
+				<div className="text-body leading-normal">
 					<Markdown text={entry.text} />
 					{!entry.final ? (
 						<span className="lo-caret" aria-hidden />
@@ -48,7 +48,7 @@ function Entry({ entry }: { entry: TranscriptEntry }) {
 		case "notice":
 		case "compaction":
 			return (
-				<p className="py-1 text-center text-meta text-ink-dim">
+				<p className="text-center text-meta text-ink-dim">
 					{entry.text}
 				</p>
 			);
@@ -86,7 +86,7 @@ export function Transcript({ entries }: { entries: TranscriptEntry[] }) {
 			ref={scrollRef}
 			onScroll={onScroll}
 			className={cn(
-				"lo-scroll flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto px-4 py-3",
+				"lo-scroll flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto px-3 py-2",
 			)}
 		>
 			{hiddenCount > 0 ? (

--- a/local_operator/mobile/web/src/components/transcript.tsx
+++ b/local_operator/mobile/web/src/components/transcript.tsx
@@ -48,7 +48,7 @@ function Entry({ entry }: { entry: TranscriptEntry }) {
 		case "notice":
 		case "compaction":
 			return (
-				<p className="text-center text-meta text-ink-dim">
+				<p className="text-meta text-ink-dim">
 					{entry.text}
 				</p>
 			);

--- a/local_operator/mobile/web/src/components/ui/disclosure.tsx
+++ b/local_operator/mobile/web/src/components/ui/disclosure.tsx
@@ -39,7 +39,7 @@ export function Disclosure({
 				aria-expanded={open}
 				onClick={() => setOpen(!open)}
 				className={cn(
-					"flex min-h-11 w-full items-center gap-1 text-left select-none",
+					"flex min-h-8 w-full items-center gap-1 text-left select-none",
 					headerClassName,
 				)}
 			>

--- a/local_operator/mobile/web/src/components/ui/sheet.tsx
+++ b/local_operator/mobile/web/src/components/ui/sheet.tsx
@@ -8,6 +8,7 @@
  * click dismisses; there is no drag gesture in v1.
  */
 import { useEffect, type ReactNode } from "react";
+import { createPortal } from "react-dom";
 import { cn } from "../../lib/cn";
 
 export function Sheet({
@@ -32,8 +33,18 @@ export function Sheet({
 	}, [open, onClose]);
 
 	if (!open) return null;
-	return (
-		<div className="fixed inset-0 z-50" role="dialog" aria-modal="true">
+	/* Portal to body so a parent transform (the iOS visualViewport pin
+	   on the session column) cannot trap `position: fixed` and clip the
+	   sheet to a sliver at the column's bottom. */
+	return createPortal(
+		<div
+			className="fixed inset-0 z-50 flex justify-center"
+			role="dialog"
+			aria-modal="true"
+		>
+			{/* The phone column is max-w-md; keep the sheet inside it even
+			    after portaling out of the transformed session root. */}
+			<div className="relative h-full w-full max-w-md">
 			<button
 				type="button"
 				aria-label="close"
@@ -42,14 +53,14 @@ export function Sheet({
 			/>
 			<div
 				className={cn(
-					"lo-sheet-panel absolute right-0 bottom-0 left-0 max-h-[85dvh]",
+					"lo-sheet-panel absolute right-0 bottom-0 left-0 h-[70dvh] max-h-[85dvh]",
 					"flex flex-col rounded-t-lg border-t border-control bg-elevated shadow-overlay",
 					/* The panel clears the home indicator; content sits above it. */
 					"pb-[env(safe-area-inset-bottom)]",
 				)}
 			>
 				{title ? (
-					<div className="flex items-center justify-between px-4 pt-3 pb-2">
+					<div className="flex items-center justify-between px-3 pt-2 pb-1">
 						<span className="text-meta font-medium tracking-[0.08em] text-ink-muted">
 							{title}
 						</span>
@@ -67,6 +78,8 @@ export function Sheet({
 					{children}
 				</div>
 			</div>
-		</div>
+			</div>
+		</div>,
+		document.body,
 	);
 }

--- a/local_operator/mobile/web/src/components/ui/sheet.tsx
+++ b/local_operator/mobile/web/src/components/ui/sheet.tsx
@@ -50,7 +50,7 @@ export function Sheet({
 			/>
 			<div
 				className={cn(
-					"lo-sheet-panel absolute right-0 bottom-0 left-0 h-[70dvh] max-h-[85dvh]",
+					"lo-sheet-panel absolute right-0 bottom-0 left-0 max-h-[85dvh]",
 					"flex flex-col rounded-t-lg border-t border-control bg-elevated shadow-overlay",
 					/* The panel clears the home indicator; content sits above it. */
 					"pb-[env(safe-area-inset-bottom)]",

--- a/local_operator/mobile/web/src/components/ui/sheet.tsx
+++ b/local_operator/mobile/web/src/components/ui/sheet.tsx
@@ -8,7 +8,6 @@
  * click dismisses; there is no drag gesture in v1.
  */
 import { useEffect, type ReactNode } from "react";
-import { createPortal } from "react-dom";
 import { cn } from "../../lib/cn";
 
 export function Sheet({
@@ -33,18 +32,16 @@ export function Sheet({
 	}, [open, onClose]);
 
 	if (!open) return null;
-	/* Portal to body so a parent transform (the iOS visualViewport pin
-	   on the session column) cannot trap `position: fixed` and clip the
-	   sheet to a sliver at the column's bottom. */
-	return createPortal(
+	/* In-flow overlay, not a portal: the cmux screenshot surface is the
+	   phone column, and a body portal paints outside it. The session
+	   column is `relative` and no longer uses transform, so `absolute
+	   inset-0` covers exactly the column. */
+	return (
 		<div
-			className="fixed inset-0 z-50 flex justify-center"
+			className="absolute inset-0 z-50"
 			role="dialog"
 			aria-modal="true"
 		>
-			{/* The phone column is max-w-md; keep the sheet inside it even
-			    after portaling out of the transformed session root. */}
-			<div className="relative h-full w-full max-w-md">
 			<button
 				type="button"
 				aria-label="close"
@@ -78,8 +75,6 @@ export function Sheet({
 					{children}
 				</div>
 			</div>
-			</div>
-		</div>,
-		document.body,
+		</div>
 	);
 }

--- a/local_operator/mobile/web/src/screens/new-session.tsx
+++ b/local_operator/mobile/web/src/screens/new-session.tsx
@@ -79,7 +79,7 @@ export function NewSessionScreen() {
 				</button>
 				<h1 className="text-heading">new session</h1>
 			</header>
-			<main className="flex flex-1 flex-col gap-4 px-4 pb-4">
+			<main className="flex flex-1 flex-col gap-3 px-3 pb-3">
 				<section className="flex flex-col gap-2">
 					<label
 						htmlFor="cwd-input"
@@ -109,7 +109,7 @@ export function NewSessionScreen() {
 										type="button"
 										onClick={() => setCwd(p)}
 										className={cn(
-											"flex min-h-11 items-center gap-2 rounded-sm px-2 text-left active:bg-elevated",
+											"flex min-h-8 items-center gap-2 rounded-sm px-2 text-left active:bg-elevated",
 											cwd === p && "bg-accent-wash",
 										)}
 									>
@@ -176,7 +176,7 @@ export function NewSessionScreen() {
 							setModel(null);
 							setModelSheetOpen(false);
 						}}
-						className="flex min-h-11 items-center rounded-sm px-3 text-left text-ink-muted active:bg-surface"
+						className="flex min-h-8 items-center rounded-sm px-2 text-left text-ink-muted active:bg-surface"
 					>
 						default
 					</button>
@@ -188,7 +188,7 @@ export function NewSessionScreen() {
 								setModel(m);
 								setModelSheetOpen(false);
 							}}
-							className="flex min-h-11 items-center gap-2 rounded-sm px-3 text-left active:bg-surface"
+							className="flex min-h-8 items-center gap-2 rounded-sm px-2 text-left active:bg-surface"
 						>
 							<span className="min-w-0 flex-1 truncate text-body">
 								{m.name}

--- a/local_operator/mobile/web/src/screens/new-session.tsx
+++ b/local_operator/mobile/web/src/screens/new-session.tsx
@@ -67,7 +67,7 @@ export function NewSessionScreen() {
 	};
 
 	return (
-		<div className="relative mx-auto flex min-h-full w-full max-w-md flex-col">
+		<div className="relative mx-auto flex h-dvh w-full max-w-md flex-col">
 			<header className="flex items-center gap-2 px-2 pt-[max(env(safe-area-inset-top),0.75rem)] pb-3">
 				<button
 					type="button"

--- a/local_operator/mobile/web/src/screens/new-session.tsx
+++ b/local_operator/mobile/web/src/screens/new-session.tsx
@@ -67,7 +67,7 @@ export function NewSessionScreen() {
 	};
 
 	return (
-		<div className="mx-auto flex min-h-full w-full max-w-md flex-col">
+		<div className="relative mx-auto flex min-h-full w-full max-w-md flex-col">
 			<header className="flex items-center gap-2 px-2 pt-[max(env(safe-area-inset-top),0.75rem)] pb-3">
 				<button
 					type="button"

--- a/local_operator/mobile/web/src/screens/past-sessions.tsx
+++ b/local_operator/mobile/web/src/screens/past-sessions.tsx
@@ -43,7 +43,7 @@ export function PastSessionsScreen() {
 				</button>
 				<h1 className="text-heading">past sessions</h1>
 			</header>
-			<main className="flex flex-1 flex-col gap-1 px-4 pb-4">
+			<main className="flex flex-1 flex-col gap-0.5 px-2 pb-3">
 				{error ? (
 					<p className="text-body-sm text-danger">{error}</p>
 				) : sessions === null ? (
@@ -58,7 +58,7 @@ export function PastSessionsScreen() {
 							<button
 								type="button"
 								onClick={() => copy(s.id)}
-								className="flex min-h-11 w-full items-center gap-2 rounded-sm px-2 text-left active:bg-elevated"
+								className="flex min-h-8 w-full items-center gap-2 rounded-sm px-2 text-left active:bg-elevated"
 							>
 								<span className="min-w-0 flex-1">
 									<span className="block truncate text-body">

--- a/local_operator/mobile/web/src/screens/session-list.tsx
+++ b/local_operator/mobile/web/src/screens/session-list.tsx
@@ -30,30 +30,30 @@ function SessionCard({ s, home }: { s: SessionSummary; home: string }) {
 			type="button"
 			onClick={() => navigate(`/s/${s.pid}`)}
 			className={cn(
-				"flex w-full flex-col gap-1.5 rounded-md px-3 py-3 text-left select-none active:bg-elevated",
+				"flex w-full flex-col gap-0.5 rounded-md px-2 py-1.5 text-left select-none active:bg-elevated",
 				s.ended && "text-ink-disabled",
 			)}
 		>
 			<div className="flex items-center gap-2">
 				{s.needs_attention && pendingLabel ? (
-					<>
-						<span
-							className="lo-pulse inline-block size-2 shrink-0 rounded-full bg-danger"
-							aria-hidden
-						/>
-						<span className="text-meta text-danger">
-							{pendingLabel}
-						</span>
-					</>
+					<span
+						className="lo-pulse inline-block size-1.5 shrink-0 rounded-full bg-danger"
+						aria-hidden
+					/>
 				) : null}
 				<span
 					className={cn(
-						"min-w-0 flex-1 truncate text-heading",
+						"min-w-0 flex-1 truncate text-body-sm font-medium",
 						s.streaming && !s.ended && "lo-shimmer",
 					)}
 				>
 					{s.conversation_name || "untitled"}
 				</span>
+				{s.needs_attention && pendingLabel ? (
+					<span className="shrink-0 text-meta text-danger">
+						{pendingLabel}
+					</span>
+				) : null}
 				{s.subagents_running > 0 ? (
 					<span className="shrink-0 font-mono text-mono-sm text-ink-dim">
 						⟳ {s.subagents_running}
@@ -64,29 +64,18 @@ function SessionCard({ s, home }: { s: SessionSummary; home: string }) {
 						{s.todos_open}
 					</span>
 				) : null}
+				{s.ended ? (
+					<span className="shrink-0 text-meta text-ink-dim">ended</span>
+				) : null}
 			</div>
 			<div className="flex items-baseline gap-2">
-				<span className="shrink-0 font-mono text-mono-sm text-ink-muted">
-					{basename(s.cwd)}
-				</span>
 				<span className="min-w-0 truncate font-mono text-mono-sm text-ink-dim">
-					{shortenHome(s.cwd, home)}
+					{basename(s.cwd)}
+					{home ? ` · ${shortenHome(s.cwd, home)}` : ""}
 				</span>
-			</div>
-			<div className="flex items-center gap-2">
-				<span className="min-w-0 flex-1 truncate text-meta text-ink-dim">
+				<span className="ml-auto shrink-0 font-mono text-mono-sm text-ink-dim">
 					{s.model_label}
 				</span>
-				{s.degraded ? (
-					<span className="shrink-0 rounded-sm bg-warning-wash px-1.5 text-meta text-warning">
-						reconnecting
-					</span>
-				) : null}
-				{s.ended ? (
-					<span className="shrink-0 rounded-sm bg-sunken px-1.5 text-meta text-ink-dim">
-						ended
-					</span>
-				) : null}
 			</div>
 		</button>
 	);
@@ -111,7 +100,7 @@ function ThemePicker({
 							applyTheme(t.id);
 							setCurrent(t.id);
 						}}
-						className="flex min-h-11 items-center gap-3 rounded-sm px-3 text-left active:bg-surface"
+						className="flex min-h-8 items-center gap-2 rounded-sm px-2 text-left active:bg-surface"
 					>
 						<span
 							className={cn(
@@ -153,18 +142,18 @@ export function SessionListScreen() {
 
 	return (
 		<div className="mx-auto flex min-h-full w-full max-w-md flex-col">
-			<header className="flex items-center gap-3 px-4 pt-[max(env(safe-area-inset-top),1.25rem)] pb-4">
+			<header className="flex items-center gap-2 px-3 pt-[max(env(safe-area-inset-top),0.75rem)] pb-2">
 				<img
 					src="/mark.png"
 					alt=""
-					width={28}
-					height={28}
+					width={20}
+					height={20}
 				/>
 				<h1 className="text-meta font-medium tracking-[0.18em] text-ink">
 					local operator
 				</h1>
 			</header>
-			<main className="flex flex-1 flex-col px-2 pb-4">
+			<main className="flex flex-1 flex-col px-1 pb-2">
 				{sessions.length === 0 ? (
 					<div className="flex flex-1 flex-col items-center justify-center gap-2 px-6 text-center">
 						<p className="text-body text-ink-muted">
@@ -184,7 +173,7 @@ export function SessionListScreen() {
 					</div>
 				)}
 			</main>
-			<footer className="flex items-center gap-2 border-t border-hairline px-4 py-3 pb-[max(env(safe-area-inset-bottom),0.75rem)]">
+			<footer className="flex items-center gap-2 border-t border-hairline px-3 py-2 pb-[max(env(safe-area-inset-bottom),0.5rem)]">
 				<button
 					type="button"
 					onClick={() => navigate("/new")}

--- a/local_operator/mobile/web/src/screens/session-list.tsx
+++ b/local_operator/mobile/web/src/screens/session-list.tsx
@@ -61,7 +61,7 @@ function SessionCard({ s, home }: { s: SessionSummary; home: string }) {
 				) : null}
 				{s.todos_open ? (
 					<span className="shrink-0 font-mono text-mono-sm text-ink-dim">
-						{s.todos_open}
+						☐ {s.todos_open}
 					</span>
 				) : null}
 				{s.ended ? (
@@ -70,8 +70,7 @@ function SessionCard({ s, home }: { s: SessionSummary; home: string }) {
 			</div>
 			<div className="flex items-baseline gap-2">
 				<span className="min-w-0 truncate font-mono text-mono-sm text-ink-dim">
-					{basename(s.cwd)}
-					{home ? ` · ${shortenHome(s.cwd, home)}` : ""}
+					{home ? shortenHome(s.cwd, home) : s.cwd}
 				</span>
 				<span className="ml-auto shrink-0 font-mono text-mono-sm text-ink-dim">
 					{s.model_label}

--- a/local_operator/mobile/web/src/screens/session-list.tsx
+++ b/local_operator/mobile/web/src/screens/session-list.tsx
@@ -14,7 +14,7 @@ import { Sheet } from "../components/ui/sheet";
 import { navigate } from "../router";
 import { retainSessionListStream, useSessions } from "../store";
 import { applyTheme, getTheme, THEMES } from "../theme";
-import { basename, shortenHome } from "../lib/format";
+import { shortenHome } from "../lib/format";
 import type { SessionSummary } from "../types";
 import { cn } from "../lib/cn";
 

--- a/local_operator/mobile/web/src/screens/session-list.tsx
+++ b/local_operator/mobile/web/src/screens/session-list.tsx
@@ -141,7 +141,7 @@ export function SessionListScreen() {
 	}, []);
 
 	return (
-		<div className="mx-auto flex min-h-full w-full max-w-md flex-col">
+		<div className="relative mx-auto flex min-h-full w-full max-w-md flex-col">
 			<header className="flex items-center gap-2 px-3 pt-[max(env(safe-area-inset-top),0.75rem)] pb-2">
 				<img
 					src="/mark.png"

--- a/local_operator/mobile/web/src/screens/session-list.tsx
+++ b/local_operator/mobile/web/src/screens/session-list.tsx
@@ -141,7 +141,7 @@ export function SessionListScreen() {
 	}, []);
 
 	return (
-		<div className="relative mx-auto flex min-h-full w-full max-w-md flex-col">
+		<div className="relative mx-auto flex h-dvh w-full max-w-md flex-col">
 			<header className="flex items-center gap-2 px-3 pt-[max(env(safe-area-inset-top),0.75rem)] pb-2">
 				<img
 					src="/mark.png"

--- a/local_operator/mobile/web/src/screens/session-view.tsx
+++ b/local_operator/mobile/web/src/screens/session-view.tsx
@@ -70,8 +70,11 @@ export function SessionScreen({ pid }: { pid: number }) {
 		const el = rootRef.current;
 		if (!vv || !el) return;
 		const sync = () => {
+			/* Height + top, never transform: a transform on this column
+			   creates a containing block that traps `position: fixed`
+			   sheets (slash, model, effort) and clips them to a sliver. */
 			el.style.height = `${vv.height}px`;
-			el.style.transform = `translateY(${vv.offsetTop}px)`;
+			el.style.top = `${vv.offsetTop}px`;
 		};
 		sync();
 		vv.addEventListener("resize", sync);
@@ -80,7 +83,7 @@ export function SessionScreen({ pid }: { pid: number }) {
 			vv.removeEventListener("resize", sync);
 			vv.removeEventListener("scroll", sync);
 			el.style.height = "";
-			el.style.transform = "";
+			el.style.top = "";
 		};
 	}, []);
 
@@ -88,7 +91,7 @@ export function SessionScreen({ pid }: { pid: number }) {
 		return (
 			<div
 				ref={rootRef}
-				className="mx-auto flex h-dvh w-full max-w-md flex-col overflow-hidden"
+				className="relative mx-auto flex h-dvh w-full max-w-md flex-col overflow-hidden"
 			>
 				<header className="flex items-center gap-2 border-b border-hairline px-1 py-1 pt-[max(env(safe-area-inset-top),0.25rem)]">
 					<button
@@ -114,7 +117,7 @@ export function SessionScreen({ pid }: { pid: number }) {
 	return (
 		<div
 			ref={rootRef}
-			className="mx-auto flex h-dvh w-full max-w-md flex-col overflow-hidden"
+			className="relative mx-auto flex h-dvh w-full max-w-md flex-col overflow-hidden"
 		>
 			<Header projection={projection} />
 
@@ -143,6 +146,7 @@ export function SessionScreen({ pid }: { pid: number }) {
 			) : null}
 
 			<Composer
+				pid={pid}
 				projection={projection}
 				onOpenModels={() => setModelsOpen(true)}
 				onOpenEffort={() => setEffortOpen(true)}
@@ -153,6 +157,7 @@ export function SessionScreen({ pid }: { pid: number }) {
 			<ModelSheet
 				open={modelsOpen}
 				onClose={() => setModelsOpen(false)}
+				pid={pid}
 				projection={projection}
 			/>
 		</div>

--- a/local_operator/mobile/web/src/screens/session-view.tsx
+++ b/local_operator/mobile/web/src/screens/session-view.tsx
@@ -35,7 +35,7 @@ function Header({
 				? "lo-pulse bg-accent"
 				: "bg-success";
 	return (
-		<header className="flex items-center gap-2 border-b border-hairline px-2 py-2 pt-[max(env(safe-area-inset-top),0.5rem)]">
+		<header className="flex items-center gap-2 border-b border-hairline px-1 py-1 pt-[max(env(safe-area-inset-top),0.25rem)]">
 			<button
 				type="button"
 				onClick={() => navigate("/")}
@@ -48,7 +48,7 @@ function Header({
 				className={cn("size-2 shrink-0 rounded-full", status)}
 				aria-hidden
 			/>
-			<span className="min-w-0 flex-1 truncate text-heading">
+			<span className="min-w-0 flex-1 truncate text-body-sm font-medium">
 				{projection.conversation_name || "untitled"}
 			</span>
 		</header>
@@ -90,7 +90,7 @@ export function SessionScreen({ pid }: { pid: number }) {
 				ref={rootRef}
 				className="mx-auto flex h-dvh w-full max-w-md flex-col overflow-hidden"
 			>
-				<header className="flex items-center gap-2 border-b border-hairline px-2 py-2 pt-[max(env(safe-area-inset-top),0.5rem)]">
+				<header className="flex items-center gap-2 border-b border-hairline px-1 py-1 pt-[max(env(safe-area-inset-top),0.25rem)]">
 					<button
 						type="button"
 						onClick={() => navigate("/")}

--- a/local_operator/mobile/web/src/screens/session-view.tsx
+++ b/local_operator/mobile/web/src/screens/session-view.tsx
@@ -40,7 +40,7 @@ function Header({
 				type="button"
 				onClick={() => navigate("/")}
 				aria-label="back to sessions"
-				className="flex min-h-11 min-w-11 items-center justify-center rounded-sm text-ink-muted active:bg-elevated"
+				className="flex min-h-8 min-w-8 items-center justify-center rounded-sm text-ink-muted active:bg-elevated"
 			>
 				‹
 			</button>
@@ -98,7 +98,7 @@ export function SessionScreen({ pid }: { pid: number }) {
 						type="button"
 						onClick={() => navigate("/")}
 						aria-label="back to sessions"
-						className="flex min-h-11 min-w-11 items-center justify-center rounded-sm text-ink-muted active:bg-elevated"
+						className="flex min-h-8 min-w-8 items-center justify-center rounded-sm text-ink-muted active:bg-elevated"
 					>
 						‹
 					</button>

--- a/tests/unit/mobile/test_install.py
+++ b/tests/unit/mobile/test_install.py
@@ -1,0 +1,84 @@
+"""The launchd control commands have to work from whatever state launchd is
+actually in — a plist can exist while the agent was never bootstrapped, and
+`restart` failing with "Could not find service" is exactly that gap.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import patch
+
+from local_operator.mobile import install
+
+
+class FakeProc:
+    def __init__(self, returncode: int = 0, stdout: str = "", stderr: str = "") -> None:
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+class FakePlistPath:
+    """A plist path that reports existing without touching the filesystem.
+
+    ``service_action`` bootstraps only when the plist exists; pointing the
+    mock at a real path couples the test to whatever happens to be in
+    ~/Library/LaunchAgents, so the fake stands in for the file."""
+
+    def __init__(self, exists: bool = True) -> None:
+        self._exists = exists
+
+    def exists(self) -> bool:
+        return self._exists
+
+    def __str__(self) -> str:
+        return "/tmp/fake.plist"
+
+    def __fspath__(self) -> str:
+        return str(self)
+
+
+def test_restart_bootstraps_when_the_agent_is_missing() -> None:
+    calls: list[list[str]] = []
+
+    def run(*cmd: str) -> subprocess.CompletedProcess[str]:
+        calls.append(list(cmd))
+        # _launchctl is called with the arguments only ("print", ...), not
+        # the "launchctl" argv[0].
+        if list(cmd)[0] == "print":
+            # Real launchctl: "Bad request." on stdout, the service message on
+            # stderr, exit 113.
+            return FakeProc(  # type: ignore[return-value]
+                returncode=113, stdout="Bad request.", stderr='Could not find service "x"'
+            )
+        return FakeProc(returncode=0)  # type: ignore[return-value]
+
+    with (
+        patch.object(install, "_launchctl", side_effect=run),
+        patch.object(install, "plist_path", return_value=FakePlistPath()),
+    ):
+        result = install.service_action("restart")
+
+    assert result["ok"] is True
+    verbs = [c[0] for c in calls]
+    # print (missing) -> bootstrap -> kickstart -k, in that order.
+    assert verbs == ["print", "bootstrap", "kickstart"]
+
+
+def test_restart_does_not_bootstrap_a_live_agent() -> None:
+    calls: list[list[str]] = []
+
+    def run(*cmd: str) -> subprocess.CompletedProcess[str]:
+        calls.append(list(cmd))
+        if list(cmd)[0] == "print":
+            return FakeProc(returncode=0, stdout="pid = 4242")  # type: ignore[return-value]
+        return FakeProc(returncode=0)  # type: ignore[return-value]
+
+    with (
+        patch.object(install, "_launchctl", side_effect=run),
+        patch.object(install, "plist_path", return_value=FakePlistPath()),
+    ):
+        result = install.service_action("restart")
+
+    assert result["ok"] is True
+    assert not any(c[1:2] == ["bootstrap"] for c in calls)


### PR DESCRIPTION
## What

Three field fixes from the first real install of the mobile control plane (#188), plus a density pass so the phone UI matches the TUI instead of reading like a marketing list.

### Launchd restart (ef41e90)
`lop mobile restart` returned `Could not find service` when the plist existed but the agent had never bootstrapped (or had been booted out). `start` / `restart` now bootstrap on demand. Also raises the control-socket `StreamReader` limit to the registrant's 1 MB so a transcript push no longer raises `ValueError` and leaves the session on `connecting…`.

### Density (a41acd4)
- Transcript is TUI ledger rhythm: `gap-2`, tool rows `min-h-8` on a filled surface (running / failed / done), notices flush.
- Session roster is two lines (name + cwd · model), matching the desktop sidebar.
- Pickers (slash, model, effort, theme) drop to `min-h-8`; 44px stays on send / approve / new session.
- Sheets stay in-column (no body portal, no `transform` trap).

### Projection pid (9199f0f)
The fold stamped `pid: 0`, so drafts and composer commands missed the real session. The daemon overlays the discovery-record pid, and the route pid is passed into Composer / ModelSheet / EffortSheet. Slash sheet distinguishes loading from an empty catalogue.

## How to verify

```bash
cd local_operator/mobile/web && pnpm build
LOP_MOBILE_PASSWORD=test lop mobile start --port 4098
open http://127.0.0.1:4098
```

## Testing evidence

Drove a real daemon on :4098 through the cmux browser:

- Login → session list (roster two-line)
- Prompt → approval → wrote `/tmp/mobile-e2e.txt` (`test`)
- Todos 2/2, model switch (restored), effort switch (restored), prompt / steer / abort
- Past sessions (20 rows), slash sheet, session switch

Stills: roster, session, past, slash in /tmp/e2e-*.png.

58 mobile unit tests pass (launchd restart, daemon dial, projection fold).

## Reviewer notes

- No credential or auth changes.
- `install.py` change is macOS launchd-only.
- Web dist is built and served from `local_operator/mobile/web/dist/` (gitignored; built at release / local verify).
