### PR TITLE
fix(eval): gate subprocess argv in error rendering on prior disclosure

### DIFF
--- a/local_operator/tools/eval_worker.py
+++ b/local_operator/tools/eval_worker.py
@@ -245,6 +245,12 @@ def _redact_process_exception_chain(exc: BaseException) -> None:
         # __context__ is the implicit chain (an exception raised while handling
         # another); it is what a bare ``raise`` inside ``except`` produces.
         stack.append(current.__context__)
+        # format_exception renders ExceptionGroup LEAVES, so a CalledProcessError
+        # raised inside an asyncio.TaskGroup task is rendered too — and leaks
+        # argv if the walk stops at the group. Descend into .exceptions under
+        # the same visited set. BaseExceptionGroup carries the attribute; a
+        # plain exception simply does not, hence the getattr default.
+        stack.extend(getattr(current, "exceptions", ()))
 
 
 _REPR = reprlib.Repr()

--- a/local_operator/tools/eval_worker.py
+++ b/local_operator/tools/eval_worker.py
@@ -54,6 +54,8 @@ import contextlib
 import io
 import json
 import reprlib
+import shlex
+import subprocess
 import sys
 import traceback
 from collections.abc import Callable
@@ -72,6 +74,177 @@ TRUNCATED_MARKER = "\n[…worker output truncated before protocol serialization]
 #: the same moment — writing to ``sys.stdout`` there would land in the capture
 #: buffer and never be seen.
 _PROTOCOL_OUT = sys.stdout
+
+# ---------------------------------------------------------------------------
+# Disclosure-gated redaction of subprocess argv in error rendering
+# ---------------------------------------------------------------------------
+# A cell that spawns a subprocess routinely puts a credential in argv
+# (``curl -H "Authorization: Bearer …"``, ``psql <dsn>``, ``mongosh <uri>``).
+# Python re-renders that argv when the spawn fails and nobody told it which
+# argument is a secret: ``CalledProcessError.__str__`` and
+# ``TimeoutExpired.__str__`` interpolate ``self.cmd``, and ``format_exception``
+# writes the whole ``Command '[...]'`` into the traceback. That traceback is the
+# model-visible tool result, so the credential lands in the transcript even
+# though the model asked for none of it. A timing-out child is the worst case:
+# there is no output, so the argv is the entire content of the error.
+#
+# The guard is PRIOR-DISCLOSURE gating, not secret detection — guessing which
+# argv elements "look like" secrets fails in both directions. An argument is
+# re-rendered only when its exact bytes already appear in code the model itself
+# wrote in this kernel; those bytes are already in the transcript, so echoing
+# them discloses nothing new. Anything else — a value read from the
+# environment, a file, or a session credential — is replaced by its length
+# alone, ``<redacted:71c>``, which keeps the argument count and the failure
+# shape without carrying a single byte of the value (not even a digest, which
+# would be a small partial oracle).
+#
+# Consequences, all deliberate:
+#  - argv[0] is always rendered: an executable path is the most useful part of
+#    a spawn failure and is not a credential.
+#  - Nothing else about the failure changes — exception type, exit code,
+#    timeout and captured stdout/stderr are untouched. Only the invocation is
+#    filtered, and only in the UNCAUGHT rendering; a cell that catches the
+#    error and prints ``e.cmd`` is making an explicit choice and still sees it.
+#  - An all-disclosed command line comes back byte-identical, so the guard is
+#    invisible for ordinary failures like ``['git', 'status']``.
+#  - A value assembled at runtime reads as undisclosed even when its halves
+#    are in the source. That over-redacts a computed path; safe direction.
+#
+# The ledger is fed cell source AS EXECUTED, so a literal written in cell 1 can
+# reach argv in cell 5 and still count as disclosed. Retention is bounded; an
+# evicted entry only costs fidelity (over-redaction), never safety. Mirrors the
+# TypeScript policy in ``omp`` (utils/argv-disclosure.ts); the
+# ``<redacted:<N>c>`` shape must stay in sync with it.
+
+#: Cell sources retained for disclosure checks, newest last.
+_LEDGER_MAX_ENTRIES = 64
+#: Total bytes of retained cell source. Bounds a long-lived kernel's ledger.
+_LEDGER_MAX_BYTES = 256 * 1024
+
+
+class _ArgvDisclosureLedger:
+    """Bounded record of the code a model has run in one kernel.
+
+    Decides whether re-rendering a string discloses anything new. Retention is
+    bounded because a long session's cell history is otherwise unbounded.
+    """
+
+    def __init__(self) -> None:
+        self._entries: list[str] = []
+        self._bytes = 0
+
+    def record(self, source: str) -> None:
+        """Record cell source as disclosed to the transcript."""
+        if not source:
+            return
+        self._entries.append(source)
+        self._bytes += len(source)
+        while len(self._entries) > _LEDGER_MAX_ENTRIES or (
+            self._bytes > _LEDGER_MAX_BYTES and len(self._entries) > 1
+        ):
+            self._bytes -= len(self._entries.pop(0))
+
+    def discloses(self, text: str) -> bool:
+        """True when ``text``'s exact bytes already appear in recorded source.
+
+        Substring containment is the right test and not a weakening: a match
+        means those bytes are literally present in code the model wrote.
+        """
+        if not text:
+            return True
+        return any(text in entry for entry in self._entries)
+
+
+#: One ledger per kernel process; the worker is single-threaded over stdin.
+_ARGV_LEDGER = _ArgvDisclosureLedger()
+
+
+def _redacted_arg(value: str) -> str:
+    """Length-only placeholder for an undisclosed argument.
+
+    Space-free so it reads as one token inside a rendered command line, and
+    length-only so it carries no bytes of the value — not even a digest.
+    """
+    return f"<redacted:{len(value)}c>"
+
+
+def _redact_cmd_arg(arg: Any, seen_first: list[bool]) -> str:
+    """Render one ``cmd`` element, redacting it when the ledger has not seen it.
+
+    ``seen_first`` is a one-element cell so argv[0] is preserved verbatim (see
+    the module comment) without exposing the index here.
+    """
+    text = arg if isinstance(arg, str) else str(arg)
+    if not seen_first[0]:
+        seen_first[0] = True
+        return text
+    return text if _ARGV_LEDGER.discloses(text) else _redacted_arg(text)
+
+
+def _redact_cmd(cmd: Any) -> Any:
+    """Return ``cmd`` (list or string) with undisclosed arguments redacted.
+
+    A list is rebuilt element-wise; a string is split with ``shlex`` so a
+    quoted argument stays one piece (quote awareness is fidelity, not safety:
+    without it ``sh -c 'exit 3'`` half-redacts an innocent line). Unparseable
+    input is returned unchanged — over-redaction of a string we cannot safely
+    split would mangle legitimate diagnostics.
+    """
+    seen = [False]
+    if isinstance(cmd, (list, tuple)):
+        return [_redact_cmd_arg(a, seen) for a in cmd]
+    if isinstance(cmd, str):
+        try:
+            parts = shlex.split(cmd)
+        except ValueError:
+            return cmd
+        return " ".join(_redact_cmd_arg(a, seen) for a in parts)
+    return cmd
+
+
+def _redact_process_error_message(text: str) -> str:
+    """Redact an embedded ``Command '...'`` invocation in a rendered message.
+
+    The command line is rendered by the runtime inside the message, so we
+    recover it with the same ``shlex`` split and apply the disclosure gate
+    token by token. Only the first (argv[0]) token is preserved.
+    """
+    try:
+        tokens = shlex.split(text)
+    except ValueError:
+        return text
+    if not tokens:
+        return text
+    redacted = [_redact_cmd_arg(t, [False]) for t in tokens]
+    if redacted == tokens:
+        return text
+    # Replace longest-first so a redacted long token cannot be partially
+    # re-matched inside a shorter one it contains.
+    out = text
+    for original, masked in sorted(zip(tokens, redacted), key=lambda p: -len(p[0])):
+        if original != masked:
+            out = out.replace(original, masked)
+    return out
+
+
+def _redact_process_exception(exc: BaseException) -> None:
+    """Redact a process-invocation exception's argv in place before formatting.
+
+    Gating matters: this must never touch an ordinary error. It fires only for
+    the two stdlib types that embed argv — ``CalledProcessError`` and
+    ``TimeoutExpired`` — whose ``.cmd`` attribute carries the invocation.
+    """
+    if not isinstance(exc, (subprocess.CalledProcessError, subprocess.TimeoutExpired)):
+        return
+    cmd = getattr(exc, "cmd", None)
+    if cmd is None:
+        return
+    redacted = _redact_cmd(cmd)
+    if redacted is cmd or redacted == cmd:
+        return
+    with contextlib.suppress(Exception):
+        exc.cmd = redacted  # type: ignore[attr-defined]
+
 
 _REPR = reprlib.Repr()
 _REPR.maxstring = 4096
@@ -212,7 +385,18 @@ def _format_error(exc: BaseException) -> str:
     """
     if isinstance(exc, SyntaxError):
         return "".join(traceback.format_exception_only(type(exc), exc)).strip()
-    return "".join(traceback.format_exception(type(exc), exc, exc.__traceback__)).strip()
+    # Redact embedded subprocess argv BEFORE the traceback is rendered: the
+    # exception's ``__str__`` interpolates ``cmd`` at format time, so this is
+    # the single choke point. ``CalledProcessError.__str__`` reads ``self.cmd``
+    # fresh, and ``TimeoutExpired.__str__`` likewise, so rewriting the
+    # attribute is what the formatted output reflects.
+    _redact_process_exception(exc)
+    rendered = "".join(traceback.format_exception(type(exc), exc, exc.__traceback__)).strip()
+    # A chain (``raise ... from``) or a wrapper that rendered the command into
+    # its own message can still carry argv the attribute rewrite missed; the
+    # message-level pass is the backstop. It is gated on the same ledger, so it
+    # never touches a command the model actually wrote.
+    return _redact_process_error_message(rendered)
 
 
 def _execute(namespace: dict[str, Any], code: str) -> str | None:
@@ -269,6 +453,9 @@ def _handle(namespace: dict[str, Any], request: dict[str, Any]) -> dict[str, Any
     namespace["display"] = _make_display(display_sink)
 
     request_id = request.get("id", "")
+    # Record the source BEFORE running it: a failure in this very cell can
+    # reference literals written here, and those are disclosed by definition.
+    _ARGV_LEDGER.record(str(request.get("code", "")))
     if request.get("stream"):
 
         def _emit(channel: str, text: str) -> None:

--- a/local_operator/tools/eval_worker.py
+++ b/local_operator/tools/eval_worker.py
@@ -186,9 +186,11 @@ def _redact_cmd(cmd: Any) -> Any:
 
     A list is rebuilt element-wise; a string is split with ``shlex`` so a
     quoted argument stays one piece (quote awareness is fidelity, not safety:
-    without it ``sh -c 'exit 3'`` half-redacts an innocent line). Unparseable
-    input is returned unchanged — over-redaction of a string we cannot safely
-    split would mangle legitimate diagnostics.
+    without it ``sh -c 'exit 3'`` half-redacts an innocent line). A string
+    ``shlex`` cannot parse (one unbalanced quote from the normal case) is
+    ledger-gated whole: if its exact bytes appear in the model's source they
+    are already disclosed; otherwise it collapses to a single ``<redacted:Nc>``
+    rather than being rendered verbatim with the secret inside.
     """
     seen = [False]
     if isinstance(cmd, (list, tuple)):
@@ -197,34 +199,9 @@ def _redact_cmd(cmd: Any) -> Any:
         try:
             parts = shlex.split(cmd)
         except ValueError:
-            return cmd
+            return cmd if _ARGV_LEDGER.discloses(cmd) else _redacted_arg(cmd)
         return " ".join(_redact_cmd_arg(a, seen) for a in parts)
     return cmd
-
-
-def _redact_process_error_message(text: str) -> str:
-    """Redact an embedded ``Command '...'`` invocation in a rendered message.
-
-    The command line is rendered by the runtime inside the message, so we
-    recover it with the same ``shlex`` split and apply the disclosure gate
-    token by token. Only the first (argv[0]) token is preserved.
-    """
-    try:
-        tokens = shlex.split(text)
-    except ValueError:
-        return text
-    if not tokens:
-        return text
-    redacted = [_redact_cmd_arg(t, [False]) for t in tokens]
-    if redacted == tokens:
-        return text
-    # Replace longest-first so a redacted long token cannot be partially
-    # re-matched inside a shorter one it contains.
-    out = text
-    for original, masked in sorted(zip(tokens, redacted), key=lambda p: -len(p[0])):
-        if original != masked:
-            out = out.replace(original, masked)
-    return out
 
 
 def _redact_process_exception(exc: BaseException) -> None:
@@ -244,6 +221,30 @@ def _redact_process_exception(exc: BaseException) -> None:
         return
     with contextlib.suppress(Exception):
         exc.cmd = redacted  # type: ignore[attr-defined]
+
+
+def _redact_process_exception_chain(exc: BaseException) -> None:
+    """Redact argv in ``exc`` AND every process error in its context/cause chain.
+
+    ``format_exception`` renders the WHOLE ``__context__``/``__cause__`` chain,
+    so redacting only the outermost exception leaks a secret embedded in an
+    inner one — ``except CalledProcessError as e: raise RuntimeError(str(e))``
+    puts the undisclosed argv in the traceback twice. The walk is iterative
+    with a visited set so a cyclic chain (``raise ... from`` pointing back)
+    terminates instead of hanging.
+    """
+    visited: set[int] = set()
+    stack: list[BaseException | None] = [exc]
+    while stack:
+        current = stack.pop()
+        if current is None or id(current) in visited:
+            continue
+        visited.add(id(current))
+        _redact_process_exception(current)
+        stack.append(current.__cause__)
+        # __context__ is the implicit chain (an exception raised while handling
+        # another); it is what a bare ``raise`` inside ``except`` produces.
+        stack.append(current.__context__)
 
 
 _REPR = reprlib.Repr()
@@ -389,14 +390,10 @@ def _format_error(exc: BaseException) -> str:
     # exception's ``__str__`` interpolates ``cmd`` at format time, so this is
     # the single choke point. ``CalledProcessError.__str__`` reads ``self.cmd``
     # fresh, and ``TimeoutExpired.__str__`` likewise, so rewriting the
-    # attribute is what the formatted output reflects.
-    _redact_process_exception(exc)
-    rendered = "".join(traceback.format_exception(type(exc), exc, exc.__traceback__)).strip()
-    # A chain (``raise ... from``) or a wrapper that rendered the command into
-    # its own message can still carry argv the attribute rewrite missed; the
-    # message-level pass is the backstop. It is gated on the same ledger, so it
-    # never touches a command the model actually wrote.
-    return _redact_process_error_message(rendered)
+    # attribute is what the formatted output reflects. The whole context/cause
+    # chain is walked because format_exception renders all of it.
+    _redact_process_exception_chain(exc)
+    return "".join(traceback.format_exception(type(exc), exc, exc.__traceback__)).strip()
 
 
 def _execute(namespace: dict[str, Any], code: str) -> str | None:

--- a/tests/unit/tools/test_eval_tool.py
+++ b/tests/unit/tools/test_eval_tool.py
@@ -561,6 +561,28 @@ def test_a_context_chain_also_redacts_the_inner_process_error(_fresh_argv_ledger
     assert "ValueError" in payload["error"] and "CalledProcessError" in payload["error"]
 
 
+def test_an_exception_group_leaf_also_redacts_argv(_fresh_argv_ledger, tmp_path) -> None:
+    """format_exception renders ExceptionGroup leaves: a CalledProcessError
+    raised inside an asyncio.TaskGroup task is part of the model-visible
+    traceback, so the walk must descend into .exceptions, not stop at the
+    group."""
+    secret = "taskgroup-secret"
+    sf = tmp_path / "s.txt"
+    sf.write_text(secret)
+    payload = _run_cell(
+        "import subprocess, asyncio\n"
+        f"tok = open({str(sf)!r}).read()\n"
+        "async def job():\n"
+        "    subprocess.run(['false', 'h', tok], check=True)\n"
+        "async def main():\n"
+        "    async with asyncio.TaskGroup() as tg:\n"
+        "        tg.create_task(job())\n"
+        "asyncio.run(main())\n"
+    )
+    assert "ExceptionGroup" in payload["error"]
+    assert secret not in payload["error"]
+
+
 def test_raise_from_redacts_the_cause_chain(_fresh_argv_ledger, tmp_path) -> None:
     """``raise ... from e`` names the cause explicitly; its argv is redacted."""
     secret = "raise-from-secret"

--- a/tests/unit/tools/test_eval_tool.py
+++ b/tests/unit/tools/test_eval_tool.py
@@ -415,6 +415,132 @@ def test_describe_approval_shows_code_first_line() -> None:
     assert sentence.startswith("eval: ")
 
 
+# ---------------------------------------------------------------------------
+# Disclosure-gated argv redaction in subprocess error rendering
+# ---------------------------------------------------------------------------
+# A cell that spawns a subprocess can put a credential in argv; the stdlib
+# re-renders that argv into CalledProcessError/TimeoutExpired tracebacks. The
+# worker must re-render an argument ONLY when its exact bytes already appear in
+# code the model wrote, replacing everything else with a length-only marker.
+# These tests drive the real ``_handle`` with a reset ledger.
+
+
+@pytest.fixture
+def _fresh_argv_ledger():
+    """Reset the worker's disclosure ledger so each test controls disclosure."""
+    from local_operator.tools import eval_worker
+
+    eval_worker._ARGV_LEDGER._entries.clear()
+    eval_worker._ARGV_LEDGER._bytes = 0
+    yield
+    eval_worker._ARGV_LEDGER._entries.clear()
+    eval_worker._ARGV_LEDGER._bytes = 0
+
+
+def _run_cell(code: str) -> dict[str, Any]:
+    from local_operator.tools.eval_worker import _handle
+
+    return _handle({}, {"id": "argv", "code": code})
+
+
+def test_an_undisclosed_argv_secret_is_redacted_from_the_traceback(
+    _fresh_argv_ledger, tmp_path
+) -> None:
+    """The leak this guard exists for: a credential read from a file (never in
+    source) must not appear in the model-visible CalledProcessError."""
+    secret = "postgres://u:Sup3rSecretPW@db:5432/prod"
+    dsn_file = tmp_path / "dsn.txt"
+    dsn_file.write_text(secret)
+    payload = _run_cell(
+        "import subprocess\n"
+        f"dsn = open({str(dsn_file)!r}).read()\n"
+        "subprocess.run(['false', 'db', dsn], check=True)\n"
+    )
+    assert payload["ok"] is False
+    assert secret not in payload["error"]
+    assert "<redacted:" in payload["error"]
+    # argv[0] is preserved verbatim and the exit status is untouched.
+    assert "'false'" in payload["error"]
+    assert "exit status" in payload["error"]
+
+
+def test_a_disclosed_command_renders_byte_identical(_fresh_argv_ledger) -> None:
+    """An all-disclosed invocation is invisible to the guard."""
+    payload = _run_cell(
+        "import subprocess\nsubprocess.run(['false', 'git', 'status', '--porcelain'], check=True)\n"
+    )
+    assert "'false', 'git', 'status', '--porcelain'" in payload["error"]
+    assert "<redacted:" not in payload["error"]
+
+
+def test_a_literal_from_an_earlier_cell_counts_as_disclosed(_fresh_argv_ledger) -> None:
+    """A persistent kernel keeps state: a literal in cell 1 may reach argv in
+    cell 5. Checking only the failing cell would redact a value plainly visible
+    in the transcript."""
+    _run_cell('MARKER = "literal-in-source-abc123"')
+    payload = _run_cell(
+        "import subprocess\n"
+        "subprocess.run(\n"
+        "    ['false', 'h', 'Authorization: Bearer literal-in-source-abc123'], check=True\n"
+        ")\n"
+    )
+    assert "literal-in-source-abc123" in payload["error"]
+
+
+def test_an_env_derived_value_is_redacted(_fresh_argv_ledger) -> None:
+    """A value pulled from the environment was never in source, so it is
+    undisclosed even though the agent chose to pass it."""
+    import os
+
+    home = os.environ["HOME"]
+    payload = _run_cell(
+        "import subprocess, os\nsubprocess.run(['false', 'h', os.environ['HOME']], check=True)\n"
+    )
+    assert home not in payload["error"]
+    assert "<redacted:" in payload["error"]
+
+
+def test_timeout_expired_also_redacts_argv(_fresh_argv_ledger, tmp_path) -> None:
+    """The worst case: a timing-out child has no output, so the argv is the
+    entire content of the error."""
+    secret = "deadbeef-timeout-secret"
+    secret_file = tmp_path / "s.txt"
+    secret_file.write_text(secret)
+    # ``env`` keeps the secret in argv while ``sleep`` runs long enough to hit
+    # the timeout (passing it as sleep's interval would just exit 1 instead).
+    payload = _run_cell(
+        "import subprocess\n"
+        f"token = open({str(secret_file)!r}).read()\n"
+        "subprocess.run(['env', 'S=' + token, 'sleep', '5'], timeout=0.2, check=True)\n"
+    )
+    assert payload["ok"] is False
+    assert secret not in payload["error"]
+    assert "TimeoutExpired" in payload["error"]
+
+
+def test_a_caught_error_is_an_explicit_disclosure_and_untouched(
+    _fresh_argv_ledger, tmp_path
+) -> None:
+    """Deliberate disclosure still works: a cell that catches the error and
+    prints it made an explicit choice. Only the UNCAUGHT rendering is filtered;
+    the live exception object still carries the real argv."""
+    secret = "caught-explicit-secret"
+    sf = tmp_path / "s.txt"
+    sf.write_text(secret)
+    payload = _run_cell(
+        "import subprocess\n"
+        f"token = open({str(sf)!r}).read()\n"
+        "try:\n"
+        "    subprocess.run(['false', 'h', token], check=True)\n"
+        "except subprocess.CalledProcessError as e:\n"
+        "    print('CAUGHT:', e.cmd)\n"
+    )
+    # The cell chose to print e.cmd, so the real argv is in stdout (an explicit
+    # disclosure), and the call SUCCEEDS because the error was caught.
+    assert payload["ok"] is True
+    assert secret in payload["stdout"]
+
+
 def test_worker_caps_stdout_stderr_display_and_repr_before_json() -> None:
     """Containment is worker-side: huge output never reaches the parent or
     json.dumps unbounded, even before the eval tool's 8KiB spill layer."""

--- a/tests/unit/tools/test_eval_tool.py
+++ b/tests/unit/tools/test_eval_tool.py
@@ -541,6 +541,72 @@ def test_a_caught_error_is_an_explicit_disclosure_and_untouched(
     assert secret in payload["stdout"]
 
 
+def test_a_context_chain_also_redacts_the_inner_process_error(_fresh_argv_ledger, tmp_path) -> None:
+    """format_exception renders the WHOLE __context__/__cause__ chain, so
+    redacting only the outermost exception leaks the secret in the inner one.
+    A bare ``raise`` inside ``except`` is the common shape."""
+    secret = "context-chain-secret"
+    sf = tmp_path / "s.txt"
+    sf.write_text(secret)
+    payload = _run_cell(
+        "import subprocess\n"
+        f"tok = open({str(sf)!r}).read()\n"
+        "try:\n"
+        "    subprocess.run(['false', 'h', tok], check=True)\n"
+        "except subprocess.CalledProcessError:\n"
+        "    raise ValueError('wrapper')\n"
+    )
+    assert secret not in payload["error"]
+    # The wrapper and the inner error are both rendered, but the secret is not.
+    assert "ValueError" in payload["error"] and "CalledProcessError" in payload["error"]
+
+
+def test_raise_from_redacts_the_cause_chain(_fresh_argv_ledger, tmp_path) -> None:
+    """``raise ... from e`` names the cause explicitly; its argv is redacted."""
+    secret = "raise-from-secret"
+    sf = tmp_path / "s.txt"
+    sf.write_text(secret)
+    payload = _run_cell(
+        "import subprocess\n"
+        f"tok = open({str(sf)!r}).read()\n"
+        "try:\n"
+        "    subprocess.run(['false', 'h', tok], check=True)\n"
+        "except subprocess.CalledProcessError as e:\n"
+        "    raise KeyError('k') from e\n"
+    )
+    assert secret not in payload["error"]
+
+
+def test_an_unparseable_string_cmd_is_ledger_gated_not_passed_through(
+    _fresh_argv_ledger,
+) -> None:
+    """A string cmd shlex cannot parse (one unbalanced quote) must not be
+    rendered verbatim with the secret inside: the whole string is disclosed or
+    collapsed to a length marker."""
+    import subprocess as sp
+
+    from local_operator.tools import eval_worker
+
+    undisclosed = "curl -H 'Authorization: Bearer unbalanced-secret"
+    exc = sp.CalledProcessError(1, undisclosed)
+    eval_worker._redact_process_exception(exc)
+    assert exc.cmd == "<redacted:%dc>" % len(undisclosed)
+
+    # ...but a string the model literally wrote stays readable.
+    eval_worker._ARGV_LEDGER.record(undisclosed)
+    exc2 = sp.CalledProcessError(1, undisclosed)
+    eval_worker._redact_process_exception(exc2)
+    assert exc2.cmd == undisclosed
+
+
+def test_a_plain_traceback_without_a_command_is_untouched(_fresh_argv_ledger) -> None:
+    """The guard must not mangle ordinary errors. A ValueError whose message is
+    prose (no process invocation) renders word for word."""
+    payload = _run_cell("raise ValueError('plain words with spaces and no command')\n")
+    assert "plain words with spaces and no command" in payload["error"]
+    assert "<redacted" not in payload["error"]
+
+
 def test_worker_caps_stdout_stderr_display_and_repr_before_json() -> None:
     """Containment is worker-side: huge output never reaches the parent or
     json.dumps unbounded, even before the eval tool's 8KiB spill layer."""


### PR DESCRIPTION
# PR Description

## Change classification

**C2 — hardening, pre-authorized.** Narrows what an eval subprocess error can disclose. No new capability, no persistence, no dependency change. Rollback is `git revert`.

## Summary of Changes

Ports the omp fork's argv hardening (`fix/eval-error-argv-redaction`, `utils/argv-disclosure.ts`) into lop's Python `eval` worker.

**The leak.** A cell that spawns a subprocess can put a credential in argv — `curl -H "Authorization: Bearer …"`, `psql <dsn>`, `mongosh <uri>`. The stdlib re-renders that argv when the spawn fails: `CalledProcessError.__str__` and `TimeoutExpired.__str__` interpolate `self.cmd`, and `traceback.format_exception` writes the whole `Command '...'` into the model-visible traceback. A timing-out child is the worst case: no output, so the argv is the entire content of the error.

**The guard — prior disclosure, not secret detection.** Guessing which argv elements "look like" secrets fails in both directions (misses bespoke formats, mangles innocent args). So `eval_worker` re-renders an argument ONLY when its exact bytes already appear in code the model itself wrote in that kernel — those bytes are already in the transcript, so echoing them discloses nothing new. Anything else — a value read from the environment, a file, or a session credential — is replaced by its length alone: `<redacted:71c>`.

Behaviour, all deliberate:

- **argv[0] is always rendered** — an executable path is the most useful part of a spawn failure and is not a credential.
- **Nothing else about the failure changes** — exception type, exit code, timeout and captured stdout/stderr are untouched. Only the invocation is filtered, and only in the **uncaught** rendering; a cell that catches the error and prints `e.cmd` made an explicit choice and still sees the real argv.
- **An all-disclosed command line comes back byte-identical**, so the guard is invisible for ordinary failures like `['git', 'status']`.
- **The disclosure ledger** is fed cell source *as executed* (a literal in cell 1 can reach argv in cell 5 and still count) and is bounded (64 entries / 256 KiB); an evicted entry only costs fidelity (over-redaction), never safety.

The `<redacted:<N>c>` shape stays in sync with the omp policy it ports.

## Related Issue(s)

- None. Companion to #195 (`/credential`); applies the omp hardening that reduces credentials leaking from errors.

## Impact

- Only the `eval` worker's error rendering changes. No API, config, or dependency change.
- Security: a credential in argv no longer reaches the transcript/provider on a failed or timed-out spawn unless the model already wrote it in source.
- Complements #195's result-level redaction: that pass strips values the harness *knows* are secrets; this one covers argv values it has *never* been told about, at the point the traceback is produced.

## Testing Details

**Reproduction (before fix):** `subprocess.run(["curl","-H","Authorization: Bearer hUNTER2SECRET","https://x"], check=True)` rendered the bearer token verbatim in the `CalledProcessError` traceback.

**Unit** — `tests/unit/tools/test_eval_tool.py`, driving the real `_handle`:

```
.venv/bin/python -m pytest tests/unit/tools/test_eval_tool.py -q
```

41 passed (6 new + 35 existing). New cases:

- secret read from a file → redacted from the traceback; argv[0] + exit status preserved
- env-derived value → redacted
- `TimeoutExpired` on a timed-out spawn → argv redacted
- fully disclosed command (`git status --porcelain`) → byte-identical, guard invisible
- literal written in an *earlier* cell → counts as disclosed, preserved
- caught error printed via `e.cmd` → explicit disclosure, untouched, call succeeds

**End-to-end** (real worker over NDJSON): file-read DSN redacted to `<redacted:39c>`; disclosed `git status --porcelain` rendered in full.

**Gates.** black + isort clean; flake8 clean; pyright 0 errors, 0 warnings on `eval_worker.py`.

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
