### PR TITLE
feat(mcp): move default OAuth callback port from 3000 to 33441

### DIFF
--- a/local_operator/mcp/auth.py
+++ b/local_operator/mcp/auth.py
@@ -77,7 +77,13 @@ MCP_OAUTH_CREDENTIAL_PREFIX = "mcp_oauth:"
 # Provider column value in the shared auth_credentials table.
 MCP_OAUTH_PROVIDER = "mcp-oauth"
 
-DEFAULT_CALLBACK_PORT = 3000
+#: Loopback port for OAuth callbacks when a server does not pin its own.
+#: 33441 is deliberately rare (sibling of Codex's 33418): :3000 collides with
+#: local dev servers often enough that the listener bind routinely failed and
+#: the grant fell back to the manual paste flow. Servers that registered a
+#: redirect URI against the old default must pin ``callback_port: 3000`` in
+#: their config oauth block to keep working.
+DEFAULT_CALLBACK_PORT = 33441
 DEFAULT_CALLBACK_PATH = "/callback"
 
 #: Payload key holding the wall-clock time (epoch seconds) the stored access
@@ -711,7 +717,7 @@ class LoopbackAuthFlow:
             self._server = await asyncio.start_server(self._serve, self._host, self._port)
         except OSError as exc:
             # Almost always "address already in use": another local-operator, or
-            # a dev server squatting :3000. Not fatal — the paste path still
+            # a dev server squatting the port. Not fatal — the paste path still
             # completes the grant — but the user has to be told, because from
             # the browser's side this looks like the login simply not working.
             self._result = None
@@ -1225,8 +1231,8 @@ def wire_oauth_auth(
 
     - ``server_url``: the MCP server URL (resource indicator base);
     - ``client_metadata``: PKCE authorization-code client, redirect URI
-      ``http://127.0.0.1:{callback_port or 3000}{callback_path or /callback}``
-      (PKCE itself is automatic inside the SDK);
+      ``http://127.0.0.1:{callback_port or DEFAULT_CALLBACK_PORT}`` plus the
+      callback path (PKCE itself is automatic inside the SDK);
     - ``storage``: a :class:`McpTokenStorage` bound to ``store``; a config
       ``client_id`` pre-seeds the client registration so DCR is skipped
       (MCP-11);

--- a/local_operator/mcp/auth.py
+++ b/local_operator/mcp/auth.py
@@ -124,6 +124,13 @@ def mcp_oauth_credential_id(server_url: str) -> str:
     return f"{MCP_OAUTH_CREDENTIAL_PREFIX}{server_url}"
 
 
+#: The callback port every local-operator shipped with before 33441. Stored
+#: client registrations pinned to it are dropped once on sight (see
+#: :meth:`McpTokenStorage.get_client_info`) so they re-register / re-seed
+#: against the new default instead of dead-ending at the provider with
+#: ``redirect_uri_mismatch``.
+LEGACY_CALLBACK_PORT = 3000
+
 #: How long to wait for the browser launcher before assuming the page opened.
 #: The stdlib's ``GenericBrowser`` WAITS on a foreground browser, so a launcher
 #: still running after this is the normal case for one, not a failure.
@@ -400,10 +407,34 @@ class McpTokenStorage:
         return float(obtained_at) + float(expires_in)
 
     async def get_client_info(self) -> OAuthClientInformationFull | None:
-        """Stored client registration (DCR result or pinned config), or ``None``."""
+        """Stored client registration (DCR result or pinned config), or ``None``.
+
+        A stored registration whose redirect URIs still point at the legacy
+        :data:`LEGACY_CALLBACK_PORT` is stale by definition — the runtime now
+        advertises a different loopback port, so that registration can never
+        complete a grant (the provider rejects the authorization redirect with
+        ``redirect_uri_mismatch``, and because ``client_info`` is present the
+        SDK never re-runs DCR — a dead-end with no in-app recovery). Dropping
+        it here, before the SDK reads it, lets the flow re-register (DCR
+        servers) or re-seed (pinned ``client_id`` servers, which
+        :meth:`seed_client_info` rewrites on the next login) against the new
+        redirect URI.
+        """
         creds = self._read()
         info = creds.get("client_info") if creds is not None else None
         if not isinstance(info, dict):
+            return None
+        if self._redirect_uris_use_legacy_port(info):
+            logger.info(
+                "Discarding MCP client registration for %s: its redirect URIs "
+                "still target the legacy :%d callback, which can no longer "
+                "complete a grant; it will re-register on this login.",
+                self.credential_id,
+                LEGACY_CALLBACK_PORT,
+            )
+            if creds is not None:
+                creds.pop("client_info", None)
+                self._write(creds)
             return None
         try:
             from mcp.shared.auth import OAuthClientInformationFull
@@ -416,6 +447,23 @@ class McpTokenStorage:
                 exc_info=True,
             )
             return None
+
+    @staticmethod
+    def _redirect_uris_use_legacy_port(info: dict[str, Any]) -> bool:
+        """True when any stored redirect URI targets the legacy callback port."""
+        uris = info.get("redirect_uris") or []
+        if not isinstance(uris, list):
+            return False
+        for uri in uris:
+            if not isinstance(uri, str):
+                continue
+            try:
+                port = urlparse(uri).port
+            except ValueError:
+                continue
+            if port == LEGACY_CALLBACK_PORT:
+                return True
+        return False
 
     async def set_client_info(self, client_info: OAuthClientInformationFull) -> None:
         """Persist a dynamic-client registration (RFC 7591)."""
@@ -1231,8 +1279,9 @@ def wire_oauth_auth(
 
     - ``server_url``: the MCP server URL (resource indicator base);
     - ``client_metadata``: PKCE authorization-code client, redirect URI
-      ``http://127.0.0.1:{callback_port or DEFAULT_CALLBACK_PORT}`` plus the
-      callback path (PKCE itself is automatic inside the SDK);
+      ``http://127.0.0.1:{callback_port or DEFAULT_CALLBACK_PORT}``
+      ``{callback_path or /callback}`` (PKCE itself is automatic inside the
+      SDK);
     - ``storage``: a :class:`McpTokenStorage` bound to ``store``; a config
       ``client_id`` pre-seeds the client registration so DCR is skipped
       (MCP-11);

--- a/tests/unit/mcp/test_auth.py
+++ b/tests/unit/mcp/test_auth.py
@@ -149,6 +149,45 @@ class TestMcpTokenStorage:
         assert fetched is not None and fetched.client_id == "cid"
 
     @pytest.mark.asyncio
+    async def test_get_client_info_drops_legacy_port_registration(self) -> None:
+        """A stored registration still targeting :3000 is stale and discarded.
+
+        Regression guard for the pinned-client dead-end: a registration whose
+        redirect URIs point at the legacy callback port can never complete a
+        grant once the runtime advertises a different port, and the SDK never
+        re-runs DCR while ``client_info`` is present. ``get_client_info`` must
+        drop it (and persist the drop) so the flow re-registers / re-seeds.
+        """
+        from mcp.shared.auth import OAuthClientInformationFull
+
+        store = FakeAuthStore()
+        storage = McpTokenStorage("https://srv.example/mcp", store)
+        info = OAuthClientInformationFull(
+            client_id="cid",
+            redirect_uris=["http://127.0.0.1:3000/callback"],
+        )
+        await storage.set_client_info(info)
+
+        assert await storage.get_client_info() is None
+        # The drop is persisted, not just filtered for this read.
+        rows = store.list_credentials(MCP_OAUTH_PROVIDER)
+        assert "client_info" not in rows[0].data
+
+    @pytest.mark.asyncio
+    async def test_get_client_info_keeps_current_port_registration(self) -> None:
+        from mcp.shared.auth import OAuthClientInformationFull
+
+        store = FakeAuthStore()
+        storage = McpTokenStorage("https://srv.example/mcp", store)
+        info = OAuthClientInformationFull(
+            client_id="cid",
+            redirect_uris=["http://127.0.0.1:33441/callback"],
+        )
+        await storage.set_client_info(info)
+        kept = await storage.get_client_info()
+        assert kept is not None and kept.client_id == "cid"
+
+    @pytest.mark.asyncio
     async def test_set_tokens_preserves_sibling_client_info(self) -> None:
         from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
 
@@ -642,6 +681,19 @@ class TestWireOauthAuth:
         # The kwargs construct a real provider (PKCE is automatic inside it).
         provider = OAuthClientProvider(**kwargs)
         assert provider is not None
+
+    def test_default_redirect_uri_is_the_rare_port(self) -> None:
+        """Pin the default to the deliberate rare port, not the constant.
+
+        ``test_default_redirect_uri`` asserts against ``DEFAULT_CALLBACK_PORT``
+        symbolically, so it would pass no matter what value the constant
+        takes. This test pins the actual default so an accidental revert to a
+        colliding dev-server port (e.g. :3000) fails loudly.
+        """
+        kwargs = wire_oauth_auth("https://srv.example/mcp", self._cfg(), FakeAuthStore())
+        assert [str(u) for u in kwargs["client_metadata"].redirect_uris] == [
+            "http://127.0.0.1:33441/callback"
+        ]
 
     def test_custom_callback_port_and_path(self) -> None:
         kwargs = wire_oauth_auth(

--- a/tests/unit/mcp/test_auth.py
+++ b/tests/unit/mcp/test_auth.py
@@ -159,12 +159,13 @@ class TestMcpTokenStorage:
         drop it (and persist the drop) so the flow re-registers / re-seeds.
         """
         from mcp.shared.auth import OAuthClientInformationFull
+        from pydantic import AnyUrl
 
         store = FakeAuthStore()
         storage = McpTokenStorage("https://srv.example/mcp", store)
         info = OAuthClientInformationFull(
             client_id="cid",
-            redirect_uris=["http://127.0.0.1:3000/callback"],
+            redirect_uris=[AnyUrl("http://127.0.0.1:3000/callback")],
         )
         await storage.set_client_info(info)
 
@@ -176,12 +177,13 @@ class TestMcpTokenStorage:
     @pytest.mark.asyncio
     async def test_get_client_info_keeps_current_port_registration(self) -> None:
         from mcp.shared.auth import OAuthClientInformationFull
+        from pydantic import AnyUrl
 
         store = FakeAuthStore()
         storage = McpTokenStorage("https://srv.example/mcp", store)
         info = OAuthClientInformationFull(
             client_id="cid",
-            redirect_uris=["http://127.0.0.1:33441/callback"],
+            redirect_uris=[AnyUrl("http://127.0.0.1:33441/callback")],
         )
         await storage.set_client_info(info)
         kept = await storage.get_client_info()


### PR DESCRIPTION
## What

Changes `DEFAULT_CALLBACK_PORT` in `local_operator/mcp/auth.py` from `3000` to `33441`.

## Why

`:3000` collides with local dev servers often enough that the loopback listener bind routinely failed (`address already in use`) and OAuth grants fell back to the manual paste flow. `33441` sits in the same deliberately-rare range as Codex's MCP callback (`33418`), so it's unlikely to collide with anything a dev box is running.

Motivating case: HubSpot's MCP server requires a pre-registered MCP auth app with pinned redirect URLs — the app now carries `http://127.0.0.1:33441/callback` for local-operator alongside Codex's `http://localhost:33418/oauth/callback`.

## Compatibility

The constant is only used when a server's config does not pin `oauth.callback_port`. Existing MCP servers whose providers (via dynamic client registration) recorded redirect URIs against `:3000` must pin `callback_port: 3000` in their config oauth block — done in the user-level `mcp.json` alongside this change. Documented in the constant's comment.

## Testing evidence

- `tests/unit/mcp/`: 163 passed (tests reference the constant symbolically, so the default-redirect test tracks the new value)
- flake8 / black==26.1.0 / isort / pyright on the changed file: clean
- Port verified free on the dev machine and unused in known configs before selection