### PR TITLE
fix(tui): copy assistant messages as markdown, not the rendered frame

### DIFF
--- a/local_operator/tui/widgets/_copy_markdown.py
+++ b/local_operator/tui/widgets/_copy_markdown.py
@@ -110,9 +110,20 @@ def _row_word(rendered_row: str) -> str:
     leaves the bare number as the "word", which is why an ordered list anchored
     to nothing (the F3 review finding).
     """
-    for token in rendered_row.split():
+    tokens = rendered_row.split()
+    for index, token in enumerate(tokens):
         if _MARKER_TOKEN_RE.fullmatch(token):
-            continue  # a bullet, bar or ordered marker, not content
+            if not token.isdigit():
+                continue  # a bullet, bar, or ordered marker-with-dot: structure
+            # A BARE number is an ordered-list marker only when it is a short
+            # list number followed by the item's text (`` 1 alpha``). A long
+            # number (``2026 roadmap``) or a number that begins an item's content
+            # (``- 3 ways``) is CONTENT and must be returned as the anchor —
+            # skipping it dropped every such line from the copy (G1/G2).
+            preceded_by_marker = index > 0 and bool(_MARKER_TOKEN_RE.fullmatch(tokens[index - 1]))
+            if len(token) <= 2 and index + 1 < len(tokens) and not preceded_by_marker:
+                continue  # standalone ordered marker
+            # number-led content: fall through and return it
         return _first_word(token)
     return ""
 
@@ -349,18 +360,6 @@ def slice_markdown(source: str, mapping: list[int | None], first_row: int, last_
                 fence_lang = lines[i].strip()[len(fence_marker) :]
                 open_marker_line = i
                 break
-    # The quote prefix to re-apply to a mid-quote slice. It is derived from the
-    # first QUOTE line in the slice and applied only to lines that are themselves
-    # quotes — a trailing heading or paragraph after the quote run keeps its own
-    # form (the F1c review finding, where every non-covered line was re-quoted).
-    quote_prefix = ""
-    for i in sorted(picked):
-        if i not in covered:
-            qm = _QUOTE_RE.match(lines[i])
-            if qm is not None:
-                quote_prefix = qm.group(0)
-                break
-
     # Prepend the opener only when the slice does not already include the
     # fence's own opening marker line; append the closer only when it does not
     # include the closing marker. Without the symmetric end check a fence whose
@@ -373,16 +372,11 @@ def slice_markdown(source: str, mapping: list[int | None], first_row: int, last_
     out: list[str] = []
     if in_fence_at_start and fence_marker and not includes_open:
         out.append(fence_marker + fence_lang)
+    # Every picked line is emitted AS WRITTEN. Quote lines already carry their
+    # own ``>``/``>>`` prefix in the source, so nested levels survive the copy
+    # (the G3 review finding, where re-applying a single prefix flattened them).
     for i in sorted(picked):
-        text = lines[i]
-        # Re-apply the quote prefix only to lines that are quotes in the source;
-        # everything else (headings, paragraphs, blanks, fence lines) is emitted
-        # as written.
-        if quote_prefix and i not in covered and _QUOTE_RE.match(text):
-            body = _QUOTE_RE.sub("", text)
-            out.append((quote_prefix + body) if body else quote_prefix.rstrip())
-        else:
-            out.append(text)
+        out.append(lines[i])
     if in_fence_at_start and fence_marker and not includes_close:
         out.append(fence_marker)
     return "\n".join(out).strip("\n")

--- a/local_operator/tui/widgets/_copy_markdown.py
+++ b/local_operator/tui/widgets/_copy_markdown.py
@@ -63,31 +63,58 @@ def _strip_markup(line: str) -> str:
 #: A rendered row's leading structure: a quote bar (``▌ ``), a bullet (``• ``)
 #: or an ordered marker (``1. ``), any of them nested. Stripped before the
 #: row's first CONTENT word is read so it can be anchored to its source line.
-_RENDERED_PREFIX_RE = re.compile(r"^\s*(?:(?:▌|•|◦|▪|\d{1,9}[.)])\s+)*")
+_RENDERED_PREFIX_RE = re.compile(r"^\s*(?:(?:▌|•|◦|▪|\d{1,9}[.)])\s*)*")
 
 #: A leading LIST marker on a rendered row (bullet or number). A new list item
 #: always opens with one and a wrapped continuation never does, so its presence
 #: means the row starts a new source line. The quote bar is NOT in this set:
 #: Rich repeats ``▌`` on every row of a quote, continuations included, so a bar
 #: says nothing about whether the row is a new source line.
-_RENDERED_MARKER_RE = re.compile(r"^\s*(?:•|◦|▪|\d{1,9}[.)])\s")
+_RENDERED_MARKER_RE = re.compile(r"^\s*(?:•|◦|▪|\d{1,9}[.)])(?:\s|$)")
+
+#: A single whitespace-delimited token that is ONLY a structure marker (quote
+#: bar, bullet, or ordered number) — skipped when reading a row's content word.
+#: Rich renders an ordered marker as a bare number (`` 1 alpha`` splits to the
+#: token ``1``, the ``.`` is not painted), so the marker token is a bullet, a
+#: bar, an ordered marker WITH its dot, or a bare integer.
+_MARKER_TOKEN_RE = re.compile(r"(?:▌|•|◦|▪|\d{1,9}[.)]|\d{1,9})")
 
 
 def _first_word(text: str) -> str:
     """The first run of non-space, non-markup characters, lowercased.
 
     ``**bold** lead`` anchors on ``bold``; the asterisks never reach the frame.
+    A token that is ONLY a list marker (``1.``, ``-``) or only punctuation is
+    skipped, so an ordered item anchors on its first content word (``alpha`` in
+    ``1. alpha``), not on the marker — stripping ``.`` off a bare ``1`` used to
+    leave an empty anchor and the item never matched (the F3 review finding).
+    As a last resort a token that stripping empties entirely is returned raw,
+    so a punctuation-led line still has something to anchor on.
     """
+    fallback = ""
     for token in text.split():
         word = token.strip("*_`~#>|-+.")
         if word:
             return word.lower()
-    return ""
+        if not fallback and token.strip("*_`~"):
+            fallback = token.lower()
+    return fallback
 
 
 def _row_word(rendered_row: str) -> str:
-    """A rendered row's first content word, structure markers stripped."""
-    return _first_word(_RENDERED_PREFIX_RE.sub("", rendered_row))
+    """A rendered row's first content word, structure markers stripped.
+
+    The marker strip and the word read are one loop rather than a regex sub
+    followed by a scan, because a marker and its text can be separated by a
+    single space (``1 alpha``) — a ``\\s+``-after-marker pattern misses that and
+    leaves the bare number as the "word", which is why an ordered list anchored
+    to nothing (the F3 review finding).
+    """
+    for token in rendered_row.split():
+        if _MARKER_TOKEN_RE.fullmatch(token):
+            continue  # a bullet, bar or ordered marker, not content
+        return _first_word(token)
+    return ""
 
 
 def classify(lines: list[str]) -> tuple[set[int], set[int]]:
@@ -199,42 +226,42 @@ def align(source: str, rendered_rows: list[str]) -> list[int | None]:
             placed = current
             budget -= 1
         else:
-            # Two passes so a STRUCTURAL start wins over a plain paragraph whose
-            # first word happens to match — otherwise a quote line's first word
-            # can steal a row meant for a later item.
-            for want_structure in (True, False):
-                for look in range(src, min(src + _LOOKAHEAD, n)):
-                    line = src_lines[look]
-                    if look in markers:
-                        continue  # backtick rows paint nothing; step over
-                    if look in covered:
-                        if not want_structure and line.strip() and row.strip() == line.strip():
-                            placed = look
-                            break
-                        continue
-                    if not line.strip():
-                        continue  # content is further on; blanks pair with blank rows
-                    structural = bool(
-                        _LIST_RE.match(line) or _QUOTE_RE.match(line) or _HEADING_RE.match(line)
-                    )
-                    if want_structure and not structural:
-                        continue
-                    anchor = _first_word(_strip_markup(line)) or _first_word(line)
-                    if word and anchor and word == anchor:
+            # Scan in SOURCE ORDER and take the first line this row can anchor
+            # to. Rendered rows and source lines are monotonic, so the earliest
+            # match is the right one — a plain paragraph anchors to ITSELF, never
+            # to a later quote that merely shares its first word (the F1 review
+            # finding, where a two-pass structural-first scan let the quote steal
+            # the paragraph's row). A fence body line matches on its exact text;
+            # anything else on its first content word, markup stripped.
+            for look in range(src, min(src + _LOOKAHEAD, n)):
+                line = src_lines[look]
+                if look in markers:
+                    continue  # backtick rows paint nothing; step over
+                if look in covered:
+                    if line.strip() and row.strip() == line.strip():
                         placed = look
                         break
-                    # An hr or a table divider renders as a bar with no anchor word.
-                    if not want_structure and _is_rule_like(line) and _is_rule_like(row):
-                        placed = look
-                        break
-                    # A table body row renders as its cells with the pipes
-                    # dropped; match it on the first cell's word. The divider
-                    # (a rule-like line) is caught above.
-                    if not want_structure and "|" in line and word and word in line.lower():
-                        placed = look
-                        break
-                if placed is not None:
+                    continue
+                if not line.strip():
+                    continue  # content is further on; blanks pair with blank rows
+                anchor = _first_word(_strip_markup(line)) or _first_word(line)
+                if word and anchor and word == anchor:
+                    placed = look
                     break
+                # An hr or a table divider renders as a bar with no anchor word.
+                if _is_rule_like(line) and _is_rule_like(row):
+                    placed = look
+                    break
+                # A table body row renders as its cells with the pipes dropped;
+                # match it on the first cell's word. Rich truncates a long cell
+                # with ``…``, so also match a truncated stem: the rendered word
+                # is the cell's prefix, not a substring of the full line (the F4
+                # review finding).
+                if "|" in line and word:
+                    stem = word.rstrip("…")
+                    if word in line.lower() or (stem and stem in line.lower()):
+                        placed = look
+                        break
             if placed is not None:
                 src = placed + 1
                 # A fence body line and a table row occupy exactly one row.
@@ -278,21 +305,29 @@ def slice_markdown(source: str, mapping: list[int | None], first_row: int, last_
         return ""
 
     # Fill the source lines between the first and last picked line. The walk
-    # maps the rendered rows it could place; the lines between them belong to
-    # the selection too — a fence's marker rows, the blank before a trailing
-    # paragraph, and the quote lines Rich merged into one wrapped block (a
-    # quote's consecutive ``>`` lines render as a single paragraph, so only the
-    # first anchors and the rest must be recovered here). Filling the whole
-    # contiguous span is what keeps that content instead of closing up.
+    # places rows by POSITION (earliest matching source line wins), so a gap
+    # line here is always inside the selected span, never an unselected block
+    # that happens to share a first word — the F1 failure came from the walk
+    # mis-anchoring, not from filling. Filling recovers the lines that render
+    # nothing of their own: fence markers, blank separators, reference-link
+    # definitions, and the quote lines Rich merged into one wrapped block.
     lo, hi = min(picked), max(picked)
     picked.update(range(lo, hi + 1))
+
+    # A selection that reaches the LAST rendered row covers the whole message,
+    # so it also covers any trailing source lines that render nothing of their
+    # own — a reference-link definition or a trailing blank. Without this those
+    # are dropped from a full-message copy (the F1b review finding).
+    n_rows = len(mapping)
+    if last_row >= n_rows - 1:
+        picked.update(range(hi, len(lines)))
 
     # Rich renders a quote's consecutive ``>`` lines as ONE wrapped block, so a
     # selection that reaches into a quote has highlighted the WHOLE merged block
     # even though only the first source line anchored. Extend the slice to the
-    # end of the quote run so the copy carries every line the reader saw, not
-    # just the one that happened to anchor. (Same recovery for a list, whose
-    # items likewise reflow together at some widths.)
+    # end of the quote run — stopping at the first line that is not itself a
+    # quote (a blank ends the run, so a following paragraph or heading is never
+    # absorbed). The run-stop is what the F1 finding's blanket fill lacked.
     n = len(lines)
     last = max(picked)
     if _QUOTE_RE.match(lines[last]):
@@ -305,29 +340,49 @@ def slice_markdown(source: str, mapping: list[int | None], first_row: int, last_
     in_fence_at_start = first in covered and first not in markers
     fence_marker = ""
     fence_lang = ""
+    open_marker_line: int | None = None
     if in_fence_at_start:
         for i in range(first, -1, -1):
             if i in markers:
                 m = _FENCE_RE.match(lines[i])
                 fence_marker = m.group(1)  # type: ignore[union-attr]
                 fence_lang = lines[i].strip()[len(fence_marker) :]
+                open_marker_line = i
                 break
+    # The quote prefix to re-apply to a mid-quote slice. It is derived from the
+    # first QUOTE line in the slice and applied only to lines that are themselves
+    # quotes — a trailing heading or paragraph after the quote run keeps its own
+    # form (the F1c review finding, where every non-covered line was re-quoted).
     quote_prefix = ""
-    if first not in covered:
-        qm = _QUOTE_RE.match(lines[first])
-        if qm is not None:
-            quote_prefix = qm.group(0)
+    for i in sorted(picked):
+        if i not in covered:
+            qm = _QUOTE_RE.match(lines[i])
+            if qm is not None:
+                quote_prefix = qm.group(0)
+                break
 
+    # Prepend the opener only when the slice does not already include the
+    # fence's own opening marker line; append the closer only when it does not
+    # include the closing marker. Without the symmetric end check a fence whose
+    # body runs to a blank line gets a spurious closing fence AFTER the trailing
+    # paragraph, swallowing it into the code block on paste (the F2 finding).
+    includes_open = open_marker_line in picked if open_marker_line is not None else False
+    includes_close = any(
+        i in markers and i != open_marker_line and i > (open_marker_line or -1) for i in picked
+    )
     out: list[str] = []
-    if in_fence_at_start and fence_marker:
+    if in_fence_at_start and fence_marker and not includes_open:
         out.append(fence_marker + fence_lang)
     for i in sorted(picked):
         text = lines[i]
-        if quote_prefix and i not in covered:
+        # Re-apply the quote prefix only to lines that are quotes in the source;
+        # everything else (headings, paragraphs, blanks, fence lines) is emitted
+        # as written.
+        if quote_prefix and i not in covered and _QUOTE_RE.match(text):
             body = _QUOTE_RE.sub("", text)
             out.append((quote_prefix + body) if body else quote_prefix.rstrip())
         else:
             out.append(text)
-    if in_fence_at_start and fence_marker:
+    if in_fence_at_start and fence_marker and not includes_close:
         out.append(fence_marker)
     return "\n".join(out).strip("\n")

--- a/local_operator/tui/widgets/_copy_markdown.py
+++ b/local_operator/tui/widgets/_copy_markdown.py
@@ -1,0 +1,333 @@
+"""Markdown-source copy for the assistant block.
+
+A copy of an assistant message should paste as MARKDOWN, not as the rendered
+frame: the frame turns a blockquote into a ``▌`` bar, a bullet into ``•``, a
+table into box-drawing and a heading into bare bold text — none of which a
+messenger or email client recognises, and all of which interrupt a paste with
+ASCII furniture. The block already holds the message's source
+(``AssistantBlock._full_text``), so the clipboard can carry that, mapped to
+whatever the reader actually highlighted.
+
+Rendered→markdown is lossy in BOTH directions (a quote's two source lines
+merge into one wrapped row; a table becomes box-drawing; ``**`` vanishes), so
+the frame cannot be reverse-parsed back to source. The only honest source of
+markdown is the source itself. The work here is therefore ALIGNMENT: given the
+flattened rows the block painted and the source lines it was built from,
+decide which source lines each rendered row came from, so a selection can be
+sliced out of the source.
+
+The alignment leans on what Rich's markdown renderer guarantees (verified
+against ``flatten`` at several widths): a paragraph WRAPS, so its continuation
+rows carry no marker; but every LIST ITEM, BLOCKQUOTE LINE, HEADING and FENCED
+CODE line starts a fresh rendered row, and a fence's backtick rows vanish.
+Those are anchors. Between anchors, rows wrap. Blank source lines render as
+blank rows except at the very top and bottom of the message, where the
+renderer trims them.
+"""
+
+from __future__ import annotations
+
+import re
+
+#: A line that opens or closes a fenced code block.
+_FENCE_RE = re.compile(r"^\s{0,3}(`{3,}|~{3,})")
+#: A list item (bullet or ordered).
+_LIST_RE = re.compile(r"^\s{0,3}(?:[-+*]|\d{1,9}[.)])\s")
+#: A blockquote line (one or more ``>`` levels).
+_QUOTE_RE = re.compile(r"^\s{0,3}(?:>\s?)+")
+#: An ATX heading.
+_HEADING_RE = re.compile(r"^\s{0,3}#{1,6}\s")
+#: A horizontal rule.
+_HR_RE = re.compile(r"^\s{0,3}(?:([-*_])\s*){3,}$")
+
+#: How far ahead of the walk pointer a row may find its source line. Wide
+#: enough to step over a fence marker, a table divider and a run of blank
+#: lines; the monotonic guard keeps a wide window from skipping content.
+_LOOKAHEAD = 12
+
+
+def _strip_markup(line: str) -> str:
+    """The visible text a structural source line contributes, marker removed.
+
+    A list item renders its text after the bullet, a quote after the bar, a
+    heading after the ``#``s. Inline markup is left alone — the renderer keeps
+    the visible characters of ``**bold**`` even though it drops the asterisks,
+    so anchoring compares on the first plain WORD (see :func:`_first_word`).
+    """
+    line = _QUOTE_RE.sub("", line)
+    line = _LIST_RE.sub("", line)
+    line = _HEADING_RE.sub("", line)
+    return line.strip()
+
+
+#: A rendered row's leading structure: a quote bar (``▌ ``), a bullet (``• ``)
+#: or an ordered marker (``1. ``), any of them nested. Stripped before the
+#: row's first CONTENT word is read so it can be anchored to its source line.
+_RENDERED_PREFIX_RE = re.compile(r"^\s*(?:(?:▌|•|◦|▪|\d{1,9}[.)])\s+)*")
+
+#: A leading LIST marker on a rendered row (bullet or number). A new list item
+#: always opens with one and a wrapped continuation never does, so its presence
+#: means the row starts a new source line. The quote bar is NOT in this set:
+#: Rich repeats ``▌`` on every row of a quote, continuations included, so a bar
+#: says nothing about whether the row is a new source line.
+_RENDERED_MARKER_RE = re.compile(r"^\s*(?:•|◦|▪|\d{1,9}[.)])\s")
+
+
+def _first_word(text: str) -> str:
+    """The first run of non-space, non-markup characters, lowercased.
+
+    ``**bold** lead`` anchors on ``bold``; the asterisks never reach the frame.
+    """
+    for token in text.split():
+        word = token.strip("*_`~#>|-+.")
+        if word:
+            return word.lower()
+    return ""
+
+
+def _row_word(rendered_row: str) -> str:
+    """A rendered row's first content word, structure markers stripped."""
+    return _first_word(_RENDERED_PREFIX_RE.sub("", rendered_row))
+
+
+def classify(lines: list[str]) -> tuple[set[int], set[int]]:
+    """(fence-covered lines, fence-marker lines) for ``lines``.
+
+    Covered is every line inside a fenced block, markers included; markers is
+    the subset that opens or closes one (they render NOTHING — the backticks
+    are not painted). Both are needed: a body line copies verbatim, a marker
+    line is re-added around a mid-fence slice rather than copied as text.
+    """
+    covered: set[int] = set()
+    markers: set[int] = set()
+    in_fence = False
+    fence_char = ""
+    for i, line in enumerate(lines):
+        match = _FENCE_RE.match(line)
+        if match is not None:
+            marker = match.group(1)
+            if not in_fence:
+                in_fence = True
+                fence_char = marker[0]
+                markers.add(i)
+                covered.add(i)
+            elif marker[0] == fence_char and set(line.strip()) <= {fence_char}:
+                in_fence = False
+                markers.add(i)
+                covered.add(i)
+            continue
+        if in_fence:
+            covered.add(i)
+    return covered, markers
+
+
+def align(source: str, rendered_rows: list[str]) -> list[int | None]:
+    """Map each rendered row to the source line it came from (or ``None``).
+
+    ``None`` marks a blank separator row (or a row the walk could not place),
+    which a copy slices around rather than from. The walk is monotonic —
+    rendered rows and source lines are in the same order — so a single pointer
+    advances through the source as rows are consumed. A non-blank row first
+    tries to CONTINUE the source line it is on (a wrap), then looks ahead a
+    bounded window for the source line that starts it. A blank row consumes a
+    blank source line when one is next, else marks a separator.
+    """
+    src_lines = source.split("\n")
+    covered, markers = classify(src_lines)
+    n = len(src_lines)
+
+    def paints(i: int) -> bool:
+        """Does source line ``i`` put any glyph on the frame?"""
+        if i in markers:
+            return False
+        return bool(src_lines[i].strip())
+
+    # Lead/trail trim: the renderer drops blank rows at the message edges, so
+    # the walk starts at the first line that paints and stops after the last.
+    first_paint = 0
+    while first_paint < n and not paints(first_paint):
+        first_paint += 1
+
+    mapping: list[int | None] = []
+    src = first_paint  # next unconsumed source line
+    current: int | None = None  # source line rows are currently wrapping within
+    budget = 0  # rendered rows the current source line may still wrap to
+    for row in rendered_rows:
+        word = _row_word(row)
+
+        if not row.strip():
+            # A blank row consumes the next blank source line when one is here
+            # (a paragraph break), else it is a renderer separator (around a
+            # quote or table) with no source line of its own.
+            if src < n and src not in covered and not src_lines[src].strip():
+                mapping.append(src)
+                src += 1
+            else:
+                mapping.append(None)
+            current = None  # any break ends a wrap in progress
+            budget = 0
+            continue
+
+        placed: int | None = None
+        # A fence body line and a table row never wrap — each occupies exactly
+        # its own row — so a row inside either is never a continuation.
+        no_wrap_now = current is not None and (current in covered or "|" in src_lines[current])
+        # A STRUCTURAL source line (list item, quote line, heading) always opens
+        # a fresh rendered row, so if this row's first content word matches one
+        # ahead, it STARTS that line — it is never a wrap of the current one.
+        # That is what stops a quote line's wrap budget swallowing the next
+        # ``>`` line (whose first word matches) while still letting the quote's
+        # own continuation (whose first word does not) wrap.
+        starts_structural = False
+        if not no_wrap_now:
+            for look in range(src, min(src + _LOOKAHEAD, n)):
+                line = src_lines[look]
+                if look in covered or not line.strip():
+                    continue
+                if _LIST_RE.match(line) or _QUOTE_RE.match(line) or _HEADING_RE.match(line):
+                    anchor = _first_word(_strip_markup(line)) or _first_word(line)
+                    if word and anchor and word == anchor:
+                        starts_structural = True
+                    break
+        if (
+            current is not None
+            and budget > 0
+            and not no_wrap_now
+            and not starts_structural
+            and not _RENDERED_MARKER_RE.match(row)
+        ):
+            placed = current
+            budget -= 1
+        else:
+            # Two passes so a STRUCTURAL start wins over a plain paragraph whose
+            # first word happens to match — otherwise a quote line's first word
+            # can steal a row meant for a later item.
+            for want_structure in (True, False):
+                for look in range(src, min(src + _LOOKAHEAD, n)):
+                    line = src_lines[look]
+                    if look in markers:
+                        continue  # backtick rows paint nothing; step over
+                    if look in covered:
+                        if not want_structure and line.strip() and row.strip() == line.strip():
+                            placed = look
+                            break
+                        continue
+                    if not line.strip():
+                        continue  # content is further on; blanks pair with blank rows
+                    structural = bool(
+                        _LIST_RE.match(line) or _QUOTE_RE.match(line) or _HEADING_RE.match(line)
+                    )
+                    if want_structure and not structural:
+                        continue
+                    anchor = _first_word(_strip_markup(line)) or _first_word(line)
+                    if word and anchor and word == anchor:
+                        placed = look
+                        break
+                    # An hr or a table divider renders as a bar with no anchor word.
+                    if not want_structure and _is_rule_like(line) and _is_rule_like(row):
+                        placed = look
+                        break
+                    # A table body row renders as its cells with the pipes
+                    # dropped; match it on the first cell's word. The divider
+                    # (a rule-like line) is caught above.
+                    if not want_structure and "|" in line and word and word in line.lower():
+                        placed = look
+                        break
+                if placed is not None:
+                    break
+            if placed is not None:
+                src = placed + 1
+                # A fence body line and a table row occupy exactly one row.
+                # Everything else — paragraphs, list items and quote lines alike
+                # — may wrap; the starts-structural check above re-anchors the
+                # next item or quote line when the wrap runs out.
+                budget = 0 if (placed in covered or "|" in src_lines[placed]) else _LOOKAHEAD
+        mapping.append(placed)
+        current = placed
+    return mapping
+
+
+def _is_rule_like(text: str) -> bool:
+    """A row whose visible content is only rule/divider characters."""
+    body = text.strip().strip("|")
+    return bool(body) and set(body) <= {"-", "─", ":", " ", "=", "_"}
+
+
+def slice_markdown(source: str, mapping: list[int | None], first_row: int, last_row: int) -> str:
+    """The markdown for rendered rows ``first_row..last_row`` inclusive.
+
+    Takes the source lines those rows map to, then re-fences and re-quotes the
+    slice so it is valid markdown on its own: a slice that opens inside a code
+    fence gets the fence's backticks wrapped around it, and a slice from inside
+    a blockquote gets the ``> `` prefix re-applied to each line. Without the
+    repair a mid-fence or mid-quote selection would paste as unformatted text
+    with no sign of what it was.
+    """
+    if first_row > last_row:
+        return ""
+    lines = source.split("\n")
+    covered, markers = classify(lines)
+    picked: set[int] = set()
+    for row in range(first_row, last_row + 1):
+        if row >= len(mapping):
+            break
+        src = mapping[row]
+        if src is not None:
+            picked.add(src)
+    if not picked:
+        return ""
+
+    # Fill the source lines between the first and last picked line. The walk
+    # maps the rendered rows it could place; the lines between them belong to
+    # the selection too — a fence's marker rows, the blank before a trailing
+    # paragraph, and the quote lines Rich merged into one wrapped block (a
+    # quote's consecutive ``>`` lines render as a single paragraph, so only the
+    # first anchors and the rest must be recovered here). Filling the whole
+    # contiguous span is what keeps that content instead of closing up.
+    lo, hi = min(picked), max(picked)
+    picked.update(range(lo, hi + 1))
+
+    # Rich renders a quote's consecutive ``>`` lines as ONE wrapped block, so a
+    # selection that reaches into a quote has highlighted the WHOLE merged block
+    # even though only the first source line anchored. Extend the slice to the
+    # end of the quote run so the copy carries every line the reader saw, not
+    # just the one that happened to anchor. (Same recovery for a list, whose
+    # items likewise reflow together at some widths.)
+    n = len(lines)
+    last = max(picked)
+    if _QUOTE_RE.match(lines[last]):
+        j = last + 1
+        while j < n and _QUOTE_RE.match(lines[j]):
+            picked.add(j)
+            j += 1
+
+    first = min(picked)
+    in_fence_at_start = first in covered and first not in markers
+    fence_marker = ""
+    fence_lang = ""
+    if in_fence_at_start:
+        for i in range(first, -1, -1):
+            if i in markers:
+                m = _FENCE_RE.match(lines[i])
+                fence_marker = m.group(1)  # type: ignore[union-attr]
+                fence_lang = lines[i].strip()[len(fence_marker) :]
+                break
+    quote_prefix = ""
+    if first not in covered:
+        qm = _QUOTE_RE.match(lines[first])
+        if qm is not None:
+            quote_prefix = qm.group(0)
+
+    out: list[str] = []
+    if in_fence_at_start and fence_marker:
+        out.append(fence_marker + fence_lang)
+    for i in sorted(picked):
+        text = lines[i]
+        if quote_prefix and i not in covered:
+            body = _QUOTE_RE.sub("", text)
+            out.append((quote_prefix + body) if body else quote_prefix.rstrip())
+        else:
+            out.append(text)
+    if in_fence_at_start and fence_marker:
+        out.append(fence_marker)
+    return "\n".join(out).strip("\n")

--- a/local_operator/tui/widgets/_copy_markdown.py
+++ b/local_operator/tui/widgets/_copy_markdown.py
@@ -111,17 +111,23 @@ def _row_word(rendered_row: str) -> str:
     to nothing (the F3 review finding).
     """
     tokens = rendered_row.split()
+    # Whether the row is indented. Rich paints an ordered-list marker with a
+    # leading space (`` 1 alpha``, `` 100 item``); a number-led PARAGRAPH is
+    # flush left (``2026 roadmap``). The indent is what tells a bare-number
+    # marker from number-led content, at ANY marker width — a length cap broke
+    # three-digit lists (the H1 review finding).
+    indented = rendered_row[:1] in (" ", "\t")
     for index, token in enumerate(tokens):
         if _MARKER_TOKEN_RE.fullmatch(token):
             if not token.isdigit():
                 continue  # a bullet, bar, or ordered marker-with-dot: structure
-            # A BARE number is an ordered-list marker only when it is a short
-            # list number followed by the item's text (`` 1 alpha``). A long
-            # number (``2026 roadmap``) or a number that begins an item's content
-            # (``- 3 ways``) is CONTENT and must be returned as the anchor —
-            # skipping it dropped every such line from the copy (G1/G2).
+            # A bare number is an ordered-list marker only when it is indented
+            # and followed by the item's text. A number that begins CONTENT —
+            # a flush-left number-led paragraph (``2026 roadmap``), or an item's
+            # own text after a bullet (``- 3 ways``) — is the row's anchor and
+            # must be returned, not skipped (the G1/G2 review findings).
             preceded_by_marker = index > 0 and bool(_MARKER_TOKEN_RE.fullmatch(tokens[index - 1]))
-            if len(token) <= 2 and index + 1 < len(tokens) and not preceded_by_marker:
+            if indented and index + 1 < len(tokens) and not preceded_by_marker:
                 continue  # standalone ordered marker
             # number-led content: fall through and return it
         return _first_word(token)

--- a/local_operator/tui/widgets/assistant.py
+++ b/local_operator/tui/widgets/assistant.py
@@ -40,9 +40,12 @@ from rich.cells import cell_len
 from rich.console import Console, RenderableType
 from rich.markdown import Markdown
 from rich.text import Text
+from textual.content import Content
+from textual.selection import Selection
 
 from local_operator.tui import theme as theme_mod
 from local_operator.tui.markdown_theme import brand_markdown_theme
+from local_operator.tui.widgets import _copy_markdown
 from local_operator.tui.widgets.transcript import TranscriptBlock
 
 #: Reference-link definition line: ``[label]: target`` (TUI-010 refusal).
@@ -583,3 +586,46 @@ class AssistantBlock(TranscriptBlock):
     def text(self) -> str:
         """The accumulated message text (for tests and export)."""
         return self._full_text
+
+    def get_selection(self, selection: Selection) -> tuple[str, str] | None:
+        """The selected text as MARKDOWN, so it pastes cleanly anywhere.
+
+        The base :meth:`TranscriptBlock.get_selection` copies the rendered
+        frame, which is the right rule for the transcript's plain-text blocks
+        but wrong for a markdown message: the frame turns a blockquote into a
+        ``▌`` bar, a bullet into ``•``, a table into box-drawing and a heading
+        into bare bold text. Pasted into a messenger or an email that is
+        furniture, not content — the ``▌`` welded to every quoted line is the
+        report this method answers. The block already holds the message's
+        source, so the clipboard carries that instead, mapped to the rows the
+        reader actually highlighted.
+
+        The selection and the frame stay the same computation: the highlighted
+        rows come from ``Selection.get_span`` exactly as the base method reads
+        them, and those row indices are aligned back to source lines by
+        :func:`_copy_markdown.align`. A partial selection is sliced out of the
+        source and re-fenced / re-quoted so it is valid markdown on its own.
+        When the source cannot be aligned (an empty message, or a frame the
+        walker cannot place), the method falls back to the base frame copy so a
+        copy never comes back empty-handed.
+        """
+        visual = self._render()
+        if not isinstance(visual, Content):
+            return None
+        if not self._full_text.strip():
+            return super().get_selection(selection)
+        rows = visual.plain.split("\n")
+        first_row: int | None = None
+        last_row: int | None = None
+        for index in range(len(rows)):
+            if selection.get_span(index) is not None:
+                if first_row is None:
+                    first_row = index
+                last_row = index
+        if first_row is None or last_row is None:
+            return None
+        mapping = _copy_markdown.align(self._full_text, rows)
+        copied = _copy_markdown.slice_markdown(self._full_text, mapping, first_row, last_row)
+        if not copied:
+            return super().get_selection(selection)
+        return copied, "\n"

--- a/tests/unit/tui/test_copy_markdown.py
+++ b/tests/unit/tui/test_copy_markdown.py
@@ -1,0 +1,98 @@
+"""The rendered→source alignment behind markdown copy.
+
+These tests pin the engine directly (no app) so a misalignment names the
+construct that broke rather than surfacing as a wrong clipboard three calls
+away. Each builds the real flattened frame at a width, aligns it, and slices.
+"""
+
+from __future__ import annotations
+
+import pytest
+from rich.console import Console
+from rich.markdown import Markdown
+
+from local_operator.tui.markdown_theme import (
+    brand_markdown_theme,
+    install_markdown_theme,
+)
+from local_operator.tui.widgets._copy_markdown import align, slice_markdown
+from local_operator.tui.widgets.assistant import flatten
+
+MIXED = """Intro sentence here.
+
+- first bullet that is long enough to wrap onto a second rendered row definitely
+- second bullet
+
+> a quoted line that is also long enough to wrap around onto more than one row
+> second quoted source line
+
+```python
+def f(x):
+    return x
+```
+
+Closing paragraph.
+"""
+
+
+@pytest.fixture(autouse=True)
+def _theme() -> None:
+    install_markdown_theme()
+
+
+def _rows(source: str, width: int) -> list[str]:
+    console = Console(width=width, theme=brand_markdown_theme())
+    return flatten(Markdown(source), width, console).plain.split("\n")
+
+
+def _full_slice(source: str, width: int) -> str:
+    rows = _rows(source, width)
+    return slice_markdown(source, align(source, rows), 0, len(rows) - 1)
+
+
+@pytest.mark.parametrize("width", [40, 44, 64, 78, 120])
+def test_full_message_slices_to_its_source(width: int) -> None:
+    """A whole-message copy is the message's markdown, at any width.
+
+    The wrap changes with the width; the source must not. This is the property
+    that makes the copy independent of how the frame happened to fold.
+    """
+    copied = _full_slice(MIXED, width)
+    assert copied.split() == MIXED.strip().split()  # same words, same order
+    assert "- first bullet" in copied and "- second bullet" in copied
+    assert "> a quoted line" in copied and "> second quoted source line" in copied
+    assert "```python" in copied and "```" in copied
+    assert "▌" not in copied and "•" not in copied
+
+
+def test_a_quote_slice_is_requoted() -> None:
+    """Selecting only the quote pastes a valid blockquote, not bare lines."""
+    rows = _rows(MIXED, 44)
+    mapping = align(MIXED, rows)
+    quote_rows = [i for i, r in enumerate(rows) if r.strip().startswith("▌")]
+    copied = slice_markdown(MIXED, mapping, quote_rows[0], quote_rows[-1])
+    assert copied == (
+        "> a quoted line that is also long enough to wrap around onto more than one row\n"
+        "> second quoted source line"
+    )
+
+
+def test_a_mid_fence_slice_is_refenced() -> None:
+    """Selecting the code rows re-wraps them in the fence, language kept."""
+    rows = _rows(MIXED, 44)
+    mapping = align(MIXED, rows)
+    code_rows = [i for i, r in enumerate(rows) if r.strip() in {"def f(x):", "return x"}]
+    copied = slice_markdown(MIXED, mapping, code_rows[0], code_rows[-1])
+    assert copied == "```python\ndef f(x):\n    return x\n```"
+
+
+def test_bold_inside_a_quote_keeps_its_markers() -> None:
+    """Inline markup survives the round trip through the frame."""
+    source = (
+        "A reply:\n\n"
+        "> Thanks for the report. I verified the **flagged** value in out/main/index.jsc:\n"
+        "> it's the public project API key (phc_...), publishable by design.\n"
+    )
+    copied = _full_slice(source, 76)
+    assert "**flagged**" in copied
+    assert copied.count("> ") >= 2  # both quote lines, re-prefixed

--- a/tests/unit/tui/test_copy_markdown.py
+++ b/tests/unit/tui/test_copy_markdown.py
@@ -152,3 +152,28 @@ def test_a_truncated_table_cell_still_anchors() -> None:
     assert body, "no truncated row found to test"
     copied = slice_markdown(source, mapping, body[0], body[-1])
     assert long_cell in copied
+
+
+# -- review-round-2 regressions (G1–G3) ---------------------------------------
+def test_a_number_led_paragraph_is_not_read_as_a_list_marker() -> None:
+    """G1: ``2026 roadmap`` glues the digits to the content (no marker space),
+    so the paragraph anchors and copies — it is not an ordered-list marker."""
+    assert _full_slice("2026 roadmap items are here", 40) == "2026 roadmap items are here"
+
+
+def test_an_item_whose_content_starts_with_a_number_copies() -> None:
+    """G2: ``- 3 ways`` / ``> 3 ways`` begin their content with a number; the
+    number is content, not a marker, so the items anchor and copy."""
+    assert _full_slice("- 3 ways to fix it\n- 4 more things", 40) == (
+        "- 3 ways to fix it\n- 4 more things"
+    )
+    copied = _full_slice("> 3 ways forward\n> 5 steps back", 40)
+    assert "3 ways forward" in copied and "5 steps back" in copied
+
+
+def test_a_nested_quote_keeps_its_levels() -> None:
+    """G3: each quote line keeps its own ``>``/``>>`` prefix from the source —
+    re-applying a single prefix would flatten the nesting."""
+    assert _full_slice("> outer\n>> inner\n> outer again", 40) == (
+        "> outer\n>> inner\n> outer again"
+    )

--- a/tests/unit/tui/test_copy_markdown.py
+++ b/tests/unit/tui/test_copy_markdown.py
@@ -96,3 +96,59 @@ def test_bold_inside_a_quote_keeps_its_markers() -> None:
     copied = _full_slice(source, 76)
     assert "**flagged**" in copied
     assert copied.count("> ") >= 2  # both quote lines, re-prefixed
+
+
+# -- review-round regressions (F1–F5) -----------------------------------------
+def test_a_paragraph_sharing_a_quotes_first_word_is_not_swallowed() -> None:
+    """F1a: the earliest matching source line wins, so a paragraph anchors to
+    itself, not to a later quote that happens to share its first word."""
+    source = "See the docs below.\n\n> See the quoted reply line one that wraps a bit"
+    copied = _full_slice(source, 40)
+    assert "See the docs below." in copied
+    assert "> See the quoted reply line" in copied
+
+
+def test_a_reference_link_definition_survives_a_full_copy() -> None:
+    """F1b: a link definition renders nothing, so it never anchors — but a copy
+    that reaches the end of the message must still carry it."""
+    source = "See [the docs][docs] now.\n\n[docs]: https://example.com"
+    copied = _full_slice(source, 40)
+    assert "[docs]: https://example.com" in copied
+
+
+def test_a_heading_after_a_quote_is_not_requoted() -> None:
+    """F1c: the quote prefix applies to quote lines only, not to a heading or
+    paragraph that follows the quote run."""
+    source = "> quote line\n\n## Notes\n\nbody text"
+    copied = _full_slice(source, 40)
+    assert "## Notes" in copied and "> ## Notes" not in copied
+    assert "body text" in copied and "> body text" not in copied
+
+
+def test_a_fence_with_a_blank_line_stays_balanced() -> None:
+    """F2: the closing fence is appended only when the slice does not already
+    include the fence's own closing marker — never after a trailing paragraph."""
+    source = "```\nfirst\n\nsecond\n```\n\nafter para"
+    copied = _full_slice(source, 40)
+    assert copied.count("```") == 2
+    assert copied.rstrip().endswith("after para")
+
+
+def test_an_ordered_list_copies_with_its_markers() -> None:
+    """F3: Rich paints an ordered marker as a bare number (`` 1 alpha``), which
+    must not be read as the item's content word — the items anchor and copy."""
+    assert _full_slice("1. alpha\n2. beta\n3. gamma", 40) == "1. alpha\n2. beta\n3. gamma"
+    mixed = _full_slice("1. first\n2. second\n   - sub a\n   - sub b\n3. third", 40)
+    assert "1. first" in mixed and "3. third" in mixed
+
+
+def test_a_truncated_table_cell_still_anchors() -> None:
+    """F4: Rich truncates a long cell with ``…``; the row anchors on the stem."""
+    long_cell = "x" * 80
+    source = f"| name | value |\n|------|-------|\n| {long_cell} | 1 |"
+    rows = _rows(source, 50)
+    mapping = align(source, rows)
+    body = [i for i, r in enumerate(rows) if "…" in r or "xxx" in r]
+    assert body, "no truncated row found to test"
+    copied = slice_markdown(source, mapping, body[0], body[-1])
+    assert long_cell in copied

--- a/tests/unit/tui/test_copy_markdown.py
+++ b/tests/unit/tui/test_copy_markdown.py
@@ -177,3 +177,24 @@ def test_a_nested_quote_keeps_its_levels() -> None:
     assert _full_slice("> outer\n>> inner\n> outer again", 40) == (
         "> outer\n>> inner\n> outer again"
     )
+
+
+# -- review-round-3 regression (H1) -------------------------------------------
+@pytest.mark.parametrize(
+    "source",
+    [
+        "100. item hundred\n101. item hundred one",  # three-digit markers
+        "1. alpha\n2. beta",  # one-digit markers
+        "2026 roadmap",  # number-led paragraph (flush left)
+        "42",  # a paragraph that is only a number
+        "- 7",  # an item that is only a number
+        "- 3 ways to fix",  # an item whose content starts with a number
+        "1. first\n\n2026 was the year",  # ordered list, then a number-led paragraph
+    ],
+)
+def test_number_markers_and_number_led_content_both_anchor(source: str) -> None:
+    """H1: the marker/content discriminator is the row's INDENT, not the number's
+    length — Rich indents a real ordered marker (`` 100 item``) at any width and
+    leaves a number-led paragraph flush left (``2026 roadmap``)."""
+    copied = _full_slice(source, 40)
+    assert copied.split() == source.strip().split()

--- a/tests/unit/tui/test_transcript_selection.py
+++ b/tests/unit/tui/test_transcript_selection.py
@@ -217,13 +217,16 @@ async def test_rich_block_is_not_selectable() -> None:
 
 # -- markdown: what actually lands on the clipboard --------------------------
 @pytest.mark.asyncio
-async def test_markdown_copies_as_the_rendered_frame() -> None:
-    """The whole assistant message, copied — the acceptance case.
+async def test_markdown_copies_as_markdown() -> None:
+    """The whole assistant message copies as its source markdown.
 
-    Every construct at once, because the interesting thing is that they are
-    consistent: bold and inline code lose their markers, the fence loses its
-    backticks and keeps its indentation, the ordered list keeps its rendered
-    marker, and the link keeps its label.
+    The copy is NOT the rendered frame: a messenger or email client does not
+    recognise a ``▌`` quote bar or a ``•`` bullet, so the clipboard carries the
+    message's markdown, which Slack, GitHub, Linear and Notion all render and
+    which reads as tidy plain text anywhere else. Bold keeps its ``**``, the
+    fence keeps its backticks and language, the list keeps its markers, and the
+    link keeps its label (its URL stays on the frame as a hyperlink, asserted
+    below).
     """
     app = StyledTranscriptApp()
     async with app.run_test(size=(64, 40)) as pilot:
@@ -235,14 +238,12 @@ async def test_markdown_copies_as_the_rendered_frame() -> None:
 
         copied = _copy_all(app, block)
         assert copied is not None, "the agent message contributed nothing to the copy"
-        assert copied == "\n".join(MARKDOWN_ROWS)
         # The five constructs, called out so a failure says WHICH one moved.
-        assert "**" not in copied and "plan" in copied  # bold
-        assert "`" not in copied and "inline_code" in copied  # inline code
-        assert "```" not in copied  # fence markers
-        assert "def f(x):\n    return x + 1" in copied  # the code, verbatim
-        assert "https://example.com/x" not in copied  # the URL is not text
-        assert "link" in copied  # its label is
+        assert "**plan**" in copied  # bold keeps its markers
+        assert "`inline_code`" in copied  # inline code keeps its backticks
+        assert "```python\ndef f(x):\n    return x + 1\n```" in copied  # fence, verbatim
+        assert "1. first step" in copied and "2. second step" in copied  # ordered list
+        assert "[link](https://example.com/x)" in copied  # the link, label and URL
 
 
 @pytest.mark.asyncio
@@ -272,13 +273,12 @@ async def test_link_url_stays_on_the_frame_as_a_hyperlink() -> None:
 
 
 @pytest.mark.asyncio
-async def test_fenced_code_copies_without_the_pad() -> None:
-    """A code fence pastes as runnable code, trailing pad trimmed.
+async def test_fenced_code_copies_as_a_fence() -> None:
+    """A code fence copies as a fenced block: backticks, language, no pad.
 
-    Rich pads every rendered row out to the full width, and ``Syntax`` paints
-    its ground across all of it. Without the right-trim in
-    ``TranscriptBlock.get_selection`` a two-line snippet arrives with fifty
-    spaces welded to each line.
+    Copying the source rather than the frame means the trailing pad Rich paints
+    across every row never reaches the clipboard at all, and the block arrives
+    as a runnable, language-tagged fence a markdown reader renders as code.
     """
     app = StyledTranscriptApp()
     async with app.run_test(size=(64, 40)) as pilot:
@@ -287,7 +287,86 @@ async def test_fenced_code_copies_without_the_pad() -> None:
         block.update_text("```python\nx = 1\n```")
         block.finalize_text()
         await pilot.pause()
-        assert _copy_all(app, block) == "x = 1"
+        assert _copy_all(app, block) == "```python\nx = 1\n```"
+
+
+# -- markdown copy: the regression this feature answers -----------------------
+@pytest.mark.asyncio
+async def test_blockquote_copies_as_markdown_not_the_bar() -> None:
+    """A blockquote's ``▌`` never reaches the clipboard — the reported bug.
+
+    The reader drags over a quoted reply and pastes it into Slack or an email;
+    what arrives must be the ``>`` markdown those clients render, not the
+    half-block bar Rich painted. Bold inside the quote keeps its ``**`` for the
+    same reason.
+    """
+    app = StyledTranscriptApp()
+    async with app.run_test(size=(80, 40)) as pilot:
+        block = AssistantBlock()
+        await _mounted(app, block)
+        block.update_text(
+            "Here is a reply you can paste:\n\n"
+            "> Thanks for the report. I verified the **flagged** value in out/main/index.jsc:\n"
+            "> it's the public project API key (phc_...), publishable by design.\n"
+        )
+        block.finalize_text()
+        await pilot.pause()
+        copied = _copy_all(app, block)
+        assert copied is not None
+        assert "▌" not in copied
+        assert "> Thanks for the report. I verified the **flagged** value" in copied
+        assert "> it's the public project API key" in copied
+
+
+@pytest.mark.asyncio
+async def test_table_copies_as_markdown_pipes() -> None:
+    """A table copies as markdown pipes, not box-drawing.
+
+    The rendered frame draws the table with ``─`` rules and drops the pipes;
+    pasted into a markdown reader that is not a table. The source pipes survive
+    the copy, header row and divider included.
+    """
+    app = StyledTranscriptApp()
+    async with app.run_test(size=(80, 40)) as pilot:
+        block = AssistantBlock()
+        await _mounted(app, block)
+        block.update_text(
+            "Results:\n\n| Name | Score |\n|------|-------|\n| alpha | 0.91 |\n| beta | 0.87 |\n"
+        )
+        block.finalize_text()
+        await pilot.pause()
+        copied = _copy_all(app, block)
+        assert copied is not None
+        assert "| Name | Score |" in copied
+        assert "| alpha | 0.91 |" in copied
+        assert "─" not in copied
+
+
+@pytest.mark.asyncio
+async def test_a_multi_block_copy_joins_plain_and_markdown() -> None:
+    """A drag across a user block and an answer copies both, cleanly.
+
+    The user block copies its text verbatim (no ``▌``), the assistant block its
+    markdown; ``Screen.get_selected_text`` joins the two contributions, so this
+    pins the seam rather than each block alone.
+    """
+    app = StyledTranscriptApp()
+    async with app.run_test(size=(80, 40)) as pilot:
+        user = UserBlock("summarise the ingest path")
+        assistant = AssistantBlock()
+        await _mounted(app, user, assistant)
+        assistant.update_text("Here is the **plan**.")
+        assistant.finalize_text()
+        await pilot.pause()
+        app.screen.selections = {
+            user: Selection(None, None),
+            assistant: Selection(None, None),
+        }
+        copied = app.screen.get_selected_text()
+        assert copied is not None
+        assert "▌" not in copied
+        assert "summarise the ingest path" in copied
+        assert "**plan**" in copied
 
 
 # -- the other blocks --------------------------------------------------------
@@ -363,11 +442,14 @@ async def test_tool_card_expanded_output_copies_unindented() -> None:
 
 # -- highlight and clipboard cannot disagree ---------------------------------
 @pytest.mark.asyncio
-async def test_partial_selection_copies_only_the_highlighted_rows() -> None:
-    """A drag over rows 5-6 copies rows 5-6, clipped at the drag's columns.
+async def test_partial_selection_copies_a_valid_markdown_slice() -> None:
+    """A drag over the fence's rows copies the fence, closed.
 
-    The same ``Selection.get_span`` the highlight uses, so this is the
-    invariant rather than a second implementation of the arithmetic.
+    The highlighted rows come from the same ``Selection.get_span`` the band
+    uses, so the copy covers what was lit — but a partial markdown selection is
+    re-fenced on the way out, because raw ``def f(x):\\n    retu`` is neither
+    the code the reader pointed at nor valid markdown. The slice opens and
+    closes the fence so it pastes as a code block.
     """
     app = StyledTranscriptApp()
     async with app.run_test(size=(64, 40)) as pilot:
@@ -378,7 +460,8 @@ async def test_partial_selection_copies_only_the_highlighted_rows() -> None:
         await pilot.pause()
         # From the start of the fence's first row to mid-way through its second.
         selection = Selection.from_offsets(Offset(x=0, y=5), Offset(x=8, y=6))
-        assert block.get_selection(selection) == ("def f(x):\n    retu", "\n")
+        expected = ("```python\ndef f(x):\n    return x + 1\n```", "\n")
+        assert block.get_selection(selection) == expected
 
 
 @pytest.mark.asyncio
@@ -572,24 +655,14 @@ async def test_resize_rebuilds_at_the_new_width() -> None:
 
 
 @pytest.mark.asyncio
-async def test_streaming_copy_is_the_streaming_frame() -> None:
-    """A mid-stream copy is the mid-stream FRAME, splice and all.
+async def test_streaming_copy_is_stable_across_the_splice() -> None:
+    """A mid-stream copy and a settled copy carry the same markdown.
 
-    The live block is a spliced frozen prefix plus a freshly flattened tail,
-    and the settled one is a single flatten of the whole text. Those two do NOT
-    produce identical rows, and that difference PREDATES the flatten: the old
-    ``Group(Markdown(prefix), Markdown(tail))`` splice dropped the blank row
-    markdown puts between two block elements in exactly the same place.
-    Measured on this message at 64 columns, the frozen prefix ends
-    ``"```\\n\\n"`` and the tail is ``"Done."``, so the live frame runs
-    ``return x + 1`` straight into ``Done.`` where the settled frame separates
-    them — one row that appears when the turn settles.
-
-    Asserted rather than fixed because the copy rule is "the glyphs that were
-    highlighted", so a copy taken mid-stream SHOULD be the mid-stream frame,
-    and closing the gap means changing the boundary semantics that TUI-010 and
-    TUI-011 pin. What must hold, and does, is that the words and their order
-    never depend on when the copy was taken.
+    The copy is the message's source, aligned to the highlighted rows — so it
+    does not inherit the live frame's splice gap (the frozen prefix plus a fresh
+    tail drops a blank row the settled frame keeps). What must hold is that the
+    words and their order never depend on when the copy was taken, and that the
+    markdown constructs survive either way.
     """
     app = StyledTranscriptApp()
     async with app.run_test(size=(64, 40)) as pilot:
@@ -609,11 +682,7 @@ async def test_streaming_copy_is_the_streaming_frame() -> None:
         assert settled is not None
 
         assert live.split() == settled.split()  # same words, same order
-        assert [row for row in live.split("\n") if row] == [
-            row for row in settled.split("\n") if row
-        ]
-        # The pre-existing difference, named so a change to it is deliberate.
-        assert live.count("\n\n") == settled.count("\n\n") - 1
+        assert "**plan**" in live and "```python" in live
 
 
 def test_the_splice_reproduces_the_group_it_replaced() -> None:
@@ -806,11 +875,11 @@ async def test_releasing_a_drag_puts_the_frame_on_the_clipboard() -> None:
 
         await _drag(app, pilot, (block.region.x, block.region.y), (79, 23))
 
-        # The RENDERED frame, which is the whole rule: no ``**`` around
-        # "plan", no backticks around "inline_code", no trailing pad — and the
-        # paragraph break kept, because the reader selected two paragraphs.
+        # The message's MARKDOWN: ``**`` around "plan", backticks around
+        # "inline_code", and the paragraph break kept, because the reader
+        # selected two paragraphs.
         assert app._clipboard.splitlines() == [
-            "Here is the plan with inline_code.",
+            "Here is the **plan** with `inline_code`.",
             "",
             "Second paragraph here.",
         ]


### PR DESCRIPTION
## Problem

Dragging over an assistant message and releasing copied the **rendered frame**, so a markdown blockquote arrived on the clipboard as a `▌` bar welded to the front of every quoted line, a bullet as `•`, a table as box-drawing and a heading as bare bold text. Pasted into Slack, Gmail or any markdown reader that is furniture, not content. Reported as "the sidebar motif interrupts the paste" — which turned out to be a `> …` blockquote in the agent's reply, not a user message at all (`UserBlock.copy_gutter` already strips its own rule correctly).

## Fix

`AssistantBlock.get_selection` now copies the message's **source markdown**, mapped to the rows the reader highlighted, instead of the rendered frame. Rendered → markdown is lossy in both directions (a quote's consecutive `>` lines merge into one wrapped row, a table becomes box-drawing, `**` vanishes), so the frame cannot be reverse-parsed; the work is alignment. The new `local_operator/tui/widgets/_copy_markdown.py` walks the flattened rows against the source lines using the anchors Rich's markdown renderer guarantees — every list item, quote line, heading and fence body line starts a fresh rendered row — then slices the source and re-fences / re-quotes a partial selection so it is valid markdown on its own:

- **Blockquotes** copy as `> ` lines (the `▌` never reaches the clipboard).
- **Tables** copy as markdown pipes, header and divider kept.
- **Bold / inline code** keep their `**` and backticks.
- **Fenced code** keeps its backticks and language; a mid-fence selection is re-wrapped in the fence.
- **A mid-quote selection** re-applies the `> ` prefix so it pastes as a blockquote.

`UserBlock`, `NoticeBlock` and `ToolCard` keep the frame copy (gutter-stripped) they already had — a user's own prompt pastes verbatim, the right rule for plain text. The terminal's own Cmd+C remains the way to grab the literal frame when that is what is wanted.

**The highlight band is unchanged.** The copy is content-only; the selection rows come from the same `Selection.get_span` the band uses, so the highlight and the clipboard cannot disagree. The before/after frames below are pixel-identical.

## Change class

C2 — standard/pre-authorized; a clipboard-content change confined to the assistant block's copy path, no contract changes, no rendered-UI change.

## Testing evidence

**Unit:** full TUI suite `tests/unit/tui` — **2097 passed, 4 skipped**. New `tests/unit/tui/test_copy_markdown.py` (8 tests) pins the alignment engine across widths (40–120) and constructs; updated `test_transcript_selection.py` asserts the markdown contract (blockquote → `>`, table → pipes, bold → `**`, fence → backticks+language, partial selection re-fenced, multi-block join). Gates: `flake8`, `black`, `isort`, `pyright` all clean on the changed files.

**End to end (real `OperatorApp` under `run_test`, 90×30 terminal, assistant message with a blockquote and a table):** selected the whole block and copied.

Before (`origin/main`) — clipboard carries the `▌` bar and box-drawing table:

```
▌ Thanks for the report. I verified the flagged value in out/main/index.jsc: it's
▌ the public project API key (phc_...), publishable by design.

 Name   Score
 ────────────
 alpha  0.91
```

After (this branch) — clean markdown, no `▌`, table pipes intact:

```
> Thanks for the report. I verified the **flagged** value in out/main/index.jsc:
> it's the public project API key (phc_...), publishable by design.

| Name | Score |
|------|-------|
| alpha | 0.91 |
```

**Visual before/after (real app frame, `save_screenshot`):** identical highlight band and layout — only the clipboard content changed (the toast's line count differs by one because the old frame-copy kept an extra blank row).

Before: ![before](https://github.com/damianvtran/lo-scratch/releases/download/pr-copy-markdown-frames/copy_before.png)

After: ![after](https://github.com/damianvtran/lo-scratch/releases/download/pr-copy-markdown-frames/copy_after.png)
