### PR TITLE
feat(mcp): add logout and reauth subcommands with picker suggestions

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -94,6 +94,23 @@ variant prints the authorization URL and accepts the **full redirect URL** (or
 a `code state` pair) on stdin; `state` (and `iss` when present) are parsed
 back out so the SDK's state validation passes.
 
+Plain `login` reuses whatever the store still holds — a refreshable token or a
+stored client registration short-circuits the grant. When that is wrong (an
+account switch, a scope change, a consent screen that must come back up), use
+the two companions:
+
+```
+/mcp logout <name>   # forget the stored credential and disconnect
+/mcp reauth <name>   # forget, then run a fresh interactive grant
+local-operator mcp logout <name>
+local-operator mcp reauth <name>
+```
+
+`logout` removes the whole credential row (token *and* client registration),
+so the next login re-registers via DCR or re-seeds a pinned `client_id` from
+config. `reauth` refuses to start the browser flow if the old row could not
+be removed, because a login on top of a surviving row would not be a re-auth.
+
 ## Per-tool filters
 
 A server can expose hundreds of tools while a session needs only a handful.

--- a/local_operator/cli.py
+++ b/local_operator/cli.py
@@ -494,6 +494,18 @@ def build_cli_parser() -> argparse.ArgumentParser:
         parents=[parent_parser],
     )
     mcp_login_parser.add_argument("name", type=str, help="Server name to authenticate")
+    mcp_logout_parser = mcp_subparsers.add_parser(
+        "logout",
+        help="Remove the stored OAuth credential for one MCP server",
+        parents=[parent_parser],
+    )
+    mcp_logout_parser.add_argument("name", type=str, help="Server name to log out")
+    mcp_reauth_parser = mcp_subparsers.add_parser(
+        "reauth",
+        help="Log out of one OAuth MCP server and run a fresh authorization",
+        parents=[parent_parser],
+    )
+    mcp_reauth_parser.add_argument("name", type=str, help="Server name to re-authenticate")
 
     # Built separately so provider transports stay off the CLI import path.
     from local_operator.web_search.cli import add_search_subparser
@@ -1061,8 +1073,30 @@ async def _mcp_login_server(name: str, cwd: Path) -> int:
         await manager.disconnect_all()
 
 
+async def _mcp_reauth_server(name: str, cwd: Path) -> int:
+    """Log out of one OAuth MCP server, then run a fresh interactive grant.
+
+    Plain ``mcp login`` reuses whatever the store still holds — the SDK only
+    runs a browser grant once the stored token can neither be used nor
+    refreshed, and a stored client registration short-circuits DCR. That is
+    wrong for the cases reauth exists for: an account switch, a scope change,
+    or a consent screen that needs to come back up. So reauth removes the row
+    first (same deletion as ``mcp logout``, erroring on an unknown or
+    non-OAuth name so a typo does not turn into an unexpected browser tab)
+    and then runs exactly the login connect path — one implementation of what
+    "authenticated" means.
+    """
+    from local_operator.mcp.auth import mcp_logout_server
+
+    error = mcp_logout_server(name, cwd)
+    if error is not None:
+        print(f"error: MCP reauth failed for {name!r}: {error}", file=sys.stderr)
+        return 1
+    return await _mcp_login_server(name, cwd)
+
+
 def mcp_command(args: argparse.Namespace) -> int:
-    """Dispatch ``mcp list|add|login|remove`` to MCP configuration and auth.
+    """Dispatch ``mcp list|add|login|logout|reauth|remove`` to MCP configuration and auth.
 
     Lazy import: the MCP package keeps its SDK imports lazy too, and this
     CLI must survive builds where it has not landed yet.
@@ -1105,6 +1139,19 @@ def mcp_command(args: argparse.Namespace) -> int:
         import asyncio
 
         return asyncio.run(_mcp_login_server(args.name, Path.cwd()))
+    if args.mcp_command == "logout":
+        from local_operator.mcp.auth import mcp_logout_server
+
+        error = mcp_logout_server(args.name, Path.cwd())
+        if error is not None:
+            print(f"error: MCP logout failed: {error}", file=sys.stderr)
+            return 1
+        print(f"Removed the stored OAuth credential for MCP server {args.name!r}.")
+        return 0
+    if args.mcp_command == "reauth":
+        import asyncio
+
+        return asyncio.run(_mcp_reauth_server(args.name, Path.cwd()))
     if args.mcp_command == "remove":
         return mcp_config.remove_server(args.name, scope=getattr(args, "scope", "global"))
 

--- a/local_operator/guides/mcp/GUIDE.md
+++ b/local_operator/guides/mcp/GUIDE.md
@@ -37,6 +37,8 @@ local-operator mcp add linear --url https://mcp.linear.app/mcp --oauth
 local-operator mcp login linear
 ```
 
+Inside the TUI, `/mcp` lists servers and `/mcp login <name>` runs the same grant. To forget a stored credential or force a fresh consent (account switch, scope change): `/mcp logout <name>` / `local-operator mcp logout <name>`, and `/mcp reauth <name>` / `local-operator mcp reauth <name>` to log out and re-authorize in one step.
+
 Add `--scope project` to write `<cwd>/.local-operator/mcp.json`; the default global scope writes `~/.local-operator/mcp.json`. Use repeated `--env KEY=VALUE` only when the server must receive that variable. Do not put long-lived secrets in committed project configuration.
 
 Check and remove entries:

--- a/local_operator/mcp/auth.py
+++ b/local_operator/mcp/auth.py
@@ -232,6 +232,10 @@ class StructuralAuthStore(Protocol):
         """Return one row by integer id, or ``None``."""
         ...
 
+    def delete_credential(self, credential_id: int) -> None:
+        """Remove one row entirely (``/mcp logout`` / ``mcp logout``)."""
+        ...
+
 
 @runtime_checkable
 class ManagedAuthStore(StructuralAuthStore, Protocol):
@@ -334,6 +338,31 @@ class McpTokenStorage:
             logger.debug("MCP token write failed for %s", self.credential_id, exc_info=True)
 
     # --- SDK TokenStorage protocol ---------------------------------------
+
+    def clear(self) -> bool:
+        """Delete this server's credential row entirely (logout). Returns
+        ``True`` when a row existed and was removed.
+
+        The row carries BOTH the OAuth grant and any client registration
+        (``seed_client_info`` pins it via ``project_id``, DCR writes it via
+        ``set_client_info``), so removal is what makes the next login run a
+        genuinely fresh grant — new consent, new registration — instead of
+        silently reusing the stored client info. A pinned ``client_id`` from
+        config is re-seeded by ``wire_oauth_auth`` on the next connect, so
+        losing the row never strands a pinned-client server.
+        """
+        store = self._store
+        if store is None:
+            return False
+        row = self._read_row()
+        if row is None:
+            return False
+        try:
+            store.delete_credential(row.id)
+        except Exception:
+            logger.debug("MCP credential delete failed for %s", self.credential_id, exc_info=True)
+            return False
+        return True
 
     async def get_tokens(self) -> OAuthToken | None:
         """Stored access/refresh tokens as an ``OAuthToken``, or ``None``."""
@@ -489,6 +518,80 @@ class McpTokenStorage:
         creds = self._read() or {}
         creds["client_info"] = info.model_dump(mode="json")
         self._write(creds)
+
+
+def oauth_server_names(cwd: str | os.PathLike[str]) -> list[str]:
+    """Names of configured OAuth-enabled servers, in config order.
+
+    The ``/mcp login|reauth|logout`` argument lists are filled from this, so
+    they offer exactly the servers those commands can act on — a stdio or
+    API-key server has no OAuth grant to log into or out of, and offering it
+    would be a row whose only outcome is a warning notice.
+    """
+    from local_operator.mcp.config import load_all_mcp_configs
+
+    configs, _sources = load_all_mcp_configs(cwd)
+    return [
+        name
+        for name, cfg in configs.items()
+        if getattr(getattr(cfg, "auth", None), "type", None) == "oauth"
+    ]
+
+
+def mcp_logout_server(
+    name: str,
+    cwd: str | os.PathLike[str],
+    store: StructuralAuthStore | None = None,
+) -> str | None:
+    """Remove the stored OAuth credential for one configured server.
+
+    Returns an error string on failure, ``None`` on success — the two callers
+    (CLI and TUI) phrase their own output, so the helper reports outcomes,
+    not prose. Unknown names and non-OAuth configs are errors, not no-ops:
+    logging out of a server that holds no credential is a valid ask (the
+    store may still carry a stale row from a since-removed config write), but
+    a name the config does not know at all is a typo the user wants told
+    about.
+
+    The deletion goes through the REAL store (``_resolve_store(None)``), not
+    the session manager's possibly-injected one: logout must remove the
+    persisted row every future process will read, which is the shared
+    ``auth.db`` regardless of what one session was handed.
+    """
+    from local_operator.mcp.config import load_all_mcp_configs
+
+    configs, _sources = load_all_mcp_configs(cwd)
+    cfg = configs.get(name)
+    if cfg is None:
+        return f"MCP server {name!r} is not configured"
+    auth = getattr(cfg, "auth", None)
+    if auth is None or getattr(auth, "type", None) != "oauth":
+        return f"MCP server {name!r} does not use OAuth login"
+    storage = McpTokenStorage(cfg.url, store)
+    if not storage.clear():
+        return f"no stored credential for MCP server {name!r} — nothing to log out of"
+    return None
+
+
+def mcp_logged_out_servers(store: StructuralAuthStore | None = None) -> set[str]:
+    """Server URLs that still hold an ``mcp-oauth`` credential row.
+
+    Read-only companion to :func:`mcp_logout_server` so the ``/mcp logout``
+    picker can offer only servers that actually have something to remove
+    (mirroring how ``/logout`` offers only providers holding a credential).
+    An unreadable store degrades to the empty set: the list is then empty and
+    the picker's own notice says why, rather than offering rows whose removal
+    would fail.
+    """
+    store = _resolve_store(store)
+    if store is None:
+        return set()
+    try:
+        rows = store.list_credentials(MCP_OAUTH_PROVIDER)
+    except Exception:
+        logger.debug("MCP credential listing failed", exc_info=True)
+        return set()
+    return {row.identity_key for row in rows if row.identity_key}
 
 
 def parse_oauth_callback_input(raw: str) -> tuple[str, str | None, str | None]:

--- a/local_operator/mcp/auth.py
+++ b/local_operator/mcp/auth.py
@@ -547,11 +547,12 @@ def mcp_logout_server(
 
     Returns an error string on failure, ``None`` on success — the two callers
     (CLI and TUI) phrase their own output, so the helper reports outcomes,
-    not prose. Unknown names and non-OAuth configs are errors, not no-ops:
-    logging out of a server that holds no credential is a valid ask (the
-    store may still carry a stale row from a since-removed config write), but
-    a name the config does not know at all is a typo the user wants told
-    about.
+    not prose. All three failure shapes — unknown name, non-OAuth config,
+    nothing stored — are reported as errors, but they are DIFFERENT errors:
+    a name the config does not know is a typo the user wants told about,
+    while a known OAuth server holding no credential is a no-op worth
+    distinguishing from a successful removal (the caller's message says
+    which).
 
     The deletion goes through the REAL store (``_resolve_store(None)``), not
     the session manager's possibly-injected one: logout must remove the
@@ -567,30 +568,34 @@ def mcp_logout_server(
     auth = getattr(cfg, "auth", None)
     if auth is None or getattr(auth, "type", None) != "oauth":
         return f"MCP server {name!r} does not use OAuth login"
-    storage = McpTokenStorage(cfg.url, store)
+    # Only remote configs carry ``url``; a stdio config reaching here would
+    # have already failed the OAuth check above, so the getattr is a type
+    # narrowing rather than a guess.
+    storage = McpTokenStorage(getattr(cfg, "url", ""), store)
     if not storage.clear():
         return f"no stored credential for MCP server {name!r} — nothing to log out of"
     return None
 
 
-def mcp_logged_out_servers(store: StructuralAuthStore | None = None) -> set[str]:
-    """Server URLs that still hold an ``mcp-oauth`` credential row.
+def mcp_logged_out_servers(store: StructuralAuthStore | None = None) -> set[str] | None:
+    """Server URLs that still hold an ``mcp-oauth`` credential row, or
+    ``None`` when the store could not be read.
 
     Read-only companion to :func:`mcp_logout_server` so the ``/mcp logout``
     picker can offer only servers that actually have something to remove
     (mirroring how ``/logout`` offers only providers holding a credential).
-    An unreadable store degrades to the empty set: the list is then empty and
-    the picker's own notice says why, rather than offering rows whose removal
-    would fail.
+    ``None`` rather than the empty set on failure: an unreadable store is not
+    the same answer as "no credentials anywhere", and the picker needs the
+    difference to say so instead of rendering a bare empty list.
     """
     store = _resolve_store(store)
     if store is None:
-        return set()
+        return None
     try:
         rows = store.list_credentials(MCP_OAUTH_PROVIDER)
     except Exception:
         logger.debug("MCP credential listing failed", exc_info=True)
-        return set()
+        return None
     return {row.identity_key for row in rows if row.identity_key}
 
 

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -141,6 +141,7 @@ from local_operator.tui.widgets.editor import (
     EditorSubmitted,
     InterruptRequested,
     ModelQueryOpened,
+    RefreshArgumentChoices,
     StopRequested,
     resolve_markers,
 )
@@ -450,9 +451,16 @@ SLASH_COMMANDS: list[SlashCommand] = [
     ),
     # The listing is the receipt.
     SlashCommand("skills", "List loaded skills"),
-    # The listing is the receipt; `/mcp login <name>` re-authorizes an OAuth
-    # server whose grant expired (startup never opens a browser on its own).
-    SlashCommand("mcp", "List MCP servers (/mcp login <name> to re-authorize)"),
+    # The listing is the receipt; the subcommands re-authorize or forget an
+    # OAuth server whose grant expired (startup never opens a browser on its
+    # own). OPTIONAL: bare `/mcp` answers something (the listing), so Enter
+    # still sends it and the subcommand list is an offer for the next
+    # keystroke, matching `/approvals`.
+    SlashCommand(
+        "mcp",
+        "List MCP servers (login/logout/reauth <name> to manage OAuth)",
+        arguments=ArgumentMode.OPTIONAL,
+    ),
     # The flow narrates itself: URL block, progress notices, then success.
     # REQUIRED for both: bare, neither has anything to run — the provider list
     # IS the command, which is why completing the word opens it instead of
@@ -8501,6 +8509,10 @@ class OperatorApp(App[None]):
             picker.set_choices(self._approval_choices())
             picker.set_notice("")
             return
+        if message.command == "mcp":
+            picker.set_choices(self._mcp_argument_choices(editor))
+            picker.set_notice("")
+            return
         if message.command in ("theme", "themes"):
             # Seeded on the CURRENT theme's row (F2): the highlight previews
             # live, so opening the list must not flash the screen to whatever
@@ -8551,6 +8563,29 @@ class OperatorApp(App[None]):
         # picker it is in the user's eye-line, self-clearing, unrepeatable, and it
         # costs the transcript nothing.
         picker.set_notice(reason)
+
+    def on_refresh_argument_choices(self, message: RefreshArgumentChoices) -> None:
+        """Refill an open argument list whose rows depend on a sub-slot.
+
+        Posted by the editor when the FIRST argument word of a two-level
+        command changes — ``/mcp login `` must stop offering verbs and start
+        offering the servers login can act on, and ArgumentQueryOpened never
+        fires for that because the command word stood still. Refilling through
+        the same builders the opening used keeps one implementation of what
+        each list offers.
+
+        Currently only ``/mcp`` is two-level; other commands never trigger the
+        editor's post, so a fall-through here is dead code rather than a
+        silent wrong list.
+        """
+        message.stop()
+        editor = self._editor()
+        if editor.argument_command != message.command:
+            # Same staleness guard as on_argument_query_opened: the buffer may
+            # have moved on in the tick the message spent queued.
+            return
+        if message.command == "mcp":
+            editor.picker.set_choices(self._mcp_argument_choices(editor))
 
     def _credential_choices(self) -> list[ArgumentChoice]:
         """The verbs ``/credential`` offers, plus each stored key to forget.
@@ -9271,15 +9306,18 @@ class OperatorApp(App[None]):
             return None
 
     def _cmd_mcp(self, arg: str, notice: NoticeFn) -> None:
-        """``/mcp`` lists servers; ``/mcp login <name>`` runs an OAuth grant.
+        """``/mcp`` lists servers; its subcommands manage OAuth grants.
 
-        The login subcommand is the in-TUI twin of ``local-operator mcp login``:
-        it exists because startup and auto-reconnect are deliberately
+        ``/mcp login <name>`` is the in-TUI twin of ``local-operator mcp
+        login``: it exists because startup and auto-reconnect are deliberately
         non-interactive (they never pop a browser tab), so an expired grant
         surfaces as an actionable failure and this command is the one place a
-        user can deliberately re-authorize without leaving the session. The
-        flow runs on a worker so the UI stays responsive while the browser
-        round trip completes.
+        user can deliberately re-authorize without leaving the session.
+        ``/mcp logout <name>`` forgets the stored credential and disconnects;
+        ``/mcp reauth <name>`` is the two composed — forget first, so the
+        fresh grant cannot be short-circuited by a stored registration or a
+        refreshable token. The browser flow runs on a worker so the UI stays
+        responsive while the round trip completes.
         """
         parts = arg.split()
         if not parts:
@@ -9290,13 +9328,14 @@ class OperatorApp(App[None]):
                 notice("no MCP servers configured.")
             return
         sub = parts[0].lower()
-        if sub != "login":
+        if sub not in ("login", "logout", "reauth"):
             self._system_notice(
-                f"unknown mcp subcommand: {parts[0]} — try /mcp login <name>", "warning"
+                f"unknown mcp subcommand: {parts[0]} — try /mcp login|logout|reauth <name>",
+                "warning",
             )
             return
         if len(parts) < 2:
-            self._system_notice("usage: /mcp login <name>", "warning")
+            self._system_notice(f"usage: /mcp {sub} <name>", "warning")
             return
         name = parts[1]
         manager = getattr(self._session, "mcp_manager", None)
@@ -9311,25 +9350,193 @@ class OperatorApp(App[None]):
         if auth is None or getattr(auth, "type", None) != "oauth":
             self._system_notice(f"MCP server {name!r} does not use OAuth login.", "warning")
             return
+        if sub == "logout":
+            self._mcp_logout(manager, name, cfg)
+            return
+        # ``reauth`` is logout + login run as ONE grant: plain login reuses a
+        # stored client registration and any refreshable token, which is wrong
+        # for an account switch or scope change — the consent screen has to
+        # come back up, and that only happens once the row is gone.
+        if sub == "reauth":
+            removed = self._mcp_logout(manager, name, cfg, verb="reauth", disconnect=False)
+            if not removed:
+                return
         notice(f"logging in to MCP server {name}…")
         # ``exclusive=True``: two concurrent logins would both bind the same
         # loopback redirect port and the second grant would fail mid-browser
-        # round trip; the newest request wins and cancels the stale one.
+        # round trip; the newest request wins and cancels the stale one. The
+        # group exclusivity is ALSO why reauth defers its disconnect into the
+        # worker instead of firing it here: a second worker posted to the same
+        # exclusive group would cancel whichever one came first.
         self.run_worker(
-            self._mcp_login_worker(manager, name),
+            self._mcp_login_worker(manager, name, disconnect_first=sub == "reauth"),
             thread=False,
             group="mcp-login",
             exclusive=True,
         )
 
-    async def _mcp_login_worker(self, manager: Any, name: str) -> None:
+    def _mcp_logout(
+        self,
+        manager: Any,
+        name: str,
+        cfg: Any,
+        *,
+        verb: str = "logout",
+        disconnect: bool = True,
+    ) -> bool:
+        """Remove the stored OAuth credential for ``name`` and disconnect it.
+
+        Returns whether the removal happened, so ``reauth`` can chain into the
+        login only when the old grant is actually gone. Deletion goes through
+        the module helper, which writes to the shared ``auth.db`` — the row
+        every future session will read — rather than any store this one
+        session was injected with.
+
+        The live connection is torn down too, deliberately AFTER the row is
+        deleted: the manager's auto-reconnect would otherwise read the stored
+        credential during the teardown's own reconnect window and quietly
+        re-authenticate the session the user just logged out of. ``reauth``
+        passes ``disconnect=False`` and lets the login worker do the teardown
+        itself instead — two workers posted back-to-back to the SAME
+        exclusive group would see the first cancelled by the second, and a
+        skipped disconnect is a reconnect racing a fresh grant. The session
+        ends up disconnected with no stored grant, which is the only state a
+        logout can honestly leave behind — the tools drop out on the next
+        tools-changed repaint.
+        """
+        from local_operator.mcp.auth import mcp_logout_server
+
+        try:
+            error = mcp_logout_server(name, os.getcwd())
+        except Exception as exc:  # noqa: BLE001 — a failed logout is a notice, not a crash
+            self._system_notice(f"MCP {verb} failed for {name!r}: {exc}", "error")
+            return False
+        if error is not None:
+            self._system_notice(f"MCP {verb} failed for {name!r}: {error}", "warning")
+            return False
+        if disconnect:
+            # run_worker takes a callable (a coroutine is not one and would
+            # never be awaited), so the disconnect is wrapped, not passed
+            # directly. Same exclusive group as the login worker: a logout
+            # immediately followed by a login must not leave this teardown
+            # racing the fresh grant.
+            async def _disconnect() -> None:
+                await manager.disconnect_server(name)
+
+            self.run_worker(
+                _disconnect,
+                thread=False,
+                group="mcp-login",
+                exclusive=True,
+            )
+        if verb == "logout":
+            self._system_notice(
+                f"logged out of MCP server {name!r} — its credential is removed and the "
+                "server will stay disconnected until /mcp login.",
+                "success",
+            )
+        self._refresh_mcp_status()
+        return True
+
+    def _mcp_argument_choices(self, editor: Any) -> list[ArgumentChoice]:
+        """Rows for the ``/mcp <…>`` list: subcommands, then their servers.
+
+        Which list is showing is decided by the buffer, not by stored picker
+        state: with no subcommand typed yet the argument IS the subcommand
+        slot, so the verbs are offered; once one is there the argument is the
+        server slot, so OAuth-enabled servers are offered — exactly the ones
+        login/reauth/logout can act on, per the same rule ``/logout`` uses
+        (offering a server with no grant would be a row whose only outcome is
+        a warning).
+
+        The rows are complete-then-keep-typing shapes: choosing a verb leaves
+        ``/mcp login `` in the buffer with the cursor past the space, which
+        re-opens this same list in the server slot — one list, two turns of
+        the crank, no bespoke two-level picker. Because the matcher compares
+        against the WHOLE argument (``login n`` will not match the ``notion``
+        row), the server rows are offered as ``login notion``-style compound
+        names; completing one replaces the whole argument and lands as the
+        ready-to-run ``/mcp login notion``.
+        """
+        from local_operator.mcp.auth import mcp_logged_out_servers, oauth_server_names
+        from local_operator.tui.widgets.command_picker import slash_argument
+
+        argument = slash_argument(editor.text, editor._argument_commands)
+        if argument is None:
+            return []
+        sub, _space, _rest = argument.partition(" ")
+        if not _space:
+            return [
+                ArgumentChoice("login", "Authorize an OAuth server (opens the browser)"),
+                ArgumentChoice("logout", "Forget a server's stored OAuth credential", alert=True),
+                ArgumentChoice(
+                    "reauth", "Forget, then authorize again — account switch or scope change"
+                ),
+            ]
+        verb = sub.lower()
+        if verb not in ("login", "logout", "reauth"):
+            return []
+        try:
+            names = oauth_server_names(os.getcwd())
+        except Exception:
+            return []
+        manager = getattr(self._session, "mcp_manager", None)
+        if verb == "logout":
+            # Only what can actually be removed — the /logout rule. The store
+            # read degrades to the empty set when unreadable, and an empty
+            # list is then the honest answer to "what can I log out of". Rows
+            # are keyed by server NAME but the store is keyed by URL, so the
+            # config (via the manager) supplies the mapping.
+            stored = mcp_logged_out_servers()
+            names = [
+                name
+                for name in names
+                if self._mcp_server_url(name, manager) in stored
+            ]
+        choices: list[ArgumentChoice] = []
+        for name in names:
+            status = manager.get_connection_status(name) if manager is not None else ""
+            choices.append(
+                ArgumentChoice(
+                    f"{verb} {name}",
+                    f"{verb.capitalize()} OAuth server '{name}'",
+                    detail=status,
+                    # Every row on a logout list destroys a credential, so the
+                    # danger tint is a property of the verb, not of a row that
+                    # went wrong — the same rule /logout applies to providers.
+                    alert=verb == "logout",
+                )
+            )
+        return choices
+
+    def _mcp_server_url(self, name: str, manager: Any) -> str | None:
+        """The configured URL for one server, or ``None`` when unknown."""
+        if manager is None:
+            return None
+        cfg = manager.get_server_config(name)
+        return getattr(cfg, "url", None) if cfg is not None else None
+
+    async def _mcp_login_worker(
+        self, manager: Any, name: str, *, disconnect_first: bool = False
+    ) -> None:
         """Run one interactive MCP OAuth exchange, reporting into the transcript.
 
         The manager's ``connect_configured_server`` opens the browser
         (interactive=True) and waits for the loopback redirect. Success fires
         ``on_tools_changed``, which the session's wiring uses to merge the new
         tools in and repaint the band.
+
+        ``disconnect_first`` is the reauth shape: the stale connection is
+        torn down HERE, inside the worker, rather than by a separate one —
+        the group is exclusive, so a second worker would have cancelled this
+        one (or been cancelled by it), and either way the teardown could be
+        skipped while the grant proceeded.
         """
+        if disconnect_first:
+            try:
+                await manager.disconnect_server(name)
+            except Exception:  # noqa: BLE001 — a stuck teardown must not block the grant
+                logger.debug("MCP disconnect before reauth failed for %s", name, exc_info=True)
         try:
             conn = await manager.connect_configured_server(name, timeout_ms=600_000)
         except Exception as exc:  # noqa: BLE001 — report any failure, don't crash the app

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -9477,8 +9477,11 @@ class OperatorApp(App[None]):
             return [
                 ArgumentChoice("login", "Authorize an OAuth server (opens the browser)"),
                 ArgumentChoice("logout", "Forget a server's stored OAuth credential", alert=True),
+                # The differentiating clause leads: at narrow widths the tail
+                # truncates, and "forget, then authorize again" is the part
+                # login does not already say.
                 ArgumentChoice(
-                    "reauth", "Forget, then authorize again — account switch or scope change"
+                    "reauth", "Forget first, then authorize — for an account or scope change"
                 ),
             ]
         verb = sub.lower()
@@ -9501,14 +9504,40 @@ class OperatorApp(App[None]):
                 editor.picker.set_notice("credential store unreadable — cannot list logouts")
                 return []
             names = [name for name in names if self._mcp_server_url(name, manager) in stored]
+        # The verb→server swap is otherwise only inferable from the row
+        # shapes; a one-line notice names what this list is FOR while the
+        # server slot is open (it clears on the next slot change — the
+        # self-clearing rule every picker fill follows).
+        editor.picker.set_notice(
+            {
+                "login": "choose a server to authorize (opens the browser)",
+                "reauth": "choose a server to forget, then re-authorize",
+                "logout": "choose a credential to forget",
+            }[verb]
+        )
         choices: list[ArgumentChoice] = []
         for name in names:
             status = manager.get_connection_status(name) if manager is not None else ""
+            # Per-verb detail: a bare "connected" next to a login row reads as
+            # a contradiction (why log in when connected?), and on a logout
+            # row the danger column must name what is being REMOVED — the
+            # credential — not the connection that happens to be up.
+            if verb == "logout":
+                detail = "stored credential"
+                if status == "connected":
+                    detail += " · connected"
+            elif verb == "reauth":
+                detail = "connected — will re-authorize" if status == "connected" else status
+            else:
+                detail = "connected — will re-use" if status == "connected" else status
             choices.append(
                 ArgumentChoice(
                     f"{verb} {name}",
-                    f"{verb.capitalize()} OAuth server '{name}'",
-                    detail=status,
+                    # The name already says what the row does (`login linear`);
+                    # restating it as "Login OAuth server 'linear'" spends the
+                    # description cells saying nothing.
+                    "",
+                    detail=detail,
                     # Every row on a logout list destroys a credential, so the
                     # danger tint is a property of the verb, not of a row that
                     # went wrong — the same rule /logout applies to providers.

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -9500,11 +9500,7 @@ class OperatorApp(App[None]):
                 # been rather than rendering a bare empty one.
                 editor.picker.set_notice("credential store unreadable — cannot list logouts")
                 return []
-            names = [
-                name
-                for name in names
-                if self._mcp_server_url(name, manager) in stored
-            ]
+            names = [name for name in names if self._mcp_server_url(name, manager) in stored]
         choices: list[ArgumentChoice] = []
         for name in names:
             status = manager.get_connection_status(name) if manager is not None else ""

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -8510,8 +8510,11 @@ class OperatorApp(App[None]):
             picker.set_notice("")
             return
         if message.command == "mcp":
-            picker.set_choices(self._mcp_argument_choices(editor))
+            # Clear BEFORE the fill: the builder may set a notice of its own
+            # (an unreadable credential store on the logout list), and a
+            # blanket clear after it would erase exactly that.
             picker.set_notice("")
+            picker.set_choices(self._mcp_argument_choices(editor))
             return
         if message.command in ("theme", "themes"):
             # Seeded on the CURRENT theme's row (F2): the highlight previews
@@ -8585,7 +8588,12 @@ class OperatorApp(App[None]):
             # have moved on in the tick the message spent queued.
             return
         if message.command == "mcp":
-            editor.picker.set_choices(self._mcp_argument_choices(editor))
+            picker = editor.picker
+            # Same self-clearing rule as every sibling fill, applied BEFORE
+            # for the same reason as the opening branch: the builder may set
+            # a notice of its own that must survive the refill.
+            picker.set_notice("")
+            picker.set_choices(self._mcp_argument_choices(editor))
 
     def _credential_choices(self) -> list[ArgumentChoice]:
         """The verbs ``/credential`` offers, plus each stored key to forget.
@@ -9482,12 +9490,16 @@ class OperatorApp(App[None]):
             return []
         manager = getattr(self._session, "mcp_manager", None)
         if verb == "logout":
-            # Only what can actually be removed — the /logout rule. The store
-            # read degrades to the empty set when unreadable, and an empty
-            # list is then the honest answer to "what can I log out of". Rows
-            # are keyed by server NAME but the store is keyed by URL, so the
+            # Only what can actually be removed — the /logout rule. Rows are
+            # keyed by server NAME but the store is keyed by URL, so the
             # config (via the manager) supplies the mapping.
             stored = mcp_logged_out_servers()
+            if stored is None:
+                # An unreadable store is NOT the same answer as "no
+                # credentials anywhere": say so where the list would have
+                # been rather than rendering a bare empty one.
+                editor.picker.set_notice("credential store unreadable — cannot list logouts")
+                return []
             names = [
                 name
                 for name in names

--- a/local_operator/tui/widgets/command_picker.py
+++ b/local_operator/tui/widgets/command_picker.py
@@ -853,6 +853,14 @@ class CommandPicker(Static):
         detail_style = row_bg + Style(
             color=theme_mod.semantic_color("danger" if choice.alert else "muted")
         )
+        # The NAME carries the danger too: on `/logout`-style lists the detail
+        # column may hold an innocuous state word ("connected") or nothing at
+        # all, so tinting only the detail could leave a destructive row
+        # visually identical to a benign one — which is what happened on the
+        # `/mcp logout` list. The name is the cell every destructive row has.
+        name_style = s.name
+        if choice.alert and not s.selected:
+            name_style = row_bg + Style(color=theme_mod.semantic_color("danger"))
 
         span = max(1, width - _GUTTER_CELLS - _EDGE_MARGIN)
         detail = choice.detail.strip()
@@ -879,7 +887,7 @@ class CommandPicker(Static):
         if description and width > DESCRIPTION_COLLAPSE_WIDTH:
             column = max(1, min(self._primary_column(), body))
             clipped = truncate_cells(name, max(1, column - _PRIMARY_COLUMN_GAP))
-            row.append(clipped, style=s.name)
+            row.append(clipped, style=name_style)
             used = cell_len(clipped)
             gap = max(_PRIMARY_COLUMN_GAP, column - used)
             remaining = body - used - gap
@@ -891,7 +899,7 @@ class CommandPicker(Static):
             # rebuild as a name-only row rather than ship a stub description.
             row = self._gutter(s)
 
-        row.append(truncate_cells(name, max(1, body)), style=s.name)
+        row.append(truncate_cells(name, max(1, body)), style=name_style)
         return self._append_detail(row, width, detail, column_cells, detail_style, row_bg)
 
     def _append_detail(

--- a/local_operator/tui/widgets/command_picker.py
+++ b/local_operator/tui/widgets/command_picker.py
@@ -11,7 +11,7 @@ highlight a different command than the one that gets run.
 Layout — a borderless two-column list, one row per suggestion (D4):
 
     ❯ /model  /models    Show or switch model (provider/id)
-      /mcp               List MCP servers (/mcp login <name> to re-authorize)
+      /mcp               List MCP servers (login/logout/reauth <name> to manage OAuth)
 
 * The 2-cell selection gutter lines up with ``#prompt-chevron``, so the
   highlighted ``❯`` sits directly under the prompt's own ``❯`` and every

--- a/local_operator/tui/widgets/editor.py
+++ b/local_operator/tui/widgets/editor.py
@@ -443,6 +443,27 @@ class ArgumentQueryOpened(Message):
         self.command = command
 
 
+class RefreshArgumentChoices(Message):
+    """Posted when the rows an open argument list should offer have changed
+    UNDER the same command word — which :class:`ArgumentQueryOpened` can never
+    see, because it fires on the command-word transition only.
+
+    Exists for two-level arguments: ``/mcp`` offers its subcommands in the
+    first argument slot and the servers that subcommand can act on in the
+    second, so the choice set changes when the subcommand is completed while
+    the command word stands still. The editor tracks the SUBCOMMAND slot and
+    posts this when it changes; the app refills the picker exactly like an
+    opening. Keeping this per-command and explicit (rather than refilling
+    every list per keystroke) preserves the cost argument
+    :class:`ArgumentQueryOpened` documents — a credential-store read per
+    character typed.
+    """
+
+    def __init__(self, command: str) -> None:
+        super().__init__()
+        self.command = command
+
+
 class ArgumentHighlightChanged(Message):
     """Posted when the row the user's eye is on in an ARGUMENT list changes.
 
@@ -528,6 +549,9 @@ class Editor(TextArea):
         # the same reason as the pickers — _sync_picker() reads it during
         # super().__init__().
         self._argument_command: str | None = None
+        #: The first argument SLOT of a two-level command (``/mcp login``)
+        #: whose choice set depends on it; ``None`` for one-level commands.
+        self._argument_subcommand: str | None = None
         # Command words (primaries AND aliases) whose argument opens the value
         # list, and the subset of those the bare command cannot stand without.
         # DERIVED from the registry in :meth:`set_commands` rather than listed
@@ -1954,17 +1978,30 @@ class Editor(TextArea):
         list_argument = slash_argument(self.text, self._argument_commands)
         if list_argument is None:
             self._argument_command = None
+            self._argument_subcommand = None
             self._picker.sync(self.text)
         else:
             command = self._command_word()
             if command != self._argument_command:
                 self._argument_command = command
+                self._argument_subcommand = None
                 # Drop the previous command's rows before asking for this one's.
                 # `/login` offers every provider and `/logout` only the ones with a
                 # credential, so carrying them across would briefly offer a logout
                 # from an account the user never had.
                 self._picker.set_choices([])
                 self.post_message(ArgumentQueryOpened(command or ""))
+            elif command == "mcp":
+                # `/mcp` is two-level: verbs in the first argument slot,
+                # servers in the second. ArgumentQueryOpened fires on the
+                # command WORD, so without this the verb rows would stay up
+                # after `login` was completed and the server slot would have
+                # nothing to offer. Tracked rather than refreshed per
+                # keystroke: the row set only changes when the verb does.
+                subcommand = list_argument.partition(" ")[0].lower() if list_argument else ""
+                if subcommand != self._argument_subcommand:
+                    self._argument_subcommand = subcommand
+                    self.post_message(RefreshArgumentChoices(command))
             self._picker.sync_argument(list_argument)
         argument = slash_argument(self.text, self.MODEL_COMMANDS)
         if argument is None:

--- a/tests/unit/mcp/test_auth.py
+++ b/tests/unit/mcp/test_auth.py
@@ -258,6 +258,21 @@ class TestMcpTokenStorage:
         storage._store = None
         assert storage.clear() is False
 
+    def test_clear_when_the_delete_itself_fails_reports_false_and_keeps_the_row(self) -> None:
+        """The case the reauth safety depends on: a FAILED delete must never
+        be reported as a successful logout — clear() is False and the row
+        survives, so the caller refuses to run a "fresh" grant on top of it."""
+
+        class RefusingStore(FakeAuthStore):
+            def delete_credential(self, credential_id: int) -> None:
+                raise RuntimeError("database is locked")
+
+        store = RefusingStore()
+        storage = McpTokenStorage("https://srv.example/mcp", store)
+        storage._write({"tokens": {"access_token": "a"}})
+        assert storage.clear() is False
+        assert len(store.list_credentials(MCP_OAUTH_PROVIDER)) == 1
+
 
 class TestRealAuthStoreConformance:
     """MCP-03: the real providers AuthStore satisfies the MCP adapter."""
@@ -386,7 +401,8 @@ class TestLogoutHelpers:
             lambda cwd: (self._configs(), {}),
         )
         assert "not configured" in (mcp_logout_server("linar", Path("/anywhere")) or "")
-        assert "does not use OAuth" in (mcp_logout_server("stdio", Path("/anywhere")) or "")
+        not_oauth = mcp_logout_server("stdio", Path("/anywhere")) or ""
+        assert "does not use OAuth" in not_oauth
 
     def test_logged_out_servers_keys_by_url(self) -> None:
         """The picker list is keyed by server NAME but the store by URL; the
@@ -397,12 +413,18 @@ class TestLogoutHelpers:
         )
         assert mcp_logged_out_servers(store) == {"https://mcp.linear.app/mcp"}
 
-    def test_logged_out_servers_degrades_to_empty(self) -> None:
+    def test_logged_out_servers_distinguishes_an_unreadable_store(self) -> None:
+        """None, not the empty set: an unreadable store is not the same
+        answer as "no credentials anywhere", and the picker needs the
+        difference to say so."""
+
         class ExplodingStore(FakeAuthStore):
-            def list_credentials(self, provider=None, include_disabled=False):  # type: ignore[no-untyped-def]
+            def list_credentials(  # type: ignore[no-untyped-def]
+                self, provider=None, include_disabled=False
+            ):
                 raise RuntimeError("database is locked")
 
-        assert mcp_logged_out_servers(ExplodingStore()) == set()
+        assert mcp_logged_out_servers(ExplodingStore()) is None
 
 
 class TestCallbackInputParsing:

--- a/tests/unit/mcp/test_auth.py
+++ b/tests/unit/mcp/test_auth.py
@@ -20,7 +20,10 @@ from local_operator.mcp.auth import (
     MCP_OAUTH_PROVIDER,
     McpTokenStorage,
     StructuralAuthStore,
+    mcp_logged_out_servers,
+    mcp_logout_server,
     mcp_oauth_credential_id,
+    oauth_server_names,
     parse_oauth_callback_input,
     wire_oauth_auth,
 )
@@ -76,6 +79,10 @@ class FakeAuthStore:
             if row.id == credential_id:
                 return row
         return None
+
+    def delete_credential(self, credential_id: int) -> None:
+        # Mirrors the real store's logout path: the row is GONE, not disabled.
+        self.rows = [row for row in self.rows if row.id != credential_id]
 
 
 def test_fake_satisfies_structural_protocol() -> None:
@@ -222,6 +229,35 @@ class TestMcpTokenStorage:
         )
         assert await storage.get_tokens() is None
 
+    def test_clear_removes_the_row_and_reports_whether_one_existed(self) -> None:
+        """Logout is a deletion, not a disable: after clear() the SDK's next
+        ``get_tokens`` finds nothing and starts a genuinely fresh grant."""
+        store = FakeAuthStore()
+        storage = McpTokenStorage("https://srv.example/mcp", store)
+        storage._write({"tokens": {"access_token": "a"}})
+        assert store.list_credentials(MCP_OAUTH_PROVIDER)
+
+        assert storage.clear() is True
+        assert store.list_credentials(MCP_OAUTH_PROVIDER) == []
+        # A second clear is a reportable no-op, not an error: "nothing to log
+        # out of" is information the caller phrases, not a failure.
+        assert storage.clear() is False
+
+    def test_clear_removes_sibling_client_info(self) -> None:
+        """The row carries the client registration too; leaving it behind
+        would let the next login silently reuse it instead of re-registering."""
+        store = FakeAuthStore()
+        storage = McpTokenStorage("https://srv.example/mcp", store)
+        storage.seed_client_info("client-1")
+        assert storage._read() is not None
+        assert storage.clear() is True
+        assert storage._read() is None
+
+    def test_clear_with_no_store_degrades_to_false(self) -> None:
+        storage = McpTokenStorage("https://srv.example/mcp", store=None)
+        storage._store = None
+        assert storage.clear() is False
+
 
 class TestRealAuthStoreConformance:
     """MCP-03: the real providers AuthStore satisfies the MCP adapter."""
@@ -280,6 +316,93 @@ class TestRealAuthStoreConformance:
             assert second is not None and second.access_token == "acc-2"
         finally:
             store.close()
+
+    @pytest.mark.asyncio
+    async def test_clear_roundtrip_through_real_store(self, tmp_path) -> None:
+        """Logout deletes the real row, and a fresh storage instance (i.e. the
+        next process) finds nothing — the whole point of the command."""
+        from mcp.shared.auth import OAuthToken
+
+        from local_operator.providers.auth_store import AuthStore
+
+        store = AuthStore(db_path=tmp_path / "auth.db")
+        try:
+            url = "https://mcp.example.com/sse"
+            storage = McpTokenStorage(url, store)
+            await storage.set_tokens(OAuthToken(access_token="acc", token_type="Bearer"))
+            assert storage.clear() is True
+            fresh = McpTokenStorage(url, store)
+            assert await fresh.get_tokens() is None
+            assert store.list_credentials("mcp-oauth") == []
+        finally:
+            store.close()
+
+
+class TestLogoutHelpers:
+    """``mcp_logout_server`` / ``oauth_server_names`` / ``mcp_logged_out_servers``."""
+
+    def _configs(self) -> dict[str, Any]:
+        return {
+            "linear": MCPHttpServerConfig(
+                url="https://mcp.linear.app/mcp", auth=MCPAuthConfig(type="oauth")
+            ),
+            "stdio": MCPHttpServerConfig(url="https://stdio.example/mcp"),
+        }
+
+    def test_oauth_server_names_offers_only_oauth_servers(self, monkeypatch) -> None:
+        """A stdio/API-key server has no grant to manage; offering it would be
+        a row whose only outcome is a warning notice."""
+        monkeypatch.setattr(
+            "local_operator.mcp.config.load_all_mcp_configs",
+            lambda cwd: (self._configs(), {}),
+        )
+        assert oauth_server_names(Path("/anywhere")) == ["linear"]
+
+    def test_logout_removes_the_stored_credential(self, monkeypatch) -> None:
+        monkeypatch.setattr(
+            "local_operator.mcp.config.load_all_mcp_configs",
+            lambda cwd: (self._configs(), {}),
+        )
+        store = FakeAuthStore()
+        McpTokenStorage("https://mcp.linear.app/mcp", store)._write(
+            {"tokens": {"access_token": "a"}}
+        )
+        assert mcp_logout_server("linear", Path("/anywhere"), store) is None
+        assert store.list_credentials(MCP_OAUTH_PROVIDER) == []
+
+    def test_logout_without_a_stored_credential_says_so(self, monkeypatch) -> None:
+        monkeypatch.setattr(
+            "local_operator.mcp.config.load_all_mcp_configs",
+            lambda cwd: (self._configs(), {}),
+        )
+        error = mcp_logout_server("linear", Path("/anywhere"), FakeAuthStore())
+        assert error is not None and "nothing to log out of" in error
+
+    def test_logout_of_unknown_or_non_oauth_server_is_an_error(self, monkeypatch) -> None:
+        """A name the config does not know is a typo the user wants told
+        about — silently succeeding would claim a credential was removed."""
+        monkeypatch.setattr(
+            "local_operator.mcp.config.load_all_mcp_configs",
+            lambda cwd: (self._configs(), {}),
+        )
+        assert "not configured" in (mcp_logout_server("linar", Path("/anywhere")) or "")
+        assert "does not use OAuth" in (mcp_logout_server("stdio", Path("/anywhere")) or "")
+
+    def test_logged_out_servers_keys_by_url(self) -> None:
+        """The picker list is keyed by server NAME but the store by URL; the
+        helper returns the store's keys so the caller can do the mapping."""
+        store = FakeAuthStore()
+        McpTokenStorage("https://mcp.linear.app/mcp", store)._write(
+            {"tokens": {"access_token": "a"}}
+        )
+        assert mcp_logged_out_servers(store) == {"https://mcp.linear.app/mcp"}
+
+    def test_logged_out_servers_degrades_to_empty(self) -> None:
+        class ExplodingStore(FakeAuthStore):
+            def list_credentials(self, provider=None, include_disabled=False):  # type: ignore[no-untyped-def]
+                raise RuntimeError("database is locked")
+
+        assert mcp_logged_out_servers(ExplodingStore()) == set()
 
 
 class TestCallbackInputParsing:

--- a/tests/unit/test_cli_new.py
+++ b/tests/unit/test_cli_new.py
@@ -558,9 +558,7 @@ def test_mcp_logout_command_reports_removal(
 ) -> None:
     """The CLI's logout is the module helper plus phrasing: success names the
     server whose credential is gone, failure carries the helper's reason."""
-    monkeypatch.setattr(
-        "local_operator.mcp.auth.mcp_logout_server", lambda name, cwd: None
-    )
+    monkeypatch.setattr("local_operator.mcp.auth.mcp_logout_server", lambda name, cwd: None)
     assert cli.mcp_command(argparse.Namespace(mcp_command="logout", name="linear")) == 0
     assert "'linear'" in capsys.readouterr().out
 

--- a/tests/unit/test_cli_new.py
+++ b/tests/unit/test_cli_new.py
@@ -308,6 +308,12 @@ def test_mcp_subcommands(parser: argparse.ArgumentParser) -> None:
 
     login_args = parser.parse_args(["mcp", "login", "linear"])
     assert login_args.mcp_command == "login"
+    logout_args = parser.parse_args(["mcp", "logout", "linear"])
+    assert logout_args.mcp_command == "logout"
+    assert logout_args.name == "linear"
+    reauth_args = parser.parse_args(["mcp", "reauth", "linear"])
+    assert reauth_args.mcp_command == "reauth"
+    assert reauth_args.name == "linear"
     assert login_args.name == "linear"
 
     args = parser.parse_args(["mcp", "remove", "files", "--scope", "project"])
@@ -545,6 +551,64 @@ async def test_mcp_login_connects_and_disconnects_target(
     assert instances[0].cwd == tmp_path
     assert instances[0].disconnected is True
     assert "discovered 2 tools" in capsys.readouterr().out
+
+
+def test_mcp_logout_command_reports_removal(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    """The CLI's logout is the module helper plus phrasing: success names the
+    server whose credential is gone, failure carries the helper's reason."""
+    monkeypatch.setattr(
+        "local_operator.mcp.auth.mcp_logout_server", lambda name, cwd: None
+    )
+    assert cli.mcp_command(types.SimpleNamespace(mcp_command="logout", name="linear")) == 0
+    assert "'linear'" in capsys.readouterr().out
+
+    monkeypatch.setattr(
+        "local_operator.mcp.auth.mcp_logout_server",
+        lambda name, cwd: "no stored credential for MCP server 'linear'",
+    )
+    assert cli.mcp_command(types.SimpleNamespace(mcp_command="logout", name="linear")) == 1
+    assert "nothing" not in capsys.readouterr().out  # reason goes to stderr
+
+
+@pytest.mark.asyncio
+async def test_mcp_reauth_removes_then_logs_in(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Reauth must delete BEFORE the grant starts — a login over a surviving
+    row would reuse the stored registration and never show the consent
+    screen, which is the entire reason reauth exists."""
+    calls: list[str] = []
+    monkeypatch.setattr(
+        "local_operator.mcp.auth.mcp_logout_server",
+        lambda name, cwd: calls.append("logout") or None,
+    )
+
+    async def fake_login(name: str, cwd: Path) -> int:
+        calls.append("login")
+        return 0
+
+    monkeypatch.setattr(cli, "_mcp_login_server", fake_login)
+    assert await cli._mcp_reauth_server("linear", tmp_path) == 0
+    assert calls == ["logout", "login"]
+
+
+@pytest.mark.asyncio
+async def test_mcp_reauth_stops_when_removal_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    monkeypatch.setattr(
+        "local_operator.mcp.auth.mcp_logout_server",
+        lambda name, cwd: "MCP server 'linar' is not configured",
+    )
+
+    async def fake_login(name: str, cwd: Path) -> int:
+        raise AssertionError("login must not start when removal failed")
+
+    monkeypatch.setattr(cli, "_mcp_login_server", fake_login)
+    assert await cli._mcp_reauth_server("linar", tmp_path) == 1
+    assert "not configured" in capsys.readouterr().err
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_cli_new.py
+++ b/tests/unit/test_cli_new.py
@@ -561,14 +561,14 @@ def test_mcp_logout_command_reports_removal(
     monkeypatch.setattr(
         "local_operator.mcp.auth.mcp_logout_server", lambda name, cwd: None
     )
-    assert cli.mcp_command(types.SimpleNamespace(mcp_command="logout", name="linear")) == 0
+    assert cli.mcp_command(argparse.Namespace(mcp_command="logout", name="linear")) == 0
     assert "'linear'" in capsys.readouterr().out
 
     monkeypatch.setattr(
         "local_operator.mcp.auth.mcp_logout_server",
         lambda name, cwd: "no stored credential for MCP server 'linear'",
     )
-    assert cli.mcp_command(types.SimpleNamespace(mcp_command="logout", name="linear")) == 1
+    assert cli.mcp_command(argparse.Namespace(mcp_command="logout", name="linear")) == 1
     assert "nothing" not in capsys.readouterr().out  # reason goes to stderr
 
 

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -1954,6 +1954,12 @@ class FakeMcpManager:
         self._connected = list(connected)
         self._callback: Any = None
         self.inner_calls: list[list[Any]] = []
+        # Set by tests that exercise the login/logout/reauth paths: the
+        # config lookup the app does before dispatching a subcommand, and the
+        # record of what the workers were asked to do.
+        self._configs: dict[str, Any] = {}
+        self.disconnects: list[str] = []
+        self.connects: list[tuple[str, Any]] = []
 
     def get_all_server_names(self) -> list[str]:
         return sorted(self._configured)
@@ -1963,6 +1969,22 @@ class FakeMcpManager:
 
     def get_connection_status(self, name: str) -> str:
         return "connected" if name in self._connected else "disconnected"
+
+    def get_server_config(self, name: str) -> Any:
+        return self._configs.get(name)
+
+    async def disconnect_server(self, name: str) -> None:
+        self.disconnects.append(name)
+        if name in self._connected:
+            self._connected.remove(name)
+
+    async def connect_configured_server(self, name: str, *, timeout_ms: Any = None) -> Any:
+        # No browser in tests: the fake answers as an already-valid grant
+        # would, so the login worker's success path is what gets exercised.
+        self.connects.append((name, timeout_ms))
+        if name not in self._connected:
+            self._connected.append(name)
+        return SimpleNamespace(tools=["tool-a", "tool-b"])
 
     def set_on_tools_changed(self, callback: Any) -> None:
         self._callback = callback
@@ -2182,6 +2204,261 @@ async def test_mcp_command_puts_the_status_in_a_column() -> None:
         # The detail after the status column lines up too, or the padding only
         # moved the ragged edge one field to the right.
         assert rows[0].index("npx") == rows[1].index("command not found"), rows
+
+
+@pytest.mark.asyncio
+async def test_mcp_logout_removes_the_credential_and_disconnects() -> None:
+    """``/mcp logout <name>`` forgets the stored OAuth row AND tears the live
+    connection down — deleting the row alone would leave the session's tools
+    authenticated with a grant the user just revoked."""
+    from local_operator.mcp.config import MCPAuthConfig, MCPHttpServerConfig
+
+    configs = {
+        "linear": MCPHttpServerConfig(
+            url="https://mcp.linear.app/mcp", auth=MCPAuthConfig(type="oauth")
+        )
+    }
+    manager = FakeMcpManager(["linear"], ["linear"])
+    manager._configs = configs
+    session = McpSession(manager=manager, startup=McpStartupOutcome())
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 24)) as pilot:
+        for _ in range(6):
+            await pilot.pause()
+        app.query_one(Toast).dismiss_toast()
+        with (
+            patch(
+                "local_operator.mcp.config.load_all_mcp_configs",
+                return_value=(configs, {}),
+            ),
+            patch("local_operator.mcp.auth.mcp_logout_server", return_value=None) as logout,
+        ):
+            await _type_command(pilot, app, "mcp logout linear")
+            for _ in range(6):
+                await pilot.pause()
+        assert logout.call_count == 1
+        assert manager.disconnects == ["linear"]
+        text = _transcript_text(app)
+        assert "logged out of MCP server 'linear'" in text
+
+
+@pytest.mark.asyncio
+async def test_mcp_logout_of_a_server_with_no_credential_refuses() -> None:
+    """The destructive row must not report success when nothing was removed:
+    'logged out' after a no-op deletion would claim a grant was revoked that
+    never existed."""
+    from local_operator.mcp.config import MCPAuthConfig, MCPHttpServerConfig
+
+    configs = {
+        "linear": MCPHttpServerConfig(
+            url="https://mcp.linear.app/mcp", auth=MCPAuthConfig(type="oauth")
+        )
+    }
+    manager = FakeMcpManager(["linear"], ["linear"])
+    manager._configs = configs
+    session = McpSession(manager=manager, startup=McpStartupOutcome())
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 24)) as pilot:
+        for _ in range(6):
+            await pilot.pause()
+        app.query_one(Toast).dismiss_toast()
+        with (
+            patch(
+                "local_operator.mcp.config.load_all_mcp_configs",
+                return_value=(configs, {}),
+            ),
+            patch(
+                "local_operator.mcp.auth.mcp_logout_server",
+                return_value="no stored credential for MCP server 'linear' — nothing to log out of",
+            ),
+        ):
+            await _type_command(pilot, app, "mcp logout linear")
+            for _ in range(6):
+                await pilot.pause()
+        assert manager.disconnects == [], "a failed removal must not disconnect anyway"
+        # The notice wraps across transcript rows at this width, so match the
+        # phrase that cannot split.
+        assert "no stored credential" in _transcript_text(app)
+
+
+@pytest.mark.asyncio
+async def test_mcp_reauth_removes_then_runs_a_fresh_grant() -> None:
+    """Reauth is logout + login as ONE step: plain login reuses a stored
+    client registration or refreshable token, which is exactly what an account
+    switch cannot afford. The login only starts once the old row is gone."""
+    from local_operator.mcp.config import MCPAuthConfig, MCPHttpServerConfig
+
+    configs = {
+        "linear": MCPHttpServerConfig(
+            url="https://mcp.linear.app/mcp", auth=MCPAuthConfig(type="oauth")
+        )
+    }
+    manager = FakeMcpManager(["linear"], ["linear"])
+    manager._configs = configs
+    session = McpSession(manager=manager, startup=McpStartupOutcome())
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 24)) as pilot:
+        for _ in range(6):
+            await pilot.pause()
+        app.query_one(Toast).dismiss_toast()
+        with (
+            patch(
+                "local_operator.mcp.config.load_all_mcp_configs",
+                return_value=(configs, {}),
+            ),
+            patch("local_operator.mcp.auth.mcp_logout_server", return_value=None) as logout,
+        ):
+            await _type_command(pilot, app, "mcp reauth linear")
+            for _ in range(20):
+                await pilot.pause()
+                if manager.disconnects and manager.connects:
+                    break
+        assert logout.call_count == 1
+        assert manager.disconnects == ["linear"]
+        assert manager.connects == [("linear", 600_000)]
+        assert "authenticated MCP server 'linear'" in _transcript_text(app)
+
+
+@pytest.mark.asyncio
+async def test_mcp_reauth_never_logs_in_on_top_of_a_surviving_row() -> None:
+    """A login over a row that failed to delete is NOT a re-auth — the stored
+    registration would short-circuit the grant — so a failed removal stops the
+    chain instead of popping a misleading browser tab."""
+    from local_operator.mcp.config import MCPAuthConfig, MCPHttpServerConfig
+
+    configs = {
+        "linear": MCPHttpServerConfig(
+            url="https://mcp.linear.app/mcp", auth=MCPAuthConfig(type="oauth")
+        )
+    }
+    manager = FakeMcpManager(["linear"], ["linear"])
+    manager._configs = configs
+    session = McpSession(manager=manager, startup=McpStartupOutcome())
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 24)) as pilot:
+        for _ in range(6):
+            await pilot.pause()
+        app.query_one(Toast).dismiss_toast()
+        with (
+            patch(
+                "local_operator.mcp.config.load_all_mcp_configs",
+                return_value=(configs, {}),
+            ),
+            patch(
+                "local_operator.mcp.auth.mcp_logout_server",
+                return_value="no stored credential for MCP server 'linear' — nothing to log out of",
+            ),
+        ):
+            await _type_command(pilot, app, "mcp reauth linear")
+            for _ in range(8):
+                await pilot.pause()
+        assert manager.connects == [], "the grant must not start when removal failed"
+        assert "MCP reauth failed" in _transcript_text(app)
+
+
+@pytest.mark.asyncio
+async def test_mcp_unknown_subcommand_names_the_three_verbs() -> None:
+    """Before logout/reauth existed, mistyping `/mcp relogin` was told only
+    about login — the one discoverability surface the verbs have besides the
+    argument list."""
+    manager = FakeMcpManager(["linear"], ["linear"])
+    session = McpSession(manager=manager, startup=McpStartupOutcome())
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 24)) as pilot:
+        for _ in range(6):
+            await pilot.pause()
+        app.query_one(Toast).dismiss_toast()
+        await _type_command(pilot, app, "mcp relogin linear")
+        for _ in range(4):
+            await pilot.pause()
+        text = _transcript_text(app)
+        assert "unknown mcp subcommand" in text
+        assert "login|logout|reauth" in text
+
+
+@pytest.mark.asyncio
+async def test_mcp_argument_list_offers_subcommands_then_servers() -> None:
+    """The suggestion UX: typing `/mcp ` offers the three verbs; once a verb
+    is chosen the SAME list turns into the OAuth servers that verb can act
+    on, as ready-to-run `login notion`-style rows."""
+    from local_operator.mcp.config import MCPAuthConfig, MCPHttpServerConfig
+
+    configs = {
+        "linear": MCPHttpServerConfig(
+            url="https://mcp.linear.app/mcp", auth=MCPAuthConfig(type="oauth")
+        ),
+        "stdio": MCPHttpServerConfig(url="https://stdio.example/mcp"),
+    }
+    manager = FakeMcpManager(["linear", "stdio"], ["linear"])
+    manager._configs = configs
+    session = McpSession(manager=manager, startup=McpStartupOutcome())
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 24)) as pilot:
+        for _ in range(6):
+            await pilot.pause()
+        editor = app.query_one(Editor)
+        with patch(
+            "local_operator.mcp.config.load_all_mcp_configs",
+            return_value=(configs, {}),
+        ):
+            editor.load_text("/mcp ")
+            for _ in range(6):
+                await pilot.pause()
+            verb_rows = [name for name, _ in editor.picker.suggestions()]
+            assert verb_rows == ["login", "logout", "reauth"], verb_rows
+
+            editor.load_text("/mcp login ")
+            for _ in range(6):
+                await pilot.pause()
+            server_rows = [name for name, _ in editor.picker.suggestions()]
+            assert server_rows == ["login linear"], server_rows
+
+            # Narrowing still matches against the WHOLE argument: `login lin`
+            # must keep offering the compound row, or the row the user is
+            # looking at would vanish the moment they filtered to it.
+            editor.load_text("/mcp login lin")
+            for _ in range(6):
+                await pilot.pause()
+            assert [name for name, _ in editor.picker.suggestions()] == ["login linear"]
+
+
+@pytest.mark.asyncio
+async def test_mcp_logout_list_offers_only_servers_holding_a_credential() -> None:
+    """The `/logout` rule applied to MCP: a logout row for a server with no
+    stored grant promises a removal that can only end in a warning, so the
+    list is pre-filtered by the credential store (keyed by URL)."""
+    from local_operator.mcp.config import MCPAuthConfig, MCPHttpServerConfig
+
+    configs = {
+        "linear": MCPHttpServerConfig(
+            url="https://mcp.linear.app/mcp", auth=MCPAuthConfig(type="oauth")
+        ),
+        "notion": MCPHttpServerConfig(
+            url="https://mcp.notion.com/mcp", auth=MCPAuthConfig(type="oauth")
+        ),
+    }
+    manager = FakeMcpManager(["linear", "notion"], ["linear"])
+    manager._configs = configs
+    session = McpSession(manager=manager, startup=McpStartupOutcome())
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 24)) as pilot:
+        for _ in range(6):
+            await pilot.pause()
+        editor = app.query_one(Editor)
+        with (
+            patch(
+                "local_operator.mcp.config.load_all_mcp_configs",
+                return_value=(configs, {}),
+            ),
+            patch(
+                "local_operator.mcp.auth.mcp_logged_out_servers",
+                return_value={"https://mcp.linear.app/mcp"},
+            ),
+        ):
+            editor.load_text("/mcp logout ")
+            for _ in range(6):
+                await pilot.pause()
+            assert [name for name, _ in editor.picker.suggestions()] == ["logout linear"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tui/test_approvals_ux.py
+++ b/tests/unit/tui/test_approvals_ux.py
@@ -489,6 +489,9 @@ def test_the_registry_states_which_commands_offer_values() -> None:
         # and the space opens the ramp list with live preview.
         "theme": ArgumentMode.OPTIONAL,
         "approvals": ArgumentMode.OPTIONAL,
+        # OPTIONAL like `/approvals`: bare `/mcp` lists the servers, and the
+        # space opens the login/logout/reauth subcommand list.
+        "mcp": ArgumentMode.OPTIONAL,
         "login": ArgumentMode.REQUIRED,
         "logout": ArgumentMode.REQUIRED,
         # OPTIONAL like `/effort`: bare `/credential` lists the names in


### PR DESCRIPTION
## What

Adds the two missing OAuth-management subcommands to both surfaces, plus the suggestion UX for discovering them:

- **`local-operator mcp logout <name>` / `/mcp logout <name>`** — deletes the server's stored credential row (token *and* client registration) and tears the live connection down. Deletion happens *before* the disconnect so the manager's auto-reconnect cannot quietly re-authenticate from the row being deleted.
- **`local-operator mcp reauth <name>` / `/mcp reauth <name>`** — logout + login as one step. Plain `login` reuses a refreshable token or a stored client registration, which is wrong for an account switch or scope change; reauth removes the row first and **refuses to start the browser grant if removal failed**, because a login over a surviving row is not a re-auth.
- **`/mcp` suggestion UX** — the command gains `ArgumentMode.OPTIONAL` (bare `/mcp` still lists servers, matching `/approvals`) and a two-level argument list:
  - `/mcp ` offers `login` / `logout` / `reauth` with one-line descriptions;
  - `/mcp login ` (etc.) offers the OAuth-enabled servers that verb can act on, as ready-to-run `login notion`-style compound rows (the matcher compares the whole argument), each with the server's live connection status in the detail column;
  - `/mcp logout ` offers only servers that actually hold a stored credential (mirroring `/logout`'s rule) and carries the danger tint.

## Why

The only OAuth surface was `mcp login`. There was no way to log out of an MCP server, and no way to force a fresh consent screen — the exact situation behind recurring "OAuth authorization expired" session incidents, where the user has to know the token store exists to fix it.

## Implementation notes

- `McpTokenStorage.clear()` deletes the whole row: the row carries the client registration too, and leaving it would let the next login silently reuse it instead of re-registering (DCR) or re-seeding (pinned `client_id`). `StructuralAuthStore` gains `delete_credential`, matching the real `AuthStore`.
- `mcp_logout_server()` in `mcp/auth.py` is the single implementation; the CLI and TUI are phrasing layers over it. It goes through the real shared `auth.db`, not a session-injected store.
- The TUI reauth teardown runs **inside** the login worker: the `mcp-login` worker group is `exclusive=True`, so a back-to-back disconnect worker would be cancelled by the login worker (verified — this was a real bug caught by the pilot test).
- Two-level arguments needed one new editor message, `RefreshArgumentChoices`: `ArgumentQueryOpened` fires on the command-*word* transition only, so the verb→server switch under a standing `/mcp` would otherwise leave stale verb rows up. The editor tracks the subcommand slot and posts on change; the app refills through the same builders, preserving the "no store read per keystroke" cost argument.

## Testing evidence

- `tests/unit/tui/` + `tests/unit/mcp/` + `tests/unit/test_cli_new.py`: **2361 passed, 4 skipped** (includes new tests: `clear()` semantics against fake *and* real SQLite stores, logout helpers, CLI dispatch/order/refusal, TUI dispatch for all three verbs, the two-level suggestion flow incl. whole-argument narrowing, and the registry-mode pin)
- Lint: ruff output on changed files is identical to baseline modulo line-number shifts (no new findings)
- Visual check (real app via `run_test`, SVG → PNG):

`/mcp ` verbs · `/mcp login ` servers w/ status · `/mcp logout ` credential-holding servers only — screenshots captured from the running TUI during development; picker renders three rows, status column aligned, danger tint on logout rows.
