### PR TITLE
fix(mcp): stamp token_endpoint_auth_method in pinned client seed

### DIFF
--- a/local_operator/mcp/auth.py
+++ b/local_operator/mcp/auth.py
@@ -479,12 +479,25 @@ class McpTokenStorage:
         finds it via ``get_client_info`` and skips dynamic client
         registration entirely — required for providers whose redirect URI was
         registered against a fixed loopback port (pinned-redirect providers).
+
+        ``token_endpoint_auth_method`` must be stamped here, not left at its
+        ``None`` default: the SDK's ``prepare_token_auth`` only sends the
+        ``client_secret`` when the method names a secret-based scheme, so a
+        seed that omits it reaches the token endpoint with no secret at all
+        and the provider rejects the exchange (HubSpot: ``BAD_CLIENT_SECRET``).
+        Because :func:`wire_oauth_auth` re-seeds on EVERY login, a value
+        hand-patched into the store is overwritten before it can be used —
+        the method has to be correct at the source. ``client_secret_post``
+        matches the providers that pin a client (and HubSpot's advertised
+        ``token_endpoint_auth_methods_supported``); with no secret the method
+        is ``none``.
         """
         from mcp.shared.auth import OAuthClientInformationFull
 
         info = OAuthClientInformationFull(
             client_id=client_id,
             client_secret=client_secret,
+            token_endpoint_auth_method="client_secret_post" if client_secret else "none",
         )
         creds = self._read() or {}
         creds["client_info"] = info.model_dump(mode="json")

--- a/tests/unit/mcp/test_auth.py
+++ b/tests/unit/mcp/test_auth.py
@@ -764,6 +764,30 @@ class TestWireOauthAuth:
         rows = store.list_credentials(MCP_OAUTH_PROVIDER)
         assert rows[0].data["client_info"]["token_endpoint_auth_method"] == "none"
 
+    def test_reseed_overwrites_stale_token_endpoint_auth_method(self) -> None:
+        """The field-recovery path this fix depends on: a stored registration
+        whose method is wrong/absent (written before the stamp, or by hand)
+        must be corrected by the re-seed ``wire_oauth_auth`` runs on every
+        login — not left to fail the token exchange again."""
+        from mcp.shared.auth import OAuthClientInformationFull
+
+        store = FakeAuthStore()
+        storage = McpTokenStorage("https://srv.example/mcp", store)
+        # Pre-fix shape: a pinned registration with no auth method stamped.
+        bad = OAuthClientInformationFull(client_id="pinned-cid", client_secret="sec")
+        assert bad.token_endpoint_auth_method is None
+        import asyncio
+
+        asyncio.run(storage.set_client_info(bad))
+
+        cfg = MCPHttpServerConfig(
+            url="https://srv.example/mcp",
+            auth=MCPAuthConfig(type="oauth", client_id="pinned-cid", client_secret="sec"),
+        )
+        wire_oauth_auth("https://srv.example/mcp", cfg, store)
+        rows = store.list_credentials(MCP_OAUTH_PROVIDER)
+        assert rows[0].data["client_info"]["token_endpoint_auth_method"] == "client_secret_post"
+
     @pytest.mark.asyncio
     async def test_preseeded_client_info_visible_to_sdk(self) -> None:
         cfg = MCPHttpServerConfig(

--- a/tests/unit/mcp/test_auth.py
+++ b/tests/unit/mcp/test_auth.py
@@ -739,6 +739,31 @@ class TestWireOauthAuth:
         assert rows[0].data["client_info"]["client_id"] == "pinned-cid"
         assert rows[0].data["client_info"]["client_secret"] == "sec"
 
+    def test_seeded_client_info_stamps_token_endpoint_auth_method(self) -> None:
+        """A pinned seed must name a secret-based auth method, or the secret
+        is never sent and the provider rejects the token exchange (HubSpot's
+        ``BAD_CLIENT_SECRET``). The method has to be correct at the source
+        because ``wire_oauth_auth`` re-seeds on every login, overwriting any
+        hand-patched store value."""
+        cfg = MCPHttpServerConfig(
+            url="https://srv.example/mcp",
+            auth=MCPAuthConfig(type="oauth", client_id="pinned-cid", client_secret="sec"),
+        )
+        store = FakeAuthStore()
+        wire_oauth_auth("https://srv.example/mcp", cfg, store)
+        rows = store.list_credentials(MCP_OAUTH_PROVIDER)
+        assert rows[0].data["client_info"]["token_endpoint_auth_method"] == "client_secret_post"
+
+    def test_seeded_client_info_without_secret_uses_no_auth(self) -> None:
+        cfg = MCPHttpServerConfig(
+            url="https://srv.example/mcp",
+            auth=MCPAuthConfig(type="oauth", client_id="pinned-cid"),
+        )
+        store = FakeAuthStore()
+        wire_oauth_auth("https://srv.example/mcp", cfg, store)
+        rows = store.list_credentials(MCP_OAUTH_PROVIDER)
+        assert rows[0].data["client_info"]["token_endpoint_auth_method"] == "none"
+
     @pytest.mark.asyncio
     async def test_preseeded_client_info_visible_to_sdk(self) -> None:
         cfg = MCPHttpServerConfig(


### PR DESCRIPTION
## What

`seed_client_info` now stamps `token_endpoint_auth_method` on the pinned client registration: `client_secret_post` when a secret is configured, `none` otherwise.

## Why

HubSpot MCP login hung/failed at the token exchange with `BAD_CLIENT_SECRET — missing or invalid client secret`, even though the correct secret was in `mcp.json`. Root cause: the seed built `OAuthClientInformationFull(client_id, client_secret)` with `token_endpoint_auth_method` left at its `None` default. The SDK's `prepare_token_auth` only includes the secret when the method names a secret-based scheme, so every token exchange went out with **no** `client_secret` and HubSpot (a pinned-client provider; DCR is skipped for it) rejected it.

The kicker: `wire_oauth_auth` calls `seed_client_info` on **every** login, unconditionally overwriting the stored `client_info`. So hand-patching `token_endpoint_auth_method` into the credential store didn't survive a single login attempt — the method had to be fixed at the source.

## Testing evidence

- Reproduced end-to-end against the real credential store and HubSpot: token exchange `POST https://mcp.hubspot.com/oauth/v3/token` returned `400 BAD_CLIENT_SECRET` before the fix.
- After the fix, validated the seeded registration carries `token_endpoint_auth_method="client_secret_post"` and `prepare_token_auth` puts `client_secret` in the token body.
- New tests: `test_seeded_client_info_stamps_token_endpoint_auth_method`, `test_seeded_client_info_without_secret_uses_no_auth`. Full `tests/unit/mcp/test_auth.py`: 59 passed.
- Gates: flake8 / black==26.1.0 / isort / pyright clean.

## Note

Full live completion of the OAuth grant (browser consent → token stored) additionally depends on the consent redirect being captured, which is a separate UX gap tracked elsewhere (the TUI swallows the consent URL). This PR fixes the token-exchange rejection that made even a *captured* grant fail.