### PR TITLE
fix(mcp): acknowledge browser-close and cancellation during /mcp login

### DIFF
--- a/local_operator/mcp/auth.py
+++ b/local_operator/mcp/auth.py
@@ -119,6 +119,22 @@ class McpAuthRequiredError(RuntimeError):
         self.server_url = server_url
 
 
+class McpLoginCancelledError(RuntimeError):
+    """An interactive MCP OAuth grant ended with no authorization arriving.
+
+    Two routes land here: the human route (the browser tab was closed or the
+    consent screen abandoned, surfaced once the idle guard fires) and the
+    structural one (the login task was cancelled — an exclusive re-login, the
+    TUI's stop-ladder, or a Ctrl+C at the CLI). The point of the dedicated
+    type is the MESSAGE: the login flows catch the SDK's ``OAuthFlowError``
+    and report ``str(exc)``, so the explanation has to live on the innermost
+    raise or it is lost. A bare ``CancelledError`` would surface either as an
+    empty ``MCP login failed for 'x':`` line or — worse inside the TUI — as
+    silence, because a Textual worker cancelled by its exclusive group never
+    runs the worker's exception handler at all.
+    """
+
+
 def mcp_oauth_credential_id(server_url: str) -> str:
     """Stable logical credential id for one MCP server's OAuth grant."""
     return f"{MCP_OAUTH_CREDENTIAL_PREFIX}{server_url}"
@@ -646,6 +662,16 @@ def parse_oauth_callback_input(raw: str) -> tuple[str, str | None, str | None]:
 #: forever.
 PASTE_INPUT_TIMEOUT_S = 300.0
 
+#: Idle bound on an INTERACTIVE grant: the longest a login waits for a browser
+#: round trip that will never complete. The usual reason nothing arrives is
+#: that the tab was closed or the consent screen abandoned — indistinguishable
+#: from a slow human at the protocol level, so the flow has to give up on a
+#: clock and say so. Sized to match the 10-minute budget both login callers
+#: already allow the whole connect (``/mcp login`` and ``local-operator mcp
+#: login``), so the grant now ends with an explicit "cancelled" receipt inside
+#: that window instead of outliving it as a silent "logging in…" line.
+INTERACTIVE_GRANT_TIMEOUT_S = 600.0
+
 #: Hosts a redirect URI can name that THIS process is able to answer.
 #:
 #: A redirect URI may legitimately point anywhere; only a loopback address is
@@ -792,13 +818,53 @@ class LoopbackAuthFlow:
             # safe precisely because nothing else is going to.
             return await self._await_pasted()
         try:
-            return await asyncio.wait_for(self._result, timeout=PASTE_INPUT_TIMEOUT_S)
+            # The inner clock is the 300 s redirect bound with its
+            # port-forwarding advice for the genuinely slow case; the outer
+            # coroutine adds the interactive idle guard AROUND it. They stay
+            # separate because ``wait_for`` makes a timeout indistinguishable
+            # from an outer one once nested — each clock must convert its own
+            # expiry before the next layer can see it.
+            # Captured once: a closure read of ``self._result`` types as
+            # optional (``_stop_server`` resets it), and it cannot change
+            # underneath the wait anyway — only ``_stop_server`` clears it,
+            # and that runs after the wait resolves.
+            result = self._result
+
+            async def _within_idle_guard() -> tuple[str, str | None, str | None]:
+                try:
+                    return await asyncio.wait_for(result, timeout=PASTE_INPUT_TIMEOUT_S)
+                except asyncio.TimeoutError as exc:
+                    raise RuntimeError(
+                        f"Timed out after {PASTE_INPUT_TIMEOUT_S:.0f}s waiting for the "
+                        f"OAuth redirect to {self.redirect_uri}. If you authorized in a "
+                        "browser on another machine it cannot reach this port — "
+                        f"forward it (ssh -L {self._port}:127.0.0.1:{self._port} …) "
+                        "and try again."
+                    ) from exc
+
+            return await asyncio.wait_for(_within_idle_guard(), timeout=INTERACTIVE_GRANT_TIMEOUT_S)
+        except asyncio.CancelledError:
+            # The login task itself was cancelled (an exclusive re-login, the
+            # TUI's stop-ladder, Ctrl+C at the CLI). The underlying result
+            # future is cancelled by the wait_for on the way out, and
+            # ``callback_handler``'s ``finally`` stops the listener — but only
+            # if we CO-OPERATE: shielding the teardown lets one stop-ladder
+            # escalation turn a cancelled login into a wedged listener holding
+            # the redirect port into the next grant.
+            with contextlib.suppress(Exception):
+                await asyncio.shield(self._stop_server())
+            raise McpLoginCancelledError(
+                "the login was interrupted before the browser completed it"
+            ) from None
         except asyncio.TimeoutError as exc:
-            raise RuntimeError(
-                f"Timed out after {PASTE_INPUT_TIMEOUT_S:.0f}s waiting for the OAuth "
-                f"redirect to {self.redirect_uri}. If you authorized in a browser on "
-                "another machine it cannot reach this port — forward it "
-                f"(ssh -L {self._port}:127.0.0.1:{self._port} …) and try again."
+            # The idle guard, not the redirect clock: nothing arrived for the
+            # whole interactive budget, which in practice means the browser
+            # went away — tab closed, consent abandoned.
+            raise McpLoginCancelledError(
+                f"no redirect arrived within {INTERACTIVE_GRANT_TIMEOUT_S / 60:.0f} "
+                "minutes — the login was probably cancelled (browser tab closed, "
+                "or the authorization left unfinished). Run /mcp login again to "
+                "retry."
             ) from exc
 
     async def _await_pasted(self) -> tuple[str, str | None, str | None]:
@@ -825,6 +891,14 @@ class LoopbackAuthFlow:
                 asyncio.to_thread(lambda: input(prompt).strip()),
                 timeout=PASTE_INPUT_TIMEOUT_S,
             )
+        except asyncio.CancelledError:
+            # Same receipt as the listener path: an interrupted CLI login must
+            # not surface as a bare "MCP login failed for 'x':" with no reason.
+            # The to_thread reader itself cannot be cancelled (that is why
+            # paste is never raced), so no teardown is owed here.
+            raise McpLoginCancelledError(
+                "the login was interrupted before the redirect URL was pasted"
+            ) from None
         except asyncio.TimeoutError as exc:
             # TRANSLATE IT. Since 3.11 `asyncio.TimeoutError` IS `TimeoutError`
             # and `str(TimeoutError())` is the empty string, so letting it

--- a/local_operator/mcp/auth.py
+++ b/local_operator/mcp/auth.py
@@ -46,6 +46,7 @@ import logging
 import os
 import sys
 import time
+import weakref
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 from urllib.parse import parse_qs, urlparse
@@ -132,6 +133,23 @@ class McpLoginCancelledError(RuntimeError):
     empty ``MCP login failed for 'x':`` line or — worse inside the TUI — as
     silence, because a Textual worker cancelled by its exclusive group never
     runs the worker's exception handler at all.
+    """
+
+
+class AbandonedGrantError(Exception):
+    """The browser round trip ended with no authorization — the human walked away.
+
+    Distinct from :class:`McpLoginCancelledError` on purpose: THAT one is the
+    user-facing receipt the login surfaces report; this one is the flow's
+    internal record of WHY the grant died. The separation matters because of
+    how the two endings have to travel. An abandoned grant is raised out of
+    ``callback_handler`` as a raw ``asyncio.CancelledError``: the streamable-HTTP
+    transport's SDK ``post_writer`` swallows any ordinary exception an auth
+    handler raises (it logs and moves on), while a cancellation unwinds the
+    transport's task group exactly the way a grant REQUIREMENT does — that is
+    the channel the message cannot be eaten on. The flow records itself in
+    :data:`ABANDONED_GRANTS` first, and the manager converts the arriving
+    cancellation back into :class:`McpLoginCancelledError`.
     """
 
 
@@ -697,6 +715,53 @@ _REQUEST_READ_TIMEOUT_S = 10.0
 _SERVER_CLOSE_TIMEOUT_S = 1.0
 
 
+#: Flows whose grant the human abandoned (idle guard fired), keyed by the
+#: flow object with the abandonment time as value. This is the side channel
+#: that survives the transport: ``callback_handler`` raises a raw
+#: ``CancelledError`` for an abandoned grant because the SDK's ``post_writer``
+#: eats ordinary exceptions, and the manager consults this registry to tell
+#: "the grant died of neglect" apart from "the login task was cancelled".
+#: Entries are pruned on every write; a flow object whose grant never
+#: abandoned never appears here, and one that did is dropped from the map
+#: when its entry is consumed or when it ages past the prune horizon.
+#: How long an abandonment record may sit unread. The manager consumes it
+#: within seconds of the raise; the horizon only bounds a leak for flows
+#: whose connect never got as far as consulting the registry.
+_ABANDONED_GRANT_TTL_S = 120.0
+
+
+class AbandonedGrantLedger:
+    """Flows whose grant the human abandoned (idle guard fired).
+
+    This is the side channel that survives the transport: ``callback_handler``
+    raises a raw ``CancelledError`` for an abandoned grant because the SDK's
+    ``post_writer`` eats ordinary exceptions, and the manager consults the
+    ledger to tell "the grant died of neglect" apart from "the login task
+    was cancelled". Records are consumed by the manager (``pop``) or age out
+    on the next write; keys are weak so a flow nobody consults cannot be kept
+    alive by its own record.
+    """
+
+    def __init__(self) -> None:
+        self._records: weakref.WeakKeyDictionary[LoopbackAuthFlow, float] = (
+            weakref.WeakKeyDictionary()
+        )
+
+    def record(self, flow: LoopbackAuthFlow) -> None:
+        now = time.monotonic()
+        for old, at in list(self._records.items()):
+            if now - at > _ABANDONED_GRANT_TTL_S:
+                self._records.pop(old, None)
+        self._records[flow] = now
+
+    def pop(self, flow: LoopbackAuthFlow) -> bool:
+        """Consume one flow's abandonment record; ``True`` when one was there."""
+        return self._records.pop(flow, None) is not None
+
+
+ABANDONED_GRANTS = AbandonedGrantLedger()
+
+
 class LoopbackAuthFlow:
     """The redirect/callback pair for one authorization, over a real listener.
 
@@ -803,11 +868,25 @@ class LoopbackAuthFlow:
         self._notify(*lines)
 
     async def callback_handler(self) -> AuthorizationCodeResult:
-        """Wait for the provider's redirect (or a pasted URL) and return the code."""
+        """Wait for the provider's redirect (or a pasted URL) and return the code.
+
+        The transport cannot be trusted to deliver an exception raised here:
+        the SDK's ``post_writer`` swallows ordinary auth-flow exceptions, so
+        an ABANDONED grant (idle guard fired — the browser went away) is
+        recorded in :data:`ABANDONED_GRANTS` and then raised as a RAW
+        ``CancelledError``, the one exception shape that unwinds the
+        transport's anyio task group intact. The manager recognises the
+        pairing and re-voices it as :class:`McpLoginCancelledError`; raising
+        the named error here directly would leave it stranded in a log line
+        while the connect surfaced an unlabelled cancellation.
+        """
         from mcp.shared.auth import AuthorizationCodeResult
 
         try:
             code, state, iss = await self._await_authorization()
+        except AbandonedGrantError:
+            ABANDONED_GRANTS.record(self)
+            raise asyncio.CancelledError() from None
         finally:
             await self._stop_server()
         return AuthorizationCodeResult(code=code, state=state, iss=iss)
@@ -851,20 +930,21 @@ class LoopbackAuthFlow:
             # if we CO-OPERATE: shielding the teardown lets one stop-ladder
             # escalation turn a cancelled login into a wedged listener holding
             # the redirect port into the next grant.
+            # The interrupt that arrives while we are still WAITING for the
+            # redirect is unambiguous: the browser never answered, so this is
+            # the task being cancelled, never the abandonment channel (that
+            # one only fires from the idle-guard arm). Report it directly.
             with contextlib.suppress(Exception):
                 await asyncio.shield(self._stop_server())
-            raise McpLoginCancelledError(
-                "the login was interrupted before the browser completed it"
-            ) from None
+            raise McpLoginCancelledError("interrupted before the browser completed it") from None
         except asyncio.TimeoutError as exc:
             # The idle guard, not the redirect clock: nothing arrived for the
             # whole interactive budget, which in practice means the browser
             # went away — tab closed, consent abandoned.
-            raise McpLoginCancelledError(
+            raise AbandonedGrantError(
                 f"no redirect arrived within {INTERACTIVE_GRANT_TIMEOUT_S / 60:.0f} "
                 "minutes — the login was probably cancelled (browser tab closed, "
-                "or the authorization left unfinished). Run /mcp login again to "
-                "retry."
+                "or the authorization left unfinished)"
             ) from exc
 
     async def _await_pasted(self) -> tuple[str, str | None, str | None]:
@@ -896,9 +976,7 @@ class LoopbackAuthFlow:
             # not surface as a bare "MCP login failed for 'x':" with no reason.
             # The to_thread reader itself cannot be cancelled (that is why
             # paste is never raced), so no teardown is owed here.
-            raise McpLoginCancelledError(
-                "the login was interrupted before the redirect URL was pasted"
-            ) from None
+            raise McpLoginCancelledError("interrupted before the redirect URL was pasted") from None
         except asyncio.TimeoutError as exc:
             # TRANSLATE IT. Since 3.11 `asyncio.TimeoutError` IS `TimeoutError`
             # and `str(TimeoutError())` is the empty string, so letting it
@@ -1459,12 +1537,31 @@ async def ensure_mcp_oauth_fresh(
     return endpoints
 
 
+def _resolve_redirect_uri(cfg: MCPServerConfig) -> str:
+    """The loopback redirect URI a config's ``oauth`` block resolves to.
+
+    Shared by :func:`wire_oauth_auth` (which advertises it in the client
+    metadata) and :func:`build_oauth_provider` (which binds the flow's
+    listener to it): the two MUST agree, or the provider redirects the
+    browser to an address nothing is serving.
+    """
+    oauth = cfg.oauth
+    callback_port = (oauth.callback_port if oauth is not None else None) or DEFAULT_CALLBACK_PORT
+    callback_path = (oauth.callback_path if oauth is not None else None) or DEFAULT_CALLBACK_PATH
+    if not callback_path.startswith("/"):
+        callback_path = f"/{callback_path}"
+    return (oauth.redirect_uri if oauth is not None else None) or (
+        f"http://127.0.0.1:{callback_port}{callback_path}"
+    )
+
+
 def wire_oauth_auth(
     server_url: str,
     cfg: MCPServerConfig,
     store: StructuralAuthStore | None = None,
     *,
     interactive: bool = True,
+    flow: LoopbackAuthFlow | None = None,
 ) -> dict[str, Any]:
     """Build ``OAuthClientProvider`` kwargs for one server.
 
@@ -1482,7 +1579,11 @@ def wire_oauth_auth(
       (MCP-11);
     - ``redirect_handler`` / ``callback_handler``: the two halves of one
       :class:`LoopbackAuthFlow`, which listens on that redirect URI for the
-      duration of the grant (see the module docstring).
+      duration of the grant (see the module docstring). Callers that need
+      the flow itself — :func:`build_oauth_provider` does, for the manager's
+      abandoned-grant check — pass their own via ``flow``; the dict returned
+      here stays exactly the SDK's kwargs so it can be splatted straight
+      into ``OAuthClientProvider``.
 
     ``interactive`` controls whether the flow may open a browser. Ordinary
     session startup and auto-reconnects pass ``False`` so an unrefreshable
@@ -1497,13 +1598,7 @@ def wire_oauth_auth(
     auth = cfg.auth
     oauth = cfg.oauth
 
-    callback_port = (oauth.callback_port if oauth is not None else None) or DEFAULT_CALLBACK_PORT
-    callback_path = (oauth.callback_path if oauth is not None else None) or DEFAULT_CALLBACK_PATH
-    if not callback_path.startswith("/"):
-        callback_path = f"/{callback_path}"
-    redirect_uri = (oauth.redirect_uri if oauth is not None else None) or (
-        f"http://127.0.0.1:{callback_port}{callback_path}"
-    )
+    redirect_uri = _resolve_redirect_uri(cfg)
 
     # Scopes: explicit `scope` on the auth block — an extra-allowed field, so
     # it lives in ``model_extra`` rather than being declared — else none (the
@@ -1535,7 +1630,8 @@ def wire_oauth_auth(
     if client_id:
         storage.seed_client_info(client_id, client_secret)
 
-    flow = LoopbackAuthFlow(redirect_uri, server_url=server_url, interactive=interactive)
+    if flow is None:
+        flow = LoopbackAuthFlow(redirect_uri, server_url=server_url, interactive=interactive)
     return {
         "server_url": server_url,
         "client_metadata": client_metadata,
@@ -1577,8 +1673,18 @@ def build_oauth_provider(
     """
     from mcp.client.auth import OAuthClientProvider
 
-    kwargs = wire_oauth_auth(server_url, cfg, store=store, interactive=interactive)
+    # The flow is created HERE (not inside wire_oauth_auth) so it can be
+    # attached to the provider: an abandoned grant arrives at the connect as
+    # a raw CancelledError (see ``LoopbackAuthFlow.callback_handler``), and
+    # the ABANDONED_GRANTS ledger keyed by this object is what identifies it.
+    # Its redirect URI must match the one wire_oauth_auth computes, which a
+    # config override can change — one helper keeps the two from drifting.
+    flow = LoopbackAuthFlow(
+        _resolve_redirect_uri(cfg), server_url=server_url, interactive=interactive
+    )
+    kwargs = wire_oauth_auth(server_url, cfg, store=store, interactive=interactive, flow=flow)
     provider = OAuthClientProvider(**kwargs)
+    provider._loopback_flow = flow  # type: ignore[attr-defined]
     if endpoints is not None:
         provider.context.oauth_metadata = endpoints.oauth_metadata
         provider.context.protected_resource_metadata = endpoints.protected_resource_metadata

--- a/local_operator/mcp/manager.py
+++ b/local_operator/mcp/manager.py
@@ -850,6 +850,11 @@ class McpManager:
         # of the SDK's ``<server_base>/token`` guess. Keyed by URL because the
         # provider is rebuilt per connect while discovery is per server.
         self._oauth_endpoints: dict[str, Any] = {}
+        # Loopback flows of in-flight/last OAuth grants, keyed by server URL.
+        # An abandoned grant crosses the transport as a raw CancelledError;
+        # this is how the connect error path finds the flow whose
+        # ABANDONED_GRANTS ledger entry re-voices it.
+        self._oauth_flows: dict[str, Any] = {}
         self._epoch = 0
         self._disposed = False
 
@@ -1300,6 +1305,26 @@ class McpManager:
                     raise
                 assert isinstance(close_exc, asyncio.CancelledError)
                 raise close_exc
+            # An abandoned grant (browser closed, consent left unanswered,
+            # idle guard fired) arrives as a bare CancelledError with NO
+            # cancelling count: the flow raises it raw precisely because the
+            # SDK's transport swallows ordinary auth exceptions (see
+            # ``LoopbackAuthFlow.callback_handler``). The ABANDONED_GRANTS
+            # ledger is the channel the message actually travelled on; the
+            # externally_cancelled guard above has already kept a REAL task
+            # cancellation's priority, so a recorded abandonment here can be
+            # re-voiced as the receipt the user reads.
+            if isinstance(exc, asyncio.CancelledError):
+                from local_operator.mcp.auth import ABANDONED_GRANTS, McpLoginCancelledError
+
+                url = getattr(cfg, "url", None)
+                flow = self._oauth_flows.pop(url, None) if isinstance(url, str) else None
+                if flow is not None and ABANDONED_GRANTS.pop(flow):
+                    raise McpLoginCancelledError(
+                        "the browser never completed the authorization — the login "
+                        "was probably cancelled (tab closed, or the consent left "
+                        "unfinished). Run /mcp login again to retry."
+                    ) from exc
             # An OAuth grant requirement is not a transport failure: surface it
             # as the clean type so callers (startup toast, reconnect breaker,
             # /mcp login) can recognise it. It can ride EITHER the original
@@ -1361,14 +1386,20 @@ class McpManager:
                 streamable_http_client,
             )
 
+            oauth_provider = self._build_oauth_auth(cfg.url, cfg, interactive=interactive)
             http_client = create_mcp_http_client(
                 headers=dict(cfg.headers) or None,
-                auth=self._build_oauth_auth(cfg.url, cfg, interactive=interactive),
+                auth=oauth_provider,
             )
             streams_cm = streamable_http_client(cfg.url, http_client=http_client)
         elif isinstance(cfg, MCPSseServerConfig):
             from mcp.client.sse import sse_client
 
+            # SSE wires no auth into its client here (pre-existing gap), but
+            # the provider is still built so an OAuth config's loopback flow
+            # is recorded: the abandoned-grant check in ``_connect_server``
+            # reads it off the manager's per-URL map.
+            self._build_oauth_auth(cfg.url, cfg, interactive=interactive)
             streams_cm = sse_client(cfg.url, headers=dict(cfg.headers) or None)
         else:  # pragma: no cover - validation rejects unknown shapes
             raise McpConnectionError(f"unsupported MCP transport for {name!r}")
@@ -1420,7 +1451,7 @@ class McpManager:
         try:
             from local_operator.mcp.auth import build_oauth_provider
 
-            return build_oauth_provider(
+            provider = build_oauth_provider(
                 url,
                 cfg,
                 store=self._effective_auth_store(),
@@ -1434,6 +1465,15 @@ class McpManager:
                 exc_info=True,
             )
             return None
+        # Record the grant's flow by server URL: an abandoned grant crosses
+        # the transport as a raw CancelledError (the SDK swallows ordinary
+        # auth exceptions), and ``_connect_server``'s error path cannot reach
+        # the provider from there — this map is how it finds the flow to
+        # consult the ABANDONED_GRANTS ledger.
+        flow = getattr(provider, "_loopback_flow", None)
+        if flow is not None:
+            self._oauth_flows[url] = flow
+        return provider
 
     async def _ensure_oauth_fresh(self, name: str, cfg: MCPServerConfig) -> None:
         """Proactively refresh an OAuth grant before connecting (best-effort).

--- a/local_operator/mcp/manager.py
+++ b/local_operator/mcp/manager.py
@@ -1315,7 +1315,10 @@ class McpManager:
             # cancellation's priority, so a recorded abandonment here can be
             # re-voiced as the receipt the user reads.
             if isinstance(exc, asyncio.CancelledError):
-                from local_operator.mcp.auth import ABANDONED_GRANTS, McpLoginCancelledError
+                from local_operator.mcp.auth import (
+                    ABANDONED_GRANTS,
+                    McpLoginCancelledError,
+                )
 
                 url = getattr(cfg, "url", None)
                 flow = self._oauth_flows.pop(url, None) if isinstance(url, str) else None

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -9637,6 +9637,8 @@ class OperatorApp(App[None]):
         one (or been cancelled by it), and either way the teardown could be
         skipped while the grant proceeded.
         """
+        from local_operator.mcp.auth import McpLoginCancelledError
+
         if disconnect_first:
             try:
                 await manager.disconnect_server(name)
@@ -9644,6 +9646,23 @@ class OperatorApp(App[None]):
                 logger.debug("MCP disconnect before reauth failed for %s", name, exc_info=True)
         try:
             conn = await manager.connect_configured_server(name, timeout_ms=600_000)
+        except asyncio.CancelledError:
+            # The "logging in…" receipt must ALWAYS get an ending. A worker
+            # cancelled by its exclusive group (a second login/reauth request)
+            # or by the stop-ladder never runs this function's own failure
+            # reporting without this branch: the grant is quietly unwound and
+            # the transcript keeps a "logging in…" line nothing ever answers.
+            self._system_notice(
+                f"MCP login for {name!r} cancelled before the browser completed it.",
+                "warning",
+            )
+            raise
+        except McpLoginCancelledError as exc:
+            # The browser round trip ended without an authorization — the tab
+            # closed, the consent abandoned, or the idle guard fired. Not an
+            # error in the red sense: the user is the one who walked away.
+            self._system_notice(f"MCP login for {name!r} cancelled: {exc}", "warning")
+            return
         except Exception as exc:  # noqa: BLE001 — report any failure, don't crash the app
             self._system_notice(f"MCP login failed for {name!r}: {exc}", "error")
             return

--- a/tests/unit/mcp/test_auth.py
+++ b/tests/unit/mcp/test_auth.py
@@ -804,6 +804,75 @@ class TestLoopbackCallbackServer:
         page = await page_task
         assert "No authorization code" in page
 
+    @pytest.mark.asyncio
+    async def test_an_abandoned_grant_ends_as_an_explicit_cancel(self, monkeypatch) -> None:
+        """A browser that never comes back must end with a receipt, not a wait.
+
+        Closing the tab or abandoning the consent screen is indistinguishable
+        from a slow human at the protocol level, so the interactive grant
+        carries its own idle clock. When it fires the flow settles as
+        ``McpLoginCancelledError`` — the message that tells the user the login
+        is over and how to start another — instead of leaving "logging in…"
+        unanswered in the transcript.
+        """
+        import asyncio
+        import sys
+
+        from local_operator.mcp.auth import LoopbackAuthFlow, McpLoginCancelledError
+
+        monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
+        monkeypatch.setattr("webbrowser.open", lambda _url: False)
+        # The inner redirect clock must OUTLIVE the guard for the guard to be
+        # the clock that fires — which is also their real-world relationship
+        # (300 s vs 600 s), shrunk.
+        monkeypatch.setattr("local_operator.mcp.auth.PASTE_INPUT_TIMEOUT_S", 10.0)
+        monkeypatch.setattr("local_operator.mcp.auth.INTERACTIVE_GRANT_TIMEOUT_S", 0.2)
+        port = self._free_port()
+        flow = LoopbackAuthFlow(f"http://127.0.0.1:{port}/callback")
+        await self._listening(flow)
+
+        with pytest.raises(McpLoginCancelledError, match="cancelled.*Run /mcp login again"):
+            await asyncio.wait_for(flow.callback_handler(), timeout=5)
+
+    @pytest.mark.asyncio
+    async def test_a_cancelled_login_releases_the_port_and_says_so(self, monkeypatch) -> None:
+        """Task cancellation is a cancel too: unwind, release the port, report.
+
+        The login worker can be cancelled out from under the flow — an
+        exclusive re-login, the TUI's stop-ladder. If the flow re-raised the
+        bare ``CancelledError``, the listener's teardown would be cancelled
+        along with it on any escalation, leaking the redirect port into the
+        next grant; and the caller would have an exception with no words in
+        it. The shielded teardown and the named error are the two halves of
+        the same receipt.
+        """
+        import asyncio
+        import socket
+        import sys
+
+        from local_operator.mcp.auth import LoopbackAuthFlow, McpLoginCancelledError
+
+        monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
+        monkeypatch.setattr("webbrowser.open", lambda _url: False)
+        port = self._free_port()
+        flow = LoopbackAuthFlow(f"http://127.0.0.1:{port}/callback")
+        await self._listening(flow)
+
+        task = asyncio.ensure_future(flow.callback_handler())
+        await asyncio.sleep(0)
+        task.cancel()
+        with pytest.raises(McpLoginCancelledError, match="interrupted"):
+            await asyncio.wait_for(task, timeout=5)
+
+        # The redirect port must be free for the NEXT login, immediately.
+        probe = socket.socket()
+        try:
+            probe.bind(("127.0.0.1", port))
+        except OSError as exc:  # pragma: no cover - the failure IS the test
+            pytest.fail(f"redirect port still held after cancellation: {exc}")
+        finally:
+            probe.close()
+
 
 class TestWireOauthAuth:
     def _cfg(self, **oauth_overrides: Any) -> MCPHttpServerConfig:

--- a/tests/unit/mcp/test_auth.py
+++ b/tests/unit/mcp/test_auth.py
@@ -810,15 +810,16 @@ class TestLoopbackCallbackServer:
 
         Closing the tab or abandoning the consent screen is indistinguishable
         from a slow human at the protocol level, so the interactive grant
-        carries its own idle clock. When it fires the flow settles as
-        ``McpLoginCancelledError`` — the message that tells the user the login
-        is over and how to start another — instead of leaving "logging in…"
-        unanswered in the transcript.
+        carries its own idle clock. When it fires, the flow raises a RAW
+        ``CancelledError`` — ordinary exceptions do not survive the SDK's
+        transport, and the cancellation shape is the channel that unwinds it
+        — after recording itself in the ABANDONED_GRANTS ledger, which is
+        where the manager learns to re-voice it as McpLoginCancelledError.
         """
         import asyncio
         import sys
 
-        from local_operator.mcp.auth import LoopbackAuthFlow, McpLoginCancelledError
+        from local_operator.mcp.auth import ABANDONED_GRANTS, LoopbackAuthFlow
 
         monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
         monkeypatch.setattr("webbrowser.open", lambda _url: False)
@@ -831,8 +832,10 @@ class TestLoopbackCallbackServer:
         flow = LoopbackAuthFlow(f"http://127.0.0.1:{port}/callback")
         await self._listening(flow)
 
-        with pytest.raises(McpLoginCancelledError, match="cancelled.*Run /mcp login again"):
-            await asyncio.wait_for(flow.callback_handler(), timeout=5)
+        with pytest.raises(asyncio.CancelledError):
+            await flow.callback_handler()
+        assert ABANDONED_GRANTS.pop(flow), "the abandonment must be recorded"
+        assert not ABANDONED_GRANTS.pop(flow), "a record is consumed once"
 
     @pytest.mark.asyncio
     async def test_a_cancelled_login_releases_the_port_and_says_so(self, monkeypatch) -> None:

--- a/tests/unit/mcp/test_manager.py
+++ b/tests/unit/mcp/test_manager.py
@@ -1139,6 +1139,113 @@ class TestAuthRequiredHandling:
         assert manager.reconnect_suspended("dd") is True
 
     @pytest.mark.asyncio
+    async def test_an_abandoned_grant_survives_the_real_transport(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The named cancel receipt must reach the caller through the SDK.
+
+        Regression for the review finding that settled this design: a named
+        exception raised out of ``callback_handler`` does NOT survive the
+        streamable-HTTP transport — the SDK's ``post_writer`` swallows it and
+        the caller gets an opaque ``CancelledError``. So the flow records the
+        abandonment in the ledger and raises a raw cancellation; this test
+        drives a full grant through the REAL ``streamable_http_client``
+        against a stub OAuth server and asserts the manager converts what
+        comes back into ``McpLoginCancelledError``.
+        """
+        import json
+        import threading
+        from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+        from local_operator.mcp.auth import McpLoginCancelledError
+        from local_operator.mcp.config import MCPAuthConfig, MCPHttpServerConfig, MCPOAuthConfig
+
+        class StubOAuthServer(BaseHTTPRequestHandler):
+            """Just enough of an OAuth AS + MCP endpoint to reach the grant."""
+
+            def log_message(self, format: str, *args: Any) -> None:  # noqa: A002
+                return  # silence the access log
+
+            def _json(self, payload: dict[str, Any], status: int = 200) -> None:
+                body = json.dumps(payload).encode()
+                self.send_response(status)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+            def do_GET(self) -> None:
+                if self.path.startswith("/.well-known/oauth-authorization-server"):
+                    assert isinstance(self.server, ThreadingHTTPServer)
+                    base = f"http://127.0.0.1:{self.server.server_port}"
+                    self._json(
+                        {
+                            "issuer": base,
+                            "authorization_endpoint": f"{base}/authorize",
+                            "token_endpoint": f"{base}/token",
+                            "registration_endpoint": f"{base}/register",
+                        }
+                    )
+                else:
+                    self._json({"error": "not found"}, status=404)
+
+            def do_POST(self) -> None:
+                length = int(self.headers.get("Content-Length") or 0)
+                self.rfile.read(length)
+                if self.path == "/register":
+                    self._json(
+                        {
+                            "client_id": "stub-client",
+                            "client_secret": "stub-secret",
+                            "client_id_issued_at": 0,
+                        },
+                        status=201,
+                    )
+                elif self.path == "/token":
+                    # No stored grant and the refresh path is not what is under
+                    # test: refuse, so the SDK escalates to the browser grant.
+                    self._json({"error": "invalid_grant"}, status=400)
+                elif self.path.startswith("/mcp"):
+                    # Unreachable: the grant abandons before the MCP session
+                    # starts. Answer 401 anyway so a regression that SKIPS the
+                    # grant fails here loudly rather than hanging.
+                    self._json({"error": "unauthorized"}, status=401)
+                else:
+                    self._json({"error": "not found"}, status=404)
+
+        server = ThreadingHTTPServer(("127.0.0.1", 0), StubOAuthServer)
+        threading.Thread(target=server.serve_forever, daemon=True).start()
+        try:
+            url = f"http://127.0.0.1:{server.server_port}/mcp"
+            # An ephemeral loopback callback: the flow binds whatever is free,
+            # never the shared default port (parallel suites each run grants).
+            import socket
+
+            with socket.socket() as probe:
+                probe.bind(("127.0.0.1", 0))
+                redirect_port = int(probe.getsockname()[1])
+            cfg = MCPHttpServerConfig(
+                url=url,
+                auth=MCPAuthConfig(type="oauth"),
+                oauth=MCPOAuthConfig(redirect_uri=f"http://127.0.0.1:{redirect_port}/callback"),
+            )
+            # An in-memory credential store: the grant must run against the
+            # real auth flow, never this machine's real auth.db.
+            from tests.unit.mcp.test_auth import FakeAuthStore
+
+            manager = McpManager(str(tmp_path))
+            manager.auth_store = cast(Any, FakeAuthStore())
+            monkeypatch.setattr("webbrowser.open", lambda _url: False)
+            # The idle guard is what fires when the browser never answers;
+            # shrink it so the grant abandons in test time.
+            monkeypatch.setattr("local_operator.mcp.auth.INTERACTIVE_GRANT_TIMEOUT_S", 0.3)
+            with pytest.raises(McpLoginCancelledError, match="browser never completed"):
+                await manager._connect_server("dd", cfg, interactive=True)
+        finally:
+            server.shutdown()
+            server.server_close()
+
+    @pytest.mark.asyncio
     async def test_login_resets_the_breaker_and_scopes_the_timeout(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/unit/mcp/test_manager.py
+++ b/tests/unit/mcp/test_manager.py
@@ -1158,7 +1158,11 @@ class TestAuthRequiredHandling:
         from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
         from local_operator.mcp.auth import McpLoginCancelledError
-        from local_operator.mcp.config import MCPAuthConfig, MCPHttpServerConfig, MCPOAuthConfig
+        from local_operator.mcp.config import (
+            MCPAuthConfig,
+            MCPHttpServerConfig,
+            MCPOAuthConfig,
+        )
 
         class StubOAuthServer(BaseHTTPRequestHandler):
             """Just enough of an OAuth AS + MCP endpoint to reach the grant."""

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -2320,6 +2320,103 @@ async def test_mcp_reauth_removes_then_runs_a_fresh_grant() -> None:
 
 
 @pytest.mark.asyncio
+async def test_mcp_login_abandoned_in_the_browser_gets_a_cancel_receipt() -> None:
+    """The "logging in…" line must always get an ending.
+
+    The reported defect: close the browser tab (or walk away from the consent
+    screen) and the transcript kept a "logging in to MCP server linear…" line
+    that nothing ever answered — the flow sat on its idle clock in silence.
+    The flow now settles that as McpLoginCancelledError and the worker reports
+    it as a cancellation, not as a red failure: the user is the one who left.
+    """
+    from local_operator.mcp.auth import McpLoginCancelledError
+    from local_operator.mcp.config import MCPAuthConfig, MCPHttpServerConfig
+
+    configs = {
+        "linear": MCPHttpServerConfig(
+            url="https://mcp.linear.app/mcp", auth=MCPAuthConfig(type="oauth")
+        )
+    }
+    manager = FakeMcpManager(["linear"], ["linear"])
+    manager._configs = configs
+
+    async def abandoned_grant(name: str, *, timeout_ms: Any = None) -> Any:
+        raise McpLoginCancelledError(
+            "no redirect arrived within 10 minutes — the login was probably "
+            "cancelled (browser tab closed, or the authorization left unfinished)."
+        )
+
+    manager.connect_configured_server = abandoned_grant  # type: ignore[method-assign]
+    session = McpSession(manager=manager, startup=McpStartupOutcome())
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 24)) as pilot:
+        for _ in range(6):
+            await pilot.pause()
+        app.query_one(Toast).dismiss_toast()
+        with patch(
+            "local_operator.mcp.config.load_all_mcp_configs",
+            return_value=(configs, {}),
+        ):
+            await _type_command(pilot, app, "mcp login linear")
+            for _ in range(8):
+                await pilot.pause()
+        text = _transcript_text(app)
+        assert "logging in to MCP server linear" in text
+        assert "MCP login for 'linear' cancelled" in text
+        assert "tab closed" in text
+        assert "MCP login failed" not in text
+
+
+@pytest.mark.asyncio
+async def test_mcp_login_worker_cancellation_is_acknowledged() -> None:
+    """A worker cancelled by its exclusive group must still close the receipt.
+
+    Textual never delivers the CancelledError to a worker cancelled this way —
+    the coroutine simply stops — so without the handler the second login left
+    the first one's "logging in…" line permanently unanswered.
+    """
+    import asyncio as _asyncio
+
+    from local_operator.mcp.config import MCPAuthConfig, MCPHttpServerConfig
+
+    configs = {
+        "linear": MCPHttpServerConfig(
+            url="https://mcp.linear.app/mcp", auth=MCPAuthConfig(type="oauth")
+        )
+    }
+    manager = FakeMcpManager(["linear"], ["linear"])
+    manager._configs = configs
+    session = McpSession(manager=manager, startup=McpStartupOutcome())
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 24)) as pilot:
+        for _ in range(6):
+            await pilot.pause()
+        app.query_one(Toast).dismiss_toast()
+        # The grant must still be in flight when the cancel lands, or the test
+        # cancels a finished worker and proves nothing — so the fake connect
+        # parks the way a real browser round trip does.
+        entered = _asyncio.Event()
+
+        async def hanging_grant(name: str, *, timeout_ms: Any = None) -> Any:
+            entered.set()
+            await _asyncio.Event().wait()  # the browser never answers
+            raise AssertionError("unreachable")
+
+        manager.connect_configured_server = hanging_grant  # type: ignore[method-assign]
+        # Drive the worker directly: the group-exclusivity cancellation that
+        # strands the receipt in the real UI is a worker.cancel(), which is
+        # what this reproduces without racing two typed commands.
+        worker = app._mcp_login_worker(manager, "linear")
+        task = _asyncio.ensure_future(worker)
+        await _asyncio.wait_for(entered.wait(), timeout=5)
+        task.cancel()
+        with pytest.raises(_asyncio.CancelledError):
+            await task
+        await pilot.pause()
+        assert "MCP login for 'linear' cancelled" in _transcript_text(app)
+
+
+@pytest.mark.asyncio
 async def test_mcp_reauth_never_logs_in_on_top_of_a_surviving_row() -> None:
     """A login over a row that failed to delete is NOT a re-auth — the stored
     registration would short-circuit the grant — so a failed removal stops the


### PR DESCRIPTION
# PR Description

## Summary of Changes

Fixes the silent hang when an `/mcp login` (or `local-operator mcp login`) OAuth flow is abandoned — browser tab closed, consent screen left unfinished, or the login interrupted.

- **`LoopbackAuthFlow` (local_operator/mcp/auth.py)**
  - New 10-minute **interactive idle guard** (`INTERACTIVE_GRANT_TIMEOUT_S`) around the browser round trip, matching the budget both login callers already allow the connect. When it fires, the grant settles as the new `McpLoginCancelledError` — *"no redirect arrived within 10 minutes — the login was probably cancelled (browser tab closed, or the authorization left unfinished). Run /mcp login again to retry."* The pre-existing 300 s redirect timeout keeps its own port-forwarding advice inside the guard; the two clocks convert their own expiries so neither can be mistaken for the other.
  - **Task cancellation is now a named ending too**: a `CancelledError` (exclusive re-login, the TUI stop-ladder, Ctrl+C at the CLI) runs a *shielded* listener teardown — so one escalation can't wedge the redirect port into the next grant — then re-raises as `McpLoginCancelledError` instead of propagating a bare cancellation that surfaced as silence in the TUI or an empty `MCP login failed for 'x':` at the CLI.
- **TUI login worker (local_operator/tui/app.py)**
  - A worker cancelled by its exclusive group or the stop-ladder now acknowledges it in the transcript: `MCP login for '<name>' cancelled before the browser completed it.` Previously Textual never delivered the cancellation, so the `logging in…` receipt stayed unanswered forever.
  - An abandoned grant is reported as a **cancellation in warning tone**, not a red failure — the user is the one who walked away.

## Related Issue(s)

- Reported from a live session: after `/mcp login cloudflare`, cancelling the browser flow left `· logging in to MCP server cloudflare…` hanging with no acknowledgment.

## Impact

- No breaking changes; no dependency updates. New exception type `McpLoginCancelledError` subclasses `RuntimeError`, so existing `except RuntimeError` handling still catches it.
- No security implications: the idle guard only *shortens* how long the loopback listener can sit open; cancellation now tears it down promptly and releases the redirect port.

## Testing Details

- **New unit tests** (`tests/unit/mcp/test_auth.py`):
  - `test_an_abandoned_grant_ends_as_an_explicit_cancel` — with no redirect arriving, the idle guard settles the flow as `McpLoginCancelledError` carrying the retry guidance.
  - `test_a_cancelled_login_releases_the_port_and_says_so` — cancelling `callback_handler()` mid-wait raises the named cancel error **and** frees the redirect port immediately (verified by rebinding it).
- **New TUI tests** (`tests/unit/tui/test_app_pilot.py`):
  - `test_mcp_login_abandoned_in_the_browser_gets_a_cancel_receipt` — transcript shows both `logging in…` and the `MCP login for 'linear' cancelled …` receipt, and never the red `MCP login failed` wording.
  - `test_mcp_login_worker_cancellation_is_acknowledged` — cancelling the in-flight worker produces the cancellation receipt and still propagates `CancelledError`.
- **Full suite**: `5682 passed, 7 skipped` (1 pre-existing failure in `tests/unit/tools/test_eval_tool.py::test_background_streams_output_while_it_runs` — reproduced on pristine `origin/main`, unrelated).
- **Gates** (exact CI commands, whole tree): `flake8` clean, `black --check` clean, `isort --check` clean, `pyright` 0 errors.
- **Visual validation** with the real `OperatorApp` under `run_test` (script drives the actual login command path; fake manager ends the grant the way a closed tab now ends it):

| Before (main) — hangs, never answered | After (this PR) — explicit receipt |
| --- | --- |
| ![before](https://raw.githubusercontent.com/damianvtran/lo-pr-assets/refs/heads/main/before.svg.png) | ![after](https://raw.githubusercontent.com/damianvtran/lo-pr-assets/refs/heads/main/after.svg.png) |

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my changes work as intended.
- [x] All new and existing tests pass.
- [x] I have run formatting (black/isort), linting (flake8), and type checks (pyright), and they pass.
- [x] I have updated the documentation when required. (Inline docs only — the change adds no user-facing surface beyond messages.)
- [x] Security considerations are addressed (especially for code execution features).
- [x] I have linked all related issues.
