### PR TITLE
fix(wake): deliver mid-turn wakes courteously, never interrupting a running tool

### DIFF
--- a/local_operator/harness/loop.py
+++ b/local_operator/harness/loop.py
@@ -1092,7 +1092,11 @@ class AgentLoop:
         queue: asyncio.Queue[AgentEvent | _ToolDone | _BatchDone] = asyncio.Queue()
         results_by_slot: list[ToolResult | None] = [None] * len(batch)
         tasks: list[asyncio.Task[None]] = []
-        peek = config.has_urgent_steering_messages or config.has_steering_messages
+        peek = (
+            config.has_urgent_steering_messages
+            if config.has_urgent_steering_messages is not None
+            else config.has_steering_messages
+        )
         poll_interruptible = config.interrupt_mode == "immediate" and peek is not None
         # Set by the abort watcher so the runners' cancellation handlers can
         # tell an abort apart from a steering interrupt and label their
@@ -1645,7 +1649,11 @@ class AgentLoop:
 
     @staticmethod
     def _peek_steering(config: LoopConfig) -> bool:
-        peek = config.has_urgent_steering_messages or config.has_steering_messages
+        peek = (
+            config.has_urgent_steering_messages
+            if config.has_urgent_steering_messages is not None
+            else config.has_steering_messages
+        )
         if peek is None:
             return False
         try:

--- a/local_operator/harness/loop.py
+++ b/local_operator/harness/loop.py
@@ -1062,6 +1062,9 @@ class AgentLoop:
         ``STEERING_INTERRUPT_POLL_S`` while ``interrupt_mode == "immediate"``);
         on a steering signal the tool task is cancelled and paired with a
         synthetic skipped result so tool_use/tool_result pairing stays legal.
+        The poll uses the URGENT peek: courtesy injections (a scheduled wake
+        riding the busy path) share the steering queue but must wait for the
+        next successful tool boundary rather than kill a running tool.
         On generator cancellation (GeneratorExit) every runner task is
         cancelled before this generator returns.
 
@@ -1089,9 +1092,8 @@ class AgentLoop:
         queue: asyncio.Queue[AgentEvent | _ToolDone | _BatchDone] = asyncio.Queue()
         results_by_slot: list[ToolResult | None] = [None] * len(batch)
         tasks: list[asyncio.Task[None]] = []
-        poll_interruptible = (
-            config.interrupt_mode == "immediate" and config.has_steering_messages is not None
-        )
+        peek = config.has_urgent_steering_messages or config.has_steering_messages
+        poll_interruptible = config.interrupt_mode == "immediate" and peek is not None
         # Set by the abort watcher so the runners' cancellation handlers can
         # tell an abort apart from a steering interrupt and label their
         # synthetic results correctly.
@@ -1643,10 +1645,11 @@ class AgentLoop:
 
     @staticmethod
     def _peek_steering(config: LoopConfig) -> bool:
-        if config.has_steering_messages is None:
+        peek = config.has_urgent_steering_messages or config.has_steering_messages
+        if peek is None:
             return False
         try:
-            return bool(config.has_steering_messages())
+            return bool(peek())
         except Exception:
             return False
 

--- a/local_operator/harness/types.py
+++ b/local_operator/harness/types.py
@@ -1207,6 +1207,17 @@ class LoopConfig(BaseModel):
         default=None, exclude=True
     )
 
+    # Urgency counterpart to ``has_steering_messages``: a peek that returns
+    # True only when queued steering may cancel a RUNNING tool. The plain
+    # peek feeds the immediate-interrupt poll, and courtesy injections (a
+    # scheduled wake riding the busy path) share the steering queue with user
+    # steers — without this split a wake's timer landing mid-`bash` would
+    # kill the tool, exactly the interruption wakes exist not to cause. User
+    # steers stay immediate; the session wires this to "a non-wake message is
+    # queued". ``None`` falls back to the plain peek so existing hosts keep
+    # immediate semantics for everything they queue.
+    has_urgent_steering_messages: Callable[[], bool] | None = Field(default=None, exclude=True)
+
     interrupt_mode: Literal["immediate", "wait"] = "wait"
     # Epoch-ms deadline for the whole run, if any.
     deadline: float | None = None

--- a/local_operator/harness/types.py
+++ b/local_operator/harness/types.py
@@ -1214,8 +1214,10 @@ class LoopConfig(BaseModel):
     # steers — without this split a wake's timer landing mid-`bash` would
     # kill the tool, exactly the interruption wakes exist not to cause. User
     # steers stay immediate; the session wires this to "a non-wake message is
-    # queued". ``None`` falls back to the plain peek so existing hosts keep
-    # immediate semantics for everything they queue.
+    # queued". SUBSET, not superset: plain ≥ urgent always holds, so wiring
+    # them the other way round would make every courtesy wake an interrupt.
+    # ``None`` falls back to the plain peek so existing hosts keep immediate
+    # semantics for everything they queue.
     has_urgent_steering_messages: Callable[[], bool] | None = Field(default=None, exclude=True)
 
     interrupt_mode: Literal["immediate", "wait"] = "wait"

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -1797,11 +1797,18 @@ class Session:
             # wakes first and the reply still answers the user.
             catchup = self._take_resume_catchup()
             if catchup is not None:
-                # Folded ahead of a real user prompt, the catch-up interrupts
-                # work it precedes — the same busy-path obligation applies, so
-                # the text carries the resume guidance here too.
+                # Folded ahead of a real user prompt, the catch-up precedes
+                # the work it shares the turn with — the same busy-path
+                # obligation applies, so the text carries the guidance here
+                # too. On a FRESH session this prompt starts the work rather
+                # than resuming it, so the note names that instead of
+                # claiming work was already under way.
+                fresh = not self._context.messages
                 catchup.details["text"] = self._append_busy_resume_note(
-                    str(catchup.details["text"])
+                    str(catchup.details["text"]),
+                    continue_what=(
+                        "continue with the user's request that follows" if fresh else None
+                    ),
                 )
             initial: list[AgentMessage] = (
                 [catchup, Message.user(text, images)]
@@ -4030,7 +4037,7 @@ class Session:
         self._spawn_background(self._prompt_messages([wake_message]))
 
     @staticmethod
-    def _append_busy_resume_note(text: str) -> str:
+    def _append_busy_resume_note(text: str, *, continue_what: str | None = None) -> str:
         """The busy-path suffix: what to do after the wake's task is handled.
 
         A wake that lands mid-turn interrupts NOTHING (courtesy delivery), so
@@ -4039,13 +4046,19 @@ class Session:
         fresh instruction and 'do the wake task, then go back' is exactly the
         behaviour a wake firing mid-task used to lose. Idle-path deliveries
         stay clean: they open their own turn, so there is no prior work to
-        resume."""
+        resume.
+
+        ``continue_what`` names the interrupted work when "the work you were
+        doing" is not literally true — a catch-up folded ahead of a FRESH
+        session's first prompt interrupts nothing yet, so it continues with
+        the user's request instead of resuming anything."""
+        continuation = continue_what or "resume the work you were doing when it fired"
         return (
             f"{text}\n\n"
             "(This wake fired while you were already working. It was held for a "
             "tool boundary so nothing in flight was interrupted: handle the "
-            "wake's task now, then resume the work you were doing when it "
-            "fired unless this wake makes it obsolete.)"
+            f"wake's task now, then {continuation} unless this wake makes it "
+            "obsolete.)"
         )
 
     def _missed_delivery_note(self, due: DueWake) -> str | None:
@@ -4151,6 +4164,9 @@ class Session:
         if self._disposed:
             return
         self._disposed = True
+        # A courtesy wake still queued here was never delivered, so its count
+        # must not survive to misclassify a later enqueue on a reused Session.
+        self._courtesy_wake_count = 0
         try:
             # HC-14: abort the in-flight turn and await its completion (bounded)
             # before flushing — its persistence must land on a live transcript.

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -11,10 +11,15 @@ Ported semantics:
   sync or async, and one raising never breaks the others (isolated with a
   warning).
 - Steering messages interrupt tool batches (``interrupt_mode="immediate"``);
-  ``steer()`` is the public injection point.
+  ``steer()`` is the public injection point. Courtesy injections — a wake
+  that fires mid-turn — are the exception: they ride the queue but are
+  excluded from the interrupt poll (``_has_urgent_steering``), so they join
+  at the next successful tool boundary instead of killing the running call.
 - Wakes persist as a ``wake_schedules`` custom transcript entry (newest wins)
   and deliver through the prompt path as a user-attributed
-  ``wake_prompt`` custom message.
+  ``wake_prompt`` custom message. A wake delivered into an ongoing turn
+  carries resume guidance in its text (``_append_busy_resume_note``): handle
+  the wake's task, then continue the work it landed in.
 - Compaction is checked after each turn via a LAZY import of
   ``local_operator.compaction.api`` — a missing module degrades to
   no-compaction. Binding wiring: prune tool outputs BEFORE the trigger math,
@@ -870,6 +875,16 @@ class Session:
         )
         self._handlers: list[EventHandler] = []
         self._steering_queue: asyncio.Queue[AgentMessage] = asyncio.Queue()
+        # Count of courtesy wake_prompt messages sitting in the steering
+        # queue. The immediate-interrupt poll may cancel a RUNNING tool only
+        # for steering the user actually typed (see ``_has_urgent_steering``):
+        # a scheduled wake's timer landing mid-`bash` must ride the next
+        # boundary instead of killing work it has no right to interrupt. A
+        # count, not message ids: ``queue._queue`` is asyncio-private, and the
+        # only producer/consumer ordering question a count cannot answer is
+        # settled by the decrement happening at the same drain the delivery
+        # does.
+        self._courtesy_wake_count = 0
         # Host-registered teardown (see add_dispose_hook): resources the
         # composition root owns but the session's lifetime governs.
         self._dispose_hooks: list[Callable[[], Awaitable[None] | None]] = []
@@ -1781,6 +1796,13 @@ class Session:
             # M2). One turn, user message LAST, so the model reads the folded
             # wakes first and the reply still answers the user.
             catchup = self._take_resume_catchup()
+            if catchup is not None:
+                # Folded ahead of a real user prompt, the catch-up interrupts
+                # work it precedes — the same busy-path obligation applies, so
+                # the text carries the resume guidance here too.
+                catchup.details["text"] = self._append_busy_resume_note(
+                    str(catchup.details["text"])
+                )
             initial: list[AgentMessage] = (
                 [catchup, Message.user(text, images)]
                 if catchup is not None
@@ -2337,6 +2359,7 @@ class Session:
                 stream_fn=self._stream_fn,
                 get_steering_messages=self._drain_steering,
                 has_steering_messages=lambda: not self._steering_queue.empty(),
+                has_urgent_steering_messages=self._has_urgent_steering,
                 get_aside_messages=self._drain_asides,
                 get_follow_up_messages=self._todo_continuation,
                 resolve_fallback_tool=self._fallback_tool_resolver,
@@ -2693,12 +2716,25 @@ class Session:
             message = self._steering_queue.get_nowait()
             await self._transcript.append_message(message)
             messages.append(message)
+        # The drain is the ONLY consumer, so every courtesy message queued
+        # before this boundary just left with it; anything queued after is a
+        # fresh count.
+        self._courtesy_wake_count = 0
         if messages:
             # After persistence, not before: the receipt says the message is in
             # the conversation, and it is only in the conversation once it is on
             # disk and in the list being handed back to the loop.
             await self._emit(SteeringDeliveredEvent(count=len(messages)))
         return messages
+
+    def _has_urgent_steering(self) -> bool:
+        """The interrupt poll's peek: True only when queued steering may cancel
+        a RUNNING tool. Wakes queued while a turn streamed are counted as
+        courtesy (``_courtesy_wake_count``) and excluded — they wait for the
+        next successful tool boundary, delivered by ``_drain_steering`` like
+        any other steering. A queue holding nothing but courtesy wakes answers
+        False, so their timers can never kill an in-flight `bash`."""
+        return self._steering_queue.qsize() > self._courtesy_wake_count
 
     async def _drain_asides(self) -> list[Aside]:
         """Drain queued aside thunks (the loop materializes them at the
@@ -3797,6 +3833,11 @@ class Session:
         receipt event was already emitted by ``_take_resume_catchup``.
         """
         if self._is_streaming:
+            # Same courtesy as a live wake delivery: never a reason to cancel
+            # the running tool, and the text must carry the resume guidance
+            # because the turn the catch-up lands in has work to return to.
+            catchup.details["text"] = self._append_busy_resume_note(str(catchup.details["text"]))
+            self._courtesy_wake_count += 1
             self._steering_queue.put_nowait(catchup)
             return
         self._spawn_background(self._prompt_messages([catchup]))
@@ -3953,6 +3994,14 @@ class Session:
         missed_note = self._missed_delivery_note(due)
         if missed_note:
             text = f"{missed_note}\n\n{text}"
+        busy = self._is_streaming
+        if busy:
+            # The resume guidance rides the text itself: the wake reached a
+            # turn that was already working, and the message is the only
+            # channel that can tell the agent to fold the wake in and then
+            # CONTINUE that work. Idle-path deliveries stay clean — they open
+            # their own turn, so there is no prior work to resume.
+            text = self._append_busy_resume_note(text)
         wake_message = CustomMessage(
             custom_type=WAKE_PROMPT_MESSAGE_TYPE,
             attribution="user",
@@ -3970,11 +4019,34 @@ class Session:
                 occurrence=due.occurrence,
             )
         )
-        if self._is_streaming:
-            # Busy: ride the next steering boundary instead of racing the turn.
+        if busy:
+            # Busy: ride the next successful tool boundary instead of racing
+            # the turn — and mark the message COURTESY so the immediate-
+            # interrupt poll does not cancel the tool it landed in the middle
+            # of (see _has_urgent_steering).
+            self._courtesy_wake_count += 1
             self._steering_queue.put_nowait(wake_message)
             return
         self._spawn_background(self._prompt_messages([wake_message]))
+
+    @staticmethod
+    def _append_busy_resume_note(text: str) -> str:
+        """The busy-path suffix: what to do after the wake's task is handled.
+
+        A wake that lands mid-turn interrupts NOTHING (courtesy delivery), so
+        the turn's own work is still owed when the wake is done — the note
+        names that obligation, because the alarm envelope alone reads as a
+        fresh instruction and 'do the wake task, then go back' is exactly the
+        behaviour a wake firing mid-task used to lose. Idle-path deliveries
+        stay clean: they open their own turn, so there is no prior work to
+        resume."""
+        return (
+            f"{text}\n\n"
+            "(This wake fired while you were already working. It was held for a "
+            "tool boundary so nothing in flight was interrupted: handle the "
+            "wake's task now, then resume the work you were doing when it "
+            "fired unless this wake makes it obsolete.)"
+        )
 
     def _missed_delivery_note(self, due: DueWake) -> str | None:
         """The 'this wake fired late' prefix, or None for a punctual fire.

--- a/tests/unit/harness/test_loop.py
+++ b/tests/unit/harness/test_loop.py
@@ -14,6 +14,7 @@ import pytest
 
 from local_operator.harness.loop import (
     ABORT_DRAIN_TIMEOUT_S,
+    STEERING_INTERRUPT_POLL_S,
     AgentLoop,
     LoopContext,
     _consume_claim,
@@ -430,6 +431,117 @@ async def test_steering_interrupts_between_exclusive_calls():
     assert any(
         isinstance(m, Message) and m.text == "stop that" for m in stream.requests[1].messages
     )
+
+
+@pytest.mark.asyncio
+async def test_courtesy_steering_waits_for_the_running_tool():
+    """has_urgent_steering_messages separates may-interrupt steering from
+    courtesy injections: with it answering False, a queued message rides the
+    queue PAST the running interruptible tool and is delivered at the next
+    boundary instead of cancelling the call."""
+    tool_started = asyncio.Event()
+    release_tool = asyncio.Event()
+    steering_flag = {"queued": False, "drained": False}
+
+    async def blocking_execute(tool_call_id, args, signal, on_update, context):
+        tool_started.set()
+        await release_tool.wait()
+        return ToolResult(tool_call_id=tool_call_id, tool_name="a", content=[TextContent(text="a")])
+
+    tool_a = AgentTool(
+        name="a",
+        parameters={"type": "object"},
+        interruptible=True,
+        execute=blocking_execute,
+    )
+
+    async def get_steering():
+        if steering_flag["queued"] and not steering_flag["drained"]:
+            steering_flag["drained"] = True
+            return [Message.user("scheduled wake")]
+        return []
+
+    stream = ScriptedStream(
+        [
+            [
+                tool_call_delta(0, id="c1", name="a", args="{}"),
+                StreamEndEvent(stop_reason="toolUse"),
+            ],
+            [StreamTextDelta(delta="ok"), StreamEndEvent(stop_reason="stop")],
+        ]
+    )
+    context = LoopContext(tools=[tool_a])
+    config = make_config(
+        stream,
+        interrupt_mode="immediate",
+        get_steering_messages=get_steering,
+        has_steering_messages=lambda: steering_flag["queued"] and not steering_flag["drained"],
+        has_urgent_steering_messages=lambda: False,  # nothing here may interrupt
+    )
+    loop = AgentLoop()
+    events: list[Any] = []
+
+    async def run() -> None:
+        async for event in loop.run([Message.user("go")], context, config, None):
+            events.append(event)
+
+    task = asyncio.ensure_future(run())
+    await asyncio.wait_for(tool_started.wait(), timeout=5)
+    steering_flag["queued"] = True
+    # A poll cycle passes with the tool still running: no cancellation.
+    await asyncio.sleep(STEERING_INTERRUPT_POLL_S * 3)
+    assert not task.done(), "courtesy steering cancelled the running tool"
+    release_tool.set()
+    await asyncio.wait_for(task, timeout=5)
+
+    # The tool produced its REAL result (no synthetic skip), and the steering
+    # message was delivered into the follow-up model call.
+    tool_messages = [m for m in context.messages if isinstance(m, Message) and m.role == "tool"]
+    assert len(tool_messages) == 1 and not tool_messages[0].is_error
+    assert any(
+        isinstance(m, Message) and m.text == "scheduled wake" for m in stream.requests[1].messages
+    )
+
+
+@pytest.mark.asyncio
+async def test_urgent_steering_still_interrupts_a_running_tool():
+    """The urgent peek answering True keeps the immediate semantics: the
+    running interruptible tool is cancelled and the steer jumps the queue."""
+    tool_started = asyncio.Event()
+    outcome: dict[str, str] = {}
+    drained = {"done": False}
+
+    async def get_steering():
+        if drained["done"]:
+            return []
+        drained["done"] = True
+        return [Message.user("stop that")]
+
+    stream = ScriptedStream(
+        [
+            [
+                tool_call_delta(0, id="c1", name="block", args="{}"),
+                StreamEndEvent(stop_reason="toolUse"),
+            ],
+            [StreamTextDelta(delta="ok"), StreamEndEvent(stop_reason="stop")],
+        ]
+    )
+    context = LoopContext(
+        tools=[_blocking_tool("block", tool_started, interruptible=True, outcome=outcome)]
+    )
+    config = make_config(
+        stream,
+        interrupt_mode="immediate",
+        get_steering_messages=get_steering,
+        has_steering_messages=lambda: True,
+        has_urgent_steering_messages=lambda: True,
+    )
+
+    messages = await AgentLoop().run_to_end([Message.user("go")], context, config, None)
+
+    assert outcome == {"block": "cancelled"}
+    results = [m for m in messages if isinstance(m, Message) and m.role == "tool"]
+    assert results[0].is_error and "skipped" in results[0].text.lower()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/session/test_session.py
+++ b/tests/unit/session/test_session.py
@@ -385,6 +385,91 @@ def _persisted_wakes_payload(schedules) -> dict[str, object]:
 
 
 @pytest.mark.asyncio
+async def test_wake_delivery_mid_turn_waits_for_the_running_tool(tmp_path):
+    """A wake firing mid-turn is courtesy steering: the running tool completes
+    untouched, and the wake's text reaches the next model call carrying the
+    resume guidance (handle the wake, then continue the interrupted work)."""
+    from local_operator.harness.wake import DueWake, WakeSchedule
+
+    tool_started = asyncio.Event()
+    release_tool = asyncio.Event()
+
+    async def blocking_execute(tool_call_id, args, signal, on_update, context):
+        tool_started.set()
+        await release_tool.wait()
+        return ToolResult(
+            tool_call_id=tool_call_id,
+            tool_name="block",
+            content=[TextContent(text="finished")],
+        )
+
+    tool = AgentTool(
+        name="block",
+        parameters={"type": "object", "properties": {}},
+        interruptible=True,  # even an interruptible tool must survive a wake
+        execute=blocking_execute,
+    )
+    stream = ScriptedStream(
+        [
+            [
+                StreamToolCallDelta(index=0, id="c1", name="block", argument_delta="{}"),
+                StreamEndEvent(stop_reason="toolUse"),
+            ],
+            [StreamTextDelta(delta="ack"), StreamEndEvent(stop_reason="stop")],
+        ]
+    )
+    session = make_session(tmp_path, stream, tools=[tool])
+
+    prompt_task = asyncio.ensure_future(session.prompt("long task"))
+    await wait_for(lambda: tool_started.is_set())
+
+    schedule = WakeSchedule(id="w1", message="wake up", next_due_at=0, created_at=0)
+    due = DueWake(schedule=schedule, occurrence=1, planned_total=1, final=True)
+    await session._deliver_wake(due)
+    # The wake is queued; the tool must still be running uninterrupted.
+    assert not session._steering_queue.empty()
+    assert not session._has_urgent_steering()
+
+    release_tool.set()
+    await prompt_task
+
+    assert stream.requests[1].messages, "the wake must reach the follow-up model call"
+    wake_texts = [
+        m.text for m in stream.requests[1].messages if "(alarm) Scheduled wake w1" in m.text
+    ]
+    assert wake_texts, "the queued wake never reached the model"
+    assert "wake up" in wake_texts[0]
+    assert "resume the work" in wake_texts[0]
+    # The tool ran to completion — its real result, not a synthetic skip.
+    tool_messages = [
+        m for m in stream.requests[1].messages if isinstance(m, Message) and m.role == "tool"
+    ]
+    assert any("finished" in m.text for m in tool_messages)
+    await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_idle_wake_delivery_carries_no_resume_note(tmp_path):
+    """A wake that opens its OWN turn has no interrupted work to return to,
+    so the resume guidance stays out of its text."""
+    from local_operator.harness.wake import DueWake, WakeSchedule
+
+    stream = ScriptedStream([[StreamTextDelta(delta="ack"), StreamEndEvent(stop_reason="stop")]])
+    session = make_session(tmp_path, stream)
+
+    schedule = WakeSchedule(id="w1", message="wake up", next_due_at=0, created_at=0)
+    due = DueWake(schedule=schedule, occurrence=1, planned_total=1, final=True)
+    await session._deliver_wake(due)
+    await wait_for(lambda: bool(stream.requests))
+
+    wake_texts = [
+        m.text for m in stream.requests[0].messages if "(alarm) Scheduled wake w1" in m.text
+    ]
+    assert wake_texts and "resume the work" not in wake_texts[0]
+    await session.dispose()
+
+
+@pytest.mark.asyncio
 async def test_resume_aggregates_overdue_wakes_into_one_catchup(tmp_path):
     """Close lop with overdue wakes, reopen: ONE aggregated catch-up prompt —
     not one turn per overdue schedule — and it names each missed schedule."""

--- a/tests/unit/session/test_session.py
+++ b/tests/unit/session/test_session.py
@@ -449,6 +449,44 @@ async def test_wake_delivery_mid_turn_waits_for_the_running_tool(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_fresh_session_catchup_fold_continues_instead_of_resuming(tmp_path):
+    """A catch-up folded ahead of a FRESH session's first prompt interrupts no
+    work, so its guidance says 'continue with the user's request', not
+    'resume the work you were doing' (review round 1, m1)."""
+    import time as _time
+
+    from local_operator.harness.wake import WakeSchedule
+
+    now = int(_time.time() * 1000)
+    overdue = WakeSchedule(
+        id="w1", message="check the backup", next_due_at=now - 3_600_000, created_at=now - 4_000_000
+    )
+    transcript = Transcript(tmp_path / "sess")
+    await transcript.append_custom("wake_schedules", _persisted_wakes_payload([overdue]))
+
+    stream = ScriptedStream([[StreamTextDelta(delta="ack"), StreamEndEvent(stop_reason="stop")]])
+    session = Session(
+        model=MODEL,
+        stream_fn=stream,
+        tools=[],
+        transcript=transcript,
+        system_blocks_provider=lambda: [],
+    )
+    await session.async_init()
+    # The catch-up is held behind the resume grace; expire it so the prompt
+    # folds the catch-up instead of running bare.
+    session._resume_grace_ends_ms = 0
+    await session.prompt("hello")
+
+    texts = [m.text for m in stream.requests[0].messages]
+    catchup_texts = [t for t in texts if "came due while it was down" in t]
+    assert catchup_texts, "the folded catch-up never reached the model"
+    assert "continue with the user's request" in catchup_texts[0]
+    assert "resume the work you were doing" not in catchup_texts[0]
+    await session.dispose()
+
+
+@pytest.mark.asyncio
 async def test_idle_wake_delivery_carries_no_resume_note(tmp_path):
     """A wake that opens its OWN turn has no interrupted work to return to,
     so the resume guidance stays out of its text."""


### PR DESCRIPTION
## Summary

A scheduled wake whose timer fired mid-turn was placed on the steering queue, where the immediate-interrupt poll treated it exactly like a typed steer: it **cancelled the in-flight interruptible tool** (`bash`, `web_search`, `eval`, MCP tools) with a synthetic skipped result. And once delivered, the alarm envelope gave the agent no indication that the work it landed in the middle of was still owed afterwards — the wake task was done and the prior task silently dropped.

This change makes mid-turn wake deliveries **courteous**:

1. **Wakes never interrupt a running tool.** `LoopConfig` gains `has_urgent_steering_messages`, an urgency counterpart to `has_steering_messages`. The interrupt poll now consults the *urgent* peek; the session wires it to answer False while everything queued is a courtesy wake, so the wake rides to the **next successful tool boundary** and is delivered there like any other steering. User-typed steers keep their immediate, may-cancel semantics. Hosts that never set the new peek fall back to the plain one, preserving today's behaviour for them.
2. **The wake text carries resume guidance on the busy path.** A wake delivered into an ongoing turn (a mid-turn fire, a resume catch-up queued mid-turn, or a catch-up folded ahead of a user prompt) appends: *handle the wake's task now, then resume the work you were doing when it fired unless this wake makes it obsolete.* Idle-path deliveries open their own turn and stay clean.

## Test plan

- [x] New loop tests: courtesy steering waits for the running interruptible tool and is delivered at the next boundary with the tool's real result; urgent steering still cancels immediately (both in `tests/unit/harness/test_loop.py`)
- [x] New session tests: a wake firing mid-turn leaves the running tool untouched, reaches the next model call with the resume note; an idle wake carries no resume note (`tests/unit/session/test_session.py`)
- [x] Existing steering-interrupt and abort tests unchanged and green
- [x] Full unit suite, flake8, black, isort, pyright