### PR TITLE
fix(tui): stop auto-copying on highlight in the composer

### DIFF
--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -2756,17 +2756,24 @@ class OperatorApp(App[None]):
         self._put_on_clipboard(self.screen.get_selected_text())
 
     def on_editor_copied(self, message: EditorCopied) -> None:
-        """A drag over the COMPOSER copies too, and says so identically.
+        """A composer copy says so identically to a transcript one.
 
         The composer is invisible to ``Screen.selections`` — ``TextArea`` clears
         the screen selection on every caret move, and the mouse-down that starts
         the drag is a caret move — so :meth:`on_text_selected` sees nothing to
         copy and the highlight the user is looking at goes nowhere. The widget
-        therefore reports its own release (``Editor._copy_drag``), and it lands
-        HERE rather than writing the clipboard itself so that both gestures
+        therefore reports its own copies (``Editor._copy_drag``), and they land
+        HERE rather than writing the clipboard themselves so that both gestures
         share one clipboard write and one toast: a copy out of the input must be
         indistinguishable from a copy out of the transcript, or the receipt
         becomes evidence about which widget you dragged over.
+
+        A composer copy is always EXPLICIT now: the widget posts this only
+        after an armed gesture (``Editor.copy_on_release``), never for a bare
+        drag — a composer highlight is usually the first half of a retype or
+        delete, so copying it on release clobbered the clipboard with text the
+        user was about to discard. The transcript keeps release-copies, where a
+        highlight is read-only text being taken.
 
         Only THIS path tags the card for later withdrawal: the composer's copy
         is the one an edit to the composer can falsify. A transcript copy goes

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -2762,18 +2762,18 @@ class OperatorApp(App[None]):
         the screen selection on every caret move, and the mouse-down that starts
         the drag is a caret move — so :meth:`on_text_selected` sees nothing to
         copy and the highlight the user is looking at goes nowhere. The widget
-        therefore reports its own copies (``Editor._copy_drag``), and they land
+        therefore reports its own copies (``Editor.action_copy``), and they land
         HERE rather than writing the clipboard themselves so that both gestures
         share one clipboard write and one toast: a copy out of the input must be
         indistinguishable from a copy out of the transcript, or the receipt
-        becomes evidence about which widget you dragged over.
+        becomes evidence about which widget you copied from.
 
         A composer copy is always EXPLICIT now: the widget posts this only
-        after an armed gesture (``Editor.copy_on_release``), never for a bare
-        drag — a composer highlight is usually the first half of a retype or
-        delete, so copying it on release clobbered the clipboard with text the
-        user was about to discard. The transcript keeps release-copies, where a
-        highlight is read-only text being taken.
+        from highlight-then-Ctrl+C, never from a drag — a composer highlight
+        is usually the first half of a retype or delete, so copying it on
+        release clobbered the clipboard with text the user was about to
+        discard. The transcript keeps release-copies, where a highlight is
+        read-only text being taken.
 
         Only THIS path tags the card for later withdrawal: the composer's copy
         is the one an edit to the composer can falsify. A transcript copy goes

--- a/local_operator/tui/widgets/editor.py
+++ b/local_operator/tui/widgets/editor.py
@@ -6,7 +6,8 @@ submit-on-Enter. The subclass inverts that and takes the terminal key idioms:
 - ``Enter`` submits (posts :class:`EditorSubmitted`); with the command picker
   open it first completes the highlighted command, THEN submits
 - ``Shift+Enter`` inserts a newline
-- ``Ctrl+C`` posts :class:`InterruptRequested` (abort the turn) — never exits
+- ``Ctrl+C`` copies a live range (posts :class:`EditorCopied`); with no range
+  it posts :class:`InterruptRequested` (abort the turn) — never exits
 - ``Ctrl+D`` on an EMPTY buffer quits; otherwise it falls through to delete
 - ``Up``/``Down`` move the picker's highlight while it is open; otherwise they
   cycle prompt history when the caret sits at the top/bottom edge of the
@@ -18,9 +19,13 @@ Key interception happens in :meth:`_on_key`, which runs BEFORE TextArea's
 document-insert path, so a handled key never reaches the buffer. Unhandled
 keys fall through to the stock editor behavior.
 
-Releasing a drag over the composer COPIES the highlighted text, the same rule
-the transcript follows and for the same reason — neither Ctrl+C nor cmd+C is
-available to bind here. See :meth:`Editor._copy_drag`.
+A drag over the composer SELECTS and does not copy. The transcript copies on
+release because a highlight there is read-only text being taken; in the
+composer a highlight is usually the first half of a retype or delete, so
+copying on release clobbered the clipboard with text the user was discarding.
+The copy gesture is explicit: highlight, then Ctrl+C — :meth:`_on_key` routes
+the press to :meth:`action_copy` while a real range is live. See
+:meth:`Editor._copy_drag` for why no other key can carry it.
 
 The caret is SOLID and never blinks, and on an EMPTY composer it gets a cell of
 its own to the left of the placeholder rather than inverting the placeholder's
@@ -368,10 +373,9 @@ class EditorCopyStale(Message):
 class EditorCopied(Message):
     """Posted when a composer drag finishes on a real selection AND copy is armed.
 
-    Posted only by the composer's two explicit-copy paths —
-    :meth:`Editor.action_copy` (the highlight-then-Ctrl+C press) and
-    :meth:`Editor._copy_drag` (an ARMED drag's release). A bare drag reaches
-    neither: drag-copy is the transcript's gesture, not the composer's.
+    Posted only by :meth:`Editor.action_copy` (the highlight-then-Ctrl+C
+    press). A drag never reaches this: drag-copy is the transcript's
+    gesture, not the composer's.
 
     Carries the text rather than leaving the app to re-read the widget: the
     selection is live state, and by the time a message is delivered a later
@@ -649,22 +653,6 @@ class Editor(TextArea):
         self._copy_gesture = False
         #: The selection `_copy_drag` took, while `_copy_gesture` holds.
         self._copied_selection: Selection | None = None
-        #: Whether the NEXT mouse-up that completes a drag copies what it
-        #: highlighted. The composer does NOT copy on release by default — a
-        #: highlight there is usually the first half of a retype or delete, so
-        #: copying it clobbers the clipboard with text the user was discarding.
-        #: ``action_copy`` arms this for the highlight-then-Ctrl+C sequence,
-        #: the one reliable copy key the composer has (see :meth:`_copy_drag`
-        #: for why no other key can carry the copy). Not gated on
-        #: ``selected_text``: the selection clears itself on the press that
-        #: retypes or deletes the range — select-to-overwrite is THE composer
-        #: gesture — so a gated flag could never fire and an ungated one fires
-        #: on exactly the next completed drag, whose release is when the copy
-        #: happens anyway. Set rather than consumed: while a copy's highlight
-        #: is still on screen the gesture (and its Ctrl+C deferral) is live,
-        #: so re-pressing Ctrl+C there means copy again, not interrupt. It
-        #: stands down with the gesture in :meth:`watch_selection`.
-        self.copy_on_release: bool = False
         self.set_commands(commands or [])
 
     def render_line(self, y: int) -> Strip:
@@ -1571,11 +1559,12 @@ class Editor(TextArea):
         the base class still finalises ``_selecting`` and releases the mouse
         afterwards; it never touches the selection, so nothing overwrites this.
 
-        The release is also where a drag becomes a COPY — but only while
-        :attr:`copy_on_release` holds. Drag-copy is the transcript's gesture,
-        where a highlight is read-only text being taken; in the composer a
-        highlight is usually the first half of a replace or delete, so the
-        release copies nothing by default and :meth:`_copy_drag` explains why.
+        A drag over the composer is NEVER a copy. Drag-copy is the
+        transcript's gesture, where a highlight is read-only text being taken;
+        in the composer a highlight is usually the first half of a replace or
+        delete, so copying on release clobbered the clipboard with text the
+        user was about to throw away. The copy gesture here is explicit:
+        highlight, then Ctrl+C — see :meth:`action_copy`.
         """
         pressed = self._pressed_marker
         self._pressed_marker = None
@@ -1588,13 +1577,15 @@ class Editor(TextArea):
             # clicked one marker, which means "act on this chip" (the gesture
             # exists so backspace can delete it whole), not "take a copy of
             # it". Copying here would put text on the clipboard and raise a
-            # receipt for it on a CLICK, which is precisely the noise
-            # :meth:`_copy_drag` avoids by ignoring collapsed selections.
+            # receipt for it on a CLICK, which is the same noise a drag-copy
+            # would be.
             return
-        self._copy_drag()
 
     def _copy_drag(self) -> None:
-        """Copy a composer drag on release — but ONLY while :attr:`copy_on_release`.
+        """A composer drag never copies. Kept as a named no-op so the tests
+        that used to drive this path still have a method to name, and so a
+        future reader looking for the old release-copies rule finds the
+        reason it is gone rather than a silent absence.
 
         The release-copies rule was imported from the transcript, where it is
         right: a highlight over an answer is read-only text being taken, and no
@@ -1605,9 +1596,10 @@ class Editor(TextArea):
         the composer it automatically copies … often you're just highlighting
         to select and potentially cut/delete a part, the copy can end up
         clearing something you have in the clipboard." So the release copies
-        NOTHING here by default: a composer highlight is selection, not copy.
+        NOTHING: a composer highlight is selection, not copy. The copy gesture
+        is explicit — highlight, then Ctrl+C — see :meth:`action_copy`.
 
-        Why no key can substitute, and therefore why the transcript's
+        Why no other key can substitute, and therefore why the transcript's
         release-copies rule exists there at all:
 
         * **The release does not reach the app.** ``OperatorApp.on_text_selected``
@@ -1620,72 +1612,25 @@ class Editor(TextArea):
           own select machinery is bypassed and ``_select_state`` never leaves
           ``None``.
 
-        * **No key can rescue it.** ``TextArea`` binds ``ctrl+c,super+c`` to
-          ``action_copy``, and neither key arrives: cmd+C is eaten by the
-          terminal (Ghostty binds ``super+c=copy_to_clipboard:mixed`` without
-          ``performable:``), and Ctrl+C is consumed by :meth:`_on_key` as this
-          app's interrupt before any binding runs. That is deliberate — the
-          interrupt cannot become conditional on a live highlight.
+        * **No key can rescue it on its own.** ``TextArea`` binds
+          ``ctrl+c,super+c`` to ``action_copy``, and neither key arrives:
+          cmd+C is eaten by the terminal (Ghostty binds
+          ``super+c=copy_to_clipboard:mixed`` without ``performable:``), and
+          Ctrl+C is consumed by :meth:`_on_key` as this app's interrupt before
+          any binding runs. That is deliberate — the interrupt cannot become
+          conditional on a live highlight. :meth:`_on_key` therefore routes
+          the press to :meth:`action_copy` itself when a real range is live,
+          which is the one copy sequence the composer has.
 
-        So ``action_copy`` is re-armed with ``copy_on_release`` for exactly one
-        press: the only reliable copy key the composer has is the
-        highlight-then-Ctrl+C sequence (the press defers its interrupt meaning
-        through :attr:`copy_in_flight` while a real range is live), and arming
-        on the keypress keeps that sequence copying without making every
-        select-to-edit drag a clipboard write.
-
-        Only a real range copies. A plain click leaves ``start == end`` and is
-        not a copy — nor is the marker click above, which the caller returns on
-        before reaching here because that selection is the app's, made so
-        backspace can delete the chip whole.
-
-        ``selected_text`` is the DOCUMENT's text, which is the right claim for
-        an input: what a user copies out of a field is what they typed and can
-        paste back, so an attachment marker copies as the ``[Image #1, …]`` text
-        that cites it — the same characters :meth:`_submit` would send, and the
-        ones that re-cite the image if pasted into another draft. In a read-only
-        composer (subagent view) that text is the app's rather than the user's,
-        and it copies too: what the field shows is what a drag over it takes.
-
-        Only THIS widget's own drag copies, which ``_selecting`` is the record
-        of — ``TextArea._on_mouse_down`` sets it and ``TextArea._on_mouse_up``
-        clears it, and this runs in between (review round 1, F1/F2). Without
-        that gate every mouse-up delivered here copies, and two of them are not
-        copy gestures at all:
-
-        * A drag that STARTS in the transcript and is released over the composer
-          — the ordinary way to select to the end of the answer, since the
-          composer is docked below it. ``TextArea`` leaves a selection live
-          after its own drag, so the composer still holds the last range the
-          user highlighted in it, and re-copying that range overwrites the
-          transcript copy the same release just made. Measured: the user dragged
-          the agent's answer and got their own draft, with a toast confirming
-          it.
-        * A bare mouse-up over a selection made with shift+arrows, which no
-          mouse gesture asked to copy.
-
-        A guard phrased as "did the PRESS land in this widget" would fix the
-        first and miss the second; ``_selecting`` answers the question that
-        actually matters, which is whether this widget is mid-drag.
+        An earlier version of this method copied on an ARMED release
+        (``copy_on_release``, set by an explicit copy so the next drag
+        matched the transcript's). That was a hidden mode whose lifetime
+        could not be stated correctly: the arm outlived the highlight that
+        authorised it (review round 1, F1) and nothing on screen showed it
+        was on (design round 1, D2). Dropped rather than patched — a
+        composer copy is always the explicit press, never a drag.
         """
-        if not self.copy_on_release:
-            return
-        if not self._selecting:
-            return
-        text = self.selected_text
-        if not text:
-            return
-        self._copied = True
-        self._copy_gesture = True
-        # WHICH range the copy took, so `watch_selection` can tell this copy's
-        # own highlight from any later one and retire the claim when it goes.
-        # Without that distinction a shift+arrow selection made after the copied
-        # range had been collapsed silently re-armed the app's Ctrl+C deferral,
-        # and the next two presses quit with the draft unfiled (D22, design
-        # round 7). `#:` is for attribute declarations, and this is an
-        # assignment in a method body (R17 NIT-1).
-        self._copied_selection = self.selection
-        self.post_message(EditorCopied(text))
+        return
 
     @property
     def copy_in_flight(self) -> bool:
@@ -1707,42 +1652,38 @@ class Editor(TextArea):
         return self._selecting or self._copy_gesture
 
     def action_copy(self) -> None:
-        """Copy the selection — and arm the NEXT completed drag to copy on release.
+        """Copy the live range. THE composer's copy gesture.
 
         The composer cannot rely on Textual's binding reaching this method on
         its own: cmd+C is eaten by the terminal and Ctrl+C is the app's
         interrupt (see :meth:`_copy_drag`), so :meth:`_on_key` routes the
-        highlight-then-Ctrl+C sequence here directly. But this override exists
-        for the keyboard path as a whole (and any caller of the ``copy``
-        action): a copy the user explicitly asked for arms the follow-up drag,
-        because a user who just copied out of the composer is selecting to
-        TAKE, and the release-copy gesture they get next matches the
-        transcript's. The flag is deliberately not consumed on use — see the
-        attribute for the lifetime argument.
+        highlight-then-Ctrl+C sequence here directly. This override exists so
+        that path — and any other caller of the ``copy`` action — writes the
+        clipboard through the SAME message a transcript copy uses, rather than
+        ``super().action_copy()``: Textual's base writes silently, and this
+        app's rule is that a copy says so. One clipboard write and one receipt
+        for every gesture, or the toast becomes evidence about which key
+        carried it.
 
-        The copy itself goes through the SAME message as a drag-copy rather
-        than ``super().action_copy()``: Textual's base writes the clipboard
-        silently, and this app's rule is that a copy says so — one clipboard
-        write and one receipt for every gesture, or the toast becomes
-        evidence about which key carried it.
-
-        The gesture flags are deliberately NOT set here, and the reason is
-        the D20/D22 trap the drag path already fell into: ``_copy_gesture``
-        is what defers Ctrl+C's interrupt meaning while a copy's highlight is
-        on screen, and a highlight outlives every gesture — it sits there
-        until the caret moves. A press is over the instant it lands, so
-        leaving the gesture armed after one defers the NEXT press for as long
-        as the stale highlight happens to remain: the user presses Ctrl+C on
-        a minutes-old range expecting the draft rung and gets a re-copy
-        instead, with the exit ladder's second tap a lost draft away. The
+        The gesture flags are deliberately NOT set here. ``_copy_gesture`` is
+        what defers Ctrl+C's interrupt meaning while a copy's highlight is on
+        screen, and a highlight outlives every gesture — it sits there until
+        the caret moves. A press is over the instant it lands, so leaving the
+        gesture armed after one would defer the NEXT press for as long as the
+        stale highlight happens to remain: the user presses Ctrl+C on a
+        minutes-old range expecting the draft rung and gets a re-copy instead,
+        with the exit ladder's second tap a lost draft away (D17/D20). The
         receipt flag IS set — the toast it drives is a claim about the
-        clipboard, and editing the copied text falsifies it exactly as it
-        does for a drag-copy (D3).
+        clipboard, and editing the copied text falsifies it (D3).
+
+        A live range on a subsequent press copies AGAIN rather than
+        interrupting: that is the explicit-copy rule itself, not a leftover
+        deferral. Collapsing the caret (an arrow, a click) is what hands the
+        key back to the draft/interrupt rungs.
         """
         text = self.selected_text
         if not text:
             raise SkipAction()
-        self.copy_on_release = True
         self._copied = True
         self.post_message(EditorCopied(text))
 
@@ -1760,11 +1701,6 @@ class Editor(TextArea):
         highlight on screen, whether that is a caret move collapsing it or a new
         selection replacing it. `_copied_selection` is what makes "the same
         highlight" checkable rather than merely "a highlight".
-
-        ``copy_on_release`` stands down with the gesture too: it is armed by an
-        explicit copy, and once the highlight that copy was about is gone the
-        user's next selection is a new decision — the select-to-edit default
-        must be the state they return to, not a mode they are stuck in.
 
         Deliberately NOT posting ``EditorCopyStale``: moving the caret is not
         the user editing the text their receipt describes, so the toast remains
@@ -1785,7 +1721,6 @@ class Editor(TextArea):
         ):
             self._copy_gesture = False
             self._copied_selection = None
-            self.copy_on_release = False
 
     # -- paste ----------------------------------------------------------------
     async def _on_paste(self, event: events.Paste) -> None:
@@ -1988,10 +1923,6 @@ class Editor(TextArea):
             self._copy_gesture = False
             self._copied_selection = None
             self.post_message(EditorCopyStale())
-        # An edit ends the copy conversation whether or not a receipt was up:
-        # the buffer the arm referred to is being rewritten, so a drag after
-        # this keystroke is a new decision (select-to-edit by default again).
-        self.copy_on_release = False
         self._sync_picker()
         if touched:
             self._release_uncited(touched)
@@ -2062,7 +1993,6 @@ class Editor(TextArea):
         self._copied = False
         self._copy_gesture = False
         self._copied_selection = None
-        self.copy_on_release = False
         super().load_text(text)
         self._sync_picker()
 

--- a/local_operator/tui/widgets/editor.py
+++ b/local_operator/tui/widgets/editor.py
@@ -63,6 +63,7 @@ from rich.cells import cell_len
 from rich.segment import Segment
 from rich.style import Style as RichStyle
 from textual import events
+from textual.actions import SkipAction
 from textual.content import Content
 from textual.expand_tabs import expand_tabs_inline
 from textual.geometry import Offset
@@ -365,7 +366,12 @@ class EditorCopyStale(Message):
 
 
 class EditorCopied(Message):
-    """Posted when a drag over the composer finishes on a real selection.
+    """Posted when a composer drag finishes on a real selection AND copy is armed.
+
+    Posted only by the composer's two explicit-copy paths —
+    :meth:`Editor.action_copy` (the highlight-then-Ctrl+C press) and
+    :meth:`Editor._copy_drag` (an ARMED drag's release). A bare drag reaches
+    neither: drag-copy is the transcript's gesture, not the composer's.
 
     Carries the text rather than leaving the app to re-read the widget: the
     selection is live state, and by the time a message is delivered a later
@@ -643,6 +649,22 @@ class Editor(TextArea):
         self._copy_gesture = False
         #: The selection `_copy_drag` took, while `_copy_gesture` holds.
         self._copied_selection: Selection | None = None
+        #: Whether the NEXT mouse-up that completes a drag copies what it
+        #: highlighted. The composer does NOT copy on release by default — a
+        #: highlight there is usually the first half of a retype or delete, so
+        #: copying it clobbers the clipboard with text the user was discarding.
+        #: ``action_copy`` arms this for the highlight-then-Ctrl+C sequence,
+        #: the one reliable copy key the composer has (see :meth:`_copy_drag`
+        #: for why no other key can carry the copy). Not gated on
+        #: ``selected_text``: the selection clears itself on the press that
+        #: retypes or deletes the range — select-to-overwrite is THE composer
+        #: gesture — so a gated flag could never fire and an ungated one fires
+        #: on exactly the next completed drag, whose release is when the copy
+        #: happens anyway. Set rather than consumed: while a copy's highlight
+        #: is still on screen the gesture (and its Ctrl+C deferral) is live,
+        #: so re-pressing Ctrl+C there means copy again, not interrupt. It
+        #: stands down with the gesture in :meth:`watch_selection`.
+        self.copy_on_release: bool = False
         self.set_commands(commands or [])
 
     def render_line(self, y: int) -> Strip:
@@ -1051,7 +1073,22 @@ class Editor(TextArea):
             event.prevent_default()
             return
         if key == "ctrl+c":
-            self.post_message(InterruptRequested())
+            # A REAL RANGE makes this press a copy, ahead of its interrupt
+            # meaning. ``TextArea``'s ``ctrl+c`` binding never runs — the key
+            # is consumed here first — so the highlight-then-Ctrl+C sequence
+            # the field report names would otherwise be the one copy gesture
+            # with no effect at all. Only a real range qualifies: a selection
+            # is STATE that persists until the caret moves, but a collapsed
+            # caret is the resting state of the composer, and gating the
+            # interrupt on "some range is live" is D17's lost-draft bug this
+            # ordering exists to avoid. A stale LIVE range is safe to copy
+            # through: it has start != end, so it survives the checks in the
+            # app's interrupt rung that guard the exit ladder, and the press
+            # means "take this", not "scrap my draft".
+            if self.selected_text:
+                self.action_copy()
+            else:
+                self.post_message(InterruptRequested())
             event.stop()
             event.prevent_default()
             return
@@ -1534,9 +1571,11 @@ class Editor(TextArea):
         the base class still finalises ``_selecting`` and releases the mouse
         afterwards; it never touches the selection, so nothing overwrites this.
 
-        The release is also where a drag over the composer becomes a COPY, for
-        the same reason it is in the transcript — see :meth:`_copy_drag` and
-        ``OperatorApp.on_text_selected``.
+        The release is also where a drag becomes a COPY — but only while
+        :attr:`copy_on_release` holds. Drag-copy is the transcript's gesture,
+        where a highlight is read-only text being taken; in the composer a
+        highlight is usually the first half of a replace or delete, so the
+        release copies nothing by default and :meth:`_copy_drag` explains why.
         """
         pressed = self._pressed_marker
         self._pressed_marker = None
@@ -1555,11 +1594,21 @@ class Editor(TextArea):
         self._copy_drag()
 
     def _copy_drag(self) -> None:
-        """Put a composer drag on the clipboard, exactly as the transcript does.
+        """Copy a composer drag on release — but ONLY while :attr:`copy_on_release`.
 
-        Reported from the field: text highlighted in the composer "doesn't copy
-        properly" — the drag paints a highlight and the clipboard keeps whatever
-        it held before. Both halves of the app's copy story miss this widget:
+        The release-copies rule was imported from the transcript, where it is
+        right: a highlight over an answer is read-only text being taken, and no
+        key can carry it (below). In the composer the same gesture is usually
+        the first half of an EDIT — drag a phrase to retype it, drag a word to
+        delete it — so a copy on release clobbered the user's clipboard with
+        text they were about to throw away. Reported: "when you highlight in
+        the composer it automatically copies … often you're just highlighting
+        to select and potentially cut/delete a part, the copy can end up
+        clearing something you have in the clipboard." So the release copies
+        NOTHING here by default: a composer highlight is selection, not copy.
+
+        Why no key can substitute, and therefore why the transcript's
+        release-copies rule exists there at all:
 
         * **The release does not reach the app.** ``OperatorApp.on_text_selected``
           copies ``Screen.get_selected_text()``, but a ``TextArea`` never
@@ -1567,23 +1616,23 @@ class Editor(TextArea):
           ``app.clear_selection()`` on every caret move, and the mouse-down that
           begins a composer drag moves the caret — so ``Screen.selections`` is
           wiped on the first event of the gesture and stays empty for the rest
-          of it. Measured before this fix: after a drag over the composer,
-          ``editor.selected_text`` was ``'summarise the inges'`` while
-          ``screen.get_selected_text()`` was ``None`` and the clipboard was ``''``.
-          The base class also captures the mouse on press, so ``Screen``'s own
-          select machinery is bypassed and ``_select_state`` never leaves ``None``.
+          of it. The base class also captures the mouse on press, so ``Screen``'s
+          own select machinery is bypassed and ``_select_state`` never leaves
+          ``None``.
 
         * **No key can rescue it.** ``TextArea`` binds ``ctrl+c,super+c`` to
           ``action_copy``, and neither key arrives: cmd+C is eaten by the
           terminal (Ghostty binds ``super+c=copy_to_clipboard:mixed`` without
           ``performable:``), and Ctrl+C is consumed by :meth:`_on_key` as this
           app's interrupt before any binding runs. That is deliberate — the
-          interrupt cannot become conditional on a live highlight — so the
-          composer is left with a highlight and no way to spend it.
+          interrupt cannot become conditional on a live highlight.
 
-        The fix is the rule the transcript already states: **the release IS the
-        copy**. The gesture carries itself, the user gets the same toast, and no
-        key changes meaning.
+        So ``action_copy`` is re-armed with ``copy_on_release`` for exactly one
+        press: the only reliable copy key the composer has is the
+        highlight-then-Ctrl+C sequence (the press defers its interrupt meaning
+        through :attr:`copy_in_flight` while a real range is live), and arming
+        on the keypress keeps that sequence copying without making every
+        select-to-edit drag a clipboard write.
 
         Only a real range copies. A plain click leaves ``start == end`` and is
         not a copy — nor is the marker click above, which the caller returns on
@@ -1619,6 +1668,8 @@ class Editor(TextArea):
         first and miss the second; ``_selecting`` answers the question that
         actually matters, which is whether this widget is mid-drag.
         """
+        if not self.copy_on_release:
+            return
         if not self._selecting:
             return
         text = self.selected_text
@@ -1655,6 +1706,46 @@ class Editor(TextArea):
         """
         return self._selecting or self._copy_gesture
 
+    def action_copy(self) -> None:
+        """Copy the selection — and arm the NEXT completed drag to copy on release.
+
+        The composer cannot rely on Textual's binding reaching this method on
+        its own: cmd+C is eaten by the terminal and Ctrl+C is the app's
+        interrupt (see :meth:`_copy_drag`), so :meth:`_on_key` routes the
+        highlight-then-Ctrl+C sequence here directly. But this override exists
+        for the keyboard path as a whole (and any caller of the ``copy``
+        action): a copy the user explicitly asked for arms the follow-up drag,
+        because a user who just copied out of the composer is selecting to
+        TAKE, and the release-copy gesture they get next matches the
+        transcript's. The flag is deliberately not consumed on use — see the
+        attribute for the lifetime argument.
+
+        The copy itself goes through the SAME message as a drag-copy rather
+        than ``super().action_copy()``: Textual's base writes the clipboard
+        silently, and this app's rule is that a copy says so — one clipboard
+        write and one receipt for every gesture, or the toast becomes
+        evidence about which key carried it.
+
+        The gesture flags are deliberately NOT set here, and the reason is
+        the D20/D22 trap the drag path already fell into: ``_copy_gesture``
+        is what defers Ctrl+C's interrupt meaning while a copy's highlight is
+        on screen, and a highlight outlives every gesture — it sits there
+        until the caret moves. A press is over the instant it lands, so
+        leaving the gesture armed after one defers the NEXT press for as long
+        as the stale highlight happens to remain: the user presses Ctrl+C on
+        a minutes-old range expecting the draft rung and gets a re-copy
+        instead, with the exit ladder's second tap a lost draft away. The
+        receipt flag IS set — the toast it drives is a claim about the
+        clipboard, and editing the copied text falsifies it exactly as it
+        does for a drag-copy (D3).
+        """
+        text = self.selected_text
+        if not text:
+            raise SkipAction()
+        self.copy_on_release = True
+        self._copied = True
+        self.post_message(EditorCopied(text))
+
     def watch_selection(self, selection: Selection) -> None:
         """Retire the copy receipt's GESTURE claim when the highlight changes.
 
@@ -1669,6 +1760,11 @@ class Editor(TextArea):
         highlight on screen, whether that is a caret move collapsing it or a new
         selection replacing it. `_copied_selection` is what makes "the same
         highlight" checkable rather than merely "a highlight".
+
+        ``copy_on_release`` stands down with the gesture too: it is armed by an
+        explicit copy, and once the highlight that copy was about is gone the
+        user's next selection is a new decision — the select-to-edit default
+        must be the state they return to, not a mode they are stuck in.
 
         Deliberately NOT posting ``EditorCopyStale``: moving the caret is not
         the user editing the text their receipt describes, so the toast remains
@@ -1689,6 +1785,7 @@ class Editor(TextArea):
         ):
             self._copy_gesture = False
             self._copied_selection = None
+            self.copy_on_release = False
 
     # -- paste ----------------------------------------------------------------
     async def _on_paste(self, event: events.Paste) -> None:
@@ -1877,13 +1974,13 @@ class Editor(TextArea):
         # touched. Both halves are measured BEFORE the edit, because afterwards
         # the range is gone and the citation positions have moved.
         touched = self._attachments_touched_by(edit)
-        # Select-to-overwrite is the commonest edit in any input, and after this
-        # widget started copying on release it also became a clipboard write:
-        # the user drags a word to replace it, types, and a receipt asserting a
-        # copy of characters that no longer exist sits on screen for another
-        # five seconds (design round 1, D3). The clipboard keeps what it took
-        # — that is what a copy IS, and silently un-copying would be worse —
-        # but the CLAIM is retired the moment its subject is edited away.
+        # Select-to-overwrite is the commonest edit in any input, and when it
+        # follows a copy it falsifies the copy's receipt: the user drags a word
+        # to replace it, types, and a receipt asserting a copy of characters
+        # that no longer exist sits on screen for another five seconds (design
+        # round 1, D3). The clipboard keeps what it took — that is what a copy
+        # IS, and silently un-copying would be worse — but the CLAIM is retired
+        # the moment its subject is edited away.
         stale_receipt = self._copied
         result = super().edit(edit)
         if stale_receipt:
@@ -1891,6 +1988,10 @@ class Editor(TextArea):
             self._copy_gesture = False
             self._copied_selection = None
             self.post_message(EditorCopyStale())
+        # An edit ends the copy conversation whether or not a receipt was up:
+        # the buffer the arm referred to is being rewritten, so a drag after
+        # this keystroke is a new decision (select-to-edit by default again).
+        self.copy_on_release = False
         self._sync_picker()
         if touched:
             self._release_uncited(touched)
@@ -1961,6 +2062,7 @@ class Editor(TextArea):
         self._copied = False
         self._copy_gesture = False
         self._copied_selection = None
+        self.copy_on_release = False
         super().load_text(text)
         self._sync_picker()
 

--- a/tests/unit/tui/test_steering_approval.py
+++ b/tests/unit/tui/test_steering_approval.py
@@ -73,7 +73,7 @@ from local_operator.tui.widgets.transcript import (
 )
 
 from .test_app_pilot import FakeSession, _factory
-from .test_transcript_selection import _cell, _composer_copy_drag
+from .test_transcript_selection import _cell, _composer_copy
 
 
 class SteerableSession(FakeSession):
@@ -2954,19 +2954,16 @@ async def test_moving_the_caret_after_a_copy_gives_ctrl_c_back_to_the_draft() ->
         await pilot.pause()
         await pilot.pause()
 
-        # A REAL drag-copy, driven through the widget's own mouse path rather
-        # than by hand-setting flags — armed first, since a composer drag only
-        # copies after an explicit copy has armed the release (a bare
-        # highlight is selection, not copy: the clobber this file's sibling
-        # tests removed). Round 19 (MAJOR-1) caught the hand-set stand-in
-        # going vacuous when `copy_in_flight` moved from `_copied` to
-        # `_copy_gesture`: the stand-in never armed the deferral, so the test
-        # verified that a caret move retires something already retired. Driving
-        # the real gesture ties this guard to whatever predicate the widget
-        # actually arms, so a future re-pointing cannot silently disarm it.
-        await _composer_copy_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 10))
-        assert editor.copy_in_flight, "the drag must arm the deferral for this test to bite"
+        # A REAL explicit copy, driven through the widget's own key path
+        # rather than by hand-setting flags. Round 19 (MAJOR-1) caught a
+        # hand-set stand-in going vacuous when `copy_in_flight` moved from
+        # `_copied` to `_copy_gesture`. The press itself does not claim the
+        # gesture flag (a highlight outlives the press, and deferring the
+        # next Ctrl+C for that long is D17/D20); what this test pins is that
+        # collapsing the highlight hands the key back to the draft.
+        await _composer_copy(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 10))
         assert editor.selected_text, "the copy's own highlight must be on screen"
+        assert editor._copied, "the receipt must be armed for this to mean anything"
 
         # Moving the caret collapses the highlight — the copy is over, and the
         # user can see that it is.

--- a/tests/unit/tui/test_steering_approval.py
+++ b/tests/unit/tui/test_steering_approval.py
@@ -73,7 +73,7 @@ from local_operator.tui.widgets.transcript import (
 )
 
 from .test_app_pilot import FakeSession, _factory
-from .test_transcript_selection import _cell, _composer_drag
+from .test_transcript_selection import _cell, _composer_copy_drag
 
 
 class SteerableSession(FakeSession):
@@ -2879,18 +2879,20 @@ async def test_the_expired_row_recounts_rather_than_restating_a_stale_number() -
 
 
 @pytest.mark.asyncio
-async def test_a_stale_highlight_does_not_divert_ctrl_c_from_the_draft() -> None:
-    """D17, design round 5. Gate on the GESTURE, not on the selection.
+async def test_a_stale_highlight_copies_but_cannot_arm_the_exit_ladder() -> None:
+    """D17, design round 5. A stale range is a copy now — and ONLY a copy.
 
-    A selection is state that persists until the caret moves, so "the composer
-    has a highlight" stays true long after any copy ended. Gating on it meant a
-    composer holding a stale range took the interrupt, ARMED the exit ladder,
-    and a second reflexive tap quit the app with the draft never filed — the
-    exact hazard this rung was added to remove, reintroduced by its own guard.
-
-    A real drag-copy is covered from the other side by
-    `test_a_composer_drag_still_leaves_ctrl_c_as_the_interrupt` in
-    `test_transcript_selection.py`, which this must not break.
+    This test used to assert that a stale highlight "does not divert Ctrl+C
+    from the draft". The explicit-copy gesture changed the answer at the
+    source: highlight-then-Ctrl+C IS the composer's copy now, so the press
+    takes the range — deliberately, because a live range means the user can
+    see what Ctrl+C will act on, which is the property the old selection
+    gate lacked. What D17 actually protects survives unchanged: no abort,
+    the draft untouched (it is not being scrapped, it is being quoted), the
+    exit ladder NOT armed, and the reflexive second tap still not an exit.
+    The draft rung this test used to exercise is covered on clean state by
+    `test_ctrl_c_with_no_selection_never_reaches_the_interrupt` in
+    `test_transcript_selection.py`.
     """
     session = SteerableSession()
     app = OperatorApp(lambda: _factory(session))
@@ -2912,15 +2914,18 @@ async def test_a_stale_highlight_does_not_divert_ctrl_c_from_the_draft() -> None
         await pilot.press("ctrl+c")
         await pilot.pause(0.1)
 
-        # The draft rung takes it: filed, not aborted, ladder NOT armed.
+        # The copy takes the key, and nothing else moves: no abort, the draft
+        # still there, and the ladder unarmed.
         assert session.aborts == [], "a stale highlight diverted the key to the interrupt"
-        assert editor.text == "", "the draft was not cleared"
-        assert "a half-typed prompt I do not want to lose" in editor.prompt_history()
+        assert editor.text == "a half-typed prompt I do not want to lose", "the draft was touched"
 
         # And the second press must not quit, which is the damage D17 named.
+        # The range is still live, so this press copies again — it must NOT
+        # have started counting rungs.
         await pilot.press("ctrl+c")
         await pilot.pause(0.1)
         assert app.is_running, "a second reflexive tap exited the app"
+        assert session.aborts == [], "the second tap became an abort"
 
 
 @pytest.mark.asyncio
@@ -2950,13 +2955,16 @@ async def test_moving_the_caret_after_a_copy_gives_ctrl_c_back_to_the_draft() ->
         await pilot.pause()
 
         # A REAL drag-copy, driven through the widget's own mouse path rather
-        # than by hand-setting flags. Round 19 (MAJOR-1) caught the hand-set
-        # stand-in going vacuous when `copy_in_flight` moved from `_copied` to
+        # than by hand-setting flags — armed first, since a composer drag only
+        # copies after an explicit copy has armed the release (a bare
+        # highlight is selection, not copy: the clobber this file's sibling
+        # tests removed). Round 19 (MAJOR-1) caught the hand-set stand-in
+        # going vacuous when `copy_in_flight` moved from `_copied` to
         # `_copy_gesture`: the stand-in never armed the deferral, so the test
         # verified that a caret move retires something already retired. Driving
         # the real gesture ties this guard to whatever predicate the widget
         # actually arms, so a future re-pointing cannot silently disarm it.
-        await _composer_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 10))
+        await _composer_copy_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 10))
         assert editor.copy_in_flight, "the drag must arm the deferral for this test to bite"
         assert editor.selected_text, "the copy's own highlight must be on screen"
 

--- a/tests/unit/tui/test_transcript_selection.py
+++ b/tests/unit/tui/test_transcript_selection.py
@@ -63,6 +63,7 @@ from rich.text import Text
 from textual import events
 from textual.content import Content
 from textual.geometry import Offset
+from textual.document._document import Selection as DocumentSelection
 from textual.selection import Selection
 from textual.visual import RichVisual
 
@@ -1130,7 +1131,7 @@ async def test_ctrl_c_with_a_live_range_copies_it() -> None:
         await pilot.pause()
         editor = await _composer(app, pilot, "summarise the ingest path please")
         app._clipboard = ""
-        editor.selection = Selection((0, 0), (0, 20))
+        editor.selection = DocumentSelection((0, 0), (0, 20))
         await pilot.pause()
 
         await pilot.press("ctrl+c")
@@ -1479,7 +1480,7 @@ async def test_the_read_only_composer_still_copies_what_it_shows() -> None:
         # Read-only or not, the gesture is the explicit one: a range, then
         # Ctrl+C. The text is the app's, which is exactly why someone would
         # lift it out — and why it never sits on the clipboard unasked.
-        editor.selection = Selection((0, 0), (0, 7))
+        editor.selection = DocumentSelection((0, 0), (0, 7))
         await pilot.pause()
         await pilot.press("ctrl+c")
         await pilot.pause()
@@ -2039,7 +2040,7 @@ async def test_a_new_selection_after_a_copy_does_not_rearm_the_interrupt() -> No
         # actually protects is that an unrelated selection cannot resurrect
         # a leftover deferral that would abort or quit; the press copies the
         # range on screen, nothing else.
-        editor.selection = Selection((0, 10), (0, 20))
+        editor.selection = DocumentSelection((0, 10), (0, 20))
         await pilot.pause()
         assert (
             editor.selected_text == "the ingest"

--- a/tests/unit/tui/test_transcript_selection.py
+++ b/tests/unit/tui/test_transcript_selection.py
@@ -1009,9 +1009,11 @@ async def test_the_highlight_outlives_the_copy() -> None:
 #   docstrings name) and Ctrl+C is consumed by `Editor._on_key` as this app's
 #   interrupt before any binding runs.
 #
-# So the composer reports its own release (`Editor._copy_drag` ->
-# `EditorCopied`) and the app answers it through the same clipboard write and
-# the same toast as the transcript.
+# The first fix copied on release, matching the transcript. That clobbered
+# the clipboard on every select-to-edit drag — the reported follow-up. The
+# composer now copies only on an explicit Ctrl+C (`Editor.action_copy` ->
+# `EditorCopied`); a drag selects and nothing more. The app still answers
+# through the same clipboard write and the same toast as the transcript.
 
 
 async def _composer_drag(
@@ -1019,29 +1021,14 @@ async def _composer_drag(
     pilot: Any,
     start: tuple[int, int],
     end: tuple[int, int],
-    *,
-    copy: bool = False,
 ) -> None:
     """A drag over the composer, as `Screen._forward_event` receives it.
 
     Separate from `_drag` only in that it does not assert a screen selection
     afterwards: over a `TextArea` there is never going to be one, which is the
-    whole reason this path exists.
-
-    ``copy=True`` arms `copy_on_release` with an explicit Ctrl+C over the
-    drag's own cells mapped to document locations. Only tests that need the
-    arm WITHOUT the helper's full ceremony (sentinel, row-0 span — see
-    `_composer_copy_drag`) should pass it; the rest belong on the helper.
+    whole reason this path exists. A composer drag never copies — that is the
+    rule this file exists to pin — so there is no `copy=` switch.
     """
-    if copy:
-        editor = app.query_one(Editor)
-        editor.selection = Selection(
-            editor.get_target_document_location(_mouse(app, events.MouseDown, *start)),
-            editor.get_target_document_location(_mouse(app, events.MouseUp, *end)),
-        )
-        await pilot.pause()
-        await pilot.press("ctrl+c")
-        await pilot.pause()
     app.screen._forward_event(_mouse(app, events.MouseDown, *start))
     await pilot.pause()
     if start != end:
@@ -1052,48 +1039,22 @@ async def _composer_drag(
     await pilot.pause()
 
 
-async def _composer_copy_drag(
+async def _composer_copy(
     app: OperatorApp,
     pilot: Any,
     start: tuple[int, int],
     end: tuple[int, int],
 ) -> None:
-    """An ARMED composer drag: the release copies, as after an explicit copy.
+    """The composer's copy gesture: drag to select, then Ctrl+C.
 
-    The composer no longer copies on a bare release — a highlight there is
-    usually the first half of a retype or delete, so the release copies only
-    while the user has signalled "I am taking text" by asking for a copy first
-    (`Editor.copy_on_release`). Most copy-behaviour tests in this file are
-    about what an explicit copy takes and claims, so they drive this helper
-    and keep every assertion they already made; tests about the DEFAULT are
-    the ones that state the new rule.
-
-    The arming copy's own range is the drag's row-0 span. It cannot be the
-    drag's exact range: a range ending on a LATER row would keep the caret at
-    that row, and the drag's row-0 mouse-down would land outside it — which
-    the selection watcher reads as the copy's highlight being replaced and
-    disarms the flag the drag is meant to exercise. A row-0 span contains the
-    drag's down, and collapsing to a caret INSIDE the range is not a
-    disarm (a select-to-retype lands there too). A single-row drag's arm is
-    therefore its own range exactly; a multi-row one's is the first row —
-    both are what a user who just copied "this part" would actually do.
+    The drag is how a user makes the range (and how these tests' coordinates
+    were written); it copies nothing. The press is the copy. Tests that used
+    to drive an armed drag keep their coordinates and their assertions about
+    WHAT was taken.
     """
-    app._clipboard = "SENTINEL"
-    editor = app.query_one(Editor)
-    # `get_target_document_location` needs a full event; `Offset` is all it
-    # reads. The UP event is aimed one column PAST the drag's end column:
-    # drag selection ends EXCLUSIVE at the released cell, so this keeps the
-    # arming range a strict superset of the drag's row-0 span — a single-row
-    # drag's release would otherwise collapse to the copy's own caret, and
-    # the watcher's literal `!=` disarms on it.
-    editor.selection = Selection(
-        editor.get_target_document_location(_mouse(app, events.MouseDown, *start)),
-        editor.get_target_document_location(_mouse(app, events.MouseUp, end[0] + 1, start[1])),
-    )
-    await pilot.pause()
+    await _composer_drag(app, pilot, start, end)
     await pilot.press("ctrl+c")
     await pilot.pause()
-    await _composer_drag(app, pilot, start, end)
 
 
 async def _composer(app: OperatorApp, pilot: Any, text: str) -> Editor:
@@ -1179,74 +1140,62 @@ async def test_ctrl_c_with_a_live_range_copies_it_and_arms_the_next_drag() -> No
         # The explicit copy also kept the draft and raised no interrupt: it
         # consumed the press entirely.
         assert editor.text == "summarise the ingest path please"
-        assert editor.copy_on_release, "an explicit copy must arm the follow-up drag"
+        toast = app.query_one(Toast)
+        assert toast.message == "copied 20 characters"
 
-        # And the very next drag copies on release — the armed gesture. What
-        # matters is that the release wrote the NEW highlight (a bare drag
-        # would leave the first copy's text on the clipboard); the drag's own
-        # `selected_text` is the claim, as in every other composer test.
-        await _composer_drag(app, pilot, _cell(editor, 0, 29), _cell(editor, 0, 34))
-        assert editor.selected_text == app._clipboard
-        assert app._clipboard == "ase"
+        # And a subsequent drag copies NOTHING — there is no armed-next-drag
+        # mode. Review round 1 F1: the arm outlived the highlight that
+        # authorised it and clobbered the clipboard on a later select-to-edit.
+        # Design round 1 D2: it was a hidden mode with nothing on screen to
+        # show it was on. Dropped rather than patched.
+        await _composer_drag(app, pilot, _cell(editor, 0, 24), _cell(editor, 0, 34))
+        assert app._clipboard == "summarise the ingest"
 
 
 @pytest.mark.asyncio
-async def test_the_drag_copy_arm_retires_with_the_highlight_it_copied() -> None:
-    """The arm is not a mode the user gets stuck in.
+async def test_a_drag_after_an_explicit_copy_still_copies_nothing() -> None:
+    """F1, review round 1. There is no armed-next-drag mode.
 
-    It belongs to the copy conversation: once the copy's highlight leaves the
-    screen the next selection is a new decision, and the select-to-edit
-    default must be the state the user returns to. Otherwise one stray copy
-    would turn every later select-to-delete back into a clipboard clobber,
-    which is the defect this change exists to remove.
-
-    Driven with the REAL armed drag rather than the bare press: the arm is
-    the next drag's, so its retirement is the gesture flag's retirement —
-    after the follow-up drag copies, the user carrying on (moving the caret
-    off the range that drag took) is what ends the conversation.
+    An earlier version of this change armed the NEXT drag to copy on release
+    after an explicit Ctrl+C, so a user taking several passages could keep
+    dragging. The arm never retired when the copied highlight left the
+    screen (the press did not set `_copy_gesture`, and `watch_selection`
+    only disarmed inside that branch), so a later select-to-edit clobbered
+    the clipboard — the original defect, one keystroke later. Dropped: a
+    composer copy is always the explicit press.
     """
     app = _pilot_app()
     async with app.run_test(size=(80, 24)) as pilot:
         await pilot.pause()
         editor = await _composer(app, pilot, "summarise the ingest path please")
-        await _composer_copy_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 20))
-        assert editor.copy_on_release, "the armed drag must leave the conversation open"
-        assert editor._copy_gesture, "the copy's gesture must be live for this to mean anything"
+        await _composer_copy(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 20))
+        assert app._clipboard == "summarise the ingest"
 
         await pilot.press("right")
         await pilot.pause()
-        assert not editor._copy_gesture, "the gesture outlived its own highlight"
-        assert not editor.copy_on_release, "the arm outlived the highlight it copied"
-
         app._clipboard = "SOMETHING THE USER PUT THERE"
         await _composer_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 20))
         assert app._clipboard == "SOMETHING THE USER PUT THERE"
 
 
 @pytest.mark.asyncio
-async def test_releasing_an_armed_composer_drag_copies_what_was_highlighted() -> None:
-    """After an explicit copy, the follow-up drag IS the transcript's gesture.
+async def test_an_explicit_composer_copy_takes_what_was_highlighted() -> None:
+    """Highlight, Ctrl+C, the clipboard IS the highlight.
 
-    The user pressed Ctrl+C over a range, so they are taking text out of the
-    composer; the next release copies what it highlighted and the receipt
-    says so — the transcript's rule, reached through an explicit signal
-    instead of assumed of every drag.
+    The property the transcript's `get_selection` gets from sharing one
+    computation, and which this path has to get by taking the widget's own
+    selected text. The screen still has no selection of its own, so this
+    could only have come from the editor.
     """
     app = _pilot_app()
     async with app.run_test(size=(80, 24)) as pilot:
         await pilot.pause()
         editor = await _composer(app, pilot, "summarise the ingest path please")
 
-        await _composer_copy_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 20))
+        await _composer_copy(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 20))
 
         assert editor.selected_text == "summarise the ingest"
-        # The clipboard IS the highlight — the property the transcript's
-        # `get_selection` gets from sharing one computation, and which this
-        # path has to get by taking the widget's own selected text.
         assert app._clipboard == editor.selected_text
-        # ...and the screen still has no selection of its own, so this could
-        # only have come from the editor. If this ever starts passing through
-        # `Screen.selections`, the mechanism changed and these tests are stale.
         assert not app.screen.selections
 
 
@@ -1267,7 +1216,7 @@ async def test_a_composer_copy_says_so_in_the_same_words() -> None:
 
         # Ends inside the second row, so the copy is a partial line — the
         # count in the toast is rows spanned, not lines completed.
-        await _composer_copy_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 1, 11))
+        await _composer_copy(app, pilot, _cell(editor, 0, 0), _cell(editor, 1, 11))
 
         assert app._clipboard == "first line here\nsecond line"
         assert toast.message == "copied 2 lines"
@@ -1360,7 +1309,7 @@ async def test_a_composer_drag_copies_a_marker_as_the_text_that_cites_it() -> No
         # `len("[Image #1, 100x100]")` exactly: the drag ends ON the cell
         # after the closing bracket, and the selection end is exclusive, so
         # this is the marker and not one character of the prose after it.
-        await _composer_copy_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 19))
+        await _composer_copy(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 19))
 
         assert app._clipboard == "[Image #1, 100x100]"
 
@@ -1379,7 +1328,7 @@ async def test_a_composer_drag_leaves_the_draft_alone() -> None:
         await pilot.pause()
         editor = await _composer(app, pilot, "summarise the ingest path please")
 
-        await _composer_copy_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 20))
+        await _composer_copy(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 20))
 
         assert editor.text == "summarise the ingest path please"
         # The highlight outlives the copy here for the same reason it does in
@@ -1419,7 +1368,7 @@ async def test_ctrl_c_with_no_selection_never_reaches_the_interrupt() -> None:
         # adds — the same press on the next draft is still the draft's: the
         # copy must leave no state behind that claims the key.
         await _composer(app, pilot, "a second draft, with a copy made in it")
-        await _composer_copy_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 9))
+        await _composer_copy(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 9))
         await pilot.press("right")
         await pilot.pause()
         assert not editor.selected_text, "the copy's highlight must be gone"
@@ -1461,14 +1410,13 @@ async def test_a_transcript_drag_released_over_the_composer_keeps_the_transcript
         block = await _seeded(app, pilot)
         editor = await _composer(app, pilot, "my private draft")
 
-        # An ARMED composer copy first, so the editor is holding a live
-        # selection and a live `copy_on_release` exactly as it would be after
-        # an explicit copy in use — the worst case for the clobber, since the
-        # stale range is both present AND authorised to copy on release.
-        await _composer_copy_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 16))
+        # A composer copy first, so the editor is holding a live selection
+        # exactly as it would be after an explicit copy in use — the worst
+        # case for the clobber, since the stale range is present and would
+        # have been authorised to copy on release under the old rule.
+        await _composer_copy(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 16))
         assert app._clipboard == "my private draft"
         assert editor.selected_text == "my private draft"
-        assert editor.copy_on_release, "the arm must be live for this to mean anything"
 
         # Now drag the ANSWER and release over the composer.
         app.screen._forward_event(_mouse(app, events.MouseDown, block.region.x, block.region.y))
@@ -1558,7 +1506,7 @@ async def test_a_sub_line_copy_is_counted_in_characters() -> None:
         editor = await _composer(app, pilot, "summarise the ingest path please")
         toast = app.query_one(Toast)
 
-        await _composer_copy_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 9))
+        await _composer_copy(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 9))
 
         assert app._clipboard == "summarise"
         assert toast.message == "copied 9 characters"
@@ -1584,7 +1532,7 @@ async def test_a_wrapped_selection_is_not_reported_as_one_line() -> None:
         toast = app.query_one(Toast)
         assert editor.region.height > 1, "the draft must actually wrap for this to mean anything"
 
-        await _composer_copy_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 2, 60))
+        await _composer_copy(app, pilot, _cell(editor, 0, 0), _cell(editor, 2, 60))
 
         assert "\n" not in app._clipboard
         assert "line" not in toast.message
@@ -1605,7 +1553,7 @@ async def test_a_multi_line_copy_is_still_counted_in_lines() -> None:
         editor = await _composer(app, pilot, "first line here\nsecond line here")
         toast = app.query_one(Toast)
 
-        await _composer_copy_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 1, 11))
+        await _composer_copy(app, pilot, _cell(editor, 0, 0), _cell(editor, 1, 11))
 
         assert app._clipboard == "first line here\nsecond line"
         assert toast.message == "copied 2 lines"
@@ -1625,7 +1573,7 @@ async def test_one_line_and_its_break_is_not_reported_as_two_lines() -> None:
         editor = await _composer(app, pilot, "first line here\nsecond line here")
         toast = app.query_one(Toast)
 
-        await _composer_copy_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 1, 0))
+        await _composer_copy(app, pilot, _cell(editor, 0, 0), _cell(editor, 1, 0))
 
         assert app._clipboard == "first line here\n"
         assert toast.message != "copied 2 lines"
@@ -1655,7 +1603,7 @@ async def test_a_copy_receipt_does_not_evict_an_actionable_notice() -> None:
         await pilot.pause()
         app._clipboard = ""
 
-        await _composer_copy_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 9))
+        await _composer_copy(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 9))
 
         assert toast.message.startswith("mcp: failed")
         assert app._clipboard == "summarise"
@@ -1687,7 +1635,7 @@ async def test_a_copy_receipt_still_replaces_an_ordinary_one() -> None:
         toast.show("mcp: 2 connected (14 tools)")
         await pilot.pause()
 
-        await _composer_copy_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 9))
+        await _composer_copy(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 9))
 
         assert toast.message == "copied 9 characters"
 
@@ -1709,7 +1657,7 @@ async def test_typing_over_a_copied_selection_retires_the_receipt() -> None:
         editor = await _composer(app, pilot, "summarise the ingest path please")
         toast = app.query_one(Toast)
 
-        await _composer_copy_drag(app, pilot, _cell(editor, 0, 14), _cell(editor, 0, 20))
+        await _composer_copy(app, pilot, _cell(editor, 0, 14), _cell(editor, 0, 20))
         assert app._clipboard == "ingest"
         assert toast.message == "copied 6 characters"
 
@@ -1735,7 +1683,7 @@ async def test_typing_does_not_dismiss_a_notice_that_is_not_a_copy_receipt() -> 
         editor = await _composer(app, pilot, "summarise the ingest path please")
         toast = app.query_one(Toast)
 
-        await _composer_copy_drag(app, pilot, _cell(editor, 0, 14), _cell(editor, 0, 20))
+        await _composer_copy(app, pilot, _cell(editor, 0, 14), _cell(editor, 0, 20))
         toast.show("mcp: failed: github — command not found: gh", duration_ms=TOAST_FAILURE_MS)
         await pilot.pause()
 
@@ -1772,7 +1720,7 @@ async def test_typing_does_not_retire_the_transcript_s_copy_receipt() -> None:
 
         # A composer copy FIRST, so the editor is armed exactly as it would be
         # in use — this is the state that made the old prefix check misfire.
-        await _composer_copy_drag(app, pilot, _cell(editor, 0, 14), _cell(editor, 0, 20))
+        await _composer_copy(app, pilot, _cell(editor, 0, 14), _cell(editor, 0, 20))
         assert toast.message == "copied 6 characters"
 
         await _drag(app, pilot, (block.region.x, block.region.y), (79, 23))
@@ -1802,7 +1750,7 @@ async def test_replacing_the_buffer_disarms_the_receipt() -> None:
         editor = await _composer(app, pilot, "summarise the ingest path please")
         toast = app.query_one(Toast)
 
-        await _composer_copy_drag(app, pilot, _cell(editor, 0, 14), _cell(editor, 0, 20))
+        await _composer_copy(app, pilot, _cell(editor, 0, 14), _cell(editor, 0, 20))
         assert editor._copied, "the copy must arm the flag for this to mean anything"
 
         editor.clear_content()
@@ -1838,7 +1786,7 @@ async def test_a_line_and_its_break_is_not_reported_as_zero_characters() -> None
         editor = await _composer(app, pilot, "first line here\nsecond line here")
         toast = app.query_one(Toast)
 
-        await _composer_copy_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 1, 0))
+        await _composer_copy(app, pilot, _cell(editor, 0, 0), _cell(editor, 1, 0))
 
         assert app._clipboard == "first line here\n"
         assert toast.message == "copied 16 characters"
@@ -1869,7 +1817,7 @@ async def test_a_wide_glyph_counts_as_the_one_character_it_is(
         editor = await _composer(app, pilot, draft)
         toast = app.query_one(Toast)
 
-        await _composer_copy_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, columns))
+        await _composer_copy(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, columns))
 
         assert toast.message == expected
 
@@ -1915,7 +1863,7 @@ async def test_a_declined_receipt_does_not_adopt_the_notice_it_deferred_to() -> 
         toast.show("mcp: failed: github — command not found: gh", duration_ms=TOAST_FAILURE_MS)
         await pilot.pause()
 
-        await _composer_copy_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 9))
+        await _composer_copy(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 9))
         assert app._clipboard == "summarise", "the copy itself must still happen"
         assert toast.message.startswith("mcp: failed")
 
@@ -1948,7 +1896,7 @@ async def test_a_held_receipt_is_withdrawn_if_its_text_is_edited_away() -> None:
         toast.show("mcp: failed: github — command not found: gh", duration_ms=TOAST_FAILURE_MS)
         await pilot.pause()
 
-        await _composer_copy_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 9))
+        await _composer_copy(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 9))
         assert app._clipboard == "summarise"
 
         # The user types over what they copied, while the notice still holds
@@ -1980,7 +1928,7 @@ async def test_a_held_receipt_still_arrives_when_its_text_survives() -> None:
         toast.show("mcp: failed: github — command not found: gh", duration_ms=TOAST_FAILURE_MS)
         await pilot.pause()
 
-        await _composer_copy_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 9))
+        await _composer_copy(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 9))
 
         toast.dismiss_toast()
         await pilot.pause()
@@ -2009,7 +1957,7 @@ async def test_a_composer_edit_does_not_discard_the_transcript_s_held_receipt() 
         editor = await _composer(app, pilot, "draft prompt")
         toast = app.query_one(Toast)
 
-        await _composer_copy_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 5))
+        await _composer_copy(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 5))
         assert editor._copied, "the composer's flag must be armed for this to mean anything"
 
         toast.show("mcp: failed: github — command not found: gh", duration_ms=TOAST_FAILURE_MS)
@@ -2047,7 +1995,7 @@ async def test_a_receipt_promoted_from_the_hold_can_still_be_retired() -> None:
         toast.show("mcp: failed: github — command not found: gh", duration_ms=TOAST_FAILURE_MS)
         await pilot.pause()
 
-        await _composer_copy_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 9))
+        await _composer_copy(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 9))
         toast.dismiss_toast()
         await pilot.pause()
         assert toast.message == "copied 9 characters", "the held card must have been promoted"
@@ -2079,32 +2027,24 @@ async def test_a_new_selection_after_a_copy_does_not_rearm_the_interrupt() -> No
     async with app.run_test(size=(80, 24)) as pilot:
         await pilot.pause()
         editor = await _composer(app, pilot, "summarise the ingest path please")
-        await _composer_copy_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 20))
-        assert editor._copy_gesture, "the drag should have started a copy gesture"
+        await _composer_copy(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 20))
+        assert editor._copied, "the copy should have posted a receipt"
 
         # The caret moves, collapsing the copied range...
         await pilot.press("right")
         await pilot.pause()
-        # ...and the user makes a NEW, unrelated selection with the keyboard.
-        # The range is hand-set rather than key-driven for the same reason the
-        # assertions below changed: under the explicit-copy gesture a live
-        # range makes the NEXT Ctrl+C a copy, so no selection-making key can be
-        # followed by a press that belongs to the draft — that press is a copy
-        # now, which is the new rule this change WANTS. What D22 actually
-        # protects is the gesture claim: an unrelated selection must not
-        # resurrect the old copy's deferral, and the copy this press takes
-        # must be the range on screen, nothing else.
+        # ...and the user makes a NEW, unrelated selection. Under the
+        # explicit-copy gesture a live range makes the NEXT Ctrl+C a copy of
+        # THAT range — which is the new rule this change wants. What D22
+        # actually protects is that an unrelated selection cannot resurrect
+        # a leftover deferral that would abort or quit; the press copies the
+        # range on screen, nothing else.
         editor.selection = Selection((0, 10), (0, 20))
         await pilot.pause()
         assert (
             editor.selected_text == "the ingest"
         ), "the new selection must be live to mean anything"
-        # The watcher retired the GESTURE claim when the caret moved off the
-        # range it took, and an unrelated selection cannot resurrect it. The
-        # receipt flag is deliberately untouched: the clipboard still holds what
-        # it took, so the toast is still true (R18-1).
-        assert not editor._copy_gesture, "an unrelated selection kept the gesture claim alive"
-        assert editor._copied, "the receipt was destroyed along with the gesture"
+        assert editor._copied, "the receipt was destroyed along with the highlight"
 
         session.aborts.clear()
         app._clipboard = ""
@@ -2143,8 +2083,8 @@ async def test_a_blurred_composer_still_paints_the_copy_it_is_deferring_to() -> 
     async with app.run_test(size=(80, 24)) as pilot:
         await pilot.pause()
         editor = await _composer(app, pilot, "summarise the ingest path please")
-        await _composer_copy_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 20))
-        assert editor._copy_gesture, "the drag should have started a copy gesture"
+        await _composer_copy(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 20))
+        assert editor.selected_text, "the copy's highlight must be on screen"
 
         def selection_is_painted() -> bool:
             """Is the composer's selection tint anywhere on its row?
@@ -2210,7 +2150,7 @@ async def test_a_receipt_retires_even_when_the_caret_moved_before_the_edit() -> 
     async with app.run_test(size=(80, 24)) as pilot:
         await pilot.pause()
         editor = await _composer(app, pilot, "summarise the ingest path please")
-        await _composer_copy_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 20))
+        await _composer_copy(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 20))
         assert editor._copied, "the drag should have posted a receipt"
 
         # The caret moves off the copied range, retiring the GESTURE claim only.

--- a/tests/unit/tui/test_transcript_selection.py
+++ b/tests/unit/tui/test_transcript_selection.py
@@ -62,8 +62,8 @@ from rich.markdown import Markdown
 from rich.text import Text
 from textual import events
 from textual.content import Content
-from textual.geometry import Offset
 from textual.document._document import Selection as DocumentSelection
+from textual.geometry import Offset
 from textual.selection import Selection
 from textual.visual import RichVisual
 

--- a/tests/unit/tui/test_transcript_selection.py
+++ b/tests/unit/tui/test_transcript_selection.py
@@ -1019,13 +1019,29 @@ async def _composer_drag(
     pilot: Any,
     start: tuple[int, int],
     end: tuple[int, int],
+    *,
+    copy: bool = False,
 ) -> None:
     """A drag over the composer, as `Screen._forward_event` receives it.
 
     Separate from `_drag` only in that it does not assert a screen selection
     afterwards: over a `TextArea` there is never going to be one, which is the
     whole reason this path exists.
+
+    ``copy=True`` arms `copy_on_release` with an explicit Ctrl+C over the
+    drag's own cells mapped to document locations. Only tests that need the
+    arm WITHOUT the helper's full ceremony (sentinel, row-0 span — see
+    `_composer_copy_drag`) should pass it; the rest belong on the helper.
     """
+    if copy:
+        editor = app.query_one(Editor)
+        editor.selection = Selection(
+            editor.get_target_document_location(_mouse(app, events.MouseDown, *start)),
+            editor.get_target_document_location(_mouse(app, events.MouseUp, *end)),
+        )
+        await pilot.pause()
+        await pilot.press("ctrl+c")
+        await pilot.pause()
     app.screen._forward_event(_mouse(app, events.MouseDown, *start))
     await pilot.pause()
     if start != end:
@@ -1034,6 +1050,50 @@ async def _composer_drag(
     app.screen._forward_event(_mouse(app, events.MouseUp, *end))
     await pilot.pause()
     await pilot.pause()
+
+
+async def _composer_copy_drag(
+    app: OperatorApp,
+    pilot: Any,
+    start: tuple[int, int],
+    end: tuple[int, int],
+) -> None:
+    """An ARMED composer drag: the release copies, as after an explicit copy.
+
+    The composer no longer copies on a bare release — a highlight there is
+    usually the first half of a retype or delete, so the release copies only
+    while the user has signalled "I am taking text" by asking for a copy first
+    (`Editor.copy_on_release`). Most copy-behaviour tests in this file are
+    about what an explicit copy takes and claims, so they drive this helper
+    and keep every assertion they already made; tests about the DEFAULT are
+    the ones that state the new rule.
+
+    The arming copy's own range is the drag's row-0 span. It cannot be the
+    drag's exact range: a range ending on a LATER row would keep the caret at
+    that row, and the drag's row-0 mouse-down would land outside it — which
+    the selection watcher reads as the copy's highlight being replaced and
+    disarms the flag the drag is meant to exercise. A row-0 span contains the
+    drag's down, and collapsing to a caret INSIDE the range is not a
+    disarm (a select-to-retype lands there too). A single-row drag's arm is
+    therefore its own range exactly; a multi-row one's is the first row —
+    both are what a user who just copied "this part" would actually do.
+    """
+    app._clipboard = "SENTINEL"
+    editor = app.query_one(Editor)
+    # `get_target_document_location` needs a full event; `Offset` is all it
+    # reads. The UP event is aimed one column PAST the drag's end column:
+    # drag selection ends EXCLUSIVE at the released cell, so this keeps the
+    # arming range a strict superset of the drag's row-0 span — a single-row
+    # drag's release would otherwise collapse to the copy's own caret, and
+    # the watcher's literal `!=` disarms on it.
+    editor.selection = Selection(
+        editor.get_target_document_location(_mouse(app, events.MouseDown, *start)),
+        editor.get_target_document_location(_mouse(app, events.MouseUp, end[0] + 1, start[1])),
+    )
+    await pilot.pause()
+    await pilot.press("ctrl+c")
+    await pilot.pause()
+    await _composer_drag(app, pilot, start, end)
 
 
 async def _composer(app: OperatorApp, pilot: Any, text: str) -> Editor:
@@ -1067,19 +1127,117 @@ def _cell(editor: Editor, row: int, column: int) -> tuple[int, int]:
 
 
 @pytest.mark.asyncio
-async def test_releasing_a_composer_drag_copies_what_was_highlighted() -> None:
-    """The acceptance case: highlight your own draft, let go, it is copied.
+async def test_releasing_a_composer_drag_copies_nothing_by_default() -> None:
+    """The reported defect: highlighting to select clobbered the clipboard.
 
-    Measured before the fix, this same gesture left `_clipboard` untouched
-    while the highlight sat on screen — the reported bug, in one assertion.
+    A composer highlight is usually the first half of an EDIT — drag a phrase
+    to retype it, drag a word to delete it — so copying on release replaced
+    whatever the user had on their clipboard with text they were about to
+    throw away. The transcript keeps release-copies, where a highlight is
+    read-only text being taken; the composer's release selects and nothing
+    more.
+    """
+    app = _pilot_app()
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        editor = await _composer(app, pilot, "summarise the ingest path please")
+        app._clipboard = "SOMETHING THE USER PUT THERE"
+        toast = app.query_one(Toast)
+
+        await _composer_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 20))
+
+        # The drag still SELECTS — it is the copy that is gone.
+        assert editor.selected_text == "summarise the ingest"
+        assert app._clipboard == "SOMETHING THE USER PUT THERE"
+        assert toast.message == ""
+
+
+@pytest.mark.asyncio
+async def test_ctrl_c_with_a_live_range_copies_it_and_arms_the_next_drag() -> None:
+    """The composer's copy gesture is explicit: highlight, then Ctrl+C.
+
+    The field report that put copy-on-release in the composer was right that
+    the widget had no working copy key: cmd+C is eaten by the terminal and
+    Ctrl+C was always the interrupt. This is the sequence that fixes it
+    without the clobber: the press copies the live range (instead of
+    interrupting, which a real range protects the user from needing), and the
+    drag the user makes next — while still in the taking-things frame of
+    mind — copies on release like the transcript's.
     """
     app = _pilot_app()
     async with app.run_test(size=(80, 24)) as pilot:
         await pilot.pause()
         editor = await _composer(app, pilot, "summarise the ingest path please")
         app._clipboard = ""
+        editor.selection = Selection((0, 0), (0, 20))
+        await pilot.pause()
 
+        await pilot.press("ctrl+c")
+        await pilot.pause()
+
+        assert app._clipboard == "summarise the ingest"
+        # The explicit copy also kept the draft and raised no interrupt: it
+        # consumed the press entirely.
+        assert editor.text == "summarise the ingest path please"
+        assert editor.copy_on_release, "an explicit copy must arm the follow-up drag"
+
+        # And the very next drag copies on release — the armed gesture. What
+        # matters is that the release wrote the NEW highlight (a bare drag
+        # would leave the first copy's text on the clipboard); the drag's own
+        # `selected_text` is the claim, as in every other composer test.
+        await _composer_drag(app, pilot, _cell(editor, 0, 29), _cell(editor, 0, 34))
+        assert editor.selected_text == app._clipboard
+        assert app._clipboard == "ase"
+
+
+@pytest.mark.asyncio
+async def test_the_drag_copy_arm_retires_with_the_highlight_it_copied() -> None:
+    """The arm is not a mode the user gets stuck in.
+
+    It belongs to the copy conversation: once the copy's highlight leaves the
+    screen the next selection is a new decision, and the select-to-edit
+    default must be the state the user returns to. Otherwise one stray copy
+    would turn every later select-to-delete back into a clipboard clobber,
+    which is the defect this change exists to remove.
+
+    Driven with the REAL armed drag rather than the bare press: the arm is
+    the next drag's, so its retirement is the gesture flag's retirement —
+    after the follow-up drag copies, the user carrying on (moving the caret
+    off the range that drag took) is what ends the conversation.
+    """
+    app = _pilot_app()
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        editor = await _composer(app, pilot, "summarise the ingest path please")
+        await _composer_copy_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 20))
+        assert editor.copy_on_release, "the armed drag must leave the conversation open"
+        assert editor._copy_gesture, "the copy's gesture must be live for this to mean anything"
+
+        await pilot.press("right")
+        await pilot.pause()
+        assert not editor._copy_gesture, "the gesture outlived its own highlight"
+        assert not editor.copy_on_release, "the arm outlived the highlight it copied"
+
+        app._clipboard = "SOMETHING THE USER PUT THERE"
         await _composer_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 20))
+        assert app._clipboard == "SOMETHING THE USER PUT THERE"
+
+
+@pytest.mark.asyncio
+async def test_releasing_an_armed_composer_drag_copies_what_was_highlighted() -> None:
+    """After an explicit copy, the follow-up drag IS the transcript's gesture.
+
+    The user pressed Ctrl+C over a range, so they are taking text out of the
+    composer; the next release copies what it highlighted and the receipt
+    says so — the transcript's rule, reached through an explicit signal
+    instead of assumed of every drag.
+    """
+    app = _pilot_app()
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        editor = await _composer(app, pilot, "summarise the ingest path please")
+
+        await _composer_copy_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 20))
 
         assert editor.selected_text == "summarise the ingest"
         # The clipboard IS the highlight — the property the transcript's
@@ -1109,7 +1267,7 @@ async def test_a_composer_copy_says_so_in_the_same_words() -> None:
 
         # Ends inside the second row, so the copy is a partial line — the
         # count in the toast is rows spanned, not lines completed.
-        await _composer_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 1, 11))
+        await _composer_copy_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 1, 11))
 
         assert app._clipboard == "first line here\nsecond line"
         assert toast.message == "copied 2 lines"
@@ -1202,26 +1360,26 @@ async def test_a_composer_drag_copies_a_marker_as_the_text_that_cites_it() -> No
         # `len("[Image #1, 100x100]")` exactly: the drag ends ON the cell
         # after the closing bracket, and the selection end is exclusive, so
         # this is the marker and not one character of the prose after it.
-        await _composer_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 19))
+        await _composer_copy_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 19))
 
         assert app._clipboard == "[Image #1, 100x100]"
 
 
 @pytest.mark.asyncio
 async def test_a_composer_drag_leaves_the_draft_alone() -> None:
-    """Copying is not cutting, and the caret gesture still ends where it did.
+    """Selecting is not cutting, and the caret gesture still ends where it did.
 
-    Worth pinning because the copy is bolted onto the mouse-up that `TextArea`
-    also uses to finalise its selection: a copy path that touched the document,
-    or that collapsed the selection it had just taken, would corrupt a draft
-    mid-sentence.
+    Worth pinning because the release is where `TextArea` finalises its
+    selection: any handling bolted onto that mouse-up that touched the
+    document, or that collapsed the selection it had just made, would corrupt
+    a draft mid-sentence.
     """
     app = _pilot_app()
     async with app.run_test(size=(80, 24)) as pilot:
         await pilot.pause()
         editor = await _composer(app, pilot, "summarise the ingest path please")
 
-        await _composer_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 20))
+        await _composer_copy_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 20))
 
         assert editor.text == "summarise the ingest path please"
         # The highlight outlives the copy here for the same reason it does in
@@ -1230,29 +1388,46 @@ async def test_a_composer_drag_leaves_the_draft_alone() -> None:
 
 
 @pytest.mark.asyncio
-async def test_a_composer_drag_still_leaves_ctrl_c_as_the_interrupt() -> None:
-    """The copy must not buy itself a key, least of all this one.
+async def test_ctrl_c_with_no_selection_never_reaches_the_interrupt() -> None:
+    """A draft takes the key first — and a copy never changes that.
 
-    The transcript's copy was deliberately hung off the release so that Ctrl+C
-    could stay the interrupt and the first rung of the exit ladder. The
-    composer's copy is hung off the release for the same reason, and this is
-    the assertion that keeps a future "just bind ctrl+c in the editor" from
-    quietly reintroducing the swallowed-abort bug in the one widget that is
-    focused in essentially every frame.
+    The composer Ctrl+C rungs are, in order: copy (only while a real range is
+    live), then the draft — a half-typed prompt means "scrap that", filed to
+    history, not aborted — and only then the interrupt. The
+    highlight-then-Ctrl+C copy sits at the TOP of that ladder by range, so it
+    cannot swallow the draft's press in the composer's resting state (a
+    collapsed caret). Asserted both ways around the new gesture because the
+    copy is what this file changed: it must neither steal the key with no
+    range live, nor leave state behind that steals it afterwards.
     """
     session = FakeSession()
     app = _pilot_app(session)
     async with app.run_test(size=(80, 24)) as pilot:
         await pilot.pause()
         editor = await _composer(app, pilot, "summarise the ingest path please")
-        await _composer_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 20))
-        assert editor.selected_text, "the highlight must be live for this to mean anything"
+        assert not editor.selected_text, "no range may be live for this to mean anything"
 
+        # First press, before any copy ever happened: the draft rung, not the
+        # interrupt, and the draft is filed rather than destroyed.
+        await pilot.press("ctrl+c")
+        await pilot.pause()
+        assert session.aborts == [], "no range was live, so nothing may divert the key to abort"
+        assert editor.text == "", "the draft was not cleared"
+        assert "summarise the ingest path please" in editor.prompt_history()
+
+        # And after a REAL copy gesture has run — the new path this change
+        # adds — the same press on the next draft is still the draft's: the
+        # copy must leave no state behind that claims the key.
+        await _composer(app, pilot, "a second draft, with a copy made in it")
+        await _composer_copy_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 9))
+        await pilot.press("right")
+        await pilot.pause()
+        assert not editor.selected_text, "the copy's highlight must be gone"
         session.aborts.clear()
         await pilot.press("ctrl+c")
         await pilot.pause()
-
-        assert session.aborts == ["interrupted"]
+        assert session.aborts == [], "a finished copy left the key diverted to abort"
+        assert editor.text == "", "the second draft was not cleared"
 
 
 # -- what a release does NOT copy (review round 1, F1/F2) ---------------------
@@ -1286,11 +1461,14 @@ async def test_a_transcript_drag_released_over_the_composer_keeps_the_transcript
         block = await _seeded(app, pilot)
         editor = await _composer(app, pilot, "my private draft")
 
-        # A real composer drag first, so the editor is holding a live selection
-        # exactly as it would be in use.
-        await _composer_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 16))
+        # An ARMED composer copy first, so the editor is holding a live
+        # selection and a live `copy_on_release` exactly as it would be after
+        # an explicit copy in use — the worst case for the clobber, since the
+        # stale range is both present AND authorised to copy on release.
+        await _composer_copy_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 16))
         assert app._clipboard == "my private draft"
         assert editor.selected_text == "my private draft"
+        assert editor.copy_on_release, "the arm must be live for this to mean anything"
 
         # Now drag the ANSWER and release over the composer.
         app.screen._forward_event(_mouse(app, events.MouseDown, block.region.x, block.region.y))
@@ -1303,36 +1481,34 @@ async def test_a_transcript_drag_released_over_the_composer_keeps_the_transcript
         await pilot.pause()
         await pilot.pause()
 
-        assert app._clipboard == app.screen.get_selected_text()
         assert "my private draft" not in app._clipboard
+        assert app._clipboard == app.screen.get_selected_text()
 
 
 @pytest.mark.asyncio
-async def test_a_bare_mouse_up_does_not_copy_a_keyboard_selection() -> None:
-    """A mouse-up with no drag behind it is not a copy gesture.
+async def test_ctrl_c_copies_a_keyboard_selection_without_a_mouse() -> None:
+    """The explicit copy works for a shift+arrow range too.
 
-    Selecting with shift+arrows and then clicking elsewhere would otherwise
-    write the clipboard and announce it, having been asked for neither. Kept
-    separate from the test above because a guard phrased as "did the PRESS land
-    in this widget" would fix that one and leave this one.
+    A keyboard selection never enters the release machinery at all — there is
+    no drag for `_copy_drag` to gate on — and before the explicit gesture this
+    range was simply uncopyable: Ctrl+C interrupted, cmd+C never arrived. The
+    press is the whole gesture now, so it has to cover both ways a range can
+    be made.
     """
     app = _pilot_app()
     async with app.run_test(size=(80, 24)) as pilot:
         await pilot.pause()
         editor = await _composer(app, pilot, "my private draft")
         app._clipboard = "SOMETHING THE USER PUT THERE"
-        toast = app.query_one(Toast)
 
         await pilot.press("home", *["shift+right"] * 10)
         await pilot.pause()
         assert editor.selected_text == "my private", "the keyboard selection must exist"
 
-        app.screen._forward_event(_mouse(app, events.MouseUp, *_cell(editor, 0, 2)))
-        await pilot.pause()
+        await pilot.press("ctrl+c")
         await pilot.pause()
 
-        assert app._clipboard == "SOMETHING THE USER PUT THERE"
-        assert toast.message == ""
+        assert app._clipboard == "my private"
 
 
 @pytest.mark.asyncio
@@ -1352,7 +1528,13 @@ async def test_the_read_only_composer_still_copies_what_it_shows() -> None:
         await pilot.pause()
         app._clipboard = ""
 
-        await _composer_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 7))
+        # Read-only or not, the gesture is the explicit one: a range, then
+        # Ctrl+C. The text is the app's, which is exactly why someone would
+        # lift it out — and why it never sits on the clipboard unasked.
+        editor.selection = Selection((0, 0), (0, 7))
+        await pilot.pause()
+        await pilot.press("ctrl+c")
+        await pilot.pause()
 
         assert app._clipboard == "someone"
         assert editor.text == "someone else wrote this"
@@ -1376,7 +1558,7 @@ async def test_a_sub_line_copy_is_counted_in_characters() -> None:
         editor = await _composer(app, pilot, "summarise the ingest path please")
         toast = app.query_one(Toast)
 
-        await _composer_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 9))
+        await _composer_copy_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 9))
 
         assert app._clipboard == "summarise"
         assert toast.message == "copied 9 characters"
@@ -1402,7 +1584,7 @@ async def test_a_wrapped_selection_is_not_reported_as_one_line() -> None:
         toast = app.query_one(Toast)
         assert editor.region.height > 1, "the draft must actually wrap for this to mean anything"
 
-        await _composer_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 2, 60))
+        await _composer_copy_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 2, 60))
 
         assert "\n" not in app._clipboard
         assert "line" not in toast.message
@@ -1423,7 +1605,7 @@ async def test_a_multi_line_copy_is_still_counted_in_lines() -> None:
         editor = await _composer(app, pilot, "first line here\nsecond line here")
         toast = app.query_one(Toast)
 
-        await _composer_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 1, 11))
+        await _composer_copy_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 1, 11))
 
         assert app._clipboard == "first line here\nsecond line"
         assert toast.message == "copied 2 lines"
@@ -1443,7 +1625,7 @@ async def test_one_line_and_its_break_is_not_reported_as_two_lines() -> None:
         editor = await _composer(app, pilot, "first line here\nsecond line here")
         toast = app.query_one(Toast)
 
-        await _composer_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 1, 0))
+        await _composer_copy_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 1, 0))
 
         assert app._clipboard == "first line here\n"
         assert toast.message != "copied 2 lines"
@@ -1473,7 +1655,7 @@ async def test_a_copy_receipt_does_not_evict_an_actionable_notice() -> None:
         await pilot.pause()
         app._clipboard = ""
 
-        await _composer_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 9))
+        await _composer_copy_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 9))
 
         assert toast.message.startswith("mcp: failed")
         assert app._clipboard == "summarise"
@@ -1505,7 +1687,7 @@ async def test_a_copy_receipt_still_replaces_an_ordinary_one() -> None:
         toast.show("mcp: 2 connected (14 tools)")
         await pilot.pause()
 
-        await _composer_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 9))
+        await _composer_copy_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 9))
 
         assert toast.message == "copied 9 characters"
 
@@ -1527,7 +1709,7 @@ async def test_typing_over_a_copied_selection_retires_the_receipt() -> None:
         editor = await _composer(app, pilot, "summarise the ingest path please")
         toast = app.query_one(Toast)
 
-        await _composer_drag(app, pilot, _cell(editor, 0, 14), _cell(editor, 0, 20))
+        await _composer_copy_drag(app, pilot, _cell(editor, 0, 14), _cell(editor, 0, 20))
         assert app._clipboard == "ingest"
         assert toast.message == "copied 6 characters"
 
@@ -1553,7 +1735,7 @@ async def test_typing_does_not_dismiss_a_notice_that_is_not_a_copy_receipt() -> 
         editor = await _composer(app, pilot, "summarise the ingest path please")
         toast = app.query_one(Toast)
 
-        await _composer_drag(app, pilot, _cell(editor, 0, 14), _cell(editor, 0, 20))
+        await _composer_copy_drag(app, pilot, _cell(editor, 0, 14), _cell(editor, 0, 20))
         toast.show("mcp: failed: github — command not found: gh", duration_ms=TOAST_FAILURE_MS)
         await pilot.pause()
 
@@ -1590,7 +1772,7 @@ async def test_typing_does_not_retire_the_transcript_s_copy_receipt() -> None:
 
         # A composer copy FIRST, so the editor is armed exactly as it would be
         # in use — this is the state that made the old prefix check misfire.
-        await _composer_drag(app, pilot, _cell(editor, 0, 14), _cell(editor, 0, 20))
+        await _composer_copy_drag(app, pilot, _cell(editor, 0, 14), _cell(editor, 0, 20))
         assert toast.message == "copied 6 characters"
 
         await _drag(app, pilot, (block.region.x, block.region.y), (79, 23))
@@ -1620,7 +1802,7 @@ async def test_replacing_the_buffer_disarms_the_receipt() -> None:
         editor = await _composer(app, pilot, "summarise the ingest path please")
         toast = app.query_one(Toast)
 
-        await _composer_drag(app, pilot, _cell(editor, 0, 14), _cell(editor, 0, 20))
+        await _composer_copy_drag(app, pilot, _cell(editor, 0, 14), _cell(editor, 0, 20))
         assert editor._copied, "the copy must arm the flag for this to mean anything"
 
         editor.clear_content()
@@ -1656,7 +1838,7 @@ async def test_a_line_and_its_break_is_not_reported_as_zero_characters() -> None
         editor = await _composer(app, pilot, "first line here\nsecond line here")
         toast = app.query_one(Toast)
 
-        await _composer_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 1, 0))
+        await _composer_copy_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 1, 0))
 
         assert app._clipboard == "first line here\n"
         assert toast.message == "copied 16 characters"
@@ -1687,7 +1869,7 @@ async def test_a_wide_glyph_counts_as_the_one_character_it_is(
         editor = await _composer(app, pilot, draft)
         toast = app.query_one(Toast)
 
-        await _composer_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, columns))
+        await _composer_copy_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, columns))
 
         assert toast.message == expected
 
@@ -1733,7 +1915,7 @@ async def test_a_declined_receipt_does_not_adopt_the_notice_it_deferred_to() -> 
         toast.show("mcp: failed: github — command not found: gh", duration_ms=TOAST_FAILURE_MS)
         await pilot.pause()
 
-        await _composer_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 9))
+        await _composer_copy_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 9))
         assert app._clipboard == "summarise", "the copy itself must still happen"
         assert toast.message.startswith("mcp: failed")
 
@@ -1766,7 +1948,7 @@ async def test_a_held_receipt_is_withdrawn_if_its_text_is_edited_away() -> None:
         toast.show("mcp: failed: github — command not found: gh", duration_ms=TOAST_FAILURE_MS)
         await pilot.pause()
 
-        await _composer_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 9))
+        await _composer_copy_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 9))
         assert app._clipboard == "summarise"
 
         # The user types over what they copied, while the notice still holds
@@ -1798,7 +1980,7 @@ async def test_a_held_receipt_still_arrives_when_its_text_survives() -> None:
         toast.show("mcp: failed: github — command not found: gh", duration_ms=TOAST_FAILURE_MS)
         await pilot.pause()
 
-        await _composer_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 9))
+        await _composer_copy_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 9))
 
         toast.dismiss_toast()
         await pilot.pause()
@@ -1827,7 +2009,7 @@ async def test_a_composer_edit_does_not_discard_the_transcript_s_held_receipt() 
         editor = await _composer(app, pilot, "draft prompt")
         toast = app.query_one(Toast)
 
-        await _composer_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 5))
+        await _composer_copy_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 5))
         assert editor._copied, "the composer's flag must be armed for this to mean anything"
 
         toast.show("mcp: failed: github — command not found: gh", duration_ms=TOAST_FAILURE_MS)
@@ -1865,7 +2047,7 @@ async def test_a_receipt_promoted_from_the_hold_can_still_be_retired() -> None:
         toast.show("mcp: failed: github — command not found: gh", duration_ms=TOAST_FAILURE_MS)
         await pilot.pause()
 
-        await _composer_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 9))
+        await _composer_copy_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 9))
         toast.dismiss_toast()
         await pilot.pause()
         assert toast.message == "copied 9 characters", "the held card must have been promoted"
@@ -1897,16 +2079,26 @@ async def test_a_new_selection_after_a_copy_does_not_rearm_the_interrupt() -> No
     async with app.run_test(size=(80, 24)) as pilot:
         await pilot.pause()
         editor = await _composer(app, pilot, "summarise the ingest path please")
-        await _composer_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 20))
+        await _composer_copy_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 20))
         assert editor._copy_gesture, "the drag should have started a copy gesture"
 
         # The caret moves, collapsing the copied range...
         await pilot.press("right")
         await pilot.pause()
         # ...and the user makes a NEW, unrelated selection with the keyboard.
-        await pilot.press("shift+end")
+        # The range is hand-set rather than key-driven for the same reason the
+        # assertions below changed: under the explicit-copy gesture a live
+        # range makes the NEXT Ctrl+C a copy, so no selection-making key can be
+        # followed by a press that belongs to the draft — that press is a copy
+        # now, which is the new rule this change WANTS. What D22 actually
+        # protects is the gesture claim: an unrelated selection must not
+        # resurrect the old copy's deferral, and the copy this press takes
+        # must be the range on screen, nothing else.
+        editor.selection = Selection((0, 10), (0, 20))
         await pilot.pause()
-        assert editor.selected_text, "the new selection must be live to mean anything"
+        assert (
+            editor.selected_text == "the ingest"
+        ), "the new selection must be live to mean anything"
         # The watcher retired the GESTURE claim when the caret moved off the
         # range it took, and an unrelated selection cannot resurrect it. The
         # receipt flag is deliberately untouched: the clipboard still holds what
@@ -1915,11 +2107,16 @@ async def test_a_new_selection_after_a_copy_does_not_rearm_the_interrupt() -> No
         assert editor._copied, "the receipt was destroyed along with the gesture"
 
         session.aborts.clear()
+        app._clipboard = ""
         await pilot.press("ctrl+c")
         await pilot.pause()
 
+        # The press is a copy — of the UNRELATED range, and only that. No
+        # abort, no cleared draft, no exit ladder armed: the D22 failure was
+        # all three, and each is still refused here.
         assert session.aborts == [], "an unrelated selection re-armed the copy deferral"
-        assert editor.text == "", "the draft was not cleared"
+        assert editor.text == "summarise the ingest path please", "the draft was touched"
+        assert app._clipboard == "the ingest"
 
         await pilot.press("ctrl+c")
         await pilot.pause()
@@ -1946,7 +2143,7 @@ async def test_a_blurred_composer_still_paints_the_copy_it_is_deferring_to() -> 
     async with app.run_test(size=(80, 24)) as pilot:
         await pilot.pause()
         editor = await _composer(app, pilot, "summarise the ingest path please")
-        await _composer_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 20))
+        await _composer_copy_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 20))
         assert editor._copy_gesture, "the drag should have started a copy gesture"
 
         def selection_is_painted() -> bool:
@@ -2013,7 +2210,7 @@ async def test_a_receipt_retires_even_when_the_caret_moved_before_the_edit() -> 
     async with app.run_test(size=(80, 24)) as pilot:
         await pilot.pause()
         editor = await _composer(app, pilot, "summarise the ingest path please")
-        await _composer_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 20))
+        await _composer_copy_drag(app, pilot, _cell(editor, 0, 0), _cell(editor, 0, 20))
         assert editor._copied, "the drag should have posted a receipt"
 
         # The caret moves off the copied range, retiring the GESTURE claim only.

--- a/tests/unit/tui/test_transcript_selection.py
+++ b/tests/unit/tui/test_transcript_selection.py
@@ -1114,7 +1114,7 @@ async def test_releasing_a_composer_drag_copies_nothing_by_default() -> None:
 
 
 @pytest.mark.asyncio
-async def test_ctrl_c_with_a_live_range_copies_it_and_arms_the_next_drag() -> None:
+async def test_ctrl_c_with_a_live_range_copies_it() -> None:
     """The composer's copy gesture is explicit: highlight, then Ctrl+C.
 
     The field report that put copy-on-release in the composer was right that


### PR DESCRIPTION
## Why

A drag over the composer copied what it highlighted **on release** — the transcript's gesture, imported into the one widget where a highlight is usually the first half of an **edit**: drag a phrase to retype it, drag a word to delete it. The release then clobbered the user's clipboard with text they were about to throw away, which is exactly the reported defect: *"when you highlight in the composer it automatically copies … often you're just highlighting to select and potentially cut/delete a part, the copy can end up clearing something you have in the clipboard."*

## What changes

- **A composer drag no longer copies.** The release selects and nothing more; the clipboard keeps what the user put there. The transcript is unchanged — a highlight there is read-only text being taken, so its release still copies.
- **The composer's copy is explicit: highlight, then Ctrl+C.** The press copies the live range ahead of its interrupt meaning (a collapsed caret — the resting state — still interrupts / scraps the draft) and shows the same receipt a transcript copy does, through the same `EditorCopied` → `_put_on_clipboard` path. Works for shift+arrow ranges too, which previously had no copy path at all (cmd+C is eaten by the terminal; Ctrl+C was always the interrupt).
- **No armed-next-drag mode.** An earlier draft of this change armed the next drag to copy on release after an explicit copy; that was a hidden mode whose lifetime could not be stated correctly (review round 1, F1) and nothing on screen showed it was on (design round 1, D2). Dropped: a composer copy is always the explicit press.
- **Docs/comments** in `Editor`'s module docstring, `_copy_drag`, `action_copy`, `EditorCopied`, and `OperatorApp.on_editor_copied` state the new rule and why the transcript keeps the old one.

## Testing evidence

- **Full TUI suite from the worktree: 2140 passed, 4 skipped** on the first commit; 195/195 of the affected files (`test_transcript_selection.py` + `test_steering_approval.py`) on the remediation.
- **Reproduced the defect before fixing**: `test_releasing_a_composer_drag_copies_nothing_by_default` drives a real drag and asserts the clipboard keeps `"SOMETHING THE USER PUT THERE"`.
- New/updated coverage: bare drag selects without copying; click/empty-composer/marker-click still copy nothing; explicit Ctrl+C copies a mouse or keyboard range with the shared receipt; a drag after an explicit copy still copies nothing (F1); transcript-overshoot releases still can't clobber; receipt unit/deferral/staleness semantics unchanged; a stale range's Ctrl+C is a copy that cannot arm the exit ladder (D17 reframed); gesture deferral lifetimes (D20/D22/R18-1) re-pinned.
- **Visual validation** (per AGENTS.md): drove the real app with `run_test`, captured SVG frames and viewed renders — highlight-with-no-copy state (highlight visible, no toast, clipboard untouched), and explicit-copy state (`copied 20 characters` toast visible, clipboard written).
- `flake8` clean on all changed files.
