### PR TITLE
chore(release): bump version to 0.19.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.19.1"
+version = "0.19.2"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@radienthq.com" }]


### PR DESCRIPTION
## Summary

Patch bump to 0.19.2 so the GitHub release / PyPI publish of #210 (mobile control plane: self-healing bundle, bidirectional user-message sync, lazy history, resume+search, attach button) carries the right version.

Change class: C1 — version metadata only, no runtime path. Standard/pre-authorized.

## Testing evidence

No runtime path: this is a one-line `pyproject.toml` version bump. Validated by `grep '^version' pyproject.toml` reading `0.19.2`.