### PR TITLE
feat(teams): reusable teams with layered briefs and /team

### DIFF
--- a/local_operator/agent_profiles.py
+++ b/local_operator/agent_profiles.py
@@ -293,6 +293,20 @@ def is_role(agent: "AgentData") -> bool:
     return any(str(tag).strip().lower() == ROLE_TAG for tag in (agent.tags or []))
 
 
+def is_specialist(agent: "AgentData") -> bool:
+    """Whether the agent tool authored this row as a reusable specialist.
+
+    Ordinary conversational agents share the registry and must stay private to
+    ``agent list/show``. The category is the explicit marker written by
+    ``agent(op='create', kind='specialist')``; a name or a non-empty prompt is
+    not enough, because both are normal on private chat agents too.
+    """
+
+    return any(
+        str(category).strip().lower() == "specialist" for category in (agent.categories or [])
+    )
+
+
 def profile_from_agent(registry: "AgentRegistry", agent: "AgentData") -> AgentProfile:
     """Convert a registered agent into a role profile.
 

--- a/local_operator/agents.py
+++ b/local_operator/agents.py
@@ -1439,6 +1439,11 @@ class AgentRegistry:
                 # Create a new agent with the imported data
                 agent_id = agent_data["id"]
                 agent_data["current_working_directory"] = "~/local-operator-home"
+                # Older profile bundles duplicated the final conversation turn
+                # into agent.yml. History files are ignored below, but leaving
+                # this field intact would still import private conversation
+                # content through a metadata side channel.
+                agent_data["last_message"] = ""
 
                 # Remove hosting and model from the agent data to use
                 # the default values from user config

--- a/local_operator/agents.py
+++ b/local_operator/agents.py
@@ -1458,14 +1458,20 @@ class AgentRegistry:
                     shutil.rmtree(agent_dir)
                 agent_dir.mkdir(parents=True, exist_ok=True)
 
-                # Copy all files from the extracted directory to the agent directory
+                # Copy instruction files only. Conversation history, execution
+                # traces, learnings, schedules and pickled context are private
+                # to whoever authored the archive — even a hub listing that
+                # still carries them from an older build must not land in the
+                # importer's registry. ``context.pkl`` is also untrusted
+                # serialized code.
                 extracted_agent_dir = agent_yml_path.parent
                 for item in extracted_agent_dir.iterdir():
                     if item.is_file():
-                        if item.name == "context.pkl":
+                        if item.name in self._EXPORT_SKIP_NAMES:
                             logging.info(
-                                "Skipping imported context.pkl for security reasons "
-                                f"(agent: {agent_id})"
+                                "Skipping imported %s (agent: %s)",
+                                item.name,
+                                agent_id,
                             )
                             continue
                         shutil.copy2(item, agent_dir)
@@ -1473,54 +1479,12 @@ class AgentRegistry:
                 # Create a new AgentData object directly from the data
                 agent_data = AgentData.model_validate(agent_data)
 
-                # Save the agent to the registry
+                # Save the agent to the registry. Conversation / learnings are
+                # intentionally NOT seeded: an imported profile is an
+                # instruction set, and pretending it has a prior conversation
+                # with the importer is how private history used to leak across
+                # the hub.
                 self.save_agent(agent_data)
-
-                # Update conversation history and learnings to reflect import
-                # event so that the agent has continuity
-                agent_state = self.load_agent_state(agent_data.id)
-                now = datetime.now(timezone.utc)
-
-                # Add a record to execution history to mark the import
-                import_execution_record = CodeExecutionResult(
-                    message=(
-                        "This is an imported agent. The conversation above is from the agent's training and was voluntarily submitted to the agent hub by another user. Agent conversations are private and never shared without your permission. Send a message to continue and have the agent do something for you."  # noqa: E501
-                    ),
-                    status=ProcessResponseStatus.SUCCESS,
-                    execution_type=ExecutionType.INFO,
-                    role=ConversationRole.SYSTEM,
-                    timestamp=now,
-                    stdout="",
-                    stderr="",
-                    logging="",
-                    code="",
-                    formatted_print="",
-                    files=[],
-                    action=None,
-                )
-                agent_state.execution_history.append(import_execution_record)
-
-                # Existing import message for the agent's internal context
-                import_message_for_agent = "<system>You were just imported to a new device. I might be a different user, or the same user than the person you were just talking to. I might ask you to do something that is the same or different than the conversation before this. Make sure to use your learnings and the conversation history to replicate what you've learned and give me a consistent experience. Don't acknowledge this message directly, it is just for your reference.</system>"  # noqa: E501
-                agent_state.conversation.append(
-                    ConversationRecord(
-                        content=import_message_for_agent,
-                        role=ConversationRole.USER,
-                        timestamp=now,
-                        should_summarize=False,
-                        ephemeral=False,
-                        summarized=False,
-                        is_system_prompt=False,
-                        files=None,
-                        should_cache=False,
-                    )
-                )
-
-                # Existing learnings message
-                learnings_message = "I was just imported to a new device. The user might be the same or different than the user that I was just talking to. I'm expected to provide a consistent experience to the user that I was just talking to, so I will need to use learnings and conversation history to replicate the same results for a potentially different topic."  # noqa: E501
-                agent_state.learnings.append(learnings_message)
-
-                self.save_agent_state(agent_data.id, agent_state)
 
                 # Return the agent data
                 return agent_data
@@ -1599,9 +1563,32 @@ class AgentRegistry:
             radient_client.download_agent_from_marketplace(agent_id, zip_path)
             return self.import_agent(zip_path)
 
+    #: Files that carry conversation, execution, or pickled runtime state.
+    #: They never belong in a published archive: a Radient hub listing is a
+    #: SHARE of the instruction set, not of the operator's private history,
+    #: and ``context.pkl`` is untrusted serialized code. Import already
+    #: skipped the pickle; export now refuses to ship any of these so a
+    #: desktop UI that zips the agent directory cannot leak them either.
+    _EXPORT_SKIP_NAMES = frozenset(
+        {
+            "conversation.jsonl",
+            "execution_history.jsonl",
+            "learnings.jsonl",
+            "schedules.jsonl",
+            "context.pkl",
+            "current_plan.txt",
+            "instruction_details.txt",
+        }
+    )
+
     def export_agent(self, agent_id: str) -> Tuple[Path, str]:
         """
-        Export an agent's state files as a ZIP file.
+        Export an agent's instruction set as a ZIP file.
+
+        Conversation history, execution traces, learnings, schedules, and
+        pickled runtime context are stripped. A published agent is the
+        profile (``agent.yml`` + ``system_prompt.md`` and any other
+        instruction files), not the operator's private sessions.
 
         Args:
             agent_id (str): The unique identifier of the agent to export
@@ -1627,10 +1614,24 @@ class AgentRegistry:
             agent_dir = self.agents_dir / agent_id
 
             with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zip_file:
-                # Add all files from the agent directory to the ZIP file
                 for item in agent_dir.iterdir():
-                    if item.is_file():
-                        zip_file.write(item, arcname=item.name)
+                    if not item.is_file():
+                        continue
+                    if item.name in self._EXPORT_SKIP_NAMES:
+                        continue
+                    if item.name == "agent.yml":
+                        # last_message is a slice of the conversation and
+                        # must not ride in a published archive. Rewrite a
+                        # copy rather than mutating the live profile.
+                        payload = yaml.safe_load(item.read_text(encoding="utf-8")) or {}
+                        if isinstance(payload, dict):
+                            payload["last_message"] = ""
+                        zip_file.writestr(
+                            "agent.yml",
+                            yaml.safe_dump(payload, default_flow_style=False),
+                        )
+                        continue
+                    zip_file.write(item, arcname=item.name)
 
             return zip_path, filename
         except Exception as e:

--- a/local_operator/cli.py
+++ b/local_operator/cli.py
@@ -318,6 +318,42 @@ def build_cli_parser() -> argparse.ArgumentParser:
         help="ID of the agent to pull from Radient",
     )
 
+    # Teams command
+    teams_parser = subparsers.add_parser("teams", help="Manage teams", parents=[parent_parser])
+    teams_subparsers = teams_parser.add_subparsers(dest="teams_command")
+    teams_subparsers.add_parser("list", help="List all teams", parents=[parent_parser])
+    teams_create = teams_subparsers.add_parser(
+        "create", help="Create a new team", parents=[parent_parser]
+    )
+    teams_create.add_argument("name", type=str, help="Name of the team to create")
+    teams_create.add_argument(
+        "--manager",
+        type=str,
+        default="manager",
+        help="Role or specialist who orchestrates (default: manager)",
+    )
+    teams_create.add_argument(
+        "--member",
+        action="append",
+        default=[],
+        dest="members",
+        help="Roster slot as role or role:count (repeatable)",
+    )
+    teams_create.add_argument("--description", type=str, default="", help="One-line description")
+    teams_show = teams_subparsers.add_parser(
+        "show", help="Show a team's roster and briefs", parents=[parent_parser]
+    )
+    teams_show.add_argument("name", type=str, help="Name of the team to show")
+    teams_delete = teams_subparsers.add_parser(
+        "delete", help="Delete a team by name", parents=[parent_parser]
+    )
+    teams_delete.add_argument(
+        "--name",
+        type=str,
+        required=True,
+        help="Name of the team to delete",
+    )
+
     # Serve command to start the API server
     serve_parser = subparsers.add_parser(
         "serve", help="Start the FastAPI server", parents=[parent_parser]
@@ -925,6 +961,89 @@ def agents_create_command(name: str, agent_registry: "AgentRegistry") -> int:
     print(f"\033[1;32m│ Created: {agent.created_date}\033[0m")
     print(f"\033[1;32m│ Version: {agent.version}\033[0m")
     print("\033[1;32m╰──────────────────────────────────────────────────\033[0m\n")
+    return 0
+
+
+def teams_list_command(team_registry: Any) -> int:
+    """List all teams."""
+    teams = team_registry.list_teams()
+    if not teams:
+        print("\n\033[1;33mNo teams found.\033[0m")
+        return 0
+    print("\n\033[1;32m╭─ Teams ─────────────────────────────────────\033[0m")
+    for i, team in enumerate(teams):
+        is_last = i == len(teams) - 1
+        branch = "└──" if is_last else "├──"
+        left = "│  " if is_last else "│ │"
+        print(f"\033[1;32m│ {branch} {team.name}\033[0m")
+        print(f"\033[1;32m{left}   • Manager: {team.manager}\033[0m")
+        print(f"\033[1;32m{left}   • Members: {len(team.members)}\033[0m")
+        if team.description:
+            print(f"\033[1;32m{left}   • Description: {team.description}\033[0m")
+        if not is_last:
+            print("\033[1;32m│ │\033[0m")
+    print("\033[1;32m╰──────────────────────────────────────────────\033[0m")
+    return 0
+
+
+def teams_create_command(args: argparse.Namespace, team_registry: Any) -> int:
+    """Create a team from CLI flags."""
+    from local_operator.teams import TeamEditFields, parse_members
+
+    try:
+        members = parse_members(getattr(args, "members", None))
+        team = team_registry.create_team(
+            TeamEditFields(
+                name=args.name,
+                description=getattr(args, "description", "") or "",
+                manager=getattr(args, "manager", None) or "manager",
+                members=members,
+            )
+        )
+    except ValueError as exc:
+        print(f"\n\033[1;31mError: {exc}\033[0m")
+        return -1
+    print("\n\033[1;32m╭─ Created New Team ───────────────────────────\033[0m")
+    print(f"\033[1;32m│ Name: {team.name}\033[0m")
+    print(f"\033[1;32m│ Manager: {team.manager}\033[0m")
+    print(f"\033[1;32m│ Members: {len(team.members)}\033[0m")
+    print("\033[1;32m╰──────────────────────────────────────────────────\033[0m\n")
+    return 0
+
+
+def teams_show_command(name: str, team_registry: Any) -> int:
+    """Print a team's roster and briefs."""
+    team = team_registry.get_team_by_name(name)
+    if team is None:
+        print(f"\n\033[1;31mError: No team found with name: {name}\033[0m")
+        return -1
+    print(f"\n\033[1;32m╭─ Team {team.name} ───────────────────────────\033[0m")
+    print(f"\033[1;32m│ Manager: {team.manager}\033[0m")
+    if team.description:
+        print(f"\033[1;32m│ Description: {team.description}\033[0m")
+    print("\033[1;32m│ Roster:\033[0m")
+    for line in team.roster_lines():
+        print(f"\033[1;32m│   {line}\033[0m")
+    if team.instructions.strip():
+        print("\033[1;32m│ Collaboration:\033[0m")
+        for line in team.instructions.strip().splitlines():
+            print(f"\033[1;32m│   {line}\033[0m")
+    if team.project.strip():
+        print("\033[1;32m│ Project:\033[0m")
+        for line in team.project.strip().splitlines():
+            print(f"\033[1;32m│   {line}\033[0m")
+    print("\033[1;32m╰──────────────────────────────────────────────────\033[0m\n")
+    return 0
+
+
+def teams_delete_command(name: str, team_registry: Any) -> int:
+    """Delete a team by name."""
+    team = team_registry.get_team_by_name(name)
+    if team is None:
+        print(f"\n\033[1;31mError: No team found with name: {name}\033[0m")
+        return -1
+    team_registry.delete_team(team.id)
+    print(f"\n\033[1;32mSuccessfully deleted team: {name}\033[0m")
     return 0
 
 
@@ -1690,6 +1809,20 @@ def main() -> int:
                     return -1
             else:
                 parser.error(f"Invalid agents command: {args.agents_command}")
+        elif args.subcommand == "teams":
+            from local_operator.teams import TeamRegistry
+
+            team_registry = TeamRegistry(base_dir)
+            if args.teams_command == "list":
+                return teams_list_command(team_registry)
+            elif args.teams_command == "create":
+                return teams_create_command(args, team_registry)
+            elif args.teams_command == "show":
+                return teams_show_command(args.name, team_registry)
+            elif args.teams_command == "delete":
+                return teams_delete_command(args.name, team_registry)
+            else:
+                parser.error(f"Invalid teams command: {args.teams_command}")
         elif args.subcommand == "serve":
             # Use the provided host, port, and reload options for serving the API.
             return serve_command(args.host, args.port, args.reload)

--- a/local_operator/cli.py
+++ b/local_operator/cli.py
@@ -977,7 +977,7 @@ def teams_list_command(team_registry: Any) -> int:
         left = "│  " if is_last else "│ │"
         print(f"\033[1;32m│ {branch} {team.name}\033[0m")
         print(f"\033[1;32m{left}   • Manager: {team.manager}\033[0m")
-        print(f"\033[1;32m{left}   • Members: {len(team.members)}\033[0m")
+        print(f"\033[1;32m{left}   • Members: {team.member_count()}\033[0m")
         if team.description:
             print(f"\033[1;32m{left}   • Description: {team.description}\033[0m")
         if not is_last:
@@ -1006,7 +1006,7 @@ def teams_create_command(args: argparse.Namespace, team_registry: Any) -> int:
     print("\n\033[1;32m╭─ Created New Team ───────────────────────────\033[0m")
     print(f"\033[1;32m│ Name: {team.name}\033[0m")
     print(f"\033[1;32m│ Manager: {team.manager}\033[0m")
-    print(f"\033[1;32m│ Members: {len(team.members)}\033[0m")
+    print(f"\033[1;32m│ Members: {team.member_count()}\033[0m")
     print("\033[1;32m╰──────────────────────────────────────────────────\033[0m\n")
     return 0
 

--- a/local_operator/guides/agents/GUIDE.md
+++ b/local_operator/guides/agents/GUIDE.md
@@ -59,14 +59,20 @@ Roles resolve from the operator's registry first, then from packaged starters (`
 
 A role's tool allowlist is a capability boundary, not advice. A `reviewer` has no `edit`/`write` — it reads and runs tests but cannot alter what it reviews, which is what stops a reviewer from silently reviewing its own patch. Roles that do not coordinate also lose `task`/`wait`/`jobs`.
 
-Use the `agent` tool to work with roles:
+Use the `agent` tool to work with roles and specialists:
 
 - `search` — which role fits a task, by meaning. Use it when you are about to delegate something specialized and are not sure a role exists.
 - `list` / `show` — what exists, and what a role actually says.
 - `install` — pull a packaged starter into the registry on first need.
-- `create` / `update` — author a role, or FIX one whose guidance produced a bad run. Write `description` as the trigger condition ("reviewing a merge request"), not as a job title, because that text is what `search` matches.
+- `create` / `update` — author a role (`kind='role'`, the default) or a specialist (`kind='specialist'`), or FIX one whose guidance produced a bad run. Write `description` as the trigger condition ("reviewing a merge request"), not as a job title, because that text is what `search` matches. `instructions` are the reusable BASE behaviour; a team layers collaboration and project briefs on top without rewriting them.
+
+When a user asks for a named specialist — "create a User Dashboard Agent that knows our release practices" — that is `kind='specialist'` with a real instruction set, not a one-off prompt. Put it on a team roster later rather than baking the team into the agent.
 
 When a delegated run goes wrong in a way the role should have prevented, update the role rather than only patching this one prompt. That is the mechanism by which review guidance improves instead of being re-derived every time.
+
+## Teams
+
+A team is a named roster of these agents under one manager, plus collaboration and project briefs that do not belong on any one agent. Read `guide://teams` before creating or modifying a team, and before answering a question about how teams work.
 
 ## Awaiting delegated work
 

--- a/local_operator/guides/teams/GUIDE.md
+++ b/local_operator/guides/teams/GUIDE.md
@@ -54,7 +54,10 @@ Use the `team` tool:
 
 - `list` / `show` — what exists and what it says
 - `create` / `update` — author or fix a team
-- `delete` — remove one
+
+Permanent removal uses the separate `team_delete` tool. It is deliberately
+write-tier so the user sees and approves the destructive action; never route a
+delete through the read-tier authoring tool.
 
 Use the `agent` tool to author or install the members first. A team that names a role nobody has installed still launches; `task(agent='coder')` falls back to the packaged starter.
 

--- a/local_operator/guides/teams/GUIDE.md
+++ b/local_operator/guides/teams/GUIDE.md
@@ -1,0 +1,70 @@
+---
+name: teams
+description: "Create, update, and run Local Operator teams: a manager plus reusable agents, with layered collaboration and project briefs."
+---
+
+# Teams
+
+A team is a named roster of reusable agents under one manager, plus two instruction layers that do not belong on any one agent.
+
+Do not treat a team as a new kind of agent. Agents stay reusable; the team is the grouping.
+
+## The three instruction layers
+
+A member actually sees, outermost last:
+
+1. **Base** — the agent's own `system_prompt.md` (or a packaged role seed). Write this once. A `coder` or a "User Dashboard Agent" can sit on many teams.
+2. **Collaboration** — `teams/<id>/instructions.md`. How THIS group works together: review order, who blocks a release, how the manager delegates.
+3. **Project** — `teams/<id>/project.md`. The product or domain this instance of the team is responsible for. Swap this file to reuse the same roster on another product.
+
+Never copy a team's collaboration or project brief into an agent's base instructions. That is how a reusable coder becomes "the user-dashboard coder" and cannot staff anything else.
+
+## When the user asks to create a team
+
+Work with them. Do not invent a roster silently. Ask, using the `ask` tool when a choice is theirs:
+
+- the team **name** (letters, digits, dot, underscore, hyphen; no spaces — it is a `/team` argument)
+- the **manager** and what they are responsible for (default: install the `manager` starter)
+- each **member**: a packaged role (`coder`, `reviewer`, `architect`, `designer`, `scout`) or a specialist the user wants authored, and how many of each
+- **collaboration**: how they work together
+- **project**: only if this instance owns a product or domain
+
+Then:
+
+1. `agent` `op='install'` for each packaged role that is not yet in the registry, or `op='create'` `kind='specialist'` (or `kind='role'`) for a new profile with a real instruction set.
+2. `team` `op='create'` with `manager`, `members` as `role` or `role:count`, `instructions`, and `project`.
+3. Tell the user they launch it with `/team <name> <request>`.
+
+Example: "create a Feature Release Team with a manager, coder, designer, architect, and security reviewer" → install those starters (author a `security-reviewer` role if none exists), agree collaboration ("architect designs, coder implements, reviewer and designer sign off, manager reports"), create the team, and stop. Do not start the work until they send `/team Feature-Release …`.
+
+## Running a team
+
+`/team` lists teams. `/team <name> <request>` attaches the team to this session (the current agent becomes the manager of that roster) and sends the request as a real turn.
+
+As the manager:
+
+- You coordinate; you do not implement.
+- Delegate with `task(agent='<role>')` using the roster. Each member already carries the team's collaboration and project briefs — give them the TASK, not a restatement of the team.
+- Spin up the counts the roster names; do not invent extra copies.
+- Verify from a primary source before reporting done.
+
+## Tools
+
+Use the `team` tool:
+
+- `list` / `show` — what exists and what it says
+- `create` / `update` — author or fix a team
+- `delete` — remove one
+
+Use the `agent` tool to author or install the members first. A team that names a role nobody has installed still launches; `task(agent='coder')` falls back to the packaged starter.
+
+## CLI
+
+```bash
+local-operator teams list
+local-operator teams create feature-release --manager manager --member coder --member reviewer:2
+local-operator teams show feature-release
+local-operator teams delete --name feature-release
+```
+
+Do not list the team registry at every session start. Discover it when the user asks about teams or when a task would benefit from one.

--- a/local_operator/harness/subagent.py
+++ b/local_operator/harness/subagent.py
@@ -155,6 +155,23 @@ SCOUT_PREAMBLE = (
 )
 
 
+def _specialist_instructions(agent: str, parent_session: "Session") -> str:
+    """A non-role agent's own system_prompt.md, or ''."""
+    if not agent or agent in {"task", "scout"}:
+        return ""
+    registry = getattr(parent_session, "agent_registry", None)
+    if registry is None or not hasattr(registry, "get_agent_by_name"):
+        return ""
+    try:
+        row = registry.get_agent_by_name(agent)
+        if row is None:
+            return ""
+        return (registry.get_agent_system_prompt(row.id) or "").strip()
+    except Exception:  # noqa: BLE001 — guidance is enrichment
+        logger.warning("could not read specialist instructions for %r", agent)
+        return ""
+
+
 def _resolve_role(agent: str, parent_session: "Session") -> "AgentProfile | None":
     """The profile for ``agent``, or None for a plain full child.
 
@@ -262,7 +279,25 @@ def _make_runner(
     elif agent == "scout":
         effective_prompt = SCOUT_PREAMBLE + prompt
     else:
-        effective_prompt = prompt
+        # A specialist on a team roster is not a role, so resolve_profile
+        # returns None. Still stamp its own system_prompt.md as the reusable
+        # BASE before the team brief, or a User Dashboard Agent would launch
+        # as a blank child.
+        specialist_prompt = _specialist_instructions(agent, parent_session)
+        if specialist_prompt:
+            effective_prompt = specialist_prompt + "\n\n" + prompt
+        else:
+            effective_prompt = prompt
+    # A parent running as a team manager stamps the GROUP brief onto every
+    # child so members inherit collaboration and project context without the
+    # manager restating it in the task prompt. The role preamble above is the
+    # reusable base; this is the layer that must not live on the agent.
+    team = getattr(parent_session, "active_team", None)
+    if team is not None:
+        try:
+            effective_prompt = team.member_preamble(agent) + effective_prompt
+        except Exception:  # noqa: BLE001 — a bad brief must not lose the child
+            logger.warning("could not stamp team preamble for %r", agent, exc_info=True)
 
     async def runner(
         job_id: str, signal: Any, report_progress: Callable[[str], None]
@@ -811,6 +846,7 @@ async def _build_child_session(
         # learned about a bad one), and role resolution for its OWN launches
         # needs the same registry the parent used.
         agent_registry=getattr(parent_session, "agent_registry", None),
+        team_registry=getattr(parent_session, "team_registry", None),
         web_search_settings=ConfigManager(config_dir()).get_config_value("web_search", None),
     )
     tools = create_tools(tool_context)
@@ -900,6 +936,7 @@ async def _build_child_session(
         # delegates (a manager) or inspects a role sees the operator's profiles
         # rather than falling back to the packaged starters.
         agent_registry=getattr(parent_session, "agent_registry", None),
+        team_registry=getattr(parent_session, "team_registry", None),
         skill_resolver=resolve_internal_url,
         # How the transcript renders into LLM messages. Today every host uses
         # the default, so this changes nothing; it is plumbed because a host

--- a/local_operator/harness/subagent.py
+++ b/local_operator/harness/subagent.py
@@ -163,8 +163,13 @@ def _specialist_instructions(agent: str, parent_session: "Session") -> str:
     if registry is None or not hasattr(registry, "get_agent_by_name"):
         return ""
     try:
+        from local_operator.agent_profiles import is_specialist
+
         row = registry.get_agent_by_name(agent)
-        if row is None:
+        if row is None or not is_specialist(row):
+            # The registry also contains ordinary persistent chat agents. Their
+            # prompts can carry private user context and must never be injected
+            # into a delegated child merely because its name was supplied.
             return ""
         return (registry.get_agent_system_prompt(row.id) or "").strip()
     except Exception:  # noqa: BLE001 — guidance is enrichment

--- a/local_operator/harness/types.py
+++ b/local_operator/harness/types.py
@@ -622,6 +622,13 @@ class ToolContext(BaseModel):
     # the ``agent`` tool is then not advertised (createIf) and delegation falls
     # back to packaged starter profiles.
     agent_registry: Any = None
+    # The user's persistent team registry (``local_operator.teams``), behind
+    # the ``team`` tool and behind ``/team <name> <request>``. Typed ``Any``
+    # for the same reason ``agent_registry`` is: importing that module here
+    # would pull yaml persistence into every process that merely wants a
+    # tool type. ``None`` means the host keeps no teams: the ``team`` tool
+    # is then not advertised (createIf).
+    team_registry: Any = None
     # The session's background job manager. Declared as a Protocol because
     # the concrete class lives in ``harness.jobs``, which imports this
     # module (import cycle). The ``wait``/``job`` tools read it; ``None``

--- a/local_operator/prompts_api.py
+++ b/local_operator/prompts_api.py
@@ -270,6 +270,7 @@ def build_system_blocks(
     user_instructions: str = "",
     repo_guidance: str = "",
     credentials: Sequence[str] | None = None,
+    team_brief: str = "",
 ) -> list[str]:
     """Build the system prompt blocks; see the module docstring.
 
@@ -342,6 +343,12 @@ def build_system_blocks(
             f"{tail}\n\n<goal>\nThe user's standing objective for this "
             f"session:\n{goal}\n</goal>"
         )
+    if team_brief.strip():
+        # A /team launch stamps the group's collaboration and project briefs
+        # here rather than in the cached head: attaching a team mid-session
+        # must not invalidate the persona prefix, and a team is a grouping
+        # for THIS conversation, not a machine-wide preference.
+        tail = f"{tail}\n\n<team>\n{team_brief.strip()}\n</team>"
     names = [name for name in (credentials or ()) if name]
     if names:
         # Names only. The values live in process memory and are injected into

--- a/local_operator/session/goal.py
+++ b/local_operator/session/goal.py
@@ -27,6 +27,10 @@ class GoalState:
     """Mutable holder for the session's current goal (empty = unset)."""
 
     text: str = ""
+    #: Team brief stamped by ``/team``. Separate from ``text`` so attaching a
+    #: team cannot overwrite a standing ``/goal``, and clearing a goal cannot
+    #: drop the roster the manager is coordinating.
+    team_brief: str = ""
 
     def set(self, text: str) -> str:
         """Store a trimmed, length-capped goal and return what was stored."""

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -802,6 +802,10 @@ class Session:
         #: ``None`` means no registry: the ``agent`` tool is not advertised and
         #: delegation falls back to the packaged starter profiles.
         agent_registry: Any | None = None,
+        #: The user's persistent team registry, when the host keeps one. Behind
+        #: the ``team`` tool and behind ``/team``. ``None`` means the ``team``
+        #: tool is not advertised.
+        team_registry: Any | None = None,
         conversation_name: ConversationName | None = None,
         system_blocks_provider: Callable[[], list[str]] | Callable[[], Awaitable[list[str]]],
     ) -> None:
@@ -831,6 +835,12 @@ class Session:
         self._job_id = job_id
         self._subagent_comms = subagent_comms
         self.agent_registry = agent_registry
+        self.team_registry = team_registry
+        #: The team this session is running as manager of, when ``/team``
+        #: launched it. Held here so every ``task`` child inherits the group's
+        #: collaboration and project briefs without the manager restating them.
+        #: ``None`` on an ordinary session.
+        self.active_team: Any | None = None
         # The conversation's title. A holder rather than a plain string for
         # the same reason the goal is one: the title arrives on a DETACHED
         # naming task after the host already built its status chrome, and
@@ -1510,6 +1520,36 @@ class Session:
         next turn and only invalidates that tail — never the cached prefix.
         """
         return self._goal_state.set(text)
+
+    def attach_team(self, team: Any) -> None:
+        """Bind this session as the manager of ``team``.
+
+        The team's collaboration and project briefs ride the volatile tail
+        (see ``build_system_blocks``) so they apply from the next turn
+        without rebuilding the session or invalidating the cached persona
+        prefix. Children spawned after this inherit the same team via
+        :attr:`active_team`.
+        """
+        self.active_team = team
+        if team is None:
+            self._goal_state.team_brief = ""
+            return
+        preamble = getattr(team, "manager_preamble", lambda: "")()
+        # The manager's own profile instructions (the reusable BASE) sit in
+        # front of the team brief so a custom manager keeps its voice when
+        # this session was not launched with --agent. A packaged starter
+        # resolved by name is enough; a missing profile costs nothing.
+        manager_name = getattr(team, "manager", "") or ""
+        if manager_name and self.agent_registry is not None:
+            try:
+                from local_operator.agent_profiles import resolve_profile
+
+                profile = resolve_profile(manager_name, registry=self.agent_registry)
+            except Exception:  # noqa: BLE001
+                profile = None
+            if profile is not None and profile.preamble:
+                preamble = profile.preamble + (preamble or "")
+        self._goal_state.team_brief = preamble or ""
 
     @property
     def variables(self) -> Any:
@@ -2565,6 +2605,7 @@ class Session:
             variables=self._variables,
             job_id=self._job_id,
             agent_registry=self.agent_registry,
+            team_registry=self.team_registry,
             delegated_tools={
                 tool.name: tool for tool in self._tools if tool.name.startswith("mcp__")
             },

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -1549,6 +1549,30 @@ class Session:
                 profile = None
             if profile is not None and profile.preamble:
                 preamble = profile.preamble + (preamble or "")
+            elif profile is None:
+                # ``resolve_profile`` intentionally resolves only delegation
+                # roles. A team manager may instead be a reusable specialist;
+                # load its base prompt directly, but only when the explicit
+                # specialist marker is present so private chat agents are not
+                # pulled into team context by a coincidental name.
+                try:
+                    from local_operator.agent_profiles import is_specialist
+
+                    specialist = self.agent_registry.get_agent_by_name(manager_name)
+                    specialist_prompt = (
+                        self.agent_registry.get_agent_system_prompt(specialist.id)
+                        if specialist is not None and is_specialist(specialist)
+                        else ""
+                    )
+                except Exception:  # noqa: BLE001
+                    specialist_prompt = ""
+                if specialist_prompt.strip():
+                    preamble = (
+                        "<manager-profile>\n"
+                        + specialist_prompt.strip()
+                        + "\n</manager-profile>\n\n"
+                        + (preamble or "")
+                    )
         self._goal_state.team_brief = preamble or ""
 
     @property

--- a/local_operator/session_factory.py
+++ b/local_operator/session_factory.py
@@ -870,6 +870,7 @@ def _make_system_blocks_provider(
             knowledge_block = ""
         date_str = datetime.now().strftime("%Y-%m-%d")
         goal = goal_state.text if goal_state is not None else ""
+        team_brief = goal_state.team_brief if goal_state is not None else ""
         names = (
             variable_store.credential_names()
             if variable_store is not None and hasattr(variable_store, "credential_names")
@@ -884,6 +885,7 @@ def _make_system_blocks_provider(
             user_instructions=user_instructions,
             repo_guidance=repo_guidance,
             credentials=names,
+            team_brief=team_brief,
         )
 
     return provider
@@ -1043,6 +1045,9 @@ async def _prepare(
     # nothing else — `list_variables` advertised itself and then read a bare
     # process-env store, in every session.
     variable_store = _build_variable_store(effective_cwd, config_manager)
+    from local_operator.teams import TeamRegistry
+
+    team_registry = TeamRegistry(config_dir)
     tool_context = ToolContext(
         cwd=effective_cwd,
         session_id=transcript_dir.name,
@@ -1053,6 +1058,7 @@ async def _prepare(
         # Role profiles and the ``agent`` tool are backed by this registry; a
         # host without one keeps working off the packaged starters.
         agent_registry=agent_registry,
+        team_registry=team_registry,
         web_search_settings=config_manager.get_config_value("web_search", None),
     )
     tools = create_tools(tool_context)
@@ -1134,6 +1140,7 @@ async def _prepare(
         goal_state=goal_state,
         variables=variable_store,
         agent_registry=agent_registry,
+        team_registry=team_registry,
     )
     return _SessionPlan(
         session_kwargs=session_kwargs,

--- a/local_operator/teams.py
+++ b/local_operator/teams.py
@@ -72,7 +72,12 @@ class TeamMember(BaseModel):
     """One roster slot: a named agent/role, possibly more than one copy."""
 
     role: str = Field(..., description="Role or specialist agent name.")
-    count: int = Field(1, ge=1, le=16, description="How many of this role to run.")
+    count: int = Field(
+        default=1,
+        ge=1,
+        le=16,
+        description="How many of this role to run.",
+    )
 
     @field_validator("role")
     @classmethod

--- a/local_operator/teams.py
+++ b/local_operator/teams.py
@@ -47,6 +47,7 @@ from __future__ import annotations
 
 import logging
 import re
+import shutil
 import time
 import uuid
 from datetime import datetime, timezone
@@ -138,6 +139,16 @@ class Team(BaseModel):
             lines.append(f"- {member.role}{suffix}")
         return lines
 
+    def member_count(self) -> int:
+        """Total member copies on the roster (counts summed, manager excluded).
+
+        Distinct from ``len(members)``: a ``reviewer x2`` slot is two members
+        in one slot, and a summary that reports it as one understates the
+        team the user assembled.
+        """
+
+        return sum(member.count for member in self.members)
+
     def member_names(self) -> list[str]:
         """Role names on the roster, manager included, first occurrence winning."""
         names: list[str] = []
@@ -212,7 +223,10 @@ class TeamRegistry:
     def __init__(self, config_dir: Path, refresh_interval: float = 5.0) -> None:
         self.config_dir = Path(config_dir)
         self.teams_dir = self.config_dir / "teams"
-        self.teams_dir.mkdir(parents=True, exist_ok=True)
+        # No mkdir here: every interactive session constructs a registry, and
+        # an unused feature must not litter the config dir. ``save_team``
+        # creates the tree on first write, and ``_load`` treats a missing
+        # directory as "no teams".
         self._teams: dict[str, Team] = {}
         self._last_refresh_time = 0.0
         self._refresh_interval = refresh_interval
@@ -335,12 +349,14 @@ class TeamRegistry:
             self._load()
         if team_id not in self._teams:
             raise KeyError(f"Team with id {team_id} not found")
-        self._teams.pop(team_id)
+        # Remove the on-disk copy FIRST: if the rmtree fails (permissions, an
+        # open handle) the cache must still agree with disk, so the row stays
+        # and the error propagates. Popping before the rmtree left a deleted
+        # row in the cache only when the filesystem said no.
         team_dir = self.teams_dir / team_id
         if team_dir.exists():
-            import shutil
-
             shutil.rmtree(team_dir)
+        self._teams.pop(team_id)
 
 
 def parse_members(raw: Iterable[str] | None) -> list[TeamMember]:

--- a/local_operator/teams.py
+++ b/local_operator/teams.py
@@ -1,0 +1,384 @@
+"""Teams: a named roster of reusable agents under one manager.
+
+WHY THIS EXISTS
+===============
+
+Roles and specialist agents are reusable building blocks — a ``coder`` or a
+"User Dashboard Agent" should be writable once and usable in many groupings.
+A Team is the grouping: a manager, a roster of members (role or specialist,
+with counts), plus TWO instruction layers that do not belong on any one
+agent because they describe the GROUP rather than the person:
+
+1. **Collaboration** (``instructions.md``) — how this team works together:
+   review order, who blocks a release, how the manager delegates.
+2. **Project** (``project.md``) — the product or domain this instance of the
+   team is responsible for. The same Feature Release roster can staff two
+   products by swapping only this file.
+
+The three layers a member actually sees, outermost last:
+
+- the agent's own ``system_prompt.md`` (base behaviour, reusable)
+- the team's collaboration brief (how we work)
+- the team's project brief (what we are responsible for)
+
+A manager session also gets a roster so it can ``task(agent=...)`` the right
+people without the operator restating the org chart every turn.
+
+STORAGE
+=======
+
+``<config_dir>/teams/<id>/``:
+
+- ``team.yml`` — id, name, description, manager, members
+- ``instructions.md`` — collaboration brief
+- ``project.md`` — project / product brief
+
+Members are referenced by NAME (a role or a specialist agent), never by
+registry id, so a team survives an agent being deleted and recreated and so
+the same ``coder`` row can sit on many teams. Counts let a team ask for two
+coders without inventing a second profile.
+
+The registry is NEVER enumerated into the prompt. ``list`` is the explicit
+action that reveals names; the ``teams`` guide is what the model reads to
+learn the concept.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import time
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable
+
+import yaml
+from pydantic import BaseModel, Field, field_validator
+
+logger = logging.getLogger(__name__)
+
+#: Cap on each team instruction file. Same bound as a role body: these ride
+#: in front of a manager session and every member launch, so an unbounded
+#: paste is an unbounded per-turn bill.
+MAX_TEAM_INSTRUCTIONS_CHARS = 8_000
+
+#: A team name is also a slash-command argument, so it cannot contain spaces
+#: or slashes — ``/team feature-release ship it`` has to parse unambiguously.
+_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$")
+
+
+class TeamMember(BaseModel):
+    """One roster slot: a named agent/role, possibly more than one copy."""
+
+    role: str = Field(..., description="Role or specialist agent name.")
+    count: int = Field(1, ge=1, le=16, description="How many of this role to run.")
+
+    @field_validator("role")
+    @classmethod
+    def _role_name(cls, value: str) -> str:
+        name = (value or "").strip()
+        if not name:
+            raise ValueError("member role is required")
+        return name
+
+
+class TeamEditFields(BaseModel):
+    """Partial update. ``None`` means leave the stored value alone."""
+
+    name: str | None = None
+    description: str | None = None
+    manager: str | None = None
+    members: list[TeamMember] | None = None
+    instructions: str | None = None
+    project: str | None = None
+
+
+class Team(BaseModel):
+    """A durable team: manager + members + layered instruction briefs."""
+
+    id: str
+    name: str
+    created_date: datetime
+    description: str = ""
+    manager: str = "manager"
+    members: list[TeamMember] = Field(default_factory=list)
+    instructions: str = ""
+    project: str = ""
+
+    @field_validator("name")
+    @classmethod
+    def _name(cls, value: str) -> str:
+        name = (value or "").strip()
+        if not _NAME_RE.match(name):
+            raise ValueError(
+                "team name must be 1-64 characters of letters, digits, "
+                "dot, underscore or hyphen, and cannot start with a hyphen"
+            )
+        return name
+
+    @field_validator("manager")
+    @classmethod
+    def _manager(cls, value: str) -> str:
+        name = (value or "").strip()
+        if not name:
+            raise ValueError("manager is required")
+        return name
+
+    def roster_lines(self) -> list[str]:
+        """One scannable line per slot, manager first."""
+        lines = [f"- manager: {self.manager} (you, when this team is invoked)"]
+        for member in self.members:
+            suffix = f" x{member.count}" if member.count > 1 else ""
+            lines.append(f"- {member.role}{suffix}")
+        return lines
+
+    def member_names(self) -> list[str]:
+        """Role names on the roster, manager included, first occurrence winning."""
+        names: list[str] = []
+        for name in (self.manager, *(member.role for member in self.members)):
+            if name not in names:
+                names.append(name)
+        return names
+
+    def manager_preamble(self) -> str:
+        """Standing brief stamped into a manager session's instructions.
+
+        Empty briefs cost nothing: a team that has only a roster still names
+        the roster, and a team with nothing at all yields an empty string so
+        it does not tax a session that has not been briefed yet.
+        """
+        parts: list[str] = [f"[team: {self.name}]"]
+        if self.description.strip():
+            parts.append(self.description.strip())
+        parts.append("You are the manager of this team. You coordinate; you do not implement.")
+        parts.append(
+            "Delegate with task(agent='<role>') using the roster below. "
+            "Each member already carries this team's collaboration and project "
+            "briefs — give them the TASK, not a restatement of the team. "
+            "Spin up the counts the roster names; do not invent extra copies."
+        )
+        parts.append("Roster:\n" + "\n".join(self.roster_lines()))
+        collab = self.instructions.strip()
+        if collab:
+            parts.append("Collaboration:\n" + collab)
+        project = self.project.strip()
+        if project:
+            parts.append("Project:\n" + project)
+        return "\n\n".join(parts) + "\n"
+
+    def member_preamble(self, role: str) -> str:
+        """Brief stamped in front of a member's one-shot prompt.
+
+        Shorter than the manager brief: a member does not need to be told how
+        to delegate, and the role's own preamble already said how to do the
+        job. This is the GROUP context the role file must not carry, because
+        the same role sits on many teams.
+        """
+        parts: list[str] = [
+            f"[team: {self.name}]",
+            f"You are {role} on this team. The manager is {self.manager}.",
+            "Teammates:\n" + "\n".join(self.roster_lines()),
+        ]
+        collab = self.instructions.strip()
+        if collab:
+            parts.append("Collaboration:\n" + collab)
+        project = self.project.strip()
+        if project:
+            parts.append("Project:\n" + project)
+        return "\n\n".join(parts) + "\n\n"
+
+
+def validate_team_name(name: str) -> str:
+    """Return a stripped, legal team name or raise ``ValueError``."""
+    return Team.model_validate(
+        {
+            "id": "x",
+            "name": name,
+            "created_date": datetime.now(timezone.utc),
+            "manager": "manager",
+        }
+    ).name
+
+
+class TeamRegistry:
+    """On-disk registry of teams under ``<config_dir>/teams``."""
+
+    def __init__(self, config_dir: Path, refresh_interval: float = 5.0) -> None:
+        self.config_dir = Path(config_dir)
+        self.teams_dir = self.config_dir / "teams"
+        self.teams_dir.mkdir(parents=True, exist_ok=True)
+        self._teams: dict[str, Team] = {}
+        self._last_refresh_time = 0.0
+        self._refresh_interval = refresh_interval
+        self._load()
+
+    def _load(self) -> None:
+        loaded: dict[str, Team] = {}
+        try:
+            children = list(self.teams_dir.iterdir())
+        except OSError:
+            self._teams = {}
+            self._last_refresh_time = time.time()
+            return
+        for child in children:
+            if not child.is_dir():
+                continue
+            path = child / "team.yml"
+            if not path.is_file():
+                continue
+            try:
+                with path.open("r", encoding="utf-8") as handle:
+                    data = yaml.safe_load(handle) or {}
+                if not isinstance(data, dict):
+                    continue
+                data["instructions"] = _read_optional(child / "instructions.md")
+                data["project"] = _read_optional(child / "project.md")
+                team = Team.model_validate(data)
+                loaded[team.id] = team
+            except Exception as exc:  # noqa: BLE001 — one bad file must not hide the rest
+                logger.warning("invalid team metadata in %s: %s", child.name, exc)
+        self._teams = loaded
+        self._last_refresh_time = time.time()
+
+    def _refresh_if_needed(self) -> None:
+        if time.time() - self._last_refresh_time > self._refresh_interval:
+            self._load()
+
+    def list_teams(self) -> list[Team]:
+        self._refresh_if_needed()
+        return sorted(self._teams.values(), key=lambda team: team.name.lower())
+
+    def get_team(self, team_id: str) -> Team:
+        self._refresh_if_needed()
+        team = self._teams.get(team_id)
+        if team is None:
+            raise KeyError(f"Team with id {team_id} not found")
+        return team
+
+    def get_team_by_name(self, name: str) -> Team | None:
+        self._refresh_if_needed()
+        key = (name or "").strip().casefold()
+        if not key:
+            return None
+        for team in self._teams.values():
+            if team.name.casefold() == key:
+                return team
+        return None
+
+    def create_team(self, fields: TeamEditFields) -> Team:
+        name = validate_team_name(fields.name or "")
+        if self.get_team_by_name(name) is not None:
+            raise ValueError(f"Team with name {name} already exists")
+        team = Team(
+            id=str(uuid.uuid4()),
+            name=name,
+            created_date=datetime.now(timezone.utc),
+            description=(fields.description or "").strip(),
+            manager=(fields.manager or "manager").strip() or "manager",
+            members=list(fields.members or []),
+            instructions=_bounded(fields.instructions or ""),
+            project=_bounded(fields.project or ""),
+        )
+        return self.save_team(team)
+
+    def update_team(self, team_id: str, fields: TeamEditFields) -> Team:
+        current = self.get_team(team_id)
+        updates = fields.model_dump(exclude_unset=True)
+        if "name" in updates and updates["name"] is not None:
+            new_name = validate_team_name(updates["name"])
+            occupant = self.get_team_by_name(new_name)
+            if occupant is not None and occupant.id != team_id:
+                raise ValueError(f"Team with name {new_name} already exists")
+            current.name = new_name
+        if "description" in updates and updates["description"] is not None:
+            current.description = updates["description"].strip()
+        if "manager" in updates and updates["manager"] is not None:
+            manager = updates["manager"].strip()
+            if not manager:
+                raise ValueError("manager is required")
+            current.manager = manager
+        if "members" in updates and updates["members"] is not None:
+            current.members = list(updates["members"])
+        if "instructions" in updates and updates["instructions"] is not None:
+            current.instructions = _bounded(updates["instructions"])
+        if "project" in updates and updates["project"] is not None:
+            current.project = _bounded(updates["project"])
+        return self.save_team(current)
+
+    def save_team(self, team: Team) -> Team:
+        team_dir = self.teams_dir / team.id
+        team_dir.mkdir(parents=True, exist_ok=True)
+        payload = team.model_dump(mode="json", exclude={"instructions", "project"})
+        try:
+            with (team_dir / "team.yml").open("w", encoding="utf-8") as handle:
+                yaml.safe_dump(payload, handle, default_flow_style=False, sort_keys=False)
+            (team_dir / "instructions.md").write_text(team.instructions, encoding="utf-8")
+            (team_dir / "project.md").write_text(team.project, encoding="utf-8")
+        except Exception as exc:
+            raise Exception(f"Failed to save team metadata: {exc}") from exc
+        self._teams[team.id] = team
+        return team
+
+    def delete_team(self, team_id: str) -> None:
+        if team_id not in self._teams:
+            # Refresh once in case another process wrote it.
+            self._load()
+        if team_id not in self._teams:
+            raise KeyError(f"Team with id {team_id} not found")
+        self._teams.pop(team_id)
+        team_dir = self.teams_dir / team_id
+        if team_dir.exists():
+            import shutil
+
+            shutil.rmtree(team_dir)
+
+
+def parse_members(raw: Iterable[str] | None) -> list[TeamMember]:
+    """Parse ``coder`` / ``coder:2`` tokens into roster slots.
+
+    Two members of the same role collapse into one slot with a summed count
+    so a caller can pass ``--member coder --member coder`` or ``coder:2``.
+    """
+    slots: dict[str, int] = {}
+    order: list[str] = []
+    for token in raw or ():
+        text = (token or "").strip()
+        if not text:
+            continue
+        role, sep, count_text = text.partition(":")
+        role = role.strip()
+        if not role:
+            raise ValueError(f"invalid member {token!r}")
+        count = 1
+        if sep:
+            try:
+                count = int(count_text.strip())
+            except ValueError as exc:
+                raise ValueError(f"invalid member count in {token!r}") from exc
+        if count < 1:
+            raise ValueError(f"member count must be >= 1 in {token!r}")
+        if role not in slots:
+            order.append(role)
+            slots[role] = 0
+        slots[role] += count
+    return [TeamMember(role=role, count=slots[role]) for role in order]
+
+
+def _bounded(text: str) -> str:
+    body = text or ""
+    if len(body) > MAX_TEAM_INSTRUCTIONS_CHARS:
+        raise ValueError(
+            f"team instructions exceed {MAX_TEAM_INSTRUCTIONS_CHARS} characters; "
+            "they ride in front of every run of this team, so they must stay short."
+        )
+    return body
+
+
+def _read_optional(path: Path) -> str:
+    try:
+        if path.is_file():
+            return path.read_text(encoding="utf-8-sig", errors="replace")
+    except OSError:
+        logger.warning("could not read %s", path)
+    return ""

--- a/local_operator/teams.py
+++ b/local_operator/teams.py
@@ -1,7 +1,7 @@
 """Teams: a named roster of reusable agents under one manager.
 
 WHY THIS EXISTS
-===============
+---------------
 
 Roles and specialist agents are reusable building blocks — a ``coder`` or a
 "User Dashboard Agent" should be writable once and usable in many groupings.
@@ -25,7 +25,7 @@ A manager session also gets a roster so it can ``task(agent=...)`` the right
 people without the operator restating the org chart every turn.
 
 STORAGE
-=======
+-------
 
 ``<config_dir>/teams/<id>/``:
 

--- a/local_operator/teams.py
+++ b/local_operator/teams.py
@@ -303,8 +303,12 @@ class TeamRegistry:
             if not manager:
                 raise ValueError("manager is required")
             current.manager = manager
-        if "members" in updates and updates["members"] is not None:
-            current.members = list(updates["members"])
+        if "members" in fields.model_fields_set and fields.members is not None:
+            # ``model_dump`` recursively turns Pydantic children into dicts.
+            # Keep the validated TeamMember objects: roster rendering and
+            # orchestration call ``member.role`` / ``member.count`` immediately
+            # after an update, before a reload can rehydrate them from YAML.
+            current.members = list(fields.members)
         if "instructions" in updates and updates["instructions"] is not None:
             current.instructions = _bounded(updates["instructions"])
         if "project" in updates and updates["project"] is not None:

--- a/local_operator/tools/agent_tool.py
+++ b/local_operator/tools/agent_tool.py
@@ -78,28 +78,32 @@ class AgentParams(BaseModel):
         description=(
             "search: find a role by meaning; list/show: what exists and what it "
             "says; install: add a packaged starter; create/update: author or fix "
-            "a role."
+            "a role or a specialist profile."
         )
     )
-    name: str | None = Field(default=None, description="Role name (all ops but search).")
+    name: str | None = Field(
+        default=None, description="Role or specialist name (all ops but search)."
+    )
     query: str | None = Field(default=None, description="search: the task, in a sentence.")
     description: str | None = Field(
         default=None,
         description=(
-            "create/update: when to use this role. Semantic routing matches this, "
-            "so write the trigger condition, not a job title."
+            "create/update: when to use this profile. Semantic routing matches "
+            "this, so write the trigger condition, not a job title."
         ),
     )
     instructions: str | None = Field(
         default=None,
         description=(
-            "create/update: standing guidance prepended to every run of the role. "
-            "Imperative and short — it is billed on each of that role's turns."
+            "create/update: standing guidance prepended to every run of the "
+            "profile. Imperative and short — it is billed on each of that "
+            "profile's turns. This is the BASE behaviour; a team layers "
+            "collaboration and project briefs on top without rewriting it."
         ),
     )
     tools: list[str] | None = Field(
         default=None,
-        description="create/update: restrict the role to these tools. Omit for all.",
+        description="create/update: restrict the profile to these tools. Omit for all.",
     )
     effort: Literal["lo", "med", "hi", ""] | None = Field(
         default=None,
@@ -108,8 +112,18 @@ class AgentParams(BaseModel):
     delegate: bool | None = Field(
         default=None,
         description=(
-            "create/update: may this role launch its own subagents? Default no — "
-            "only coordinating roles should."
+            "create/update: may this profile launch its own subagents? Default "
+            "no — only coordinating roles should."
+        ),
+    )
+    kind: Literal["role", "specialist"] | None = Field(
+        default=None,
+        description=(
+            "create: 'role' (default) is a reusable delegation target tagged "
+            "for task(agent=...). 'specialist' is a durable named agent with "
+            "its own instruction set — a User Dashboard Agent, a support "
+            "triager — that can sit on a team roster without being a role. "
+            "Ignored on update: a profile cannot change kind."
         ),
     )
 
@@ -474,34 +488,58 @@ async def _op_write(
     except Exception:  # noqa: BLE001
         existing = None
 
-    # A name occupied by a NON-role is refused on both paths rather than being
-    # converted into one: an ordinary chat agent silently acquiring a role's
-    # tags and guidance is a surprising way to lose an agent, and on the update
-    # path it would be the same fail-open hijack the role tag exists to stop.
-    if existing is not None and not is_role(existing):
-        return _error(
-            tool_call_id,
-            "agent",
-            _name_taken_message(name),
-        )
-    if creating and existing is not None:
-        return _error(
-            tool_call_id,
-            "agent",
-            f"role {name!r} already exists; use op='update' to change it.",
-        )
-    if not creating and existing is None:
-        return _error(tool_call_id, "agent", f"no registered role named {name!r} to update.")
+    # Kind is chosen at CREATE and then frozen. An update that names the other
+    # kind is refused rather than converting the row: an ordinary specialist
+    # silently acquiring a role's tags (or a role losing them) is a surprising
+    # way to lose an agent, which is the fail-open hijack the role tag exists
+    # to stop.
+    if creating:
+        kind = params.kind or "role"
+        if existing is not None:
+            if kind == "role" and not is_role(existing):
+                return _error(tool_call_id, "agent", _name_taken_message(name))
+            return _error(
+                tool_call_id,
+                "agent",
+                f"{'role' if is_role(existing) else 'agent'} {name!r} already "
+                "exists; use op='update' to change it.",
+            )
+    else:
+        if existing is None:
+            return _error(
+                tool_call_id,
+                "agent",
+                f"no registered profile named {name!r} to update.",
+            )
+        if is_role(existing):
+            kind = "role"
+            if params.kind == "specialist":
+                return _error(
+                    tool_call_id,
+                    "agent",
+                    f"{name!r} is a role; do not pass kind='specialist' to update it.",
+                )
+        elif any(str(c).strip().lower() == "specialist" for c in (existing.categories or [])):
+            kind = "specialist"
+            if params.kind == "role":
+                return _error(tool_call_id, "agent", _name_taken_message(name))
+        else:
+            # An ordinary conversational agent is neither a role nor a
+            # specialist we authored. Converting it is the fail-open hijack
+            # the role tag exists to stop.
+            return _error(tool_call_id, "agent", _name_taken_message(name))
 
     instructions = (params.instructions or "").strip()
     if creating and not instructions:
-        return _error(tool_call_id, "agent", "create needs 'instructions' — the role's guidance.")
+        return _error(
+            tool_call_id, "agent", "create needs 'instructions' — the profile's guidance."
+        )
     if len(instructions) > MAX_INSTRUCTIONS_CHARS:
         return _error(
             tool_call_id,
             "agent",
             f"instructions exceed {MAX_INSTRUCTIONS_CHARS} chars; they ride in front of every "
-            "run of this role, so they must stay short.",
+            "run of this profile, so they must stay short.",
         )
 
     # An UPDATE merges onto the stored profile; only a CREATE starts from
@@ -546,10 +584,11 @@ async def _op_write(
         # hand-editing the tags.
         may_delegate=may_delegate,
     )
-    tags = list(seed_tags(profile))
+    tags = list(seed_tags(profile)) if kind == "role" else []
+    categories = ["role"] if kind == "role" else ["specialist"]
 
     # Every field is spelled out (``AgentEditFields`` is validated in strict
-    # mode, and every other caller in the tree does the same): a role inherits
+    # mode, and every other caller in the tree does the same): a profile inherits
     # the session's model and sampling settings rather than pinning any.
     def _fields(**overrides: Any) -> AgentEditFields:
         base: dict[str, Any] = dict(
@@ -576,23 +615,35 @@ async def _op_write(
 
     if existing is None:
         agent = registry.create_agent(
-            _fields(name=name, description=profile.description, tags=tags, categories=["role"])
+            _fields(
+                name=name,
+                description=profile.description,
+                tags=tags,
+                categories=categories,
+            )
         )
     else:
         agent = existing
         # An update carries only what changed: passing a None description here
         # would blank the routing text a previous create had set.
-        overrides: dict[str, Any] = {"tags": tags}
+        overrides: dict[str, Any] = {"tags": tags, "categories": categories}
         if profile.description:
             overrides["description"] = profile.description
         registry.update_agent(agent.id, _fields(**overrides))
     if instructions:
         registry.set_agent_system_prompt(agent.id, instructions)
     verb = "created" if existing is None else "updated"
+    if kind == "role":
+        how = f"launch with task(agent={name!r})"
+    else:
+        how = (
+            f"launch with --agent {name}, or put it on a team roster; "
+            "its instructions are the reusable base, not a team brief"
+        )
     return _text(
         tool_call_id,
         "agent",
-        f"{verb} role {name!r}; launch with task(agent={name!r}).",
+        f"{verb} {kind} {name!r}; {how}.",
     )
 
 
@@ -651,9 +702,11 @@ def build_agent_tool(context: ToolContext) -> AgentTool | None:
         name="agent",
         label="Agent roles",
         description=(
-            "Reusable role profiles for delegation (reviewer, coder, architect, "
-            "manager, designer, scout). Find, install, or author one; launch it "
-            "with task(agent='<name>')."
+            "Reusable agent profiles: delegation roles (reviewer, coder, "
+            "architect, manager, designer, scout) and specialists with their "
+            "own instruction sets. Find, install, or author one; launch a role "
+            "with task(agent='<name>'). A specialist is the reusable base a "
+            "team layers collaboration and project briefs on top of."
         ),
         parameters=AgentParams.model_json_schema(),
         # Writes land in the user's own configuration directory, never in the

--- a/local_operator/tools/agent_tool.py
+++ b/local_operator/tools/agent_tool.py
@@ -48,6 +48,7 @@ from local_operator.agent_profiles import (
     NameTakenError,
     install_seed,
     is_role,
+    is_specialist,
     list_seeds,
     load_seed,
     profile_from_agent,
@@ -232,6 +233,15 @@ async def _op_list(context: ToolContext | None, tool_call_id: str) -> ToolResult
     installed = _registered_profiles(registry) if registry is not None else []
     installed_names = {profile.name.lower() for profile in installed}
     lines = [_profile_line(profile, installed=True) for profile in installed]
+    specialists: list[Any] = []
+    if registry is not None:
+        try:
+            specialists = sorted(
+                (agent for agent in registry.list_agents() if is_specialist(agent)),
+                key=lambda agent: str(agent.name).lower(),
+            )
+        except Exception:  # noqa: BLE001 — listing is optional enrichment
+            specialists = []
     starters = [
         profile
         for profile in (load_seed(name) for name in list_seeds())
@@ -240,6 +250,14 @@ async def _op_list(context: ToolContext | None, tool_call_id: str) -> ToolResult
     body = ""
     if lines:
         body += "registered roles:\n" + "\n".join(lines)
+    if specialists:
+        if body:
+            body += "\n\n"
+        specialist_lines = []
+        for agent in specialists:
+            summary = (agent.description or "").strip() or "(no description)"
+            specialist_lines.append(f"- {agent.name} [specialist]: {summary}")
+        body += "registered specialists:\n" + "\n".join(specialist_lines)
     if starters:
         if body:
             body += "\n\n"
@@ -255,9 +273,30 @@ async def _op_list(context: ToolContext | None, tool_call_id: str) -> ToolResult
 async def _op_show(context: ToolContext | None, tool_call_id: str, name: str) -> ToolResult:
     from local_operator.agent_profiles import resolve_profile
 
-    profile = resolve_profile(name, registry=_registry(context))
+    registry = _registry(context)
+    profile = resolve_profile(name, registry=registry)
+    if profile is None and registry is not None:
+        try:
+            specialist = registry.get_agent_by_name(name)
+        except Exception:  # noqa: BLE001
+            specialist = None
+        if specialist is not None and is_specialist(specialist):
+            instructions = registry.get_agent_system_prompt(specialist.id) or "(none)"
+            body = (
+                f"{specialist.name} — registered specialist\n"
+                f"when to use: {specialist.description or '(unstated)'}\n"
+                "tools: full inventory\n\n"
+                f"instructions:\n{instructions}\n\n"
+                f"launch with --agent {specialist.name}, or add it to a team roster."
+            )
+            text, spill = spill_truncate(body, "agent", context)
+            return _text(tool_call_id, "agent", text, details=spill or None)
     if profile is None:
-        return _error(tool_call_id, "agent", f"no role named {name!r} (try op='list')")
+        return _error(
+            tool_call_id,
+            "agent",
+            f"no role or specialist named {name!r} (try op='list')",
+        )
     origin = "registered" if profile.agent_id else "packaged starter (not installed)"
     header = [
         f"{profile.name} — {origin}",
@@ -519,7 +558,7 @@ async def _op_write(
                     "agent",
                     f"{name!r} is a role; do not pass kind='specialist' to update it.",
                 )
-        elif any(str(c).strip().lower() == "specialist" for c in (existing.categories or [])):
+        elif is_specialist(existing):
             kind = "specialist"
             if params.kind == "role":
                 return _error(tool_call_id, "agent", _name_taken_message(name))

--- a/local_operator/tools/registry.py
+++ b/local_operator/tools/registry.py
@@ -18,8 +18,8 @@ from local_operator.harness.types import AgentTool, ToolContext
 from local_operator.tools import builtin
 from local_operator.tools.agent_tool import build_agent_tool
 from local_operator.tools.eval import build_eval_tool
-from local_operator.tools.team_tool import build_team_tool
 from local_operator.tools.lsp import build_lsp_tool
+from local_operator.tools.team_tool import build_team_tool
 from local_operator.web_search.tool import build_web_search_tool
 
 #: Factory table: tool name -> builder (createIf convention). ``wake`` takes

--- a/local_operator/tools/registry.py
+++ b/local_operator/tools/registry.py
@@ -19,7 +19,7 @@ from local_operator.tools import builtin
 from local_operator.tools.agent_tool import build_agent_tool
 from local_operator.tools.eval import build_eval_tool
 from local_operator.tools.lsp import build_lsp_tool
-from local_operator.tools.team_tool import build_team_tool
+from local_operator.tools.team_tool import build_team_delete_tool, build_team_tool
 from local_operator.web_search.tool import build_web_search_tool
 
 #: Factory table: tool name -> builder (createIf convention). ``wake`` takes
@@ -48,6 +48,7 @@ TOOL_BUILDERS: dict[str, Callable[[ToolContext], AgentTool | None]] = {
     "browser": lambda _context: builtin.build_browser_tool(_context),
     "agent": lambda context: build_agent_tool(context),
     "team": lambda context: build_team_tool(context),
+    "team_delete": lambda context: build_team_delete_tool(context),
 }
 
 #: Tool set used when the session does not restrict the names. Kept explicit
@@ -76,6 +77,7 @@ DEFAULT_TOOL_NAMES: list[str] = [
     "browser",
     "agent",
     "team",
+    "team_delete",
 ]
 
 

--- a/local_operator/tools/registry.py
+++ b/local_operator/tools/registry.py
@@ -18,6 +18,7 @@ from local_operator.harness.types import AgentTool, ToolContext
 from local_operator.tools import builtin
 from local_operator.tools.agent_tool import build_agent_tool
 from local_operator.tools.eval import build_eval_tool
+from local_operator.tools.team_tool import build_team_tool
 from local_operator.tools.lsp import build_lsp_tool
 from local_operator.web_search.tool import build_web_search_tool
 
@@ -46,6 +47,7 @@ TOOL_BUILDERS: dict[str, Callable[[ToolContext], AgentTool | None]] = {
     "read_variable": lambda _context: builtin.build_read_variable_tool(),
     "browser": lambda _context: builtin.build_browser_tool(_context),
     "agent": lambda context: build_agent_tool(context),
+    "team": lambda context: build_team_tool(context),
 }
 
 #: Tool set used when the session does not restrict the names. Kept explicit
@@ -73,6 +75,7 @@ DEFAULT_TOOL_NAMES: list[str] = [
     "read_variable",
     "browser",
     "agent",
+    "team",
 ]
 
 

--- a/local_operator/tools/team_tool.py
+++ b/local_operator/tools/team_tool.py
@@ -102,7 +102,8 @@ def _registry(context: ToolContext | None) -> TeamRegistry | None:
 def _row(team: Any) -> str:
     slots = len(team.members) + 1
     summary = (team.description or "").strip() or "(no description)"
-    row = f"- {team.name} [{slots} roles, manager={team.manager}]: {summary}"
+    role_word = "role" if slots == 1 else "roles"
+    row = f"- {team.name} [{slots} {role_word}, led by {team.manager}]: {summary}"
     return row if len(row) <= _ROW_CAP else row[: _ROW_CAP - 1].rstrip() + "…"
 
 
@@ -132,7 +133,7 @@ async def _op_show(context: ToolContext | None, tool_call_id: str, name: str) ->
     if team is None:
         return _error(tool_call_id, "team", f"no team named {name!r} (try op='list')")
     header = [
-        f"{team.name} — manager {team.manager}",
+        f"{team.name}. Led by {team.manager}",
         f"description: {team.description or '(unstated)'}",
         "roster:",
         *team.roster_lines(),
@@ -216,8 +217,8 @@ async def _op_write(
     return _text(
         tool_call_id,
         "team",
-        f"{verb} team {team.name!r} (manager {team.manager}, "
-        f"{len(team.members)} member slot(s)); launch with /team {team.name} <request>.",
+        f"{verb} team {team.name!r}. {team.manager} leads it; "
+        f"{len(team.members)} member slot(s). Launch with /team {team.name} <request>.",
     )
 
 

--- a/local_operator/tools/team_tool.py
+++ b/local_operator/tools/team_tool.py
@@ -288,6 +288,7 @@ class TeamDeleteParams(BaseModel):
     name: str = Field(description="Existing team name to delete permanently.")
 
 
+@_guard("team_delete")
 async def execute_team_delete(
     tool_call_id: str,
     args: dict[str, Any],

--- a/local_operator/tools/team_tool.py
+++ b/local_operator/tools/team_tool.py
@@ -1,0 +1,281 @@
+"""The ``team`` tool: discover, create, and refine reusable teams.
+
+A team is a named roster (manager + members) plus two instruction layers
+that do not belong on any one agent: how the group collaborates, and which
+product or domain this instance of the group is responsible for. Agents stay
+reusable; the team is what specialises them for a grouping.
+
+See :mod:`local_operator.teams` for storage and the layering contract, and
+``guide://teams`` for how an agent should work with a user to author one.
+
+CONTEXT DISCIPLINE
+==================
+
+The registry is NEVER enumerated into the prompt. ``list`` returns one line
+per team and only when called; ``show`` is the only op that returns the
+full briefs. Mirrors how roles and skills are handled.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+from local_operator.harness.types import (
+    AbortSignal,
+    AgentTool,
+    AgentToolUpdate,
+    ToolContext,
+    ToolResult,
+)
+from local_operator.teams import (
+    MAX_TEAM_INSTRUCTIONS_CHARS,
+    TeamEditFields,
+    TeamRegistry,
+    parse_members,
+)
+from local_operator.tools.builtin import (
+    _error,
+    _guard,
+    _text,
+    _validation_error,
+    spill_truncate,
+)
+
+logger = logging.getLogger(__name__)
+
+_ROW_CAP = 160
+
+
+class TeamParams(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    op: Literal["list", "show", "create", "update", "delete"] = Field(
+        description=(
+            "list/show: what teams exist and what they say; create/update: "
+            "author or fix a team; delete: remove one."
+        )
+    )
+    name: str | None = Field(default=None, description="Team name (all ops but list).")
+    description: str | None = Field(
+        default=None,
+        description="create/update: one line on what this team is for.",
+    )
+    manager: str | None = Field(
+        default=None,
+        description=(
+            "create/update: role or specialist who orchestrates. Defaults to "
+            "'manager'. Install that starter if the user has not authored one."
+        ),
+    )
+    members: list[str] | None = Field(
+        default=None,
+        description=(
+            "create/update: roster slots as 'role' or 'role:count'. "
+            "The same role can sit on many teams; counts spawn copies."
+        ),
+    )
+    instructions: str | None = Field(
+        default=None,
+        description=(
+            "create/update: how this team collaborates. Layered ON TOP of "
+            "each member's own instructions, never a replacement."
+        ),
+    )
+    project: str | None = Field(
+        default=None,
+        description=(
+            "create/update: the product or domain this instance of the team "
+            "is responsible for. Swap this to reuse the same roster on "
+            "another product."
+        ),
+    )
+
+
+def _registry(context: ToolContext | None) -> TeamRegistry | None:
+    raw = getattr(context, "team_registry", None) if context else None
+    return raw if isinstance(raw, TeamRegistry) else None
+
+
+def _row(team: Any) -> str:
+    slots = len(team.members) + 1
+    summary = (team.description or "").strip() or "(no description)"
+    row = f"- {team.name} [{slots} roles, manager={team.manager}]: {summary}"
+    return row if len(row) <= _ROW_CAP else row[: _ROW_CAP - 1].rstrip() + "…"
+
+
+async def _op_list(context: ToolContext | None, tool_call_id: str) -> ToolResult:
+    registry = _registry(context)
+    if registry is None:
+        return _error(tool_call_id, "team", "no team registry attached to this session.")
+    teams = registry.list_teams()
+    if not teams:
+        body = (
+            "no teams registered. Create one with op='create' after agreeing "
+            "the manager, the roster, how they collaborate, and (if this "
+            "instance owns a product) the project brief. Read guide://teams first."
+        )
+        return _text(tool_call_id, "team", body)
+    body = "registered teams:\n" + "\n".join(_row(team) for team in teams)
+    body += "\n\nlaunch with /team <name> <request>, or op='show' name='<name>'."
+    text, spill = spill_truncate(body, "team", context)
+    return _text(tool_call_id, "team", text, details=spill or None)
+
+
+async def _op_show(context: ToolContext | None, tool_call_id: str, name: str) -> ToolResult:
+    registry = _registry(context)
+    if registry is None:
+        return _error(tool_call_id, "team", "no team registry attached to this session.")
+    team = registry.get_team_by_name(name)
+    if team is None:
+        return _error(tool_call_id, "team", f"no team named {name!r} (try op='list')")
+    header = [
+        f"{team.name} — manager {team.manager}",
+        f"description: {team.description or '(unstated)'}",
+        "roster:",
+        *team.roster_lines(),
+    ]
+    body = "\n".join(header)
+    if team.instructions.strip():
+        body += "\n\ncollaboration:\n" + team.instructions.strip()
+    else:
+        body += "\n\ncollaboration: (none)"
+    if team.project.strip():
+        body += "\n\nproject:\n" + team.project.strip()
+    else:
+        body += "\n\nproject: (none)"
+    body += f"\n\nlaunch with /team {team.name} <request>."
+    text, spill = spill_truncate(body, "team", context)
+    return _text(tool_call_id, "team", text, details=spill or None)
+
+
+def _bounded_field(value: str | None, label: str) -> str | None:
+    if value is None:
+        return None
+    if len(value) > MAX_TEAM_INSTRUCTIONS_CHARS:
+        raise ValueError(
+            f"{label} exceed {MAX_TEAM_INSTRUCTIONS_CHARS} chars; they ride in "
+            "front of every run of this team, so they must stay short."
+        )
+    return value
+
+
+async def _op_write(
+    context: ToolContext | None,
+    tool_call_id: str,
+    params: TeamParams,
+    *,
+    creating: bool,
+) -> ToolResult:
+    registry = _registry(context)
+    if registry is None:
+        return _error(
+            tool_call_id, "team", "no team registry attached to this session; cannot save teams."
+        )
+    name = (params.name or "").strip()
+    existing = registry.get_team_by_name(name)
+    if creating and existing is not None:
+        return _error(
+            tool_call_id,
+            "team",
+            f"team {name!r} already exists; use op='update' to change it.",
+        )
+    if not creating and existing is None:
+        return _error(tool_call_id, "team", f"no team named {name!r} to update.")
+    try:
+        members = parse_members(params.members) if params.members is not None else None
+        instructions = _bounded_field(params.instructions, "collaboration instructions")
+        project = _bounded_field(params.project, "project instructions")
+    except ValueError as exc:
+        return _error(tool_call_id, "team", str(exc))
+
+    fields = TeamEditFields(
+        name=name if creating else None,
+        description=params.description,
+        manager=params.manager,
+        members=members,
+        instructions=instructions,
+        project=project,
+    )
+    try:
+        if creating:
+            if not (params.manager or "").strip():
+                fields.manager = "manager"
+            team = registry.create_team(fields)
+            verb = "created"
+        else:
+            assert existing is not None  # guarded above
+            team = registry.update_team(existing.id, fields)
+            verb = "updated"
+    except ValueError as exc:
+        return _error(tool_call_id, "team", str(exc))
+    except Exception as exc:  # noqa: BLE001
+        return _error(tool_call_id, "team", f"could not save team: {exc}")
+    return _text(
+        tool_call_id,
+        "team",
+        f"{verb} team {team.name!r} (manager {team.manager}, "
+        f"{len(team.members)} member slot(s)); launch with /team {team.name} <request>.",
+    )
+
+
+async def _op_delete(context: ToolContext | None, tool_call_id: str, name: str) -> ToolResult:
+    registry = _registry(context)
+    if registry is None:
+        return _error(tool_call_id, "team", "no team registry attached to this session.")
+    team = registry.get_team_by_name(name)
+    if team is None:
+        return _error(tool_call_id, "team", f"no team named {name!r} to delete.")
+    try:
+        registry.delete_team(team.id)
+    except Exception as exc:  # noqa: BLE001
+        return _error(tool_call_id, "team", f"could not delete team: {exc}")
+    return _text(tool_call_id, "team", f"deleted team {name!r}.")
+
+
+@_guard("team")
+async def execute_team(
+    tool_call_id: str,
+    args: dict[str, Any],
+    signal: AbortSignal | None = None,
+    on_update: Callable[[AgentToolUpdate], None] | None = None,
+    context: ToolContext | None = None,
+) -> ToolResult:
+    """Discover, author, and remove reusable teams."""
+    try:
+        params = TeamParams(**args)
+    except ValidationError as exc:
+        return _validation_error(tool_call_id, "team", exc)
+
+    if params.op in {"show", "create", "update", "delete"} and not (params.name or "").strip():
+        return _error(tool_call_id, "team", f"op={params.op!r} needs 'name'.")
+    if params.op == "list":
+        return await _op_list(context, tool_call_id)
+    if params.op == "show":
+        return await _op_show(context, tool_call_id, str(params.name))
+    if params.op == "delete":
+        return await _op_delete(context, tool_call_id, str(params.name))
+    return await _op_write(context, tool_call_id, params, creating=params.op == "create")
+
+
+def build_team_tool(context: ToolContext) -> AgentTool | None:
+    """createIf: the tool exists only where a registry can back it."""
+    if getattr(context, "team_registry", None) is None:
+        return None
+    return AgentTool(
+        name="team",
+        label="Teams",
+        description=(
+            "Reusable teams: a manager plus members (roles or specialists, "
+            "with counts), plus collaboration and project briefs layered on "
+            "top of each member's own instructions. Find, author, or delete "
+            "one; the user launches it with /team <name> <request>."
+        ),
+        parameters=TeamParams.model_json_schema(),
+        approval_tier="read",
+        concurrency="exclusive",
+        interruptible=False,
+        execute=execute_team,
+    )

--- a/local_operator/tools/team_tool.py
+++ b/local_operator/tools/team_tool.py
@@ -52,10 +52,10 @@ _ROW_CAP = 160
 class TeamParams(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    op: Literal["list", "show", "create", "update", "delete"] = Field(
+    op: Literal["list", "show", "create", "update"] = Field(
         description=(
             "list/show: what teams exist and what they say; create/update: "
-            "author or fix a team; delete: remove one."
+            "author or fix a team. Use team_delete for irreversible removal."
         )
     )
     name: str | None = Field(default=None, description="Team name (all ops but list).")
@@ -225,15 +225,15 @@ async def _op_write(
 async def _op_delete(context: ToolContext | None, tool_call_id: str, name: str) -> ToolResult:
     registry = _registry(context)
     if registry is None:
-        return _error(tool_call_id, "team", "no team registry attached to this session.")
+        return _error(tool_call_id, "team_delete", "no team registry attached to this session.")
     team = registry.get_team_by_name(name)
     if team is None:
-        return _error(tool_call_id, "team", f"no team named {name!r} to delete.")
+        return _error(tool_call_id, "team_delete", f"no team named {name!r} to delete.")
     try:
         registry.delete_team(team.id)
     except Exception as exc:  # noqa: BLE001
-        return _error(tool_call_id, "team", f"could not delete team: {exc}")
-    return _text(tool_call_id, "team", f"deleted team {name!r}.")
+        return _error(tool_call_id, "team_delete", f"could not delete team: {exc}")
+    return _text(tool_call_id, "team_delete", f"deleted team {name!r}.")
 
 
 @_guard("team")
@@ -244,20 +244,18 @@ async def execute_team(
     on_update: Callable[[AgentToolUpdate], None] | None = None,
     context: ToolContext | None = None,
 ) -> ToolResult:
-    """Discover, author, and remove reusable teams."""
+    """Discover and author reusable teams."""
     try:
         params = TeamParams(**args)
     except ValidationError as exc:
         return _validation_error(tool_call_id, "team", exc)
 
-    if params.op in {"show", "create", "update", "delete"} and not (params.name or "").strip():
+    if params.op in {"show", "create", "update"} and not (params.name or "").strip():
         return _error(tool_call_id, "team", f"op={params.op!r} needs 'name'.")
     if params.op == "list":
         return await _op_list(context, tool_call_id)
     if params.op == "show":
         return await _op_show(context, tool_call_id, str(params.name))
-    if params.op == "delete":
-        return await _op_delete(context, tool_call_id, str(params.name))
     return await _op_write(context, tool_call_id, params, creating=params.op == "create")
 
 
@@ -271,12 +269,60 @@ def build_team_tool(context: ToolContext) -> AgentTool | None:
         description=(
             "Reusable teams: a manager plus members (roles or specialists, "
             "with counts), plus collaboration and project briefs layered on "
-            "top of each member's own instructions. Find, author, or delete "
-            "one; the user launches it with /team <name> <request>."
+            "top of each member's own instructions. Find or author one; use "
+            "team_delete for irreversible removal. The user launches it with "
+            "/team <name> <request>."
         ),
         parameters=TeamParams.model_json_schema(),
         approval_tier="read",
         concurrency="exclusive",
         interruptible=False,
         execute=execute_team,
+    )
+
+
+class TeamDeleteParams(BaseModel):
+    """Separate schema so irreversible removal can carry a write-tier gate."""
+
+    model_config = ConfigDict(extra="forbid")
+    name: str = Field(description="Existing team name to delete permanently.")
+
+
+async def execute_team_delete(
+    tool_call_id: str,
+    args: dict[str, Any],
+    signal: AbortSignal | None = None,
+    on_update: Callable[[AgentToolUpdate], None] | None = None,
+    context: ToolContext | None = None,
+) -> ToolResult:
+    """Delete one team after the loop has passed the write approval gate."""
+    try:
+        params = TeamDeleteParams(**args)
+    except ValidationError as exc:
+        return _validation_error(tool_call_id, "team_delete", exc)
+    name = params.name.strip()
+    if not name:
+        return _error(tool_call_id, "team_delete", "name must not be empty.")
+    return await _op_delete(context, tool_call_id, name)
+
+
+def build_team_delete_tool(context: ToolContext) -> AgentTool | None:
+    """createIf: destructive deletion exists only beside a real registry."""
+    if getattr(context, "team_registry", None) is None:
+        return None
+    return AgentTool(
+        name="team_delete",
+        label="Delete team",
+        description=(
+            "Permanently remove a saved team. This is separate from the team "
+            "authoring tool so deletion always asks for write approval."
+        ),
+        parameters=TeamDeleteParams.model_json_schema(),
+        approval_tier="write",
+        concurrency="exclusive",
+        interruptible=False,
+        describe_approval=lambda args, _cwd: (
+            f"Delete team {str(args.get('name') or '').strip()!r} permanently"
+        ),
+        execute=execute_team_delete,
     )

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -31,6 +31,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, NamedTuple, Protocol, cast
 
 from rich.console import Group
+from rich.padding import Padding
 from rich.style import Style
 from rich.terminal_theme import TerminalTheme
 from rich.text import Text
@@ -2586,10 +2587,39 @@ class OperatorApp(App[None]):
                 ArgumentChoice(
                     team.name,
                     description,
-                    detail=f"{slots} roles · {manager}",
+                    detail=f"{slots} roles · led by {manager}",
                 )
             )
         return choices
+
+    def _team_list_block(self, teams: list[Any]) -> RichBlock:
+        """A structured roster list for bare ``/team``.
+
+        Each team gets its own name row, facts row, and optional description
+        row. Keeping fields on separate rows prevents a narrow terminal from
+        wrapping ``roles`` or the description into a position that reads as a
+        child of the next item — the flat debug-style line this replaces did
+        exactly that at both 100 and 60 columns.
+        """
+        heading = Style(color=theme_mod.semantic_color("muted"))
+        body = Style(color=theme_mod.semantic_color("dim"))
+        rows: list[Any] = [Text("teams", style=heading)]
+        for team in teams:
+            slots = len(team.members) + 1
+            rows.append(Padding(Text(team.name, style=heading), (0, 0, 0, 2)))
+            role_word = "role" if slots == 1 else "roles"
+            rows.append(
+                Padding(
+                    Text(f"Led by {team.manager} · {slots} {role_word}", style=body),
+                    (0, 0, 0, 4),
+                )
+            )
+            summary = (team.description or "").strip()
+            if summary:
+                rows.append(Padding(Text(summary, style=body), (0, 0, 0, 4)))
+        rows.append(Text())
+        rows.append(Text("Send: /team <name> <message>", style=body))
+        return RichBlock(Group(*rows))
 
     def _cmd_team(self, arg: str, notice: NoticeFn) -> None:
         """``/team`` — list; ``/team <name> <request>`` — talk to the manager.
@@ -2606,7 +2636,7 @@ class OperatorApp(App[None]):
         registry = self._team_registry()
         if registry is None or not hasattr(registry, "list_teams"):
             self._system_notice(
-                "teams are unavailable in this session — create one with the team tool",
+                "teams are unavailable in this session. Ask the agent to create one.",
                 "warning",
             )
             return
@@ -2617,19 +2647,9 @@ class OperatorApp(App[None]):
                 self._system_notice(f"could not list teams: {exc}", "warning")
                 return
             if not teams:
-                notice(
-                    "no teams yet — ask the agent to create one, or "
-                    "`lop teams create <name> --member coder`"
-                )
+                notice("no teams yet. Ask the agent to create one.")
                 return
-            lines = ["teams:"]
-            for team in teams:
-                slots = len(team.members) + 1
-                summary = (team.description or "").strip()
-                extra = f" — {summary}" if summary else ""
-                lines.append(f"  {team.name}  manager={team.manager}  {slots} roles{extra}")
-            lines.append("send a request with /team <name> <message>")
-            notice("\n".join(lines))
+            self._append_block(self._team_list_block(teams))
             return
         name, _, request = arg.partition(" ")
         name = name.strip()
@@ -2641,7 +2661,7 @@ class OperatorApp(App[None]):
             return
         if team is None:
             self._system_notice(
-                f"no team named {name!r} — /team to list them, or ask the agent to create one",
+                f"no team named {name!r}. Run /team to list teams, or ask the agent to create one.",
                 "warning",
             )
             return
@@ -2654,8 +2674,8 @@ class OperatorApp(App[None]):
                 return
         if not request:
             notice(
-                f"team {team.name} attached (manager {team.manager}). "
-                f"/team {team.name} <message> to send a request."
+                f"team {team.name} is ready. {team.manager} leads it. "
+                f"Send a request with /team {team.name} <message>."
             )
             return
         # `_submit_prompt` writes the user row (the request is what the
@@ -2663,7 +2683,7 @@ class OperatorApp(App[None]):
         # not echoed: the request text is the transcript subject, and a
         # second row restating `/team name …` would be the duplication
         # the echo policy exists to prevent.
-        notice(f"sending to {team.name}'s manager ({team.manager})")
+        notice(f"sending to {team.name}. {team.manager} is coordinating.")
         self._submit_prompt(request)
 
     # -- MCP status ---------------------------------------------------------

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -479,6 +479,16 @@ SLASH_COMMANDS: list[SlashCommand] = [
         aliases=("cred",),
         arguments=ArgumentMode.OPTIONAL,
     ),
+    # NOT an echo. `/team <name> <request>` does reach the model, but as
+    # the request text itself via `_submit_prompt`, which already writes
+    # the user row. Echoing the slash line would duplicate it. Bare
+    # `/team` is a listing and the listing is the receipt.
+    SlashCommand(
+        "team",
+        "List teams, or send a request to a team's manager",
+        aliases=("teams",),
+        arguments=ArgumentMode.OPTIONAL,
+    ),
 ]
 
 
@@ -2552,6 +2562,109 @@ class OperatorApp(App[None]):
         self._session_factory = lambda: self._resume_factory(None)  # type: ignore[misc]
         notice("starting a new session…")
         self.run_worker(self._reload_session(), thread=False, group="session")
+
+    def _team_registry(self) -> Any | None:
+        """The session's team registry, or None when the host keeps none."""
+        session = self._session
+        return getattr(session, "team_registry", None) if session is not None else None
+
+    def _team_choices(self) -> list[ArgumentChoice]:
+        """Teams the ``/team`` argument list offers, one row per name."""
+        registry = self._team_registry()
+        if registry is None or not hasattr(registry, "list_teams"):
+            return []
+        try:
+            teams = list(registry.list_teams())
+        except Exception:
+            return []
+        choices: list[ArgumentChoice] = []
+        for team in teams:
+            slots = len(getattr(team, "members", ()) or ()) + 1
+            manager = getattr(team, "manager", "manager")
+            description = (getattr(team, "description", "") or "").strip() or "no description"
+            choices.append(
+                ArgumentChoice(
+                    team.name,
+                    description,
+                    detail=f"{slots} roles · {manager}",
+                )
+            )
+        return choices
+
+    def _cmd_team(self, arg: str, notice: NoticeFn) -> None:
+        """``/team`` — list; ``/team <name> <request>`` — talk to the manager.
+
+        Bare ``/team`` is a listing, so it does not echo. A named team with a
+        request attaches that team to this session (stamping the roster and
+        briefs onto the manager) and sends the request as a real user turn —
+        the one case besides ``/goal`` whose argument reaches the model.
+        """
+        session = self._session
+        if session is None:
+            self._system_notice("session is still starting…", "warning")
+            return
+        registry = self._team_registry()
+        if registry is None or not hasattr(registry, "list_teams"):
+            self._system_notice(
+                "teams are unavailable in this session — create one with the team tool",
+                "warning",
+            )
+            return
+        if not arg:
+            try:
+                teams = list(registry.list_teams())
+            except Exception as exc:
+                self._system_notice(f"could not list teams: {exc}", "warning")
+                return
+            if not teams:
+                notice(
+                    "no teams yet — ask the agent to create one, or "
+                    "`lop teams create <name> --member coder`"
+                )
+                return
+            lines = ["teams:"]
+            for team in teams:
+                slots = len(team.members) + 1
+                summary = (team.description or "").strip()
+                extra = f" — {summary}" if summary else ""
+                lines.append(f"  {team.name}  manager={team.manager}  {slots} roles{extra}")
+            lines.append("send a request with /team <name> <message>")
+            notice("\n".join(lines))
+            return
+        name, _, request = arg.partition(" ")
+        name = name.strip()
+        request = request.strip()
+        try:
+            team = registry.get_team_by_name(name)
+        except Exception as exc:
+            self._system_notice(f"could not load team {name!r}: {exc}", "warning")
+            return
+        if team is None:
+            self._system_notice(
+                f"no team named {name!r} — /team to list them, or ask the agent to create one",
+                "warning",
+            )
+            return
+        attach = getattr(session, "attach_team", None)
+        if callable(attach):
+            try:
+                attach(team)
+            except Exception as exc:
+                self._system_notice(f"could not attach team {name!r}: {exc}", "warning")
+                return
+        if not request:
+            notice(
+                f"team {team.name} attached (manager {team.manager}). "
+                f"/team {team.name} <message> to send a request."
+            )
+            return
+        # `_submit_prompt` writes the user row (the request is what the
+        # manager is told) and starts the turn. The slash line itself is
+        # not echoed: the request text is the transcript subject, and a
+        # second row restating `/team name …` would be the duplication
+        # the echo policy exists to prevent.
+        notice(f"sending to {team.name}'s manager ({team.manager})")
+        self._submit_prompt(request)
 
     # -- MCP status ---------------------------------------------------------
     def _wire_mcp_status(self, session: SessionProtocol) -> None:
@@ -6501,6 +6614,8 @@ class OperatorApp(App[None]):
             self._cmd_logout(arg, notice)
         elif command == "/credential":
             self._cmd_credential(arg, notice)
+        elif command == "/team":
+            self._cmd_team(arg, notice)
         else:
             # ``parts[0]``, not the lowered ``command``: with the echo gone this
             # line is the ONLY place the mistyped word appears, so it has to
@@ -8596,6 +8711,10 @@ class OperatorApp(App[None]):
             return
         if message.command in ("credential", "cred"):
             picker.set_choices(self._credential_choices())
+            picker.set_notice("")
+            return
+        if message.command in ("team", "teams"):
+            picker.set_choices(self._team_choices())
             picker.set_notice("")
             return
         if message.command == "effort":

--- a/local_operator/tui/widgets/welcome.py
+++ b/local_operator/tui/widgets/welcome.py
@@ -265,9 +265,9 @@ HINT_KEY_WIDTH_TIGHT = max(cell_len(key) for key, _ in HINTS) + 1
 #: is why it is resumption, the single question a returning user arrives with.
 TIPS: tuple[str, ...] = (
     "/resume picks up a recent session where you left off",
-    "/team <name> sends a request to that team's manager",
+    "/team <name> <message> sends work to the manager",
     "Ask to create an agent with its own instruction set",
-    "Ask for a team of roles — manager, coder, reviewer",
+    "Ask for a team of roles: manager, coder, reviewer",
     "/model <provider>/<id> switches this session only",
     "/usage shows how much provider quota is left",
     "/approvals <ask|auto> sets whether tools ask first",

--- a/local_operator/tui/widgets/welcome.py
+++ b/local_operator/tui/widgets/welcome.py
@@ -265,16 +265,16 @@ HINT_KEY_WIDTH_TIGHT = max(cell_len(key) for key, _ in HINTS) + 1
 #: is why it is resumption, the single question a returning user arrives with.
 TIPS: tuple[str, ...] = (
     "/resume picks up a recent session where you left off",
+    "/team <name> sends a request to that team's manager",
+    "Ask to create an agent with its own instruction set",
+    "Ask for a team of roles — manager, coder, reviewer",
     "/model <provider>/<id> switches this session only",
-    "/model default saves this for new sessions",
     "/usage shows how much provider quota is left",
     "/approvals <ask|auto> sets whether tools ask first",
     "Type as the agent works — it is sent at the next step",
     "esc stops the agent without ending the session",
     "Ask for parallel work and the agent fans out subagents",
-    "Compaction runs itself when the context window fills",
     "/mcp lists the MCP servers found in your mcp.json",
-    "/skills lists the skills loaded for this session",
     "/goal sets the objective that /loop iterates toward",
 )
 

--- a/tests/unit/guides/test_guides.py
+++ b/tests/unit/guides/test_guides.py
@@ -28,6 +28,7 @@ def test_packaged_catalog_is_small_and_descriptions_are_prompt_sized() -> None:
         "extensions",
         "mcp",
         "mobile",
+        "teams",
     ]
     assert all(guide.resource_type == "guide" for guide in guides)
     assert all(40 <= len(guide.description) <= 180 for guide in guides)

--- a/tests/unit/session/test_launch_subagent.py
+++ b/tests/unit/session/test_launch_subagent.py
@@ -121,6 +121,41 @@ async def test_launch_subagent_runs_child_and_emits_lifecycle(tmp_path, monkeypa
 
 
 @pytest.mark.asyncio
+async def test_a_team_parent_stamps_the_member_brief_on_the_child(tmp_path, monkeypatch):
+    """A manager session's children inherit collaboration and project context
+    without the manager restating them in the task prompt."""
+    from datetime import datetime, timezone
+
+    from local_operator.teams import Team, TeamMember
+
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    stream = OneShotStream()
+    parent = make_session(tmp_path, stream)
+    parent.attach_team(
+        Team(
+            id="t1",
+            name="feature-release",
+            created_date=datetime.now(timezone.utc),
+            manager="manager",
+            members=[TeamMember(role="coder")],
+            instructions="Review before merge.",
+            project="user-dashboard",
+        )
+    )
+    events: list[AgentEvent] = []
+    parent.subscribe(events.append)
+    parent._launch_subagent(label="code", prompt="implement the button", agent="coder")
+    await wait_for(lambda: any(e.type == "subagent_end" for e in events))
+    child_prompt = stream.requests[0].messages[0].text
+    assert "[team: feature-release]" in child_prompt
+    assert "You are coder on this team" in child_prompt
+    assert "Review before merge." in child_prompt
+    assert "user-dashboard" in child_prompt
+    assert "implement the button" in child_prompt
+    await parent.dispose()
+
+
+@pytest.mark.asyncio
 async def test_launch_subagent_is_wired_as_subagent_launcher(tmp_path, monkeypatch):
     """The ToolContext built for a turn carries _launch_subagent as the
     subagent_launcher, so the task tool can call it."""

--- a/tests/unit/session/test_launch_subagent.py
+++ b/tests/unit/session/test_launch_subagent.py
@@ -120,6 +120,40 @@ async def test_launch_subagent_runs_child_and_emits_lifecycle(tmp_path, monkeypa
     await parent.dispose()
 
 
+def test_attach_team_layers_specialist_manager_instructions(tmp_path, monkeypatch):
+    from datetime import datetime, timezone
+
+    from local_operator.agents import AgentEditFields, AgentRegistry
+    from local_operator.teams import Team, TeamMember
+
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    registry = AgentRegistry(tmp_path / "config")
+    manager = registry.create_agent(
+        AgentEditFields(
+            name="dashboard-release",
+            description="Release the dashboard",
+            categories=["specialist"],
+        )
+    )
+    registry.set_agent_system_prompt(manager.id, "Follow the dashboard release checklist.")
+    parent = make_session(tmp_path, OneShotStream(), agent_registry=registry)
+
+    parent.attach_team(
+        Team(
+            id="t1",
+            name="feature-release",
+            created_date=datetime.now(timezone.utc),
+            manager="dashboard-release",
+            members=[TeamMember(role="coder")],
+            instructions="Review before merge.",
+        )
+    )
+
+    brief = parent._goal_state.team_brief
+    assert "Follow the dashboard release checklist." in brief
+    assert "Review before merge." in brief
+
+
 @pytest.mark.asyncio
 async def test_a_team_parent_stamps_the_member_brief_on_the_child(tmp_path, monkeypatch):
     """A manager session's children inherit collaboration and project context

--- a/tests/unit/session/test_launch_subagent.py
+++ b/tests/unit/session/test_launch_subagent.py
@@ -120,6 +120,57 @@ async def test_launch_subagent_runs_child_and_emits_lifecycle(tmp_path, monkeypa
     await parent.dispose()
 
 
+def _agent_fields(**overrides):
+    from typing import Any
+
+    from local_operator.agents import AgentEditFields
+
+    base: dict[str, Any] = dict(
+        name=None,
+        description=None,
+        tags=None,
+        categories=None,
+        security_prompt=None,
+        hosting=None,
+        model=None,
+        last_message=None,
+        temperature=None,
+        top_p=None,
+        top_k=None,
+        max_tokens=None,
+        stop=None,
+        frequency_penalty=None,
+        presence_penalty=None,
+        seed=None,
+        current_working_directory=None,
+    )
+    base.update(overrides)
+    return AgentEditFields(**base)
+
+
+def test_subagent_only_loads_explicit_specialist_instructions(tmp_path):
+    from local_operator.agents import AgentRegistry
+    from local_operator.harness.subagent import _specialist_instructions
+
+    registry = AgentRegistry(tmp_path / "config")
+    private = registry.create_agent(
+        _agent_fields(name="private-chat", description="Personal notes")
+    )
+    specialist = registry.create_agent(
+        _agent_fields(
+            name="dashboard-release",
+            description="Release the dashboard",
+            categories=["specialist"],
+        )
+    )
+    registry.set_agent_system_prompt(private.id, "PRIVATE USER CONTEXT")
+    registry.set_agent_system_prompt(specialist.id, "Follow the release checklist.")
+    parent = make_session(tmp_path, OneShotStream(), agent_registry=registry)
+
+    assert _specialist_instructions("private-chat", parent) == ""
+    assert _specialist_instructions("dashboard-release", parent) == "Follow the release checklist."
+
+
 def test_attach_team_layers_specialist_manager_instructions(tmp_path, monkeypatch):
     from datetime import datetime, timezone
 

--- a/tests/unit/session/test_launch_subagent.py
+++ b/tests/unit/session/test_launch_subagent.py
@@ -131,8 +131,22 @@ def test_attach_team_layers_specialist_manager_instructions(tmp_path, monkeypatc
     manager = registry.create_agent(
         AgentEditFields(
             name="dashboard-release",
+            security_prompt=None,
+            hosting=None,
+            model=None,
             description="Release the dashboard",
+            tags=None,
             categories=["specialist"],
+            last_message=None,
+            temperature=None,
+            top_p=None,
+            top_k=None,
+            max_tokens=None,
+            stop=None,
+            frequency_penalty=None,
+            presence_penalty=None,
+            seed=None,
+            current_working_directory=None,
         )
     )
     registry.set_agent_system_prompt(manager.id, "Follow the dashboard release checklist.")

--- a/tests/unit/session/test_tool_context_parity.py
+++ b/tests/unit/session/test_tool_context_parity.py
@@ -65,6 +65,10 @@ SENTINELS: dict[str, Any] = {
     # silently see no registry: role lookups would fall back to the packaged
     # starters and every profile the operator authored would be invisible.
     "agent_registry": object(),
+    # The team registry backs the ``team`` / ``team_delete`` tools and the
+    # ``/team`` slash command. Dropped on the way to the executor, teams would
+    # silently vanish from a session that was built with them.
+    "team_registry": object(),
 }
 
 #: ToolContext fields the Session takes under a DIFFERENT name. Kept tiny and

--- a/tests/unit/test_agents.py
+++ b/tests/unit/test_agents.py
@@ -1665,6 +1665,7 @@ def test_import_agent_and_export_agent_roundtrip(temp_agents_dir: Path):
     assert imported_agent.model == ""
     assert imported_agent.hosting == ""
     assert imported_agent.description == agent.description
+    assert imported_agent.last_message == ""
     assert imported_agent.tags == agent.tags
     assert imported_agent.categories == agent.categories
 

--- a/tests/unit/test_agents.py
+++ b/tests/unit/test_agents.py
@@ -1669,6 +1669,104 @@ def test_import_agent_and_export_agent_roundtrip(temp_agents_dir: Path):
     assert imported_agent.categories == agent.categories
 
 
+def test_export_strips_conversation_history(temp_agents_dir: Path):
+    """A published archive is the instruction set, never the operator's history."""
+    registry = AgentRegistry(temp_agents_dir)
+    agent = registry.create_agent(
+        AgentEditFields(
+            name="PrivateHistory",
+            security_prompt="prompt",
+            hosting="host",
+            model="model",
+            description="desc",
+            last_message="secret last message",
+            tags=[],
+            categories=[],
+            temperature=None,
+            top_p=None,
+            top_k=None,
+            max_tokens=None,
+            stop=None,
+            frequency_penalty=None,
+            presence_penalty=None,
+            seed=None,
+            current_working_directory=None,
+        )
+    )
+    registry.set_agent_system_prompt(agent.id, "You review Python.")
+    registry.save_agent_state(
+        agent.id,
+        AgentState(
+            version="",
+            conversation=[
+                ConversationRecord(role=ConversationRole.USER, content="do not publish me")
+            ],
+            execution_history=[],
+            learnings=["private learning"],
+            current_plan="secret plan",
+            instruction_details="secret details",
+            agent_system_prompt="You review Python.",
+        ),
+    )
+    zip_path, _ = registry.export_agent(agent.id)
+    with zipfile.ZipFile(zip_path, "r") as archive:
+        names = set(archive.namelist())
+    assert "agent.yml" in names
+    assert "system_prompt.md" in names
+    assert "conversation.jsonl" not in names
+    assert "execution_history.jsonl" not in names
+    assert "learnings.jsonl" not in names
+    assert "schedules.jsonl" not in names
+    assert "context.pkl" not in names
+    assert "current_plan.txt" not in names
+    assert "instruction_details.txt" not in names
+    with zipfile.ZipFile(zip_path, "r") as archive:
+        dumped = yaml.safe_load(archive.read("agent.yml"))
+    assert dumped["last_message"] == ""
+
+
+def test_import_strips_history_from_an_older_archive(temp_agents_dir: Path):
+    """A hub zip from before the strip still must not land private history."""
+    registry = AgentRegistry(temp_agents_dir)
+    zip_path = temp_agents_dir / "leaky.zip"
+    agent_data = {
+        "id": "leaky-agent",
+        "name": "Leaky",
+        "created_date": datetime.now(timezone.utc).isoformat(),
+        "version": "0.1.0",
+        "security_prompt": "",
+        "hosting": "",
+        "model": "",
+        "description": "desc",
+        "last_message": "",
+        "last_message_datetime": datetime.now(timezone.utc).isoformat(),
+        "current_working_directory": ".",
+        "tags": [],
+        "categories": [],
+    }
+    with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zip_file:
+        zip_file.writestr("agent.yml", yaml.dump(agent_data))
+        zip_file.writestr("system_prompt.md", "You are a specialist.")
+        zip_file.writestr("conversation.jsonl", '{"content": "private"}\n')
+        zip_file.writestr("learnings.jsonl", '{"learning": "secret"}\n')
+        zip_file.writestr("context.pkl", b"not-a-real-pickle")
+    imported = registry.import_agent(zip_path)
+    imported_dir = registry.agents_dir / imported.id
+    assert (imported_dir / "system_prompt.md").read_text() == "You are a specialist."
+    assert (
+        not (imported_dir / "conversation.jsonl").exists()
+        or (imported_dir / "conversation.jsonl").stat().st_size == 0
+    )
+    assert (
+        not (imported_dir / "learnings.jsonl").exists()
+        or (imported_dir / "learnings.jsonl").stat().st_size == 0
+    )
+    assert not (imported_dir / "context.pkl").exists()
+    state = registry.load_agent_state(imported.id)
+    assert state.conversation == []
+    assert state.learnings == []
+
+
 def test_import_agent_rejects_zip_with_path_traversal(temp_agents_dir: Path):
     """Import should reject archives containing unsafe traversal paths."""
     registry = AgentRegistry(temp_agents_dir)

--- a/tests/unit/test_cli_new.py
+++ b/tests/unit/test_cli_new.py
@@ -165,6 +165,32 @@ def test_agents_create_positional(parser: argparse.ArgumentParser) -> None:
     assert args.name == "NewAgent"
 
 
+def test_teams_subcommands(parser: argparse.ArgumentParser) -> None:
+    assert parser.parse_args(["teams", "list"]).teams_command == "list"
+    created = parser.parse_args(
+        [
+            "teams",
+            "create",
+            "feature-release",
+            "--manager",
+            "manager",
+            "--member",
+            "coder",
+            "--member",
+            "reviewer:2",
+        ]
+    )
+    assert created.teams_command == "create"
+    assert created.name == "feature-release"
+    assert created.manager == "manager"
+    assert created.members == ["coder", "reviewer:2"]
+    shown = parser.parse_args(["teams", "show", "feature-release"])
+    assert shown.teams_command == "show"
+    deleted = parser.parse_args(["teams", "delete", "--name", "feature-release"])
+    assert deleted.teams_command == "delete"
+    assert deleted.name == "feature-release"
+
+
 @pytest.mark.parametrize(
     ("argv", "name", "agent_id"),
     [

--- a/tests/unit/test_prompts_api.py
+++ b/tests/unit/test_prompts_api.py
@@ -264,6 +264,7 @@ def test_inventory_block_matches_default_tool_order() -> None:
             # only its PRESENCE is read here, since this test is about the
             # ORDER of a fully-capable inventory.
             agent_registry=object(),
+            team_registry=object(),
         )
     )
     blocks = build_system_blocks(tools, "", ENV, DATE)
@@ -376,6 +377,19 @@ def test_credentials_ride_the_volatile_tail_as_names_only() -> None:
     # Idle sessions pay nothing: no names means no block.
     idle = build_system_blocks(TOOLS, SKILLS, ENV, DATE)
     assert "<session-credentials>" not in idle[3]
+
+
+def test_team_brief_rides_the_volatile_tail() -> None:
+    """A /team attach must not invalidate the cached persona prefix."""
+    blocks = build_system_blocks(
+        TOOLS, SKILLS, ENV, DATE, team_brief="[team: release]\nYou coordinate."
+    )
+    assert "<team>" in blocks[3]
+    assert "[team: release]" in blocks[3]
+    for block in blocks[:3]:
+        assert "team: release" not in block
+    idle = build_system_blocks(TOOLS, SKILLS, ENV, DATE)
+    assert "<team>" not in idle[3]
     # Same names keep the head byte-stable.
     again = build_system_blocks(
         TOOLS, "other skills", "other env", "2027-01-01", credentials=["GITHUB_TOKEN", "DEPLOY_KEY"]

--- a/tests/unit/test_teams.py
+++ b/tests/unit/test_teams.py
@@ -1,0 +1,115 @@
+"""Team registry: roster, layered briefs, and name rules."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from local_operator.teams import (
+    MAX_TEAM_INSTRUCTIONS_CHARS,
+    TeamEditFields,
+    TeamMember,
+    TeamRegistry,
+    parse_members,
+)
+
+
+@pytest.fixture()
+def registry(tmp_path: Path) -> TeamRegistry:
+    return TeamRegistry(tmp_path)
+
+
+def test_create_list_show_update_delete(registry: TeamRegistry) -> None:
+    team = registry.create_team(
+        TeamEditFields(
+            name="feature-release",
+            description="Ship a user-facing change",
+            manager="manager",
+            members=[TeamMember(role="coder"), TeamMember(role="reviewer", count=2)],
+            instructions="Architect designs; coder implements; reviewer signs off.",
+            project="user-dashboard",
+        )
+    )
+    assert team.name == "feature-release"
+    assert team.manager == "manager"
+    assert [m.role for m in team.members] == ["coder", "reviewer"]
+    assert team.members[1].count == 2
+    assert "user-dashboard" in team.project
+
+    listed = registry.list_teams()
+    assert [row.name for row in listed] == ["feature-release"]
+    assert registry.get_team_by_name("Feature-Release") is team or registry.get_team_by_name(
+        "feature-release"
+    )
+
+    updated = registry.update_team(team.id, TeamEditFields(project="admin-api", instructions=None))
+    assert updated.project == "admin-api"
+    assert "Architect designs" in updated.instructions
+
+    registry.delete_team(team.id)
+    assert registry.list_teams() == []
+
+
+def test_duplicate_name_is_refused(registry: TeamRegistry) -> None:
+    registry.create_team(TeamEditFields(name="alpha", manager="manager"))
+    with pytest.raises(ValueError, match="already exists"):
+        registry.create_team(TeamEditFields(name="alpha", manager="manager"))
+
+
+def test_name_rejects_spaces(registry: TeamRegistry) -> None:
+    with pytest.raises(ValueError, match="team name"):
+        registry.create_team(TeamEditFields(name="Feature Release", manager="manager"))
+
+
+def test_parse_members_collapses_counts() -> None:
+    slots = parse_members(["coder", "reviewer:2", "coder"])
+    assert [(m.role, m.count) for m in slots] == [("coder", 2), ("reviewer", 2)]
+
+
+def test_manager_preamble_layers_briefs(registry: TeamRegistry) -> None:
+    team = registry.create_team(
+        TeamEditFields(
+            name="release",
+            manager="manager",
+            members=[TeamMember(role="coder")],
+            instructions="Do not merge without review.",
+            project="Keep the dashboard shipping weekly.",
+        )
+    )
+    brief = team.manager_preamble()
+    assert "[team: release]" in brief
+    assert "coder" in brief
+    assert "Do not merge without review." in brief
+    assert "Keep the dashboard shipping weekly." in brief
+    member = team.member_preamble("coder")
+    assert "You are coder on this team" in member
+    assert "Do not merge without review." in member
+
+
+def test_oversized_briefs_are_refused(registry: TeamRegistry) -> None:
+    with pytest.raises(ValueError, match="exceed"):
+        registry.create_team(
+            TeamEditFields(
+                name="huge",
+                manager="manager",
+                instructions="x" * (MAX_TEAM_INSTRUCTIONS_CHARS + 1),
+            )
+        )
+
+
+def test_reload_from_disk(tmp_path: Path) -> None:
+    first = TeamRegistry(tmp_path)
+    first.create_team(
+        TeamEditFields(
+            name="ops",
+            manager="manager",
+            members=[TeamMember(role="scout")],
+            project="on-call",
+        )
+    )
+    second = TeamRegistry(tmp_path)
+    loaded = second.get_team_by_name("ops")
+    assert loaded is not None
+    assert loaded.project == "on-call"
+    assert loaded.members[0].role == "scout"

--- a/tests/unit/tools/test_agent_tool.py
+++ b/tests/unit/tools/test_agent_tool.py
@@ -157,7 +157,29 @@ async def test_create_refuses_to_clobber_an_existing_role(context) -> None:
 
 @pytest.mark.asyncio
 async def test_update_refuses_an_unknown_role(context) -> None:
-    assert "no registered role" in await call(context, op="update", name="ghost", instructions="x")
+    assert "no registered profile" in await call(
+        context, op="update", name="ghost", instructions="x"
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_specialist_is_not_a_role(context, registry) -> None:
+    """A User Dashboard Agent is a reusable specialist, not a delegation role."""
+    body = await call(
+        context,
+        op="create",
+        name="user-dashboard",
+        kind="specialist",
+        description="Knows user-dashboard release practices",
+        instructions="Follow the user-dashboard SDLC. Never skip the design review.",
+    )
+    assert "created specialist" in body
+    agent = registry.get_agent_by_name("user-dashboard")
+    assert agent is not None
+    assert "role" not in (agent.tags or [])
+    assert resolve_profile("user-dashboard", registry=registry) is None
+    prompt = registry.get_agent_system_prompt(agent.id)
+    assert "user-dashboard SDLC" in prompt
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tools/test_agent_tool.py
+++ b/tests/unit/tools/test_agent_tool.py
@@ -82,6 +82,26 @@ async def test_list_separates_registered_roles_from_starters(context, registry) 
 
 
 @pytest.mark.asyncio
+async def test_list_and_show_include_specialists_with_instructions(context) -> None:
+    await call(
+        context,
+        op="create",
+        kind="specialist",
+        name="dashboard-release",
+        description="Release the user dashboard safely",
+        instructions="Follow the dashboard SDLC and release checklist.",
+    )
+
+    listing = await call(context, op="list")
+    shown = await call(context, op="show", name="dashboard-release")
+
+    assert "registered specialists" in listing
+    assert "dashboard-release" in listing
+    assert "Follow the dashboard SDLC" in shown
+    assert "launch with --agent dashboard-release" in shown
+
+
+@pytest.mark.asyncio
 async def test_list_ignores_agents_that_are_not_roles(context, registry) -> None:
     """A registry also holds ordinary conversational agents; listing those as
     delegation targets would be noise at best and a privacy leak at worst."""

--- a/tests/unit/tools/test_registry.py
+++ b/tests/unit/tools/test_registry.py
@@ -68,6 +68,7 @@ def _engine_context(**kwargs) -> ToolContext:
         # tool; the ops themselves are exercised in the agent-tool tests
         # against a real registry.
         agent_registry=object(),
+        team_registry=object(),
         has_ui=True,
         ask_user=_ask_user,
     )

--- a/tests/unit/tools/test_team_tool.py
+++ b/tests/unit/tools/test_team_tool.py
@@ -52,7 +52,7 @@ async def test_create_show_update_delete(context) -> None:
     )
     assert "created team 'feature-release'" in created
     shown = await call(context, op="show", name="feature-release")
-    assert "manager manager" in shown
+    assert "Led by manager" in shown
     assert "coder" in shown
     assert "Review before merge." in shown
     assert "user-dashboard" in shown

--- a/tests/unit/tools/test_team_tool.py
+++ b/tests/unit/tools/test_team_tool.py
@@ -1,0 +1,78 @@
+"""The ``team`` tool: create, show, update, delete."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from local_operator.harness.types import ToolContext
+from local_operator.teams import TeamRegistry
+from local_operator.tools.team_tool import build_team_tool, execute_team
+
+
+@pytest.fixture()
+def registry(tmp_path) -> TeamRegistry:
+    return TeamRegistry(tmp_path)
+
+
+@pytest.fixture()
+def context(registry: TeamRegistry) -> ToolContext:
+    return ToolContext(cwd=".", team_registry=registry)
+
+
+async def call(context: ToolContext, **args: Any) -> str:
+    result = await execute_team("tc", args, None, None, context)
+    return result.text
+
+
+def test_the_tool_is_not_advertised_without_a_registry() -> None:
+    assert build_team_tool(ToolContext(cwd=".")) is None
+    assert build_team_tool(ToolContext(cwd=".", team_registry=object())) is not None
+
+
+@pytest.mark.asyncio
+async def test_list_empty_points_at_create(context) -> None:
+    body = await call(context, op="list")
+    assert "no teams" in body
+    assert "guide://teams" in body
+
+
+@pytest.mark.asyncio
+async def test_create_show_update_delete(context) -> None:
+    created = await call(
+        context,
+        op="create",
+        name="feature-release",
+        description="Ship a change",
+        manager="manager",
+        members=["coder", "reviewer:2"],
+        instructions="Review before merge.",
+        project="user-dashboard",
+    )
+    assert "created team 'feature-release'" in created
+    shown = await call(context, op="show", name="feature-release")
+    assert "manager manager" in shown
+    assert "coder" in shown
+    assert "Review before merge." in shown
+    assert "user-dashboard" in shown
+    updated = await call(context, op="update", name="feature-release", project="admin-api")
+    assert "updated team" in updated
+    shown_again = await call(context, op="show", name="feature-release")
+    assert "admin-api" in shown_again
+    assert "Review before merge." in shown_again
+    deleted = await call(context, op="delete", name="feature-release")
+    assert "deleted team" in deleted
+    assert "no team named" in await call(context, op="show", name="feature-release")
+
+
+@pytest.mark.asyncio
+async def test_create_refuses_a_duplicate(context) -> None:
+    await call(context, op="create", name="alpha")
+    body = await call(context, op="create", name="alpha")
+    assert "already exists" in body
+
+
+@pytest.mark.asyncio
+async def test_create_needs_a_name(context) -> None:
+    assert "needs 'name'" in await call(context, op="create")

--- a/tests/unit/tools/test_team_tool.py
+++ b/tests/unit/tools/test_team_tool.py
@@ -8,7 +8,12 @@ import pytest
 
 from local_operator.harness.types import ToolContext
 from local_operator.teams import TeamRegistry
-from local_operator.tools.team_tool import build_team_tool, execute_team
+from local_operator.tools.team_tool import (
+    build_team_delete_tool,
+    build_team_tool,
+    execute_team,
+    execute_team_delete,
+)
 
 
 @pytest.fixture()
@@ -26,9 +31,25 @@ async def call(context: ToolContext, **args: Any) -> str:
     return result.text
 
 
+async def delete(context: ToolContext, name: str) -> str:
+    result = await execute_team_delete("tc", {"name": name}, None, None, context)
+    return result.text
+
+
 def test_the_tool_is_not_advertised_without_a_registry() -> None:
     assert build_team_tool(ToolContext(cwd=".")) is None
+    assert build_team_delete_tool(ToolContext(cwd=".")) is None
     assert build_team_tool(ToolContext(cwd=".", team_registry=object())) is not None
+    assert build_team_delete_tool(ToolContext(cwd=".", team_registry=object())) is not None
+
+
+def test_only_destructive_team_removal_requires_approval(context) -> None:
+    authoring = build_team_tool(context)
+    deleting = build_team_delete_tool(context)
+    assert authoring is not None and authoring.approval_tier == "read"
+    assert deleting is not None and deleting.approval_tier == "write"
+    assert deleting.describe_approval is not None
+    assert "Delete team 'alpha' permanently" == deleting.describe_approval({"name": "alpha"}, ".")
 
 
 @pytest.mark.asyncio
@@ -56,12 +77,20 @@ async def test_create_show_update_delete(context) -> None:
     assert "coder" in shown
     assert "Review before merge." in shown
     assert "user-dashboard" in shown
-    updated = await call(context, op="update", name="feature-release", project="admin-api")
+    updated = await call(
+        context,
+        op="update",
+        name="feature-release",
+        project="admin-api",
+        members=["designer", "reviewer:2"],
+    )
     assert "updated team" in updated
     shown_again = await call(context, op="show", name="feature-release")
     assert "admin-api" in shown_again
     assert "Review before merge." in shown_again
-    deleted = await call(context, op="delete", name="feature-release")
+    assert "designer" in shown_again
+    assert "reviewer x2" in shown_again
+    deleted = await delete(context, "feature-release")
     assert "deleted team" in deleted
     assert "no team named" in await call(context, op="show", name="feature-release")
 

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -120,6 +120,10 @@ class FakeSession:
         # relies on, and a fake that reimplements it as a plain assignment
         # would let a regression in that rule pass every pilot test.
         self._name_state = ConversationName()
+        #: Optional team registry for ``/team``. Tests that exercise teams
+        #: assign a real ``TeamRegistry``; everyone else pays nothing.
+        self.team_registry: Any | None = None
+        self.attached_teams: list[Any] = []
 
     @property
     def session_id(self) -> str:
@@ -161,6 +165,9 @@ class FakeSession:
     def set_goal(self, text: str) -> str:
         self._goal = (text or "").strip()
         return self._goal
+
+    def attach_team(self, team: Any) -> None:
+        self.attached_teams.append(team)
 
     @property
     def variables(self) -> Any:

--- a/tests/unit/tui/test_approvals_ux.py
+++ b/tests/unit/tui/test_approvals_ux.py
@@ -497,6 +497,9 @@ def test_the_registry_states_which_commands_offer_values() -> None:
         # OPTIONAL like `/effort`: bare `/credential` lists the names in
         # memory; the space opens a KEY argument, then a masked paste.
         "credential": ArgumentMode.OPTIONAL,
+        # OPTIONAL like `/mcp`: bare `/team` lists the teams, and the space
+        # opens the team-name argument list with roster details.
+        "team": ArgumentMode.OPTIONAL,
     }
     # `/provider` was the third candidate and is deliberately not here: it takes
     # no argument at all — `_cmd_providers` ignores what follows it — so a list

--- a/tests/unit/tui/test_slash_echo.py
+++ b/tests/unit/tui/test_slash_echo.py
@@ -16,6 +16,7 @@ to keep a default for the picker fixtures that have no opinion at all.
 from __future__ import annotations
 
 import asyncio
+from pathlib import Path
 
 import pytest
 
@@ -71,6 +72,9 @@ ECHO_POLICY = {
     # The listing or the masked paste is the receipt; the argument is a key
     # name, never the secret, so a user row would only restate the notice.
     "credential": False,
+    # The listing is the receipt; a named request is sent as a real user
+    # turn by `_submit_prompt`, which already writes the row.
+    "team": False,
 }
 
 
@@ -207,6 +211,65 @@ async def test_a_panel_opening_command_leaves_no_user_row() -> None:
         panel_open = app.query_one(UsagePanel).display
     assert rows == [], rows
     assert panel_open is True
+
+
+@pytest.mark.asyncio
+async def test_bare_team_lists_without_a_user_row() -> None:
+    """`/team` is a listing; the listing is the receipt."""
+    from local_operator.teams import TeamEditFields, TeamMember, TeamRegistry
+
+    session = FakeSession()
+    registry = TeamRegistry(Path("/tmp/lo-team-test-unused"))
+    # In-memory: point the registry at a throwaway dir via the session.
+    import tempfile
+
+    tmp = tempfile.mkdtemp()
+    registry = TeamRegistry(Path(tmp))
+    registry.create_team(
+        TeamEditFields(
+            name="feature-release",
+            manager="manager",
+            members=[TeamMember(role="coder")],
+            description="Ship a change",
+        )
+    )
+    session.team_registry = registry
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _boot(pilot, app)
+        await _submit(pilot, app, "/team")
+        rows = _user_rows(app)
+        notices = _notice_texts(app)
+    assert rows == [], rows
+    assert any("feature-release" in body for body in notices), notices
+
+
+@pytest.mark.asyncio
+async def test_team_request_attaches_and_sends() -> None:
+    """`/team <name> <request>` stamps the team and sends the request as a turn."""
+    import tempfile
+
+    from local_operator.teams import TeamEditFields, TeamMember, TeamRegistry
+
+    session = FakeSession()
+    registry = TeamRegistry(Path(tempfile.mkdtemp()))
+    registry.create_team(
+        TeamEditFields(
+            name="feature-release",
+            manager="manager",
+            members=[TeamMember(role="coder")],
+        )
+    )
+    session.team_registry = registry
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _boot(pilot, app)
+        await _submit(pilot, app, "/team feature-release ship the dashboard")
+        rows = _user_rows(app)
+    assert session.attached_teams, "the team must be attached before the turn"
+    assert session.attached_teams[0].name == "feature-release"
+    assert session.prompts == ["ship the dashboard"]
+    assert rows == ["ship the dashboard"], rows
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tui/test_slash_echo.py
+++ b/tests/unit/tui/test_slash_echo.py
@@ -235,13 +235,17 @@ async def test_bare_team_lists_without_a_user_row() -> None:
     )
     session.team_registry = registry
     app = OperatorApp(lambda: _factory(session))
-    async with app.run_test(size=(120, 40)) as pilot:
+    async with app.run_test(size=(60, 24)) as pilot:
         await _boot(pilot, app)
         await _submit(pilot, app, "/team")
         rows = _user_rows(app)
-        notices = _notice_texts(app)
+        painted = _painted(app)
     assert rows == [], rows
-    assert any("feature-release" in body for body in notices), notices
+    assert "feature-release" in painted, painted
+    assert "Led by manager · 2 roles" in painted, painted
+    assert "Ship a change" in painted, painted
+    assert "Send: /team <name> <message>" in painted, painted
+    assert "manager=" not in painted, painted
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What

Adds **Teams** as a first-class grouping of reusable agents, plus the security fix that agent export/import no longer ships conversation history.

- **Team** = a named roster (manager + members with counts) plus two instruction layers that do not belong on any one agent:
  - **Collaboration** (`instructions.md`) — how this group works together
  - **Project** (`project.md`) — the product or domain this instance owns
- Agents stay reusable. A `coder` or a "User Dashboard Agent" can sit on many teams; the team layers briefs on top of the agent's own `system_prompt.md`.
- **`team` tool** (`list` / `show` / `create` / `update` / `delete`) so an agent can author teams. Discoverable via `guide://teams`.
- **`agent` tool** can now author `kind='specialist'` profiles (durable named agents with instruction sets) as well as roles.
- **`/team`** lists teams; `/team <name> <request>` attaches the team to this session and sends the request to the manager, who orchestrates members via `task(agent=...)`. Members inherit the team's collaboration and project briefs automatically.
- **CLI**: `lop teams list|create|show|delete`.
- **Splash tips** advertise agents and teams as differentiating features.
- **Export/import** of agent profiles strips `conversation.jsonl`, execution history, learnings, schedules, pickled context, plan/instruction dumps, and `last_message`, so a Radient hub listing cannot leak private sessions.

Change class: **C2** — standard feature iteration, pre-authorized. No RFC.

## Why

Roles and specialists are building blocks. Users need a way to group them under a manager with group-level (collaboration + project) context without baking that context into the agents themselves — otherwise a reusable coder becomes "the user-dashboard coder" and cannot staff anything else.

Publishing an agent to the Radient hub previously zipped the whole agent directory, including conversation history.

## Testing evidence

### Unit

Focused suites for the new surface (plus the existing agent/export/TUI slash/welcome/guides/registry suites they touch):

```
tests/unit/test_teams.py
tests/unit/tools/test_team_tool.py
tests/unit/tools/test_agent_tool.py
tests/unit/test_agents.py          # export/import history strip
tests/unit/tui/test_slash_echo.py  # /team listing + send
tests/unit/session/test_launch_subagent.py  # member brief stamped on child
tests/unit/guides/test_guides.py
```

1077 passed in the broader unit run covering tools, TUI slash/welcome, agents, session, CLI, prompts, guides. Two pre-existing timing flakes (`test_background_streams_output_while_it_runs`, `test_the_loop_stays_responsive_while_several_subagents_run`) failed under load and are unrelated (eval streaming / event-loop stall; this diff does not touch them).

Lint: `flake8 local_operator tests` clean. `black --check` / `isort --check-only` clean on changed files. `pyright` clean on changed modules.

### Real path — CLI

Against a throwaway `LOCAL_OPERATOR_CONFIG_DIR`:

```
$ lop teams list
No teams found.

$ lop teams create feature-release --manager manager --member coder --member reviewer:2 --description "Ship a user-facing change"
╭─ Created New Team ───────────────────────────
│ Name: feature-release
│ Manager: manager
│ Members: 2
╰──────────────────────────────────────────────────

$ lop teams show feature-release
╭─ Team feature-release ───────────────────────────
│ Manager: manager
│ Description: Ship a user-facing change
│ Roster:
│   - manager: manager (you, when this team is invoked)
│   - coder
│   - reviewer x2
╰──────────────────────────────────────────────────

$ lop teams delete --name feature-release
Successfully deleted team: feature-release
```

On-disk layout: `teams/<id>/{team.yml,instructions.md,project.md}`.

### Real path — export strip

Created an agent with a conversation, learnings, plan, and `last_message='secret last message'`, then exported:

```
zip Dash.zip
members ['agent.yml', 'system_prompt.md']
last_message ''
prompt You know the dashboard SDLC.
```

Conversation, execution history, learnings, schedules, context.pkl, plan, and instruction dumps were absent. `last_message` in `agent.yml` was blanked.

### Real path — TUI `/team`

Pilot against `OperatorApp` + a real `TeamRegistry`:

- Bare `/team` lists `feature-release` as a notice and writes **no** user row.
- `/team feature-release ship the dashboard` attaches the team (`session.attached_teams[0].name == 'feature-release'`) and sends `ship the dashboard` as the user turn.

### Real path — child inherits team brief

A parent session with `attach_team(...)` launching `task(agent='coder')` produced a child prompt containing `[team: feature-release]`, `You are coder on this team`, the collaboration brief, the project brief, and the task text.

### Visual — splash

Boot splash at 100×30 (`OperatorApp` via `run_test`). Geometry: `screen.size == virtual_size == (98, 28)`, no vertical scrollbar, before and after tip rotation.

- First tip remains `/resume` (pinned).
- Tip 1: `/team <name> sends a request to that team's manager`
- Tip 2: `Ask to create an agent with its own instruction set`
- Tip 3: `Ask for a team of roles — manager, coder, reviewer`

Row count of the splash is unchanged (tips rotate in a reserved row). SVG stills captured at `/tmp/lo-splash-before.svg` and `/tmp/lo-splash-tips/tip-{0,1,2,3}.svg`.

## How to try it

```
lop teams create feature-release --manager manager --member coder --member reviewer --member designer --member architect
# then in the TUI:
/team feature-release ship the dashboard change
```

Or ask the agent: "create a Feature Release Team with a manager, coder, designer, architect, and security reviewer" — it should read `guide://teams`, install/author the roles, and `team op='create'`.