### PR TITLE
fix(providers): deplete every account on a provider before failing over

### DIFF
--- a/local_operator/guides/configuration/GUIDE.md
+++ b/local_operator/guides/configuration/GUIDE.md
@@ -122,11 +122,18 @@ values:
 
 This route keeps the configured primary first. At a new user-message boundary,
 Local Operator checks a provider's live OAuth quota when that provider exposes
-one. It rotates through usable accounts on the same provider before moving to
-the listed model routes. Reserve quota can select a lower-effort route without
-blocking the account; fully exhausted account-wide quota skips same-provider
-effort changes because they cannot restore capacity. Usage endpoints that are
-missing or unreachable fail open.
+one. It rotates through usable accounts on the same provider — including
+accounts whose remaining quota is under the reserve threshold — and only
+moves to the next listed provider once every account on the current one is
+at 0%. A model-tier cap (Anthropic's `7 day (Fable)` against `claude-fable-5`)
+is still per account: siblings on that provider are tried before the chain
+leaves it. Reserve quota can select a lower-effort route on the *same*
+provider without blocking the account; it is not a licence to hop providers
+while spendable quota remains. Fully exhausted account-wide quota skips
+same-provider effort changes because they cannot restore capacity. A
+fallback whose own provider is already at 0% is skipped so the cascade does
+not pin a maxed hop. Usage endpoints that are missing or unreachable fail
+open.
 
 Provider errors use the same ordered chain. A successful fallback stays pinned
 through tool calls and other model calls in that user message, and a cooldown

--- a/local_operator/model/configure.py
+++ b/local_operator/model/configure.py
@@ -1489,8 +1489,9 @@ class SessionStreamFn:
     Hard fallback stays pinned for the rest of a user message, so tool loops,
     compaction and naming do not re-send a warm prompt to a provider that just
     rejected it. Optional usage preflight runs once at the message boundary,
-    rotates through same-provider OAuth accounts first, then selects the first
-    configured provider/model/effort route with working auth.
+    rotates through same-provider OAuth accounts first (including accounts
+    under the reserve threshold), then selects the first configured
+    provider/model/effort route with working auth and remaining quota.
     """
 
     USAGE_CHECK_TTL_S = 60.0
@@ -1756,13 +1757,114 @@ class SessionStreamFn:
         except Exception:
             return False
 
+    async def _provider_quota_availability(
+        self,
+        provider: str,
+        model_id: str,
+        *,
+        reserve_percent: float,
+        cache: dict[str, str],
+    ) -> str:
+        """Whether ``provider`` still has spendable quota for ``model_id``.
+
+        ``usable`` means at least one account still has remaining > 0
+        (healthy *or* reserve — reserve is still spendable). ``depleted``
+        means every account that answered is at 0%. ``unknown`` is fail-open:
+        no endpoint, no report, or a fetch error, so the caller must not
+        skip the target on a missing signal.
+
+        Cached per provider+model for one preflight walk so a chain that
+        lists several models on the same host does not re-hit the usage
+        endpoint, while still letting a Fable hop and an Opus hop on the
+        same Anthropic pool disagree (their binding windows differ).
+        """
+        cache_key = f"{provider}/{model_id}"
+        cached = cache.get(cache_key)
+        if cached is not None:
+            return cached
+
+        from local_operator.providers.usage import (
+            fetch_usage,
+            usage_health,
+            usage_supported,
+        )
+
+        if not usage_supported(provider):
+            cache[cache_key] = "unknown"
+            return "unknown"
+
+        saw_depleted = False
+        saw_unknown = False
+        try:
+            accesses = await self._auth_store.list_oauth_accesses(provider)
+        except Exception:
+            accesses = []
+        for access in accesses:
+            try:
+                report = await fetch_usage(
+                    self._http,
+                    provider,
+                    access_token=access.access_token,
+                    account_id=access.account_id,
+                    oauth_creds=access.raw,
+                )
+            except Exception:
+                saw_unknown = True
+                continue
+            if report is None:
+                saw_unknown = True
+                continue
+            health = usage_health(report, model_id, reserve_percent=reserve_percent)
+            if health.state == "unknown":
+                saw_unknown = True
+                continue
+            if health.state != "depleted":
+                cache[cache_key] = "usable"
+                return "usable"
+            saw_depleted = True
+
+        if accesses:
+            # OAuth is the subscription the user is spending. Skip only when
+            # EVERY account answered depleted; a missing report is fail-open
+            # so an unread sibling cannot hide remaining quota.
+            availability = "depleted" if saw_depleted and not saw_unknown else "unknown"
+            cache[cache_key] = availability
+            return availability
+
+        # No OAuth rows; an API-key quota route (Z.AI, Kimi balance) may
+        # still have a number. One secret per provider, so a single probe
+        # is the whole answer.
+        try:
+            # read_only: a quota probe must not pin stickiness on a
+            # provider we may then skip as depleted.
+            api_key = await self._auth_store.get_api_key(provider, self._session_id, read_only=True)
+        except Exception:
+            api_key = None
+        if api_key:
+            try:
+                report = await fetch_usage(self._http, provider, api_key=api_key)
+            except Exception:
+                report = None
+            if report is not None:
+                health = usage_health(report, model_id, reserve_percent=reserve_percent)
+                if health.state == "depleted":
+                    cache[cache_key] = "depleted"
+                    return "depleted"
+                if health.state != "unknown":
+                    cache[cache_key] = "usable"
+                    return "usable"
+
+        cache[cache_key] = "unknown"
+        return "unknown"
+
     async def _first_available_fallback(
         self,
         model: ModelSpec,
         *,
         different_provider: bool = False,
+        reserve_percent: float = 10.0,
     ) -> Any | None:
-        """The first configured fallback with working auth, bench-aware.
+        """The first configured fallback with working auth, bench- and quota-aware.
 
         "First configured" alone is what replayed the waterfall on every
         message boundary: with the chain's head providers down, each quota
@@ -1773,17 +1875,27 @@ class SessionStreamFn:
         ``FailoverRouteState.mark_target_failed``) are therefore passed over
         here, so a session that has settled on a working fallback stays on it.
 
-        The bench is a preference, not a verdict: when EVERY authed candidate
-        is benched, the first of them is returned anyway — returning ``None``
-        would report "no configured fallback" to a user who has several, and
-        the stream walk's own retry machinery is the right place to discover
-        which bench has expired.
+        A target whose provider is *quota-depleted* is skipped the same way:
+        pinning a maxed Kimi/Qwen hop just to watch it fail (or, worse, to
+        treat its last 10% as another reason to hop) is how the cascade
+        burned past a provider that still had spendable quota. Reserve is
+        still usable — only a 0% remaining verdict skips. Unknown/unreachable
+        usage fails open, matching preflight's own contract.
+
+        The bench (and the depleted skip) is a preference, not a verdict:
+        when EVERY authed candidate is benched or depleted, the first of
+        them is returned anyway — returning ``None`` would report "no
+        configured fallback" to a user who has several, and the stream
+        walk's own retry machinery is the right place to discover which
+        bench has expired.
         """
         from local_operator.providers.failover import parse_selector
 
         first_benched: Any | None = None
+        first_depleted: Any | None = None
+        quota_cache: dict[str, str] = {}
         for target in self._fallback_targets(model):
-            provider, _model_id = parse_selector(target.selector)
+            provider, target_model = parse_selector(target.selector)
             if different_provider and provider == model.provider:
                 continue
             if not await self._target_has_auth(target):
@@ -1792,8 +1904,18 @@ class SessionStreamFn:
                 if first_benched is None:
                     first_benched = target
                 continue
+            availability = await self._provider_quota_availability(
+                provider,
+                target_model,
+                reserve_percent=reserve_percent,
+                cache=quota_cache,
+            )
+            if availability == "depleted":
+                if first_depleted is None:
+                    first_depleted = target
+                continue
             return target
-        return first_benched
+        return first_benched or first_depleted
 
     @staticmethod
     def _storage_provider(provider: str) -> str:
@@ -1895,6 +2017,7 @@ class SessionStreamFn:
                     fallback = await self._first_available_fallback(
                         model,
                         different_provider=True,
+                        reserve_percent=retry.usage_reserve_percent,
                     )
                     if fallback is not None:
                         await self._route_state.activate(
@@ -1943,8 +2066,57 @@ class SessionStreamFn:
                 else f" ({health.remaining_fraction * 100:.0f}% remaining)"
             )
             condition = "quota exhausted" if health.state == "depleted" else "quota low"
+            storage = self._storage_provider(model.provider)
             if health.scope != "account":
-                fallback = await self._first_available_fallback(model)
+                # A model-tier cap (Anthropic's ``7 day (Fable)`` against
+                # ``claude-fable-5``) is still per ACCOUNT. Jumping to the
+                # next provider here is what skipped three Anthropic logins
+                # that still had Fable headroom — the reported cascade that
+                # hopped Anthropic → Kimi (10% remaining) → Qwen (maxed) →
+                # Grok while Fable quota sat idle. Rotate siblings first;
+                # only the last account on this provider may leave it.
+                row = self._auth_store.get_credential(access.credential_id)
+                siblings = [
+                    candidate
+                    for candidate in self._auth_store.list_credentials(storage)
+                    if candidate.id != access.credential_id
+                    and (row is None or candidate.credential_type == row.credential_type)
+                    and not self._auth_store.is_blocked(candidate.id, storage)
+                ]
+                if siblings:
+                    if health.state == "depleted":
+                        self._auth_store.block_credential(
+                            access.credential_id,
+                            storage,
+                            block_ms=max(
+                                60_000,
+                                health.reset_after_ms or self.DEFAULT_USAGE_BLOCK_MS,
+                            ),
+                        )
+                    else:
+                        self._auth_store.deprioritize_credential(
+                            model.provider, access.credential_id
+                        )
+                    await self._notice(
+                        f"{model.provider} {condition}{remaining} for {model.model_id} "
+                        f"— trying another {model.provider} account before provider fallback"
+                    )
+                    continue
+                if health.state == "reserve":
+                    # Last account, still holding this model's quota. Same
+                    # rule as the account-scope path: reserve is not a
+                    # licence to leave the provider.
+                    await self._notice(
+                        f"{model.provider} {condition}{remaining} for {model.model_id} "
+                        f"— continuing until {model.provider} quota is exhausted",
+                        "info",
+                    )
+                    self._route_state.clear()
+                    return
+                fallback = await self._first_available_fallback(
+                    model,
+                    reserve_percent=retry.usage_reserve_percent,
+                )
                 if fallback is None:
                     await self._notice(
                         f"{model.provider} {condition}{remaining} for {model.model_id}; "
@@ -1957,7 +2129,6 @@ class SessionStreamFn:
                 )
                 return
 
-            storage = self._storage_provider(model.provider)
             if await self._apply_account_health(
                 model,
                 access,
@@ -1993,8 +2164,10 @@ class SessionStreamFn:
         over to another provider — strands real shared headroom. Rotation is
         reserved for accounts whose SHARED windows are genuinely binding; a
         tier-only cap keeps the account in service, and the last account with
-        any shared headroom is always allowed to spend it down to zero before
-        a provider fallback is even considered.
+        any shared headroom — including remaining under the reserve
+        threshold — is always allowed to spend it down to zero before
+        a provider fallback is even considered. Reserve is a preference
+        between siblings of the same provider, not a hop to the next one.
         """
         from local_operator.providers.failover import parse_selector
 
@@ -2023,11 +2196,37 @@ class SessionStreamFn:
             # A different effort cannot revive a fully exhausted provider,
             # but it can preserve reserve quota by reducing token spend.
             different_provider=health.state == "depleted",
+            reserve_percent=retry.usage_reserve_percent,
         )
         if not siblings and fallback is None:
             await self._notice(
                 f"{model.provider} {condition}{remaining}; no configured fallback is available"
             )
+            return False
+
+        if not siblings and health.state == "reserve":
+            # Last account on this provider, still holding spendable quota.
+            # Crossing the reserve threshold used to hop to the next chain
+            # entry (Kimi at 10% remaining → Qwen maxed → Grok) while this
+            # account could still serve. Reserve is a preference BETWEEN
+            # siblings of the same provider, not a licence to leave the
+            # provider; spend it to zero, then fail over. A same-provider
+            # lower-effort hop is still allowed — it reduces token spend
+            # without abandoning remaining quota.
+            if fallback is not None:
+                fallback_provider, _model_id = parse_selector(fallback.selector)
+                if fallback_provider == model.provider:
+                    await self._route_state.activate(
+                        fallback,
+                        f"{model.provider} {condition}{remaining}",
+                    )
+                    return False
+            await self._notice(
+                f"{model.provider} {condition}{remaining} — continuing until "
+                f"{model.provider} quota is exhausted",
+                "info",
+            )
+            self._route_state.clear()
             return False
 
         if tier_binding and shared_above_reserve:

--- a/local_operator/model/configure.py
+++ b/local_operator/model/configure.py
@@ -1862,6 +1862,13 @@ class SessionStreamFn:
                 else:
                     cache[cache_key] = "usable"
                     return "usable"
+            if any(row.id != selected.credential_id for row in api_key_rows):
+                # The read-only cascade exposes the winning key, not every
+                # lower-priority sibling's secret. A depleted selected key is
+                # therefore not proof the provider is empty when another
+                # enabled key row exists; fail open and let the stream's
+                # credential rotation walk that pool (review F5).
+                saw_unknown = True
         elif api_key_rows:
             # An unblocked OAuth row shadows lower API-key rows. The stream
             # reaches them after a provider-side quota error, but preflight

--- a/local_operator/model/configure.py
+++ b/local_operator/model/configure.py
@@ -1793,12 +1793,24 @@ class SessionStreamFn:
             cache[cache_key] = "unknown"
             return "unknown"
 
+        # Enumerate configured rows before asking for refreshed accesses.
+        # ``list_oauth_accesses`` deliberately omits a row whose refresh fails;
+        # without this comparison, one omitted/unknown account plus one depleted
+        # account looked like proof the WHOLE provider was depleted (review F1).
+        rows = self._auth_store.list_credentials(provider)
+        oauth_rows = [row for row in rows if row.credential_type == "oauth"]
+        api_key_rows = [row for row in rows if row.credential_type == "api_key"]
+
         saw_depleted = False
         saw_unknown = False
         try:
             accesses = await self._auth_store.list_oauth_accesses(provider)
         except Exception:
             accesses = []
+            saw_unknown = bool(oauth_rows)
+        if {access.credential_id for access in accesses} != {row.id for row in oauth_rows}:
+            saw_unknown = True
+
         for access in accesses:
             try:
                 report = await fetch_usage(
@@ -1823,39 +1835,43 @@ class SessionStreamFn:
                 return "usable"
             saw_depleted = True
 
-        if accesses:
-            # OAuth is the subscription the user is spending. Skip only when
-            # EVERY account answered depleted; a missing report is fail-open
-            # so an unread sibling cannot hide remaining quota.
-            availability = "depleted" if saw_depleted and not saw_unknown else "unknown"
-            cache[cache_key] = availability
-            return availability
-
-        # No OAuth rows; an API-key quota route (Z.AI, Kimi balance) may
-        # still have a number. One secret per provider, so a single probe
-        # is the whole answer.
+        # Probe the credential the wire cascade would ACTUALLY select now.
+        # Usage enumeration includes blocked OAuth rows for visibility, while
+        # routing correctly falls through to a healthy API key (review F4).
+        # ``read_only`` keeps this quota question from moving stickiness.
         try:
-            # read_only: a quota probe must not pin stickiness on a
-            # provider we may then skip as depleted.
-            api_key = await self._auth_store.get_api_key(provider, self._session_id, read_only=True)
+            selected = await self._auth_store.get_oauth_access(
+                provider, self._session_id, read_only=True
+            )
         except Exception:
-            api_key = None
-        if api_key:
+            selected = None
+            saw_unknown = True
+        if selected is not None and selected.kind == "api_key":
             try:
-                report = await fetch_usage(self._http, provider, api_key=api_key)
+                report = await fetch_usage(self._http, provider, api_key=selected.access_token)
             except Exception:
                 report = None
-            if report is not None:
+            if report is None:
+                saw_unknown = True
+            else:
                 health = usage_health(report, model_id, reserve_percent=reserve_percent)
                 if health.state == "depleted":
-                    cache[cache_key] = "depleted"
-                    return "depleted"
-                if health.state != "unknown":
+                    saw_depleted = True
+                elif health.state == "unknown":
+                    saw_unknown = True
+                else:
                     cache[cache_key] = "usable"
                     return "usable"
+        elif api_key_rows:
+            # An unblocked OAuth row shadows lower API-key rows. The stream
+            # reaches them after a provider-side quota error, but preflight
+            # cannot safely resolve a lower tier without changing routing.
+            # Unknown is fail-open: the key may still hold spendable balance.
+            saw_unknown = True
 
-        cache[cache_key] = "unknown"
-        return "unknown"
+        availability = "depleted" if saw_depleted and not saw_unknown else "unknown"
+        cache[cache_key] = availability
+        return availability
 
     async def _first_available_fallback(
         self,
@@ -2011,6 +2027,7 @@ class SessionStreamFn:
                             shared_remaining,
                             tier_binding,
                             retry,
+                            attempted_ids,
                         ):
                             continue
                         return
@@ -2080,6 +2097,7 @@ class SessionStreamFn:
                     candidate
                     for candidate in self._auth_store.list_credentials(storage)
                     if candidate.id != access.credential_id
+                    and candidate.id not in attempted_ids
                     and (row is None or candidate.credential_type == row.credential_type)
                     and not self._auth_store.is_blocked(candidate.id, storage)
                 ]
@@ -2111,7 +2129,7 @@ class SessionStreamFn:
                         f"— continuing until {model.provider} quota is exhausted",
                         "info",
                     )
-                    self._route_state.clear()
+                    await self._route_state.clear_settled("primary model still has quota")
                     return
                 fallback = await self._first_available_fallback(
                     model,
@@ -2137,6 +2155,7 @@ class SessionStreamFn:
                 shared_remaining,
                 tier_binding,
                 retry,
+                attempted_ids,
             ):
                 continue
             return
@@ -2150,6 +2169,7 @@ class SessionStreamFn:
         shared_remaining: float | None,
         tier_binding: bool,
         retry: Any,
+        attempted_ids: set[int],
     ) -> bool:
         """Act on a low/depleted account-scope verdict.
 
@@ -2188,6 +2208,7 @@ class SessionStreamFn:
             candidate
             for candidate in self._auth_store.list_credentials(storage)
             if candidate.id != access.credential_id
+            and candidate.id not in attempted_ids
             and (row is None or candidate.credential_type == row.credential_type)
             and not self._auth_store.is_blocked(candidate.id, storage)
         ]
@@ -2198,12 +2219,6 @@ class SessionStreamFn:
             different_provider=health.state == "depleted",
             reserve_percent=retry.usage_reserve_percent,
         )
-        if not siblings and fallback is None:
-            await self._notice(
-                f"{model.provider} {condition}{remaining}; no configured fallback is available"
-            )
-            return False
-
         if not siblings and health.state == "reserve":
             # Last account on this provider, still holding spendable quota.
             # Crossing the reserve threshold used to hop to the next chain
@@ -2226,7 +2241,13 @@ class SessionStreamFn:
                 f"{model.provider} quota is exhausted",
                 "info",
             )
-            self._route_state.clear()
+            await self._route_state.clear_settled("primary model still has quota")
+            return False
+
+        if not siblings and fallback is None:
+            await self._notice(
+                f"{model.provider} {condition}{remaining}; no configured fallback is available"
+            )
             return False
 
         if tier_binding and shared_above_reserve:

--- a/local_operator/providers/usage.py
+++ b/local_operator/providers/usage.py
@@ -346,7 +346,40 @@ def usage_health(
         if fraction is not None:
             measured.append((limit, max(0.0, min(1.0, 1.0 - fraction))))
     if not measured:
-        return QuotaHealth("unknown")
+        # Balance-only endpoints (Moonshot/Kimi and DeepSeek) expose an
+        # absolute ``remaining`` amount but no total, so a positive balance
+        # cannot honestly be converted to a percentage. Exact zero is
+        # different: it is definitive exhaustion regardless of the missing
+        # denominator. Recognize only that boundary; positive amounts remain
+        # unknown/fail-open rather than inventing a quota percentage (review
+        # F3).
+        zero_balance = [
+            limit
+            for limit in relevant
+            if limit.amount.remaining is not None and limit.amount.remaining <= 0
+        ]
+        if not zero_balance:
+            return QuotaHealth("unknown")
+        reset_after = max(
+            (
+                value
+                for value in (limit.resets_in_ms(now_ms) for limit in zero_balance)
+                if value is not None
+            ),
+            default=None,
+        )
+        scope: Literal["account", "model", "unknown"]
+        if all(limit.tier and not limit.shared for limit in zero_balance):
+            scope = "model"
+        else:
+            scope = "account"
+        return QuotaHealth(
+            "depleted",
+            remaining_fraction=0.0,
+            reset_after_ms=reset_after,
+            scope=scope,
+            binding_labels=tuple(limit.label for limit in zero_balance),
+        )
 
     remaining = min(value for _limit, value in measured)
     threshold = min(100.0, max(0.0, float(reserve_percent))) / 100.0

--- a/local_operator/providers/usage.py
+++ b/local_operator/providers/usage.py
@@ -353,13 +353,17 @@ def usage_health(
         # denominator. Recognize only that boundary; positive amounts remain
         # unknown/fail-open rather than inventing a quota percentage (review
         # F3).
-        zero_balance = [
-            limit
-            for limit in relevant
-            if limit.amount.remaining is not None and limit.amount.remaining <= 0
-        ]
-        if not zero_balance:
+        balances = [limit for limit in relevant if limit.amount.remaining is not None]
+        # DeepSeek returns one row per currency. One empty wallet does not
+        # exhaust an account that still has funds in another, so exact-zero is
+        # definitive only when EVERY denominator-less balance row is non-
+        # positive. A mixed zero/positive report remains unknown rather than
+        # being skipped (review F6).
+        if not balances or any(
+            limit.amount.remaining is not None and limit.amount.remaining > 0 for limit in balances
+        ):
             return QuotaHealth("unknown")
+        zero_balance = balances
         reset_after = max(
             (
                 value

--- a/tests/unit/model/test_configure.py
+++ b/tests/unit/model/test_configure.py
@@ -1039,6 +1039,107 @@ async def test_preflight_skips_a_fully_spent_fallback_to_the_next_usable(tmp_pat
 
 
 @pytest.mark.asyncio
+async def test_fallback_quota_is_unknown_when_an_oauth_account_is_omitted(tmp_path) -> None:
+    """One unread OAuth sibling prevents a provider-wide depleted verdict.
+
+    ``list_oauth_accesses`` omits refresh failures. If the one access it does
+    return is at 0%, the missing row is still UNKNOWN — not proof that every
+    account is depleted (agent review F1)."""
+    store = AuthStore(tmp_path / "auth.db")
+    first = store.upsert_credential("anthropic", _oauth("oauth-a", "account-a"))
+    second = store.upsert_credential("anthropic", _oauth("oauth-b", "account-b"))
+    stream = create_stream_fn(store, {"retry": {"usageAwareFallback": True}})
+
+    access = await store.get_oauth_access("anthropic", "session-a")
+    assert access is not None
+    survivor = first if access.credential_id == first.id else second
+
+    try:
+        with (
+            patch.object(store, "list_oauth_accesses", return_value=[access]),
+            patch(
+                "local_operator.providers.usage.fetch_usage",
+                side_effect=lambda *_args, **_kwargs: _anthropic_usage(100.0),
+            ),
+        ):
+            verdict = await stream._provider_quota_availability(
+                "anthropic", "claude-opus-5", reserve_percent=10, cache={}
+            )
+
+        assert survivor.id in {first.id, second.id}
+        assert verdict == "unknown"
+    finally:
+        await stream.close()
+        store.close()
+
+
+@pytest.mark.asyncio
+async def test_reserve_only_pool_settles_back_from_a_pinned_fallback(tmp_path) -> None:
+    """After every sibling is checked, reserve quota wins over the old pin.
+
+    Both Anthropic accounts have 5% Fable quota. The previous fallback must
+    clear after the second probe; attempted accounts are not counted as fresh
+    siblings that send the walk around once more (agent review F2)."""
+    store = AuthStore(tmp_path / "auth.db")
+    store.upsert_credential("anthropic", _oauth("oauth-a", "account-a"))
+    store.upsert_credential("anthropic", _oauth("oauth-b", "account-b"))
+    stream = create_stream_fn(
+        store,
+        {"retry": {"usageAwareFallback": True, "usageReservePercent": 10}},
+        session_id=_session_hashing_to_first_row(2),
+    )
+    model = ModelSpec(provider="anthropic", model_id="claude-fable-5")
+    stream._primary_selector = "anthropic/claude-fable-5"
+    await stream._route_state.activate(FallbackTarget("kimi/k3"), "previous failure", cooldown_ms=0)
+    # Permit the boundary probe of the primary while retaining the active pin.
+    stream._route_state.primary_retry_at_ms = 0
+
+    try:
+        with patch(
+            "local_operator.providers.usage.fetch_usage",
+            side_effect=lambda *_args, **_kwargs: _anthropic_fable_usage(95.0),
+        ):
+            await stream.preflight_usage(model)
+
+        assert stream._route_state.active is None
+    finally:
+        await stream.close()
+        store.close()
+
+
+@pytest.mark.asyncio
+async def test_blocked_depleted_oauth_does_not_hide_healthy_api_key(tmp_path) -> None:
+    """Availability follows the credential tier routing will actually use.
+
+    A blocked OAuth row is still enumerated for usage and reports 0%, but the
+    wire cascade falls through to the API key. Its healthy report prevents the
+    provider from being skipped (agent review F4)."""
+    store = AuthStore(tmp_path / "auth.db")
+    oauth = store.upsert_credential("kimi", _oauth("oauth-kimi", "kimi-a"))
+    store.block_credential(oauth.id, "kimi", block_ms=60_000)
+    api = store.upsert_credential("kimi", {"key": "sk-kimi", "source": "login"})
+    stream = create_stream_fn(store, {"retry": {"usageAwareFallback": True}})
+
+    selected = await store.get_oauth_access("kimi", "session-a", read_only=True)
+    assert selected is not None and selected.credential_id == api.id
+
+    async def usage_for_access(_client, provider, *, access_token=None, api_key=None, **_kwargs):
+        assert provider == "kimi"
+        return _kimi_usage(100.0 if access_token else 20.0)
+
+    try:
+        with patch("local_operator.providers.usage.fetch_usage", side_effect=usage_for_access):
+            verdict = await stream._provider_quota_availability(
+                "kimi", "k3", reserve_percent=10, cache={}
+            )
+
+        assert verdict == "usable"
+    finally:
+        await stream.close()
+        store.close()
+
+
+@pytest.mark.asyncio
 async def test_transport_fallback_cooldown_skips_quota_probe(tmp_path) -> None:
     store = AuthStore(tmp_path / "auth.db")
     store.upsert_credential("anthropic", _oauth("oauth-a", "account-a"))

--- a/tests/unit/model/test_configure.py
+++ b/tests/unit/model/test_configure.py
@@ -1140,6 +1140,39 @@ async def test_blocked_depleted_oauth_does_not_hide_healthy_api_key(tmp_path) ->
 
 
 @pytest.mark.asyncio
+async def test_depleted_selected_api_key_does_not_hide_an_unprobed_sibling(tmp_path) -> None:
+    """One empty key is not proof every key on the provider is empty.
+
+    The credential store exposes only the selected secret. When another API
+    key row exists, a depleted selected key therefore fails open so the stream
+    rotation can reach the sibling instead of skipping the provider (review
+    F5)."""
+    store = AuthStore(tmp_path / "auth.db")
+    first = store.upsert_credential("kimi", {"key": "sk-empty", "source": "login"})
+    second = store.upsert_credential("kimi", {"key": "sk-funded", "source": "login"})
+    session = _session_hashing_to_first_row(2)
+    stream = create_stream_fn(store, {"retry": {"usageAwareFallback": True}}, session_id=session)
+
+    selected = await store.get_oauth_access("kimi", session, read_only=True)
+    assert selected is not None and selected.credential_id == first.id
+
+    try:
+        with patch(
+            "local_operator.providers.usage.fetch_usage",
+            side_effect=lambda *_args, **_kwargs: _kimi_usage(100.0),
+        ):
+            verdict = await stream._provider_quota_availability(
+                "kimi", "k3", reserve_percent=10, cache={}
+            )
+
+        assert second.id != selected.credential_id
+        assert verdict == "unknown"
+    finally:
+        await stream.close()
+        store.close()
+
+
+@pytest.mark.asyncio
 async def test_transport_fallback_cooldown_skips_quota_probe(tmp_path) -> None:
     store = AuthStore(tmp_path / "auth.db")
     store.upsert_credential("anthropic", _oauth("oauth-a", "account-a"))

--- a/tests/unit/model/test_configure.py
+++ b/tests/unit/model/test_configure.py
@@ -569,10 +569,13 @@ async def test_preflight_fallback_selection_skips_benched_targets(tmp_path) -> N
     try:
         # The stream driver benched zai after it exhausted its provider.
         stream._route_state.mark_target_failed(FallbackTarget("zai/glm-5.3"), cooldown_ms=300_000)
-        with patch(
-            "local_operator.providers.usage.fetch_usage",
-            side_effect=lambda *_args, **_kwargs: _anthropic_usage(100.0),
-        ):
+
+        async def usage_for_access(_client, provider, **_kwargs):
+            # Anthropic is the exhausted primary; fallbacks must look usable
+            # so the quota-aware skip does not hide the bench preference.
+            return _anthropic_usage(100.0 if provider == "anthropic" else 20.0)
+
+        with patch("local_operator.providers.usage.fetch_usage", side_effect=usage_for_access):
             await stream.preflight_usage(model)
 
         # Preflight pinned the SECOND fallback, not the benched head.
@@ -612,7 +615,9 @@ async def test_preflight_fallback_uses_a_benched_target_when_nothing_else_remain
         stream._route_state.mark_target_failed(FallbackTarget("zai/glm-5.3"), cooldown_ms=300_000)
         with patch(
             "local_operator.providers.usage.fetch_usage",
-            side_effect=lambda *_args, **_kwargs: _anthropic_usage(100.0),
+            side_effect=lambda _client, provider, **_kwargs: _anthropic_usage(
+                100.0 if provider == "anthropic" else 20.0
+            ),
         ):
             await stream.preflight_usage(model)
 
@@ -768,7 +773,13 @@ async def test_reserve_account_is_not_blocked_when_falling_back_cross_provider(t
     A lone reserve account with a cross-provider fallback used to be blocked
     until its window reset before the session moved to the fallback. The block
     is cross-process, so it also stranded every OTHER session — including ones
-    whose fallback chains could not rescue them."""
+    whose fallback chains could not rescue them.
+
+    Crossing the reserve threshold is also no longer a reason to LEAVE the
+    provider: the last account still holding spendable quota stays in
+    service until it is genuinely at 0%. The fallback is configured so the
+    old hop-at-10% behaviour would have pinned openai; staying on anthropic
+    is the contract this test now pins."""
     store = AuthStore(tmp_path / "auth.db")
     account = store.upsert_credential("anthropic", _oauth("oauth-a", "account-a"))
     store.upsert_credential("openai", {"key": "sk-openai", "source": "login"})
@@ -793,10 +804,235 @@ async def test_reserve_account_is_not_blocked_when_falling_back_cross_provider(t
             await stream.preflight_usage(model)
 
         assert not store.is_blocked(account.id, "anthropic")
-        assert stream._route_state.active == FallbackTarget("openai/gpt-5.3-codex")
+        assert stream._route_state.active is None
         # Another session (or process) with no fallback still reaches the account.
         access = await store.get_oauth_access("anthropic", "some-other-session")
         assert access is not None and access.credential_id == account.id
+    finally:
+        await stream.close()
+        store.close()
+
+
+def _anthropic_fable_usage(fable_used: float, five_hour_used: float = 0.0) -> UsageReport:
+    """The shape of a Fable request: the scoped weekly is the binding window.
+
+    Shared 5h/7d still apply (they always do), but a Fable model is also gated
+    by ``7 day (Fable)``. That is ``scope="model"`` when the Fable window is
+    the tightest — the path that used to hop providers without rotating
+    siblings."""
+    return UsageReport(
+        provider="anthropic",
+        limits=[
+            UsageLimit(
+                id="anthropic:5h",
+                label="5 hour",
+                amount=UsageAmount(used=five_hour_used, limit=100.0, unit="percent"),
+                window="5h",
+                shared=True,
+                resets_at_ms=10**15,
+            ),
+            UsageLimit(
+                id="anthropic:7d:fable",
+                label="7 day (Fable)",
+                amount=UsageAmount(used=fable_used, limit=100.0, unit="percent"),
+                window="7d",
+                shared=False,
+                tier="fable",
+                resets_at_ms=10**15,
+            ),
+        ],
+    )
+
+
+def _kimi_usage(used_percent: float) -> UsageReport:
+    return UsageReport(
+        provider="kimi",
+        limits=[
+            UsageLimit(
+                id="kimi:total",
+                label="Total quota",
+                amount=UsageAmount(used=used_percent, limit=100.0, unit="percent"),
+                shared=True,
+                resets_at_ms=10**15,
+            )
+        ],
+    )
+
+
+@pytest.mark.asyncio
+async def test_model_tier_cap_rotates_siblings_before_leaving_the_provider(tmp_path) -> None:
+    """A spent Fable weekly is per account, not per provider.
+
+    The reported cascade: primary on ``claude-fable-5``, first Anthropic
+    login's Fable window at 100% while siblings still had Fable headroom
+    (and every login still had 5h/7d), yet preflight hopped to Kimi because
+    ``scope="model"`` skipped sibling rotation. The first account is taken
+    out of rotation; the sibling with remaining Fable quota serves; no
+    provider failover fires."""
+    store = AuthStore(tmp_path / "auth.db")
+    first = store.upsert_credential("anthropic", _oauth("oauth-a", "account-a"))
+    second = store.upsert_credential("anthropic", _oauth("oauth-b", "account-b"))
+    store.upsert_credential("kimi", _oauth("oauth-kimi", "kimi-a"))
+    session = _session_hashing_to_first_row(2)
+    stream = create_stream_fn(
+        store,
+        {
+            "retry": {
+                "usageAwareFallback": True,
+                "usageReservePercent": 10,
+                "fallbackChains": {"default": ["kimi/k3"]},
+            }
+        },
+        session_id=session,
+    )
+    notices: list[str] = []
+    stream.set_notice_handler(lambda text, kind: notices.append(text))
+    model = ModelSpec(provider="anthropic", model_id="claude-fable-5")
+
+    async def usage_for_access(_client, provider, *, access_token=None, **_kwargs):
+        if provider == "kimi":
+            return _kimi_usage(90.0)
+        return _anthropic_fable_usage(100.0 if access_token == "oauth-a" else 16.0)
+
+    try:
+        with patch("local_operator.providers.usage.fetch_usage", side_effect=usage_for_access):
+            await stream.preflight_usage(model)
+
+        assert store.is_blocked(first.id, "anthropic")
+        assert not store.is_blocked(second.id, "anthropic")
+        selected = await store.get_oauth_access("anthropic", session)
+        assert selected is not None and selected.credential_id == second.id
+        assert stream._route_state.active is None
+        assert any("trying another anthropic account" in notice for notice in notices)
+    finally:
+        await stream.close()
+        store.close()
+
+
+@pytest.mark.asyncio
+async def test_last_account_in_reserve_stays_on_the_provider(tmp_path) -> None:
+    """Reserve is a preference between siblings, not a hop to the next provider.
+
+    One Anthropic account at 5% remaining, chain next is Kimi at 10% remaining
+    then a maxed Qwen then Grok. The old policy pinned Kimi the moment the
+    last Anthropic account crossed the 10% threshold, then pinned past Kimi
+    for the same reason. Spendable quota on the current provider must be
+    emptied before the cascade moves."""
+    store = AuthStore(tmp_path / "auth.db")
+    account = store.upsert_credential("anthropic", _oauth("oauth-a", "account-a"))
+    store.upsert_credential("kimi", _oauth("oauth-kimi", "kimi-a"))
+    store.upsert_credential("xai", _oauth("oauth-xai", "xai-a"))
+    stream = create_stream_fn(
+        store,
+        {
+            "retry": {
+                "usageAwareFallback": True,
+                "usageReservePercent": 10,
+                "fallbackChains": {
+                    "default": ["kimi/k3", "alibaba-token-plan/qwen3.8-max", "xai/grok-4.6"]
+                },
+            }
+        },
+        session_id="session-a",
+    )
+    notices: list[str] = []
+    stream.set_notice_handler(lambda text, kind: notices.append(f"{kind}:{text}"))
+    model = ModelSpec(provider="anthropic", model_id="claude-fable-5")
+
+    async def usage_for_access(_client, provider, *, access_token=None, **_kwargs):
+        if provider == "kimi":
+            return _kimi_usage(90.0)
+        if provider == "xai":
+            return _kimi_usage(0.0)
+        return _anthropic_fable_usage(95.0)
+
+    try:
+        with patch("local_operator.providers.usage.fetch_usage", side_effect=usage_for_access):
+            await stream.preflight_usage(model)
+
+        assert not store.is_blocked(account.id, "anthropic")
+        assert stream._route_state.active is None
+        selected = await store.get_oauth_access("anthropic", "session-a")
+        assert selected is not None and selected.credential_id == account.id
+        assert any("continuing until anthropic quota is exhausted" in n for n in notices)
+    finally:
+        await stream.close()
+        store.close()
+
+
+@pytest.mark.asyncio
+async def test_preflight_skips_a_depleted_fallback_provider(tmp_path) -> None:
+    """A maxed fallback is not a place to land.
+
+    Anthropic genuinely exhausted, Kimi at 10% remaining, Qwen at 100%. The
+    cascade must pin Kimi (spendable reserve) rather than Qwen (already
+    empty) or hopping past Kimi because 10% looks like a reason to leave."""
+    store = AuthStore(tmp_path / "auth.db")
+    store.upsert_credential("anthropic", _oauth("oauth-a", "account-a"))
+    store.upsert_credential("kimi", _oauth("oauth-kimi", "kimi-a"))
+    store.upsert_credential("xai", _oauth("oauth-xai", "xai-a"))
+    stream = create_stream_fn(
+        store,
+        {
+            "retry": {
+                "usageAwareFallback": True,
+                "usageReservePercent": 10,
+                "fallbackChains": {"default": ["kimi/k3", "xai/grok-4.6"]},
+            }
+        },
+        session_id="session-a",
+    )
+    model = ModelSpec(provider="anthropic", model_id="claude-opus-5")
+
+    async def usage_for_access(_client, provider, **_kwargs):
+        if provider == "anthropic":
+            return _anthropic_usage(100.0)
+        if provider == "kimi":
+            return _kimi_usage(90.0)
+        return _kimi_usage(100.0)
+
+    try:
+        with patch("local_operator.providers.usage.fetch_usage", side_effect=usage_for_access):
+            await stream.preflight_usage(model)
+
+        assert stream._route_state.active == FallbackTarget("kimi/k3")
+    finally:
+        await stream.close()
+        store.close()
+
+
+@pytest.mark.asyncio
+async def test_preflight_skips_a_fully_spent_fallback_to_the_next_usable(tmp_path) -> None:
+    """When the chain's head fallback is at 0%, land on the next that isn't."""
+    store = AuthStore(tmp_path / "auth.db")
+    store.upsert_credential("anthropic", _oauth("oauth-a", "account-a"))
+    store.upsert_credential("kimi", _oauth("oauth-kimi", "kimi-a"))
+    store.upsert_credential("xai", _oauth("oauth-xai", "xai-a"))
+    stream = create_stream_fn(
+        store,
+        {
+            "retry": {
+                "usageAwareFallback": True,
+                "usageReservePercent": 10,
+                "fallbackChains": {"default": ["kimi/k3", "xai/grok-4.6"]},
+            }
+        },
+        session_id="session-a",
+    )
+    model = ModelSpec(provider="anthropic", model_id="claude-opus-5")
+
+    async def usage_for_access(_client, provider, **_kwargs):
+        if provider == "anthropic":
+            return _anthropic_usage(100.0)
+        if provider == "kimi":
+            return _kimi_usage(100.0)
+        return _kimi_usage(20.0)
+
+    try:
+        with patch("local_operator.providers.usage.fetch_usage", side_effect=usage_for_access):
+            await stream.preflight_usage(model)
+
+        assert stream._route_state.active == FallbackTarget("xai/grok-4.6")
     finally:
         await stream.close()
         store.close()

--- a/tests/unit/providers/test_usage.py
+++ b/tests/unit/providers/test_usage.py
@@ -121,6 +121,42 @@ def test_usage_health_shared_window_reaches_reserve() -> None:
     assert health.reset_after_ms == 10_000
 
 
+def test_usage_health_exact_zero_balance_is_depleted_without_a_total() -> None:
+    """An absolute zero is exhaustion even when percentage is unknowable.
+
+    Moonshot/Kimi's API-key endpoint reports only ``available_balance``. A
+    positive balance remains unknown because no denominator exists, but exact
+    zero must let fallback selection skip the empty provider (review F3)."""
+    zero = UsageReport(
+        provider="kimi",
+        limits=[
+            UsageLimit(
+                id="kimi:balance",
+                label="Balance (USD)",
+                amount=UsageAmount(remaining=0.0, unit="usd"),
+                window="lifetime",
+            )
+        ],
+    )
+    positive = UsageReport(
+        provider="kimi",
+        limits=[
+            UsageLimit(
+                id="kimi:balance",
+                label="Balance (USD)",
+                amount=UsageAmount(remaining=10.0, unit="usd"),
+                window="lifetime",
+            )
+        ],
+    )
+
+    health = usage_health(zero, "k3")
+    assert health.state == "depleted"
+    assert health.scope == "account"
+    assert health.remaining_fraction == 0.0
+    assert usage_health(positive, "k3").state == "unknown"
+
+
 def test_usage_health_depleted_reset_ignores_windows_merely_in_reserve() -> None:
     """The depleted horizon counts only fully-spent windows.
 

--- a/tests/unit/providers/test_usage.py
+++ b/tests/unit/providers/test_usage.py
@@ -150,11 +150,30 @@ def test_usage_health_exact_zero_balance_is_depleted_without_a_total() -> None:
         ],
     )
 
+    mixed = UsageReport(
+        provider="deepseek",
+        limits=[
+            UsageLimit(
+                id="deepseek:balance:usd",
+                label="Balance (USD)",
+                amount=UsageAmount(remaining=0.0, unit="usd"),
+                window="lifetime",
+            ),
+            UsageLimit(
+                id="deepseek:balance:cny",
+                label="Balance (CNY)",
+                amount=UsageAmount(remaining=10.0, unit="unknown"),
+                window="lifetime",
+            ),
+        ],
+    )
+
     health = usage_health(zero, "k3")
     assert health.state == "depleted"
     assert health.scope == "account"
     assert health.remaining_fraction == 0.0
     assert usage_health(positive, "k3").state == "unknown"
+    assert usage_health(mixed, "deepseek-chat").state == "unknown"
 
 
 def test_usage_health_depleted_reset_ignores_windows_merely_in_reserve() -> None:


### PR DESCRIPTION
## Summary of Changes

Quota-aware preflight hopped providers while spendable quota remained on the current one. Two defects combined:

1. **A model-tier cap skipped sibling rotation.** Anthropic's `7 day (Fable)` against `claude-fable-5` is `scope="model"`. That branch jumped straight to the next configured provider, so three Anthropic logins that still had Fable (and 5h/7d) headroom were never asked.
2. **The 10% reserve threshold was treated as a reason to leave the provider.** The last account holding remaining quota (Kimi at 90% used / 10% remaining) was abandoned for the next chain entry, which then hopped again because *it* was at 10% remaining — landing on a maxed Qwen and then Grok.

The expected cascade is: spend every Anthropic account (including Fable) to 0%, then fully consume Kimi, and only then move on.

## Fix

- **Sibling rotation on model-scope verdicts.** A spent Fable weekly is still per account. The first login is blocked/demoted and the walk continues on the same provider; only the last account may leave it.
- **Reserve stays on the provider.** Crossing `usageReservePercent` is a preference *between siblings of the same provider*, not a licence to hop. The last account with remaining > 0 stays in service until it is genuinely at 0%. A same-provider lower-effort hop is still allowed (it reduces token spend without abandoning remaining quota).
- **Quota-aware fallback selection.** `_first_available_fallback` now probes each candidate provider's live quota and skips a hop whose every account is at 0%, so the cascade does not pin a maxed Kimi/Qwen. Reserve is still usable. Unknown/unreachable usage fails open. The existing bench preference is unchanged (benched targets still outrank depleted ones; an all-benched/all-depleted chain still returns its first authed candidate rather than "no configured fallback").

## Change class

C2 — standard/pre-authorized; behaviour fix in the quota-aware failover router with a bounded blast radius (preflight route selection), no contract changes.

## Related Issue(s)

Follow-on to #191 (exhaust accounts before failing over) and #180 (stop blocking reserve accounts). Those closed the all-blocked and reserve-*block* paths; this closes the model-scope skip and the reserve-*hop* path.

## Impact

- No breaking changes, no dependency updates.
- Sessions on a multi-account Anthropic pool with a Fable (or other scoped-tier) primary will now rotate through those accounts before leaving Anthropic.
- A provider sitting under the reserve threshold will keep serving until it is empty, instead of immediately pinning the next chain entry.
- Fallback selection may spend one extra usage request per candidate provider at a message boundary (cached per provider+model for the walk). Fail-open if the endpoint is missing or errors.

## Testing Details

**Unit tests** (mutation-checked by construction: the new cases fail on `origin/main`):

- `test_model_tier_cap_rotates_siblings_before_leaving_the_provider` — Fable at 100% on account A, 16% on account B → A blocked, B serves, no Kimi pin.
- `test_last_account_in_reserve_stays_on_the_provider` — last Anthropic account at 5% remaining, Kimi at 10% remaining → stay on Anthropic.
- `test_preflight_skips_a_depleted_fallback_provider` — Anthropic exhausted, Kimi at 10% remaining, XAI maxed → pin Kimi (spendable reserve), not XAI.
- `test_preflight_skips_a_fully_spent_fallback_to_the_next_usable` — Kimi at 0%, XAI at 20% → pin XAI.
- `test_reserve_account_is_not_blocked_when_falling_back_cross_provider` — updated: last account in reserve no longer hops; still not blocked.

```
tests/unit/model/test_configure.py
82 passed
```

Gates clean on the changed Python files: flake8, black, isort, pyright.

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my changes work as intended.
- [x] All new and existing tests pass.
- [x] I have run formatting (black/isort), linting (flake8), and type checks (pyright), and they pass.
- [x] I have updated the documentation when required.
- [x] Security considerations are addressed (especially for code execution features).
- [x] I have linked all related issues.