### PR TITLE
feat(tui): run shell commands straight from the composer with !

### DIFF
--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -89,7 +89,9 @@ from local_operator.harness.types import (
     StreamTextDelta,
     StreamUsageEvent,
     TextContent,
+    ToolCall,
     ToolContext,
+    ToolResult,
     Usage,
     WakeDeliveredEvent,
 )
@@ -986,6 +988,11 @@ class Session:
         self._background_tasks: set[asyncio.Task[Any]] = set()
         self._signal: AbortSignal | None = None
         self._is_streaming = False
+        #: Bang-mode receipts that completed while a turn or manual compaction
+        #: owned the message list. They cannot be spliced into a live provider
+        #: batch, but dropping them would make a visible command disappear on
+        #: resume. The owner flushes this FIFO before releasing `_turn_lock`.
+        self._pending_shell_records: list[tuple[str, ToolResult]] = []
         self._turn_lock = asyncio.Lock()  # serializes prompt() and wake deliveries
         # True only while an ON-DEMAND compaction holds ``_turn_lock``. The
         # automatic pass runs inside a turn and is covered by ``_is_streaming``;
@@ -1978,6 +1985,10 @@ class Session:
             )
         await self._turn_lock.acquire()
         try:
+            # Close the narrow completion-after-final-flush race: a shell
+            # receipt may have queued while the previous owner still held the
+            # lock. It must be visible before this prompt builds its request.
+            await self._flush_shell_records()
             # A fresh user prompt supersedes any earlier interrupt request.
             self._abort_requested = False
             if self._is_streaming:
@@ -2473,6 +2484,9 @@ class Session:
         if self._disposed:
             raise RuntimeError("session is disposed")
         async with self._turn_lock:
+            # Same shell-receipt boundary as prompt(): a wake turn must not
+            # build from context that omits a command already visible in TUI.
+            await self._flush_shell_records()
             # Same flush as prompt(): a wake-delivery turn is still a prompt
             # path, and the catch-up must not be stranded behind it.
             self._handle_missed_wakes()
@@ -2507,6 +2521,10 @@ class Session:
         finally:
             self._turn_task = None
             await self._flush_held_end()
+            # A bang-mode command may have completed while this turn owned the
+            # provider message list. Persist it before releasing `_turn_lock`,
+            # when no next prompt can build from a half-updated conversation.
+            await self._flush_shell_records()
 
     async def _flush_held_end(self) -> None:
         """Emit the boundary event the pipeline was holding, if any."""
@@ -3309,6 +3327,10 @@ class Session:
             return await self._run_compaction(planned, reason="manual")
         finally:
             self._compacting = False
+            # `record_shell` queues while manual compaction owns the message
+            # list. Fold those receipts into the newly compacted context before
+            # another prompt can acquire the lock and build its request.
+            await self._flush_shell_records()
             self._turn_lock.release()
 
     @staticmethod
@@ -3958,6 +3980,60 @@ class Session:
         # splice its own messages through the middle of them.
         self._context.messages.extend(messages)
 
+    async def record_shell(self, command: str, result: ToolResult) -> None:
+        """Persist a user-typed bang-mode command into the conversation.
+
+        The TUI runs the command itself (it is not a turn) and then asks the
+        session to remember it, so the next prompt — and a resume — can see
+        what just happened. omp and opencode both do this: a `! git status`
+        the user ran is context, not a secret.
+
+        A receipt that lands while a turn or manual compaction owns the message
+        list is QUEUED, never discarded: splicing it into a live provider batch
+        would produce an unsendable list, while dropping it would make a command
+        the user can see disappear on resume. The lock owner flushes the FIFO at
+        its safe boundary before another prompt can start.
+        """
+        if self._is_streaming or self._turn_lock.locked():
+            self._pending_shell_records.append((command, result))
+            return
+        # Serialize the idle write too. A prompt can otherwise acquire the lock
+        # while transcript.append_message is awaiting and build its request from
+        # a half-written synthetic exchange. Re-check the FIFO after acquisition
+        # to flush anything that raced us while we waited.
+        async with self._turn_lock:
+            await self._flush_shell_records()
+            await self._persist_shell_record(command, result)
+
+    async def _persist_shell_record(self, command: str, result: ToolResult) -> None:
+        """Append one synthetic bash exchange to transcript and live context."""
+        # Synthetic assistant+tool pair rather than a single user dump: the
+        # TUI's resume replay already knows how to mount a ToolCard from a
+        # call and its result, and a wall of stdout attributed to the user
+        # would read as something they typed.
+        user = Message.user(f"! {command}")
+        assistant = Message.assistant("")
+        assistant.tool_calls = [
+            ToolCall(id=result.tool_call_id, name="bash", arguments={"command": command})
+        ]
+        tool = Message.tool_result(result)
+        messages = [user, assistant, tool]
+        for message in messages:
+            await self._transcript.append_message(message)
+        self._context.messages.extend(messages)
+
+    async def _flush_shell_records(self) -> None:
+        """Persist queued bang-mode receipts in completion order.
+
+        Called only by the turn/compaction owner while it still holds
+        ``_turn_lock``. Pop AFTER each successful write so a transcript failure
+        leaves the unpersisted tail available to the next boundary or dispose.
+        """
+        while self._pending_shell_records:
+            command, result = self._pending_shell_records[0]
+            await self._persist_shell_record(command, result)
+            self._pending_shell_records.pop(0)
+
     # -- wakes -------------------------------------------------------------------
 
     def _load_wake_schedules(self) -> None:
@@ -4430,6 +4506,12 @@ class Session:
             self._task_group = None
             await self.jobs.dispose()
             self._wake.dispose()
+            # A shell receipt can be queued behind a turn that was just aborted.
+            # Its normal turn-finally flush should already have run, but this
+            # last-resort pass keeps disposal durable if teardown reached here
+            # through a host path without a turn task.
+            if self._pending_shell_records:
+                await self._flush_shell_records()
             self._transcript.flush()
         finally:
             # ``finally``: host-owned resources must be released even when the

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -4002,8 +4002,11 @@ class Session:
         # a half-written synthetic exchange. Re-check the FIFO after acquisition
         # to flush anything that raced us while we waited.
         async with self._turn_lock:
+            # Queue-then-flush rather than a direct write: the FIFO pops only
+            # after a successful transcript write, so a failure here leaves the
+            # receipt for the next boundary instead of losing it.
+            self._pending_shell_records.append((command, result))
             await self._flush_shell_records()
-            await self._persist_shell_record(command, result)
 
     async def _persist_shell_record(self, command: str, result: ToolResult) -> None:
         """Append one synthetic bash exchange to transcript and live context."""
@@ -4025,9 +4028,12 @@ class Session:
     async def _flush_shell_records(self) -> None:
         """Persist queued bang-mode receipts in completion order.
 
-        Called only by the turn/compaction owner while it still holds
-        ``_turn_lock``. Pop AFTER each successful write so a transcript failure
-        leaves the unpersisted tail available to the next boundary or dispose.
+        Called while ``_turn_lock`` is held at the turn, wake, compaction and
+        prompt boundaries, and once more from :meth:`dispose` after the app has
+        settled the shell worker — the lock serializes the boundary callers,
+        and teardown ordering serializes the dispose one. Pop AFTER each
+        successful write so a transcript failure leaves the unpersisted tail
+        available to the next boundary or dispose.
         """
         while self._pending_shell_records:
             command, result = self._pending_shell_records[0]

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -5502,14 +5502,19 @@ class OperatorApp(App[None]):
             # execute_bash reports a nonzero exit as a SUCCESSFUL tool result
             # (the model is expected to read the code and recover), but the
             # bang path's reader is a HUMAN whose collapsed card said `✓` on a
-            # command that failed (design round 1, D1). The header line is the
-            # tool's stable contract — `exit code: N` opens every result — so
-            # deriving the mark from it cannot disagree with the body.
-            head = _first_line(res.text)
-            if not head.startswith("exit code: "):
-                return False
-            code = head[len("exit code: ") :].split(" ", 1)[0]
-            return code.isdigit() and code != "0"
+            # command that failed (design round 1, D1). The header lines are
+            # the tool's stable contract — `exit code: N` opens every result,
+            # or `TIMEOUT after Ns` ahead of it when the deadline killed the
+            # process — so deriving the mark from them cannot disagree with
+            # the body. Scan the first lines, not just the first: the timeout
+            # notice is PREPENDED (round 3 minor).
+            for head in res.text.splitlines()[:3]:
+                if head.startswith("TIMEOUT after "):
+                    return True
+                if head.startswith("exit code: "):
+                    code = head[len("exit code: ") :].split(" ", 1)[0]
+                    return code.lstrip("-").isdigit() and code != "0"
+            return False
 
         async def run_shell() -> None:
             try:

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -5498,6 +5498,19 @@ class OperatorApp(App[None]):
             except Exception:
                 logger.debug("could not persist bang-mode result", exc_info=True)
 
+        def _nonzero_exit(res: ToolResult) -> bool:
+            # execute_bash reports a nonzero exit as a SUCCESSFUL tool result
+            # (the model is expected to read the code and recover), but the
+            # bang path's reader is a HUMAN whose collapsed card said `✓` on a
+            # command that failed (design round 1, D1). The header line is the
+            # tool's stable contract — `exit code: N` opens every result — so
+            # deriving the mark from it cannot disagree with the body.
+            head = _first_line(res.text)
+            if not head.startswith("exit code: "):
+                return False
+            code = head[len("exit code: ") :].split(" ", 1)[0]
+            return code.isdigit() and code != "0"
+
         async def run_shell() -> None:
             try:
                 result = await execute_bash(
@@ -5519,6 +5532,11 @@ class OperatorApp(App[None]):
                     )
                 )
                 return
+            if _nonzero_exit(result):
+                # A nonzero exit is a FAILURE on this surface. Persist it as
+                # one so a resumed session restores the same ✗ the live card
+                # showed — the replay derives its state off `is_error`.
+                result = result.model_copy(update={"is_error": True})
             # Aborting paints the receipt immediately, but the worker remains
             # authoritative until the subprocess is reaped. Do not overwrite
             # that interrupted frame with execute_bash's abort result; DO still

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -133,6 +133,7 @@ from local_operator.tui.widgets.editor import (
     ASIDE_PLACEHOLDER,
     DEFAULT_PLACEHOLDER,
     READ_ONLY_PLACEHOLDER,
+    SHELL_PLACEHOLDER,
     ArgumentHighlightChanged,
     ArgumentQueryOpened,
     Attachment,
@@ -144,6 +145,7 @@ from local_operator.tui.widgets.editor import (
     InterruptRequested,
     ModelQueryOpened,
     RefreshArgumentChoices,
+    ShellModeChanged,
     StopRequested,
     resolve_markers,
 )
@@ -644,6 +646,14 @@ ASIDE_LAYOUT_CLASS = "aside"
 #: went off again. Flipped in exactly one place, see
 #: ``OperatorApp._sync_composer_focus``.
 COMPOSER_FOCUSED_CLASS = "-composer-focused"
+
+#: Class the input dock carries while bang-mode is on. The chevron stays the
+#: same glyph — ``composer_cells`` finds the row by it — and the class is
+#: what the stylesheet reads to paint it ``string`` rather than the focus
+#: brightness. ``string`` is the ramp's command/success green, a step off
+#: the accent, so a shell-mode composer does not spend the "turn is live"
+#: ink (D5) and still reads as a different MODE from the resting field.
+COMPOSER_SHELL_CLASS = "-composer-shell"
 
 #: How long after a terminal resize the floating overlay cards re-measure
 #: themselves. They are hosted in `width: auto` containers, so Textual sends
@@ -1191,6 +1201,20 @@ class OperatorApp(App[None]):
         # the turn boundary (never mid-turn, so a turn is never half-applied).
         self._loop_running: bool = False
         self._loop_cancelled: bool = False
+        #: AbortSignal for the in-flight bang-mode command, if any. Owned by
+        #: the app rather than the session because bang-mode is a TUI gesture
+        #: — the session's abort stops a TURN, and a user-typed `sleep 30`
+        #: is not one. Esc/Ctrl+C abort this the same way they abort a turn.
+        self._shell_signal: Any = None
+        #: The ToolCard currently painting a bang-mode run, so a second
+        #: submit cannot start another command over a live one (omp refuses
+        #: a second bash while one is running) and so Esc can mark it
+        #: interrupted rather than leaving a running row forever.
+        self._shell_card: ToolCard | None = None
+        #: Textual worker owning the command above. Kept separately from the
+        #: card/signal so a session swap can abort and AWAIT process reaping
+        #: before disposing the session captured by the worker.
+        self._shell_worker: Any = None
         # The one pending tool-approval prompt, if any. The TUI owns approvals
         # (see widgets/approval.py) because the default stdin gate deadlocks
         # under a full-screen app; `_approve_all` is the session-scoped "allow
@@ -1296,6 +1320,13 @@ class OperatorApp(App[None]):
         #: INSIDE the aside took number 1, so the restored marker resolved to
         #: the aside's image instead (review round 17).
         self._aside_draft_images: dict[int, Attachment] = {}
+        #: Whether bang-mode was ON when the aside borrowed the composer. The
+        #: aside disables the gesture for the life of the card, but the command
+        #: the user had half typed is stashed and returned verbatim — returning
+        #: it into a composer that silently left bang-mode would arm Enter with
+        #: a shell command aimed at the model. Restored in `_close_aside` with
+        #: the draft it belongs to.
+        self._aside_draft_shell_mode: bool = False
         # The reasoning-effort level the USER picked, or None while the model's
         # own default stands. Held on the app rather than only on the session
         # spec because the session is replaceable — `/new`, `/reload` and
@@ -2099,6 +2130,11 @@ class OperatorApp(App[None]):
         # outlives a turn: the flow runs as a worker, not inside the turn, so
         # nothing else here would ever settle it.
         self._settle_key_prompt()
+        # A bang-mode command captured THIS session for cwd, variables and
+        # durable history. Abort and await its worker before disposing that
+        # session, or `/new`/`/resume` can leave a subprocess writing into an
+        # unmounted card and a transcript whose owner has already gone away.
+        await self._settle_shell_command()
         # The working line belongs to the turn being thrown away. Left standing
         # it does two kinds of damage: the widget goes on animating a turn that
         # no longer exists, and the stale `_working_block` reference makes
@@ -3354,7 +3390,7 @@ class OperatorApp(App[None]):
         # Only `text` is checked: an attachment cannot exist without its
         # `[Image #N]` marker standing in the buffer, and a marker is text. A
         # screenshot pasted with no words still submits, carrying its marker.
-        if not text:
+        if not text and not message.shell:
             return
         # The aside owns the composer while it is up. EVERYTHING goes to it,
         # slash-shaped lines included: the card is a MODE, its footer says so
@@ -3365,6 +3401,20 @@ class OperatorApp(App[None]):
         # bargain a modal surface makes.
         if self._aside_is_open():
             self._ask_aside(text)
+            return
+        if message.shell:
+            if self._shell_card is not None:
+                # The editor already cleared and recorded. Hand the line back
+                # the same way `/btw` retracts the question that opened it:
+                # exact history pop, then restore the buffer so the user can
+                # retry (or Esc-abort the running one) without retyping.
+                editor = self._editor()
+                recorded = text if text.lstrip().startswith("!") else f"! {text}"
+                editor.forget_last_prompt(recorded)
+                editor.load_text(recorded)
+                self._notice("a command is already running — esc to cancel it first", "warning")
+                return
+            self._run_shell_command(text)
             return
         if text.startswith("/"):
             # Nothing but dispatch. A slash command writes its own rows: the
@@ -3613,6 +3663,14 @@ class OperatorApp(App[None]):
             return
         dock.set_class(focused, COMPOSER_FOCUSED_CLASS)
 
+    def on_shell_mode_changed(self, message: ShellModeChanged) -> None:
+        """Follow the composer's bang-mode onto the dock class the sheet reads."""
+        try:
+            dock = self.query_one("#input-dock")
+        except NoMatches:
+            return
+        dock.set_class(message.active, COMPOSER_SHELL_CLASS)
+
     def on_interrupt_requested(self, message: InterruptRequested) -> None:
         """Ctrl+C from the composer — the NORMAL path, since it holds focus.
 
@@ -3856,6 +3914,11 @@ class OperatorApp(App[None]):
         self._settle_key_prompt()
         if self._session is not None:
             self._session.abort("interrupted")
+        # A bang-mode command is not a turn, so aborting the session does
+        # not reach it. Same key, same meaning: stop the work in front of
+        # the user. After the session abort so a live turn and a live
+        # command both die on one press rather than racing.
+        self._abort_shell_command()
 
     def action_stop(self) -> None:
         """Esc: stop. One press, one meaning, wherever focus happens to be.
@@ -4024,6 +4087,12 @@ class OperatorApp(App[None]):
         children = self._running_subagents(session)
 
         if not (pending or streaming or children):
+            # A bang-mode command is the one remaining thing Esc can stop
+            # when no turn is running. Checked HERE rather than above the
+            # streaming test so a live turn still takes the first press —
+            # the command is local and cheap to re-run, the turn is not.
+            if self._abort_shell_command():
+                return
             # Nothing to stop. Explicitly NOT clearing the composer.
             return
 
@@ -5171,6 +5240,10 @@ class OperatorApp(App[None]):
         parked for ``on_unmount`` instead of dying with the frame
         (``_park_unadopted_session``).
         """
+        # Unlike paint-only workers, bang-mode owns a subprocess and a durable
+        # receipt. Abort and join it BEFORE the blanket cancellation: cancelling
+        # execute_bash directly can bypass its normal result/persistence path.
+        await self._settle_shell_command()
         self.workers.cancel_all()
         await super()._shutdown()
 
@@ -5336,6 +5409,10 @@ class OperatorApp(App[None]):
         # And the login key prompt, which is awaited by a worker rather than by
         # a turn and so is not covered by either of the two above.
         self._settle_key_prompt()
+        # `_shutdown` normally settled this before Textual pruned the tree.
+        # Keep unmount independently correct for reduced test hosts and any
+        # future path that calls the hook directly.
+        await self._settle_shell_command()
         # First, and synchronously: the restore is one write on a driver that
         # is still up, and everything below it can await. An exception in
         # session teardown would otherwise leave the user's shell wearing this
@@ -5351,6 +5428,150 @@ class OperatorApp(App[None]):
             self._controller.dispose()
         if self._session is not None:
             await self._session.dispose()
+
+    def _run_shell_command(self, text: str) -> None:
+        """Run a bang-mode command locally, without starting a turn.
+
+        The bang is a MODE SWITCH, not a prompt: omp and opencode both run
+        the command in-process and paint the result as a tool row, so the
+        next real prompt can see what just happened. Empty submit is a
+        no-op (the mode already left on Enter) rather than an error, because
+        a user who entered bang-mode by accident and pressed Enter should
+        land back on the resting composer, not on a red notice.
+        """
+        command = text.lstrip()
+        if command.startswith("!"):
+            # Recalled history stores the bang; dedicated-mode submit does
+            # not. Strip one leading bang (and its following space) so both
+            # paths run the same command. A second bang is part of the
+            # command (`!!` is a shell event, not our exclude-from-context
+            # — omp's `!!` is a different product and we do not ship it).
+            command = command[1:].lstrip()
+        if not command:
+            return
+        from local_operator.harness.types import (
+            AbortSignal,
+            AgentToolUpdate,
+            ToolContext,
+        )
+        from local_operator.tools.builtin import execute_bash
+
+        call_id = f"shell-{time.monotonic_ns()}"
+        card = ToolCard(call_id, "bash", {"command": command})
+        self._append_block(UserBlock(f"! {command}"))
+        self._append_block(card)
+        signal = AbortSignal()
+        self._shell_signal = signal
+        self._shell_card = card
+        session = self._session
+        cwd = os.getcwd()
+        session_cwd = getattr(session, "_cwd", None) if session is not None else None
+        if isinstance(session_cwd, str) and session_cwd:
+            cwd = session_cwd
+        context = ToolContext(
+            cwd=cwd,
+            session_id=getattr(session, "session_id", "") or "",
+            agent_id=getattr(session, "agent_id", "") or "",
+            has_ui=True,
+            variables=getattr(session, "variables", None),
+        )
+
+        def on_update(update: AgentToolUpdate) -> None:
+            detail = _partial_text(update)
+            if detail:
+                card.set_partial_detail(detail)
+
+        async def run_shell() -> None:
+            try:
+                result = await execute_bash(
+                    call_id,
+                    {"command": command},
+                    signal,
+                    on_update,
+                    context,
+                )
+            except Exception as error:  # surface, never crash the app
+                if self._shell_card is card:
+                    card.mark_failed(str(error), str(error))
+                return
+            # Aborting paints the receipt immediately, but the worker remains
+            # authoritative until the subprocess is reaped. Do not overwrite
+            # that interrupted frame with execute_bash's abort result; DO still
+            # persist the result so the command cannot disappear on resume.
+            if self._shell_card is card and not signal.aborted:
+                if result.is_error:
+                    card.mark_failed(_first_line(result.text), result.text, result.details)
+                else:
+                    card.mark_done(result.text, result.details)
+            record = getattr(session, "record_shell", None) if session is not None else None
+            if callable(record):
+                try:
+                    await cast(Callable[..., Awaitable[None]], record)(command, result)
+                except Exception:
+                    logger.debug("could not persist bang-mode result", exc_info=True)
+
+        def _clear_shell_state() -> None:
+            if self._shell_card is card:
+                self._shell_card = None
+            if self._shell_signal is signal:
+                self._shell_signal = None
+
+        worker: Any = None
+
+        async def run_and_clear() -> None:
+            try:
+                await run_shell()
+            finally:
+                _clear_shell_state()
+                if self._shell_worker is worker:
+                    self._shell_worker = None
+
+        worker = self.run_worker(run_and_clear(), thread=False, group="shell")
+        self._shell_worker = worker
+
+    def _abort_shell_command(self) -> bool:
+        """Abort the in-flight bang-mode command. True if there was one.
+
+        The card is marked interrupted HERE rather than waiting for
+        ``execute_bash`` to return an error, because the stop key's job is
+        to change the frame on this press: a running row that stayed
+        running until the process reaped would look like Esc did nothing.
+        """
+        signal = self._shell_signal
+        card = self._shell_card
+        if signal is None and card is None:
+            return False
+        if signal is not None and not signal.aborted:
+            signal.abort("interrupted")
+        if card is not None:
+            card.mark_interrupted()
+        # Keep the card/signal registered until execute_bash has reaped the
+        # process. This both refuses a second command during teardown and lets
+        # the worker persist the interrupted result before clearing ownership.
+        return True
+
+    async def _settle_shell_command(self) -> None:
+        """Abort and await the in-flight bang-mode worker, if any.
+
+        Session replacement calls this before disposal because the worker
+        captures that session for cwd, variables and history. Bounded process
+        teardown lives in ``execute_bash``; Worker.wait merely joins it here.
+        """
+        worker = self._shell_worker
+        if worker is None:
+            return
+        self._abort_shell_command()
+        try:
+            await worker.wait()
+        except BaseException:  # noqa: BLE001 — replacement must always proceed
+            logger.debug("settling bang-mode worker failed", exc_info=True)
+        finally:
+            if self._shell_worker is worker:
+                self._shell_worker = None
+            # Cancellation can skip the worker's own finally; release stale UI
+            # ownership here as the last word before the session is replaced.
+            self._shell_signal = None
+            self._shell_card = None
 
     def _submit_prompt(
         self,
@@ -6279,12 +6500,16 @@ class OperatorApp(App[None]):
         except Exception:
             return  # a stripped harness with no composer
         editor.read_only = read_only
-        # The placeholder is the composer's own voice, and while the mode is
-        # on it was still printing `Message Local Operator…` — an imperative
-        # invitation from a field that refuses every key, greyed to the point
-        # of being hard to read but present enough to invite. State the
-        # constraint where the hands are.
-        editor.placeholder = READ_ONLY_PLACEHOLDER if read_only else DEFAULT_PLACEHOLDER
+        # The placeholder is the composer's own voice. Read-only always
+        # wins (the subagent page refuses every key); giving the composer
+        # back restores whichever mode it was actually in, so bang-mode's
+        # invitation is not overwritten by the resting prompt.
+        if read_only:
+            editor.placeholder = READ_ONLY_PLACEHOLDER
+        elif editor.shell_mode:
+            editor.placeholder = SHELL_PLACEHOLDER
+        else:
+            editor.placeholder = DEFAULT_PLACEHOLDER
         # Not focusable while inert: a caret in a field that refuses every key
         # is the most misleading thing this mode could paint, and ↑↓ have to
         # reach the transcript that the hint says they scroll. The caret is
@@ -8407,6 +8632,14 @@ class OperatorApp(App[None]):
         # Taken BEFORE `clear_content`, which drops them.
         self._aside_draft_images = editor.attachments()
         editor.clear_content()
+        self._aside_draft_shell_mode = editor.shell_mode
+        # Bang-mode is a main-chat gesture. A `!` typed into the aside is
+        # the start of a question, and a command run from a card that
+        # promised "off the record" would both break the promise and eat
+        # the character. Returned in `_close_aside`. BEFORE the aside
+        # placeholder: leaving bang-mode restores the resting invitation,
+        # which would overwrite `Ask the aside…` if this ran after.
+        editor.set_allows_shell(False)
         editor.placeholder = ASIDE_PLACEHOLDER
         # The command list is borrowed too, and returned in `_close_aside`.
         # `on_editor_submitted` routes a slash-shaped line to the aside as a
@@ -8503,7 +8736,17 @@ class OperatorApp(App[None]):
         self._aside_draft = None
         self._aside_draft_images = {}
         editor = self._editor()
-        editor.placeholder = DEFAULT_PLACEHOLDER
+        editor.set_allows_shell(True)
+        # The stashed draft comes back into the mode it was typed in: a
+        # half-typed `!` command returned to a composer that silently left
+        # bang-mode would send the command to the model on the next Enter.
+        editor.set_shell_mode(self._aside_draft_shell_mode)
+        self._aside_draft_shell_mode = False
+        # `set_shell_mode` is a no-op when the state is unchanged — which is
+        # the common case (the aside was opened from the resting composer) —
+        # and then the aside's own placeholder would stay on screen. The mode
+        # decides the voice either way.
+        editor.placeholder = SHELL_PLACEHOLDER if editor.shell_mode else DEFAULT_PLACEHOLDER
         editor.load_text(draft or "")
         # AFTER `load_text`: adoption re-keys onto the markers now in the
         # buffer, so the text has to be there first.

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -73,6 +73,8 @@ from local_operator.harness.types import (
     AskQuestion,
     ImageContent,
     Message,
+    TextContent,
+    ToolResult,
 )
 from local_operator.harness.wake import WAKE_PROMPT_MESSAGE_TYPE
 from local_operator.logger import current_log_file
@@ -3412,6 +3414,10 @@ class OperatorApp(App[None]):
                 recorded = text if text.lstrip().startswith("!") else f"! {text}"
                 editor.forget_last_prompt(recorded)
                 editor.load_text(recorded)
+                # The line comes back IN the mode it was submitted from, so
+                # the placeholder matches the buffer and Enter re-runs it as a
+                # command once the running one is settled.
+                editor.set_shell_mode(True)
                 self._notice("a command is already running — esc to cancel it first", "warning")
                 return
             self._run_shell_command(text)
@@ -5481,6 +5487,17 @@ class OperatorApp(App[None]):
             if detail:
                 card.set_partial_detail(detail)
 
+        async def persist(result: ToolResult) -> None:
+            """One persistence hop; a spawn failure is still a completed
+            command, so the "never dropped" invariant covers it too."""
+            record = getattr(session, "record_shell", None) if session is not None else None
+            if not callable(record):
+                return
+            try:
+                await cast(Callable[..., Awaitable[None]], record)(command, result)
+            except Exception:
+                logger.debug("could not persist bang-mode result", exc_info=True)
+
         async def run_shell() -> None:
             try:
                 result = await execute_bash(
@@ -5491,8 +5508,16 @@ class OperatorApp(App[None]):
                     context,
                 )
             except Exception as error:  # surface, never crash the app
-                if self._shell_card is card:
+                if self._shell_card is card and not signal.aborted:
                     card.mark_failed(str(error), str(error))
+                await persist(
+                    ToolResult(
+                        tool_call_id=call_id,
+                        tool_name="bash",
+                        content=[TextContent(text=f"error: {error}")],
+                        is_error=True,
+                    )
+                )
                 return
             # Aborting paints the receipt immediately, but the worker remains
             # authoritative until the subprocess is reaped. Do not overwrite
@@ -5503,12 +5528,7 @@ class OperatorApp(App[None]):
                     card.mark_failed(_first_line(result.text), result.text, result.details)
                 else:
                     card.mark_done(result.text, result.details)
-            record = getattr(session, "record_shell", None) if session is not None else None
-            if callable(record):
-                try:
-                    await cast(Callable[..., Awaitable[None]], record)(command, result)
-                except Exception:
-                    logger.debug("could not persist bang-mode result", exc_info=True)
+            await persist(result)
 
         def _clear_shell_state() -> None:
             if self._shell_card is card:

--- a/local_operator/tui/local_operator.tcss
+++ b/local_operator/tui/local_operator.tcss
@@ -394,6 +394,18 @@ ToolCard:focus, WakeBlock:focus {
     color: $lo-fg;
 }
 
+/* Bang-mode recolors the chevron, not the glyph. `composer_cells` finds the
+ * row by `❯`, and swapping the character would make every focus/caret test
+ * miss the composer the moment the mode was on. `string` is the ramp's
+ * command/success green — a step off the accent, so a shell-mode composer
+ * does not spend the "turn is live" ink (D5) and still reads as a different
+ * MODE from the resting field. Outranks the focus brightness: the mode is
+ * the louder fact, and a focused shell-mode chevron that went `fg` would
+ * look identical to a focused prompt. */
+#input-dock.-composer-shell #prompt-chevron {
+    color: $lo-string;
+}
+
 Editor {
     width: 1fr;
     height: auto;

--- a/local_operator/tui/widgets/__init__.py
+++ b/local_operator/tui/widgets/__init__.py
@@ -17,6 +17,7 @@ from local_operator.tui.widgets.editor import (
     EditorQuit,
     EditorSubmitted,
     InterruptRequested,
+    ShellModeChanged,
 )
 from local_operator.tui.widgets.status_line import StatusLine
 from local_operator.tui.widgets.toast import Toast
@@ -35,6 +36,7 @@ __all__ = [
     "EditorQuit",
     "EditorSubmitted",
     "InterruptRequested",
+    "ShellModeChanged",
     "NoticeBlock",
     "StatusLine",
     "Toast",

--- a/local_operator/tui/widgets/editor.py
+++ b/local_operator/tui/widgets/editor.py
@@ -14,6 +14,13 @@ submit-on-Enter. The subclass inverts that and takes the terminal key idioms:
   buffer, and inside the text they keep their cursor-move meaning
 - ``Tab`` completes the highlighted command WITHOUT submitting
 - ``Esc`` dismisses the picker, leaving the typed text alone
+- ``!`` on an EMPTY composer enters shell mode (the bang is consumed, not
+  typed). Enter then runs the buffer as a local shell command instead of
+  sending a prompt; Esc or backspace on an empty shell-mode buffer leaves
+  the mode. omp and opencode both ship this gesture; the dedicated-mode
+  half is opencode's (caret-at-start ``!`` flips a mode, Esc/backspace
+  empty leaves it) and the submit-of-a-leading-bang half is omp's, so a
+  history recall of ``! ls`` still runs as a command.
 
 Key interception happens in :meth:`_on_key`, which runs BEFORE TextArea's
 document-insert path, so a handled key never reaches the buffer. Unhandled
@@ -338,6 +345,8 @@ class EditorSubmitted(Message):
         text: str,
         images: list[ImageContent] | None = None,
         attachments: Mapping[int, Attachment] | None = None,
+        *,
+        shell: bool = False,
     ) -> None:
         super().__init__()
         self.text = text
@@ -353,6 +362,12 @@ class EditorSubmitted(Message):
         #: widget sees an empty map and silently drops the images (review round
         #: 19). Restores need the numbers, which the ordered list has lost.
         self.attachments = dict(attachments or {})
+        #: True when this submit is a SHELL command, not a prompt. The editor
+        #: is the authority: it alone knows whether the bang-mode flag was on
+        #: at Enter, and the buffer is cleared before the app sees the
+        #: message, so the flag has to ride along the same way attachments do.
+        #: Defaulted so every existing construction site keeps working.
+        self.shell = shell
 
 
 class EditorCopyStale(Message):
@@ -413,6 +428,21 @@ class StopRequested(Message):
 
     def __init__(self) -> None:
         super().__init__()
+
+
+class ShellModeChanged(Message):
+    """Posted when bang-mode is entered or left.
+
+    The editor owns the mode (it is a property of the composer, like the
+    slash picker) and the app owns the chrome that has to follow it — the
+    dock class that recolors the chevron. The message is the seam: a
+    widget that reached into ``#input-dock`` would invert the dependency
+    this module is arranged around.
+    """
+
+    def __init__(self, active: bool) -> None:
+        super().__init__()
+        self.active = active
 
 
 class EditorQuit(Message):
@@ -514,6 +544,14 @@ READ_ONLY_PLACEHOLDER = "Read-only — press esc to reply"
 #: chrome and `esc` is never shed from it — and this says what typing here
 #: will do. Half the cells, so it also survives a narrow terminal.
 ASIDE_PLACEHOLDER = "Ask the aside…"
+
+#: What the composer says in bang-mode. Same shape as
+#: :data:`DEFAULT_PLACEHOLDER` — what typing here WILL DO, not how to leave.
+#: Esc and empty-buffer backspace already leave the mode, and naming them
+#: here would spend the invitation on an exit the user has not asked for
+#: yet. opencode's "Run a command…" is the sentence; the ellipsis matches
+#: the resting placeholder's cadence.
+SHELL_PLACEHOLDER = "Run a command…"
 
 
 class Editor(TextArea):
@@ -653,6 +691,19 @@ class Editor(TextArea):
         self._copy_gesture = False
         #: The selection `_copy_drag` took, while `_copy_gesture` holds.
         self._copied_selection: Selection | None = None
+        #: Bang-mode: Enter runs a local shell command instead of sending a
+        #: prompt. Owned here because it is a property of the COMPOSER (the
+        #: same way the slash picker is), not of the app: the key that enters
+        #: it is intercepted before TextArea inserts, and the key that leaves
+        #: it has to win over Esc-means-stop. The app follows via
+        #: :class:`ShellModeChanged`.
+        self._shell_mode = False
+        #: The aside turns this off for as long as it owns the composer: a
+        #: bang-mode command run from a card that promised "off the record"
+        #: would both break the promise and eat the ``!`` the user typed as
+        #: the start of a question. Default on; the main chat is the only
+        #: surface that runs commands.
+        self._allows_shell = True
         self.set_commands(commands or [])
 
     def render_line(self, y: int) -> Strip:
@@ -844,6 +895,37 @@ class Editor(TextArea):
         """
         lowered = name.lower()
         return lowered in self.MODEL_COMMANDS or lowered in self._required_argument_commands
+
+    @property
+    def shell_mode(self) -> bool:
+        """Whether Enter will run a local shell command instead of a prompt."""
+        return self._shell_mode
+
+    def set_shell_mode(self, active: bool) -> None:
+        """Enter or leave bang-mode. No-op when already in that state.
+
+        The placeholder swap is the mode's own voice, the same way the aside
+        and the subagent page each have one. Restoring goes through
+        :data:`DEFAULT_PLACEHOLDER` rather than whatever was showing, because
+        the only other placeholders are modes that refuse this one (the aside
+        owns the composer; the subagent page is read-only) and a user leaving
+        bang-mode is returning to the resting composer.
+        """
+        if self._shell_mode == active:
+            return
+        self._shell_mode = active
+        self.placeholder = SHELL_PLACEHOLDER if active else DEFAULT_PLACEHOLDER
+        self.post_message(ShellModeChanged(active))
+
+    def set_allows_shell(self, allowed: bool) -> None:
+        """Whether bang-mode may be entered from this composer.
+
+        The aside turns this off; leaving bang-mode first so a mode that
+        started in the main chat cannot survive the card taking the field.
+        """
+        if not allowed:
+            self.set_shell_mode(False)
+        self._allows_shell = allowed
 
     def clear_content(self) -> None:
         """Empty the buffer and leave history navigation."""
@@ -1038,6 +1120,16 @@ class Editor(TextArea):
             # LAST escape branch on purpose: every picker case above has already
             # returned, so this is Esc with nothing on screen to dismiss.
             #
+            # Bang-mode takes it first, and keeps the draft. opencode's Esc in
+            # shell mode is "leave the mode", not "scrap the command": a user
+            # who typed `ls` and changed their mind still has `ls` to send as
+            # a prompt, and a user who entered the mode by accident is one
+            # keystroke from the resting composer. Stop is one Esc away after.
+            if self._shell_mode:
+                self.set_shell_mode(False)
+                event.stop()
+                event.prevent_default()
+                return
             # It has to be handled rather than left to bubble, because
             # ``TextArea`` binds Escape to ``blur``. That made Esc a silent trap:
             # the first press moved focus out of the composer (so the user's next
@@ -1085,6 +1177,22 @@ class Editor(TextArea):
             event.stop()
             event.prevent_default()
             return
+        # Bang-mode entry. Consumed rather than inserted, matching opencode:
+        # the bang is the MODE SWITCH, not the first character of the command,
+        # so the buffer the user then types is the command itself. Gated on an
+        # EMPTY buffer so a `!` in `echo hi!` or a mid-sentence `wow!` is just
+        # a character, and on `_allows_shell` so the aside cannot eat one.
+        if (
+            not self._shell_mode
+            and self._allows_shell
+            and not self.read_only
+            and not self.text
+            and event.character == "!"
+        ):
+            self.set_shell_mode(True)
+            event.stop()
+            event.prevent_default()
+            return
         if key == "up" and self._caret_at_top_edge() and self._history:
             self._navigate_history(-1)
             event.stop()
@@ -1104,17 +1212,40 @@ class Editor(TextArea):
     # -- submit -------------------------------------------------------------
     def _submit(self) -> None:
         text = self.text
+        # Bang-mode is a MODE, but a recalled `! ls` is TEXT that still means
+        # the same thing — omp's submit path, which treats a leading bang as
+        # the command even when the dedicated mode is off. Detected HERE so
+        # the history entry and the message agree about what was sent.
+        shell = self._shell_mode or (
+            self._allows_shell
+            and text.lstrip().startswith("!")
+            and not text.lstrip().startswith("/")
+        )
+        recorded = text
+        if shell and self._shell_mode and text.strip() and not text.lstrip().startswith("!"):
+            # History of a dedicated-mode submit is stored WITH the bang so
+            # Up-arrow recall re-runs as a command rather than as a prompt
+            # that happens to look like one. The buffer itself never held
+            # the bang (it was consumed on entry), so it is prefixed here.
+            recorded = f"! {text}"
         # Checked HERE, before the post, because that is the only place the
         # entry can be prevented rather than removed afterwards — see
         # :meth:`set_records_history`.
-        if text.strip() and self._records_history:
-            self._record_history(text)
+        if recorded.strip() and self._records_history:
+            self._record_history(recorded)
         self._picker.close()
         # Only the attachments the text STILL REFERS TO. The marker is the
         # authority: pasting three screenshots and deleting two must send one,
         # because the deleted markers are the user saying they changed their
         # mind, and silently sending all three is both surprising and expensive.
-        self.post_message(EditorSubmitted(text, self.referenced_images(), self._attachments))
+        self.post_message(
+            EditorSubmitted(text, self.referenced_images(), self._attachments, shell=shell)
+        )
+        # Leave the mode WITH the buffer: a submit that stayed in bang-mode
+        # would leave the placeholder saying "Run a command…" over an empty
+        # field the next Enter would treat as a no-op, which reads as a
+        # stuck mode. opencode resets to normal on submit for the same reason.
+        self.set_shell_mode(False)
         self.clear_content()
 
     def referenced_images(self) -> list[ImageContent]:
@@ -1362,6 +1493,13 @@ class Editor(TextArea):
                 del self._attachments[index]
 
     def action_delete_left(self) -> None:
+        # Empty-buffer backspace leaves bang-mode, matching opencode. The
+        # bang was consumed on entry, so there is no character to delete:
+        # the mode IS the character, and backspace on nothing is the
+        # honest inverse of the key that entered.
+        if self._shell_mode and not self.text:
+            self.set_shell_mode(False)
+            return
         if not self._delete_marker(before=True):
             super().action_delete_left()
 

--- a/local_operator/tui/widgets/editor.py
+++ b/local_operator/tui/widgets/editor.py
@@ -545,13 +545,13 @@ READ_ONLY_PLACEHOLDER = "Read-only — press esc to reply"
 #: will do. Half the cells, so it also survives a narrow terminal.
 ASIDE_PLACEHOLDER = "Ask the aside…"
 
-#: What the composer says in bang-mode. Same shape as
-#: :data:`DEFAULT_PLACEHOLDER` — what typing here WILL DO, not how to leave.
-#: Esc and empty-buffer backspace already leave the mode, and naming them
-#: here would spend the invitation on an exit the user has not asked for
-#: yet. opencode's "Run a command…" is the sentence; the ellipsis matches
-#: the resting placeholder's cadence.
-SHELL_PLACEHOLDER = "Run a command…"
+#: What the composer says in bang-mode. The first clause is opencode's
+#: sentence — what typing here WILL DO — and the second names the way out,
+#: because entry is taught three ways (tip, placeholder, green chevron) while
+#: exit was taught by nothing on screen (design round 1, D2): the placeholder
+#: is the one surface guaranteed visible the moment the mode opens on an
+#: empty buffer, which is exactly when a first-timer looks for the door.
+SHELL_PLACEHOLDER = "Run a command… — esc to leave"
 
 
 class Editor(TextArea):

--- a/local_operator/tui/widgets/welcome.py
+++ b/local_operator/tui/widgets/welcome.py
@@ -247,9 +247,10 @@ HINT_KEY_WIDTH_TIGHT = max(cell_len(key) for key, _ in HINTS) + 1
 #:
 #: Every entry names something THIS BUILD ANSWERS — a command in
 #: ``local_operator.tui.app.SLASH_COMMANDS``, a key in
-#: ``OperatorApp.BINDINGS``, or a tool the agent is actually handed — because a
-#: splash advertising a command the app rejects is worse than a blank row, and
-#: this is the one screen a first-run user reads word for word.
+#: ``OperatorApp.BINDINGS``, a composer gesture (bang-mode), or a tool the
+#: agent is actually handed — because a splash advertising a command the app
+#: rejects is worse than a blank row, and this is the one screen a first-run
+#: user reads word for word.
 #:
 #: Each one leads with the command or the verb so that the width tiers can
 #: truncate the tail and still leave something actionable behind; each is a
@@ -274,7 +275,7 @@ TIPS: tuple[str, ...] = (
     "Type as the agent works — it is sent at the next step",
     "esc stops the agent without ending the session",
     "Ask for parallel work and the agent fans out subagents",
-    "/mcp lists the MCP servers found in your mcp.json",
+    "! on an empty composer runs a shell command",
     "/goal sets the objective that /loop iterates toward",
 )
 

--- a/tests/unit/session/test_aside.py
+++ b/tests/unit/session/test_aside.py
@@ -286,11 +286,9 @@ async def test_record_shell_queues_mid_turn_and_flushes_before_the_next_prompt(t
         session._turn_lock.release()
 
     assert session._pending_shell_records == []
-    assert [m.role for m in session._context.messages if isinstance(m, Message)] == [
-        "user",
-        "assistant",
-        "tool",
-    ]
+    typed = [m for m in session._context.messages if isinstance(m, Message)]
+    assert typed == list(session._context.messages)  # every entry is a real message
+    assert [m.role for m in typed] == ["user", "assistant", "tool"]
     first = session._context.messages[0]
     assert isinstance(first, Message)
     assert first.text == "! echo hi"

--- a/tests/unit/session/test_aside.py
+++ b/tests/unit/session/test_aside.py
@@ -230,3 +230,74 @@ async def test_adopt_aside_is_refused_while_the_turn_lock_is_held(tmp_path) -> N
     finally:
         session._turn_lock.release()
     await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_record_shell_writes_a_user_call_and_result(tmp_path) -> None:
+    """A bang-mode command is context, not a secret: the next turn and a
+    resume both have to see it. Synthetic assistant+tool so the TUI's
+    existing replay path mounts a ToolCard rather than a wall of stdout
+    attributed to the user."""
+    from local_operator.harness.types import ToolResult
+
+    session = make_session(tmp_path, RecordingStream())
+    result = ToolResult(
+        tool_call_id="shell-1",
+        tool_name="bash",
+        content=[TextContent(text="exit code: 0\n--- stdout ---\nhi\n--- stderr ---\n(empty)")],
+    )
+
+    await session.record_shell("echo hi", result)
+
+    messages = session._context.messages
+    assert all(isinstance(m, Message) for m in messages)
+    typed = [m for m in messages if isinstance(m, Message)]
+    assert [m.role for m in typed] == ["user", "assistant", "tool"]
+    assert typed[0].text == "! echo hi"
+    assert typed[1].tool_calls[0].name == "bash"
+    assert typed[1].tool_calls[0].arguments == {"command": "echo hi"}
+    assert typed[2].tool_call_id == "shell-1"
+    assert typed[2].text.startswith("exit code: 0")
+    replayed = session._transcript.build_llm_history()
+    assert all(isinstance(m, Message) for m in replayed)
+    assert [m.role for m in replayed if isinstance(m, Message)] == ["user", "assistant", "tool"]
+    await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_record_shell_queues_mid_turn_and_flushes_before_the_next_prompt(tmp_path) -> None:
+    """Splicing into a live tool batch is unsendable, but a visible command
+    must not disappear. The receipt waits behind the lock and becomes context
+    before the next prompt builds its request."""
+    from local_operator.harness.types import ToolResult
+
+    session = make_session(tmp_path, RecordingStream())
+    result = ToolResult(tool_call_id="shell-1", tool_name="bash", content=[TextContent(text="x")])
+    await session._turn_lock.acquire()
+    session._is_streaming = True
+    try:
+        await session.record_shell("echo hi", result)
+        assert session._context.messages == []
+        assert session._transcript.entries() == []
+        assert session._pending_shell_records == [("echo hi", result)]
+    finally:
+        session._is_streaming = False
+        await session._flush_shell_records()
+        session._turn_lock.release()
+
+    assert session._pending_shell_records == []
+    assert [m.role for m in session._context.messages if isinstance(m, Message)] == [
+        "user",
+        "assistant",
+        "tool",
+    ]
+    first = session._context.messages[0]
+    assert isinstance(first, Message)
+    assert first.text == "! echo hi"
+    replayed = session._transcript.build_llm_history()
+    assert [m.role for m in replayed if isinstance(m, Message)] == [
+        "user",
+        "assistant",
+        "tool",
+    ]
+    await session.dispose()

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -26,6 +26,7 @@ from local_operator.tui import theme as theme_mod
 from local_operator.tui.app import (
     BOOT_LAYOUT_CLASS,
     COMPOSER_FOCUSED_CLASS,
+    COMPOSER_SHELL_CLASS,
     MODEL_SWITCH_MID_TURN_NOTICE,
     PERSIST_HINT,
     SLASH_COMMANDS,
@@ -36,7 +37,12 @@ from local_operator.tui.autocomplete import ArgumentChoice
 from local_operator.tui.events import TurnEnded, TurnStarted
 from local_operator.tui.widgets.approval import ApprovalPrompt
 from local_operator.tui.widgets.assistant import AssistantBlock
-from local_operator.tui.widgets.editor import ASIDE_PLACEHOLDER, Editor
+from local_operator.tui.widgets.editor import (
+    ASIDE_PLACEHOLDER,
+    DEFAULT_PLACEHOLDER,
+    SHELL_PLACEHOLDER,
+    Editor,
+)
 from local_operator.tui.widgets.session_picker import SessionPickerScreen
 from local_operator.tui.widgets.toast import Toast
 from local_operator.tui.widgets.tool_card import ToolCard
@@ -80,6 +86,10 @@ class FakeSession:
     def __init__(self) -> None:
         self.prompts: list[str] = []
         self.aborts: list[str] = []
+        #: Bang-mode commands this fake was asked to persist. A list of
+        #: ``(command, result)`` so a test can say the TUI recorded what ran
+        #: without standing up a real transcript.
+        self.shell_records: list[tuple[str, Any]] = []
         #: Reasons passed to `cancel_subagents`, and how many children the next
         #: call should report stopping. Staged by tests that exercise the Esc
         #: ladder's second press.
@@ -190,6 +200,9 @@ class FakeSession:
 
     async def prompt(self, text: str, images: Sequence[ImageContent] | None = None) -> None:
         self.prompts.append(text)
+
+    async def record_shell(self, command: str, result: Any) -> None:
+        self.shell_records.append((command, result))
 
     def steer(self, text: str, images: Sequence[ImageContent] | None = None) -> None:
         pass
@@ -569,6 +582,272 @@ async def test_shift_enter_inserts_newline_without_submit() -> None:
         # No submit happened; the buffer carries a newline.
         assert session.prompts == []
         assert editor.text == "a\nb"
+
+
+@pytest.mark.asyncio
+async def test_bang_on_empty_composer_enters_shell_mode() -> None:
+    """opencode's dedicated-mode half: ``!`` on an empty field is consumed,
+    the placeholder becomes the command invitation, and the dock class the
+    stylesheet reads for the chevron's string-green is on."""
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        editor = app.query_one(Editor)
+        editor.focus()
+        await pilot.pause()
+        await pilot.press("!")
+        await pilot.pause()
+        assert editor.shell_mode is True
+        assert editor.text == ""
+        assert editor.placeholder == SHELL_PLACEHOLDER
+        assert app.query_one("#input-dock").has_class(COMPOSER_SHELL_CLASS)
+        assert chevron_colour(composer_cells(app)) == theme_mod.semantic_color("string").lower()
+        assert chevron_colour(composer_cells(app)) != theme_mod.semantic_color("accent").lower()
+
+
+@pytest.mark.asyncio
+async def test_bang_inside_a_draft_is_just_a_character() -> None:
+    """A ``!`` in `echo hi!` or mid-sentence is not a mode switch."""
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        editor = app.query_one(Editor)
+        editor.focus()
+        await pilot.pause()
+        await pilot.press("h", "i", "!")
+        await pilot.pause()
+        assert editor.shell_mode is False
+        assert editor.text == "hi!"
+        assert editor.placeholder == DEFAULT_PLACEHOLDER
+
+
+@pytest.mark.asyncio
+async def test_escape_and_empty_backspace_leave_shell_mode() -> None:
+    """opencode's exits: Esc keeps a draft, empty-buffer backspace is the
+    inverse of the bang that entered. Neither posts a stop."""
+    session = FakeSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        editor = app.query_one(Editor)
+        editor.focus()
+        await pilot.pause()
+        await pilot.press("!")
+        await pilot.press("l", "s")
+        await pilot.pause()
+        await pilot.press("escape")
+        await pilot.pause()
+        assert editor.shell_mode is False
+        assert editor.text == "ls"
+        assert editor.placeholder == DEFAULT_PLACEHOLDER
+        assert not app.query_one("#input-dock").has_class(COMPOSER_SHELL_CLASS)
+        assert session.aborts == []
+
+        editor.clear_content()
+        await pilot.press("!")
+        await pilot.pause()
+        await pilot.press("backspace")
+        await pilot.pause()
+        assert editor.shell_mode is False
+        assert editor.text == ""
+        assert session.aborts == []
+
+
+@pytest.mark.asyncio
+async def test_shell_mode_submit_runs_the_command_not_a_prompt() -> None:
+    """Enter in bang-mode runs bash locally: a user row, a tool card, no
+    ``prompt()``, and the result is persisted so the next turn can see it."""
+    session = FakeSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        editor = app.query_one(Editor)
+        editor.focus()
+        await pilot.pause()
+        await pilot.press("!")
+        for key in "echo bang-mode-ok":
+            await pilot.press("space" if key == " " else key)
+        await pilot.press("enter")
+        # The worker has to actually spawn /bin/sh; a couple of pauses is
+        # not a bound, so wait for the card to settle.
+        for _ in range(40):
+            await pilot.pause()
+            if session.shell_records:
+                break
+        assert session.prompts == []
+        assert editor.shell_mode is False
+        assert editor.text == ""
+        transcript = app.query_one(TranscriptView)
+        blocks = transcript.blocks()
+        assert any(isinstance(block, UserBlock) for block in blocks)
+        cards = [block for block in blocks if isinstance(block, ToolCard)]
+        assert len(cards) == 1
+        assert cards[0].tool_name == "bash"
+        assert cards[0]._state == "success"
+        assert session.shell_records
+        command, result = session.shell_records[0]
+        assert command == "echo bang-mode-ok"
+        assert "bang-mode-ok" in result.text
+        # History stored WITH the bang so Up-arrow recall re-runs as a command.
+        assert editor.prompt_history()[-1] == "! echo bang-mode-ok"
+
+
+@pytest.mark.asyncio
+async def test_a_recalled_bang_line_still_runs_as_a_command() -> None:
+    """omp's submit-of-a-leading-bang half: history stores the bang, so Up
+    then Enter re-runs as a command even though dedicated mode is off.
+
+    ``!`` on an empty composer is consumed, so the only way a leading bang
+    lands in the buffer is a recall (or a paste). That is the path this
+    pins — without it, Up after ``! echo hi`` would send ``! echo hi`` as
+    a prompt.
+    """
+    session = FakeSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        editor = app.query_one(Editor)
+        editor.focus()
+        await pilot.pause()
+        await pilot.press("!")
+        for key in "echo first":
+            await pilot.press("space" if key == " " else key)
+        await pilot.press("enter")
+        for _ in range(40):
+            await pilot.pause()
+            if session.shell_records:
+                break
+        assert len(session.shell_records) == 1
+        await pilot.press("up")
+        await pilot.pause()
+        assert editor.shell_mode is False
+        assert editor.text == "! echo first"
+        await pilot.press("enter")
+        for _ in range(40):
+            await pilot.pause()
+            if len(session.shell_records) >= 2:
+                break
+        assert session.prompts == []
+        assert [command for command, _ in session.shell_records] == [
+            "echo first",
+            "echo first",
+        ]
+
+
+@pytest.mark.asyncio
+async def test_empty_shell_submit_is_a_noop() -> None:
+    """A user who entered bang-mode by accident and pressed Enter lands
+    back on the resting composer, not on a red notice."""
+    session = FakeSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        editor = app.query_one(Editor)
+        editor.focus()
+        await pilot.pause()
+        await pilot.press("!")
+        await pilot.press("enter")
+        await pilot.pause()
+        assert editor.shell_mode is False
+        assert session.prompts == []
+        assert session.shell_records == []
+        assert app.query_one(TranscriptView).blocks() == []
+
+
+@pytest.mark.asyncio
+async def test_esc_aborts_a_running_shell_command() -> None:
+    """Esc on a live bang-mode command stops it the same way it stops a
+    turn: the card is interrupted on this press, not after the process
+    reaps."""
+    session = FakeSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        editor = app.query_one(Editor)
+        editor.focus()
+        await pilot.pause()
+        await pilot.press("!")
+        for key in "sleep 30":
+            await pilot.press("space" if key == " " else key)
+        await pilot.press("enter")
+        # Wait until the card is on screen and still running — the whole
+        # point of this test is the in-flight state, not the settled one.
+        card = None
+        for _ in range(40):
+            await pilot.pause()
+            cards = [
+                block
+                for block in app.query_one(TranscriptView).blocks()
+                if isinstance(block, ToolCard)
+            ]
+            if cards:
+                card = cards[0]
+                if card._state == "running":
+                    break
+        assert card is not None
+        assert card._state == "running"
+        await pilot.press("escape")
+        await pilot.pause()
+        assert card._state == "interrupted"
+        # The card stays owned until execute_bash has reaped the process and
+        # persisted its interrupted result. Clearing it on the key press made
+        # the receipt disappear on resume.
+        assert app._shell_card is card
+        for _ in range(40):
+            await pilot.pause()
+            if app._shell_card is None:
+                break
+        assert app._shell_card is None
+        assert session.shell_records
+        command, result = session.shell_records[0]
+        assert command == "sleep 30"
+        assert result.is_error is True
+        assert "interrupted" in result.text.lower()
+
+
+@pytest.mark.asyncio
+async def test_reload_aborts_and_settles_shell_before_disposing_its_session() -> None:
+    """A session swap cannot strand the bang-mode subprocess or let its
+    completion write into a session that `/reload` already disposed."""
+    first = FakeSession()
+    second = FakeSession()
+    order: list[str] = []
+
+    async def record_shell(command: str, result: Any) -> None:
+        assert first.disposed is False
+        order.append("recorded")
+        first.shell_records.append((command, result))
+
+    async def dispose() -> None:
+        order.append("disposed")
+        first.disposed = True
+
+    first.record_shell = record_shell  # type: ignore[method-assign]
+    first.dispose = dispose  # type: ignore[method-assign]
+    app = OperatorApp(lambda: _factory(first))
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        editor = app.query_one(Editor)
+        editor.focus()
+        await pilot.press("!")
+        for key in "sleep 30":
+            await pilot.press("space" if key == " " else key)
+        await pilot.press("enter")
+        for _ in range(40):
+            await pilot.pause()
+            if app._shell_card is not None:
+                break
+        assert app._shell_card is not None
+
+        app._session_factory = lambda: _factory(second)  # type: ignore[assignment]
+        await app._reload_session()
+        await pilot.pause()
+
+        assert order == ["recorded", "disposed"]
+        assert first.shell_records[0][0] == "sleep 30"
+        assert app._shell_worker is None
+        assert app._shell_card is None
+        assert app._session is second
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -806,6 +806,33 @@ async def test_esc_aborts_a_running_shell_command() -> None:
 
 
 @pytest.mark.asyncio
+async def test_a_failing_command_marks_the_card_failed_and_persists_it_so() -> None:
+    """A nonzero exit is a FAILURE on the human-facing surface: the collapsed
+    card says ✗, and the persisted result carries is_error so a resumed
+    session restores the same mark (design round 1, D1)."""
+    session = FakeSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        editor = app.query_one(Editor)
+        editor.focus()
+        await pilot.press("!")
+        for key in "exit 3":
+            await pilot.press("space" if key == " " else key)
+        await pilot.press("enter")
+        for _ in range(40):
+            await pilot.pause()
+            if session.shell_records:
+                break
+        assert session.shell_records, "the failed command must still be persisted"
+        command, result = session.shell_records[0]
+        assert command == "exit 3"
+        assert result.is_error is True
+        cards = [b for b in app.query_one(TranscriptView).blocks() if isinstance(b, ToolCard)]
+        assert cards and cards[-1]._state == "error"
+
+
+@pytest.mark.asyncio
 async def test_a_refused_second_command_comes_back_in_shell_mode() -> None:
     """The refused line is handed back IN the mode it was submitted from: the
     placeholder matches the buffer, and Enter re-runs it as a command once

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -833,6 +833,33 @@ async def test_a_failing_command_marks_the_card_failed_and_persists_it_so() -> N
 
 
 @pytest.mark.asyncio
+async def test_a_signal_killed_command_marks_the_card_failed() -> None:
+    """A negative exit code (SIGKILL — the same shape a timeout's kill
+    produces) is a failure on the human-facing surface, not a `✓` with a
+    scary body (round 3 minor)."""
+    session = FakeSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        editor = app.query_one(Editor)
+        editor.focus()
+        await pilot.press("!")
+        for key in "kill -9 $$":
+            await pilot.press("space" if key == " " else key)
+        await pilot.press("enter")
+        for _ in range(40):
+            await pilot.pause()
+            if session.shell_records:
+                break
+        assert session.shell_records
+        command, result = session.shell_records[0]
+        assert command == "kill -9 $$"
+        assert result.is_error is True
+        cards = [b for b in app.query_one(TranscriptView).blocks() if isinstance(b, ToolCard)]
+        assert cards and cards[-1]._state == "error"
+
+
+@pytest.mark.asyncio
 async def test_a_refused_second_command_comes_back_in_shell_mode() -> None:
     """The refused line is handed back IN the mode it was submitted from: the
     placeholder matches the buffer, and Enter re-runs it as a command once

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -806,6 +806,46 @@ async def test_esc_aborts_a_running_shell_command() -> None:
 
 
 @pytest.mark.asyncio
+async def test_a_refused_second_command_comes_back_in_shell_mode() -> None:
+    """The refused line is handed back IN the mode it was submitted from: the
+    placeholder matches the buffer, and Enter re-runs it as a command once
+    the running one is settled — not as a prompt to the model."""
+    session = FakeSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        editor = app.query_one(Editor)
+        editor.focus()
+        await pilot.press("!")
+        for key in "sleep 30":
+            await pilot.press("space" if key == " " else key)
+        await pilot.press("enter")
+        for _ in range(40):
+            await pilot.pause()
+            if app._shell_card is not None:
+                break
+        assert app._shell_card is not None
+
+        await pilot.press("!")
+        for key in "echo second":
+            await pilot.press("space" if key == " " else key)
+        await pilot.press("enter")
+        await pilot.pause()
+
+        assert editor.shell_mode is True
+        assert editor.text == "! echo second"
+        assert editor.placeholder == SHELL_PLACEHOLDER
+        await pilot.press("escape")  # leave the mode
+        await pilot.press("escape")  # abort the running command
+        for _ in range(40):
+            await pilot.pause()
+            if session.shell_records:
+                break
+        # The aborted first command persists; the refused second did not run.
+        assert [c for c, _ in session.shell_records] == ["sleep 30"]
+
+
+@pytest.mark.asyncio
 async def test_reload_aborts_and_settles_shell_before_disposing_its_session() -> None:
     """A session swap cannot strand the bang-mode subprocess or let its
     completion write into a session that `/reload` already disposed."""

--- a/tests/unit/tui/test_aside.py
+++ b/tests/unit/tui/test_aside.py
@@ -29,6 +29,7 @@ from local_operator.tui.widgets.aside_panel import AsidePanel, AsideTurn
 from local_operator.tui.widgets.editor import (
     ASIDE_PLACEHOLDER,
     DEFAULT_PLACEHOLDER,
+    SHELL_PLACEHOLDER,
     Editor,
 )
 from local_operator.tui.widgets.transcript import TranscriptView
@@ -150,6 +151,54 @@ async def test_the_aside_answers_from_the_live_conversation() -> None:
         assert sent.role == "user"
         assert "what did I ask you to do?" in sent.text
         assert "OFF" in sent.text and "RECORD" in sent.text
+
+
+@pytest.mark.asyncio
+async def test_closing_the_aside_returns_the_composer_to_bang_mode() -> None:
+    """The aside borrows the composer and disables bang-mode for the life of
+    the card, but the half-typed command comes back IN the mode it was typed
+    in — a `echo hi` returned to a composer that silently left bang-mode
+    would arm Enter with a shell command aimed at the model."""
+    session = AsideSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        editor = app.query_one(Editor)
+        editor.focus()
+        await pilot.press("!")
+        for key in "echo hi":
+            await pilot.press("space" if key == " " else key)
+        assert editor.shell_mode is True
+        await pilot.press("ctrl+b")
+        await pilot.pause()
+        assert editor.shell_mode is False
+        await pilot.press("escape")  # the user's door out of the card
+        await pilot.pause()
+        assert editor.shell_mode is True
+        assert editor.text == "echo hi"
+        assert editor.placeholder == SHELL_PLACEHOLDER
+
+
+@pytest.mark.asyncio
+async def test_bang_inside_the_aside_is_the_start_of_a_question() -> None:
+    """Bang-mode is a main-chat gesture. A ``!`` typed into the aside is
+    the first character of a question, not a command — the card promised
+    off the record, and eating the bang would both break that and run a
+    shell command the user never asked the conversation to see."""
+    session = AsideSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        editor = app.query_one(Editor)
+        editor.focus()
+        await pilot.pause()
+        await _open_with_question(pilot, app, "why?")
+        editor.clear_content()
+        await pilot.press("!")
+        await pilot.pause()
+        assert editor.shell_mode is False
+        assert editor.text == "!"
+        assert editor.placeholder == ASIDE_PLACEHOLDER
 
 
 # -- the contract ----------------------------------------------------------


### PR DESCRIPTION
## Summary

Bang-mode for the composer, after the precedent both omp and opencode ship: `!` on an **empty** composer enters a dedicated shell mode — the bang is consumed, the placeholder becomes the command invitation, and the chevron turns string-green (a step off the accent, so a shell-mode composer does not spend the "turn is live" ink). `Enter` runs the buffer as a local shell command instead of sending a prompt; `Esc` or backspace on an empty buffer leaves the mode. A `!` typed inside a draft stays a character, and a recalled `! line` from history still runs as a command (omp's submit-of-a-leading-bang half, which is what makes Up-then-Enter re-run work).

The command and its result paint as a user row plus a bash `ToolCard` (live partial output, exit-code styling, `Esc` aborts a running command and marks it interrupted). The session persists each run as a synthetic user/assistant/tool exchange so the next prompt — and a resume — can see what ran: a `! git status` the user ran is context, not a secret. Receipts that complete while a turn or compaction owns the message list are queued and flushed at the safe lock boundary, never spliced into a live provider batch and never dropped; idle writes are serialized on the same lock so a prompt cannot build from a half-written exchange.

Lifecycle, per reviewer findings: the in-flight command is a tracked Textual worker; `/new`, `/resume`, `/reload` and quit abort and await it before disposing the session it captured (cwd, variables, history), so a swap never strands a subprocess writing into an unmounted card. The aside stashes and restores the mode with the draft it borrows, so a half-typed command never comes back into a composer that silently left bang-mode.

The splash's rotating tip pool teaches the gesture: `! on an empty composer runs a shell command`.

## Test plan

- [x] New TUI tests: `!` on empty enters the mode (placeholder + dock class), `!` inside a draft is a character, Esc/empty-backspace leave it, submit runs the command and never a prompt, recalled bang lines re-run as commands, empty submit is a no-op, Esc aborts a running command and the interrupted result is persisted, `/reload` settles the shell worker before disposing its session, the aside round-trips the mode with the draft
- [x] New session tests: `record_shell` writes the user/assistant/tool exchange to context and transcript; a mid-turn receipt queues and flushes before the next prompt builds its request
- [x] Aside test: `!` typed inside the aside stays the start of a question
- [x] Splash tip tests: pool size/width/rotation invariants still hold with the new entry
- [x] Visual validation: before/after SVG stills of the composer (resting `Message Local Operator…` vs bang-mode `Run a command…` with string-green chevron), extracted text and colour verified from the frames
- [x] Full unit suite (188 files, ~5700 tests) in four parallel chunks: 5700 passed, 7 skipped, 1 pre-existing load-sensitive flake (`test_background_streams_output_while_it_runs`) that passes in isolation on this branch and on pristine `origin/main`
- [x] Gates: flake8, black --check, isort --check-only, pyright — all clean
- [ ] Agent review round(s) posted on this PR until no blocker/major findings remain
