### PR TITLE
fix(session): omit images from context when the active model cannot receive them

### DIFF
--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -873,6 +873,13 @@ class Session:
         #: offending block is IN the history, so an un-degraded retry sends it
         #: again, and the session is otherwise unusable for good.
         self._images_rejected = False
+        #: Latch for the text-only-model omission announcement (see
+        #: :meth:`_render_history`). The omission itself is not sticky — it
+        #: reads the CURRENT spec every render — but its announcement is:
+        #: every render of an image-bearing history on a text-only model would
+        #: otherwise re-post the notice, and a transcript that repeats the same
+        #: warning on every turn is noise the user learns to ignore.
+        self._text_only_omission_announced = False
         self._compaction_settings = _coerce_compaction_settings(compaction_settings)
         self._yolo = yolo
         self._has_ui = has_ui
@@ -1099,8 +1106,78 @@ class Session:
             # one-line notice.
             return _without_images(rendered)
         if not self._model.supports_images:
+            # ``rendered`` is the PRE-strip view here: exactly what the
+            # omission is about to take away, and what the announcement
+            # reports on.
+            self._announce_text_only_omission_once(rendered)
             return _without_images(rendered, model_incapable=True)
         return _rebound_history_images(rendered)
+
+    def _announce_text_only_omission_once(self, rendered: list[Message] | None = None) -> None:
+        """Say, once per session, that the active model is not seeing the
+        conversation's images.
+
+        Fires from the render rather than ONLY from ``set_model`` so EVERY
+        path that strips images explains itself: a mid-session switch, a
+        resume booted on a text-only default (the boot render runs in the
+        TUI's preloaded-context measurement, before any turn), a new image
+        attached after the switch. A switch-only notice left those paths
+        silent — a user who opened yesterday's screenshot-heavy session under
+        a new text-only default got answers that ignored the screenshots and
+        no line saying why (design review round 1, D1). ``set_model`` ALSO
+        calls this on a vision→text-only flip so a switch explains itself
+        immediately, without waiting for the next render.
+
+        The latch makes it once-per-session, not once-per-render: the render
+        runs on every provider call, and a repeating warning is noise. The
+        omission itself stays non-sticky — it reads the current spec on every
+        render — so switching to a vision model restores the images without
+        touching this latch.
+
+        ``_spawn_background`` because renders also happen from sync callers
+        (the usage breakdown) where no loop is running; the omission still
+        applies there, only the announcement is skipped.
+        """
+        if self._text_only_omission_announced:
+            return
+        if rendered is None:
+            # The PRE-strip view: ``_render_history`` would hand back the
+            # stripped one for this spec, which never has anything to report.
+            rendered = _rebound_history_images(
+                self._convert_to_llm(self._live_todo_reminders(list(self._context.messages)))
+            )
+        if not any(
+            isinstance(block, ImageContent) for message in rendered for block in message.content
+        ):
+            return
+        self._text_only_omission_announced = True
+        # ``model_label`` — the provider/model_id vocabulary the status band
+        # and the switch receipt already use — rather than the display name:
+        # two names for the same object two lines apart read as two models
+        # (design review round 1, D3).
+        label = self.model_label
+        logger.warning(
+            "model %s does not accept images; omitting them from this session's "
+            "context while it is active (%s)",
+            label,
+            self._image_drop_diagnostic(),
+        )
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return
+        self._spawn_background(
+            self._emit(
+                NoticeEvent(
+                    text=(
+                        f"{label} does not accept images — the images in this "
+                        "conversation are omitted from its context. Switch to a "
+                        "model that accepts images to see them again."
+                    ),
+                    kind="warning",
+                )
+            )
+        )
 
     def _live_todo_reminders(self, messages: list[AgentMessage]) -> list[AgentMessage]:
         """``messages`` without todo reminders the list has since outrun.
@@ -1220,64 +1297,6 @@ class Session:
                 kind="warning",
             )
         )
-
-    def _degrade_for_text_only_model(self, model: ModelSpec) -> None:
-        """Schedule the notice that a fresh spec cannot receive the session's
-        images — iff the history actually carries any.
-
-        The check runs over the render the omission is about to act on —
-        convert plus rebound, BEFORE the strip — so the notice fires exactly
-        when the omission takes effect, and never on a text-only conversation
-        (a notice about images nobody sent is noise on every switch to a
-        cheaper model). It cannot ask :meth:`_render_history` itself: for this
-        spec that view already has the blocks stripped.
-
-        ``_spawn_background`` rather than ``await``: ``set_model`` is sync on
-        :class:`~local_operator.session.protocol.SessionProtocol` — every
-        host calls it without awaiting — and the notice is advisory. The
-        render itself already omits the blocks, so a notice that never runs
-        (a host with no loop, a session disposed mid-switch) costs nothing
-        but the line in the transcript.
-        """
-
-        async def announce() -> None:
-            # The PRE-omission render: ``_render_history`` itself strips the
-            # image blocks for this spec, so asking it would always find
-            # nothing to report on. The convert+rebound view is exactly what
-            # the omission is about to take away.
-            rendered = _rebound_history_images(
-                self._convert_to_llm(self._live_todo_reminders(list(self._context.messages)))
-            )
-            if not any(
-                isinstance(block, ImageContent) for message in rendered for block in message.content
-            ):
-                return
-            label = model.display_name or model.model_id
-            logger.warning(
-                "model %s does not accept images; omitting them from this session's "
-                "context while it is active (%s)",
-                label,
-                self._image_drop_diagnostic(),
-            )
-            await self._emit(
-                NoticeEvent(
-                    text=(
-                        f"{label} does not accept images — the images in this "
-                        "conversation are omitted from its context while it is "
-                        "active. Switch back to a vision model to restore them."
-                    ),
-                    kind="warning",
-                )
-            )
-
-        try:
-            asyncio.get_running_loop()
-        except RuntimeError:
-            # No loop to carry the notice (a host that swaps specs outside a
-            # running loop, e.g. construction-time configuration). The render
-            # still omits the images; only the announcement is lost.
-            return
-        self._spawn_background(announce())
 
     def _image_drop_diagnostic(self) -> str:
         """Structure of the images this degrade is about to drop, for the log.
@@ -1537,15 +1556,11 @@ class Session:
         previous = self._model
         self._model = model
         if previous.supports_images and not model.supports_images:
-            # Landing on a model that cannot receive images while the history
-            # still carries them must not surface as a provider 4xx on the next
-            # turn: the render already omits the blocks (see
-            # :meth:`_render_history`), and the user who just switched deserves
-            # to hear WHY the model no longer sees the screenshots. Same-model
-            # knob changes (``/effort``, the server's sampling overrides) copy
-            # the spec and cannot flip the capability, so this fires only on a
-            # genuine move onto a text-only model.
-            self._degrade_for_text_only_model(model)
+            # A genuine move onto a text-only model (same-model knob changes
+            # copy the spec and cannot flip the capability): explain the
+            # omission now, through the same once-per-session latch the
+            # render uses, instead of waiting for the next render to say it.
+            self._announce_text_only_omission_once()
         if (previous.provider, previous.model_id) == (model.provider, model.model_id):
             # Same model, different knobs (effort, sampling): nothing routing
             # or quota related has moved, so leave the frozen per-message state

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -1072,7 +1072,9 @@ class Session:
         # hook is installed by the front end long after this returns.
         self._merge_capability_tools()
 
-    def _render_history(self, messages: list[AgentMessage]) -> list[Message]:
+    def _render_history(
+        self, messages: list[AgentMessage], *, keep_images: bool = False
+    ) -> list[Message]:
         """The configured transcript→LLM conversion, minus anything the active
         model cannot be sent.
 
@@ -1094,7 +1096,10 @@ class Session:
           failure behind a session switched onto a text-only model while the
           history still carries screenshots. This one is NOT sticky: it reads
           the CURRENT spec, so switching back to a vision model restores the
-          images on the very next render.
+          images on the very next render. ``keep_images=True`` suspends ONLY
+          this strip (compaction's kept-window rebuild, which must not bake
+          the omission into the live context); the sticky provider strip and
+          the announcement still apply.
 
         Expired todo reminders are dropped here for the same reason: every path
         that reaches a provider has to be free of them.
@@ -1105,7 +1110,7 @@ class Session:
             # dropping first saves decoding a block that is about to become a
             # one-line notice.
             return _without_images(rendered)
-        if not self._model.supports_images:
+        if not self._model.supports_images and not keep_images:
             # ``rendered`` is the PRE-strip view here: exactly what the
             # omission is about to take away, and what the announcement
             # reports on.
@@ -1134,21 +1139,30 @@ class Session:
         render — so switching to a vision model restores the images without
         touching this latch.
 
-        ``_spawn_background`` because renders also happen from sync callers
-        (the usage breakdown) where no loop is running; the omission still
-        applies there, only the announcement is skipped.
+        ``_spawn_background`` because ``set_model`` is sync and the
+        announcement is advisory: the render already applies the omission, so
+        a notice that never runs costs nothing but the log line.
         """
         if self._text_only_omission_announced:
             return
         if rendered is None:
-            # The PRE-strip view: ``_render_history`` would hand back the
-            # stripped one for this spec, which never has anything to report.
-            rendered = _rebound_history_images(
-                self._convert_to_llm(self._live_todo_reminders(list(self._context.messages)))
-            )
+            # Presence check only: the plain convert output already carries
+            # every image block, and the rebound pass would spend a decode
+            # (and a Pillow re-encode for any oversized block) on a question
+            # the header sniff cannot answer. ``set_model`` calls this on the
+            # TUI event loop; a paste-heavy history must not stall a keypress.
+            rendered = self._convert_to_llm(self._live_todo_reminders(list(self._context.messages)))
         if not any(
             isinstance(block, ImageContent) for message in rendered for block in message.content
         ):
+            return
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            # No loop to carry the notice (a render from a sync caller, e.g.
+            # construction-time configuration). The omission still applies;
+            # only the announcement is skipped — and the latch stays unset so
+            # a later render WITH a loop can still announce.
             return
         self._text_only_omission_announced = True
         # ``model_label`` — the provider/model_id vocabulary the status band
@@ -1162,10 +1176,6 @@ class Session:
             label,
             self._image_drop_diagnostic(),
         )
-        try:
-            asyncio.get_running_loop()
-        except RuntimeError:
-            return
         self._spawn_background(
             self._emit(
                 NoticeEvent(
@@ -1211,7 +1221,7 @@ class Session:
 
         return [message for message in messages if not expired(message)]
 
-    def _render_for_compaction(self) -> list[Message]:
+    def _render_for_compaction(self, *, keep_images: bool = False) -> list[Message]:
         """The rendered history a compaction pass plans and commits against.
 
         :meth:`_render_history` minus the todo reminders, because a reminder is
@@ -1250,7 +1260,8 @@ class Session:
         movement or user turn.
         """
         return self._render_history(
-            [message for message in self._context.messages if not _is_todo_reminder(message)]
+            [message for message in self._context.messages if not _is_todo_reminder(message)],
+            keep_images=keep_images,
         )
 
     async def _degrade_if_image_rejected(self, error: BaseException | str) -> None:
@@ -3455,7 +3466,21 @@ class Session:
         await self._emit(CompactionStartEvent(reason=reason))
         try:
             to_summarize = plan.llm_history[: plan.cut]
-            kept = plan.llm_history[plan.cut :]
+            # The KEPT window is rebuilt from the UNSTRIPPED render. The plan's
+            # ``llm_history`` went through the capability strip (the summary
+            # request must not carry images a text-only model cannot take),
+            # but committing stripped messages into ``_context.messages``
+            # would bake the omission into the live session: the notice text
+            # would replace the image blocks for good, and switching back to
+            # a vision model would restore nothing for the kept window — the
+            # exact stickiness this degrade was written to avoid (agent review
+            # round 1, MAJOR 1). The transcript is untouched either way, so
+            # resume and ``/export`` keep their frames; this keeps the LIVE
+            # context honest too. The strip still applies to what the next
+            # request SENDS (``_render_history`` re-renders on the way out).
+            kept = self._render_for_compaction(keep_images=True)[plan.cut :]
+            if not kept:
+                kept = plan.llm_history[plan.cut :]
             summary, preserve_data = await self._produce_summary(
                 compaction_api, to_summarize, plan.strategy
             )

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -531,6 +531,14 @@ def _replayed_user_message(content: list[Content], entry_id: str | None) -> Mess
 #: reading a summary whose "the screenshots below" no longer has any below.
 IMAGE_DROPPED_NOTICE = "[image omitted: the provider rejected it and it has been dropped]"
 
+#: Stands in for an image the ACTIVE model cannot receive, so a turn that
+#: follows a switch to a text-only model still makes sense. Distinct from
+#: :data:`IMAGE_DROPPED_NOTICE` on purpose: the provider refusal is a sticky
+#: session condition the user cannot undo, while this one lasts only as long
+#: as the current model does — switching back to a vision model restores the
+#: images, and the notice must not claim they are gone for good.
+IMAGE_OMITTED_TEXT_ONLY_NOTICE = "[image omitted: the current model does not accept images]"
+
 
 def _rebound_history_images(messages: list[Message]) -> list[Message]:
     """Shrink any image block in the rendered history that is over the cap.
@@ -582,19 +590,29 @@ def _rebound_history_images(messages: list[Message]) -> list[Message]:
     return out
 
 
-def _without_images(messages: list[Message]) -> list[Message]:
+def _without_images(messages: list[Message], *, model_incapable: bool = False) -> list[Message]:
     """Every message with its image blocks replaced by a one-line notice.
 
     Used after a provider has refused an image (see
-    :func:`~local_operator.providers.failover.is_image_rejection`). Applied to
-    the RENDERED history rather than to the transcript, so nothing is destroyed:
-    the archive keeps its frames, ``/export`` still has them, and a later
-    session on a provider that accepts them is unaffected.
+    :func:`~local_operator.providers.failover.is_image_rejection`), and when
+    the active model is KNOWN not to accept images (``model_incapable=True``:
+    the session was switched onto a text-only spec while the history still
+    carries image blocks). Applied to the RENDERED history rather than to the
+    transcript, so nothing is destroyed: the archive keeps its frames,
+    ``/export`` still has them, and a later session on a provider that accepts
+    them is unaffected.
+
+    The notice wording differs by cause (see
+    :data:`IMAGE_OMITTED_TEXT_ONLY_NOTICE`): a provider refusal is permanent
+    for the session, a model's incapacity is not, and a notice that apologised
+    as if the images were gone for good would lie to the model the moment a
+    vision model is switched back in.
 
     Consecutive images collapse to ONE notice. A snapcompact archive replays as
     fifty-odd frames between two text edges, and fifty identical apology lines
     would cost more context than the summary they are standing in for.
     """
+    notice = IMAGE_OMITTED_TEXT_ONLY_NOTICE if model_incapable else IMAGE_DROPPED_NOTICE
     out: list[Message] = []
     for message in messages:
         if not any(isinstance(block, ImageContent) for block in message.content):
@@ -603,9 +621,9 @@ def _without_images(messages: list[Message]) -> list[Message]:
         content: list[Content] = []
         for block in message.content:
             if isinstance(block, ImageContent):
-                if content and getattr(content[-1], "text", None) == IMAGE_DROPPED_NOTICE:
+                if content and getattr(content[-1], "text", None) == notice:
                     continue
-                content.append(TextContent(text=IMAGE_DROPPED_NOTICE))
+                content.append(TextContent(text=notice))
             else:
                 content.append(block)
         out.append(message.model_copy(update={"content": content}))
@@ -1048,14 +1066,28 @@ class Session:
         self._merge_capability_tools()
 
     def _render_history(self, messages: list[AgentMessage]) -> list[Message]:
-        """The configured transcript→LLM conversion, minus anything a provider
-        has already refused.
+        """The configured transcript→LLM conversion, minus anything the active
+        model cannot be sent.
 
         Every path that builds wire history goes through here rather than
-        calling ``_convert_to_llm`` directly, because the degrade has to hold
-        for ALL of them. Compaction is the one that matters most: it has to
-        send the history to summarise it, so a poisoned block makes even the
-        escape hatch fail (anthropics/claude-code#50708).
+        calling ``_convert_to_llm`` directly, because BOTH degrades have to
+        hold for ALL of them. Compaction is the one that matters most: it has
+        to send the history to summarise it, so a poisoned block makes even
+        the escape hatch fail (anthropics/claude-code#50708) — and the same
+        goes for a text-only model, whose refusal would otherwise brick the
+        session exactly the way a provider refusal did.
+
+        Two independent reasons strip images, checked in order of stickiness:
+
+        - ``_images_rejected``: a provider REFUSED an image block, so the
+          session never sends one again, whatever model it is on now.
+        - the active spec's ``supports_images``: the model is KNOWN not to
+          accept images (registry/discovery metadata), so the blocks are
+          omitted instead of spending a request on a guaranteed refusal — the
+          failure behind a session switched onto a text-only model while the
+          history still carries screenshots. This one is NOT sticky: it reads
+          the CURRENT spec, so switching back to a vision model restores the
+          images on the very next render.
 
         Expired todo reminders are dropped here for the same reason: every path
         that reaches a provider has to be free of them.
@@ -1066,6 +1098,8 @@ class Session:
             # dropping first saves decoding a block that is about to become a
             # one-line notice.
             return _without_images(rendered)
+        if not self._model.supports_images:
+            return _without_images(rendered, model_incapable=True)
         return _rebound_history_images(rendered)
 
     def _live_todo_reminders(self, messages: list[AgentMessage]) -> list[AgentMessage]:
@@ -1186,6 +1220,64 @@ class Session:
                 kind="warning",
             )
         )
+
+    def _degrade_for_text_only_model(self, model: ModelSpec) -> None:
+        """Schedule the notice that a fresh spec cannot receive the session's
+        images — iff the history actually carries any.
+
+        The check runs over the render the omission is about to act on —
+        convert plus rebound, BEFORE the strip — so the notice fires exactly
+        when the omission takes effect, and never on a text-only conversation
+        (a notice about images nobody sent is noise on every switch to a
+        cheaper model). It cannot ask :meth:`_render_history` itself: for this
+        spec that view already has the blocks stripped.
+
+        ``_spawn_background`` rather than ``await``: ``set_model`` is sync on
+        :class:`~local_operator.session.protocol.SessionProtocol` — every
+        host calls it without awaiting — and the notice is advisory. The
+        render itself already omits the blocks, so a notice that never runs
+        (a host with no loop, a session disposed mid-switch) costs nothing
+        but the line in the transcript.
+        """
+
+        async def announce() -> None:
+            # The PRE-omission render: ``_render_history`` itself strips the
+            # image blocks for this spec, so asking it would always find
+            # nothing to report on. The convert+rebound view is exactly what
+            # the omission is about to take away.
+            rendered = _rebound_history_images(
+                self._convert_to_llm(self._live_todo_reminders(list(self._context.messages)))
+            )
+            if not any(
+                isinstance(block, ImageContent) for message in rendered for block in message.content
+            ):
+                return
+            label = model.display_name or model.model_id
+            logger.warning(
+                "model %s does not accept images; omitting them from this session's "
+                "context while it is active (%s)",
+                label,
+                self._image_drop_diagnostic(),
+            )
+            await self._emit(
+                NoticeEvent(
+                    text=(
+                        f"{label} does not accept images — the images in this "
+                        "conversation are omitted from its context while it is "
+                        "active. Switch back to a vision model to restore them."
+                    ),
+                    kind="warning",
+                )
+            )
+
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            # No loop to carry the notice (a host that swaps specs outside a
+            # running loop, e.g. construction-time configuration). The render
+            # still omits the images; only the announcement is lost.
+            return
+        self._spawn_background(announce())
 
     def _image_drop_diagnostic(self) -> str:
         """Structure of the images this degrade is about to drop, for the log.
@@ -1444,6 +1536,16 @@ class Session:
         """
         previous = self._model
         self._model = model
+        if previous.supports_images and not model.supports_images:
+            # Landing on a model that cannot receive images while the history
+            # still carries them must not surface as a provider 4xx on the next
+            # turn: the render already omits the blocks (see
+            # :meth:`_render_history`), and the user who just switched deserves
+            # to hear WHY the model no longer sees the screenshots. Same-model
+            # knob changes (``/effort``, the server's sampling overrides) copy
+            # the spec and cannot flip the capability, so this fires only on a
+            # genuine move onto a text-only model.
+            self._degrade_for_text_only_model(model)
         if (previous.provider, previous.model_id) == (model.provider, model.model_id):
             # Same model, different knobs (effort, sampling): nothing routing
             # or quota related has moved, so leave the frozen per-message state

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -6704,6 +6704,12 @@ class OperatorApp(App[None]):
         # The chosen effort rides along when the new model accepts it: a user
         # who dropped to `low` for cost did not mean "until I switch models".
         session.set_model(self._spec_with_chosen_effort(spec))
+        # A text-only model renders the history WITHOUT its images (see
+        # ``Session._render_history``), so the estimate painted for the vision
+        # model overstates what the new one actually carries. Re-measure so
+        # the band agrees with what the next request sends; the measure's own
+        # exact-count guard makes this a no-op once a turn has reported.
+        self._measure_preloaded_context(session)
         # A different model may well have a dial, so the per-model refusal latch
         # goes with the old one.
         self._effort_refusal_shown = None

--- a/tests/unit/session/test_session.py
+++ b/tests/unit/session/test_session.py
@@ -40,6 +40,7 @@ from local_operator.harness.types import (
 from local_operator.providers.failover import ProviderError
 from local_operator.session.session import (
     IMAGE_DROPPED_NOTICE,
+    IMAGE_OMITTED_TEXT_ONLY_NOTICE,
     SESSION_INCIDENT_MESSAGE_TYPE,
     Session,
     _paired_prefix,
@@ -48,6 +49,12 @@ from local_operator.session.transcript import Transcript
 from local_operator.tools.builtin import TODO_REMINDER_MESSAGE_TYPE
 
 MODEL = ModelSpec(provider="test", model_id="m", context_window=100_000)
+TEXT_ONLY_MODEL = ModelSpec(
+    provider="test",
+    model_id="Text Only Test",
+    context_window=100_000,
+    supports_images=False,
+)
 
 
 async def wait_for(predicate, timeout: float = 2.0) -> None:
@@ -1532,6 +1539,100 @@ async def test_an_ordinary_failure_leaves_images_alone(tmp_path):
     await session.prompt("go")
     assert not session._images_rejected
     assert _image_blocks(stream.requests[0]) == 1
+    await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_switching_to_a_text_only_model_omits_images_from_context(tmp_path):
+    """The reported failure: a session with screenshots in its history was
+    switched onto a model that cannot receive images, and every turn died with
+    the provider's no-image-endpoint refusal until the session was abandoned.
+
+    The render now omits the blocks for a model whose spec says
+    ``supports_images=False`` — proactively, not after a wasted 4xx — and the
+    switch announces WHY the model no longer sees the images. And because the
+    omission reads the CURRENT spec, switching back to a vision model restores
+    the images on the very next request: the transcript was never touched.
+    """
+    stream = ScriptedStream(
+        [[StreamTextDelta(delta="ok"), StreamEndEvent(stop_reason="stop")] for _ in range(2)]
+    )
+    session = make_session(tmp_path, stream)
+    events: list[AgentEvent] = []
+    session.subscribe(events.append)
+    await session.seed_history(
+        [
+            Message(
+                role="user",
+                content=[TextContent(text="look at this"), ImageContent(data="Zm9v")],
+            )
+        ]
+    )
+
+    session.set_model(TEXT_ONLY_MODEL)
+    await wait_for(lambda: any(event.type == "notice" for event in events))
+
+    await session.prompt("what was in the image?")
+    request = stream.requests[-1]
+    assert _image_blocks(request) == 0, "the text-only model was sent the image"
+    sent = [
+        block.text
+        for message in request.messages
+        for block in message.content
+        if isinstance(block, TextContent)
+    ]
+    assert IMAGE_OMITTED_TEXT_ONLY_NOTICE in sent, "the model was left with a silent hole"
+    assert not session._images_rejected, "a capability switch must not trip the sticky degrade"
+    notices = [event for event in events if isinstance(event, NoticeEvent)]
+    assert any(
+        "Text Only Test" in event.text and "does not accept images" in event.text
+        for event in notices
+    ), "the switch did not explain the omission"
+
+    # Switching back to a vision model restores the images: the omission was
+    # never written into the transcript.
+    session.set_model(MODEL)
+    await session.prompt("and now?")
+    assert _image_blocks(stream.requests[-1]) == 1, "the restore did not put the image back"
+    await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_switching_to_a_text_only_model_without_images_stays_quiet(tmp_path):
+    """The notice answers "where did my screenshots go"; a text-only
+    conversation has nothing to omit, so the switch must not apologise for
+    images nobody sent — that would be noise on every drop to a cheaper model.
+    """
+    stream = ScriptedStream([[StreamTextDelta(delta="ok"), StreamEndEvent(stop_reason="stop")]])
+    session = make_session(tmp_path, stream)
+    events: list[AgentEvent] = []
+    session.subscribe(events.append)
+
+    session.set_model(TEXT_ONLY_MODEL)
+    await asyncio.sleep(0.05)  # the announce task, if any, runs immediately
+    assert [event for event in events if isinstance(event, NoticeEvent)] == []
+    await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_a_text_only_model_from_the_start_never_receives_images(tmp_path):
+    """A session BOOTED on a text-only model with a replayed vision history
+    (a resume of a session that ran on a vision model) omits the blocks from
+    its very first request — no switch and no refusal needed."""
+    stream = ScriptedStream([[StreamTextDelta(delta="ok"), StreamEndEvent(stop_reason="stop")]])
+    transcript = Transcript(tmp_path / "sess")
+    session = Session(
+        model=TEXT_ONLY_MODEL,
+        stream_fn=stream,
+        tools=[],
+        transcript=transcript,
+        system_blocks_provider=lambda: ["stable", "env"],
+    )
+    await session.seed_history(
+        [Message(role="user", content=[TextContent(text="hi"), ImageContent(data="Zm9v")])]
+    )
+    await session.prompt("go")
+    assert _image_blocks(stream.requests[0]) == 0
     await session.dispose()
 
 

--- a/tests/unit/session/test_session.py
+++ b/tests/unit/session/test_session.py
@@ -1570,9 +1570,11 @@ async def test_switching_to_a_text_only_model_omits_images_from_context(tmp_path
     )
 
     session.set_model(TEXT_ONLY_MODEL)
-    await wait_for(lambda: any(event.type == "notice" for event in events))
 
     await session.prompt("what was in the image?")
+    # The announcement rides the first render that strips the blocks, so it
+    # lands right after the turn that triggered it.
+    await wait_for(lambda: any(isinstance(event, NoticeEvent) for event in events))
     request = stream.requests[-1]
     assert _image_blocks(request) == 0, "the text-only model was sent the image"
     sent = [
@@ -1598,6 +1600,51 @@ async def test_switching_to_a_text_only_model_omits_images_from_context(tmp_path
 
 
 @pytest.mark.asyncio
+async def test_the_text_only_omission_notice_fires_exactly_once(tmp_path):
+    """The announcement is latched: the render runs on every provider call, so
+    an unlatched notice would repaint the same warning on every turn until the
+    user learns to ignore it. One explanation per session is the contract."""
+    stream = ScriptedStream(
+        [[StreamTextDelta(delta="ok"), StreamEndEvent(stop_reason="stop")] for _ in range(2)]
+    )
+    session = make_session(tmp_path, stream)
+    events: list[AgentEvent] = []
+    session.subscribe(events.append)
+    await session.seed_history(
+        [Message(role="user", content=[TextContent(text="look"), ImageContent(data="Zm9v")])]
+    )
+
+    session.set_model(TEXT_ONLY_MODEL)
+    await session.prompt("one")
+    await session.prompt("two")
+    notices = [event for event in events if isinstance(event, NoticeEvent)]
+    assert len(notices) == 1, f"the omission was announced {len(notices)} times"
+    await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_a_new_attachment_on_a_text_only_model_is_announced(tmp_path):
+    """A screenshot pasted AFTER the switch must not vanish silently: the
+    first render that carries it posts the omission notice, so the transcript
+    answers "where did my image go" right under the prompt that cites it
+    (design review round 1, D2)."""
+    stream = ScriptedStream([[StreamTextDelta(delta="ok"), StreamEndEvent(stop_reason="stop")]])
+    session = make_session(tmp_path, stream)
+    events: list[AgentEvent] = []
+    session.subscribe(events.append)
+
+    session.set_model(TEXT_ONLY_MODEL)
+    await asyncio.sleep(0.05)  # no images yet: nothing to announce
+    assert [event for event in events if isinstance(event, NoticeEvent)] == []
+
+    await session.prompt("look at this", [ImageContent(data="Zm9v")])
+    assert _image_blocks(stream.requests[-1]) == 0
+    notices = [event for event in events if isinstance(event, NoticeEvent)]
+    assert len(notices) == 1 and "does not accept images" in notices[0].text
+    await session.dispose()
+
+
+@pytest.mark.asyncio
 async def test_switching_to_a_text_only_model_without_images_stays_quiet(tmp_path):
     """The notice answers "where did my screenshots go"; a text-only
     conversation has nothing to omit, so the switch must not apologise for
@@ -1618,7 +1665,9 @@ async def test_switching_to_a_text_only_model_without_images_stays_quiet(tmp_pat
 async def test_a_text_only_model_from_the_start_never_receives_images(tmp_path):
     """A session BOOTED on a text-only model with a replayed vision history
     (a resume of a session that ran on a vision model) omits the blocks from
-    its very first request — no switch and no refusal needed."""
+    its very first request — no switch and no refusal needed — and the
+    announcement still lands: the render-latch notice covers the boot path
+    the switch-only notice left silent (design review round 1, D1)."""
     stream = ScriptedStream([[StreamTextDelta(delta="ok"), StreamEndEvent(stop_reason="stop")]])
     transcript = Transcript(tmp_path / "sess")
     session = Session(
@@ -1628,11 +1677,14 @@ async def test_a_text_only_model_from_the_start_never_receives_images(tmp_path):
         transcript=transcript,
         system_blocks_provider=lambda: ["stable", "env"],
     )
+    events: list[AgentEvent] = []
+    session.subscribe(events.append)
     await session.seed_history(
         [Message(role="user", content=[TextContent(text="hi"), ImageContent(data="Zm9v")])]
     )
     await session.prompt("go")
     assert _image_blocks(stream.requests[0]) == 0
+    await wait_for(lambda: any(isinstance(event, NoticeEvent) for event in events))
     await session.dispose()
 
 

--- a/tests/unit/session/test_session.py
+++ b/tests/unit/session/test_session.py
@@ -1634,7 +1634,8 @@ async def test_a_new_attachment_on_a_text_only_model_is_announced(tmp_path):
     session.subscribe(events.append)
 
     session.set_model(TEXT_ONLY_MODEL)
-    await asyncio.sleep(0.05)  # no images yet: nothing to announce
+    # No images yet: the latch stays unset, so the switch itself is quiet.
+    assert session._text_only_omission_announced is False
     assert [event for event in events if isinstance(event, NoticeEvent)] == []
 
     await session.prompt("look at this", [ImageContent(data="Zm9v")])
@@ -1656,7 +1657,10 @@ async def test_switching_to_a_text_only_model_without_images_stays_quiet(tmp_pat
     session.subscribe(events.append)
 
     session.set_model(TEXT_ONLY_MODEL)
-    await asyncio.sleep(0.05)  # the announce task, if any, runs immediately
+    # No images in the history: the latch stays unset and nothing is posted.
+    # Asserting the latch directly is deterministic where sleeping and counting
+    # notices only proves a negative (agent review round 1, NIT 1).
+    assert session._text_only_omission_announced is False
     assert [event for event in events if isinstance(event, NoticeEvent)] == []
     await session.dispose()
 
@@ -1685,6 +1689,133 @@ async def test_a_text_only_model_from_the_start_never_receives_images(tmp_path):
     await session.prompt("go")
     assert _image_blocks(stream.requests[0]) == 0
     await wait_for(lambda: any(isinstance(event, NoticeEvent) for event in events))
+    await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_compaction_on_a_text_only_model_keeps_images_in_the_live_context(
+    tmp_path, monkeypatch
+):
+    """A compaction committed while on a text-only model must NOT bake the
+    omission into the live context (agent review round 1, MAJOR 1).
+
+    The summary request is stripped (the text-only model cannot take images),
+    but the KEPT window is rebuilt from the unstripped render, so switching
+    back to a vision model afterwards still restores the screenshots for the
+    kept messages — the non-sticky contract holds across a compaction."""
+    from pydantic import BaseModel, Field
+
+    class CompactionSettings(BaseModel):
+        enabled: bool = True
+        reserve_tokens: int = 16384
+        keep_recent_tokens: int = 20000
+        threshold_percent: float = 0.80
+        threshold_tokens: int = Field(default=600_000)
+        auto_continue: bool = False
+        mid_turn_enabled: bool = False
+
+    compacted = {"done": False}
+    summary_requests: list[list[Message]] = []
+
+    def estimate_messages_tokens(messages):
+        return 5_000 if compacted["done"] else 90_000
+
+    def messages_tokens_upper_bound(messages):
+        return 5_500 if compacted["done"] else 95_000
+
+    fake_api = types.ModuleType("local_operator.compaction.api")
+    setattr(fake_api, "CompactionSettings", CompactionSettings)
+    setattr(
+        fake_api,
+        "prune_tool_outputs",
+        lambda messages, now_ts, last, **kw: (list(messages), False),
+    )
+    setattr(fake_api, "estimate_messages_tokens", estimate_messages_tokens)
+    setattr(fake_api, "messages_tokens_upper_bound", messages_tokens_upper_bound)
+    setattr(
+        fake_api, "compaction_context_tokens", lambda provider, local: max(provider or 0, local)
+    )
+    # Cut after the FIRST entry: it is summarized away (and its image must
+    # NOT reach the summary request), while the second image-bearing message
+    # lands in the KEPT window — exactly the blocks the strip would have
+    # baked out of the live context.
+    setattr(fake_api, "find_cut_point", lambda messages, keep: 1)
+    setattr(
+        fake_api,
+        "resolve_threshold_tokens",
+        lambda window, settings: min(int(window * 0.8), 600_000),
+    )
+    setattr(fake_api, "RECOVERY_BAND", 0.8)
+    setattr(
+        fake_api,
+        "should_compact",
+        lambda ctx_tokens, window, settings: ctx_tokens
+        > fake_api.resolve_threshold_tokens(window, settings),
+    )
+
+    async def summarize(messages, complete_fn):
+        compacted["done"] = True
+        summary_requests.append(list(messages))
+        return "SUMMARY"
+
+    setattr(fake_api, "summarize_messages", summarize)
+
+    fake_pkg = types.ModuleType("local_operator.compaction")
+    setattr(fake_pkg, "api", fake_api)
+    monkeypatch.setitem(sys.modules, "local_operator.compaction", fake_pkg)
+    monkeypatch.setitem(sys.modules, "local_operator.compaction.api", fake_api)
+    monkeypatch.setitem(
+        sys.modules,
+        "local_operator.compaction.thresholds",
+        types.ModuleType("local_operator.compaction.thresholds"),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "local_operator.compaction.snapcompact",
+        types.ModuleType("local_operator.compaction.snapcompact"),
+    )
+
+    stream = ScriptedStream(
+        [[StreamTextDelta(delta="ok"), StreamEndEvent(stop_reason="stop")] for _ in range(2)]
+    )
+    session = make_session(tmp_path, stream, compaction_settings=CompactionSettings())
+    await session.seed_history(
+        [
+            Message(
+                role="user",
+                content=[TextContent(text="first shot"), ImageContent(data="Zm9v")],
+            ),
+            Message(
+                role="user",
+                content=[TextContent(text="second shot"), ImageContent(data="Zm9v")],
+            ),
+        ]
+    )
+    session.set_model(TEXT_ONLY_MODEL)
+
+    await session.prompt("go")
+    # The pass ran and its summary request carried no image blocks.
+    assert compacted["done"]
+    assert summary_requests
+    assert not any(
+        isinstance(block, ImageContent)
+        for message in summary_requests[0]
+        for block in message.content
+    ), "the summary request was sent images the model cannot take"
+
+    # The kept window in the LIVE context still holds the image block...
+    kept_images = [
+        block
+        for message in session._context.messages
+        if isinstance(message, Message)
+        for block in message.content
+        if isinstance(block, ImageContent)
+    ]
+    assert kept_images, "the compaction baked the omission into the live context"
+    # ...so switching back to a vision model restores it on the wire.
+    session.set_model(MODEL)
+    await session.prompt("again")
+    assert _image_blocks(stream.requests[-1]) == 1
     await session.dispose()
 
 


### PR DESCRIPTION
## Why

Switching a session onto a model that cannot receive images while the conversation still carries screenshots bricked the session with `invalid request (HTTP 404): No endpoints found that support image input` on every subsequent turn — the exact shape of the poisoned-image failure this codebase already defends against on the provider side. The image blocks live in the history, so every request (and `/compact`, which must send the history to summarise it) re-sends them and fails identically until the session is abandoned.

The registry/discovery layer already KNOWS which models are text-only (`ModelSpec.supports_images`), so the refusal is predictable and the blocks can be omitted proactively instead of spending a request on a guaranteed 4xx.

## What changes

- **`Session._render_history`** strips image blocks (replacing them with a one-line notice) whenever the ACTIVE spec says `supports_images=False`, in addition to the existing sticky provider-refusal degrade. It reads the CURRENT spec, so the omission is not sticky: switching back to a vision model restores the images on the very next render. The transcript is never touched — `/export`, archives and later vision sessions keep the images.
- **New notice wording** for the capability case (`IMAGE_OMITTED_TEXT_ONLY_NOTICE`, "[image omitted: the current model does not accept images]"), distinct from the provider-refusal notice on purpose: a refusal is permanent for the session, a model's incapacity lasts only as long as the model is active, and the notice must not claim the images are gone for good.
- **`Session.set_model`** announces the omission when the history actually carries images: a warning `NoticeEvent` on the session stream (a transcript line in the TUI) naming the model and saying the images are omitted while it is active and how to restore them. Fire-and-forget via `_spawn_background` because `set_model` is sync on the protocol; the render already omits the blocks, so the notice is advisory. No notice on a text-only conversation — nothing to apologise for.
- **TUI `/model`** re-measures the context band after a switch, since the estimate painted for a vision model overstates what a text-only model actually carries once its render drops the image blocks.
- **Tests** (3 new): switch-to-text-only omits the blocks, inserts the notice into context, emits the warning and does NOT trip the sticky degrade; switching back restores the images; a text-only conversation stays quiet on switch; a session booted on a text-only model with a replayed vision history omits from its first request.

## Testing evidence

- New tests fail for the right reason on the pre-change render (image blocks present, no notice) and pass after.
- `tests/unit/session`: 244 passed. `tests/unit/tui`: 2140 passed, 4 skipped. Full `tests/unit`: **5695 passed, 7 skipped**.
- Gates clean on the changed files and tree-wide: `flake8`, `black --check`, `isort --check-only`, `pyright` (0 errors).
- Visual validation per AGENTS.md: drove the real `OperatorApp` with a real `Session` seeded with an image, captured before/after SVG frames and viewed them rendered. Before: transcript shows the image row, no notice. After `set_model` onto a text-only spec: the warning notice appears in the transcript — "DeepSeek V4 Pro does not accept images — the images in this conversation are omitted from its context while it is active. Switch back to a vision model to restore them." — and the log carries the structural diagnostic (`1 image block(s); first: mime=image/png ...`). No layout reflow: the band and composer are identical between frames.
