### PR TITLE
feat(tui): settle bang-mode cards open — the output is the point

### DIFF
--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -1141,6 +1141,12 @@ class OperatorApp(App[None]):
         #: the same conversation) would paint its receipt twice (review round
         #: 2, m2).
         self._live_wake_receipts: set[tuple[str, object]] = set()
+        #: A bang-mode user row (`! <command>`) seen by the history replay but
+        #: not yet paired with its bash card. The persisted shape is
+        #: user/assistant/tool, so the assistant message immediately after a
+        #: bang row carries the call whose card should open on settle — the
+        #: resume half of the open-on-settle contract the live path makes.
+        self._replay_bang_pending = False
         #: What the CURRENT turn has already been billed for, per model call, by
         #: `on_context_usage_reported`. `on_turn_ended` prices the same turn as a
         #: whole and is the authoritative figure, so it adds only the difference
@@ -1918,6 +1924,9 @@ class OperatorApp(App[None]):
                 call_id = getattr(message, "tool_call_id", None)
                 if call_id:
                     results[call_id] = message
+        # Fresh batch, fresh pairing: a flag left by an earlier replay (or a
+        # truncated one) must not open a card in this conversation.
+        self._replay_bang_pending = False
 
         appended = False
         transcript = self._transcript_view()
@@ -1967,9 +1976,22 @@ class OperatorApp(App[None]):
                         self._append_block(UserBlock(text, len(replay_images)))
                         self._append_image_blocks(replay_images, marker_text=text)
                         appended = True
+                    # A bang-mode receipt replays as open as it lived: the
+                    # user row is `! <command>` and the assistant message that
+                    # follows carries exactly one bash call. Remembered so the
+                    # call's card can open on settle, the same contract the
+                    # live path makes.
+                    if text.startswith("! "):
+                        self._replay_bang_pending = True
                     continue
                 if role != "assistant":
                     continue
+                # Consume the pending bang marker on EVERY assistant message:
+                # record_shell writes the call-bearing assistant immediately
+                # after the `!` row, and a later unrelated turn must never
+                # inherit the open-on-settle flag.
+                bang_pending = self._replay_bang_pending
+                self._replay_bang_pending = False
                 if text:
                     block = AssistantBlock()
                     block.update_text(text)
@@ -1978,7 +2000,16 @@ class OperatorApp(App[None]):
                     appended = True
                 tool_calls = getattr(message, "tool_calls", None) or []
                 for call in tool_calls:
-                    self._replay_tool_call(call, results)
+                    # Only the FIRST call of a bang assistant message is the
+                    # command's own card; the shape record_shell writes has
+                    # exactly one, so consuming here is exact in practice and
+                    # conservative in theory.
+                    open_settled = bool(
+                        bang_pending
+                        and tool_calls[0] is call
+                        and getattr(call, "name", "") == "bash"
+                    )
+                    self._replay_tool_call(call, results, open_on_settle=open_settled)
                     appended = True
                 stop = getattr(message, "stop_reason", None)
                 if stop == "refusal":
@@ -2016,7 +2047,9 @@ class OperatorApp(App[None]):
             # off the bottom of a viewport pinned to the replay's last frame.
             transcript.follow_tail()
 
-    def _replay_tool_call(self, call: Any, results: dict[str, Any]) -> None:
+    def _replay_tool_call(
+        self, call: Any, results: dict[str, Any], *, open_on_settle: bool = False
+    ) -> None:
         """Mount one settled tool row for a call from a previous session.
 
         The card is built exactly as a live one is — same constructor, same
@@ -2029,6 +2062,8 @@ class OperatorApp(App[None]):
             getattr(call, "name", "") or "",
             getattr(call, "arguments", None) or {},
         )
+        if open_on_settle:
+            card.open_on_settle()
         self._append_block(card)
         result = results.get(getattr(call, "id", "") or "")
         if result is None:
@@ -5464,6 +5499,10 @@ class OperatorApp(App[None]):
 
         call_id = f"shell-{time.monotonic_ns()}"
         card = ToolCard(call_id, "bash", {"command": command})
+        # The user ran this command TO SEE its output; a collapsed receipt
+        # hides exactly that behind a click nobody asked for. The card opens
+        # at its first settle (and stays a normal collapsible row after).
+        card.open_on_settle()
         self._append_block(UserBlock(f"! {command}"))
         self._append_block(card)
         signal = AbortSignal()

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -2074,6 +2074,14 @@ class OperatorApp(App[None]):
         result_text = getattr(result, "text", "") or ""
         payload = getattr(result, "provider_payload", None) or {}
         details = payload.get("details") if isinstance(payload, dict) else None
+        if getattr(result, "is_error", False) and result_text.startswith("aborted ("):
+            # A user-stopped bang command persists as an error result (the
+            # model-facing shape), but the LIVE frame it came from was the dim
+            # shut `interrupted ⊘` row. Replaying it through the error branch
+            # would reopen the user's own Esc as a red failure (design round
+            # 1, D1). The aborted prefix is execute_bash's stable contract.
+            card.restore(state="interrupted")
+            return
         if getattr(result, "is_error", False):
             card.restore(
                 state="error",

--- a/local_operator/tui/widgets/tool_card.py
+++ b/local_operator/tui/widgets/tool_card.py
@@ -786,8 +786,10 @@ class ToolCard(ExpandableActionBlock):
 
         Runs between the settle's own `_refresh_row` and `finalize` so the
         block is measured at its expanded height from its first frame. The
-        gap refresh mirrors what `toggle_expanded` does for a user toggle;
-        the transcript's sticky-bottom anchor follows the growth on its own.
+        gap refresh is `refresh_gap_around` — the same call the live-growth
+        tick makes — because the height changes the spacing above as well as
+        below; the transcript's sticky-bottom anchor follows the growth on
+        its own.
         """
         if not self._open_on_settle:
             return

--- a/local_operator/tui/widgets/tool_card.py
+++ b/local_operator/tui/widgets/tool_card.py
@@ -675,6 +675,11 @@ class ToolCard(ExpandableActionBlock):
         #: :meth:`restore` — and the running state has to refuse it too.
         self._started: float | None = time.monotonic()
         self._expanded = False
+        #: A host that knows the user ran this call TO SEE its output (the
+        #: composer's bang-mode) asks the card to open the moment it settles,
+        #: because a collapsed receipt hides exactly the bytes the command was
+        #: run for behind a click nobody asked for. Consumed once, at settle.
+        self._open_on_settle = False
         self._hovered = False
         #: True while the row holds keyboard focus. Tracked separately from
         #: hover: both light the hint, but a pointer leaving the row must not
@@ -714,6 +719,7 @@ class ToolCard(ExpandableActionBlock):
         self.remove_class("tool-running")
         self.add_class("tool-success")
         self._refresh_row()
+        self._apply_open_on_settle()
         self.finalize()
 
     def mark_failed(
@@ -738,6 +744,7 @@ class ToolCard(ExpandableActionBlock):
         self.remove_class("tool-running")
         self.add_class("tool-error")
         self._refresh_row()
+        self._apply_open_on_settle()
         self.finalize()
 
     def mark_interrupted(self) -> None:
@@ -760,7 +767,39 @@ class ToolCard(ExpandableActionBlock):
         self.remove_class("tool-running")
         self.add_class("tool-interrupted")
         self._refresh_row()
+        self._apply_open_on_settle()
         self.finalize()
+
+    def open_on_settle(self) -> None:
+        """Ask the card to open the moment it settles, once.
+
+        Bang-mode's contract: the user typed the command to read its output,
+        so the settled card starts expanded instead of collapsing the result
+        behind `⟨expand⟩`. A settle with nothing to reveal (empty output) is
+        a no-op — :meth:`can_expand` decides — and a user collapse after the
+        open is final, because the flag is consumed at the first settle.
+        """
+        self._open_on_settle = True
+
+    def _apply_open_on_settle(self) -> None:
+        """Honour :meth:`open_on_settle` now that a result is absorbed.
+
+        Runs between the settle's own `_refresh_row` and `finalize` so the
+        block is measured at its expanded height from its first frame. The
+        gap refresh mirrors what `toggle_expanded` does for a user toggle;
+        the transcript's sticky-bottom anchor follows the growth on its own.
+        """
+        if not self._open_on_settle:
+            return
+        self._open_on_settle = False
+        if self._expanded or not self.can_expand():
+            return
+        self._expanded = True
+        self.set_class(True, self.EXPANDED_CLASS)
+        self._refresh_row()
+        parent = self.parent if isinstance(self.parent, TranscriptView) else None
+        if parent is not None:
+            parent.refresh_gap_around(self)
 
     def _elapsed(self) -> float | None:
         """Seconds this call has been running, or ``None`` when unknowable.
@@ -823,6 +862,7 @@ class ToolCard(ExpandableActionBlock):
             self._absorb_result(result_text, details)
             self.add_class("tool-success")
         self._refresh_row()
+        self._apply_open_on_settle()
         self.finalize()
 
     def set_composing(self, argument_bytes: int, tool_name: str = "") -> None:

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -860,6 +860,87 @@ async def test_a_signal_killed_command_marks_the_card_failed() -> None:
 
 
 @pytest.mark.asyncio
+async def test_a_bang_card_settles_open() -> None:
+    """The user ran the command to READ its output, so the settled card is
+    already open — a collapsed receipt hides exactly the bytes the command
+    was run for behind a click nobody asked for."""
+    session = FakeSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        editor = app.query_one(Editor)
+        editor.focus()
+        await pilot.press("!")
+        for key in "echo open-me":
+            await pilot.press("space" if key == " " else key)
+        await pilot.press("enter")
+        for _ in range(40):
+            await pilot.pause()
+            if session.shell_records:
+                break
+        cards = [b for b in app.query_one(TranscriptView).blocks() if isinstance(b, ToolCard)]
+        assert cards
+        assert cards[-1]._state == "success"
+        assert cards[-1].expanded is True
+        # The open is a settle-time decision, not a stuck mode: the flag is
+        # consumed, so a user collapse is final.
+        assert cards[-1]._open_on_settle is False
+
+
+@pytest.mark.asyncio
+async def test_a_replayed_bang_card_opens_and_ordinary_calls_stay_shut() -> None:
+    """Resume parity for the open-on-settle contract: a bang receipt replays
+    open, while an agent-issued bash call in the same history stays a normal
+    collapsible row."""
+    session = FakeSession()
+    session._history = [
+        SimpleNamespace(
+            role="user", text="! echo hi", tool_calls=None, content=[], custom_type=None
+        ),
+        SimpleNamespace(
+            role="assistant",
+            text="",
+            tool_calls=[
+                SimpleNamespace(id="shell-1", name="bash", arguments={"command": "echo hi"})
+            ],
+            custom_type=None,
+        ),
+        SimpleNamespace(
+            role="tool",
+            tool_call_id="shell-1",
+            text="exit code: 0\nhi",
+            is_error=False,
+            provider_payload=None,
+            content=[],
+        ),
+        SimpleNamespace(
+            role="user", text="what did I just run?", tool_calls=None, content=[], custom_type=None
+        ),
+        SimpleNamespace(
+            role="assistant",
+            text="",
+            tool_calls=[SimpleNamespace(id="agent-1", name="bash", arguments={"command": "ls"})],
+            custom_type=None,
+        ),
+        SimpleNamespace(
+            role="tool",
+            tool_call_id="agent-1",
+            text="exit code: 0\nfile",
+            is_error=False,
+            provider_payload=None,
+            content=[],
+        ),
+    ]
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        cards = [b for b in app.query_one(TranscriptView).blocks() if isinstance(b, ToolCard)]
+        assert len(cards) == 2
+        assert cards[0].expanded is True  # the bang receipt
+        assert cards[1].expanded is False  # an ordinary agent call
+
+
+@pytest.mark.asyncio
 async def test_a_refused_second_command_comes_back_in_shell_mode() -> None:
     """The refused line is handed back IN the mode it was submitted from: the
     placeholder matches the buffer, and Enter re-runs it as a command once

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -941,6 +941,121 @@ async def test_a_replayed_bang_card_opens_and_ordinary_calls_stay_shut() -> None
 
 
 @pytest.mark.asyncio
+async def test_a_failing_bang_card_settles_open_too() -> None:
+    """Failure is exactly when the output matters most, so the open-on-settle
+    contract covers the error settle as well."""
+    session = FakeSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        editor = app.query_one(Editor)
+        editor.focus()
+        await pilot.press("!")
+        for key in "exit 3":
+            await pilot.press("space" if key == " " else key)
+        await pilot.press("enter")
+        for _ in range(40):
+            await pilot.pause()
+            if session.shell_records:
+                break
+        cards = [b for b in app.query_one(TranscriptView).blocks() if isinstance(b, ToolCard)]
+        assert cards
+        assert cards[-1]._state == "error"
+        assert cards[-1].expanded is True
+
+
+@pytest.mark.asyncio
+async def test_a_replayed_aborted_bang_card_stays_shut_and_dim() -> None:
+    """The user's own Esc must not come back as a red failure on resume: the
+    persisted abort result is an error-shaped message, but the live frame it
+    came from was the dim shut `interrupted` row (design round 1, D1)."""
+    session = FakeSession()
+    session._history = [
+        SimpleNamespace(
+            role="user", text="! sleep 30", tool_calls=None, content=[], custom_type=None
+        ),
+        SimpleNamespace(
+            role="assistant",
+            text="",
+            tool_calls=[
+                SimpleNamespace(id="shell-1", name="bash", arguments={"command": "sleep 30"})
+            ],
+            custom_type=None,
+        ),
+        SimpleNamespace(
+            role="tool",
+            tool_call_id="shell-1",
+            text="aborted (interrupted): sleep 30",
+            is_error=True,
+            provider_payload=None,
+            content=[],
+        ),
+    ]
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        cards = [b for b in app.query_one(TranscriptView).blocks() if isinstance(b, ToolCard)]
+        assert len(cards) == 1
+        assert cards[0]._state == "interrupted"
+        assert cards[0].expanded is False
+
+
+@pytest.mark.asyncio
+async def test_a_bang_call_with_no_recorded_result_stays_shut() -> None:
+    """A session killed between the call and its answer replays `interrupted`
+    with nothing absorbed — open-on-settle must not force such a card open."""
+    session = FakeSession()
+    session._history = [
+        SimpleNamespace(
+            role="user", text="! sleep 30", tool_calls=None, content=[], custom_type=None
+        ),
+        SimpleNamespace(
+            role="assistant",
+            text="",
+            tool_calls=[
+                SimpleNamespace(id="shell-1", name="bash", arguments={"command": "sleep 30"})
+            ],
+            custom_type=None,
+        ),
+    ]
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        cards = [b for b in app.query_one(TranscriptView).blocks() if isinstance(b, ToolCard)]
+        assert len(cards) == 1
+        assert cards[0]._state == "interrupted"
+        assert cards[0].expanded is False
+
+
+@pytest.mark.asyncio
+async def test_a_user_collapse_after_settle_is_final() -> None:
+    """Open-on-settle is a settle-time decision, not a stuck mode: the flag is
+    consumed at the first settle, so closing the card stays closed."""
+    session = FakeSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        editor = app.query_one(Editor)
+        editor.focus()
+        await pilot.press("!")
+        for key in "echo hi":
+            await pilot.press("space" if key == " " else key)
+        await pilot.press("enter")
+        for _ in range(40):
+            await pilot.pause()
+            if session.shell_records:
+                break
+        cards = [b for b in app.query_one(TranscriptView).blocks() if isinstance(b, ToolCard)]
+        assert cards and cards[-1].expanded is True
+        cards[-1].toggle_expanded()
+        await pilot.pause()
+        assert cards[-1].expanded is False
+        for _ in range(10):
+            await pilot.pause()
+        assert cards[-1].expanded is False
+
+
+@pytest.mark.asyncio
 async def test_a_refused_second_command_comes_back_in_shell_mode() -> None:
     """The refused line is handed back IN the mode it was submitted from: the
     placeholder matches the buffer, and Enter re-runs it as a command once


### PR DESCRIPTION
## Summary

Follow-up to #218's bang-mode. A settled bang receipt collapsed to a one-line `bash ✓ 0.3s` row, hiding exactly the output the user ran the command to read behind a `⟨expand⟩` click nobody asked for. Now the card settles **open**:

- `ToolCard.open_on_settle()` asks the card to expand at its first settle (success, failure, or interrupted). The flag is consumed at settle, so a user collapse afterwards is final; a settle with nothing to reveal stays shut because `can_expand()` decides.
- The live bang path sets it when it mounts the card.
- The resume replay pairs a persisted `! <command>` user row with the single bash call its assistant message carries and opens that card too, so a resumed session shows the same frame the live one did. Ordinary agent-issued bash calls are untouched and stay collapsible.

## Test plan

- [x] New tests: a bang card settles expanded with the flag consumed (`test_a_bang_card_settles_open`); a replayed history opens the bang card while an ordinary agent bash call stays shut (`test_a_replayed_bang_card_opens_and_ordinary_calls_stay_shut`)
- [x] Visual validation: before/after stills of the settled card — collapsed one-liner vs open with the command's output rows visible (`/tmp/expand-before.svg`, `/tmp/expand-after.svg`)
- [x] Gates: flake8, black --check, isort --check-only, pyright — clean
- [x] Full unit suite in four chunks (below)
- [ ] Agent review + design review rounds posted on this PR until clean
