### PR TITLE
feat(tui): say who ran a bang command — you: chip and model context

### DIFF
--- a/local_operator/prompts_md/system.md
+++ b/local_operator/prompts_md/system.md
@@ -52,6 +52,11 @@ real result beats a guess every time.
   you run them. If an approval request is declined, stop that action and say so.
 - Treat unknown files as the user's work: never overwrite or delete code you
   did not create without checking first.
+- A `! <command>` user message followed by a bash tool call and its result is
+  a command the USER ran directly from the composer (bang-mode), not one you
+  issued: read it as context the user produced — what they ran and what came
+  back — never as your own earlier action, and never re-run it on the
+  strength of it appearing in the conversation.
 - Keep secrets secret. Never print credentials, tokens, or keys into results.
 - The host may auto-approve read-only actions and prompt for writes and
   commands; respect denials without retrying the identical action.

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -2004,12 +2004,12 @@ class OperatorApp(App[None]):
                     # command's own card; the shape record_shell writes has
                     # exactly one, so consuming here is exact in practice and
                     # conservative in theory.
-                    open_settled = bool(
+                    user_run = bool(
                         bang_pending
                         and tool_calls[0] is call
                         and getattr(call, "name", "") == "bash"
                     )
-                    self._replay_tool_call(call, results, open_on_settle=open_settled)
+                    self._replay_tool_call(call, results, user_run=user_run)
                     appended = True
                 stop = getattr(message, "stop_reason", None)
                 if stop == "refusal":
@@ -2048,7 +2048,7 @@ class OperatorApp(App[None]):
             transcript.follow_tail()
 
     def _replay_tool_call(
-        self, call: Any, results: dict[str, Any], *, open_on_settle: bool = False
+        self, call: Any, results: dict[str, Any], *, user_run: bool = False
     ) -> None:
         """Mount one settled tool row for a call from a previous session.
 
@@ -2061,9 +2061,8 @@ class OperatorApp(App[None]):
             getattr(call, "id", "") or "",
             getattr(call, "name", "") or "",
             getattr(call, "arguments", None) or {},
+            user_run=user_run,
         )
-        if open_on_settle:
-            card.open_on_settle()
         self._append_block(card)
         result = results.get(getattr(call, "id", "") or "")
         if result is None:
@@ -5506,11 +5505,9 @@ class OperatorApp(App[None]):
         from local_operator.tools.builtin import execute_bash
 
         call_id = f"shell-{time.monotonic_ns()}"
-        card = ToolCard(call_id, "bash", {"command": command})
-        # The user ran this command TO SEE its output; a collapsed receipt
-        # hides exactly that behind a click nobody asked for. The card opens
-        # at its first settle (and stays a normal collapsible row after).
-        card.open_on_settle()
+        # user_run: the row says WHO ran it (`you:` chip) and opens at settle,
+        # because the user ran the command to read its output.
+        card = ToolCard(call_id, "bash", {"command": command}, user_run=True)
         self._append_block(UserBlock(f"! {command}"))
         self._append_block(card)
         signal = AbortSignal()

--- a/local_operator/tui/widgets/tool_card.py
+++ b/local_operator/tui/widgets/tool_card.py
@@ -590,6 +590,7 @@ class ToolCard(ExpandableActionBlock):
         tool_name: str,
         args: dict[str, object] | None = None,
         intent: str | None = None,
+        user_run: bool = False,
     ) -> None:
         super().__init__()
         self.tool_call_id = tool_call_id
@@ -680,6 +681,17 @@ class ToolCard(ExpandableActionBlock):
         #: because a collapsed receipt hides exactly the bytes the command was
         #: run for behind a click nobody asked for. Consumed once, at settle.
         self._open_on_settle = False
+        #: The call was typed by the USER (bang-mode), not issued by the model.
+        #: Without a visible say-so the receipt is byte-identical to an
+        #: agent-run bash row, so a reader scrolling back cannot tell their
+        #: own commands from the agent's, and the model reading the context
+        #: cannot tell a command it ran from one that "just appeared". The
+        #: row answers with a `you:` chip ahead of the summary; the system
+        #: prompt answers for the model. A user-run command is also one the
+        #: user ran to SEE, so the flag implies open-on-settle.
+        self.user_run = user_run
+        if user_run:
+            self._open_on_settle = True
         self._hovered = False
         #: True while the row holds keyboard focus. Tracked separately from
         #: hover: both light the hint, but a pointer leaving the row must not
@@ -1742,6 +1754,20 @@ class ToolCard(ExpandableActionBlock):
         # `begin_running` now clears the field, and this makes the invariant
         # checkable from the render side too, so the next way to leave it set
         # cannot reopen the same hole.
+        # A user-run receipt leads with a two-cell attribution chip. It sits
+        # INSIDE the summary budget so the truncation ladder keeps it ahead of
+        # the command — scrolling back to find your own `! git status` works
+        # exactly when the row is narrow enough to hide everything else.
+        if self.user_run:
+            chip = "you: "
+            chip_cells = cell_len(chip)
+            if chip_cells < budget:
+                row_chip = chip
+                budget -= chip_cells
+            else:
+                row_chip = ""
+        else:
+            row_chip = ""
         composed = self._compose_facts and self._state in ("composing", "interrupted")
         if composed:
             # The label is shed WHOLE before the facts are touched, the same
@@ -1781,6 +1807,11 @@ class ToolCard(ExpandableActionBlock):
         row.append(icon + " ", style=icon_style)
         row.append(name, style=name_style)
         row.append(" ", style=dim)
+        if row_chip:
+            # `dim`, the quietest ink: the attribution is chrome, and the
+            # command after it is the fact. It survives every shed rung
+            # because the budget above already paid for it.
+            row.append(row_chip, style=dim)
         row.append(summary, style=summary_style)
 
         # ONE right-aligned tail: the slot and the status share a single pad,

--- a/local_operator/tui/widgets/tool_card.py
+++ b/local_operator/tui/widgets/tool_card.py
@@ -1754,7 +1754,7 @@ class ToolCard(ExpandableActionBlock):
         # `begin_running` now clears the field, and this makes the invariant
         # checkable from the render side too, so the next way to leave it set
         # cannot reopen the same hole.
-        # A user-run receipt leads with a two-cell attribution chip. It sits
+        # A user-run receipt leads with a five-cell attribution chip. It sits
         # INSIDE the summary budget so the truncation ladder keeps it ahead of
         # the command — scrolling back to find your own `! git status` works
         # exactly when the row is narrow enough to hide everything else.
@@ -1808,10 +1808,15 @@ class ToolCard(ExpandableActionBlock):
         row.append(name, style=name_style)
         row.append(" ", style=dim)
         if row_chip:
-            # `dim`, the quietest ink: the attribution is chrome, and the
-            # command after it is the fact. It survives every shed rung
-            # because the budget above already paid for it.
-            row.append(row_chip, style=dim)
+            # Chrome quieter than the fact while live (the summary is
+            # `muted` there); one step BRIGHTER than the fact once settled,
+            # when the summary drops to `dim` — the attribution is the thing
+            # a reader scrolling back is hunting for, and a chip that faded
+            # to the same ink as the command stopped separating the two
+            # (design round 1, D1). It survives every shed rung because the
+            # budget above already paid for it.
+            chip_style = muted if not running else dim
+            row.append(row_chip, style=chip_style)
         row.append(summary, style=summary_style)
 
         # ONE right-aligned tail: the slot and the status share a single pad,

--- a/tests/unit/test_prompts_api.py
+++ b/tests/unit/test_prompts_api.py
@@ -189,7 +189,7 @@ def test_the_system_prompt_names_user_run_bang_receipts() -> None:
     blocks = build_system_blocks(TOOLS, SKILLS, ENV, DATE)
     head = blocks[0]
     assert "bang-mode" in head
-    assert "the USER ran directly" in head or "USER ran directly" in head
+    assert "the USER ran directly" in head
     instructions, inventory, env_block, skills = blocks
 
     # block 0: stable instructions only

--- a/tests/unit/test_prompts_api.py
+++ b/tests/unit/test_prompts_api.py
@@ -180,6 +180,16 @@ def test_blocks_isolate_volatile_content() -> None:
     # never invalidate the conversation prefix after it.
     blocks = build_system_blocks(TOOLS, SKILLS, ENV, DATE)
     assert len(blocks) == 4
+
+
+def test_the_system_prompt_names_user_run_bang_receipts() -> None:
+    """The model must be able to tell a command the USER ran (bang-mode) from
+    one it issued itself: a `! <command>` user message + bash call + result is
+    user-produced context, never the model's own earlier action."""
+    blocks = build_system_blocks(TOOLS, SKILLS, ENV, DATE)
+    head = blocks[0]
+    assert "bang-mode" in head
+    assert "the USER ran directly" in head or "USER ran directly" in head
     instructions, inventory, env_block, skills = blocks
 
     # block 0: stable instructions only

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -941,6 +941,87 @@ async def test_a_replayed_bang_card_opens_and_ordinary_calls_stay_shut() -> None
 
 
 @pytest.mark.asyncio
+async def test_a_bang_card_says_who_ran_it() -> None:
+    """A user-run receipt is visually distinguishable from an agent-run bash
+    row: the summary leads with a `you:` chip, live and after resume, and the
+    chip survives truncation at narrow widths."""
+    session = FakeSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        editor = app.query_one(Editor)
+        editor.focus()
+        await pilot.press("!")
+        for key in "echo attribution":
+            await pilot.press("space" if key == " " else key)
+        await pilot.press("enter")
+        for _ in range(40):
+            await pilot.pause()
+            if session.shell_records:
+                break
+        cards = [b for b in app.query_one(TranscriptView).blocks() if isinstance(b, ToolCard)]
+        assert cards
+        assert cards[-1].user_run is True
+        assert "you:" in cards[-1]._build_row(80).plain
+        # The chip is inside the summary budget, so a narrow row keeps it.
+        assert "you:" in cards[-1]._build_row(40).plain
+        # An ordinary agent card carries no chip.
+        plain = ToolCard("x", "bash", {"command": "ls"})
+        assert "you:" not in plain._build_row(80).plain
+
+
+@pytest.mark.asyncio
+async def test_a_replayed_bang_card_says_who_ran_it() -> None:
+    """Resume parity for the attribution: the replayed bang row carries the
+    same `you:` chip the live one showed, and an ordinary bash call does not."""
+    session = FakeSession()
+    session._history = [
+        SimpleNamespace(
+            role="user", text="! echo hi", tool_calls=None, content=[], custom_type=None
+        ),
+        SimpleNamespace(
+            role="assistant",
+            text="",
+            tool_calls=[
+                SimpleNamespace(id="shell-1", name="bash", arguments={"command": "echo hi"})
+            ],
+            custom_type=None,
+        ),
+        SimpleNamespace(
+            role="tool",
+            tool_call_id="shell-1",
+            text="exit code: 0\nhi",
+            is_error=False,
+            provider_payload=None,
+            content=[],
+        ),
+        SimpleNamespace(
+            role="assistant",
+            text="",
+            tool_calls=[SimpleNamespace(id="agent-1", name="bash", arguments={"command": "ls"})],
+            custom_type=None,
+        ),
+        SimpleNamespace(
+            role="tool",
+            tool_call_id="agent-1",
+            text="exit code: 0\nfile",
+            is_error=False,
+            provider_payload=None,
+            content=[],
+        ),
+    ]
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        cards = [b for b in app.query_one(TranscriptView).blocks() if isinstance(b, ToolCard)]
+        assert len(cards) == 2
+        assert cards[0].user_run is True
+        assert "you:" in cards[0]._build_row(80).plain
+        assert cards[1].user_run is False
+        assert "you:" not in cards[1]._build_row(80).plain
+
+
+@pytest.mark.asyncio
 async def test_a_failing_bang_card_settles_open_too() -> None:
     """Failure is exactly when the output matters most, so the open-on-settle
     contract covers the error settle as well."""


### PR DESCRIPTION
## Summary

Follow-up to #218/#221. A user-run bang receipt was byte-identical to an agent-run bash row — a reader scrolling back could not tell their own commands from the agent's, and the model reading the context could not tell a command it issued from one that merely appeared in the conversation. This change makes both surfaces say who ran it:

- **The card**: `ToolCard` gains `user_run`. A user-run row's summary leads with a dim `you:` chip that lives inside the summary budget, so the truncation ladder keeps the attribution ahead of the command at narrow widths. The resume replay pairs the persisted `! <command>` user row with its bash call and carries the same chip. `user_run` implies open-on-settle (a user-run command is one the user ran to see), subsuming the #221 flag.
- **The model context**: the system prompt names the grammar — a `! <command>` user message followed by a bash tool call and its result is a command the USER ran directly from the composer: read it as user-produced context, never as the model's own earlier action, never re-run on its appearance. (The persisted triple already carries the `!` prefix in the user message; this makes the reading explicit.)

## Test plan

- [x] New tests: `test_a_bang_card_says_who_ran_it` (chip live, chip survives 40-col truncation, absent on ordinary cards), `test_a_replayed_bang_card_says_who_ran_it` (resume parity, ordinary call unchipped), `test_the_system_prompt_names_user_run_bang_receipts`
- [x] Visual validation: rendered frame with both rows — agent `bash ls` vs user `bash you: cat ~/.zshrc` (`/tmp/chip-tall.svg`)
- [x] Gates: flake8, black --check, isort --check-only, pyright — clean
- [x] Full unit suite in four chunks (below)
- [ ] Agent review + design review rounds posted on this PR until clean
