### PR TITLE
fix(providers): surface OpenRouter mid-stream error chunks as named failures

### DIFF
--- a/local_operator/providers/clients.py
+++ b/local_operator/providers/clients.py
@@ -195,6 +195,57 @@ def _openrouter_upstream_text(error: Mapping[str, Any]) -> str:
     return raw.strip()[:500]
 
 
+def _compat_stream_error(chunk: Mapping[str, Any]) -> ProviderError:
+    """An in-band mid-stream failure on an OpenAI-compatible stream.
+
+    Once a gateway has committed HTTP 200 it can no longer signal an upstream
+    failure via the status line, so OpenRouter delivers it INSIDE the stream:
+    a ``chat.completion.chunk`` carrying a top-level ``error`` object (``code``,
+    ``message``, ``metadata.error_type``) alongside ``finish_reason: "error"``.
+    The chunk parser used to read only ``choices`` and ``usage``, so the error
+    object was dropped and the terminal finish reason surfaced later as a
+    wordless ``stop_reason="error"`` — the turn died as a silent interruption:
+    no incident for the model, no retry, no failover, no credential rotation.
+    Raising here hands the failure to the failover driver, which names it,
+    journals it, and retries or rotates while the budget lasts.
+
+    Simpler compatible servers send the error as a bare string instead of an
+    object; both shapes feed the same cascade, mirroring
+    :func:`_extract_error_message`'s slots without its response-body fallback
+    (the body is a live stream here and must not be read).
+    """
+    error = chunk.get("error")
+    status: int | None = None
+    error_type = ""
+    if isinstance(error, Mapping):
+        message = _first_text(error.get("message"), error.get("detail"), error.get("msg"))
+        upstream = _openrouter_upstream_text(error)
+        if message and upstream and upstream not in message:
+            message = f"{message}: {upstream}"
+        else:
+            message = message or upstream
+        code = error.get("code")
+        if isinstance(code, int):
+            status = code
+        elif isinstance(code, str) and code.isdigit():
+            status = int(code)
+        metadata = error.get("metadata")
+        if isinstance(metadata, Mapping):
+            error_type = str(metadata.get("error_type") or "")
+    else:
+        message = _first_text(error)
+    if not message:
+        message = error_type or "provider ended the stream with an error"
+    elif error_type and error_type not in message:
+        message = f"{error_type}: {message}"
+    return ProviderError(
+        status,
+        message,
+        retryable=status is None or status == 429 or status >= 500,
+        auth_error=status in (401, 403),
+    )
+
+
 #: Ceiling on any advertised wait. A ``Retry-After`` is provider-supplied and
 #: reaches SQLite: a usage-limit failure feeds ``retry_after_ms_from_error``
 #: into ``AuthStore.rotate_sibling`` → ``block_credential(block_ms=...)``, which
@@ -715,6 +766,12 @@ _FINISH_TO_STOP_REASON = {
     # saw nothing and could not tell a refusal from a no-op, which matters
     # because the remedy (rephrase, or switch models) is theirs to choose.
     "content_filter": "refusal",
+    # OpenRouter terminates a mid-stream upstream failure with this finish
+    # reason. The accompanying chunk normally carries the top-level ``error``
+    # object the parser raises; when a gateway sends the reason WITHOUT the
+    # object, the end event below still names the failure instead of passing
+    # the raw word through as an exotic-but-successful stop reason.
+    "error": "error",
 }
 
 
@@ -1084,6 +1141,12 @@ class OpenAICompatClient:
                     chunk = json.loads(data)
                 except json.JSONDecodeError:
                     continue
+                if isinstance(chunk.get("error"), (Mapping, str)):
+                    # In-band mid-stream failure: the status line already said
+                    # 200, so this chunk is the only channel the failure has.
+                    # Raise it NAMED; swallowing it left turns dying as
+                    # wordless interruptions (see _compat_stream_error).
+                    raise _compat_stream_error(chunk)
                 if isinstance(chunk.get("usage"), Mapping):
                     raw = chunk["usage"]
                     details = raw.get("prompt_tokens_details") or {}
@@ -1162,6 +1225,10 @@ class OpenAICompatClient:
             # rendered and there is no refusal prose: "sent no message" under a
             # partial reply is the D1 contradiction again (review R3-1).
             error = _refusal_error(marker, "".join(refusal_parts), streamed_text=streamed_text)
+        elif stop_reason == "error":
+            # A wordless error end is exactly the silent-interruption defect:
+            # the loop journals `error` as the incident, so name the reason.
+            error = f"provider ended the stream with finish_reason '{finish_reason}'"
         yield StreamEndEvent(
             stop_reason=stop_reason,
             usage=usage,

--- a/local_operator/providers/clients.py
+++ b/local_operator/providers/clients.py
@@ -210,9 +210,13 @@ def _compat_stream_error(chunk: Mapping[str, Any]) -> ProviderError:
     journals it, and retries or rotates while the budget lasts.
 
     Simpler compatible servers send the error as a bare string instead of an
-    object; both shapes feed the same cascade, mirroring
-    :func:`_extract_error_message`'s slots without its response-body fallback
-    (the body is a live stream here and must not be read).
+    object. The message cascade follows :func:`_extract_error_message`'s slots
+    (message, detail, msg, then the ``metadata.raw`` upstream text) but not its
+    floors: that function's last resort is ``error.status``/``error.code`` and
+    its response-body fallback, neither of which belongs here — ``code`` is
+    already consumed as the status, and the body is a live stream that must
+    not be read. ``error_type`` plus a substantive default is the better
+    floor. The composed message is capped like every other error frame.
     """
     error = chunk.get("error")
     status: int | None = None
@@ -240,7 +244,7 @@ def _compat_stream_error(chunk: Mapping[str, Any]) -> ProviderError:
         message = f"{error_type}: {message}"
     return ProviderError(
         status,
-        message,
+        _capped(message),
         retryable=status is None or status == 429 or status >= 500,
         auth_error=status in (401, 403),
     )
@@ -1227,8 +1231,9 @@ class OpenAICompatClient:
             error = _refusal_error(marker, "".join(refusal_parts), streamed_text=streamed_text)
         elif stop_reason == "error":
             # A wordless error end is exactly the silent-interruption defect:
-            # the loop journals `error` as the incident, so name the reason.
-            error = f"provider ended the stream with finish_reason '{finish_reason}'"
+            # the loop journals `error` as the incident, so name the failure,
+            # not just the wire field that signalled it.
+            error = f"provider reported a mid-stream failure (finish_reason '{finish_reason}')"
         yield StreamEndEvent(
             stop_reason=stop_reason,
             usage=usage,

--- a/tests/unit/providers/test_clients.py
+++ b/tests/unit/providers/test_clients.py
@@ -302,7 +302,10 @@ async def test_openai_compat_error_finish_reason_without_error_object() -> None:
     end = events[-1]
     assert isinstance(end, StreamEndEvent)
     assert end.stop_reason == "error"
-    assert end.error is not None and "error" in end.error
+    # The incident text must name the failure, not merely contain the word
+    # "error" — a regression to a tautology like "error: error" would still
+    # pass a substring check.
+    assert end.error == "provider reported a mid-stream failure (finish_reason 'error')"
 
 
 async def test_openai_compat_tool_history_roundtrip() -> None:

--- a/tests/unit/providers/test_clients.py
+++ b/tests/unit/providers/test_clients.py
@@ -159,6 +159,152 @@ async def test_openai_compat_text_tool_usage() -> None:
     assert end.usage is not None and end.usage.output_tokens == 7
 
 
+async def test_openai_compat_mid_stream_error_chunk_raises_named_error() -> None:
+    """OpenRouter mid-stream failures arrive in-band on HTTP 200.
+
+    The gateway commits 200 before the upstream dies, so the failure is a
+    ``chat.completion.chunk`` with a top-level ``error`` object and
+    ``finish_reason: "error"``. The parser must raise it NAMED (status,
+    message, retryability) so the failover driver can journal, retry and
+    rotate — the old behaviour dropped the object and the turn died as a
+    wordless interruption.
+    """
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            content=_sse(
+                [
+                    {"id": "gen-1", "choices": [{"delta": {"content": "Gate"}, "index": 0}]},
+                    {
+                        "id": "gen-1",
+                        "object": "chat.completion.chunk",
+                        "provider": "OpenAI",
+                        "error": {
+                            "code": 429,
+                            "message": "Rate limit exceeded",
+                            "metadata": {"error_type": "rate_limit_exceeded"},
+                        },
+                        "choices": [
+                            {"index": 0, "delta": {"content": ""}, "finish_reason": "error"}
+                        ],
+                    },
+                ]
+            ),
+            headers={"content-type": "text/event-stream"},
+        )
+
+    client = OpenAICompatClient(
+        "https://api.test.example/v1",
+        http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+    )
+    with pytest.raises(ProviderError) as excinfo:
+        await _collect(
+            client.stream(ChatRequest(model=_spec(), messages=[Message.user("hi")]), "sk-test")
+        )
+    error = excinfo.value
+    assert error.status == 429
+    assert error.retryable is True
+    assert error.kind == "quota"
+    assert "Rate limit exceeded" in str(error)
+
+
+async def test_openai_compat_mid_stream_error_chunk_unwraps_upstream_raw() -> None:
+    """A 502-class chunk carries the upstream text in ``metadata.raw``."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            content=_sse(
+                [
+                    {
+                        "id": "gen-2",
+                        "error": {
+                            "code": 502,
+                            "message": "Provider returned error",
+                            "metadata": {
+                                "raw": json.dumps({"error": {"message": "upstream overloaded"}})
+                            },
+                        },
+                        "choices": [
+                            {"index": 0, "delta": {"content": ""}, "finish_reason": "error"}
+                        ],
+                    },
+                ]
+            ),
+            headers={"content-type": "text/event-stream"},
+        )
+
+    client = OpenAICompatClient(
+        "https://api.test.example/v1",
+        http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+    )
+    with pytest.raises(ProviderError) as excinfo:
+        await _collect(
+            client.stream(ChatRequest(model=_spec(), messages=[Message.user("hi")]), "sk-test")
+        )
+    error = excinfo.value
+    assert error.status == 502
+    assert error.kind == "transient"
+    assert "Provider returned error" in str(error)
+    assert "upstream overloaded" in str(error)
+
+
+async def test_openai_compat_mid_stream_error_chunk_bare_string() -> None:
+    """Simpler compatible servers send the error as a bare string."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            content=_sse([{"error": "upstream connection reset"}]),
+            headers={"content-type": "text/event-stream"},
+        )
+
+    client = OpenAICompatClient(
+        "https://api.test.example/v1",
+        http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+    )
+    with pytest.raises(ProviderError) as excinfo:
+        await _collect(
+            client.stream(ChatRequest(model=_spec(), messages=[Message.user("hi")]), "sk-test")
+        )
+    assert "upstream connection reset" in str(excinfo.value)
+
+
+async def test_openai_compat_error_finish_reason_without_error_object() -> None:
+    """A bare ``finish_reason: "error"`` still names the failure.
+
+    Without the top-level error object the old parser passed the raw reason
+    through as an exotic stop reason and the loop recorded a wordless error
+    turn — no incident, no diagnosis. The end event now carries the reason in
+    ``error`` so the session journals it.
+    """
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            content=_sse(
+                [
+                    {"id": "gen-3", "choices": [{"delta": {"content": "x"}, "index": 0}]},
+                    {"id": "gen-3", "choices": [{"delta": {}, "finish_reason": "error"}]},
+                ]
+            ),
+            headers={"content-type": "text/event-stream"},
+        )
+
+    client = OpenAICompatClient(
+        "https://api.test.example/v1",
+        http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+    )
+    events = await _collect(
+        client.stream(ChatRequest(model=_spec(), messages=[Message.user("hi")]), "sk-test")
+    )
+    end = events[-1]
+    assert isinstance(end, StreamEndEvent)
+    assert end.stop_reason == "error"
+    assert end.error is not None and "error" in end.error
+
+
 async def test_openai_compat_tool_history_roundtrip() -> None:
     """Assistant tool_calls and tool results serialize for replay.
 

--- a/tests/unit/providers/test_failover.py
+++ b/tests/unit/providers/test_failover.py
@@ -4,6 +4,7 @@ streaming with fake clients/auth."""
 from __future__ import annotations
 
 import asyncio
+import json
 import random
 import time
 from collections.abc import AsyncIterator
@@ -23,6 +24,7 @@ from local_operator.harness.types import (
 from local_operator.model.configure import build_model_spec
 from local_operator.providers import failover as failover_module
 from local_operator.providers.auth_store import AuthStore
+from local_operator.providers.clients import OpenAICompatClient
 from local_operator.providers.failover import (
     AUTH_RETRY_MAX_ATTEMPTS,
     CHAIN_EFFORT_LADDER,
@@ -1544,6 +1546,65 @@ class TestTransientFailuresAreRetriedOnEveryCallPath:
             )
         assert excinfo.value.kind == "timeout"
         assert str(excinfo.value) == "provider timeout: ReadTimeout"
+
+    async def test_an_openrouter_error_chunk_after_partial_output_arrives_named(self) -> None:
+        """The reported incident, end to end: visible deltas, then an in-band
+        error chunk on an HTTP 200 stream.
+
+        The real OpenAI-compatible client raises the named ``ProviderError``
+        from the error chunk; ``stream_with_failover`` has already forwarded
+        output, so it must re-raise it NAMED — no retry (which would duplicate
+        the visible deltas) and no silent wordless end. This is the exact
+        combination the client-level and driver-level tests each cover only
+        half of.
+        """
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            lines = [
+                "data: "
+                + json.dumps({"choices": [{"delta": {"content": "Gate"}, "index": 0}]}),
+                "data: "
+                + json.dumps(
+                    {
+                        "id": "gen-9",
+                        "error": {
+                            "code": 429,
+                            "message": "Rate limit exceeded",
+                            "metadata": {"error_type": "rate_limit_exceeded"},
+                        },
+                        "choices": [
+                            {"index": 0, "delta": {"content": ""}, "finish_reason": "error"}
+                        ],
+                    }
+                ),
+                "data: [DONE]",
+            ]
+            return httpx.Response(
+                200,
+                content="\n\n".join(lines).encode() + b"\n\n",
+                headers={"content-type": "text/event-stream"},
+            )
+
+        http = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+        async def client_for(spec: ModelSpec) -> Any:
+            return OpenAICompatClient("https://api.test.example/v1", http_client=http)
+
+        seen: list[Any] = []
+        with pytest.raises(ProviderError) as excinfo:
+            async for event in stream_with_failover(
+                _request(), FakeAuth({"openai": ["k"]}), {"retry": {"baseDelayMs": 1}}, client_for
+            ):
+                seen.append(event)
+        error = excinfo.value
+        assert error.status == 429
+        assert error.kind == "quota"
+        assert "Rate limit exceeded" in str(error)
+        # The visible delta was forwarded exactly once; nothing was replayed.
+        assert [e for e in seen if isinstance(e, StreamTextDelta)] == [
+            StreamTextDelta(delta="Gate")
+        ]
+        await http.aclose()
 
     async def test_the_one_shot_call_the_session_makes_is_marked_replayable(self) -> None:
         """Wiring, not policy: ``_one_shot_complete`` is the compaction summary

--- a/tests/unit/providers/test_failover.py
+++ b/tests/unit/providers/test_failover.py
@@ -1561,8 +1561,7 @@ class TestTransientFailuresAreRetriedOnEveryCallPath:
 
         def handler(request: httpx.Request) -> httpx.Response:
             lines = [
-                "data: "
-                + json.dumps({"choices": [{"delta": {"content": "Gate"}, "index": 0}]}),
+                "data: " + json.dumps({"choices": [{"delta": {"content": "Gate"}, "index": 0}]}),
                 "data: "
                 + json.dumps(
                     {


### PR DESCRIPTION
## Why

A long session kept "interrupting" itself: the model would compose a `bash` call, the stream would die ~2s later, and the tool row settled as `interrupted · N B composed / never sent` with no diagnosis anywhere — no incident line for the model, no error frame for the user. Forensics on the session transcript and `~/Library/Logs/local-operator/local-operator.log` showed the exact signature:

- `httpx` logged `POST https://openrouter.ai/api/v1/chat/completions "HTTP/1.1 200 OK"` for the dying request;
- no `model stream failed` warning and no `session_incident` was journaled;
- the persisted assistant turn carried `stop_reason: "error"` with truncated tool-call arguments.

OpenRouter's docs name the mechanism: once the gateway has committed HTTP 200, an upstream failure (provider disconnect, timeout, overload) can no longer use the status line, so it arrives **in-band** as a `chat.completion.chunk` with a top-level `error` object (`code`, `message`, `metadata.error_type`) and `choices[0].finish_reason: "error"`. The OpenAI-compatible chunk parser read only `choices` and `usage`, so the error object was dropped, and `_FINISH_TO_STOP_REASON` passed the raw `"error"` finish reason through as an exotic-but-successful stop reason. The loop then recorded a wordless error turn: the failover driver never saw a failure, so there was no retry, no model fallback, no credential rotation — just a silent interruption. The session hit it while pinned to an OpenRouter fallback route after its Anthropic OAuth credentials rate-limited, i.e. exactly when resilience mattered most.

## What changes

- **`OpenAICompatClient.stream`** now recognises the in-band error chunk and raises it NAMED via a new `_compat_stream_error` helper: status from `error.code`, message from the same cascade `_extract_error_message` uses (including unwrapping OpenRouter's `metadata.raw` upstream text), `retryable`/`auth_error` from status. Raising hands the failure to `stream_with_failover`, which retries with backoff or rotates credentials while the budget lasts when nothing has been forwarded yet, and re-raises it named after partial output so the loop journals the incident instead of a wordless interruption.
- **`_FINISH_TO_STOP_REASON`** gains an explicit `"error"` entry with a comment, and the end event for that stop reason carries an `error` string naming the finish reason — a wordless error turn is no longer representable on this wire.
- **4 regression tests** against `httpx.MockTransport` fixtures of the documented OpenRouter shapes: 429 rate-limit chunk (asserts status/retryable/kind `quota`/message), 502 chunk with `metadata.raw` upstream text (asserts both texts surface), bare-string `error` variant, and a bare `finish_reason: "error"` without an error object (asserts the end event names the failure).

## Testing evidence

- The four new tests reproduce the documented wire shapes and fail on the pre-change parser (error chunk silently consumed, `"error"` passed through as stop reason).
- `tests/unit/providers` on the PR base: 580 passed.
- Full `tests/unit` on the PR base (origin/main): **5767 passed, 7 skipped** (~15 min).
- Gates clean on the changed files: `flake8`, `black --check`, `isort --check-only`, `pyright` (0 errors, 0 warnings).
- End-to-end behaviour after the fix: the same OpenRouter failure now surfaces as a named incident (e.g. `rate limit or quota exceeded (HTTP 429): Rate limit exceeded`) that the failover layer retries/rotates on, and the session journals it for the model — instead of a silent `never sent` row.
