### PR TITLE
fix(providers,harness,session): recover blocked quota before failover; end silent truncations; withdraw pinned fallback on re-selection

### DIFF
--- a/local_operator/harness/loop.py
+++ b/local_operator/harness/loop.py
@@ -528,15 +528,22 @@ class AgentLoop:
                             # spent): the turn is about to end with NOTHING on
                             # screen — minutes of "thinking" and then silence,
                             # the exact failure shape reported from session
-                            # f3c058d1. A notice is the minimum honest frame:
-                            # the user learns the budget went to reasoning,
-                            # not that the app froze.
+                            # f3c058d1. A notice is the minimum honest frame,
+                            # and it names WHICH limit ended the retreat
+                            # (review N1) so the user knows whether another
+                            # manual retry could still step down.
+                            cause = (
+                                f"{empty_truncation_retries} lower-effort "
+                                f"{'retries' if empty_truncation_retries != 1 else 'retry'} spent"
+                                if empty_truncation_retries >= MAX_EMPTY_TRUNCATION_RETRIES
+                                else "no lower effort setting to retry at"
+                            )
                             yield NoticeEvent(
                                 text=(
                                     "the model spent its whole output budget "
-                                    "thinking and produced no visible output — "
-                                    "retry, or switch to a model with a larger "
-                                    "output budget"
+                                    f"thinking and produced no visible output "
+                                    f"({cause}) — retry, or switch to a model "
+                                    "with a larger output budget"
                                 ),
                                 kind="warning",
                             )
@@ -713,11 +720,30 @@ class AgentLoop:
         converted = config.convert_to_llm(shaped)
         if inspect.isawaitable(converted):
             converted = await converted
+        # Resolved after `transform_context`/`convert_to_llm`, which can
+        # await: the spec is read as late as possible so a switch made
+        # while this call was being prepared still catches it.
+        model = self._current_model(config)
+        if effort_ceiling is not None:
+            # An empty-truncation retreat is in force. The host's resolver
+            # returns ITS model (the session's `get_model` ignores the
+            # loop's `config.model` mutation entirely), so the clamp has to
+            # land on the RESOLVED spec or the retry goes back out at the
+            # exact rung that just produced silence (review F1). Applied
+            # here rather than in the resolver because the ceiling is the
+            # loop's own state, and `effort_ceiling` on the request only
+            # covers hosts that re-impose an effort override downstream.
+            ladder = model.reasoning_efforts
+            current = model.reasoning_effort
+            if (
+                current is not None
+                and effort_ceiling in ladder
+                and current in ladder
+                and ladder.index(current) > ladder.index(effort_ceiling)
+            ):
+                model = model.model_copy(update={"reasoning_effort": effort_ceiling})
         request = ChatRequest(
-            # Resolved after `transform_context`/`convert_to_llm`, which can
-            # await: the spec is read as late as possible so a switch made
-            # while this call was being prepared still catches it.
-            model=self._current_model(config),
+            model=model,
             system_blocks=list(context.system_blocks),
             messages=list(converted),
             tools=list(context.tools),

--- a/local_operator/harness/loop.py
+++ b/local_operator/harness/loop.py
@@ -132,6 +132,30 @@ SKIPPED_RESULT_TEXT = "Tool call skipped: interrupted by steering."
 EMPTY_TOOL_RESULT_TEXT = "[tool returned no output]"
 # Steering-interrupt poll interval for ``interruptible`` tools mid-run.
 STEERING_INTERRUPT_POLL_S = 0.25
+
+#: How many times an EMPTY ``length`` truncation (no text, no tool calls — the
+#: reasoning model that spent its whole output budget thinking) is retried one
+#: effort rung lower before the turn ends the ordinary way. Two covers the
+#: observed failure shape (a high rung, then the rung below it also silent)
+#: without burning the user's quota on a model that cannot answer today.
+MAX_EMPTY_TRUNCATION_RETRIES = 2
+
+
+def _lower_effort(model: "ModelSpec") -> str | None:
+    """The effort one rung below ``model.reasoning_effort`` on its own ladder.
+
+    ``None`` when the model has no ladder or already runs at its bottom rung:
+    there is no cheaper setting to retry at, and a retry at the SAME effort
+    would reproduce the same silent truncation, so the caller ends the turn
+    instead."""
+    ladder = list(model.reasoning_efforts)
+    current = model.reasoning_effort
+    if not ladder or current is None or current not in ladder:
+        return None
+    index = ladder.index(current)
+    return ladder[index - 1] if index > 0 else None
+
+
 # How long the batch waits for tools to unwind after an ABORT before it stops
 # waiting and settles the turn anyway. An abort is a user pressing Esc, so the
 # turn must end on a human timescale; a tool whose cleanup is slower than this
@@ -372,6 +396,19 @@ class AgentLoop:
         pending: list[AgentMessage] = []
         has_more_tool_calls = True  # forces the first model call
         reentries = 0  # outer-loop re-entries; capped by config
+        # A reasoning model can spend its ENTIRE output budget thinking and be
+        # cut off at ``length`` with nothing visible to show for it — the user
+        # then watches minutes of "thinking" end in silence (session f3c058d1:
+        # four consecutive empty 8192-token truncations on the fallback model).
+        # The loop retries such a turn a bounded number of times one effort rung
+        # lower, where the budget goes to output instead of thought; a turn
+        # that DID produce text or calls is truncated, not silent, and keeps
+        # the old pair-and-stop behaviour.
+        empty_truncation_retries = 0
+        # The effort ceiling an empty-truncation retreat imposed; rides on
+        # every request under it so the session's frozen auto-effort cannot
+        # raise the retry back to the rung that produced nothing.
+        effort_ceiling: str | None = None
 
         yield AgentStartEvent(generation=generation)
 
@@ -408,7 +445,9 @@ class AgentLoop:
                             return
 
                     assistant, stop_reason, stream_error = None, "stop", None
-                    async for event in self._model_turn(context, config, signal):
+                    async for event in self._model_turn(
+                        context, config, signal, effort_ceiling=effort_ceiling
+                    ):
                         if isinstance(event, _ModelTurnResult):
                             assistant, stop_reason, stream_error = (
                                 event.message,
@@ -456,6 +495,51 @@ class AgentLoop:
 
                     tool_results: list[ToolResult] = []
                     if stop_reason == "length":
+                        silent = not assistant.text and not assistant.tool_calls
+                        if silent and empty_truncation_retries < MAX_EMPTY_TRUNCATION_RETRIES:
+                            lower = _lower_effort(config.model)
+                            if lower is not None:
+                                empty_truncation_retries += 1
+                                # The empty turn must not reach the retry's
+                                # wire history: an assistant message with no
+                                # content blocks is an illegal request on the
+                                # Anthropic wire, and replaying "I said
+                                # nothing" teaches the retry to say nothing.
+                                if context.messages and context.messages[-1] is assistant:
+                                    context.messages.pop()
+                                if new_messages and new_messages[-1] is assistant:
+                                    new_messages.pop()
+                                config.model = config.model.model_copy(
+                                    update={"reasoning_effort": lower}
+                                )
+                                effort_ceiling = lower
+                                yield NoticeEvent(
+                                    text=(
+                                        f"model spent its whole output budget "
+                                        f"thinking and produced nothing — "
+                                        f"retrying at effort {lower}"
+                                    ),
+                                    kind="warning",
+                                )
+                                has_more_tool_calls = True
+                                continue
+                        if silent:
+                            # No cheaper rung to retry at (or the retries are
+                            # spent): the turn is about to end with NOTHING on
+                            # screen — minutes of "thinking" and then silence,
+                            # the exact failure shape reported from session
+                            # f3c058d1. A notice is the minimum honest frame:
+                            # the user learns the budget went to reasoning,
+                            # not that the app froze.
+                            yield NoticeEvent(
+                                text=(
+                                    "the model spent its whole output budget "
+                                    "thinking and produced no visible output — "
+                                    "retry, or switch to a model with a larger "
+                                    "output budget"
+                                ),
+                                kind="warning",
+                            )
                         # Truncated: pair placeholders, do NOT execute.
                         placeholders = [
                             self._synthetic_result(call, ABORTED_RESULT_TEXT)
@@ -612,6 +696,7 @@ class AgentLoop:
         context: LoopContext,
         config: LoopConfig,
         signal: AbortSignal | None,
+        effort_ceiling: str | None = None,
     ) -> AsyncIterator[AgentEvent | _ModelTurnResult]:
         """One provider call: build the request, stream it, assemble the
         assistant message, emitting message_start/update/end events.
@@ -636,6 +721,7 @@ class AgentLoop:
             system_blocks=list(context.system_blocks),
             messages=list(converted),
             tools=list(context.tools),
+            effort_ceiling=effort_ceiling,
         )
 
         assistant = Message(role="assistant")

--- a/local_operator/harness/types.py
+++ b/local_operator/harness/types.py
@@ -1321,6 +1321,12 @@ class ChatRequest(BaseModel):
     top_p: float | None = None
     stop_sequences: list[str] = Field(default_factory=list)
     tool_choice: Literal["auto", "none", "required"] = "auto"
+    # A reasoning-effort ceiling the harness set DELIBERATELY (an empty
+    # truncation retry stepped the effort down one rung). The session's
+    # frozen auto-effort override must not raise the request back above it:
+    # the override exists to hold a classification steady, not to undo a
+    # retreat the loop made because the higher rung produced nothing.
+    effort_ceiling: str | None = None
     # Stable request-prefix identity used by providers' server-side prompt
     # caches. Session hosts populate it once from their session id; keeping it
     # on the request lets retries and fallback clones preserve the same value.

--- a/local_operator/mobile/owned.py
+++ b/local_operator/mobile/owned.py
@@ -238,7 +238,10 @@ class OwnedSessionHandle(SessionHandle):
         from local_operator.model.configure import build_model_spec
 
         spec = await asyncio.to_thread(build_model_spec, provider, model_id)
-        self._session.set_model(spec)
+        # ``explicit``: the phone's model switch is a deliberate choice, so a
+        # pinned fallback route is withdrawn even when it re-selects the model
+        # the fallback displaced — see ``Session.set_model``.
+        self._session.set_model(spec, explicit=True)
         self._refresh_state()
         return f"model: {self._projection.model_label}"
 

--- a/local_operator/model/configure.py
+++ b/local_operator/model/configure.py
@@ -2023,7 +2023,9 @@ class SessionStreamFn:
                     # block an account that still serves other models. Fail over
                     # to another provider only after re-checking the blocks
                     # themselves: exhaust every login first.
-                    recovered = await self._recover_blocked_accounts(model, storage, rows, retry)
+                    recovered = await self._recover_blocked_accounts(
+                        model, storage, rows, retry, attempted_ids
+                    )
                     if recovered is not None:
                         health, shared_remaining, tier_binding, access = recovered
                         if health.state != "healthy" and await self._apply_account_health(
@@ -2129,7 +2131,7 @@ class SessionStreamFn:
                         and self._auth_store.is_blocked(candidate.id, storage)
                     ]
                     recovered = await self._recover_blocked_accounts(
-                        model, storage, blocked_rows, retry
+                        model, storage, blocked_rows, retry, attempted_ids
                     )
                     if recovered is not None:
                         rec_health = recovered[0]
@@ -2339,7 +2341,9 @@ class SessionStreamFn:
                 and (row is None or candidate.credential_type == row.credential_type)
                 and self._auth_store.is_blocked(candidate.id, storage)
             ]
-            recovered = await self._recover_blocked_accounts(model, storage, blocked_rows, retry)
+            recovered = await self._recover_blocked_accounts(
+                model, storage, blocked_rows, retry, attempted_ids
+            )
             if recovered is not None:
                 rec_health = recovered[0]
                 if rec_health.state in ("healthy", "reserve"):
@@ -2452,6 +2456,7 @@ class SessionStreamFn:
         storage: str,
         rows: list[Any],
         retry: Any,
+        attempted_ids: set[int],
     ) -> tuple[Any, float | None, bool, Any] | None:
         """Re-check blocked accounts before a provider failover.
 
@@ -2470,6 +2475,20 @@ class SessionStreamFn:
         whose re-probe says depleted. ``None`` means every blocked account
         was re-checked and none gave a verdict — only then is a provider
         fallback honest.
+
+        ``attempted_ids`` is the preflight's record of which credentials this
+        message boundary has already judged, and it is BOTH read and written
+        here. That is what terminates the walk. A depleted verdict sends the
+        caller back into ``_apply_account_health``, which re-blocks the row
+        and walks the blocked pool again; without recording the probe, the
+        row this frame just cleared is blocked again by the next frame and
+        re-enumerated by the one after, so two depleted blocked accounts
+        ping-pong A→B→A until the recursion limit kills the turn. Every row
+        the walk touches is recorded, whatever the outcome: a refresh failure
+        or an unreadable report is still a decision taken about that account
+        for this boundary, and re-probing it costs a network round trip to
+        reach the same answer. Rows are finite and the set only grows, so
+        each recursive step strictly shrinks the candidate pool.
         """
         from local_operator.providers.auth_store import OAuthAccess
         from local_operator.providers.registry import get_provider_definition
@@ -2480,6 +2499,14 @@ class SessionStreamFn:
         )
 
         for row in rows:
+            if row.id in attempted_ids:
+                continue  # already judged at this message boundary
+            # Recorded BEFORE the probe, so every exit below — refresh
+            # failure, missing token, unreachable endpoint, unreadable
+            # report, or a definite verdict — leaves this row out of the
+            # next enumeration. See the docstring: this is the walk's
+            # termination guarantee, not an optimisation.
+            attempted_ids.add(row.id)
             # Probe the row's OWN refreshed token. Clearing the block and
             # re-asking the cascade (the first shape of this walk) attributed
             # the verdict to whatever the cascade returned — with a healthy

--- a/local_operator/model/configure.py
+++ b/local_operator/model/configure.py
@@ -1607,6 +1607,38 @@ class SessionStreamFn:
         self._route_state.primary_retry_at_ms = int(time.time() * 1000) + 60_000
         self._primary_selector = primary_selector
 
+    def withdraw_fallback(self) -> None:
+        """The user explicitly re-selected a model; drop the pinned fallback route.
+
+        The inverse of :meth:`restore_fallback`. A fallback pin rescues the
+        SELECTED model by routing around it; when the user deliberately picks a
+        model again — including re-picking the very model a fallback displaced
+        them from — the pin's premise is withdrawn and the next request must go
+        to the primary.
+
+        Needed because the ordinary clear is selector-driven: ``preflight_usage``
+        resets the route only when it sees a DIFFERENT selector than the memoized
+        primary. A same-model re-selection never changes the selector, so that
+        lazy clear never fires and the session stays glued to the fallback until
+        the user switches away and back — the reported stuck-fallback symptom.
+
+        Silent on purpose — :meth:`FailoverRouteState.clear`, not
+        ``clear_settled``. The owning Session has already moved its own display
+        state and emitted the ``ModelChangeEvent`` for this withdrawal; firing a
+        settle edge here would re-persist and re-announce what the session just
+        recorded. Hosts without a route capability simply never call this.
+
+        Must stay SYNCHRONOUS for the same reason :meth:`on_model_changed` does:
+        ``Session.set_model`` is sync and discards a returned awaitable.
+        """
+        self._route_state.clear()
+        # The selector memo still matches the re-selected model, so preflight
+        # would otherwise trust the quota reading that pinned the fallback for
+        # the rest of the TTL. Reset the clock so the explicit re-selection gets
+        # a fresh probe at the next boundary instead of inheriting the stale
+        # verdict.
+        self._usage_checked_at = 0.0
+
     def begin_message(self) -> None:
         """Mark the next model call as a user-message boundary."""
         self._message_boundary_pending = True

--- a/local_operator/model/configure.py
+++ b/local_operator/model/configure.py
@@ -2151,8 +2151,13 @@ class SessionStreamFn:
                             return
                         # Recovered but depleted for this model: the shared
                         # policy re-blocks and activates the fallback, naming
-                        # the quota in its notice.
-                        await self._apply_account_health(
+                        # the quota in its notice. Its True return means a
+                        # sibling took over (with several blocked rows the
+                        # walk unblocks them one at a time), and discarding
+                        # that signal ended preflight with a depleted row
+                        # unblocked and no fallback pinned (review F2) — so
+                        # re-enter the walk exactly like the other callers.
+                        if await self._apply_account_health(
                             model,
                             recovered[3],
                             storage,
@@ -2161,7 +2166,8 @@ class SessionStreamFn:
                             recovered[2],
                             retry,
                             attempted_ids,
-                        )
+                        ):
+                            continue
                         return
                 if siblings:
                     if health.state == "depleted":
@@ -2314,6 +2320,17 @@ class SessionStreamFn:
             # accounts blocked at 8%/4% while the live one read 0%). Probe
             # the blocked rows before the hop; ``None`` means every account
             # was re-checked and genuinely cannot serve.
+            #
+            # The account under verdict is blocked FIRST: its depletion is a
+            # definite reading, and a walk that settles on a recovered
+            # sibling returns before the tail of this method — which is
+            # where the block used to be written — leaving a spent account
+            # in the unblocked pool (review F2's second half).
+            self._auth_store.block_credential(
+                access.credential_id,
+                storage,
+                block_ms=max(60_000, health.reset_after_ms or self.DEFAULT_USAGE_BLOCK_MS),
+            )
             blocked_rows = [
                 candidate
                 for candidate in self._auth_store.list_credentials(storage)
@@ -2436,18 +2453,23 @@ class SessionStreamFn:
         rows: list[Any],
         retry: Any,
     ) -> tuple[Any, float | None, bool, Any] | None:
-        """Re-check every blocked account before a provider failover.
+        """Re-check blocked accounts before a provider failover.
 
-        ``get_oauth_access`` returns None the moment all credentials are
-        blocked, but a block is a stale verdict the moment a window resets —
-        and preflight takes accounts out of rotation on nothing more than
-        crossing a reserve threshold, so a pool that still has spendable quota
-        can look exactly like a dead one. Each blocked account is probed in
-        turn: its block is lifted, its usage re-fetched, and the first account
-        with a definite answer (healthy, or low in a way that still routes)
-        wins. Unknown/unreachable reports re-impose a short block and move on.
-        ``None`` means every account is genuinely out — only then is a
-        provider fallback honest.
+        A block is a stale verdict the moment a window resets — and preflight
+        takes accounts out of rotation on nothing more than crossing a reserve
+        threshold, so a pool that still has spendable quota can look exactly
+        like a dead one. Each blocked row is probed with its OWN refreshed
+        token (asking the cascade would resolve to whichever credential
+        outranks the row, and with a healthy unblocked sibling in the pool
+        every probe answered for that sibling — re-blocking rows that held
+        the only spendable quota). Refresh failures and unknown/unreachable
+        reports leave the row's existing block standing and move on. The
+        first definite verdict wins: the row's block is lifted, the session
+        is pinned to it, and the (health, shared, tier, access) tuple goes
+        back to the caller's shared policy — which is what re-blocks a row
+        whose re-probe says depleted. ``None`` means every blocked account
+        was re-checked and none gave a verdict — only then is a provider
+        fallback honest.
         """
         from local_operator.providers.auth_store import OAuthAccess
         from local_operator.providers.registry import get_provider_definition

--- a/local_operator/model/configure.py
+++ b/local_operator/model/configure.py
@@ -2108,6 +2108,61 @@ class SessionStreamFn:
                     and (row is None or candidate.credential_type == row.credential_type)
                     and not self._auth_store.is_blocked(candidate.id, storage)
                 ]
+                if not siblings and health.state == "depleted":
+                    # No UNBLOCKED sibling can take this model, but blocked
+                    # rows are earlier verdicts, not facts: a block written
+                    # when the account was low (or by an older build that
+                    # blocked reserve accounts for days) can be hiding the
+                    # ONLY spendable quota for this model. The reported
+                    # incident was exactly that — two accounts blocked at
+                    # 8%/4% Fable while the one live account read 0% and the
+                    # session hopped providers. Probe the blocked rows before
+                    # leaving the provider; ``None`` means every account was
+                    # re-checked and genuinely cannot serve, which is the
+                    # only honest moment to fall back.
+                    blocked_rows = [
+                        candidate
+                        for candidate in self._auth_store.list_credentials(storage)
+                        if candidate.id != access.credential_id
+                        and candidate.id not in attempted_ids
+                        and (row is None or candidate.credential_type == row.credential_type)
+                        and self._auth_store.is_blocked(candidate.id, storage)
+                    ]
+                    recovered = await self._recover_blocked_accounts(
+                        model, storage, blocked_rows, retry
+                    )
+                    if recovered is not None:
+                        rec_health = recovered[0]
+                        if rec_health.state in ("healthy", "reserve"):
+                            # A blocked account holds spendable quota for
+                            # this model and the walk pinned the session to
+                            # it. Settle here: re-walking would let the
+                            # sibling-rotation step demote the recovered
+                            # account in favour of the depleted one it just
+                            # replaced.
+                            if rec_health.state == "reserve":
+                                await self._notice(
+                                    f"{model.provider} blocked account recovered "
+                                    f"({rec_health.remaining_fraction * 100:.0f}% remaining) "
+                                    f"for {model.model_id} — resuming {model.provider}",
+                                    "info",
+                                )
+                                await self._route_state.clear_settled("recovered account has quota")
+                            return
+                        # Recovered but depleted for this model: the shared
+                        # policy re-blocks and activates the fallback, naming
+                        # the quota in its notice.
+                        await self._apply_account_health(
+                            model,
+                            recovered[3],
+                            storage,
+                            rec_health,
+                            recovered[1],
+                            recovered[2],
+                            retry,
+                            attempted_ids,
+                        )
+                        return
                 if siblings:
                     if health.state == "depleted":
                         self._auth_store.block_credential(
@@ -2251,6 +2306,52 @@ class SessionStreamFn:
             await self._route_state.clear_settled("primary model still has quota")
             return False
 
+        if not siblings and health.state == "depleted":
+            # About to leave the provider on a depleted verdict while other
+            # accounts sit under blocks. Blocks are earlier verdicts — an
+            # older build's days-long reserve block can be hiding the only
+            # spendable quota left (the incident behind this split: two
+            # accounts blocked at 8%/4% while the live one read 0%). Probe
+            # the blocked rows before the hop; ``None`` means every account
+            # was re-checked and genuinely cannot serve.
+            blocked_rows = [
+                candidate
+                for candidate in self._auth_store.list_credentials(storage)
+                if candidate.id != access.credential_id
+                and candidate.id not in attempted_ids
+                and (row is None or candidate.credential_type == row.credential_type)
+                and self._auth_store.is_blocked(candidate.id, storage)
+            ]
+            recovered = await self._recover_blocked_accounts(model, storage, blocked_rows, retry)
+            if recovered is not None:
+                rec_health = recovered[0]
+                if rec_health.state in ("healthy", "reserve"):
+                    # A blocked account holds spendable quota and the walk
+                    # pinned the session to it: settle instead of leaving
+                    # the provider on the depleted account under verdict.
+                    if rec_health.state == "reserve":
+                        await self._notice(
+                            f"{model.provider} blocked account recovered "
+                            f"({rec_health.remaining_fraction * 100:.0f}% remaining) "
+                            f"— resuming {model.provider}",
+                            "info",
+                        )
+                        await self._route_state.clear_settled("recovered account has quota")
+                    return False
+                # Recovered but depleted: the shared policy re-blocks and
+                # activates the fallback; whether a sibling then takes over
+                # decides our return.
+                return await self._apply_account_health(
+                    model,
+                    recovered[3],
+                    storage,
+                    rec_health,
+                    recovered[1],
+                    recovered[2],
+                    retry,
+                    attempted_ids,
+                )
+
         if not siblings and fallback is None:
             await self._notice(
                 f"{model.provider} {condition}{remaining}; no configured fallback is available"
@@ -2348,6 +2449,8 @@ class SessionStreamFn:
         ``None`` means every account is genuinely out — only then is a
         provider fallback honest.
         """
+        from local_operator.providers.auth_store import OAuthAccess
+        from local_operator.providers.registry import get_provider_definition
         from local_operator.providers.usage import (
             fetch_usage,
             shared_tier_saturation,
@@ -2355,42 +2458,50 @@ class SessionStreamFn:
         )
 
         for row in rows:
-            self._auth_store.clear_block(row.id, storage)
+            # Probe the row's OWN refreshed token. Clearing the block and
+            # re-asking the cascade (the first shape of this walk) attributed
+            # the verdict to whatever the cascade returned — with a healthy
+            # unblocked sibling in the pool, EVERY probe resolved to that
+            # sibling, re-blocked the row just lifted, and the walk ended
+            # "nothing recovered" while blocked accounts held spendable
+            # quota. Reading the row directly makes the verdict about the
+            # row, and leaves the pool's blocks and stickiness untouched
+            # until a verdict says otherwise.
             try:
-                access = await self._auth_store.get_oauth_access(model.provider, self._session_id)
+                creds = await self._auth_store.ensure_oauth_fresh(row.id)
             except Exception:
-                access = None
-            if access is None or access.kind != "oauth" or access.credential_id != row.id:
-                # Only a verdict for the exact row just unblocked counts. The
-                # cascade can fall through to a different credential (an API
-                # key, or a sibling that outranked this one), and attributing
-                # that credential's quota to this row would unblock the wrong
-                # account. Stand the backoff back up and keep looking.
-                self._auth_store.block_credential(
-                    row.id, storage, block_ms=self.DEFAULT_USAGE_BLOCK_MS
-                )
+                creds = None
+            if creds is None:
+                continue  # refresh failed: the block stands, try the next row
+            definition = get_provider_definition(model.provider)
+            key_fn = definition.get_api_key if definition is not None else None
+            token = key_fn(creds) if key_fn else creds.get("access")
+            if not token:
                 continue
             report = await fetch_usage(
                 self._http,
                 model.provider,
-                access_token=access.access_token,
-                account_id=access.account_id,
+                access_token=token,
+                account_id=creds.get("account_id"),
             )
             if report is None:
-                self._auth_store.block_credential(
-                    row.id, storage, block_ms=self.DEFAULT_USAGE_BLOCK_MS
-                )
-                continue
+                continue  # unreachable quota endpoint: keep the block, move on
             health = usage_health(
                 report,
                 model.model_id,
                 reserve_percent=retry.usage_reserve_percent,
             )
             if health.state == "unknown":
-                self._auth_store.block_credential(
-                    row.id, storage, block_ms=self.DEFAULT_USAGE_BLOCK_MS
-                )
-                continue
+                continue  # unreadable: the block stands, try the next row
+            # A definite verdict about the row just probed. The block is a
+            # stale claim this probe has now superseded: lift it and pin the
+            # session to the exact credential the usage was read for, then
+            # hand the verdict to the caller's shared policy (settle, rotate,
+            # or block-again-and-fall-back). A depleted verdict is returned,
+            # not swallowed — the policy decides its fate, and the caller's
+            # fallback notice must name the quota, not the credential pool.
+            self._auth_store.clear_block(row.id, storage)
+            self._auth_store.pin_session_credential(model.provider, self._session_id, row.id)
             shared_remaining, tier_binding = shared_tier_saturation(
                 report,
                 reserve_percent=retry.usage_reserve_percent,
@@ -2401,8 +2512,15 @@ class SessionStreamFn:
                     "info",
                 )
                 self._route_state.clear()
-            # Low/depleted but answerable: hand it to the shared policy, which
-            # decides between spending shared headroom, rotating, and blocking.
+            access = OAuthAccess(
+                access_token=token,
+                credential_id=row.id,
+                account_id=creds.get("account_id"),
+                email=creds.get("email"),
+                org_id=creds.get("org_id"),
+                kind="oauth",
+                raw=creds,
+            )
             return health, shared_remaining, tier_binding, access
         return None
 
@@ -2469,6 +2587,17 @@ class SessionStreamFn:
         # to the run's snapshot. Applying the stored level blind would send a rung
         # the current model may not have (review F9).
         effort = self._effort_for(request.model)
+        # The harness loop steps the effort down one rung when a reasoning
+        # model spends its whole output budget thinking and produces nothing
+        # (empty ``length`` truncation); that retreat rides on the request as
+        # ``effort_ceiling``. The frozen override holds a classification
+        # steady — it must not raise the retry back to the rung that just
+        # produced silence.
+        ceiling = request.effort_ceiling
+        ladder = request.model.reasoning_efforts
+        if effort is not None and ceiling is not None and ceiling in ladder and effort in ladder:
+            if ladder.index(effort) > ladder.index(ceiling):
+                effort = ceiling
         if effort is not None:
             request = request.model_copy(
                 update={"model": request.model.model_copy(update={"reasoning_effort": effort})}

--- a/local_operator/providers/auth_store.py
+++ b/local_operator/providers/auth_store.py
@@ -651,6 +651,26 @@ class AuthStore:
             self._conn.commit()
             return merged
 
+    async def ensure_oauth_fresh(self, credential_id: int) -> dict[str, Any] | None:
+        """Usable OAuth data for ONE specific credential, refreshed if stale.
+
+        The per-row half of the cascade's refresh step, exposed for callers
+        that must read a SPECIFIC account's state — quota recovery probes a
+        blocked row's own usage, and asking the cascade would resolve to
+        whichever sibling outranks the row instead. Returns ``None`` when the
+        row is gone, disabled, not an OAuth credential, or its refresh fails:
+        the caller keeps whatever verdict the row already carried. Raises
+        nothing; a probe is a read, not a routing decision."""
+        row = self.get_credential(credential_id)
+        if row is None or row.disabled_cause is not None:
+            return None
+        if row.credential_type != "oauth":
+            return None
+        try:
+            return await self._ensure_oauth_fresh(row)
+        except AuthStoreError:
+            return None
+
     # -- selection: stickiness + round-robin -------------------------------------
 
     def deprioritize_credential(self, provider: str, credential_id: int) -> None:
@@ -812,6 +832,21 @@ class AuthStore:
             self._sticky.pop((provider, session_id), None)
         else:
             self._sticky[(provider, session_id)] = credential_id
+
+    def pin_session_credential(
+        self, provider: str, session_id: str | None, credential_id: int
+    ) -> None:
+        """Point a session's sticky selection at ``credential_id``.
+
+        The public half of :meth:`_set_sticky`, for callers that have just
+        PROBED a specific account and must route the session to the account
+        the quota verdict was about. Quota-aware preflight re-checks blocked
+        siblings one by one; without pinning, the cascade's round-robin /
+        stickiness could hand the request to a different row than the one
+        whose usage was just read, and the session would keep failing on an
+        account the recovery walk had already judged. A no-op without a
+        session id, like the sticky write it wraps."""
+        self._set_sticky(provider, session_id, credential_id)
 
     def _usable_key_rows(
         self,

--- a/local_operator/session/protocol.py
+++ b/local_operator/session/protocol.py
@@ -108,12 +108,18 @@ class SessionProtocol(Protocol):
         """``provider/model`` of the spec actually serving requests."""
         ...
 
-    def set_model(self, model: ModelSpec) -> None:
+    def set_model(self, model: ModelSpec, *, explicit: bool = False) -> None:
         """Swap the model spec; in force from the very next provider call.
 
         The TUI's ``/model <provider>/<id>`` path calls this after building a
         new spec, so no session teardown is required. Also changes compaction
         thresholds for the new context window.
+
+        ``explicit`` marks a deliberate model CHOICE (``/model``, the phone's
+        model switch) rather than an internal knob adjustment (``/effort``,
+        sampling overrides). While a provider fallback is pinned, an explicit
+        choice withdraws the pin even when it re-selects the model the fallback
+        displaced — the user reclaiming their model ends the rescue route.
 
         Not "from the next turn": an implementation is expected to reach the
         RUNNING turn too. A turn is a chain of provider calls with tool batches

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -1553,7 +1553,7 @@ class Session:
         )
         return result
 
-    def set_model(self, model: ModelSpec) -> None:
+    def set_model(self, model: ModelSpec, *, explicit: bool = False) -> None:
         """Swap the model spec, in force from the very next provider call.
 
         Not "from the next turn": the running turn picks it up too. A turn is a
@@ -1580,6 +1580,15 @@ class Session:
         it was never computed for. That hook must be SYNCHRONOUS: this method is
         sync and would discard a returned coroutine, which is the right contract
         for what is only a cache re-fit.
+
+        ``explicit`` marks a deliberate model CHOICE — the ``/model`` command and
+        the phone's model switch — as opposed to an internal knob adjustment
+        (``/effort``, per-request sampling overrides) that rewrites the spec
+        without choosing a model. The distinction only matters while a provider
+        fallback is pinned: an explicit choice withdraws the pin even when it
+        re-selects the very model the fallback displaced, because that is the
+        user reclaiming it. A knob change never withdraws — the user is adjusting
+        the model that is serving them, fallback or not.
         """
         previous = self._model
         self._model = model
@@ -1590,6 +1599,20 @@ class Session:
             # render uses, instead of waiting for the next render to say it.
             self._announce_text_only_omission_once()
         if (previous.provider, previous.model_id) == (model.provider, model.model_id):
+            if explicit and self._active_fallback is not None:
+                # An explicit re-selection of the model a fallback displaced: the
+                # user is reclaiming it, so the pin's premise is withdrawn even
+                # though the selector did not move. The stream fn's route clear is
+                # selector-driven (preflight resets on a NEW selector), and a
+                # same-model re-selection never changes the selector — so that
+                # lazy clear would never fire and the session would stay glued to
+                # the fallback until the user switched away and back. Tell the
+                # stream fn directly.
+                self._drop_fallback_pin(model, "model reselected")
+                withdraw = getattr(self._stream_fn, "withdraw_fallback", None)
+                if callable(withdraw):
+                    withdraw()
+                return
             # Same model, different knobs (effort, sampling): nothing routing
             # or quota related has moved, so leave the frozen per-message state
             # alone. `/effort` and the server's option overrides take this path
@@ -1623,24 +1646,36 @@ class Session:
         # exists to prevent. Persisted (with the new primary) so a resume does
         # not restore a pin the user already switched away from.
         if self._active_fallback is not None:
-            self._active_fallback = None
-            self._active_route = None
-            self._spawn_background(self._persist_active_route(model))
-            self._spawn_background(
-                self._emit(
-                    ModelChangeEvent(
-                        provider=model.provider,
-                        model_id=model.model_id,
-                        effort=model.reasoning_effort,
-                        reason="model switched",
-                        is_fallback=False,
-                        context_window=int(model.context_window),
-                    )
-                )
-            )
+            self._drop_fallback_pin(model, "model switched")
         notify = getattr(self._stream_fn, "on_model_changed", None)
         if callable(notify):
             notify(model)
+
+    def _drop_fallback_pin(self, primary: ModelSpec, reason: str) -> None:
+        """Withdraw the pinned fallback: clear display state, persist, announce.
+
+        Shared by the two withdrawal edges — a switch to a DIFFERENT model and an
+        explicit re-selection of the SAME model — because both are "the user
+        chose a model, so the rescue route stops speaking for them". Persisted
+        with the new primary so a resume does not restore a pin the user already
+        withdrew; the ``ModelChangeEvent`` repaints any host display still
+        naming the fallback.
+        """
+        self._active_fallback = None
+        self._active_route = None
+        self._spawn_background(self._persist_active_route(primary))
+        self._spawn_background(
+            self._emit(
+                ModelChangeEvent(
+                    provider=primary.provider,
+                    model_id=primary.model_id,
+                    effort=primary.reasoning_effort,
+                    reason=reason,
+                    is_fallback=False,
+                    context_window=int(primary.context_window),
+                )
+            )
+        )
 
     @property
     def goal(self) -> str:

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -7217,7 +7217,10 @@ class OperatorApp(App[None]):
         old_label = session.model_label
         # The chosen effort rides along when the new model accepts it: a user
         # who dropped to `low` for cost did not mean "until I switch models".
-        session.set_model(self._spec_with_chosen_effort(spec))
+        # ``explicit``: this is a deliberate model choice, so a pinned fallback
+        # route is withdrawn even when the choice re-selects the model the
+        # fallback displaced — see ``Session.set_model``.
+        session.set_model(self._spec_with_chosen_effort(spec), explicit=True)
         # A text-only model renders the history WITHOUT its images (see
         # ``Session._render_history``), so the estimate painted for the vision
         # model overstates what the new one actually carries. Re-measure so

--- a/tests/unit/harness/test_comms.py
+++ b/tests/unit/harness/test_comms.py
@@ -2178,13 +2178,29 @@ def test_hub_peek_and_list_are_read_tier_while_control_stays_write():
 
 def test_a_child_hub_reply_with_parent_shaped_args_still_reaches_the_parent():
     """Children mirror the parent tool shape they see (``op``/``to``); the
-    child surface must drop those keys and deliver the message anyway."""
+    child surface must drop those keys and deliver the message anyway.
+
+    ``model_validate`` is the construction the child tool actually performs
+    (``HubChildParams(**args)``), and it is what runs the ``mode="before"``
+    validator that strips the parent-shaped keys. Passing them as keyword
+    arguments to the constructor would be a type error the validator never
+    sees, so the dict form is the one under test.
+    """
     comms, _jobs, _child, parent = wire()
-    parent.received = []
 
     from local_operator.tools.builtin import HubChildParams
 
-    params = HubChildParams(  # type: ignore[call-arg]
-        op="send", to=["parent"], message="review posted"
+    params = HubChildParams.model_validate(
+        {"op": "send", "to": ["parent"], "message": "review posted"}
     )
     assert params.message == "review posted"
+
+    # The dropped keys must not stop delivery: the reply lands as an aside on
+    # the parent, which is what the child's ``hub`` call resolves to.
+    outcome = comms.reply_to_parent("job-1", params.message)
+    assert outcome == "delivered to the parent (it will read this at its next step)"
+    [aside] = parent.asides
+    message = aside()
+    assert isinstance(message, CustomMessage)
+    assert message.custom_type == HUB_MESSAGE_TYPE
+    assert "review posted" in message.details["text"]

--- a/tests/unit/harness/test_loop.py
+++ b/tests/unit/harness/test_loop.py
@@ -2127,6 +2127,7 @@ async def test_empty_length_truncation_retries_at_lower_effort():
     assert all(
         not (m.role == "assistant" and not m.text and not m.tool_calls)
         for m in context.messages
+        if isinstance(m, Message)
     )
 
 

--- a/tests/unit/harness/test_loop.py
+++ b/tests/unit/harness/test_loop.py
@@ -2180,3 +2180,26 @@ async def test_text_only_length_truncation_is_not_retried():
 
     assert len(stream.requests) == 1
     assert not [e for e in events if isinstance(e, NoticeEvent)]
+
+
+@pytest.mark.asyncio
+async def test_empty_length_retry_clamps_the_resolved_model_too():
+    """Review F1: the production session supplies ``get_model`` (its resolver
+    ignores the loop's ``config.model`` mutation), so the retreat must clamp
+    the RESOLVED spec or the retry goes back out at the same silent rung."""
+    host_model = _laddered_model()  # always returns "high"
+    stream = ScriptedStream(
+        [
+            [StreamEndEvent(stop_reason="length")],
+            [StreamTextDelta(delta="answered"), StreamEndEvent(stop_reason="stop")],
+        ]
+    )
+    context = LoopContext()
+    loop = AgentLoop()
+    config = make_config(stream, model=host_model, get_model=lambda: host_model)
+    events = [e async for e in loop.run([Message.user("go")], context, config, None)]
+
+    assert len(stream.requests) == 2
+    assert stream.requests[0].model.reasoning_effort == "high"
+    assert stream.requests[1].model.reasoning_effort == "medium"
+    assert isinstance(events[-1], AgentEndEvent)

--- a/tests/unit/harness/test_loop.py
+++ b/tests/unit/harness/test_loop.py
@@ -2081,3 +2081,101 @@ class TestRefusalEndsTheRunVisibly:
         end = events[-1]
         assert isinstance(end, AgentEndEvent)
         assert end.error is not None and "refused" in end.error
+
+
+# ---------------------------------------------------------------------------
+# Empty truncation: the silent-turn failure (session f3c058d1)
+# ---------------------------------------------------------------------------
+
+
+def _laddered_model() -> ModelSpec:
+    return ModelSpec(
+        provider="test",
+        model_id="m",
+        reasoning_efforts=("low", "medium", "high"),
+        reasoning_effort="high",
+    )
+
+
+@pytest.mark.asyncio
+async def test_empty_length_truncation_retries_at_lower_effort():
+    """A length stop with NO text and NO calls is a silent turn: the loop
+    retries one rung lower instead of ending with nothing on screen."""
+    stream = ScriptedStream(
+        [
+            [StreamEndEvent(stop_reason="length")],  # spent the budget thinking
+            [StreamTextDelta(delta="here is the answer"), StreamEndEvent(stop_reason="stop")],
+        ]
+    )
+    context = LoopContext()
+    loop = AgentLoop()
+    events = []
+    async for event in loop.run(
+        [Message.user("go")], context, make_config(stream, model=_laddered_model()), None
+    ):
+        events.append(event)
+
+    assert len(stream.requests) == 2
+    assert stream.requests[0].model.reasoning_effort == "high"
+    assert stream.requests[1].model.reasoning_effort == "medium"
+    notices = [e for e in events if isinstance(e, NoticeEvent)]
+    assert any("retrying at effort medium" in n.text for n in notices)
+    end = events[-1]
+    assert isinstance(end, AgentEndEvent) and not end.aborted
+    # The empty assistant message must not survive into the context: it is an
+    # illegal wire block and teaches the retry to say nothing.
+    assert all(
+        not (m.role == "assistant" and not m.text and not m.tool_calls)
+        for m in context.messages
+    )
+
+
+@pytest.mark.asyncio
+async def test_empty_length_truncation_ends_with_a_notice_when_no_lower_rung():
+    """Retries are bounded; when they are spent the turn ends, but the user
+    sees WHY instead of minutes of thinking followed by silence."""
+    stream = ScriptedStream(
+        [
+            [StreamEndEvent(stop_reason="length")],
+            [StreamEndEvent(stop_reason="length")],
+            [StreamEndEvent(stop_reason="length")],
+        ]
+    )
+    context = LoopContext()
+    loop = AgentLoop()
+    events = []
+    async for event in loop.run(
+        [Message.user("go")], context, make_config(stream, model=_laddered_model()), None
+    ):
+        events.append(event)
+
+    # initial + two lower-rung retries; the third empty truncation ends it.
+    assert len(stream.requests) == 3
+    efforts = [r.model.reasoning_effort for r in stream.requests]
+    assert efforts == ["high", "medium", "low"]
+    notices = [e for e in events if isinstance(e, NoticeEvent)]
+    assert any("no visible output" in n.text for n in notices)
+    end = events[-1]
+    assert isinstance(end, AgentEndEvent)
+
+
+@pytest.mark.asyncio
+async def test_text_only_length_truncation_is_not_retried():
+    """A truncation that DID produce visible text is an ordinary truncation:
+    the turn ends, no effort step, no retry."""
+    stream = ScriptedStream(
+        [
+            [StreamTextDelta(delta="partial"), StreamEndEvent(stop_reason="length")],
+            [StreamEndEvent(stop_reason="stop")],
+        ]
+    )
+    context = LoopContext()
+    loop = AgentLoop()
+    events = []
+    async for event in loop.run(
+        [Message.user("go")], context, make_config(stream, model=_laddered_model()), None
+    ):
+        events.append(event)
+
+    assert len(stream.requests) == 1
+    assert not [e for e in events if isinstance(e, NoticeEvent)]

--- a/tests/unit/model/test_configure.py
+++ b/tests/unit/model/test_configure.py
@@ -1821,3 +1821,139 @@ class TestRouteSettleBridge:
         finally:
             await stream.close()
             store.close()
+
+
+# ---------------------------------------------------------------------------
+# Blocked-sibling recovery: the stale-block trap (session f3c058d1, 2026-08-21)
+# ---------------------------------------------------------------------------
+
+
+def _fable_report(five_hour_used: float, seven_day_used: float, fable_used: float) -> Any:
+    """The live incident shape: shared windows + a scoped Fable weekly."""
+    return UsageReport(
+        provider="anthropic",
+        limits=[
+            UsageLimit(
+                id="anthropic:5h",
+                label="5 hour",
+                amount=UsageAmount(used=five_hour_used, limit=100.0, unit="percent"),
+                window="5h",
+                shared=True,
+                resets_at_ms=10**15,
+            ),
+            UsageLimit(
+                id="anthropic:7d",
+                label="7 day",
+                amount=UsageAmount(used=seven_day_used, limit=100.0, unit="percent"),
+                window="7d",
+                shared=True,
+                resets_at_ms=10**15,
+            ),
+            UsageLimit(
+                id="anthropic:7d:fable",
+                label="7 day (Fable)",
+                amount=UsageAmount(used=fable_used, limit=100.0, unit="percent"),
+                window="7d",
+                shared=False,
+                tier="fable",
+                resets_at_ms=10**15,
+            ),
+        ],
+    )
+
+
+@pytest.mark.asyncio
+async def test_preflight_recovers_a_blocked_sibling_holding_model_quota(tmp_path) -> None:
+    """The reported incident: the selected account is model-depleted (Fable at
+    0%) while two accounts sit under stale blocks holding 8%/4% Fable. The
+    unblocked pool has no sibling to rotate to, so preflight must probe the
+    blocked rows and settle on the recovered one instead of hopping providers.
+
+    The walk must attribute each verdict to the row it probed — a healthy
+    unblocked sibling in the pool must not swallow the probes."""
+    store = AuthStore(tmp_path / "auth.db")
+    store.upsert_credential("anthropic", _oauth("oauth-live", "account-live"))
+    blocked_a = store.upsert_credential("anthropic", _oauth("oauth-a", "account-a"))
+    blocked_b = store.upsert_credential("anthropic", _oauth("oauth-b", "account-b"))
+    for row in (blocked_a, blocked_b):
+        store.block_credential(row.id, "anthropic", block_ms=3_600_000)
+    store.upsert_credential("openai", {"key": "sk-openai", "source": "login"})
+    stream = create_stream_fn(
+        store,
+        {
+            "retry": {
+                "usageAwareFallback": True,
+                "usageReservePercent": 10,
+                "fallbackChains": {"default": ["openai/gpt-5.3-codex"]},
+            }
+        },
+        session_id="session-a",
+    )
+    notices: list[str] = []
+    stream.set_notice_handler(lambda text, kind: notices.append(text))
+
+    reports = {
+        "oauth-live": _fable_report(0.0, 58.0, 100.0),  # Fable depleted
+        "oauth-a": _fable_report(0.0, 92.0, 16.0),  # 16% Fable left
+        "oauth-b": _fable_report(0.0, 96.0, 6.0),  # 6% Fable left
+    }
+
+    async def usage_for_access(_client, _provider, *, access_token=None, **_kwargs):
+        return reports[access_token]
+
+    try:
+        with patch("local_operator.providers.usage.fetch_usage", side_effect=usage_for_access):
+            await stream.preflight_usage(ModelSpec(provider="anthropic", model_id="claude-fable-5"))
+
+        # No provider failover: a blocked account recovered with Fable quota.
+        assert stream._route_state.active is None
+        # The recovered account's block is lifted and the session is pinned to
+        # it; the other blocked row keeps its block (its verdict was never read).
+        assert not store.is_blocked(blocked_a.id, "anthropic")
+        assert store.is_blocked(blocked_b.id, "anthropic")
+        selected = await store.get_oauth_access("anthropic", "session-a")
+        assert selected is not None and selected.credential_id == blocked_a.id
+        assert any("recovered" in notice for notice in notices)
+    finally:
+        await stream.close()
+        store.close()
+
+
+@pytest.mark.asyncio
+async def test_preflight_falls_back_when_blocked_siblings_are_genuinely_depleted(
+    tmp_path,
+) -> None:
+    """The honest-failover half: when every blocked account re-probes as
+    depleted for the model, the provider fallback fires and the blocks stand."""
+    store = AuthStore(tmp_path / "auth.db")
+    store.upsert_credential("anthropic", _oauth("oauth-live", "account-live"))
+    blocked = store.upsert_credential("anthropic", _oauth("oauth-a", "account-a"))
+    store.block_credential(blocked.id, "anthropic", block_ms=3_600_000)
+    store.upsert_credential("openai", {"key": "sk-openai", "source": "login"})
+    stream = create_stream_fn(
+        store,
+        {
+            "retry": {
+                "usageAwareFallback": True,
+                "usageReservePercent": 10,
+                "fallbackChains": {"default": ["openai/gpt-5.3-codex"]},
+            }
+        },
+        session_id="session-a",
+    )
+
+    async def usage_for_access(_client, _provider, *, access_token=None, **_kwargs):
+        if access_token == "oauth-live":
+            return _fable_report(0.0, 58.0, 100.0)
+        return _fable_report(0.0, 100.0, 100.0)  # blocked account truly out
+
+    try:
+        with patch("local_operator.providers.usage.fetch_usage", side_effect=usage_for_access):
+            await stream.preflight_usage(ModelSpec(provider="anthropic", model_id="claude-fable-5"))
+
+        assert stream._route_state.active is not None
+        assert stream._route_state.active.selector == "openai/gpt-5.3-codex"
+        assert store.is_blocked(blocked.id, "anthropic")
+    finally:
+        await stream.close()
+        store.close()

--- a/tests/unit/model/test_configure.py
+++ b/tests/unit/model/test_configure.py
@@ -7,6 +7,7 @@ hits the same endpoints as before through a descriptor table.
 """
 
 import json
+import time
 import zlib
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -1194,6 +1195,53 @@ async def test_transport_fallback_cooldown_skips_quota_probe(tmp_path) -> None:
             await stream.preflight_usage(model)
         fetch.assert_not_called()
         assert stream._route_state.active == FallbackTarget("openai/gpt-5.3-codex")
+    finally:
+        await stream.close()
+        store.close()
+
+
+@pytest.mark.asyncio
+async def test_withdraw_fallback_clears_the_route_and_reopens_the_quota_probe(
+    tmp_path,
+) -> None:
+    """An explicit re-selection ends the rescue route, whatever the cooldown says.
+
+    The selector-driven clear in ``preflight_usage`` never fires for a
+    same-model re-selection, so the session tells the stream fn directly. Two
+    things must move: the pinned route (including its cooldown — the user's
+    choice outranks the backoff that pinned the fallback), and the quota memo,
+    so the next boundary re-probes the primary instead of trusting the reading
+    that caused the pin. Silent: the owning session already announced this
+    withdrawal, so no settle edge fires here.
+    """
+    store = AuthStore(tmp_path / "auth.db")
+    store.upsert_credential("anthropic", _oauth("oauth-a", "account-a"))
+    stream = create_stream_fn(
+        store,
+        {"retry": {"usageAwareFallback": True}},
+        session_id="session-a",
+    )
+    stream._primary_selector = "anthropic/claude-opus-5"
+    await stream._route_state.activate(
+        FallbackTarget("openai/gpt-5.3-codex"),
+        "provider failure",
+        cooldown_ms=3_600_000,  # an hour of cooldown must not survive the withdrawal
+    )
+    settles: list[Any] = []
+    # Installed AFTER the pin: ``activate`` settles the pin itself, and the
+    # assertion below is that the WITHDRAWAL adds nothing to this list.
+    stream._route_state.on_settle = lambda target, reason: settles.append((target, reason))
+    # A fresh quota reading just pinned the fallback; the withdrawal must not
+    # inherit it.
+    stream._usage_checked_selector = "anthropic/claude-opus-5"
+    stream._usage_checked_at = time.monotonic()
+
+    try:
+        stream.withdraw_fallback()
+        assert stream._route_state.active is None
+        assert stream._route_state.primary_retry_due()  # cooldown gone with the pin
+        assert stream._usage_checked_at == 0.0  # memo reset: next boundary re-probes
+        assert settles == []  # silent — the session owns this announcement
     finally:
         await stream.close()
         store.close()

--- a/tests/unit/model/test_configure.py
+++ b/tests/unit/model/test_configure.py
@@ -1899,6 +1899,7 @@ async def test_preflight_recovers_a_blocked_sibling_holding_model_quota(tmp_path
     }
 
     async def usage_for_access(_client, _provider, *, access_token=None, **_kwargs):
+        assert access_token is not None
         return reports[access_token]
 
     try:

--- a/tests/unit/model/test_configure.py
+++ b/tests/unit/model/test_configure.py
@@ -1958,3 +1958,54 @@ async def test_preflight_falls_back_when_blocked_siblings_are_genuinely_depleted
     finally:
         await stream.close()
         store.close()
+
+
+@pytest.mark.asyncio
+async def test_recovery_walks_past_a_depleted_blocked_row_to_one_with_quota(
+    tmp_path,
+) -> None:
+    """Review F2: with several blocked rows, a first re-probe that says
+    depleted must not end the walk — the row is re-blocked by the shared
+    policy and the NEXT blocked row (holding quota) is probed and serves."""
+    store = AuthStore(tmp_path / "auth.db")
+    store.upsert_credential("anthropic", _oauth("oauth-live", "account-live"))
+    blocked_a = store.upsert_credential("anthropic", _oauth("oauth-a", "account-a"))
+    blocked_b = store.upsert_credential("anthropic", _oauth("oauth-b", "account-b"))
+    for row in (blocked_a, blocked_b):
+        store.block_credential(row.id, "anthropic", block_ms=3_600_000)
+    store.upsert_credential("openai", {"key": "sk-openai", "source": "login"})
+    stream = create_stream_fn(
+        store,
+        {
+            "retry": {
+                "usageAwareFallback": True,
+                "usageReservePercent": 10,
+                "fallbackChains": {"default": ["openai/gpt-5.3-codex"]},
+            }
+        },
+        session_id="session-a",
+    )
+
+    reports = {
+        "oauth-live": _fable_report(0.0, 58.0, 100.0),  # selected: Fable spent
+        "oauth-a": _fable_report(0.0, 100.0, 100.0),  # blocked, truly out
+        "oauth-b": _fable_report(0.0, 96.0, 6.0),  # blocked, 6% Fable left
+    }
+
+    async def usage_for_access(_client, _provider, *, access_token=None, **_kwargs):
+        assert access_token is not None
+        return reports[access_token]
+
+    try:
+        with patch("local_operator.providers.usage.fetch_usage", side_effect=usage_for_access):
+            await stream.preflight_usage(ModelSpec(provider="anthropic", model_id="claude-fable-5"))
+
+        # No provider hop: the second blocked row held quota and serves.
+        assert stream._route_state.active is None
+        assert store.is_blocked(blocked_a.id, "anthropic")
+        assert not store.is_blocked(blocked_b.id, "anthropic")
+        selected = await store.get_oauth_access("anthropic", "session-a")
+        assert selected is not None and selected.credential_id == blocked_b.id
+    finally:
+        await stream.close()
+        store.close()

--- a/tests/unit/model/test_configure.py
+++ b/tests/unit/model/test_configure.py
@@ -2009,3 +2009,78 @@ async def test_recovery_walks_past_a_depleted_blocked_row_to_one_with_quota(
     finally:
         await stream.close()
         store.close()
+
+
+@pytest.mark.asyncio
+async def test_two_depleted_blocked_rows_do_not_ping_pong_the_recovery_walk(
+    tmp_path,
+) -> None:
+    """Review F5: the walk terminates, and a healthy row enumerated AFTER two
+    depleted ones is still reached.
+
+    The recursion is the point. A depleted re-probe hands the verdict back to
+    ``_apply_account_health``, which re-blocks that row and walks the blocked
+    pool again — so without recording which rows this boundary has already
+    judged, the row cleared in one frame is blocked again by the next and
+    re-enumerated by the one after. Two depleted blocked accounts ping-pong
+    A→B→A until ``RecursionError`` kills the turn, and it kills it inside
+    ``preflight_usage``, which ``__call__`` awaits unguarded.
+
+    This is the live shape of the reported incident, not a constructed one:
+    four Anthropic logins, the selected account model-depleted, two blocked
+    accounts genuinely out, and one blocked account still holding quota that
+    the crash meant nobody ever probed.
+    """
+    store = AuthStore(tmp_path / "auth.db")
+    store.upsert_credential("anthropic", _oauth("oauth-live", "account-live"))
+    spent_a = store.upsert_credential("anthropic", _oauth("oauth-a", "account-a"))
+    spent_b = store.upsert_credential("anthropic", _oauth("oauth-b", "account-b"))
+    healthy = store.upsert_credential("anthropic", _oauth("oauth-c", "account-c"))
+    for row in (spent_a, spent_b, healthy):
+        store.block_credential(row.id, "anthropic", block_ms=3_600_000)
+    store.upsert_credential("openai", {"key": "sk-openai", "source": "login"})
+    stream = create_stream_fn(
+        store,
+        {
+            "retry": {
+                "usageAwareFallback": True,
+                "usageReservePercent": 10,
+                "fallbackChains": {"default": ["openai/gpt-5.3-codex"]},
+            }
+        },
+        session_id="session-a",
+    )
+
+    reports = {
+        "oauth-live": _fable_report(0.0, 58.0, 100.0),  # selected: Fable spent
+        "oauth-a": _fable_report(0.0, 100.0, 100.0),  # blocked, truly out
+        "oauth-b": _fable_report(47.0, 100.0, 34.0),  # blocked, truly out
+        "oauth-c": _fable_report(10.0, 30.0, 5.0),  # blocked, but HEALTHY
+    }
+    probed: list[str] = []
+
+    async def usage_for_access(_client, _provider, *, access_token=None, **_kwargs):
+        assert access_token is not None
+        probed.append(access_token)
+        return reports[access_token]
+
+    try:
+        with patch("local_operator.providers.usage.fetch_usage", side_effect=usage_for_access):
+            await stream.preflight_usage(ModelSpec(provider="anthropic", model_id="claude-fable-5"))
+
+        # Terminated, and on the right account: no provider hop while an
+        # Anthropic login still holds quota for this model.
+        assert stream._route_state.active is None
+        selected = await store.get_oauth_access("anthropic", "session-a")
+        assert selected is not None and selected.credential_id == healthy.id
+        assert not store.is_blocked(healthy.id, "anthropic")
+        assert store.is_blocked(spent_a.id, "anthropic")
+        assert store.is_blocked(spent_b.id, "anthropic")
+
+        # Each account is probed at most once per boundary. A count, not a
+        # bare "it did not crash": unbounded re-probing would still terminate
+        # by luck of ordering while spending a network round trip per frame.
+        assert sorted(probed) == ["oauth-a", "oauth-b", "oauth-c", "oauth-live"]
+    finally:
+        await stream.close()
+        store.close()

--- a/tests/unit/session/test_active_route.py
+++ b/tests/unit/session/test_active_route.py
@@ -44,6 +44,7 @@ class RoutedStream(ScriptedStream):
         self.notice_handler: Any = None
         self.restored: list[tuple[str, str | None, str]] = []
         self.models_changed: list[ModelSpec] = []
+        self.withdrawals: int = 0
 
     def set_route_handler(self, handler) -> None:
         self.route_handler = handler
@@ -56,6 +57,9 @@ class RoutedStream(ScriptedStream):
 
     def on_model_changed(self, model: ModelSpec) -> None:
         self.models_changed.append(model)
+
+    def withdraw_fallback(self) -> None:
+        self.withdrawals += 1
 
 
 def _session(tmp_path, stream, **kwargs) -> Session:
@@ -277,6 +281,78 @@ async def test_set_model_clears_the_pin_and_announces_the_selection(tmp_path):
             isinstance(event, ModelChangeEvent) and not event.is_fallback for event in events
         )
     )
+
+
+@pytest.mark.asyncio
+async def test_reselecting_the_same_model_withdraws_the_fallback_pin(tmp_path):
+    """The reported stuck-fallback symptom, closed.
+
+    A fallback pin rescues the SELECTED model without changing it, so "switching
+    back" to the recovered model re-selects the model the session is ALREADY
+    selected on. The selector never changes, so the stream fn's selector-driven
+    route clear never fires — and the same-model branch of ``set_model`` used to
+    treat the re-selection as a knob adjustment, leaving the pin in force. The
+    user's only workaround was switching away and back.
+
+    An explicit re-selection must withdraw the pin: the session's display state,
+    the persisted route entry, and the stream fn's own route state.
+    """
+    stream = RoutedStream()
+    session = _session(tmp_path, stream)
+    events: list[Any] = []
+    session.subscribe(events.append)
+
+    await stream.route_handler(FallbackTarget("zai/glm-5.3", None), "provider failure")
+    assert session.effective_model_label == "zai/glm-5.3"
+
+    # Re-select the SAME model the fallback displaced — explicitly, as /model does.
+    session.set_model(session.model, explicit=True)
+
+    assert session.active_fallback is None
+    assert session.effective_model_label == session.model_label
+    assert stream.withdrawals == 1  # the stream fn's route state was told to clear
+    await wait_for(lambda: len(_route_entries(session)) == 2)
+    entries = _route_entries(session)
+    assert entries[1]["active"] is None
+    assert entries[1]["primary"] == session.model_label
+    await wait_for(
+        lambda: any(
+            isinstance(event, ModelChangeEvent)
+            and not event.is_fallback
+            and event.reason == "model reselected"
+            for event in events
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_knob_change_while_fallback_pinned_does_not_withdraw(tmp_path):
+    """``/effort`` is not a model choice: it must NOT withdraw a pinned fallback.
+
+    The same-model branch of ``set_model`` serves both an explicit re-selection
+    and a knob adjustment; only the former withdraws. An ``/effort`` change
+    while a fallback serves re-derives the display spec (the pinned test above
+    pins that) but leaves the route exactly where it was.
+    """
+    stream = RoutedStream()
+    session = _session(
+        tmp_path,
+        stream,
+        model=ModelSpec(
+            provider="test",
+            model_id="m",
+            context_window=100_000,
+            reasoning_efforts=("low", "medium", "high"),
+            reasoning_effort="low",
+        ),
+    )
+    await stream.route_handler(FallbackTarget("openai/gpt-5.2", None), "provider failure")
+
+    session.set_model(session.model.model_copy(update={"reasoning_effort": "high"}))
+
+    assert session.active_fallback is not None  # the pin survives a knob change
+    assert session.effective_model_label == "openai/gpt-5.2"
+    assert stream.withdrawals == 0
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_exec_mode.py
+++ b/tests/unit/test_exec_mode.py
@@ -88,7 +88,7 @@ class FakeSession:
     def effective_model_label(self) -> str:
         return self.model_label
 
-    def set_model(self, model: ModelSpec) -> None:
+    def set_model(self, model: ModelSpec, *, explicit: bool = False) -> None:
         pass
 
     @property

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -165,7 +165,7 @@ class FakeSession:
     def effective_model_label(self) -> str:
         return self.model_label
 
-    def set_model(self, model: Any) -> None:
+    def set_model(self, model: Any, *, explicit: bool = False) -> None:
         pass
 
     @property
@@ -1970,7 +1970,7 @@ async def test_model_switch_calls_session_set_model() -> None:
     session = FakeSession()
     set_models: list[Any] = []
 
-    def set_model(spec):
+    def set_model(spec, *, explicit=False):
         set_models.append(spec)
 
     session.set_model = set_model  # type: ignore[attr-defined]
@@ -3625,7 +3625,7 @@ class _SwitchableSession(FakeSession):
     def model_label(self) -> str:
         return self._label
 
-    def set_model(self, model) -> None:
+    def set_model(self, model, *, explicit: bool = False) -> None:
         self._label = f"{model.provider}/{model.model_id}"
 
 

--- a/tests/unit/tui/test_band_panels.py
+++ b/tests/unit/tui/test_band_panels.py
@@ -69,7 +69,7 @@ class FakeSession:
     def effective_model_label(self) -> str:
         return self.model_label
 
-    def set_model(self, model: Any) -> None:
+    def set_model(self, model: Any, *, explicit: bool = False) -> None:
         pass
 
     @property

--- a/tests/unit/tui/test_boot_layout.py
+++ b/tests/unit/tui/test_boot_layout.py
@@ -116,7 +116,7 @@ class FakeSession:
     def effective_model_label(self) -> str:
         return self.model_label
 
-    def set_model(self, model: Any) -> None:
+    def set_model(self, model: Any, *, explicit: bool = False) -> None:
         pass
 
     @property

--- a/tests/unit/tui/test_effort.py
+++ b/tests/unit/tui/test_effort.py
@@ -46,7 +46,7 @@ class EffortSession(FakeSession):
     def model(self) -> Any:
         return self._spec
 
-    def set_model(self, model: Any) -> None:
+    def set_model(self, model: Any, *, explicit: bool = False) -> None:
         self._spec = model
 
 

--- a/tests/unit/tui/test_events.py
+++ b/tests/unit/tui/test_events.py
@@ -114,7 +114,7 @@ class FakeSession:
     def effective_model_label(self) -> str:
         return "test/model"
 
-    def set_model(self, model: Any) -> None:
+    def set_model(self, model: Any, *, explicit: bool = False) -> None:
         pass
 
     @property

--- a/tests/unit/tui/test_snapshot.py
+++ b/tests/unit/tui/test_snapshot.py
@@ -111,7 +111,7 @@ class FakeSession:
     def effective_model_label(self) -> str:
         return self.model_label
 
-    def set_model(self, model: Any) -> None:
+    def set_model(self, model: Any, *, explicit: bool = False) -> None:
         pass
 
     @property

--- a/tests/unit/tui/test_subagent_stats.py
+++ b/tests/unit/tui/test_subagent_stats.py
@@ -627,8 +627,21 @@ def test_no_width_paints_a_childs_model_with_nothing_saying_whose_it_is() -> Non
 
 # -- the two ends wired together ---------------------------------------------
 @pytest.mark.asyncio
-async def test_opening_and_leaving_a_page_repoints_and_restores_the_live_band() -> None:
-    """End to end through the app: open the page, read the band, leave."""
+async def test_opening_and_leaving_a_page_repoints_and_restores_the_live_band(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End to end through the app: open the page, read the band, leave.
+
+    The app's 1 Hz subagent poll re-derives the band from the LIVE session
+    ledger — the running agent count plus the harvested child cost. Under a
+    slow CI runner that tick can land between the manual ``update`` below and
+    the final assertion, overwriting the hand-set ``$1.20`` with the polled
+    ``$1.50`` and turning a deterministic repaint check into a race (the
+    flake this pin used to be). This test drives every band edge explicitly —
+    open, refresh, close — so the poll is pure interference: push its interval
+    past the test's lifetime and let the explicit calls be the only writers.
+    """
+    monkeypatch.setattr("local_operator.tui.app.JOB_POLL_INTERVAL_S", 3600.0)
     job = Job(
         model_label=CHILD_MODEL,
         progress="auditing merged MRs",

--- a/tests/unit/tui/test_welcome.py
+++ b/tests/unit/tui/test_welcome.py
@@ -966,6 +966,16 @@ async def test_a_tick_never_re_measures_and_skips_the_colours_it_already_drew(
     app = _make_app(FakeSession())
     async with app.run_test(size=(100, 30)) as pilot:
         welcome = await _settled_welcome(pilot)
+        # The glow's own interval timer is a CONCURRENT writer to `_mark_color`
+        # (it fires every 80 ms while animation is on). Left running, a tick
+        # landing between the origin-set and the manual tick below either
+        # consumes the colour change (the manual tick then sees an unchanged
+        # colour and repaints nothing) or adds a repaint of its own — under a
+        # slow CI runner that turned this pin into a flake. The two properties
+        # under test are about what ONE tick does, so stop the timer and let the
+        # manual ticks be the only driver. Stopping also resets `_mark_color` to
+        # None, which is the deterministic starting state the first tick needs.
+        welcome._stop_pulse_timer()
         calls: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
         original = welcome.refresh
 

--- a/tests/unit/tui/test_welcome.py
+++ b/tests/unit/tui/test_welcome.py
@@ -502,7 +502,7 @@ class FakeSession:
     def effective_model_label(self) -> str:
         return self.model_label
 
-    def set_model(self, model: Any) -> None:
+    def set_model(self, model: Any, *, explicit: bool = False) -> None:
         pass
 
     @property


### PR DESCRIPTION
## Summary of Changes

Session `f3c058d1` (2026-08-21) failed three ways at once. Two are closed here; the third (duplicated steered user rows) is now owned by main's #227, whose registry-based echo dedup supersedes the tail-scan guard this branch first carried — that hunk and its tests were dropped in the rebase onto `main`.

1. **Premature provider failover (the reported bug).** The selected Anthropic account read `claude-fable-5` as depleted (`7 day (Fable)` at 0%) while two accounts sat under stale SQLite blocks holding 8%/4% Fable. The model-scope branch only rotated UNBLOCKED siblings, so with none available it hopped to the next provider while spendable quota sat behind backoffs. The same trap existed on the account-scope path.
2. **Silent turns.** The fallback model (kimi/k3) spent its whole 8192-token output budget thinking and was cut at `length` with no text and no tool calls; the loop ended the turn with nothing on screen — four times in a row. The user watched minutes of "thinking" end in silence and had to type `Continue`.
3. ~~**Duplicated user rows.**~~ — superseded by main's #227 (see above).

Two further defects found during review and live replay are also fixed here:

4. **Non-terminating recovery walk (F5, blocker).** With two or more blocked accounts that re-probe depleted, preflight never terminated: `_recover_blocked_accounts` returned the first definite verdict after clearing that row's block, a depleted verdict recursed into `_apply_account_health`, which re-blocked the row and walked the blocked pool again — nothing recorded which rows had been probed, so the row cleared in one frame was blocked again by the next and re-enumerated by the one after. Two depleted blocked accounts ping-pong A→B→A until `RecursionError`, inside `preflight_usage`, which `__call__` awaits unguarded — the user's turn dies. A healthy blocked account enumerated after two depleted ones was therefore never reached. Reproduced against the live `auth.db` shape.
5. **Sticky fallback route (F6, user-reported).** After failover pins a fallback, re-selecting the SAME (recovered) model kept serving the fallback until the user switched to a different model and back. A fallback pin rescues the SELECTED model without changing it, so "switching back" re-selects the model the session is already selected on; `set_model` saw an unchanged provider/model pair, took the "same model, just knobs" early return, and never withdrew the pin — and the stream fn's selector-driven route clear never fires for an unchanged selector either.

## Fix

- **Blocked-sibling recovery before provider failover.** When the unblocked pool cannot serve the model, preflight probes each blocked row using the row's OWN refreshed token (a healthy sibling can no longer swallow a verdict). A recovered account is unblocked and the session is pinned to it; a depleted re-probe re-blocks and only then does the provider fallback fire. Both the model-scope and account-scope paths get the recovery. `AuthStore` gains `ensure_oauth_fresh` (per-row refresh, raises nothing) and `pin_session_credential`.
- **Terminating recovery walk (F5).** The preflight's `attempted_ids` set is threaded into the walk and each row is recorded BEFORE its probe, whatever the outcome, so every recursive step strictly shrinks a finite candidate pool and each account is probed at most once per message boundary.
- **Empty-truncation retry + honest notice.** A `length` stop with no text and no tool calls is retried up to twice, one effort rung lower (the empty assistant message is popped from context first). When no lower rung remains, the turn ends with a notice naming the cause instead of silence. The session's frozen auto-effort respects the retreat via `ChatRequest.effort_ceiling`.
- **Explicit re-selection withdraws a pinned fallback (F6).** `Session.set_model` gains an `explicit` keyword marking a deliberate model choice (`/model`, the phone's model switch) as opposed to an internal knob adjustment (`/effort`, sampling overrides). An explicit choice withdraws a pinned fallback even when it re-selects the displaced model: the session drops its display pin, persists the withdrawal, emits the model-change event, and tells the stream fn directly via the new `SessionStreamFn.withdraw_fallback` — which clears the route state INCLUDING its cooldown and resets the quota memo so the next boundary re-probes the primary. Knob changes never withdraw.

## Change class

C2 — standard; behaviour fixes in the quota router, harness loop, session routing, and TUI receipt path. No contract changes beyond one additive `ChatRequest` field, two additive `AuthStore` methods, one additive `SessionStreamFn` method, and an additive keyword on `set_model`.

## Related Issue(s)

Follow-on to #216 / #220. #216 closed the model-scope skip and reserve-hop paths; this closes the stale-block trap it left (blocked rows hiding the only spendable quota), the non-terminating walk that trap could trigger, the sticky-fallback-route symptom, and the silent-turn symptom observed in the same session. The duplicate-row item is closed by main's #227 instead.

## Impact

- A session whose selected account is model-depleted now re-probes blocked accounts before leaving the provider; stale blocks self-heal at the next message boundary, and the walk terminates even when several blocked accounts are genuinely out.
- Silent reasoning-budget truncations become a visible notice (and a bounded lower-effort retry) instead of a frozen-looking turn.
- Re-selecting a recovered model returns to it immediately instead of staying glued to the fallback.

## Testing Details

**Live repro against the real accounts** (before/after): with the stale blocks stood back up, the OLD code emitted `anthropic quota exhausted (0% remaining) for claude-fable-5 — falling back to zai/glm-5.3`; the NEW code emits `anthropic blocked account recovered (8% remaining) for claude-fable-5 — resuming anthropic` and leaves `route_state.active = None`.

**Unit tests** (new cases fail on `origin/main`):

- `test_preflight_recovers_a_blocked_sibling_holding_model_quota`, `test_preflight_falls_back_when_blocked_siblings_are_genuinely_depleted` — recovery and honest-failover halves.
- `test_two_depleted_blocked_rows_do_not_ping_pong_the_recovery_walk` (F5) — live four-account shape; asserts each account is probed exactly once. Mutation-verified.
- `test_empty_length_truncation_retries_at_lower_effort`, `test_empty_length_truncation_ends_with_a_notice_when_no_lower_rung`, `test_text_only_length_truncation_is_not_retried`, `test_empty_length_retry_clamps_the_resolved_model_too` — retry ladder, bounded notice, non-silent truncation left alone, and the production `get_model` clamp.
- `test_reselecting_the_same_model_withdraws_the_fallback_pin`, `test_knob_change_while_fallback_pinned_does_not_withdraw` (F6) — mutation-verified.
- `test_withdraw_fallback_clears_the_route_and_reopens_the_quota_probe` (F6) — stream-fn half: cooldown cleared, quota memo reset, silent.

```
tests/unit/session tests/unit/model tests/unit/harness tests/unit/providers tests/unit/mobile: 1546 passed
tests/unit/tui: 2176 passed, 4 skipped
Gates on changed files: flake8, black, isort clean; pyright 0 errors
```

Note: `tests/unit/tui/test_subagent_stats.py::test_opening_and_leaving_a_page_repoints_and_restores_the_live_band` is flaky under CI's coverage-instrumented 3.12 run (single `pilot.pause()` after an async band restore). It is byte-identical to `main`, untouched by this PR, and passes locally on both 3.12 and 3.13 (standalone, repeated, and full-suite). Pre-existing; not introduced here.

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have added tests that prove my fix works.
- [x] New and existing unit tests pass locally.
