### PR TITLE
fix(providers): trust OpenRouter's reported cost over token×rate estimates

### DIFF
--- a/local_operator/harness/subagent.py
+++ b/local_operator/harness/subagent.py
@@ -673,8 +673,14 @@ def _accumulate_usage(job: Any, usage: "Usage | None") -> None:
     # its last one. ``None`` keeps the "not reported" meaning distinct from a
     # real zero; a message that DID report folds its amount in, and messages
     # that did not (mix-and-match is not a real provider today) leave it alone.
+    # Floored via the pricing helper so a malformed or negative amount cannot
+    # inflate a credit into the child's running total.
     if usage.usd_cost is not None:
-        total.usd_cost = (total.usd_cost or 0.0) + usage.usd_cost
+        from local_operator.model.configure import _usage_cost
+
+        amount = _usage_cost(usage)
+        if amount is not None:
+            total.usd_cost = (total.usd_cost or 0.0) + amount
     if usage.context_tokens is not None:
         total.context_tokens = usage.context_tokens
 

--- a/local_operator/harness/subagent.py
+++ b/local_operator/harness/subagent.py
@@ -668,6 +668,13 @@ def _accumulate_usage(job: Any, usage: "Usage | None") -> None:
     total.output_tokens += usage.output_tokens
     total.cache_read_tokens += usage.cache_read_tokens
     total.cache_write_tokens += usage.cache_write_tokens
+    # A provider-reported dollar amount is summed the same way the token buckets
+    # are: a tool-using child's money is spread across its earlier calls, not
+    # its last one. ``None`` keeps the "not reported" meaning distinct from a
+    # real zero; a message that DID report folds its amount in, and messages
+    # that did not (mix-and-match is not a real provider today) leave it alone.
+    if usage.usd_cost is not None:
+        total.usd_cost = (total.usd_cost or 0.0) + usage.usd_cost
     if usage.context_tokens is not None:
         total.context_tokens = usage.context_tokens
 

--- a/local_operator/harness/subagent.py
+++ b/local_operator/harness/subagent.py
@@ -675,12 +675,11 @@ def _accumulate_usage(job: Any, usage: "Usage | None") -> None:
     # that did not (mix-and-match is not a real provider today) leave it alone.
     # Floored via the pricing helper so a malformed or negative amount cannot
     # inflate a credit into the child's running total.
-    if usage.usd_cost is not None:
-        from local_operator.model.configure import _usage_cost
+    from local_operator.model.configure import _usage_cost
 
-        amount = _usage_cost(usage)
-        if amount is not None:
-            total.usd_cost = (total.usd_cost or 0.0) + amount
+    amount = _usage_cost(usage)
+    if amount is not None:
+        total.usd_cost = (total.usd_cost or 0.0) + amount
     if usage.context_tokens is not None:
         total.context_tokens = usage.context_tokens
 

--- a/local_operator/harness/types.py
+++ b/local_operator/harness/types.py
@@ -231,6 +231,15 @@ class Usage(BaseModel):
     # count, so this stays 0 there and the whole output reads as generation,
     # which is the honest thing to report when the wire does not separate it.
     reasoning_tokens: int = 0
+    # Provider-reported dollar cost for this one request, when the provider
+    # precomputes billing (OpenRouter's ``usage.cost``). This is the ground truth
+    # a caller must prefer over any token×rate reconstruction: the provider has
+    # already applied per-route pricing, reasoning-token splits, cache discounts
+    # and time/value overrides that a single flat table price cannot express.
+    # ``None`` means "not reported" and is distinct from a real ``0.0`` (a call
+    # the provider billed as free) — the same three-way split the TUI's
+    # ``None``-vs-``$0.0000`` contract already draws.
+    usd_cost: float | None = None
 
     @property
     def total_tokens(self) -> int:

--- a/local_operator/model/configure.py
+++ b/local_operator/model/configure.py
@@ -21,6 +21,7 @@ import dataclasses
 import functools
 import inspect
 import logging
+import math
 import os
 import re
 import time
@@ -3034,7 +3035,12 @@ def _usage_cost(usage: Any) -> float | None:
         cost = float(value)
     except (TypeError, ValueError):
         return None
-    return cost if cost >= 0 else None
+    # Require finiteness as well as a non-negative sign. ``inf`` is wire-reachable
+    # (``json.loads`` accepts the non-standard ``Infinity``/``NaN`` literals by
+    # default), passes a bare ``>= 0`` guard, and — because ``inf + x == inf`` —
+    # would permanently pin every summed turn/session/child total at infinity with
+    # no recovery. Non-finite falls back to the estimate, exactly like negatives.
+    return cost if (math.isfinite(cost) and cost >= 0) else None
 
 
 def _usage_field(usage: Any, name: str) -> int:

--- a/local_operator/model/configure.py
+++ b/local_operator/model/configure.py
@@ -2985,10 +2985,20 @@ def cost_for_usage(provider: str, model_info: ModelInfo, usage: Any) -> float:
     arrives rehydrated from a serialized child event, where it is a plain mapping
     with the same field names.
 
+    When ``usage`` carries a provider-reported dollar amount
+    (``usd_cost``, e.g. OpenRouter's ``usage.cost``), that is returned verbatim
+    and the token arithmetic is skipped entirely. The provider already applied
+    per-route pricing, reasoning-token splits, cache discounts and any overrides
+    that a single flat table price cannot express, so a reconstruction here can
+    only be wronger than the number the provider printed on the bill.
+
     The caller is responsible for deciding whether ``model_info`` is priced at
     all; this returns 0.0 for a zero-priced model, which is arithmetically true
     and is exactly why a UI must not render it blindly.
     """
+    reported = _usage_cost(usage)
+    if reported is not None:
+        return reported
     read = _usage_field(usage, "cache_read_tokens")
     written = _usage_field(usage, "cache_write_tokens")
     plain = _usage_field(usage, "input_tokens")
@@ -3004,6 +3014,27 @@ def cost_for_usage(provider: str, model_info: ModelInfo, usage: Any) -> float:
         read,
         written,
     )
+
+
+def _usage_cost(usage: Any) -> float | None:
+    """The provider-reported dollar cost on a ``Usage``, or ``None`` when absent.
+
+    Duck-typed for the same reason as :func:`_usage_field`: ``usage`` can be a
+    ``Usage`` model or a rehydrated mapping. ``None`` is "not reported" — a
+    caller must not collapse it into ``0.0`` ("billed as free"). Coerced and
+    floored so a malformed report (negative, non-numeric) degrades to the
+    estimate instead of aborting the pricing path.
+    """
+    value = (
+        usage.get("usd_cost") if isinstance(usage, Mapping) else getattr(usage, "usd_cost", None)
+    )
+    if value is None:
+        return None
+    try:
+        cost = float(value)
+    except (TypeError, ValueError):
+        return None
+    return cost if cost >= 0 else None
 
 
 def _usage_field(usage: Any, name: str) -> int:

--- a/local_operator/providers/clients.py
+++ b/local_operator/providers/clients.py
@@ -111,6 +111,35 @@ def _first_text(*candidates: Any) -> str:
     return ""
 
 
+def _usd_cost(raw_usage: Mapping[str, Any] | None) -> float | None:
+    """A provider's own precomputed dollar cost for one request, or ``None``.
+
+    Some providers (OpenRouter's ``usage.cost``) bill the request themselves and
+    return the amount they charged. That number is authoritative in a way no
+    token×rate reconstruction can be: it already reflects the per-route price the
+    request actually landed on, reasoning-token splits, cache discounts, and any
+    time- or value-banded overrides — none of which a single flat table row can
+    express. Return it as ``None`` when absent, so a caller can tell "the
+    provider didn't say" apart from a real ``0.0`` (billed as free).
+
+    Defensive about shape: the field is a JSON number, but a provider that spells
+    it as a numeric string must not turn into an exception that aborts a stream.
+    """
+    if not isinstance(raw_usage, Mapping):
+        return None
+    value = raw_usage.get("cost")
+    if value is None:
+        return None
+    try:
+        cost = float(value)
+    except (TypeError, ValueError):
+        return None
+    if cost < 0:
+        # A negative bill is malformed provider data, not a credit to hand back.
+        return None
+    return cost
+
+
 #: Longest provider message carried into an error frame. Every branch of the
 #: cascade below is bounded by it: the frame is one wrapped notice line in a
 #: terminal, and a provider that answers with a 3 KB error object must not spend
@@ -1180,6 +1209,14 @@ class OpenAICompatClient:
                         # trigger prefers over its own estimate, and what the
                         # TUI status line reports.
                         context_tokens=int(raw.get("prompt_tokens", 0)) or None,
+                        # OpenRouter (and any OpenAI-compatible aggregator that
+                        # precomputes billing) reports the dollar amount it
+                        # actually charged here. Prefer it over the token×rate
+                        # estimate: the routed provider's own price, reasoning-
+                        # token split, cache discount and any override are all
+                        # already baked in, and none of them are recoverable from
+                        # the flat per-model table price.
+                        usd_cost=_usd_cost(raw),
                     )
                     yield StreamUsageEvent(usage=usage)
                 choices = chunk.get("choices") or []

--- a/local_operator/providers/clients.py
+++ b/local_operator/providers/clients.py
@@ -22,6 +22,7 @@ import asyncio
 import email.utils
 import json
 import logging
+import math
 import re
 import time
 from collections.abc import AsyncIterator, Mapping, Sequence
@@ -134,8 +135,12 @@ def _usd_cost(raw_usage: Mapping[str, Any] | None) -> float | None:
         cost = float(value)
     except (TypeError, ValueError):
         return None
-    if cost < 0:
-        # A negative bill is malformed provider data, not a credit to hand back.
+    if not math.isfinite(cost) or cost < 0:
+        # A negative bill is malformed provider data, not a credit to hand back,
+        # and a non-finite one (``json.loads`` parses the non-standard literals
+        # ``Infinity``/``NaN`` by default, so ``inf`` is wire-reachable) would
+        # poison every summed total forever — ``inf + x == inf`` never recovers.
+        # Both fall through to ``None`` so the token×rate estimate answers.
         return None
     return cost
 

--- a/local_operator/tui/costs.py
+++ b/local_operator/tui/costs.py
@@ -27,6 +27,7 @@ Nothing here raises. A price is never worth a broken frame.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import Any
 
 __all__ = ["turn_cost", "job_cost"]
@@ -51,6 +52,19 @@ def turn_cost(model_label: str, usage: Any) -> float | None:
     if usage is None or not model_label:
         return None
     try:
+        # A provider-reported dollar amount is authoritative without a table:
+        # OpenRouter (and any aggregator that precomputes billing) returns the
+        # exact charge it printed, per-routed-provider pricing and reasoning
+        # splits included. It must win even when the model has no published price
+        # row, because the provider's bill is the fact the table is an estimate of.
+        reported = (
+            usage.get("usd_cost")
+            if isinstance(usage, Mapping)
+            else getattr(usage, "usd_cost", None)
+        )
+        if reported is not None:
+            return float(reported)
+
         from local_operator.model.configure import cost_for_usage, resolve_model_info
 
         provider, _, model_id = model_label.partition("/")

--- a/local_operator/tui/costs.py
+++ b/local_operator/tui/costs.py
@@ -27,7 +27,6 @@ Nothing here raises. A price is never worth a broken frame.
 
 from __future__ import annotations
 
-from collections.abc import Mapping
 from typing import Any
 
 __all__ = ["turn_cost", "job_cost"]
@@ -57,15 +56,22 @@ def turn_cost(model_label: str, usage: Any) -> float | None:
         # exact charge it printed, per-routed-provider pricing and reasoning
         # splits included. It must win even when the model has no published price
         # row, because the provider's bill is the fact the table is an estimate of.
-        reported = (
-            usage.get("usd_cost")
-            if isinstance(usage, Mapping)
-            else getattr(usage, "usd_cost", None)
+        #
+        # Coerced and floored through the SAME helper the pricing path uses on
+        # the wire values rather than a bare ``float()`` here: a negative or
+        # non-numeric amount is malformed provider data and must fall back to the
+        # estimate, not render an upside-down credit or degrade the whole turn to
+        # unpriceable while a table price exists. (The wire client already drops
+        # these to ``None``, but ``turn_cost`` also serves rehydrated mappings.)
+        from local_operator.model.configure import (
+            _usage_cost,
+            cost_for_usage,
+            resolve_model_info,
         )
-        if reported is not None:
-            return float(reported)
 
-        from local_operator.model.configure import cost_for_usage, resolve_model_info
+        reported = _usage_cost(usage)
+        if reported is not None:
+            return reported
 
         provider, _, model_id = model_label.partition("/")
         info = resolve_model_info(provider, model_id)

--- a/local_operator/tui/events.py
+++ b/local_operator/tui/events.py
@@ -488,14 +488,12 @@ class EventController:
             # provider was the authority for the whole turn. Floored through the
             # shared pricing helper rather than a bare ``float()``: a negative or
             # malformed figure must not inflate a credit into the running total.
-            reported = getattr(message_usage, "usd_cost", None)
-            if reported is not None:
-                from local_operator.model.configure import _usage_cost
+            from local_operator.model.configure import _usage_cost
 
-                amount = _usage_cost(message_usage)
-                if amount is not None:
-                    totals["usd"] += amount
-                    usd_reported = True
+            amount = _usage_cost(message_usage)
+            if amount is not None:
+                totals["usd"] += amount
+                usd_reported = True
             usage = message_usage
             context_tokens = (
                 getattr(message_usage, "context_tokens", None)

--- a/local_operator/tui/events.py
+++ b/local_operator/tui/events.py
@@ -485,11 +485,17 @@ class EventController:
             # message carried one so the aggregate keeps the model-vs-provider
             # distinction: off (``None``) means no provider reported a figure and
             # the estimate is the only answer; on with a real total means the
-            # provider was the authority for the whole turn.
+            # provider was the authority for the whole turn. Floored through the
+            # shared pricing helper rather than a bare ``float()``: a negative or
+            # malformed figure must not inflate a credit into the running total.
             reported = getattr(message_usage, "usd_cost", None)
             if reported is not None:
-                totals["usd"] += float(reported)
-                usd_reported = True
+                from local_operator.model.configure import _usage_cost
+
+                amount = _usage_cost(message_usage)
+                if amount is not None:
+                    totals["usd"] += amount
+                    usd_reported = True
             usage = message_usage
             context_tokens = (
                 getattr(message_usage, "context_tokens", None)

--- a/local_operator/tui/events.py
+++ b/local_operator/tui/events.py
@@ -468,7 +468,8 @@ class EventController:
         # last one. context_tokens is a point-in-time size, taken from the
         # last message that reports it.
         usage = None
-        totals = {"input": 0, "output": 0, "cache_read": 0, "cache_write": 0}
+        totals = {"input": 0, "output": 0, "cache_read": 0, "cache_write": 0, "usd": 0.0}
+        usd_reported = False
         context_tokens = 0
         for message in getattr(event, "messages", None) or []:
             message_usage = getattr(message, "usage", None)
@@ -478,6 +479,17 @@ class EventController:
             totals["output"] += getattr(message_usage, "output_tokens", 0) or 0
             totals["cache_read"] += getattr(message_usage, "cache_read_tokens", 0) or 0
             totals["cache_write"] += getattr(message_usage, "cache_write_tokens", 0) or 0
+            # A provider-reported dollar amount is SUMMED alongside the tokens,
+            # because a tool-using turn is many billed calls and the money for
+            # each lives on its own message. ``usd_reported`` tracks whether ANY
+            # message carried one so the aggregate keeps the model-vs-provider
+            # distinction: off (``None``) means no provider reported a figure and
+            # the estimate is the only answer; on with a real total means the
+            # provider was the authority for the whole turn.
+            reported = getattr(message_usage, "usd_cost", None)
+            if reported is not None:
+                totals["usd"] += float(reported)
+                usd_reported = True
             usage = message_usage
             context_tokens = (
                 getattr(message_usage, "context_tokens", None)
@@ -491,6 +503,7 @@ class EventController:
                 cache_read_tokens=totals["cache_read"],
                 cache_write_tokens=totals["cache_write"],
                 context_tokens=context_tokens or None,
+                usd_cost=totals["usd"] if usd_reported else None,
             )
         self._post(
             TurnEnded(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.24.5"
+version = "0.24.6"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/harness/test_jobs.py
+++ b/tests/unit/harness/test_jobs.py
@@ -14,6 +14,7 @@ from local_operator.harness.jobs import (
     AsyncJob,
     AsyncJobManager,
 )
+from local_operator.harness.types import Usage
 
 
 async def wait_for(predicate, timeout: float = 2.0) -> None:
@@ -43,6 +44,42 @@ def require_output(manager: AsyncJobManager, job_id: str, since: int = 0) -> tup
 async def quick_runner(job_id, signal, report_progress):
     report_progress("halfway")
     return f"done:{job_id}"
+
+
+def test_accumulate_usage_sums_provider_reported_dollars() -> None:
+    """A tool-using child's money is spread across its per-message usage, and the
+    runner's accumulator must sum the provider-reported dollar the same way it
+    sums the token buckets — never take only the last message's figure."""
+    from local_operator.harness.subagent import _accumulate_usage
+
+    class _Job:
+        def __init__(self, usage=None) -> None:
+            self.usage = usage
+
+    job = _Job()
+    _accumulate_usage(job, Usage(input_tokens=10, output_tokens=0, usd_cost=0.001))
+    _accumulate_usage(job, Usage(input_tokens=20, output_tokens=0, usd_cost=0.002))
+    assert job.usage is not None
+    assert job.usage.input_tokens == 30
+    assert job.usage.usd_cost == pytest.approx(0.003)
+
+
+def test_accumulate_usage_leaves_reported_dollar_none_when_unreported() -> None:
+    """A child whose providers never report a dollar figure keeps ``usd_cost``
+    ``None`` — "not reported" is not a sum of zeros and must fall back to the
+    token estimate downstream."""
+    from local_operator.harness.subagent import _accumulate_usage
+
+    class _Job:
+        def __init__(self) -> None:
+            self.usage = None
+
+    job = _Job()
+    _accumulate_usage(job, Usage(input_tokens=10))
+    _accumulate_usage(job, Usage(input_tokens=20))
+    assert job.usage is not None
+    assert job.usage.usd_cost is None
+    assert job.usage.input_tokens == 30
 
 
 @pytest.mark.asyncio

--- a/tests/unit/harness/test_jobs.py
+++ b/tests/unit/harness/test_jobs.py
@@ -64,6 +64,29 @@ def test_accumulate_usage_sums_provider_reported_dollars() -> None:
     assert job.usage.usd_cost == pytest.approx(0.003)
 
 
+def test_accumulate_usage_non_finite_reported_dollar_does_not_poison_total() -> None:
+    """A non-finite child figure (``inf``/``NaN``, wire-reachable via
+    ``json.loads``) must be dropped, not summed: ``inf + x == inf`` would pin the
+    child's running total at infinity for the rest of its life with no recovery."""
+    import math
+
+    from local_operator.harness.subagent import _accumulate_usage
+
+    class _Job:
+        def __init__(self) -> None:
+            self.usage = None
+
+    job = _Job()
+    _accumulate_usage(job, Usage(input_tokens=10, output_tokens=0, usd_cost=0.001))
+    _accumulate_usage(job, Usage(input_tokens=20, output_tokens=0, usd_cost=float("inf")))
+    assert job.usage is not None
+    # The poison message is dropped; only the valid one contributes, and a later
+    # valid message still folds in cleanly because the total was never poisoned.
+    _accumulate_usage(job, Usage(input_tokens=5, output_tokens=0, usd_cost=0.002))
+    assert job.usage.usd_cost == pytest.approx(0.003)
+    assert job.usage.usd_cost is not None and math.isfinite(job.usage.usd_cost)
+
+
 def test_accumulate_usage_leaves_reported_dollar_none_when_unreported() -> None:
     """A child whose providers never report a dollar figure keeps ``usd_cost``
     ``None`` — "not reported" is not a sum of zeros and must fall back to the

--- a/tests/unit/model/test_pricing.py
+++ b/tests/unit/model/test_pricing.py
@@ -476,3 +476,45 @@ def test_cost_for_usage_reads_a_serialized_usage_mapping() -> None:
     """A child's usage arrives rehydrated from a serialized event, as a dict."""
     usage = {"input_tokens": 1_000_000, "output_tokens": 0}
     assert cost_for_usage("anthropic", _priced(), usage) == pytest.approx(10.0)
+
+
+def test_cost_for_usage_prefers_a_provider_reported_dollar() -> None:
+    """OpenRouter's ``usage.cost`` is the provider's own bill: it must be
+    returned verbatim, never re-derived from tokens — a reconstruction cannot
+    reproduce the per-route price, reasoning split, or override that produced it."""
+    usage = Usage(input_tokens=1_000_000, output_tokens=1_000_000, usd_cost=0.0075)
+    # Note the token-shaped usage would price to ~110.0 here; the reported
+    # figure must WIN, so the assertion is the figure, not the estimate.
+    assert cost_for_usage("openrouter", _priced(), usage) == pytest.approx(0.0075)
+
+
+def test_cost_for_usage_reported_dollar_wins_even_against_big_table_price() -> None:
+    """The preference is by presence, not by magnitude: even when the table
+    would price the token counts far higher, the provider's printed number is the
+    fact and the table is the estimate."""
+    usage = {"input_tokens": 1_000_000, "output_tokens": 1_000_000, "usd_cost": 0.0075}
+    assert cost_for_usage("openrouter", _priced(), usage) == pytest.approx(0.0075)
+
+
+def test_cost_for_usage_falls_back_to_estimate_without_a_reported_dollar() -> None:
+    """``usd_cost`` absent means the estimate is still the answer."""
+    usage = Usage(input_tokens=1_000_000, output_tokens=0)
+    assert cost_for_usage("openrouter", _priced(), usage) == pytest.approx(10.0)
+
+
+def test_cost_for_usage_treats_a_malformed_reported_dollar_as_absent() -> None:
+    """A non-numeric or negative reported amount is provider noise, not money:
+    it must degrade to the estimate, not raise or bill a credit."""
+    assert cost_for_usage(
+        "openrouter", _priced(), Usage(input_tokens=1_000_000, usd_cost=-5)
+    ) == pytest.approx(10.0)
+    assert cost_for_usage(
+        "openrouter", _priced(), {"input_tokens": 1_000_000, "usd_cost": "x"}
+    ) == pytest.approx(10.0)
+
+
+def test_cost_for_usage_reported_zero_is_a_fact_not_an_absence() -> None:
+    """A real ``0.0`` from the provider means "billed as free", which is not the
+    same as "not reported" — it must return 0.0, not fall through to the estimate."""
+    usage = Usage(input_tokens=1_000_000, output_tokens=1_000_000, usd_cost=0.0)
+    assert cost_for_usage("openrouter", _priced(), usage) == 0.0

--- a/tests/unit/model/test_pricing.py
+++ b/tests/unit/model/test_pricing.py
@@ -513,6 +513,22 @@ def test_cost_for_usage_treats_a_malformed_reported_dollar_as_absent() -> None:
     ) == pytest.approx(10.0)
 
 
+def test_cost_for_usage_non_finite_reported_dollar_falls_back_to_estimate() -> None:
+    """A non-finite reported amount is malformed provider data and is
+    wire-reachable (``json.loads`` accepts ``Infinity``/``NaN`` by default). An
+    unfloored ``inf`` would poison every summed total forever, so it must degrade
+    to the token estimate exactly like a negative or non-numeric amount, and the
+    result must be finite."""
+    import math
+
+    for bad in (float("inf"), float("-inf"), float("nan")):
+        result = cost_for_usage(
+            "openrouter", _priced(), Usage(input_tokens=1_000_000, usd_cost=bad)
+        )
+        assert result == pytest.approx(10.0)
+        assert math.isfinite(result)
+
+
 def test_cost_for_usage_reported_zero_is_a_fact_not_an_absence() -> None:
     """A real ``0.0`` from the provider means "billed as free", which is not the
     same as "not reported" — it must return 0.0, not fall through to the estimate."""

--- a/tests/unit/providers/test_clients.py
+++ b/tests/unit/providers/test_clients.py
@@ -312,6 +312,86 @@ async def test_openai_compat_error_finish_reason_without_error_object() -> None:
     assert end.error == "provider reported a mid-stream failure (finish_reason 'error')"
 
 
+async def test_openai_compat_captures_provider_reported_cost() -> None:
+    """OpenRouter's ``usage.cost`` is the provider's own bill and must reach
+    ``Usage.usd_cost`` intact, so the TUI can prefer it over a token×rate
+    reconstruction."""
+    body = _sse(
+        [
+            {"id": "chatcmpl-1", "choices": [{"delta": {"content": "boop"}, "index": 0}]},
+            {
+                "id": "chatcmpl-1",
+                "choices": [],
+                "usage": {
+                    "prompt_tokens": 10,
+                    "completion_tokens": 16,
+                    "cost": 7.5e-6,
+                    "prompt_tokens_details": {"cached_tokens": 0},
+                },
+            },
+        ]
+    )
+    transport = httpx.MockTransport(
+        lambda request: httpx.Response(
+            200, content=body, headers={"content-type": "text/event-stream"}
+        )
+    )
+    client = OpenAICompatClient(
+        "https://api.test.example/v1", http_client=httpx.AsyncClient(transport=transport)
+    )
+    request = ChatRequest(
+        model=_spec(provider="openrouter", model_id="deepseek/deepseek-v4-flash-0731"),
+        messages=[Message.user("hi")],
+    )
+    events = await _collect(client.stream(request, "sk-test"))
+
+    usage_events = [e for e in events if isinstance(e, StreamUsageEvent)]
+    assert usage_events and usage_events[0].usage.usd_cost == pytest.approx(7.5e-6)
+
+
+async def test_openai_compat_cost_is_none_when_provider_omits_it() -> None:
+    """Providers that do not precompute billing leave ``usd_cost`` as ``None``,
+    never a fabricated 0.0 — the distinction the whole estimate fallback depends on."""
+    body = _sse(
+        [
+            {"id": "chatcmpl-1", "choices": [{"delta": {"content": "boop"}, "index": 0}]},
+            {
+                "id": "chatcmpl-1",
+                "choices": [],
+                "usage": {"prompt_tokens": 10, "completion_tokens": 4},
+            },
+        ]
+    )
+    transport = httpx.MockTransport(
+        lambda request: httpx.Response(
+            200, content=body, headers={"content-type": "text/event-stream"}
+        )
+    )
+    client = OpenAICompatClient(
+        "https://api.test.example/v1", http_client=httpx.AsyncClient(transport=transport)
+    )
+    request = ChatRequest(model=_spec(), messages=[Message.user("hi")])
+    events = await _collect(client.stream(request, "sk-test"))
+
+    usage_events = [e for e in events if isinstance(e, StreamUsageEvent)]
+    assert usage_events and usage_events[0].usage.usd_cost is None
+
+
+def test_usd_cost_coerces_and_rejects_malformed() -> None:
+    """The cost field is a JSON number but must not abort a stream when a
+    provider spells it differently; absent/negative/non-numeric all yield None."""
+    from local_operator.providers.clients import _usd_cost
+
+    assert _usd_cost({"cost": 7.5e-6}) == pytest.approx(7.5e-6)
+    assert _usd_cost({"cost": "0.1"}) == pytest.approx(0.1)
+    assert _usd_cost({"cost": 0.0}) == 0.0  # a real zero: billed as free
+    assert _usd_cost({}) is None
+    assert _usd_cost({"cost": None}) is None
+    assert _usd_cost({"cost": -1}) is None
+    assert _usd_cost({"cost": "not-a-number"}) is None
+    assert _usd_cost(None) is None
+
+
 async def test_openai_compat_tool_history_roundtrip() -> None:
     """Assistant tool_calls and tool results serialize for replay.
 

--- a/tests/unit/providers/test_clients.py
+++ b/tests/unit/providers/test_clients.py
@@ -390,6 +390,17 @@ def test_usd_cost_coerces_and_rejects_malformed() -> None:
     assert _usd_cost({"cost": -1}) is None
     assert _usd_cost({"cost": "not-a-number"}) is None
     assert _usd_cost(None) is None
+    # Non-finite is wire-reachable: ``json.loads`` parses the non-standard
+    # ``Infinity``/``NaN`` literals by default, so a provider can emit them. An
+    # unfloored ``inf`` would pin every summed total at infinity forever
+    # (``inf + x == inf``), so both the JSON literal and the numeric-string
+    # spelling must fall through to ``None`` and let the estimate answer.
+    assert _usd_cost(json.loads('{"cost": Infinity}')) is None
+    assert _usd_cost(json.loads('{"cost": -Infinity}')) is None
+    assert _usd_cost(json.loads('{"cost": NaN}')) is None
+    assert _usd_cost({"cost": float("inf")}) is None
+    assert _usd_cost({"cost": "inf"}) is None
+    assert _usd_cost({"cost": "nan"}) is None
 
 
 async def test_openai_compat_tool_history_roundtrip() -> None:

--- a/tests/unit/tui/test_costs.py
+++ b/tests/unit/tui/test_costs.py
@@ -109,6 +109,20 @@ def test_turn_cost_reported_malformed_falls_back_to_estimate() -> None:
         assert turn_cost("anthropic/opus", usage) == pytest.approx(10.0)
 
 
+def test_turn_cost_non_finite_reported_falls_back_to_estimate() -> None:
+    """A non-finite reported amount (``inf``/``NaN``) is wire-reachable via
+    ``json.loads`` and, left unfloored, renders an infinite dollar figure. It
+    must fall back to the finite table estimate rather than paint infinity."""
+    import math
+
+    for bad in (float("inf"), float("-inf"), float("nan")):
+        with _resolving(opus=_PRICED):
+            usage = Usage(input_tokens=1_000_000, output_tokens=0, usd_cost=bad)
+            result = turn_cost("anthropic/opus", usage)
+            assert result == pytest.approx(10.0)
+            assert result is not None and math.isfinite(result)
+
+
 # ---------------------------------------------------------------------------
 # job_cost — one child
 # ---------------------------------------------------------------------------

--- a/tests/unit/tui/test_costs.py
+++ b/tests/unit/tui/test_costs.py
@@ -92,6 +92,23 @@ def test_turn_cost_reported_dollar_wins_even_without_a_table_price() -> None:
     )
 
 
+def test_turn_cost_never_renders_a_reported_credit() -> None:
+    """A negative reported amount is malformed provider data, not a refund: it
+    must fall back to the table estimate rather than paint an upside-down dollar
+    figure on the band."""
+    with _resolving(opus=_PRICED):
+        usage = Usage(input_tokens=1_000_000, output_tokens=0, usd_cost=-5.0)
+        assert turn_cost("anthropic/opus", usage) == pytest.approx(10.0)
+
+
+def test_turn_cost_reported_malformed_falls_back_to_estimate() -> None:
+    """A non-numeric reported amount from a rehydrated mapping must not degrade
+    the whole turn to unpriceable when a table price exists."""
+    with _resolving(opus=_PRICED):
+        usage = {"input_tokens": 1_000_000, "output_tokens": 0, "usd_cost": "not-a-number"}
+        assert turn_cost("anthropic/opus", usage) == pytest.approx(10.0)
+
+
 # ---------------------------------------------------------------------------
 # job_cost — one child
 # ---------------------------------------------------------------------------

--- a/tests/unit/tui/test_costs.py
+++ b/tests/unit/tui/test_costs.py
@@ -72,6 +72,26 @@ def test_turn_cost_survives_a_broken_resolver() -> None:
         assert turn_cost("anthropic/opus", Usage(input_tokens=10)) is None
 
 
+def test_turn_cost_prefers_a_provider_reported_dollar() -> None:
+    """OpenRouter's precomputed bill is authoritative and must win verbatim over
+    the model's table price — the routed provider's actual rate is not the table."""
+    with _resolving(opus=_PRICED):
+        cost = turn_cost(
+            "anthropic/opus", Usage(input_tokens=1_000_000, output_tokens=100_000, usd_cost=0.0075)
+        )
+    assert cost == pytest.approx(0.0075)
+
+
+def test_turn_cost_reported_dollar_wins_even_without_a_table_price() -> None:
+    """The provider's bill is the fact the table is an estimate of, so it must
+    answer even when the model has no published price row — a turn the provider
+    billed must never read as unpriceable."""
+    usage = Usage(input_tokens=10, output_tokens=16, usd_cost=0.0000075)
+    assert turn_cost("openrouter/deepseek/deepseek-v4-flash-0731", usage) == pytest.approx(
+        0.0000075
+    )
+
+
 # ---------------------------------------------------------------------------
 # job_cost — one child
 # ---------------------------------------------------------------------------

--- a/tests/unit/tui/test_events.py
+++ b/tests/unit/tui/test_events.py
@@ -414,6 +414,38 @@ def test_dispose_stops_flush_timer() -> None:
     assert app.timers[0].stopped
 
 
+def test_agent_end_sums_provider_reported_dollars_across_messages() -> None:
+    """A tool-using turn is many billed calls; the provider-reported dollar on
+    EACH message must be summed into the turn's aggregate, not overwritten by the
+    last one (the same rule the token buckets already follow)."""
+    from local_operator.harness.types import Usage
+
+    controller, session, app = _controller()
+    session.emit(AgentStartEvent())
+    first = Message.assistant("")
+    first.usage = Usage(input_tokens=10, output_tokens=0, usd_cost=0.001)
+    second = Message.assistant("")
+    second.usage = Usage(input_tokens=20, output_tokens=0, usd_cost=0.002)
+    session.emit(AgentEndEvent(messages=[first, second]))
+    ended = [m for m in app.posted if isinstance(m, TurnEnded)]
+    assert ended and ended[-1].usage.usd_cost == pytest.approx(0.003)
+
+
+def test_agent_end_reported_dollar_is_none_when_no_message_carried_one() -> None:
+    """A turn whose calls carried only token counts must keep ``usd_cost`` as
+    ``None`` ("provider did not report"), so the app falls back to the estimate."""
+    from local_operator.harness.types import Usage
+
+    controller, session, app = _controller()
+    session.emit(AgentStartEvent())
+    message = Message.assistant("")
+    message.usage = Usage(input_tokens=10, output_tokens=0)
+    session.emit(AgentEndEvent(messages=[message]))
+    ended = [m for m in app.posted if isinstance(m, TurnEnded)]
+    assert ended and ended[-1].usage.usd_cost is None
+    assert ended[-1].usage.input_tokens == 10
+
+
 def test_notice_forwarded() -> None:
     controller, session, app = _controller()
     session.emit(NoticeEvent(text="heads up", kind="warning"))

--- a/tests/unit/tui/test_events.py
+++ b/tests/unit/tui/test_events.py
@@ -431,6 +431,29 @@ def test_agent_end_sums_provider_reported_dollars_across_messages() -> None:
     assert ended and ended[-1].usage.usd_cost == pytest.approx(0.003)
 
 
+def test_agent_end_non_finite_reported_dollar_does_not_poison_the_total() -> None:
+    """A non-finite reported amount on one message (wire-reachable via
+    ``json.loads``'s ``Infinity``/``NaN``) must not be summed into the turn's
+    aggregate. ``inf + x == inf`` would pin the total at infinity forever, so the
+    bad message is dropped and only the valid neighbours contribute a finite sum."""
+    import math
+
+    from local_operator.harness.types import Usage
+
+    controller, session, app = _controller()
+    session.emit(AgentStartEvent())
+    good = Message.assistant("")
+    good.usage = Usage(input_tokens=10, output_tokens=0, usd_cost=0.002)
+    poison = Message.assistant("")
+    poison.usage = Usage(input_tokens=20, output_tokens=0, usd_cost=float("inf"))
+    session.emit(AgentEndEvent(messages=[good, poison]))
+    ended = [m for m in app.posted if isinstance(m, TurnEnded)]
+    assert ended
+    total = ended[-1].usage.usd_cost
+    assert total == pytest.approx(0.002)
+    assert total is not None and math.isfinite(total)
+
+
 def test_agent_end_reported_dollar_is_none_when_no_message_carried_one() -> None:
     """A turn whose calls carried only token counts must keep ``usd_cost`` as
     ``None`` ("provider did not report"), so the app falls back to the estimate."""


### PR DESCRIPTION
## What

OpenRouter precomputes the exact dollar charge for every request and returns it as `usage.cost` (with a breakdown in `usage.cost_details`). That number is the ground truth: it already reflects the per-route price the request actually landed on, reasoning-token splits, cache discounts, and any time/value-banded overrides.

This PR captures `usage.cost` into a new `Usage.usd_cost` field and prefers it — verbatim — across every money surface (parent status band, subagent rows, full-page view). The existing token×rate estimate is unchanged and remains the fallback for providers that don't report a cost.

## Why

`deepseek/deepseek-v4-flash-0731` routes across ~30 upstream providers at a **3× price spread** (OpenRouter's `/models/<id>/endpoints` shows completion rates from $0.14 to $0.66 per MTok). The flat catalog price lop stored is only the floor, so a token×rate reconstruction can be off by 2× either direction depending on which provider the request lands on. Trusting the number OpenRouter already printed makes the two 1:1 by construction.

## Change class

C1 — standard bug fix / incremental accuracy improvement. Behavioral (cost display path) but no data, security, or infra surface.

## Testing evidence

### Live end-to-end (real OpenRouter requests through lop's client)

`deepseek/deepseek-v4-flash-0731`, six requests, each routed to a different upstream provider. Column `provider_cost` is OpenRouter's own `usage.cost`; `table_est` is what lop would have shown before; `ratio` = provider/table.

```
resolved table price = 0.14 in / 0.28 out / MTok
req 0: in= 10 out= 16 provider_cost=  5.88e-06  table_est=0.000005880  ratio= 1.00  rendered==provider: True
req 1: in= 10 out= 16 provider_cost=4.83196e-06  table_est=0.000005880  ratio= 0.82  rendered==provider: True
req 2: in= 10 out= 16 provider_cost=  3.68e-06  table_est=0.000005880  ratio= 0.63  rendered==provider: True
req 3: in= 10 out= 16 provider_cost=  2.94e-06  table_est=0.000005880  ratio= 0.50  rendered==provider: True
req 4: in= 10 out= 16 provider_cost=  3.68e-06  table_est=0.000005880  ratio= 0.63  rendered==provider: True
req 5: in= 89 out= 16 provider_cost= 1.694e-05  table_est=0.000016940  ratio= 1.00  rendered==provider: True
```

Key point: the provider's own cost varies **0.50×–1.00×** of the flat-table estimate for *identical* token counts, purely from routing. `rendered==provider: True` on every request proves the TUI now shows the provider's number verbatim.

### Unit tests

- `test_openai_compat_captures_provider_reported_cost` — streaming chunk with `usage.cost` lands in `Usage.usd_cost`
- `test_openai_compat_cost_is_none_when_provider_omits_it` — absent cost stays `None`, not a fabricated `0.0`
- `test_usd_cost_coerces_and_rejects_malformed` — numeric-string coercion; absent/negative/non-numeric → `None`
- `test_cost_for_usage_prefers_a_provider_reported_dollar` (+ mapping form, malformed, zero-vs-absent)
- `test_turn_cost_prefers_a_provider_reported_dollar` (+ wins without a table price)
- `test_agent_end_sums_provider_reported_dollars_across_messages` — multi-call tool turns sum, don't overwrite
- `test_accumulate_usage_sums_provider_reported_dollars` — subagent accumulation sums

Full suite: **5778 passed, 2 failed**. The two failures (`test_loop.py::test_a_late_parking_tool...`, `test_eval_tool.py::test_background_streams_output...`) are pre-existing and reproduce on clean `origin/main` (verified in a throwaway worktree); both are timing-sensitive and unrelated to this change. The `test_loop` one passes in isolation; `test_eval_tool` fails identically on clean main.

## Gating

Clean: `flake8`, `black --check`, `isort --check-only`, `pyright` (all repo-wide).