### PR TITLE
perf(mcp): close connections concurrently and wait on process exit

### DIFF
--- a/local_operator/mcp/manager.py
+++ b/local_operator/mcp/manager.py
@@ -369,10 +369,29 @@ CHILD_QUIET_ENV: dict[str, str] = {
 #: How long teardown waits for the stderr pump after the child has exited. The
 #: pipe is normally at EOF already and this returns instantly; the bound only
 #: bites when a surviving descendant still holds the write end, and there is
-#: nothing more of the SERVER's own output to wait for in that case. Short
-#: because ``disconnect_all`` tears connections down one at a time, so this is
-#: paid per server on quit.
+#: nothing more of the SERVER's own output to wait for in that case. Kept
+#: short even though ``disconnect_all`` now closes connections concurrently:
+#: any single stdio server still pays it inline on ``/mcp reconnect`` and
+#: ``disconnect_server``, where nothing overlaps it.
 STDERR_DRAIN_GRACE_S = 0.25
+
+#: Grace a stdio server gets at each rung of teardown (stdin EOF, then
+#: SIGTERM, then SIGKILL) before escalation to the next rung. The wait is
+#: event-driven — ``process.wait()`` wakes the moment the child exits — so a
+#: prompt server pays nothing and only a stubborn one sits out a rung. The
+#: value preserves the budget of the 0.1 s polling loop it replaced (20 ticks
+#: per rung); what changed is the wake latency, not the patience.
+STDIO_EXIT_GRACE_S = 2.0
+
+#: Bound on closing ONE connection's exit stack (see
+#: :meth:`McpManager._teardown_connection`). Bounded at all because a remote
+#: transport's close is network I/O — the streamable-HTTP transport DELETEs
+#: its session on an HTTP client whose connect timeout alone is 30 s — and a
+#: dead network must not be able to hold quit hostage for that long. Five
+#: seconds matches the session's other dispose bounds (turn abort, browser
+#: close, title flush): comfortably above any healthy close, and a pause a
+#: person will sit through once rather than a hang they will kill -9.
+CONNECTION_TEARDOWN_TIMEOUT_S = 5.0
 
 #: Stderr lines retained per stdio server for the failure report. A Python
 #: traceback plus the banner that preceded it fits inside this; a chatty server
@@ -618,27 +637,44 @@ async def _stdio_transport(
             stderr_drained.set()
 
     async def _stop() -> None:
-        """Close stdin, give the server a grace window, then kill the tree."""
-        stdin = process.stdin
-        if stdin is not None:
-            with suppress(Exception):
-                await stdin.aclose()
-        exited = False
-        for _ in range(20):
-            if process.returncode is not None:
-                exited = True
-                break
-            await asyncio.sleep(0.1)
-        if not exited:
+        """Close stdin, give the server a grace window, then kill the tree.
+
+        EVENT-DRIVEN: each rung awaits ``process.wait()`` under a deadline
+        rather than polling ``returncode`` on a 0.1 s tick. The polling loop
+        this replaced charged up to a full tick of pure latency per rung on
+        every quit — a child that exited 1 ms after a poll still cost 99 ms —
+        and teardown is exactly the path where that latency is user-visible
+        (the terminal is already released; the user is watching the prompt).
+
+        CANCELLATION-SAFE on purpose: ``_teardown_connection`` bounds the
+        stack close, and the cancel it delivers on timeout lands on whichever
+        await is current in here. Absorbing that cancel without killing the
+        child would leak the process past the session — on Linux
+        ``start_new_session`` detaches it from our process group entirely (see
+        :func:`stdio_start_new_session`), so it would not even die with us.
+        Kill first, then let the cancellation propagate.
+        """
+        try:
+            stdin = process.stdin
+            if stdin is not None:
+                with suppress(Exception):
+                    await stdin.aclose()
+            with anyio.move_on_after(STDIO_EXIT_GRACE_S):
+                await process.wait()
+                return
             for stop_process in (process.terminate, process.kill):
                 with suppress(Exception):
                     stop_process()
-                for _ in range(20):
-                    if process.returncode is not None:
-                        break
-                    await asyncio.sleep(0.1)
-                if process.returncode is not None:
-                    break
+                with anyio.move_on_after(STDIO_EXIT_GRACE_S):
+                    await process.wait()
+                    return
+        except asyncio.CancelledError:
+            # The bounded teardown gave up on waiting; the child must not
+            # outlive the session that owns it. ``kill`` is synchronous (one
+            # signal), so this cannot itself block the cancellation.
+            with suppress(Exception):
+                process.kill()
+            raise
 
     try:
         async with anyio.create_task_group() as tg:
@@ -1213,8 +1249,19 @@ class McpManager:
             # real McpConnectionError they can turn into a tool result (MCP-08).
             _settle_future_error(future, McpConnectionError("MCP manager disposed"))
         self._connect_futures.clear()
-        for name in list(self._connections):
-            await self._teardown_connection(name)
+        # CONCURRENTLY, not one at a time: teardown is per-connection I/O — a
+        # remote session-terminate round trip, a child process exit plus its
+        # stderr drain grace — and paying it serially made quit latency grow
+        # with the server count (measured 1.6 s across seven servers where the
+        # slowest single one needed 0.95 s). The teardowns share no state:
+        # each pops its own entry from ``_connections`` and closes its own
+        # stack, so the only thing serial order bought was the wait.
+        names = list(self._connections)
+        if names:
+            await asyncio.gather(
+                *(self._teardown_connection(name) for name in names),
+                return_exceptions=True,
+            )
         for watcher in list(self._watchers):
             watcher.cancel()
         for task in list(self._notify_tasks):
@@ -2129,14 +2176,26 @@ class McpManager:
         return conn
 
     async def _teardown_connection(self, name: str) -> None:
-        """Close one connection's stack without touching registries."""
+        """Close one connection's stack without touching registries.
+
+        BOUNDED (:data:`CONNECTION_TEARDOWN_TIMEOUT_S`): a remote transport's
+        close sends a session-terminate request over the network, and a dead
+        network or wedged server must not hold session dispose — the path the
+        user experiences as "quit hangs" — for the HTTP client's own 30 s
+        connect timeout. On timeout the close is CANCELLED: the stdio
+        transport responds by killing its child (see ``_stop``), and a
+        cancelled remote close simply drops the connection on the floor,
+        which is what a dead network leaves anyway. ``TimeoutError`` is an
+        ``Exception``, so the existing suppress covers it; a real
+        cancellation from above still propagates.
+        """
         conn = self._connections.pop(name, None)
         if conn is None:
             return
         conn.closed_event.set()
         if conn.stack is not None:
             with suppress(Exception):
-                await conn.stack.aclose()
+                await asyncio.wait_for(conn.stack.aclose(), CONNECTION_TEARDOWN_TIMEOUT_S)
 
     # --- notifications -------------------------------------------------------
 

--- a/local_operator/mcp/manager.py
+++ b/local_operator/mcp/manager.py
@@ -703,9 +703,10 @@ async def _stdio_transport(
                 # Let the stderr pump finish before the cancel below kills it.
                 # Without this wait a server that died DURING the handshake
                 # loses the last lines of its own stderr — exactly the ones
-                # saying why — because `_stop` returns up to one 0.1 s poll
-                # before the pump has drained them, and `_connect_server`
-                # quotes that tail into the error the user is shown.
+                # saying why: `_stop` observes the exit the moment it happens,
+                # which can be BEFORE the pump has consumed what is still
+                # sitting in the pipe, and `_connect_server` quotes that tail
+                # into the error the user is shown.
                 #
                 # Bounded because EOF is not guaranteed: the write end is held
                 # by every process that inherited it, so a server that spawned

--- a/tests/unit/mcp/test_manager.py
+++ b/tests/unit/mcp/test_manager.py
@@ -875,6 +875,41 @@ class TestTeardownLatency:
         assert manager._connections == {}
 
 
+async def _pid_from_stderr(stderr_log: Any) -> int:
+    """The pid a transport child reported on its own stderr.
+
+    The tests below assert about a SPECIFIC process, not about anything that
+    merely matches a ``pgrep`` pattern — a pattern match can hit an unrelated
+    process on a shared machine in both directions (false leak, and a false
+    pass of the ``== ""`` assertion). The child prints ``pid=<n>`` to stderr,
+    the transport's stderr pump captures it, and this reads it back.
+    """
+    import re
+
+    for _ in range(100):
+        match = re.search(r"pid=(\d+)", stderr_log.tail_text())
+        if match:
+            return int(match.group(1))
+        await asyncio.sleep(0.05)
+    raise AssertionError("child never reported its pid on stderr")
+
+
+def _process_is_alive(pid: int) -> bool:
+    """True when ``pid`` names a RUNNING process; a zombie counts as dead.
+
+    ``os.kill(pid, 0)`` cannot be the probe: a child killed but not yet
+    waited on is a zombie, which still answers signal 0 — the kill-on-cancel
+    path deliberately does not wait (see ``_stop``), so the reaped-vs-leaked
+    question must accept ``Z`` as dead.
+    """
+    import subprocess as sp
+
+    out = sp.run(
+        ["ps", "-p", str(pid), "-o", "stat="], capture_output=True, text=True
+    ).stdout.strip()
+    return bool(out) and not out.startswith("Z")
+
+
 class TestStdioStopIsEventDriven:
     """The stdio ``_stop`` waits on process exit, not on a polling tick.
 
@@ -916,19 +951,30 @@ class TestStdioStopIsEventDriven:
         ``_teardown_connection`` cancels the stack close at its bound; the
         cancel lands inside ``_stop``'s waits, and absorbing it without a
         kill would leave the server running past the session.
+
+        TWO cancels, deliberately. The first is consumed at the parked
+        ``sleep(3600)`` — after it, the transport's ``finally`` runs ``_stop``
+        UNcancelled, and the ordinary kill rung would reap the child even if
+        the ``except CancelledError`` handler were deleted (review round 1,
+        F1: the single-cancel version of this test passed with the handler
+        removed). The second cancel is timed to land while ``_stop`` sits in
+        its EOF-rung wait, which is the state a bounded dispose actually
+        delivers: only the handler reaps the child from there, so this is
+        the arrangement that fails when the handler is gone.
         """
-        import signal
         import sys
 
         import local_operator.mcp.manager as manager_mod
         from local_operator.mcp.config import MCPStdioServerConfig
         from local_operator.mcp.manager import McpServerStderr, _stdio_transport
 
-        # Ignores stdin EOF and SIGTERM: only SIGKILL removes it.
+        # Reports its pid, then ignores stdin EOF and SIGTERM: only SIGKILL
+        # removes it, so a surviving pid can only mean the kill never came.
         script = (
-            "import signal, sys, time\n"
+            "import os, signal, sys, time\n"
             "signal.signal(signal.SIGTERM, signal.SIG_IGN)\n"
-            "print('pid', flush=True)\n"
+            "sys.stderr.write(f'pid={os.getpid()}\\n')\n"
+            "sys.stderr.flush()\n"
             "while True: time.sleep(0.2)\n"
         )
         cfg = MCPStdioServerConfig(command=sys.executable, args=["-c", script])
@@ -945,23 +991,20 @@ class TestStdioStopIsEventDriven:
         manager_mod.STDIO_EXIT_GRACE_S = 0.2  # keep the ladder fast in CI
         try:
             task = asyncio.get_running_loop().create_task(run())
-            await asyncio.sleep(0.5)  # let the child start
+            pid = await _pid_from_stderr(stderr_log)
+            task.cancel()
+            # Let the first cancel unwind the park and start ``_stop``; well
+            # under the 0.2 s grace, so the second cancel lands inside the
+            # EOF-rung wait rather than after the ladder has finished.
+            await asyncio.sleep(0.05)
             task.cancel()
             with pytest.raises(asyncio.CancelledError):
                 await task
         finally:
             manager_mod.STDIO_EXIT_GRACE_S = original
-        # The transport's finally ran under cancellation; the child must be
-        # gone. We cannot read its pid from outside the closure, so assert
-        # the observable: no python child of ours is still running the
-        # stubborn script.
-        import subprocess as sp
-
-        out = sp.run(
-            ["pgrep", "-f", "signal.SIG_IGN"], capture_output=True, text=True
-        ).stdout.strip()
-        assert out == "", f"stubborn child leaked: pids {out!r}"
-        _ = signal  # imported for the docstring's contract, used in the child
+        # The kill-on-cancel path does not wait on the child, so it may be a
+        # zombie — which is dead for this purpose. Alive means leaked.
+        assert not _process_is_alive(pid), f"stubborn child leaked: pid {pid}"
 
     @pytest.mark.asyncio
     async def test_sigterm_rung_still_reaps_a_deaf_reader(self) -> None:
@@ -969,7 +1012,12 @@ class TestStdioStopIsEventDriven:
 
         Guards the escalation ladder itself: event-driven waits must still
         escalate (EOF grace → terminate → kill) rather than returning early
-        on the first rung's timeout.
+        on the first rung's timeout. The assertion is on the child's PID, not
+        on reaching the end of the context — ``_stop`` runs under
+        ``suppress(Exception)`` and every wait in it is bounded, so the
+        context exits cleanly even when the ladder is broken (review round 1,
+        F2: a ``_stop`` mutated to return after the first rung passed the
+        reach-the-end version of this test while leaking the child).
         """
         import sys
 
@@ -977,8 +1025,15 @@ class TestStdioStopIsEventDriven:
         from local_operator.mcp.config import MCPStdioServerConfig
         from local_operator.mcp.manager import McpServerStderr, _stdio_transport
 
-        # Never reads stdin; dies on SIGTERM (the default disposition).
-        script = "import time\nwhile True: time.sleep(0.2)\n"
+        # Reports its pid; never reads stdin; dies on SIGTERM (the default
+        # disposition). Ladder rung 1 (EOF grace) therefore expires, and only
+        # rung 2's terminate can reap it.
+        script = (
+            "import os, sys, time\n"
+            "sys.stderr.write(f'pid={os.getpid()}\\n')\n"
+            "sys.stderr.flush()\n"
+            "while True: time.sleep(0.2)\n"
+        )
         cfg = MCPStdioServerConfig(command=sys.executable, args=["-c", script])
         stderr_log = McpServerStderr("deaf")
         # Shrink the per-rung grace so the EOF rung times out quickly.
@@ -986,11 +1041,13 @@ class TestStdioStopIsEventDriven:
         manager_mod.STDIO_EXIT_GRACE_S = 0.2
         try:
             async with _stdio_transport(cfg, lambda: None, stderr_log):
-                await asyncio.sleep(0.3)
-            # Reaching here at all proves the ladder escalated past the EOF
-            # rung and reaped the child via terminate.
+                pid = await _pid_from_stderr(stderr_log)
         finally:
             manager_mod.STDIO_EXIT_GRACE_S = original
+        # Rung 2 awaits ``process.wait()`` after terminating, so a reaped
+        # child is GONE (not even a zombie); alive means the ladder never
+        # escalated past the EOF rung.
+        assert not _process_is_alive(pid), f"deaf child leaked: pid {pid}"
 
 
 class TestWindowsProcessTarget:

--- a/tests/unit/mcp/test_manager.py
+++ b/tests/unit/mcp/test_manager.py
@@ -792,6 +792,207 @@ class TestSecuritySurface:
         await manager.disconnect_all()
 
 
+class TestTeardownLatency:
+    """Quit-path teardown: concurrent across servers, bounded per connection.
+
+    The user-visible cost of these properties is the pause between the app
+    releasing the terminal and the resume hint printing: ``disconnect_all``
+    runs inside ``Session.dispose`` on every quit, so a serial or unbounded
+    teardown is experienced as "quit hangs".
+    """
+
+    @pytest.mark.asyncio
+    async def test_disconnect_all_closes_connections_concurrently(
+        self, project: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Total teardown time is the slowest close, not the sum of closes.
+
+        Serial teardown made quit latency grow with the server count
+        (measured: 1.6 s across seven real servers where the slowest single
+        one needed 0.95 s). Two closes of 0.2 s each must therefore finish
+        in ~0.2 s, not ~0.4 s — asserted through a concurrency high-water
+        mark rather than wall time, so a slow CI box cannot flake this.
+        """
+        manager = McpManager(str(project))
+        in_flight = 0
+        peak = 0
+
+        class SlowStack:
+            async def aclose(self) -> None:
+                nonlocal in_flight, peak
+                in_flight += 1
+                peak = max(peak, in_flight)
+                await asyncio.sleep(0.05)
+                in_flight -= 1
+
+        async def fake_connect(name: str, cfg: Any) -> ServerConnection:
+            conn = _make_conn(name, cfg)
+            conn.stack = cast(Any, SlowStack())
+            return conn
+
+        monkeypatch.setattr(manager, "_connect_server", fake_connect)
+        await manager.discover_and_connect()
+        assert len(manager._connections) == 2
+        await manager.disconnect_all()
+        assert peak == 2, "closes ran serially; teardown latency sums per server"
+        assert manager._connections == {}
+
+    @pytest.mark.asyncio
+    async def test_teardown_connection_bounds_a_wedged_close(
+        self, project: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A close that never returns is cancelled at the teardown bound.
+
+        A remote transport's close is network I/O (streamable-HTTP DELETEs
+        its session on a client whose connect timeout alone is 30 s), so a
+        dead network could otherwise hold quit hostage. The bound is patched
+        down for the test; what is asserted is that the cancel is delivered
+        and dispose proceeds.
+        """
+        import local_operator.mcp.manager as manager_mod
+
+        monkeypatch.setattr(manager_mod, "CONNECTION_TEARDOWN_TIMEOUT_S", 0.05)
+        manager = McpManager(str(project))
+        cancelled = asyncio.Event()
+
+        class WedgedStack:
+            async def aclose(self) -> None:
+                try:
+                    await asyncio.sleep(3600)
+                except asyncio.CancelledError:
+                    cancelled.set()
+                    raise
+
+        async def fake_connect(name: str, cfg: Any) -> ServerConnection:
+            conn = _make_conn(name, cfg)
+            conn.stack = cast(Any, WedgedStack())
+            return conn
+
+        monkeypatch.setattr(manager, "_connect_server", fake_connect)
+        await manager.discover_and_connect()
+        await asyncio.wait_for(manager.disconnect_all(), timeout=2.0)
+        assert cancelled.is_set(), "the wedged close was never cancelled"
+        assert manager._connections == {}
+
+
+class TestStdioStopIsEventDriven:
+    """The stdio ``_stop`` waits on process exit, not on a polling tick.
+
+    The 0.1 s polling loop it replaced charged up to a full tick of latency
+    per server on every quit — pure wait after the child had already exited.
+    """
+
+    @pytest.mark.asyncio
+    async def test_prompt_child_costs_no_polling_tick(self) -> None:
+        """A child that exits on stdin EOF is reaped in well under 0.1 s.
+
+        Wall-clock bound on purpose: the property under test IS latency, and
+        the old implementation fails this by construction (its first
+        returncode check happens at the 0.1 s tick). The margin (0.09 s vs
+        the old floor of ~0.1 s) is small, so the child does nothing but
+        exit; a busier assertion would flake instead of measure.
+        """
+        import sys
+        import time
+
+        from local_operator.mcp.config import MCPStdioServerConfig
+        from local_operator.mcp.manager import McpServerStderr, _stdio_transport
+
+        # Exits the moment stdin reaches EOF — the polite-quit handshake.
+        script = "import sys\nsys.stdin.read()\n"
+        cfg = MCPStdioServerConfig(command=sys.executable, args=["-c", script])
+        stderr_log = McpServerStderr("prompt")
+        async with _stdio_transport(cfg, lambda: None, stderr_log):
+            # Give the child a beat to reach its read() before teardown.
+            await asyncio.sleep(0.3)
+            t0 = time.monotonic()
+        elapsed = time.monotonic() - t0
+        assert elapsed < 0.09, f"teardown took {elapsed:.3f}s; polling tick is back"
+
+    @pytest.mark.asyncio
+    async def test_stubborn_child_is_killed_on_cancellation(self) -> None:
+        """Cancelling a bounded teardown must not leak the child process.
+
+        ``_teardown_connection`` cancels the stack close at its bound; the
+        cancel lands inside ``_stop``'s waits, and absorbing it without a
+        kill would leave the server running past the session.
+        """
+        import signal
+        import sys
+
+        import local_operator.mcp.manager as manager_mod
+        from local_operator.mcp.config import MCPStdioServerConfig
+        from local_operator.mcp.manager import McpServerStderr, _stdio_transport
+
+        # Ignores stdin EOF and SIGTERM: only SIGKILL removes it.
+        script = (
+            "import signal, sys, time\n"
+            "signal.signal(signal.SIGTERM, signal.SIG_IGN)\n"
+            "print('pid', flush=True)\n"
+            "while True: time.sleep(0.2)\n"
+        )
+        cfg = MCPStdioServerConfig(command=sys.executable, args=["-c", script])
+        stderr_log = McpServerStderr("stubborn")
+
+        async def run() -> None:
+            cm = _stdio_transport(cfg, lambda: None, stderr_log)
+            async with cm:
+                # Park until cancelled; teardown then runs under cancellation,
+                # which is the state a bounded dispose delivers it in.
+                await asyncio.sleep(3600)
+
+        original = manager_mod.STDIO_EXIT_GRACE_S
+        manager_mod.STDIO_EXIT_GRACE_S = 0.2  # keep the ladder fast in CI
+        try:
+            task = asyncio.get_running_loop().create_task(run())
+            await asyncio.sleep(0.5)  # let the child start
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+        finally:
+            manager_mod.STDIO_EXIT_GRACE_S = original
+        # The transport's finally ran under cancellation; the child must be
+        # gone. We cannot read its pid from outside the closure, so assert
+        # the observable: no python child of ours is still running the
+        # stubborn script.
+        import subprocess as sp
+
+        out = sp.run(
+            ["pgrep", "-f", "signal.SIG_IGN"], capture_output=True, text=True
+        ).stdout.strip()
+        assert out == "", f"stubborn child leaked: pids {out!r}"
+        _ = signal  # imported for the docstring's contract, used in the child
+
+    @pytest.mark.asyncio
+    async def test_sigterm_rung_still_reaps_a_deaf_reader(self) -> None:
+        """A child that ignores stdin EOF but honours SIGTERM exits at rung 2.
+
+        Guards the escalation ladder itself: event-driven waits must still
+        escalate (EOF grace → terminate → kill) rather than returning early
+        on the first rung's timeout.
+        """
+        import sys
+
+        import local_operator.mcp.manager as manager_mod
+        from local_operator.mcp.config import MCPStdioServerConfig
+        from local_operator.mcp.manager import McpServerStderr, _stdio_transport
+
+        # Never reads stdin; dies on SIGTERM (the default disposition).
+        script = "import time\nwhile True: time.sleep(0.2)\n"
+        cfg = MCPStdioServerConfig(command=sys.executable, args=["-c", script])
+        stderr_log = McpServerStderr("deaf")
+        # Shrink the per-rung grace so the EOF rung times out quickly.
+        original = manager_mod.STDIO_EXIT_GRACE_S
+        manager_mod.STDIO_EXIT_GRACE_S = 0.2
+        try:
+            async with _stdio_transport(cfg, lambda: None, stderr_log):
+                await asyncio.sleep(0.3)
+            # Reaching here at all proves the ladder escalated past the EOF
+            # rung and reaped the child via terminate.
+        finally:
+            manager_mod.STDIO_EXIT_GRACE_S = original
+
+
 class TestWindowsProcessTarget:
     """MCP-10: the Win32 spawn target is ONE string (no list2cmdline pass)."""
 


### PR DESCRIPTION
## Why

Quitting the TUI with a double Ctrl+C left a visible pause between the terminal being handed back and the resume hint printing. The app looks gone — alternate screen released, shell scrollback restored — and the user sits at a dead prompt while teardown finishes behind it.

Profiling a real configured session (7 MCP servers) put nearly all of it in one place. `McpManager.disconnect_all` runs from `Session.dispose` on every quit, via the dispose hook `session_factory` registers:

```
##PHASE settle_shell:        0.000s
##PHASE close_browser:       0.000s
##PHASE flush_name:          0.000s
##PHASE mcp.disconnect_all:  0.751s   <-- effectively all of it
##PHASE Session.dispose:     0.751s
##PHASE on_unmount:          0.875s
##PHASE App._shutdown:       0.878s
```

Per-connection timing showed the shape — independent I/O paid one after another:

```
##CONN slack: 0.114s   ##CONN cloudflare: 0.000s  ##CONN hubspot: 0.096s
##CONN linear: 0.001s  ##CONN notion: 0.057s      ##CONN datadog: 0.953s
##CONN google-workspace: 0.411s
##ALL disconnect_all: 1.632s
```

So quit latency grew with the server count: 1.63s across seven servers whose slowest single close was 0.95s. Nothing about the closes needs ordering — each pops its own entry from `_connections` and closes its own `AsyncExitStack`.

Two smaller wastes sat underneath it. The stdio `_stop` ladder polled `process.returncode` on a 100ms tick, so a child that exited 1ms after a poll still cost ~99ms of pure latency per rung — on the one path where that latency is user-visible. And `_teardown_connection` was unbounded, while the streamable-HTTP transport's close DELETEs its session over an HTTP client whose *connect* timeout alone is 30s: a dead network could hold quit far past any bound the session applies elsewhere (turn abort, browser close, and title flush are all 5s).

## What changes

Three changes to `local_operator/mcp/manager.py`. None alters what teardown *does*:

- **`disconnect_all` closes the connection stacks concurrently** (`asyncio.gather`, `return_exceptions=True`). The teardowns share no state, so serial order only bought the wait.
- **`_teardown_connection` bounds one close** at `CONNECTION_TEARDOWN_TIMEOUT_S = 5.0`, matching the session's other dispose bounds. On timeout the close is cancelled; the existing `suppress(Exception)` covers `TimeoutError`, and a real cancellation from above still propagates.
- **The stdio `_stop` ladder awaits `process.wait()` under a deadline** (`STDIO_EXIT_GRACE_S = 2.0`) instead of polling. Patience per rung is unchanged (the old loop was 20 × 0.1s); only the wake latency is. It also **kills the child if cancelled**, so the new teardown bound cannot leak a server process that outlives the session — on Linux `start_new_session` detaches it from our process group, so it would not die with us.

`STDERR_DRAIN_GRACE_S` keeps its 0.25s value: single-connection paths (`/mcp reconnect`, `disconnect_server`) still pay it inline with nothing to overlap it. Its comment, which justified the value by "`disconnect_all` tears connections down one at a time", is corrected.

## Testing evidence

**End-to-end, in a pty, on this machine with the same 7 configured MCP servers.** A harness starts the real TUI on a pty, lets it boot, sends Ctrl+C twice, and timestamps the alternate-screen release (`ESC[?1049l` — the moment the app looks quit) against process exit. Everything in that gap is teardown the user sits through:

| run | before (`origin/main`) | after |
| --- | --- | --- |
| 1 | 0.971s | 0.595s |
| 2 | 1.307s | 0.724s |
| 3 | 0.971s | 0.710s |

Same binary, same venv, same session config — the "before" rows are the identical harness with only `manager.py` stashed. Phase profile after the change, matching the one above:

```
##PHASE mcp.disconnect_all:  0.254s   (was 0.751s)
##PHASE Session.dispose:     0.255s   (was 0.751s)
##PHASE on_unmount:          0.448s   (was 0.875s)
##PHASE App._shutdown:       0.452s   (was 0.878s)
```

Per-connection after: the total is now the slowest single close (`datadog` 0.253s) rather than the sum — `##ALL disconnect_all: 0.254s`, down from 1.632s.

**New regression tests** (5, in `tests/unit/mcp/test_manager.py`), each failing against the pre-change code:

- `test_disconnect_all_closes_connections_concurrently` — asserts a concurrency high-water mark of 2, not wall time, so a slow CI box cannot flake it.
- `test_teardown_connection_bounds_a_wedged_close` — a close that sleeps forever is cancelled at the bound and dispose proceeds.
- `test_prompt_child_costs_no_polling_tick` — a real child process that exits on stdin EOF is reaped in <0.09s; the old implementation fails by construction, since its first `returncode` check happens at the 0.1s tick.
- `test_stubborn_child_is_killed_on_cancellation` — a real child that ignores SIGTERM does not survive a cancelled teardown (asserted via `pgrep`, i.e. no leaked process).
- `test_sigterm_rung_still_reaps_a_deaf_reader` — the escalation ladder still escalates (EOF grace → terminate → kill) rather than returning early on the first rung's timeout.

**Suites and gates**, run over the whole tree exactly as CI does:

- `tests/unit`: **5776 passed, 7 skipped** (914s)
- `tests/unit/mcp/test_manager.py`: 43 passed
- `flake8 .` clean · `black --check .` 439 files unchanged · `isort --check .` clean · `pyright .` **0 errors, 0 warnings**

## Risk and rollback

Change class C1 — a bounded latency fix on the teardown path, no contract or data change. The blast radius is session dispose and `/mcp reconnect`; both are exercised by the tests above and by the pty runs. Rollback is a straight revert of the single commit.
