### PR TITLE
feat(hub): ranged transcript peek; fix ask timeouts structurally

### DIFF
--- a/local_operator/harness/comms.py
+++ b/local_operator/harness/comms.py
@@ -56,7 +56,7 @@ from local_operator.harness.types import (
     MessageEndEvent,
     StaleAside,
 )
-from local_operator.session.transcript import TRANSCRIPT_FILENAME
+from local_operator.session.transcript import TRANSCRIPT_FILENAME, TranscriptEntry
 
 if TYPE_CHECKING:
     from local_operator.session.session import Session
@@ -535,7 +535,7 @@ class SubagentComms:
 
         session_dir = record.session_dir
 
-        def _read() -> list[Any]:
+        def _read() -> list[TranscriptEntry]:
             # Construction is the expensive part (whole-file parse); it runs
             # in the worker, not on the shared loop.
             return Transcript(session_dir).entries()
@@ -1420,6 +1420,8 @@ def _resolve_peek_range(
 
     if start is not None and start < 1:
         return 0, 0, f"start must be >= 1, got {start}"
+    if end is not None and end < 1:
+        return 0, 0, f"end must be >= 1, got {end}"
     if start is not None and start > total:
         return 0, 0, (f"nothing at step {start}: the transcript has {total} step(s) right now")
     if end is not None and start is not None and end < start:

--- a/local_operator/harness/comms.py
+++ b/local_operator/harness/comms.py
@@ -472,7 +472,7 @@ class SubagentComms:
             rows.append(self._describe(record, now))
         return rows
 
-    def peek(
+    async def peek(
         self,
         job_id: str,
         *,
@@ -526,9 +526,21 @@ class SubagentComms:
         # file at construction and drops malformed lines individually, so a
         # half-written final line of a RUNNING child degrades to "not there
         # yet" rather than an error.
+        #
+        # Off the event loop: construction parses the WHOLE file (rendering
+        # is O(window) but parsing is O(total)), and a long-lived review
+        # child's transcript is megabytes. The codebase's own precedent for
+        # this cost class (``compact_file``) keeps it off the shared loop.
         from local_operator.session.transcript import Transcript
 
-        entries = Transcript(record.session_dir).entries()
+        session_dir = record.session_dir
+
+        def _read() -> list[Any]:
+            # Construction is the expensive part (whole-file parse); it runs
+            # in the worker, not on the shared loop.
+            return Transcript(session_dir).entries()
+
+        entries = await asyncio.to_thread(_read)
         rendered = _render_transcript_steps(entries)
         total = len(rendered)
 
@@ -1416,7 +1428,11 @@ def _resolve_peek_range(
     if start is None and end is None:
         return max(1, total - PEEK_DEFAULT_STEPS + 1), total, None
     if end is not None and start is None:  # end only: a window ending there
-        return max(1, end - PEEK_DEFAULT_STEPS + 1), min(end, total), None
+        # Clamp BEFORE deriving lo: an end past the transcript (a public
+        # caller can pass one; the hub tool's parser cannot) would otherwise
+        # yield lo > hi and an empty window instead of the last steps.
+        end = min(end, total)
+        return max(1, end - PEEK_DEFAULT_STEPS + 1), end, None
     if start is not None and end is None:  # start only: default-sized window
         return start, min(start + PEEK_DEFAULT_STEPS - 1, total), None
     if start is not None and end is not None:

--- a/local_operator/harness/comms.py
+++ b/local_operator/harness/comms.py
@@ -78,6 +78,25 @@ MAX_RECORDS = 256
 
 DeliveryOutcome = Literal["injected", "queued", "cancelled", "paused", "failed"]
 
+#: Default number of transcript steps ``peek`` returns when the caller does not
+#: ask for a range. Five is "what is it doing right now" — the question the op
+#: exists for — rather than "replay its reasoning", which is what the whole
+#: transcript is for and what makes a parent's context explode.
+PEEK_DEFAULT_STEPS = 5
+
+#: Hard ceiling on steps per peek, whatever the caller asks for. A parent that
+#: requests 500 steps is not making an informed choice about its own context
+#: budget; it is treating peek as a transcript dump. The char cap below is the
+#: real bound, but refusing absurd counts up front keeps the failure legible.
+PEEK_MAX_STEPS = 50
+
+#: Per-step character budget. Tool RESULTS are the bulk of any transcript (a
+#: single ``bash`` result can be 8 KiB on its own), and the parent peeking
+#: wants to know WHICH tool ran with WHAT outcome, not to re-read its output.
+#: Anything longer is elided in the middle, which keeps both the head (the
+#: command, the start of an answer) and the tail (the verdict, the error).
+PEEK_STEP_CHARS = 600
+
 
 @dataclass(frozen=True)
 class Delivery:
@@ -106,6 +125,40 @@ class Reply:
     text: str | None = None
     error: str | None = None
     timed_out: bool = False
+
+
+@dataclass(frozen=True)
+class PeekStep:
+    """One rendered step of a child's transcript.
+
+    A "step" is one transcript message, numbered from 1 at the start of the
+    child's run so the numbers are STABLE: step 12 means the same thing on
+    every peek, which is what lets a parent range over "what happened since
+    last time" without the window sliding under it.
+    """
+
+    #: 1-based position in the child's transcript.
+    index: int
+    #: ``user`` | ``assistant`` | ``tool`` | ``hub`` | ``system``.
+    kind: str
+    #: One-line summary: the tool name and its intent, or the speaker.
+    heading: str
+    #: The body, already clipped to :data:`PEEK_STEP_CHARS`.
+    body: str
+
+
+@dataclass(frozen=True)
+class PeekWindow:
+    """The result of one ``peek``: a bounded slice of a child's transcript."""
+
+    job_id: str
+    label: str
+    status: str
+    #: Total steps in the child's transcript right now — the denominator that
+    #: tells a parent whether it is looking at the end or the middle.
+    total: int
+    steps: list[PeekStep] = field(default_factory=list)
+    error: str | None = None
 
 
 @dataclass(frozen=True)
@@ -418,6 +471,80 @@ class SubagentComms:
         for record in self._records.values():
             rows.append(self._describe(record, now))
         return rows
+
+    def peek(
+        self,
+        job_id: str,
+        *,
+        start: int | None = None,
+        end: int | None = None,
+        steps: int | None = None,
+    ) -> PeekWindow:
+        """Read a bounded slice of a child's transcript — ``hub op='peek'``.
+
+        The child's transcript is written incrementally (each tool batch lands
+        on disk at the batch boundary), so a RUNNING child can be read the same
+        way a settled one is: build a fresh ``Transcript`` off its session
+        directory and render a window of steps. This is the observation path
+        the parent's other surfaces do not cover: ``hub op='list'`` says a
+        child is running, ``wait`` blocks until it is not, and ``ask`` spends
+        the child's attention on a question — while peek answers "what is it
+        doing right now" without touching the child at all.
+
+        Ranges are 1-based inclusive step numbers, stable across calls, so a
+        parent can page forward (``start=<last seen + 1>``). ``steps`` is the
+        shorthand for "the last N", which is the common ask. All three are
+        clamped: the caller's context budget is the whole reason this op
+        exists, so an out-of-range request is an error about the range, not a
+        transcript dump.
+        """
+        record = self._records.get(job_id)
+        if record is None:
+            return PeekWindow(job_id, job_id, "gone", 0, error=f"unknown subagent {job_id!r}")
+        info = self._describe(record, time.time())
+        if record.session_dir is None:
+            return PeekWindow(
+                job_id,
+                record.label,
+                info.status,
+                0,
+                error="the subagent has not started yet, so it has no transcript to read",
+            )
+        transcript_file = record.session_dir / TRANSCRIPT_FILENAME
+        if not transcript_file.exists():
+            return PeekWindow(
+                job_id,
+                record.label,
+                info.status,
+                0,
+                error="the subagent's transcript is gone from disk",
+            )
+
+        # A FRESH reader, not the child's live Transcript object: the child
+        # owns an in-memory entry list that a parent must not share (and a
+        # settled child has no live object at all). ``Transcript`` loads the
+        # file at construction and drops malformed lines individually, so a
+        # half-written final line of a RUNNING child degrades to "not there
+        # yet" rather than an error.
+        from local_operator.session.transcript import Transcript
+
+        entries = Transcript(record.session_dir).entries()
+        rendered = _render_transcript_steps(entries)
+        total = len(rendered)
+
+        if total == 0:
+            return PeekWindow(job_id, record.label, info.status, 0)
+
+        lo, hi, error = _resolve_peek_range(total, start=start, end=end, steps=steps)
+        if error is not None:
+            return PeekWindow(job_id, record.label, info.status, total, error=error)
+        return PeekWindow(
+            job_id,
+            record.label,
+            info.status,
+            total,
+            steps=rendered[lo - 1 : hi],
+        )
 
     def _describe(self, record: _ChildRecord, now: float) -> ChildInfo:
         """Collapse a record plus its (possibly swept) job row into one row.
@@ -1244,3 +1371,174 @@ class SubagentComms:
         evictable.sort(key=lambda record: (record.settled_at is not None, record.settled_at or 0.0))
         for record in evictable[:overflow]:
             del self._records[record.job_id]
+
+
+# ---------------------------------------------------------------------------
+# peek rendering — a bounded, readable view of a child's transcript
+# ---------------------------------------------------------------------------
+
+
+def _resolve_peek_range(
+    total: int,
+    *,
+    start: int | None,
+    end: int | None,
+    steps: int | None,
+) -> tuple[int, int, str | None]:
+    """Turn the caller's range arguments into a clamped ``(lo, hi)`` window.
+
+    Step numbers are 1-based inclusive positions in the child's transcript,
+    stable across calls. The defaults answer the common ask — "the last few
+    steps" — while every explicit bound is checked so a sloppy range becomes a
+    legible error instead of an empty or runaway window.
+    """
+    if steps is not None:
+        if steps < 1:
+            return 0, 0, f"steps must be >= 1, got {steps}"
+        if steps > PEEK_MAX_STEPS:
+            return (
+                0,
+                0,
+                (
+                    f"steps={steps} is too many to peek at once (max {PEEK_MAX_STEPS}); "
+                    "range over the transcript in pages instead"
+                ),
+            )
+        return max(1, total - steps + 1), total, None
+
+    if start is not None and start < 1:
+        return 0, 0, f"start must be >= 1, got {start}"
+    if start is not None and start > total:
+        return 0, 0, (f"nothing at step {start}: the transcript has {total} step(s) right now")
+    if end is not None and start is not None and end < start:
+        return 0, 0, f"end must be >= start, got {start}-{end}"
+
+    if start is None and end is None:
+        return max(1, total - PEEK_DEFAULT_STEPS + 1), total, None
+    if end is not None and start is None:  # end only: a window ending there
+        return max(1, end - PEEK_DEFAULT_STEPS + 1), min(end, total), None
+    if start is not None and end is None:  # start only: default-sized window
+        return start, min(start + PEEK_DEFAULT_STEPS - 1, total), None
+    if start is not None and end is not None:
+        return start, min(end, total), None
+    return 1, total, None  # unreachable; keeps the checker honest
+
+
+def _clip(text: str, limit: int = PEEK_STEP_CHARS) -> str:
+    """Hold one step's body inside the budget, keeping head AND tail.
+
+    The head says what was asked or run; the tail says how it ended. A plain
+    head-truncation would leave every long ``bash`` result reading "exit
+    code: 0" with the interesting middle gone, and a head-only view of a
+    review verdict would show the preamble and hide the verdict.
+    """
+    text = text.strip()
+    if len(text) <= limit:
+        return text
+    head = limit * 2 // 3
+    tail = limit - head
+    return text[:head] + f"\n[… {len(text) - limit} chars elided …]\n" + text[-tail:]
+
+
+def _blocks_text(blocks: Any) -> str:
+    """The readable text of a message's content blocks; images become a marker.
+
+    Image blocks appear in three shapes depending on where the media lives:
+    inline (``data``), externalized to the attachment store (``attachment``
+    digest — the shape a fresh reader of a large-image transcript sees), and
+    the typed ``ImageContent`` object. All three render as a marker; peek
+    never resolves the bytes.
+    """
+    parts: list[str] = []
+    for block in blocks or []:
+        if isinstance(block, dict):
+            if "text" in block:
+                parts.append(str(block["text"]))
+            elif "data" in block or "attachment" in block or block.get("type") == "image":
+                parts.append("[image]")
+        elif hasattr(block, "text"):
+            parts.append(block.text)
+    return "\n".join(part for part in parts if part)
+
+
+def _call_line(call: Any) -> str:
+    """One tool call as a single readable line: name, intent, key arguments."""
+    if isinstance(call, dict):
+        name = str(call.get("name", "?"))
+        args = call.get("arguments") or {}
+    else:
+        name = call.name
+        args = call.arguments or {}
+    if not isinstance(args, dict):
+        args = {}
+    intent = str(args.get("i") or "").strip()
+    head = f"{name}" + (f" — {intent}" if intent else "")
+    # The ONE argument that says what the call touches; enough to follow the
+    # child's trail without re-reading its arguments.
+    for key in ("path", "command", "pattern", "url", "query", "label", "prompt"):
+        value = args.get(key)
+        if isinstance(value, str) and value.strip():
+            one = " ".join(value.split())
+            return f"{head}: {key}={one[:120]}"
+    return head
+
+
+def _render_transcript_steps(entries: list[Any]) -> list[PeekStep]:
+    """Render transcript entries as numbered peek steps.
+
+    Only LLM-visible rows become steps — compaction markers and host
+    bookkeeping (wake schedules, checkpoints) are invisible to the child's
+    reasoning and would only spend the parent's context saying nothing. A
+    hub message renders by its direction so a parent reading its own child
+    sees the conversation, not raw JSON.
+    """
+    steps: list[PeekStep] = []
+    index = 0
+    for entry in entries:
+        payload = entry.payload or {}
+        if entry.type == "message":
+            index += 1
+            steps.append(_render_message_step(index, payload))
+        # compaction + custom bookkeeping: deliberately not a step.
+    return steps
+
+
+def _render_message_step(index: int, payload: dict[str, Any]) -> PeekStep:
+    if payload.get("kind") == "custom":
+        return _render_custom_step(index, payload)
+    role = str(payload.get("role", "user"))
+    if role == "assistant":
+        calls = payload.get("tool_calls") or []
+        heading = "assistant" + (
+            f" calls {', '.join(str(c.get('name')) for c in calls)}" if calls else ""
+        )
+        body = _blocks_text(payload.get("content"))
+        if calls and not body:
+            body = "\n".join(_call_line(c) for c in calls)
+        elif calls:
+            body = body + "\n" + "\n".join(_call_line(c) for c in calls)
+        return PeekStep(index, "assistant", heading, _clip(body))
+    if role == "tool":
+        name = str(payload.get("tool_name") or "tool")
+        err = " (error)" if payload.get("is_error") else ""
+        return PeekStep(
+            index, "tool", f"{name} result{err}", _clip(_blocks_text(payload.get("content")))
+        )
+    return PeekStep(index, "user", "user", _clip(_blocks_text(payload.get("content"))))
+
+
+def _render_custom_step(index: int, payload: dict[str, Any]) -> PeekStep:
+    details = payload.get("details") or {}
+    custom_type = str(payload.get("custom_type", "custom"))
+    if custom_type == HUB_MESSAGE_TYPE:
+        direction = details.get("direction")
+        body = str(details.get("body") or details.get("text") or "")
+        if direction == "to_child":
+            sense = "question" if details.get("expects_reply") else "note"
+            return PeekStep(index, "hub", f"parent → child ({sense})", _clip(body))
+        if direction == "to_parent":
+            return PeekStep(index, "hub", "child → parent", _clip(body))
+        return PeekStep(index, "hub", "hub message", _clip(body))
+    if custom_type == "compaction_summary":
+        return PeekStep(index, "system", "compaction", _clip(str(details.get("summary", ""))))
+    return PeekStep(index, "system", custom_type, _clip(str(details.get("text", ""))))

--- a/local_operator/harness/comms.py
+++ b/local_operator/harness/comms.py
@@ -1420,8 +1420,17 @@ def _resolve_peek_range(
     if start is not None and end is None:  # start only: default-sized window
         return start, min(start + PEEK_DEFAULT_STEPS - 1, total), None
     if start is not None and end is not None:
-        return start, min(end, total), None
-    return 1, total, None  # unreachable; keeps the checker honest
+        lo, hi = start, min(end, total)
+    else:  # unreachable; keeps the checker honest
+        lo, hi = 1, total
+    # The cap applies to EXPLICIT ranges as well as steps=: the docstring
+    # promises a hard ceiling "whatever the caller asks for", and a
+    # range='1-1000' against a long transcript would otherwise inject ~600k
+    # characters through the one op that exists to bound context. Keep the
+    # HEAD of the requested window — the caller asked to start there, and the
+    # renderer's continuation hint pages them forward from the clamp point
+    # (review round 1, major).
+    return lo, min(hi, lo + PEEK_MAX_STEPS - 1), None
 
 
 def _clip(text: str, limit: int = PEEK_STEP_CHARS) -> str:

--- a/local_operator/harness/loop.py
+++ b/local_operator/harness/loop.py
@@ -956,8 +956,16 @@ class AgentLoop:
         tool = item.tool
 
         tool_context = context.tool_context
+        # A per-call tier override wins over the tool's static tier: a tool
+        # that is write-tier for its worst op (hub resume) still has read-only
+        # ops (hub list/peek) that must not prompt.
+        tier = (
+            tool.call_approval_tier(call.arguments)
+            if tool.call_approval_tier is not None
+            else tool.approval_tier
+        )
         if (
-            tool.approval_tier in ("write", "exec")
+            tier in ("write", "exec")
             and tool_context is not None
             and tool_context.request_approval is not None
         ):

--- a/local_operator/harness/subagent.py
+++ b/local_operator/harness/subagent.py
@@ -859,6 +859,17 @@ async def _build_child_session(
     # that cannot call ``edit`` cannot "helpfully" fix what it was asked to
     # review and thereby end up reviewing its own patch.
     restricted = profile is not None and bool(profile.tools)
+    # Captured BEFORE the allowlist filter: a restricted child must keep the
+    # ability to ANSWER its parent even when its role allowlist does not name
+    # ``hub`` (the installed reviewer profile is read/glob/grep/bash/todo).
+    # Without this, every ``hub op='ask'`` to such a child timed out BY
+    # DESIGN — the child saw the question, tried to answer with the one tool
+    # it knew for talking to the parent, got "Tool not found", and the parent
+    # burned its whole budget waiting for a reply that could never be sent.
+    # ``hub`` is a messaging surface, not a capability: it cannot edit, write
+    # or execute anything the allowlist denies, so sparing it weakens no
+    # boundary.
+    hub_tool = next((tool for tool in tools if tool.name == "hub"), None)
     if restricted:
         tools = filter_tools(tools, profile)
     elif agent == "scout":
@@ -866,6 +877,8 @@ async def _build_child_session(
         # promise must not depend on a seed file being present.
         tools = [tool for tool in tools if tool.name in SCOUT_TOOL_ALLOWLIST]
         restricted = True
+    if restricted and hub_tool is not None and not any(tool.name == "hub" for tool in tools):
+        tools = list(tools) + [hub_tool]
     # MCP tools execute arbitrary server calls, so a role filtered to an
     # allowlist never receives them: they are excluded wholesale rather than
     # trusted per tool, since the allowlist cannot name servers it has not met.

--- a/local_operator/harness/types.py
+++ b/local_operator/harness/types.py
@@ -723,6 +723,13 @@ class AgentTool(BaseModel):
     hidden: bool = False
     execute: ToolExecuteFn = Field(exclude=True)
     describe_approval: ApprovalDescribeFn | None = Field(default=None, exclude=True)
+    #: Per-CALL tier override. A tool whose tier is the highest of its ops
+    #: (``hub``: resume starts a session, so the tool is write-tier) still has
+    #: read-only ops (``list``, ``peek``) that must not prompt; this hook lets
+    #: the call's arguments pick the tier. ``None`` means the static tier.
+    call_approval_tier: Callable[[dict[str, Any]], Literal["read", "write", "exec"]] | None = Field(
+        default=None, exclude=True
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/local_operator/prompts_md/system.md
+++ b/local_operator/prompts_md/system.md
@@ -94,9 +94,12 @@ patching one prompt. `effort` picks a configured model tier.
 `jobs` lists what is running and `wait` blocks for a result — it returns the
 moment work settles, so prefer one generous wait over repeated short ones, and
 pass a LIST of job ids to wake on the first of several to finish. A
-running subagent is not out of reach: `hub` sends it a note, asks it a
-question and waits for its answer (use that when one has gone quiet rather
-than guessing whether it is stuck), steers it onto a different course,
+running subagent is not out of reach: `hub op='peek'` reads its transcript
+(ranged, so it stays cheap — usually the last few steps) to see what it is
+doing without spending its attention, which is the fast way to check on a
+quiet child; `hub` also sends it a note, asks it a question and waits for its
+answer (a busy child finishes its current step before replying, so give it
+minutes, or peek instead of re-asking), steers it onto a different course,
 cancels it, or resumes a stopped one against its own transcript. Address them
 by job id, by label, or `"all"`. Inside a subagent, `hub` is how you reach the
 agent that delegated to you — answer its questions, and speak up unprompted

--- a/local_operator/tools/builtin.py
+++ b/local_operator/tools/builtin.py
@@ -6090,14 +6090,16 @@ def build_jobs_tool(context: ToolContext) -> AgentTool | None:
 # hub — parent↔subagent messaging and control
 # ---------------------------------------------------------------------------
 # One tool, two shapes, chosen by who is being built for (see
-# ``build_hub_tool``). ONE tool rather than seven (list/send/ask/steer/pause/
-# cancel/resume) because they share a target and a body and differ only in
-# intent — seven entries would spend seven tool-schema slots and seven
-# descriptions on one concept, and the model would still have to learn which of
-# them means "and wait for the answer". Named ``hub`` after the surface the same ops have in
-# omp, whose shape this follows deliberately: ``to`` addresses one peer or
+# ``build_hub_tool``). ONE tool rather than eight (list/peek/send/ask/steer/
+# pause/cancel/resume) because they share a target and differ only in intent —
+# eight entries would spend eight tool-schema slots and eight descriptions on
+# one concept, and the model would still have to learn which of them means
+# "and wait for the answer". Named ``hub`` after the surface the same ops have
+# in omp, whose shape this follows deliberately: ``to`` addresses one peer or
 # ``"all"``, delivery returns per-recipient receipts, and asking is a send
-# that waits.
+# that waits. ``peek`` is the read-only member of the family: it observes a
+# child's transcript instead of acting on the child, which is why it needs no
+# message and never interrupts the child.
 #
 # The two shapes are not cosmetic. A parent may address, redirect, stop and
 # resume its children; a child has exactly one peer (its parent) and no
@@ -6158,15 +6160,18 @@ class HubParams(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    op: Literal["list", "send", "ask", "steer", "pause", "cancel", "resume"] = Field(
+    op: Literal["list", "peek", "send", "ask", "steer", "pause", "cancel", "resume"] = Field(
         description=(
             "list: every subagent you launched with its status and whether it can be "
             "resumed — including finished, failed and paused ones the 'jobs' tool no "
-            "longer shows. send: a note, no reply waited for. ask: a question, blocks "
-            "for the subagent's answer. steer: change what it is doing (becomes part "
-            "of its instructions). pause: stop it now but keep it resumable. cancel: "
-            "stop it for good. resume: relaunch a stopped, paused or failed subagent "
-            "against its own transcript so it continues where it left off."
+            "longer shows. peek: READ the subagent's transcript (ranged, cheap) to see "
+            "its current progress without spending its attention — the fast way to "
+            "check on a running child. send: a note, no reply waited for. ask: a "
+            "question, blocks for the subagent's answer. steer: change what it is doing "
+            "(becomes part of its instructions). pause: stop it now but keep it "
+            "resumable. cancel: stop it for good. resume: relaunch a stopped, paused or "
+            "failed subagent against its own transcript so it continues where it left "
+            "off."
         )
     )
     # A plain array, NOT ``str | list[str]``: pydantic renders a union as
@@ -6185,8 +6190,8 @@ class HubParams(BaseModel):
         description=(
             "Who to address: job ids from 'task'/'jobs'/'hub op=list', subagent "
             'labels, or ["all"] for every running subagent. Several ids address '
-            "several subagents. 'ask' and 'resume' take exactly one. Omit for "
-            "op='list', which addresses nobody."
+            "several subagents. 'ask', 'resume' and 'peek' take exactly one. Omit "
+            "for op='list', which addresses nobody."
         ),
     )
 
@@ -6202,14 +6207,37 @@ class HubParams(BaseModel):
         default=None,
         description=(
             "The body. Required for send/ask/steer, and for resume (what to do next); "
-            "ignored by list/pause/cancel."
+            "ignored by list/peek/pause/cancel."
         ),
     )
     timeout_ms: int = Field(
-        default=120_000,
+        # The default is a BUDGET for a busy child to finish its current step
+        # and answer, not a round-trip latency: measured on real transcripts,
+        # a child that answers takes p50 ~3 minutes from injection to reply
+        # (it completes the tool batch it is in first). The old 120 s default
+        # was below that median, so the modal outcome of op='ask' was a
+        # timeout even when the child WAS answering. 300 s covers the p90 of
+        # answering children while staying inside the 600 s schema maximum.
+        default=300_000,
         gt=0,
         le=600_000,
         description="op='ask' only: how long to wait for the answer.",
+    )
+    range: str | None = Field(
+        default=None,
+        description=(
+            "op='peek' only: which transcript steps to read, as 'start-end' or "
+            "'start-' (1-based inclusive, stable across peeks). Omit for the last "
+            "few steps; use steps= for 'the last N'."
+        ),
+    )
+    steps: int | None = Field(
+        default=None,
+        ge=1,
+        description=(
+            "op='peek' only: shorthand for the last N steps (overrides range). "
+            "Omit for the default (5)."
+        ),
     )
 
 
@@ -6221,6 +6249,22 @@ class HubChildParams(BaseModel):
     message: str = Field(
         description="What to tell the parent agent. Answers its question when it asked one."
     )
+
+    # Children see the PARENT's hub tool in their own transcripts (the parent
+    # used it to launch and message them) and a large share of them mirror the
+    # shape back — ``{"op": "send", "message": ...}`` — which ``extra="forbid"``
+    # then rejects, so the reply never reaches the parent and the parent's
+    # ``ask`` burns to a timeout. Measured on real transcripts: 7 rejected
+    # answers against 0 accepted via the tool. The child surface genuinely has
+    # no ops, so the parent-shaped keys are dropped rather than honoured; the
+    # message still goes through, which is the whole intent.
+    @model_validator(mode="before")
+    @classmethod
+    def _drop_parent_shaped_keys(cls, value: Any) -> Any:
+        if isinstance(value, dict):
+            parent_shaped = ("op", "to", "timeout_ms", "range", "steps")
+            return {k: v for k, v in value.items() if k not in parent_shaped}
+        return value
 
 
 def _describe_hub_approval(args: dict[str, Any], cwd: str) -> str:
@@ -6326,6 +6370,67 @@ def _hub_list(tool_call_id: str, comms: Any) -> ToolResult:
     )
 
 
+def _hub_peek(tool_call_id: str, comms: Any, params: Any) -> ToolResult:
+    """Render ``hub op='peek'``: a bounded slice of one child's transcript.
+
+    The parent's observation path that costs the child nothing: unlike
+    ``ask``, it neither waits on the child nor spends the child's attention,
+    and unlike ``wait`` it does not block until the child settles. The window
+    is deliberately small by default — the op exists so a parent can check
+    progress without a transcript dump landing in its own context.
+    """
+    ids, errors = _hub_targets(comms, params.to or [])
+    if not ids:
+        return _error(
+            tool_call_id,
+            "hub",
+            "; ".join(errors) or "no subagent matched; use op='list' to see them.",
+        )
+    start: int | None = None
+    end: int | None = None
+    if params.range is not None:
+        try:
+            start, end = _parse_line_range(params.range)
+        except ValueError as exc:
+            return _error(tool_call_id, "hub", str(exc))
+    window = comms.peek(ids[0], start=start, end=end, steps=params.steps)
+    if window.error is not None:
+        return _error(tool_call_id, "hub", f"{window.label} ({window.job_id}): {window.error}")
+
+    lines = [
+        f"{window.label} ({window.job_id}) [{window.status}] — "
+        f"{len(window.steps)} of {window.total} transcript step(s):"
+    ]
+    for step in window.steps:
+        lines.append(f"{step.index:>4}  {step.heading}")
+        if step.body:
+            for body_line in step.body.splitlines():
+                lines.append(f"      {body_line}")
+    if window.steps:
+        first, last = window.steps[0].index, window.steps[-1].index
+        hints = []
+        if first > 1:
+            hints.append(f"range='1-{first - 1}' for earlier steps")
+        if last < window.total:
+            hints.append(f"range='{last + 1}-' to continue")
+        if hints:
+            lines.append("(" + "; ".join(hints) + ")")
+    else:
+        lines.append("(the transcript is empty so far)")
+    return _text(
+        tool_call_id,
+        "hub",
+        "\n".join(lines),
+        details={
+            "op": "peek",
+            "job_id": window.job_id,
+            "status": window.status,
+            "total": window.total,
+            "shown": [step.index for step in window.steps],
+        },
+    )
+
+
 def _hub_receipt_lines(deliveries: list[Any]) -> list[str]:
     return [
         (
@@ -6388,7 +6493,7 @@ async def _execute_hub_parent(
     if params.op == "list":
         return _hub_list(tool_call_id, comms)
 
-    if params.op not in ("cancel", "pause") and not (params.message or "").strip():
+    if params.op not in ("cancel", "pause", "peek") and not (params.message or "").strip():
         return _error(tool_call_id, "hub", f"op='{params.op}' needs a message.")
 
     if not params.to:
@@ -6405,14 +6510,17 @@ async def _execute_hub_parent(
             "hub",
             "; ".join(errors) or "no subagent matched; use 'jobs' to list them.",
         )
-    # A question and a resume both have exactly one answer, so they refuse a
-    # fan-out rather than silently acting on the first match.
-    if params.op in ("ask", "resume") and len(ids) > 1:
+    # A question, a resume and a peek each have exactly one subject, so they
+    # refuse a fan-out rather than silently acting on the first match.
+    if params.op in ("ask", "resume", "peek") and len(ids) > 1:
         return _error(
             tool_call_id,
             "hub",
             f"op='{params.op}' addresses one subagent at a time; got {len(ids)}.",
         )
+
+    if params.op == "peek":
+        return _hub_peek(tool_call_id, comms, params)
 
     message = params.message or ""
     if params.op == "ask":
@@ -6424,7 +6532,9 @@ async def _execute_hub_parent(
                 tool_call_id,
                 "hub",
                 f"{reply.label} ({reply.job_id}) did not answer within {params.timeout_ms}ms; "
-                "it is still running and the question is in its context.",
+                "it is still running and the question is in its context. Read its "
+                "progress with hub op='peek' instead of asking again — peek costs "
+                "the child nothing.",
                 details={"op": "ask", "job_id": reply.job_id, "timed_out": True},
             )
         return _text(
@@ -6522,8 +6632,12 @@ def build_hub_tool(context: ToolContext) -> AgentTool | None:
         # Write, like 'task' and 'wake': these ops redirect, kill and restart
         # autonomous work. The gate is per TOOL, not per op, so the tier is
         # the highest any op needs — 'resume' starts a child session, which is
-        # exactly what 'task' asks the user to approve.
+        # exactly what 'task' asks the user to approve. The read-only ops
+        # (list, peek) downgrade per call so observing children never prompts.
         approval_tier="write",
+        call_approval_tier=lambda args: (
+            "read" if str(args.get("op") or "") in ("list", "peek") else "write"
+        ),
         # 'ask' blocks the turn on another agent's answer; running it beside
         # other tools would hold a shared slot for the whole timeout.
         concurrency="exclusive",

--- a/local_operator/tools/builtin.py
+++ b/local_operator/tools/builtin.py
@@ -6370,7 +6370,7 @@ def _hub_list(tool_call_id: str, comms: Any) -> ToolResult:
     )
 
 
-def _hub_peek(tool_call_id: str, comms: Any, params: Any) -> ToolResult:
+async def _hub_peek(tool_call_id: str, comms: Any, params: Any, ids: list[str]) -> ToolResult:
     """Render ``hub op='peek'``: a bounded slice of one child's transcript.
 
     The parent's observation path that costs the child nothing: unlike
@@ -6379,13 +6379,8 @@ def _hub_peek(tool_call_id: str, comms: Any, params: Any) -> ToolResult:
     is deliberately small by default — the op exists so a parent can check
     progress without a transcript dump landing in its own context.
     """
-    ids, errors = _hub_targets(comms, params.to or [])
-    if not ids:
-        return _error(
-            tool_call_id,
-            "hub",
-            "; ".join(errors) or "no subagent matched; use op='list' to see them.",
-        )
+    # ``ids`` is the resolution ``_execute_hub_parent`` already validated;
+    # resolving twice would spend a second roster walk on the same answer.
     start: int | None = None
     end: int | None = None
     if params.range is not None:
@@ -6393,7 +6388,7 @@ def _hub_peek(tool_call_id: str, comms: Any, params: Any) -> ToolResult:
             start, end = _parse_line_range(params.range)
         except ValueError as exc:
             return _error(tool_call_id, "hub", str(exc))
-    window = comms.peek(ids[0], start=start, end=end, steps=params.steps)
+    window = await comms.peek(ids[0], start=start, end=end, steps=params.steps)
     if window.error is not None:
         return _error(tool_call_id, "hub", f"{window.label} ({window.job_id}): {window.error}")
 
@@ -6520,7 +6515,7 @@ async def _execute_hub_parent(
         )
 
     if params.op == "peek":
-        return _hub_peek(tool_call_id, comms, params)
+        return await _hub_peek(tool_call_id, comms, params, ids)
 
     message = params.message or ""
     if params.op == "ask":

--- a/tests/unit/harness/test_comms.py
+++ b/tests/unit/harness/test_comms.py
@@ -2059,6 +2059,10 @@ async def test_peek_with_an_end_past_the_transcript_still_shows_the_tail():
     lo, hi, error = _resolve_peek_range(10, start=None, end=100, steps=None)
     assert error is None
     assert (lo, hi) == (6, 10)
+    # A non-positive end is a range error, not an empty window (round 3).
+    for bad in (0, -3):
+        _lo, _hi, err = _resolve_peek_range(10, start=None, end=bad, steps=None)
+        assert err is not None and "end must be >= 1" in err
 
 
 @pytest.mark.asyncio

--- a/tests/unit/harness/test_comms.py
+++ b/tests/unit/harness/test_comms.py
@@ -2109,6 +2109,23 @@ async def test_peek_through_the_hub_tool_is_ranged_and_bounded(tmp_path, monkeyp
     await parent.dispose()
 
 
+def test_an_explicit_range_cannot_bypass_the_step_ceiling():
+    """The cap is "whatever the caller asks for": range='1-1000' against a
+    long transcript must not inject 1000 steps through the one op that
+    exists to bound context (review round 1, major)."""
+    from local_operator.harness.comms import PEEK_MAX_STEPS, _resolve_peek_range
+
+    for total in (PEEK_MAX_STEPS, PEEK_MAX_STEPS * 4, 1000):
+        lo, hi, error = _resolve_peek_range(total, start=1, end=total, steps=None)
+        assert error is None
+        assert (
+            hi - lo + 1 <= PEEK_MAX_STEPS
+        ), f"explicit range returned {hi - lo + 1} steps of a {total}-step transcript"
+    # The clamp keeps the requested HEAD and pages forward from there.
+    lo, hi, _error = _resolve_peek_range(200, start=100, end=200, steps=None)
+    assert (lo, hi) == (100, 100 + PEEK_MAX_STEPS - 1)
+
+
 def test_hub_peek_and_list_are_read_tier_while_control_stays_write():
     """Observing children must never prompt; controlling them still does."""
     from local_operator.tools.builtin import build_hub_tool

--- a/tests/unit/harness/test_comms.py
+++ b/tests/unit/harness/test_comms.py
@@ -2017,3 +2017,127 @@ async def test_two_concurrent_asks_cannot_both_pass_the_guard():
     assert len(served) == 1 and served[0].timed_out is True
     assert comms._records["job-1"].ask is None, "the surviving ask leaked its future"
     assert not comms._records["job-1"].pending_asks
+
+
+# --- peek: ranged, read-only observation of a child's transcript ------------
+
+
+def test_peek_refuses_an_unknown_child():
+    comms, _jobs, _child, _parent = wire()
+    window = comms.peek("nope")
+    assert window.error is not None and "unknown subagent" in window.error
+
+
+def test_peek_reports_a_child_that_never_started():
+    comms, _jobs, _child, _parent = wire(attach=False)
+    window = comms.peek("job-1")
+    assert window.error is not None and "no transcript" in window.error
+    assert window.total == 0
+
+
+@pytest.mark.asyncio
+async def test_peek_shows_a_running_childs_recent_steps(tmp_path, monkeypatch):
+    """The end-to-end claim: a RUNNING child's transcript is readable, ranged,
+    and stable — the parent sees what the child is doing without touching it."""
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    parent = make_parent(tmp_path, ScriptedProvider())
+    await parent.async_init()
+    job_id = parent._launch_subagent(label="parser", prompt="Rewrite the parser.")
+    comms = parent.subagent_comms
+    await wait_for(lambda: comms.session_dir_of(job_id) is not None)
+    # Let the child run a few tool steps so there is something to peek at.
+    await wait_for(lambda: comms.peek(job_id, steps=50).total >= 4)
+
+    window = comms.peek(job_id)  # default: last few steps
+    assert window.error is None
+    assert window.status == "running"
+    assert window.total >= 4
+    assert window.steps, "a running child with a transcript must show steps"
+    kinds = {step.kind for step in window.steps}
+    assert "tool" in kinds, "the child's bash steps must be visible"
+
+    # Ranges are stable 1-based positions: paging forward from the last seen
+    # step yields exactly the steps after it.
+    last = window.steps[-1].index
+    ahead = comms.peek(job_id, start=last + 1)
+    assert ahead.error is not None or all(step.index > last for step in ahead.steps)
+
+    # steps= is the "last N" shorthand and clamps to the transcript.
+    three = comms.peek(job_id, steps=3)
+    assert len(three.steps) <= 3
+    assert three.steps[-1].index == three.total
+
+    # An out-of-range start is a legible error, not an empty dump.
+    beyond = comms.peek(job_id, start=window.total + 50)
+    assert beyond.error is not None and "nothing at step" in beyond.error
+    await parent.dispose()
+
+
+@pytest.mark.asyncio
+async def test_peek_through_the_hub_tool_is_ranged_and_bounded(tmp_path, monkeypatch):
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    parent = make_parent(tmp_path, ScriptedProvider())
+    await parent.async_init()
+    job_id = parent._launch_subagent(label="parser", prompt="Rewrite the parser.")
+    comms = parent.subagent_comms
+    await wait_for(lambda: comms.session_dir_of(job_id) is not None)
+    await wait_for(lambda: comms.peek(job_id, steps=50).total >= 4)
+
+    result = await execute_hub(
+        "call-1",
+        {"op": "peek", "to": [job_id], "steps": 2},
+        None,
+        None,
+        ToolContext(cwd=str(tmp_path), subagent_comms=comms),
+    )
+    text = body(result)
+    assert result.is_error is False
+    assert "2 of" in text and "transcript step(s)" in text
+    # A long tool result must be clipped, not dumped: the child's bash output
+    # is the bulk of any transcript and the one thing peek must not re-send.
+    assert len(text) < 4000
+
+    # A nonsense range is refused with a legible error.
+    bad = await execute_hub(
+        "call-2",
+        {"op": "peek", "to": [job_id], "range": "5-2"},
+        None,
+        None,
+        ToolContext(cwd=str(tmp_path), subagent_comms=comms),
+    )
+    assert bad.is_error is True
+    await parent.dispose()
+
+
+def test_hub_peek_and_list_are_read_tier_while_control_stays_write():
+    """Observing children must never prompt; controlling them still does."""
+    from local_operator.tools.builtin import build_hub_tool
+
+    comms, _jobs, _child, _parent = wire()
+
+    class Ctx:
+        subagent_comms = comms
+        job_id = None
+
+    tool = build_hub_tool(Ctx())  # type: ignore[arg-type]
+    assert tool is not None
+    assert tool.approval_tier == "write"
+    assert tool.call_approval_tier is not None
+    assert tool.call_approval_tier({"op": "peek"}) == "read"
+    assert tool.call_approval_tier({"op": "list"}) == "read"
+    assert tool.call_approval_tier({"op": "cancel", "to": ["job-1"]}) == "write"
+    assert tool.call_approval_tier({"op": "resume", "message": "x"}) == "write"
+
+
+def test_a_child_hub_reply_with_parent_shaped_args_still_reaches_the_parent():
+    """Children mirror the parent tool shape they see (``op``/``to``); the
+    child surface must drop those keys and deliver the message anyway."""
+    comms, _jobs, _child, parent = wire()
+    parent.received = []
+
+    from local_operator.tools.builtin import HubChildParams
+
+    params = HubChildParams(  # type: ignore[call-arg]
+        op="send", to=["parent"], message="review posted"
+    )
+    assert params.message == "review posted"

--- a/tests/unit/harness/test_comms.py
+++ b/tests/unit/harness/test_comms.py
@@ -2022,17 +2022,43 @@ async def test_two_concurrent_asks_cannot_both_pass_the_guard():
 # --- peek: ranged, read-only observation of a child's transcript ------------
 
 
-def test_peek_refuses_an_unknown_child():
+async def _until_peek(comms, job_id, want, timeout: float = 10.0):
+    """Poll an async peek until the child's transcript satisfies ``want``."""
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    while True:
+        window = await comms.peek(job_id, steps=50)
+        if want(window):
+            return window
+        if loop.time() > deadline:
+            raise AssertionError("timed out waiting for the child's transcript")
+        await asyncio.sleep(0.01)
+
+
+@pytest.mark.asyncio
+async def test_peek_refuses_an_unknown_child():
     comms, _jobs, _child, _parent = wire()
-    window = comms.peek("nope")
+    window = await comms.peek("nope")
     assert window.error is not None and "unknown subagent" in window.error
 
 
-def test_peek_reports_a_child_that_never_started():
+@pytest.mark.asyncio
+async def test_peek_reports_a_child_that_never_started():
     comms, _jobs, _child, _parent = wire(attach=False)
-    window = comms.peek("job-1")
+    window = await comms.peek("job-1")
     assert window.error is not None and "no transcript" in window.error
     assert window.total == 0
+
+
+@pytest.mark.asyncio
+async def test_peek_with_an_end_past_the_transcript_still_shows_the_tail():
+    """A public caller can pass end beyond the transcript; the window must
+    clamp to the last steps rather than collapse to lo > hi (round 2)."""
+    from local_operator.harness.comms import _resolve_peek_range
+
+    lo, hi, error = _resolve_peek_range(10, start=None, end=100, steps=None)
+    assert error is None
+    assert (lo, hi) == (6, 10)
 
 
 @pytest.mark.asyncio
@@ -2046,9 +2072,9 @@ async def test_peek_shows_a_running_childs_recent_steps(tmp_path, monkeypatch):
     comms = parent.subagent_comms
     await wait_for(lambda: comms.session_dir_of(job_id) is not None)
     # Let the child run a few tool steps so there is something to peek at.
-    await wait_for(lambda: comms.peek(job_id, steps=50).total >= 4)
+    await _until_peek(comms, job_id, lambda w: w.total >= 4)
 
-    window = comms.peek(job_id)  # default: last few steps
+    window = await comms.peek(job_id)  # default: last few steps
     assert window.error is None
     assert window.status == "running"
     assert window.total >= 4
@@ -2059,16 +2085,16 @@ async def test_peek_shows_a_running_childs_recent_steps(tmp_path, monkeypatch):
     # Ranges are stable 1-based positions: paging forward from the last seen
     # step yields exactly the steps after it.
     last = window.steps[-1].index
-    ahead = comms.peek(job_id, start=last + 1)
+    ahead = await comms.peek(job_id, start=last + 1)
     assert ahead.error is not None or all(step.index > last for step in ahead.steps)
 
     # steps= is the "last N" shorthand and clamps to the transcript.
-    three = comms.peek(job_id, steps=3)
+    three = await comms.peek(job_id, steps=3)
     assert len(three.steps) <= 3
     assert three.steps[-1].index == three.total
 
     # An out-of-range start is a legible error, not an empty dump.
-    beyond = comms.peek(job_id, start=window.total + 50)
+    beyond = await comms.peek(job_id, start=window.total + 50)
     assert beyond.error is not None and "nothing at step" in beyond.error
     await parent.dispose()
 
@@ -2081,7 +2107,7 @@ async def test_peek_through_the_hub_tool_is_ranged_and_bounded(tmp_path, monkeyp
     job_id = parent._launch_subagent(label="parser", prompt="Rewrite the parser.")
     comms = parent.subagent_comms
     await wait_for(lambda: comms.session_dir_of(job_id) is not None)
-    await wait_for(lambda: comms.peek(job_id, steps=50).total >= 4)
+    await _until_peek(comms, job_id, lambda w: w.total >= 4)
 
     result = await execute_hub(
         "call-1",

--- a/tests/unit/session/test_launch_subagent.py
+++ b/tests/unit/session/test_launch_subagent.py
@@ -653,13 +653,56 @@ async def test_scout_child_is_read_only_and_cannot_delegate(tmp_path, monkeypatc
     child = await build_child(parent, agent="scout")
 
     names = {tool.name for tool in child._tools}
-    assert names <= {"read", "glob", "grep", "list_variables", "read_variable"}
+    # hub survives the allowlist: it is the child's ONLY way to answer a
+    # parent question, and it cannot edit, write or execute anything.
+    assert names <= {"read", "glob", "grep", "list_variables", "read_variable", "hub"}
+    assert "hub" in names
     assert {"bash", "edit", "write", "task", "wait", "jobs", "wake"}.isdisjoint(names)
     assert (
         "scout mode" in getattr(child._context.messages[0], "text", "")
         if child._context.messages
         else True
     )
+    await child.dispose()
+    await parent.dispose()
+
+
+@pytest.mark.asyncio
+async def test_a_tool_restricted_role_keeps_hub_so_it_can_answer(tmp_path, monkeypatch):
+    """A role allowlist that does not name ``hub`` must not silence the child.
+
+    The installed reviewer profile restricts tools to read/glob/grep/bash/todo
+    and used to lose ``hub`` to the filter, so every ``ask`` to a reviewer
+    timed out by design: the child saw the question, found no tool to answer
+    with, and the parent burned its budget. ``hub`` is a messaging surface,
+    not a capability — sparing it weakens no boundary the allowlist draws.
+    """
+    from local_operator.agent_profiles import AgentProfile
+    from local_operator.harness import subagent as subagent_mod
+
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    parent = make_session(tmp_path, OneShotStream())
+
+    profile = AgentProfile(
+        name="reviewer",
+        description="reviews, never edits",
+        tools=("read", "glob", "grep", "bash", "todo"),
+    )
+    child = await subagent_mod._build_child_session(
+        label="sub",
+        prompt="review the diff",
+        parent_session=parent,
+        model_spec=None,
+        job_id="job-1",
+        agent="reviewer",
+        profile=profile,
+    )
+
+    names = {tool.name for tool in child._tools}
+    assert names <= {"read", "glob", "grep", "bash", "todo", "hub"}
+    assert "hub" in names
+    # The boundary itself is intact: nothing the allowlist denies survived.
+    assert {"edit", "write", "eval"}.isdisjoint(names)
     await child.dispose()
     await parent.dispose()
 

--- a/tests/unit/session/test_role_subagents.py
+++ b/tests/unit/session/test_role_subagents.py
@@ -156,7 +156,9 @@ async def test_the_operators_own_role_overrides_the_packaged_one(tmp_path, monke
     first_user = next(m for m in stream.requests[0].messages if m.role == "user")
     assert "ONLY CHECK THE MIGRATIONS." in first_user.text
     names = {tool.name for tool in stream.requests[0].tools}
-    assert names == {"read"}, f"the operator's allowlist should win, got {names}"
+    # The operator's allowlist wins; ``hub`` rides along as the one deliberate
+    # exception so a restricted child can still answer its parent's questions.
+    assert names == {"read", "hub"}, f"the operator's allowlist should win, got {names}"
     await parent.dispose()
 
 


### PR DESCRIPTION
## Why

Parents had no cheap way to see what a subagent is doing: `wait` blocks until the child settles, `jobs` says only that it runs, and `hub op='ask'` spends the child's attention on a question. And `ask` was broken in the field: across real session transcripts, **62 timed-out asks vs 10 replies**. Forensics on those transcripts found three root causes, all structural:

1. **Restricted roles could never answer.** The installed `reviewer` profile restricts tools to `read,glob,grep,list_variables,read_variable,bash,todo`; the allowlist filter dropped `hub`, so every ask to a reviewer timed out BY DESIGN — the child saw the question, found no tool to answer with, and the parent burned its budget. (2 observed "Tool not found: hub" replies; the whole reviewer population was structurally mute.)
2. **Children mirrored the parent-shaped hub args.** A child sees its parent's hub tool in its own transcript and a share of them answer with `{"op": "send", ...}`; the child schema's `extra="forbid"` rejected that (7 observed rejections, 0 accepted via the tool), so the reply never reached the parent.
3. **The ask budget sat below real answer latency.** Measured on real transcripts: a child that answers takes p50 ~174 s from injection to reply (it finishes its current tool batch first). The 120 s default was below that median, so the modal outcome of `ask` was a timeout even when the child WAS answering.

## What changes

**New: `hub op='peek'`** — a ranged, read-only view of a child's transcript:
- `comms.peek()` builds a fresh `Transcript` reader off the child's session dir. Verified empirically that a RUNNING child's transcript is written per tool batch, so peek is fresh for live children.
- Stable 1-based step numbers (so a parent can page `range='N-'` across peeks), default = last 5 steps, `steps=N` shorthand (max 50), per-step 600-char cap with head+tail elision (tool results are the bulk of any transcript; peek keeps the command and the verdict, not the 8 KiB between).
- Renders hub messages by direction (`parent → child (question)`), clips long bodies, marks images, skips compaction/bookkeeping rows.
- Read-tier via a new `AgentTool.call_approval_tier` hook (loop.py): `list`/`peek` never prompt; `send/steer/pause/cancel/resume` stay write-tier.

**Ask fixes:**
- `subagent.py`: a restricted child keeps `hub` even when its role allowlist doesn't name it — messaging, not capability; it cannot edit/write/exec anything the allowlist denies.
- `builtin.py`: `HubChildParams` drops parent-shaped keys (`op`, `to`, `timeout_ms`, `range`, `steps`) before validation so a mirrored call still delivers the message.
- `builtin.py`: ask default timeout 120 s → 300 s (above the measured p50, inside the 600 s schema max), and the timeout receipt now points the parent at `peek` instead of inviting another ask.
- `system.md`: teaches the parent the peek-first observation pattern and that a busy child answers in minutes.

## Testing evidence

- **Unit**: 6 new tests in `tests/unit/harness/test_comms.py` (peek unknown / never-started / ranged-on-a-live-child / hub-tool-bounded / read-tier-matrix / child-schema-leniency) + 2 in `test_launch_subagent.py` (restricted role keeps hub; scout keeps hub) + updated exact-allowlist assertions in `test_role_subagents.py` and `test_launch_subagent.py`. Full `tests/unit` (non-TUI): **3603 passed, 3 skipped** — the single failure (`test_background_streams_output_while_it_runs`) also fails on clean origin/main (verified via `git stash`), i.e. pre-existing and unrelated.
- **Gates** clean on all changed files: `flake8`, `black --check`, `isort --check-only`, `pyright` (0 errors).
- **Live end-to-end (worktree build, openrouter)**:
  - Parent launched a `counter` child and peeked twice while it ran: `counter (7c02313c1c51) [running] — 1 of 1 transcript step(s): 1 user …` — ranged, bounded, correct status, no approval prompt.
  - Parent launched a **reviewer-role** child (the restricted profile) and `ask`ed "Are you alive?" → `rev (603ff9c728cf) replied: yes`. Before this change that ask could only time out.
- **Forensic basis** (pre-fix, real transcripts): of the 62 timed-out asks, 61 correlated to a child outcome and decomposed as 22 child-answered-in-text (watcher path, budget too short), 19 child never answered, 11 question never injected, 9 child answered via hub but the reply was rejected (7 parent-shaped args, 2 missing tool).
