### PR TITLE
fix(providers): omit sampling params when Anthropic adaptive thinking is on

### DIFF
--- a/local_operator/providers/clients.py
+++ b/local_operator/providers/clients.py
@@ -1720,7 +1720,6 @@ class AnthropicClient:
                 "none": {"type": "none"},
                 "required": {"type": "any"},
             }.get(request.tool_choice, {"type": "auto"})
-        body.update(_sampling_params(request))
         effort = _reasoning_effort(request)
         if effort is not None:
             # `output_config`, NOT a `thinking` budget: Anthropic's effort
@@ -1735,6 +1734,22 @@ class AnthropicClient:
             # model with no effort ladder is still sent neither key.
             body["thinking"] = {"type": "adaptive"}
             body["output_config"] = {"effort": effort}
+        else:
+            # The sampling pair goes out ONLY when thinking does not. Anthropic
+            # rejects the combination — HTTP 400 ``` `temperature` may only be
+            # set to 1 when thinking is enabled or in adaptive mode ``` (and the
+            # same for `top_p`), observed live on `claude-opus-4-8` on
+            # 2026-08-21 — and every turn on such a model died on it. Generation
+            # 5+ never hit this because `_NO_SAMPLING_PARAMS` already drops the
+            # pair, but 4.5–4.9 models accept temperature on its own while
+            # carrying an effort ladder, and the ladder is what switches
+            # adaptive thinking on above. Keying the omission on the SAME gate
+            # that writes `thinking` (rather than on a second model-name list)
+            # means any future model with an effort ladder is automatically
+            # safe: whichever way the gate resolves, the body is one Anthropic
+            # accepts. Omitting the pair costs nothing real — with thinking on,
+            # the only accepted value is the provider default.
+            body.update(_sampling_params(request))
         if request.stop_sequences:
             body["stop_sequences"] = list(request.stop_sequences)
         return body

--- a/tests/unit/providers/test_clients.py
+++ b/tests/unit/providers/test_clients.py
@@ -1508,6 +1508,47 @@ def test_request_sampling_overrides_reach_the_wire_when_supported(wire: str, top
     assert body[top_p_key] == 0.15
 
 
+def test_anthropic_omits_sampling_when_adaptive_thinking_is_on() -> None:
+    """Thinking and the sampling pair are mutually exclusive on Anthropic's wire.
+
+    ``claude-opus-4-8`` accepts ``temperature`` on its own — it is NOT in
+    ``_NO_SAMPLING_PARAMS`` — but it carries an effort ladder, and the ladder is
+    what switches ``thinking: {"type": "adaptive"}`` on. Anthropic answers that
+    combination with HTTP 400 ``` `temperature` may only be set to 1 when
+    thinking is enabled or in adaptive mode ``` (observed live 2026-08-21),
+    which killed every turn on the 4.5–4.9 generation. Generation 5+ never hit
+    it only because the sampling rule already dropped the pair.
+
+    The guard is keyed on the SAME gate that writes ``thinking`` — not on a
+    second model-name list — so any future model that gains an effort ladder is
+    automatically safe whichever way the gate resolves.
+    """
+    spec = ModelSpec(
+        provider="anthropic",
+        model_id="claude-opus-4-8",
+        reasoning=True,
+        reasoning_effort="high",
+        reasoning_efforts=("low", "medium", "high", "xhigh", "max"),
+        temperature=0.2,
+        top_p=0.9,
+    )
+    body = AnthropicClient()._build_body(ChatRequest(model=spec, messages=[Message.user("hi")]))
+    assert body["thinking"] == {"type": "adaptive"}
+    assert body["output_config"] == {"effort": "high"}
+    # ABSENT, not null: the 400 is about the key appearing at all.
+    assert "temperature" not in body
+    assert "top_p" not in body
+
+    # And the flip side: clearing the effort level turns thinking off, which
+    # makes the sampling pair legal again — it must come back, because losing
+    # a real setting silently would be the worse bug.
+    plain = spec.model_copy(update={"reasoning_effort": None})
+    body = AnthropicClient()._build_body(ChatRequest(model=plain, messages=[Message.user("hi")]))
+    assert "thinking" not in body
+    assert body["temperature"] == 0.2
+    assert body["top_p"] == 0.9
+
+
 def test_anthropic_oauth_prepends_the_claude_code_identity() -> None:
     """A subscription credential MUST carry the Claude Code identity block first.
 


### PR DESCRIPTION
## Why

Starting a session on `claude-opus-4-8` (and any 4.5–4.9 Anthropic model with an effort ladder) died on every turn with:

```
Error: invalid request (HTTP 400): `temperature` may only be set to 1 when thinking is enabled or in adaptive mode.
```

Reproduced live before the fix (installed `lop`, 2026-08-21):

```
$ lop --hosting anthropic --model claude-opus-4-8 --no-tui exec "Say hello and then run the shell command 'echo repro-test'." --yolo
...
WARNING - model stream failed: invalid request (HTTP 400): `temperature` may only be set to 1 when thinking is enabled or in adaptive mode.
Error: invalid request (HTTP 400): `temperature` may only be set to 1 when thinking is enabled or in adaptive mode.
```

The Anthropic body builder writes two things independently:

- `_sampling_params(request)` — `temperature`/`top_p`, sent because `claude-opus-4-8` is not in `_NO_SAMPLING_PARAMS` (it accepts the pair on its own; only generation 5+ rejects it outright).
- `thinking: {"type": "adaptive"}` + `output_config: {"effort": ...}` — sent because the model has an effort ladder (`claude-[a-z]+-4-(?:[7-9]|...)` in `_EFFORT_TABLE`).

Anthropic rejects the *combination*: with thinking enabled or adaptive, `temperature` may only be 1, and any other value is a 400. So the 4.5–4.9 generation — sampling-capable AND ladder-carrying — hit the 400 on every request. Generation 5+ never did, only because the sampling rule already drops the pair.

## What changes

One change in `AnthropicClient._build_body` (`local_operator/providers/clients.py`): the sampling pair is written **only on the branch where thinking is not**. The omission is keyed on the *same* gate that writes the `thinking` key — not on a second model-name list — so any current or future Anthropic model with an effort ladder sends a body the API accepts whichever way the gate resolves. When the effort level is cleared (thinking off), the pair comes back, so a real setting is never lost silently.

Omitting the pair alongside thinking costs nothing real: with thinking on, the only value Anthropic accepts is the provider default.

## Testing evidence

**Reproduction passing after the fix** — the exact command that 400'd above, run from this checkout:

```
$ .venv/bin/local-operator --hosting anthropic --model claude-opus-4-8 --no-tui exec "Say hello and then run the shell command 'echo repro-test'." --yolo
● bash Running echo repro-test
Done. The command ran successfully and printed `repro-test`.
```

The session started, the model streamed, called the bash tool, and completed — the full real path including a tool round-trip, not just a first token.

**Regression test** (`test_anthropic_omits_sampling_when_adaptive_thinking_is_on`): a sampling-capable spec with an effort ladder produces a body with `thinking`/`output_config` and **no** `temperature`/`top_p`; the same spec with the effort level cleared produces `temperature`/`top_p` and no `thinking`. Existing guards (`test_sampling_params_still_sent_when_model_accepts_them`, wired through a `claude-sonnet-4-5` spec without a ladder) still pass, so sampling is not lost for models where it is legal.

**Gates:**

- `pytest tests/unit -q` (minus tui): 3608 passed, 3 skipped
- `pytest tests/unit/tui -q` (colour env per AGENTS.md): pass — see comment below if posted separately
- `flake8` (repo `.flake8`, max-line-length 100): clean
- `black --check` / `isort --check-only --profile black`: clean
- `pyright` on changed files: 0 errors

No UI change, so no design round is needed.
