### PR TITLE
feat(prompts): add narration policy to curb repeated pre-tool-call exposition

### DIFF
--- a/local_operator/prompts_md/system.md
+++ b/local_operator/prompts_md/system.md
@@ -45,6 +45,21 @@ real result beats a guess every time.
   again. Report being stuck only after real alternatives are exhausted, with
   what you tried and the exact blocker.
 
+## Narration
+
+Text between tool calls is chat the user reads and context you re-buy on every
+later turn — spend it only when it says something new. The `i` intent on each
+call (see Tools) already tells the user what you are doing: never write a text
+block that restates it, announces a routine next step, or opens with filler
+("Now the…", "Let me…", "Okay,").
+
+Speak between calls only on material change: a discovery that alters the plan,
+a decision between real alternatives, a blocker, or the start of a substantial
+phase — one or two sentences, without recapping what earlier text or the todo
+list already says. Routine reads, searches, and obvious follow-ons proceed
+silently; related progress folds into the next real update or the final
+answer.
+
 ## Safety rules
 
 - Destructive or irreversible operations — deleting data, force-pushing,
@@ -115,7 +130,9 @@ Most tools take `i`: a concise intent, present participle, 2–6 words, no
 period, capitalized. Name what you are accomplishing, never the tool or the
 mechanism — "Auditing tickets against merged MRs", not "Running bash" or
 "Reading a file". It is what the user sees while the call runs, and it is the
-only account of your reasoning they get without reading the transcript.
+only account of your reasoning they get without reading the transcript —
+which is why a prose preamble restating it before the call is pure waste (see
+Narration).
 
 MCP servers appear separately in `<mcps>` with only bounded local summaries;
 their tool schemas are deliberately absent. Read `mcp://<server>` to inspect


### PR DESCRIPTION
## Why

Session transcripts show near-per-call prose preambles from the model — six consecutive variants of "Now the `test_welcome.py` flake. Let me confirm/check/read/investigate…" in one observed run — each immediately followed by a tool call whose `i` intent restates the same thing. Three causes, all in the prompt design:

1. **`system.md` has no interstitial-narration policy.** The only brevity rule ("Be concise. Lead with the answer…") reads as a final-answer rule; nothing governs text *between* tool calls. Models tuned on commentary-channel behaviour (Codex-style) fill that vacuum by default.
2. **The intent field makes the preamble 100% redundant, but the prompt never says so.** The intent paragraph calls `i` "the only account of your reasoning they get" yet never closes the loop with "therefore don't also narrate it in prose" — the model treats intent and prose as two independent surfaces and fills both.
3. **Narration self-reinforces.** Each line stays in context, is re-billed every later turn, and gets imitated, so one preamble becomes a per-call pattern.

Comparison with peer harnesses:
- **opencode** (`session/prompt/gpt.txt`) has an explicit commentary policy: updates only for "a discovery, a tradeoff, a blocker, a substantial plan, or the start of a non-trivial edit"; "Do not narrate routine reads, searches, obvious next steps… Combine related progress into a single update"; no openers/acknowledgements.
- **omp** (`system-prompt.md`) suppresses bluntly (`NEVER narrate…`, "prose brief; evidence… complete") and carries the same `i` intent-tracing field lop has.

## What changes

`local_operator/prompts_md/system.md` only (+18/−1):

- **New `## Narration` section** between Working principles and Safety rules — opencode's material-change criteria (discovery altering the plan, decision between real alternatives, blocker, start of a substantial phase) fused with omp's suppression stance, framed around lop's existing `i` intent: never restate it, no routine-step announcements, no filler openers, silence for routine reads/searches, related progress folds into the next real update.
- **One clause appended to the intent paragraph** in `## Tools` cross-referencing Narration, closing the two-surfaces loop at the point the habit starts.

Deliberately *not* placed in `INTENT_DESCRIPTION` (`harness/intent.py`): that string is replicated into every tool's schema, so policy there would be paid ~20× per request.

The model still describes its thoughts — at material change points, which is the intended behaviour, rather than per call.

## Testing evidence

This is a prompt-content change with no code path; validation is that the change renders into the prompt the runtime actually sends plus regression on the renderer:

- `tests/unit/test_prompts_api.py`: **30 passed** (template engine + system-prompt block builder).
- Runtime path exercised directly: `prompts_api.render_template('system.md', {})` returns the prompt with the `## Narration` section present and intact (asserted, output captured in the review thread).
- Section structure verified: `['## Working principles', '## Narration', '## Safety rules', '## Tools']`.
- Behavioural effect on live model output is inherently statistical and will be observed across subsequent sessions after `lop-update`; no assertion of measured reduction is made here.