### PR TITLE
fix(session): stop the startup sweep racing a sibling's just-created session

### DIFF
--- a/local_operator/session/retention.py
+++ b/local_operator/session/retention.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 
 import logging
 import shutil
+import time
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -57,6 +58,26 @@ MAX_AGE_DAYS_KEY = "session_retention_max_age_days"
 DEFAULT_MAX_SESSIONS = 0
 DEFAULT_MAX_BYTES = 0
 DEFAULT_MAX_AGE_DAYS = 0
+
+#: How old an EMPTY session directory must be before the reaper may take it.
+#:
+#: A session directory is empty from the moment ``_prepare`` creates it until
+#: the first turn is appended to ``transcript.jsonl`` — and that window is as
+#: long as the user takes to type their first message. ``live_dir`` only
+#: protects the sweeping process's OWN session; on an install running many
+#: concurrent sessions, a sibling process starting up in that window saw a
+#: fresh empty directory, judged it abandoned, and rmtree'd a session another
+#: process was about to write into. Its first append then died on
+#: ``FileNotFoundError: .../transcript.jsonl`` — observed in production on an
+#: install with ~12 concurrent sessions, where new sessions started minutes
+#: apart reliably raced each other.
+#:
+#: One hour is deliberately generous: an empty directory costs nothing while
+#: it waits, and a directory abandoned by a crashed run is still reclaimed by
+#: any startup an hour later. The transcript's self-healing append (see
+#: ``Transcript._append``) backstops the pathological case of a session left
+#: idle past the grace window before its first message.
+EMPTY_DIR_GRACE_SECONDS = 3600.0
 
 
 @dataclass(frozen=True)
@@ -123,6 +144,12 @@ def sweep_sessions(
     the user the whole session, and the benefit (bounded disk) is
     recoverable by hand at any time.
 
+    An empty directory younger than :data:`EMPTY_DIR_GRACE_SECONDS` is also
+    skipped, whoever owns it: a fresh empty directory is indistinguishable
+    from a sibling process's session that has not received its first message
+    yet, and reaping one killed exactly such a session on a real install.
+    ``now`` exists so tests can move the clock instead of the filesystem.
+
     Idempotent and safe to call on every startup: a missing ``sessions_dir``
     is a no-op rather than an error — the first run of a fresh install has
     not created it yet, and a startup path that raises there would be a
@@ -135,6 +162,7 @@ def sweep_sessions(
     evicted = 0
     errors = 0
     bytes_remaining = 0
+    moment = time.time() if now is None else now
     live_resolved = live_dir.resolve() if live_dir is not None else None
     try:
         children = [child for child in sessions_dir.iterdir() if child.is_dir()]
@@ -156,7 +184,19 @@ def sweep_sessions(
         if size > 0:
             bytes_remaining += size
             continue
-        # Literally empty: no files at all, not even a marker. Deleting
+        try:
+            age = moment - child.stat().st_mtime
+        except OSError:
+            # Removed by another process between the size walk and the stat.
+            continue
+        if age < EMPTY_DIR_GRACE_SECONDS:
+            # Empty but fresh: this is what a sibling's just-created session
+            # looks like before its first turn lands. ``live_dir`` cannot
+            # protect it (it only names OUR session), so age is the only
+            # signal that separates "abandoned" from "about to be written".
+            continue
+        # Literally empty AND past the grace window: no files at all, not
+        # even a marker, and nothing has claimed it for an hour. Deleting
         # it loses nothing, and it was never a real session.
         try:
             shutil.rmtree(child)

--- a/local_operator/session/retention.py
+++ b/local_operator/session/retention.py
@@ -185,6 +185,14 @@ def sweep_sessions(
             bytes_remaining += size
             continue
         try:
+            # A directory's st_mtime is bumped whenever an entry is added to
+            # or removed from it, so for a directory that is still empty this
+            # is its CREATION time — exactly the "how long has this been
+            # waiting for its first turn" signal the grace window needs. The
+            # one edge case: creating and then deleting a transient file
+            # inside an otherwise-empty dir resets this clock, extending the
+            # grace window rather than shortening it, which stays on the safe
+            # side (an unreaped empty dir costs nothing).
             age = moment - child.stat().st_mtime
         except OSError:
             # Removed by another process between the size walk and the stat.

--- a/local_operator/session/transcript.py
+++ b/local_operator/session/transcript.py
@@ -370,11 +370,26 @@ class Transcript:
             # one mkdir restores; ``self._entries`` still holds every prior
             # entry, so the recreated file is rebuilt complete rather than
             # starting truncated.
-            try:
-                with self.path.open("a", encoding="utf-8") as handle:
-                    handle.write(entry.to_json() + "\n")
-                    handle.flush()
-            except FileNotFoundError:
+            #
+            # The FILE alone vanishing (directory intact) is the same wound
+            # with a quieter symptom: ``"a"`` mode recreates the file without
+            # raising, so the append succeeds and the transcript silently
+            # holds one row while memory holds the whole session — a resume
+            # would then replay a single message as if the rest never
+            # happened. Checked BEFORE the append because that path never
+            # raises; both cases rebuild from ``self._entries`` under the
+            # same lock.
+            rebuild = not self.path.exists()
+            if not rebuild:
+                try:
+                    with self.path.open("a", encoding="utf-8") as handle:
+                        handle.write(entry.to_json() + "\n")
+                        handle.flush()
+                except FileNotFoundError:
+                    # Directory removed between the exists() check and the
+                    # open — the race is real, so the window is too.
+                    rebuild = True
+            if rebuild:
                 self.directory.mkdir(parents=True, exist_ok=True)
                 with self.path.open("w", encoding="utf-8") as handle:
                     for row in self._entries:

--- a/local_operator/session/transcript.py
+++ b/local_operator/session/transcript.py
@@ -359,9 +359,27 @@ class Transcript:
             # ``Session._offloaded`` is where the loop-responsiveness win
             # actually comes from (1360 ms -> 56 ms); this write is a few
             # hundred microseconds and is not worth a correctness hazard.
-            with self.path.open("a", encoding="utf-8") as handle:
-                handle.write(entry.to_json() + "\n")
-                handle.flush()
+            #
+            # Self-healing against a vanished directory: another process's
+            # startup sweep (or a user tidying by hand) can remove a session
+            # directory while it still looks empty — the gap between Session
+            # construction and the first turn is as long as the user takes to
+            # type their first message, and the retention sweep's ``live_dir``
+            # only protects the sweeping process's OWN session. Dying on
+            # FileNotFoundError here costs the whole session for a directory
+            # one mkdir restores; ``self._entries`` still holds every prior
+            # entry, so the recreated file is rebuilt complete rather than
+            # starting truncated.
+            try:
+                with self.path.open("a", encoding="utf-8") as handle:
+                    handle.write(entry.to_json() + "\n")
+                    handle.flush()
+            except FileNotFoundError:
+                self.directory.mkdir(parents=True, exist_ok=True)
+                with self.path.open("w", encoding="utf-8") as handle:
+                    for row in self._entries:
+                        handle.write(row.to_json() + "\n")
+                    handle.flush()
         return entry
 
     # -- replay -------------------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.24.4"
+version = "0.24.5"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/session/test_retention.py
+++ b/tests/unit/session/test_retention.py
@@ -16,6 +16,7 @@ from local_operator.session.retention import (
     DEFAULT_MAX_AGE_DAYS,
     DEFAULT_MAX_BYTES,
     DEFAULT_MAX_SESSIONS,
+    EMPTY_DIR_GRACE_SECONDS,
     sweep_from_config,
     sweep_sessions,
 )
@@ -30,6 +31,22 @@ def _session(root, name: str, *, size: int = 1024, age_days: float = 0.0):
     when = time.time() - age_days * 86400
     for path in (directory / "transcript.jsonl", directory):
         os.utime(path, (when, when))
+    return directory
+
+
+def _hollow(root, name: str, *, age_seconds: float = EMPTY_DIR_GRACE_SECONDS + 60.0):
+    """An EMPTY session directory old enough for the reaper to take it.
+
+    Aged past the grace window by default because that is what "abandoned"
+    means now: a fresh empty directory is indistinguishable from a sibling
+    process's session awaiting its first message, and must survive.
+    """
+    import os
+
+    directory = root / name
+    directory.mkdir(parents=True)
+    when = time.time() - age_seconds
+    os.utime(directory, (when, when))
     return directory
 
 
@@ -66,10 +83,8 @@ def test_live_dir_is_never_reaped_even_when_empty(tmp_path):
     It is empty by construction; ``live_dir`` is the belt that keeps the
     sweep from rmtree'ing it in the same call that created it."""
     sessions = tmp_path / "sessions"
-    live = sessions / "live"
-    live.mkdir(parents=True)
-    other = sessions / "other"
-    other.mkdir(parents=True)
+    live = _hollow(sessions, "live")
+    other = _hollow(sessions, "other")
 
     result = sweep_sessions(sessions, live_dir=live)
 
@@ -83,7 +98,7 @@ def test_empty_directories_are_reaped(tmp_path):
     turn; 23 of 147 directories on a real install were exactly this. A
     directory that contains nothing holds nothing to lose."""
     sessions = tmp_path / "sessions"
-    (sessions / "hollow").mkdir(parents=True)
+    _hollow(sessions, "hollow")
     _session(sessions, "real")
 
     result = sweep_sessions(sessions, max_sessions=0, max_bytes=0, max_age_days=0)
@@ -102,8 +117,7 @@ def test_a_marker_alone_protects_the_directory(tmp_path):
     from local_operator.resume import ORIGIN_SUBAGENT, mark_session_origin
 
     sessions = tmp_path / "sessions"
-    hollow = sessions / "hollow"
-    hollow.mkdir(parents=True)
+    hollow = _hollow(sessions, "hollow")
     mark_session_origin(hollow, ORIGIN_SUBAGENT, label="review")
 
     result = sweep_sessions(sessions)
@@ -127,7 +141,7 @@ def test_any_content_at_all_protects_the_directory(tmp_path):
 
 def test_sweep_is_idempotent(tmp_path):
     sessions = tmp_path / "sessions"
-    (sessions / "hollow").mkdir(parents=True)
+    _hollow(sessions, "hollow")
     _session(sessions, "real")
 
     first = sweep_sessions(sessions)
@@ -147,7 +161,7 @@ def test_sibling_stores_under_the_config_dir_are_untouched(tmp_path):
     this module's business.
     """
     sessions = tmp_path / "sessions"
-    (sessions / "hollow").mkdir(parents=True)
+    _hollow(sessions, "hollow")
     _session(sessions, "real")
     spill = tmp_path / "spill"
     spill.mkdir()
@@ -237,7 +251,7 @@ def test_undeletable_empty_directory_is_reported_not_raised(tmp_path, monkeypatc
     """Reclaiming disk must never be the reason a session fails to start."""
     sessions = tmp_path / "sessions"
     for i in range(3):
-        (sessions / f"hollow{i}").mkdir(parents=True)
+        _hollow(sessions, f"hollow{i}")
     _session(sessions, "real")
 
     def boom(_path):
@@ -249,6 +263,42 @@ def test_undeletable_empty_directory_is_reported_not_raised(tmp_path, monkeypatc
     assert result.errors == 3
     assert result.evicted == 0
     assert len(list(sessions.iterdir())) == 4
+
+
+def test_a_fresh_empty_directory_survives_a_sibling_sweep(tmp_path):
+    """THE regression this grace window exists for. ``_prepare`` creates the
+    session directory before the user has typed a word; a sibling process
+    starting up in that window used to reap it as "empty", and the session's
+    first append died on FileNotFoundError — observed on a real install
+    running ~12 concurrent sessions. ``live_dir`` cannot help: it names the
+    SWEEPING process's session, not the victim's."""
+    sessions = tmp_path / "sessions"
+    victim = sessions / "just-created-by-another-process"
+    victim.mkdir(parents=True)  # fresh mtime — exactly what _prepare leaves
+
+    result = sweep_sessions(sessions, live_dir=None)
+
+    assert victim.exists()
+    assert result.evicted == 0
+
+
+def test_grace_window_boundary(tmp_path):
+    """Inside the window survives; past it is reaped. ``now`` moves the
+    clock so the boundary is tested without sleeping or utime races."""
+    import os
+
+    sessions = tmp_path / "sessions"
+    fresh = _hollow(sessions, "fresh", age_seconds=0.0)
+    aged = _hollow(sessions, "aged", age_seconds=0.0)
+    base = time.time()
+    for path, when in ((fresh, base), (aged, base - EMPTY_DIR_GRACE_SECONDS - 1)):
+        os.utime(path, (when, when))
+
+    result = sweep_sessions(sessions, now=base)
+
+    assert fresh.exists()
+    assert not aged.exists()
+    assert result.evicted == 1
 
 
 def test_a_transcript_is_never_deleted_even_when_a_failure_cascade_hits(tmp_path, monkeypatch):

--- a/tests/unit/session/test_retention.py
+++ b/tests/unit/session/test_retention.py
@@ -10,6 +10,7 @@ no transcript, no content — which is definitionally not a session.
 
 from __future__ import annotations
 
+import os
 import time
 
 from local_operator.session.retention import (
@@ -23,8 +24,6 @@ from local_operator.session.retention import (
 
 
 def _session(root, name: str, *, size: int = 1024, age_days: float = 0.0):
-    import os
-
     directory = root / name
     directory.mkdir(parents=True)
     (directory / "transcript.jsonl").write_text("x" * size)
@@ -41,8 +40,6 @@ def _hollow(root, name: str, *, age_seconds: float = EMPTY_DIR_GRACE_SECONDS + 6
     means now: a fresh empty directory is indistinguishable from a sibling
     process's session awaiting its first message, and must survive.
     """
-    import os
-
     directory = root / name
     directory.mkdir(parents=True)
     when = time.time() - age_seconds
@@ -285,8 +282,6 @@ def test_a_fresh_empty_directory_survives_a_sibling_sweep(tmp_path):
 def test_grace_window_boundary(tmp_path):
     """Inside the window survives; past it is reaped. ``now`` moves the
     clock so the boundary is tested without sleeping or utime races."""
-    import os
-
     sessions = tmp_path / "sessions"
     fresh = _hollow(sessions, "fresh", age_seconds=0.0)
     aged = _hollow(sessions, "aged", age_seconds=0.0)

--- a/tests/unit/session/test_transcript.py
+++ b/tests/unit/session/test_transcript.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import shutil
 
 import pytest
 
@@ -42,8 +43,6 @@ async def test_append_recreates_a_vanished_directory(tmp_path):
     The append now recreates the directory and rebuilds the file from the
     in-memory entries, so nothing already appended is lost either.
     """
-    import shutil
-
     directory = tmp_path / "sess"
     transcript = Transcript(directory)
     await transcript.append_message(Message.user("before the deletion"))
@@ -56,6 +55,32 @@ async def test_append_recreates_a_vanished_directory(tmp_path):
     assert len(lines) == 2  # rebuilt complete, not truncated to the new row
     texts = [json.loads(line)["payload"]["content"][0]["text"] for line in lines]
     assert texts == ["before the deletion", "after the deletion"]
+
+
+@pytest.mark.asyncio
+async def test_append_rebuilds_when_only_the_file_vanished(tmp_path):
+    """The quieter variant of the vanished-directory wound (review R1-1).
+
+    Deleting just ``transcript.jsonl`` with the directory intact never
+    raises: ``"a"`` mode recreates the file, so the append "succeeds" while
+    the file silently holds one row and memory holds the whole session — a
+    resume would then replay a single message as if the rest never
+    happened. The append must notice the file is gone and rebuild it
+    complete from the in-memory entries.
+    """
+    directory = tmp_path / "sess"
+    transcript = Transcript(directory)
+    await transcript.append_message(Message.user("one"))
+    await transcript.append_message(Message.assistant("two"))
+
+    transcript.path.unlink()  # the user tidied the file, not the directory
+
+    await transcript.append_message(Message.user("three"))
+
+    lines = transcript.path.read_text().splitlines()
+    assert len(lines) == 3  # rebuilt complete, not restarted at one row
+    texts = [json.loads(line)["payload"]["content"][0]["text"] for line in lines]
+    assert texts == ["one", "two", "three"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/session/test_transcript.py
+++ b/tests/unit/session/test_transcript.py
@@ -31,6 +31,34 @@ async def test_append_message_writes_jsonl(transcript):
 
 
 @pytest.mark.asyncio
+async def test_append_recreates_a_vanished_directory(tmp_path):
+    """The session must survive its directory being deleted underneath it.
+
+    A sibling process's startup sweep (or a user tidying ``sessions/`` by
+    hand) can remove a directory that still looks empty — the gap between
+    Session construction and the first turn is as long as the user takes to
+    type. The old behaviour was fatal: the first append raised
+    ``FileNotFoundError: .../transcript.jsonl`` and the whole session died.
+    The append now recreates the directory and rebuilds the file from the
+    in-memory entries, so nothing already appended is lost either.
+    """
+    import shutil
+
+    directory = tmp_path / "sess"
+    transcript = Transcript(directory)
+    await transcript.append_message(Message.user("before the deletion"))
+
+    shutil.rmtree(directory)  # what the racing sweep used to do
+
+    await transcript.append_message(Message.assistant("after the deletion"))
+
+    lines = transcript.path.read_text().splitlines()
+    assert len(lines) == 2  # rebuilt complete, not truncated to the new row
+    texts = [json.loads(line)["payload"]["content"][0]["text"] for line in lines]
+    assert texts == ["before the deletion", "after the deletion"]
+
+
+@pytest.mark.asyncio
 async def test_reloads_from_disk(tmp_path):
     directory = tmp_path / "sess"
     first = Transcript(directory)


### PR DESCRIPTION
## Why

A user opened a new lop session, typed their first message, and the turn died with:

```
× [Errno 2] No such file or directory: '/Users/damian/.local-operator/sessions/b7ab67ca742a/transcript.jsonl'
```

The #192 rewrite ended policy eviction of transcripts (`sessions/` on this install is 59 MB across 257 dirs, all intact), but the **empty-directory reaper it kept still races concurrent sessions**:

1. `_prepare` (`session_factory.py`) mkdirs the session directory, then runs `sweep_from_config(..., live_dir=<own dir>)`. The directory stays **empty until the first turn is appended** — a window as long as the user takes to type their first message. No `origin.json` marker is written for a user's main session, so nothing marks it as claimed.
2. `live_dir` only protects the sweeping process's **own** session. A sibling lop process starting up in that window sees a fresh, literally-empty directory, judges it abandoned, and `rmtree`s it.
3. The victim's first `Transcript._append` opens `transcript.jsonl` in `"a"` mode inside a directory that no longer exists → the exact `FileNotFoundError` above, killing the session before its first turn.

On an install routinely running ~12 concurrent lop sessions (verified via `ps`), new sessions start minutes apart, so this race fires in practice. Reproduced deterministically against unmodified `origin/main` with the real code paths (evidence below).

## What changes

Two independent defences, either sufficient alone:

- **`session/retention.py`** — an empty directory is only reaped once older than `EMPTY_DIR_GRACE_SECONDS` (1 h), measured off the directory mtime with a `now` parameter for tests. A fresh empty directory is indistinguishable from a sibling's session awaiting its first message; age is the only signal `live_dir` cannot provide. An abandoned dir still gets reclaimed by any startup an hour later, and an empty dir costs nothing while it waits.
- **`session/transcript.py`** — the synchronous `_append` self-heals a vanished directory: on `FileNotFoundError` it recreates the directory and rebuilds the file from the in-memory `_entries`, so even a mid-session deletion (sweep race, manual tidy) neither kills the run nor truncates history. The append stays synchronous per the existing comment's constraint.

Tests: existing empty-dir reap tests now use a `_hollow` helper aged past the grace window (that is what "abandoned" now means); three new regression tests cover the fresh-dir survival, the grace boundary (via `now`), and the self-healing append.

## Testing evidence

**Reproduction on unmodified `origin/main`** (real `sweep_sessions` + real `Transcript`, two simulated processes):

```
sweep result: evicted=1  victim_exists=False
append died: [Errno 2] No such file or directory: '.../sessions/7b1b3ca030df/transcript.jsonl'
```

**Same script on this branch:**

```
sweep result: evicted=0  victim_exists=True
first append survived: True  rows=1
```

**Mutation checks** (each mutation confirmed applied by content, files restored from copies and verified with `cmp`):

- `git checkout origin/main -- transcript.py` → `test_append_recreates_a_vanished_directory` fails with the production `FileNotFoundError`.
- `EMPTY_DIR_GRACE_SECONDS = 3600.0 → 0.0` (applied via content-asserted script) → both new retention tests fail.

**Suites and gates** (run in the branch worktree; module resolution verified to import the worktree's patched files):

- `tests/unit/session` + `tests/unit/test_session_factory.py`: **343 passed**.
- Full `tests/unit` minus TUI: **3621 passed, 3 skipped, 1 failed** — the failure is `tests/unit/tools/test_eval_tool.py::test_background_streams_output_while_it_runs`, which fails identically on a pristine `origin/main` worktree on this machine (timing-sensitive under ~12 concurrent lop processes); pre-existing, unrelated.
- `flake8`, `black --check`, `isort --check-only`, `pyright` on all four changed files: clean / 0 errors.

## Change class

C2 — standard, pre-authorized. Bug fix to session durability with regression tests; no contract or schema change.
