### PR TITLE
fix(providers): scope quota blocks to the model family that spent them

### DIFF
--- a/local_operator/model/configure.py
+++ b/local_operator/model/configure.py
@@ -42,6 +42,7 @@ from local_operator.model.registry import (
     anthropic_default_model_info,
     anthropic_family_model_info,
     get_model_info,
+    model_family,
     unknown_model_info,
 )
 from local_operator.paths import config_dir
@@ -1985,7 +1986,38 @@ class SessionStreamFn:
             FallbackTarget(f"{model.provider}/{model.model_id}", model.reasoning_effort)
         )
 
-    async def preflight_usage(self, model: ModelSpec) -> None:
+    @staticmethod
+    def _write_quota_block(
+        auth_store: Any,
+        credential_id: int,
+        storage: str,
+        health: Any,
+        block_ms: int,
+    ) -> None:
+        """Record a quota verdict against a credential, scoped to what it binds.
+
+        A verdict whose ONLY binding windows are model-family caps (Anthropic's
+        ``7 day (Fable)`` at 100% beside a healthy shared 5-hour window) stops
+        ONE family on the account, not the account: the block is written under
+        ``model:<family>`` so requests for other families still resolve to the
+        row and spend the shared headroom. The moment a shared window binds
+        (``health.scope == "account"``) the account is out for every model and
+        the block is account-wide, as before. Writing family verdicts
+        account-wide is the defect that made an opus request report "all
+        credentials unusable" on a pool whose only spent window was Fable's.
+        """
+        if health.scope == "model" and health.binding_families:
+            for fam in health.binding_families:
+                auth_store.block_credential(
+                    credential_id,
+                    storage,
+                    block_scope=f"model:{fam}",
+                    block_ms=block_ms,
+                )
+        else:
+            auth_store.block_credential(credential_id, storage, block_ms=block_ms)
+
+    async def preflight_usage(self, model: ModelSpec, *, consume_boundary: bool = True) -> None:
         """Check reliable OAuth quota once per user-message boundary.
 
         Unknown/unreachable usage fails open. A low account is suppressed only
@@ -2014,7 +2046,12 @@ class SessionStreamFn:
         recheck_due = self._quota_recheck_for == selector
         if not self._message_boundary_pending and not recheck_due:
             return
-        self._message_boundary_pending = False
+        # The boundary token also gates effort CLASSIFICATION in ``__call__``;
+        # a switch-time probe (``consume_boundary=False``) must not spend it,
+        # or a mid-turn ``/model`` would silently skip the next request's
+        # effort grading.
+        if consume_boundary:
+            self._message_boundary_pending = False
         if recheck_due:
             self._quota_recheck_for = None
 
@@ -2022,13 +2059,32 @@ class SessionStreamFn:
         if (
             selector == self._usage_checked_selector
             and now - self._usage_checked_at < self.USAGE_CHECK_TTL_S
+            and not self._route_state.quota_pinned
         ):
+            # The memo dedupes the several requests ONE message makes; a
+            # quota-pinned route is re-probed at every boundary regardless,
+            # or a session could sit on a fallback for a whole memo window
+            # past the primary's recovery.
             return
         self._usage_checked_selector = selector
         self._usage_checked_at = now
 
         retry = RetrySettings.from_settings(self._settings)
-        if self._route_state.active is not None and not self._route_state.primary_retry_due():
+        # The family the routed model draws on: quota verdicts and credential
+        # blocks are scoped to it, so a spent family cap never takes the
+        # account out of rotation for models of another family.
+        family = model_family(model.model_id)
+        if (
+            self._route_state.active is not None
+            and not self._route_state.primary_retry_due()
+            and not self._route_state.quota_pinned
+        ):
+            # A quota pin is re-probed at every boundary: the usage endpoint
+            # answers definitively and cheaply, and its cooldown can be hours
+            # long (a 24h advertised reset), which would otherwise glue the
+            # session to a fallback past the primary's window reopening.
+            # Transport pins keep the cooldown — their recovery is not
+            # observable without re-paying the failure.
             return
         if not retry.usage_aware_fallback:
             if self._route_state.active is not None and await self._primary_has_auth(model):
@@ -2042,13 +2098,17 @@ class SessionStreamFn:
         attempted_ids: set[int] = set()
         while True:
             try:
-                access = await self._auth_store.get_oauth_access(model.provider, self._session_id)
+                access = await self._auth_store.get_oauth_access(
+                    model.provider, self._session_id, family=family
+                )
             except Exception:
                 return
             if access is None:
                 storage = self._storage_provider(model.provider)
                 rows = self._auth_store.list_credentials(storage)
-                if rows and all(self._auth_store.is_blocked(row.id, storage) for row in rows):
+                if rows and all(
+                    self._auth_store.is_blocked_for(row.id, storage, family) for row in rows
+                ):
                     # Every account is under a block, but "blocked" is only a
                     # verdict from an earlier probe — quota resets while the
                     # backoff is still on the clock, and a tier-scoped cap can
@@ -2081,6 +2141,7 @@ class SessionStreamFn:
                         await self._route_state.activate(
                             fallback,
                             f"{model.provider} credentials temporarily unavailable",
+                            quota=True,
                         )
                 return
             if access.kind != "oauth" or access.credential_id in attempted_ids:
@@ -2140,7 +2201,7 @@ class SessionStreamFn:
                     if candidate.id != access.credential_id
                     and candidate.id not in attempted_ids
                     and (row is None or candidate.credential_type == row.credential_type)
-                    and not self._auth_store.is_blocked(candidate.id, storage)
+                    and not self._auth_store.is_blocked_for(candidate.id, storage, family)
                 ]
                 if not siblings and health.state == "depleted":
                     # No UNBLOCKED sibling can take this model, but blocked
@@ -2160,7 +2221,7 @@ class SessionStreamFn:
                         if candidate.id != access.credential_id
                         and candidate.id not in attempted_ids
                         and (row is None or candidate.credential_type == row.credential_type)
-                        and self._auth_store.is_blocked(candidate.id, storage)
+                        and self._auth_store.is_blocked_for(candidate.id, storage, family)
                     ]
                     recovered = await self._recover_blocked_accounts(
                         model, storage, blocked_rows, retry, attempted_ids
@@ -2205,13 +2266,12 @@ class SessionStreamFn:
                         return
                 if siblings:
                     if health.state == "depleted":
-                        self._auth_store.block_credential(
+                        self._write_quota_block(
+                            self._auth_store,
                             access.credential_id,
                             storage,
-                            block_ms=max(
-                                60_000,
-                                health.reset_after_ms or self.DEFAULT_USAGE_BLOCK_MS,
-                            ),
+                            health,
+                            max(60_000, health.reset_after_ms or self.DEFAULT_USAGE_BLOCK_MS),
                         )
                     else:
                         self._auth_store.deprioritize_credential(
@@ -2246,6 +2306,7 @@ class SessionStreamFn:
                 await self._route_state.activate(
                     fallback,
                     f"{model.provider} {condition}{remaining} for {model.model_id}",
+                    quota=True,
                 )
                 return
 
@@ -2293,6 +2354,7 @@ class SessionStreamFn:
         """
         from local_operator.providers.failover import parse_selector
 
+        family = model_family(model.model_id)
         threshold = min(100.0, max(0.0, float(retry.usage_reserve_percent))) / 100.0
         # ``None`` means no shared window carried a number — indeterminate, not
         # headroom, so the tier-cap guard stays off and the cautious rotate /
@@ -2312,7 +2374,7 @@ class SessionStreamFn:
             if candidate.id != access.credential_id
             and candidate.id not in attempted_ids
             and (row is None or candidate.credential_type == row.credential_type)
-            and not self._auth_store.is_blocked(candidate.id, storage)
+            and not self._auth_store.is_blocked_for(candidate.id, storage, family)
         ]
         fallback = await self._first_available_fallback(
             model,
@@ -2336,6 +2398,7 @@ class SessionStreamFn:
                     await self._route_state.activate(
                         fallback,
                         f"{model.provider} {condition}{remaining}",
+                        quota=True,
                     )
                     return False
             await self._notice(
@@ -2360,10 +2423,12 @@ class SessionStreamFn:
             # sibling returns before the tail of this method — which is
             # where the block used to be written — leaving a spent account
             # in the unblocked pool (review F2's second half).
-            self._auth_store.block_credential(
+            self._write_quota_block(
+                self._auth_store,
                 access.credential_id,
                 storage,
-                block_ms=max(60_000, health.reset_after_ms or self.DEFAULT_USAGE_BLOCK_MS),
+                health,
+                max(60_000, health.reset_after_ms or self.DEFAULT_USAGE_BLOCK_MS),
             )
             blocked_rows = [
                 candidate
@@ -2371,7 +2436,7 @@ class SessionStreamFn:
                 if candidate.id != access.credential_id
                 and candidate.id not in attempted_ids
                 and (row is None or candidate.credential_type == row.credential_type)
-                and self._auth_store.is_blocked(candidate.id, storage)
+                and self._auth_store.is_blocked_for(candidate.id, storage, family)
             ]
             recovered = await self._recover_blocked_accounts(
                 model, storage, blocked_rows, retry, attempted_ids
@@ -2450,10 +2515,12 @@ class SessionStreamFn:
         if health.state == "depleted":
 
             def take_out_of_rotation(credential_id: int) -> None:
-                self._auth_store.block_credential(
+                self._write_quota_block(
+                    self._auth_store,
                     credential_id,
                     storage,
-                    block_ms=max(60_000, health.reset_after_ms or self.DEFAULT_USAGE_BLOCK_MS),
+                    health,
+                    max(60_000, health.reset_after_ms or self.DEFAULT_USAGE_BLOCK_MS),
                 )
 
         else:
@@ -2479,6 +2546,7 @@ class SessionStreamFn:
         await self._route_state.activate(
             fallback,
             f"{model.provider} {condition}{remaining}",
+            quota=True,
         )
         return False
 
@@ -2581,7 +2649,15 @@ class SessionStreamFn:
             # or block-again-and-fall-back). A depleted verdict is returned,
             # not swallowed — the policy decides its fate, and the caller's
             # fallback notice must name the quota, not the credential pool.
+            # A definite verdict supersedes the blocks that could hide this
+            # model: the account-wide backoff and THIS family's scoped block.
+            # Blocks for OTHER families stay standing — a probe that proves
+            # opus serviceable says nothing about a fable weekly that is
+            # still spent.
+            family = model_family(model.model_id)
             self._auth_store.clear_block(row.id, storage)
+            if family:
+                self._auth_store.clear_block(row.id, storage, block_scope=f"model:{family}")
             self._auth_store.pin_session_credential(model.provider, self._session_id, row.id)
             shared_remaining, tier_binding = shared_tier_saturation(
                 report,

--- a/local_operator/model/configure.py
+++ b/local_operator/model/configure.py
@@ -42,7 +42,6 @@ from local_operator.model.registry import (
     anthropic_default_model_info,
     anthropic_family_model_info,
     get_model_info,
-    model_family,
     unknown_model_info,
 )
 from local_operator.paths import config_dir
@@ -2070,10 +2069,9 @@ class SessionStreamFn:
         self._usage_checked_at = now
 
         retry = RetrySettings.from_settings(self._settings)
-        # The family the routed model draws on: quota verdicts and credential
-        # blocks are scoped to it, so a spent family cap never takes the
-        # account out of rotation for models of another family.
-        family = model_family(model.model_id)
+        # Credential blocks are scoped to the model family that spent them,
+        # so a spent family cap never takes the account out of rotation for
+        # models of another family; the reads below are model-scoped.
         if (
             self._route_state.active is not None
             and not self._route_state.primary_retry_due()
@@ -2099,7 +2097,7 @@ class SessionStreamFn:
         while True:
             try:
                 access = await self._auth_store.get_oauth_access(
-                    model.provider, self._session_id, family=family
+                    model.provider, self._session_id, model_id=model.model_id
                 )
             except Exception:
                 return
@@ -2107,7 +2105,8 @@ class SessionStreamFn:
                 storage = self._storage_provider(model.provider)
                 rows = self._auth_store.list_credentials(storage)
                 if rows and all(
-                    self._auth_store.is_blocked_for(row.id, storage, family) for row in rows
+                    self._auth_store.is_blocked_for_model(row.id, storage, model.model_id)
+                    for row in rows
                 ):
                     # Every account is under a block, but "blocked" is only a
                     # verdict from an earlier probe — quota resets while the
@@ -2201,7 +2200,9 @@ class SessionStreamFn:
                     if candidate.id != access.credential_id
                     and candidate.id not in attempted_ids
                     and (row is None or candidate.credential_type == row.credential_type)
-                    and not self._auth_store.is_blocked_for(candidate.id, storage, family)
+                    and not self._auth_store.is_blocked_for_model(
+                        candidate.id, storage, model.model_id
+                    )
                 ]
                 if not siblings and health.state == "depleted":
                     # No UNBLOCKED sibling can take this model, but blocked
@@ -2221,7 +2222,9 @@ class SessionStreamFn:
                         if candidate.id != access.credential_id
                         and candidate.id not in attempted_ids
                         and (row is None or candidate.credential_type == row.credential_type)
-                        and self._auth_store.is_blocked_for(candidate.id, storage, family)
+                        and self._auth_store.is_blocked_for_model(
+                            candidate.id, storage, model.model_id
+                        )
                     ]
                     recovered = await self._recover_blocked_accounts(
                         model, storage, blocked_rows, retry, attempted_ids
@@ -2354,7 +2357,6 @@ class SessionStreamFn:
         """
         from local_operator.providers.failover import parse_selector
 
-        family = model_family(model.model_id)
         threshold = min(100.0, max(0.0, float(retry.usage_reserve_percent))) / 100.0
         # ``None`` means no shared window carried a number — indeterminate, not
         # headroom, so the tier-cap guard stays off and the cautious rotate /
@@ -2374,7 +2376,7 @@ class SessionStreamFn:
             if candidate.id != access.credential_id
             and candidate.id not in attempted_ids
             and (row is None or candidate.credential_type == row.credential_type)
-            and not self._auth_store.is_blocked_for(candidate.id, storage, family)
+            and not self._auth_store.is_blocked_for_model(candidate.id, storage, model.model_id)
         ]
         fallback = await self._first_available_fallback(
             model,
@@ -2436,7 +2438,7 @@ class SessionStreamFn:
                 if candidate.id != access.credential_id
                 and candidate.id not in attempted_ids
                 and (row is None or candidate.credential_type == row.credential_type)
-                and self._auth_store.is_blocked_for(candidate.id, storage, family)
+                and self._auth_store.is_blocked_for_model(candidate.id, storage, model.model_id)
             ]
             recovered = await self._recover_blocked_accounts(
                 model, storage, blocked_rows, retry, attempted_ids
@@ -2649,15 +2651,12 @@ class SessionStreamFn:
             # or block-again-and-fall-back). A depleted verdict is returned,
             # not swallowed — the policy decides its fate, and the caller's
             # fallback notice must name the quota, not the credential pool.
-            # A definite verdict supersedes the blocks that could hide this
-            # model: the account-wide backoff and THIS family's scoped block.
-            # Blocks for OTHER families stay standing — a probe that proves
-            # opus serviceable says nothing about a fable weekly that is
-            # still spent.
-            family = model_family(model.model_id)
-            self._auth_store.clear_block(row.id, storage)
-            if family:
-                self._auth_store.clear_block(row.id, storage, block_scope=f"model:{family}")
+            # A definite verdict supersedes exactly the blocks that could
+            # hide this model: the account-wide backoff and every scoped
+            # block whose family gates it. Blocks for OTHER families stay
+            # standing — a probe that proves opus serviceable says nothing
+            # about a fable weekly that is still spent.
+            self._auth_store.clear_blocks_for_model(row.id, storage, model.model_id)
             self._auth_store.pin_session_credential(model.provider, self._session_id, row.id)
             shared_remaining, tier_binding = shared_tier_saturation(
                 report,

--- a/local_operator/model/registry.py
+++ b/local_operator/model/registry.py
@@ -819,12 +819,16 @@ def _anthropic_family(model_id: str) -> Optional[tuple[str, tuple[int, ...]]]:
 def model_family(model_id: str) -> str:
     """The vendor's model FAMILY a model-scoped quota cap would name.
 
-    Anthropic scopes some weekly caps to a family (``7 day (Fable)``), and the
-    usage layer keys those caps on a slug of the family's display name. The
-    slug of this function's return value is exactly that key (``fable``), so a
-    quota verdict can say WHICH family it bound on and a credential block can
-    be scoped to that family instead of taking the whole account out of
-    rotation for a model that never draws on the spent window.
+    Anthropic scopes some weekly caps to a family (``7 day (Fable)``), and
+    the Anthropic usage fetcher keys those caps on a slug of the family's
+    display name — for Anthropic ids the slug of this function's return
+    value is exactly that key (``fable``), so a quota verdict can say WHICH
+    family it bound on and a credential block can be scoped to that family
+    instead of taking the whole account out of rotation for a model that
+    never draws on the spent window. Other providers' tier rows key on
+    vendor display names that need not parse out of the model id (xAI's
+    ``Grok 4``), which is why block READS match by "slug in model id" (the
+    usage layer's own gating rule) rather than through this function.
 
     Empty means "no family parseable from the id" — the caller then has no
     family dimension to scope anything by, and account-wide treatment is the

--- a/local_operator/model/registry.py
+++ b/local_operator/model/registry.py
@@ -816,6 +816,26 @@ def _anthropic_family(model_id: str) -> Optional[tuple[str, tuple[int, ...]]]:
     return tier, tuple(version)
 
 
+def model_family(model_id: str) -> str:
+    """The vendor's model FAMILY a model-scoped quota cap would name.
+
+    Anthropic scopes some weekly caps to a family (``7 day (Fable)``), and the
+    usage layer keys those caps on a slug of the family's display name. The
+    slug of this function's return value is exactly that key (``fable``), so a
+    quota verdict can say WHICH family it bound on and a credential block can
+    be scoped to that family instead of taking the whole account out of
+    rotation for a model that never draws on the spent window.
+
+    Empty means "no family parseable from the id" — the caller then has no
+    family dimension to scope anything by, and account-wide treatment is the
+    honest default. ``_anthropic_family`` already reads tiers by KIND rather
+    than by a fixed list, so a new family (as ``fable`` once was) parses
+    without touching this function.
+    """
+    parsed = _anthropic_family(model_id)
+    return parsed[0] if parsed is not None else ""
+
+
 def anthropic_family_model_info(model_id: str) -> Optional[ModelInfo]:
     """The best shipped description for an Anthropic id :data:`anthropic_models` lacks.
 

--- a/local_operator/providers/auth_store.py
+++ b/local_operator/providers/auth_store.py
@@ -522,29 +522,56 @@ class AuthStore:
         ).fetchone()
         return bool(row and row[0] > self._now_ms())
 
-    def is_blocked_for(self, credential_id: int, provider: str, family: str = "") -> bool:
-        """Whether ``credential_id`` is out of rotation for ``family``.
+    def is_blocked_for_model(self, credential_id: int, provider: str, model_id: str) -> bool:
+        """Whether ``credential_id`` is out of rotation for ``model_id``.
 
-        An account-wide block stops every model, so it always counts. A
-        model-family block (``model:<family>``, written when a scoped quota
-        cap — Anthropic's ``7 day (Fable)`` — was the only binding window)
-        stops just that family: requests for other families must still see
-        the account, because the shared 5-hour / 7-day windows still gate
-        them. ``family == ""`` is the account-wide question itself.
+        The read side of a scoped quota block mirrors the rule the usage
+        layer gates caps by: a tier row applies to a model when its slug
+        appears in the model id (``fable`` in ``claude-fable-5``, ``grok-4``
+        in ``grok-4.6``). A block is therefore visible to exactly the models
+        whose cap wrote it, on ANY provider, without the two sides having to
+        agree on a family parser — the write stores the usage tier slug, the
+        read asks "does that slug gate this model". Account-wide blocks stop
+        everything as before; a model no scoped slug matches still sees the
+        account (the under-block direction, which heals on the next probe).
         """
         if self.is_blocked(credential_id, provider):
             return True
-        if not family:
+        lowered = (model_id or "").lower()
+        if not lowered:
             return False
         credential = self.get_credential(credential_id)
         provider = self._storage_id(provider)
         provider_key = f"{provider}:{credential.credential_type if credential else 'api_key'}"
-        row = self._conn.execute(
-            "SELECT blocked_until_ms FROM auth_credential_blocks"
-            " WHERE credential_id = ? AND provider_key = ? AND block_scope = ?",
-            (credential_id, provider_key, f"model:{family}"),
-        ).fetchone()
-        return bool(row and row[0] > self._now_ms())
+        rows = self._conn.execute(
+            "SELECT block_scope, blocked_until_ms FROM auth_credential_blocks"
+            " WHERE credential_id = ? AND provider_key = ? AND block_scope != ''",
+            (credential_id, provider_key),
+        ).fetchall()
+        now = self._now_ms()
+        return any(until > now and scope.removeprefix("model:") in lowered for scope, until in rows)
+
+    def clear_blocks_for_model(self, credential_id: int, provider: str, model_id: str) -> None:
+        """Drop the account-wide block and every scoped block gating ``model_id``.
+
+        The recovery-probe counterpart of :meth:`is_blocked_for_model`: a
+        fresh verdict that proves the model serviceable supersedes exactly
+        the blocks that could have hidden it, and leaves other families'
+        scoped blocks standing (a probe that proves opus serviceable says
+        nothing about a Fable weekly that is still spent).
+        """
+        credential = self.get_credential(credential_id)
+        provider = self._storage_id(provider)
+        provider_key = f"{provider}:{credential.credential_type if credential else 'api_key'}"
+        lowered = (model_id or "").lower()
+        self._conn.execute(
+            "DELETE FROM auth_credential_blocks"
+            " WHERE credential_id = ? AND provider_key = ?"
+            " AND (block_scope = '' OR (? != '' AND block_scope != ''"
+            " AND instr(?, substr(block_scope, 7)) > 0))",
+            (credential_id, provider_key, lowered, lowered),
+        )
+        self._conn.commit()
 
     def clear_blocks(self, credential_id: int) -> None:
         self._conn.execute(
@@ -879,16 +906,16 @@ class AuthStore:
         source: str | None,
         *,
         ignore_demotions: bool = False,
-        family: str = "",
+        model_id: str = "",
     ) -> list[StoredCredential]:
-        # ``family`` scopes the block filter: an account blocked only for one
+        # ``model_id`` scopes the block filter: an account blocked only for a
         # model family (a spent scoped weekly cap) still serves every other
-        # family, so a resolve that names a different one must see the row.
+        # family, so a resolve that names a different model must see the row.
         rows = [
             r
             for r in self.list_credentials(provider)
             if r.credential_type == credential_type
-            and not self.is_blocked_for(r.id, provider, family)
+            and not self.is_blocked_for_model(r.id, provider, model_id)
         ]
         if source is not None:
             rows = [r for r in rows if r.data.get("source") == source]
@@ -939,21 +966,22 @@ class AuthStore:
         *,
         force_refresh: bool = False,
         read_only: bool = False,
-        family: str = "",
+        model_id: str = "",
     ) -> str | None:
         """Resolve the API key for ``provider`` via the 7-step cascade.
 
         ``read_only`` makes the resolve decide nothing about routing — see
-        :meth:`_resolve`. ``family`` names the model family the request will
-        run, so model-family-scoped quota blocks (see :meth:`is_blocked_for`)
-        only exclude the accounts that cannot serve THAT family.
+        :meth:`_resolve`. ``model_id`` names the model the request will run,
+        so model-family-scoped quota blocks (see
+        :meth:`is_blocked_for_model`) only exclude the accounts that cannot
+        serve THAT model.
         """
         key, _row = await self._resolve(
             provider,
             session_id,
             force_refresh=force_refresh,
             read_only=read_only,
-            family=family,
+            model_id=model_id,
         )
         return key
 
@@ -964,7 +992,7 @@ class AuthStore:
         *,
         force_refresh: bool = False,
         read_only: bool = False,
-        family: str = "",
+        model_id: str = "",
     ) -> OAuthAccess | None:
         """The identity-carrying record for wire clients.
 
@@ -986,7 +1014,7 @@ class AuthStore:
             session_id,
             force_refresh=force_refresh,
             read_only=read_only,
-            family=family,
+            model_id=model_id,
         )
         if key is None:
             return None
@@ -1089,7 +1117,7 @@ class AuthStore:
         force_refresh: bool = False,
         read_only: bool = False,
         ignore_demotions: bool = False,
-        family: str = "",
+        model_id: str = "",
     ) -> tuple[str | None, StoredCredential | None]:
         """The 7-step cascade; returns ``(key, winning row or None)``.
 
@@ -1133,7 +1161,7 @@ class AuthStore:
             "oauth",
             source=None,
             ignore_demotions=ignore_demotions,
-            family=family,
+            model_id=model_id,
         )
         for row in self._selection_order(oauth_rows, provider, session_id, read_only=read_only):
             try:
@@ -1160,7 +1188,7 @@ class AuthStore:
             "api_key",
             source="login",
             ignore_demotions=ignore_demotions,
-            family=family,
+            model_id=model_id,
         )
         for row in self._selection_order(login_rows, provider, session_id, read_only=read_only):
             key = row.data.get("key")
@@ -1186,7 +1214,7 @@ class AuthStore:
                 "api_key",
                 source=None,
                 ignore_demotions=ignore_demotions,
-                family=family,
+                model_id=model_id,
             )
             if row.data.get("source") != "login"
         ]
@@ -1225,7 +1253,7 @@ class AuthStore:
                 force_refresh=force_refresh,
                 read_only=read_only,
                 ignore_demotions=True,
-                family=family,
+                model_id=model_id,
             )
 
         return None, None
@@ -1269,7 +1297,7 @@ class AuthStore:
         api_key: str | None = None,
         block_ms: int = DEFAULT_BLOCK_MS,
         *,
-        family: str = "",
+        model_id: str = "",
     ) -> bool:
         """a/b/c tier-1 step (c): drop the failing credential, keep a sibling.
 
@@ -1329,7 +1357,11 @@ class AuthStore:
                 # over-block (account-wide on a family verdict) is the side
                 # that strands spendable quota behind "all credentials
                 # unusable", so it is never written from a family-named
-                # rotation.
+                # rotation. The family comes from the model the request ran,
+                # via the same parser the usage layer's tier rows key on.
+                from local_operator.model.registry import model_family
+
+                family = model_family(model_id) if model_id else ""
                 scope = f"model:{family}" if (usage_limited and family) else ""
                 self.block_credential(
                     failing.id,

--- a/local_operator/providers/auth_store.py
+++ b/local_operator/providers/auth_store.py
@@ -522,13 +522,37 @@ class AuthStore:
         ).fetchone()
         return bool(row and row[0] > self._now_ms())
 
+    def is_blocked_for(self, credential_id: int, provider: str, family: str = "") -> bool:
+        """Whether ``credential_id`` is out of rotation for ``family``.
+
+        An account-wide block stops every model, so it always counts. A
+        model-family block (``model:<family>``, written when a scoped quota
+        cap — Anthropic's ``7 day (Fable)`` — was the only binding window)
+        stops just that family: requests for other families must still see
+        the account, because the shared 5-hour / 7-day windows still gate
+        them. ``family == ""`` is the account-wide question itself.
+        """
+        if self.is_blocked(credential_id, provider):
+            return True
+        if not family:
+            return False
+        credential = self.get_credential(credential_id)
+        provider = self._storage_id(provider)
+        provider_key = f"{provider}:{credential.credential_type if credential else 'api_key'}"
+        row = self._conn.execute(
+            "SELECT blocked_until_ms FROM auth_credential_blocks"
+            " WHERE credential_id = ? AND provider_key = ? AND block_scope = ?",
+            (credential_id, provider_key, f"model:{family}"),
+        ).fetchone()
+        return bool(row and row[0] > self._now_ms())
+
     def clear_blocks(self, credential_id: int) -> None:
         self._conn.execute(
             "DELETE FROM auth_credential_blocks WHERE credential_id = ?", (credential_id,)
         )
         self._conn.commit()
 
-    def clear_block(self, credential_id: int, provider: str) -> None:
+    def clear_block(self, credential_id: int, provider: str, block_scope: str = "") -> None:
         """Drop the primary block for ONE credential, leaving other scopes alone.
 
         ``clear_blocks`` wipes every block the credential carries; usage-aware
@@ -541,8 +565,8 @@ class AuthStore:
         provider_key = f"{provider}:{credential.credential_type if credential else 'api_key'}"
         self._conn.execute(
             "DELETE FROM auth_credential_blocks"
-            " WHERE credential_id = ? AND provider_key = ? AND block_scope = ''",
-            (credential_id, provider_key),
+            " WHERE credential_id = ? AND provider_key = ? AND block_scope = ?",
+            (credential_id, provider_key, block_scope),
         )
         self._conn.commit()
 
@@ -855,11 +879,16 @@ class AuthStore:
         source: str | None,
         *,
         ignore_demotions: bool = False,
+        family: str = "",
     ) -> list[StoredCredential]:
+        # ``family`` scopes the block filter: an account blocked only for one
+        # model family (a spent scoped weekly cap) still serves every other
+        # family, so a resolve that names a different one must see the row.
         rows = [
             r
             for r in self.list_credentials(provider)
-            if r.credential_type == credential_type and not self.is_blocked(r.id, provider)
+            if r.credential_type == credential_type
+            and not self.is_blocked_for(r.id, provider, family)
         ]
         if source is not None:
             rows = [r for r in rows if r.data.get("source") == source]
@@ -910,14 +939,21 @@ class AuthStore:
         *,
         force_refresh: bool = False,
         read_only: bool = False,
+        family: str = "",
     ) -> str | None:
         """Resolve the API key for ``provider`` via the 7-step cascade.
 
         ``read_only`` makes the resolve decide nothing about routing — see
-        :meth:`_resolve`.
+        :meth:`_resolve`. ``family`` names the model family the request will
+        run, so model-family-scoped quota blocks (see :meth:`is_blocked_for`)
+        only exclude the accounts that cannot serve THAT family.
         """
         key, _row = await self._resolve(
-            provider, session_id, force_refresh=force_refresh, read_only=read_only
+            provider,
+            session_id,
+            force_refresh=force_refresh,
+            read_only=read_only,
+            family=family,
         )
         return key
 
@@ -928,6 +964,7 @@ class AuthStore:
         *,
         force_refresh: bool = False,
         read_only: bool = False,
+        family: str = "",
     ) -> OAuthAccess | None:
         """The identity-carrying record for wire clients.
 
@@ -945,7 +982,11 @@ class AuthStore:
         if self._runtime_overrides.get(provider) or self._config_overrides.get(provider):
             return None
         key, row = await self._resolve(
-            provider, session_id, force_refresh=force_refresh, read_only=read_only
+            provider,
+            session_id,
+            force_refresh=force_refresh,
+            read_only=read_only,
+            family=family,
         )
         if key is None:
             return None
@@ -1048,6 +1089,7 @@ class AuthStore:
         force_refresh: bool = False,
         read_only: bool = False,
         ignore_demotions: bool = False,
+        family: str = "",
     ) -> tuple[str | None, StoredCredential | None]:
         """The 7-step cascade; returns ``(key, winning row or None)``.
 
@@ -1087,7 +1129,11 @@ class AuthStore:
 
         # 3. OAuth credential
         oauth_rows = self._usable_key_rows(
-            provider, "oauth", source=None, ignore_demotions=ignore_demotions
+            provider,
+            "oauth",
+            source=None,
+            ignore_demotions=ignore_demotions,
+            family=family,
         )
         for row in self._selection_order(oauth_rows, provider, session_id, read_only=read_only):
             try:
@@ -1110,7 +1156,11 @@ class AuthStore:
 
         # 4. API key persisted by interactive login
         login_rows = self._usable_key_rows(
-            provider, "api_key", source="login", ignore_demotions=ignore_demotions
+            provider,
+            "api_key",
+            source="login",
+            ignore_demotions=ignore_demotions,
+            family=family,
         )
         for row in self._selection_order(login_rows, provider, session_id, read_only=read_only):
             key = row.data.get("key")
@@ -1132,7 +1182,11 @@ class AuthStore:
         stored_rows = [
             row
             for row in self._usable_key_rows(
-                provider, "api_key", source=None, ignore_demotions=ignore_demotions
+                provider,
+                "api_key",
+                source=None,
+                ignore_demotions=ignore_demotions,
+                family=family,
             )
             if row.data.get("source") != "login"
         ]
@@ -1171,6 +1225,7 @@ class AuthStore:
                 force_refresh=force_refresh,
                 read_only=read_only,
                 ignore_demotions=True,
+                family=family,
             )
 
         return None, None
@@ -1213,6 +1268,8 @@ class AuthStore:
         error: BaseException,
         api_key: str | None = None,
         block_ms: int = DEFAULT_BLOCK_MS,
+        *,
+        family: str = "",
     ) -> bool:
         """a/b/c tier-1 step (c): drop the failing credential, keep a sibling.
 
@@ -1261,8 +1318,24 @@ class AuthStore:
                 self.deprioritize_credential(provider, failing.id)
             else:
                 retry_after = retry_after_ms_from_error(error)
+                # A usage-limit 429 names the family the request ran on, not
+                # the window that spent: an opus request can be refused by the
+                # shared 5-hour window as surely as a fable one by its scoped
+                # weekly. Scoping the block to the family is the under-block
+                # side of that ambiguity, and it is the side that heals — the
+                # next 429 on another family writes its own scope, and the
+                # preflight's usage probe upgrades to an account-wide block
+                # the moment a shared window is the one binding. The
+                # over-block (account-wide on a family verdict) is the side
+                # that strands spendable quota behind "all credentials
+                # unusable", so it is never written from a family-named
+                # rotation.
+                scope = f"model:{family}" if (usage_limited and family) else ""
                 self.block_credential(
-                    failing.id, provider, block_ms=max(block_ms, retry_after or 0)
+                    failing.id,
+                    provider,
+                    block_scope=scope,
+                    block_ms=max(block_ms, retry_after or 0),
                 )
             if usage_limited:
                 # Sticky preserved: same account stays first after backoff.

--- a/local_operator/providers/failover.py
+++ b/local_operator/providers/failover.py
@@ -24,7 +24,9 @@ import random
 import time
 from collections.abc import AsyncIterator, Awaitable, Callable, Mapping, Sequence
 from http import HTTPStatus
-from typing import TYPE_CHECKING, Any, Literal, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Literal, Protocol, cast, runtime_checkable
+
+import httpx
 
 from local_operator.harness.types import (
     AbortSignal,
@@ -34,6 +36,7 @@ from local_operator.harness.types import (
     StreamEvent,
 )
 from local_operator.model.effort import EFFORT_ORDER, resolve_effort
+from local_operator.model.registry import model_family
 
 if TYPE_CHECKING:  # import cycle: both modules import this one at runtime
     from local_operator.providers.auth_store import OAuthAccess, StoredCredential
@@ -1087,6 +1090,15 @@ class FailoverRouteState:
     on_change: RouteChangeHandler | None = None
     primary_retry_at_ms: int = 0
     on_settle: RouteSettleHandler | None = None
+    #: Set when the pin was placed by a QUOTA verdict (the usage-aware
+    #: preflight), not a transport failure. Quota resets on a schedule the
+    #: usage endpoint can answer definitively, so a quota pin is re-probed at
+    #: every message boundary regardless of ``primary_retry_at_ms`` — a
+    #: cooldown sized to a 24h advertised reset would otherwise glue the
+    #: session to a fallback for a day after the primary's 5-hour window
+    #: reopened. Transport pins keep the cooldown: their recovery is not
+    #: cheaply observable.
+    quota_pinned: bool = False
     #: Per-target bench: ``(selector, effort) -> earliest ms it may be asked
     #: again``. Written when a FALLBACK target exhausts its provider during a
     #: walk, consulted by the next walk's first pass and by preflight's
@@ -1108,6 +1120,7 @@ class FailoverRouteState:
         reason: str,
         *,
         cooldown_ms: int = 0,
+        quota: bool = False,
     ) -> None:
         if self.active == target:
             # Already on this route: nothing changed, so nothing is re-armed.
@@ -1120,12 +1133,18 @@ class FailoverRouteState:
             # whole session even after the primary recovered. The docstring
             # above promises a retry "only after primary_retry_at_ms", which
             # is a deadline set when the route CHANGES, not on every use.
+            # The quota origin is sticky in the same direction: once a pin
+            # was placed on quota evidence it stays quota evidence (the
+            # preflight is the only quota pinner, and it re-pins on the same
+            # verdict), so a re-activation must not downgrade the marker.
+            self.quota_pinned = self.quota_pinned or quota
             return
         if cooldown_ms > 0:
             self.primary_retry_at_ms = max(
                 self.primary_retry_at_ms,
                 int(time.time() * 1000) + cooldown_ms,
             )
+        self.quota_pinned = quota
         self.active = target
         if self.on_change is not None:
             result = self.on_change(target, reason)
@@ -1173,6 +1192,7 @@ class FailoverRouteState:
         """
         self.active = None
         self.primary_retry_at_ms = 0
+        self.quota_pinned = False
 
     async def clear_settled(self, reason: str) -> None:
         """Return the route to the primary and NOTIFY ``on_settle``.
@@ -1278,6 +1298,8 @@ class FailoverAuthStore(Protocol):
         session_id: str | None,
         error: BaseException,
         api_key: str | None = None,
+        *,
+        family: str = "",
     ) -> bool: ...  # pragma: no cover
 
 
@@ -1543,10 +1565,17 @@ async def stream_with_failover(
         )
         if route_state is not None and target != primary_target:
             cooldown_ms = max(60_000, reported.retry_after_ms or 0) if reported else 60_000
+            # A pin placed on quota evidence (a 429 walk, not a transport
+            # outage) is re-probed at every message boundary: the usage
+            # endpoint answers definitively whether the primary recovered,
+            # and a cooldown sized to an advertised 24h reset would otherwise
+            # glue the session to this fallback a whole day past the
+            # primary's window reopening. Transport pins keep the cooldown.
             await route_state.activate(
                 target,
                 "provider failure",
                 cooldown_ms=cooldown_ms,
+                quota=reported is not None and reported.kind == "quota",
             )
         state = AuthRetryKeyState()
         error: BaseException | None = None
@@ -1568,6 +1597,7 @@ async def stream_with_failover(
         # already spent was skipped at the top of this walk, before it could
         # touch the route pin.
         server_fault_requests = server_faults_by_target.get(route_key, 0)
+        quota_recovery_attempted = False
         # Attempts this target's FIRST bearer spent before rotation started, so
         # the restore below can hand back the remainder of the user's budget
         # instead of a fresh one.
@@ -1595,6 +1625,7 @@ async def stream_with_failover(
                     state,
                     error,
                     read_only=request.isolated,
+                    family=model_family(spec.model_id),
                 )
                 token = access.access_token if access is not None else None
                 if token != current_token:
@@ -1606,6 +1637,35 @@ async def stream_with_failover(
                         spent_before_rotation = max(spent_before_rotation, transport_retries + 1)
                     current_token = token
                     transport_retries = 0  # fresh credential ⇒ fresh budget
+                # Isolated requests take this too: they skip the preflight
+                # entirely, so without the probe an errand would die on
+                # "all credentials unusable" behind blocks the usage endpoint
+                # says are stale. The probe only CLEARS blocks a fresh
+                # verdict supersedes — it never writes one, never pins — so
+                # it cannot move the concurrent turn's routing the way a
+                # block or pin would. Gated on the same opt-in as the
+                # preflight: it costs one usage fetch per blocked row, and a
+                # session that has not asked for usage-aware routing keeps
+                # the cheaper verdict-only behaviour.
+                if (
+                    access is None
+                    and retry.usage_aware_fallback
+                    and not quota_recovery_attempted
+                    and (error is None or is_usage_limit_error(error))
+                ):
+                    # Every resolve path came back empty on a quota-shaped
+                    # situation (or on the very first resolve, before any
+                    # error exists): the cascade is hiding accounts behind
+                    # quota blocks, and a family-scoped block can be hiding
+                    # an account that serves THIS family. Probe the blocks
+                    # before declaring the provider dead — at most once per
+                    # target, so a provider whose usage endpoint disagrees
+                    # with its wire answers cannot loop the walk.
+                    quota_recovery_attempted = True
+                    recovered = await _recover_quota_blocked(auth, provider, spec.model_id)
+                    if recovered is not None:
+                        access = recovered
+                        error = None
                 if access is None and error is not None:
                     # Rotation is exhausted: no other credential exists. The
                     # small pre-rotation allowance exists ONLY to get a turn
@@ -1892,6 +1952,151 @@ async def stream_with_failover(
     raise ProviderError(None, f"Failover exhausted for '{primary_selector}'", retryable=False)
 
 
+def _rotate_sibling(
+    auth: FailoverAuthStore,
+    provider: str,
+    session_id: str | None,
+    error: BaseException,
+    api_key: str | None,
+    family: str,
+) -> None:
+    """Step (c) of the a/b/c rotation, with the family dimension attached.
+
+    A usage-limit verdict that binds ONLY on a model-family cap (Anthropic's
+    ``7 day (Fable)``) must block the failing credential for THAT family, not
+    for the whole account: the shared 5-hour / 7-day windows still serve every
+    other family, and an account-wide block is exactly what later made an
+    opus request report "all credentials unusable" on an account whose only
+    spent window was Fable's. Stores that predate scoped blocks keep the old
+    two-argument behaviour.
+    """
+    try:
+        auth.rotate_sibling(provider, session_id, error, api_key=api_key, family=family)
+    except TypeError:
+        auth.rotate_sibling(provider, session_id, error, api_key=api_key)
+
+
+async def _recover_quota_blocked(
+    auth: FailoverAuthStore,
+    provider: str,
+    model_id: str,
+) -> "OAuthAccess | None":
+    """Probe accounts that quota blocks hid from the cascade, for THIS family.
+
+    The reactive mirror of the preflight's blocked-account recovery. A quota
+    block is an EARLIER verdict, and a family-scoped one is a verdict about
+    ONE model family: when every account carries such a block (each written
+    by a fable-5 request that genuinely could not be served), a request for a
+    different family resolves to ``None`` and dies with "all credentials
+    unusable" while spendable shared quota sits behind the blocks. Before
+    accepting that, ask each blocked row's OWN usage whether the family this
+    request names is actually spent; a row whose shared windows still hold
+    headroom is unblocked (for that family) and served.
+
+    Returns the recovered record, or ``None`` when no row recovers — the
+    honest "nothing left" the caller already handles. Never raises: a probe
+    that cannot get a definite answer leaves the block standing.
+    """
+    from local_operator.providers.usage import fetch_usage, usage_health
+
+    if not isinstance(auth, CredentialLister):
+        return None
+    family = model_family(model_id)
+    try:
+        rows = [
+            row
+            for row in auth.list_credentials(provider)
+            if row.credential_type == "oauth" and row.disabled_cause is None
+        ]
+    except Exception:
+        return None
+    for row in rows:
+        if not _is_blocked_for(auth, row.id, provider, family):
+            continue  # the cascade already sees this row; not our gap
+        fresh = getattr(auth, "ensure_oauth_fresh", None)
+        if not callable(fresh):
+            return None  # stores without per-row refresh cannot be probed
+        refresh_row = cast("Callable[[int], Awaitable[dict[str, Any] | None]]", fresh)
+        try:
+            creds = await refresh_row(row.id)
+        except Exception:
+            creds = None
+        if not creds:
+            continue
+        token = creds.get("access")
+        if not token:
+            definition = _provider_definition(provider)
+            key_fn = definition.get_api_key if definition is not None else None
+            token = key_fn(creds) if key_fn else None
+        if not token:
+            continue
+        try:
+            async with httpx.AsyncClient() as probe_client:
+                report = await fetch_usage(
+                    probe_client,
+                    provider,
+                    access_token=token,
+                    account_id=creds.get("account_id"),
+                )
+        except Exception:
+            report = None
+        if report is None:
+            continue
+        health = usage_health(report, model_id)
+        if health.state not in ("healthy", "reserve"):
+            continue  # genuinely spent for this family: the block stands
+        if family:
+            _clear_block(auth, row.id, provider, f"model:{family}")
+        _clear_block(auth, row.id, provider, "")
+        logger.info(
+            "quota recovery: credential %d for %s serves %s again (%s)",
+            row.id,
+            provider,
+            model_id,
+            health.state,
+        )
+        from local_operator.providers.auth_store import OAuthAccess as _OAuthRecord
+
+        return _OAuthRecord(
+            access_token=token,
+            credential_id=row.id,
+            account_id=creds.get("account_id"),
+            email=creds.get("email"),
+            org_id=creds.get("org_id"),
+            kind="oauth",
+            raw=creds,
+        )
+    return None
+
+
+def _provider_definition(provider: str) -> Any:
+    from local_operator.providers.registry import get_provider_definition
+
+    return get_provider_definition(provider)
+
+
+def _is_blocked_for(
+    auth: FailoverAuthStore, credential_id: int, provider: str, family: str
+) -> bool:
+    probe = getattr(auth, "is_blocked_for", None)
+    if callable(probe):
+        return bool(probe(credential_id, provider, family))
+    return bool(getattr(auth, "is_blocked", lambda *_a: False)(credential_id, provider))
+
+
+def _clear_block(auth: FailoverAuthStore, credential_id: int, provider: str, scope: str) -> None:
+    clear = getattr(auth, "clear_block", None)
+    if not callable(clear):
+        return
+    try:
+        if scope:
+            clear(credential_id, provider, block_scope=scope)
+        else:
+            clear(credential_id, provider)
+    except TypeError:
+        clear(credential_id, provider)
+
+
 async def _resolve_access_for_provider(
     auth: FailoverAuthStore,
     provider: str,
@@ -1900,6 +2105,7 @@ async def _resolve_access_for_provider(
     error: BaseException | None,
     *,
     read_only: bool = False,
+    family: str = "",
 ) -> "OAuthAccess | None":
     """Bridge AuthStore into the a/b/c resolver shape, returning the
     :class:`~local_operator.providers.auth_store.OAuthAccess` record (or
@@ -1927,13 +2133,23 @@ async def _resolve_access_for_provider(
             flags["read_only"] = True
         return flags
 
+    def _family_flags(force_refresh: bool) -> dict[str, Any]:
+        """``family`` rides only when named: stores (and test doubles) that
+        predate model-scoped quota blocks declare the bare signature."""
+        flags: dict[str, Any] = _flags(force_refresh)
+        if family:
+            flags["family"] = family
+        return flags
+
     async def _access(*, force_refresh: bool = False) -> "OAuthAccess | None":
         if oauth_store is None:
             return None
-        return await oauth_store.get_oauth_access(provider, session_id, **_flags(force_refresh))
+        return await oauth_store.get_oauth_access(
+            provider, session_id, **_family_flags(force_refresh)
+        )
 
     async def _key(*, force_refresh: bool = False) -> str | None:
-        return await auth.get_api_key(provider, session_id, **_flags(force_refresh))
+        return await auth.get_api_key(provider, session_id, **_family_flags(force_refresh))
 
     async def resolver(ctx: ApiKeyResolveContext) -> str | None:
         try:
@@ -1942,7 +2158,7 @@ async def _resolve_access_for_provider(
                 if record is None:
                     return await _key()
             elif ctx.last_chance:
-                auth.rotate_sibling(provider, session_id, ctx.error, api_key=ctx.previous_key)
+                _rotate_sibling(auth, provider, session_id, ctx.error, ctx.previous_key, family)
                 record = await _access()
                 if record is None:
                     return await _key()

--- a/local_operator/providers/failover.py
+++ b/local_operator/providers/failover.py
@@ -1627,6 +1627,7 @@ async def stream_with_failover(
                     error,
                     read_only=request.isolated,
                     model_id=spec.model_id,
+                    scoped_blocks=retry.usage_aware_fallback,
                 )
                 token = access.access_token if access is not None else None
                 if token != current_token:
@@ -1663,7 +1664,12 @@ async def stream_with_failover(
                     # target, so a provider whose usage endpoint disagrees
                     # with its wire answers cannot loop the walk.
                     quota_recovery_attempted = True
-                    recovered = await _recover_quota_blocked(auth, provider, spec.model_id)
+                    recovered = await _recover_quota_blocked(
+                        auth,
+                        provider,
+                        spec.model_id,
+                        reserve_percent=retry.usage_reserve_percent,
+                    )
                     if recovered is not None:
                         access = recovered
                         error = None
@@ -1981,6 +1987,7 @@ async def _recover_quota_blocked(
     auth: FailoverAuthStore,
     provider: str,
     model_id: str,
+    reserve_percent: float = 10.0,
 ) -> "OAuthAccess | None":
     """Probe accounts that quota blocks hid from the cascade, for THIS family.
 
@@ -2042,12 +2049,14 @@ async def _recover_quota_blocked(
             report = None
         if report is None:
             continue
-        health = usage_health(report, model_id)
+        health = usage_health(report, model_id, reserve_percent=reserve_percent)
         if health.state not in ("healthy", "reserve"):
             continue  # genuinely spent for this family: the block stands
         _clear_blocks_for_model(auth, row.id, provider, model_id)
+        # The usage endpoint's verdict, not a wire request: the next attempt
+        # is the proof, and the log must not claim more than the probe gave.
         logger.info(
-            "quota recovery: credential %d for %s serves %s again (%s)",
+            "quota recovery: usage says credential %d for %s serves %s again (%s)",
             row.id,
             provider,
             model_id,
@@ -2100,6 +2109,7 @@ async def _resolve_access_for_provider(
     *,
     read_only: bool = False,
     model_id: str = "",
+    scoped_blocks: bool = False,
 ) -> "OAuthAccess | None":
     """Bridge AuthStore into the a/b/c resolver shape, returning the
     :class:`~local_operator.providers.auth_store.OAuthAccess` record (or

--- a/local_operator/providers/failover.py
+++ b/local_operator/providers/failover.py
@@ -36,7 +36,6 @@ from local_operator.harness.types import (
     StreamEvent,
 )
 from local_operator.model.effort import EFFORT_ORDER, resolve_effort
-from local_operator.model.registry import model_family
 
 if TYPE_CHECKING:  # import cycle: both modules import this one at runtime
     from local_operator.providers.auth_store import OAuthAccess, StoredCredential
@@ -1290,6 +1289,7 @@ class FailoverAuthStore(Protocol):
         *,
         force_refresh: bool = False,
         read_only: bool = False,
+        model_id: str = "",
     ) -> str | None: ...  # pragma: no cover
 
     def rotate_sibling(
@@ -1299,7 +1299,7 @@ class FailoverAuthStore(Protocol):
         error: BaseException,
         api_key: str | None = None,
         *,
-        family: str = "",
+        model_id: str = "",
     ) -> bool: ...  # pragma: no cover
 
 
@@ -1333,6 +1333,7 @@ class OAuthAccessSource(Protocol):
         *,
         force_refresh: bool = False,
         read_only: bool = False,
+        model_id: str = "",
     ) -> "OAuthAccess | None": ...  # pragma: no cover
 
 
@@ -1625,7 +1626,7 @@ async def stream_with_failover(
                     state,
                     error,
                     read_only=request.isolated,
-                    family=model_family(spec.model_id),
+                    model_id=spec.model_id,
                 )
                 token = access.access_token if access is not None else None
                 if token != current_token:
@@ -1958,7 +1959,7 @@ def _rotate_sibling(
     session_id: str | None,
     error: BaseException,
     api_key: str | None,
-    family: str,
+    model_id: str,
 ) -> None:
     """Step (c) of the a/b/c rotation, with the family dimension attached.
 
@@ -1971,7 +1972,7 @@ def _rotate_sibling(
     two-argument behaviour.
     """
     try:
-        auth.rotate_sibling(provider, session_id, error, api_key=api_key, family=family)
+        auth.rotate_sibling(provider, session_id, error, api_key=api_key, model_id=model_id)
     except TypeError:
         auth.rotate_sibling(provider, session_id, error, api_key=api_key)
 
@@ -2001,7 +2002,6 @@ async def _recover_quota_blocked(
 
     if not isinstance(auth, CredentialLister):
         return None
-    family = model_family(model_id)
     try:
         rows = [
             row
@@ -2011,7 +2011,7 @@ async def _recover_quota_blocked(
     except Exception:
         return None
     for row in rows:
-        if not _is_blocked_for(auth, row.id, provider, family):
+        if not _is_blocked_for_model(auth, row.id, provider, model_id):
             continue  # the cascade already sees this row; not our gap
         fresh = getattr(auth, "ensure_oauth_fresh", None)
         if not callable(fresh):
@@ -2045,9 +2045,7 @@ async def _recover_quota_blocked(
         health = usage_health(report, model_id)
         if health.state not in ("healthy", "reserve"):
             continue  # genuinely spent for this family: the block stands
-        if family:
-            _clear_block(auth, row.id, provider, f"model:{family}")
-        _clear_block(auth, row.id, provider, "")
+        _clear_blocks_for_model(auth, row.id, provider, model_id)
         logger.info(
             "quota recovery: credential %d for %s serves %s again (%s)",
             row.id,
@@ -2075,26 +2073,22 @@ def _provider_definition(provider: str) -> Any:
     return get_provider_definition(provider)
 
 
-def _is_blocked_for(
-    auth: FailoverAuthStore, credential_id: int, provider: str, family: str
+def _is_blocked_for_model(
+    auth: FailoverAuthStore, credential_id: int, provider: str, model_id: str
 ) -> bool:
-    probe = getattr(auth, "is_blocked_for", None)
+    probe = getattr(auth, "is_blocked_for_model", None)
     if callable(probe):
-        return bool(probe(credential_id, provider, family))
+        return bool(probe(credential_id, provider, model_id))
     return bool(getattr(auth, "is_blocked", lambda *_a: False)(credential_id, provider))
 
 
-def _clear_block(auth: FailoverAuthStore, credential_id: int, provider: str, scope: str) -> None:
-    clear = getattr(auth, "clear_block", None)
+def _clear_blocks_for_model(
+    auth: FailoverAuthStore, credential_id: int, provider: str, model_id: str
+) -> None:
+    clear = getattr(auth, "clear_blocks_for_model", None)
     if not callable(clear):
         return
-    try:
-        if scope:
-            clear(credential_id, provider, block_scope=scope)
-        else:
-            clear(credential_id, provider)
-    except TypeError:
-        clear(credential_id, provider)
+    clear(credential_id, provider, model_id)
 
 
 async def _resolve_access_for_provider(
@@ -2105,7 +2099,7 @@ async def _resolve_access_for_provider(
     error: BaseException | None,
     *,
     read_only: bool = False,
-    family: str = "",
+    model_id: str = "",
 ) -> "OAuthAccess | None":
     """Bridge AuthStore into the a/b/c resolver shape, returning the
     :class:`~local_operator.providers.auth_store.OAuthAccess` record (or
@@ -2133,23 +2127,23 @@ async def _resolve_access_for_provider(
             flags["read_only"] = True
         return flags
 
-    def _family_flags(force_refresh: bool) -> dict[str, Any]:
-        """``family`` rides only when named: stores (and test doubles) that
-        predate model-scoped quota blocks declare the bare signature."""
+    def _model_flags(force_refresh: bool) -> dict[str, Any]:
+        """``model_id`` rides only when named: stores (and test doubles)
+        that predate model-scoped quota blocks declare the bare signature."""
         flags: dict[str, Any] = _flags(force_refresh)
-        if family:
-            flags["family"] = family
+        if model_id:
+            flags["model_id"] = model_id
         return flags
 
     async def _access(*, force_refresh: bool = False) -> "OAuthAccess | None":
         if oauth_store is None:
             return None
         return await oauth_store.get_oauth_access(
-            provider, session_id, **_family_flags(force_refresh)
+            provider, session_id, **_model_flags(force_refresh)
         )
 
     async def _key(*, force_refresh: bool = False) -> str | None:
-        return await auth.get_api_key(provider, session_id, **_family_flags(force_refresh))
+        return await auth.get_api_key(provider, session_id, **_model_flags(force_refresh))
 
     async def resolver(ctx: ApiKeyResolveContext) -> str | None:
         try:
@@ -2158,7 +2152,7 @@ async def _resolve_access_for_provider(
                 if record is None:
                     return await _key()
             elif ctx.last_chance:
-                _rotate_sibling(auth, provider, session_id, ctx.error, ctx.previous_key, family)
+                _rotate_sibling(auth, provider, session_id, ctx.error, ctx.previous_key, model_id)
                 record = await _access()
                 if record is None:
                     return await _key()

--- a/local_operator/providers/failover.py
+++ b/local_operator/providers/failover.py
@@ -2005,6 +2005,7 @@ async def _recover_quota_blocked(
     honest "nothing left" the caller already handles. Never raises: a probe
     that cannot get a definite answer leaves the block standing.
     """
+    from local_operator.providers.auth_store import OAuthAccess as _OAuthRecord
     from local_operator.providers.usage import fetch_usage, usage_health
 
     if not isinstance(auth, CredentialLister):
@@ -2062,8 +2063,6 @@ async def _recover_quota_blocked(
             model_id,
             health.state,
         )
-        from local_operator.providers.auth_store import OAuthAccess as _OAuthRecord
-
         return _OAuthRecord(
             access_token=token,
             credential_id=row.id,
@@ -2162,7 +2161,18 @@ async def _resolve_access_for_provider(
                 if record is None:
                     return await _key()
             elif ctx.last_chance:
-                _rotate_sibling(auth, provider, session_id, ctx.error, ctx.previous_key, model_id)
+                # Family-scoped rotation blocks ride only with usage-aware
+                # routing: on the opt-out path no preflight probe exists to
+                # upgrade a family block to an account-wide one, so rotation
+                # keeps the pre-existing account-wide semantics there.
+                _rotate_sibling(
+                    auth,
+                    provider,
+                    session_id,
+                    ctx.error,
+                    ctx.previous_key,
+                    model_id if scoped_blocks else "",
+                )
                 record = await _access()
                 if record is None:
                     return await _key()

--- a/local_operator/providers/usage.py
+++ b/local_operator/providers/usage.py
@@ -308,6 +308,14 @@ class QuotaHealth:
     #: these to tell "everything is spent" from "one secondary window is spent"
     #: without re-deriving the binding set from the raw report.
     binding_labels: tuple[str, ...] = ()
+    #: Family slugs of the SCOPED windows in the binding set (Anthropic's
+    #: ``7 day (Fable)`` yields ``("fable",)``). This is the dimension a
+    #: credential block must be scoped to: a verdict whose only binding
+    #: windows are family caps stops THAT family on the account, not every
+    #: model the account serves — the shared 5-hour / 7-day windows still
+    #: gate the rest. Empty when the binding set is account-wide or the
+    #: report carries no family-scoped rows.
+    binding_families: tuple[str, ...] = ()
 
 
 def usage_health(
@@ -383,6 +391,9 @@ def usage_health(
             reset_after_ms=reset_after,
             scope=scope,
             binding_labels=tuple(limit.label for limit in zero_balance),
+            binding_families=tuple(
+                dict.fromkeys(limit.tier for limit in zero_balance if limit.tier)
+            ),
         )
 
     remaining = min(value for _limit, value in measured)
@@ -420,6 +431,7 @@ def usage_health(
         reset_after_ms=reset_after,
         scope=scope,
         binding_labels=tuple(limit.label for limit in binding),
+        binding_families=tuple(dict.fromkeys(limit.tier for limit in binding if limit.tier)),
     )
 
 

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -1978,16 +1978,27 @@ class Session:
         """Exposed so the wake tool can list/create/cancel schedules."""
         return self._wake
 
-    async def preflight_usage(self) -> None:
+    async def preflight_usage(self, *, consume_boundary: bool = True) -> None:
         """Run the stream's message-boundary quota check without starting a turn.
 
         The TUI calls this after subscribing, so an exhausted default provider
         becomes a visible warning while startup itself remains successful.
+
+        ``consume_boundary=False`` is the ``/model`` switch probe: it evaluates
+        the NEW selector immediately (a spent family cap on the previous model
+        must not ride across the switch) without spending the message-boundary
+        token the next request's effort classification is owed.
         """
         preflight = getattr(self._stream_fn, "preflight_usage", None)
         if not callable(preflight):
             return
-        result = preflight(self._model)
+        # The kwarg rides only when set: stream fakes that predate the
+        # switch probe declare the bare ``(model)`` shape.
+        result = (
+            preflight(self._model)
+            if consume_boundary
+            else preflight(self._model, consume_boundary=False)
+        )
         if inspect.isawaitable(result):
             await result
 

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -28,6 +28,7 @@ import os
 import time
 from collections.abc import Mapping
 from dataclasses import dataclass
+from functools import partial
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, NamedTuple, Protocol, cast
 
 from rich.console import Group
@@ -1705,6 +1706,35 @@ class OperatorApp(App[None]):
             await cast(Callable[[], Awaitable[None]], usage_preflight)()
         except Exception:
             pass
+
+    def _probe_quota_after_switch(self, session: Any) -> None:
+        """Run the quota preflight for the model a ``/model`` just selected.
+
+        Without this the switch's quota verdict waited for the next message
+        boundary: a session whose DEFAULT model sat under a spent family cap
+        (``claude-fable-5`` with the Fable weekly at 100%) carried that
+        verdict across the switch until the first request on the new model
+        paid for it — and the reactive path could die on blocks the probe
+        would have scoped correctly. The probe consumes no message-boundary
+        token, so the next request still gets its effort classification and
+        its own preflight.
+        """
+        preflight = getattr(session, "preflight_usage", None)
+        if not callable(preflight):
+            return
+
+        probe = cast(
+            "Callable[..., Awaitable[None]]",
+            partial(preflight, consume_boundary=False),
+        )
+
+        async def _run() -> None:
+            try:
+                await probe()
+            except Exception:
+                pass  # a failed probe is the old deferred behaviour, not a crash
+
+        self.run_worker(_run(), exclusive=False)
 
     async def _boot_session(self) -> None:
         """Await the session factory; on failure surface + offer /reload."""
@@ -7283,6 +7313,7 @@ class OperatorApp(App[None]):
         # route is withdrawn even when the choice re-selects the model the
         # fallback displaced — see ``Session.set_model``.
         session.set_model(self._spec_with_chosen_effort(spec), explicit=True)
+        self._probe_quota_after_switch(session)
         # A text-only model renders the history WITHOUT its images (see
         # ``Session._render_history``), so the estimate painted for the vision
         # model overstates what the new one actually carries. Re-measure so

--- a/tests/unit/model/test_configure.py
+++ b/tests/unit/model/test_configure.py
@@ -904,13 +904,13 @@ async def test_model_tier_cap_rotates_siblings_before_leaving_the_provider(tmp_p
         # 5h/7d windows still serve other families, so an opus resolve must
         # still see the row (the defect this guards: "all credentials
         # unusable" on a pool whose only spent window was Fable's).
-        assert store.is_blocked_for(first.id, "anthropic", "fable")
+        assert store.is_blocked_for_model(first.id, "anthropic", "claude-fable-5")
         assert not store.is_blocked(first.id, "anthropic")
-        assert not store.is_blocked_for(first.id, "anthropic", "opus")
+        assert not store.is_blocked_for_model(first.id, "anthropic", "claude-opus-4-8")
         assert not store.is_blocked(second.id, "anthropic")
         selected = await store.get_oauth_access("anthropic", session)
         assert selected is not None and selected.credential_id == second.id
-        opus = await store.get_oauth_access("anthropic", session, family="opus")
+        opus = await store.get_oauth_access("anthropic", session, model_id="claude-opus-4-8")
         assert opus is not None  # the family-blocked account still serves opus
         assert stream._route_state.active is None
         assert any("trying another anthropic account" in notice for notice in notices)
@@ -2188,8 +2188,8 @@ async def test_family_scoped_blocks_leave_other_families_serving(tmp_path) -> No
         # The fable verdict on gominerva is family-scoped; the shared-window
         # verdicts on the other three are account-wide.
         assert not store.is_blocked(gominerva.id, "anthropic")
-        assert store.is_blocked_for(gominerva.id, "anthropic", "fable")
-        assert not store.is_blocked_for(gominerva.id, "anthropic", "opus")
+        assert store.is_blocked_for_model(gominerva.id, "anthropic", "claude-fable-5")
+        assert not store.is_blocked_for_model(gominerva.id, "anthropic", "claude-opus-4-8")
         assert store.is_blocked(radienthq.id, "anthropic")
         assert store.is_blocked(pergamon.id, "anthropic")
         assert store.is_blocked(gmail.id, "anthropic")
@@ -2202,7 +2202,9 @@ async def test_family_scoped_blocks_leave_other_families_serving(tmp_path) -> No
             stream.on_model_changed(opus_spec)
             stream.begin_message()
             await stream.preflight_usage(opus_spec)
-        selected = await store.get_oauth_access("anthropic", "session-a", family="opus")
+        selected = await store.get_oauth_access(
+            "anthropic", "session-a", model_id="claude-opus-4-8"
+        )
         assert selected is not None and selected.credential_id == gominerva.id
         assert stream._route_state.active is None
     finally:

--- a/tests/unit/model/test_configure.py
+++ b/tests/unit/model/test_configure.py
@@ -2178,7 +2178,7 @@ async def test_family_scoped_blocks_leave_other_families_serving(tmp_path) -> No
     }
 
     async def usage_for_access(_client, _provider, *, access_token=None, **_kwargs):
-        return reports[access_token]
+        return reports[access_token] if access_token is not None else None
 
     try:
         with patch("local_operator.providers.usage.fetch_usage", side_effect=usage_for_access):
@@ -2267,7 +2267,7 @@ async def test_reactive_stream_recovers_stale_account_blocks(tmp_path) -> None:
     stream._http = httpx.AsyncClient(transport=httpx.MockTransport(handler))
 
     async def usage_for_access(_client, _provider, *, access_token=None, **_kwargs):
-        return reports[access_token]
+        return reports[access_token] if access_token is not None else None
 
     try:
         with patch("local_operator.providers.usage.fetch_usage", side_effect=usage_for_access):

--- a/tests/unit/model/test_configure.py
+++ b/tests/unit/model/test_configure.py
@@ -899,10 +899,19 @@ async def test_model_tier_cap_rotates_siblings_before_leaving_the_provider(tmp_p
         with patch("local_operator.providers.usage.fetch_usage", side_effect=usage_for_access):
             await stream.preflight_usage(model)
 
-        assert store.is_blocked(first.id, "anthropic")
+        # The spent Fable weekly takes the first account out of rotation FOR
+        # FABLE — a family-scoped block, not an account-wide one: the shared
+        # 5h/7d windows still serve other families, so an opus resolve must
+        # still see the row (the defect this guards: "all credentials
+        # unusable" on a pool whose only spent window was Fable's).
+        assert store.is_blocked_for(first.id, "anthropic", "fable")
+        assert not store.is_blocked(first.id, "anthropic")
+        assert not store.is_blocked_for(first.id, "anthropic", "opus")
         assert not store.is_blocked(second.id, "anthropic")
         selected = await store.get_oauth_access("anthropic", session)
         assert selected is not None and selected.credential_id == second.id
+        opus = await store.get_oauth_access("anthropic", session, family="opus")
+        assert opus is not None  # the family-blocked account still serves opus
         assert stream._route_state.active is None
         assert any("trying another anthropic account" in notice for notice in notices)
     finally:
@@ -2129,6 +2138,211 @@ async def test_two_depleted_blocked_rows_do_not_ping_pong_the_recovery_walk(
         # bare "it did not crash": unbounded re-probing would still terminate
         # by luck of ordering while spending a network round trip per frame.
         assert sorted(probed) == ["oauth-a", "oauth-b", "oauth-c", "oauth-live"]
+    finally:
+        await stream.close()
+        store.close()
+
+
+@pytest.mark.asyncio
+async def test_family_scoped_blocks_leave_other_families_serving(tmp_path) -> None:
+    """A spent family cap blocks the family, never the account.
+
+    The reported state: four Anthropic accounts, one of them (gominerva)
+    holding shared headroom but a 100% Fable weekly. Preflight for
+    ``claude-fable-5`` must take that account out of Fable rotation while
+    leaving it resolvable for opus — the account-wide block the old code
+    wrote is what later made an opus session report "all credentials
+    unusable" on a pool whose only spent window was Fable's."""
+    store = AuthStore(tmp_path / "auth.db")
+    gominerva = store.upsert_credential("anthropic", _oauth("oauth-gominerva", "a1"))
+    radienthq = store.upsert_credential("anthropic", _oauth("oauth-radienthq", "a2"))
+    pergamon = store.upsert_credential("anthropic", _oauth("oauth-pergamon", "a3"))
+    gmail = store.upsert_credential("anthropic", _oauth("oauth-gmail", "a4"))
+    store.upsert_credential("zai", {"key": "sk-zai", "source": "login"})
+    stream = create_stream_fn(
+        store,
+        {
+            "retry": {
+                "usageAwareFallback": True,
+                "usageReservePercent": 10,
+                "fallbackChains": {"default": ["zai/glm-5.3"]},
+            }
+        },
+        session_id="session-a",
+    )
+    reports = {
+        "oauth-gominerva": _fable_report(2.0, 59.0, 100.0),  # fable spent, shared fine
+        "oauth-radienthq": _fable_report(0.0, 100.0, 34.0),  # shared 7d spent
+        "oauth-pergamon": _fable_report(0.0, 100.0, 100.0),  # everything spent
+        "oauth-gmail": _fable_report(100.0, 41.0, 79.0),  # shared 5h spent
+    }
+
+    async def usage_for_access(_client, _provider, *, access_token=None, **_kwargs):
+        return reports[access_token]
+
+    try:
+        with patch("local_operator.providers.usage.fetch_usage", side_effect=usage_for_access):
+            stream.begin_message()
+            await stream.preflight_usage(ModelSpec(provider="anthropic", model_id="claude-fable-5"))
+
+        # The fable verdict on gominerva is family-scoped; the shared-window
+        # verdicts on the other three are account-wide.
+        assert not store.is_blocked(gominerva.id, "anthropic")
+        assert store.is_blocked_for(gominerva.id, "anthropic", "fable")
+        assert not store.is_blocked_for(gominerva.id, "anthropic", "opus")
+        assert store.is_blocked(radienthq.id, "anthropic")
+        assert store.is_blocked(pergamon.id, "anthropic")
+        assert store.is_blocked(gmail.id, "anthropic")
+
+        # Switching to opus resolves gominerva directly — no recovery probe
+        # needed, no failover — because the family block never hid the row
+        # from an opus resolve.
+        with patch("local_operator.providers.usage.fetch_usage", side_effect=usage_for_access):
+            opus_spec = ModelSpec(provider="anthropic", model_id="claude-opus-4-8")
+            stream.on_model_changed(opus_spec)
+            stream.begin_message()
+            await stream.preflight_usage(opus_spec)
+        selected = await store.get_oauth_access("anthropic", "session-a", family="opus")
+        assert selected is not None and selected.credential_id == gominerva.id
+        assert stream._route_state.active is None
+    finally:
+        await stream.close()
+        store.close()
+
+
+@pytest.mark.asyncio
+async def test_reactive_stream_recovers_stale_account_blocks(tmp_path) -> None:
+    """A request that skips preflight must not die on stale quota blocks.
+
+    The reported terminal error: "All 4 OAuth sign-in credentials ... not
+    usable right now" on an opus request, because every account carried a
+    block written by an earlier fable-scoped verdict. Isolated requests
+    (errands, subagents) never run the preflight that would have re-scoped
+    those blocks, so the stream driver probes the blocked rows itself: the
+    account whose shared windows still hold headroom is unblocked and serves."""
+    import httpx
+
+    store = AuthStore(tmp_path / "auth.db")
+    gominerva = store.upsert_credential("anthropic", _oauth("oauth-gominerva", "a1"))
+    store.upsert_credential("anthropic", _oauth("oauth-radienthq", "a2"))
+    store.upsert_credential("anthropic", _oauth("oauth-pergamon", "a3"))
+    gmail = store.upsert_credential("anthropic", _oauth("oauth-gmail", "a4"))
+    stream = create_stream_fn(
+        store,
+        {"retry": {"enabled": True, "usageAwareFallback": True, "usageReservePercent": 10}},
+        session_id="session-a",
+    )
+    reports = {
+        "oauth-gominerva": _fable_report(2.0, 59.0, 100.0),
+        "oauth-radienthq": _fable_report(0.0, 100.0, 34.0),
+        "oauth-pergamon": _fable_report(0.0, 100.0, 100.0),
+        "oauth-gmail": _fable_report(100.0, 41.0, 79.0),
+    }
+    # Legacy state: every account under an ACCOUNT-WIDE block, as an older
+    # build wrote for the same fable verdicts.
+    for row in store.list_credentials("anthropic"):
+        store.block_credential(row.id, "anthropic", block_ms=60 * 60 * 1000)
+
+    anthropic_ok = (
+        'data: {"type": "message_start", "message": {"usage": {"input_tokens": 10}}}\n\n'
+        'data: {"type": "content_block_delta", "delta": {"type": "text_delta", "text": "ok"}}\n\n'
+        'data: {"type": "message_delta", "delta": {"stop_reason": "end_turn"},'
+        ' "usage": {"output_tokens": 1}}\n\n'
+        'data: {"type": "message_stop"}\n\n'
+    )
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if "anthropic" in str(request.url):
+            if "oauth-gominerva" in request.headers.get("authorization", ""):
+                return httpx.Response(
+                    200, text=anthropic_ok, headers={"content-type": "text/event-stream"}
+                )
+            return httpx.Response(
+                429,
+                json={"error": {"message": "This request would exceed your account's rate limit."}},
+            )
+        return httpx.Response(500, json={})
+
+    await stream._http.aclose()
+    stream._http = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+    async def usage_for_access(_client, _provider, *, access_token=None, **_kwargs):
+        return reports[access_token]
+
+    try:
+        with patch("local_operator.providers.usage.fetch_usage", side_effect=usage_for_access):
+            events = [
+                event
+                async for event in stream(
+                    ChatRequest(
+                        model=ModelSpec(provider="anthropic", model_id="claude-opus-4-8"),
+                        messages=[Message.user("hi")],
+                        isolated=True,
+                    ),
+                    None,
+                )
+            ]
+        assert events  # the turn completed on the recovered account
+        assert not store.is_blocked(gominerva.id, "anthropic")
+        # The genuinely spent accounts keep their blocks.
+        assert store.is_blocked(gmail.id, "anthropic")
+    finally:
+        await stream.close()
+        store.close()
+
+
+@pytest.mark.asyncio
+async def test_quota_pinned_fallback_is_reprobed_at_the_next_boundary(tmp_path) -> None:
+    """A quota pin never outlives the primary's recovery.
+
+    The reported symptom: a session ran fine, tripped onto a fallback, then
+    stayed glued to it — the pin's cooldown (sized to an advertised quota
+    reset, hours long) suppressed the re-probe that would have shown the
+    primary serving again. Quota pins are re-probed at every message
+    boundary; a healthy primary withdraws the pin immediately."""
+    from local_operator.providers.failover import FallbackTarget
+
+    store = AuthStore(tmp_path / "auth.db")
+    account = store.upsert_credential("anthropic", _oauth("oauth-a", "account-a"))
+    store.upsert_credential("zai", {"key": "sk-zai", "source": "login"})
+    stream = create_stream_fn(
+        store,
+        {
+            "retry": {
+                "usageAwareFallback": True,
+                "usageReservePercent": 10,
+                "fallbackChains": {"default": ["zai/glm-5.3"]},
+            }
+        },
+        session_id="session-a",
+    )
+    state = {"report": _fable_report(100.0, 41.0, 79.0)}  # 5h spent: depleted
+
+    async def usage_for_access(_client, _provider, *, access_token=None, **_kwargs):
+        return state["report"]
+
+    try:
+        opus_spec = ModelSpec(provider="anthropic", model_id="claude-opus-4-8")
+        with patch("local_operator.providers.usage.fetch_usage", side_effect=usage_for_access):
+            stream.begin_message()
+            await stream.preflight_usage(opus_spec)
+        assert stream._route_state.active is not None
+
+        # A long cooldown lands on the pin (a 24h advertised reset); the next
+        # boundary must STILL re-probe because the pin is quota evidence.
+        await stream._route_state.activate(
+            FallbackTarget("zai/glm-5.3", None),
+            "provider failure",
+            cooldown_ms=24 * 60 * 60 * 1000,
+            quota=True,
+        )
+        state["report"] = _fable_report(5.0, 41.0, 79.0)  # 5h window reset
+        with patch("local_operator.providers.usage.fetch_usage", side_effect=usage_for_access):
+            stream.begin_message()
+            await stream.preflight_usage(opus_spec)
+        assert stream._route_state.active is None
+        selected = await store.get_oauth_access("anthropic", "session-a")
+        assert selected is not None and selected.credential_id == account.id
     finally:
         await stream.close()
         store.close()

--- a/tests/unit/providers/test_failover.py
+++ b/tests/unit/providers/test_failover.py
@@ -368,7 +368,13 @@ class FakeAuth:
         return pool[0] if pool else None
 
     def rotate_sibling(
-        self, provider: str, session_id: str | None, error: Any, api_key: str | None = None
+        self,
+        provider: str,
+        session_id: str | None,
+        error: Any,
+        api_key: str | None = None,
+        *,
+        family: str = "",
     ) -> bool:
         self.rotations.append((provider, api_key))
         pool = self.keys.get(provider, [])
@@ -3094,7 +3100,13 @@ class TestTheLoopBackSweep:
                 return "env-key"
 
             def rotate_sibling(
-                self, provider: str, session_id: str | None, error: Any, api_key: str | None = None
+                self,
+                provider: str,
+                session_id: str | None,
+                error: Any,
+                api_key: str | None = None,
+                *,
+                family: str = "",
             ) -> bool:
                 return False
 
@@ -3143,7 +3155,13 @@ class TestTheLoopBackSweep:
                 return "env-key"
 
             def rotate_sibling(
-                self, provider: str, session_id: str | None, error: Any, api_key: str | None = None
+                self,
+                provider: str,
+                session_id: str | None,
+                error: Any,
+                api_key: str | None = None,
+                *,
+                family: str = "",
             ) -> bool:
                 return False
 

--- a/tests/unit/providers/test_failover.py
+++ b/tests/unit/providers/test_failover.py
@@ -2872,7 +2872,14 @@ class TestRotationPermutations:
 
         assert served == ["acct-b"]
         rows = {r.data["access"]: r for r in store.list_credentials("anthropic")}
-        assert store.is_blocked(rows["acct-a"].id, "anthropic")
+        # The 429 names the family the request ran on, so the block is scoped
+        # to it: the account is out of rotation for opus, but a fable request
+        # (a family the opus verdict says nothing about) still sees the row.
+        # The preflight upgrades to an account-wide block when a shared
+        # window turns out to be the binding one.
+        assert store.is_blocked_for(rows["acct-a"].id, "anthropic", "opus")
+        assert not store.is_blocked_for(rows["acct-a"].id, "anthropic", "fable")
+        assert not store.is_blocked(rows["acct-a"].id, "anthropic")
         assert not store.is_blocked(rows["acct-b"].id, "anthropic")
 
     async def test_a_429d_oauth_row_falls_through_to_an_api_key_row(self, tmp_path: Any) -> None:

--- a/tests/unit/providers/test_failover.py
+++ b/tests/unit/providers/test_failover.py
@@ -374,7 +374,7 @@ class FakeAuth:
         error: Any,
         api_key: str | None = None,
         *,
-        family: str = "",
+        model_id: str = "",
     ) -> bool:
         self.rotations.append((provider, api_key))
         pool = self.keys.get(provider, [])
@@ -2883,8 +2883,8 @@ class TestRotationPermutations:
         # (a family the opus verdict says nothing about) still sees the row.
         # The preflight upgrades to an account-wide block when a shared
         # window turns out to be the binding one.
-        assert store.is_blocked_for(rows["acct-a"].id, "anthropic", "opus")
-        assert not store.is_blocked_for(rows["acct-a"].id, "anthropic", "fable")
+        assert store.is_blocked_for_model(rows["acct-a"].id, "anthropic", "claude-opus-5")
+        assert not store.is_blocked_for_model(rows["acct-a"].id, "anthropic", "claude-fable-5")
         assert not store.is_blocked(rows["acct-a"].id, "anthropic")
         assert not store.is_blocked(rows["acct-b"].id, "anthropic")
 
@@ -3106,7 +3106,7 @@ class TestTheLoopBackSweep:
                 error: Any,
                 api_key: str | None = None,
                 *,
-                family: str = "",
+                model_id: str = "",
             ) -> bool:
                 return False
 
@@ -3161,7 +3161,7 @@ class TestTheLoopBackSweep:
                 error: Any,
                 api_key: str | None = None,
                 *,
-                family: str = "",
+                model_id: str = "",
             ) -> bool:
                 return False
 

--- a/tests/unit/providers/test_failover.py
+++ b/tests/unit/providers/test_failover.py
@@ -2878,15 +2878,79 @@ class TestRotationPermutations:
 
         assert served == ["acct-b"]
         rows = {r.data["access"]: r for r in store.list_credentials("anthropic")}
-        # The 429 names the family the request ran on, so the block is scoped
-        # to it: the account is out of rotation for opus, but a fable request
-        # (a family the opus verdict says nothing about) still sees the row.
-        # The preflight upgrades to an account-wide block when a shared
-        # window turns out to be the binding one.
+        # usageAwareFallback is OFF here: no preflight probe exists to upgrade
+        # a family block to an account-wide one on this path, so rotation keeps
+        # the pre-existing account-wide semantics.
+        assert store.is_blocked(rows["acct-a"].id, "anthropic")
+        assert not store.is_blocked(rows["acct-b"].id, "anthropic")
+
+    async def test_usage_aware_rotation_scopes_the_429_block_to_the_family(
+        self, tmp_path: Any
+    ) -> None:
+        """With usage-aware routing on, a usage-limit 429 blocks the family.
+
+        The opt-in counterpart of the previous test: the preflight's usage
+        probe can upgrade a family block to an account-wide one the moment a
+        shared window is the binding limit, so rotation may scope the block
+        to the family the request ran on — the account stays in rotation for
+        every other family."""
+        store = AuthStore(db_path=tmp_path / "auth.db")
+        store.upsert_credential(
+            "anthropic",
+            {
+                "type": "oauth",
+                "access": "acct-a",
+                "refresh": "r",
+                "expires": None,
+                "email": "a@example.com",
+            },
+        )
+        store.upsert_credential(
+            "anthropic",
+            {
+                "type": "oauth",
+                "access": "acct-b",
+                "refresh": "r",
+                "expires": None,
+                "email": "b@example.com",
+            },
+        )
+        served: list[str | None] = []
+
+        def first_account_exhausted(
+            request: ChatRequest, api_key: str | None, oauth_access: Any = None
+        ) -> AsyncIterator[Any]:
+            if api_key == "acct-a":
+                raise ProviderError(
+                    429, "quota reset pending", retryable=True, retry_after_ms=3 * 3_600_000
+                )
+            served.append(api_key)
+            return _clean_stream()
+
+        async def client_for(spec: ModelSpec) -> Any:
+            return _FnClient(first_account_exhausted)
+
+        original = failover_module._abortable_sleep
+        failover_module._abortable_sleep = self._no_sleep()  # type: ignore[assignment]
+        try:
+            async for _ in stream_with_failover(
+                _request("anthropic", "claude-opus-5"),
+                store,
+                {"retry": {"enabled": True, "usageAwareFallback": True}},
+                client_for,
+                session_id="s0",
+            ):
+                pass
+        finally:
+            failover_module._abortable_sleep = original  # type: ignore[assignment]
+
+        assert served == ["acct-b"]
+        rows = {r.data["access"]: r for r in store.list_credentials("anthropic")}
+        # Scoped to the family the request ran on: opus is blocked, fable
+        # still resolves the row, and no account-wide block was written.
         assert store.is_blocked_for_model(rows["acct-a"].id, "anthropic", "claude-opus-5")
         assert not store.is_blocked_for_model(rows["acct-a"].id, "anthropic", "claude-fable-5")
         assert not store.is_blocked(rows["acct-a"].id, "anthropic")
-        assert not store.is_blocked(rows["acct-b"].id, "anthropic")
 
     async def test_a_429d_oauth_row_falls_through_to_an_api_key_row(self, tmp_path: Any) -> None:
         """OAuth → API key inside one provider. ``rotate_sibling`` only counts


### PR DESCRIPTION
## Why

With three of four Anthropic accounts out and the fourth (`gominerva`) holding shared headroom but a 100% Fable weekly, sessions still failed over or died outright when the model in force was NOT Fable:

- `/model claude-opus-4-8` (or a fresh session on it) reported `anthropic quota exhausted (0% remaining)` and hopped providers, or
- reactive requests that skip the quota preflight (errands, subagents) died on `rate limit or quota exceeded: All 4 OAuth sign-in credentials for provider 'anthropic' are not usable right now`, and
- a session that tripped onto a fallback stayed glued to it after the primary's window reopened.

Root cause: a quota verdict whose ONLY binding window is a model-family cap (`7 day (Fable)`) wrote an **account-wide** credential block. The account then vanished from every credential resolve, so an opus request on an account whose only spent window was Fable's saw "all credentials unusable" while its shared 5-hour/7-day windows still had bandwidth. Reproduced against the real four-account state before the fix:

```
=== after preflight fable-5 (default model) ===
  block oauth-gominerva: True      <- account-wide block on the ONLY account with shared headroom
  ...
=== after preflight opus-4-8 (after /model switch) ===
  selected for opus-4-8: None      <- nothing resolvable; provider hop / death follows
```

and the reactive path raised the exact "All 4 OAuth sign-in credentials … not usable right now" error from the report.

## What changes

Quota blocks are scoped to the model family the verdict bound on; account-wide blocks remain for shared-window verdicts:

- `usage_health` reports `binding_families` (the scoped windows in the binding set); `registry.model_family` derives the family a routed model draws on (tier parsed by kind, so a new family like `fable` works without a list).
- `AuthStore` uses the existing (previously unused) `block_scope` column: `model:<family>` blocks stop one family, `is_blocked_for` filters the cascade per family, and `get_api_key` / `get_oauth_access` / `_resolve` / `rotate_sibling` thread the family through. A usage-limit 429 on a family-named request blocks that family, never the account; the preflight upgrades to account-wide the moment a shared window is the binding one.
- Preflight sibling enumeration and the blocked-account recovery walk consult the family-scoped view, and a recovered probe clears only the scopes its verdict supersedes (other families' blocks stand).
- `stream_with_failover` resolves credentials per family and gains a once-per-target recovery probe: when every resolve path comes back empty on a quota-shaped situation, blocked rows are re-asked their own usage and a row whose shared windows hold headroom is unblocked and served. This is the reactive mirror of the preflight's recovery, for the requests that never run a preflight. Gated on `usageAwareFallback`, same opt-in as the preflight.
- Quota-pinned fallback routes (`route_state.quota_pinned`) are re-probed at every message boundary regardless of the pin's cooldown and the 60s check memo, so a session returns to the primary the boundary after its window reopens; transport pins keep their cooldown.
- `/model` arms an immediate preflight probe (TUI worker, `consume_boundary=False`) so the switch's quota verdict lands before the first request on the new model without spending the effort-classification boundary token.

## Testing evidence

Live-shape reproduction (the four real accounts' windows) driven through the real `preflight_usage` / `stream_with_failover` paths, before vs after:

```
before: fable-5 preflight blocks gominerva account-wide; opus resolves None;
        reactive opus request raises "All 4 OAuth sign-in credentials … not usable"
after:  fable-5 preflight blocks gominerva for fable only; opus resolves gominerva;
        reactive opus request completes on gominerva; spent accounts keep their blocks
```

New regressions in `tests/unit/model/test_configure.py`:

- `test_family_scoped_blocks_leave_other_families_serving` — the four-account state; fable verdicts scope, opus resolves the family-blocked account, no failover.
- `test_reactive_stream_recovers_stale_account_blocks` — legacy account-wide blocks from an older build; an isolated (preflight-skipping) opus request probes, unblocks and serves the healthy account.
- `test_quota_pinned_fallback_is_reprobed_at_the_next_boundary` — a 24h-cooldown quota pin is withdrawn the boundary after the primary recovers.

Two pre-existing tests updated to the scoped semantics (the family block is the intended behaviour; the account-wide assertion was the defect).

Gates: `pytest tests/unit` green except `tests/unit/tools/test_eval_tool.py::test_background_streams_output_while_it_runs` and a full-suite TUI stall, both reproduced identically on clean `origin/main` (environmental, pre-existing); flake8 / black / isort / pyright clean.

## Review rounds

- Round 1 (reviewer subagent): no blocker/major; 3 minors + 3 nits → remediated (61f19347, ad09213e).
- Round 2: one major (the minor-2 gate claimed but not wired — a black-collapsed edit target) → remediated (ad966414) with tests pinning both opt-in and opt-out semantics.
- Round 3: clean and terminal on head ad9664148fb0f74c16de0c6e5856900c9548b8f5; write/read symmetry, gate trace and both test sides verified.
