### PR TITLE
fix(session): preserve a mid-session /model switch across resume

### DIFF
--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -141,6 +141,24 @@ logger = logging.getLogger(__name__)
 #: ``latest_custom``'s backward scan land on "no fallback pinned" after one.
 ACTIVE_ROUTE_CUSTOM_TYPE = "active_model_route"
 
+#: Transcript custom-entry type recording the model the user explicitly
+#: SELECTED mid-session (``/model <provider>/<id>``), so a resumed session
+#: comes back on it instead of silently reverting to the boot default. The
+#: sibling of :data:`ACTIVE_ROUTE_CUSTOM_TYPE`, which records where a
+#: provider FALLBACK routed requests; this one records where the USER did.
+#: Without it a ``/model`` switch survived exactly as long as the process:
+#: quit and ``--resume`` replayed the whole conversation onto the config
+#: default, which contradicts what the transcript itself shows the user
+#: choosing.
+#:
+#: Each row snapshots ``boot`` — the selector the session was CONSTRUCTED
+#: with — beside the selection, so the restore can tell a journalled switch
+#: that still applies from one stranded by a changed boot selection (a
+#: ``/model default`` write, an edited agent profile, an explicit
+#: ``--hosting``/``--model`` flag on the resume itself). A changed boot
+#: selection wins: it is the newer, more deliberate choice.
+SELECTED_MODEL_CUSTOM_TYPE = "selected_model"
+
 #: How many times the title writer will chase a name that moved under its own
 #: append before giving up and leaving the rest to the dispose flush. A cap
 #: rather than "until it settles" so the bound is structural: the chase is a
@@ -876,6 +894,26 @@ class Session:
         #: ``_background_tasks`` because dispose CANCELS those and this one has
         #: to be awaited instead — see :meth:`_spawn_conversation_name_write`.
         self._conversation_name_task: "asyncio.Future[None] | None" = None
+        #: The ``provider/model_id`` this session was CONSTRUCTED with — the
+        #: boot selection resolved from agent > CLI flag > config. Captured
+        #: before any restore or switch moves ``_model``, because it is the
+        #: reference every ``selected_model`` journal row carries: a resume
+        #: whose boot selection no longer matches a row's ``boot`` must NOT
+        #: adopt that row (the changed default/flag/profile is the newer
+        #: choice). See :data:`SELECTED_MODEL_CUSTOM_TYPE`.
+        self._boot_selector = f"{model.provider}/{model.model_id}"
+        #: True while a mid-session model selection has not reached the
+        #: transcript yet; the same dispose-flush contract as the title (the
+        #: write is a background task, and dispose cancels background tasks,
+        #: so a switch made just before ctrl+c needs the flush to land it).
+        self._selected_model_dirty = False
+        #: The in-flight journal write for the selection, tracked apart from
+        #: ``_background_tasks`` for the same reason the title's write is:
+        #: dispose CANCELS background tasks, and a cancel that lands before
+        #: the wrapped coroutine's first await leaves it un-awaited (asyncio
+        #: then reports it at GC time) as well as unwritten. The flush AWAITS
+        #: this task instead — see :meth:`_spawn_selected_model_write`.
+        self._selected_model_task: "asyncio.Future[None] | None" = None
         self._system_blocks_provider = system_blocks_provider
         self._convert_to_llm = convert_to_llm or _default_convert_to_llm
         #: Set once a provider refuses a request because of an image block, and
@@ -1050,6 +1088,13 @@ class Session:
         # session would otherwise need its own copy of this, and the one that
         # forgot would boot nameless.
         self._load_conversation_name()
+        # The model the user explicitly SELECTED mid-session, restored before
+        # the fallback pin below — deliberately in that order, because the pin's
+        # own guard compares its persisted primary against the CURRENT
+        # selection: a fallback that rescued the switched-to model must find
+        # that model already restored, or the pin reads as stranded and is
+        # dropped.
+        self._restore_selected_model()
         # Which model is ACTUALLY serving requests, when that is not the
         # selected one: the spec of the pinned fallback route, or None while
         # the primary serves. Owned by the session (not read off the stream
@@ -1638,6 +1683,14 @@ class Session:
                 if refreshed is not None:
                     self._active_fallback = refreshed
             return
+        # A genuine model change is a SELECTION, and selections outlive the
+        # process: journal it so `--resume` comes back on this model instead
+        # of the boot default (see SELECTED_MODEL_CUSTOM_TYPE). Every knob
+        # change (`/effort`, the server's sampling overrides) took the
+        # same-pair early return above, so only real switches reach this line
+        # and the journal stays one row per switch, not one per keystroke.
+        self._selected_model_dirty = True
+        self._spawn_selected_model_write()
         # An explicit switch withdraws the fallback pin's premise: the pin
         # rescued the PREVIOUS selection, and the stream fn's preflight will
         # clear its own route state the moment it sees the new selector. The
@@ -4529,6 +4582,194 @@ class Session:
             },
         )
 
+    # -- selected model (mid-session /model switch persistence) --------------
+
+    def _spawn_selected_model_write(self) -> None:
+        """Start (or coalesce onto) the background journal write for the
+        selection. The same contract as :meth:`_spawn_conversation_name_write`
+        and for the same reason: ``dispose`` cancels ``_background_tasks``
+        wholesale, and a switch made in the closing moments of a session is
+        exactly the write that must still reach disk — so this task is tracked
+        separately and AWAITED by :meth:`_flush_selected_model` instead of
+        being cancelled with the rest.
+
+        One task at a time: the payload is read at write time, so a second
+        switch landing while a write is in flight is covered by the dirty
+        flag — the flush re-persists whatever is in force at teardown.
+        """
+        if self._disposed:
+            return
+        task = self._selected_model_task
+        if task is not None and not task.done():
+            return
+        try:
+            task = asyncio.ensure_future(self._persist_selected_model())
+            # Consume the exception explicitly, as the title's writer does: a
+            # failed journal write is tolerated (the flush retries), but a
+            # task whose exception nobody reads is reported by the loop at GC
+            # time as if the session had leaked it.
+            task.add_done_callback(self._on_selected_model_written)
+            self._selected_model_task = task
+        except RuntimeError:
+            # No running loop (a session driven synchronously in tests). The
+            # dispose flush is the backstop; the selection is not lost.
+            self._selected_model_task = None
+
+    @staticmethod
+    def _on_selected_model_written(task: "asyncio.Future[None]") -> None:
+        """Retrieve the selection write's outcome so asyncio does not report
+        it; the dispose flush is what actually retries a failure."""
+        if task.cancelled():
+            return
+        error = task.exception()
+        if error is not None:
+            logger.debug("model selection write failed; will retry at dispose", exc_info=error)
+
+    async def _persist_selected_model(self) -> None:
+        """Journal the model the user is on (newest entry wins on replay).
+
+        A full snapshot per switch, like every other custom-entry journal
+        here: ``latest_custom`` scans backward and stops at the first hit, so
+        replay cost does not grow with the number of switches. The dirty flag
+        is cleared only AFTER the append lands — a write cancelled at teardown
+        never reaches that line, so the entry still reads as outstanding to
+        :meth:`_flush_selected_model` and is retried there instead of lost.
+
+        A duplicate row (append landed, clear did not) is harmless by
+        construction: each row is a snapshot of the same state, and the
+        backward scan reads one.
+        """
+        model = self._model
+        payload = {
+            "selector": f"{model.provider}/{model.model_id}",
+            "effort": model.reasoning_effort,
+            "boot": self._boot_selector,
+        }
+        await self._transcript.append_custom(SELECTED_MODEL_CUSTOM_TYPE, payload)
+        current = self._model
+        if (f"{current.provider}/{current.model_id}", current.reasoning_effort) == (
+            payload["selector"],
+            payload["effort"],
+        ):
+            self._selected_model_dirty = False
+        else:
+            # The selection moved under the append. Start another pass now
+            # rather than leaving the newer selection to the dispose flush:
+            # the session can run for hours after a switch, and "correct only
+            # if you quit" is not a persistence contract. The current task is
+            # still registered until its callback returns, so scheduling onto
+            # the next loop tick lets `_spawn_selected_model_write` see it as
+            # done and create exactly one successor.
+            asyncio.get_running_loop().call_soon(self._spawn_selected_model_write)
+
+    def _restore_selected_model(self) -> None:
+        """Re-adopt the model a ``/model`` switch selected before the quit.
+
+        Guarded twice, each a real situation rather than paranoia:
+
+        - persisted ``boot`` differs from THIS construction's boot selection →
+          the journal belongs to a boot default the user has since changed (a
+          ``/model default`` write, an edited agent profile, an explicit
+          ``--hosting``/``--model`` flag on the resume command itself). The
+          changed selection is the newer choice and wins; adopting the row
+          would make the flag the user just typed silently not work.
+        - the journalled selector equals the boot selection → the user
+          switched and later switched back; nothing to do, and skipping the
+          no-op keeps a fresh session's construction byte-identical to one
+          that never switched.
+
+        Tolerant of a malformed or unresolvable entry, matching
+        :meth:`_load_conversation_name`: a resume must not be refused because
+        one bookkeeping row could not be read, and a selector whose provider
+        no longer resolves (an uninstalled registry entry) logs and falls
+        back to the boot model rather than constructing a session around a
+        spec that cannot serve requests.
+
+        Restores quietly (no event, no journal write): construction runs
+        before any front end subscribes, so hosts read ``model`` when they
+        build their chrome, and re-journalling the row it just read would
+        grow the transcript on every resume.
+        """
+        details = self._transcript.latest_custom(SELECTED_MODEL_CUSTOM_TYPE)
+        if not details:
+            return
+        selector = str(details.get("selector") or "")
+        if "/" not in selector:
+            return
+        boot = str(details.get("boot") or "")
+        if boot != self._boot_selector:
+            return
+        if selector == self._boot_selector:
+            return
+        raw_effort = details.get("effort")
+        effort = str(raw_effort) if isinstance(raw_effort, str) and raw_effort else None
+        # Validate the PROVIDER before adopting the row, exactly as the TUI's
+        # `/model` does and for the same reason: `spec_for_target` does not
+        # raise on an unknown provider, it returns a spec with `base_url=None`.
+        # A provider that has since left the registry (a renamed id, a build
+        # without it) would therefore resume the session onto a spec that
+        # cannot serve requests, and the failure would surface on the first
+        # prompt as a network error rather than as the stale journal row it is.
+        from local_operator.providers.registry import get_provider_definition
+
+        provider = selector.split("/", 1)[0]
+        if get_provider_definition(provider) is None:
+            logger.warning(
+                "dropping persisted model selection naming an unknown provider: %r", selector
+            )
+            return
+        # The SAME derivation `/model` itself lands on: `spec_for_target`
+        # builds the target model's own spec (its base_url, window,
+        # capabilities) and carries only session sampling preferences across
+        # — re-deriving instead of persisting the whole spec means a registry
+        # update between quit and resume is picked up rather than replayed
+        # stale.
+        spec = self._spec_for_route(selector, effort)
+        if spec is None:
+            logger.warning("dropping unresolvable persisted model selection: %r", selector)
+            return
+        self._model = spec
+        # Same synchronous re-fit hook `set_model` ends on. Nothing is frozen
+        # this early, but a stream fn that keys caches by selector must start
+        # keyed to the model that will actually serve, not the boot default.
+        notify = getattr(self._stream_fn, "on_model_changed", None)
+        if callable(notify):
+            notify(spec)
+
+    async def _flush_selected_model(self) -> None:
+        """Land an outstanding selection write before the session tears down.
+
+        The ordinary write is a background task and :meth:`dispose` CANCELS
+        background tasks, so a ``/model`` switch in the closing moments of a
+        session — the switch-then-ctrl+c this feature exists for — could be
+        cancelled before reaching disk, and the next ``--resume`` would open
+        on the boot default again. Bounded like the title's flush and for the
+        same reason: teardown must not hang on a wedged filesystem, and a
+        timeout costs one journal row, never the conversation.
+        """
+        deadline = time.monotonic() + _NAME_FLUSH_TIMEOUT_S
+        task = self._selected_model_task
+        if task is not None and not task.done():
+            try:
+                await asyncio.wait_for(
+                    asyncio.shield(task), timeout=max(0.0, deadline - time.monotonic())
+                )
+            except BaseException:  # noqa: BLE001 — fall through to the retry
+                pass
+        if not self._selected_model_dirty:
+            return
+        try:
+            # Bounded with what REMAINS of the shared deadline, like the
+            # title's flush: the append takes the transcript lock, and an
+            # unbounded wait here would let a wedged filesystem hold dispose
+            # open indefinitely.
+            await asyncio.wait_for(
+                self._persist_selected_model(),
+                timeout=max(0.0, deadline - time.monotonic()),
+            )
+        except Exception:
+            logger.warning("failed to persist the model selection", exc_info=True)
+
     def _restore_active_route(self) -> None:
         """Re-adopt the fallback that was serving when this session last ran.
 
@@ -4781,6 +5022,11 @@ class Session:
             # session (a `/rename` before ctrl+d) would be cancelled in flight
             # and never reach the transcript the next `--resume` reads.
             await self._flush_conversation_name()
+            # Same window, same reason: the selection journal's ordinary write
+            # is a background task about to be cancelled, and a `/model`
+            # switch made moments before quitting is exactly the write that
+            # must still land for the next `--resume` to honour it.
+            await self._flush_selected_model()
             # HC-11: cancel tracked background tasks (wake deliveries, aside
             # persistence), then close the session task group.
             for task in list(self._background_tasks):

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -1657,6 +1657,7 @@ class Session:
                 withdraw = getattr(self._stream_fn, "withdraw_fallback", None)
                 if callable(withdraw):
                     withdraw()
+                self._journal_effort_if_selection_in_force(previous, model)
                 return
             # Same model, different knobs (effort, sampling): nothing routing
             # or quota related has moved, so leave the frozen per-message state
@@ -1682,6 +1683,7 @@ class Session:
                 refreshed = self._spec_for_route(*self._active_route)
                 if refreshed is not None:
                     self._active_fallback = refreshed
+            self._journal_effort_if_selection_in_force(previous, model)
             return
         # A genuine model change is a SELECTION, and selections outlive the
         # process: journal it so `--resume` comes back on this model instead
@@ -1703,6 +1705,39 @@ class Session:
         notify = getattr(self._stream_fn, "on_model_changed", None)
         if callable(notify):
             notify(model)
+
+    def _journal_effort_if_selection_in_force(self, previous: ModelSpec, model: ModelSpec) -> None:
+        """Re-journal the selection when a knob change moves the effort on a
+        model the user SWITCHED to, so the restored effort tracks it.
+
+        The ``selected_model`` row carries an effort field, and a switch
+        followed by a SEPARATE ``/effort`` change would otherwise leave that
+        field frozen at the switch's level: the ``/effort`` call takes
+        ``set_model``'s same-pair early return and never reaches the journal
+        write, so a resume would come back on the switched model at its
+        DEFAULT effort — silently dropping the level the user chose and, on a
+        reasoning model, quietly changing cost (review round 1, F1).
+
+        Bounded twice, and each bound is load-bearing:
+
+        - **Only an actual effort move.** A sampling-only override
+          (temperature / top_p, the server's ``ChatRequest.options`` path)
+          rides ``set_model`` on the same pair too, and the journal stores no
+          sampling — so re-journalling on those would append identical rows for
+          a change the row cannot even express.
+        - **Only a non-boot selection.** The boot model deliberately persists
+          no effort (the ``/effort`` non-goal): ``_restore_selected_model``
+          skips a row whose selector equals the boot selector, so a boot-model
+          effort change has nothing to restore onto and journalling one would
+          both be inert and break the non-goal. A selection the user switched
+          to already has a row whose effort must stay truthful.
+        """
+        if previous.reasoning_effort == model.reasoning_effort:
+            return
+        if f"{model.provider}/{model.model_id}" == self._boot_selector:
+            return
+        self._selected_model_dirty = True
+        self._spawn_selected_model_write()
 
     def _drop_fallback_pin(self, primary: ModelSpec, reason: str) -> None:
         """Withdraw the pinned fallback: clear display state, persist, announce.

--- a/tests/unit/session/test_selected_model.py
+++ b/tests/unit/session/test_selected_model.py
@@ -75,7 +75,14 @@ def _selection_entries(session: Session) -> list[dict[str, Any]]:
 
 @pytest.mark.asyncio
 async def test_a_switch_is_journalled_with_the_boot_selector(tmp_path):
-    """``set_model`` records the selection, the effort, and what it booted on."""
+    """``set_model`` records the selection, the effort, and what it booted on.
+
+    Deliberately WITHOUT ``explicit=True``: journalling keys on the model pair
+    actually changing, not on the ``explicit`` flag (which only governs
+    fallback-pin withdrawal). A host that swaps the model without the flag —
+    the FastAPI server applying a model override, say — still made a selection
+    that must survive a resume.
+    """
     stream = NotifyingStream()
     session = _session(tmp_path, stream)
 
@@ -110,7 +117,7 @@ async def test_resume_comes_back_on_the_switched_model(tmp_path):
 
     stream = NotifyingStream()
     session = _session(tmp_path, stream)
-    session.set_model(SWITCHED)
+    session.set_model(SWITCHED, explicit=True)
     await session.dispose()  # what ctrl+c does
 
     resumed_stream = NotifyingStream()
@@ -138,7 +145,7 @@ async def test_a_switch_made_moments_before_quitting_still_lands(tmp_path):
     stream = NotifyingStream()
     session = _session(tmp_path, stream)
 
-    session.set_model(SWITCHED)
+    session.set_model(SWITCHED, explicit=True)
     await session.dispose()  # no await between the switch and the teardown
 
     resumed = _session(tmp_path, NotifyingStream())
@@ -152,7 +159,7 @@ async def test_switching_back_leaves_the_resume_on_the_boot_model(tmp_path):
     stream = NotifyingStream()
     session = _session(tmp_path, stream)
 
-    session.set_model(SWITCHED)
+    session.set_model(SWITCHED, explicit=True)
     session.set_model(MODEL)
     await session.dispose()
 
@@ -176,7 +183,7 @@ async def test_a_changed_boot_selection_outranks_the_journalled_switch(tmp_path)
     """
     stream = NotifyingStream()
     session = _session(tmp_path, stream)
-    session.set_model(SWITCHED)
+    session.set_model(SWITCHED, explicit=True)
     await session.dispose()
 
     rebooted_stream = NotifyingStream()
@@ -223,13 +230,95 @@ async def test_the_switched_effort_rides_the_restore(tmp_path):
     stream = NotifyingStream()
     session = _session(tmp_path, stream)
 
-    session.set_model(SWITCHED.model_copy(update={"reasoning_effort": "high"}))
+    session.set_model(SWITCHED.model_copy(update={"reasoning_effort": "high"}), explicit=True)
     await session.dispose()
 
     resumed = _session(tmp_path, NotifyingStream())
     assert resumed.model_label == "anthropic/claude-opus-5"
     assert resumed.model.reasoning_effort == "high"
     await resumed.dispose()
+
+
+@pytest.mark.asyncio
+async def test_an_effort_change_after_a_switch_updates_the_restored_effort(tmp_path):
+    """Switch, THEN a separate `/effort`, and the resume honours the level.
+
+    The F1 case from review round 1: a `/effort` change takes `set_model`'s
+    same-pair early return, so without re-journalling the selection row's
+    effort field stays frozen at the switch's level and the resume comes back
+    on the switched model at its DEFAULT effort — silently dropping the level
+    the user chose and, on a reasoning model, quietly changing cost.
+
+    Distinct from `test_the_switched_effort_rides_the_restore`, where the
+    effort rides the switch itself in ONE call; here the two are separate
+    actions, which is the path that regressed.
+    """
+    stream = NotifyingStream()
+    session = _session(tmp_path, stream)
+
+    session.set_model(SWITCHED, explicit=True)
+    # Let the SWITCH's journal write LAND before the effort change. This is
+    # what makes the two genuinely separate actions rather than one coalesced
+    # write: without the await the deferred switch-write would snapshot the
+    # post-/effort spec at flush time and the row would be truthful by
+    # accident — the mutant that disables the re-journal would still pass.
+    # With the switch's row already on disk carrying `effort: None`, only the
+    # re-journal keeps the restored level correct.
+    await wait_for(lambda: len(_selection_entries(session)) == 1)
+    assert _selection_entries(session)[0]["effort"] is None  # the frozen row
+
+    # A separate /effort change on the switched model (same pair, so it takes
+    # set_model's early return and never reaches the journal write itself).
+    session.set_model(session.model.model_copy(update={"reasoning_effort": "low"}))
+    await session.dispose()
+
+    resumed = _session(tmp_path, NotifyingStream())
+    assert resumed.model_label == "anthropic/claude-opus-5"
+    assert resumed.model.reasoning_effort == "low"
+    await resumed.dispose()
+
+
+@pytest.mark.asyncio
+async def test_an_effort_change_on_the_boot_model_still_does_not_journal(tmp_path):
+    """The `/effort` re-journal is scoped to a non-boot SELECTION.
+
+    A boot-model effort change has no selection row to keep truthful (the boot
+    model deliberately persists none — the `/effort` non-goal), so it must not
+    manufacture one. Guards the re-journal added for F1 against widening the
+    non-goal it was careful to respect.
+    """
+    stream = NotifyingStream()
+    session = _session(tmp_path, stream)
+
+    session.set_model(MODEL.model_copy(update={"reasoning_effort": "high"}))
+    await session.dispose()
+
+    assert _selection_entries(session) == []
+    resumed = _session(tmp_path, NotifyingStream())
+    assert resumed.model_label == "test/m"
+    await resumed.dispose()
+
+
+@pytest.mark.asyncio
+async def test_a_sampling_only_change_after_a_switch_does_not_rejournal(tmp_path):
+    """A temperature/top_p override on a switched model appends no new row.
+
+    Sampling rides `set_model` on the same pair (the server's
+    `ChatRequest.options` path), and the selection row stores no sampling, so
+    re-journalling on it would append an identical row for a change the row
+    cannot express. Only an actual effort MOVE re-journals.
+    """
+    stream = NotifyingStream()
+    session = _session(tmp_path, stream)
+
+    session.set_model(SWITCHED, explicit=True)
+    await wait_for(lambda: len(_selection_entries(session)) == 1)
+    session.set_model(session.model.model_copy(update={"temperature": 0.9}))
+    await session.dispose()
+
+    # Still exactly one row: the switch's. No sampling-driven duplicate.
+    assert len(_selection_entries(session)) == 1
+    await session.dispose()
 
 
 @pytest.mark.asyncio
@@ -289,7 +378,7 @@ async def test_a_resume_does_not_regrow_the_journal(tmp_path):
     """
     stream = NotifyingStream()
     session = _session(tmp_path, stream)
-    session.set_model(SWITCHED)
+    session.set_model(SWITCHED, explicit=True)
     await session.dispose()
 
     for _ in range(3):
@@ -310,7 +399,7 @@ async def test_a_bare_stream_fn_still_restores(tmp_path):
     switched model.
     """
     session = _session(tmp_path, ScriptedStream([[StreamEndEvent(stop_reason="stop")]]))
-    session.set_model(SWITCHED)
+    session.set_model(SWITCHED, explicit=True)
     await session.dispose()
 
     resumed = _session(tmp_path, ScriptedStream([[StreamEndEvent(stop_reason="stop")]]))

--- a/tests/unit/session/test_selected_model.py
+++ b/tests/unit/session/test_selected_model.py
@@ -1,0 +1,318 @@
+"""The mid-session model selection survives quitting and resuming.
+
+``/model <provider>/<id>`` switches the SESSION, and before this the switch
+lived only in memory: quitting (ctrl+c) and coming back with ``--resume``
+replayed the whole conversation onto the boot default, contradicting what the
+transcript itself showed the user choosing.
+
+The mechanism is a ``selected_model`` custom transcript entry, the sibling of
+``active_model_route``: that one records where a provider FALLBACK routed
+requests, this one records where the USER did. Both are journalled on the edge
+and read back at construction.
+
+Each row carries the boot selector the session was constructed with, which is
+what lets the restore tell a switch that still applies from one stranded by a
+changed boot selection — a ``/model default`` write, an edited agent profile,
+or an explicit ``--hosting``/``--model`` flag on the resume itself.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from local_operator.harness.types import ModelSpec, StreamEndEvent
+from local_operator.session.session import SELECTED_MODEL_CUSTOM_TYPE, Session
+from local_operator.session.transcript import Transcript
+
+from .test_session import MODEL, ScriptedStream, wait_for
+
+#: What the user switches TO in these tests. A different provider as well as a
+#: different id, so a restore that carried the boot spec's transport identity
+#: across (the bug ``spec_for_target`` exists to prevent) shows up as a wrong
+#: provider rather than only a wrong label. A REAL registry entry, because the
+#: restore re-derives the spec through the registry rather than replaying a
+#: persisted copy — see :func:`test_resume_comes_back_on_the_switched_model`.
+SWITCHED = ModelSpec(provider="anthropic", model_id="claude-opus-5", context_window=200_000)
+
+
+class NotifyingStream(ScriptedStream):
+    """A stream fn carrying the model-changed capability the session calls.
+
+    The restore is expected to drive it for the same reason ``set_model``
+    does: a stream fn that keys caches by selector must start keyed to the
+    model that will actually serve, not to the boot default.
+    """
+
+    def __init__(self, turns=None) -> None:
+        super().__init__(turns or [[StreamEndEvent(stop_reason="stop")]])
+        self.models_changed: list[ModelSpec] = []
+
+    def on_model_changed(self, model: ModelSpec) -> None:
+        self.models_changed.append(model)
+
+
+def _session(tmp_path, stream, **kwargs) -> Session:
+    transcript = Transcript(tmp_path / "sess")
+    return Session(
+        model=kwargs.pop("model", MODEL),
+        stream_fn=stream,
+        tools=[],
+        transcript=transcript,
+        system_blocks_provider=lambda: ["stable", "env"],
+        **kwargs,
+    )
+
+
+def _selection_entries(session: Session) -> list[dict[str, Any]]:
+    return [
+        entry.payload["details"]
+        for entry in session._transcript.entries()
+        if entry.type == "custom" and entry.payload.get("custom_type") == SELECTED_MODEL_CUSTOM_TYPE
+    ]
+
+
+@pytest.mark.asyncio
+async def test_a_switch_is_journalled_with_the_boot_selector(tmp_path):
+    """``set_model`` records the selection, the effort, and what it booted on."""
+    stream = NotifyingStream()
+    session = _session(tmp_path, stream)
+
+    session.set_model(SWITCHED)
+    await wait_for(lambda: bool(_selection_entries(session)))
+
+    assert _selection_entries(session) == [
+        {"selector": "anthropic/claude-opus-5", "effort": None, "boot": "test/m"}
+    ]
+    await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_resume_comes_back_on_the_switched_model(tmp_path):
+    """The reported bug: switch, quit, resume — and stay on the new model.
+
+    Asserted through the spec rather than the label alone: the restore
+    re-derives the target's OWN metadata through the registry, so a resumed
+    session carries the switched model's transport identity and window — not
+    the boot model's, and not a stale copy of what was journalled.
+
+    The window assertion is deliberately against the REGISTRY's figure rather
+    than the 200k the journalling session was constructed with: they differ,
+    which is what makes this able to tell re-derivation from replay. A test
+    pinning 200k would pass on a restore that simply replayed the persisted
+    spec, which is the implementation this one exists to rule out.
+    """
+    from local_operator.model.configure import build_model_spec
+
+    registry_window = build_model_spec("anthropic", "claude-opus-5").context_window
+    assert registry_window != SWITCHED.context_window  # the control for the assert below
+
+    stream = NotifyingStream()
+    session = _session(tmp_path, stream)
+    session.set_model(SWITCHED)
+    await session.dispose()  # what ctrl+c does
+
+    resumed_stream = NotifyingStream()
+    resumed = _session(tmp_path, resumed_stream)
+
+    assert resumed.model_label == "anthropic/claude-opus-5"
+    assert resumed.model.base_url == "https://api.anthropic.com"
+    assert resumed.model.context_window == registry_window
+    # The stream fn is told, or the restore is display-only and the first
+    # request goes back to the boot model.
+    assert [m.model_id for m in resumed_stream.models_changed] == ["claude-opus-5"]
+    await resumed.dispose()
+
+
+@pytest.mark.asyncio
+async def test_a_switch_made_moments_before_quitting_still_lands(tmp_path):
+    """The switch-then-ctrl+c case, which is how the bug is actually hit.
+
+    ``dispose`` cancels background tasks, so without the dispose flush the
+    journal write for a switch made in the closing moments of a session is
+    cancelled in flight and the next ``--resume`` opens on the boot default.
+    Disposing with no intervening await is what reproduces it: the spawned
+    write never gets a turn of the event loop.
+    """
+    stream = NotifyingStream()
+    session = _session(tmp_path, stream)
+
+    session.set_model(SWITCHED)
+    await session.dispose()  # no await between the switch and the teardown
+
+    resumed = _session(tmp_path, NotifyingStream())
+    assert resumed.model_label == "anthropic/claude-opus-5"
+    await resumed.dispose()
+
+
+@pytest.mark.asyncio
+async def test_switching_back_leaves_the_resume_on_the_boot_model(tmp_path):
+    """Newest row wins: a switch and a switch back resume on the boot model."""
+    stream = NotifyingStream()
+    session = _session(tmp_path, stream)
+
+    session.set_model(SWITCHED)
+    session.set_model(MODEL)
+    await session.dispose()
+
+    resumed_stream = NotifyingStream()
+    resumed = _session(tmp_path, resumed_stream)
+
+    assert resumed.model_label == "test/m"
+    # The no-op restore is skipped outright rather than re-derived, so nothing
+    # is announced to a stream fn that was already keyed to this model.
+    assert resumed_stream.models_changed == []
+    await resumed.dispose()
+
+
+@pytest.mark.asyncio
+async def test_a_changed_boot_selection_outranks_the_journalled_switch(tmp_path):
+    """``/model default`` (or ``--model``) between runs wins over the journal.
+
+    The changed boot selection is the newer, more deliberate choice — and a
+    restore that overrode it would make the flag the user just typed silently
+    not work.
+    """
+    stream = NotifyingStream()
+    session = _session(tmp_path, stream)
+    session.set_model(SWITCHED)
+    await session.dispose()
+
+    rebooted_stream = NotifyingStream()
+    rebooted = Session(
+        model=ModelSpec(provider="openai", model_id="gpt-6", context_window=400_000),
+        stream_fn=rebooted_stream,
+        tools=[],
+        transcript=Transcript(tmp_path / "sess"),
+        system_blocks_provider=lambda: ["stable", "env"],
+    )
+
+    assert rebooted.model_label == "openai/gpt-6"
+    assert rebooted_stream.models_changed == []
+    await rebooted.dispose()
+
+
+@pytest.mark.asyncio
+async def test_an_effort_change_is_not_a_switch(tmp_path):
+    """``/effort`` copies the spec in place; it must not journal a selection.
+
+    Same-model knob changes take ``set_model``'s early return, so the journal
+    stays one row per real switch rather than one per keystroke.
+    """
+    stream = NotifyingStream()
+    session = _session(tmp_path, stream)
+
+    session.set_model(MODEL.model_copy(update={"reasoning_effort": "high"}))
+    await session.dispose()
+
+    assert _selection_entries(session) == []
+    resumed = _session(tmp_path, NotifyingStream())
+    assert resumed.model_label == "test/m"
+    await resumed.dispose()
+
+
+@pytest.mark.asyncio
+async def test_the_switched_effort_rides_the_restore(tmp_path):
+    """A switch carrying an effort level resumes on that level.
+
+    The level is part of what the user chose: ``/model`` carries the chosen
+    effort onto the new model when it accepts one, so dropping it on resume
+    would silently move them off it.
+    """
+    stream = NotifyingStream()
+    session = _session(tmp_path, stream)
+
+    session.set_model(SWITCHED.model_copy(update={"reasoning_effort": "high"}))
+    await session.dispose()
+
+    resumed = _session(tmp_path, NotifyingStream())
+    assert resumed.model_label == "anthropic/claude-opus-5"
+    assert resumed.model.reasoning_effort == "high"
+    await resumed.dispose()
+
+
+@pytest.mark.asyncio
+async def test_an_unresolvable_selection_falls_back_to_the_boot_model(tmp_path):
+    """A journalled provider that no longer resolves must not break the resume.
+
+    Losing a switch is survivable; refusing to open the conversation is not.
+    And the row must be DROPPED rather than adopted: ``spec_for_target`` does
+    not raise on an unknown provider, it returns a spec with ``base_url=None``,
+    so a restore that skipped the registry check would resume the session onto
+    a model that cannot serve requests and fail on the first prompt as a
+    network error instead.
+    """
+    stream = NotifyingStream()
+    session = _session(tmp_path, stream)
+    await session._transcript.append_custom(
+        SELECTED_MODEL_CUSTOM_TYPE,
+        {"selector": "no-such-provider/no-such-model", "effort": None, "boot": "test/m"},
+    )
+    await session.dispose()
+
+    resumed = _session(tmp_path, NotifyingStream())
+    assert resumed.model_label == "test/m"
+    await resumed.dispose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "details",
+    [
+        {},
+        {"selector": ""},
+        {"selector": "no-slash", "boot": "test/m"},
+        {"selector": 17, "boot": "test/m"},
+        {"selector": "anthropic/claude-opus-5"},  # no boot recorded
+    ],
+)
+async def test_a_malformed_row_is_tolerated(tmp_path, details):
+    """A resume is never refused because one bookkeeping row is unreadable."""
+    stream = NotifyingStream()
+    session = _session(tmp_path, stream)
+    await session._transcript.append_custom(SELECTED_MODEL_CUSTOM_TYPE, details)
+    await session.dispose()
+
+    resumed = _session(tmp_path, NotifyingStream())
+    assert resumed.model_label == "test/m"
+    await resumed.dispose()
+
+
+@pytest.mark.asyncio
+async def test_a_resume_does_not_regrow_the_journal(tmp_path):
+    """Restoring reads the row; it must not write another one.
+
+    A resume that re-journalled what it just read would append a row per
+    launch, so a long-lived conversation's transcript would grow with the
+    number of times it has been opened rather than with its content.
+    """
+    stream = NotifyingStream()
+    session = _session(tmp_path, stream)
+    session.set_model(SWITCHED)
+    await session.dispose()
+
+    for _ in range(3):
+        resumed = _session(tmp_path, NotifyingStream())
+        await resumed.dispose()
+
+    final = _session(tmp_path, NotifyingStream())
+    assert len(_selection_entries(final)) == 1
+    await final.dispose()
+
+
+@pytest.mark.asyncio
+async def test_a_bare_stream_fn_still_restores(tmp_path):
+    """Hosts constructing sessions with plain stream functions degrade.
+
+    ``on_model_changed`` is an optional capability, so its absence must cost
+    the cache re-fit and nothing else — the session still resumes on the
+    switched model.
+    """
+    session = _session(tmp_path, ScriptedStream([[StreamEndEvent(stop_reason="stop")]]))
+    session.set_model(SWITCHED)
+    await session.dispose()
+
+    resumed = _session(tmp_path, ScriptedStream([[StreamEndEvent(stop_reason="stop")]]))
+    assert resumed.model_label == "anthropic/claude-opus-5"
+    await resumed.dispose()


### PR DESCRIPTION
## Summary of Changes

Bug fix. A `/model <provider>/<id>` switch changes the session's live model spec, but the switch lived only in memory — quitting the TUI (ctrl+c) and coming back with `--resume` replayed the whole conversation onto the **boot default**, silently losing the switched model. This contradicts what the transcript itself shows the user choosing.

The fix journals each switch as a `selected_model` custom transcript entry — the sibling of the existing `active_model_route` entry. That one records where a provider **fallback** routed requests; this one records where the **user** did. Both are written on the edge and read back at construction.

Key design points:

- **Boot-selector guard.** Each row carries the `provider/model_id` the session was constructed with. On resume the restore adopts the row only when that boot selector still matches; a changed boot selection — a `/model default` write, an edited agent profile, or an explicit `--hosting`/`--model` flag on the resume itself — is the newer, more deliberate choice and wins. Without this, a flag the user just typed would silently not work.
- **Dispose-flush contract.** The write goes through the same tracked-task + dispose-flush path the conversation title uses, because the real failure mode is a switch made *moments before quitting*: `dispose` cancels background tasks, so without the flush the journal write is cancelled in flight and the resume opens on the boot default again.
- **Re-derivation, not replay.** The restore rebuilds the spec through `spec_for_target` (the same derivation `/model` itself lands on) rather than replaying a persisted copy, so a registry update between quit and resume is picked up rather than replayed stale. It validates the provider first, because `spec_for_target` returns a `base_url=None` spec for an unknown provider rather than raising — a stranded row is dropped, not adopted onto a spec that cannot serve requests.

Change class: **C1 (standard, pre-authorized)** — a scoped bug fix with a clear rollback (revert one commit), no contract, schema, auth, or migration surface.

## Related Issue(s)

- Related: none filed (bug reported directly).

## Impact

- No breaking changes. Adds one append-only `selected_model` custom transcript entry type; older builds ignore unknown custom entries on replay, and this build tolerates a missing/malformed row by falling back to the boot model.
- No dependency updates.
- No security implications. The entry stores a `provider/model_id` selector and effort level only — no credentials or secrets. Restore validates the provider against the registry before adopting a row.
- Performance: one extra backward `latest_custom` scan at construction (already done for the title and route entries) and one small append per real `/model` switch. `/effort` and sampling-only spec changes take `set_model`'s same-pair early return and journal nothing.

## Testing Details

**Behavioural reproduction** (the reported bug), driven through the real factory + session path against an isolated config dir — switch the model via `Session.set_model` (what `/model` does), `dispose` (what ctrl+c does), then `create_session(resume=<id>)`:

```
before fix:  session boots on test/config-default → switched to test/switched-model → resumed on: test/config-default  → LOST
after fix:   session boots on test/config-default → switched to test/switched-model → resumed on: test/switched-model → PRESERVED
```

**New regression suite** `tests/unit/session/test_selected_model.py` (15 tests), covering: switch is journalled with the boot selector; resume comes back on the switched model (asserted through the re-derived registry window + base_url, with a control proving it differs from the journalled figure — so it cannot pass on a stale replay); switch-then-immediate-dispose still lands via the flush; switch-back resumes on the boot model (newest row wins); a changed boot selection outranks the journal; `/effort` is not a switch; the switched effort rides the restore; an unresolvable/unknown-provider row is dropped not fatal; malformed rows tolerated (parametrized); resume does not regrow the journal; a bare stream fn still restores.

**Mutation-tested** — both halves of the fix were proven load-bearing:
- Disabling `_restore_selected_model()` → 4 tests fail.
- Removing the `_flush_selected_model()` dispose call → 5 tests fail.
Restored byte-identical after each (verified with `cmp`).

**Gates** (rebased onto current `main`, PR head `ea03e25f14a678de9c5b6f66589c639a7bf00063`):
- `flake8` / `black --check` / `isort --check-only` / `pyright` — clean.
- `pytest tests/unit/session tests/unit/test_session_factory.py` — 351 passed.
- `pytest tests/unit/tui` — 2174 passed, 4 skipped (1 pre-existing unrelated wake-test warning).

No runtime UI delta to screenshot: the status band already renders whatever model the session is on. This fix only changes *which* model that is after a resume, which the behavioural reproduction above demonstrates directly. A design round follows on the MR for the user-visible behaviour.

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my changes work as intended.
- [x] All new and existing tests pass.
- [x] I have run formatting (black/isort), linting (flake8), and type checks (pyright), and they pass.
- [x] I have updated the documentation when required (none required; in-code why/constraint comments added).
- [x] Security considerations are addressed (no secrets in the entry; provider validated on restore).
- [x] I have linked all related issues.
