### PR TITLE
feat(session): persist subagents, statuses, and todos across resume

### DIFF
--- a/local_operator/harness/comms.py
+++ b/local_operator/harness/comms.py
@@ -472,6 +472,76 @@ class SubagentComms:
             rows.append(self._describe(record, now))
         return rows
 
+    # -- persistence ----------------------------------------------------------
+
+    def snapshot(self) -> list[dict[str, Any]]:
+        """The durable half of every record, for persistence to the transcript.
+
+        Only the fields that survive a process exit and matter to a resumed
+        session: the identity (``job_id``/``label``), the transcript directory
+        that makes resume possible, and the settled outcome so the roster can
+        say how a child ended after its job row is long gone. The live handles
+        (``child``, ``unsubscribe``, ``ask``, ``pending``) are deliberately
+        omitted — they belong to a running loop and cannot cross a restart.
+
+        ``session_dir`` is stored as a string (``Path`` is not JSON-native) and
+        a record with none (a child that never started, so has no transcript)
+        is skipped entirely: it is not resumable and carries nothing a resumed
+        session could act on.
+        """
+        rows: list[dict[str, Any]] = []
+        for record in self._records.values():
+            if record.session_dir is None:
+                continue
+            rows.append(
+                {
+                    "job_id": record.job_id,
+                    "label": record.label,
+                    "session_dir": str(record.session_dir),
+                    "outcome": record.outcome,
+                    "error_text": record.error_text,
+                    "paused": record.paused,
+                    "settled_at": record.settled_at,
+                }
+            )
+        return rows
+
+    def restore(self, rows: list[dict[str, Any]]) -> None:
+        """Rebuild settled records from a persisted snapshot at resume.
+
+        This is the resume basis: ``hub op='resume'`` needs the
+        ``job_id \u2192 session_dir`` mapping to relaunch a child against its old
+        transcript, and the roster needs the recorded outcome to say how each
+        child ended. Both die with the process, so without rehydrating them a
+        resumed session cannot see \u2014 let alone continue \u2014 the children the
+        previous one launched.
+
+        Every restored record is SETTLED: its live child is gone, so it carries
+        no ``child`` handle and is marked ``settled`` with the persisted
+        ``settled_at`` (so eviction order and the roster's age column stay
+        meaningful). A row whose ``job_id`` is already present is skipped \u2014 a
+        live child of this session must never be clobbered by a stale snapshot
+        of its predecessor.
+        """
+        for row in rows:
+            job_id = str(row.get("job_id") or "")
+            if not job_id or job_id in self._records:
+                continue
+            raw_dir = row.get("session_dir")
+            session_dir = Path(str(raw_dir)) if raw_dir else None
+            record = _ChildRecord(
+                job_id=job_id,
+                label=str(row.get("label") or job_id),
+                session_dir=session_dir,
+                settled=True,
+                settled_at=row.get("settled_at"),
+                paused=bool(row.get("paused")),
+                outcome=(str(row["outcome"]) if row.get("outcome") is not None else None),
+                error_text=(str(row["error_text"]) if row.get("error_text") is not None else None),
+            )
+            self._records[job_id] = record
+        self._evict_overflow()
+
     async def peek(
         self,
         job_id: str,
@@ -642,7 +712,19 @@ class SubagentComms:
         # in fact have succeeded — the same disagreement as F1, in the safe
         # direction. The later branches still veto it when there is genuinely
         # nothing to resume.
-        resumable = status in ("completed", "failed", "cancelled", "paused", "gone")
+        # ``interrupted`` is the resume feature's own status: a child that was
+        # running when the process exited, rehydrated from the persisted roster.
+        # Its transcript survived on disk, so it is exactly the case ``resume``
+        # was built for — the later transcript-existence check still vetoes it
+        # if the directory is gone.
+        resumable = status in (
+            "completed",
+            "failed",
+            "cancelled",
+            "paused",
+            "gone",
+            "interrupted",
+        )
         detail = detail if resumable else "not resumable in this state"
         if status in ("running", "queued", "starting"):
             resumable, detail = False, "still running; cancel or pause it first"

--- a/local_operator/harness/jobs.py
+++ b/local_operator/harness/jobs.py
@@ -52,7 +52,16 @@ OUTPUT_TAIL_CHARS = 64_000
 #: the bare word ``cancelled`` beside a duration that was spent waiting.
 CANCELLED_BEFORE_START = "cancelled before it started"
 
-JobStatus = Literal["running", "completed", "failed", "cancelled"]
+#: ``interrupted`` is a RESTORE-only status: it names a ``task`` row that was
+#: ``running`` when the process exited, rehydrated from the persisted roster on
+#: the next resume. It never arises from a live transition — a job the manager
+#: itself settles becomes completed/failed/cancelled — so every LIVE reader
+#: (capacity math, retention sweep, delivery) treats it as terminal. It exists
+#: only so a resumed session can SHOW the child that was cut off mid-run and,
+#: when its transcript survived on disk, offer to resume it (see
+#: ``SubagentComms.roster``/``resume``), instead of the row vanishing with the
+#: process.
+JobStatus = Literal["running", "completed", "failed", "cancelled", "interrupted"]
 JobType = Literal["bash", "task"]
 
 # run(job_id, signal, report_progress) -> awaitable text result
@@ -166,6 +175,16 @@ class AsyncJob(BaseModel):
     # keyboard, which no try/except can catch. It cannot change under a
     # running child, so once is right. ``0`` = not recorded.
     context_window: int = 0
+    # Set on a row rehydrated from the persisted roster at resume (see
+    # ``AsyncJobManager.restore``). A restored row is a HISTORICAL record, not a
+    # live job: it has no asyncio task, no abort signal, and no runner, so it
+    # can never be cancelled, delivered, or promoted. The retention sweep skips
+    # it (it has no ``settled_at`` clock to age against and the resumed session
+    # must keep showing it), and capacity math already ignores it because its
+    # status is terminal. Kept as an explicit flag rather than inferred from a
+    # missing task because a reader must be able to tell "this session started
+    # it" from "a previous session did" without consulting the task table.
+    restored: bool = False
 
 
 class AsyncJobManager:
@@ -184,10 +203,20 @@ class AsyncJobManager:
         on_job_complete: (
             Callable[[str, str, "AsyncJob | None"], Awaitable[None] | None] | None
         ) = None,
+        on_roster_change: Callable[[], None] | None = None,
     ) -> None:
         self._max_running = max_running
         self._retention_ms = retention_ms
         self._on_job_complete = on_job_complete
+        # Fired (best-effort, synchronously) whenever the SET of ``task`` rows
+        # or one of their statuses changes, so the session can re-snapshot the
+        # roster to disk without the manager knowing what a transcript is. Kept
+        # as a bare callback rather than a persist coroutine because the manager
+        # runs it on the hot path of every registration and settle: it signals
+        # "something changed", and the owner decides how (and how cheaply) to
+        # persist. A raising callback must never break job bookkeeping, so the
+        # single call site guards it.
+        self._on_roster_change = on_roster_change
         self._jobs: dict[str, AsyncJob] = {}
         self._signals: dict[str, AbortSignal] = {}
         self._tasks: dict[str, asyncio.Task[None]] = {}
@@ -228,6 +257,60 @@ class AsyncJobManager:
             1 for job in self._jobs.values() if job.status == "running" and not job.queued
         )
         return running >= self._max_running
+
+    def _notify_roster_change(self) -> None:
+        """Signal the owner that the task roster moved (add / settle / status).
+
+        Best-effort: a persistence hook that raises must not corrupt the job
+        table or leave a settle half-applied, so the exception is swallowed
+        with a warning. Always called AFTER the mutation it reports, never
+        before, so a listener that re-reads the roster sees the new state.
+        """
+        if self._on_roster_change is None:
+            return
+        try:
+            self._on_roster_change()
+        except Exception:  # noqa: BLE001 - a bad listener must not break jobs
+            logger.warning("roster-change listener raised", exc_info=True)
+
+    def restore(self, rows: list["AsyncJob"]) -> None:
+        """Rehydrate task rows from a persisted roster at resume.
+
+        The manager's ``_jobs`` table lives only in memory, so a resumed
+        session opens with an empty subagent panel even though the children ran
+        and their transcripts survive on disk. This re-seeds the table from the
+        snapshot the session persisted (see ``Session._persist_subagent_roster``)
+        so the panel, the ``jobs`` tool, and ``hub op='list'`` show the children
+        the previous process launched.
+
+        A row that was ``running`` when the process died is downgraded to
+        ``interrupted`` here: its asyncio task is gone, so it is not live, and
+        presenting it as ``running`` would spin a status the manager can never
+        settle. Every restored row is flagged ``restored`` and carries no task,
+        signal, or runner — it is a historical record. Rows are NOT re-run;
+        resuming one is an explicit ``hub op='resume'`` that starts a fresh job
+        against the old transcript.
+
+        Idempotent-ish: a row whose id is already present (a live job of this
+        session) is left untouched, so a mis-timed double restore cannot
+        clobber a running child.
+        """
+        changed = False
+        for row in rows:
+            if row.id in self._jobs:
+                continue
+            if row.status == "running":
+                # No task backs it any more; a live-looking row would spin a
+                # spinner forever and invite a cancel that finds nothing.
+                row.status = "interrupted"
+            row.restored = True
+            # A restored row owns no runtime handles; drop any the snapshot
+            # carried so nothing downstream tries to await or cancel a task
+            # that does not exist.
+            self._jobs[row.id] = row
+            changed = True
+        if changed:
+            self._notify_roster_change()
 
     # -- registration -------------------------------------------------------
 
@@ -289,6 +372,10 @@ class AsyncJobManager:
             # Parked behind a caller-managed gate; holds no execution slot and
             # keeps its runner for start_queued().
             self._queued_runners[job_id] = run
+        # A new row is a roster change the owner may want to persist (task rows
+        # only carry a resumable transcript, but the listener filters that).
+        if type == "task":
+            self._notify_roster_change()
         return job_id
 
     def start_queued(self, job_id: str) -> bool:
@@ -412,6 +499,8 @@ class AsyncJobManager:
                 logger.warning("job %s pre-start cleanup raised", job_id, exc_info=True)
         self._settle(job)
         self._sweep_due()
+        if job.type == "task":
+            self._notify_roster_change()
         return True
 
     # -- lifecycle ----------------------------------------------------------
@@ -525,6 +614,8 @@ class AsyncJobManager:
             self._settle(job)
             self._tasks.pop(job.id, None)
             self._sweep_due()
+            if job.type == "task":
+                self._notify_roster_change()
             return
         except Exception as exc:
             job.status = "failed"
@@ -532,6 +623,12 @@ class AsyncJobManager:
             logger.warning("background job %s failed", job.id, exc_info=True)
         self._settle(job)
         self._tasks.pop(job.id, None)
+        # After the settle stamp, before delivery: a listener re-reading the
+        # roster now sees the terminal status, and persisting here (rather than
+        # only after delivery) means a crash between settle and delivery still
+        # leaves the outcome on disk for the next resume.
+        if job.type == "task":
+            self._notify_roster_change()
         try:
             await self._deliver(job)
         except Exception:
@@ -632,7 +729,15 @@ class AsyncJobManager:
         for job_id in [
             job_id
             for job_id, job in self._jobs.items()
-            if job.status != "running" and job.settled_at is not None and job.settled_at < cutoff
+            # ``restored`` rows are exempt: they carry the PREVIOUS session's
+            # settle stamp, which is almost always already past the retention
+            # window, so an unguarded sweep would evict every rehydrated child
+            # on the first pass after resume — the exact rows this feature
+            # exists to keep visible. They leave only when the session ends.
+            if not job.restored
+            and job.status != "running"
+            and job.settled_at is not None
+            and job.settled_at < cutoff
         ]:
             del self._jobs[job_id]
             self._signals.pop(job_id, None)

--- a/local_operator/harness/jobs.py
+++ b/local_operator/harness/jobs.py
@@ -283,34 +283,45 @@ class AsyncJobManager:
         so the panel, the ``jobs`` tool, and ``hub op='list'`` show the children
         the previous process launched.
 
-        A row that was ``running`` when the process died is downgraded to
+        A row that was actually RUNNING when the process died is downgraded to
         ``interrupted`` here: its asyncio task is gone, so it is not live, and
         presenting it as ``running`` would spin a status the manager can never
-        settle. Every restored row is flagged ``restored`` and carries no task,
-        signal, or runner — it is a historical record. Rows are NOT re-run;
-        resuming one is an explicit ``hub op='resume'`` that starts a fresh job
-        against the old transcript.
+        settle. A row that was still ``queued`` (parked behind the capacity
+        gate, ``status == "running"`` with ``queued == True``) never ran and has
+        no transcript, so it is NOT interrupted — it is simply gone; it is
+        dropped rather than restored, matching the comms side, which already
+        skips it in ``snapshot()`` because its record has no ``session_dir``.
+        Every restored row is flagged ``restored`` and carries no runtime
+        handles (an ``AsyncJob`` serializes none — the abort signal and asyncio
+        task live in the manager's own ``_signals``/``_tasks`` maps, which the
+        snapshot never touched — so there is nothing to clear). Rows are NOT
+        re-run; resuming one is an explicit ``hub op='resume'`` that starts a
+        fresh job against the old transcript.
 
         Idempotent-ish: a row whose id is already present (a live job of this
         session) is left untouched, so a mis-timed double restore cannot
         clobber a running child.
+
+        Deliberately does NOT fire ``on_roster_change``: rehydrating the table
+        is not a roster *change* the owner needs to persist — the snapshot being
+        read is already on disk — and notifying here would re-append a
+        byte-identical snapshot on every resume (and, if a host ever constructs
+        a Session off-loop, raise a spurious warning from the persist spawn).
         """
-        changed = False
         for row in rows:
             if row.id in self._jobs:
                 continue
             if row.status == "running":
+                if row.queued:
+                    # Parked and never started, so it has no transcript to show
+                    # or resume; a ``⇥ interrupted`` row for it would invite a
+                    # resume that finds nothing. Drop it entirely.
+                    continue
                 # No task backs it any more; a live-looking row would spin a
                 # spinner forever and invite a cancel that finds nothing.
                 row.status = "interrupted"
             row.restored = True
-            # A restored row owns no runtime handles; drop any the snapshot
-            # carried so nothing downstream tries to await or cancel a task
-            # that does not exist.
             self._jobs[row.id] = row
-            changed = True
-        if changed:
-            self._notify_roster_change()
 
     # -- registration -------------------------------------------------------
 
@@ -394,6 +405,12 @@ class AsyncJobManager:
         progress = self._progress_fn(job_id)
         task = asyncio.ensure_future(self._run_job(job, runner(job_id, signal, progress)))
         self._tasks[job_id] = task
+        # The queued -> running transition is a status-affecting task-row change
+        # like register/settle/cancel, so it notifies too: without this the flag
+        # move only reaches disk at the next roster event, and a snapshot taken
+        # in between would restore the row as if it were still parked.
+        if job.type == "task":
+            self._notify_roster_change()
         return True
 
     # -- delivery -----------------------------------------------------------

--- a/local_operator/harness/subagent.py
+++ b/local_operator/harness/subagent.py
@@ -356,6 +356,20 @@ def _make_runner(
                 # this module composes the child, and its transcript directory
                 # is what makes the child resumable later.
                 comms.attach(job_id, child, child._transcript.directory)
+                # The child's transcript directory is the WHOLE basis of resume,
+                # and it becomes known only here (the runner just built the
+                # child). The job-manager roster hook fired at registration —
+                # before this session_dir existed — so persist again now that
+                # the record carries a resumable directory, or a crash between
+                # launch and settle would leave a snapshot naming a child with
+                # no way to reach its transcript. Best-effort: a failed persist
+                # must never stop the child from running.
+                schedule_persist = getattr(parent_session, "_schedule_subagent_persist", None)
+                if callable(schedule_persist):
+                    try:
+                        schedule_persist()
+                    except Exception:  # noqa: BLE001 - persistence is not load-bearing here
+                        logger.warning("could not persist roster after attach", exc_info=True)
             await emit(SubagentStartEvent(job_id=job_id, label=label, agent_id=child.agent_id))
             unsubscribe = child.subscribe(
                 _make_relay(job_id, label, job, emit, report_progress, final)

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -56,7 +56,11 @@ from typing import TYPE_CHECKING, Any, Literal, TypeGuard
 from local_operator.compaction.tokens import IMAGE_TOKEN_ESTIMATE, approx_text_tokens
 from local_operator.harness.approval import ApprovalGate
 from local_operator.harness.comms import HUB_MESSAGE_TYPE, SubagentComms
-from local_operator.harness.jobs import JOB_RESULT_MESSAGE_TYPE, AsyncJobManager
+from local_operator.harness.jobs import (
+    JOB_RESULT_MESSAGE_TYPE,
+    AsyncJob,
+    AsyncJobManager,
+)
 from local_operator.harness.loop import AgentLoop, LoopContext
 from local_operator.harness.subagent import run_subagent
 from local_operator.harness.types import (
@@ -121,7 +125,9 @@ from local_operator.session.transcript import Transcript
 from local_operator.tools.builtin import (
     TODO_REMINDER_MESSAGE_TYPE,
     open_todos,
+    restore_todos,
     todo_fingerprint,
+    todo_snapshot,
 )
 
 if TYPE_CHECKING:
@@ -158,6 +164,23 @@ ACTIVE_ROUTE_CUSTOM_TYPE = "active_model_route"
 #: ``--hosting``/``--model`` flag on the resume itself). A changed boot
 #: selection wins: it is the newer, more deliberate choice.
 SELECTED_MODEL_CUSTOM_TYPE = "selected_model"
+
+#: Transcript custom-entry type holding a snapshot of the subagents this
+#: session launched (see ``SubagentComms.snapshot``) plus their job rows (see
+#: ``AsyncJobManager``). Both structures live only in memory, so without this a
+#: resumed session opens with an empty subagent panel and no way to reach —
+#: let alone resume — the children the previous process started, even though
+#: their transcripts survive on disk. Re-snapshotted (newest-wins, like every
+#: custom entry) whenever the roster moves; loaded once at construction.
+SUBAGENT_ROSTER_CUSTOM_TYPE = "subagent_roster"
+
+#: Transcript custom-entry type holding the session's todo list. The todo tool
+#: keeps the live list in a module-level table keyed by session id (see
+#: ``local_operator.tools.builtin.TODO_STORE``), which the process loses on
+#: exit; this is the durable copy a resume rehydrates so the todo panel and the
+#: continuation guardrail come back exactly where they were. Snapshotted after
+#: every turn (the only place the list can have moved) and on demand.
+TODO_SNAPSHOT_CUSTOM_TYPE = "todo_snapshot"
 
 #: How many times the title writer will chase a name that moved under its own
 #: append before giving up and leaving the rest to the dispose flush. A cap
@@ -665,6 +688,27 @@ def _pruned_ids(messages: Sequence[AgentMessage]) -> set[str]:
     }
 
 
+def _subagent_job_row(job: AsyncJob) -> dict[str, Any]:
+    """One task job as a persistable dict for the roster snapshot.
+
+    Drops the two fields that are heavy and reconstructable, keeping the
+    snapshot small enough to re-write on every roster move:
+
+    - ``trajectory`` holds up to ``TRAJECTORY_CAP`` serialized child events —
+      hundreds of dicts per child — and a resumed reader recovers the same
+      detail on demand from the child's own transcript via ``hub op='peek'``,
+      so persisting it would cost the transcript a large write per event for a
+      view nobody has opened.
+    - the abort ``signal`` and asyncio ``task`` never survive a process anyway
+      (``model_dump`` already omits them; they are runtime handles).
+
+    Everything the subagent panel paints — label, status, timings, model,
+    usage, context window, prompt — is kept. ``model_dump(mode="json")`` makes
+    the nested ``Usage`` JSON-native.
+    """
+    return job.model_dump(mode="json", exclude={"trajectory"})
+
+
 def _parsed_usage(payload: dict[str, Any]) -> Usage | None:
     """One persisted ``usage`` payload as a :class:`Usage`, or ``None``.
 
@@ -1013,6 +1057,11 @@ class Session:
         # with a byte-identical list is not nudged a second time. Reset per user
         # turn in _run_turn_pipeline; see :meth:`_todo_continuation`.
         self._todo_reminder_fingerprint: tuple[tuple[str, str], ...] | None = None
+        # The todo fingerprint that was last WRITTEN to the transcript, so the
+        # post-turn snapshot only appends when the list actually moved. Seeded
+        # from disk on a resume (``_load_todo_snapshot`` sets it) so the first
+        # turn after a restore does not re-persist an unchanged restored list.
+        self._persisted_todo_fingerprint: tuple[tuple[str, str], ...] | None = None
 
         self._disposed = False
         # Session-scoped task group (HC-11): wake deliveries and aside
@@ -1054,6 +1103,10 @@ class Session:
         # behaviour is exactly what it was before this was configurable.
         self.jobs = AsyncJobManager(
             on_job_complete=self._on_job_completed,
+            # The manager signals every task-roster move here; the session folds
+            # both halves (job rows + comms records) into ONE persisted snapshot
+            # so a resume can rebuild the subagent panel and the resume basis.
+            on_roster_change=self._schedule_subagent_persist,
             **_configured_max_running(),
         )
         self._wake = WakeScheduler(
@@ -1095,6 +1148,14 @@ class Session:
         # that model already restored, or the pin reads as stranded and is
         # dropped.
         self._restore_selected_model()
+        # Subagents and todos: both live only in memory during a session, so a
+        # resume rebuilds them from the transcript here — the job rows and comms
+        # records that make the subagent panel and ``hub op='resume'`` work, and
+        # the todo list the panel and the continuation guardrail read. Ordered
+        # after the history replay (the transcript is already loaded) and before
+        # the first turn (nothing has written to either store yet).
+        self._load_subagent_roster()
+        self._load_todo_snapshot()
         # Which model is ACTUALLY serving requests, when that is not the
         # selected one: the spec of the pinned fallback route, or None while
         # the primary serves. Owned by the session (not read off the stream
@@ -3037,6 +3098,14 @@ class Session:
             # messages after the compaction entry that superseded them.
             await self._persist_new_messages(new_messages)
 
+            # Snapshot the todo list when it moved this turn. Guarded by the
+            # same full-list fingerprint the continuation guardrail uses, so an
+            # unchanged list costs one tuple comparison and no transcript write,
+            # while any add/done/block/drop/init lands on disk for the next
+            # resume. Placed on the normal path (a turn that raised past here
+            # still has last turn's snapshot; the next clean turn re-writes it).
+            await self._maybe_persist_todos()
+
             pending_incident = self._pending_incident
             self._pending_incident = None
             if pending_incident:
@@ -3106,9 +3175,21 @@ class Session:
         exception escaping into a TaskGroup would cancel every sibling task.
         """
         if self._disposed:
+            # Close the coroutine we were handed rather than dropping it: a
+            # caller building ``self._spawn_background(self._coro())`` has
+            # already created it, and a disposed session that merely returned
+            # left it unawaited — an "coroutine was never awaited" warning, and
+            # under a background subagent runner racing dispose it is a real
+            # path (the runner schedules a roster persist just as teardown
+            # flips this flag).
+            coro.close()
             return
 
+        started = False
+
         async def _guarded() -> None:
+            nonlocal started
+            started = True
             try:
                 await coro
             except asyncio.CancelledError:
@@ -3121,7 +3202,21 @@ class Session:
         else:
             task = asyncio.ensure_future(_guarded())
         self._background_tasks.add(task)
-        task.add_done_callback(self._background_tasks.discard)
+
+        def _on_done(finished: asyncio.Task[Any]) -> None:
+            self._background_tasks.discard(finished)
+            # If dispose cancelled this task before ``_guarded`` ever ran (it
+            # was still pending), the wrapper's ``try`` never entered and the
+            # INNER ``coro`` was created but never awaited — Python reports it
+            # as "coroutine was never awaited". Closing it here, from the one
+            # callback that fires for every task including a cancelled-pending
+            # one, is what suppresses that. ``started`` is the discriminator:
+            # once the wrapper began, ``await coro`` drove the coroutine and a
+            # late ``close()`` would be redundant (and is skipped).
+            if not started:
+                coro.close()
+
+        task.add_done_callback(_on_done)
 
     def _build_tool_context(self) -> ToolContext:
         # This context is REBUILT on every turn, so anything that must outlive
@@ -4592,6 +4687,150 @@ class Session:
             {"schedules": [schedule.model_dump() for schedule in schedules]},
         )
 
+    # -- subagent roster (resume basis) --------------------------------------
+
+    def _schedule_subagent_persist(self) -> None:
+        """Roster-change hook from ``AsyncJobManager`` (synchronous).
+
+        The manager fires this on the hot path of a registration or settle, so
+        it must not block or await: it spawns the snapshot write on the session
+        task group and returns at once. A child session (one with a ``job_id``)
+        does not persist a roster of its own — it is itself a leaf whose
+        transcript the PARENT already tracks — so the hook is a no-op there,
+        keeping a grandchild's churn off the child's transcript.
+        """
+        if self._disposed or self._job_id is not None:
+            return
+        self._spawn_background(self._persist_subagent_roster())
+
+    async def _persist_subagent_roster(self) -> None:
+        """Snapshot the task job rows AND the comms records to the transcript.
+
+        Both halves are needed and neither alone suffices. The job ROWS carry
+        what the subagent panel paints (label, status, model, usage, elapsed);
+        the comms RECORDS carry what ``hub op='resume'`` needs (the
+        ``job_id \u2192 session_dir`` mapping and how each child settled). They are
+        written together, newest-wins like every custom entry, so a resume reads
+        one coherent snapshot rather than two that drifted.
+
+        Only ``task`` rows are stored: ``bash`` jobs are host-local processes
+        that cannot outlive the process that spawned them, so persisting them
+        would only invite a resume to show a job it can never touch.
+        """
+        try:
+            rows = [
+                _subagent_job_row(job)
+                for job in self.jobs.list()
+                if getattr(job, "type", "") == "task"
+            ]
+            records = self._subagent_comms.snapshot() if self._subagent_comms is not None else []
+            # Nothing to record means no append: a session that never delegated
+            # must not pay a transcript write (and, at teardown, a wedged-mount
+            # timeout) for an empty roster it will never read back.
+            if not rows and not records:
+                return
+            await self._transcript.append_custom(
+                SUBAGENT_ROSTER_CUSTOM_TYPE,
+                {"jobs": rows, "records": records},
+            )
+        except Exception:  # noqa: BLE001 - persistence must never break a turn
+            logger.warning("could not persist subagent roster", exc_info=True)
+
+    async def _final_persist_snapshots(self) -> None:
+        """Write the last roster and todo snapshots at teardown, in order.
+
+        Split out so :meth:`dispose` can bound the pair with a single
+        ``wait_for``: both are transcript appends and neither may hang teardown.
+        """
+        await self._persist_subagent_roster()
+        await self._maybe_persist_todos()
+
+    def _load_subagent_roster(self) -> None:
+        """Rehydrate the subagent panel and the resume basis from disk.
+
+        Reads the newest snapshot and feeds each half to its owner: the comms
+        records to ``SubagentComms.restore`` (the resume basis) and the job rows
+        to ``AsyncJobManager.restore`` (the panel). Restoring the records
+        MINTS the comms instance if this session had not yet — a resumed session
+        that launched children last time is exactly one that needs it — so the
+        roster is populated before the first turn can ask for it.
+
+        Malformed rows are dropped individually rather than failing the whole
+        load: a resume that lost one child's row is far better than one that
+        booted with an empty panel because a single entry was unreadable.
+        """
+        details = self._transcript.latest_custom(SUBAGENT_ROSTER_CUSTOM_TYPE)
+        if not details:
+            return
+        records = details.get("records") or []
+        if records:
+            # ``self.subagent_comms`` (the property) mints the instance on first
+            # use; restoring into it is what makes the children addressable.
+            try:
+                self.subagent_comms.restore(list(records))
+            except Exception:  # noqa: BLE001 - a bad snapshot must not stop boot
+                logger.warning("could not restore subagent records", exc_info=True)
+        rows: list[AsyncJob] = []
+        for raw in details.get("jobs") or []:
+            try:
+                rows.append(AsyncJob.model_validate(raw))
+            except Exception:
+                logger.warning("dropping malformed persisted subagent row: %r", raw)
+        if rows:
+            try:
+                self.jobs.restore(rows)
+            except Exception:  # noqa: BLE001 - a bad snapshot must not stop boot
+                logger.warning("could not restore subagent job rows", exc_info=True)
+
+    # -- todo list (resume) --------------------------------------------------
+
+    async def _maybe_persist_todos(self) -> None:
+        """Snapshot the todo list to the transcript when it moved this turn.
+
+        The todo tool keeps the live list in a process-local table, so a
+        transcript snapshot is the only durable copy a resume can read. Guarded
+        by the FULL-list fingerprint (the same one the continuation guardrail
+        compares): an unchanged list is one tuple comparison and no write, while
+        any init/add/done/block/drop lands a fresh newest-wins entry. Never
+        raises — a status write must not break a turn.
+        """
+        fingerprint = todo_fingerprint(self._session_id)
+        if fingerprint == self._persisted_todo_fingerprint:
+            return
+        if not fingerprint and self._persisted_todo_fingerprint is None:
+            # An empty list that was never persisted is the ordinary
+            # never-used-todos session: record nothing and, importantly, do
+            # not append an empty snapshot at teardown (which on a wedged mount
+            # would charge the dispose budget). The guard above already lets a
+            # list that went from populated back to empty through, because its
+            # persisted fingerprint is then non-None.
+            return
+        try:
+            await self._transcript.append_custom(
+                TODO_SNAPSHOT_CUSTOM_TYPE,
+                {"items": todo_snapshot(self._session_id)},
+            )
+            self._persisted_todo_fingerprint = fingerprint
+        except Exception:  # noqa: BLE001 - persistence must never break a turn
+            logger.warning("could not persist todo snapshot", exc_info=True)
+
+    def _load_todo_snapshot(self) -> None:
+        """Rehydrate the todo list from disk so the panel and guardrail return.
+
+        A child session shares no todo store with its parent (the store is keyed
+        by session id), so this is safe for both — a child simply finds no
+        snapshot under its own id and does nothing. The persisted fingerprint is
+        seeded from the restored list so the first post-resume turn does not
+        re-write a list that has not changed.
+        """
+        details = self._transcript.latest_custom(TODO_SNAPSHOT_CUSTOM_TYPE)
+        if not details:
+            return
+        items = details.get("items") or []
+        if items:
+            restore_todos(self._session_id, list(items))
+            self._persisted_todo_fingerprint = todo_fingerprint(self._session_id)
+
     # -- active model route (fallback persistence) ---------------------------
 
     async def _persist_active_route(self, primary: ModelSpec) -> None:
@@ -5075,6 +5314,28 @@ class Session:
                     await self._tg_stack.aclose()
                 self._tg_stack = None
             self._task_group = None
+            # Snapshot the roster and todos ONE last time, directly (the task
+            # group is closed, so ``_spawn_background`` no longer runs) and
+            # BEFORE ``jobs.dispose`` cancels the running children — a child
+            # cancelled by teardown settles ``cancelled``, and persisting after
+            # that would record a status the resume then offers to "resume"
+            # from a run the user only stopped by quitting. Persisting first
+            # captures each child as it actually stood at quit. Guarded so a
+            # write failure never blocks the rest of teardown. Skipped for a
+            # child session (it persists no roster of its own).
+            if self._job_id is None:
+                try:
+                    # Bounded like the conversation-name flush above: a snapshot
+                    # is a transcript append, and teardown must not hang on a
+                    # wedged mount or behind a lock a stuck writer holds. A lost
+                    # final snapshot is cheap — the per-turn and roster-change
+                    # snapshots already captured all but the last few
+                    # milliseconds — so the deadline favours proceeding.
+                    await asyncio.wait_for(
+                        self._final_persist_snapshots(), timeout=_NAME_FLUSH_TIMEOUT_S
+                    )
+                except (Exception, asyncio.TimeoutError):  # noqa: BLE001
+                    logger.warning("final roster/todo snapshot did not land", exc_info=True)
             await self.jobs.dispose()
             self._wake.dispose()
             # A shell receipt can be queued behind a turn that was just aborted.

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -688,25 +688,57 @@ def _pruned_ids(messages: Sequence[AgentMessage]) -> set[str]:
     }
 
 
+#: The ONLY ``AsyncJob`` fields the roster snapshot carries. An allowlist, not
+#: an exclude set, because the whole task-row list is re-appended on every
+#: roster move and custom entries are never reclaimed (``compact_file`` folds
+#: only the message prune journal) — so anything unbounded here is written once
+#: per surviving child per move, i.e. O(children²) bytes of superseded data on
+#: disk. The fields kept are all small and bounded: the identity, the timings
+#: the panel prices elapsed from, the model/usage/window it paints, and the
+#: routing/queue flags a restore needs. Everything a reader might want beyond
+#: this — the child's full ``result_text``, its verbatim ``prompt`` (documented
+#: "Unbounded on purpose"), the ``trajectory``, the live ``output_tail`` — is
+#: recoverable on demand from the child's OWN transcript via ``hub op='peek'``,
+#: the same argument the trajectory exclusion already made, carried to its
+#: conclusion.
+_ROSTER_ROW_FIELDS = frozenset(
+    {
+        "id",
+        "type",
+        "status",
+        "start_time",
+        "started_at",
+        "settled_at",
+        "label",
+        "queued",
+        "agent_id",
+        "owner_id",
+        "model_label",
+        "context_window",
+        "usage",
+        "restored",
+    }
+)
+
+#: Cap on the one free-text field the row keeps. ``error_text`` drives the
+#: panel's one-line summary for a restored FAILED row, so it is worth keeping —
+#: but a stack trace or a giant provider error must not reintroduce the
+#: unbounded-growth M1 fix removes, so it is clipped to a sentence's worth.
+_ROSTER_ERROR_CAP = 2_000
+
+
 def _subagent_job_row(job: AsyncJob) -> dict[str, Any]:
-    """One task job as a persistable dict for the roster snapshot.
+    """One task job as a slim, bounded dict for the roster snapshot.
 
-    Drops the two fields that are heavy and reconstructable, keeping the
-    snapshot small enough to re-write on every roster move:
-
-    - ``trajectory`` holds up to ``TRAJECTORY_CAP`` serialized child events —
-      hundreds of dicts per child — and a resumed reader recovers the same
-      detail on demand from the child's own transcript via ``hub op='peek'``,
-      so persisting it would cost the transcript a large write per event for a
-      view nobody has opened.
-    - the abort ``signal`` and asyncio ``task`` never survive a process anyway
-      (``model_dump`` already omits them; they are runtime handles).
-
-    Everything the subagent panel paints — label, status, timings, model,
-    usage, context window, prompt — is kept. ``model_dump(mode="json")`` makes
-    the nested ``Usage`` JSON-native.
+    Projects the job onto :data:`_ROSTER_ROW_FIELDS` (see its note for why an
+    allowlist rather than an exclude set), plus a length-capped ``error_text``
+    so a restored failed row can still say why it failed. ``model_dump(
+    mode="json")`` makes the nested ``Usage`` JSON-native.
     """
-    return job.model_dump(mode="json", exclude={"trajectory"})
+    row = job.model_dump(mode="json", include=set(_ROSTER_ROW_FIELDS))
+    if job.error_text:
+        row["error_text"] = job.error_text[:_ROSTER_ERROR_CAP]
+    return row
 
 
 def _parsed_usage(payload: dict[str, Any]) -> Usage | None:

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -4790,6 +4790,15 @@ class Session:
         Malformed rows are dropped individually rather than failing the whole
         load: a resume that lost one child's row is far better than one that
         booted with an empty panel because a single entry was unreadable.
+
+        A restored row has NO in-process page detail: the slim snapshot
+        projection (:func:`_subagent_job_row`) drops ``prompt``, ``result_text``
+        and ``trajectory``, so opening a restored child's full-page view shows
+        an empty body (the view folds those and handles ``None`` without
+        raising). That is the accepted tradeoff of not writing a child's full
+        output to the parent transcript on every roster move — the detail lives
+        in the CHILD's own transcript and is recovered by resuming or
+        ``hub op='peek'``-ing it, never by re-reading it here.
         """
         details = self._transcript.latest_custom(SUBAGENT_ROSTER_CUSTOM_TYPE)
         if not details:

--- a/local_operator/tools/builtin.py
+++ b/local_operator/tools/builtin.py
@@ -3775,6 +3775,47 @@ def open_todos(session_id: str) -> list[dict[str, str]]:
     return [dict(item) for item in items if item.get("status") == "pending"]
 
 
+def todo_snapshot(session_id: str) -> list[dict[str, str]]:
+    """A deep copy of the FULL todo list for ``session_id`` (``[]`` when none).
+
+    The durable form the session persists to its transcript so a resume can
+    rebuild the list (see ``Session._persist_todo_snapshot``). Unlike
+    :func:`open_todos` this keeps EVERY item — done, dropped, blocked, pending —
+    and every field (including a blocked item's ``reason``), because the panel
+    and the progress counter render the whole list, not just the open subset.
+
+    Reads the same SESSION-ID branch of the store as :func:`open_todos`; the
+    caveat there about a host-attached ``ToolContext.todos`` store applies here
+    identically. Copies so a caller holding the result never mutates the store.
+    """
+    items = TODO_STORE.get(session_id)
+    if not items:
+        return []
+    return [dict(item) for item in items]
+
+
+def restore_todos(session_id: str, items: list[dict[str, str]]) -> None:
+    """Seed ``session_id``'s todo list from a persisted snapshot at resume.
+
+    The inverse of :func:`todo_snapshot`. Writes straight into the same
+    module-level table the todo tool uses, so the restored list is
+    indistinguishable from one the tool built — the panel reads it, and the
+    continuation guardrail's fingerprint (:func:`todo_fingerprint`) matches what
+    it was before the restart.
+
+    A no-op when there is nothing to restore or the id is empty, and it REFUSES
+    to overwrite a list the current session already has: restore runs once at
+    construction, before any turn, so a populated slot means a live list that
+    must win over a stale snapshot. Each item is copied so the store never
+    aliases the caller's list.
+    """
+    if not session_id or not items:
+        return
+    if TODO_STORE.get(session_id):
+        return
+    TODO_STORE[session_id] = [dict(item) for item in items]
+
+
 def todo_fingerprint(session_id: str) -> tuple[tuple[str, str], ...]:
     """``(text, status)`` for EVERY item of ``session_id``'s list, in order.
 

--- a/local_operator/tui/widgets/subagent_panel.py
+++ b/local_operator/tui/widgets/subagent_panel.py
@@ -59,7 +59,16 @@ GLYPH_QUEUED = "⏳"
 #: persisted roster on resume (see ``AsyncJobManager`` status ``interrupted``).
 #: Its own mark — neither ✓ (it did not finish) nor ✗ (it did not fail): the
 #: run was cut off, and if its transcript survived it can be resumed.
-GLYPH_INTERRUPTED = "⇥"
+#:
+#: ``↺`` (U+21BA) over the earlier ``⇥``: the tab-arrow read as a Tab key once
+#: the accompanying word dropped under the panel's narrow-width reduction
+#: (design review round 1, D1), whereas the open circle-arrow says "suspended,
+#: pick it back up" — which is exactly the resumability the state carries, so
+#: it doubles as the D2 cue. Chosen for width too: it is ``east_asian_width=N``
+#: (locked to one cell) and outside the emoji-presentation block, so unlike the
+#: media-control marks (``⏸``/``⏯``, siblings of the wide ``⏳`` queued glyph) it
+#: cannot balloon to a two-cell colour emoji and shear the time column.
+GLYPH_INTERRUPTED = "↺"
 
 #: Rows the panel spends on chrome rather than on jobs: the ``Subagents``
 #: caption. Named because :meth:`SubagentPanel.predicted_rows` adds it to the

--- a/local_operator/tui/widgets/subagent_panel.py
+++ b/local_operator/tui/widgets/subagent_panel.py
@@ -55,6 +55,11 @@ GLYPH_FAILED = "✗"
 #: WAITING mark rather than a settled one: it has not run, so ✓ would lie.
 GLYPH_CANCELLED = "⊘"
 GLYPH_QUEUED = "⏳"
+#: A child that was RUNNING when a previous process exited, rehydrated from the
+#: persisted roster on resume (see ``AsyncJobManager`` status ``interrupted``).
+#: Its own mark — neither ✓ (it did not finish) nor ✗ (it did not fail): the
+#: run was cut off, and if its transcript survived it can be resumed.
+GLYPH_INTERRUPTED = "⇥"
 
 #: Rows the panel spends on chrome rather than on jobs: the ``Subagents``
 #: caption. Named because :meth:`SubagentPanel.predicted_rows` adds it to the
@@ -119,6 +124,12 @@ def status_glyph(
         return GLYPH_FAILED, "failed", "danger"
     if status == "cancelled":
         return GLYPH_CANCELLED, "cancelled", "dim"
+    if status == "interrupted":
+        # Rehydrated from a previous process's roster; the run was cut off, not
+        # finished or failed. Muted rather than danger — nothing went wrong, the
+        # process simply ended — and its own word so a reader can tell it apart
+        # from a clean cancel and know it may be resumable.
+        return GLYPH_INTERRUPTED, "interrupted", "muted"
     return GLYPH_DONE, status or "completed", "dim"
 
 
@@ -330,6 +341,13 @@ def _read_row(job: Any, *, fallback_id: str, current: bool) -> RowFacts:
             # itself. Cancelled-while-PARKED does not reach here empty — the
             # manager stamps ``CANCELLED_BEFORE_START`` on it, which is the
             # more specific sentence and wins on its own.
+            activity = status_glyph(status)[1]
+        elif not activity and status == "interrupted":
+            # A restored ``interrupted`` row carries no ``result_text`` (its run
+            # never settled), so like the cancelled-mid-run case it would rest
+            # on a 1-cell glyph alone. Spell the word so the row says WHY it is
+            # not a clean outcome — the process ended under it — and reads the
+            # same as the page it opens.
             activity = status_glyph(status)[1]
     if current and not running:
         # The page IS this row's detail, three rows above it. Repeating a

--- a/tests/unit/harness/test_comms_persistence.py
+++ b/tests/unit/harness/test_comms_persistence.py
@@ -1,0 +1,112 @@
+"""Persisting and rehydrating the subagent roster across a resume.
+
+``SubagentComms._records`` is the resume basis: it holds the
+``job_id -> session_dir`` mapping ``hub op='resume'`` relaunches a child from,
+and the recorded outcome the roster shows after a child's job row is swept.
+Both die with the process, so a resumed session cannot see — let alone continue
+— the children the previous one launched unless the records are rebuilt from
+disk.
+
+``snapshot`` writes the durable half and ``restore`` reads it back. These tests
+pin that the round trip preserves resumability and the recorded outcome, that a
+child which never got a transcript is not persisted (there is nothing to
+resume), and that restore never clobbers a live record.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from local_operator.harness.comms import SubagentComms
+from local_operator.session.transcript import TRANSCRIPT_FILENAME
+from tests.unit.harness.test_comms import FakeChild, FakeJobs, FakeParent
+
+
+def _comms_with_settled_child(tmp_path: Path, jobs: FakeJobs) -> SubagentComms:
+    """A comms holding one launched-then-settled child with a real transcript."""
+    parent = FakeParent(jobs)
+    comms = SubagentComms(parent)  # type: ignore[arg-type]
+    session_dir = tmp_path / "child"
+    session_dir.mkdir()
+    (session_dir / TRANSCRIPT_FILENAME).write_text("{}\n", encoding="utf-8")
+    jobs.add("job1", status="running")
+    comms.record_launch("job1", "explore the repo")
+    comms.attach("job1", FakeChild(), session_dir)  # type: ignore[arg-type]
+    comms.record_outcome("job1", "completed")
+    comms.detach("job1")
+    jobs.jobs["job1"].status = "completed"
+    return comms
+
+
+def test_snapshot_captures_the_resumable_fields(tmp_path) -> None:
+    comms = _comms_with_settled_child(tmp_path, FakeJobs())
+    rows = comms.snapshot()
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["job_id"] == "job1"
+    assert row["label"] == "explore the repo"
+    assert row["session_dir"] == str(tmp_path / "child")
+    assert row["outcome"] == "completed"
+
+
+def test_a_never_started_child_is_not_snapshotted(tmp_path) -> None:
+    """No transcript directory means nothing to resume, so nothing to persist."""
+    parent = FakeParent(FakeJobs())
+    comms = SubagentComms(parent)  # type: ignore[arg-type]
+    comms.record_launch("parked", "queued behind the gate")  # never attached
+    assert comms.snapshot() == []
+
+
+def test_restore_rebuilds_a_resumable_record(tmp_path) -> None:
+    """The round trip: snapshot from one comms, restore into a fresh one, and
+    the resumed roster shows the child as resumable with its transcript."""
+    jobs_a = FakeJobs()
+    rows = _comms_with_settled_child(tmp_path, jobs_a).snapshot()
+
+    # A fresh session: empty jobs manager (the row was swept), empty comms.
+    fresh = SubagentComms(FakeParent(FakeJobs()))  # type: ignore[arg-type]
+    fresh.restore(rows)
+
+    roster = fresh.roster()
+    assert len(roster) == 1
+    info = roster[0]
+    assert info.job_id == "job1"
+    assert info.label == "explore the repo"
+    assert info.status == "completed"
+    assert info.resumable is True
+    assert info.session_id == "child"
+
+
+def test_restore_preserves_a_failure_outcome(tmp_path) -> None:
+    jobs = FakeJobs()
+    parent = FakeParent(jobs)
+    comms = SubagentComms(parent)  # type: ignore[arg-type]
+    session_dir = tmp_path / "c2"
+    session_dir.mkdir()
+    (session_dir / TRANSCRIPT_FILENAME).write_text("{}\n", encoding="utf-8")
+    jobs.add("j2", status="running")
+    comms.record_launch("j2", "flaky task")
+    comms.attach("j2", FakeChild(), session_dir)  # type: ignore[arg-type]
+    comms.record_outcome("j2", "failed", "boom")
+    comms.detach("j2")
+
+    fresh = SubagentComms(FakeParent(FakeJobs()))  # type: ignore[arg-type]
+    fresh.restore(comms.snapshot())
+    info = fresh.roster()[0]
+    assert info.status == "failed"
+    assert info.detail is not None and "boom" in info.detail
+
+
+def test_restore_skips_an_id_that_is_already_live(tmp_path) -> None:
+    """A stale snapshot must not overwrite a running child of this session."""
+    jobs = FakeJobs()
+    comms = SubagentComms(FakeParent(jobs))  # type: ignore[arg-type]
+    jobs.add("dup", status="running")
+    comms.record_launch("dup", "live child")
+    live_child = FakeChild()
+    comms.attach("dup", live_child, tmp_path / "live")  # type: ignore[arg-type]
+
+    comms.restore([{"job_id": "dup", "label": "stale", "session_dir": str(tmp_path / "old")}])
+    # The live record's label and transcript survive the stale restore.
+    assert comms.label_of("dup") == "live child"
+    assert comms.session_dir_of("dup") == tmp_path / "live"

--- a/tests/unit/harness/test_jobs_restore.py
+++ b/tests/unit/harness/test_jobs_restore.py
@@ -1,0 +1,145 @@
+"""Restoring a task roster across a process boundary.
+
+The subagent panel, the ``jobs`` tool, and ``hub op='list'`` all read
+``AsyncJobManager._jobs``, which lives only in memory. Before this feature a
+resumed session opened with an empty panel even though the children ran and
+their transcripts survived on disk. ``AsyncJobManager.restore`` re-seeds the
+table from a persisted snapshot; these tests pin the four properties that make
+the rehydrated rows honest:
+
+* a row that was ``running`` when the process died comes back as
+  ``interrupted`` (its task is gone; a live-looking row would spin forever);
+* every restored row is flagged so retention and capacity treat it as the
+  historical record it is, and the sweep never evicts it;
+* a live job of the current session is never clobbered by a stale snapshot;
+* the roster-change hook fires on registration, settle, and restore so the
+  owner can persist without polling.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from local_operator.harness.jobs import AsyncJob, AsyncJobManager
+
+
+async def wait_for(predicate, timeout: float = 2.0) -> None:
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    while not predicate():
+        if loop.time() > deadline:
+            raise AssertionError("timed out waiting for condition")
+        await asyncio.sleep(0.01)
+
+
+def _row(job_id: str, status: str = "completed", **kw) -> AsyncJob:
+    return AsyncJob(id=job_id, type="task", status=status, start_time=1.0, label=job_id, **kw)
+
+
+@pytest.mark.asyncio
+async def test_restore_seeds_rows_and_flags_them() -> None:
+    manager = AsyncJobManager()
+    manager.restore([_row("aaa", status="completed", settled_at=2.0)])
+    job = manager.get("aaa")
+    assert job is not None
+    assert job.status == "completed"
+    assert job.restored is True
+    # It appears in the list surface the panel and the jobs tool read.
+    assert [j.id for j in manager.list()] == ["aaa"]
+
+
+@pytest.mark.asyncio
+async def test_running_row_restores_as_interrupted() -> None:
+    """A child cut off mid-run has no task any more; ``running`` would lie."""
+    manager = AsyncJobManager()
+    manager.restore([_row("bbb", status="running")])
+    job = manager.get("bbb")
+    assert job is not None
+    assert job.status == "interrupted"
+    assert job.restored is True
+
+
+@pytest.mark.asyncio
+async def test_restored_rows_are_never_swept() -> None:
+    """Retention ages against ``settled_at``; a restored row carries the
+    PREVIOUS session's stamp, which is already past the window — so an
+    unguarded sweep would evict every rehydrated child on the first pass."""
+    manager = AsyncJobManager(retention_ms=1)
+    # settled_at far in the past → past the 1 ms window immediately.
+    manager.restore([_row("ccc", status="completed", settled_at=1.0)])
+    manager._sweep_due()  # the sweep the runner calls after every settle
+    assert manager.get("ccc") is not None
+
+
+@pytest.mark.asyncio
+async def test_restore_never_clobbers_a_live_row() -> None:
+    manager = AsyncJobManager()
+
+    async def runner(job_id, signal, report_progress):
+        await asyncio.sleep(5)
+        return "late"
+
+    live_id = manager.register("task", "live", runner)
+    await asyncio.sleep(0)  # let the runner enter so dispose can cancel it cleanly
+    # A stale snapshot naming the same id must not overwrite the running job.
+    manager.restore([_row(live_id, status="completed")])
+    live = manager.get(live_id)
+    assert live is not None
+    assert live.status == "running"
+    assert live.restored is False
+    await manager.dispose()
+
+
+@pytest.mark.asyncio
+async def test_roster_change_hook_fires_on_register_settle_and_restore() -> None:
+    calls: list[str] = []
+    manager = AsyncJobManager(on_roster_change=lambda: calls.append("x"))
+
+    async def runner(job_id, signal, report_progress):
+        return "ok"
+
+    job_id = manager.register("task", "t", runner)
+    assert calls  # registration fired it
+    before_settle = len(calls)
+    await wait_for(lambda: manager.get(job_id).status == "completed")  # type: ignore[union-attr]
+    assert len(calls) > before_settle  # settle fired it again
+    before_restore = len(calls)
+    manager.restore([_row("zzz")])
+    assert len(calls) > before_restore  # restore fired it too
+    await manager.dispose()
+
+
+@pytest.mark.asyncio
+async def test_bash_rows_do_not_trigger_the_roster_hook() -> None:
+    """Only ``task`` rows carry a resumable transcript; a bash job firing the
+    roster hook would append a snapshot for a process a resume can never
+    touch."""
+    calls: list[str] = []
+    manager = AsyncJobManager(on_roster_change=lambda: calls.append("x"))
+
+    async def runner(job_id, signal, report_progress):
+        return "ok"
+
+    manager.register("bash", "b", runner)
+    await asyncio.sleep(0)  # let the runner enter and settle so nothing is left unawaited
+    assert calls == []
+    await manager.dispose()
+
+
+@pytest.mark.asyncio
+async def test_a_raising_hook_does_not_break_bookkeeping() -> None:
+    def boom() -> None:
+        raise RuntimeError("bad listener")
+
+    manager = AsyncJobManager(on_roster_change=boom)
+
+    async def runner(job_id, signal, report_progress):
+        return "ok"
+
+    # Registration must still return an id and track the job despite the raise.
+    job_id = manager.register("task", "t", runner)
+    assert manager.get(job_id) is not None
+    await wait_for(lambda: manager.get(job_id).status == "completed")  # type: ignore[union-attr]
+    await manager.dispose()

--- a/tests/unit/harness/test_jobs_restore.py
+++ b/tests/unit/harness/test_jobs_restore.py
@@ -22,7 +22,7 @@ import asyncio
 
 import pytest
 
-from local_operator.harness.jobs import AsyncJob, AsyncJobManager
+from local_operator.harness.jobs import AsyncJob, AsyncJobManager, JobStatus
 
 
 async def wait_for(predicate, timeout: float = 2.0) -> None:
@@ -34,7 +34,7 @@ async def wait_for(predicate, timeout: float = 2.0) -> None:
         await asyncio.sleep(0.01)
 
 
-def _row(job_id: str, status: str = "completed", **kw) -> AsyncJob:
+def _row(job_id: str, status: JobStatus = "completed", **kw) -> AsyncJob:
     return AsyncJob(id=job_id, type="task", status=status, start_time=1.0, label=job_id, **kw)
 
 

--- a/tests/unit/harness/test_jobs_restore.py
+++ b/tests/unit/harness/test_jobs_restore.py
@@ -67,10 +67,25 @@ async def test_restored_rows_are_never_swept() -> None:
     PREVIOUS session's stamp, which is already past the window — so an
     unguarded sweep would evict every rehydrated child on the first pass."""
     manager = AsyncJobManager(retention_ms=1)
-    # settled_at far in the past → past the 1 ms window immediately.
+    # Two rows the same age (settled far in the past → past the 1 ms window):
+    # one restored, one an ordinary settled row. The control proves the sweep
+    # WOULD evict at this age, so the restored row surviving the SAME call is
+    # the exemption changing the outcome, not the age being safe.
     manager.restore([_row("ccc", status="completed", settled_at=1.0)])
+    manager._jobs["ddd"] = _row("ddd", status="completed", settled_at=1.0)
     manager._sweep_due()  # the sweep the runner calls after every settle
-    assert manager.get("ccc") is not None
+    assert manager.get("ccc") is not None  # restored: exempt
+    assert manager.get("ddd") is None  # ordinary same-age row: evicted
+
+
+@pytest.mark.asyncio
+async def test_a_queued_row_is_dropped_not_restored_as_interrupted() -> None:
+    """A parked task (status running + queued) never started and has no
+    transcript, so restoring it as ``interrupted`` would paint a resumable row
+    for a child that never ran. It is dropped instead."""
+    manager = AsyncJobManager()
+    manager.restore([_row("qqq", status="running", queued=True)])
+    assert manager.get("qqq") is None
 
 
 @pytest.mark.asyncio
@@ -93,7 +108,7 @@ async def test_restore_never_clobbers_a_live_row() -> None:
 
 
 @pytest.mark.asyncio
-async def test_roster_change_hook_fires_on_register_settle_and_restore() -> None:
+async def test_roster_change_hook_fires_on_register_and_settle() -> None:
     calls: list[str] = []
     manager = AsyncJobManager(on_roster_change=lambda: calls.append("x"))
 
@@ -105,10 +120,19 @@ async def test_roster_change_hook_fires_on_register_settle_and_restore() -> None
     before_settle = len(calls)
     await wait_for(lambda: manager.get(job_id).status == "completed")  # type: ignore[union-attr]
     assert len(calls) > before_settle  # settle fired it again
-    before_restore = len(calls)
-    manager.restore([_row("zzz")])
-    assert len(calls) > before_restore  # restore fired it too
     await manager.dispose()
+
+
+@pytest.mark.asyncio
+async def test_restore_does_not_fire_the_roster_hook() -> None:
+    """Rehydrating the table is not a roster CHANGE to persist: the snapshot
+    being read is already on disk, so notifying would re-append a byte-identical
+    one on every resume (and could raise off-loop)."""
+    calls: list[str] = []
+    manager = AsyncJobManager(on_roster_change=lambda: calls.append("x"))
+    manager.restore([_row("zzz")])
+    assert calls == []
+    assert manager.get("zzz") is not None  # but the row WAS restored
 
 
 @pytest.mark.asyncio

--- a/tests/unit/session/test_resume_subagents_todos.py
+++ b/tests/unit/session/test_resume_subagents_todos.py
@@ -263,6 +263,16 @@ async def test_snapshot_entry_is_written_for_a_launched_child(tmp_path, monkeypa
     assert entries
     latest = entries[-1].payload["details"]
     # Job rows carry the manager's own ``id`` key; comms records carry job_id.
-    assert any(r["id"] == job_id for r in latest["jobs"])
+    row = next(r for r in latest["jobs"] if r["id"] == job_id)
     assert any(r["job_id"] == job_id for r in latest["records"])
+    # The snapshot is a SLIM projection: the unbounded fields a heavy child
+    # carries (its full reply, its verbatim prompt, its trajectory, its live
+    # output tail) must not be written — they are recoverable from the child's
+    # own transcript, and re-appending them on every roster move is the
+    # O(children^2) footprint the projection exists to prevent (review R1 M1).
+    for heavy in ("result_text", "prompt", "trajectory", "output_tail", "latest_details"):
+        assert heavy not in row, f"{heavy} must not be in the roster snapshot"
+    # But the fields the panel actually paints ARE kept.
+    for kept in ("id", "label", "status", "start_time"):
+        assert kept in row
     await parent.dispose()

--- a/tests/unit/session/test_resume_subagents_todos.py
+++ b/tests/unit/session/test_resume_subagents_todos.py
@@ -1,0 +1,268 @@
+"""Subagents and todos survive a resume.
+
+THE bug: after quitting and resuming a session, the subagent list, their
+statuses, and the todo list all vanished — even though the children's
+transcripts were still on disk and could in principle be continued. Every one
+of those structures lived only in memory:
+
+* ``AsyncJobManager._jobs`` — the rows the subagent panel and the ``jobs`` tool
+  paint;
+* ``SubagentComms._records`` — the roster and the ``job_id -> session_dir``
+  mapping ``hub op='resume'`` relaunches a child from;
+* ``TODO_STORE[session_id]`` — the todo list the panel and the continuation
+  guardrail read.
+
+The session now snapshots all three to its transcript as custom entries and
+rehydrates them at construction, exactly the way wake schedules and the
+conversation title already did. These tests drive a REAL parent session and a
+REAL child run through a scripted provider, tear the session down, reopen it on
+the same directory, and assert the children and todos come back — and, the
+whole point, that a restored child is still resumable.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from local_operator.harness.types import (
+    AbortSignal,
+    ChatRequest,
+    StreamEndEvent,
+    StreamTextDelta,
+)
+from local_operator.session.session import (
+    SUBAGENT_ROSTER_CUSTOM_TYPE,
+    TODO_SNAPSHOT_CUSTOM_TYPE,
+    Session,
+)
+from local_operator.session.transcript import Transcript
+from local_operator.tools.builtin import TODO_STORE, execute_todo
+from tests.unit.session.test_launch_subagent import MODEL, OneShotStream
+
+
+@pytest.fixture(autouse=True)
+def _clean_todo_store():
+    """The todo tool's store is a MODULE-GLOBAL keyed by session id, and every
+    session in this suite opens on ``tmp_path/"sess"`` — so its id is ``"sess"``
+    for all of them, and a list one test leaves would be read by the next (and,
+    worse, by ``test_session.py`` sessions sharing that id, whose transcript
+    entry counts then include a todo snapshot they never wrote). Clear it on the
+    way in and out so each test starts and ends with an empty store.
+    """
+    TODO_STORE.clear()
+    yield
+    TODO_STORE.clear()
+
+
+async def wait_for(predicate, timeout: float = 5.0) -> None:
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    while not predicate():
+        if loop.time() > deadline:
+            raise AssertionError("timed out waiting for condition")
+        await asyncio.sleep(0.005)
+
+
+def _status(session, job_id: str) -> str | None:
+    """The status of ``job_id`` on ``session``'s manager, or ``None`` when the
+    row is not (yet) present — narrowed so assertions never index ``None``."""
+    job = session.jobs.get(job_id)
+    return None if job is None else job.status
+
+
+async def _todo(ctx, call_id: str, args: dict[str, object]) -> None:
+    """Drive the todo tool with the full positional signature its guard
+    decorator declares (signal / on_update default to ``None``)."""
+    await execute_todo(call_id, args, None, None, ctx)
+
+
+class IdleStream:
+    """A parent stream that answers every turn with a single text delta.
+
+    The parent never calls a tool here — the test drives ``_launch_subagent``
+    and the todo tool directly — so one text turn is all it needs.
+    """
+
+    def __init__(self) -> None:
+        self.requests: list[ChatRequest] = []
+
+    def __call__(self, request: ChatRequest, signal: AbortSignal | None):
+        self.requests.append(request)
+
+        async def gen():
+            yield StreamTextDelta(delta="ok")
+            yield StreamEndEvent(stop_reason="stop")
+
+        return gen()
+
+
+def _session(tmp_path, stream) -> Session:
+    return Session(
+        model=MODEL,
+        stream_fn=stream,
+        tools=[],
+        transcript=Transcript(tmp_path / "sess"),
+        system_blocks_provider=lambda: ["stable"],
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_completed_subagent_is_restored_and_resumable(tmp_path, monkeypatch):
+    """Launch a real child, let it finish, tear down, resume — the child is
+    back on the roster AND ``hub op='resume'`` can pick it up."""
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+
+    parent = _session(tmp_path, OneShotStream())
+    await parent.async_init()
+    job_id = parent._launch_subagent(label="explore", prompt="do a thing")
+    await wait_for(lambda: _status(parent, job_id) == "completed")
+    # Let the post-settle roster snapshot land on the task group.
+    await asyncio.sleep(0.05)
+    session_dir = parent.subagent_comms.session_dir_of(job_id)
+    assert session_dir is not None
+    await parent.dispose()
+
+    # Resume: a fresh Session over the same transcript directory.
+    resumed = _session(tmp_path, IdleStream())
+    await resumed.async_init()
+
+    # The panel's data source — the job manager — shows the child again.
+    rows = [j for j in resumed.jobs.list() if j.type == "task"]
+    assert len(rows) == 1
+    assert rows[0].id == job_id
+    assert rows[0].label == "explore"
+    assert rows[0].status == "completed"
+    assert rows[0].restored is True
+
+    # The roster shows it and marks it resumable, and resume actually starts a
+    # fresh job against the OLD transcript directory.
+    roster = resumed.subagent_comms.roster()
+    assert len(roster) == 1
+    assert roster[0].resumable is True
+    assert resumed.subagent_comms.session_dir_of(job_id) == session_dir
+
+    new_job_id, error = resumed.subagent_comms.resume(job_id, "keep going")
+    assert error is None
+    assert new_job_id and new_job_id != job_id
+    await resumed.dispose()
+
+
+@pytest.mark.asyncio
+async def test_a_running_child_restores_as_interrupted(tmp_path, monkeypatch):
+    """A child still running when the process exits comes back as
+    ``interrupted`` — not a spinning ``running`` its manager can never settle —
+    and stays resumable because its transcript survived."""
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+
+    class HangingStream:
+        """A child stream that never ends, so the child is still 'running' at
+        teardown — the crash-mid-run case."""
+
+        def __call__(self, request: ChatRequest, signal: AbortSignal | None):
+            async def gen():
+                yield StreamTextDelta(delta="working")
+                await asyncio.sleep(30)
+                yield StreamEndEvent(stop_reason="stop")
+
+            return gen()
+
+    parent = _session(tmp_path, HangingStream())
+    await parent.async_init()
+    job_id = parent._launch_subagent(label="long", prompt="a long job")
+    # Wait until the child has attached (its session_dir is known) so the
+    # snapshot names a resumable transcript.
+    await wait_for(lambda: parent.subagent_comms.session_dir_of(job_id) is not None)
+    await asyncio.sleep(0.05)  # let the post-attach snapshot land
+    # dispose cancels the running child; the roster snapshot on disk still
+    # holds the row as it was persisted (running) BEFORE the cancel.
+    await parent.dispose()
+
+    resumed = _session(tmp_path, IdleStream())
+    await resumed.async_init()
+    rows = [j for j in resumed.jobs.list() if j.type == "task"]
+    assert len(rows) == 1
+    assert rows[0].status == "interrupted"
+    info = resumed.subagent_comms.roster()[0]
+    assert info.status == "interrupted"
+    assert info.resumable is True
+    await resumed.dispose()
+
+
+@pytest.mark.asyncio
+async def test_todos_survive_a_resume(tmp_path):
+    """A todo list built during a turn comes back after a resume, with every
+    item and status intact."""
+    TODO_STORE.pop((tmp_path / "sess").name, None)
+    parent = _session(tmp_path, IdleStream())
+    await parent.async_init()
+    sid = parent.session_id
+
+    ctx = parent._build_tool_context()
+    await _todo(ctx, "t1", {"op": "init", "items": ["alpha", "beta", "gamma"]})
+    await _todo(ctx, "t2", {"op": "done", "items": ["alpha"]})
+    await _todo(ctx, "t3", {"op": "block", "items": ["beta"], "reason": "waiting on X"})
+    # Persist happens at turn end; drive one turn so the snapshot is written.
+    await parent.prompt("anything")
+    await parent.dispose()
+    # Clear the live store so the resume genuinely rehydrates from disk.
+    TODO_STORE.pop(sid, None)
+
+    resumed = _session(tmp_path, IdleStream())
+    await resumed.async_init()
+    items = TODO_STORE.get(resumed.session_id) or []
+    by_text = {i["text"]: i for i in items}
+    assert by_text["alpha"]["status"] == "done"
+    assert by_text["beta"]["status"] == "blocked"
+    assert by_text["beta"].get("reason") == "waiting on X"
+    assert by_text["gamma"]["status"] == "pending"
+    await resumed.dispose()
+
+
+@pytest.mark.asyncio
+async def test_unchanged_todos_are_not_re_persisted_every_turn(tmp_path):
+    """The post-turn snapshot is guarded by a fingerprint, so a turn that did
+    not touch the list writes no new snapshot entry."""
+    TODO_STORE.pop((tmp_path / "sess").name, None)
+    parent = _session(tmp_path, IdleStream())
+    await parent.async_init()
+    ctx = parent._build_tool_context()
+    await _todo(ctx, "t1", {"op": "init", "items": ["one"]})
+    await parent.prompt("turn one")
+
+    def _count() -> int:
+        return sum(
+            1
+            for e in parent._transcript.entries()
+            if e.type == "custom" and e.payload.get("custom_type") == TODO_SNAPSHOT_CUSTOM_TYPE
+        )
+
+    after_first = _count()
+    assert after_first >= 1
+    await parent.prompt("turn two — no todo change")
+    assert _count() == after_first  # unchanged list wrote nothing new
+    await parent.dispose()
+
+
+@pytest.mark.asyncio
+async def test_snapshot_entry_is_written_for_a_launched_child(tmp_path, monkeypatch):
+    """A launched child writes a roster snapshot custom entry to the
+    transcript — the durable record the resume reads."""
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    parent = _session(tmp_path, OneShotStream())
+    await parent.async_init()
+    job_id = parent._launch_subagent(label="x", prompt="p")
+    await wait_for(lambda: _status(parent, job_id) == "completed")
+    await asyncio.sleep(0.05)
+    entries = [
+        e
+        for e in parent._transcript.entries()
+        if e.type == "custom" and e.payload.get("custom_type") == SUBAGENT_ROSTER_CUSTOM_TYPE
+    ]
+    assert entries
+    latest = entries[-1].payload["details"]
+    # Job rows carry the manager's own ``id`` key; comms records carry job_id.
+    assert any(r["id"] == job_id for r in latest["jobs"])
+    assert any(r["job_id"] == job_id for r in latest["records"])
+    await parent.dispose()


### PR DESCRIPTION
## Summary of Changes

Bug fix. After quitting the TUI and coming back with `--resume`, the subagent list, each subagent's status, and the todo list all disappeared and never came back — the subagent panel opened empty, the todo panel opened empty, and there was no way to see, let alone continue, a child that was mid-run, failed, or sitting in a settled state when the process exited. This happened even though the child's own transcript survived on disk and was in principle resumable.

The cause is that all three structures lived only in memory:

- `AsyncJobManager._jobs` — the rows the subagent panel and the `jobs` tool paint;
- `SubagentComms._records` — the roster (`hub op='list'`) and the `job_id -> session_dir` mapping `hub op='resume'` relaunches a child from;
- `TODO_STORE[session_id]` — the todo list the panel and the continuation guardrail read.

The fix snapshots all three to the session transcript as custom entries and rehydrates them at construction — the same mechanism wake schedules (`wake_schedules`), the conversation title (`conversation_name`), and the fallback route (`active_model_route`) already use to survive a resume.

Key design points:

- **One coherent roster snapshot.** The job rows and the comms records are folded into a single `subagent_roster` custom entry, written together (newest-wins) so a resume never reads two halves that drifted. It is re-snapshotted on every roster move (register / settle / cancel, via a new `on_roster_change` hook on the manager) **and immediately after a child attaches**, because the child's transcript directory — the whole basis of resume — only becomes known then, and the registration snapshot fired before it existed.

- **`interrupted` is a restore-only status.** A row that was `running` when the process died has no asyncio task any more, so `restore()` downgrades it to a new `interrupted` status rather than presenting a live-looking `running` the manager can never settle. It is resumable when its transcript survived. Restored rows carry a `restored` flag and are exempt from the retention sweep (they hold the *previous* session's settle stamp, already past the window, so an unguarded sweep would evict every rehydrated child on the first pass).

- **Todos are snapshotted only when they move.** The post-turn snapshot is guarded by the same full-list fingerprint the continuation guardrail uses, so an unchanged list costs one tuple comparison and no write. A never-used-todos session writes nothing at all.

- **Teardown stays bounded.** A final flush on `dispose` captures the last few milliseconds (a todo changed, or a child settled, moments before quit), but it is wrapped in the same `wait_for` budget the conversation-title flush uses and skips entirely when there is nothing to record — so a wedged mount can never hang teardown. This surfaced (and the PR fixes) a latent leak in `_spawn_background`: a background task cancelled before its wrapper ran left its inner coroutine unawaited.

Change class: **C1 (standard, pre-authorized)** — a scoped resume/persistence fix with a clear rollback (revert one commit). It adds two append-only custom transcript entry types; no contract, schema, auth, or migration surface. Older builds ignore unknown custom entries on replay, and this build tolerates a missing or malformed snapshot by falling back to an empty roster / list.

## Related Issue(s)

- Related: none filed (reported directly: "after quitting lop and resuming a session, the subagents, subagent statuses, todos all disappear and don't come back").

## Impact

- No breaking changes. Two new append-only custom entry types (`subagent_roster`, `todo_snapshot`); a session that never delegates and never uses todos writes neither.
- No dependency updates.
- No security implications. The roster snapshot stores labels, statuses, timings, model ids, token counts, and each child's transcript **directory name** — no credentials, no message bodies (the child's own transcript, already on disk, holds those). The heavy/reconstructable `trajectory` (up to 500 serialized child events) is deliberately excluded and recovered on demand via `hub op='peek'`.
- Performance: one small append per roster move and per todo-moving turn (both already-cheap `latest_custom` reads at construction). Restored rows are re-seeded once at boot.

## Testing Details

**Behavioural reproduction** — launch a real subagent, set a todo list, `dispose` (what ctrl+d does), then reopen a fresh `Session` on the same directory (what `--resume` does):

```
main (before fix):
  before quit:  subagents=['explore the repo'] todos=[('ship the fix','pending'),('write tests','done')]
  after resume: subagents=[] todos=[]
  resumable:    []
  hub resume:   new_job=None error="unknown subagent ''"

this branch (after fix):
  before quit:  subagents=['explore the repo'] todos=[('ship the fix','pending'),('write tests','done')]
  after resume: subagents=[('explore the repo','completed')] todos=[('ship the fix','pending'),('write tests','done')]
  resumable:    [('explore the repo', True)]
  hub resume:   new_job='252a9cb1ec5d' error=None
```

The child, its status, and the todos all come back, the roster marks it resumable, and `hub op='resume'` successfully relaunches it against the old transcript.

**New unit suites:**
- `tests/unit/session/test_resume_subagents_todos.py` (5 tests) — the round trip against a REAL parent session and REAL child run: a completed child is restored and resumable; a child still running at exit restores as `interrupted` and stays resumable; todos survive with every status (done/blocked+reason/pending) intact; an unchanged list is not re-persisted every turn; a launched child writes a `subagent_roster` entry.
- `tests/unit/harness/test_jobs_restore.py` (7 tests) — `restore()` seeds and flags rows; a running row becomes `interrupted`; restored rows are never swept; a live row is never clobbered by a stale snapshot; the roster-change hook fires on register/settle/restore; bash rows do not fire it; a raising hook does not break bookkeeping.
- `tests/unit/harness/test_comms_persistence.py` (5 tests) — snapshot captures the resumable fields; a never-started child (no transcript) is not persisted; restore rebuilds a resumable record; a failure outcome round-trips; restore skips an id already live.

**Visual (subagent panel, real `OperatorApp` loading the stylesheet):** before/after stills of the panel rendering an `interrupted` restored row. On `main` the interrupted row falls through to `✓` (a success check over a run that was cut off); on this branch it renders `⇥ interrupted` in muted ink, distinct from a clean cancel or a failure. Attached below.

**Gates** (branch head `9a01f1828acc4980a2e80440b72719b6d9e62ff1`, off current `main`):
- `flake8` / `black --check` / `isort --check-only` / `pyright` — clean (whole tree).
- `pytest tests/unit/session tests/unit/harness` — 564 passed.
- `pytest tests/unit/tui` — 2209 passed, 4 skipped.

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my changes work as intended.
- [x] All new and existing tests pass.
- [x] I have run formatting (black/isort), linting (flake8), and type checks (pyright), and they pass.
- [x] I have updated the documentation when required (none required; in-code why/constraint comments added throughout).
- [x] Security considerations are addressed (no secrets or message bodies in the snapshot; heavy trajectory excluded).
- [x] I have linked all related issues.
