### PR TITLE
fix(mcp): close mid-session OAuth refresh race and defer the startup report until settled

### DIFF
--- a/local_operator/mcp/auth.py
+++ b/local_operator/mcp/auth.py
@@ -1641,6 +1641,147 @@ def wire_oauth_auth(
     }
 
 
+def _make_refresh_coordinating_provider(
+    kwargs: dict[str, Any],
+    *,
+    server_url: str,
+    storage: "McpTokenStorage",
+    endpoints: DiscoveredOAuthEndpoints | None,
+) -> Any:
+    """An ``OAuthClientProvider`` whose in-flow refresh is race-free across processes.
+
+    Why this subclass exists: the SDK loads the stored tokens ONCE in
+    ``_initialize`` and never re-reads storage afterwards, and its in-flow
+    refresh (``async_auth_flow`` -> ``_refresh_token``) spends whatever refresh
+    token that first read put in memory, under NO cross-process lock. That is
+    fine for a token that expires and is refreshed once. It is destructive for a
+    provider that ROTATES its refresh token on every use (Notion: an 8-hour
+    access token plus a rotating refresh token) the moment more than one
+    local-operator process is alive: this harness runs one process per cmux
+    workspace, so several long-lived sessions cross the same 8-hour boundary
+    still holding the same in-memory refresh token from when they booted. They
+    each POST it; the authorization server rotates; the first wins and every
+    other session's brand-new token is already dead. The SDK then
+    ``clear_tokens()`` and the next request opens a FULL browser grant — the
+    "Notion logged out again" the user sees, several times a day.
+
+    :func:`ensure_mcp_oauth_fresh` already closes this race for the STARTUP
+    refresh with a cross-process file lock and a re-read under it; its own
+    docstring notes that the SDK's in-flow refresh is the remaining unlocked
+    path. This subclass extends the same guard to that path: before the SDK
+    would refresh, it re-reads the persisted token under
+    :func:`_oauth_refresh_lock` and, if a sibling process already rotated it,
+    ADOPTS the fresh token into the context and skips the refresh entirely.
+    Only when the store still holds an expired token does exactly one process
+    perform the exchange — against the discovered endpoint, so a provider whose
+    token endpoint is not ``<server_base>/token`` (Datadog) refreshes rather
+    than 404-ing into a browser grant.
+
+    Degradation is honest: with no discovered ``endpoints`` (metadata discovery
+    failed at startup) the re-read/adopt step still runs — which alone removes
+    the common case, where a sibling already refreshed — and only the
+    self-performed exchange falls back to the SDK's own unlocked refresh, i.e.
+    exactly the pre-fix behaviour for that one provider.
+    """
+    from mcp.client.auth import OAuthClientProvider
+
+    class _RefreshCoordinatingOAuthProvider(OAuthClientProvider):
+        # Bound on the re-read/refresh interception: a stuck lock acquisition or
+        # a hung endpoint must not park an authenticated request forever. The
+        # file lock is only ever held for one token POST (REFRESH_HTTP_TIMEOUT_S)
+        # plus the SQLite read, so a peer that legitimately holds it clears well
+        # inside this bound; overrunning it means a leaked lock, and degrading to
+        # the SDK's own refresh is strictly better than blocking the request.
+        _refresh_coord_server_url = server_url
+        _refresh_coord_storage = storage
+        _refresh_coord_endpoints = endpoints
+
+        async def _coordinate_inflight_refresh(self) -> None:
+            """Re-sync from the store (and refresh once, race-free) if the SDK is
+            about to refresh. No-op unless the loaded token is invalid AND
+            refreshable — exactly the SDK's own in-flow refresh trigger, so this
+            never adds a round trip to a request that would have gone through
+            unauthenticated-refresh-free."""
+            ctx = self.context
+            # Gate on the SAME predicate the SDK's async_auth_flow uses so we
+            # intercept precisely when it would refresh, and never otherwise.
+            if ctx.is_token_valid() or not ctx.can_refresh_token():
+                return
+            try:
+                async with _oauth_refresh_lock(self._refresh_coord_server_url):
+                    # Re-read under the lock: a sibling process may have rotated
+                    # the token while we waited. Adopting its result is what
+                    # turns a double-spend into a no-op.
+                    stored = await ctx.storage.get_tokens()
+                    if stored is not None and stored.access_token:
+                        ctx.current_tokens = stored
+                        ctx.token_expiry_time = self._refresh_coord_storage.stored_token_expiry()
+                    if ctx.is_token_valid():
+                        return  # a peer already refreshed; do not spend again
+                    endpoints = self._refresh_coord_endpoints
+                    if endpoints is None:
+                        # No discovered endpoint: leave the stale token in place
+                        # and let the SDK's own (unlocked) in-flow refresh run —
+                        # the pre-fix path for this one provider. The re-read
+                        # above already handled the common racing case.
+                        return
+                    refreshed = await _refresh_oauth_token_locked(
+                        self._refresh_coord_server_url,
+                        self._refresh_coord_storage,
+                        endpoints,
+                    )
+                    if refreshed:
+                        new_tokens = await ctx.storage.get_tokens()
+                        if new_tokens is not None:
+                            ctx.current_tokens = new_tokens
+                            ctx.token_expiry_time = (
+                                self._refresh_coord_storage.stored_token_expiry()
+                            )
+            except Exception:  # noqa: BLE001 — coordination is best-effort
+                # A failed re-read/refresh must never break the request: fall
+                # through to the SDK's own auth flow, which will refresh (or, if
+                # that fails, surface the non-interactive McpAuthRequiredError).
+                logger.debug(
+                    "MCP in-flight refresh coordination failed for %s",
+                    self._refresh_coord_server_url,
+                    exc_info=True,
+                )
+
+        async def async_auth_flow(self, request):  # type: ignore[override]
+            # Ensure tokens+client_info are loaded (so is_token_valid /
+            # can_refresh_token below are meaningful), then coordinate the
+            # refresh, then hand off to the SDK's flow. The SDK re-checks
+            # is_token_valid under its own lock and will skip its refresh branch
+            # because we have already made the token valid. context.lock is NOT
+            # held across the coordination (it is not reentrant and the SDK
+            # re-acquires it), matching how the SDK itself only holds it inside
+            # the flow.
+            async with self.context.lock:
+                if not self._initialized:
+                    await self._initialize()
+            await self._coordinate_inflight_refresh()
+            # Delegate to the SDK flow by hand, forwarding the RESPONSE the
+            # caller sends back into each yield: httpx drives an auth flow with
+            # ``gen.asend(response)``, and a plain ``async for ...: yield`` would
+            # swallow those sent values (the sub-generator would see ``None`` for
+            # every ``response = yield`` and crash on ``response.status_code``).
+            # Manual pumping is the only correct way to delegate a receiving
+            # async generator — there is no ``yield from`` for them.
+            inner = super().async_auth_flow(request)
+            try:
+                outgoing = await inner.__anext__()
+            except StopAsyncIteration:
+                return
+            while True:
+                response = yield outgoing
+                try:
+                    outgoing = await inner.asend(response)
+                except StopAsyncIteration:
+                    return
+
+    return _RefreshCoordinatingOAuthProvider(**kwargs)
+
+
 def build_oauth_provider(
     server_url: str,
     cfg: MCPServerConfig,
@@ -1671,8 +1812,6 @@ def build_oauth_provider(
     SDK's ``<server_base>/token`` guess (which 404s for providers like Datadog
     whose token endpoint lives on a different host).
     """
-    from mcp.client.auth import OAuthClientProvider
-
     # The flow is created HERE (not inside wire_oauth_auth) so it can be
     # attached to the provider: an abandoned grant arrives at the connect as
     # a raw CancelledError (see ``LoopbackAuthFlow.callback_handler``), and
@@ -1683,13 +1822,19 @@ def build_oauth_provider(
         _resolve_redirect_uri(cfg), server_url=server_url, interactive=interactive
     )
     kwargs = wire_oauth_auth(server_url, cfg, store=store, interactive=interactive, flow=flow)
-    provider = OAuthClientProvider(**kwargs)
+    storage = kwargs["storage"]
+    # A refresh-coordinating provider (not the bare SDK one): its in-flow
+    # refresh re-reads the store under the cross-process lock so several
+    # long-lived sessions cannot double-spend a rotating refresh token
+    # mid-session — see :func:`_make_refresh_coordinating_provider`.
+    provider = _make_refresh_coordinating_provider(
+        kwargs, server_url=server_url, storage=storage, endpoints=endpoints
+    )
     provider._loopback_flow = flow  # type: ignore[attr-defined]
     if endpoints is not None:
         provider.context.oauth_metadata = endpoints.oauth_metadata
         provider.context.protected_resource_metadata = endpoints.protected_resource_metadata
         provider.context.auth_server_url = endpoints.auth_server_url
-    storage = kwargs["storage"]
     try:
         expiry = storage.stored_token_expiry()
     except Exception:  # noqa: BLE001 — a metadata read must not block a connect

--- a/local_operator/mcp/auth.py
+++ b/local_operator/mcp/auth.py
@@ -1767,17 +1767,53 @@ def _make_refresh_coordinating_provider(
             # every ``response = yield`` and crash on ``response.status_code``).
             # Manual pumping is the only correct way to delegate a receiving
             # async generator — there is no ``yield from`` for them.
+            #
+            # The whole pump is wrapped so the inner generator is ALWAYS closed
+            # and any exception/cancellation is delivered INTO it, never dropped
+            # on the floor. This matters because the SDK's ``async_auth_flow``
+            # holds ``context.lock`` across its entire body: httpx re-raises a
+            # transport error mid-flow (``_send_handling_auth`` does
+            # ``raise exc`` after ``response.aclose()``), and if we let that
+            # unwind past us without closing ``inner``, the SDK generator is
+            # suspended forever at its ``yield`` still holding the lock — every
+            # later request to this server then deadlocks on ``context.lock``.
+            # ``athrow`` runs the SDK's own ``finally`` (which releases the lock
+            # via the ``async with`` exit); ``aclose`` covers the GeneratorExit
+            # path when httpx closes the OUTER flow (its ``finally:
+            # await auth_flow.aclose()``).
             inner = super().async_auth_flow(request)
             try:
-                outgoing = await inner.__anext__()
-            except StopAsyncIteration:
-                return
-            while True:
-                response = yield outgoing
                 try:
-                    outgoing = await inner.asend(response)
+                    outgoing = await inner.__anext__()
                 except StopAsyncIteration:
                     return
+                while True:
+                    try:
+                        response = yield outgoing
+                    except GeneratorExit:
+                        # The outer flow is being closed (httpx's finally, or a
+                        # cancellation): close the inner one so the SDK unwinds
+                        # its lock, then let the close propagate.
+                        raise
+                    except BaseException as exc:  # noqa: BLE001
+                        # An exception thrown INTO us (httpx ``athrow`` on a
+                        # transport fault): deliver it into the SDK generator so
+                        # its ``finally`` runs and the lock is released, then
+                        # relay whatever it yields or re-raises.
+                        try:
+                            outgoing = await inner.athrow(exc)
+                        except StopAsyncIteration:
+                            return
+                        continue
+                    try:
+                        outgoing = await inner.asend(response)
+                    except StopAsyncIteration:
+                        return
+            finally:
+                # Unconditional: a normal return, a raise, or a GeneratorExit all
+                # pass through here, so the SDK generator (and its held lock) is
+                # never left suspended. Idempotent if already exhausted/closed.
+                await inner.aclose()
 
     return _RefreshCoordinatingOAuthProvider(**kwargs)
 

--- a/local_operator/mcp/manager.py
+++ b/local_operator/mcp/manager.py
@@ -1591,11 +1591,17 @@ class McpManager:
     def _auth_required_text(name: str, exc: McpAuthRequiredError) -> str:
         """The startup-toast wording for a server that needs an OAuth login.
 
-        Names the command that fixes it. The same string lands in the durable
-        transcript notice and in ``/mcp``, so one helper keeps all three
-        surfaces agreeing.
+        Leads with the COMMAND that fixes it rather than the diagnosis. The
+        toast renders this after a ``failed: <name> — `` prefix and then clamps
+        to the card width, so the tail is what gets truncated: putting
+        ``run /mcp login <name>`` first keeps the one actionable thing on screen
+        even on a narrow terminal, where ``needs authorization — run /mcp login
+        <name>`` used to sever the command mid-word (design review D1). One
+        ``—`` only, so the composed line is not a chain of dashes (D4). The same
+        string lands in the durable transcript notice and in ``/mcp``, so one
+        helper keeps all three surfaces agreeing.
         """
-        return f"needs authorization — run /mcp login {name}"
+        return f"run /mcp login {name} to authorize"
 
     def _fire_auth_required(self, name: str, exc: McpAuthRequiredError) -> None:
         """Notify the UI that ``name`` needs an OAuth login (best-effort).

--- a/local_operator/mcp/manager.py
+++ b/local_operator/mcp/manager.py
@@ -869,6 +869,29 @@ class McpManager:
         # mid-session expiry) need this dedicated hook to reach the user as a
         # toast. Signature: (server_name, message).
         self.on_auth_required: Callable[[str, str], None] | None = None
+        # UI/session-installed sink fired ONCE per discovery round when every
+        # server that missed the 250 ms startup gate has reached a terminal
+        # state (connected or failed). It exists because the boot report is a
+        # SNAPSHOT taken at the gate: OAuth HTTP servers do PRM/ASM discovery and
+        # a possible token refresh before their transport opens, so they almost
+        # always miss the gate and are still connecting when the snapshot is
+        # taken. A single server that fails FAST would otherwise flip the report
+        # to "N of M up — failed: X" while the slow successes are still in
+        # flight, reporting the momentary authed count as if it were final. This
+        # fires when the round actually settles so the front end can re-report
+        # the COMBINED outcome once. Signature: (). Never fires when no server
+        # was deferred (the gate snapshot was already final).
+        self.on_startup_settled: Callable[[], None] | None = None
+        # Combined per-server startup failures for the CURRENT round, accumulated
+        # across both the gate pass and the background continuations, so the
+        # settled outcome names every failure and not just the ones fast enough
+        # to lose the race to the gate. Reset at the start of each round; a
+        # server that later connects is cleared from it.
+        self._startup_failures: dict[str, str] = {}
+        # Servers deferred past the gate this round and not yet settled. When it
+        # drains, ``on_startup_settled`` fires. Emptiness is also how the front
+        # end tells "the boot snapshot was final" from "still connecting".
+        self._startup_deferred: set[str] = set()
         # Servers already toasted for an auth requirement, so a dead grant that
         # a tool call keeps retrying does not re-raise the toast on every
         # attempt. Cleared per server when it connects again.
@@ -1080,6 +1103,10 @@ class McpManager:
         self._configs = configs
         self._sources = sources
         self._disposed = False
+        # Fresh accumulators for this round: the settled outcome is built from
+        # these, not from the gate snapshot alone (see on_startup_settled).
+        self._startup_failures = {}
+        self._startup_deferred = set()
 
         result = McpLoadResult()
         if configs and not _sdk_available():
@@ -1096,7 +1123,9 @@ class McpManager:
         for name, cfg in configs.items():
             errors = validate_server_config(name, cfg)
             if errors:
-                result.errors[name] = "; ".join(errors)
+                message = "; ".join(errors)
+                result.errors[name] = message
+                self._startup_failures[name] = message
                 continue
             tasks[name] = asyncio.get_running_loop().create_task(self._connect_server(name, cfg))
 
@@ -1115,13 +1144,16 @@ class McpManager:
                 # Actionable, not raw: the startup toast is where a user first
                 # learns a server needs a login, and "run /mcp login <name>" is
                 # the one thing they can do about it.
-                result.errors[name] = self._auth_required_text(name, exc)
+                message = self._auth_required_text(name, exc)
+                result.errors[name] = message
+                self._startup_failures[name] = message
                 logger.info("MCP server %r needs authorization: %s", name, exc)
                 waiter = self._connect_futures.pop(name, None)
                 _settle_future_error(waiter, exc)
                 continue
             except Exception as exc:
                 result.errors[name] = str(exc)
+                self._startup_failures[name] = str(exc)
                 logger.warning("MCP server %r failed to connect: %s", name, exc)
                 # A parked waiter (reload) must fail, not hang (MCP-08).
                 waiter = self._connect_futures.pop(name, None)
@@ -1133,6 +1165,11 @@ class McpManager:
         for name, task in tasks.items():
             if name in done_names:
                 continue
+            # Deferred past the gate: its terminal state is not yet known, so it
+            # joins the settle set. When this set drains (every deferred server
+            # connected or failed), the round is settled and the front end can
+            # re-report the combined outcome instead of the gate snapshot.
+            self._startup_deferred.add(name)
             # Still pending at the gate: defer from cache, or contribute nothing.
             cached = self.tool_cache.get(name) if self.tool_cache is not None else None
             if cached:
@@ -1602,6 +1639,48 @@ class McpManager:
             self._notify_tasks.add(task)
             task.add_done_callback(self._notify_tasks.discard)
 
+    def _settle_deferred(self, name: str) -> None:
+        """Mark one deferred server settled; fire the round callback when last.
+
+        Called from the background continuation once ``name`` reaches a terminal
+        state (connected or failed), whatever the outcome. When the deferred set
+        empties, the discovery round is fully settled and ``on_startup_settled``
+        fires so the front end re-reports the COMBINED outcome — the gate
+        snapshot it reported first was taken while these servers were still
+        connecting. Fires at most once per round (the set is only refilled by a
+        new ``_connect_round``); a manager with nothing deferred never arms it.
+        """
+        self._startup_deferred.discard(name)
+        if self._startup_deferred:
+            return
+        sink = self.on_startup_settled
+        if sink is None:
+            return
+        try:
+            sink()
+        except Exception:  # noqa: BLE001 — a UI hook must never break the manager
+            logger.debug("mcp on_startup_settled sink raised", exc_info=True)
+
+    def startup_failures(self) -> dict[str, str]:
+        """The combined per-server startup failures for the current round.
+
+        Accumulated across the gate pass and the background continuations, so it
+        names every failure and not only the ones that lost the race to the
+        250 ms gate. This is what the settled re-report reads instead of a
+        second, momentary ``get_connected_servers`` snapshot.
+        """
+        return dict(self._startup_failures)
+
+    def startup_settling(self) -> bool:
+        """True while servers deferred past the startup gate are still settling.
+
+        The boot report reads this to mark its snapshot provisional: a settling
+        outcome suppresses the failure/success surface until
+        ``on_startup_settled`` fires with the complete tally. False means the
+        gate snapshot was already final (nothing was deferred, or every deferred
+        server has since settled)."""
+        return bool(self._startup_deferred)
+
     async def _finish_pending(
         self, name: str, task: asyncio.Task[ServerConnection], epoch: int
     ) -> None:
@@ -1609,6 +1688,10 @@ class McpManager:
         try:
             conn = await task
         except asyncio.CancelledError:
+            # A cancelled continuation is teardown/reload, not a settled server:
+            # the deferred set is reset wholesale by the next round, so do NOT
+            # fire the settle callback off a cancellation (it would report a
+            # half-torn-down round).
             return
         except Exception as exc:
             logger.warning("MCP server %r failed to connect after the gate: %s", name, exc)
@@ -1631,6 +1714,14 @@ class McpManager:
                 # The startup toast has already been dismissed by the time an
                 # after-gate connect fails, so raise a fresh one via the UI hook.
                 self._fire_auth_required(name, auth_exc)
+            # Record the failure into the round accumulator (an auth requirement
+            # as its actionable text, else the raw reason) and settle this
+            # deferred server BEFORE firing tools-changed, so the front end that
+            # re-reports on settle sees the complete failure map.
+            if isinstance(auth_exc, McpAuthRequiredError):
+                self._startup_failures[name] = self._auth_required_text(name, auth_exc)
+            else:
+                self._startup_failures[name] = str(exc)
             # Re-fetch the waiter: a reload during the await may have swapped
             # it, and settling the stale one would strand the current waiters.
             _settle_future_error(self._connect_futures.get(name), exc)
@@ -1638,14 +1729,22 @@ class McpManager:
             self._tools_by_server.pop(name, None)  # drop the deferred slice
             self._unregister_origins(name)
             self._rebuild_agent_names()
+            self._settle_deferred(name)
             self._fire_tools_changed()
             return
         if self._disposed or epoch != self._epoch:
             if conn.stack is not None:
                 with suppress(Exception):
                     await conn.stack.aclose()
+            # A disposed/superseded round is not a settled one: leave the settle
+            # callback to the round that is actually current.
             return
+        # A late success clears any earlier failure recorded for this server and
+        # settles it. Order matches the failure arm: accounting first, then the
+        # tools-changed fire that may trigger the settle re-report.
+        self._startup_failures.pop(name, None)
         self._register_connection(conn)  # settles the waiter future
+        self._settle_deferred(name)
         self._fire_tools_changed()
 
     def _register_connection(self, conn: ServerConnection) -> None:

--- a/local_operator/mcp/manager.py
+++ b/local_operator/mcp/manager.py
@@ -1714,14 +1714,25 @@ class McpManager:
                 # The startup toast has already been dismissed by the time an
                 # after-gate connect fails, so raise a fresh one via the UI hook.
                 self._fire_auth_required(name, auth_exc)
-            # Record the failure into the round accumulator (an auth requirement
-            # as its actionable text, else the raw reason) and settle this
-            # deferred server BEFORE firing tools-changed, so the front end that
-            # re-reports on settle sees the complete failure map.
-            if isinstance(auth_exc, McpAuthRequiredError):
-                self._startup_failures[name] = self._auth_required_text(name, auth_exc)
-            else:
-                self._startup_failures[name] = str(exc)
+            # Whether this continuation still belongs to the CURRENT round. A
+            # reload()/dispose() during the await bumps the epoch, and a stale
+            # continuation must not write the new round's startup accounting —
+            # the success arm below already guards on this, and the failure arm
+            # needs the same guard for the accumulator and the settle callback
+            # (F2). The waiter-settling and auth-required surfacing below are
+            # NOT guarded: a parked waiter must fail rather than hang, and the
+            # incident/toast reflect a real failure regardless of which round
+            # owns it.
+            current_round = not self._disposed and epoch == self._epoch
+            if current_round:
+                # Record the failure into the round accumulator (an auth
+                # requirement as its actionable text, else the raw reason) and
+                # settle this deferred server BEFORE firing tools-changed, so the
+                # front end that re-reports on settle sees the complete map.
+                if isinstance(auth_exc, McpAuthRequiredError):
+                    self._startup_failures[name] = self._auth_required_text(name, auth_exc)
+                else:
+                    self._startup_failures[name] = str(exc)
             # Re-fetch the waiter: a reload during the await may have swapped
             # it, and settling the stale one would strand the current waiters.
             _settle_future_error(self._connect_futures.get(name), exc)
@@ -1729,7 +1740,8 @@ class McpManager:
             self._tools_by_server.pop(name, None)  # drop the deferred slice
             self._unregister_origins(name)
             self._rebuild_agent_names()
-            self._settle_deferred(name)
+            if current_round:
+                self._settle_deferred(name)
             self._fire_tools_changed()
             return
         if self._disposed or epoch != self._epoch:

--- a/local_operator/session/mcp_status.py
+++ b/local_operator/session/mcp_status.py
@@ -53,6 +53,16 @@ class McpStartupOutcome:
     connected: tuple[str, ...] = ()
     failures: dict[str, str] = field(default_factory=dict)
     tool_count: int = 0
+    #: True while servers deferred past the 250 ms startup gate are still
+    #: connecting, so this outcome is a PROVISIONAL snapshot, not the final
+    #: tally. OAuth HTTP servers do metadata discovery and a possible token
+    #: refresh before their transport opens, so they routinely miss the gate;
+    #: reporting failures from a settling snapshot names a server as failed
+    #: while it is in fact mid-handshake and about to succeed. Front ends
+    #: suppress the failure surface while this is True and re-report once the
+    #: manager fires ``on_startup_settled`` with a settled (``settling=False``)
+    #: outcome. False when nothing was deferred — the gate snapshot was final.
+    settling: bool = False
 
     @property
     def failed(self) -> bool:
@@ -70,5 +80,15 @@ class McpStartupOutcome:
         announcing "0 connected" while a connect is still in flight would be
         both alarming and wrong. The status band still shows the count in that
         window, and it ticks up when the connect lands.
+
+        A SETTLING snapshot is never reportable: while servers deferred past the
+        gate are still connecting, any failure in this snapshot may belong to a
+        server that is in fact mid-handshake, and any success tally is
+        incomplete. Reporting it would flash "N of M up — failed: X" a beat
+        before the slow OAuth servers land. The manager re-reports a settled
+        (``settling=False``) outcome once the round drains, and THAT one is what
+        the user sees. The live status band covers the in-between window.
         """
+        if self.settling:
+            return False
         return bool(self.connected) or bool(self.failures)

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -936,6 +936,14 @@ class Session:
         # the latter is an empty outcome. See session/mcp_status.py for why the
         # record does not live in the mcp package.
         self.mcp_startup: McpStartupOutcome | None = None
+        # Front-end sink fired once the MCP startup round SETTLES — i.e. every
+        # server deferred past the 250 ms gate has reached a terminal state and
+        # ``mcp_startup`` has been rebuilt with the combined tally. A full-screen
+        # TUI installs it to re-raise the boot toast/notice with the final
+        # numbers instead of the provisional gate snapshot; headless callers
+        # leave it None (they already print on settle in the factory). Signature:
+        # (McpStartupOutcome). See session_factory.wire_mcp_into_session.
+        self._on_mcp_startup_settled: Callable[[Any], None] | None = None
         self._aside_thunks: list[Aside] = []
         self._continuation_queue: list[AgentMessage] = []
         # Latest provider-reported usage. SEEDED from the replayed transcript

--- a/local_operator/session_factory.py
+++ b/local_operator/session_factory.py
@@ -1152,6 +1152,26 @@ async def _prepare(
     )
 
 
+def _collapse_sdk_missing_failures(
+    failures: dict[str, str], discovery_key: str, sdk_missing_error: str
+) -> dict[str, str]:
+    """Collapse an all-servers-failed-for-a-missing-SDK map to one entry.
+
+    When the MCP SDK is not installed the manager fails every configured server
+    with the SAME install instruction. Reported ONCE, as the setup problem it
+    is: N identical 90-character notices (one toast line plus one transcript
+    error per server, every launch) is noise proportional to server count for a
+    single cause, and it accuses the servers of a fault that is not theirs.
+    Compared by identity against the manager's own constant rather than by
+    substring, so re-wording it cannot silently disable this. Anything else is
+    returned unchanged. Shared by the boot snapshot and the settled re-report so
+    both surfaces collapse the same way.
+    """
+    if failures and set(failures.values()) == {sdk_missing_error}:
+        return {discovery_key: sdk_missing_error}
+    return failures
+
+
 async def wire_mcp_into_session(
     session: Session,
     builtin_tools: list[AgentTool],
@@ -1230,18 +1250,22 @@ async def wire_mcp_into_session(
         message = str(entry.get("error", "unknown error"))
         failures[path.partition("mcp:")[2] or MCP_DISCOVERY_KEY] = message
 
-    if failures and set(failures.values()) == {MCP_SDK_MISSING_ERROR}:
-        # The SDK is not installed, so the manager failed every configured server
-        # with the same install instruction. Reported ONCE, as the setup problem
-        # it is: N identical 90-character notices (one toast line plus one
-        # transcript error per server, every launch) is noise proportional to
-        # server count for a single cause, and it accuses the servers of a fault
-        # that is not theirs. Compared by identity against the manager's own
-        # constant rather than by substring, so re-wording it cannot silently
-        # disable this.
-        failures = {MCP_DISCOVERY_KEY: MCP_SDK_MISSING_ERROR}
+    failures = _collapse_sdk_missing_failures(failures, MCP_DISCOVERY_KEY, MCP_SDK_MISSING_ERROR)
 
-    if not has_ui:
+    settling = False
+    try:
+        settling = manager.startup_settling()
+    except Exception:  # noqa: BLE001 — a missing accessor must not break wiring
+        logger.debug("MCP startup_settling() unavailable", exc_info=True)
+
+    # Headless callers are one-shot and do not stay alive for the settle
+    # re-report, so they print what the gate knows. But a PROVISIONAL failure
+    # (a server still connecting past the gate) must not be announced as a hard
+    # failure on stderr either — the same false alarm the toast used to raise.
+    # While settling, print only the failures already terminal at the gate; a
+    # server still deferred is neither connected nor failed yet, and its entry
+    # (if any) is a not-yet-final one the settled re-report owns.
+    if not has_ui and not settling:
         for name, message in failures.items():
             subject = "MCP discovery" if name == MCP_DISCOVERY_KEY else f"MCP server {name}"
             print(f"\033[1;33mWarning: {subject}: {message}\033[0m", file=sys.stderr)
@@ -1251,7 +1275,47 @@ async def wire_mcp_into_session(
         connected=tuple(manager.get_connected_servers()),
         failures=failures,
         tool_count=len(mcp_tools),
+        settling=settling,
     )
+
+    # Re-report once the round settles: the boot snapshot above was taken at the
+    # 250 ms gate while OAuth HTTP servers were still connecting. When the last
+    # deferred server reaches a terminal state, rebuild ``session.mcp_startup``
+    # from the manager's COMBINED tally (every failure, the final connected set)
+    # and hand it to whatever front-end sink the session installed. Wired even
+    # when ``settling`` is False right now: a fast machine can still defer a
+    # server between this read and the callback install, and an unused callback
+    # is free.
+    def _on_startup_settled() -> None:
+        try:
+            settled_failures = _collapse_sdk_missing_failures(
+                manager.startup_failures(), MCP_DISCOVERY_KEY, MCP_SDK_MISSING_ERROR
+            )
+            outcome = McpStartupOutcome(
+                configured=tuple(manager.get_all_server_names()),
+                connected=tuple(manager.get_connected_servers()),
+                failures=settled_failures,
+                tool_count=len(manager.get_tools()),
+                settling=False,
+            )
+        except Exception:  # noqa: BLE001 — a settle rebuild must never break the manager
+            logger.debug("MCP settled outcome rebuild failed", exc_info=True)
+            return
+        session.mcp_startup = outcome
+        if not has_ui:
+            # A late failure that the gate never printed still deserves the
+            # stderr line the settling guard above withheld.
+            for name, message in settled_failures.items():
+                subject = "MCP discovery" if name == MCP_DISCOVERY_KEY else f"MCP server {name}"
+                print(f"\033[1;33mWarning: {subject}: {message}\033[0m", file=sys.stderr)
+        sink = getattr(session, "_on_mcp_startup_settled", None)
+        if sink is not None:
+            try:
+                sink(outcome)
+            except Exception:  # noqa: BLE001 — a UI hook must never break the manager
+                logger.debug("session _on_mcp_startup_settled raised", exc_info=True)
+
+    manager.on_startup_settled = _on_startup_settled
 
     # The NON-MCP base is READ BACK from the session on every refresh, not
     # snapshotted once. Session capability tools live in that inventory even

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -3204,6 +3204,33 @@ class OperatorApp(App[None]):
             self.call_later(_show)
 
         manager.on_auth_required = on_auth_required
+
+        def on_startup_settled(outcome: Any) -> None:
+            # The boot report (``_report_mcp_startup``) ran against the gate
+            # snapshot, which is SILENT while servers are still connecting
+            # (McpStartupOutcome.reportable is False when settling). This fires
+            # once the round settles with the final tally, so the toast/notice
+            # the user actually sees carries the real "N of M up" and the
+            # complete failure list — never the momentary "0 of 7" a fast
+            # failure would have flashed mid-handshake. Hop onto the Textual
+            # thread: this fires from the manager's continuation task.
+            def _report() -> None:
+                # ``session.mcp_startup`` was already rebuilt by the factory's
+                # settle callback before this ran, so re-reading the session is
+                # enough; ``outcome`` is passed for parity and future use. Read
+                # the CURRENT session, not the one captured at wire time: a
+                # session swap between boot and settle must not re-report a
+                # retired session's outcome onto the live one.
+                current = self._session
+                if current is not None:
+                    self._report_mcp_startup(current)
+
+            self.call_later(_report)
+
+        try:
+            session._on_mcp_startup_settled = on_startup_settled  # type: ignore[attr-defined]
+        except Exception:  # noqa: BLE001 — a missing attr must not break wiring
+            pass
         self._refresh_mcp_status()
 
     def _refresh_mcp_status(self) -> None:

--- a/tests/unit/mcp/test_auth.py
+++ b/tests/unit/mcp/test_auth.py
@@ -9,6 +9,7 @@ through the real SQLite store.
 
 from __future__ import annotations
 
+import contextlib
 from pathlib import Path
 from typing import Any
 
@@ -1763,6 +1764,71 @@ class TestInflightRefreshCoordination:
         await self._drive_auth_flow(provider)
 
         assert lock_calls["n"] == 0  # never entered the coordination path
+
+    @pytest.mark.asyncio
+    async def test_a_transport_error_mid_flow_releases_the_sdk_lock(self) -> None:
+        """httpx re-raises a transport fault INTO the auth flow mid-yield. The
+        manual pump must close the SDK's inner generator so its ``context.lock``
+        (held across the whole flow) is released — otherwise every later request
+        to this server deadlocks. Regression guard for the F1 blocker."""
+        from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
+
+        from local_operator.mcp.auth import build_oauth_provider
+
+        store = FakeAuthStore()
+        storage = McpTokenStorage(self.URL, store)
+        await storage.set_tokens(
+            OAuthToken(access_token="valid", refresh_token="r", expires_in=3600)
+        )
+        await storage.set_client_info(OAuthClientInformationFull(client_id="cid"))
+
+        provider = build_oauth_provider(
+            self.URL, self._cfg(), store=store, endpoints=self._endpoints()
+        )
+
+        import httpx
+
+        gen = provider.async_auth_flow(httpx.Request("POST", self.URL))
+        # Advance to the first yield (the request the SDK wants sent), then throw
+        # a transport error INTO the flow the way httpx's _send_handling_auth
+        # does on a failed send.
+        await gen.__anext__()
+        with pytest.raises(httpx.ConnectError):
+            await gen.athrow(httpx.ConnectError("connection reset"))
+        with contextlib.suppress(Exception):
+            await gen.aclose()
+
+        # The SDK holds context.lock across async_auth_flow; if the inner
+        # generator was left suspended it would still be held here.
+        assert not provider.context.lock.locked(), "SDK context.lock leaked after a mid-flow error"
+
+    @pytest.mark.asyncio
+    async def test_closing_the_flow_early_releases_the_sdk_lock(self) -> None:
+        """httpx always ``aclose()``s the outer auth flow in a ``finally``. When
+        it does so before the flow finished, the inner SDK generator must be
+        closed too so the lock is released (GeneratorExit path of F1)."""
+        from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
+
+        from local_operator.mcp.auth import build_oauth_provider
+
+        store = FakeAuthStore()
+        storage = McpTokenStorage(self.URL, store)
+        await storage.set_tokens(
+            OAuthToken(access_token="valid", refresh_token="r", expires_in=3600)
+        )
+        await storage.set_client_info(OAuthClientInformationFull(client_id="cid"))
+
+        provider = build_oauth_provider(
+            self.URL, self._cfg(), store=store, endpoints=self._endpoints()
+        )
+
+        import httpx
+
+        gen = provider.async_auth_flow(httpx.Request("POST", self.URL))
+        await gen.__anext__()  # advance to the first yield
+        await gen.aclose()  # close before feeding a response
+
+        assert not provider.context.lock.locked(), "SDK context.lock leaked after early close"
 
     @pytest.mark.asyncio
     async def test_no_endpoints_falls_back_to_sdk_refresh(

--- a/tests/unit/mcp/test_auth.py
+++ b/tests/unit/mcp/test_auth.py
@@ -1583,3 +1583,220 @@ class TestProviderEndpointPriming:
         cfg = MCPHttpServerConfig(url=self.URL, auth=MCPAuthConfig(type="oauth"))
         provider = build_oauth_provider(self.URL, cfg, store=store)
         assert provider.context.oauth_metadata is None
+
+
+class TestInflightRefreshCoordination:
+    """The in-flow (mid-session) refresh is race-free across processes.
+
+    The SDK loads tokens once and never re-reads storage, and its in-flow
+    refresh spends the in-memory refresh token under no cross-process lock.
+    For a provider that ROTATES its refresh token (Notion) with several
+    long-lived local-operator processes alive, that double-spends the token and
+    forces a browser grant. ``build_oauth_provider`` returns a subclass whose
+    ``async_auth_flow`` re-reads the store under the refresh lock first and
+    adopts a sibling's already-rotated token instead of spending a dead one.
+    """
+
+    URL = "https://mcp.example.com/v1/mcp"
+
+    def _cfg(self) -> MCPHttpServerConfig:
+        return MCPHttpServerConfig(url=self.URL, auth=MCPAuthConfig(type="oauth"))
+
+    def _endpoints(self):
+        from mcp.shared.auth import OAuthMetadata
+
+        from local_operator.mcp.auth import DiscoveredOAuthEndpoints
+
+        return DiscoveredOAuthEndpoints(
+            oauth_metadata=OAuthMetadata.model_validate(
+                {
+                    "issuer": self.URL,
+                    "authorization_endpoint": "https://a/authorize",
+                    "token_endpoint": "https://a/token",
+                }
+            )
+        )
+
+    async def _drive_auth_flow(self, provider) -> None:
+        """Pump the provider's async_auth_flow the way httpx does, feeding a
+        200 to any request it yields, so the coordination step runs but no real
+        network happens. Returns once the flow is exhausted."""
+        import httpx
+
+        gen = provider.async_auth_flow(httpx.Request("POST", self.URL))
+        try:
+            request = await gen.__anext__()
+            while True:
+                response = httpx.Response(200, request=request)
+                try:
+                    request = await gen.asend(response)
+                except StopAsyncIteration:
+                    return
+        finally:
+            await gen.aclose()
+
+    @pytest.mark.asyncio
+    async def test_adopts_sibling_rotated_token_without_refreshing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A peer process rotated the token while we held a stale one: we adopt
+        it under the lock and DO NOT spend our dead refresh token."""
+        import time
+
+        from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
+
+        from local_operator.mcp import auth as auth_mod
+        from local_operator.mcp.auth import build_oauth_provider
+
+        store = FakeAuthStore()
+        storage = McpTokenStorage(self.URL, store)
+        # Our in-memory view (what the provider loads at _initialize): expired.
+        await storage.set_tokens(
+            OAuthToken(access_token="stale", refresh_token="r-old", expires_in=60)
+        )
+        await storage.set_client_info(OAuthClientInformationFull(client_id="cid"))
+        store.rows[0].data["tokens_obtained_at"] = time.time() - 600  # age past expiry
+
+        provider = build_oauth_provider(
+            self.URL, self._cfg(), store=store, endpoints=self._endpoints()
+        )
+
+        refresh_calls = {"n": 0}
+
+        async def fake_refresh(*args: Any, **kwargs: Any) -> bool:
+            refresh_calls["n"] += 1
+            return True
+
+        monkeypatch.setattr(auth_mod, "_refresh_oauth_token_locked", fake_refresh)
+
+        # Simulate the sibling process having ALREADY rotated the token in the
+        # shared store to a fresh, valid one, after this provider loaded.
+        async def sibling_rotate() -> None:
+            sib_storage = McpTokenStorage(self.URL, store)
+            await sib_storage.set_tokens(
+                OAuthToken(access_token="fresh-by-peer", refresh_token="r-new", expires_in=3600)
+            )
+
+        await sibling_rotate()
+
+        await self._drive_auth_flow(provider)
+
+        # The peer's token was adopted; our stale refresh token was never spent.
+        assert refresh_calls["n"] == 0
+        assert provider.context.current_tokens is not None
+        assert provider.context.current_tokens.access_token == "fresh-by-peer"
+
+    @pytest.mark.asyncio
+    async def test_refreshes_once_when_store_still_stale(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """No peer rotated it: we perform exactly one locked refresh against the
+        discovered endpoint and adopt its result."""
+        import time
+
+        from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
+
+        from local_operator.mcp import auth as auth_mod
+        from local_operator.mcp.auth import build_oauth_provider
+
+        store = FakeAuthStore()
+        storage = McpTokenStorage(self.URL, store)
+        await storage.set_tokens(
+            OAuthToken(access_token="stale", refresh_token="r-old", expires_in=60)
+        )
+        await storage.set_client_info(OAuthClientInformationFull(client_id="cid"))
+        store.rows[0].data["tokens_obtained_at"] = time.time() - 600
+
+        provider = build_oauth_provider(
+            self.URL, self._cfg(), store=store, endpoints=self._endpoints()
+        )
+
+        refresh_calls = {"n": 0}
+
+        async def fake_refresh(server_url, storage_arg, endpoints) -> bool:
+            refresh_calls["n"] += 1
+            # Mirror the real refresh: persist a fresh token under the lock.
+            await storage_arg.set_tokens(
+                OAuthToken(access_token="refreshed", refresh_token="r2", expires_in=3600)
+            )
+            return True
+
+        monkeypatch.setattr(auth_mod, "_refresh_oauth_token_locked", fake_refresh)
+
+        await self._drive_auth_flow(provider)
+
+        assert refresh_calls["n"] == 1
+        assert provider.context.current_tokens is not None
+        assert provider.context.current_tokens.access_token == "refreshed"
+
+    @pytest.mark.asyncio
+    async def test_valid_token_skips_coordination_entirely(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A still-valid loaded token never re-reads the store or refreshes —
+        the coordination adds no round trip to the common case."""
+        from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
+
+        from local_operator.mcp import auth as auth_mod
+        from local_operator.mcp.auth import build_oauth_provider
+
+        store = FakeAuthStore()
+        storage = McpTokenStorage(self.URL, store)
+        await storage.set_tokens(
+            OAuthToken(access_token="valid", refresh_token="r", expires_in=3600)
+        )
+        await storage.set_client_info(OAuthClientInformationFull(client_id="cid"))
+
+        provider = build_oauth_provider(
+            self.URL, self._cfg(), store=store, endpoints=self._endpoints()
+        )
+
+        lock_calls = {"n": 0}
+        real_lock = auth_mod._oauth_refresh_lock
+
+        def counting_lock(server_url: str):
+            lock_calls["n"] += 1
+            return real_lock(server_url)
+
+        monkeypatch.setattr(auth_mod, "_oauth_refresh_lock", counting_lock)
+
+        await self._drive_auth_flow(provider)
+
+        assert lock_calls["n"] == 0  # never entered the coordination path
+
+    @pytest.mark.asyncio
+    async def test_no_endpoints_falls_back_to_sdk_refresh(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """With no discovered endpoint the re-read still runs (so a racing peer
+        is still adopted), but a self-performed refresh is left to the SDK — the
+        pre-fix path for that one provider, never a crash."""
+        import time
+
+        from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
+
+        from local_operator.mcp import auth as auth_mod
+        from local_operator.mcp.auth import build_oauth_provider
+
+        store = FakeAuthStore()
+        storage = McpTokenStorage(self.URL, store)
+        await storage.set_tokens(
+            OAuthToken(access_token="stale", refresh_token="r-old", expires_in=60)
+        )
+        await storage.set_client_info(OAuthClientInformationFull(client_id="cid"))
+        store.rows[0].data["tokens_obtained_at"] = time.time() - 600
+
+        # endpoints=None: no self-performed refresh possible.
+        provider = build_oauth_provider(self.URL, self._cfg(), store=store, endpoints=None)
+
+        refresh_calls = {"n": 0}
+
+        async def fake_refresh(*args: Any, **kwargs: Any) -> bool:
+            refresh_calls["n"] += 1
+            return True
+
+        monkeypatch.setattr(auth_mod, "_refresh_oauth_token_locked", fake_refresh)
+
+        # Must not raise; our own locked refresh is never called (no endpoint).
+        await self._drive_auth_flow(provider)
+        assert refresh_calls["n"] == 0

--- a/tests/unit/mcp/test_manager.py
+++ b/tests/unit/mcp/test_manager.py
@@ -1482,7 +1482,7 @@ class TestAuthRequiredHandling:
         seen: list[tuple[str, str]] = []
         manager.on_auth_required = lambda name, msg: seen.append((name, msg))
         manager._fire_auth_required("notion", McpAuthRequiredError("https://mcp.notion.com/mcp"))
-        assert seen == [("notion", "needs authorization — run /mcp login notion")]
+        assert seen == [("notion", "run /mcp login notion to authorize")]
 
     def test_fire_auth_required_survives_a_raising_sink(self) -> None:
         """A broken UI hook must not take down the connect machinery."""

--- a/tests/unit/mcp/test_manager.py
+++ b/tests/unit/mcp/test_manager.py
@@ -383,6 +383,52 @@ class TestStartupSettleReporting:
         await manager.disconnect_all()
 
 
+class TestStartupSettleStaleRound:
+    """A continuation that fails AFTER its round was superseded must not write
+    the new round's startup accounting or fire its settle callback (F2)."""
+
+    @pytest.mark.asyncio
+    async def test_stale_failed_continuation_does_not_touch_the_current_round(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        (tmp_path / ".local-operator").mkdir()
+        (tmp_path / ".local-operator" / "mcp.json").write_text(
+            '{"mcpServers": {"fast": {"type": "stdio", "command": "fast-cmd"},'
+            ' "slow": {"type": "stdio", "command": "slow-cmd"}}}',
+            encoding="utf-8",
+        )
+        manager = McpManager(str(tmp_path))
+        slow_release = asyncio.Event()
+
+        async def fake_connect(name: str, cfg: Any) -> ServerConnection:
+            if name == "slow":
+                await asyncio.wait_for(slow_release.wait(), timeout=10)
+                raise RuntimeError("slow failed after the gate")
+            return _make_conn(name, cfg)
+
+        monkeypatch.setattr(manager, "_connect_server", fake_connect)
+
+        settled: list[bool] = []
+        manager.on_startup_settled = lambda: settled.append(True)
+
+        await manager.discover_and_connect()
+        assert manager.startup_settling() is True
+
+        # Supersede the round the way reload()/dispose() would, WITHOUT going
+        # through _connect_round (which would legitimately reset the accumulators
+        # anyway): bump the epoch so the in-flight continuation is now stale.
+        manager._epoch += 1
+
+        # Now let the stale continuation fail. It must not record into the
+        # (freshly bumped) round's accumulator, nor fire the settle callback.
+        slow_release.set()
+        await asyncio.sleep(0.05)
+
+        assert settled == []
+        assert manager.startup_failures() == {}
+        await manager.disconnect_all()
+
+
 class TestDeferredExecuteFailure:
     @pytest.mark.asyncio
     async def test_deferred_execute_error_when_connect_fails(

--- a/tests/unit/mcp/test_manager.py
+++ b/tests/unit/mcp/test_manager.py
@@ -235,6 +235,154 @@ class TestFastStartupGate:
         await manager.disconnect_all()
 
 
+class TestStartupSettleReporting:
+    """The startup outcome is reported after the round SETTLES, not at the gate.
+
+    A server that misses the 250 ms gate (OAuth HTTP servers, which do metadata
+    discovery + refresh before connecting) is still connecting when the boot
+    snapshot is taken. A single fast failure must not flip the report to
+    "N of M up — failed: X" while the slow successes are in flight; the manager
+    accumulates the combined tally and fires ``on_startup_settled`` once every
+    deferred server has reached a terminal state.
+    """
+
+    @pytest.mark.asyncio
+    async def test_settling_true_until_deferred_drains_then_callback_fires(
+        self, project: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        manager = McpManager(str(project))
+        slow_release = asyncio.Event()
+
+        async def fake_connect(name: str, cfg: Any) -> ServerConnection:
+            if name == "slow":
+                await asyncio.wait_for(slow_release.wait(), timeout=10)
+            return _make_conn(name, cfg)
+
+        monkeypatch.setattr(manager, "_connect_server", fake_connect)
+
+        settled: list[bool] = []
+        manager.on_startup_settled = lambda: settled.append(True)
+
+        await manager.discover_and_connect()
+
+        # At the gate: fast is live, slow is deferred, so the round is settling.
+        assert manager.startup_settling() is True
+        assert settled == []
+        assert manager.startup_failures() == {}
+
+        # Release the deferred connect; its continuation settles the round.
+        slow_release.set()
+        await asyncio.sleep(0.05)
+
+        assert manager.startup_settling() is False
+        assert settled == [True]  # fired exactly once
+        assert manager.startup_failures() == {}
+        await manager.disconnect_all()
+
+    @pytest.mark.asyncio
+    async def test_fast_failure_does_not_settle_while_slow_pending(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A server failing FAST leaves the round settling until the slow one
+        lands, and the settled failure map names the fast failure alone."""
+        (tmp_path / ".local-operator").mkdir()
+        (tmp_path / ".local-operator" / "mcp.json").write_text(
+            '{"mcpServers": {"boom": {"type": "stdio", "command": "boom-cmd"},'
+            ' "slow": {"type": "stdio", "command": "slow-cmd"}}}',
+            encoding="utf-8",
+        )
+        manager = McpManager(str(tmp_path))
+        slow_release = asyncio.Event()
+
+        async def fake_connect(name: str, cfg: Any) -> ServerConnection:
+            if name == "boom":
+                raise RuntimeError("boom: spawn failed")
+            await asyncio.wait_for(slow_release.wait(), timeout=10)
+            return _make_conn(name, cfg)
+
+        monkeypatch.setattr(manager, "_connect_server", fake_connect)
+
+        settled: list[dict[str, str]] = []
+        manager.on_startup_settled = lambda: settled.append(manager.startup_failures())
+
+        await manager.discover_and_connect()
+
+        # boom failed at the gate; slow is deferred, so NOT settled yet even
+        # though a failure already exists.
+        assert manager.startup_settling() is True
+        assert settled == []
+        assert "boom" in manager.startup_failures()
+
+        slow_release.set()
+        await asyncio.sleep(0.05)
+
+        assert manager.startup_settling() is False
+        assert len(settled) == 1
+        # The settled failure map names the fast failure and not the slow
+        # success that eventually landed.
+        assert set(settled[0]) == {"boom"}
+        await manager.disconnect_all()
+
+    @pytest.mark.asyncio
+    async def test_all_fast_means_not_settling_and_no_callback(
+        self, project: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When every server settles inside the gate the boot snapshot is final:
+        nothing was deferred, so the settle callback never fires."""
+        manager = McpManager(str(project))
+
+        async def fake_connect(name: str, cfg: Any) -> ServerConnection:
+            return _make_conn(name, cfg)
+
+        monkeypatch.setattr(manager, "_connect_server", fake_connect)
+
+        settled: list[bool] = []
+        manager.on_startup_settled = lambda: settled.append(True)
+
+        await manager.discover_and_connect()
+
+        assert manager.startup_settling() is False
+        assert settled == []  # never armed
+        await manager.disconnect_all()
+
+    @pytest.mark.asyncio
+    async def test_deferred_failure_recorded_in_settled_map(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A server that fails AFTER the gate contributes its failure to the
+        settled tally — the exact case a gate-only snapshot never saw."""
+        (tmp_path / ".local-operator").mkdir()
+        (tmp_path / ".local-operator" / "mcp.json").write_text(
+            '{"mcpServers": {"fast": {"type": "stdio", "command": "fast-cmd"},'
+            ' "slow": {"type": "stdio", "command": "slow-cmd"}}}',
+            encoding="utf-8",
+        )
+        manager = McpManager(str(tmp_path))
+        slow_release = asyncio.Event()
+
+        async def fake_connect(name: str, cfg: Any) -> ServerConnection:
+            if name == "slow":
+                await asyncio.wait_for(slow_release.wait(), timeout=10)
+                raise RuntimeError("slow exploded after the gate")
+            return _make_conn(name, cfg)
+
+        monkeypatch.setattr(manager, "_connect_server", fake_connect)
+
+        settled: list[dict[str, str]] = []
+        manager.on_startup_settled = lambda: settled.append(manager.startup_failures())
+
+        await manager.discover_and_connect()
+        assert manager.startup_settling() is True
+
+        slow_release.set()
+        await asyncio.sleep(0.05)
+
+        assert manager.startup_settling() is False
+        assert len(settled) == 1
+        assert "slow" in settled[0]
+        await manager.disconnect_all()
+
+
 class TestDeferredExecuteFailure:
     @pytest.mark.asyncio
     async def test_deferred_execute_error_when_connect_fails(

--- a/tests/unit/test_session_factory.py
+++ b/tests/unit/test_session_factory.py
@@ -674,7 +674,7 @@ async def test_settling_boot_snapshot_is_provisional_and_re_reported_on_settle(
         configured=["notion", "linear"],
         connected=["linear"],
         settling=True,
-        startup_failures={"notion": "needs authorization — run /mcp login notion"},
+        startup_failures={"notion": "run /mcp login notion to authorize"},
     )
 
     async def fake_discover(cwd, auth_store=None):

--- a/tests/unit/test_session_factory.py
+++ b/tests/unit/test_session_factory.py
@@ -538,16 +538,31 @@ async def test_knowledge_selection_freezes_after_the_first_session_query() -> No
 
 
 class FakeMcpManager:
-    def __init__(self, configured: list[str] | None = None, connected: list[str] | None = None):
+    def __init__(
+        self,
+        configured: list[str] | None = None,
+        connected: list[str] | None = None,
+        settling: bool = False,
+        startup_failures: dict[str, str] | None = None,
+    ):
         self.disconnected = 0
         self.callback: Callable[[list[Any]], Any] | None = None
         self._configured = list(configured or [])
         self._connected = list(connected or [])
         self.tools: list[Any] = []
         self.meta: dict[str, dict[str, Any]] = {}
+        self._settling = settling
+        self._startup_failures = dict(startup_failures or {})
+        self.on_startup_settled: Callable[[], None] | None = None
 
     def set_on_tools_changed(self, cb) -> None:
         self.callback = cb
+
+    def startup_settling(self) -> bool:
+        return self._settling
+
+    def startup_failures(self) -> dict[str, str]:
+        return dict(self._startup_failures)
 
     def get_all_server_names(self) -> list[str]:
         return sorted(self._configured)
@@ -640,6 +655,59 @@ async def test_mcp_tools_stay_lazy_across_live_updates_and_dispose(monkeypatch) 
     await session.dispose()
     assert session.disposed == 1
     assert manager.disconnected == 1
+
+
+@pytest.mark.asyncio
+async def test_settling_boot_snapshot_is_provisional_and_re_reported_on_settle(
+    monkeypatch,
+) -> None:
+    """A boot snapshot taken while servers are still connecting past the gate is
+    marked ``settling`` (so front ends stay quiet), and the manager's
+    ``on_startup_settled`` callback rebuilds ``mcp_startup`` with the final
+    combined tally and notifies the session's settle sink."""
+    builtin = MagicMock(name="builtin_tool")
+    session = FakeSessionShell()
+    session.tools = [builtin]
+    # notion deferred past the gate: configured but not yet connected, so the
+    # round is settling and one server has a not-yet-final auth failure.
+    manager = FakeMcpManager(
+        configured=["notion", "linear"],
+        connected=["linear"],
+        settling=True,
+        startup_failures={"notion": "needs authorization — run /mcp login notion"},
+    )
+
+    async def fake_discover(cwd, auth_store=None):
+        return manager, [MagicMock(name="mcp_tool")], []
+
+    monkeypatch.setattr("local_operator.mcp.discover_and_load_mcp_tools", fake_discover)
+
+    settled_outcomes: list[Any] = []
+    session._on_mcp_startup_settled = settled_outcomes.append
+
+    await wire_mcp_into_session(session, [builtin], ".", has_ui=True)
+
+    # Boot snapshot: provisional, so a front end suppresses its failure surface.
+    boot = session.mcp_startup
+    assert boot is not None
+    assert boot.settling is True
+    assert boot.reportable is False
+    # The manager installed a settle callback.
+    assert manager.on_startup_settled is not None
+
+    # The round settles: notion connected after the gate.
+    manager._settling = False
+    manager._connected = ["notion", "linear"]
+    manager._startup_failures = {}
+    manager.on_startup_settled()
+
+    settled = session.mcp_startup
+    assert settled is not None
+    assert settled.settling is False
+    assert set(settled.connected) == {"notion", "linear"}
+    assert settled.failures == {}
+    # The session's settle sink was handed the final outcome.
+    assert settled_outcomes == [settled]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tui/test_toast.py
+++ b/tests/unit/tui/test_toast.py
@@ -164,6 +164,37 @@ def test_servers_still_connecting_past_the_gate_stay_quiet() -> None:
     assert format_mcp_startup(pending) is None
 
 
+def test_a_settling_snapshot_with_a_failure_stays_quiet() -> None:
+    """A failure in a SETTLING snapshot must not be toasted: servers deferred
+    past the gate are still connecting, and one of them failing fast would
+    otherwise flash "N of M up — failed: X" a beat before the slow OAuth
+    servers land. The manager re-reports a settled outcome once the round
+    drains, and THAT one is what the user sees."""
+    settling = McpStartupOutcome(
+        configured=("notion", "linear"),
+        connected=(),
+        failures={"notion": "needs authorization"},
+        settling=True,
+    )
+    assert format_mcp_startup(settling) is None
+
+
+def test_the_same_failure_toasts_once_the_round_has_settled() -> None:
+    """The settled (``settling=False``) re-report is the one that surfaces."""
+    settled = McpStartupOutcome(
+        configured=("notion", "linear"),
+        connected=("linear",),
+        failures={"notion": "needs authorization"},
+        settling=False,
+    )
+    payload = format_mcp_startup(settled)
+    assert payload is not None
+    text, _duration = payload
+    lines = text.plain.split("\n")
+    assert lines[0] == f"{ICON_MCP} MCP: 1 of 2 servers up"
+    assert lines[1] == "failed: notion — needs authorization"
+
+
 def test_a_hard_discovery_failure_does_not_invent_a_server_tally() -> None:
     """The config layer never produced a server list on that path, so "0 of 0
     servers up" would be meaningless and quietly wrong about what broke."""


### PR DESCRIPTION
## Why

MCP OAuth servers re-request authorization far more often in local-operator than in other harnesses (omp, opencode, where a login lasts a month), and Notion in particular logs out several times a day. Two independent defects in the installed runtime (`origin/main`) cause it. Both were diagnosed against the live credential store and the SDK source.

**1. The mid-session OAuth refresh is not race-safe across processes.** #185 correctly serialized the *startup* refresh with a cross-process file lock (`~/.local-operator/mcp_oauth_refresh.lock`) and a re-read under it — but its own docstring notes the remaining gap: the SDK's own *in-flow* refresh (triggered by a 401 mid-session, `mcp/client/auth/oauth2.py`) takes no such lock and spends whatever refresh token it loaded once at `_initialize`. This harness runs **one process per cmux workspace**, so several long-lived sessions cross the same token-expiry boundary while each still holds the same in-memory refresh token from when it booted. For a provider that **rotates** its refresh token on every use, that is destructive.

Notion is the worst case: its stored token (read from `auth.db`) is an **8-hour** access token with a **rotating** refresh token, so every long-lived session must refresh ~3×/day and the losers of the race are logged out. Providers other harnesses keep you signed into either don't rotate or issue long-lived access tokens, so their concurrent sessions rarely collide.

Reproduced against a mock rotating-token endpoint with 6 concurrent sessions all holding the same stale refresh token (the real scenario — all pre-initialized, released together):

```
=== BASELINE (bare SDK provider, pre-fix) ===
token POSTs to server: 6
invalid_grant (double-spend) hits: 5
session access tokens: ['acc1', None, None, None, None, None]
sessions left with NO token (=> browser grant): 5
```

Five of six sessions get `invalid_grant` → the SDK `clear_tokens()` → a full browser grant on each. That is the repeated Notion logout.

**2. The startup report cries wolf: "one server failed" is announced as "N of M up" while the rest are still connecting.** `session.mcp_startup` is a single snapshot taken at the 250 ms startup gate. OAuth HTTP servers routinely miss that gate — they run PRM/ASM discovery plus a possible token refresh *before* their transport opens. A server that fails *fast* (a validation error, one auth-expired server) flips the boot toast to `MCP: 0 of 7 servers up — failed: X` a beat before the six slow OAuth servers land. The background continuations then connect fine and fix the live status band, but they never update `mcp_startup`, so the toast and the durable transcript notice keep asserting the pessimistic tally — exactly the "if one MCP fails it reports that all failed" behaviour.

## What changes

**Fix 1 — a refresh-coordinating OAuth provider (`local_operator/mcp/auth.py`).** `build_oauth_provider` now returns a small `OAuthClientProvider` subclass whose `async_auth_flow`, before the SDK would refresh, re-reads the persisted token under the **same** `_oauth_refresh_lock` the startup path uses. If a sibling process already rotated the token it **adopts** that fresh token and skips the refresh entirely; otherwise it performs **exactly one** locked refresh against the discovered token endpoint (`_refresh_oauth_token_locked`, already used by the startup path). The coordination is gated on the SDK's own refresh predicate (`not is_token_valid() and can_refresh_token()`), so a still-valid token adds no round trip. With no discovered endpoint the re-read/adopt still runs (removing the common racing case) and only the self-performed refresh falls back to the SDK's own path — the pre-fix behaviour for that one provider, never a crash.

While wiring this I found and fixed a **real generator-delegation bug**: a plain `async for … yield` does not forward httpx's `asend(response)` values into the SDK's *receiving* auth generator (the sub-generator sees `None` for every `response = yield` and crashes on `response.status_code`). The provider now pumps the sub-generator by hand, which is the only correct way to delegate a receiving async generator.

**Fix 2 — defer the startup report until the round settles** (`mcp/manager.py`, `session/mcp_status.py`, `session_factory.py`, `session/session.py`, `tui/app.py`). The manager accumulates the combined per-server outcome across the gate pass *and* the background continuations (`_startup_failures`), tracks servers still connecting past the gate (`_startup_deferred`), and fires a new `on_startup_settled` callback once the last deferred server reaches a terminal state. `McpStartupOutcome` gains a `settling` flag: while settling, `reportable` is `False` so the toast/notice stay quiet (the live status-band lamp still covers that window), and the front end re-reports the final combined tally once the round settles. Nothing deferred ⇒ the gate snapshot was already final and the callback never arms.

## Testing evidence

**Concurrency reproduction (the core of fix 1), before → after.** Same 6-concurrent-session rotating-token scenario as above, now with the refresh-coordinating provider:

```
=== WITH FIX (realistic: all pre-initialized with r0, released together) ===
token POSTs to server: 1
invalid_grant (double-spend) hits: 0
session access tokens: ['acc1', 'acc1', 'acc1', 'acc1', 'acc1', 'acc1']
sessions left with NO token (=> browser grant): 0
RESULT: PASS
```

6 sessions → **1** refresh POST, **0** double-spends, **0** browser grants, all sharing the one live rotated token. (Baseline in the Why section: 5 double-spends, 5 forced grants.)

**Unit tests** (all new, all pass):
- `tests/unit/mcp/test_auth.py::TestInflightRefreshCoordination` (4): adopts a sibling's rotated token without refreshing; performs exactly one locked refresh when the store is still stale; a valid token never enters the lock; no-endpoint falls back without crashing.
- `tests/unit/mcp/test_manager.py::TestStartupSettleReporting` (4): settling stays true until the deferred set drains then the callback fires once; a fast failure does not settle the round while a slow server is pending, and the settled map names only the real failure; all-fast means not-settling and no callback; a deferred (after-gate) failure is recorded in the settled map.
- `tests/unit/tui/test_toast.py` (2): a settling snapshot with a failure stays quiet; the same outcome toasts once settled.
- `tests/unit/test_session_factory.py` (1): the boot snapshot is provisional (`settling`, `reportable=False`) and `on_startup_settled` rebuilds `mcp_startup` with the final tally and notifies the session sink.

Full unit suite: **3457 passed, 3 skipped, 1 failed**. The one failure is `test_eval_tool::test_background_streams_output_while_it_runs`, an environmental flake unrelated to this change: it reproduces on a clean, unmodified worktree under `/private/tmp` and passes under `/Users`, and this MR touches zero eval/jobs/harness code. Gates clean: `flake8`, `black --check`, `isort --check-only`, `pyright` (0 errors).

**Visual evidence (fix 2, real `OperatorApp` rendered frames).** Captured via `run_test` + `app.save_screenshot` on the real app (the one that loads the stylesheet), then rendered and viewed. Both frames drive the actual `_report_mcp_startup` path.

- **Settling frame** — the boot moment a fast failure used to flash a false `MCP: 0 of 2 servers up — failed: notion` toast. With the fix the toast is **suppressed** (the outcome's `settling` flag makes it non-reportable); the splash is clean and the status-band MCP lamp still shows the count, so the in-between window is covered without a false alarm.
- **Settled frame** — once the deferred server reaches a terminal state the round settles and the **accurate** report appears: toast `⊙ MCP: 1 of 2 servers up` / `failed: notion — run /mcp login notion to authorize` (the full command survives the width clamp after the design-review copy fix), plus the durable transcript notice `✗ MCP notion failed: run /mcp login notion to authorize`.

Rendered PNGs are attached to the PR discussion (GitHub CLI cannot embed images in the body).

## Review gate

- **Agent code review:** round 1 (1 blocker — a `context.lock` leak in the async-generator delegation — + 2 minor, all remediated) → round 2 (verified terminal) → round 3 (copy-change convergence, terminal). All rounds by a reviewer subagent distinct from the author.
- **Design review:** round 1 (D1/D4 remediated — the truncated `/mcp login` command and a double em-dash — D2/D3 rejected as shot-harness artifacts, D5 deferred) → round 2 (terminal). By a designer subagent.
- Both rounds are clean and fresh on the current head `a52e8277`.

## Change class

C2 (standard, pre-authorized). Behavioural fix to MCP OAuth handling; degrades safely (a failed coordination falls through to the SDK's own refresh, a missing accessor to the old snapshot), no schema or contract change. Runtime publication via `lop-update` is a separate step held until this is merged.
