### PR TITLE
feat(tui): autofill team/agent name completions and highlight recognized slash commands

### DIFF
--- a/docs/design/composer-ux-autofill-and-highlight.md
+++ b/docs/design/composer-ux-autofill-and-highlight.md
@@ -1,0 +1,621 @@
+# Composer UX: name-autofill for `/team`·`/agent`, and slash-command syntax highlighting
+
+Design for two related composer changes. **No production code here** — this is
+the seam the coder implements. All line numbers are against the worktree
+`/tmp/lop-composer-ux` (branch `dev-composer-ux`, cut from `origin/main`) as
+read during this design pass; treat them as "the method named X near line N",
+not as offsets to patch blindly.
+
+Ground-truth note: the manager's brief cited older line numbers (editor
+`_run_argument` ~1720, `_apply_command` ~1654, etc.). The **methods are all
+real and unchanged in behaviour**; only the numbers drifted. Current numbers
+are used throughout below. Nothing in the brief's architecture was found wrong.
+
+---
+
+## 0. What the code actually does today (verified)
+
+**Registry** (`local_operator/tui/autocomplete.py`):
+- `ArgumentMode` enum (lines 29–58): `NONE` / `OPTIONAL` / `REQUIRED`. Its
+  docstring is explicit that the mode answers two questions: does a space open
+  the value list, and may Enter on the command ROW also send it.
+- `SlashCommand` frozen dataclass (lines 67–112) with kw-only `echo` (98) and
+  `arguments` (107). `.names` property (109–112) = primary + aliases.
+- `slash_command_for(text)` (526–543): the ONE resolver from a typed line to a
+  registry entry, alias-aware, case-insensitive. This is the "is this a
+  recognized command" oracle the highlighter will reuse.
+
+**team/agent entries** (`local_operator/tui/app.py`):
+- `/team` (502–507) and `/agent` (515–522), both `ArgumentMode.OPTIONAL`, both
+  with aliases (`teams` / `agents`).
+- Argument rows filled in `on_argument_query_opened` (9481–9558): `team`/`teams`
+  → `_team_choices()` (9530–9532), `agent`/`agents` → `_agent_choices()`
+  (9534–9536).
+- Dispatch: `_run_slash_command` (7307) parses `arg = parts[1].strip()` (7327),
+  so any trailing space on the name is already collapsed before it reaches
+  `_cmd_team` (2829) / `_cmd_agent` (3027). Both `partition(" ")` the arg into
+  `name` + `request`; **empty request → attach-only + "ready" notice** (team
+  2884–2888; agent falls through attach then notices). **Confirmed: `/team foo `
+  + Enter already means attach-only. No dispatch change is needed.**
+
+**Editor completion** (`local_operator/tui/widgets/editor.py`):
+- Key handler (1088–1147): on Tab/Enter with a highlighted row, computes
+  `unambiguous = _picker_choice_is_unambiguous(name)` (1108) BEFORE completing,
+  then:
+  - argument mode → `_resolve_argument(name, key, unambiguous)` (1110)
+  - command-word mode, unambiguous → `_apply_command(name)` (1112), and if
+    `enter and not opens_a_list(name)` → `_submit()` (1120–1121)
+  - command-word mode, Tab → `_apply_command(name)` (1125)
+  - command-word mode, ambiguous Enter → grow common prefix (1126+)
+- `_apply_command` (2317): argument mode → destructive `_complete_argument`
+  else `_run_argument` (2339–2344); command-word mode → writes `/{name} ` and
+  moves caret to end (2350–2351).
+- `_resolve_argument` (2353): Tab or ambiguous → `_complete_argument`; else
+  `_run_argument` (2362–2365).
+- `_complete_argument` (2367): replaces the argument tail with `name`, **NO
+  trailing space** (2380), because a space terminates the arg and closes the
+  list.
+- `_run_argument` (2383): `_complete_argument` then `_submit` (2390–2391).
+- `set_commands` (887) derives `_argument_commands` (896) and
+  `_required_argument_commands` (902) from the registry. `opens_a_list` (909)
+  reads `MODEL_COMMANDS` (566) ∪ `_required_argument_commands`.
+- Render: `render_line` (709) → placeholder branch, else
+  `_paint_markers(super().render_line(y), y)` (748). `_paint_markers` (1664)
+  post-processes the finished `Strip` via `_overlay`/`Segment.apply_style(...,
+  post_style=...)` (1694–1697). `_marker_cells` (1566) computes which cells to
+  repaint, with a hot-path bail `if "[" not in line: return []` (1595–1599).
+- `COMPONENT_CLASSES` (578–581): `text-area--image-marker[-selected]`. tcss at
+  `local_operator/tui/local_operator.tcss` 459–467, using `$lo-signal`,
+  `$lo-tint-attach`, `$lo-fg`, `$lo-tint-attach-hi`.
+
+**Empirically verified** (ran `slash_argument`/`argument_suggestions` against
+the real functions): after we complete to `/team frontend-guild ` the picker is
+in ARGUMENT mode with an **empty match set** (list closes), and a subsequent
+blank Enter — with `is_open()` false and `is_pending()` false once the query is
+non-`None` — falls through to `_submit()`. Typing a message (`/team fg fix the
+bug`) keeps `slash_argument` non-None with zero matches, so the list stays
+closed and Enter submits the whole line. This is the behaviour ask #1 wants,
+and it already emerges from the tokenizer — we only have to make completion
+INSERT the trailing space for these commands.
+
+---
+
+## A. Interaction spec (ask #1)
+
+Two command *classes* from the completion's point of view:
+
+- **ENUM-tail** (`login`, `logout`, `effort`, `approvals`, `theme`, `mcp`,
+  `credential`, and the model commands): the argument IS the command. Current
+  behaviour is correct and must not change.
+- **NAME+message** (`team`, `teams`, `agent`, `agents`): the argument is a NAME
+  optionally followed by a free-text message. New behaviour: complete the name,
+  add a trailing space, leave caret after it, do NOT submit. A second Enter on
+  the blank tail does the attach-only switch (existing dispatch).
+
+| Gesture on an argument row | ENUM-tail (unchanged) | NAME+message (`/team`,`/agent`) — NEW |
+|---|---|---|
+| **Tab** | `_complete_argument`: fill name, no space, list stays (`_resolve_argument` 2362) | `_complete_name_argument`: fill name **+ trailing space**, caret at end, list closes (empty match set). No submit. |
+| **Enter, ambiguous** (fuzzy pick, >1 match) | `_complete_argument` (2363); 2nd Enter runs it | Same as Tab: fill name **+ space**, caret at end, no submit. (The name is now exact/one-match, but we still do not submit — for NAME+message "one match" is not "run", it is "ready for the message".) |
+| **Enter, unambiguous** (arrowed, typed-in-full, or single match on non-destructive list) | `_run_argument`: complete + `_submit` (2365) | `_complete_name_argument`: fill name **+ space**, caret at end. **No `_submit`.** |
+| **Click on row** (`_apply_command` arg branch 2339–2343) | non-destructive → `_run_argument` (run); `/logout` → `_complete_argument` (fill, wait) | `_complete_name_argument`: fill name **+ space**, caret at end. No submit. |
+| **Enter on blank tail** (`/team foo ˽`, caret after space, list closed) | n/a | Not a picker gesture — picker is closed, so the key handler's `if key == "enter": self._submit()` (1167–1171) fires. Dispatch collapses `arg` → attach-only. ✅ existing path. |
+| **Enter after typing a message** (`/team foo fix bug`) | n/a | Picker closed (zero matches), Enter → `_submit()` → `_cmd_team` sends the message. ✅ existing path. |
+
+Key point for the coder: the ONLY new insertion behaviour is "name **+ trailing
+space**, no submit" for the four NAME+message words. Everything after the space
+(blank-attach, message-send) is already handled by the tokenizer closing the
+list and the existing dispatch collapsing the arg. **No change to
+`_cmd_team`/`_cmd_agent`/`_run_slash_command`.**
+
+---
+
+## B. Declaration mechanism + exact methods to change
+
+### B.1 How the editor learns which commands are NAME+message
+
+Follow the established **registry-declares / editor-reads** idiom (same shape as
+`arguments` → `_argument_commands`). Two candidate mechanisms:
+
+**Option 1 — new `ArgumentMode` member `NAME`.** Add `NAME = "name"` to the
+enum (autocomplete.py 29–58), set `/team` and `/agent` to it.
+- Pro: one field already means "what is this argument"; NAME+message is exactly
+  a third answer to that question.
+- **Con (disqualifying): blast radius.** `arguments` is read in four places
+  beyond the editor: `mobile/daemon.py` 563–566 projects `cmd.arguments.name.
+  lower()` into the phone's slash catalogue (a NEW string `"name"` leaks onto
+  the mobile surface silently), and `set_commands` (896/902) plus `opens_a_list`
+  currently branch on `is not NONE` / `is REQUIRED`. A NAME member forces a
+  re-audit of every `arguments is/==` site to decide whether NAME counts as
+  "opens a list" (it does — it offers team/agent rows) and "can send when bare"
+  (it does — bare `/team` lists). That is real semantic surgery on a shared
+  enum for a two-command need. Also `on_argument_query_opened` already special-
+  cases the command word by name, so the enum member buys nothing there.
+
+**Option 2 — editor-local `NAME_ARGUMENT_COMMANDS`, derived from the registry,
+mirroring `MODEL_COMMANDS`. RECOMMENDED.**
+
+`MODEL_COMMANDS` (editor.py 566) is the exact precedent: a small class-level
+tuple of command words (with aliases spelled out) that the editor reads to give
+a subset of commands special completion behaviour, WITHOUT touching the shared
+registry enum. `/team` and `/agent` are the same kind of local exception.
+
+Concretely — two viable sub-forms; pick the first:
+
+- **B.2a (recommended): a class constant, aliases spelled out**, exactly like
+  `MODEL_COMMANDS`:
+  ```
+  #: Commands whose ARGUMENT is a NAME followed by a free-text message
+  #: (`/team <name> <request>`, `/agent <name> <message>`). Completing the
+  #: name adds a trailing space and leaves the caret after it so the user can
+  #: type the message; it does NOT submit. A blank Enter after the space is the
+  #: attach-only switch (handled by the app's dispatch, which strips the arg).
+  #: Both spellings, because the alias is itself a runnable command — same
+  #: reason MODEL_COMMANDS lists `models`.
+  NAME_ARGUMENT_COMMANDS = ("team", "teams", "agent", "agents")
+  ```
+  Place it next to `MODEL_COMMANDS`/`DESTRUCTIVE_COMMANDS` (566–572). This is
+  the least code, matches the nearest precedent exactly, and keeps the whole
+  change inside the editor.
+
+- **B.2b (alternative, only if a reviewer objects to a second hand-kept
+  tuple): a boolean field `name_argument: bool = field(default=False,
+  kw_only=True)` on `SlashCommand`**, and derive
+  `self._name_argument_commands` in `set_commands` (887) the same way
+  `_argument_commands` is derived (896). This keeps the fact on the registry
+  entry (closer to `echo`'s "policy next to the command it governs" argument)
+  at the cost of a new field. It does NOT touch `ArgumentMode`, so it avoids
+  Option 1's mobile/`opens_a_list` blast radius. Prefer B.2a for parity with
+  `MODEL_COMMANDS`; fall back to B.2b if the team's convention has shifted
+  toward registry fields since `MODEL_COMMANDS` was written. Either way the
+  editor reads a lowered-name membership test — the call sites in B.3 are
+  identical.
+
+Add a predicate mirroring `opens_a_list` (909):
+```
+def _is_name_argument_command(self, name: str) -> bool:
+    return name.lower() in self.NAME_ARGUMENT_COMMANDS   # or self._name_argument_commands
+```
+
+### B.3 Methods that change (all in editor.py)
+
+1. **New method `_complete_name_argument(self, name)`** — sibling of
+   `_complete_argument` (2367). Same tail-replacement math, but appends a
+   trailing space and moves caret to end:
+   ```
+   argument = slash_argument(self.text, self._argument_commands)
+   if argument is None:
+       return
+   self.text = f"{self.text[: len(self.text) - len(argument)]}{name} "
+   self.move_cursor(self._end_of_buffer())
+   ```
+   Docstring must state WHY it differs from `_complete_argument` (the space is
+   load-bearing: it terminates the name so the arg list closes, and it opens
+   the message tail the user now types — the inverse of `_complete_argument`'s
+   "no space so the matcher keeps matching"). Setting `self.text` funnels
+   through `load_text` → `_sync_picker` (2158–2159), which re-derives the picker
+   as ARGUMENT-mode-with-empty-matches (verified), so the list closes on the
+   same keystroke.
+
+2. **`_resolve_argument` (2353)** — branch on the command class up front:
+   ```
+   if self._is_name_argument_command(self._argument_command):
+       self._complete_name_argument(name)
+       return
+   # existing behaviour for enum-tail commands:
+   if key == "tab" or not unambiguous:
+       self._complete_argument(name)
+       return
+   self._run_argument(name)
+   ```
+   This makes Tab AND Enter (ambiguous or not) all route to
+   `_complete_name_argument` for team/agent, which is exactly the spec table:
+   for a NAME+message command neither key ever submits.
+
+3. **`_apply_command` (2317)**, argument branch (2339–2344) — add the same
+   guard before the destructive/run split:
+   ```
+   if self._picker.mode is PickerMode.ARGUMENT:
+       if self._is_name_argument_command(self._argument_command):
+           self._complete_name_argument(name)
+           return
+       if self._argument_is_destructive():
+           self._complete_argument(name)
+           return
+       self._run_argument(name)
+       return
+   ```
+   Covers the mouse-click path.
+
+4. **No change** to `_run_argument`, `_complete_argument`, the key handler
+   (1088–1147 — it already delegates to `_resolve_argument`/`_apply_command`),
+   `_run_slash_command`, `_cmd_team`, `_cmd_agent`, or the mobile projection.
+
+`_argument_command` is `Optional[str]`; the predicate must handle `None`
+(`(name or "").lower()`), because `_apply_command`'s argument branch reads it
+while a list is open — it is set, but be defensive.
+
+---
+
+## C. Highlighting design (ask #2)
+
+### C.1 Render seam
+
+Reuse the **exact** `_paint_markers` seam. `render_line` (748) already does
+`return self._paint_markers(super().render_line(y), y)`. Add a second
+post-process pass for slash highlighting. Two integration choices:
+
+- **C.1a (recommended): a sibling method `_paint_slash(strip, y)`, chained
+  inside `render_line`** so the finished strip is
+  `self._paint_slash(self._paint_markers(super().render_line(y), y), y)`.
+  Ordering: markers first, slash second, OR slash first — they never overlap
+  (a slash line has no `[Image …]` marker: the command word is the first token
+  and the marker grammar opens with `[`), so order is immaterial for
+  correctness; put slash LAST so its bail is the cheap one on prose lines.
+- C.1b: fold into `_paint_markers`. Rejected — `_paint_markers` is documented
+  as "repaint the MARKER cells", its `cells`/`edges`/`styles` machinery is
+  marker-specific, and mixing a second token grammar into it muddies a method
+  whose comments carefully explain the chip rules. A named sibling keeps each
+  pass single-purpose, matching the file's style.
+
+### C.2 What gets highlighted, and what "recognized" means
+
+Compute on **document line 0 only** (the command lives on the first non-blank
+line; multi-line = message body, no command). Highlight at most two token runs:
+
+1. **The leading `/command` token** — from the `/` through the end of the first
+   whitespace-delimited word. "Recognized" ⇔ `slash_command_for(line)` returns
+   non-None (the same resolver dispatch uses, so the highlight cannot claim a
+   command the app would reject). This covers the WHOLE slash surface (ask #2's
+   "not just team/agent").
+   - Recognized → **command style** (`text-area--slash-command`).
+   - Not recognized (`/xyz`, a typo) → **unrecognized style**
+     (`text-area--slash-unknown`), a muted/neutral treatment so the user sees
+     "this leading slash is not a command and WILL be sent as text". See D for
+     why we highlight the unknown case at all.
+
+2. **The argument NAME token** — only when the command is one whose argument is
+   a name we can validate cheaply, i.e. a NAME+message command
+   (`_is_name_argument_command`) AND the typed name matches a known team/agent.
+   - Matched name → **argument-name style** (`text-area--slash-argument`).
+   - Partial/typo name → NO highlight (leave prose colour). Do not paint an
+     "unknown name" — the picker already shows/【doesn't show】 a match, and a
+     half-typed name is a normal in-progress state, not an error.
+
+   Only the NAME (first token after the command word) is ever highlighted;
+   the free-text message tail is prose and must stay prose — that is the whole
+   point of the feature (show the user what is command vs. message).
+
+### C.3 Cheap "recognized" on the hot path
+
+`render_line` runs every keystroke-frame (the marker code calls this out at
+1595). Keep the pass O(1)-ish:
+
+- **Bail exactly like the marker pass.** First cell of the method:
+  ```
+  if y != 0 and self.scroll_offset.y == 0:  # only the first screen row can hold the command
+      ... actually: resolve the DOCUMENT line for screen row y, bail if it isn't line 0
+  line = self.document.get_line(0)
+  if not line.lstrip().startswith("/"):
+      return strip
+  ```
+  A composer whose first non-blank line does not start with `/` (the
+  overwhelming common case — prose, empty, bang-mode `!`) returns the strip
+  untouched before any tokenizing. This mirrors `_marker_cells`'s `if "[" not
+  in line` guard (1595).
+
+- **Command recognition is a dict/loop lookup**, not a regex sweep:
+  `slash_command_for(line)` splits the first token and does a `next(... in
+  entry.names ...)` over ≤ ~30 commands (526–543). Cheap. Cache is unnecessary
+  at this size; if a reviewer wants it, memoize on `(line0, commands_version)`
+  — but measure first, do not add cache complexity speculatively.
+
+- **Name recognition needs a set of known team/agent names.** DO NOT call
+  `_team_choices()`/`_agent_choices()` from the render path — those hit the
+  registry (`list_teams`, `_agent_profile_rows`) and are app-side (app.py 2773,
+  2967), not reachable cheaply from the widget every frame. Instead, **push the
+  name set into the editor when the argument list opens.** The app already
+  computes the rows in `on_argument_query_opened` (9530–9536); have it also call
+  a new `editor.set_argument_names(names: frozenset[str])` (or fold the names
+  into the existing `picker.set_choices` path and read them back off the picker
+  — the picker already holds `_choices`, and `_apply_command`-time code reads
+  `self._picker.suggestions()`). Simplest and lowest-risk:
+  - Add `editor.set_name_choices(frozenset(c.name for c in choices))` called
+    right beside `picker.set_choices(self._team_choices())` /
+    `_agent_choices()` (9531/9535). Store on `self._name_choices: frozenset[str]
+    = frozenset()`; clear it whenever the argument command changes to a
+    non-name command (in `_sync_picker`, alongside the existing
+    `set_choices([])` at 2186, when leaving a name command). The render pass
+    then does `name_token.lower() in self._name_choices` — a frozenset hit, O(1).
+  - Rationale: the render path must not do I/O or registry walks; the app owns
+    the truth and already visits it when the list opens, so it hands the widget
+    a cheap immutable snapshot. This is the same "app fills the rows when the
+    list opens" contract `on_argument_query_opened` already documents (9481–9493).
+
+  Caveat: the name set is only populated once the argument list has opened at
+  least once (the space after `/team`). If the user types `/team frontend `
+  fully by hand without the list ever having filled, `_name_choices` may be
+  empty and the name goes un-highlighted. Acceptable: highlighting is an
+  affordance, not a gate, and the list fills on the space in practice. Document
+  this as a known limitation rather than fetching on the render path.
+
+### C.4 Painting the cells
+
+Model the pass on `_paint_markers` (1664) exactly:
+- Resolve document line 0's screen-row extent (reuse the `wrapped_document` /
+  `offset_to_location` machinery — a long `/team … message` soft-wraps; the
+  command word is on the first wrapped row, so in practice only `y==0`'s section
+  carries the command token, but the name token can wrap. Keep it correct by
+  mapping document columns → screen x via `wrapped.location_to_offset`, same as
+  the marker code at 1637/1646).
+- Build `(x_start, x_end, kind)` runs for the command token and (if matched) the
+  name token, add `gutter`.
+- `edges = sorted({0, width} | {x for …})`, `strip.divide`, and for each piece
+  overlay the component style via `_overlay(piece, style)` (1695–1697,
+  `post_style`), because — same reason as the chip — TextArea's segments carry
+  explicit fg/bg and a base style would be discarded.
+- Styles resolved via `self.get_component_rich_style("text-area--slash-*")`
+  (like 1682–1683).
+
+### C.5 Placeholder / caret-at-col-0 interaction
+
+`render_line`'s placeholder branch (731–747) returns BEFORE `_paint_markers`
+when `not self.text`. So an empty buffer never reaches the slash pass — good,
+nothing to highlight. The moment the user types `/` there is text, the
+placeholder branch is skipped, and the normal `super().render_line` + post-
+process path runs. The caret cell: `_marker_cells` deliberately EXCLUDES the
+caret cell (1582–1585) because the chip is opaque; for slash highlighting the
+overlay is a foreground/soft-background tint, not an opaque chip, so it MAY
+include the caret cell safely — BUT to avoid fighting the cursor style
+(`text-area--cursor`, tcss 420–423, which swaps fg/bg), the safest choice is to
+**style foreground only** for the command word (see C.6) so the caret's inverse
+still reads on top. If a background tint is used, exclude the caret cell exactly
+as `_marker_cells` does (read `self.selection.end` / `_draw_cursor`, 1607–1615).
+Recommend **foreground-only** styles to sidestep the whole caret/selection
+interaction — a coloured command word reads as "recognized" without needing a
+ground behind it, and it composes cleanly with selection (`text-area--
+selection`, tcss 425–427) and cursor overlays.
+
+### C.6 New COMPONENT_CLASSES + tcss
+
+Add to `COMPONENT_CLASSES` (578–581):
+```
+"text-area--slash-command",     # recognized /command word
+"text-area--slash-argument",    # recognized team/agent NAME
+"text-area--slash-unknown",     # leading /word that is NOT a command
+```
+tcss (`local_operator/tui/local_operator.tcss`, beside the image-marker block
+459–467), foreground-only, using existing `$lo-*` semantic tokens (theme.py
+32–43 / 88–98 define them for both dark and light ramps):
+```
+/* A recognized slash command, tinted so the user sees the leading token is a
+ * command and will NOT be sent as message text. `signal` is the ramp's
+ * file/reference cool hue — already used by the attachment chip — and reads as
+ * "structured token", not the accent green that means "a turn is live". */
+Editor .text-area--slash-command {
+    color: $lo-signal;
+    text-style: bold;
+}
+/* The recognized team/agent NAME after the command word. `string` (the
+ * success/string green) distinguishes the resolved argument from the command
+ * word without a second ground. */
+Editor .text-area--slash-argument {
+    color: $lo-string;
+}
+/* A leading /word that resolves to NO command: dimmed so the user sees it is
+ * inert text, not a recognized command. `muted`, not a danger colour — an
+ * unknown slash is a typo-in-progress, not an error to alarm about. */
+Editor .text-area--slash-unknown {
+    color: $lo-muted;
+}
+```
+Colour choices are a starting point for the design round — the designer sub-
+agent owns the final hues/contrast (this IS a user-visible change, so a
+`### Design review` round is required). Do NOT reuse `$lo-accent` (reserved:
+"a turn is live", per the tcss header comment lines 35 and 367).
+
+---
+
+## D. Risks / edge cases
+
+1. **Multi-line buffers.** The command only exists on the first non-blank line;
+   `slash_context`/`slash_argument` both return None once a newline follows the
+   word (command_picker.py 205–207, 232–238). The highlight pass MUST gate on
+   document line 0 and bail if the first non-blank line has a newline after the
+   command token — otherwise a `/team foo\nmore text` message body could get a
+   stray command highlight. Mitigation: resolve on `self.document.get_line(0)`
+   and only paint the command token if line 0 is the first non-blank line;
+   paint the name token only while the picker's tokenizer still considers it an
+   argument (i.e. no newline yet). Simplest correct rule: **only highlight when
+   `slash_command_for(line0)` is non-None AND the buffer is single-line OR the
+   command/name tokens are entirely on line 0** — reuse the same single-line
+   discipline the tokenizers already enforce.
+
+2. **`/btw` off-record.** `/btw` IS a recognized command (app.py 451), so its
+   leading token highlights as a command — correct and desirable (the user
+   should see `/btw` is recognized). Its argument is free text (a question), NOT
+   a name, so `_is_name_argument_command("btw")` is false and nothing after
+   `/btw ` is highlighted. No special-casing needed. The aside's own composer
+   is a separate concern (it sets `set_records_history(False)`, etc.) and does
+   not change the highlight rules.
+
+3. **Unknown command → highlight as "unrecognized"?** YES, with the muted
+   `text-area--slash-unknown` treatment. Rationale: the feature's stated goal is
+   "so the user can see the command is recognized and won't be sent as part of
+   the message." The dual is equally valuable: a `/teem foo` typo that is NOT a
+   command should visibly read as inert text so the user is not surprised when
+   the whole line is sent as a prompt. This is cheap (it is the else-branch of
+   the same `slash_command_for` call) and it is the honest signal. If the
+   designer round finds the muted treatment too noisy on every half-typed
+   `/`, fall back to "highlight recognized only, leave unknown as prose" — but
+   start with the unknown treatment; it is the more informative default.
+   Note: while the command PICKER is open (`/te` mid-type), the leading word is
+   a prefix, not yet a full command. `slash_command_for` requires an exact
+   name-in-`names` match, so `/te` resolves to None and would flash "unknown"
+   on every keystroke of typing a command. **Mitigation: suppress the unknown
+   (not the recognized) highlight while the command picker is open**
+   (`self._picker.is_open()` and mode is COMMAND) — a word being actively
+   picked is not yet "unrecognized", it is "in progress". Recognized-command
+   and name highlights are unaffected.
+
+4. **Partially-matching name.** No highlight (C.2). A half-typed name is normal;
+   painting it "unknown" would flicker on every keystroke. Only an exact set
+   membership (`_name_choices`) paints the name.
+
+5. **Interaction with image-marker overlays.** A slash line has no image marker
+   (the marker grammar opens with `[` and a command opens with `/`; the command
+   word and name are on line 0, a pasted image marker would sit in the message
+   tail which is not highlighted). The two passes therefore never contend for
+   the same cells. Chaining order (C.1a) is safe either way; keeping slash LAST
+   means the cheaper bail runs on the common prose path. If a user pastes an
+   image INTO the name position (pathological), the marker pass owns those
+   cells and the name pass simply won't find a set-member match — no conflict.
+
+6. **Aliases.** `/teams`/`/agents` must highlight identically to
+   `/team`/`/agent`. `slash_command_for` resolves aliases (529–531) and
+   `NAME_ARGUMENT_COMMANDS` lists all four spellings — covered.
+
+7. **Name set staleness.** `_name_choices` is a snapshot from the last list
+   open (C.3). If a team is created mid-session and the user hand-types its name
+   before ever opening the list, it goes un-highlighted until the list next
+   opens. Acceptable, documented limitation — never fetch on the render path.
+
+8. **Theme switch.** Because styles are component classes reading `$lo-*` (not
+   Python hexes), a `/theme` switch repaints them for free — same property the
+   image-marker comment (575–577) relies on. No extra work.
+
+---
+
+## E. Test + visual-validation plan
+
+Run everything with `PYTHONPATH=/tmp/lop-composer-ux .venv/bin/python`; TUI
+tests/shots need `env -u NO_COLOR TERM=xterm-256color`.
+
+### E.1 Unit tests (extend `tests/unit/tui/test_command_picker.py`)
+
+That file already has the harness (`_PickerHost`/`CSS_PATH = TCSS_PATH`, real
+`Editor(commands=SLASH_COMMANDS)`, lines 85–108) and the exact patterns:
+`test_enter_completes_then_submits` (452), `test_tab_completes_without_
+submitting` (423), `test_click_selects_and_completes_without_submitting` (492),
+`test_enter_runs_an_unambiguous_provider` (991),
+`test_arrowing_onto_a_provider_lets_enter_run_it` (1029),
+`test_clicking_a_login_row_runs_it` (1081). Add, following those:
+
+Ask #1 (drive real keys through the mounted editor; the host records
+`submissions`):
+- `test_enter_on_a_team_row_fills_the_name_and_a_space_without_submitting` —
+  open `/team `, fill choices with a fake registry (mirror the provider-list
+  tests' choice injection), Enter on a row → buffer is `/team <name> ˽`, caret
+  at end, `host.submissions == []`.
+- `test_tab_on_a_team_row_fills_name_and_space` — same, Tab.
+- `test_click_on_a_team_row_fills_name_and_space_without_submitting` — mouse
+  path through `_apply_command`.
+- `test_arrowing_onto_a_team_row_still_does_not_submit` — the unambiguous
+  branch must NOT run for a name command (the key difference from providers).
+- `test_blank_enter_after_a_completed_team_name_submits_attach_only` — buffer
+  `/team <name> ˽`, picker closed, Enter → `host.submissions == ["/team <name> "]`
+  (attach-only; assert the arg collapses — a dispatch-level test can assert
+  `_cmd_team` took the bare-name branch, or assert the submitted text).
+- `test_typing_a_message_then_enter_sends_the_whole_line` — `/team <name> fix
+  it` + Enter → submitted text carries the message.
+- `test_agent_row_behaves_like_team` — one parametrized mirror for `/agent`.
+- **Regression guard:** `test_login_row_still_runs_on_enter` / `test_logout_
+  row_still_fills_and_waits` must stay green (they already exist ~991/1097) —
+  confirm the enum-tail path is untouched.
+
+Ask #2 (highlight): these are best as **render-strip assertions**, not just
+visual — assert the component style lands on the right cells.
+- `test_recognized_command_word_gets_the_slash_command_style` — set text
+  `/team`, render line 0, assert the `/team` cells carry
+  `text-area--slash-command`'s style (probe via the rendered `Strip` segments'
+  styles, same way marker tests inspect chips if they exist; otherwise assert
+  `get_component_rich_style` is applied by checking segment styles).
+- `test_unknown_command_word_gets_the_unknown_style_when_picker_closed` —
+  `/notacommand ` (space closes the command picker), assert `slash-unknown`.
+- `test_command_word_is_not_flagged_unknown_while_the_picker_is_open` — `/te`,
+  picker open, assert NO `slash-unknown` overlay.
+- `test_recognized_team_name_gets_the_argument_style` — push a name set
+  (`set_name_choices({"frontend-guild"})`), text `/team frontend-guild fix it`,
+  assert the NAME cells carry `slash-argument` and the message tail does NOT.
+- `test_partial_name_is_not_highlighted` — `/team front`, assert no
+  `slash-argument` overlay.
+- `test_message_body_after_the_name_stays_prose` — assert the `fix it` cells
+  carry no slash component style.
+- `test_multiline_buffer_does_not_highlight_a_second_line` — `/team foo\nmore`,
+  assert line 1 has no overlay.
+
+Also add a **mobile-projection guard** if B.2b (new field) is chosen:
+`mobile/daemon.py` 558–571 already tolerates it (it only reads `.arguments`),
+but if a `name_argument` field is added, add nothing to the mobile payload —
+assert the projected dict is unchanged (there is an existing mobile projection
+test to extend). If B.2a (editor constant) is chosen, no mobile test is needed.
+
+### E.2 Visual validation (required — user-visible change)
+
+Per AGENTS.md "Visual validation": use the REAL `OperatorApp` (the `_PickerHost`
+in `test_command_picker.py` DOES load `TCSS_PATH`, so it is acceptable for
+these composer stills; the app is even better and is what the designer round
+should use for the mobile/full-chrome context). Script with `run_test` +
+`app.save_screenshot(path)`, then RENDER the SVG and view it. Capture
+**before/after pairs** — before-frames FIRST from a throwaway worktree
+(`git worktree add --detach`), never `git stash`.
+
+Frames to capture (before = current build, after = with the change):
+
+1. **`/team ` list open** — the argument picker showing team rows. Before/after
+   should be identical for the list itself (this frame proves we didn't regress
+   the picker); the point is the composer buffer.
+2. **After selecting a team name** — buffer shows `/team frontend-guild ˽` with
+   caret after the space. BEFORE (current) this frame does not exist the same
+   way (current build would have SUBMITTED and cleared the buffer / attached);
+   the after-frame is the new resting state. Capture the after-frame showing the
+   caret parked after the space and the list closed.
+3. **With a typed message** — `/team frontend-guild fix the flaky test`, showing
+   the command word tinted, the name tinted, and the message in prose colour.
+   This is the money shot for ask #2.
+4. **Unrecognized command** — `/notacommand hello`, showing the muted
+   `slash-unknown` treatment on the leading token and prose after. Before-frame:
+   plain prose (no highlight). After: muted token.
+5. **Recognized non-name command** — e.g. `/compact` or `/usage`, showing the
+   command word tinted and (for `/usage`) no argument highlight. Confirms the
+   whole-surface scope, not just team/agent.
+6. **`/agent <name> <message>`** — one mirror frame for the agent command.
+
+For each, back the pixels with geometry per AGENTS.md §4 only if a reflow is
+suspected (the highlight is foreground-only, so no width/scrollbar change is
+expected — but confirm `app.screen.virtual_size == size` on the populated
+frame, since any accidental width change is a bug on this docked composer).
+
+### E.3 Gates (all must be clean, per AGENTS.md)
+
+```
+PYTHONPATH=/tmp/lop-composer-ux .venv/bin/python -m flake8 .
+uvx --from black==26.1.0 black --check local_operator tests
+uvx isort --check-only --profile black local_operator tests
+PYTHONPATH=/tmp/lop-composer-ux .venv/bin/python -m pyright --pythonpath .venv/bin/python .
+env -u NO_COLOR TERM=xterm-256color PYTHONPATH=/tmp/lop-composer-ux .venv/bin/python -m pytest tests/unit/tui -q
+```
+(Note: `test_slash_echo.py` pins each command's `echo` flag but NOT `arguments`
+or any new field, so neither B.2a nor B.2b trips it — verified. If B.2b adds a
+field, no echo-test change is needed.)
+
+---
+
+## Summary of the recommendation
+
+- **Ask #1:** add editor-local `NAME_ARGUMENT_COMMANDS` (mirroring
+  `MODEL_COMMANDS`), a new `_complete_name_argument` sibling of
+  `_complete_argument`, and a guard at the top of `_resolve_argument` (2353) and
+  the argument branch of `_apply_command` (2339) routing the four team/agent
+  spellings to it. No dispatch/registry/mobile changes — the tokenizer already
+  closes the list on the trailing space and the existing `arg.strip()` collapses
+  the blank tail to attach-only.
+- **Ask #2:** add a `_paint_slash` post-process pass chained after
+  `_paint_markers` in `render_line` (748), gated on line-0/leading-`/` like the
+  marker hot-path bail, using `slash_command_for` for command recognition and an
+  app-pushed `_name_choices` frozenset for name recognition (never fetch on the
+  render path). Three new component classes + foreground-only tcss.
+- Smallest change that solves it: yes — both asks stay inside `editor.py` +
+  three tcss rules, reuse two existing seams (`_complete_argument` shape,
+  `_paint_markers`/`_overlay`), and add zero new dispatch paths. The one shared-
+  surface touch (app pushing name choices) rides the `on_argument_query_opened`
+  hook that already exists for exactly this "fill when the list opens" purpose.

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -9528,12 +9528,20 @@ class OperatorApp(App[None]):
             picker.set_notice("")
             return
         if message.command in ("team", "teams"):
-            picker.set_choices(self._team_choices())
+            choices = self._team_choices()
+            picker.set_choices(choices)
             picker.set_notice("")
+            # Hand the editor a cheap immutable snapshot of the names so its
+            # syntax highlighter can recognize the typed team name without
+            # walking the registry on every render frame (see
+            # ``Editor.set_name_choices``).
+            editor.set_name_choices(frozenset(c.name.lower() for c in choices))
             return
         if message.command in ("agent", "agents"):
-            picker.set_choices(self._agent_choices())
+            choices = self._agent_choices()
+            picker.set_choices(choices)
             picker.set_notice("")
+            editor.set_name_choices(frozenset(c.name.lower() for c in choices))
             return
         if message.command == "effort":
             levels = self._effort_levels()

--- a/local_operator/tui/local_operator.tcss
+++ b/local_operator/tui/local_operator.tcss
@@ -493,12 +493,16 @@ Editor .text-area--slash-argument {
     color: $lo-string;
 }
 /* A leading /word that resolves to NO command: dimmed so the user sees it is
- * inert text that WILL be sent, not a recognized command. `muted`, not a
- * danger colour — an unknown slash is a typo-in-progress, not an error to
- * alarm about (and it is suppressed entirely while the command picker is still
- * choosing the word). */
+ * inert text that WILL be sent, not a recognized command. `dim`, not a danger
+ * colour — an unknown slash is a typo-in-progress, not an error to alarm about
+ * (and it is suppressed entirely while the command picker is still choosing the
+ * word). `dim` over `muted` (design round 1, D1): against the prose tail (`fg`)
+ * `muted` was only ~1.74:1 apart — the eye read it as "slightly dimmer", not
+ * "inert / will be sent". `dim` lands ~2.9:1 below prose and ~4.18:1 above the
+ * input ground, so the degrade-to-text read is unmistakable without tipping
+ * into an alarm colour. */
 Editor .text-area--slash-unknown {
-    color: $lo-muted;
+    color: $lo-dim;
 }
 
 /* ── startup toast ───────────────────────────────────────────────────────

--- a/local_operator/tui/local_operator.tcss
+++ b/local_operator/tui/local_operator.tcss
@@ -466,6 +466,41 @@ Editor .text-area--image-marker-selected {
     background: $lo-tint-attach-hi;
 }
 
+/* ── slash-command syntax highlighting ───────────────────────────────────
+ *
+ * Foreground-only tints on the composer's leading `/command` word and, for
+ * `/team`·`/agent`, the recognized team/agent NAME. The point is legibility of
+ * intent: the user sees which tokens are the recognized command and its
+ * argument NAME (structure that will NOT be sent as message text) versus the
+ * free-text tail that will. Foreground-only so the tint composes cleanly with
+ * the cursor's inverse and the selection ground without a competing background
+ * — see `Editor._paint_slash`. Component classes reading `$lo-*` (never a
+ * Python hex) so a `/theme` switch repaints them for free, exactly like the
+ * attachment chip above. `$lo-accent` is deliberately NOT used here: it is
+ * reserved for "a turn is live" (see this file's header), and a recognized
+ * command word is structure, not activity. */
+/* A recognized slash command. `signal` is the ramp's cool file/reference hue
+ * (already the chip's ink), which reads as "structured token", not the accent
+ * green of a live turn. Bold lifts the short word above the prose around it. */
+Editor .text-area--slash-command {
+    color: $lo-signal;
+    text-style: bold;
+}
+/* The recognized team/agent NAME after the command word. `string` (the
+ * success/string green) distinguishes the resolved argument from the command
+ * word so the two reads never collapse into one, without a second ground. */
+Editor .text-area--slash-argument {
+    color: $lo-string;
+}
+/* A leading /word that resolves to NO command: dimmed so the user sees it is
+ * inert text that WILL be sent, not a recognized command. `muted`, not a
+ * danger colour — an unknown slash is a typo-in-progress, not an error to
+ * alarm about (and it is suppressed entirely while the command picker is still
+ * choosing the word). */
+Editor .text-area--slash-unknown {
+    color: $lo-muted;
+}
+
 /* ── startup toast ───────────────────────────────────────────────────────
  *
  * Top-right transient overlay. The host HUGS its card (`width: auto`) and both

--- a/local_operator/tui/widgets/editor.py
+++ b/local_operator/tui/widgets/editor.py
@@ -2532,8 +2532,20 @@ class Editor(TextArea):
             # empty) or the name is edited (the space is gone), so it never sits
             # over a live message. Managed here because for these commands the
             # notice channel is otherwise unused (the app sets it to "").
-            hint = self._name_switch_hint(list_argument)
-            self._picker.set_notice(hint or "")
+            #
+            # GATED to NAME+message commands only (CR4, round 2). `set_notice`
+            # runs on EVERY keystroke of the argument, but the app owns the
+            # notice channel for the OTHER argument commands — `/logout` ("no
+            # stored credentials…"), `/effort` ("this model takes no effort
+            # setting"), `/mcp`'s builder notices — and sets them ONCE on the
+            # command-word change (`on_argument_query_opened`), never per
+            # keystroke. An unconditional write here called `set_notice("")` on
+            # each resync of those commands and erased a notice that is, for an
+            # empty-by-construction list, the entire content the user is reading.
+            # Only `/team`·`/agent` reach this write, and for those the app
+            # always sets the notice to "", so the hint owns the channel cleanly.
+            if self._is_name_argument_command(self._argument_command):
+                self._picker.set_notice(self._name_switch_hint(list_argument) or "")
         argument = slash_argument(self.text, self.MODEL_COMMANDS)
         if argument is None:
             if self._model_picker.is_open():

--- a/local_operator/tui/widgets/editor.py
+++ b/local_operator/tui/widgets/editor.py
@@ -571,6 +571,26 @@ class Editor(TextArea):
     #: rest: see :meth:`_picker_choice_is_unambiguous` and :meth:`_apply_command`.
     DESTRUCTIVE_COMMANDS = ("logout",)
 
+    #: Commands whose ARGUMENT is a NAME optionally followed by a free-text
+    #: message (`/team <name> <request>`, `/agent <name> <message>`). Completing
+    #: the name adds a trailing SPACE and parks the caret after it so the user
+    #: can keep typing the message — it does NOT submit, unlike the enum-tail
+    #: argument commands (`/login`, `/effort`, the model list) where the
+    #: argument IS the whole command and Enter runs it. A blank Enter after that
+    #: space is the attach-only switch, and a typed message then Enter sends it:
+    #: both already emerge from the tokenizer closing the argument list on the
+    #: space and the app's dispatch collapsing a bare name to attach-only, so no
+    #: dispatch/registry change is needed — only completion inserts the space.
+    #:
+    #: A local class tuple mirroring ``MODEL_COMMANDS`` rather than a new
+    #: ``ArgumentMode`` member: the mode enum is a shared surface (the mobile
+    #: daemon projects it, ``set_commands``/``opens_a_list`` branch on it), and a
+    #: new member would force a re-audit of every ``arguments is/==`` site for a
+    #: two-command editor-local exception. Both spellings, because the alias is
+    #: itself a runnable command — same reason ``MODEL_COMMANDS`` lists
+    #: ``models``.
+    NAME_ARGUMENT_COMMANDS = ("team", "teams", "agent", "agents")
+
     #: The attachment chip's two grounds, on top of everything ``TextArea``
     #: already declares. Component classes rather than hexes in Python so the
     #: colours sit in the stylesheet beside every other composer colour and
@@ -578,6 +598,14 @@ class Editor(TextArea):
     COMPONENT_CLASSES = TextArea.COMPONENT_CLASSES | {
         "text-area--image-marker",
         "text-area--image-marker-selected",
+        # Slash-command syntax highlighting (see :meth:`_paint_slash`). Component
+        # classes rather than Python hexes for the same reason the chip uses
+        # them: the colours live in the stylesheet beside every other composer
+        # colour and follow the theme's ``$lo-*`` variables through a theme
+        # switch for free.
+        "text-area--slash-command",  # recognized /command word
+        "text-area--slash-argument",  # recognized team/agent NAME
+        "text-area--slash-unknown",  # a leading /word that is NOT a command
     }
 
     def __init__(
@@ -608,6 +636,22 @@ class Editor(TextArea):
         # description advertises options the editor never offers.
         self._argument_commands: tuple[str, ...] = ()
         self._required_argument_commands: tuple[str, ...] = ()
+        # Every registered command word (primaries AND aliases), lower-cased,
+        # for the highlighter's "is this leading /word a real command?" oracle.
+        # Derived from the registry in :meth:`set_commands` — the render pass
+        # must not import the app (which owns ``slash_command_for``): editor.py
+        # is imported BY app.py, so the dependency only goes one way. The same
+        # name-in-``names`` membership ``slash_command_for`` uses is reproduced
+        # here so the highlight cannot claim a command the dispatch would reject.
+        self._command_names: frozenset[str] = frozenset()
+        # The team/agent NAMES the open argument list is offering, pushed by the
+        # app in ``on_argument_query_opened`` (see :meth:`set_name_choices`).
+        # A frozenset so the render pass tests membership in O(1): the render
+        # path must never walk the team/agent registries itself — that is I/O,
+        # and ``render_line`` runs on every keystroke-frame. Empty until the
+        # list has opened at least once; a name hand-typed in full before the
+        # list ever filled goes un-highlighted, an accepted affordance gap.
+        self._name_choices: frozenset[str] = frozenset()
         # tab_behavior="indent": Tab NEVER moves focus (TUI-013). Command
         # completion consumes the key first; otherwise it indents.
         super().__init__(placeholder=placeholder, soft_wrap=True, tab_behavior="indent")
@@ -745,7 +789,12 @@ class Editor(TextArea):
                     assert cursor_style is not None  # narrowed by `caret`
                     content = content.stylize(ContentStyle.from_rich_style(cursor_style), 0, 1)
                 return Strip(content.render_segments(self.visual_style), content.cell_length)
-        return self._paint_markers(super().render_line(y), y)
+        # Slash highlighting LAST so its own line-0/leading-`/` bail is the cheap
+        # rejection on the common prose path. The two passes never contend for
+        # the same cells: a marker opens with `[` and lives in the message tail,
+        # the command word and name open with `/` on line 0 — so order is
+        # immaterial for correctness (see :meth:`_paint_slash`).
+        return self._paint_slash(self._paint_markers(super().render_line(y), y), y)
 
     # -- public API ---------------------------------------------------------
     @property
@@ -905,6 +954,11 @@ class Editor(TextArea):
             if command.arguments is ArgumentMode.REQUIRED
             for name in command.names
         )
+        # Lower-cased so the highlighter's membership test matches the
+        # case-insensitive way ``slash_command_for`` resolves a typed word.
+        self._command_names = frozenset(
+            name.lower() for command in commands for name in command.names
+        )
 
     def opens_a_list(self, name: str) -> bool:
         """Whether completing the command word ``name`` opens a list INSTEAD of
@@ -919,6 +973,41 @@ class Editor(TextArea):
         """
         lowered = name.lower()
         return lowered in self.MODEL_COMMANDS or lowered in self._required_argument_commands
+
+    def _is_name_argument_command(self, name: str | None) -> bool:
+        """Whether ``name``'s argument is a NAME followed by a free-text message.
+
+        The one predicate behind both asks: completion routes team/agent rows to
+        :meth:`_complete_name_argument` (space, no submit), and the highlighter
+        only paints an argument NAME for these commands. ``name`` may be ``None``
+        because ``_apply_command`` reads ``_argument_command`` while a list is
+        open — defensive, mirroring :meth:`opens_a_list`'s lowercase test.
+        """
+        return (name or "").lower() in self.NAME_ARGUMENT_COMMANDS
+
+    def set_name_choices(self, names: frozenset[str]) -> None:
+        """The team/agent names the OPEN argument list is offering, for the
+        highlighter.
+
+        Pushed by the app from ``on_argument_query_opened`` beside the
+        ``picker.set_choices`` call — the same "app fills the rows when the list
+        opens" contract, extended to hand the widget a cheap immutable snapshot
+        it can test membership against on the render path. The render pass must
+        never walk the registries itself (that is app-side I/O on every frame),
+        so name recognition rides this snapshot; it is cleared when the argument
+        command changes to a non-name one (see :meth:`_sync_picker`).
+
+        Refreshes the composer when the snapshot actually changes: the names
+        arrive one message-loop tick AFTER the keystroke that opened the list
+        (the app answers ``ArgumentQueryOpened``), by which point ``render_line``
+        has already painted — and cached — the line without them. Without the
+        refresh the name would only light up on the NEXT keystroke, a visible
+        lag. Gated on a real change so an unchanged re-push is not a repaint.
+        """
+        if names == self._name_choices:
+            return
+        self._name_choices = names
+        self.refresh()
 
     @property
     def shell_mode(self) -> bool:
@@ -1696,6 +1785,141 @@ class Editor(TextArea):
         """``strip`` with ``style`` laid ON TOP of each segment's own style."""
         return Strip(Segment.apply_style(strip, post_style=style), strip.cell_length)
 
+    def _slash_runs(self) -> tuple[int, list[tuple[int, int, str]]] | None:
+        """The document-column spans to highlight, and the line they sit on.
+
+        Returns ``(line_index, [(col_start, col_end, component_class), …])`` or
+        ``None`` when nothing on the buffer is a slash surface. The runs are the
+        leading ``/command`` token (always, when the line starts with ``/``) and,
+        for a NAME+message command whose typed name is a known team/agent, the
+        NAME token — never the free-text message tail, which is the whole point:
+        the user sees what is command versus what will be sent.
+
+        "Recognized" for the command word is membership in ``_command_names`` —
+        the same case-insensitive ``name in entry.names`` test the app's
+        ``slash_command_for`` uses, reproduced here because editor.py cannot
+        import the app it is imported by. An unrecognized word gets the muted
+        ``slash-unknown`` treatment so an inert ``/teem`` reads as text that WILL
+        be sent — EXCEPT while the command picker is still choosing (``/te``),
+        where the word is a prefix in progress, not yet a typo.
+        """
+        lines = self.text.split("\n")
+        first = next((i for i, line in enumerate(lines) if line.strip()), None)
+        if first is None:
+            return None
+        # Single content-line discipline, identical to ``slash_context`` — once a
+        # newline follows the command line the buffer is a message body, and a
+        # stray command highlight there would contradict "this is prose".
+        if len(lines) > first + 1:
+            return None
+        line = lines[first]
+        indent = len(line) - len(line.lstrip())
+        rest = line[indent:]
+        if not rest.startswith("/"):
+            return None
+        # The command token runs from the slash through the first whitespace.
+        word_end = next((i for i, ch in enumerate(rest) if i > 0 and ch.isspace()), len(rest))
+        cmd_start, cmd_end = indent, indent + word_end
+        word = rest[1:word_end].lower()
+        runs: list[tuple[int, int, str]] = []
+        if word in self._command_names:
+            runs.append((cmd_start, cmd_end, "text-area--slash-command"))
+        else:
+            # Suppress the "unknown" flash while the word is still being picked:
+            # a prefix under an open command list is in progress, not wrong. The
+            # recognized and name highlights are unaffected by this gate.
+            picking = self._picker.mode is PickerMode.COMMAND and (
+                self._picker.is_open() or self._picker.is_pending()
+            )
+            if not picking:
+                runs.append((cmd_start, cmd_end, "text-area--slash-unknown"))
+        # The NAME token, only for /team·/agent and only when the typed name is a
+        # known team/agent (an exact snapshot hit — a half-typed name stays prose
+        # rather than flickering). ``slash_argument`` hands back everything after
+        # the command word's first space, so the name is its first token.
+        if self._is_name_argument_command(word):
+            argument = slash_argument(self.text, self._argument_commands)
+            if argument is not None:
+                lead = len(argument) - len(argument.lstrip())
+                name = argument[lead:].split(" ", 1)[0].split("\n", 1)[0]
+                if name and name.lower() in self._name_choices:
+                    # The argument tail begins one cell past the command token
+                    # (the terminating space), then any extra spaces the user
+                    # typed before the name.
+                    name_start = cmd_end + 1 + lead
+                    runs.append((name_start, name_start + len(name), "text-area--slash-argument"))
+        return (first, runs) if runs else None
+
+    def _slash_cells(self, y: int) -> list[tuple[int, int, str]]:
+        """``(x_start, x_end, component_class)`` for slash cells on screen row ``y``.
+
+        Mirrors :meth:`_marker_cells`: SCREEN row, not document line, so a long
+        ``/team <name> <message>`` that soft-wraps maps its document columns to
+        the right screen x on whichever wrapped row carries them. The command
+        token is short and rarely wraps; the name token can, so the same
+        wrap-boundary math the marker pass uses is reused here.
+        """
+        runs = self._slash_runs()
+        if runs is None:
+            return []
+        line_index, spans = runs
+        wrapped = self.wrapped_document
+        absolute_y = self.scroll_offset.y + y
+        if absolute_y >= wrapped.height:
+            return []
+        row_line, section_start = wrapped.offset_to_location(Offset(0, absolute_y))
+        if row_line != line_index:
+            # Only the command line's screen rows can carry the tokens.
+            return []
+        line = self.document.get_line(line_index)
+        offsets = wrapped.get_offsets(line_index)
+        section_index = bisect_right(offsets, section_start)
+        wraps_on = section_index < len(offsets)
+        section_end = offsets[section_index] if wraps_on else len(line)
+        gutter = self.gutter_width
+        cells: list[tuple[int, int, str]] = []
+        for col_start, col_end, component in spans:
+            start = max(col_start, section_start)
+            end = min(col_end, section_end)
+            if start >= end:
+                continue  # this token lives entirely on another wrapped row
+            x_start = wrapped.location_to_offset((line_index, start)).x
+            if wraps_on and end >= section_end:
+                # ``end`` IS the wrap offset, which location_to_offset reads as
+                # column 0 of the NEXT row; the token runs to this row's text end.
+                x_end = cell_len(
+                    expand_tabs_inline(line[section_start:section_end], self.indent_width)
+                )
+            else:
+                x_end = wrapped.location_to_offset((line_index, end)).x
+            cells.append((x_start + gutter, x_end + gutter, component))
+        return cells
+
+    def _paint_slash(self, strip: Strip, y: int) -> Strip:
+        """Overlay the slash-command / name highlight on an already-rendered row.
+
+        Foreground-only component styles (see the tcss) laid on as ``post_style``
+        for the same reason as the chip: every segment ``TextArea`` returns
+        carries an explicit fg/bg, so a base style is discarded on arrival.
+        Foreground-only is deliberate — it composes with the cursor's inverse and
+        the selection ground without fighting them, so the pass need not exclude
+        the caret cell the way the opaque chip does.
+        """
+        cells = self._slash_cells(y)
+        if not cells:
+            return strip
+        width = strip.cell_length
+        edges = sorted({0, width} | {x for start, end, _ in cells for x in (start, end)})
+        styles = {component: self.get_component_rich_style(component) for _, _, component in cells}
+        pieces: list[Strip] = []
+        for left, piece in zip(edges, strip.divide(edges[1:])):
+            component = next((comp for start, end, comp in cells if start <= left < end), None)
+            if component is None:
+                pieces.append(piece)
+                continue
+            pieces.append(self._overlay(piece, styles[component]))
+        return Strip.join(pieces)
+
     async def _on_mouse_down(self, event: events.MouseDown) -> None:
         """Note a press that landed inside a marker; the release decides.
 
@@ -2173,6 +2397,10 @@ class Editor(TextArea):
         if list_argument is None:
             self._argument_command = None
             self._argument_subcommand = None
+            # No argument list is open, so the name snapshot is stale: drop it so
+            # a highlight can never outlive the list that filled it (e.g. the
+            # command word was deleted back to `/tea`).
+            self._name_choices = frozenset()
             self._picker.sync(self.text)
         else:
             command = self._command_word()
@@ -2184,6 +2412,11 @@ class Editor(TextArea):
                 # credential, so carrying them across would briefly offer a logout
                 # from an account the user never had.
                 self._picker.set_choices([])
+                # Clear the name snapshot too: the app re-pushes it for a
+                # NAME+message command in ``on_argument_query_opened``; leaving
+                # the previous command's names would highlight `/agent frontend`
+                # against team names.
+                self._name_choices = frozenset()
                 self.post_message(ArgumentQueryOpened(command or ""))
             elif command == "mcp":
                 # `/mcp` is two-level: verbs in the first argument slot,
@@ -2337,6 +2570,13 @@ class Editor(TextArea):
         drops away on the same keystroke that chose from it.
         """
         if self._picker.mode is PickerMode.ARGUMENT:
+            # A clicked team/agent row fills the name and a space and waits for
+            # the message, exactly like Tab/Enter on the same row — a click on a
+            # NAME+message row is "chosen, now type the message", never "switch
+            # and discard whatever you were about to say".
+            if self._is_name_argument_command(self._argument_command):
+                self._complete_name_argument(name)
+                return
             if self._argument_is_destructive():
                 self._complete_argument(name)
                 return
@@ -2358,7 +2598,15 @@ class Editor(TextArea):
         fuzzy matcher guessed would make one mis-keystroke destructive. An
         ambiguous Enter completes instead — the buffer then holds the exact id,
         which is one match, so the second Enter runs it.
+
+        A NAME+message command (`/team`, `/agent`) short-circuits ALL of that:
+        Tab and Enter, ambiguous or not, fill the name and a space and never
+        submit — "one match" is not "run" for these, it is "ready for the
+        message". See :meth:`_complete_name_argument`.
         """
+        if self._is_name_argument_command(self._argument_command):
+            self._complete_name_argument(name)
+            return
         if key == "tab" or not unambiguous:
             self._complete_argument(name)
             return
@@ -2389,6 +2637,33 @@ class Editor(TextArea):
         """
         self._complete_argument(name)
         self._submit()
+
+    def _complete_name_argument(self, name: str) -> None:
+        """Fill a team/agent NAME and a trailing space, WITHOUT submitting.
+
+        The inverse of :meth:`_complete_argument`'s "no space so the matcher
+        keeps matching". Here the space is load-bearing in the other direction:
+        it terminates the name so the argument list closes (``slash_argument``
+        goes to an empty match set, verified), and it opens the free-text
+        message tail the user now types. Parking the caret after it is what lets
+        `/team frontend-guild ` become either an attach-only switch (a blank
+        Enter — the app's dispatch strips the bare name) or `/team frontend-guild
+        fix the bug` (a typed message then Enter) without either being a picker
+        gesture. Neither Tab nor Enter ever submits for these commands, because
+        for a NAME+message command "the name is chosen" is not "run it", it is
+        "ready for the message" — see :attr:`NAME_ARGUMENT_COMMANDS`.
+
+        Setting ``self.text`` funnels through ``load_text`` → ``_sync_picker``,
+        which re-derives the picker as an argument list with no matches, so the
+        list closes on the same keystroke that completed the name.
+        """
+        argument = slash_argument(self.text, self._argument_commands)
+        if argument is None:
+            return
+        # The argument is by construction the tail of the buffer, so trimming its
+        # length off the end leaves exactly `…/team ` to append the name+space.
+        self.text = f"{self.text[: len(self.text) - len(argument)]}{name} "
+        self.move_cursor(self._end_of_buffer())
 
     def _extend_to_common_prefix(self) -> None:
         """Grow the typed word to the matches' longest common prefix, no further.

--- a/local_operator/tui/widgets/editor.py
+++ b/local_operator/tui/widgets/editor.py
@@ -591,6 +591,15 @@ class Editor(TextArea):
     #: ``models``.
     NAME_ARGUMENT_COMMANDS = ("team", "teams", "agent", "agents")
 
+    #: The discoverability hint shown the moment a NAME+message name is completed
+    #: with an empty tail (ux round 1, U1/U2). Names both outcomes of the parked
+    #: caret — a blank Enter switches, a typed message sends — so the divergence
+    #: from the enum-tail commands (Enter-on-a-row runs immediately) is visible
+    #: BEFORE the user commits, not inferred from a transcript notice afterwards.
+    #: Shown in the picker's own notice row and withdrawn as soon as a message
+    #: character is typed. See :meth:`_name_switch_hint`.
+    NAME_SWITCH_HINT = "Enter to switch · type a message to send"
+
     #: The attachment chip's two grounds, on top of everything ``TextArea``
     #: already declares. Component classes rather than hexes in Python so the
     #: colours sit in the stylesheet beside every other composer colour and
@@ -652,6 +661,18 @@ class Editor(TextArea):
         # list has opened at least once; a name hand-typed in full before the
         # list ever filled goes un-highlighted, an accepted affordance gap.
         self._name_choices: frozenset[str] = frozenset()
+        # Per-render-pass memo for :meth:`_slash_runs` (CR1). ``render_line`` is
+        # called once per visible screen row and the runs are identical for every
+        # row of a frame; this caches the parse against a key of every input it
+        # reads, so the compute runs once and the other rows reuse it. ``None``
+        # until the first row of the first frame that asks.
+        # The key is a heterogeneous snapshot of every input _slash_runs reads
+        # (text, two frozensets, the argument-commands tuple, picker mode/flags),
+        # so it is typed ``tuple[object, ...]`` — it is only ever compared for
+        # equality, never indexed.
+        self._slash_runs_cache: (
+            tuple[tuple[object, ...], tuple[int, list[tuple[int, int, str]]] | None] | None
+        ) = None
         # tab_behavior="indent": Tab NEVER moves focus (TUI-013). Command
         # completion consumes the key first; otherwise it indents.
         super().__init__(placeholder=placeholder, soft_wrap=True, tab_behavior="indent")
@@ -984,6 +1005,37 @@ class Editor(TextArea):
         open — defensive, mirroring :meth:`opens_a_list`'s lowercase test.
         """
         return (name or "").lower() in self.NAME_ARGUMENT_COMMANDS
+
+    def _name_switch_hint(self, list_argument: str) -> str | None:
+        """The U1/U2 hint, or ``None`` when it must not show.
+
+        Shows ONLY in the one state it answers: a NAME+message command whose
+        argument is a completed name followed by a single terminating space and
+        nothing else — i.e. exactly the parked-caret resting state
+        ``_complete_name_argument`` produces. ``list_argument`` is the picker's
+        current argument query (everything after ``/<cmd> ``), so:
+
+        * a bare ``/team `` (empty argument) is still choosing a NAME — the row
+          list is up and answers the question, no hint;
+        * ``/team frontend-guild `` (name + one trailing space) is the moment the
+          two outcomes appear — HINT;
+        * ``/team frontend-guild fix`` (a message is being typed) has a non-empty
+          tail past the space — the user has chosen "send", withdraw the hint.
+
+        Gated on the command being a NAME+message one so it never intrudes on the
+        enum-tail argument lists, and returned as text the caller feeds to the
+        picker notice channel (empty tail only, so it cannot cover a real row).
+        """
+        if not self._is_name_argument_command(self._argument_command):
+            return None
+        # A completed name reads as `<name> ` — one internal space that
+        # terminates the name and an empty tail. `rstrip(" ")` then a re-add of a
+        # single space would be fragile; instead require exactly: a non-empty
+        # first token, and everything after the FIRST space is blank.
+        name, sep, tail = list_argument.partition(" ")
+        if not name or not sep or tail.strip():
+            return None
+        return self.NAME_SWITCH_HINT
 
     def set_name_choices(self, names: frozenset[str]) -> None:
         """The team/agent names the OPEN argument list is offering, for the
@@ -1795,6 +1847,39 @@ class Editor(TextArea):
         NAME token — never the free-text message tail, which is the whole point:
         the user sees what is command versus what will be sent.
 
+        Memoized per render pass (CR1). ``render_line(y)`` calls this once per
+        VISIBLE screen row, and the runs are identical for every row of a frame —
+        they are a property of the buffer and picker state, not of ``y``. The
+        cache key captures every input the computation reads, so a keystroke that
+        changes any of them (buffer text, the name/command snapshots, the picker
+        state that gates the unknown treatment) recomputes on the next row that
+        asks, while the other rows of the same frame reuse the result. Composer
+        buffers are small, so this is a micro-optimisation, not a hot-path fix —
+        but it makes the "cheap on the hot path" claim exact and stops the
+        per-row line-list allocation on prose frames.
+        """
+        # Every value the compute reads, so a stale run can never survive an
+        # input change. ``_command_names``/``_name_choices`` are frozensets and
+        # ``_argument_commands`` a tuple — all hashable and cheap to compare.
+        key = (
+            self.text,
+            self._command_names,
+            self._name_choices,
+            self._argument_commands,
+            self._picker.mode,
+            self._picker.is_open(),
+            self._picker.is_pending(),
+        )
+        cached = self._slash_runs_cache
+        if cached is not None and cached[0] == key:
+            return cached[1]
+        runs = self._compute_slash_runs()
+        self._slash_runs_cache = (key, runs)
+        return runs
+
+    def _compute_slash_runs(self) -> tuple[int, list[tuple[int, int, str]]] | None:
+        """The uncached body of :meth:`_slash_runs` — see its docstring.
+
         "Recognized" for the command word is membership in ``_command_names`` —
         the same case-insensitive ``name in entry.names`` test the app's
         ``slash_command_for`` uses, reproduced here because editor.py cannot
@@ -1836,12 +1921,15 @@ class Editor(TextArea):
         # The NAME token, only for /team·/agent and only when the typed name is a
         # known team/agent (an exact snapshot hit — a half-typed name stays prose
         # rather than flickering). ``slash_argument`` hands back everything after
-        # the command word's first space, so the name is its first token.
+        # the command word's first space, so the name is its first token. The
+        # single-content-line guard above has already excluded any newline in the
+        # buffer, so the name is a plain whitespace-delimited token (CR3: no
+        # second newline split is needed after that guard).
         if self._is_name_argument_command(word):
             argument = slash_argument(self.text, self._argument_commands)
             if argument is not None:
                 lead = len(argument) - len(argument.lstrip())
-                name = argument[lead:].split(" ", 1)[0].split("\n", 1)[0]
+                name = argument[lead:].split(" ", 1)[0]
                 if name and name.lower() in self._name_choices:
                     # The argument tail begins one cell past the command token
                     # (the terminating space), then any extra spaces the user
@@ -2430,6 +2518,22 @@ class Editor(TextArea):
                     self._argument_subcommand = subcommand
                     self.post_message(RefreshArgumentChoices(command))
             self._picker.sync_argument(list_argument)
+            # U1/U2 discoverability hint. The moment a NAME+message name is
+            # autofilled (or hand-typed) to `/<cmd> <name> ` with an empty tail,
+            # the picker closes and NOTHING on screen says the two outcomes now
+            # available: a blank Enter SWITCHES (attach-only), a typed message
+            # SENDS. That divergence from the enum-tail commands (where Enter on a
+            # row runs immediately) is invisible, so a first-timer reads the park
+            # as a dropped keystroke. We reuse the picker's own notice row — the
+            # codebase's bounded, self-clearing "say it where the list was" idiom
+            # (see CommandPicker.set_notice) — rather than inventing a widget. It
+            # shows only in the name-complete-empty-tail state and is withdrawn
+            # the instant a message character is typed (the tail stops being
+            # empty) or the name is edited (the space is gone), so it never sits
+            # over a live message. Managed here because for these commands the
+            # notice channel is otherwise unused (the app sets it to "").
+            hint = self._name_switch_hint(list_argument)
+            self._picker.set_notice(hint or "")
         argument = slash_argument(self.text, self.MODEL_COMMANDS)
         if argument is None:
             if self._model_picker.is_open():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.20.1"
+version = "0.21.0"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@radienthq.com" }]

--- a/tests/unit/tui/test_command_picker.py
+++ b/tests/unit/tui/test_command_picker.py
@@ -1659,6 +1659,76 @@ async def test_enum_tail_login_row_still_runs_on_enter() -> None:
 
 
 # ---------------------------------------------------------------------------
+# autofill discoverability hint (ux round 1, U1/U2) — at the parked-caret
+# moment, name both outcomes: blank Enter switches, a typed message sends.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_autofill_shows_the_switch_or_send_hint() -> None:
+    """The moment a name is autofilled with an empty tail, the picker's notice
+    row names both outcomes — the fix for U1/U2, where nothing on screen told
+    the user that Enter-now switches while type-then-Enter sends."""
+    app = PickerHarnessApp()
+    async with app.run_test(size=(100, 30)) as pilot:
+        app.editor.focus()
+        await pilot.pause()
+        app.editor.text = "/team frontend-guild"
+        await pilot.pause()
+        await pilot.press("enter")
+        await pilot.pause()
+        assert app.editor.text == "/team frontend-guild "
+        assert app.editor.picker._notice == Editor.NAME_SWITCH_HINT
+        # It shows in the picker's own notice place, not the transcript.
+        assert app.editor.picker.display
+
+
+@pytest.mark.asyncio
+async def test_the_hint_is_withdrawn_once_a_message_is_typed() -> None:
+    """Typing the first message character means the user chose "send" — the
+    hint must clear so it never sits over a live message."""
+    app = PickerHarnessApp()
+    async with app.run_test(size=(100, 30)) as pilot:
+        app.editor.focus()
+        await pilot.pause()
+        app.editor.text = "/team frontend-guild "
+        app.editor.move_cursor(app.editor._end_of_buffer())  # as the autofill leaves it
+        await pilot.pause()
+        assert app.editor.picker._notice == Editor.NAME_SWITCH_HINT
+        await pilot.press("f")
+        await pilot.pause()
+        assert app.editor.text == "/team frontend-guild f"
+        assert app.editor.picker._notice == ""
+
+
+@pytest.mark.asyncio
+async def test_a_bare_name_list_shows_no_hint() -> None:
+    """While the row list is still up (`/team ` with no name chosen), the rows
+    answer the question — the hint would compete with them, so it stays away."""
+    app = PickerHarnessApp()
+    async with app.run_test(size=(100, 30)) as pilot:
+        app.editor.focus()
+        await pilot.pause()
+        app.editor.text = "/team "
+        await pilot.pause()
+        assert app.editor.picker.is_open()  # rows are showing
+        assert app.editor.picker._notice == ""
+
+
+@pytest.mark.asyncio
+async def test_enum_tail_completion_shows_no_switch_hint() -> None:
+    """The hint is for NAME+message commands only — an enum-tail argument like
+    `/login anthropic ` must never surface it."""
+    app = PickerHarnessApp()
+    async with app.run_test(size=(100, 30)) as pilot:
+        app.editor.focus()
+        await pilot.pause()
+        app.editor.text = "/login anthropic "
+        await pilot.pause()
+        assert app.editor.picker._notice == ""
+
+
+# ---------------------------------------------------------------------------
 # slash-command syntax highlighting — the render pass paints the recognized
 # command word, the recognized name, and a muted unknown word, and nothing else.
 # ---------------------------------------------------------------------------
@@ -1710,9 +1780,11 @@ async def test_unknown_command_word_gets_the_unknown_style_when_picker_closed() 
         await pilot.pause()
         assert not app.editor.picker.is_open()
         cells = _slash_ink(app.editor)
-        muted = theme_mod.semantic_color("muted").lower()
-        assert _ink_of(cells, "/") == muted
-        assert _ink_of(cells, "notacommand") == muted
+        # `dim`, darkened from `muted` in design round 1 (D1) so the inert
+        # "will be sent as text" read lands against the prose tail.
+        dim = theme_mod.semantic_color("dim").lower()
+        assert _ink_of(cells, "/") == dim
+        assert _ink_of(cells, "notacommand") == dim
         # The message tail after the space stays prose.
         fg = theme_mod.semantic_color("fg").lower()
         assert _ink_of(cells, " hello ") == fg
@@ -1731,9 +1803,13 @@ async def test_command_word_is_not_flagged_unknown_while_the_picker_is_open() ->
         assert app.editor.picker.is_open()
         assert app.editor.picker.mode is PickerMode.COMMAND
         cells = _slash_ink(app.editor)
-        muted = theme_mod.semantic_color("muted").lower()
-        # `/te` is not a full command, but no cell is painted the unknown colour.
-        assert all(fg != muted for _, fg in cells if _.strip())
+        dim = theme_mod.semantic_color("dim").lower()
+        # `/te` is not a full command, but no /-token cell is painted the unknown
+        # colour while the picker is choosing. Restrict to the command token so a
+        # coincidental `dim` elsewhere on the row (e.g. an unfocused chevron)
+        # cannot mask a real regression.
+        token = [fg for text, fg in cells if text.strip() in ("/", "/te", "te")]
+        assert token and all(fg != dim for fg in token)
 
 
 @pytest.mark.asyncio
@@ -1753,6 +1829,45 @@ async def test_recognized_team_name_gets_the_argument_style() -> None:
         assert _ink_of(cells, "frontend-guild") == green
         # The message tail is NOT highlighted — the whole point of the feature.
         assert _ink_of(cells, " fix it ") == fg
+
+
+@pytest.mark.asyncio
+async def test_a_name_token_that_soft_wraps_is_highlighted_across_both_rows() -> None:
+    """The wrap-boundary branch of ``_slash_cells`` (the intricate new math):
+    a name longer than the composer's content width breaks mid-token across two
+    screen rows, and BOTH halves must carry the argument-name style — otherwise
+    a long team/agent name would light up only until the wrap and read as broken.
+
+    Driven at a narrow width so the name (not just name+message) straddles a wrap
+    offset, which is exactly the ``wraps_on``/``section_end`` case the straight
+    single-row tests never reach. The snapshot is pushed AFTER the text settles
+    because the harness's ``on_argument_query_opened`` re-pushes its fixed team
+    rows on the space; the app's real ordering (list opens, THEN names arrive) is
+    unaffected — this only mirrors it deterministically for a bespoke name.
+    """
+    app = PickerHarnessApp()
+    async with app.run_test(size=(24, 20)) as pilot:
+        app.editor.focus()
+        await pilot.pause()
+        # 29 chars, wider than the ~18-cell content box, so it must break inside
+        # the token rather than at the space before the message.
+        long_name = "frontend-platform-guild-alpha"
+        app.editor.text = f"/team {long_name} go now"
+        await pilot.pause()
+        app.editor.set_name_choices(frozenset({long_name}))
+        await pilot.pause()
+        wrapped = app.editor.wrapped_document
+        assert len(wrapped.get_offsets(0)) >= 2, "premise: the name itself wraps"
+        green = theme_mod.semantic_color("string").lower()
+        # Gather every green run across all the wrapped rows of document line 0.
+        painted = ""
+        for y in range(wrapped.height):
+            for text, fg in _slash_ink(app.editor, y):
+                if fg == green:
+                    painted += text
+        # The whole name is painted, contiguously, and nothing more — the message
+        # tail (`go now`) never picks up the argument-name colour.
+        assert painted == long_name
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tui/test_command_picker.py
+++ b/tests/unit/tui/test_command_picker.py
@@ -58,6 +58,21 @@ PROVIDER_CHOICES = [
 ]
 
 
+#: Team rows the `/team` argument list offers. NAME+message commands: choosing
+#: a row fills the name and a space and waits for the message, and the typed
+#: name is highlighted once it exactly matches one of these.
+TEAM_CHOICES = [
+    ArgumentChoice("frontend-guild", "Ship the web surface", detail="3 roles"),
+    ArgumentChoice("release-crew", "Cut releases", detail="2 roles"),
+]
+
+#: Agent rows the `/agent` argument list offers — the mirror of TEAM_CHOICES.
+AGENT_CHOICES = [
+    ArgumentChoice("auditor", "Audit changes for risk", detail="role"),
+    ArgumentChoice("dashboard-sme", "Knows the dashboard", detail="specialist"),
+]
+
+
 def _logout_choices() -> list[ArgumentChoice]:
     """What `/logout` offers, shaped as the app builds it.
 
@@ -111,6 +126,14 @@ class PickerHarnessApp(App[None]):
         # two sets distinct so `/logout` can be shown to offer strictly less.
         message.stop()
         self.provider_queries.append(message.command)
+        if message.command in ("team", "teams", "agent", "agents"):
+            # Mirror the app: fill the rows AND hand the editor the name snapshot
+            # its highlighter reads, so the NAME+message completion and the
+            # argument-name highlight are exercised over the real registry seam.
+            choices = TEAM_CHOICES if message.command in ("team", "teams") else AGENT_CHOICES
+            self.editor.picker.set_choices(list(choices))
+            self.editor.set_name_choices(frozenset(c.name.lower() for c in choices))
+            return
         choices = _logout_choices() if message.command == "logout" else PROVIDER_CHOICES
         self.editor.picker.set_choices(list(choices))
 
@@ -1488,3 +1511,279 @@ def test_the_wheel_on_a_closed_picker_is_a_no_op() -> None:
     picker = _picker(SLASH_COMMANDS)
     picker.on_mouse_scroll_down(_wheel_down())  # must not raise
     assert picker.suggestions() == []
+
+
+# ---------------------------------------------------------------------------
+# NAME+message completion (`/team`, `/agent`) — fill a name and a space, never
+# submit; the message tail and the blank-attach are the existing submit paths.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_enter_on_a_team_row_fills_the_name_and_a_space_without_submitting() -> None:
+    """Enter on a team row is "chosen, now type the message", not "switch now".
+
+    The key difference from a provider row (which Enter RUNS when unambiguous):
+    for a NAME+message command neither Tab nor Enter ever submits — the name is
+    filled with a trailing space and the caret parks after it.
+    """
+    app = PickerHarnessApp()
+    async with app.run_test(size=(100, 30)) as pilot:
+        app.editor.focus()
+        await pilot.pause()
+        app.editor.text = "/team frontend-guild"
+        await pilot.pause()
+        assert app.editor.picker.highlighted_name() == "frontend-guild"
+        await pilot.press("enter")
+        await pilot.pause()
+        assert app.editor.text == "/team frontend-guild "
+        assert app.editor.cursor_location == app.editor._end_of_buffer()
+        assert app.submissions == []
+        assert not app.editor.picker.is_open()
+        assert app.editor.has_focus
+
+
+@pytest.mark.asyncio
+async def test_tab_on_a_team_row_fills_name_and_space() -> None:
+    app = PickerHarnessApp()
+    async with app.run_test(size=(100, 30)) as pilot:
+        app.editor.focus()
+        await pilot.pause()
+        app.editor.text = "/team front"
+        await pilot.pause()
+        await pilot.press("tab")
+        await pilot.pause()
+        # Tab fills the name AND a space here — the opposite of the provider
+        # list, where Tab leaves no space so the matcher keeps matching.
+        assert app.editor.text == "/team frontend-guild "
+        assert app.submissions == []
+
+
+@pytest.mark.asyncio
+async def test_click_on_a_team_row_fills_name_and_space_without_submitting() -> None:
+    app = PickerHarnessApp()
+    async with app.run_test(size=(100, 30)) as pilot:
+        app.editor.focus()
+        await pilot.pause()
+        app.editor.text = "/team "
+        await pilot.pause()
+        await pilot.click(CommandPicker, offset=(4, 0))
+        await pilot.pause()
+        assert app.editor.text == "/team frontend-guild "
+        assert app.submissions == []
+        assert not app.editor.picker.is_open()
+
+
+@pytest.mark.asyncio
+async def test_arrowing_onto_a_team_row_still_does_not_submit() -> None:
+    """The unambiguous branch that RUNS a provider must not run a team row: for
+    a NAME+message command "one match / arrowed" is still only "ready"."""
+    app = PickerHarnessApp()
+    async with app.run_test(size=(100, 30)) as pilot:
+        app.editor.focus()
+        await pilot.pause()
+        app.editor.text = "/team "
+        await pilot.pause()
+        await pilot.press("down")  # arrow onto row 1 — an explicit move
+        await pilot.pause()
+        assert app.editor.picker.highlighted_name() == "release-crew"
+        await pilot.press("enter")
+        await pilot.pause()
+        assert app.editor.text == "/team release-crew "
+        assert app.submissions == []
+
+
+@pytest.mark.asyncio
+async def test_blank_enter_after_a_completed_team_name_submits_attach_only() -> None:
+    """The blank tail after the space is not a picker gesture — the list is
+    closed, so Enter submits, and the app's dispatch collapses the bare name to
+    an attach-only switch."""
+    app = PickerHarnessApp()
+    async with app.run_test(size=(100, 30)) as pilot:
+        app.editor.focus()
+        await pilot.pause()
+        app.editor.text = "/team frontend-guild "
+        await pilot.pause()
+        assert not app.editor.picker.is_open()
+        await pilot.press("enter")
+        await pilot.pause()
+        # The whole line submits; the arg is `frontend-guild ` which dispatch
+        # strips to the bare name (attach-only). We assert the submitted text.
+        assert app.submissions == ["/team frontend-guild "]
+
+
+@pytest.mark.asyncio
+async def test_typing_a_message_then_enter_sends_the_whole_line() -> None:
+    app = PickerHarnessApp()
+    async with app.run_test(size=(100, 30)) as pilot:
+        app.editor.focus()
+        await pilot.pause()
+        app.editor.text = "/team frontend-guild fix the flaky test"
+        await pilot.pause()
+        assert not app.editor.picker.is_open()
+        await pilot.press("enter")
+        await pilot.pause()
+        assert app.submissions == ["/team frontend-guild fix the flaky test"]
+
+
+@pytest.mark.asyncio
+async def test_agent_row_behaves_like_team() -> None:
+    """`/agent` is the mirror of `/team`: complete the name + space, no submit."""
+    app = PickerHarnessApp()
+    async with app.run_test(size=(100, 30)) as pilot:
+        app.editor.focus()
+        await pilot.pause()
+        app.editor.text = "/agent audit"
+        await pilot.pause()
+        assert app.editor.picker.highlighted_name() == "auditor"
+        await pilot.press("enter")
+        await pilot.pause()
+        assert app.editor.text == "/agent auditor "
+        assert app.submissions == []
+
+
+@pytest.mark.asyncio
+async def test_enum_tail_login_row_still_runs_on_enter() -> None:
+    """Regression guard: the enum-tail path is untouched — an unambiguous
+    provider Enter still completes AND runs, unlike a name command."""
+    app = PickerHarnessApp()
+    async with app.run_test(size=(100, 30)) as pilot:
+        app.editor.focus()
+        await pilot.pause()
+        app.editor.text = "/login anthropic"
+        await pilot.pause()
+        assert len(app.editor.picker.suggestions()) == 1
+        await pilot.press("enter")
+        await pilot.pause()
+        assert app.submissions == ["/login anthropic"]
+
+
+# ---------------------------------------------------------------------------
+# slash-command syntax highlighting — the render pass paints the recognized
+# command word, the recognized name, and a muted unknown word, and nothing else.
+# ---------------------------------------------------------------------------
+
+
+def _slash_ink(editor: Editor, y: int = 0) -> list[tuple[str, str | None]]:
+    """(text, fg hex) per segment of the editor's rendered row ``y``.
+
+    Reads the FINISHED strip ``render_line`` produces — the same thing the
+    terminal is sent — so the assertions probe what the user actually sees, not
+    an intention. Foreground only, because the highlight is foreground-only.
+    """
+    strip = editor.render_line(y)
+    cells: list[tuple[str, str | None]] = []
+    for segment in strip._segments:
+        style = segment.style
+        fg = style.color.get_truecolor().hex.lower() if style and style.color else None
+        cells.append((segment.text, fg))
+    return cells
+
+
+def _ink_of(cells: list[tuple[str, str | None]], text: str) -> str | None:
+    """The fg of the first segment whose text is exactly ``text``."""
+    return next(fg for seg_text, fg in cells if seg_text == text)
+
+
+@pytest.mark.asyncio
+async def test_recognized_command_word_gets_the_slash_command_style() -> None:
+    app = PickerHarnessApp()
+    async with app.run_test(size=(100, 30)) as pilot:
+        app.editor.focus()
+        await pilot.pause()
+        # A space closes the command picker so the highlight is not suppressed.
+        app.editor.text = "/usage "
+        await pilot.pause()
+        cells = _slash_ink(app.editor)
+        signal = theme_mod.semantic_color("signal").lower()
+        assert _ink_of(cells, "/") == signal
+        assert _ink_of(cells, "usage") == signal
+
+
+@pytest.mark.asyncio
+async def test_unknown_command_word_gets_the_unknown_style_when_picker_closed() -> None:
+    app = PickerHarnessApp()
+    async with app.run_test(size=(100, 30)) as pilot:
+        app.editor.focus()
+        await pilot.pause()
+        app.editor.text = "/notacommand hello"
+        await pilot.pause()
+        assert not app.editor.picker.is_open()
+        cells = _slash_ink(app.editor)
+        muted = theme_mod.semantic_color("muted").lower()
+        assert _ink_of(cells, "/") == muted
+        assert _ink_of(cells, "notacommand") == muted
+        # The message tail after the space stays prose.
+        fg = theme_mod.semantic_color("fg").lower()
+        assert _ink_of(cells, " hello ") == fg
+
+
+@pytest.mark.asyncio
+async def test_command_word_is_not_flagged_unknown_while_the_picker_is_open() -> None:
+    """A prefix under an open command list is in progress, not a typo — the
+    unknown treatment is suppressed so it does not flash on every keystroke."""
+    app = PickerHarnessApp()
+    async with app.run_test(size=(100, 30)) as pilot:
+        app.editor.focus()
+        await pilot.pause()
+        app.editor.text = "/te"
+        await pilot.pause()
+        assert app.editor.picker.is_open()
+        assert app.editor.picker.mode is PickerMode.COMMAND
+        cells = _slash_ink(app.editor)
+        muted = theme_mod.semantic_color("muted").lower()
+        # `/te` is not a full command, but no cell is painted the unknown colour.
+        assert all(fg != muted for _, fg in cells if _.strip())
+
+
+@pytest.mark.asyncio
+async def test_recognized_team_name_gets_the_argument_style() -> None:
+    app = PickerHarnessApp()
+    async with app.run_test(size=(100, 30)) as pilot:
+        app.editor.focus()
+        await pilot.pause()
+        # Open the list so the app pushes the name snapshot, then type a message.
+        app.editor.text = "/team frontend-guild fix it"
+        await pilot.pause()
+        cells = _slash_ink(app.editor)
+        signal = theme_mod.semantic_color("signal").lower()
+        green = theme_mod.semantic_color("string").lower()
+        fg = theme_mod.semantic_color("fg").lower()
+        assert _ink_of(cells, "team") == signal
+        assert _ink_of(cells, "frontend-guild") == green
+        # The message tail is NOT highlighted — the whole point of the feature.
+        assert _ink_of(cells, " fix it ") == fg
+
+
+@pytest.mark.asyncio
+async def test_partial_name_is_not_highlighted() -> None:
+    """A half-typed name is normal in-progress state, not an error — only an
+    exact snapshot hit paints the name."""
+    app = PickerHarnessApp()
+    async with app.run_test(size=(100, 30)) as pilot:
+        app.editor.focus()
+        await pilot.pause()
+        app.editor.text = "/team front"
+        await pilot.pause()
+        cells = _slash_ink(app.editor)
+        green = theme_mod.semantic_color("string").lower()
+        assert all(fg != green for _, fg in cells)
+
+
+@pytest.mark.asyncio
+async def test_multiline_buffer_does_not_highlight_a_second_line() -> None:
+    """The command lives on line 0 only; a newline makes the rest a message
+    body, and no command highlight may leak onto it."""
+    app = PickerHarnessApp()
+    async with app.run_test(size=(100, 30)) as pilot:
+        app.editor.focus()
+        await pilot.pause()
+        app.editor.text = "/team frontend-guild\nmore text"
+        await pilot.pause()
+        # A newline after the command word means neither token is a live list
+        # surface: nothing is highlighted on either row.
+        signal = theme_mod.semantic_color("signal").lower()
+        green = theme_mod.semantic_color("string").lower()
+        for y in (0, 1):
+            cells = _slash_ink(app.editor, y)
+            assert all(fg not in (signal, green) for _, fg in cells)

--- a/tests/unit/tui/test_command_picker.py
+++ b/tests/unit/tui/test_command_picker.py
@@ -1728,6 +1728,50 @@ async def test_enum_tail_completion_shows_no_switch_hint() -> None:
         assert app.editor.picker._notice == ""
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "command, notice",
+    [
+        ("logout", "no stored credentials — nothing to log out of."),
+        ("effort", "this model takes no effort setting"),
+    ],
+)
+async def test_app_owned_notice_survives_a_same_command_keystroke(
+    command: str, notice: str
+) -> None:
+    """CR4 regression (round 2): the U1/U2 hint write must NOT erase the app's
+    notices for the OTHER argument commands.
+
+    `/logout` (empty credential store) and `/effort` (a model with no effort
+    key) set an informational notice ONCE on the command-word change and never
+    re-set it per keystroke — for those empty-by-construction lists the notice
+    IS the whole content the user reads. The hint's `set_notice` runs on every
+    keystroke of the argument, so before the fix it called `set_notice("")` for
+    these non-name commands on the first query character and wiped the notice
+    (picker closed). The fix gates the write to NAME+message commands only, so a
+    same-command keystroke must leave the app-owned notice intact.
+    """
+    app = PickerHarnessApp()
+    async with app.run_test(size=(100, 30)) as pilot:
+        app.editor.focus()
+        await pilot.pause()
+        # Open the argument list, then set the notice the app would set on the
+        # command-word change (the harness does not model the empty-list case,
+        # so we set it directly — the regression is purely in the editor's
+        # per-keystroke resync, not in how the notice first arrives).
+        app.editor.text = f"/{command} "
+        await pilot.pause()
+        app.editor.picker.set_notice(notice)
+        await pilot.pause()
+        assert app.editor.picker._notice == notice, "premise: the notice is shown"
+        # Type a query character on the SAME command — this re-runs _sync_picker.
+        app.editor.text = f"/{command} x"
+        await pilot.pause()
+        assert (
+            app.editor.picker._notice == notice
+        ), "the app-owned notice must survive a same-command keystroke (CR4)"
+
+
 # ---------------------------------------------------------------------------
 # slash-command syntax highlighting — the render pass paints the recognized
 # command word, the recognized name, and a muted unknown word, and nothing else.


### PR DESCRIPTION
# PR Description

## Summary of Changes

New feature + UX fix for the composer, addressing two reported rough edges in the `/team` and `/agent` completion flow and a broader legibility gap. Version bump is **MINOR** (0.20.1 → 0.21.0).

**1. Team/agent name completion autofills instead of submitting.** Selecting a `/team` or `/agent` name suggestion — by Enter, by click, or by Tab — used to *run and submit* the line immediately, which just attached/switched the team or agent with no message. Now every one of those gestures completes the name, appends a trailing space, and parks the caret so you can type the request you actually want to send. The pre-existing behaviours still work unchanged because they ride the same dispatch:

- **Blank followup + Enter** (`/team frontend-guild ` with nothing after the space) → attach-only, exactly the old "just switch" outcome. `_run_slash_command` collapses the trailing space (`arg = parts[1].strip()`) into the bare-name branch of `_cmd_team`/`_cmd_agent`, which attaches and prints the "ready" notice.
- **Typed message + Enter** (`/team frontend-guild fix the flaky test`) → attaches and sends the message to the manager as a real user turn.

Enum-tail commands (`/login`, `/logout`, `/effort`, `/approvals`, `/model`, …) are untouched — their argument *is* the whole command, so they keep completing-in-place / running as before.

**2. Composer syntax highlighting for recognized slash commands.** The composer now tints the leading `/command` token when it resolves against the registry (the whole slash surface, not just team/agent), tints the recognized team/agent **name** token, and leaves the free-text message as plain prose — so you can see at a glance what is a command and what will be sent as the message. An **unrecognized** command word (e.g. `/notacommand`) renders muted, and the unknown treatment is suppressed while the command picker is still open so a half-typed `/te` never flashes "unknown" mid-type.

## Design

Full design doc committed at `docs/design/composer-ux-autofill-and-highlight.md`. Key decisions:

- **`NAME_ARGUMENT_COMMANDS`** editor-local tuple (mirrors the existing `MODEL_COMMANDS` idiom) marks `team`/`teams`/`agent`/`agents` as "name + free-text message" commands. Deliberately **not** a new `ArgumentMode` enum member — `arguments` is read by `mobile/daemon.py` and `set_commands`/`opens_a_list`, so a shared-enum change carries blast radius a two-command need doesn't justify.
- Highlighting reuses the existing `_paint_markers`/`_overlay` `post_style` render seam via a new `_paint_slash` pass chained in `render_line` — **foreground-only** styles that sidestep the caret/selection overlay interaction, following the theme's `$lo-*` variables (not `$lo-accent`, which is reserved) so a theme switch is free. Recognition is computed cheaply with a hot-path bail (only runs when line 0 starts with `/`); the team/agent name set is pushed from the app in `on_argument_query_opened` so the render path never does registry I/O.

## Related Issue(s)

- Related: user-reported composer UX feedback (no tracking issue).

## Impact

- No breaking changes. No dependency updates.
- No security implications — pure TUI rendering + completion behaviour.
- Performance: the highlight pass bails immediately unless line 0 begins with `/`; recognition reuses the existing single-line tokenizers and an app-pushed frozenset (no per-frame registry work).

## Testing Details

**Quality gates (all clean, run against the worktree):**

```
flake8 .                              → 0 findings
black --check (26.1.0)                → 423 files unchanged
isort --check-only --profile black    → clean
pyright                               → 0 errors, 0 warnings
pytest tests/unit/tui/test_command_picker.py → 231 passed
```

**15 new tests** in `tests/unit/tui/test_command_picker.py`, split across the two changes:

- *Autofill* — Tab/Enter/click on a `/team` and `/agent` name row each assert `host.submissions == []` (completion never submits) and that the buffer holds `…<name> ` with the caret at end; blank-Enter-attaches and typed-message-sends assert the correct submitted text; regression guards pin the login/logout enum-tail rows to their old run/complete behaviour.
- *Highlighting* — render-strip assertions that a recognized command word gets the `slash-command` style, an unknown word gets the muted `slash-unknown` style only when the picker is closed, a recognized team name gets the `slash-argument` style, a partial/unmatched name is not highlighted, and a second buffer line is never highlighted.

**Visual validation** (real `OperatorApp` + `save_screenshot`, before/after SVG pairs, before-frames captured from a detached worktree — never `git stash`):

| Frame | What it proves |
|-------|----------------|
| 1 · team list open | picker unchanged, list renders |
| 2 · name selected | caret parked **after** the trailing space, line **not** submitted |
| 3 · team with message | tri-colour: `/team` (command) · `frontend-guild` (name) · `fix the flaky test` (prose) |
| 4 · unknown command | `/notacommand` renders muted, `hello there` prose |
| 5 · recognized non-name command | command word tinted, whole slash surface covered |
| 6 · agent mirror | `/agent` behaves identically to `/team` |

Rendered PNGs of every after-frame were viewed; highlight hues are legible on the dark theme and no reflow/scrollbar was introduced between before/after. Artifacts: `/tmp/composer-shots/{1..6}-*-{before,after}.svg` and `view-{1..6}-after.png`.

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my changes work as intended.
- [x] All new and existing tests pass.
- [x] I have run formatting (black/isort), linting (flake8), and type checks (pyright), and they pass.
- [x] I have updated the documentation when required (design doc added).
- [x] Security considerations are addressed (no code-execution surface touched).
- [x] I have linked all related issues.

## Screenshots

After-frames (rendered from the real app):

- Autofill parks the caret after the space (frame 2), highlighted message (frame 3), unknown command muted (frame 4) — attached in the agent review thread; SVG/PNG artifacts under `/tmp/composer-shots/`.
