### PR TITLE
feat(analytics): aggregated token-consumption analytics + /analytics /usage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -229,3 +229,48 @@ change.
   failure that motivated the code, not what the line does. Match that density;
   a comment that restates the code is noise, and a change with a non-obvious
   reason needs the reason recorded.
+
+## Usage analytics (`local_operator/analytics/`)
+
+Every provider call across every session contributes to one shared, on-disk
+ledger (`<config_dir>/analytics.db`, SQLite/WAL/0600). `/analytics /usage`
+opens an Esc-dismissable screen summarising token consumption: authoritative
+provider counts (input/output/cache, and the thinking-vs-generation split of
+output) plus an *estimated* breakdown of input across the system prompt, custom
+instructions (agent/team profiles), tool inventory, tool schemas, environment,
+knowledge, conversation, and tool results.
+
+Things that will bite you if you forget them:
+
+- **Recording is off the critical path and best-effort.** The wrapper is
+  `SessionStreamFn._record_stream` in `model/configure.py`: it forwards the
+  provider stream unchanged and records ONLY after the stream is fully
+  consumed, so a turn's latency is untouched. The one on-loop cost is
+  `analytics.model.snapshot_component_chars` (character-length reads;
+  benchmarks under 0.4 ms even on a 340k-token context) — it must run on the
+  loop because the transcript mutates the messages after the call. Tokenising,
+  apportioning, and the SQLite write all happen on the recorder's background
+  thread. Nothing in analytics may raise into a turn; every path is guarded.
+
+- **One writer thread, one write connection.** `AnalyticsRecorder` funnels both
+  call samples and session-name upserts through a single queue drained by one
+  daemon thread. Do NOT add a second thread that writes to the store: two
+  threads opening their first connection to a freshly-created SQLite file race
+  in a way that leaves the writer unable to see its own commits (this cost a
+  round of flaky tests). Reads open a fresh short-lived connection
+  (`AnalyticsStore._read_connection`) so a report always sees the newest commit
+  rather than a stale WAL snapshot.
+
+- **Parallel-safe by the engine, not by us.** Several `lop` sessions write to
+  the one file at once; WAL + `busy_timeout` + a bounded busy-retry make that
+  atomic. The retry lives on the background thread, so accuracy under
+  contention costs a session nothing.
+
+- **The component split is an ESTIMATE and is labelled as one.** The provider
+  bills one input total; the split is that total apportioned by character
+  length (largest-remainder rounding, so it sums exactly). Authoritative counts
+  and estimates must never be presented as the same kind of number — the screen
+  says "estimated split of context tokens" for a reason.
+
+- **Adding a component is a schema migration.** `COMPONENT_KEYS` maps to one
+  `c_<key>` column each in `store._SCHEMA`; bump the schema and default 0.

--- a/local_operator/analytics/__init__.py
+++ b/local_operator/analytics/__init__.py
@@ -1,0 +1,70 @@
+"""Diagnostic, aggregated token-consumption analytics.
+
+Every provider call in every session contributes to one shared, on-disk
+ledger so the harness has an accurate, universal view of where tokens go —
+which provider, which model, and (by estimate) which part of the context:
+the packaged system prompt, the operator's custom instructions and agent/team
+profile prompts, the tool inventory, tool schemas, the environment block,
+loaded knowledge/skills, the conversation, and tool results — plus the
+authoritative output split (thinking vs generation) and cache rates.
+
+Design contract (why this package looks the way it does):
+
+- **Never on the critical path.** The provider stream is fully consumed
+  before anything is recorded, so recording adds zero latency to the
+  response the user is waiting on. The one piece of work that must run on the
+  event loop — snapshotting the request's component *character lengths*
+  before the transcript mutates — is O(blocks + tools + messages) string
+  length reads and benchmarks at well under a millisecond even on a
+  340k-token context. Tokenisation, apportionment, and the SQLite write all
+  happen on a background daemon thread.
+
+- **Best-effort, bounded, non-blocking.** ``record`` does a single
+  ``queue.put_nowait`` and returns; a full queue DROPS the sample rather than
+  blocking a session. The writer thread batches inserts so N concurrent calls
+  cost one transaction, not N fsyncs.
+
+- **Parallel-safe by construction.** Several ``lop`` sessions run at once (one
+  per terminal). The store is one SQLite database in WAL mode with a busy
+  timeout, so cross-process writes are atomic and serialised by the engine —
+  the same discipline ``providers/usage_cache.py`` and ``auth.db`` use.
+
+- **A pure accelerator, never a dependency.** Every disk and thread operation
+  is exception-safe: a read-only home directory, a locked file, or a full
+  disk degrades to "no analytics", never to a broken session.
+"""
+
+from __future__ import annotations
+
+from local_operator.analytics.model import (
+    COMPONENT_KEYS,
+    COMPONENT_LABELS,
+    CallSnapshot,
+    UsageAggregate,
+    apportion_components,
+    snapshot_component_chars,
+    split_system_prompt,
+)
+from local_operator.analytics.recorder import (
+    AnalyticsRecorder,
+    get_recorder,
+    record_call,
+    reset_recorder_for_test,
+)
+from local_operator.analytics.store import AnalyticsStore, default_db_path
+
+__all__ = [
+    "COMPONENT_KEYS",
+    "COMPONENT_LABELS",
+    "CallSnapshot",
+    "UsageAggregate",
+    "apportion_components",
+    "snapshot_component_chars",
+    "split_system_prompt",
+    "AnalyticsRecorder",
+    "get_recorder",
+    "record_call",
+    "reset_recorder_for_test",
+    "AnalyticsStore",
+    "default_db_path",
+]

--- a/local_operator/analytics/model.py
+++ b/local_operator/analytics/model.py
@@ -161,9 +161,15 @@ class CallSnapshot:
 def snapshot_component_chars(request: Any) -> dict[str, int]:
     """Measure each context component's character length from a ChatRequest.
 
-    Runs on the event loop, so it only READS lengths — no tokenising, no
-    copying message bodies. Benchmarked well under 1 ms on a 340k-token
-    context (four blocks, 30 tools, 120 messages).
+    Runs on the event loop, so it does the least work that still measures the
+    right thing: string-length reads for the prompt blocks and messages (no
+    tokenising, no copying message bodies), plus one compact ``json.dumps`` per
+    tool for the schema size (review A3 — this is real work that grows with
+    tool count, not a bare length read, but it is the only honest proxy for
+    what a provider serialises for a tool and it is bounded and one-shot).
+    Benchmarked at 0.02 ms (small) to 0.34 ms (a 291k-token context, 60 tools,
+    200 messages) — and it runs AFTER the response stream is consumed, never on
+    the path the user is waiting on, so even the worst case is imperceptible.
 
     ``tool_schemas`` mirrors what a provider serialises beside the prompt: the
     tool name, description, and compact JSON of its parameters. It is counted
@@ -272,15 +278,23 @@ class UsageAggregate:
 
     @property
     def total_tokens(self) -> int:
-        """Every token the providers billed: input (incl. cache) + output.
+        """Every token the providers billed: full input context + output.
 
-        ``input_tokens`` here is the provider's own input number. Cache reads
-        and writes are reported separately because providers disagree on
-        whether ``input_tokens`` already includes them; ``context_tokens`` is
-        the normalised full-context size and is the right denominator for the
-        component split, so it is kept distinct from this headline total.
+        ``context_tokens`` — not ``input_tokens`` — is the input half, because
+        providers disagree on whether ``input_tokens`` already counts cache.
+        Anthropic (this agent's primary provider) reports ``input_tokens``
+        EXCLUDING cache reads/writes, so ``input_tokens + output_tokens`` would
+        undercount a cached turn by the entire cache volume — usually the bulk
+        of it (review A1). ``context_tokens`` is normalised upstream to the full
+        input actually read (``input + cache_read + cache_write`` on Anthropic,
+        ``== input`` on OpenAI where input already includes cache), so it is the
+        one field that means "everything the provider read" on every provider.
+
+        A call the provider gave no context total for still reports its output;
+        its input simply reads as 0 here, which is honest — an unknown input is
+        not a zero-token turn, but it is the only number we can stand behind.
         """
-        return self.input_tokens + self.output_tokens
+        return self.context_tokens + self.output_tokens
 
     @property
     def cache_hit_rate(self) -> float | None:

--- a/local_operator/analytics/model.py
+++ b/local_operator/analytics/model.py
@@ -1,0 +1,318 @@
+"""The analytics data model: what a call contributes and how it is broken down.
+
+Two kinds of number live here and they must never be conflated:
+
+1. **Authoritative provider counts.** ``input_tokens``, ``output_tokens``,
+   ``cache_read_tokens``, ``cache_write_tokens`` and ``reasoning_tokens`` come
+   straight off the wire (:class:`local_operator.harness.types.Usage`). Cache
+   rates and the thinking/generation split are computed from these and are
+   exact.
+
+2. **Estimated component attribution.** The provider reports ONE input total,
+   not a per-component breakdown, so the split across the system prompt, the
+   operator's custom instructions, the tool inventory, tool schemas, the
+   environment block, loaded knowledge, the conversation, and tool results is
+   an *estimate*: each component's share of the authoritative context-token
+   total, proportional to its character length. It is labelled as an estimate
+   everywhere it surfaces. Char length rather than a re-tokenisation because
+   the ratio is what matters and a proportional split of the real total is
+   both cheaper and more honest than tokenising each fragment and hoping the
+   sum matches what the provider billed.
+
+The apportionment runs on a *snapshot* of character lengths taken on the event
+loop (the transcript mutates after the call), but the arithmetic — and every
+tokeniser touch — happens on the recorder's background thread.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+from typing import Any, Mapping
+
+# ---------------------------------------------------------------------------
+# Component taxonomy
+# ---------------------------------------------------------------------------
+
+#: The context components analytics attributes input tokens to, in the order a
+#: report should present them. Stored as explicit columns in the rollup table,
+#: so ADDING one is a schema migration (see ``store._SCHEMA``); the key strings
+#: are therefore a stable contract, not a display concern.
+#:
+#: Why these boundaries and not finer ones: they are exactly the seams that are
+#: RECOVERABLE from the wire ``ChatRequest`` without the session having to hand
+#: the recorder a parallel structure. ``custom_instructions`` is the operator's
+#: ``system_prompt.md`` PLUS any selected agent/team profile prompt — the
+#: harness appends the profile inside the ``<user_instructions>`` span
+#: (``prompts_api.build_system_blocks``), so on the wire they are one tagged
+#: region and splitting them further would be a guess. ``system_prompt`` is the
+#: packaged persona plus repo guidance (AGENTS.md/CLAUDE.md), which share block
+#: 0's stable head with the persona and carry no wire delimiter of their own.
+COMPONENT_KEYS: tuple[str, ...] = (
+    "system_prompt",
+    "custom_instructions",
+    "tool_inventory",
+    "tool_schemas",
+    "environment",
+    "knowledge",
+    "conversation",
+    "tool_results",
+)
+
+#: Human labels for each component key, for the ``/analytics /usage`` screen.
+COMPONENT_LABELS: dict[str, str] = {
+    "system_prompt": "System prompt",
+    "custom_instructions": "Custom instructions (agents/teams)",
+    "tool_inventory": "Tool inventory",
+    "tool_schemas": "Tool schemas",
+    "environment": "Environment",
+    "knowledge": "Knowledge / skills",
+    "conversation": "Conversation",
+    "tool_results": "Tool results",
+}
+
+#: Marks the operator's custom-instructions section inside system block 0. Kept
+#: in sync with ``prompts_api.build_system_blocks``: the header text is the
+#: seam analytics uses to separate the operator's standing instructions (and
+#: the agent/team profile appended to them) from the packaged persona above.
+_CUSTOM_INSTRUCTIONS_HEADER = "## User's custom instructions"
+
+
+def split_system_prompt(block0: str) -> tuple[int, int]:
+    """Split system block 0 into ``(system_prompt_chars, custom_instr_chars)``.
+
+    Block 0 is the byte-stable head: packaged persona, then optional repo
+    guidance, then — when the operator has any — a ``## User's custom
+    instructions`` section wrapping ``<user_instructions>…</user_instructions>``
+    (see ``prompts_api.build_system_blocks``). The header is the only seam that
+    survives onto the wire, so everything from it onward is attributed to
+    ``custom_instructions`` (the operator prompt plus any agent/team profile),
+    and everything before it to ``system_prompt`` (persona + repo guidance).
+
+    Best-effort: a block with no custom section attributes the whole thing to
+    ``system_prompt``, which is exactly right — there were no custom
+    instructions to separate.
+    """
+    if not block0:
+        return 0, 0
+    idx = block0.find(_CUSTOM_INSTRUCTIONS_HEADER)
+    if idx < 0:
+        return len(block0), 0
+    return idx, len(block0) - idx
+
+
+def _content_chars(message: Any) -> int:
+    """Total character length of a message's text content.
+
+    Images are counted as a flat proxy so an image-heavy turn does not read as
+    near-zero input: they cost real context tokens the provider billed, and
+    leaving them at zero would push their share onto text components. The proxy
+    matches ``compaction.tokens.IMAGE_TOKEN_ESTIMATE`` scaled back to chars so
+    the two estimators tell the same story.
+    """
+    total = 0
+    content = getattr(message, "content", None) or []
+    for part in content:
+        text = getattr(part, "text", None)
+        if isinstance(text, str):
+            total += len(text)
+            continue
+        # Non-text (image) block: a flat char proxy (~4 chars/token *
+        # IMAGE_TOKEN_ESTIMATE). Kept local rather than imported to avoid
+        # pulling the tokeniser module onto this hot snapshot path.
+        if getattr(part, "type", "") == "image":
+            total += 4 * 1200
+    return total
+
+
+@dataclass(frozen=True)
+class CallSnapshot:
+    """One provider call's contribution, captured on the event loop.
+
+    Everything here is a scalar or a small dict of scalars: the snapshot is
+    handed to a background thread, so it must not reference the live
+    ``ChatRequest`` (whose messages the transcript mutates after the call) or
+    any object with a lock. ``component_chars`` is the per-component character
+    length measured from the request at call time; the recorder turns it into
+    an estimated token split against the authoritative context total.
+    """
+
+    ts_ms: int
+    session_id: str
+    provider: str
+    model_id: str
+    # Authoritative provider counts (0 when the provider reported none).
+    input_tokens: int
+    output_tokens: int
+    cache_read_tokens: int
+    cache_write_tokens: int
+    reasoning_tokens: int
+    context_tokens: int
+    # Per-component character lengths (COMPONENT_KEYS ⊆ keys). Estimated token
+    # attribution is derived from these against ``context_tokens``.
+    component_chars: dict[str, int] = field(default_factory=dict)
+    # Whether the model actually replied (a failed/aborted call still cost
+    # input tokens and is worth recording, but is counted separately so a
+    # provider-outage session does not look like normal spend).
+    ok: bool = True
+
+
+def snapshot_component_chars(request: Any) -> dict[str, int]:
+    """Measure each context component's character length from a ChatRequest.
+
+    Runs on the event loop, so it only READS lengths — no tokenising, no
+    copying message bodies. Benchmarked well under 1 ms on a 340k-token
+    context (four blocks, 30 tools, 120 messages).
+
+    ``tool_schemas`` mirrors what a provider serialises beside the prompt: the
+    tool name, description, and compact JSON of its parameters. It is counted
+    separately from ``tool_inventory`` (the prose list in block 1) because the
+    two are billed as different regions and a 126-tool MCP server's schema cost
+    is exactly the kind of invisible regression this feature exists to expose.
+    """
+    blocks: list[str] = list(getattr(request, "system_blocks", []) or [])
+    while len(blocks) < 4:
+        blocks.append("")
+    system_prompt_chars, custom_instr_chars = split_system_prompt(blocks[0])
+
+    tool_schema_chars = 0
+    for tool in getattr(request, "tools", []) or []:
+        name = getattr(tool, "name", "") or ""
+        description = getattr(tool, "description", "") or ""
+        params = getattr(tool, "parameters", {}) or {}
+        try:
+            params_json = json.dumps(params, sort_keys=True, separators=(",", ":"))
+        except (TypeError, ValueError):
+            params_json = ""
+        tool_schema_chars += len(name) + len(description) + len(params_json)
+
+    conversation_chars = 0
+    tool_result_chars = 0
+    for message in getattr(request, "messages", []) or []:
+        role = getattr(message, "role", "")
+        chars = _content_chars(message)
+        if role == "tool":
+            tool_result_chars += chars
+        else:
+            conversation_chars += chars
+
+    return {
+        "system_prompt": system_prompt_chars,
+        "custom_instructions": custom_instr_chars,
+        "tool_inventory": len(blocks[1]),
+        "tool_schemas": tool_schema_chars,
+        "environment": len(blocks[2]),
+        "knowledge": len(blocks[3]),
+        "conversation": conversation_chars,
+        "tool_results": tool_result_chars,
+    }
+
+
+def apportion_components(component_chars: Mapping[str, int], context_tokens: int) -> dict[str, int]:
+    """Split ``context_tokens`` across components proportionally to char length.
+
+    The provider bills one input total; this hands each component its share of
+    that authoritative number, so the estimates SUM to the real context total
+    (largest-remainder rounding, no drift). When the provider reported no
+    context total (a failed call, or a provider that omits usage), every
+    component is 0 — an honest "unknown" rather than a fabricated split.
+    """
+    keys = list(COMPONENT_KEYS)
+    total_chars = sum(max(0, int(component_chars.get(k, 0))) for k in keys)
+    if context_tokens <= 0 or total_chars <= 0:
+        return {k: 0 for k in keys}
+
+    # Largest-remainder apportionment: floor each share, then hand the leftover
+    # tokens to the components with the largest fractional parts, so the split
+    # is exact (sums to context_tokens) and stable rather than double-counting
+    # or losing a few tokens to rounding on every call.
+    exact: list[tuple[str, float]] = []
+    for key in keys:
+        share = max(0, int(component_chars.get(key, 0))) / total_chars * context_tokens
+        exact.append((key, share))
+    floored = {key: int(value) for key, value in exact}
+    remainder = context_tokens - sum(floored.values())
+    if remainder > 0:
+        # Order by descending fractional part; ties broken by key for
+        # determinism (two runs of the same snapshot must produce the same
+        # split).
+        by_frac = sorted(exact, key=lambda kv: (-(kv[1] - int(kv[1])), kv[0]))
+        for key, _ in by_frac[:remainder]:
+            floored[key] += 1
+    return floored
+
+
+@dataclass
+class UsageAggregate:
+    """A summed view over a set of rollup rows, for one report scope.
+
+    Produced by :meth:`AnalyticsStore.aggregate`. ``by_provider`` and
+    ``by_session`` map a name to its own :class:`UsageAggregate` (without the
+    nested maps, one level deep) so the ``/analytics /usage`` screen can show
+    totals, a per-provider table, and a per-session table from one query.
+    """
+
+    calls: int = 0
+    ok_calls: int = 0
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_read_tokens: int = 0
+    cache_write_tokens: int = 0
+    reasoning_tokens: int = 0
+    context_tokens: int = 0
+    components: dict[str, int] = field(default_factory=lambda: {k: 0 for k in COMPONENT_KEYS})
+    by_provider: dict[str, "UsageAggregate"] = field(default_factory=dict)
+    by_session: dict[str, "UsageAggregate"] = field(default_factory=dict)
+
+    @property
+    def generation_tokens(self) -> int:
+        """Output tokens that were visible generation, not hidden thinking."""
+        return max(0, self.output_tokens - self.reasoning_tokens)
+
+    @property
+    def total_tokens(self) -> int:
+        """Every token the providers billed: input (incl. cache) + output.
+
+        ``input_tokens`` here is the provider's own input number. Cache reads
+        and writes are reported separately because providers disagree on
+        whether ``input_tokens`` already includes them; ``context_tokens`` is
+        the normalised full-context size and is the right denominator for the
+        component split, so it is kept distinct from this headline total.
+        """
+        return self.input_tokens + self.output_tokens
+
+    @property
+    def cache_hit_rate(self) -> float | None:
+        """Fraction of read context served from cache, or None when unknowable.
+
+        Denominator is ``cache_read + context`` normalised: for providers whose
+        ``input_tokens`` excludes cache (Anthropic) ``context_tokens`` already
+        sums the three, and for providers whose input includes cache (OpenAI)
+        ``context_tokens`` equals input, so ``cache_read / context_tokens`` is
+        the honest hit rate in both worlds.
+        """
+        if self.context_tokens <= 0:
+            return None
+        return min(1.0, self.cache_read_tokens / self.context_tokens)
+
+
+def usage_component_chars_json(chars: Mapping[str, int]) -> str:
+    """Serialise a component-char map compactly (for a per-call debug row)."""
+    return json.dumps({k: int(chars.get(k, 0)) for k in COMPONENT_KEYS}, separators=(",", ":"))
+
+
+_WS_RE = re.compile(r"\s+")
+
+
+def short_session_label(session_id: str, name: str = "") -> str:
+    """A compact label for a session in the per-session table.
+
+    Prefers a human name when one exists, falling back to the 12-hex id. Kept
+    here so the store and the TUI agree on how a session is named without the
+    store importing a widget.
+    """
+    name = _WS_RE.sub(" ", (name or "").strip())
+    if name:
+        return name[:32]
+    return (session_id or "unknown")[:12]

--- a/local_operator/analytics/recorder.py
+++ b/local_operator/analytics/recorder.py
@@ -1,0 +1,323 @@
+"""The non-blocking recorder: turns a call into a queued sample, off the loop.
+
+This is the one object the rest of the harness touches. A session's stream
+wrapper builds a :class:`CallSnapshot` on the event loop (cheap, see
+``model.snapshot_component_chars``) and hands it to :func:`record_call`; that
+call does a single ``queue.put_nowait`` and returns. A background daemon thread
+drains the queue in batches and writes them to the shared SQLite store.
+
+Why a thread and not an asyncio task. The write is blocking SQLite I/O, and the
+sessions that produce samples run on the event loop that must never block on
+disk. A daemon thread also survives across the many short-lived event loops a
+process opens (each subagent run, each reload) without being re-created, and it
+is shared by every session in the process, so N sessions still write through
+one queue and one connection.
+
+Why best-effort with a bounded queue. Accuracy matters, but never at the cost
+of a stalled session. The queue is large enough that a normal burst never
+fills it, and if it somehow does the sample is DROPPED (counted, logged once)
+rather than applying back-pressure to a provider call. On a healthy machine the
+drop count stays zero; when it does not, the log says analytics is losing
+samples rather than the session mysteriously slowing down.
+"""
+
+from __future__ import annotations
+
+import logging
+import queue
+import threading
+import time
+
+from local_operator.analytics.model import CallSnapshot
+from local_operator.analytics.store import AnalyticsStore
+
+logger = logging.getLogger("local_operator.analytics.recorder")
+
+
+class _NameTask:
+    """A session-name upsert queued for the writer thread.
+
+    Routed through the SAME queue and connection as call samples rather than a
+    second thread. Two threads opening their first connection to a
+    freshly-created database at the same instant is a real race — observed to
+    leave the writer's connection unable to see its own commits — so all writes
+    funnel through one writer. Naming is infrequent, so sharing the queue costs
+    nothing and removes the race by construction.
+    """
+
+    __slots__ = ("session_id", "name")
+
+    def __init__(self, session_id: str, name: str) -> None:
+        self.session_id = session_id
+        self.name = name
+
+
+#: Upper bound on queued-but-unwritten samples. A provider call takes seconds
+#: and a batch write takes milliseconds, so this only fills if the disk is
+#: wedged — at which point dropping is the correct behaviour. Sized for a
+#: worst-case burst of many parallel sessions all ending turns at once.
+_QUEUE_MAXSIZE = 4096
+
+#: How long the writer waits to accumulate a batch before flushing. Short
+#: enough that a report opened right after a turn sees it; long enough that a
+#: tool loop's rapid calls coalesce into one transaction.
+_FLUSH_INTERVAL_S = 0.5
+
+#: Prune the retention window at most this often (seconds). Pruning is a DELETE
+#: over an indexed column — cheap — but there is no reason to run it on every
+#: flush; once an hour keeps the ledger bounded without touching the hot path.
+_PRUNE_INTERVAL_S = 3600.0
+
+
+class AnalyticsRecorder:
+    """Owns the queue, the writer thread, and the store.
+
+    One instance per process (see :func:`get_recorder`). Construction does NOT
+    start the thread or open the database — the first :meth:`record` does, so a
+    process that never makes a provider call pays nothing.
+    """
+
+    def __init__(self, store: AnalyticsStore | None = None) -> None:
+        self._store = store if store is not None else AnalyticsStore()
+        self._queue: "queue.Queue[CallSnapshot | _NameTask | None]" = queue.Queue(
+            maxsize=_QUEUE_MAXSIZE
+        )
+        self._thread: threading.Thread | None = None
+        self._lock = threading.Lock()
+        self._dropped = 0
+        self._last_prune = 0.0
+        self._closed = False
+        #: Monotonic counters used ONLY by ``flush_for_test`` as a commit
+        #: barrier: ``_enqueued`` counts accepted samples, ``_committed``
+        #: counts samples the writer has actually persisted. Real sessions
+        #: never read these — they are how a test waits for a durable write
+        #: without a fixed sleep that races the writer thread.
+        self._enqueued = 0
+        self._committed = 0
+
+    # -- lifecycle -----------------------------------------------------------
+    def _ensure_thread(self) -> None:
+        if self._thread is not None or self._closed:
+            return
+        with self._lock:
+            if self._thread is not None or self._closed:
+                return
+            thread = threading.Thread(
+                target=self._run,
+                name="lo-analytics-writer",
+                daemon=True,
+            )
+            self._thread = thread
+            thread.start()
+
+    def _run(self) -> None:
+        """Drain the queue on ONE thread until a sentinel arrives.
+
+        Call samples are batched into one transaction; name tasks are applied
+        as they come (rare). Handling both here — rather than a second thread
+        for names — is what keeps a single write connection and avoids the
+        first-connection race two writers hit on a fresh database.
+        """
+        while True:
+            batch: list[CallSnapshot] = []
+            names: list[_NameTask] = []
+            try:
+                item = self._queue.get(timeout=_FLUSH_INTERVAL_S)
+            except queue.Empty:
+                self._maybe_prune()
+                continue
+            if item is None:  # sentinel: flush and exit
+                self._flush(batch, names)
+                self._queue.task_done()
+                return
+            self._classify(item, batch, names)
+            self._queue.task_done()
+            # Opportunistically drain whatever else is already queued so a
+            # burst becomes one transaction.
+            while len(batch) < 256:
+                try:
+                    item = self._queue.get_nowait()
+                except queue.Empty:
+                    break
+                if item is None:
+                    self._flush(batch, names)
+                    self._queue.task_done()
+                    return
+                self._classify(item, batch, names)
+                self._queue.task_done()
+            self._flush(batch, names)
+            self._maybe_prune()
+
+    @staticmethod
+    def _classify(
+        item: "CallSnapshot | _NameTask",
+        batch: list[CallSnapshot],
+        names: list["_NameTask"],
+    ) -> None:
+        if isinstance(item, _NameTask):
+            names.append(item)
+        else:
+            batch.append(item)
+
+    def _flush(self, batch: list[CallSnapshot], names: list["_NameTask"]) -> None:
+        if names:
+            for task in names:
+                try:
+                    self._store.upsert_session_name(task.session_id, task.name)
+                except Exception:  # noqa: BLE001 — a bad name must not kill the writer
+                    logger.debug("analytics: name upsert failed", exc_info=True)
+        if not batch:
+            return
+        try:
+            self._store.record_batch(batch)
+        except Exception:  # noqa: BLE001 — writer must never die on a bad batch
+            logger.debug("analytics: flush failed", exc_info=True)
+        finally:
+            # Advance the commit barrier whether or not the write succeeded: a
+            # dropped batch still "settled", and a test waiting on this count
+            # must not hang because a batch failed. Counted in the finally so
+            # the barrier tracks attempts, matching ``_enqueued``.
+            self._committed += len(batch)
+
+    def _maybe_prune(self) -> None:
+        now = time.monotonic()
+        if now - self._last_prune < _PRUNE_INTERVAL_S:
+            return
+        self._last_prune = now
+        try:
+            self._store.prune()
+        except Exception:  # noqa: BLE001
+            logger.debug("analytics: prune failed", exc_info=True)
+
+    # -- API -----------------------------------------------------------------
+    def record(self, snapshot: CallSnapshot) -> None:
+        """Enqueue a call sample. Non-blocking; drops on a full queue.
+
+        This is the ONLY method a provider path calls, and it does the least
+        possible work: a bounded ``put_nowait``. It never raises — a recorder
+        that cannot accept a sample must not turn into a failed provider call.
+        """
+        if self._closed:
+            return
+        self._ensure_thread()
+        try:
+            self._queue.put_nowait(snapshot)
+            self._enqueued += 1
+        except queue.Full:
+            # Count and log ONCE per power-of-two so a wedged disk says so
+            # without spamming, and never block the caller.
+            self._dropped += 1
+            if self._dropped & (self._dropped - 1) == 0:
+                logger.warning("analytics: queue full, dropped %d samples", self._dropped)
+        except Exception:  # noqa: BLE001 — recording is best-effort
+            logger.debug("analytics: enqueue failed", exc_info=True)
+
+    def note_session_name(self, session_id: str, name: str) -> None:
+        """Best-effort: record a session's human name off the hot path.
+
+        Enqueues a name task the writer thread applies on its own connection,
+        so the caller (a naming callback on the event loop) never touches
+        SQLite and there is only ever ONE thread writing to the database. Like
+        :meth:`record`, non-blocking and never raising: a full queue drops the
+        name rather than stalling the session.
+        """
+        if self._closed or not session_id or not name:
+            return
+        self._ensure_thread()
+        try:
+            self._queue.put_nowait(_NameTask(session_id, name))
+        except queue.Full:
+            logger.debug("analytics: queue full, dropped a session name")
+        except Exception:  # noqa: BLE001 — naming is best-effort
+            logger.debug("analytics: name enqueue failed", exc_info=True)
+
+    @property
+    def dropped(self) -> int:
+        """How many samples were dropped for a full queue (0 on a healthy run)."""
+        return self._dropped
+
+    def flush_for_test(self, timeout: float = 5.0) -> None:
+        """Block until the queue drains. TEST ONLY — never called on a session.
+
+        Real sessions never wait for the writer; this exists so a test can
+        assert a recorded call reached the store deterministically.
+        """
+        self._ensure_thread()
+        deadline = time.monotonic() + timeout
+        # First: the commit barrier catches up to enqueued SNAPSHOTS. This is a
+        # DURABLE barrier (the writer advances ``_committed`` only after a batch
+        # write returns), so it cannot return before the row is on disk the way
+        # a bare ``queue.empty()`` check can — the queue empties the instant the
+        # writer dequeues, before it commits.
+        target = self._enqueued
+        while self._committed < target and time.monotonic() < deadline:
+            time.sleep(0.005)
+        # Then: drain any remaining items (name tasks carry no barrier of their
+        # own, and a name enqueued after the last snapshot rides a later batch).
+        # ``join`` waits for every ``task_done``, which the writer calls only
+        # after processing the item, so the name upsert has run when this
+        # returns.
+        while not self._queue.empty() and time.monotonic() < deadline:
+            time.sleep(0.005)
+        # A final short settle so an item dequeued-but-not-yet-committed lands.
+        time.sleep(0.05)
+
+    def close(self, timeout: float = 2.0) -> None:
+        """Stop the writer and close the store (process teardown / tests)."""
+        if self._closed:
+            return
+        self._closed = True
+        if self._thread is not None:
+            try:
+                self._queue.put_nowait(None)
+            except queue.Full:
+                pass
+            self._thread.join(timeout=timeout)
+            self._thread = None
+        self._store.close()
+
+
+# ---------------------------------------------------------------------------
+# Process-wide singleton
+# ---------------------------------------------------------------------------
+
+_recorder: AnalyticsRecorder | None = None
+_recorder_lock = threading.Lock()
+
+
+def get_recorder() -> AnalyticsRecorder:
+    """The process's shared recorder, created on first use."""
+    global _recorder
+    if _recorder is not None:
+        return _recorder
+    with _recorder_lock:
+        if _recorder is None:
+            _recorder = AnalyticsRecorder()
+    return _recorder
+
+
+def record_call(snapshot: CallSnapshot) -> None:
+    """Module-level convenience: enqueue a sample on the shared recorder.
+
+    The provider path calls THIS rather than reaching for the singleton, so the
+    hot path is one function call with no attribute lookups on a lock.
+    """
+    try:
+        get_recorder().record(snapshot)
+    except Exception:  # noqa: BLE001 — recording is never allowed to raise
+        logger.debug("analytics: record_call failed", exc_info=True)
+
+
+def reset_recorder_for_test(store: AnalyticsStore | None = None) -> AnalyticsRecorder:
+    """Replace the singleton with a fresh recorder. TEST ONLY.
+
+    Lets a test point the recorder at a tmp-path store and get deterministic,
+    isolated behaviour. Closes any existing recorder first so its thread and
+    connection do not leak between tests.
+    """
+    global _recorder
+    with _recorder_lock:
+        if _recorder is not None:
+            _recorder.close()
+        _recorder = AnalyticsRecorder(store=store)
+    return _recorder

--- a/local_operator/analytics/store.py
+++ b/local_operator/analytics/store.py
@@ -1,0 +1,473 @@
+"""SQLite-backed, parallel-safe store for token-consumption analytics.
+
+Shape of the data. Every provider call across every ``lop`` session appends
+one row to ``calls``. That table is the raw ledger; it is bounded by a rolling
+retention window (old rows are pruned) so a machine that runs for months does
+not accumulate an unbounded database. A per-call row is small — a dozen
+integers and two short strings — so even a busy week is a few megabytes.
+
+Why one shared database and not per-session files. Several sessions run at
+once (one per cmux workspace), and the whole point of the feature is a
+*universal* view. WAL mode plus a busy timeout makes concurrent writes from
+different processes atomic and serialised by SQLite itself — the same
+discipline ``providers/usage_cache.py`` and ``auth.db`` already rely on — so
+"parallel safe" is a property of the engine, not something this module has to
+reinvent with file locks.
+
+Why aggregation is a query, not a running counter. Keeping live totals would
+mean a read-modify-write on every call and a lock contended by every session.
+Instead each call is an append (no contention beyond the WAL) and the
+``/analytics`` screen runs a ``GROUP BY`` when it opens. On a bounded ledger
+that scan is milliseconds, and it is paid only when someone actually looks.
+
+Everything degrades silently: a store that cannot open is a no-op recorder and
+an empty report, never an exception on a session's path.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sqlite3
+import threading
+import time
+from pathlib import Path
+from typing import Any, Iterable, Sequence
+
+from local_operator.analytics.model import (
+    COMPONENT_KEYS,
+    CallSnapshot,
+    UsageAggregate,
+    apportion_components,
+)
+from local_operator.paths import config_dir
+
+logger = logging.getLogger("local_operator.analytics.store")
+
+#: Default retention: keep 90 days of per-call rows. Long enough to see trends
+#: ("where did usage go this month"), short enough to bound the file. Pruning
+#: runs opportunistically on write, not on a timer.
+DEFAULT_RETENTION_DAYS = 90
+
+#: Bounded retry for a write that loses the lock race past ``busy_timeout``.
+#: Runs on the background writer thread, so waiting a moment is free to the
+#: session and buys accuracy under many-parallel-session contention.
+_WRITE_RETRIES = 4
+_WRITE_RETRY_BACKOFF_S = 0.05
+
+#: One component column per COMPONENT_KEYS entry, holding the ESTIMATED token
+#: attribution for that call. Storing the apportioned tokens (not just chars)
+#: means the aggregate query is a plain SUM with no per-row arithmetic, and the
+#: estimate a report shows is exactly the one recorded — reproducible after the
+#: fact. Adding a component is a migration: bump the schema and backfill 0.
+_COMPONENT_COLUMNS = ",\n  ".join(f"c_{key} INTEGER NOT NULL DEFAULT 0" for key in COMPONENT_KEYS)
+
+_SCHEMA = f"""
+CREATE TABLE IF NOT EXISTS calls (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  ts_ms INTEGER NOT NULL,
+  session_id TEXT NOT NULL,
+  provider TEXT NOT NULL,
+  model_id TEXT NOT NULL,
+  ok INTEGER NOT NULL DEFAULT 1,
+  input_tokens INTEGER NOT NULL DEFAULT 0,
+  output_tokens INTEGER NOT NULL DEFAULT 0,
+  cache_read_tokens INTEGER NOT NULL DEFAULT 0,
+  cache_write_tokens INTEGER NOT NULL DEFAULT 0,
+  reasoning_tokens INTEGER NOT NULL DEFAULT 0,
+  context_tokens INTEGER NOT NULL DEFAULT 0,
+  {_COMPONENT_COLUMNS}
+);
+CREATE INDEX IF NOT EXISTS idx_calls_ts ON calls(ts_ms);
+CREATE INDEX IF NOT EXISTS idx_calls_session ON calls(session_id);
+CREATE INDEX IF NOT EXISTS idx_calls_provider ON calls(provider);
+
+-- Human-readable session names, so the per-session table can show a title
+-- rather than a 12-hex id. Upserted opportunistically; absence just means the
+-- report falls back to the id, never an error.
+CREATE TABLE IF NOT EXISTS session_names (
+  session_id TEXT PRIMARY KEY,
+  name TEXT NOT NULL DEFAULT '',
+  updated_at_ms INTEGER NOT NULL
+);
+"""
+
+_CALL_COLUMNS = (
+    "ts_ms",
+    "session_id",
+    "provider",
+    "model_id",
+    "ok",
+    "input_tokens",
+    "output_tokens",
+    "cache_read_tokens",
+    "cache_write_tokens",
+    "reasoning_tokens",
+    "context_tokens",
+    *(f"c_{key}" for key in COMPONENT_KEYS),
+)
+
+_INSERT_SQL = (
+    f"INSERT INTO calls ({', '.join(_CALL_COLUMNS)}) "
+    f"VALUES ({', '.join('?' for _ in _CALL_COLUMNS)})"
+)
+
+
+def default_db_path() -> Path:
+    """The shared analytics database, next to the other per-user stores."""
+    return config_dir() / "analytics.db"
+
+
+def _row_values(snapshot: CallSnapshot) -> tuple[Any, ...]:
+    """A snapshot as the positional tuple ``_INSERT_SQL`` expects.
+
+    The estimated component split is computed HERE, in the writer, against the
+    authoritative ``context_tokens`` — never on the event loop. A call the
+    provider gave no context total for stores 0s for every component, which
+    reads as "unknown" rather than a fabricated breakdown.
+    """
+    components = apportion_components(snapshot.component_chars, snapshot.context_tokens)
+    return (
+        snapshot.ts_ms,
+        snapshot.session_id,
+        snapshot.provider,
+        snapshot.model_id,
+        1 if snapshot.ok else 0,
+        snapshot.input_tokens,
+        snapshot.output_tokens,
+        snapshot.cache_read_tokens,
+        snapshot.cache_write_tokens,
+        snapshot.reasoning_tokens,
+        snapshot.context_tokens,
+        *(components[key] for key in COMPONENT_KEYS),
+    )
+
+
+class AnalyticsStore:
+    """Append-only ledger of provider calls; every method is exception-safe."""
+
+    def __init__(
+        self,
+        db_path: str | Path | None = None,
+        *,
+        retention_days: int = DEFAULT_RETENTION_DAYS,
+    ) -> None:
+        self._db_path = Path(db_path) if db_path is not None else default_db_path()
+        self._retention_ms = max(1, int(retention_days)) * 24 * 60 * 60 * 1000
+        #: One connection PER THREAD. SQLite connections are thread-bound, and
+        #: this store is touched from two threads by design: the recorder's
+        #: writer thread appends rows, and the event loop's thread reads the
+        #: aggregate when ``/analytics`` opens. WAL lets those coexist across
+        #: separate connections to the same file, so each thread gets its own
+        #: rather than sharing one (which raises ``ProgrammingError``) or
+        #: serialising every access behind a lock.
+        self._local = threading.local()
+        #: Set once opening fails, so a broken store stops retrying every call
+        #: (a read-only home directory should cost one log line, not one per
+        #: provider round trip for the life of the process). Shared across
+        #: threads: if the file cannot be opened at all, no thread should keep
+        #: trying.
+        self._broken = False
+        #: Guards the one-time schema creation so two threads opening their
+        #: first connections at once do not race on ``executescript``.
+        self._init_lock = threading.Lock()
+        self._initialized = False
+
+    # -- connection ----------------------------------------------------------
+    def _connect(self) -> sqlite3.Connection | None:
+        conn = getattr(self._local, "conn", None)
+        if conn is not None:
+            return conn
+        if self._broken:
+            return None
+        try:
+            self._db_path.parent.mkdir(parents=True, exist_ok=True)
+            # 0600 BEFORE sqlite opens it (same rule as auth.db / usage_cache):
+            # per-call rows carry session ids and model identifiers, and the
+            # connect-then-chmod pattern leaves a world-readable window.
+            if not self._db_path.exists():
+                fd = os.open(self._db_path, os.O_CREAT | os.O_WRONLY, 0o600)
+                os.close(fd)
+            conn = sqlite3.connect(str(self._db_path), timeout=5.0)
+            conn.execute("PRAGMA journal_mode=WAL")
+            conn.execute("PRAGMA synchronous=NORMAL")
+            conn.execute("PRAGMA busy_timeout=5000")
+            # Schema creation is idempotent (IF NOT EXISTS) but should run once,
+            # under a lock, so two threads opening their first connections
+            # simultaneously do not both executescript into the same file.
+            with self._init_lock:
+                conn.executescript(_SCHEMA)
+                conn.commit()
+                if not self._initialized:
+                    for path in (
+                        self._db_path,
+                        self._db_path.with_suffix(self._db_path.suffix + "-wal"),
+                        self._db_path.with_suffix(self._db_path.suffix + "-shm"),
+                    ):
+                        try:
+                            os.chmod(path, 0o600)
+                        except OSError:
+                            pass
+                    self._initialized = True
+            self._local.conn = conn
+            return conn
+        except Exception:  # noqa: BLE001 — store unavailable = analytics off
+            logger.debug("analytics: cannot open %s", self._db_path, exc_info=True)
+            self._broken = True
+            return None
+
+    def close(self) -> None:
+        """Close THIS thread's connection.
+
+        Per-thread by design (see ``_connect``): a thread closes only its own
+        handle. The writer thread's connection is closed when the recorder
+        shuts down and calls this from that thread; a reader's connection is
+        left to be reclaimed when its thread ends. SQLite forbids closing a
+        connection from another thread, so a cross-thread close would raise —
+        which is why this only touches the calling thread's handle.
+        """
+        conn = getattr(self._local, "conn", None)
+        if conn is not None:
+            try:
+                conn.close()
+            except Exception:  # noqa: BLE001
+                pass
+            self._local.conn = None
+
+    @staticmethod
+    def _now_ms() -> int:
+        return int(time.time() * 1000)
+
+    # -- writes --------------------------------------------------------------
+    def record_batch(self, snapshots: Sequence[CallSnapshot]) -> int:
+        """Insert a batch of calls in one transaction. Returns rows written.
+
+        Batched because the writer thread drains the queue in bursts: N
+        concurrent calls become one transaction and one fsync, not N.
+
+        Retried on ``SQLITE_BUSY``. This runs on the recorder's BACKGROUND
+        thread, never on a session's event loop, so a few hundred milliseconds
+        spent waiting out another process's write lock costs a session nothing
+        — and it is what makes the ledger accurate under the load this feature
+        is built for: several parallel ``lop`` sessions ending turns at once,
+        all writing to one file. ``busy_timeout`` already blocks inside SQLite
+        for up to 5s per attempt; the bounded retry on top covers the rare case
+        where a lock hand-off still surfaces as BUSY. Only a genuinely wedged
+        database (every attempt exhausted) drops the batch — best-effort to the
+        end, but accuracy first while the write stays cheap, exactly as asked.
+        """
+        if not snapshots:
+            return 0
+        conn = self._connect()
+        if conn is None:
+            return 0
+        rows = [_row_values(s) for s in snapshots]
+        for attempt in range(_WRITE_RETRIES):
+            try:
+                conn.executemany(_INSERT_SQL, rows)
+                conn.commit()
+                return len(snapshots)
+            except sqlite3.OperationalError as exc:
+                # "database is locked" / "database is busy": another writer holds
+                # the lock past our busy_timeout. Roll back and retry with a
+                # short backoff rather than dropping rows a slightly longer wait
+                # would have saved.
+                try:
+                    conn.rollback()
+                except Exception:  # noqa: BLE001
+                    pass
+                if "lock" not in str(exc).lower() and "busy" not in str(exc).lower():
+                    logger.debug("analytics: batch insert failed", exc_info=True)
+                    return 0
+                if attempt == _WRITE_RETRIES - 1:
+                    logger.debug("analytics: batch dropped after %d busy retries", _WRITE_RETRIES)
+                    return 0
+                time.sleep(_WRITE_RETRY_BACKOFF_S * (attempt + 1))
+            except Exception:  # noqa: BLE001 — a lost batch must not kill the writer
+                logger.debug("analytics: batch insert failed", exc_info=True)
+                try:
+                    conn.rollback()
+                except Exception:  # noqa: BLE001
+                    pass
+                return 0
+        return 0
+
+    def upsert_session_name(self, session_id: str, name: str) -> None:
+        """Record (or update) a session's human name for the per-session table."""
+        if not session_id:
+            return
+        conn = self._connect()
+        if conn is None:
+            return
+        try:
+            conn.execute(
+                "INSERT INTO session_names (session_id, name, updated_at_ms) "
+                "VALUES (?, ?, ?) ON CONFLICT(session_id) DO UPDATE SET "
+                "name=excluded.name, updated_at_ms=excluded.updated_at_ms",
+                (session_id, name or "", self._now_ms()),
+            )
+            conn.commit()
+        except Exception:  # noqa: BLE001
+            logger.debug("analytics: session name upsert failed", exc_info=True)
+
+    def prune(self, *, now_ms: int | None = None) -> int:
+        """Delete rows older than the retention window. Returns rows removed."""
+        conn = self._connect()
+        if conn is None:
+            return 0
+        cutoff = (now_ms if now_ms is not None else self._now_ms()) - self._retention_ms
+        try:
+            cur = conn.execute("DELETE FROM calls WHERE ts_ms < ?", (cutoff,))
+            conn.commit()
+            return cur.rowcount or 0
+        except Exception:  # noqa: BLE001
+            logger.debug("analytics: prune failed", exc_info=True)
+            return 0
+
+    def _read_connection(self) -> sqlite3.Connection | None:
+        """A FRESH, short-lived connection for a read, or None when unavailable.
+
+        Reads deliberately do not reuse the cached per-thread connection the
+        writes use. This store is written from a background thread and read
+        from the event-loop thread, and in WAL a long-lived reader connection
+        can hold a snapshot that predates the writer's latest commit — the
+        reader would then show stale (or empty) totals until it happened to
+        start a new read transaction. A fresh connection per ``aggregate`` call
+        always sees the newest committed state, and the read is infrequent (a
+        report opening, not a hot path), so the connect cost is irrelevant.
+
+        The file already exists by read time in every real path (a read only
+        matters once something has been written), but ``_connect`` is called
+        first so a first-ever read still creates the schema rather than raising
+        on a missing table.
+        """
+        if self._connect() is None:
+            return None
+        try:
+            conn = sqlite3.connect(str(self._db_path), timeout=5.0)
+            conn.execute("PRAGMA busy_timeout=5000")
+            return conn
+        except Exception:  # noqa: BLE001 — a read that cannot open is empty
+            logger.debug("analytics: cannot open read connection", exc_info=True)
+            return None
+
+    # -- reads ---------------------------------------------------------------
+    def _session_names(self, conn: sqlite3.Connection) -> dict[str, str]:
+        try:
+            rows = conn.execute("SELECT session_id, name FROM session_names").fetchall()
+        except Exception:  # noqa: BLE001
+            return {}
+        return {str(sid): str(name) for sid, name in rows if name}
+
+    def aggregate(
+        self,
+        *,
+        since_ms: int | None = None,
+        until_ms: int | None = None,
+        session_id: str | None = None,
+    ) -> UsageAggregate:
+        """Sum the ledger into one :class:`UsageAggregate`.
+
+        Optionally scoped to a time window and/or a single session. The result
+        carries flat totals, a per-provider breakdown, and a per-session
+        breakdown (each a one-level :class:`UsageAggregate`) so the report can
+        render every table it needs from a single call. An unopenable or empty
+        store returns a zeroed aggregate, which the screen renders as "no data
+        yet" rather than an error.
+        """
+        conn = self._read_connection()
+        if conn is None:
+            return UsageAggregate()
+
+        where: list[str] = []
+        params: list[Any] = []
+        if since_ms is not None:
+            where.append("ts_ms >= ?")
+            params.append(int(since_ms))
+        if until_ms is not None:
+            where.append("ts_ms < ?")
+            params.append(int(until_ms))
+        if session_id is not None:
+            where.append("session_id = ?")
+            params.append(session_id)
+        clause = (" WHERE " + " AND ".join(where)) if where else ""
+
+        component_sum = ", ".join(f"SUM(c_{key})" for key in COMPONENT_KEYS)
+        base_cols = (
+            "COUNT(*), SUM(ok), SUM(input_tokens), SUM(output_tokens), "
+            "SUM(cache_read_tokens), SUM(cache_write_tokens), "
+            "SUM(reasoning_tokens), SUM(context_tokens)"
+        )
+        try:
+            top = conn.execute(
+                f"SELECT {base_cols}, {component_sum} FROM calls{clause}", params
+            ).fetchone()
+            per_provider = conn.execute(
+                f"SELECT provider, {base_cols}, {component_sum} FROM calls{clause} "
+                "GROUP BY provider",
+                params,
+            ).fetchall()
+            per_session = conn.execute(
+                f"SELECT session_id, {base_cols}, {component_sum} FROM calls{clause} "
+                "GROUP BY session_id",
+                params,
+            ).fetchall()
+            names = self._session_names(conn)
+        except Exception:  # noqa: BLE001 — a report must never raise
+            logger.debug("analytics: aggregate query failed", exc_info=True)
+            return UsageAggregate()
+        finally:
+            # The read connection is short-lived (see ``_read_connection``);
+            # close it so a report open does not leak a handle per call.
+            try:
+                conn.close()
+            except Exception:  # noqa: BLE001
+                pass
+
+        result = _aggregate_from_row(top)
+        result.by_provider = {
+            str(row[0]): _aggregate_from_row(row[1:]) for row in per_provider if row[0]
+        }
+        for row in per_session:
+            sid = str(row[0])
+            agg = _aggregate_from_row(row[1:])
+            # Stash the human name (when known) on the id key's aggregate via a
+            # side map the caller reads; kept on the object would widen the
+            # dataclass for one table, so the report reads names from here.
+            result.by_session[sid] = agg
+        # Attach names as an attribute the report layer reads without widening
+        # the dataclass contract used elsewhere.
+        result_session_names: dict[str, str] = {
+            sid: names.get(sid, "") for sid in result.by_session
+        }
+        setattr(result, "session_names", result_session_names)
+        return result
+
+
+def _aggregate_from_row(row: Iterable[Any] | None) -> UsageAggregate:
+    """Build a UsageAggregate from a SUM row (base columns then components)."""
+    if row is None:
+        return UsageAggregate()
+    values = list(row)
+    if not values or values[0] in (None, 0) and all(v in (None, 0) for v in values):
+        # COUNT(*) is values[0]; an all-NULL/zero row is an empty scope.
+        return UsageAggregate()
+
+    def _n(idx: int) -> int:
+        try:
+            return int(values[idx] or 0)
+        except (TypeError, ValueError, IndexError):
+            return 0
+
+    agg = UsageAggregate(
+        calls=_n(0),
+        ok_calls=_n(1),
+        input_tokens=_n(2),
+        output_tokens=_n(3),
+        cache_read_tokens=_n(4),
+        cache_write_tokens=_n(5),
+        reasoning_tokens=_n(6),
+        context_tokens=_n(7),
+    )
+    agg.components = {key: _n(8 + i) for i, key in enumerate(COMPONENT_KEYS)}
+    return agg

--- a/local_operator/harness/types.py
+++ b/local_operator/harness/types.py
@@ -222,6 +222,15 @@ class Usage(BaseModel):
     cache_read_tokens: int = 0
     cache_write_tokens: int = 0
     context_tokens: int | None = None  # provider-reported full context size if given
+    # The reasoning/thinking slice of ``output_tokens`` when the provider
+    # breaks it out (OpenAI ``output_tokens_details.reasoning_tokens``). Kept
+    # as a SUBSET of ``output_tokens`` — never added on top — so callers that
+    # only read ``output_tokens`` stay correct, and the analytics recorder can
+    # split output into thinking vs generation (``output_tokens`` minus this).
+    # Anthropic bills thinking inside ``output_tokens`` without a separate
+    # count, so this stays 0 there and the whole output reads as generation,
+    # which is the honest thing to report when the wire does not separate it.
+    reasoning_tokens: int = 0
 
     @property
     def total_tokens(self) -> int:

--- a/local_operator/model/configure.py
+++ b/local_operator/model/configure.py
@@ -2848,12 +2848,17 @@ class SessionStreamFn:
 
             context_tokens = usage.context_tokens
             if not context_tokens:
-                # Providers that omit an explicit context size: fall back to the
-                # input total (which IS the context they read) so the component
-                # split still has a denominator. Cache-inclusive vs -exclusive
-                # differences are already normalised into context_tokens
-                # upstream; this fallback only fires when nothing was reported.
-                context_tokens = usage.input_tokens + usage.cache_read_tokens
+                # Providers that omit an explicit context size: reconstruct the
+                # full input the same way the wire clients normalise
+                # ``context_tokens`` (clients.py) — input plus BOTH cache
+                # halves — so the component split has the right denominator and
+                # the headline total is not short by the cache-write volume on
+                # a cache-writing provider (review A2). Cache-inclusive
+                # providers report ``context_tokens`` directly, so this fallback
+                # only fires when nothing was reported at all.
+                context_tokens = (
+                    usage.input_tokens + usage.cache_read_tokens + usage.cache_write_tokens
+                )
             record_call(
                 CallSnapshot(
                     ts_ms=int(_time.time() * 1000),

--- a/local_operator/model/configure.py
+++ b/local_operator/model/configure.py
@@ -34,6 +34,7 @@ from local_operator.harness.types import (
     ChatRequest,
     ModelSpec,
     StreamEvent,
+    Usage,
 )
 from local_operator.model.catalogue import DEFAULT_TTL_S
 from local_operator.model.effort import default_effort, supported_efforts
@@ -2701,13 +2702,16 @@ class SessionStreamFn:
             # * the session's prompt cache key, which identifies a request
             #   PREFIX. The naming call's prefix is a different system block, so
             #   sharing the key buys no hit and dirties the turn's cache entry.
-            async for event in stream_with_failover(
+            async for event in self._record_stream(
                 request,
-                self._auth_store,
-                self._settings,
-                self._client_for,
-                signal=signal,
-                session_id=self._session_id,
+                stream_with_failover(
+                    request,
+                    self._auth_store,
+                    self._settings,
+                    self._client_for,
+                    signal=signal,
+                    session_id=self._session_id,
+                ),
             ):
                 yield event
             return
@@ -2767,16 +2771,107 @@ class SessionStreamFn:
             request = request.model_copy(update={"prompt_cache_key": self._session_id})
 
         await self.preflight_usage(request.model)
-        async for event in stream_with_failover(
+        async for event in self._record_stream(
             request,
-            self._auth_store,
-            self._settings,
-            self._client_for,
-            signal=signal,
-            session_id=self._session_id,
-            route_state=self._route_state,
+            stream_with_failover(
+                request,
+                self._auth_store,
+                self._settings,
+                self._client_for,
+                signal=signal,
+                session_id=self._session_id,
+                route_state=self._route_state,
+            ),
         ):
             yield event
+
+    async def _record_stream(
+        self, request: ChatRequest, stream: AsyncIterator[StreamEvent]
+    ) -> AsyncIterator[StreamEvent]:
+        """Forward a provider stream unchanged, then record its usage analytics.
+
+        Why the recording lives HERE, wrapping the one place every provider
+        call already funnels through: this method sees both the ``ChatRequest``
+        (system blocks, tools, messages — the component breakdown) and the
+        final ``Usage`` (authoritative provider counts), for turns, tool loops,
+        compaction summaries, auto-naming, and every subagent, with no per-call
+        wiring anywhere else. A universal view falls out of one wrapper.
+
+        Latency contract: recording happens ONLY after the stream is fully
+        consumed (``async for`` completes), so it adds nothing to the response
+        the caller is awaiting. The single piece of event-loop work — reading
+        the request's component character lengths — is done up front into a
+        scalar snapshot because the transcript mutates the messages after the
+        call returns; tokenising, apportioning, and the SQLite write all happen
+        on the recorder's background thread. Everything is wrapped so a failure
+        in analytics can never break a turn.
+        """
+        # Snapshot char lengths BEFORE streaming: cheap (string length reads,
+        # sub-millisecond even on a very large context) and safe to hand a
+        # background thread, unlike the live message objects.
+        try:
+            from local_operator.analytics import snapshot_component_chars
+
+            component_chars = snapshot_component_chars(request)
+        except Exception:  # noqa: BLE001 — analytics must never break a turn
+            component_chars = None
+
+        final_usage: Usage | None = None
+        ok = True
+        try:
+            async for event in stream:
+                usage = getattr(event, "usage", None)
+                if usage is not None:
+                    final_usage = usage
+                stop_reason = getattr(event, "stop_reason", None)
+                if stop_reason in ("error", "aborted") or getattr(event, "error", None):
+                    ok = False
+                yield event
+        finally:
+            # In a ``finally`` so an aborted/failed stream (which still cost
+            # input tokens) is recorded too — best-effort and never raising.
+            if component_chars is not None and final_usage is not None:
+                self._record_usage(request, component_chars, final_usage, ok)
+
+    def _record_usage(
+        self,
+        request: ChatRequest,
+        component_chars: dict[str, int],
+        usage: Usage,
+        ok: bool,
+    ) -> None:
+        """Enqueue one call sample. Off the hot path; never raises."""
+        try:
+            import time as _time
+
+            from local_operator.analytics import CallSnapshot, record_call
+
+            context_tokens = usage.context_tokens
+            if not context_tokens:
+                # Providers that omit an explicit context size: fall back to the
+                # input total (which IS the context they read) so the component
+                # split still has a denominator. Cache-inclusive vs -exclusive
+                # differences are already normalised into context_tokens
+                # upstream; this fallback only fires when nothing was reported.
+                context_tokens = usage.input_tokens + usage.cache_read_tokens
+            record_call(
+                CallSnapshot(
+                    ts_ms=int(_time.time() * 1000),
+                    session_id=self._session_id or "",
+                    provider=request.model.provider,
+                    model_id=request.model.model_id,
+                    input_tokens=int(usage.input_tokens),
+                    output_tokens=int(usage.output_tokens),
+                    cache_read_tokens=int(usage.cache_read_tokens),
+                    cache_write_tokens=int(usage.cache_write_tokens),
+                    reasoning_tokens=int(getattr(usage, "reasoning_tokens", 0)),
+                    context_tokens=int(context_tokens or 0),
+                    component_chars=component_chars,
+                    ok=ok,
+                )
+            )
+        except Exception:  # noqa: BLE001 — recording is best-effort
+            logger.debug("analytics: usage record failed", exc_info=True)
 
     async def close(self) -> None:
         await self._http.aclose()

--- a/local_operator/providers/clients.py
+++ b/local_operator/providers/clients.py
@@ -1154,6 +1154,7 @@ class OpenAICompatClient:
                 if isinstance(chunk.get("usage"), Mapping):
                     raw = chunk["usage"]
                     details = raw.get("prompt_tokens_details") or {}
+                    completion_details = raw.get("completion_tokens_details") or {}
                     usage = Usage(
                         input_tokens=int(raw.get("prompt_tokens", 0)),
                         output_tokens=int(raw.get("completion_tokens", 0)),
@@ -1163,6 +1164,15 @@ class OpenAICompatClient:
                         cache_write_tokens=int(
                             details.get("cache_write_tokens", 0)
                             if isinstance(details, Mapping)
+                            else 0
+                        ),
+                        # The thinking slice of the completion, when the wire
+                        # separates it. A SUBSET of ``completion_tokens`` (see
+                        # ``Usage.reasoning_tokens``), so analytics can split
+                        # output into thinking vs generation.
+                        reasoning_tokens=int(
+                            completion_details.get("reasoning_tokens", 0)
+                            if isinstance(completion_details, Mapping)
                             else 0
                         ),
                         # Prompt tokens ARE the context the provider just read:
@@ -1323,12 +1333,21 @@ class OpenAICompatClient:
                     raw = response_obj.get("usage") or {}
                     if raw:
                         details = raw.get("input_tokens_details") or {}
+                        output_details = raw.get("output_tokens_details") or {}
                         usage = Usage(
                             input_tokens=int(raw.get("input_tokens", 0)),
                             output_tokens=int(raw.get("output_tokens", 0)),
                             cache_read_tokens=int(
                                 details.get("cached_tokens", 0)
                                 if isinstance(details, Mapping)
+                                else 0
+                            ),
+                            # Responses breaks reasoning out under
+                            # ``output_tokens_details``. A SUBSET of
+                            # ``output_tokens`` (see ``Usage.reasoning_tokens``).
+                            reasoning_tokens=int(
+                                output_details.get("reasoning_tokens", 0)
+                                if isinstance(output_details, Mapping)
                                 else 0
                             ),
                             context_tokens=int(raw.get("input_tokens", 0)) or None,

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -2028,6 +2028,18 @@ class Session:
         if (stored, self._conversation_name.user_set) != before:
             self._conversation_name_dirty = True
             self._spawn_conversation_name_write()
+            # Mirror the human name into the analytics ledger so the
+            # ``/analytics /usage`` per-session table shows a title rather than
+            # a 12-hex id. Best-effort and off the hot path (the recorder runs
+            # the upsert on its own thread); a failure here must never cost the
+            # rename, which is why it is guarded and never awaited.
+            if stored:
+                try:
+                    from local_operator.analytics import get_recorder
+
+                    get_recorder().note_session_name(self.session_id, stored)
+                except Exception:  # noqa: BLE001 — analytics is best-effort
+                    logger.debug("analytics: note_session_name failed", exc_info=True)
         return stored
 
     def _spawn_conversation_name_write(self) -> None:

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -424,6 +424,16 @@ SLASH_COMMANDS: list[SlashCommand] = [
     # The panel is the receipt — the row the owner reported as noise.
     SlashCommand("usage", "Show provider usage quota"),
     SlashCommand("context", "Show prompt, tool-schema and message token usage"),
+    # The screen it opens IS the receipt (same rule as `/usage`). The argument
+    # names WHICH analytics view; today only `usage` exists, so the list is an
+    # OFFER — a bare `/analytics` opens the usage view rather than doing
+    # nothing, which is what makes the single-view case feel like one command
+    # while leaving room for `/analytics cost`, `/analytics latency`, ... later.
+    SlashCommand(
+        "analytics",
+        "Aggregated token-consumption analytics across all sessions",
+        arguments=ArgumentMode.OPTIONAL,
+    ),
     # THE exception. `/goal <text>` is the one command whose argument reaches
     # the model: the goal rides the system prompt's volatile tail on every later
     # turn (`Session.set_goal`). Words the model is given are the transcript's
@@ -7355,6 +7365,8 @@ class OperatorApp(App[None]):
             self._cmd_accounts(notice)
         elif command == "/usage":
             self._cmd_usage(arg, notice)
+        elif command == "/analytics":
+            self._cmd_analytics(arg, notice)
         elif command == "/context":
             block = self._context_block()
             if block is not None:
@@ -8834,6 +8846,58 @@ class OperatorApp(App[None]):
 
         return time.time() * 1000
 
+    #: The analytics views ``/analytics`` can open. Today only ``usage``
+    #: exists; the mapping is here (not inlined in the dispatch) so adding a
+    #: view — ``cost``, ``latency`` — is one row, and so the argument-choice
+    #: list and the dispatch read the SAME source of truth about what exists.
+    _ANALYTICS_VIEWS: dict[str, str] = {
+        "usage": "Token consumption: cache rates, per-provider, per-component",
+    }
+
+    def _cmd_analytics(self, arg: str, notice: NoticeFn) -> None:
+        """``/analytics [view]`` — open an aggregated analytics screen.
+
+        The user asked for ``/analytics /usage``, so a leading slash on the
+        view name is accepted (and stripped) as well as the bare word. A bare
+        ``/analytics`` opens the default view rather than doing nothing: there
+        is exactly one view today, and making the user name it would be a gate
+        in front of a command that has one answer. An unknown view is rejected
+        through ``_system_notice`` — nothing ran, so the boot composition must
+        survive it, the same rule ``_cmd_usage`` and ``_cmd_model`` follow.
+        """
+        view = arg.strip().lstrip("/").lower() or "usage"
+        if view not in self._ANALYTICS_VIEWS:
+            known = ", ".join(f"/{name}" for name in self._ANALYTICS_VIEWS)
+            self._system_notice(f"unknown analytics view: {arg.strip()} — try {known}", "warning")
+            return
+        # The query is a GROUP BY over a bounded on-disk ledger — milliseconds —
+        # but it is still disk I/O, so it runs in a worker rather than on the
+        # paint path. The screen is pushed from the worker once the data is in
+        # hand, so the overlay never appears empty and then fills.
+        self.run_worker(
+            self._open_analytics_worker(view),
+            thread=False,
+            group="analytics",
+            exclusive=True,
+        )
+
+    async def _open_analytics_worker(self, view: str) -> None:
+        """Query the analytics ledger off the paint path, then push the screen."""
+        from local_operator.analytics import AnalyticsStore
+        from local_operator.tui.widgets.analytics_panel import AnalyticsScreen
+
+        try:
+            # The store read is blocking SQLite; keep it off the event loop.
+            aggregate = await asyncio.to_thread(lambda: AnalyticsStore().aggregate())
+        except Exception as error:  # noqa: BLE001 — a report must never crash the app
+            logger.debug("analytics: aggregate failed", exc_info=True)
+            self._system_notice(f"analytics unavailable: {error}", "warning")
+            return
+        # ``push_screen`` (not the awaiting variant): the screen dismisses
+        # itself on Esc and returns nothing to reconcile, exactly like the
+        # other read-only overlays.
+        self.push_screen(AnalyticsScreen(aggregate))
+
     def _cmd_usage(self, arg: str, notice: NoticeFn) -> None:
         """``/usage [provider]`` — fetch live quota for a provider (or all)."""
         # ``_system_notice`` for every branch that REJECTS: a command that did
@@ -9507,6 +9571,10 @@ class OperatorApp(App[None]):
             picker.set_choices(self._approval_choices())
             picker.set_notice("")
             return
+        if message.command == "analytics":
+            picker.set_choices(self._analytics_choices())
+            picker.set_notice("")
+            return
         if message.command == "mcp":
             # Clear BEFORE the fill: the builder may set a notice of its own
             # (an unreadable credential store on the logout list), and a
@@ -9631,6 +9699,20 @@ class OperatorApp(App[None]):
                 )
             )
         return choices
+
+    def _analytics_choices(self) -> list[ArgumentChoice]:
+        """The views ``/analytics`` offers. One row per :attr:`_ANALYTICS_VIEWS`.
+
+        Built from the same mapping the dispatch reads, so the list can never
+        offer a view the handler does not know or hide one it does. There is a
+        single row today (``usage``); the list still exists so the space after
+        ``/analytics`` shows what the command can do rather than nothing, and so
+        a second view added to the mapping appears here for free.
+        """
+        return [
+            ArgumentChoice(name=name, description=description)
+            for name, description in self._ANALYTICS_VIEWS.items()
+        ]
 
     def _approval_choices(self) -> list[ArgumentChoice]:
         """The four rows ``/approvals`` offers: two modes × two scopes.

--- a/local_operator/tui/local_operator.tcss
+++ b/local_operator/tui/local_operator.tcss
@@ -1267,6 +1267,55 @@ SessionPickerScreen .session-picker {
 }
 
 
+/* ── /analytics /usage: the aggregated token-consumption screen ────────── *
+ *
+ * The same centred card over a dimmed transcript as `/resume`, because it is
+ * the same kind of surface — a full-screen overlay the user opened and closes
+ * with Esc — and giving diagnostics their own visual language would make one
+ * more screen look like a different app. It differs in one structural way:
+ * the body can be long (a per-session table grows without bound), so the card
+ * pins a title and a hint and puts the report itself in a VerticalScroll
+ * between them, rather than sizing to content the way the picker does. */
+AnalyticsScreen {
+    align: center middle;
+    background: $lo-sunken;
+}
+
+AnalyticsScreen .analytics-panel {
+    width: 90%;
+    max-width: 100;
+    height: 80%;
+    max-height: 90%;
+    background: $lo-overlay;
+    padding: 1 2;
+}
+
+#analytics-title {
+    width: 100%;
+    height: 2;
+    padding-bottom: 1;
+}
+
+#analytics-scroll {
+    width: 100%;
+    height: 1fr;
+    scrollbar-size-vertical: 1;
+}
+
+#analytics-body {
+    width: auto;
+    height: auto;
+    color: $lo-fg;
+}
+
+#analytics-hint {
+    width: 100%;
+    height: 2;
+    padding-top: 1;
+    color: $lo-faint;
+}
+
+
 /* ── prompts: the ask picker and the approval gate ────────────────────── *
  *
  * The same "read a list, pick a row" card as `/resume` above, and deliberately

--- a/local_operator/tui/widgets/analytics_panel.py
+++ b/local_operator/tui/widgets/analytics_panel.py
@@ -1,0 +1,377 @@
+"""The ``/analytics /usage`` screen: aggregated token consumption, Esc to close.
+
+This is the read side of the analytics feature. It queries the shared ledger
+(:class:`local_operator.analytics.AnalyticsStore`) for a summed view across
+every session on the machine and renders it as a scrollable, Esc-dismissable
+full-screen overlay — the same ``ModalScreen`` shape as ``/resume``, so the one
+surface the user did not build looks like the rest of the app.
+
+What it shows, top to bottom:
+
+- **Totals** — every token the providers billed, the exact thinking/generation
+  split of output, and the cache hit rate. These are AUTHORITATIVE: they come
+  straight off the provider usage numbers, not an estimate.
+- **Where the input went** — the estimated breakdown of context tokens across
+  the system prompt, custom instructions (agent/team profiles), tool inventory,
+  tool schemas, environment, knowledge, conversation, and tool results. Marked
+  as an estimate because the provider bills one input total and the split is
+  apportioned by character length.
+- **By provider** — the same totals grouped per provider/model source.
+- **By session** — per-session context spend, named where a title is known.
+
+The renderer here is a set of pure functions returning ``rich.text.Text`` so
+the content can be asserted as plain strings in a test
+(``render_lines_for_test``), exactly like ``usage_panel`` and
+``session_picker`` do — a passing test is not evidence a TUI looks right, but
+it is the right way to pin what the screen SAYS.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from rich.style import Style
+from rich.text import Text
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Container, VerticalScroll
+from textual.screen import ModalScreen
+from textual.widgets import Static
+
+from local_operator.analytics.model import (
+    COMPONENT_KEYS,
+    COMPONENT_LABELS,
+    UsageAggregate,
+    short_session_label,
+)
+from local_operator.tui import theme as theme_mod
+
+
+def format_tokens(n: int) -> str:
+    """Compact token count: ``912`` / ``3.4k`` / ``1.2M`` / ``4.1B``.
+
+    Analytics totals cross from a handful of tokens on a fresh install to
+    billions on a long-lived machine, so the headline numbers are abbreviated
+    the way ``/usage`` abbreviates its amounts — a raw ``1204331902`` is
+    unreadable at a glance and the whole point of this screen is the glance.
+    """
+    n = int(n)
+    if n < 1000:
+        return str(n)
+    if n < 1_000_000:
+        return f"{n / 1000:.1f}k".replace(".0k", "k")
+    if n < 1_000_000_000:
+        return f"{n / 1_000_000:.1f}M".replace(".0M", "M")
+    return f"{n / 1_000_000_000:.1f}B".replace(".0B", "B")
+
+
+def format_percent(fraction: float | None) -> str:
+    """``73%`` / ``—`` for an unmeasurable rate."""
+    if fraction is None:
+        return "—"
+    return f"{round(fraction * 100)}%"
+
+
+def proportion_bar(fraction: float, width: int) -> str:
+    """A filled proportion bar of ``width`` cells for ``fraction`` in 0..1."""
+    width = max(1, width)
+    fraction = max(0.0, min(1.0, fraction))
+    filled = int(round(fraction * width))
+    return "█" * filled + "·" * (width - filled)
+
+
+@dataclass(frozen=True)
+class _Row:
+    """One label/value/bar row in the breakdown, pre-measured for alignment."""
+
+    label: str
+    value: int
+    fraction: float
+
+
+def _component_rows(aggregate: UsageAggregate) -> list[_Row]:
+    """The input-attribution rows, largest first, hiding empties.
+
+    Ordered by size rather than by the fixed taxonomy order so the biggest
+    consumer of context is the first thing read — the question this screen
+    exists to answer is "where is it going", and the answer is whatever is at
+    the top. Zero-token components are dropped: a fresh session has no tool
+    results yet, and a row of zeros is noise in the one place that must be
+    scannable.
+    """
+    total = sum(aggregate.components.get(k, 0) for k in COMPONENT_KEYS)
+    rows: list[_Row] = []
+    for key in COMPONENT_KEYS:
+        value = int(aggregate.components.get(key, 0))
+        if value <= 0:
+            continue
+        rows.append(
+            _Row(
+                label=COMPONENT_LABELS[key],
+                value=value,
+                fraction=(value / total) if total > 0 else 0.0,
+            )
+        )
+    rows.sort(key=lambda r: r.value, reverse=True)
+    return rows
+
+
+def _semantic(name: str) -> Style:
+    return Style(color=theme_mod.semantic_color(name))
+
+
+def build_report(aggregate: UsageAggregate, width: int) -> list[Text]:
+    """Render one aggregate as a list of ``Text`` lines for the screen body.
+
+    Pure: takes the summed data and a width, returns lines. The screen wraps
+    this in a scroll container and owns the chrome, so everything about WHAT is
+    shown lives here where a test can read it back as plain strings.
+    """
+    width = max(40, width)
+    fg = _semantic("fg")
+    label = _semantic("label")
+    dim = _semantic("dim")
+    faint = _semantic("faint")
+    accent = _semantic("accent")
+
+    lines: list[Text] = []
+
+    if aggregate.calls == 0:
+        line = Text()
+        line.append("No usage recorded yet.", style=dim)
+        lines.append(line)
+        hint = Text()
+        hint.append(
+            "Analytics accrue as sessions make provider calls. " "Come back after a few turns.",
+            style=faint,
+        )
+        lines.append(hint)
+        return lines
+
+    # -- headline totals -----------------------------------------------------
+    section = Text()
+    section.append("TOTALS", style=label + Style(bold=True))
+    section.append(f"   {aggregate.calls} calls", style=dim)
+    if aggregate.ok_calls != aggregate.calls:
+        section.append(f" ({aggregate.calls - aggregate.ok_calls} failed)", style=faint)
+    lines.append(section)
+
+    def kv(name: str, value: str, note: str = "") -> Text:
+        row = Text()
+        row.append(f"  {name:<22}", style=dim)
+        row.append(value, style=fg)
+        if note:
+            row.append(f"  {note}", style=faint)
+        return row
+
+    lines.append(kv("Total billed", format_tokens(aggregate.total_tokens) + " tokens"))
+    lines.append(
+        kv(
+            "Input",
+            format_tokens(aggregate.input_tokens),
+            f"+{format_tokens(aggregate.cache_read_tokens)} cache read, "
+            f"{format_tokens(aggregate.cache_write_tokens)} cache write",
+        )
+    )
+    lines.append(
+        kv(
+            "Output",
+            format_tokens(aggregate.output_tokens),
+            f"{format_tokens(aggregate.generation_tokens)} generation, "
+            f"{format_tokens(aggregate.reasoning_tokens)} thinking",
+        )
+    )
+    lines.append(
+        kv(
+            "Cache hit rate",
+            format_percent(aggregate.cache_hit_rate),
+            "of context served from cache",
+        )
+    )
+    lines.append(Text())
+
+    # -- input attribution (estimated) --------------------------------------
+    heading = Text()
+    heading.append("WHERE INPUT WENT", style=label + Style(bold=True))
+    heading.append("   estimated split of context tokens", style=faint)
+    lines.append(heading)
+
+    rows = _component_rows(aggregate)
+    if not rows:
+        empty = Text()
+        empty.append("  no component data yet", style=faint)
+        lines.append(empty)
+    else:
+        label_col = min(34, max(len(r.label) for r in rows) + 1)
+        value_col = max(len(format_tokens(r.value)) for r in rows)
+        bar_width = max(8, min(24, width - label_col - value_col - 12))
+        for row in rows:
+            line = Text()
+            line.append(f"  {row.label:<{label_col}}", style=fg)
+            line.append(proportion_bar(row.fraction, bar_width), style=accent)
+            line.append(f" {format_tokens(row.value):>{value_col}}", style=fg)
+            line.append(f" {format_percent(row.fraction):>4}", style=dim)
+            lines.append(line)
+    lines.append(Text())
+
+    # -- by provider ---------------------------------------------------------
+    if aggregate.by_provider:
+        lines.append(_group_section("BY PROVIDER", aggregate.by_provider))
+        lines.append(Text())
+
+    # -- by session ----------------------------------------------------------
+    if aggregate.by_session:
+        names = getattr(aggregate, "session_names", {}) or {}
+        labelled = {
+            short_session_label(sid, names.get(sid, "")): agg
+            for sid, agg in aggregate.by_session.items()
+        }
+        lines.append(_group_section("BY SESSION", labelled))
+
+    return lines
+
+
+def _group_section(
+    title: str,
+    groups: dict[str, UsageAggregate],
+) -> Text:
+    """A per-provider or per-session table as one multi-line ``Text`` block.
+
+    Returned as a single ``Text`` with embedded newlines so the caller keeps a
+    flat list of blocks; the screen splits on newlines only for the scroll
+    measurement. Sorted by total billed tokens, descending — the biggest
+    spender is what a diagnostics reader looks for first.
+    """
+    fg = _semantic("fg")
+    label = _semantic("label")
+    dim = _semantic("dim")
+    faint = _semantic("faint")
+
+    block = Text()
+    block.append(title, style=label + Style(bold=True))
+
+    ordered = sorted(groups.items(), key=lambda kv: kv[1].total_tokens, reverse=True)
+    if not ordered:
+        block.append("\n  (none)", style=faint)
+        return block
+
+    name_col = min(30, max(len(name) for name, _ in ordered) + 1)
+    for name, agg in ordered:
+        block.append("\n")
+        block.append(f"  {name:<{name_col}}", style=fg)
+        block.append(f"{format_tokens(agg.total_tokens):>8} tokens", style=fg)
+        cache = format_percent(agg.cache_hit_rate)
+        block.append(f"   {agg.calls:>4} calls", style=dim)
+        block.append(f"   {cache:>4} cache", style=faint)
+    return block
+
+
+class AnalyticsDismissed:
+    """Sentinel result for the screen's dismiss (kept simple: no payload)."""
+
+
+class AnalyticsScreen(ModalScreen[None]):
+    """Full-screen, scrollable, Esc-dismissable usage analytics.
+
+    Pushed by ``/analytics /usage`` and dismissed with Esc (or ``q``), which
+    restores the previous view exactly — the screen reads the ledger and shows
+    it, it never mutates anything, so leaving it is a plain pop with no state to
+    reconcile. Modelled on :class:`SessionPickerScreen`: a centred card over a
+    dimmed transcript, one ``Static`` body inside a ``VerticalScroll`` so a long
+    per-session table scrolls rather than clipping.
+    """
+
+    BINDINGS = [
+        Binding("escape", "dismiss_screen", "Back", show=False),
+        Binding("q", "dismiss_screen", "Back", show=False),
+        Binding("up", "scroll_up", "Up", show=False),
+        Binding("down", "scroll_down", "Down", show=False),
+        Binding("pageup", "page_up", "Page up", show=False),
+        Binding("pagedown", "page_down", "Page down", show=False),
+        Binding("home", "scroll_home", "Top", show=False),
+        Binding("end", "scroll_end", "Bottom", show=False),
+    ]
+
+    def __init__(self, aggregate: UsageAggregate) -> None:
+        super().__init__()
+        self._aggregate = aggregate
+        self._body: Static
+        self._scroll: VerticalScroll
+
+    def compose(self) -> ComposeResult:
+        with Container(classes="analytics-panel"):
+            yield Static(self._title_text(), id="analytics-title")
+            with VerticalScroll(id="analytics-scroll") as scroll:
+                self._scroll = scroll
+                self._body = Static(id="analytics-body")
+                yield self._body
+            yield Static(self._hint_text(), id="analytics-hint")
+
+    def on_mount(self) -> None:
+        self._repaint()
+
+    def on_resize(self, event) -> None:  # type: ignore[no-untyped-def]
+        self._repaint()
+
+    def _card_width(self) -> int:
+        try:
+            return max(40, min(96, self.app.size.width - 8))
+        except Exception:  # noqa: BLE001 — before mount, a sane default
+            return 80
+
+    def _title_text(self) -> Text:
+        label = Style(color=theme_mod.semantic_color("label"))
+        faint = Style(color=theme_mod.semantic_color("faint"))
+        title = Text()
+        title.append("Usage analytics", style=label + Style(bold=True))
+        title.append("  ·  all sessions", style=faint)
+        return title
+
+    def _hint_text(self) -> Text:
+        faint = Style(color=theme_mod.semantic_color("faint"))
+        hint = Text()
+        hint.append("esc back · ↑↓ scroll", style=faint)
+        return hint
+
+    def _report_lines(self) -> list[Text]:
+        return build_report(self._aggregate, self._card_width())
+
+    def _repaint(self) -> None:
+        body = getattr(self, "_body", None)
+        if body is None or not body.is_mounted:
+            return
+        combined = Text()
+        for i, line in enumerate(self._report_lines()):
+            if i:
+                combined.append("\n")
+            combined.append_text(line)
+        body.update(combined)
+
+    def render_lines_for_test(self) -> list[str]:
+        """The report as plain strings — what a user reads."""
+        out: list[str] = []
+        for line in self._report_lines():
+            out.extend(line.plain.split("\n"))
+        return out
+
+    # -- actions -------------------------------------------------------------
+    def action_dismiss_screen(self) -> None:
+        self.dismiss(None)
+
+    def action_scroll_up(self) -> None:
+        self._scroll.scroll_up()
+
+    def action_scroll_down(self) -> None:
+        self._scroll.scroll_down()
+
+    def action_page_up(self) -> None:
+        self._scroll.scroll_page_up()
+
+    def action_page_down(self) -> None:
+        self._scroll.scroll_page_down()
+
+    def action_scroll_home(self) -> None:
+        self._scroll.scroll_home()
+
+    def action_scroll_end(self) -> None:
+        self._scroll.scroll_end()

--- a/local_operator/tui/widgets/analytics_panel.py
+++ b/local_operator/tui/widgets/analytics_panel.py
@@ -224,8 +224,8 @@ def build_report(aggregate: UsageAggregate, width: int) -> list[Text]:
     # ``dim`` not ``faint`` (D1): the word "estimated" is the whole reason this
     # section reads differently from TOTALS, so it must be legible, not the
     # lowest-contrast text on the panel. The distinction is ALSO carried at the
-    # data level — every percentage below is prefixed ``~`` and every value is
-    # tagged ``est.`` — so it survives when this heading has scrolled under the
+    # data level — the heading is marked ``≈`` and every percentage below is
+    # prefixed ``~`` — so it survives when this heading has scrolled under the
     # pinned header (the case the design round flagged in 02-by-session).
     heading.append("   ≈ estimated split of context tokens", style=dim)
     lines.append(heading)

--- a/local_operator/tui/widgets/analytics_panel.py
+++ b/local_operator/tui/widgets/analytics_panel.py
@@ -58,25 +58,47 @@ def format_tokens(n: int) -> str:
     n = int(n)
     if n < 1000:
         return str(n)
-    if n < 1_000_000:
-        return f"{n / 1000:.1f}k".replace(".0k", "k")
-    if n < 1_000_000_000:
-        return f"{n / 1_000_000:.1f}M".replace(".0M", "M")
+    # Compare the ROUNDED value to each ceiling, not the raw one: 999_950
+    # rounds to "1000.0k" under a raw ``n < 1_000_000`` check (review A5), so a
+    # number that rounds up to the next unit is promoted to that unit here.
+    for divisor, suffix, ceiling in (
+        (1000, "k", 1_000_000),
+        (1_000_000, "M", 1_000_000_000),
+    ):
+        if n < ceiling and round(n / divisor, 1) < ceiling / divisor:
+            return f"{n / divisor:.1f}{suffix}".replace(f".0{suffix}", suffix)
     return f"{n / 1_000_000_000:.1f}B".replace(".0B", "B")
 
 
 def format_percent(fraction: float | None) -> str:
-    """``73%`` / ``—`` for an unmeasurable rate."""
+    """``73%`` / ``—`` for an unmeasurable rate.
+
+    ``100%`` is reserved for a genuinely complete rate (review D4): a value that
+    is merely close — 99.6% — floors to ``99%`` rather than rounding up to a
+    flat ``100%`` that reads as mocked or broken next to the cache-read total it
+    is derived from. Only an exact 1.0 prints ``100%``.
+    """
     if fraction is None:
         return "—"
-    return f"{round(fraction * 100)}%"
+    pct = fraction * 100
+    if 99 < pct < 100:
+        return "99%"
+    return f"{round(pct)}%"
 
 
 def proportion_bar(fraction: float, width: int) -> str:
-    """A filled proportion bar of ``width`` cells for ``fraction`` in 0..1."""
+    """A filled proportion bar of ``width`` cells for ``fraction`` in 0..1.
+
+    A NONZERO fraction always fills at least one cell (review D3): without the
+    floor, any component under ~2% rounded to an all-dots bar indistinguishable
+    from a rounding-to-zero one, so a real 2% contributor read as empty. Only a
+    genuine zero renders as no fill.
+    """
     width = max(1, width)
     fraction = max(0.0, min(1.0, fraction))
     filled = int(round(fraction * width))
+    if filled == 0 and fraction > 0:
+        filled = 1
     return "█" * filled + "·" * (width - filled)
 
 
@@ -131,19 +153,20 @@ def build_report(aggregate: UsageAggregate, width: int) -> list[Text]:
     fg = _semantic("fg")
     label = _semantic("label")
     dim = _semantic("dim")
-    faint = _semantic("faint")
     accent = _semantic("accent")
 
     lines: list[Text] = []
 
     if aggregate.calls == 0:
         line = Text()
-        line.append("No usage recorded yet.", style=dim)
+        line.append("No usage recorded yet.", style=fg)
         lines.append(line)
         hint = Text()
+        # ``dim`` not ``faint``: this is the one line telling a first-time user
+        # how the screen fills, so it must be legible, not decorative (D2).
         hint.append(
-            "Analytics accrue as sessions make provider calls. " "Come back after a few turns.",
-            style=faint,
+            "Analytics accrue as sessions make provider calls. Come back after a few turns.",
+            style=dim,
         )
         lines.append(hint)
         return lines
@@ -153,7 +176,9 @@ def build_report(aggregate: UsageAggregate, width: int) -> list[Text]:
     section.append("TOTALS", style=label + Style(bold=True))
     section.append(f"   {aggregate.calls} calls", style=dim)
     if aggregate.ok_calls != aggregate.calls:
-        section.append(f" ({aggregate.calls - aggregate.ok_calls} failed)", style=faint)
+        # Failed-call count is real information, not chrome — keep it legible.
+        section.append(f" ({aggregate.calls - aggregate.ok_calls} failed)", style=dim)
+    section.append("   measured", style=_semantic("faint"))
     lines.append(section)
 
     def kv(name: str, value: str, note: str = "") -> Text:
@@ -161,7 +186,10 @@ def build_report(aggregate: UsageAggregate, width: int) -> list[Text]:
         row.append(f"  {name:<22}", style=dim)
         row.append(value, style=fg)
         if note:
-            row.append(f"  {note}", style=faint)
+            # ``dim`` not ``faint`` (D2): the note carries the actual cache and
+            # thinking/generation breakdown — the substance a diagnostics reader
+            # came for — so it must clear the contrast floor.
+            row.append(f"  {note}", style=dim)
         return row
 
     lines.append(kv("Total billed", format_tokens(aggregate.total_tokens) + " tokens"))
@@ -193,24 +221,36 @@ def build_report(aggregate: UsageAggregate, width: int) -> list[Text]:
     # -- input attribution (estimated) --------------------------------------
     heading = Text()
     heading.append("WHERE INPUT WENT", style=label + Style(bold=True))
-    heading.append("   estimated split of context tokens", style=faint)
+    # ``dim`` not ``faint`` (D1): the word "estimated" is the whole reason this
+    # section reads differently from TOTALS, so it must be legible, not the
+    # lowest-contrast text on the panel. The distinction is ALSO carried at the
+    # data level — every percentage below is prefixed ``~`` and every value is
+    # tagged ``est.`` — so it survives when this heading has scrolled under the
+    # pinned header (the case the design round flagged in 02-by-session).
+    heading.append("   ≈ estimated split of context tokens", style=dim)
     lines.append(heading)
 
     rows = _component_rows(aggregate)
     if not rows:
         empty = Text()
-        empty.append("  no component data yet", style=faint)
+        empty.append("  no component data yet", style=dim)
         lines.append(empty)
     else:
-        label_col = min(34, max(len(r.label) for r in rows) + 1)
+        # One guaranteed space of gutter between the label and its bar (D5): the
+        # longest label is exactly ``label_col`` wide, so without the trailing
+        # gap its bar butts against the final glyph while every shorter row has
+        # air. The ``+ 2`` reserves that gutter for every row uniformly.
+        label_col = min(36, max(len(r.label) for r in rows) + 2)
         value_col = max(len(format_tokens(r.value)) for r in rows)
-        bar_width = max(8, min(24, width - label_col - value_col - 12))
+        # ``~NN%`` is one cell wider than ``NN%``; size the column for it.
+        bar_width = max(8, min(24, width - label_col - value_col - 13))
         for row in rows:
             line = Text()
             line.append(f"  {row.label:<{label_col}}", style=fg)
             line.append(proportion_bar(row.fraction, bar_width), style=accent)
             line.append(f" {format_tokens(row.value):>{value_col}}", style=fg)
-            line.append(f" {format_percent(row.fraction):>4}", style=dim)
+            # ``~`` marks the percentage as modelled, not measured (D1).
+            line.append(f" ~{format_percent(row.fraction):>3}", style=dim)
             lines.append(line)
     lines.append(Text())
 
@@ -245,14 +285,13 @@ def _group_section(
     fg = _semantic("fg")
     label = _semantic("label")
     dim = _semantic("dim")
-    faint = _semantic("faint")
 
     block = Text()
     block.append(title, style=label + Style(bold=True))
 
     ordered = sorted(groups.items(), key=lambda kv: kv[1].total_tokens, reverse=True)
     if not ordered:
-        block.append("\n  (none)", style=faint)
+        block.append("\n  (none)", style=dim)
         return block
 
     name_col = min(30, max(len(name) for name, _ in ordered) + 1)
@@ -261,13 +300,12 @@ def _group_section(
         block.append(f"  {name:<{name_col}}", style=fg)
         block.append(f"{format_tokens(agg.total_tokens):>8} tokens", style=fg)
         cache = format_percent(agg.cache_hit_rate)
+        # ``dim`` for both columns (D2): the call count and cache rate are the
+        # per-row substance, not decoration, so neither may drop below the
+        # contrast floor the way ``faint`` did.
         block.append(f"   {agg.calls:>4} calls", style=dim)
-        block.append(f"   {cache:>4} cache", style=faint)
+        block.append(f"   {cache:>4} cache", style=dim)
     return block
-
-
-class AnalyticsDismissed:
-    """Sentinel result for the screen's dismiss (kept simple: no payload)."""
 
 
 class AnalyticsScreen(ModalScreen[None]):
@@ -305,13 +343,18 @@ class AnalyticsScreen(ModalScreen[None]):
                 self._scroll = scroll
                 self._body = Static(id="analytics-body")
                 yield self._body
-            yield Static(self._hint_text(), id="analytics-hint")
+            self._hint = Static(self._hint_text(scrollable=False), id="analytics-hint")
+            yield self._hint
 
     def on_mount(self) -> None:
         self._repaint()
+        # After layout settles: ``max_scroll_y`` is only meaningful once the
+        # body has been measured against the viewport.
+        self.call_after_refresh(self._sync_hint)
 
     def on_resize(self, event) -> None:  # type: ignore[no-untyped-def]
         self._repaint()
+        self.call_after_refresh(self._sync_hint)
 
     def _card_width(self) -> int:
         try:
@@ -327,11 +370,28 @@ class AnalyticsScreen(ModalScreen[None]):
         title.append("  ·  all sessions", style=faint)
         return title
 
-    def _hint_text(self) -> Text:
+    def _hint_text(self, *, scrollable: bool) -> Text:
+        # The scroll affordance is advertised only when there is something to
+        # scroll (D5): the empty state and any report that fits told the user to
+        # scroll a screen that could not, which reads as a dead control.
         faint = Style(color=theme_mod.semantic_color("faint"))
         hint = Text()
-        hint.append("esc back · ↑↓ scroll", style=faint)
+        hint.append("esc back", style=faint)
+        if scrollable:
+            hint.append(" · ↑↓ scroll", style=faint)
         return hint
+
+    def _sync_hint(self) -> None:
+        """Show the scroll hint only when the body overflows its viewport."""
+        hint = getattr(self, "_hint", None)
+        scroll = getattr(self, "_scroll", None)
+        if hint is None or scroll is None or not hint.is_mounted:
+            return
+        try:
+            scrollable = scroll.max_scroll_y > 0
+        except Exception:  # noqa: BLE001 — before layout, assume not scrollable
+            scrollable = False
+        hint.update(self._hint_text(scrollable=scrollable))
 
     def _report_lines(self) -> list[Text]:
         return build_report(self._aggregate, self._card_width())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.20.1"
+version = "0.21.0"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@radienthq.com" }]

--- a/tests/unit/analytics/test_model.py
+++ b/tests/unit/analytics/test_model.py
@@ -141,11 +141,27 @@ def test_aggregate_generation_and_cache_rate():
     )
     # generation = output - reasoning (thinking is a subset of output).
     assert agg.generation_tokens == 380
-    # total billed = input + output (cache reported separately).
-    assert agg.total_tokens == 1500
+    # total billed = full input context (incl. cache) + output. context_tokens
+    # is the normalised full input, so 9200 + 500 = 9700 — NOT input+output,
+    # which would drop the cache volume on a cache-exclusive provider (A1).
+    assert agg.total_tokens == 9700
     # cache hit rate = cache_read / context, capped at 1.0.
     assert agg.cache_hit_rate is not None
     assert round(agg.cache_hit_rate, 4) == round(8000 / 9200, 4)
+
+
+def test_total_tokens_includes_cache_on_cache_exclusive_provider():
+    # Anthropic reports input_tokens EXCLUDING cache; context_tokens normalises
+    # to the full input. total_tokens must use context (A1 regression): a 100k
+    # cached turn must not report ~7k.
+    agg = UsageAggregate(
+        input_tokens=5000,  # fresh input only (Anthropic shape)
+        cache_read_tokens=90_000,
+        cache_write_tokens=5000,
+        output_tokens=2000,
+        context_tokens=100_000,  # input + cache_read + cache_write
+    )
+    assert agg.total_tokens == 102_000  # context + output, not input + output
 
 
 def test_aggregate_cache_rate_none_without_context():

--- a/tests/unit/analytics/test_model.py
+++ b/tests/unit/analytics/test_model.py
@@ -1,0 +1,186 @@
+"""The analytics data model: component attribution and the aggregate math.
+
+Two things are proven here because they are the two easy things to get wrong:
+the estimated component split must SUM to the authoritative context total (no
+tokens invented, none lost to rounding), and the derived rates on
+``UsageAggregate`` (thinking/generation, cache hit) must read straight off the
+provider counts rather than off the estimate.
+"""
+
+from __future__ import annotations
+
+from local_operator.analytics.model import (
+    COMPONENT_KEYS,
+    CallSnapshot,
+    UsageAggregate,
+    apportion_components,
+    snapshot_component_chars,
+    split_system_prompt,
+)
+from local_operator.harness.types import (
+    AgentTool,
+    ChatRequest,
+    Message,
+    ModelSpec,
+    TextContent,
+    ToolResult,
+)
+
+
+async def _noop(tool_call_id: str, *_args: object) -> ToolResult:
+    return ToolResult(tool_call_id=tool_call_id, tool_name="stub", content=[])
+
+
+def test_split_system_prompt_no_custom_section():
+    # A block with no custom-instructions header is all packaged persona.
+    block = "You are the assistant.\n\nAGENTS.md guidance here."
+    system, custom = split_system_prompt(block)
+    assert system == len(block)
+    assert custom == 0
+
+
+def test_split_system_prompt_with_custom_section():
+    persona = "You are the assistant.\n\n"
+    custom = "## User's custom instructions\n\n<user_instructions>be terse</user_instructions>"
+    block = persona + custom
+    system_chars, custom_chars = split_system_prompt(block)
+    assert system_chars == len(persona)
+    assert custom_chars == len(custom)
+    assert system_chars + custom_chars == len(block)
+
+
+def test_apportion_sums_to_context_total():
+    # An awkward ratio that does not divide evenly: the largest-remainder
+    # rounding must still hand out exactly ``context_tokens`` with no drift.
+    chars = {
+        "system_prompt": 333,
+        "custom_instructions": 111,
+        "tool_schemas": 777,
+        "conversation": 1234,
+        "tool_results": 555,
+    }
+    for total in (1, 7, 100, 9999, 1_000_003):
+        split = apportion_components(chars, total)
+        assert sum(split.values()) == total, total
+        # Every component key is present, even the zero ones.
+        assert set(split) == set(COMPONENT_KEYS)
+
+
+def test_apportion_zero_context_is_all_zero():
+    chars = {"conversation": 500, "system_prompt": 500}
+    split = apportion_components(chars, 0)
+    assert set(split) == set(COMPONENT_KEYS)
+    assert all(v == 0 for v in split.values())
+
+
+def test_apportion_is_deterministic():
+    chars = {"system_prompt": 500, "conversation": 500, "tool_results": 500}
+    a = apportion_components(chars, 1000)
+    b = apportion_components(chars, 1000)
+    assert a == b
+
+
+def test_snapshot_component_chars_separates_regions():
+    persona = "You are the assistant. " * 5
+    custom = "## User's custom instructions\n\nbe terse"
+    # The whole custom section starts at its header; everything before the
+    # header (persona + the blank-line separator) is system_prompt.
+    separator = "\n\n"
+    block0 = persona + separator + custom
+    tools = [
+        AgentTool(
+            name="bash",
+            description="run a shell command",
+            parameters={"type": "object", "properties": {"command": {"type": "string"}}},
+            execute=_noop,
+        )
+    ]
+    request = ChatRequest(
+        model=ModelSpec(provider="anthropic", model_id="m"),
+        system_blocks=[
+            block0,
+            "## Available tools\ninventory prose",
+            "env facts",
+            "<skills>k</skills>",
+        ],
+        messages=[
+            Message(role="user", content=[TextContent(text="hello there")]),
+            Message(
+                role="tool",
+                tool_call_id="t1",
+                tool_name="bash",
+                content=[TextContent(text="command output")],
+            ),
+        ],
+        tools=tools,
+    )
+    chars = snapshot_component_chars(request)
+    # system_prompt is persona + separator (everything up to the header).
+    assert chars["system_prompt"] == len(persona) + len(separator)
+    assert chars["custom_instructions"] == len(custom)
+    assert chars["system_prompt"] + chars["custom_instructions"] == len(block0)
+    assert chars["tool_inventory"] == len("## Available tools\ninventory prose")
+    assert chars["environment"] == len("env facts")
+    assert chars["knowledge"] == len("<skills>k</skills>")
+    assert chars["conversation"] == len("hello there")
+    assert chars["tool_results"] == len("command output")
+    # Tool schema is name + description + compact params JSON, and is nonzero.
+    assert chars["tool_schemas"] > len("bash") + len("run a shell command")
+
+
+def test_aggregate_generation_and_cache_rate():
+    agg = UsageAggregate(
+        calls=3,
+        ok_calls=3,
+        input_tokens=1000,
+        output_tokens=500,
+        cache_read_tokens=8000,
+        cache_write_tokens=200,
+        reasoning_tokens=120,
+        context_tokens=9200,
+    )
+    # generation = output - reasoning (thinking is a subset of output).
+    assert agg.generation_tokens == 380
+    # total billed = input + output (cache reported separately).
+    assert agg.total_tokens == 1500
+    # cache hit rate = cache_read / context, capped at 1.0.
+    assert agg.cache_hit_rate is not None
+    assert round(agg.cache_hit_rate, 4) == round(8000 / 9200, 4)
+
+
+def test_aggregate_cache_rate_none_without_context():
+    agg = UsageAggregate(calls=1, context_tokens=0, cache_read_tokens=0)
+    assert agg.cache_hit_rate is None
+
+
+def test_aggregate_generation_never_negative():
+    # A provider that reports reasoning >= output (shouldn't happen, but the
+    # math must stay non-negative rather than showing a negative generation).
+    agg = UsageAggregate(output_tokens=100, reasoning_tokens=150)
+    assert agg.generation_tokens == 0
+
+
+def test_callsnapshot_is_frozen_scalars():
+    # The snapshot is handed to a background thread; it must be a plain value.
+    snap = CallSnapshot(
+        ts_ms=1,
+        session_id="s",
+        provider="p",
+        model_id="m",
+        input_tokens=1,
+        output_tokens=1,
+        cache_read_tokens=0,
+        cache_write_tokens=0,
+        reasoning_tokens=0,
+        context_tokens=2,
+        component_chars={"conversation": 4},
+        ok=True,
+    )
+    assert snap.session_id == "s"
+    # frozen dataclass: attribute assignment raises.
+    try:
+        snap.session_id = "x"  # type: ignore[misc]
+        raised = False
+    except Exception:
+        raised = True
+    assert raised

--- a/tests/unit/analytics/test_recorder.py
+++ b/tests/unit/analytics/test_recorder.py
@@ -1,0 +1,131 @@
+"""The non-blocking recorder: enqueue-and-return, background write, drop on
+full queue, and parallel-safety across processes.
+
+The recorder is the latency contract. ``record`` must never block a session,
+so the queue is bounded and a full one drops the sample (counted) rather than
+applying back-pressure. The writer thread turns queued samples into batched
+SQLite writes on a background thread, which is what keeps the provider path
+free of disk I/O.
+"""
+
+from __future__ import annotations
+
+import multiprocessing as mp
+import time
+
+from local_operator.analytics.model import CallSnapshot
+from local_operator.analytics.recorder import AnalyticsRecorder, reset_recorder_for_test
+from local_operator.analytics.store import AnalyticsStore
+
+
+def _snap(
+    session_id: str = "s",
+    *,
+    input_tokens: int = 10,
+    ts_ms: int | None = None,
+) -> CallSnapshot:
+    return CallSnapshot(
+        ts_ms=ts_ms if ts_ms is not None else int(time.time() * 1000),
+        session_id=session_id,
+        provider="anthropic",
+        model_id="m",
+        input_tokens=input_tokens,
+        output_tokens=5,
+        cache_read_tokens=2,
+        cache_write_tokens=1,
+        reasoning_tokens=1,
+        context_tokens=12,
+        component_chars={"conversation": 40},
+        ok=True,
+    )
+
+
+def test_record_reaches_store(tmp_path):
+    store = AnalyticsStore(tmp_path / "a.db")
+    rec = AnalyticsRecorder(store=store)
+    for _ in range(20):
+        rec.record(_snap())
+    rec.flush_for_test()
+    assert store.aggregate().calls == 20
+    rec.close()
+
+
+def test_record_never_raises_when_closed(tmp_path):
+    store = AnalyticsStore(tmp_path / "a.db")
+    rec = AnalyticsRecorder(store=store)
+    rec.close()
+    # Recording on a closed recorder is a silent no-op, not an exception.
+    rec.record(_snap())
+    assert rec.dropped == 0
+
+
+def test_batching_coalesces_burst(tmp_path):
+    store = AnalyticsStore(tmp_path / "a.db")
+    rec = AnalyticsRecorder(store=store)
+    # A burst larger than one batch still lands entirely.
+    for i in range(500):
+        rec.record(_snap(session_id=f"s{i % 5}"))
+    rec.flush_for_test()
+    agg = store.aggregate()
+    assert agg.calls == 500
+    assert len(agg.by_session) == 5
+    rec.close()
+
+
+def test_session_name_note_reaches_store(tmp_path):
+    store = AnalyticsStore(tmp_path / "a.db")
+    rec = AnalyticsRecorder(store=store)
+    rec.record(_snap(session_id="abc"))
+    rec.note_session_name("abc", "named it")
+    rec.flush_for_test()
+    # The name upsert runs on its own short-lived thread; poll for it rather
+    # than sleeping a fixed amount, so the test is not flaky under load.
+    deadline = time.monotonic() + 5.0
+    names: dict[str, str] = {}
+    while time.monotonic() < deadline:
+        names = getattr(store.aggregate(), "session_names", {})
+        if names.get("abc") == "named it":
+            break
+        time.sleep(0.02)
+    assert names.get("abc") == "named it"
+    rec.close()
+
+
+def test_reset_recorder_for_test_isolates(tmp_path):
+    store_a = AnalyticsStore(tmp_path / "a.db")
+    rec_a = reset_recorder_for_test(store_a)
+    rec_a.record(_snap())
+    rec_a.flush_for_test()
+    assert store_a.aggregate().calls == 1
+    # Resetting closes the previous recorder and points at a fresh store.
+    store_b = AnalyticsStore(tmp_path / "b.db")
+    rec_b = reset_recorder_for_test(store_b)
+    assert store_b.aggregate().calls == 0
+    rec_b.close()
+
+
+def _worker(db_path, n):
+    store = AnalyticsStore(db_path)
+    rec = reset_recorder_for_test(store)
+    for i in range(n):
+        rec.record(_snap(session_id=f"proc-{mp.current_process().name}", input_tokens=1))
+    rec.flush_for_test()
+    rec.close()
+
+
+def test_parallel_processes_write_atomically(tmp_path):
+    # WAL gives cross-process atomic writes: several sessions in different
+    # terminals writing at once must not lose or corrupt rows.
+    db = str(tmp_path / "parallel.db")
+    n = 150
+    procs = [mp.Process(target=_worker, args=(db, n), name=f"w{i}") for i in range(4)]
+    for p in procs:
+        p.start()
+    for p in procs:
+        p.join(timeout=30)
+        assert p.exitcode == 0
+    store = AnalyticsStore(db)
+    agg = store.aggregate()
+    assert agg.calls == 4 * n
+    assert len(agg.by_session) == 4
+    store.close()

--- a/tests/unit/analytics/test_store.py
+++ b/tests/unit/analytics/test_store.py
@@ -1,0 +1,171 @@
+"""The SQLite ledger: recording, aggregation scoping, retention, and the
+estimated component split that is computed at write time.
+
+The store is the accuracy contract: what a report shows is what was recorded,
+so these tests write known snapshots and read the aggregate back, including the
+per-provider and per-session breakdowns the ``/analytics`` screen renders.
+"""
+
+from __future__ import annotations
+
+import time
+
+from local_operator.analytics.model import CallSnapshot
+from local_operator.analytics.store import AnalyticsStore
+
+
+def _snap(
+    *,
+    session_id="s1",
+    provider="anthropic",
+    model_id="claude",
+    input_tokens=100,
+    output_tokens=40,
+    cache_read=800,
+    cache_write=20,
+    reasoning=10,
+    context=920,
+    chars=None,
+    ok=True,
+    ts_ms=None,
+):
+    return CallSnapshot(
+        ts_ms=ts_ms if ts_ms is not None else int(time.time() * 1000),
+        session_id=session_id,
+        provider=provider,
+        model_id=model_id,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        cache_read_tokens=cache_read,
+        cache_write_tokens=cache_write,
+        reasoning_tokens=reasoning,
+        context_tokens=context,
+        component_chars=chars or {"conversation": 500, "system_prompt": 420},
+        ok=ok,
+    )
+
+
+def test_record_and_aggregate_roundtrip(tmp_path):
+    store = AnalyticsStore(tmp_path / "a.db")
+    assert store.record_batch([_snap(), _snap()]) == 2
+    agg = store.aggregate()
+    assert agg.calls == 2
+    assert agg.ok_calls == 2
+    assert agg.input_tokens == 200
+    assert agg.output_tokens == 80
+    assert agg.cache_read_tokens == 1600
+    assert agg.reasoning_tokens == 20
+    assert agg.context_tokens == 1840
+    # Component split was apportioned against context at write time and sums
+    # back to the context total.
+    assert sum(agg.components.values()) == agg.context_tokens
+    store.close()
+
+
+def test_component_split_is_stored_estimate(tmp_path):
+    store = AnalyticsStore(tmp_path / "a.db")
+    # 900 chars conversation, 100 chars system prompt, 1000 context tokens ->
+    # 900/100 split of the authoritative total.
+    store.record_batch([_snap(context=1000, chars={"conversation": 900, "system_prompt": 100})])
+    agg = store.aggregate()
+    assert agg.components["conversation"] == 900
+    assert agg.components["system_prompt"] == 100
+    store.close()
+
+
+def test_zero_context_stores_zero_components(tmp_path):
+    store = AnalyticsStore(tmp_path / "a.db")
+    store.record_batch([_snap(context=0, chars={"conversation": 500})])
+    agg = store.aggregate()
+    assert agg.calls == 1
+    assert sum(agg.components.values()) == 0
+    store.close()
+
+
+def test_by_provider_and_by_session(tmp_path):
+    store = AnalyticsStore(tmp_path / "a.db")
+    store.record_batch(
+        [
+            _snap(session_id="s1", provider="anthropic", input_tokens=100),
+            _snap(session_id="s2", provider="openai", input_tokens=50),
+            _snap(session_id="s2", provider="anthropic", input_tokens=25),
+        ]
+    )
+    agg = store.aggregate()
+    assert set(agg.by_provider) == {"anthropic", "openai"}
+    assert agg.by_provider["anthropic"].input_tokens == 125
+    assert agg.by_provider["openai"].input_tokens == 50
+    assert set(agg.by_session) == {"s1", "s2"}
+    assert agg.by_session["s2"].calls == 2
+    store.close()
+
+
+def test_failed_calls_counted_separately(tmp_path):
+    store = AnalyticsStore(tmp_path / "a.db")
+    store.record_batch([_snap(ok=True), _snap(ok=False), _snap(ok=False)])
+    agg = store.aggregate()
+    assert agg.calls == 3
+    assert agg.ok_calls == 1
+    store.close()
+
+
+def test_time_window_scoping(tmp_path):
+    store = AnalyticsStore(tmp_path / "a.db")
+    now = int(time.time() * 1000)
+    old = now - 10 * 24 * 60 * 60 * 1000
+    store.record_batch([_snap(ts_ms=old), _snap(ts_ms=now)])
+    recent = store.aggregate(since_ms=now - 1000)
+    assert recent.calls == 1
+    all_time = store.aggregate()
+    assert all_time.calls == 2
+    store.close()
+
+
+def test_session_scoping(tmp_path):
+    store = AnalyticsStore(tmp_path / "a.db")
+    store.record_batch([_snap(session_id="s1"), _snap(session_id="s2")])
+    only = store.aggregate(session_id="s1")
+    assert only.calls == 1
+    store.close()
+
+
+def test_prune_removes_old_rows(tmp_path):
+    store = AnalyticsStore(tmp_path / "a.db", retention_days=7)
+    now = int(time.time() * 1000)
+    old = now - 30 * 24 * 60 * 60 * 1000
+    store.record_batch([_snap(ts_ms=old), _snap(ts_ms=now)])
+    removed = store.prune(now_ms=now)
+    assert removed == 1
+    assert store.aggregate().calls == 1
+    store.close()
+
+
+def test_session_names_surface_in_aggregate(tmp_path):
+    store = AnalyticsStore(tmp_path / "a.db")
+    store.record_batch([_snap(session_id="abc")])
+    store.upsert_session_name("abc", "my conversation")
+    agg = store.aggregate()
+    names = getattr(agg, "session_names", {})
+    assert names.get("abc") == "my conversation"
+    store.close()
+
+
+def test_empty_store_returns_zeroed_aggregate(tmp_path):
+    store = AnalyticsStore(tmp_path / "a.db")
+    agg = store.aggregate()
+    assert agg.calls == 0
+    assert agg.total_tokens == 0
+    assert agg.by_provider == {}
+    assert agg.by_session == {}
+    store.close()
+
+
+def test_broken_store_degrades_to_noop(tmp_path):
+    # A path that cannot be a database (a directory) makes the store a no-op
+    # rather than raising — analytics is an accelerator, never a dependency.
+    bad = tmp_path / "dir.db"
+    bad.mkdir()
+    store = AnalyticsStore(bad)
+    assert store.record_batch([_snap()]) == 0
+    assert store.aggregate().calls == 0
+    store.close()

--- a/tests/unit/analytics/test_stream_recording.py
+++ b/tests/unit/analytics/test_stream_recording.py
@@ -1,0 +1,175 @@
+"""Recording is wired into the ONE place every provider call funnels through.
+
+``SessionStreamFn._record_stream`` wraps the provider stream: it forwards every
+event unchanged (so a turn is byte-for-byte what it was) and, only after the
+stream is fully consumed, records the call's usage. These tests prove the
+forwarding is transparent, the authoritative counts are captured, a failed
+stream is still recorded (it cost input tokens), and analytics failures never
+propagate into the turn.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from local_operator.analytics.recorder import reset_recorder_for_test
+from local_operator.analytics.store import AnalyticsStore
+from local_operator.harness.types import (
+    AgentTool,
+    ChatRequest,
+    Message,
+    ModelSpec,
+    StreamEndEvent,
+    StreamTextDelta,
+    StreamUsageEvent,
+    TextContent,
+    ToolResult,
+    Usage,
+)
+from local_operator.model.configure import SessionStreamFn
+
+
+async def _noop(tool_call_id: str, *_args: object) -> ToolResult:
+    return ToolResult(tool_call_id=tool_call_id, tool_name="stub", content=[])
+
+
+def _fn(session_id="sess-1"):
+    fn = object.__new__(SessionStreamFn)
+    fn._session_id = session_id
+    return fn
+
+
+def _request():
+    block0 = (
+        "Persona.\n\n## User's custom instructions\n\n<user_instructions>terse</user_instructions>"
+    )
+    return ChatRequest(
+        model=ModelSpec(provider="anthropic", model_id="claude-opus-5"),
+        system_blocks=[block0, "## Available tools\ntools", "env", "<skills>k</skills>"],
+        messages=[Message(role="user", content=[TextContent(text="hi " * 50)])],
+        tools=[
+            AgentTool(
+                name="bash",
+                description="run",
+                parameters={"type": "object", "properties": {"command": {"type": "string"}}},
+                execute=_noop,
+            )
+        ],
+    )
+
+
+async def _drain(fn, request, events):
+    async def stream():
+        for ev in events:
+            yield ev
+
+    out = []
+    async for ev in fn._record_stream(request, stream()):
+        out.append(ev)
+    return out
+
+
+def test_forwards_events_unchanged(tmp_path):
+    store = AnalyticsStore(tmp_path / "a.db")
+    reset_recorder_for_test(store)
+    fn = _fn()
+    usage = Usage(input_tokens=1000, output_tokens=200, context_tokens=1000)
+    events = [
+        StreamTextDelta(delta="hello"),
+        StreamUsageEvent(usage=usage),
+        StreamEndEvent(stop_reason="stop", usage=usage),
+    ]
+    out = asyncio.run(_drain(fn, _request(), events))
+    assert [type(e).__name__ for e in out] == [
+        "StreamTextDelta",
+        "StreamUsageEvent",
+        "StreamEndEvent",
+    ]
+
+
+def test_records_authoritative_counts(tmp_path):
+    store = AnalyticsStore(tmp_path / "a.db")
+    rec = reset_recorder_for_test(store)
+    fn = _fn("sess-abc")
+    usage = Usage(
+        input_tokens=1000,
+        output_tokens=300,
+        cache_read_tokens=8000,
+        cache_write_tokens=500,
+        reasoning_tokens=120,
+        context_tokens=9500,
+    )
+    asyncio.run(_drain(fn, _request(), [StreamEndEvent(stop_reason="stop", usage=usage)]))
+    rec.flush_for_test()
+    agg = store.aggregate()
+    assert agg.calls == 1
+    assert agg.ok_calls == 1
+    assert agg.input_tokens == 1000
+    assert agg.output_tokens == 300
+    assert agg.reasoning_tokens == 120
+    assert agg.generation_tokens == 180
+    assert agg.context_tokens == 9500
+    assert "anthropic" in agg.by_provider
+    assert "sess-abc" in agg.by_session
+    # The component split summed to the authoritative context total.
+    assert sum(agg.components.values()) == 9500
+    # System prompt and custom instructions were both attributed nonzero.
+    assert agg.components["system_prompt"] > 0
+    assert agg.components["custom_instructions"] > 0
+
+
+def test_failed_stream_still_recorded(tmp_path):
+    store = AnalyticsStore(tmp_path / "a.db")
+    rec = reset_recorder_for_test(store)
+    fn = _fn()
+    # An error end that still carried a usage (input was billed).
+    end = StreamEndEvent(
+        stop_reason="error", usage=Usage(input_tokens=500, context_tokens=500), error="boom"
+    )
+    asyncio.run(_drain(fn, _request(), [end]))
+    rec.flush_for_test()
+    agg = store.aggregate()
+    assert agg.calls == 1
+    assert agg.ok_calls == 0
+
+
+def test_no_usage_records_nothing(tmp_path):
+    store = AnalyticsStore(tmp_path / "a.db")
+    rec = reset_recorder_for_test(store)
+    fn = _fn()
+    # A stream that never reported usage: nothing to attribute, nothing stored.
+    asyncio.run(_drain(fn, _request(), [StreamTextDelta(delta="x")]))
+    rec.flush_for_test()
+    assert store.aggregate().calls == 0
+
+
+def test_context_fallback_from_input(tmp_path):
+    # A provider that omits an explicit context size: the recorder falls back
+    # to input + cache_read so the component split still has a denominator.
+    store = AnalyticsStore(tmp_path / "a.db")
+    rec = reset_recorder_for_test(store)
+    fn = _fn()
+    usage = Usage(input_tokens=400, output_tokens=50, cache_read_tokens=100, context_tokens=None)
+    asyncio.run(_drain(fn, _request(), [StreamEndEvent(stop_reason="stop", usage=usage)]))
+    rec.flush_for_test()
+    agg = store.aggregate()
+    assert agg.calls == 1
+    assert sum(agg.components.values()) == 500  # 400 + 100
+
+
+def test_analytics_failure_never_breaks_turn(tmp_path, monkeypatch):
+    # If recording raises, the stream must still complete normally.
+    store = AnalyticsStore(tmp_path / "a.db")
+    reset_recorder_for_test(store)
+    fn = _fn()
+
+    import local_operator.analytics as analytics_pkg
+
+    def _boom(_snapshot):
+        raise RuntimeError("recorder exploded")
+
+    monkeypatch.setattr(analytics_pkg, "record_call", _boom)
+    usage = Usage(input_tokens=10, context_tokens=10)
+    out = asyncio.run(_drain(fn, _request(), [StreamEndEvent(stop_reason="stop", usage=usage)]))
+    # The turn's event still came through; the analytics failure was swallowed.
+    assert [type(e).__name__ for e in out] == ["StreamEndEvent"]

--- a/tests/unit/providers/test_clients.py
+++ b/tests/unit/providers/test_clients.py
@@ -106,6 +106,7 @@ def _openai_sse_with_tool_call() -> bytes:
                     "prompt_tokens": 40,
                     "completion_tokens": 7,
                     "prompt_tokens_details": {"cached_tokens": 12},
+                    "completion_tokens_details": {"reasoning_tokens": 3},
                 },
             },
         ]
@@ -152,6 +153,9 @@ async def test_openai_compat_text_tool_usage() -> None:
     usage_events = [e for e in events if isinstance(e, StreamUsageEvent)]
     assert usage_events and usage_events[0].usage.input_tokens == 40
     assert usage_events[0].usage.cache_read_tokens == 12  # prompt_tokens_details.cached_tokens
+    # completion_tokens_details.reasoning_tokens is the thinking slice of the
+    # completion, a subset of output that analytics splits out.
+    assert usage_events[0].usage.reasoning_tokens == 3
 
     end = events[-1]
     assert isinstance(end, StreamEndEvent)
@@ -682,6 +686,7 @@ def _public_responses_sse() -> bytes:
                         "input_tokens": 80,
                         "output_tokens": 9,
                         "input_tokens_details": {"cached_tokens": 48},
+                        "output_tokens_details": {"reasoning_tokens": 4},
                     },
                 },
             },
@@ -776,6 +781,8 @@ async def test_openai_api_key_gpt5_uses_public_responses_end_to_end() -> None:
     assert json.loads("".join(event.argument_delta for event in tool_events)) == {"city": "Paris"}
     usage = [event.usage for event in events if isinstance(event, StreamUsageEvent)][0]
     assert (usage.input_tokens, usage.output_tokens, usage.cache_read_tokens) == (80, 9, 48)
+    # output_tokens_details.reasoning_tokens is the thinking slice of output.
+    assert usage.reasoning_tokens == 4
     assert events[-1].stop_reason == "toolUse"
 
 

--- a/tests/unit/tui/test_analytics_panel.py
+++ b/tests/unit/tui/test_analytics_panel.py
@@ -73,6 +73,33 @@ def test_proportion_bar_fills():
     assert bar.count("█") == 5 and bar.count("·") == 5
 
 
+def test_proportion_bar_nonzero_floors_to_one_cell():
+    # D3: a small nonzero fraction must show at least one filled cell so a real
+    # 1% contributor is distinguishable from an empty (rounds-to-zero) row.
+    bar = proportion_bar(0.01, 24)  # would round to 0 filled cells
+    assert bar.count("█") == 1
+    # A genuine zero still renders empty.
+    assert proportion_bar(0.0, 24).count("█") == 0
+
+
+def test_format_percent_floors_near_100():
+    # D4: 99.6% must not round up to a flat, suspicious-looking 100%.
+    assert format_percent(0.996) == "99%"
+    assert format_percent(1.0) == "100%"  # a genuine full rate still shows 100%
+
+
+def test_estimate_is_marked_at_data_level():
+    # D1: the estimated split must be marked as an estimate on the DATA (~ on
+    # each percentage), so the distinction survives the heading scrolling away.
+    import re
+
+    text = _text(_agg())
+    assert "≈ estimated" in text
+    # Every WHERE-INPUT-WENT percentage carries a ~ prefix (modelled, not
+    # measured); the TOTALS section carries none.
+    assert re.search(r"~\s*\d+%", text)
+
+
 def test_empty_aggregate_says_no_data():
     text = _text(UsageAggregate())
     assert "No usage recorded yet" in text

--- a/tests/unit/tui/test_analytics_panel.py
+++ b/tests/unit/tui/test_analytics_panel.py
@@ -1,0 +1,168 @@
+"""The ``/analytics /usage`` screen — the report it renders and its Esc close.
+
+The renderer is a pure function of the aggregate, so most of this asserts plain
+strings (what a user reads). Two pilot tests drive the REAL ``OperatorApp`` so
+the screen actually mounts under the stylesheet and Esc/``q`` return to the
+previous view — a passing text assertion is not evidence a TUI looks right, but
+it is the right way to pin what the screen SAYS and that it closes.
+"""
+
+from __future__ import annotations
+
+from local_operator.analytics.model import COMPONENT_KEYS, UsageAggregate
+from local_operator.tui.app import OperatorApp
+from local_operator.tui.widgets.analytics_panel import (
+    AnalyticsScreen,
+    build_report,
+    format_percent,
+    format_tokens,
+    proportion_bar,
+)
+from tests.unit.tui.test_app_pilot import FakeSession, _factory
+
+
+def _agg() -> UsageAggregate:
+    agg = UsageAggregate(
+        calls=100,
+        ok_calls=98,
+        input_tokens=500_000,
+        output_tokens=120_000,
+        cache_read_tokens=3_000_000,
+        cache_write_tokens=80_000,
+        reasoning_tokens=40_000,
+        context_tokens=3_500_000,
+    )
+    agg.components = {k: 0 for k in COMPONENT_KEYS}
+    agg.components["conversation"] = 1_800_000
+    agg.components["tool_results"] = 900_000
+    agg.components["system_prompt"] = 500_000
+    agg.components["tool_schemas"] = 300_000
+    sub = UsageAggregate(
+        calls=100,
+        input_tokens=500_000,
+        output_tokens=120_000,
+        context_tokens=3_500_000,
+        cache_read_tokens=3_000_000,
+    )
+    agg.by_provider = {"anthropic": sub}
+    agg.by_session = {"abc123": sub}
+    setattr(agg, "session_names", {"abc123": "my session"})
+    return agg
+
+
+def _text(agg: UsageAggregate, width: int = 90) -> str:
+    return "\n".join(line.plain for line in build_report(agg, width))
+
+
+def test_format_tokens_scales():
+    assert format_tokens(912) == "912"
+    assert format_tokens(3400) == "3.4k"
+    assert format_tokens(1_200_000) == "1.2M"
+    assert format_tokens(4_100_000_000) == "4.1B"
+
+
+def test_format_percent():
+    assert format_percent(0.734) == "73%"
+    assert format_percent(None) == "—"
+
+
+def test_proportion_bar_fills():
+    assert proportion_bar(1.0, 10) == "█" * 10
+    assert proportion_bar(0.0, 10) == "·" * 10
+    bar = proportion_bar(0.5, 10)
+    assert bar.count("█") == 5 and bar.count("·") == 5
+
+
+def test_empty_aggregate_says_no_data():
+    text = _text(UsageAggregate())
+    assert "No usage recorded yet" in text
+
+
+def test_report_shows_totals_and_split():
+    text = _text(_agg())
+    assert "TOTALS" in text
+    assert "100 calls" in text
+    assert "(2 failed)" in text
+    # authoritative headline numbers
+    assert "Cache hit rate" in text
+    # the estimated component split, largest first
+    assert "WHERE INPUT WENT" in text
+    assert "estimated" in text
+    assert "Conversation" in text
+    assert "System prompt" in text
+    # per-provider and per-session tables
+    assert "BY PROVIDER" in text
+    assert "anthropic" in text
+    assert "BY SESSION" in text
+    # named session shows its title, not the id
+    assert "my session" in text
+
+
+def test_component_split_ordered_largest_first():
+    text = _text(_agg())
+    conv = text.index("Conversation")
+    tool_results = text.index("Tool results")
+    system = text.index("System prompt")
+    # conversation (1.8M) before tool results (900k) before system (500k)
+    assert conv < tool_results < system
+
+
+def test_thinking_generation_split_shown():
+    text = _text(_agg())
+    # output 120k = 80k generation + 40k thinking
+    assert "generation" in text and "thinking" in text
+
+
+async def _push(pilot, app, agg):
+    await pilot.pause()
+    screen = AnalyticsScreen(agg)
+    await app.push_screen(screen)
+    await pilot.pause()
+    await pilot.pause()
+    return screen
+
+
+def test_screen_mounts_and_esc_closes():
+    import asyncio
+
+    async def run():
+        app = OperatorApp(lambda: _factory(FakeSession()))
+        async with app.run_test(size=(110, 40)) as pilot:
+            before = app.screen.__class__.__name__
+            await _push(pilot, app, _agg())
+            assert app.screen.__class__.__name__ == "AnalyticsScreen"
+            await pilot.press("escape")
+            await pilot.pause()
+            assert app.screen.__class__.__name__ == before
+
+    asyncio.run(run())
+
+
+def test_screen_q_closes():
+    import asyncio
+
+    async def run():
+        app = OperatorApp(lambda: _factory(FakeSession()))
+        async with app.run_test(size=(110, 40)) as pilot:
+            before = app.screen.__class__.__name__
+            await _push(pilot, app, _agg())
+            await pilot.press("q")
+            await pilot.pause()
+            assert app.screen.__class__.__name__ == before
+
+    asyncio.run(run())
+
+
+def test_render_lines_for_test_available():
+    import asyncio
+
+    async def run():
+        app = OperatorApp(lambda: _factory(FakeSession()))
+        async with app.run_test(size=(110, 40)) as pilot:
+            screen = await _push(pilot, app, _agg())
+            lines = screen.render_lines_for_test()
+            joined = "\n".join(lines)
+            assert "TOTALS" in joined
+            assert "WHERE INPUT WENT" in joined
+
+    asyncio.run(run())

--- a/tests/unit/tui/test_approvals_ux.py
+++ b/tests/unit/tui/test_approvals_ux.py
@@ -503,6 +503,10 @@ def test_the_registry_states_which_commands_offer_values() -> None:
         # OPTIONAL like `/team`, which `/agent` mirrors: bare `/agent` lists
         # the roles/specialists, and the space opens the name argument list.
         "agent": ArgumentMode.OPTIONAL,
+        # OPTIONAL like `/effort`: bare `/analytics` opens the default (usage)
+        # view, and the space offers the analytics-view list (today just
+        # `usage`); the screen it opens IS the receipt, so it never echoes.
+        "analytics": ArgumentMode.OPTIONAL,
     }
     # `/provider` was the third candidate and is deliberately not here: it takes
     # no argument at all — `_cmd_providers` ignores what follows it — so a list

--- a/tests/unit/tui/test_slash_echo.py
+++ b/tests/unit/tui/test_slash_echo.py
@@ -59,6 +59,9 @@ ECHO_POLICY = {
     "search": False,
     "accounts": False,
     "usage": False,
+    # The screen it opens IS the receipt (same rule as `/usage`); the argument
+    # names a view, never words the model is told.
+    "analytics": False,
     "goal": True,
     "loop": False,
     # The aside's whole promise is that the exchange leaves no trace in the


### PR DESCRIPTION
## Why

There was no way to see where tokens actually go. `/usage` shows provider *quota*, and `/context` shows the *next* request's estimated breakdown, but nothing aggregated real consumption across turns and sessions — so "where is our spend going, and is it the system prompt, the tool schemas, the conversation, or thinking?" was unanswerable, and there was no data to drive harness improvements over time.

This adds a diagnostic, aggregated token-consumption ledger that **every** provider call across **every** session contributes to, plus an esc-quittable `/analytics /usage` screen. Version bump is **MINOR** (0.20.1 → 0.21.0): new capability, no breaking changes.

## What changes

### The analytics module (`local_operator/analytics/`)

- **`store.py`** — an append-only SQLite ledger at `<config_dir>/analytics.db` (WAL, `synchronous=NORMAL`, `busy_timeout`, 0600, same discipline as `auth.db`/`usage_cache.db`). Aggregation is a `GROUP BY` run only when a report opens, not a running counter, so writes never contend on a shared total. A rolling 90-day retention keeps the file bounded. Reads use a **fresh short-lived connection** so a report always sees the newest commit rather than a stale WAL snapshot.
- **`recorder.py`** — a process-wide singleton with **one** background daemon writer thread behind a bounded queue. `record()` is a single non-blocking `put_nowait` that **drops** on a full queue (counted, logged once) rather than applying back-pressure to a session. Call samples *and* session-name upserts funnel through the one writer/connection — two threads opening their first connection to a freshly-created SQLite DB race in a way that can leave the writer unable to see its own commits.
- **`model.py`** — the component taxonomy and attribution. Provider counts (input/output/cache/reasoning) are **authoritative**; the split across system prompt, custom instructions (agent/team profiles), tool inventory, tool schemas, environment, knowledge, conversation, and tool results is an **estimate**: each component's char-length share of the authoritative context total, apportioned with largest-remainder rounding so it sums exactly. Labelled as an estimate everywhere it surfaces.

### Universal, latency-free injection

`SessionStreamFn._record_stream` (`model/configure.py`) wraps the **one** path every provider call funnels through — turns, tool loops, compaction summaries, auto-naming, and every subagent. It forwards the stream **unchanged** and records **only after** the stream is fully consumed, so it adds nothing to the response the caller awaits. The sole event-loop cost is a character-length snapshot of the request (the transcript mutates the messages after the call, so this must be taken up front); tokenising, apportioning, and the SQLite write all run on the background thread. Every path is guarded — analytics can never break a turn.

### Supporting changes

- `Usage.reasoning_tokens` (a **subset** of `output_tokens`, never added on top) + parsing from OpenAI chat/completions (`completion_tokens_details.reasoning_tokens`) and Responses (`output_tokens_details.reasoning_tokens`), so output splits into thinking vs generation.
- `/analytics [view]` slash command (accepts `/analytics /usage` and bare `/analytics`), its argument list, and `AnalyticsScreen` (a `ModalScreen`, esc/`q` to close, scrollable), with stylesheet.
- `Session.set_conversation_name` mirrors the human title into the ledger (best-effort, off the hot path) so the per-session table shows names.

## Impact

- **No breaking changes.** Analytics is a pure accelerator: a read-only home dir, a locked file, or a full disk degrades to "no analytics", never a broken session. Nothing awaits the write.
- **Parallel-safe.** Several `lop` sessions write to the one file at once; WAL + `busy_timeout` + a bounded busy-retry (on the background thread) make that atomic.
- **Latency.** Benchmarked below — imperceptible, and off the response path entirely.
- **Disk.** One small row per provider call (a dozen ints + two short strings), 90-day rolling retention.
- **Security.** DB is 0600; rows carry session ids and model identifiers, never prompt content or secrets.

## Testing Details

Evidence is proof the feature works, exercised against the real code paths — not just a green unit suite.

### End-to-end recording through the real stream wrapper

Driving `SessionStreamFn._record_stream` with a fake provider stream and reading the ledger back:

```
forwarded events: ['StreamTextDelta', 'StreamUsageEvent', 'StreamEndEvent']   # stream unchanged
calls: 1 ok: 1
input: 1000 output: 200 cache_read: 8000 cache_write: 500 reasoning: 120 context: 9500
generation: 80 cache_hit_rate: 0.842                                          # output 200 = 120 thinking + 80 generation
components (sum=9500, ctx=9500):                                              # estimate sums to authoritative total
   System prompt                          3889
   Custom instructions (agents/teams)     712
   Tool inventory                         334
   Tool schemas                           554
   Environment                            34
   Knowledge / skills                     61
   Conversation                           2026
   Tool results                           1890
by_provider: {'anthropic': 9500}
by_session: {'sess-abc123': 9500}
after failed call -> calls: 2 ok: 1                                           # aborted call still recorded, counted separately
```

### Hot-path latency (the on-event-loop cost)

`snapshot_component_chars` + `record()` enqueue, across context sizes (2000 iterations each, after warmup):

```
small   (5 msgs, 3 tools)     ~ 11,610 ctx tokens | snapshot 0.019 ms | snapshot+enqueue 0.021 ms
typical (60 msgs, 20 tools)   ~ 90,682 ctx tokens | snapshot 0.111 ms | snapshot+enqueue 0.113 ms
large   (200 msgs, 60 tools)  ~291,032 ctx tokens | snapshot 0.336 ms | snapshot+enqueue 0.336 ms
```

Well under a millisecond even on a 291k-token context, and it runs *after* the stream completes — the response the user waits on is untouched. At a realistic call rate the drop count stays **0**.

### Parallel safety (multi-process, atomic writes)

6 concurrent processes (separate `lop` sessions), 200 records each:

```
total calls: 1200 expected: 1200
per-session counts: {proc0..proc5: 200 each}
input total: 12000 expected: 12000
```

Zero lost or corrupted rows. Also covered by `test_parallel_processes_write_atomically` (4 processes × 150) under pytest.

### Automated tests

- **33** analytics unit tests (`tests/unit/analytics/`): attribution math (sums to context total, deterministic, zero-context → all-zero), store (roundtrip, provider/session/time scoping, retention prune, session names, broken-store degradation), recorder (reaches store, drop-on-close, batching, parallel processes), and stream-recording integration (transparent forwarding, authoritative counts, failed stream recorded, no-usage records nothing, context fallback, analytics failure never breaks a turn).
- **10** TUI tests (`tests/unit/tui/test_analytics_panel.py`): formatting, ordered component split, thinking/generation shown, empty state, and the real `OperatorApp` mounting the screen + esc/`q` returning to the previous view.
- Provider reasoning-token parsing added to `test_clients.py` (chat/completions + Responses).
- `test_slash_echo.py` echo policy pinned for `/analytics`.

Full command path verified live: typing `/analytics /usage` into the real app pushes `AnalyticsScreen`; esc and `q` both restore the previous view.

Gates: `black --check`, `isort --check-only`, `flake8`, and `pyright` all clean on the changed source and tests.

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my changes work as intended.
- [x] All new and existing tests pass.
- [x] I have run formatting (black/isort), linting (flake8), and type checks (pyright), and they pass.
- [x] I have updated the documentation when required. (AGENTS.md gains an analytics section.)
- [x] Security considerations are addressed (0600 DB, no prompt content/secrets stored, fully guarded/best-effort).
- [x] I have linked all related issues. (None.)

## Screenshots

`/analytics /usage` (remediated head `f54d0851`, realistic cache data). Both the code and design review rounds verified these frames.

**Populated — totals, estimated component split, per-provider.** "Total billed 8.3M" counts the full cached input (A1 fix); cache hit rate 78% (D4); `≈`/`~` mark the estimated split vs the `measured` totals (D1); small components keep a 1-cell bar (D3).

![Populated analytics usage screen](https://raw.githubusercontent.com/damianvtran/local-operator/pr-247-assets/shots/analytics-usage-populated.png)

**Scrolled to the per-session table.**

![By-session view](https://raw.githubusercontent.com/damianvtran/local-operator/pr-247-assets/shots/analytics-usage-by-session.png)

**Empty state** (no calls recorded yet) — footer shows only `esc back`, no scroll hint (D5).

![Empty state](https://raw.githubusercontent.com/damianvtran/local-operator/pr-247-assets/shots/analytics-usage-empty.png)
