### PR TITLE
feat(mobile): fix todos overflow, naming, approvals, images, and new-session UX

### DIFF
--- a/local_operator/mobile/daemon.py
+++ b/local_operator/mobile/daemon.py
@@ -393,6 +393,54 @@ def _history_page(record: SessionRecord, before: str | None, limit: int) -> tupl
     return page, has_more
 
 
+def _image_bytes(record: SessionRecord, entry_id: str, index: int) -> tuple[bytes, str] | None:
+    """Decode the ``index``-th image block of message ``entry_id`` from the
+    session's on-disk transcript into raw bytes plus mime type.
+
+    Reads from disk (not the live fold) so it serves attachments from history
+    the projection tail dropped as well as recent ones, and reuses the
+    transcript's own attachment resolution — the same base64 the model saw.
+    Returns ``None`` for any miss (unknown message, out-of-range index, a
+    reference that no longer resolves) so the caller answers a clean 404.
+
+    Runs off the event loop (``asyncio.to_thread`` at the call site): building
+    the history rehydrates every message and is not loop-safe work.
+    """
+    import base64
+    import binascii
+
+    from local_operator.harness.types import ImageContent, Message
+    from local_operator.paths import config_dir
+    from local_operator.session.transcript import Transcript
+
+    directory = config_dir() / "sessions" / record.session_id
+    if not (directory / "transcript.jsonl").exists():
+        return None
+    try:
+        transcript = Transcript(directory)
+        history = transcript.build_llm_history()
+    except Exception:  # noqa: BLE001 — an odd transcript serves no image, not a 500
+        logger.exception("image fetch: history fold failed for %s", record.session_id)
+        return None
+    message = next((m for m in history if isinstance(m, Message) and m.id == entry_id), None)
+    if message is None or not isinstance(message.content, list):
+        return None
+    images = [b for b in message.content if isinstance(b, ImageContent)]
+    # ``index`` is the position among IMAGE blocks (what _image_refs emits),
+    # not among all content blocks — text blocks do not count.
+    if index < 0 or index >= len(images):
+        return None
+    data = images[index].data
+    if not data:
+        return None
+    try:
+        raw = base64.b64decode(data)
+    except (binascii.Error, ValueError):
+        logger.warning("image fetch: undecodable base64 for %s[%d]", entry_id, index)
+        return None
+    return raw, images[index].mime_type or "image/png"
+
+
 def _fan_out(entry: SessionEntry) -> None:
     """Push the current projection to every open SSE queue for this session.
     A slow phone's queue fills; repaints supersede, so evict the oldest and
@@ -789,6 +837,41 @@ def build_app(daemon: MobileDaemon):
             }
         )
 
+    async def api_session_image(request: Request) -> Response:
+        """One image attachment's bytes, fetched lazily by the transcript.
+
+        The projection carries only lightweight image REFERENCES (entry id +
+        block index + mime) so a per-token repaint stays small; the pixels are
+        served here on demand. The bytes come from the on-disk transcript
+        (which resolves the attachment store back to inline base64), so this
+        works for history the live fold long dropped as well as the tail. The
+        response is cacheable and immutable: a message's attachments never
+        change, and the ``entry``+``i`` pair is a stable content key.
+        """
+        denied = gate(request)
+        if denied is not None:
+            return denied
+        pid = int(request.path_params["pid"])
+        entry = daemon.table.entries.get(pid)
+        if entry is None:
+            return JSONResponse({"error": "unknown session"}, status_code=404)
+        entry_id = request.query_params.get("entry", "")
+        try:
+            index = int(request.query_params.get("i", "0"))
+        except ValueError:
+            return JSONResponse({"error": "bad image index"}, status_code=400)
+        if not entry_id:
+            return JSONResponse({"error": "entry id is required"}, status_code=400)
+        found = await asyncio.to_thread(_image_bytes, entry.record, entry_id, index)
+        if found is None:
+            return JSONResponse({"error": "no such image"}, status_code=404)
+        data, mime_type = found
+        return Response(
+            content=data,
+            media_type=mime_type,
+            headers={"Cache-Control": "public, max-age=31536000, immutable"},
+        )
+
     async def api_command(request: Request) -> Response:
         """The one mutation endpoint: {op, ...} → control frame. Keeping
         mutations on one route mirrors the registrant's dispatch and keeps
@@ -830,14 +913,16 @@ def build_app(daemon: MobileDaemon):
         except ValueError:
             return JSONResponse({"error": "invalid JSON"}, status_code=400)
         cwd_raw = str(body.get("cwd") or Path.home())
-        # Resolve to a real directory under the owner's home: the picker only
-        # ever sends those, and the spawn runs with the daemon's environment,
-        # so the check is about fat-fingered/traversed input, not trust.
+        # Resolve to a real directory the picker is allowed to open: anywhere
+        # under the owner's home, OR the system temp dir. The spawn runs with
+        # the daemon's own environment (it is the owner's account either way),
+        # so the check guards against fat-fingered/traversed input, not trust
+        # — /tmp is a deliberate, common scratch root the phone offers as a
+        # starting directory, so it is on the allowlist beside home.
         cwd_path = Path(cwd_raw).expanduser().resolve()
-        home = Path.home().resolve()
-        if not cwd_path.is_dir() or not (cwd_path == home or home in cwd_path.parents):
+        if not cwd_path.is_dir() or not _spawn_dir_allowed(cwd_path):
             return JSONResponse(
-                {"error": f"not a directory under home: {cwd_raw}"}, status_code=400
+                {"error": f"not an allowed start directory: {cwd_raw}"}, status_code=400
             )
         cwd = str(cwd_path)
         provider = body.get("provider")
@@ -927,7 +1012,9 @@ def build_app(daemon: MobileDaemon):
         if denied is not None:
             return denied
         recent = await asyncio.to_thread(_recent_directories)
-        return JSONResponse({"home": str(Path.home()), "recent": recent})
+        # ``tmp`` is offered as an explicit scratch start dir beside home and
+        # the recents — the spawn gate admits it (see _spawn_dir_allowed).
+        return JSONResponse({"home": str(Path.home()), "recent": recent, "tmp": _tmp_dir()})
 
     async def api_past_sessions(request: Request) -> Response:
         """Resumable past sessions — the phone's "go back to a conversation"
@@ -965,6 +1052,7 @@ def build_app(daemon: MobileDaemon):
         Route("/api/sessions/search", api_search_sessions),
         Route("/api/sessions/{pid:int}/events", api_session_events),
         Route("/api/sessions/{pid:int}/history", api_session_history),
+        Route("/api/sessions/{pid:int}/image", api_session_image),
         Route("/api/sessions/{pid:int}/command", api_command, methods=["POST"]),
         Route("/api/commands", api_commands),
         Route("/api/models", api_models),
@@ -1050,6 +1138,27 @@ def _search_sessions(query: str, limit: int = 40) -> list[dict[str, Any]]:
         if len(out) >= limit:
             break
     return out
+
+
+def _tmp_dir() -> str:
+    """The system temp directory, resolved. Offered as a scratch start dir on
+    the phone's new-session form and admitted by the spawn gate. Resolved (not
+    the raw ``/tmp``) so it matches the gate's resolved comparison on hosts
+    where ``/tmp`` is a symlink (macOS: ``/private/tmp``)."""
+    import tempfile
+
+    return str(Path(tempfile.gettempdir()).resolve())
+
+
+def _spawn_dir_allowed(cwd_path: Path) -> bool:
+    """Whether a resolved directory may host a phone-started session: anywhere
+    under the owner's home, or the system temp dir (a common scratch root).
+    Both bounds are on RESOLVED paths so a symlinked ``/tmp`` still matches."""
+    home = Path.home().resolve()
+    if cwd_path == home or home in cwd_path.parents:
+        return True
+    tmp = Path(_tmp_dir())
+    return cwd_path == tmp or tmp in cwd_path.parents
 
 
 def _recent_directories(limit: int = 8) -> list[str]:

--- a/local_operator/mobile/daemon.py
+++ b/local_operator/mobile/daemon.py
@@ -844,9 +844,15 @@ def build_app(daemon: MobileDaemon):
         block index + mime) so a per-token repaint stays small; the pixels are
         served here on demand. The bytes come from the on-disk transcript
         (which resolves the attachment store back to inline base64), so this
-        works for history the live fold long dropped as well as the tail. The
-        response is cacheable and immutable: a message's attachments never
-        change, and the ``entry``+``i`` pair is a stable content key.
+        works for history the live fold long dropped as well as the tail.
+
+        Cacheable and immutable: the true content key is the ``entry`` id — a
+        globally-unique message uuid — plus the image-only ``i``. The ``pid``
+        in the path only routes to a live session; pids recycle, but a
+        recycled pid maps to a DIFFERENT session whose transcript does not
+        contain this message uuid, so it 404s rather than serving another
+        session's cached bytes. The uuid content key is what makes ``immutable``
+        safe despite the mutable pid in the URL.
         """
         denied = gate(request)
         if denied is not None:

--- a/local_operator/mobile/owned.py
+++ b/local_operator/mobile/owned.py
@@ -58,15 +58,27 @@ class OwnedSessionHandle(SessionHandle):
         loop: asyncio.AbstractEventLoop,
         *,
         cwd: str,
+        auto_approve: bool = False,
     ) -> None:
         self._session = session
         self._loop = loop
+        # When the owner's saved default is full-auto (``tool_approval_mode:
+        # auto``), the phone must not park a card the TUI would never show —
+        # the gate is answered ``True`` inline instead. Stored so a future
+        # per-session toggle can flip it without reconstructing the handle.
+        self._auto_approve = auto_approve
         self._on_projection: Callable[[], None] | None = None
         self._projection = SessionProjection(
             session_id=session.session_id,
             pid=0,  # stamped by the registrant's record
             kind="daemon",
-            conversation_name=getattr(session, "conversation_name", "") or "mobile session",
+            # A restored session carries its stored name; a brand-new one has
+            # none yet and the naming errand (see prompt()) fills it after the
+            # first substantive turn. Left empty rather than a stand-in like
+            # "mobile session" so the phone's own fallback (the header shows
+            # "untitled", the list shows the cwd) is what the user sees until
+            # the real title lands, instead of a placeholder that never moves.
+            conversation_name=getattr(session, "conversation_name", "") or "",
             cwd=cwd,
             model_label=session.model_label,
             model_selector=_selector(session),
@@ -74,6 +86,13 @@ class OwnedSessionHandle(SessionHandle):
             effort_ladder=_ladder(session),
         )
         self._fold = ProjectionFold(self._projection)
+        # Conversation naming is a TUI-only errand today (OperatorApp owns the
+        # naming worker), so a phone-started session used to stay "mobile
+        # session" forever — the session list and the header both read the
+        # conversation name and had nothing better to show. This latch mirrors
+        # OperatorApp._name_requested: the first substantive prompt fires ONE
+        # background naming call, alongside the turn it decorates.
+        self._name_requested = False
         # request_id -> Future the gate/ask call is parked on.
         self._pending_futures: dict[str, asyncio.Future[Any]] = {}
         # request_id -> the AskQuestion.id the harness is waiting on (the
@@ -85,10 +104,20 @@ class OwnedSessionHandle(SessionHandle):
 
     def _install_gates(self) -> None:
         async def approval_gate(tool_name: str, description: str) -> bool:
+            # Full-auto: the owner's saved default is to approve every tier,
+            # exactly as the TUI adopts ``tool_approval_mode: auto`` at boot
+            # (see OperatorApp._load_approvals_default). Answer inline so the
+            # turn never stalls on a card no front end would present.
+            if self._auto_approve:
+                return True
             request_id = secrets.token_hex(8)
             future: asyncio.Future[bool] = self._loop.create_future()
             self._pending_futures[request_id] = future
-            self._fold.set_pending(
+            # push_pending, not set_pending: a parallel tool batch can open two
+            # approvals concurrently, and each must get its own card. Clearing
+            # by request_id (pop_pending) is what keeps them independent — one
+            # answered card must not dismiss the sibling that is still waiting.
+            self._fold.push_pending(
                 PendingRequest(
                     request_id=request_id,
                     kind="approval",
@@ -103,7 +132,7 @@ class OwnedSessionHandle(SessionHandle):
                 return False
             finally:
                 self._pending_futures.pop(request_id, None)
-                self._fold.set_pending(None)
+                self._fold.pop_pending(request_id)
                 self._notify()
 
         async def ask_gate(questions: list[Any]) -> dict[str, list[str]] | None:
@@ -127,7 +156,7 @@ class OwnedSessionHandle(SessionHandle):
                     "mobile ask gate: %d questions, projecting the first only",
                     len(questions),
                 )
-            self._fold.set_pending(
+            self._fold.push_pending(
                 PendingRequest(
                     request_id=request_id,
                     kind="ask",
@@ -145,9 +174,15 @@ class OwnedSessionHandle(SessionHandle):
             finally:
                 self._pending_futures.pop(request_id, None)
                 self._pending_question_ids.pop(request_id, None)
-                self._fold.set_pending(None)
+                self._fold.pop_pending(request_id)
                 self._notify()
 
+        # Kept as attributes as well as registered on the session: the handle
+        # is the single owner of the gate behaviour, and holding the reference
+        # lets tests (and any future direct caller) exercise the exact closure
+        # the harness will await, rather than a re-implementation of it.
+        self._approval_gate = approval_gate
+        self._ask_gate = ask_gate
         self._session.set_approval_handler(approval_gate)
         self._session.set_ask_handler(ask_gate)
 
@@ -191,8 +226,58 @@ class OwnedSessionHandle(SessionHandle):
         # front so the common busy case answers immediately without a task.
         if self._session.is_streaming or getattr(self._session, "_compacting", False):
             return "not sent: session is busy — steer instead, or retry in a moment"
+        self._maybe_name_conversation(text)
         self._run_turn_task(text, image_blocks)
         return "prompt sent"
+
+    def _maybe_name_conversation(self, text: str) -> None:
+        """Name a still-unnamed conversation from its first real prompt.
+
+        The TUI's OperatorApp runs the full naming/re-titling machinery; the
+        phone only needs the FIRST-name half, because a mobile session opens
+        unnamed and the list/header have nothing to show until it is named.
+        Mirrors OperatorApp._maybe_name_conversation: skip low-signal openers
+        (a bare "hi" is usually followed by the real ask, and latching on it
+        would leave the session named after the greeting), fire at most once,
+        and run the call as a background task so the title arrives ALONGSIDE
+        the turn rather than after it.
+        """
+        from local_operator.session import naming
+
+        if self._name_requested or naming.is_low_signal(text):
+            return
+        if getattr(self._session, "conversation_name", ""):
+            # Already named (a restored session, or a prior prompt named it).
+            self._name_requested = True
+            return
+        self._name_requested = True
+        asyncio.ensure_future(self._name_conversation_worker(text))
+
+    async def _name_conversation_worker(self, text: str) -> None:
+        """Ask the model for a title once, cheaply, off the turn's lock.
+
+        ``session.complete_once`` is the same isolated, single-attempt, cheap
+        completion the TUI's naming worker uses — a 429 here is swallowed by
+        ``generate_title`` and cannot touch the turn. On success the title is
+        stored on the session (which persists it), then the projection is
+        refreshed and pushed so the phone's header and list update live.
+        """
+        from local_operator.session import naming
+
+        try:
+            title = await naming.generate_title(text, self._session.complete_once)
+        except Exception:  # noqa: BLE001 — naming is decoration; never fail a turn
+            logger.debug("mobile conversation naming failed", exc_info=True)
+            return
+        if not title or getattr(self._session, "conversation_name", ""):
+            # No title, or a user/restore named it while we were in flight:
+            # allow a later substantive prompt to retry only when still unnamed.
+            if not getattr(self._session, "conversation_name", ""):
+                self._name_requested = False
+            return
+        self._session.set_conversation_name(title, user_set=False)
+        self._refresh_state()
+        self._notify()
 
     def _run_turn_task(self, text: str, image_blocks: list["ImageContent"]) -> None:
         """Run the turn as a background task; a rejection surfaces as a notice,
@@ -368,6 +453,21 @@ async def spawn_owned_session(
     credential_manager = CredentialManager(config_dir=config_directory)
     agent_registry = AgentRegistry(config_dir=config_directory)
 
+    # The owner's saved tool-approval default. The TUI reads the SAME key at
+    # boot (OperatorApp._load_approvals_default) and adopts ``auto`` as
+    # "approve every tier"; a phone-started session must honour it too, or a
+    # device set to full-auto still pops an approval card the desktop would
+    # not. ``yolo`` stays False so the gate is INSTALLED (a per-session toggle
+    # can still switch to asking); the handle short-circuits it when auto.
+    try:
+        approval_mode = (
+            str(config_manager.get_config_value("tool_approval_mode", "ask")).strip().lower()
+        )
+    except Exception:  # noqa: BLE001 — a missing/odd config means "ask", never a crash
+        logger.debug("could not read tool_approval_mode; defaulting to ask", exc_info=True)
+        approval_mode = "ask"
+    auto_approve = approval_mode == "auto"
+
     args = argparse.Namespace(
         hosting=provider,
         model=model_id,
@@ -385,4 +485,4 @@ async def spawn_owned_session(
         has_ui=False,
         cwd=cwd,
     )
-    return OwnedSessionHandle(session, loop, cwd=cwd)
+    return OwnedSessionHandle(session, loop, cwd=cwd, auto_approve=auto_approve)

--- a/local_operator/mobile/owned.py
+++ b/local_operator/mobile/owned.py
@@ -93,6 +93,10 @@ class OwnedSessionHandle(SessionHandle):
         # OperatorApp._name_requested: the first substantive prompt fires ONE
         # background naming call, alongside the turn it decorates.
         self._name_requested = False
+        # Strong references to detached background tasks (the naming errand),
+        # so the event loop cannot garbage-collect one mid-flight and drop the
+        # title silently. Each task removes itself on completion.
+        self._background_tasks: set[asyncio.Future[Any]] = set()
         # request_id -> Future the gate/ask call is parked on.
         self._pending_futures: dict[str, asyncio.Future[Any]] = {}
         # request_id -> the AskQuestion.id the harness is waiting on (the
@@ -251,7 +255,11 @@ class OwnedSessionHandle(SessionHandle):
             self._name_requested = True
             return
         self._name_requested = True
-        asyncio.ensure_future(self._name_conversation_worker(text))
+        # Hold a strong reference until the task settles: a bare ensure_future
+        # is only weakly held by the loop and can be collected before it runs.
+        task = asyncio.ensure_future(self._name_conversation_worker(text))
+        self._background_tasks.add(task)
+        task.add_done_callback(self._background_tasks.discard)
 
     async def _name_conversation_worker(self, text: str) -> None:
         """Ask the model for a title once, cheaply, off the turn's lock.

--- a/local_operator/mobile/projection.py
+++ b/local_operator/mobile/projection.py
@@ -174,9 +174,11 @@ def fold_messages_to_entries(history: list[AgentMessage]) -> list[TranscriptEntr
                 )
             continue
         if message.role == "user":
-            # An image-only prompt (composer allows "" text + images) must not
-            # round-trip through history as an EMPTY bubble. Render a receipt
-            # line naming the attachments, matching the live fold's receipt.
+            # Carry image attachments as references so an image-only prompt
+            # (the composer allows "" text + images) renders its thumbnails on
+            # replay instead of round-tripping as an empty bubble — the same
+            # inline render the live fold produces. The bytes are fetched
+            # lazily from the image endpoint; only the reference travels here.
             refs = _image_refs(message)
             text = message.text
             entries.append(TranscriptEntry(id=message.id, kind="user", text=text, images=refs))

--- a/local_operator/mobile/projection.py
+++ b/local_operator/mobile/projection.py
@@ -109,6 +109,31 @@ def _compact(text: str, limit: int) -> str:
     return text if len(text) <= limit else text[: limit - 1] + "…"
 
 
+def _image_refs(message: AgentMessage) -> list[dict[str, Any]]:
+    """Lightweight references to a user message's image blocks — index + mime,
+    never the bytes. The phone fetches the pixels lazily from the image
+    endpoint (see daemon.api_session_image), which reads them back out of the
+    on-disk transcript by the same index. Carrying only the reference keeps a
+    per-token projection repaint from re-sending megabytes of base64.
+
+    A block with an empty ``data`` (an attachment reference that no longer
+    resolves) is still listed: the endpoint degrades it to a broken-image
+    marker, which is more honest than silently dropping the attachment row.
+    """
+    content = getattr(message, "content", None)
+    if not isinstance(content, list):
+        return []
+    refs: list[dict[str, Any]] = []
+    # ``index`` counts IMAGE blocks only (a text caption does not shift it),
+    # which is exactly what the image endpoint's _image_bytes indexes by.
+    image_index = 0
+    for block in content:
+        if isinstance(block, ImageContent):
+            refs.append({"index": image_index, "mime_type": block.mime_type or "image/png"})
+            image_index += 1
+    return refs
+
+
 def _diff_counts(details: dict[str, Any] | None) -> tuple[int, int]:
     """Green/red counts from a tool result's details, when the tool reported
     them (write/edit do). Zeroes, not guesses, everywhere else."""
@@ -152,11 +177,9 @@ def fold_messages_to_entries(history: list[AgentMessage]) -> list[TranscriptEntr
             # An image-only prompt (composer allows "" text + images) must not
             # round-trip through history as an EMPTY bubble. Render a receipt
             # line naming the attachments, matching the live fold's receipt.
-            images = sum(1 for b in message.content if isinstance(b, ImageContent))
+            refs = _image_refs(message)
             text = message.text
-            if not text.strip() and images:
-                text = f"[{images} image{'s' if images != 1 else ''} attached]"
-            entries.append(TranscriptEntry(id=message.id, kind="user", text=text))
+            entries.append(TranscriptEntry(id=message.id, kind="user", text=text, images=refs))
         elif message.role == "assistant":
             if message.text:
                 entries.append(TranscriptEntry(id=message.id, kind="assistant", text=message.text))
@@ -218,6 +241,10 @@ class ProjectionFold:
         self._subagent_started_at: dict[str, float] = {}
         # The working line's clock origin and the label's current source.
         self._activity_started_at: float | None = None
+        # Approval/ask requests waiting on the user, FIFO. Owned sessions can
+        # have several at once (a parallel tool batch); the phone renders the
+        # front one and a "1 of N" badge. See push_pending/pop_pending.
+        self._pending_queue: list[PendingRequest] = []
 
     # -- history -----------------------------------------------------------
 
@@ -236,7 +263,14 @@ class ProjectionFold:
                     )
                 continue
             if message.role == "user":
-                entries.append(TranscriptEntry(id=message.id, kind="user", text=message.text))
+                entries.append(
+                    TranscriptEntry(
+                        id=message.id,
+                        kind="user",
+                        text=message.text,
+                        images=_image_refs(message),
+                    )
+                )
             elif message.role == "assistant":
                 if message.text:
                     entries.append(
@@ -459,11 +493,22 @@ class ProjectionFold:
         if not isinstance(message, Message) or message.role != "user":
             return False
         text = message.text
+        refs = _image_refs(message)
         # De-dupe the optimistic echo: same text already sitting at the tail.
+        # A phone-sent prompt was echoed by note_user_message WITHOUT image
+        # refs (the handle has only the wire images, not a persisted id), so
+        # when the real MessageStartEvent arrives carrying the attachments,
+        # upgrade the echoed row's id and image refs in place rather than
+        # skipping it — otherwise the thumbnails never appear for the sender.
         for entry in reversed(self.projection.transcript[-3:]):
             if entry.kind in ("user", "steer") and entry.text == text:
+                if refs and not entry.images:
+                    entry.id = message.id
+                    entry.images = refs
                 return False
-        self._append(TranscriptEntry(id=message.id, kind="user", text=text, final=True))
+        self._append(
+            TranscriptEntry(id=message.id, kind="user", text=text, images=refs, final=True)
+        )
         return True
 
     def note_prompt_rejected(self, reason: str) -> None:
@@ -538,7 +583,46 @@ class ProjectionFold:
         self._bump()
 
     def set_pending(self, pending: PendingRequest | None) -> None:
-        self.projection.pending = pending
+        """Replace the whole pending queue with zero or one request.
+
+        The TUI-mirror handle (:class:`~local_operator.mobile.tui_handle`)
+        uses this: the terminal owns approval serialization, so the phone only
+        ever mirrors the ONE card the TUI shows. Owned sessions use the
+        request-identified :meth:`push_pending`/:meth:`pop_pending` instead,
+        because their gates resolve concurrently and a bare ``None`` cannot say
+        WHICH one settled.
+        """
+        self._pending_queue = [pending] if pending is not None else []
+        self._sync_pending()
+
+    def push_pending(self, pending: PendingRequest) -> None:
+        """Enqueue a request behind any already waiting; show the front one.
+
+        A tool batch can open two write/exec approvals at once (``shared``
+        tools run in parallel — see harness.loop._execute_tool_calls). Each
+        gate calls this from its own task, so without a queue the second card
+        overwrote the first and the first tool hung forever with no way to
+        answer it. FIFO: the phone answers the oldest wait first, and the next
+        surfaces on the repaint that clears it.
+        """
+        self._pending_queue.append(pending)
+        self._sync_pending()
+
+    def pop_pending(self, request_id: str) -> None:
+        """Remove a settled (or timed-out) request by id and re-front the rest.
+
+        Identified by id, not position: concurrent gates settle in whatever
+        order the user answers or a timeout fires, which is not the order they
+        were enqueued."""
+        self._pending_queue = [req for req in self._pending_queue if req.request_id != request_id]
+        self._sync_pending()
+
+    def _sync_pending(self) -> None:
+        """Project the queue onto the wire fields the phone renders: the front
+        request as ``pending`` plus the total ``pending_count`` for the "1 of
+        N" badge."""
+        self.projection.pending = self._pending_queue[0] if self._pending_queue else None
+        self.projection.pending_count = len(self._pending_queue)
         self._bump()
 
     def set_state(

--- a/local_operator/mobile/types.py
+++ b/local_operator/mobile/types.py
@@ -160,6 +160,14 @@ class TranscriptEntry:
     elapsed_s: float = 0.0
     error: str = ""
     details: dict[str, Any] = field(default_factory=dict)  # expand payload
+    # Image attachments on a user turn, as lightweight REFERENCES not bytes:
+    # each is ``{"index": int, "mime_type": str}``. The bytes are fetched
+    # lazily from ``/api/sessions/{pid}/image?entry=<id>&i=<index>`` (which
+    # reads them from the on-disk transcript), NEVER inlined here — a
+    # projection repaint fires on every streaming token, and a few hundred KB
+    # of base64 re-sent per token would swamp the SSE. ``id`` is the message
+    # id the endpoint resolves against.
+    images: list[dict[str, Any]] = field(default_factory=list)
     # assistant rows stream: ``final`` flips true on message_end
     final: bool = True
 
@@ -250,7 +258,12 @@ class SessionProjection:
     transcript: list[TranscriptEntry] = field(default_factory=list)
     todos: list[TodoItem] = field(default_factory=list)
     subagents: list[SubagentRow] = field(default_factory=list)
+    #: The FRONT waiting request; the phone renders it as the pinned card.
     pending: PendingRequest | None = None
+    #: How many requests are waiting in total (>= 1 while ``pending`` is set).
+    #: A parallel tool batch can open several approvals at once; the phone
+    #: shows "1 of N" so the user knows more cards follow this one.
+    pending_count: int = 0
     usage: dict[str, int] = field(default_factory=dict)  # input/output tokens
     version: int = 0  # projection epoch; the phone drops stale repaints
 

--- a/local_operator/mobile/web/src/api.ts
+++ b/local_operator/mobile/web/src/api.ts
@@ -103,6 +103,16 @@ export function sendCommand(
 	});
 }
 
+/** URL for one image attachment on a user turn. The bytes are served lazily
+    from the transcript (never carried in the projection), keyed by the entry
+    id plus the image-only index the ref emitted. Same-origin, cacheable and
+    immutable — a message's attachments never change — so an <img src> can use
+    it directly. */
+export function imageUrl(pid: number, entryId: string, index: number): string {
+	const q = new URLSearchParams({ entry: entryId, i: String(index) });
+	return `/api/sessions/${pid}/image?${q}`;
+}
+
 /** Older transcript entries for lazy loading. ``before`` is the id of the
     oldest entry the client already has; the daemon returns the page
     immediately older than it (chronological within the page) plus whether

--- a/local_operator/mobile/web/src/components/pending-card.tsx
+++ b/local_operator/mobile/web/src/components/pending-card.tsx
@@ -15,9 +15,15 @@ import type { PendingRequest } from "../types";
 export function PendingCard({
 	pid,
 	pending,
+	count = 1,
 }: {
 	pid: number;
 	pending: PendingRequest;
+	/** Total requests waiting, including this one. A parallel tool batch can
+	    open several approvals at once; when >1 the card shows a "1 of N" badge
+	    so the user knows more follow, and answering this one reveals the next
+	    on the repaint. */
+	count?: number;
 }) {
 	const [remember, setRemember] = useState(false);
 	const [freeText, setFreeText] = useState("");
@@ -60,10 +66,17 @@ export function PendingCard({
 	return (
 		<div className="border-accent bg-accent-wash mx-2 flex flex-col gap-2 rounded-md border p-2.5">
 			<div className="flex flex-col gap-0.5">
-				<span className="text-meta text-accent">
-					{pending.kind === "approval"
-						? "approval needed"
-						: "question"}
+				<span className="flex items-center justify-between text-meta text-accent">
+					<span>
+						{pending.kind === "approval"
+							? "approval needed"
+							: "question"}
+					</span>
+					{count > 1 ? (
+						<span className="font-mono text-mono-sm text-ink-dim">
+							1 of {count}
+						</span>
+					) : null}
 				</span>
 				<span className="text-body font-medium">{pending.title}</span>
 				{pending.detail ? (

--- a/local_operator/mobile/web/src/components/todos-panel.tsx
+++ b/local_operator/mobile/web/src/components/todos-panel.tsx
@@ -1,6 +1,13 @@
 /**
- * Todos panel: collapsible, one line per item. Default-collapsed once most
- * items are done — a finished list is context, not work in progress.
+ * Todos panel: collapsible, one line per item.
+ *
+ * On a phone the panel sits ABOVE the transcript, so a long list expanded by
+ * default pushed the actual conversation off the top of the screen (the
+ * reported "todos pop up very high"). Two guards fix that: it starts
+ * COLLAPSED (the count in the header is enough at a glance; tap to see the
+ * items), and when expanded its body is capped to ~40% of the viewport and
+ * scrolls internally, so even a 20-item list can never crowd out the
+ * messages.
  */
 import { cn } from "../lib/cn";
 import type { TodoItem } from "../types";
@@ -17,10 +24,13 @@ export function TodosPanel({ todos }: { todos: TodoItem[] }) {
 	const done = todos.filter(
 		(t) => t.status === "done" || t.status === "dropped",
 	).length;
-	const defaultOpen = !(done > 4 && done >= todos.length - 1);
 	return (
 		<Disclosure
-			defaultOpen={defaultOpen}
+			/* Collapsed by default on the phone: the panel is above the
+			   transcript, and an auto-expanded list pushed the conversation off
+			   screen. The header's count is the at-a-glance signal; tap to work
+			   the list. */
+			defaultOpen={false}
 			className="border-t border-hairline px-4"
 			header={
 				<span className="text-body-sm text-ink-muted">
@@ -31,7 +41,9 @@ export function TodosPanel({ todos }: { todos: TodoItem[] }) {
 				</span>
 			}
 		>
-			<div className="flex flex-col gap-1 pb-2 pl-5">
+			{/* Capped to ~40% of the viewport and scrolls internally: a long
+			   list can never crowd out the messages, even fully expanded. */}
+			<div className="lo-scroll flex max-h-[40dvh] flex-col gap-1 overflow-y-auto pb-2 pl-5">
 				{todos.map((t, i) => (
 					<div key={i} className="flex items-baseline gap-2">
 						<span

--- a/local_operator/mobile/web/src/components/transcript.tsx
+++ b/local_operator/mobile/web/src/components/transcript.tsx
@@ -12,28 +12,52 @@ import { useEffect, useRef, useState } from "react";
 import { Markdown } from "./markdown"
 import { ToolRow } from "./tool-row"
 import { RowBoundary } from "./row-boundary";
-import { getHistory } from "../api";
+import { getHistory, imageUrl } from "../api";
 import { cn } from "../lib/cn";
 import type { TranscriptEntry } from "../types";
 
 const PAGE = 120;
 
-function Entry({ entry }: { entry: TranscriptEntry }) {
+function Entry({ entry, pid }: { entry: TranscriptEntry; pid: number }) {
 	switch (entry.kind) {
-		case "user":
+		case "user": {
 			/* The user's own words. Right-aligned like the desktop app's bubble,
 			   but the marker of identity is the accent edge on the leading
 			   side: a user turn is the one thing in the transcript the human
 			   said, and the accent is reserved for exactly that kind of "this
 			   is what the turn is on" signal (branding §7). Surface ground +
 			   hairline keeps it quiet next to the answer that follows. */
+			const images = entry.images ?? [];
 			return (
 				<div className="flex min-w-0 justify-end">
-					<div className="max-w-[85%] rounded-md border border-hairline border-l-2 border-l-accent bg-surface px-3 py-1.5 text-body leading-normal break-words whitespace-pre-wrap">
-						{entry.text}
+					<div className="flex max-w-[85%] flex-col gap-1.5 rounded-md border border-hairline border-l-2 border-l-accent bg-surface px-3 py-1.5">
+						{/* Attachments render inline like the TUI's image block: the
+						   picture the user sent is part of the turn, not a stripped
+						   "[image attached]" note. Bytes load lazily from the image
+						   endpoint; a decode failure degrades to the browser's own
+						   broken-image glyph rather than blanking the bubble. */}
+						{images.length > 0 ? (
+							<div className="flex flex-wrap gap-1.5">
+								{images.map((img) => (
+									<img
+										key={img.index}
+										src={imageUrl(pid, entry.id, img.index)}
+										alt="attachment"
+										loading="lazy"
+										className="max-h-64 max-w-full rounded-sm border border-hairline object-contain"
+									/>
+								))}
+							</div>
+						) : null}
+						{entry.text ? (
+							<div className="text-body leading-normal break-words whitespace-pre-wrap">
+								{entry.text}
+							</div>
+						) : null}
 					</div>
 				</div>
 			);
+		}
 		case "steer":
 			return (
 				<div className="flex min-w-0 justify-end">
@@ -210,7 +234,7 @@ export function Transcript({
 				/* A boundary per row: one malformed entry must not unmount the
 				   whole app (the "tap → blank screen" failure). */
 				<RowBoundary key={e.id}>
-					<Entry entry={e} />
+					<Entry entry={e} pid={pid} />
 				</RowBoundary>
 			))}
 		</div>

--- a/local_operator/mobile/web/src/components/transcript.tsx
+++ b/local_operator/mobile/web/src/components/transcript.tsx
@@ -18,6 +18,68 @@ import type { TranscriptEntry } from "../types";
 
 const PAGE = 120;
 
+/**
+ * One inline attachment thumbnail with designed loading and failure states.
+ *
+ * A phone loads images over a flaky link, so the two off-happy-path states are
+ * common, not edge cases, and both are designed rather than left to the
+ * browser: a bare <img> would paint the native broken-image glyph on a 404
+ * (which reads as a bug) and would reflow the bubble taller the instant bytes
+ * decode (motion branding §7 rules out). Both are avoided by reserving a
+ * fixed box up front and swapping a muted placeholder in on error.
+ */
+function AttachmentImage({
+	pid,
+	entryId,
+	index,
+}: {
+	pid: number;
+	entryId: string;
+	index: number;
+}) {
+	const [state, setState] = useState<"loading" | "loaded" | "error">("loading");
+	/* The reserved frame: a fixed height so the row never jumps when the
+	   bytes arrive, capped width so a wide image cannot push the bubble past
+	   the viewport. object-contain keeps aspect within the frame. */
+	if (state === "error") {
+		return (
+			<div className="flex h-40 w-40 flex-col items-center justify-center gap-1 rounded-sm border border-hairline bg-sunken text-ink-dim">
+				<span aria-hidden className="text-body">
+					⊘
+				</span>
+				<span className="text-meta">image unavailable</span>
+			</div>
+		);
+	}
+	return (
+		<span
+			className={cn(
+				"relative block h-40 overflow-hidden rounded-sm border border-hairline",
+				state === "loading" && "w-40 bg-sunken",
+			)}
+		>
+			{state === "loading" ? (
+				<span
+					aria-hidden
+					className="absolute inset-0 flex items-center justify-center text-meta text-ink-dim"
+				>
+					loading…
+				</span>
+			) : null}
+			<img
+				src={imageUrl(pid, entryId, index)}
+				alt="attachment"
+				onLoad={() => setState("loaded")}
+				onError={() => setState("error")}
+				className={cn(
+					"h-40 max-w-full rounded-sm object-contain",
+					state === "loading" && "invisible",
+				)}
+			/>
+		</span>
+	);
+}
+
 function Entry({ entry, pid }: { entry: TranscriptEntry; pid: number }) {
 	switch (entry.kind) {
 		case "user": {
@@ -33,18 +95,18 @@ function Entry({ entry, pid }: { entry: TranscriptEntry; pid: number }) {
 					<div className="flex max-w-[85%] flex-col gap-1.5 rounded-md border border-hairline border-l-2 border-l-accent bg-surface px-3 py-1.5">
 						{/* Attachments render inline like the TUI's image block: the
 						   picture the user sent is part of the turn, not a stripped
-						   "[image attached]" note. Bytes load lazily from the image
-						   endpoint; a decode failure degrades to the browser's own
-						   broken-image glyph rather than blanking the bubble. */}
+						   "[image attached]" note. AttachmentImage owns the loading
+						   and failure states (reserved box, designed placeholder) so
+						   a flaky-link 404 or a slow decode never shows a broken
+						   glyph or reflows the bubble. */}
 						{images.length > 0 ? (
 							<div className="flex flex-wrap gap-1.5">
 								{images.map((img) => (
-									<img
+									<AttachmentImage
 										key={img.index}
-										src={imageUrl(pid, entry.id, img.index)}
-										alt="attachment"
-										loading="lazy"
-										className="max-h-64 max-w-full rounded-sm border border-hairline object-contain"
+										pid={pid}
+										entryId={entry.id}
+										index={img.index}
 									/>
 								))}
 							</div>

--- a/local_operator/mobile/web/src/screens/new-session.tsx
+++ b/local_operator/mobile/web/src/screens/new-session.tsx
@@ -44,6 +44,30 @@ export function NewSessionScreen() {
 		);
 	}, [models, filter]);
 
+	/* The tagged quick-pick rows: home first, then the temp dir (a common
+	   scratch root the daemon now admits), then recent working directories.
+	   Deduped so a recent dir that IS home or tmp does not appear twice. Each
+	   row carries an explicit ``name`` because a bare basename is a poor label
+	   for some roots — the macOS temp dir resolves to
+	   ``/private/var/folders/…/T`` whose basename is a lone "T", so tmp is
+	   named "tmp" outright. */
+	const quickPicks = useMemo(() => {
+		if (!dirs) return [] as { path: string; name: string; tag: string }[];
+		const rows: { path: string; name: string; tag: string }[] = [
+			{ path: dirs.home, name: basename(dirs.home), tag: "home" },
+		];
+		if (dirs.tmp) rows.push({ path: dirs.tmp, name: "tmp", tag: "tmp" });
+		for (const p of dirs.recent) {
+			rows.push({ path: p, name: basename(p), tag: "recent" });
+		}
+		const seen = new Set<string>();
+		return rows.filter(({ path }) => {
+			if (!path || seen.has(path)) return false;
+			seen.add(path);
+			return true;
+		});
+	}, [dirs]);
+
 	const start = async () => {
 		if (!cwd.trim() || starting) return;
 		setStarting(true);
@@ -87,42 +111,49 @@ export function NewSessionScreen() {
 					>
 						working directory
 					</label>
+					{/* The quick-pick list is the primary path — tapping a row
+					   fills the field, so most sessions start with no typing at
+					   all. Each row is TAGGED (home / tmp / recent) so the
+					   choices read as a menu rather than an undifferentiated
+					   list of paths. The free-text field below stays for the
+					   uncommon "somewhere else" case. */}
+					{dirs ? (
+						<div className="flex flex-col gap-1">
+							{quickPicks.map(({ path, name, tag }) => (
+								<button
+									key={path}
+									type="button"
+									onClick={() => setCwd(path)}
+									className={cn(
+										"flex min-h-11 items-center gap-2 rounded-sm border border-control px-3 text-left active:bg-elevated",
+										cwd === path
+											? "border-accent bg-accent-wash"
+											: "bg-surface",
+									)}
+								>
+									<span className="shrink-0 font-mono text-mono-sm text-ink">
+										{name}
+									</span>
+									<span className="min-w-0 flex-1 truncate font-mono text-mono-sm text-ink-dim">
+										{shortenHome(path, dirs.home)}
+									</span>
+									<span className="shrink-0 rounded-sm bg-sunken px-1.5 py-0.5 text-meta text-ink-dim">
+										{tag}
+									</span>
+								</button>
+							))}
+						</div>
+					) : null}
 					<input
 						id="cwd-input"
 						value={cwd}
 						onChange={(e) => setCwd(e.target.value)}
+						placeholder="or type a path…"
 						spellCheck={false}
 						autoCapitalize="off"
 						autoCorrect="off"
-						className="min-h-11 rounded-sm border border-control bg-surface px-3 font-mono text-mono text-ink outline-none"
+						className="min-h-11 rounded-sm border border-control bg-surface px-3 font-mono text-mono text-ink outline-none placeholder:text-ink-dim"
 					/>
-					{dirs ? (
-						<div className="flex flex-col gap-1">
-							{[dirs.home, ...dirs.recent]
-								.filter(
-									(p, i, all) =>
-										p && all.indexOf(p) === i,
-								)
-								.map((p) => (
-									<button
-										key={p}
-										type="button"
-										onClick={() => setCwd(p)}
-										className={cn(
-											"flex min-h-8 items-center gap-2 rounded-sm px-2 text-left active:bg-elevated",
-											cwd === p && "bg-accent-wash",
-										)}
-									>
-										<span className="shrink-0 font-mono text-mono-sm text-ink">
-											{basename(p)}
-										</span>
-										<span className="min-w-0 truncate font-mono text-mono-sm text-ink-dim">
-											{shortenHome(p, dirs.home)}
-										</span>
-									</button>
-								))}
-						</div>
-					) : null}
 				</section>
 
 				<section className="flex flex-col gap-2">

--- a/local_operator/mobile/web/src/screens/new-session.tsx
+++ b/local_operator/mobile/web/src/screens/new-session.tsx
@@ -68,6 +68,14 @@ export function NewSessionScreen() {
 		});
 	}, [dirs]);
 
+	/* Whether the current selection IS one of the quick-picks — when it is,
+	   the free-text fallback stays empty so it does not duplicate the picked
+	   row's path as an apparent fourth option (D3). */
+	const cwdIsQuickPick = useMemo(
+		() => quickPicks.some(({ path }) => path === cwd),
+		[quickPicks, cwd],
+	);
+
 	const start = async () => {
 		if (!cwd.trim() || starting) return;
 		setStarting(true);
@@ -144,15 +152,21 @@ export function NewSessionScreen() {
 							))}
 						</div>
 					) : null}
+					{/* The free-text fallback for a directory not in the picks.
+					   Demoted below the quick-picks in both order and weight,
+					   and it mirrors ``cwd`` ONLY when the selection is a custom
+					   path — when a quick-pick is active the field stays empty
+					   with its placeholder, so it never reads as a fourth option
+					   duplicating the home row's absolute path (D3). */}
 					<input
 						id="cwd-input"
-						value={cwd}
+						value={cwdIsQuickPick ? "" : cwd}
 						onChange={(e) => setCwd(e.target.value)}
-						placeholder="or type a path…"
+						placeholder="or type another path…"
 						spellCheck={false}
 						autoCapitalize="off"
 						autoCorrect="off"
-						className="min-h-11 rounded-sm border border-control bg-surface px-3 font-mono text-mono text-ink outline-none placeholder:text-ink-dim"
+						className="min-h-9 rounded-sm border border-hairline bg-transparent px-3 font-mono text-mono-sm text-ink-muted outline-none placeholder:text-ink-dim focus:border-control focus:text-ink"
 					/>
 				</section>
 

--- a/local_operator/mobile/web/src/screens/session-view.tsx
+++ b/local_operator/mobile/web/src/screens/session-view.tsx
@@ -122,7 +122,21 @@ export function SessionScreen({ pid }: { pid: number }) {
 		>
 			<Header projection={projection} />
 
-			<Transcript pid={pid} entries={projection.transcript} />
+			{projection.transcript.length === 0 && !projection.streaming ? (
+				/* A just-started session has no messages yet. An empty scroll
+				   area reads as "did it break?"; this placeholder says the
+				   session is ready and what to do next. Hidden the moment a
+				   turn begins streaming (the transcript fills from the user
+				   row up). */
+				<div className="flex flex-1 flex-col items-center justify-center gap-1 px-8 text-center">
+					<p className="text-body-sm text-ink-muted">no messages yet</p>
+					<p className="text-meta text-ink-dim">
+						send a message below to get started
+					</p>
+				</div>
+			) : (
+				<Transcript pid={pid} entries={projection.transcript} />
+			)}
 
 			{/* The aggregate working line — pinned at the foot of the transcript
 			    like the TUI's WorkingBlock, above the panels and composer. */}
@@ -141,7 +155,11 @@ export function SessionScreen({ pid }: { pid: number }) {
 			) : null}
 
 			{projection.pending ? (
-				<PendingCard pid={pid} pending={projection.pending} />
+				<PendingCard
+					pid={pid}
+					pending={projection.pending}
+					count={projection.pending_count}
+				/>
 			) : null}
 
 			{projection.degraded && !projection.ended ? (

--- a/local_operator/mobile/web/src/types.ts
+++ b/local_operator/mobile/web/src/types.ts
@@ -60,8 +60,20 @@ export interface TranscriptEntry {
 	elapsed_s: number;
 	error: string;
 	details: TranscriptEntryDetails;
+	/** Image attachments on a user turn, as lightweight references (never the
+	    bytes): each is `{index, mime_type}`. The pixels are fetched lazily from
+	    the image endpoint — see `imageUrl` in api.ts. */
+	images?: TranscriptImageRef[];
 	/** Assistant rows stream: `final` flips true on message_end. */
 	final: boolean;
+}
+
+/** A reference to one image block on a user turn. The bytes live in the
+    on-disk transcript and are served on demand, keyed by the entry id plus
+    this image-only index. */
+export interface TranscriptImageRef {
+	index: number;
+	mime_type: string;
 }
 
 export interface TodoItem {
@@ -125,6 +137,10 @@ export interface SessionProjection {
 	todos: TodoItem[];
 	subagents: SubagentRow[];
 	pending: PendingRequest | null;
+	/** How many requests are waiting in total (>= 1 while `pending` is set).
+	    A parallel tool batch can open several approvals at once; the card
+	    shows "1 of N" so the user knows more follow this one. */
+	pending_count: number;
 	/** input/output tokens. */
 	usage: Record<string, number>;
 	/** Projection epoch; drop stale repaints. */
@@ -173,6 +189,8 @@ export interface PastSession {
 export interface Directories {
 	home: string;
 	recent: string[];
+	/** The system temp dir, offered as a scratch start directory. */
+	tmp?: string;
 }
 
 /* ---- command ops (POST /api/sessions/{pid}/command) ---------------------- */

--- a/tests/unit/mobile/test_daemon.py
+++ b/tests/unit/mobile/test_daemon.py
@@ -178,6 +178,105 @@ def test_unknown_session_command_is_a_409() -> None:
     assert reply.status_code == 409
 
 
+def test_spawn_dir_gate_allows_home_and_tmp_only(tmp_path, monkeypatch) -> None:
+    """The phone may start a session anywhere under home or in the system temp
+    dir (a common scratch root), and nowhere else — the gate guards against a
+    fat-fingered/traversed path, not against the owner."""
+    from pathlib import Path
+
+    from local_operator.mobile import daemon as daemon_mod
+    from local_operator.mobile.daemon import _spawn_dir_allowed
+
+    # pytest's tmp_path already lives UNDER the real system temp dir, so pin an
+    # explicit fake tmp and home under it and assert against those bounds —
+    # otherwise "outside" would still be a child of the real /tmp and allowed.
+    home = tmp_path / "home"
+    home.mkdir()
+    fake_tmp = tmp_path / "scratch"
+    fake_tmp.mkdir()
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: home))
+    monkeypatch.setattr(daemon_mod, "_tmp_dir", lambda: str(fake_tmp.resolve()))
+
+    # Under home: allowed. Home itself: allowed.
+    sub = home / "projects"
+    sub.mkdir()
+    assert _spawn_dir_allowed(home.resolve())
+    assert _spawn_dir_allowed(sub.resolve())
+
+    # The (fake) temp dir and a child of it: allowed.
+    assert _spawn_dir_allowed(fake_tmp.resolve())
+    child = fake_tmp / "work"
+    child.mkdir()
+    assert _spawn_dir_allowed(child.resolve())
+
+    # Somewhere neither under home nor tmp: refused.
+    outside = tmp_path / "elsewhere"
+    outside.mkdir()
+    assert not _spawn_dir_allowed(outside.resolve())
+
+
+def test_directories_endpoint_offers_tmp(monkeypatch) -> None:
+    daemon = MobileDaemon(port=0, password="pw123")
+    app = build_app(daemon)
+    client = TestClient(app, follow_redirects=False)
+    client.post("/login", data={"password": "pw123"})
+    body = client.get("/api/directories").json()
+    assert "home" in body
+    assert "recent" in body
+    # /tmp is offered as a scratch start dir beside home.
+    assert body.get("tmp")
+
+
+def test_image_bytes_reads_attachment_from_transcript(tmp_path, monkeypatch) -> None:
+    """The image endpoint's helper decodes the Nth image block of a message
+    from the on-disk transcript — the lazy source the phone fetches pixels
+    from. Index counts IMAGE blocks only, matching _image_refs."""
+    import asyncio as _asyncio
+    import base64
+
+    from local_operator.harness.types import ImageContent, Message
+    from local_operator.mobile.daemon import _image_bytes
+    from local_operator.mobile.types import SessionRecord
+    from local_operator.session.transcript import Transcript
+
+    cfg = tmp_path / "config"
+    cfg.mkdir()
+    # _image_bytes imports config_dir from local_operator.paths at call time,
+    # so patching the source module is what redirects it to the fake config.
+    monkeypatch.setattr("local_operator.paths.config_dir", lambda: cfg)
+
+    session_id = "sess-img"
+    directory = cfg / "sessions" / session_id
+    directory.mkdir(parents=True)
+    raw = b"\x89PNG\r\n\x1a\nHELLO"
+    message = Message.user(
+        "look",
+        [ImageContent(data=base64.b64encode(raw).decode(), mime_type="image/png")],
+    )
+    transcript = Transcript(directory)
+    _asyncio.run(transcript.append_message(message))
+
+    record = SessionRecord(
+        pid=1,
+        kind="daemon",
+        session_id=session_id,
+        conversation_name="",
+        cwd=str(tmp_path),
+        model_label="",
+        control_port=0,
+        control_key="k",
+    )
+    found = _image_bytes(record, message.id, 0)
+    assert found is not None
+    data, mime = found
+    assert data == raw
+    assert mime == "image/png"
+
+    # Out-of-range index and unknown entry both miss cleanly.
+    assert _image_bytes(record, message.id, 1) is None
+    assert _image_bytes(record, "nope", 0) is None
+
+
 def test_slash_catalogue_excludes_terminal_chrome() -> None:
     daemon = MobileDaemon(port=0, password="pw123")
     names = [c["name"] for c in daemon.slash_commands()]

--- a/tests/unit/mobile/test_owned.py
+++ b/tests/unit/mobile/test_owned.py
@@ -1,0 +1,150 @@
+"""Owned-session handle behaviours that have no terminal to fall back on:
+full-auto approval, headless conversation naming, and the concurrent-approval
+queue wired through the fold.
+
+These are the phone-started-session equivalents of things the TUI's
+OperatorApp does (adopt ``tool_approval_mode: auto`` at boot, run the naming
+worker). The handle is exercised directly with a minimal fake session so the
+tests stay off the real provider and event loop machinery.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from local_operator.mobile.owned import OwnedSessionHandle
+
+
+class FakeSession:
+    """The slice of Session the OwnedSessionHandle touches in these tests."""
+
+    def __init__(self) -> None:
+        self.session_id = "sess-1"
+        self.model_label = "test/model"
+        self.model = None
+        self.conversation_name = ""
+        self.is_streaming = False
+        self._named: list[tuple[str, bool]] = []
+        self._complete_calls: list[tuple[str, str]] = []
+        # The naming call's reply must be wrapped in the <title> tag the
+        # parser expects; a bare string is treated as a model that ignored the
+        # format and discarded.
+        self.title_reply = "<title>A Neat Title</title>"
+
+    # -- naming seams ----------------------------------------------------------
+    def set_conversation_name(self, text: str, *, user_set: bool = True) -> str:
+        self.conversation_name = text
+        self._named.append((text, user_set))
+        return text
+
+    async def complete_once(self, system: str, prompt: str) -> str:
+        self._complete_calls.append((system, prompt))
+        return self.title_reply
+
+    # -- gate registration -----------------------------------------------------
+    def set_approval_handler(self, handler) -> None:
+        self._approval_handler = handler
+
+    def set_ask_handler(self, handler) -> None:
+        self._ask_handler = handler
+
+    # -- subscribe/selectors the handle reads at construction ------------------
+    def subscribe(self, handler):  # pragma: no cover - not exercised here
+        return lambda: None
+
+    def history(self):  # pragma: no cover - not exercised here
+        return []
+
+    @property
+    def reasoning_effort(self):  # pragma: no cover
+        return "auto"
+
+
+def make_handle(auto_approve: bool = False) -> tuple[OwnedSessionHandle, FakeSession]:
+    # The handle records whichever loop it is built on; inside an async test
+    # that is the running loop, and the sync construction test never awaits so
+    # a fresh loop is fine. get_event_loop_policy().get_event_loop() avoids the
+    # "no current event loop" deprecation of the bare accessor.
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+    session = FakeSession()
+    handle = OwnedSessionHandle(session, loop, cwd="/tmp", auto_approve=auto_approve)
+    return handle, session
+
+
+def test_default_conversation_name_is_empty_not_a_placeholder() -> None:
+    """A fresh mobile session shows nothing until named, so the phone's own
+    fallback ("untitled" / cwd) applies — never a frozen "mobile session"."""
+    handle, _ = make_handle()
+    assert handle.session_projection_seed.conversation_name == ""
+
+
+@pytest.mark.asyncio
+async def test_full_auto_approves_inline_without_a_card() -> None:
+    """With the owner's saved default at full-auto, the gate answers True
+    inline and never parks a pending card — matching the TUI's auto mode."""
+    handle, _ = make_handle(auto_approve=True)
+    gate = handle._approval_gate
+    approved = await gate("bash", "rm -rf build/")
+    assert approved is True
+    # No card was ever queued.
+    assert handle._fold.projection.pending is None
+    assert handle._fold.projection.pending_count == 0
+
+
+@pytest.mark.asyncio
+async def test_ask_mode_parks_a_card_then_resolves() -> None:
+    """Without full-auto, the gate queues a card and blocks until answered —
+    and a second concurrent gate queues behind it rather than overwriting."""
+    handle, _ = make_handle(auto_approve=False)
+    gate = handle._approval_gate
+
+    first = asyncio.ensure_future(gate("bash", "one"))
+    second = asyncio.ensure_future(gate("write", "two"))
+    await asyncio.sleep(0)  # let both gates enqueue
+
+    assert handle._fold.projection.pending_count == 2
+    front = handle._fold.projection.pending
+    assert front is not None and front.title == "bash"
+
+    # Answer the front; the second card surfaces, count drops.
+    await handle.approval_answer(front.request_id, True, False)
+    assert await first is True
+    await asyncio.sleep(0)
+    assert handle._fold.projection.pending_count == 1
+    nxt = handle._fold.projection.pending
+    assert nxt is not None and nxt.title == "write"
+
+    await handle.approval_answer(nxt.request_id, False, False)
+    assert await second is False
+    await asyncio.sleep(0)
+    assert handle._fold.projection.pending is None
+
+
+@pytest.mark.asyncio
+async def test_naming_worker_stores_a_title_once() -> None:
+    """The first substantive prompt names an unnamed session; a low-signal
+    opener does not consume the one attempt."""
+    handle, session = make_handle()
+
+    # Low-signal opener: skipped, latch not spent.
+    handle._maybe_name_conversation("hi")
+    assert handle._name_requested is False
+
+    handle._maybe_name_conversation("please refactor the billing importer")
+    assert handle._name_requested is True
+    # Let the background naming task run.
+    for _ in range(5):
+        await asyncio.sleep(0)
+    assert session.conversation_name == "A Neat Title"
+    assert session._named == [("A Neat Title", False)]
+
+    # A second prompt does not re-name.
+    handle._maybe_name_conversation("and now the invoices too")
+    for _ in range(5):
+        await asyncio.sleep(0)
+    assert session._named == [("A Neat Title", False)]

--- a/tests/unit/mobile/test_projection.py
+++ b/tests/unit/mobile/test_projection.py
@@ -8,6 +8,7 @@ from local_operator.harness.types import (
     AgentEndEvent,
     AgentMessage,
     AgentStartEvent,
+    ImageContent,
     Message,
     MessageEndEvent,
     MessageStartEvent,
@@ -25,9 +26,14 @@ from local_operator.harness.types import (
 from local_operator.mobile.projection import (
     ProjectionFold,
     _diff_counts,
+    _image_refs,
     _summarize_args,
 )
-from local_operator.mobile.types import PROJECTION_TRANSCRIPT_LIMIT, SessionProjection
+from local_operator.mobile.types import (
+    PROJECTION_TRANSCRIPT_LIMIT,
+    PendingRequest,
+    SessionProjection,
+)
 
 
 def make_fold() -> ProjectionFold:
@@ -176,3 +182,101 @@ def test_projection_version_bumps_on_every_fold() -> None:
     v0 = fold.projection.version
     fold.fold_event(NoticeEvent(text="hi"))
     assert fold.projection.version > v0
+
+
+def test_pending_queue_shows_front_and_counts() -> None:
+    """A parallel tool batch opens several approvals at once. The fold must
+    show the FRONT one and report the total, and clearing one by id must
+    surface the next — not dismiss every sibling (the mobile hang report)."""
+    fold = make_fold()
+    a = PendingRequest(request_id="a", kind="approval", title="bash")
+    b = PendingRequest(request_id="b", kind="approval", title="write")
+    fold.push_pending(a)
+    fold.push_pending(b)
+    assert fold.projection.pending is a
+    assert fold.projection.pending_count == 2
+
+    # Answering the FRONT reveals the next, count decrements.
+    fold.pop_pending("a")
+    assert fold.projection.pending is b
+    assert fold.projection.pending_count == 1
+
+    # Answering an out-of-order id (the second card) is honoured too.
+    fold.pop_pending("b")
+    assert fold.projection.pending is None
+    assert fold.projection.pending_count == 0
+
+
+def test_pop_pending_out_of_order_keeps_the_other_card() -> None:
+    """Concurrent gates settle in whatever order the user answers, not the
+    order enqueued: popping the second must leave the first still showing."""
+    fold = make_fold()
+    fold.push_pending(PendingRequest(request_id="a", kind="approval", title="bash"))
+    fold.push_pending(PendingRequest(request_id="b", kind="ask", title="which?"))
+    fold.pop_pending("b")
+    assert fold.projection.pending is not None
+    assert fold.projection.pending.request_id == "a"
+    assert fold.projection.pending_count == 1
+
+
+def test_set_pending_still_replaces_for_the_tui_mirror() -> None:
+    """The TUI-mirror handle uses set_pending: the terminal serializes its own
+    approvals, so the phone mirrors exactly one card or none."""
+    fold = make_fold()
+    fold.push_pending(PendingRequest(request_id="a", kind="approval", title="bash"))
+    fold.set_pending(PendingRequest(request_id="z", kind="ask", title="q"))
+    assert fold.projection.pending_count == 1
+    assert fold.projection.pending is not None
+    assert fold.projection.pending.request_id == "z"
+    fold.set_pending(None)
+    assert fold.projection.pending is None
+    assert fold.projection.pending_count == 0
+
+
+def test_image_refs_are_index_and_mime_only() -> None:
+    """User-turn attachments project as lightweight references (image-only
+    index + mime), never bytes — the pixels are fetched lazily so a per-token
+    repaint stays small. A text caption does not shift the index."""
+    message = Message.user(
+        "look at these",
+        [
+            ImageContent(data="AAAA", mime_type="image/png"),
+            ImageContent(data="BBBB", mime_type="image/jpeg"),
+        ],
+    )
+    refs = _image_refs(message)
+    assert refs == [
+        {"index": 0, "mime_type": "image/png"},
+        {"index": 1, "mime_type": "image/jpeg"},
+    ]
+    # No base64 leaks into the reference.
+    assert all("data" not in r for r in refs)
+
+
+def test_history_fold_carries_image_refs_on_user_rows() -> None:
+    fold = make_fold()
+    history: list[AgentMessage] = [
+        Message.user("with a shot", [ImageContent(data="AAAA", mime_type="image/png")]),
+    ]
+    fold.fold_history(history)
+    user_rows = [e for e in fold.projection.transcript if e.kind == "user"]
+    assert len(user_rows) == 1
+    assert user_rows[0].images == [{"index": 0, "mime_type": "image/png"}]
+
+
+def test_absorb_user_event_upgrades_echoed_row_with_image_refs() -> None:
+    """A phone-sent prompt is echoed WITHOUT refs (the handle has no persisted
+    id yet); the real MessageStartEvent then carries the attachments, and the
+    fold must upgrade the echoed row in place so the sender sees thumbnails."""
+    fold = make_fold()
+    fold.note_user_message("with a shot")  # optimistic echo, no images
+    echoed = fold.projection.transcript[-1]
+    assert echoed.images == []
+
+    message = Message.user("with a shot", [ImageContent(data="AAAA", mime_type="image/png")])
+    added = fold.absorb_user_event(message)
+    assert added is False  # de-duped, not a second row
+    assert len([e for e in fold.projection.transcript if e.kind == "user"]) == 1
+    upgraded = fold.projection.transcript[-1]
+    assert upgraded.id == message.id
+    assert upgraded.images == [{"index": 0, "mime_type": "image/png"}]


### PR DESCRIPTION
## Summary of Changes

Seven fixes to the mobile phone portal (`local_operator/mobile/`), all reported from real phone use. The portal is a React/TSX SPA the daemon serves; "owned" sessions are the ones started from the phone (run in a daemon-spawned child), as opposed to "mirror" sessions the TUI publishes.

**UI / layout**

- **Todos no longer crowd out the conversation.** The todos panel sits *above* the transcript, so a long list expanded by default pushed the messages off the top of the screen. It now starts **collapsed** (the `done/total` count in the header is the at-a-glance signal), and when expanded its body is capped to `~40dvh` and scrolls internally — even a 20-item list can never hide the messages.
- **Empty sessions read as ready, not broken.** A just-started session showed a blank scroll area. It now shows a `no messages yet` / `send a message below to get started` placeholder, hidden the moment a turn begins streaming.
- **New-session picker reworked + `/tmp` added.** The working-directory picker is now tagged quick-picks (**home / tmp / recent**) as the primary path, with the free-text field demoted to an "or type a path…" fallback. `/tmp` is a common scratch root, so it is offered as a start dir and the spawn gate now admits *home OR the system temp dir* (resolved, so a symlinked `/tmp` still matches). The tmp row is labelled `tmp` rather than its ugly basename (`/private/var/folders/…/T`).

**Behaviour**

- **Phone-started sessions get NAMED.** Conversation naming lived only in the TUI's `OperatorApp`, so an owned session stayed `mobile session` forever — the header and session list had nothing better to show. The owned handle now fires the same cheap, isolated, single-attempt title call (`session.complete_once` via `naming.generate_title`) on the first substantive prompt, skipping low-signal openers, and pushes the name live. The seed name is now empty (not the frozen `mobile session`), so the phone's own fallback (`untitled` / cwd) shows until the real title lands.
- **Full-auto is honoured on mobile.** A device whose saved `tool_approval_mode` is `auto` still got an approval card. The owned handle now reads that config at spawn (the same key the TUI adopts at boot in `_load_approvals_default`) and answers the approval gate inline, so full-auto sessions never park a card no front end would present.
- **Concurrent approvals no longer hang.** A parallel tool batch can open several write/exec approvals at once (`shared` tools run in parallel). The fold used to *replace* the pending card, so the second approval overwrote the first and the first tool hung forever with no way to answer it. The fold now **queues** requests (`push_pending`/`pop_pending`, cleared by request id so concurrent gates settle in any order), surfaces the front card with a **"1 of N"** badge, and reveals the next as each is answered. The TUI already serialized approvals (one card, rest queue) — this brings the phone to parity; no TUI change needed.
- **Image attachments render inline.** A sent image showed nothing in the transcript (the projection replaced it with a `[N images attached]` note). User-turn images now render inline like the TUI's image block, carried as **lightweight references** (`{index, mime_type}`) on the projection plus a lazy `GET /api/sessions/{pid}/image?entry=&i=` endpoint that decodes the bytes from the on-disk transcript. Bytes are never inlined in the projection, because a repaint fires on every streaming token and re-shipping base64 per token would swamp the SSE.

Change class: **C1 (standard, pre-authorized)** — scoped fixes to one subsystem, clear rollback (revert one commit), no schema/auth/migration surface. The one new wire field (`pending_count`) and new endpoint are additive; older phone bundles ignore both.

## Related Issue(s)

- Related: none filed (reported directly from phone use).

## Impact

- No breaking changes. Adds one projection field (`pending_count`), one transcript-entry field (`images`, references only), one directories field (`tmp`), and one read-only image endpoint — all additive and ignored by older clients.
- No dependency updates.
- Security: the image endpoint reuses the existing auth gate and reads only from the owner's own transcript store; the spawn gate is *widened by exactly one root* (system temp dir), still refusing anything outside home/tmp (`/etc` → 400, verified). Full-auto approval is adopted from the owner's own saved config, matching existing TUI behaviour — it does not lower any bar the desktop keeps.
- Performance: image bytes are fetched lazily and cached `immutable`; the projection stays small. Naming is one isolated, single-attempt completion per session, on the same path the TUI already uses.

## Testing Details

**Unit tests** (added, `tests/unit/mobile/`):

- `test_owned.py` (new): full-auto approves inline with no card; ask-mode parks a card and a *second concurrent* gate queues behind it, answering the front reveals the next; the naming worker names an unnamed session once and a low-signal opener does not spend the attempt; the default seed name is empty.
- `test_projection.py`: pending queue shows the front + counts; out-of-order pop keeps the other card; `set_pending` still replaces for the TUI mirror; image refs are index+mime only (no base64 leak); history fold and the echoed-row upgrade both carry image refs.
- `test_daemon.py`: spawn-dir gate allows home and tmp only (`/etc` refused); directories endpoint offers `tmp`; `_image_bytes` decodes the Nth image block from the transcript and misses cleanly on bad index/entry.

`pytest tests/unit/mobile tests/unit/session/test_conversation_name_persistence.py` — **63 passed**.

**Gates** (PR head `b221f5dc`):
- `flake8` / `black --check` / `isort --check-only` / `pyright` — clean on `local_operator/mobile` + tests.
- `pnpm build` (tsc + vite) — clean.

**End-to-end spawn gate** (against a throwaway daemon):
```
POST /api/sessions/start {"cwd":"<system tmp>"} → {"ok":true,"pid":15140}   # /tmp accepted
POST /api/sessions/start {"cwd":"/etc"}         → 400 not an allowed start directory
GET  /api/sessions/103/image?entry=msg-img-1&i=0 → 200 image/png 738 bytes   # lazy image served
```

**Visual validation** — every changed screen rendered in a real browser against fixture projections (screenshots attached below): empty-session placeholder, todos collapsed-by-default + expanded-with-height-cap, inline image in a user bubble, the "1 of 2" multi-approval badge, and the tagged new-session picker with the `tmp` row.

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my changes work as intended.
- [x] All new and existing tests pass.
- [x] I have run formatting (black/isort), linting (flake8), type checks (pyright), and the web build, and they pass.
- [x] I have updated the documentation when required (in-code why/constraint comments added; no doc file needed).
- [x] Security considerations are addressed (auth-gated image endpoint; spawn gate widened by one root only; full-auto adopted from the owner's own config).
- [x] I have linked all related issues.
