### PR TITLE
feat(cli): guided first-run setup state + cross-platform onboarding hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,13 +93,17 @@ pip install local-operator     # pipx install local-operator on Linux (PEP 668)
 The install provides both `local-operator` and its short alias `lop` — the
 rest of this page uses `lop`.
 
-Sign in to a provider (or skip this — the app tells you what's missing on
-first run):
+Sign in to a provider (or skip this — on an interactive terminal `lop` opens
+in a setup state and walks you through `/login`; a headless or piped run prints
+the exact commands to configure hosting, model, and a key):
 
 ```bash
 lop login           # lists login-capable providers
 lop login anthropic # OAuth sign-in in your browser
 ```
+
+`lop login <provider>` also sets it as your default hosting (and picks a
+default model) when none is configured yet, so the very next `lop` just works.
 
 Then start it:
 

--- a/local_operator/agents.py
+++ b/local_operator/agents.py
@@ -19,6 +19,7 @@ from pydantic import BaseModel, Field
 
 from local_operator.jsonl import read_jsonl, write_jsonl
 from local_operator.optional import missing_extra_error
+from local_operator.paths import default_agent_cwd
 from local_operator.types import Schedule  # Keep existing Schedule import
 from local_operator.types import (
     AgentState,
@@ -309,7 +310,7 @@ class AgentRegistry:
             presence_penalty=agent_edit_metadata.presence_penalty,
             seed=agent_edit_metadata.seed,
             current_working_directory=agent_edit_metadata.current_working_directory
-            or "~/local-operator-home",
+            or default_agent_cwd(),
         )
 
         return self.save_agent(agent_metadata)
@@ -1438,7 +1439,7 @@ class AgentRegistry:
 
                 # Create a new agent with the imported data
                 agent_id = agent_data["id"]
-                agent_data["current_working_directory"] = "~/local-operator-home"
+                agent_data["current_working_directory"] = default_agent_cwd()
                 # Older profile bundles duplicated the final conversation turn
                 # into agent.yml. History files are ignored below, but leaving
                 # this field intact would still import private conversation

--- a/local_operator/bootstrap.py
+++ b/local_operator/bootstrap.py
@@ -82,7 +82,19 @@ def resolve_hosting_model(
     if not hosting:
         raise ValueError("Hosting platform is not configured.")
     if not model_name:
-        raise ValueError("Model name is not configured.")
+        # Fall back to the provider's default model rather than erroring on a
+        # single empty field — see session_factory.resolve_hosting_model, which
+        # this mirrors. A provider with no known default still raises.
+        from local_operator.model.defaults import default_model_for
+
+        model_name = default_model_for(hosting)
+        if not model_name:
+            raise ValueError(
+                f"Model name is not configured for hosting '{hosting}', and no "
+                "default is known for it. Set one with `local-operator config "
+                "edit model_name <model>` or the --model flag (e.g. gpt-4o, "
+                "claude-3-5-sonnet-latest, deepseek-chat)."
+            )
     return hosting, model_name
 
 

--- a/local_operator/bootstrap.py
+++ b/local_operator/bootstrap.py
@@ -89,12 +89,14 @@ def resolve_hosting_model(
 
         model_name = default_model_for(hosting)
         if not model_name:
-            raise ValueError(
-                f"Model name is not configured for hosting '{hosting}', and no "
-                "default is known for it. Set one with `local-operator config "
-                "edit model_name <model>` or the --model flag (e.g. gpt-4o, "
-                "claude-3-5-sonnet-latest, deepseek-chat)."
-            )
+            # Reuse the resolver's own message rather than inlining a copy: the
+            # two are the SAME error (no default model for this hosting) and a
+            # second literal here drifts from it the first time either is
+            # reworded. Imported lazily to keep this off the session_factory
+            # stack until the rare no-default path is actually hit.
+            from local_operator.session_factory import _no_model_message
+
+            raise ValueError(_no_model_message(hosting))
     return hosting, model_name
 
 

--- a/local_operator/cli.py
+++ b/local_operator/cli.py
@@ -604,8 +604,52 @@ def _propagate_global_flags(parser: argparse.ArgumentParser) -> None:
 
 
 def credential_update_command(args: argparse.Namespace) -> int:
+    """Prompt for and store one credential. Exit 0/1/130.
+
+    The prompt used to let three ordinary interruptions escape as tracebacks:
+    Ctrl-C raised a bare ``KeyboardInterrupt`` all the way out, and an empty
+    value / closed stdin raised a ``ValueError`` whose message carried nested
+    ANSI escapes that the generic red-banner handler in ``main`` then wrapped in
+    a stack-trace panel. None of the three is a program fault \u2014 they are the
+    user cancelling or mis-entering \u2014 so each gets one plain line and a clean
+    exit code: 130 for a cancel (the shell convention for SIGINT), 1 otherwise.
+    """
+    from local_operator.ansi import strip_control_sequences
+    from local_operator.cli_style import ERROR, WARNING, paint
+    from local_operator.providers.registry import PROVIDER_REGISTRY, env_key_name
+
+    # Warn when the key is not one the registry knows, with the closest match \u2014
+    # a typo'd ``OPENAI_API_KY`` otherwise stores silently and the provider
+    # never sees it. Arbitrary keys stay allowed (custom providers are
+    # legitimate); this is advice, not a gate.
+    known_keys = {name for p in PROVIDER_REGISTRY if (name := env_key_name(p.id))}
+    if args.key not in known_keys:
+        import difflib
+
+        close = difflib.get_close_matches(args.key, sorted(known_keys), n=1)
+        hint = f" Did you mean {close[0]}?" if close else ""
+        print(
+            paint(
+                f"Warning: '{args.key}' is not a known provider key.{hint} " "Storing it anyway.",
+                WARNING,
+            ),
+            file=sys.stderr,
+        )
+
     credential_manager = CredentialManager(config_dir())
-    credential_manager.prompt_for_credential(args.key, reason="update requested")
+    try:
+        credential_manager.prompt_for_credential(args.key, reason="update requested")
+    except KeyboardInterrupt:
+        # 130 is the shell's SIGINT convention; the message is one quiet line,
+        # not the red stack-trace panel the generic handler would have drawn.
+        print("\nCancelled.", file=sys.stderr)
+        return 130
+    except (ValueError, EOFError) as exc:
+        # Empty input or a closed stdin. Strip any control sequences from the
+        # message before printing \u2014 the presenter owns the colour, and a nested
+        # escape from deeper in the stack would otherwise repaint the line.
+        print(paint(strip_control_sequences(str(exc)), ERROR), file=sys.stderr)
+        return 1
     return 0
 
 
@@ -654,7 +698,34 @@ def config_open_command() -> int:
 
 def config_edit_command(args: argparse.Namespace) -> int:
     """Edit a configuration value."""
+    from local_operator.cli_style import ERROR, paint
+
     config_manager = ConfigManager(config_dir())
+
+    # Validate the key against the shipped defaults BEFORE writing. The old
+    # ``except KeyError`` was dead code \u2014 ``update_config`` calls
+    # ``Config.set_value`` which is a plain ``dict.__setitem__`` and never
+    # raises for an unknown key \u2014 so a typo like ``config edit hostng radient``
+    # printed "Successfully updated hostng" and wrote a junk key the app never
+    # reads. difflib names the closest real key so the fix is one glance away.
+    from local_operator.config import DEFAULT_CONFIG
+
+    valid_keys = set(DEFAULT_CONFIG.values.keys())
+    if args.key not in valid_keys:
+        import difflib
+
+        close = difflib.get_close_matches(args.key, sorted(valid_keys), n=1)
+        hint = f" Did you mean '{close[0]}'?" if close else ""
+        print(
+            paint(f"Error: unknown configuration key: '{args.key}'.{hint}", ERROR),
+            file=sys.stderr,
+        )
+        print(
+            "Run `local-operator config list` to see the available keys.",
+            file=sys.stderr,
+        )
+        return 1
+
     try:
         # Parse the value to the appropriate type
         value = args.value
@@ -684,12 +755,12 @@ def config_edit_command(args: argparse.Namespace) -> int:
 
         print(f"Successfully updated {args.key} to {value}")
         return 0
-    except KeyError:
-        print(f"\n\033[1;31mError: Invalid configuration key: {args.key}\033[0m")
-        return -1
     except Exception as e:
-        print(f"\n\033[1;31mError updating configuration: {e}\033[0m")
-        return -1
+        # 1, not -1: a shell sees -1 as 255, which collides with the
+        # xargs/ssh "command not found" sentinel and contradicts the
+        # documented 0/non-zero exec contract (item A13).
+        print(paint(f"Error updating configuration: {e}", ERROR), file=sys.stderr)
+        return 1
 
 
 def config_list_command() -> int:

--- a/local_operator/cli.py
+++ b/local_operator/cli.py
@@ -1764,11 +1764,12 @@ def main() -> int:
         # own env config and the session factory does the same lazily — a
         # dead local would only invite drift.
         base_dir = config_dir()
-        agent_home_dir = Path.home() / "local-operator-home"
-
-        # Create the agent home directory if it doesn't exist
-        if not agent_home_dir.exists():
-            agent_home_dir.mkdir(parents=True, exist_ok=True)
+        # The agent home is NO LONGER created here. Creating it unconditionally
+        # before dispatch meant `config list`, `login`, `--version` and every
+        # other non-session subcommand created a workspace directory they never
+        # touch, and it hardcoded ~/local-operator-home while ignoring any
+        # override. It is now created lazily by the paths that actually run a
+        # task (session/exec/serve start), through paths.ensure_agent_home_dir.
 
         if args.subcommand == "credential":
             if args.credential_command == "update":

--- a/local_operator/cli.py
+++ b/local_operator/cli.py
@@ -636,6 +636,7 @@ def credential_update_command(args: argparse.Namespace) -> int:
             paint(
                 f"Warning: '{args.key}' is not a known provider key.{hint} " "Storing it anyway.",
                 WARNING,
+                stream=sys.stderr,
             ),
             file=sys.stderr,
         )
@@ -652,7 +653,7 @@ def credential_update_command(args: argparse.Namespace) -> int:
         # Empty input or a closed stdin. Strip any control sequences from the
         # message before printing \u2014 the presenter owns the colour, and a nested
         # escape from deeper in the stack would otherwise repaint the line.
-        print(paint(strip_control_sequences(str(exc)), ERROR), file=sys.stderr)
+        print(paint(strip_control_sequences(str(exc)), ERROR, stream=sys.stderr), file=sys.stderr)
         return 1
     return 0
 
@@ -686,6 +687,7 @@ def config_open_command() -> int:
             paint(
                 "Error: Configuration file does not exist.  Create one with `config create`.",
                 ERROR,
+                stream=sys.stderr,
             ),
             file=sys.stderr,
         )
@@ -725,7 +727,7 @@ def config_open_command() -> int:
             gui_error = e
 
     print(
-        paint(f"Error opening configuration file: {gui_error}", ERROR),
+        paint(f"Error opening configuration file: {gui_error}", ERROR, stream=sys.stderr),
         file=sys.stderr,
     )
     print(
@@ -756,7 +758,9 @@ def config_edit_command(args: argparse.Namespace) -> int:
         close = difflib.get_close_matches(args.key, sorted(valid_keys), n=1)
         hint = f" Did you mean '{close[0]}'?" if close else ""
         print(
-            paint(f"Error: unknown configuration key: '{args.key}'.{hint}", ERROR),
+            paint(
+                f"Error: unknown configuration key: '{args.key}'.{hint}", ERROR, stream=sys.stderr
+            ),
             file=sys.stderr,
         )
         print(
@@ -798,7 +802,9 @@ def config_edit_command(args: argparse.Namespace) -> int:
         # 1, not -1: a shell sees -1 as 255, which collides with the
         # xargs/ssh "command not found" sentinel and contradicts the
         # documented 0/non-zero exec contract (item A13).
-        print(paint(f"Error updating configuration: {e}", ERROR), file=sys.stderr)
+        print(
+            paint(f"Error updating configuration: {e}", ERROR, stream=sys.stderr), file=sys.stderr
+        )
         return 1
 
 
@@ -1587,7 +1593,7 @@ def _preflight_hosting_model(
         # this into the exec route from reintroducing a stdout leak.
         from local_operator.cli_style import ERROR, paint
 
-        print(paint(f"Error: {exc}", ERROR), file=sys.stderr)
+        print(paint(f"Error: {exc}", ERROR, stream=sys.stderr), file=sys.stderr)
         return 1
     except Exception:  # noqa: BLE001 — unknown providers pass through
         return None
@@ -1613,6 +1619,7 @@ def _print_first_run_quickstart(credential_manager: CredentialManager) -> None:
             "Error: Local Operator is not configured yet \u2014 no hosting provider, "
             "model, or credential is set.",
             ERROR,
+            stream=sys.stderr,
         ),
         file=sys.stderr,
     )
@@ -1629,6 +1636,7 @@ def _print_first_run_quickstart(credential_manager: CredentialManager) -> None:
             "On an interactive terminal, just run `local-operator` and log in "
             "from the setup screen.",
             INFO,
+            stream=sys.stderr,
         ),
         file=sys.stderr,
     )
@@ -1712,6 +1720,7 @@ def _preflight_api_key(
                 f"'{hosting}'. Starting anyway — run `/login {canonical}` in the "
                 f"TUI, `local-operator login {canonical}` from a shell{env_hint}.",
                 WARNING,
+                stream=sys.stderr,
             ),
             file=sys.stderr,
         )
@@ -1726,6 +1735,7 @@ def _preflight_api_key(
             f"is not configured. Set it via `local-operator login {canonical}`"
             f"{credential_hint}, or the environment.",
             ERROR,
+            stream=sys.stderr,
         ),
         file=sys.stderr,
     )
@@ -2205,6 +2215,7 @@ def main() -> int:
                             "(missing 'local_operator.tui'); remove --tui to use the "
                             "plain REPL.",
                             ERROR,
+                            stream=sys.stderr,
                         ),
                         file=sys.stderr,
                     )

--- a/local_operator/cli.py
+++ b/local_operator/cli.py
@@ -1468,7 +1468,14 @@ async def _run_headless_repl(
     # own output IS console output; lifting the level keeps its prints while
     # dropping the library chatter. WARNING and above still surface — a genuine
     # problem the user needs to see is not INFO.
+    #
+    # The noisy HTTP-client loggers are raised EXPLICITLY, not just via the root:
+    # configure_cli_logging pins each of them to INFO by name, and a child logger
+    # with its own level ignores the root's — so raising only the root left
+    # httpx's per-request line leaking. Same list configure_cli_logging quietens.
     logging.getLogger().setLevel(logging.WARNING)
+    for _noisy in ("requests", "urllib3", "httpx", "httpcore"):
+        logging.getLogger(_noisy).setLevel(logging.WARNING)
 
     console = Console(stderr=True, highlight=False)
     session = await create_session(

--- a/local_operator/cli.py
+++ b/local_operator/cli.py
@@ -677,14 +677,27 @@ def config_create_command() -> int:
 
 def config_open_command() -> int:
     """Open the configuration file using the default system editor."""
+    from local_operator.cli_style import ERROR, paint
+
     config_path = config_dir() / "config.yml"
     if not config_path.exists():
         print(
-            "\n\033[1;31mError: Configuration file does not exist.  Create one with "
-            "`config create`.\033[0m"
+            paint(
+                "Error: Configuration file does not exist.  Create one with `config create`.",
+                ERROR,
+            ),
+            file=sys.stderr,
         )
         return 1
 
+    # Try the platform GUI opener first, then fall back to $VISUAL/$EDITOR. The
+    # GUI openers do not exist on a headless/SSH Linux box (there is no
+    # xdg-open without a desktop session), and there `config open` used to fail
+    # outright — yet that is exactly the environment where a terminal editor is
+    # the ONLY way in. Only spawn an interactive editor when stdout is a tty:
+    # an editor launched from a pipe or a non-interactive shell has no terminal
+    # to draw in and would hang or error.
+    gui_error: Exception | None = None
     try:
         if platform.system() == "Windows":
             subprocess.run(["start", str(config_path)], shell=True, check=True)
@@ -694,9 +707,31 @@ def config_open_command() -> int:
             subprocess.run(["xdg-open", str(config_path)], check=True)
         print(f"Opened configuration file at {config_path}")
         return 0
-    except Exception as e:
-        print(f"\n\033[1;31mError opening configuration file: {e}\033[0m")
-        return 1
+    except Exception as e:  # noqa: BLE001 — GUI opener absent or failed
+        gui_error = e
+
+    editor = os.environ.get("VISUAL") or os.environ.get("EDITOR")
+    if editor and sys.stdout.isatty():
+        try:
+            # ``shlex.split`` so a value like ``code --wait`` or ``emacs -nw``
+            # is honoured, not treated as one impossible executable name.
+            import shlex
+
+            subprocess.run([*shlex.split(editor), str(config_path)], check=True)
+            print(f"Opened configuration file at {config_path}")
+            return 0
+        except Exception as e:  # noqa: BLE001 — editor missing or exited non-zero
+            gui_error = e
+
+    print(
+        paint(f"Error opening configuration file: {gui_error}", ERROR),
+        file=sys.stderr,
+    )
+    print(
+        f"Set $VISUAL or $EDITOR, or edit the file directly at {config_path}.",
+        file=sys.stderr,
+    )
+    return 1
 
 
 def config_edit_command(args: argparse.Namespace) -> int:
@@ -1716,8 +1751,17 @@ def main() -> int:
         parser = build_cli_parser()
         args = parser.parse_args()
 
-        # Set up the subprocess environment early
-        setup_cross_platform_environment()
+        # Prime the login-shell PATH only on paths that actually spawn
+        # subprocess work: the interactive session, exec, serve and mobile all
+        # run shell commands whose PATH must match a login terminal's, but
+        # `config list`, `credential`, `login`, `agents` and the like never
+        # spawn a tool — yet every one of them used to pay a full login-shell
+        # round-trip (`$SHELL -l -c 'echo $PATH'`) on startup. The helper keeps
+        # a per-process cache, so a session that later needs it still primes at
+        # most once. ``None`` is the bare interactive launch.
+        _SUBPROCESS_SUBCOMMANDS = frozenset({"exec", "serve", "mobile"})
+        if args.subcommand in _SUBPROCESS_SUBCOMMANDS or args.subcommand is None:
+            setup_cross_platform_environment()
 
         # Resolve `--resume` HERE, before anything is started. Left to the
         # session factory it surfaces inside the TUI as "session failed to

--- a/local_operator/cli.py
+++ b/local_operator/cli.py
@@ -15,8 +15,11 @@ Rewrite constraints (docs/REWRITE.md section E + backward-compat contracts):
 - No module-level import of textual / providers / session internals / TUI:
   those are lazy-imported at the point of use so ``import local_operator.cli``
   stays cheap and cannot break while parallel rewrite streams are mid-flight.
-- Exit codes preserved: 0 success, -1 legacy error banner; ``exec`` returns
-  0/1 per the README contract.
+- Exit codes: 0 success, 1 on error; ``exec`` returns 0/1 per the README
+  contract. (Failure paths previously returned -1, which a shell reports as
+  255 — colliding with the xargs/ssh "command not found" sentinel and
+  contradicting the exec 0/non-zero contract. Item A13 changed them to 1; a
+  quiet cancel returns 130, the SIGINT convention.)
 
 Example Usage:
     local-operator --hosting deepseek --model deepseek-chat
@@ -680,7 +683,7 @@ def config_open_command() -> int:
             "\n\033[1;31mError: Configuration file does not exist.  Create one with "
             "`config create`.\033[0m"
         )
-        return -1
+        return 1
 
     try:
         if platform.system() == "Windows":
@@ -693,7 +696,7 @@ def config_open_command() -> int:
         return 0
     except Exception as e:
         print(f"\n\033[1;31mError opening configuration file: {e}\033[0m")
-        return -1
+        return 1
 
 
 def config_edit_command(args: argparse.Namespace) -> int:
@@ -829,7 +832,7 @@ def mobile_command(args: argparse.Namespace) -> int:
             print("  it is never printed here, so it cannot leak into a transcript.")
             return 0
         print(f"\n\033[1;31m{result.get('error', 'install failed')}\033[0m")
-        return -1
+        return 1
 
     if command == "status":
         result = mobile_install.status()
@@ -855,7 +858,7 @@ def mobile_command(args: argparse.Namespace) -> int:
         result = mobile_install.service_action(command)
         if not result["ok"]:
             print(f"\n\033[1;31m{result['error']}\033[0m")
-            return -1
+            return 1
         print(f"mobile daemon {command} ok")
         return 0
 
@@ -906,7 +909,7 @@ def mobile_command(args: argparse.Namespace) -> int:
         return 0
 
     print("usage: lop mobile {install|status|start|stop|restart|logs|password|uninstall|serve}")
-    return -1
+    return 1
 
 
 def serve_command(host: str, port: int, reload: bool) -> int:
@@ -924,7 +927,7 @@ def serve_command(host: str, port: int, reload: bool) -> int:
             f"\n\033[1;31m{missing_extra_error('server', 'The HTTP API server')}\033[0m",
             file=sys.stderr,
         )
-        return -1
+        return 1
 
     print(f"Starting server at http://{host}:{port}")
     if reload:
@@ -998,10 +1001,10 @@ def agents_create_command(name: str, agent_registry: "AgentRegistry") -> int:
             name = input("\033[1;36mEnter name for new agent: \033[0m").strip()
             if not name:
                 print("\n\033[1;31mError: Agent name cannot be empty\033[0m")
-                return -1
+                return 1
         except (KeyboardInterrupt, EOFError):
             print("\n\033[1;31mAgent creation cancelled\033[0m")
-            return -1
+            return 1
 
     from local_operator.agents import AgentEditFields  # lazy: heavy module
 
@@ -1073,7 +1076,7 @@ def teams_create_command(args: argparse.Namespace, team_registry: Any) -> int:
         )
     except ValueError as exc:
         print(f"\n\033[1;31mError: {exc}\033[0m")
-        return -1
+        return 1
     print("\n\033[1;32m╭─ Created New Team ───────────────────────────\033[0m")
     print(f"\033[1;32m│ Name: {team.name}\033[0m")
     print(f"\033[1;32m│ Manager: {team.manager}\033[0m")
@@ -1087,7 +1090,7 @@ def teams_show_command(name: str, team_registry: Any) -> int:
     team = team_registry.get_team_by_name(name)
     if team is None:
         print(f"\n\033[1;31mError: No team found with name: {name}\033[0m")
-        return -1
+        return 1
     print(f"\n\033[1;32m╭─ Team {team.name} ───────────────────────────\033[0m")
     print(f"\033[1;32m│ Manager: {team.manager}\033[0m")
     if team.description:
@@ -1112,7 +1115,7 @@ def teams_delete_command(name: str, team_registry: Any) -> int:
     team = team_registry.get_team_by_name(name)
     if team is None:
         print(f"\n\033[1;31mError: No team found with name: {name}\033[0m")
-        return -1
+        return 1
     team_registry.delete_team(team.id)
     print(f"\n\033[1;32mSuccessfully deleted team: {name}\033[0m")
     return 0
@@ -1130,7 +1133,7 @@ def agents_delete_command(
         matching_agents = [a for a in agents if a.name == name]
         if not matching_agents:
             print(f"\n\033[1;31mError: No agent found with name: {name}\033[0m")
-            return -1
+            return 1
 
         agent = matching_agents[0]
         agent_registry.delete_agent(agent.id)
@@ -1144,7 +1147,7 @@ def agents_delete_command(
         api_key = credential_manager.get_credential("RADIENT_API_KEY")
         if not api_key:
             print("\n\033[1;31mError: RADIENT_API_KEY is required to delete from Radient\033[0m")
-            return -1
+            return 1
         config_manager = ConfigManager(config_dir)
         base_url = config_manager.get_config_value("radient_base_url", "https://api.radienthq.com")
         radient_client = RadientClient(api_key=api_key, base_url=base_url)
@@ -1157,10 +1160,10 @@ def agents_delete_command(
             return 0
         except Exception as e:
             print(f"\n\033[1;31mError deleting agent from Radient: {e}\033[0m")
-            return -1
+            return 1
     else:
         print("\n\033[1;31mError: Must provide --name or --id for delete\033[0m")
-        return -1
+        return 1
 
 
 # --- Additive subcommand handlers (rewrite) --------------------------------
@@ -1185,7 +1188,7 @@ def login_command(args: argparse.Namespace) -> int:
         from local_operator.providers.auth_cli import run_login
     except ImportError:
         print("\n\033[1;31mError: provider login support is not available in this build\033[0m")
-        return -1
+        return 1
     auth_store, credential_manager = _build_auth_stack(config_dir())
     try:
         return run_login(getattr(args, "provider", None), credential_manager, auth_store)
@@ -1199,7 +1202,7 @@ def logout_command(args: argparse.Namespace) -> int:
         from local_operator.providers.auth_cli import run_logout
     except ImportError:
         print("\n\033[1;31mError: provider login support is not available in this build\033[0m")
-        return -1
+        return 1
     auth_store, _credential_manager = _build_auth_stack(config_dir())
     try:
         return run_logout(args.provider, auth_store)
@@ -1213,7 +1216,7 @@ def login_status_command() -> int:
         from local_operator.providers.auth_cli import list_logins
     except ImportError:
         print("\n\033[1;31mError: provider login support is not available in this build\033[0m")
-        return -1
+        return 1
     auth_store, credential_manager = _build_auth_stack(config_dir())
     try:
         return list_logins(auth_store, credential_manager)
@@ -1295,7 +1298,7 @@ def mcp_command(args: argparse.Namespace) -> int:
         from local_operator.mcp import config as mcp_config
     except ImportError:
         print("\n\033[1;31mError: MCP support is not available in this build\033[0m")
-        return -1
+        return 1
 
     if args.mcp_command == "list":
         servers = mcp_config.list_effective_servers(Path.cwd())
@@ -1313,7 +1316,7 @@ def mcp_command(args: argparse.Namespace) -> int:
         for item in getattr(args, "server_env", None) or []:
             if "=" not in item:
                 print(f"\n\033[1;31mError: --env expects KEY=VALUE, got: {item}\033[0m")
-                return -1
+                return 1
             key, value = item.split("=", 1)
             env[key] = value
         return mcp_config.add_server(
@@ -1346,7 +1349,7 @@ def mcp_command(args: argparse.Namespace) -> int:
         return mcp_config.remove_server(args.name, scope=getattr(args, "scope", "global"))
 
     print(f"\n\033[1;31mError: Invalid mcp command: {args.mcp_command}\033[0m")
-    return -1
+    return 1
 
 
 # --- Session factory facade -------------------------------------------------
@@ -1390,7 +1393,7 @@ def _apply_run_in(run_in: Optional[str]) -> Optional[int]:
             f"\n\033[1;31mError: Invalid working directory: {run_in}\033[0m",
             file=sys.stderr,
         )
-        return -1
+        return 1
     os.chdir(run_in_path)
     # These are OPERATOR notices, not data: they must go to stderr so they
     # never interleave into the `exec --json` event stream on stdout.
@@ -1504,7 +1507,7 @@ def _preflight_hosting_model(
         # the two consistent is what stops the next person wiring this into the
         # exec route from reintroducing a stdout leak.
         print(f"\n\033[1;31mError: {exc}\033[0m", file=sys.stderr)
-        return -1
+        return 1
     except Exception:  # noqa: BLE001 — unknown providers pass through
         return None
 
@@ -1589,7 +1592,7 @@ def _preflight_api_key(
         f"login {canonical}`.\033[0m",
         file=sys.stderr,
     )
-    return -1
+    return 1
 
 
 #: Third-party modules the `server` extra provides. Used to decide whether a
@@ -1813,7 +1816,7 @@ def main() -> int:
                     print(
                         "\n\033[1;31mError: RADIENT_API_KEY is required to push to Radient\033[0m"
                     )
-                    return -1
+                    return 1
                 config_manager = ConfigManager(base_dir)
                 base_url = config_manager.get_config_value(
                     "radient_base_url", "https://api.radienthq.com"
@@ -1826,17 +1829,17 @@ def main() -> int:
                     agent = agent_registry.get_agent_by_name(args.name)
                     if not agent:
                         print(f"\n\033[1;31mError: No agent found with name: {args.name}\033[0m")
-                        return -1
+                        return 1
                 elif getattr(args, "id", None):
                     try:
                         agent = agent_registry.get_agent(args.id)
                         agent_id_to_overwrite = args.id
                     except KeyError:
                         print(f"\n\033[1;31mError: No agent found with ID: {args.id}\033[0m")
-                        return -1
+                        return 1
                 else:
                     print("\n\033[1;31mError: Must provide --name or --id for push\033[0m")
-                    return -1
+                    return 1
                 zip_path, _ = agent_registry.export_agent(agent.id)
                 try:
                     agent_id = agent_registry.upload_agent_to_radient(
@@ -1855,7 +1858,7 @@ def main() -> int:
                     return 0
                 except Exception as e:
                     print(f"\n\033[1;31mError pushing agent to Radient: {e}\033[0m")
-                    return -1
+                    return 1
             elif args.agents_command == "pull":
                 # Pull agent from Radient
                 from local_operator.clients.radient import RadientClient  # lazy
@@ -1878,7 +1881,7 @@ def main() -> int:
                     return 0
                 except Exception as e:
                     print(f"\n\033[1;31mError pulling agent from Radient: {e}\033[0m")
-                    return -1
+                    return 1
             else:
                 parser.error(f"Invalid agents command: {args.agents_command}")
         elif args.subcommand == "teams":
@@ -1949,13 +1952,13 @@ def main() -> int:
                     # (`exec --json` with a bad or absent hosting/model) is the
                     # most likely one to be scripted.
                     print(f"\n\033[1;31mError: {exc}\033[0m", file=sys.stderr)
-                    return -1
+                    return 1
                 except Exception as exc:  # noqa: BLE001
                     print(
                         f"\n\033[1;31mError: preflight failed: {exc}\033[0m",
                         file=sys.stderr,
                     )
-                    return -1
+                    return 1
                 key_result = _preflight_api_key(hosting, CredentialManager(base_dir))
                 if key_result is not None:
                     return key_result
@@ -2021,7 +2024,7 @@ def main() -> int:
                 else:
                     # This case should logically not happen
                     print("\n\033[1;31mError: Failed to create or retrieve agent.\033[0m")
-                    return -1
+                    return 1
 
         # Legacy behavior: the auto-save config value persists interactive
         # sessions via the registry's autosave agent (exec is excluded —
@@ -2068,7 +2071,7 @@ def main() -> int:
                         "build/install (missing 'local_operator.tui'); remove "
                         "--tui to use the plain REPL.\033[0m"
                     )
-                    return -1
+                    return 1
                 use_tui = False
 
         # asyncio is imported HERE, not at module scope. It is the heaviest
@@ -2194,7 +2197,7 @@ def main() -> int:
             "\n\033[1;33mPlease review and correct the error to continue.\033[0m",
             file=sys.stderr,
         )
-        return -1
+        return 1
 
 
 if __name__ == "__main__":

--- a/local_operator/cli.py
+++ b/local_operator/cli.py
@@ -155,9 +155,10 @@ def build_cli_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--model",
         type=str,
-        help="Model to use (e.g., deepseek-chat, gpt-4o, qwen2.5:14b, "
-        "claude-3-5-sonnet-20240620, moonshot-v1-32k, qwen-plus, gemini-2.0-flash, "
-        "mistral-large-latest, test-model, deepseek/deepseek-chat)",
+        help="Model to use (e.g., gpt-4o, claude-3-5-sonnet-latest, deepseek-chat, "
+        "grok-3, glm-5.3, gemini-2.0-flash-001, qwen-plus, moonshot-v1-32k, "
+        "mistral-large-latest, deepseek/deepseek-chat). Optional: when omitted, "
+        "the provider's default model is used.",
     )
     parser.add_argument(
         "--run-in",
@@ -1602,7 +1603,19 @@ def _preflight_api_key(
     if api_key:
         return None
 
-    key_name = definition.env_keys if isinstance(definition.env_keys, str) else "API key"
+    from local_operator.cli_style import ERROR, WARNING, paint
+    from local_operator.providers.registry import env_key_name
+
+    # ``env_key_name`` returns None for a CALLABLE env_keys resolver (Anthropic
+    # picks between ANTHROPIC_OAUTH_TOKEN and ANTHROPIC_API_KEY, so there is no
+    # single var to name). The old code fell back to the literal string "API
+    # key" and interpolated it into the command template, producing the invalid
+    # advice `credential update API key`. Only offer `credential update <NAME>`
+    # when there is a real env var name; otherwise recommend `login` only.
+    key_name = env_key_name(canonical)
+    credential_hint = f", `local-operator credential update {key_name}`" if key_name else ""
+    env_hint = f", or set {key_name} in the environment" if key_name else ""
+
     if not require_key:
         # Interactive start: name the fact and the remedies, then let the app
         # come up. `/login` is scoped to the TUI because the headless REPL has
@@ -1610,21 +1623,26 @@ def _preflight_api_key(
         # line stays visible on stderr (the TUI repaints over it, but its
         # splash carries the same warning).
         print(
-            f"\n\033[1;33mWarning: no credentials are configured for hosting "
-            f"platform '{hosting}'. Starting anyway — run `/login {canonical}` "
-            f"in the TUI, `local-operator login {canonical}` from a shell, or "
-            f"set {key_name} in the environment.\033[0m",
+            paint(
+                f"Warning: no credentials are configured for hosting platform "
+                f"'{hosting}'. Starting anyway — run `/login {canonical}` in the "
+                f"TUI, `local-operator login {canonical}` from a shell{env_hint}.",
+                WARNING,
+            ),
             file=sys.stderr,
         )
         return None
     # stderr: this fires on every fresh install and every typo'd --hosting,
     # i.e. it is the single most common `exec --json` failure, and a coloured
     # non-JSON line on stdout breaks the consumer it is trying to inform.
+    subject = key_name if key_name else "an API key"
     print(
-        f"\n\033[1;31mError: {key_name} is required for hosting platform "
-        f"'{hosting}' but is not configured. Set it via `local-operator "
-        f"credential update {key_name}`, the environment, or `local-operator "
-        f"login {canonical}`.\033[0m",
+        paint(
+            f"Error: {subject} is required for hosting platform '{hosting}' but "
+            f"is not configured. Set it via `local-operator login {canonical}`"
+            f"{credential_hint}, or the environment.",
+            ERROR,
+        ),
         file=sys.stderr,
     )
     return 1

--- a/local_operator/cli.py
+++ b/local_operator/cli.py
@@ -1453,10 +1453,22 @@ async def _run_headless_repl(
     stderr, Ctrl+C aborts the running turn (not the REPL), Ctrl+D/EOF exits.
     """
     import asyncio
+    import logging
 
     from rich.console import Console
 
     from local_operator.headless_print import PrintRenderer
+
+    # Raise the console threshold to WARNING for the REPL. configure_cli_logging
+    # pins the root logger at INFO, and the headless REPL — unlike the TUI,
+    # which wraps its whole run in file_logging() — prints straight to the
+    # terminal, so httpx's one-INFO-line-per-request and every other INFO record
+    # leaked into the transcript BEFORE the first prompt and between turns. The
+    # TUI's remedy (detach console handlers) is wrong here because the REPL's
+    # own output IS console output; lifting the level keeps its prints while
+    # dropping the library chatter. WARNING and above still surface — a genuine
+    # problem the user needs to see is not INFO.
+    logging.getLogger().setLevel(logging.WARNING)
 
     console = Console(stderr=True, highlight=False)
     session = await create_session(
@@ -1502,6 +1514,7 @@ def _preflight_hosting_model(
     args: argparse.Namespace,
     *,
     require_api_key: bool = True,
+    allow_setup_state: bool = False,
 ) -> int | None:
     """Startup preflight (CL-06): resolve hosting/model and verify that a
     credential source exists BEFORE any turn runs.
@@ -1529,25 +1542,89 @@ def _preflight_hosting_model(
     resolution errors stay fatal on every path: without a hosting there is no
     session to build and nothing for a login to fix.
 
-    Returns -1 (already printed) on failure, None to continue. All engine
+    ``allow_setup_state=True`` is the first-run onboarding gate (item A1/U1):
+    when NO hosting can be resolved at all AND we are on the interactive TUI
+    path (tty + TUI enabled), the app is allowed to open in a SETUP STATE
+    instead of dying at preflight. The welcome splash's ``/login`` affordance
+    and the ``/model`` / ``/provider`` surfaces are the guided setup — there is
+    no separate wizard. Every OTHER path (headless REPL, exec, non-tty) keeps
+    fail-fast, and does it with a COMPLETE quickstart that names everything
+    missing at once rather than one field at a time.
+
+    Returns 1 (already printed) on failure, None to continue. All engine
     imports stay lazy so this never weights down parser-only paths.
     """
-    try:
-        from local_operator.session_factory import resolve_hosting_model
+    from local_operator.session_factory import (
+        HostingNotConfiguredError,
+        resolve_hosting_model,
+    )
 
+    try:
         hosting, _model_name = resolve_hosting_model(current_agent, args, config_manager)
+    except HostingNotConfiguredError:
+        # No hosting resolved. On the interactive TUI path this is not an error:
+        # the app opens in a setup state so the user can `/login` from inside it.
+        if allow_setup_state:
+            return None
+        # Every other path keeps fail-fast, but with the WHOLE quickstart at
+        # once (item A1/U1) — the old message named only "Hosting platform is
+        # not configured" and the user fixed it one error at a time.
+        _print_first_run_quickstart(credential_manager)
+        return 1
     except ValueError as exc:
-        # stderr on principle, not because this path is currently reachable from
-        # `exec --json`: it is an ERROR message, and its sibling
-        # `_preflight_api_key` two functions down already writes there. Keeping
-        # the two consistent is what stops the next person wiring this into the
-        # exec route from reintroducing a stdout leak.
-        print(f"\n\033[1;31mError: {exc}\033[0m", file=sys.stderr)
+        # A model-resolution error (hosting set, no default known): fatal on
+        # every path, one line. stderr on principle, not because this path is
+        # currently reachable from `exec --json`: it is an ERROR message, and
+        # its sibling `_preflight_api_key` two functions down already writes
+        # there. Keeping the two consistent is what stops the next person wiring
+        # this into the exec route from reintroducing a stdout leak.
+        from local_operator.cli_style import ERROR, paint
+
+        print(paint(f"Error: {exc}", ERROR), file=sys.stderr)
         return 1
     except Exception:  # noqa: BLE001 — unknown providers pass through
         return None
 
     return _preflight_api_key(hosting, credential_manager, require_key=require_api_key)
+
+
+def _print_first_run_quickstart(credential_manager: CredentialManager) -> None:
+    """One complete message naming hosting, model AND key at once (item A1/U1).
+
+    The fail-fast paths (headless REPL, exec, non-tty) reach this when nothing
+    is configured. The point of naming all three missing pieces together, with
+    the exact commands, is that a scripted or headless user fixes the whole
+    thing in one pass instead of rerunning into "hosting missing", then "model
+    missing", then "key missing" \u2014 the one-error-at-a-time treadmill the
+    interactive setup state exists to avoid and this message is the non-tty
+    equivalent of.
+    """
+    from local_operator.cli_style import ERROR, INFO, paint
+
+    print(
+        paint(
+            "Error: Local Operator is not configured yet \u2014 no hosting provider, "
+            "model, or credential is set.",
+            ERROR,
+        ),
+        file=sys.stderr,
+    )
+    print(
+        paint(
+            "Set it up with (pick a provider, e.g. openai / anthropic / deepseek):\n"
+            "  local-operator login <provider>          "
+            "# stores the key AND sets hosting + a default model\n"
+            "or configure the pieces individually:\n"
+            "  local-operator config edit hosting <provider>\n"
+            "  local-operator config edit model_name <model>\n"
+            "  local-operator credential update <PROVIDER_API_KEY>\n"
+            "or pass them per-run with the --hosting and --model flags.\n"
+            "On an interactive terminal, just run `local-operator` and log in "
+            "from the setup screen.",
+            INFO,
+        ),
+        file=sys.stderr,
+    )
 
 
 def _preflight_api_key(
@@ -2095,6 +2172,45 @@ def main() -> int:
         if auto_save_enabled:
             args.train = True
 
+        # Interactive path: full-screen TUI when stdout is a tty and not
+        # disabled; plain headless REPL otherwise. ``--tui`` (CL-13) forces
+        # the TUI even when stdout is not a tty — with a clear error when
+        # that is impossible.
+        #
+        # Decided BEFORE the preflight (it used to come after) because the
+        # preflight now needs the answer: only the TUI path may open in a
+        # first-run setup state instead of failing, so ``use_tui`` gates that.
+        force_tui = bool(getattr(args, "tui", False))
+        use_tui = force_tui or (not getattr(args, "no_tui", False) and sys.stdout.isatty())
+        run_tui = None
+        if use_tui:
+            try:
+                from local_operator.tui import run_tui  # lazy: textual
+            except ImportError:
+                run_tui = None
+                if force_tui:
+                    # Forced but impossible: surface WHY, don't silently fall
+                    # back to the plain REPL (the user asked for the TUI).
+                    from local_operator.cli_style import ERROR, paint
+
+                    print(
+                        paint(
+                            "Error: the TUI is not available in this build/install "
+                            "(missing 'local_operator.tui'); remove --tui to use the "
+                            "plain REPL.",
+                            ERROR,
+                        ),
+                        file=sys.stderr,
+                    )
+                    return 1
+                use_tui = False
+
+        # Whether the app can open in a first-run setup state: only when the
+        # full-screen TUI is actually going to run, since the splash's `/login`
+        # affordance is the setup UI. The headless REPL and every non-tty path
+        # (piped stdout, `--no-tui`) keep fail-fast with the complete quickstart.
+        setup_state_ok = bool(use_tui and run_tui is not None)
+
         # Startup preflight (CL-06): hosting/model resolution fails fast with
         # the legacy message shape BEFORE any turn (the factory raises the
         # same errors mid-construction; surfacing them here keeps the user
@@ -2109,32 +2225,10 @@ def main() -> int:
             current_agent,
             args,
             require_api_key=False,
+            allow_setup_state=setup_state_ok,
         )
         if preflight_result is not None:
             return preflight_result
-
-        # Interactive path: full-screen TUI when stdout is a tty and not
-        # disabled; plain headless REPL otherwise. ``--tui`` (CL-13) forces
-        # the TUI even when stdout is not a tty — with a clear error when
-        # that is impossible.
-        force_tui = bool(getattr(args, "tui", False))
-        use_tui = force_tui or (not getattr(args, "no_tui", False) and sys.stdout.isatty())
-        run_tui = None
-        if use_tui:
-            try:
-                from local_operator.tui import run_tui  # lazy: textual
-            except ImportError:
-                run_tui = None
-                if force_tui:
-                    # Forced but impossible: surface WHY, don't silently fall
-                    # back to the plain REPL (the user asked for the TUI).
-                    print(
-                        "\n\033[1;31mError: the TUI is not available in this "
-                        "build/install (missing 'local_operator.tui'); remove "
-                        "--tui to use the plain REPL.\033[0m"
-                    )
-                    return 1
-                use_tui = False
 
         # asyncio is imported HERE, not at module scope. It is the heaviest
         # single item on the CLI's import graph (34.4 ms, +6.5 MB RSS, +77
@@ -2175,7 +2269,16 @@ def main() -> int:
                 # disabling every provider slash command while the app still
                 # starts cleanly. functools.partial pins it by name so a future
                 # signature change cannot re-introduce that silent failure.
-                tui_entry = functools.partial(run_tui, provider_controller=tui_controller)
+                # ``on_config_changed`` re-reads config.yml into THIS manager
+                # after the app's first-run ``/login`` writes hosting/model to
+                # disk. The session factory closes over this exact instance, so
+                # without the reload the post-login rebuild would resolve the
+                # same empty config and bounce back into the setup state.
+                tui_entry = functools.partial(
+                    run_tui,
+                    provider_controller=tui_controller,
+                    on_config_changed=config_manager.reload,
+                )
 
                 # ``/resume <id>`` in the TUI needs a factory that boots an
                 # ARBITRARY session, not just the one the launch args named.

--- a/local_operator/cli.py
+++ b/local_operator/cli.py
@@ -2092,11 +2092,10 @@ def main() -> int:
                     hosting, _model = resolve_hosting_model_dry(exec_args)
                 except ValueError as exc:
                     # stderr: this is the FOREGROUND `exec --json` path, so
-                    # stdout is the event stream. The byte-identical twins in
-                    # exec_mode._spawn_background were fixed earlier and these
-                    # were missed — the flag combination that reaches them
-                    # (`exec --json` with a bad or absent hosting/model) is the
-                    # most likely one to be scripted.
+                    # stdout is the event stream. Return 1 (not -1) so the
+                    # scripted `exec --json` case exits with a clean non-zero;
+                    # the byte-identical twins in exec_mode._spawn_background
+                    # follow the same contract.
                     print(f"\n\033[1;31mError: {exc}\033[0m", file=sys.stderr)
                     return 1
                 except Exception as exc:  # noqa: BLE001

--- a/local_operator/cli_style.py
+++ b/local_operator/cli_style.py
@@ -1,0 +1,91 @@
+"""ANSI styling and encoding fallbacks for the plain-print CLI paths.
+
+Why its own module, stdlib-only: the credential prompt, the ``config`` and
+``credential`` subcommands, the startup preflight and the ``login`` handlers all
+print coloured status *directly* — not through Textual — and every one of them
+sits on the CLI startup path that ``test_import_graph`` forbids from importing
+the provider graph, Textual or asyncio. A raw ``\\033[1;31m`` literal, which is
+what every one of these call sites used before, ignores three environments the
+tool is routinely run in:
+
+- ``NO_COLOR`` set (the community convention for "emit no colour anywhere"),
+- a non-tty stdout (a pipe or a captured CI log), where the escape bytes land
+  in the middle of text a scraper is trying to parse, and
+- ``TERM=dumb`` or a legacy Windows console that never learned to interpret
+  SGR, which renders the literal escapes as visible ``[1;31m`` garbage.
+
+The encoding half exists for the same class of caller: the credential prompt
+draws a box-drawing banner, and a stdout whose encoding cannot represent
+``─``/``╭`` (``PYTHONIOENCODING=ascii``, a legacy Windows code page) crashed the
+prompt with ``UnicodeEncodeError`` before it could ask for anything.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from typing import IO
+
+#: SGR parameter strings for the four semantic roles the CLI paints. Kept as
+#: bare parameters (not full escapes) so :func:`paint` owns the ``ESC[…m`` /
+#: reset framing in exactly one place — a literal reset forgotten at a call
+#: site is how colour used to bleed into the line below it.
+ERROR = "1;31"
+WARNING = "1;33"
+SUCCESS = "1;32"
+INFO = "1;34"
+CYAN = "1;36"
+
+
+def colour_enabled(stream: IO[str] | None = None) -> bool:
+    """Whether ANSI colour should be emitted to ``stream`` (default stdout).
+
+    The three gates, in the order a surprised user would check them: an
+    explicit ``NO_COLOR`` opt-out wins over everything (its mere presence, per
+    the convention, regardless of value); then the stream must be a real
+    terminal, so a redirected pipe or captured log stays plain; then ``TERM``
+    must not advertise a terminal that cannot interpret SGR.
+    """
+    if stream is None:
+        stream = sys.stdout
+    if os.environ.get("NO_COLOR") is not None:
+        return False
+    isatty = getattr(stream, "isatty", None)
+    if not callable(isatty) or not isatty():
+        return False
+    if os.environ.get("TERM") == "dumb":
+        return False
+    return True
+
+
+def paint(text: str, code: str, *, stream: IO[str] | None = None) -> str:
+    """Wrap ``text`` in the SGR ``code`` when colour is enabled for ``stream``.
+
+    Returns the text untouched otherwise, so a call site reads the same whether
+    or not the terminal takes colour — the gate lives here, never at the call
+    site, which is what keeps a new print path from reintroducing a raw escape.
+    """
+    if not colour_enabled(stream):
+        return text
+    return f"\033[{code}m{text}\033[0m"
+
+
+def can_encode(text: str, stream: IO[str] | None = None) -> bool:
+    """Whether ``stream`` (default stdout) can encode ``text`` without error.
+
+    Used by the credential banner to decide between its box-drawing and ASCII
+    forms. A ``None``/unknown encoding is treated as capable: the default
+    interpreter encoding is UTF-8, and refusing to draw the nice banner on a
+    stream that simply did not report its encoding would punish the common case
+    for the rare one.
+    """
+    if stream is None:
+        stream = sys.stdout
+    encoding = getattr(stream, "encoding", None)
+    if not encoding:
+        return True
+    try:
+        text.encode(encoding)
+    except (UnicodeEncodeError, LookupError):
+        return False
+    return True

--- a/local_operator/config.py
+++ b/local_operator/config.py
@@ -290,7 +290,12 @@ class ConfigManager:
             Config: The configuration object
         """
         if not self.config_file.exists():
-            self.config_dir.mkdir(parents=True, exist_ok=True)
+            # 0700 at CREATION only (item 17): config.yml and the transcripts and
+            # credentials beside it are the same sensitivity class as the log dir
+            # (paths.ensure_log_dir), and the default 0755 exposed the directory
+            # to every other account on a shared host. Never chmod an existing
+            # dir on upgrade — a user may have widened it on purpose.
+            self.config_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
             return _fresh_default_config()
 
         with open(self.config_file, "r", encoding="utf-8") as f:
@@ -351,7 +356,8 @@ class ConfigManager:
             config (Dict[str, Any]): Configuration dictionary to write
         """
         if not self.config_file.exists():
-            self.config_dir.mkdir(parents=True, exist_ok=True)
+            # 0700 at creation for the same reason as _load_config above (item 17).
+            self.config_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
             self.config_file.touch()
 
         # Ensure version and metadata are included

--- a/local_operator/config.py
+++ b/local_operator/config.py
@@ -253,6 +253,36 @@ class ConfigManager:
         self.config_file = self.config_dir / CONFIG_FILE_NAME
         self.config = self._load_config()
 
+    def _handle_bad_config(self, detail: str) -> None:
+        """Report an unreadable config.yml and move it aside to config.yml.bad.
+
+        Backing the file up rather than deleting it keeps the user's edits
+        recoverable, and renaming it (rather than leaving it) is what stops the
+        very next launch from failing identically: a broken file that stays in
+        place turns one bad edit into a permanent lockout. Best-effort \u2014 if the
+        rename cannot happen (read-only dir), the load still degrades to
+        defaults, which is the whole point of catching this.
+        """
+        from local_operator.cli_style import ERROR, WARNING, paint
+
+        print(paint(f"Error: {detail}", ERROR), file=sys.stderr)
+        backup = self.config_file.with_suffix(self.config_file.suffix + ".bad")
+        try:
+            self.config_file.replace(backup)
+            print(
+                paint(
+                    f"Moved the invalid file to {backup} and starting with defaults. "
+                    "Run `local-operator config create` to write a fresh one.",
+                    WARNING,
+                ),
+                file=sys.stderr,
+            )
+        except OSError:
+            print(
+                paint("Starting with default configuration.", WARNING),
+                file=sys.stderr,
+            )
+
     def _load_config(self) -> Config:
         """Load configuration from file or create with defaults if none exists.
 
@@ -264,7 +294,27 @@ class ConfigManager:
             return _fresh_default_config()
 
         with open(self.config_file, "r", encoding="utf-8") as f:
-            config_dict = yaml.safe_load(f) or deepcopy(vars(DEFAULT_CONFIG))
+            # A hand-edited config.yml with a YAML syntax error, or one whose
+            # top level parses to something other than a mapping (a bare list or
+            # scalar), used to raise a raw traceback straight out of startup \u2014
+            # the CLI died before it could say which file was wrong. Catch both:
+            # name the path and the parse error on one line, move the bad file
+            # aside to config.yml.bad so the next launch starts clean instead of
+            # failing identically forever, and point at `config create`. stderr
+            # because ConfigManager is built on the `exec --json` path, whose
+            # stdout is the event stream.
+            try:
+                loaded = yaml.safe_load(f)
+            except yaml.YAMLError as exc:
+                self._handle_bad_config(f"could not parse {self.config_file}: {exc}")
+                return _fresh_default_config()
+            if loaded is not None and not isinstance(loaded, dict):
+                self._handle_bad_config(
+                    f"{self.config_file} is not a valid configuration mapping "
+                    f"(top level is {type(loaded).__name__})"
+                )
+                return _fresh_default_config()
+            config_dict = loaded or deepcopy(vars(DEFAULT_CONFIG))
 
             # Check if config version is older than current version
             config_version = config_dict.get("version", "0.0.0")

--- a/local_operator/config.py
+++ b/local_operator/config.py
@@ -377,6 +377,19 @@ class ConfigManager:
         """
         return self.config
 
+    def reload(self) -> None:
+        """Re-read the config from disk, replacing the in-memory copy.
+
+        Exists for the first-run setup flow: the TUI's ``/login`` writes hosting
+        and model to config.yml through its own manager, and the session factory
+        captured a DIFFERENT manager instance at launch whose in-memory config
+        still reads empty. Reloading that instance before the post-login session
+        rebuild is what lets the new hosting actually take effect \u2014 without it
+        the reload resolves the same empty config and drops straight back into
+        the setup state.
+        """
+        self.config = self._load_config()
+
     def update_config(self, updates: Dict[str, Any], write: bool = True) -> None:
         """Update configuration with new values.
 

--- a/local_operator/config.py
+++ b/local_operator/config.py
@@ -265,8 +265,14 @@ class ConfigManager:
         """
         from local_operator.cli_style import ERROR, WARNING, paint
 
-        print(paint(f"Error: {detail}", ERROR), file=sys.stderr)
-        backup = self.config_file.with_suffix(self.config_file.suffix + ".bad")
+        print(paint(f"Error: {detail}", ERROR, stream=sys.stderr), file=sys.stderr)
+        # Timestamp the backup so a SECOND bad edit does not clobber the first:
+        # a plain `.bad` suffix means two broken saves in a row silently lose
+        # the earlier recoverable copy, defeating the point of keeping it. The
+        # timestamp is second-resolution, which is finer than a human can make
+        # two edits, so collisions do not happen in practice.
+        stamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+        backup = self.config_file.with_suffix(self.config_file.suffix + f".bad.{stamp}")
         try:
             self.config_file.replace(backup)
             print(
@@ -274,12 +280,13 @@ class ConfigManager:
                     f"Moved the invalid file to {backup} and starting with defaults. "
                     "Run `local-operator config create` to write a fresh one.",
                     WARNING,
+                    stream=sys.stderr,
                 ),
                 file=sys.stderr,
             )
         except OSError:
             print(
-                paint("Starting with default configuration.", WARNING),
+                paint("Starting with default configuration.", WARNING, stream=sys.stderr),
                 file=sys.stderr,
             )
 

--- a/local_operator/credentials.py
+++ b/local_operator/credentials.py
@@ -99,7 +99,13 @@ class CredentialManager:
         directory.mkdir(parents=True, exist_ok=True)
         fd, tmp_path = tempfile.mkstemp(dir=str(directory), prefix=".credentials-", suffix=".tmp")
         try:
-            os.fchmod(fd, _CREDENTIALS_MODE)
+            # os.fchmod is POSIX-only; on Windows it does not exist and calling
+            # it unconditionally raises AttributeError on every credential write
+            # (login and `credential update`). mkstemp already creates the temp
+            # at 0600 on POSIX, so the guard loses no hardening there, and
+            # Windows has no POSIX mode bits to set anyway.
+            if hasattr(os, "fchmod"):
+                os.fchmod(fd, _CREDENTIALS_MODE)
             with os.fdopen(fd, "w") as f:
                 f.write(body)
             os.replace(tmp_path, self.config_file)

--- a/local_operator/credentials.py
+++ b/local_operator/credentials.py
@@ -7,13 +7,37 @@ for accessing them when needed.
 
 import getpass
 import os
+import sys
+import tempfile
 from pathlib import Path
 from typing import Dict, List
 
 from pydantic import SecretStr
 
+from local_operator.cli_style import CYAN, SUCCESS, can_encode, paint
+
 # Name of the file used to store credentials in .env format
 CREDENTIALS_FILE_NAME: str = "credentials.env"
+
+#: Restrictive mode for the credentials file and its directory. Credentials are
+#: the highest-sensitivity data the app writes, so both the file (0600) and the
+#: directory that holds it (0700) exclude every other account on a shared host.
+_CREDENTIALS_MODE = 0o600
+_CONFIG_DIR_MODE = 0o700
+
+
+def _reject_control_chars(key: str, value: str) -> None:
+    """Refuse a credential value that would corrupt the flat ``key=value`` file.
+
+    The store is one ``key=value`` line per credential with no quoting or
+    escaping, so a newline in a value silently splits it into a second, bogus
+    entry (and a NUL/other control byte produces a line the loader cannot read
+    back). Rejecting at the boundary keeps the format an invariant rather than
+    something every writer has to remember to sanitise; a legitimate API key or
+    token never contains one of these bytes.
+    """
+    if any(ord(ch) < 0x20 or ord(ch) == 0x7F for ch in value):
+        raise ValueError(f"{key} contains control characters, which are not allowed.")
 
 
 class CredentialManager:
@@ -53,10 +77,41 @@ class CredentialManager:
         return self.credentials
 
     def write_to_file(self) -> None:
-        """Write credentials to the config file."""
-        with open(self.config_file, "w") as f:
-            for key, value in self.credentials.items():
-                f.write(f"{key}={value.get_secret_value()}\n")
+        """Write credentials to the config file atomically.
+
+        Write-to-temp then ``os.replace`` rather than truncating the real file:
+        a crash or full disk mid-write used to leave the file half-written,
+        losing every key the process had — the store has no backup, so a
+        partial write is unrecoverable data loss. ``os.replace`` is atomic on a
+        single filesystem, so a reader either sees the whole old file or the
+        whole new one, never a torn one.
+
+        The temp file is opened with 0600 via :func:`os.open` so the secret is
+        never briefly world-readable between create and chmod, and it is created
+        in the SAME directory as the target so the final ``os.replace`` is a
+        rename within one filesystem (a cross-device replace is not atomic and
+        would raise).
+        """
+        body = "".join(
+            f"{key}={value.get_secret_value()}\n" for key, value in self.credentials.items()
+        )
+        directory = self.config_file.parent
+        directory.mkdir(parents=True, exist_ok=True)
+        fd, tmp_path = tempfile.mkstemp(dir=str(directory), prefix=".credentials-", suffix=".tmp")
+        try:
+            os.fchmod(fd, _CREDENTIALS_MODE)
+            with os.fdopen(fd, "w") as f:
+                f.write(body)
+            os.replace(tmp_path, self.config_file)
+        except BaseException:
+            # Leave no half-written temp file behind on any failure path,
+            # including KeyboardInterrupt — the real file is still intact
+            # because the replace had not run yet.
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
 
     def _ensure_config_exists(self) -> None:
         """Ensure the credentials configuration file exists and has proper permissions.
@@ -69,9 +124,24 @@ class CredentialManager:
         when credentials are added via set_credential().
         """
         if not self.config_file.exists():
-            self.config_file.parent.mkdir(parents=True, exist_ok=True)
+            # 0700 on the directory, matching the log dir (paths.ensure_log_dir):
+            # transcripts and credentials are the same sensitivity class, and the
+            # default 0755 exposed the directory listing to every other account
+            # on a shared machine. Only set at CREATION — never chmod an existing
+            # directory, which may hold other things a user deliberately shared.
+            self.config_file.parent.mkdir(parents=True, exist_ok=True, mode=_CONFIG_DIR_MODE)
             self.config_file.touch()
-            self.config_file.chmod(0o600)
+            self.config_file.chmod(_CREDENTIALS_MODE)
+        else:
+            # Re-tighten a pre-existing credentials file that is looser than
+            # 0600. A file created by an older build (or copied in by hand) may
+            # be world-readable; this is the one moment we can quietly fix it
+            # without touching a directory the user may share on purpose.
+            try:
+                if (self.config_file.stat().st_mode & 0o077) != 0:
+                    self.config_file.chmod(_CREDENTIALS_MODE)
+            except OSError:
+                pass
 
     def get_credentials(self) -> Dict[str, SecretStr]:
         """Get all credentials from the config file."""
@@ -119,7 +189,12 @@ class CredentialManager:
             key (str): The environment variable key to set
             value (str): The credential value to set
             write (bool): Whether to write the credential to the config file
+
+        Raises:
+            ValueError: if the value contains control characters that would
+                corrupt the flat ``key=value`` store.
         """
+        _reject_control_chars(key, value)
         self.credentials[key] = SecretStr(value)
 
         if write:
@@ -138,34 +213,74 @@ class CredentialManager:
             SecretStr: The credential value wrapped in SecretStr
 
         Raises:
-            ValueError: If the user enters an empty credential
+            ValueError: If the user enters an empty credential.
+            EOFError: If stdin closes before a value is read (piped empty input).
+            KeyboardInterrupt: If the user cancels the prompt.
         """
         # Calculate border length based on key length
         line_length = max(50, len(key) + 12)
-        border = "─" * line_length
+        # Box drawing is decorative; on a stdout whose encoding cannot represent
+        # it (PYTHONIOENCODING=ascii, a legacy Windows code page) drawing it
+        # crashed the prompt with UnicodeEncodeError before it could ask for
+        # anything. Fall back to ASCII rules so the prompt still works there.
+        heavy = can_encode("─╭╮├┤╰╯")
+        h, tl, tr, ml, mr, bl, br = (
+            ("─", "╭", "╮", "├", "┤", "╰", "╯")
+            if heavy
+            else (
+                "-",
+                "+",
+                "+",
+                "+",
+                "+",
+                "+",
+                "+",
+            )
+        )
+        border = h * line_length
 
-        # Create box components with colors
-        cyan = "\033[1;36m"
-        blue = "\033[1;94m"
-        reset = "\033[0m"
+        # Colour is gated on NO_COLOR/tty/TERM by ``paint`` \u2014 a raw escape here
+        # painted literal ``[1;36m`` into a piped or dumb-terminal transcript.
+        def cyan(text: str) -> str:
+            return paint(text, CYAN)
 
         # Print the setup box
-        print(f"{cyan}╭{border}╮{reset}")
+        print(cyan(f"{tl}{border}{tr}"))
         setup_padding = " " * (line_length - len(key) - 7)
-        print(f"{cyan}│ {key} Setup{setup_padding}│{reset}")
-        print(f"{cyan}├{border}┤{reset}")
+        print(
+            cyan(f"│ {key} Setup{setup_padding}│")
+            if heavy
+            else cyan(f"| {key} Setup{setup_padding}|")
+        )
+        print(cyan(f"{ml}{border}{mr}"))
         reason_padding = " " * (line_length - len(key) - len(reason) - 3)
-        print(f"{cyan}│ {key} {reason}.{reason_padding}│{reset}")
-        print(f"{cyan}╰{border}╯{reset}")
+        body = f"{key} {reason}."
+        print(cyan(f"│ {body}{reason_padding}│") if heavy else cyan(f"| {body}{reason_padding}|"))
+        print(cyan(f"{bl}{border}{br}"))
 
-        # Prompt for API key using getpass to hide input
-        credential = getpass.getpass(f"{blue}Please enter your {key}: {reset}").strip()
+        prompt = paint(f"Please enter your {key}: ", "1;94")
+        if sys.stdin.isatty():
+            # Interactive terminal: getpass hides the key so it never lands in
+            # scrollback of a session that may be screen-shared.
+            credential = getpass.getpass(prompt).strip()
+        else:
+            # Non-interactive stdin (piped/scripted): getpass on a non-tty falls
+            # back to echoing the input with a warning, which is both noisy and
+            # useless for automation. Read one line from stdin instead \u2014 this is
+            # the documented automation contract: `printf '%s\\n' "$KEY" |
+            # local-operator credential update NAME`. An empty pipe raises
+            # EOFError, which the command handler turns into one plain line.
+            print(prompt, end="", flush=True)
+            line = sys.stdin.readline()
+            if line == "":
+                raise EOFError(f"{key} is required for this step.")
+            credential = line.strip()
         if not credential:
-            raise ValueError(f"\033[1;31m{key} is required for this step.\033[0m")
+            raise ValueError(f"{key} is required for this step.")
 
         # Save the new API key to config file
         self.set_credential(key, credential, write=True)
 
-        print("\n\033[1;32m✓ Credential successfully saved!\033[0m")
+        print(paint("\n✓ Credential successfully saved!", SUCCESS))
 
         return SecretStr(credential)

--- a/local_operator/credentials.py
+++ b/local_operator/credentials.py
@@ -281,6 +281,10 @@ class CredentialManager:
         # Save the new API key to config file
         self.set_credential(key, credential, write=True)
 
-        print(paint("\n✓ Credential successfully saved!", SUCCESS))
+        # ASCII fallback for the check glyph too: a stdout that cannot encode the
+        # box drawing cannot encode ✓ either, and crashing on the SUCCESS line
+        # after the key is already saved is the worst place to fail (item 14).
+        tick = "✓" if can_encode("✓") else "[ok]"
+        print(paint(f"\n{tick} Credential successfully saved!", SUCCESS))
 
         return SecretStr(credential)

--- a/local_operator/exec_mode.py
+++ b/local_operator/exec_mode.py
@@ -248,10 +248,13 @@ def _spawn_background(command: str, exec_args: ExecArgs) -> int:
         resolve_hosting_model_dry(exec_args)
     except ValueError as exc:
         print(f"\n\033[1;31mError: {exc}\033[0m", file=sys.stderr)
-        return -1
+        # Return 1, not -1: this becomes the process exit code via exit(main()),
+        # and a negative return maps to exit 255 (item 18's contract is that a
+        # preflight failure exits with a clean non-zero, not a wrapped -1).
+        return 1
     except Exception as exc:  # noqa: BLE001 — never spawn blind
         print(f"\n\033[1;31mError: preflight failed: {exc}\033[0m", file=sys.stderr)
-        return -1
+        return 1
 
     _ensure_logs_dir()
     timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")

--- a/local_operator/headless_print.py
+++ b/local_operator/headless_print.py
@@ -122,6 +122,9 @@ class PrintRenderer:
         self.failed: bool = False
         self.last_assistant_text: str = ""
         self._streaming_assistant: bool = False
+        #: The attached session, held so an auth-error line can name the active
+        #: provider in its recovery hint. ``None`` until :meth:`attach`.
+        self._session: SessionProtocol | None = None
 
     # -- subscription entry point -------------------------------------------
 
@@ -138,6 +141,7 @@ class PrintRenderer:
 
     def attach(self, session: SessionProtocol) -> Callable[[], None]:
         """Subscribe to a session, returning the unsubscribe callable."""
+        self._session = session
         return session.subscribe(self.handle)
 
     # -- internals -----------------------------------------------------------
@@ -260,8 +264,25 @@ class PrintRenderer:
                 # BEFORE ``_track_outcome`` ran, so the process printed a
                 # traceback instead of the error line and exited 0. The text is
                 # data, never markup. (Review R1-1.)
+                #
+                # Append the local recovery to an auth-classified failure so the
+                # headless user learns they can `local-operator login` / rotate
+                # the key, not just the provider's opaque refusal. No-op for
+                # every other kind. Provider is the first segment of the active
+                # model label.
+                from local_operator.providers.failover import append_auth_recovery
+
+                provider = ""
+                if self._session is not None:
+                    try:
+                        provider = (self._session.model_label or "").partition("/")[0]
+                    except Exception:
+                        provider = ""
                 self.console.print(
-                    f"Error: {event.error}", style="red", highlight=False, markup=False
+                    f"Error: {append_auth_recovery(event.error, provider or None)}",
+                    style="red",
+                    highlight=False,
+                    markup=False,
                 )
             elif event.aborted:
                 self.console.print("[red]aborted[/red]", highlight=False)

--- a/local_operator/model/configure.py
+++ b/local_operator/model/configure.py
@@ -37,6 +37,7 @@ from local_operator.harness.types import (
     Usage,
 )
 from local_operator.model.catalogue import DEFAULT_TTL_S
+from local_operator.model.defaults import DEFAULT_MODEL_NAMES as _DEFAULT_MODEL_NAMES
 from local_operator.model.effort import default_effort, supported_efforts
 from local_operator.model.registry import (
     ModelInfo,
@@ -86,19 +87,10 @@ DEFAULT_TOP_P = 0.9
 
 # Per-hosting defaults preserved byte-for-byte from the legacy chain so
 # existing config files and CLI invocations keep picking the same model.
-DEFAULT_MODEL_NAMES: dict[str, str] = {
-    "deepseek": "deepseek-chat",
-    "openai": "gpt-4o",
-    "openrouter": "google/gemini-2.0-flash-001",
-    "anthropic": "claude-3-5-sonnet-latest",
-    "kimi": "moonshot-v1-32k",
-    "alibaba": "qwen-plus",
-    "google": "gemini-2.0-flash-001",
-    "mistral": "mistral-large-latest",
-    "radient": "auto",
-    "xai": "grok-3",
-    "zai": "glm-5.3",
-}
+# Re-exported from ``model.defaults`` (the stdlib-only home) so the preflight
+# path can read the map without importing this heavy module. Kept as a name here
+# because legacy callers and tests import ``configure.DEFAULT_MODEL_NAMES``.
+DEFAULT_MODEL_NAMES = _DEFAULT_MODEL_NAMES
 
 # Sensible ModelSpec fallbacks when the legacy registry knows nothing.
 UNKNOWN_CONTEXT_WINDOW = 128_000

--- a/local_operator/model/defaults.py
+++ b/local_operator/model/defaults.py
@@ -1,0 +1,45 @@
+"""Per-provider default model ids, in a stdlib-only module.
+
+Extracted from ``model.configure`` so the startup/preflight path can answer
+"what model does this provider default to?" without importing the model
+configuration stack (pydantic, the registry, the wire clients). ``configure``
+re-exports :data:`DEFAULT_MODEL_NAMES` from here for backward compatibility, so
+there is still exactly one map; this module is only about WHERE it can be
+imported cheaply from.
+
+Why a default exists at all: with a hosting chosen but ``model_name`` empty (a
+fresh ``config edit hosting <provider>``, or a ``--hosting`` flag with no
+``--model``), the app used to raise "Model name is not configured." and die.
+There is a reasonable default per provider, so it resolves to that and prints
+what it picked instead of turning a one-field omission into a dead end.
+"""
+
+from __future__ import annotations
+
+#: The model id used when a provider is selected but no model is named. Values
+#: are deliberately conservative, broadly-available ids for each provider; a
+#: user who wants a specific model sets ``model_name`` and this is never read.
+DEFAULT_MODEL_NAMES: dict[str, str] = {
+    "deepseek": "deepseek-chat",
+    "openai": "gpt-4o",
+    "openrouter": "google/gemini-2.0-flash-001",
+    "anthropic": "claude-3-5-sonnet-latest",
+    "kimi": "moonshot-v1-32k",
+    "alibaba": "qwen-plus",
+    "google": "gemini-2.0-flash-001",
+    "mistral": "mistral-large-latest",
+    "radient": "auto",
+    "xai": "grok-3",
+    "zai": "glm-5.3",
+}
+
+
+def default_model_for(hosting: str) -> str | None:
+    """The default model id for ``hosting``, or ``None`` when there is none.
+
+    ``noop`` maps to ``test`` for the same reason the rest of the code treats
+    them as one; an unknown provider returns ``None`` so the caller can keep
+    "no default, ask the user" distinct from "the default is empty".
+    """
+    canonical = "test" if hosting == "noop" else hosting
+    return DEFAULT_MODEL_NAMES.get(canonical)

--- a/local_operator/paths.py
+++ b/local_operator/paths.py
@@ -38,6 +38,20 @@ APP_DIRNAME = "local-operator"
 #: which hold other things too.
 LOG_DIRNAME = "logs"
 
+#: Environment variable that relocates the agent's working-directory home. Its
+#: own variable rather than sharing :data:`CONFIG_DIR_ENV`: the config dir holds
+#: credentials and transcripts (private, small), while the agent home is where
+#: the model reads and writes files during a task (a workspace, potentially
+#: large) \u2014 a user isolating one does not necessarily want the other moved.
+AGENT_HOME_ENV = "LOCAL_OPERATOR_HOME"
+
+#: Directory name under the home directory when no override is set. Spelled
+#: WITHOUT a leading dot on purpose: it is a workspace the user is meant to
+#: browse, not hidden state, and every existing install already has
+#: ``~/local-operator-home`` \u2014 this change is about WHEN it is created and WHERE
+#: the path is resolved, never the default location.
+AGENT_HOME_DIRNAME = "local-operator-home"
+
 
 def config_dir() -> Path:
     """The app's configuration directory: the override, else ``~/.local-operator``.
@@ -51,6 +65,57 @@ def config_dir() -> Path:
     if override:
         return Path(override)
     return Path.home() / DEFAULT_CONFIG_DIRNAME
+
+
+def agent_home_dir() -> Path:
+    """The agent's working-directory home: the override, else ``~/local-operator-home``.
+
+    Read from the environment on every call, for the same reason
+    :func:`config_dir` is (tests monkeypatch the variable after import; a module
+    constant would freeze the developer's real home into the test session).
+
+    This does NOT honour :data:`CONFIG_DIR_ENV`. Before this existed, ``main()``
+    hardcoded ``~/local-operator-home`` and created it unconditionally on every
+    invocation \u2014 ``config list`` on a fresh machine created an agent workspace
+    it never used \u2014 and it ignored any override entirely, so a test or isolated
+    run that relocated the config dir still wrote a workspace into the real home
+    directory. Callers create it lazily at the point of use (session/agent start,
+    the server app) rather than at import or dispatch.
+    """
+    override = os.environ.get(AGENT_HOME_ENV)
+    if override:
+        return Path(override)
+    return Path.home() / AGENT_HOME_DIRNAME
+
+
+def default_agent_cwd() -> str:
+    """The default working-directory string stored in an agent record.
+
+    Returns the portable ``~/local-operator-home`` when no override is set \u2014 an
+    agent record is exported and shared, so a literal home path in it would not
+    replicate on another machine \u2014 and the absolute override path when one IS
+    set, so the stored cwd and the directory :func:`agent_home_dir` actually
+    creates cannot diverge. That divergence is precisely the class of bug
+    :func:`config_dir`'s module docstring documents: one half honouring the
+    override while the other hardcodes home, invisible until the variable is set.
+    """
+    override = os.environ.get(AGENT_HOME_ENV)
+    if override:
+        return str(Path(override))
+    return f"~/{AGENT_HOME_DIRNAME}"
+
+
+def ensure_agent_home_dir() -> Path:
+    """Create and return :func:`agent_home_dir`, creating parents as needed.
+
+    Unlike :func:`ensure_log_dir` this DOES surface a creation failure: the
+    agent home is the working directory a task runs in, so a run that cannot
+    create it has nowhere to operate and should fail loudly rather than silently
+    fall back to the process cwd.
+    """
+    directory = agent_home_dir()
+    directory.mkdir(parents=True, exist_ok=True)
+    return directory
 
 
 def log_dir() -> Path:

--- a/local_operator/providers/auth_cli.py
+++ b/local_operator/providers/auth_cli.py
@@ -156,6 +156,7 @@ def run_login(
                 storage_provider, {"key": result, "source": "login", "type": "api_key"}
             )
             print(f"Stored API key for '{storage_provider}'.")
+            _apply_login_defaults(storage_provider)
         return 0
 
     # OAuth credentials dict; stamp authorized_at if missing.
@@ -166,8 +167,47 @@ def run_login(
     print(f"Logged in to '{storage_provider}'{suffix}.")
     if result.get("grant_note"):
         print(f"Note: {result['grant_note']}")
+    _apply_login_defaults(storage_provider)
     _ = row
     return 0
+
+
+def _apply_login_defaults(provider_id: str) -> None:
+    """Make a fresh login usable: adopt it as hosting when none is set.
+
+    Before this, ``login <provider>`` stored the credential but never touched
+    the config, so the very recovery the missing-key error recommends
+    (``local-operator login openai``) looped straight back to "Hosting platform
+    is not configured" — the credential existed but nothing pointed the app at
+    it. Now, when config hosting is empty, the just-logged-in provider becomes
+    the hosting and its default model becomes ``model_name``, and we print what
+    was set so the change is not silent.
+
+    When hosting is ALREADY set we touch nothing and print nothing: a user
+    logging into a second provider to switch models later has not asked to
+    change their default, and silently repointing it would be a surprise.
+
+    Imported lazily and guarded: this is a convenience on top of a login that
+    already succeeded, so a config write failure (read-only dir) must not turn a
+    successful login into a failure.
+    """
+    try:
+        from local_operator.config import ConfigManager
+        from local_operator.model.defaults import default_model_for
+        from local_operator.paths import config_dir
+
+        manager = ConfigManager(config_dir())
+        if manager.get_config_value("hosting"):
+            return
+        manager.set_config_value("hosting", provider_id)
+        model = default_model_for(provider_id) or ""
+        message = f"Set default hosting to '{provider_id}'"
+        if model and not manager.get_config_value("model_name"):
+            manager.set_config_value("model_name", model)
+            message += f" and model to '{model}'"
+        print(f"{message}.")
+    except Exception as exc:  # noqa: BLE001 — never fail a completed login
+        print(f"Note: logged in, but could not set default hosting/model: {exc}")
 
 
 def run_logout(provider_id: str, auth_store: "AuthStore") -> int:

--- a/local_operator/providers/failover.py
+++ b/local_operator/providers/failover.py
@@ -400,6 +400,44 @@ def is_auth_error(error: BaseException) -> bool:
     return False
 
 
+def auth_recovery_hint(provider: str | None) -> str:
+    """The local remedies for an authentication failure, as one clause.
+
+    A provider's auth error shows only the provider's own words ("invalid
+    x-api-key"), which tells the user WHAT happened but not what THEY can do
+    about it from here. This is the sentence to append: rotate the stored key or
+    re-run the login. Named by provider when we know it (so the command is
+    copy-pasteable), generic otherwise. The ``/login`` form is the TUI's; the
+    shell forms work anywhere.
+    """
+    if provider:
+        return (
+            f"To fix: `/login {provider}` in the TUI, `local-operator login "
+            f"{provider}` from a shell, or `local-operator credential update "
+            f"<{provider.upper()}_API_KEY>` to replace the stored key."
+        )
+    return (
+        "To fix: re-run `/login <provider>` in the TUI, `local-operator login "
+        "<provider>` from a shell, or `local-operator credential update <KEY>`."
+    )
+
+
+def append_auth_recovery(rendered_error: str, provider: str | None) -> str:
+    """Append :func:`auth_recovery_hint` to an auth-classified rendered error.
+
+    Gated on the rendered form starting with the auth label, so a quota 403
+    (which reads "rate limit or quota exceeded" — a login cannot fix it) is left
+    alone. The rendered string is what the UI already holds, matching the
+    ``is_image_rejection`` string-form convention rather than requiring the
+    original exception at the display site.
+    """
+    if not rendered_error:
+        return rendered_error
+    if not rendered_error.lower().startswith(_KIND_LABELS["auth"]):
+        return rendered_error
+    return f"{rendered_error}\n{auth_recovery_hint(provider)}"
+
+
 def is_usage_limit_error(error: BaseException) -> bool:
     """402/429 or provider-reported quota/rate exhaustion."""
     if not isinstance(error, ProviderError):

--- a/local_operator/server/app.py
+++ b/local_operator/server/app.py
@@ -71,11 +71,13 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
 
     # Initialize on startup by setting up the credential and config managers
     config_dir = Path.home() / ".local-operator"
-    agent_home_dir = Path.home() / "local-operator-home"
+    # Honour LOCAL_OPERATOR_HOME and create it at the point of use, matching the
+    # CLI session path. The literal ``~/local-operator-home`` here ignored the
+    # override, so a relocated home still had a stray workspace created in the
+    # real home directory.
+    from local_operator.paths import ensure_agent_home_dir
 
-    # Create the agent home directory if it doesn't exist
-    if not agent_home_dir.exists():
-        agent_home_dir.mkdir(parents=True, exist_ok=True)
+    ensure_agent_home_dir()
 
     # Set up the subprocess environment for accessing shell commands
     setup_cross_platform_environment()

--- a/local_operator/server/models/schemas.py
+++ b/local_operator/server/models/schemas.py
@@ -15,6 +15,7 @@ from pydantic import BaseModel, Field
 # AgentEditFields will be used in the routes module
 from local_operator.jobs import JobResult, JobStatus
 from local_operator.model.registry import ModelInfo, ProviderDetail
+from local_operator.paths import default_agent_cwd
 from local_operator.types import (  # Added ScheduleUnit
     CodeExecutionResult,
     ConversationRecord,
@@ -270,7 +271,10 @@ class AgentCreate(BaseModel):
         description="Random number seed for deterministic generation.",
     )
     current_working_directory: str | None = Field(
-        "~/local-operator-home",
+        # default_factory so the LOCAL_OPERATOR_HOME override is honoured at
+        # model-construction time rather than frozen to the literal home path at
+        # import (see paths.default_agent_cwd).
+        default_factory=default_agent_cwd,
         description="The current working directory for the agent.  Updated whenever the "
         "agent changes its working directory through code execution.  Defaults to "
         "'~/local-operator-home'.",

--- a/local_operator/session_factory.py
+++ b/local_operator/session_factory.py
@@ -1472,8 +1472,6 @@ async def create_session(
     hosting/model configuration is missing.
     """
 
-    from local_operator.session.session import Session
-
     # Create the agent's working-directory home HERE, lazily, rather than
     # unconditionally in main() before dispatch (where it hardcoded the path
     # and ignored the override). A session is a path that actually runs a task,
@@ -1482,6 +1480,7 @@ async def create_session(
     # because the workspace root could not be created (a read-only home), so a
     # creation error degrades to the process cwd the same way an unset cwd does.
     from local_operator.paths import ensure_agent_home_dir
+    from local_operator.session.session import Session
 
     try:
         ensure_agent_home_dir()

--- a/local_operator/session_factory.py
+++ b/local_operator/session_factory.py
@@ -1437,6 +1437,20 @@ async def create_session(
 
     from local_operator.session.session import Session
 
+    # Create the agent's working-directory home HERE, lazily, rather than
+    # unconditionally in main() before dispatch (where it hardcoded the path
+    # and ignored the override). A session is a path that actually runs a task,
+    # so an agent whose cwd is the default ``~/local-operator-home`` has a real
+    # directory to land in. Best-effort: a session must not fail to build just
+    # because the workspace root could not be created (a read-only home), so a
+    # creation error degrades to the process cwd the same way an unset cwd does.
+    from local_operator.paths import ensure_agent_home_dir
+
+    try:
+        ensure_agent_home_dir()
+    except OSError:
+        pass
+
     effective_cwd = cwd if cwd is not None else os.getcwd()
     plan = await _prepare(
         args,

--- a/local_operator/session_factory.py
+++ b/local_operator/session_factory.py
@@ -231,6 +231,19 @@ def resolve_agent(args: argparse.Namespace, agent_registry: AgentRegistry) -> Ag
     )
 
 
+class HostingNotConfiguredError(ValueError):
+    """Raised when no hosting provider is resolved at all.
+
+    A dedicated subclass (rather than a bare ``ValueError`` matched by message)
+    so two callers can treat this ONE condition as "first-run setup", not
+    "error": the CLI preflight lets the interactive TUI open in a setup state
+    instead of dying, and the TUI's boot-failure handler shows the guided
+    ``/login`` affordance rather than a red "session failed to start". It stays
+    a ``ValueError`` subclass so every existing ``except ValueError`` that
+    reported the legacy message shape keeps working unchanged.
+    """
+
+
 def _no_model_message(hosting: str) -> str:
     """Error text for a provider with no known default model.
 
@@ -264,7 +277,7 @@ def resolve_hosting_model(
         model_name or getattr(args, "model", None) or config_manager.get_config_value("model_name")
     )
     if not hosting:
-        raise ValueError("Hosting platform is not configured.")
+        raise HostingNotConfiguredError("Hosting platform is not configured.")
     if not model_name:
         # A hosting with no model is not a dead end: every mainstream provider
         # has a reasonable default, so resolve to it rather than raising. Only

--- a/local_operator/session_factory.py
+++ b/local_operator/session_factory.py
@@ -231,6 +231,22 @@ def resolve_agent(args: argparse.Namespace, agent_registry: AgentRegistry) -> Ag
     )
 
 
+def _no_model_message(hosting: str) -> str:
+    """Error text for a provider with no known default model.
+
+    Names two or three concrete, current model ids so the user has something to
+    type rather than a bare "model is not configured" that leaves them to guess
+    the vocabulary. Kept beside the resolver, stdlib-only, so the preflight path
+    stays off the model-configuration stack.
+    """
+    return (
+        f"Model name is not configured for hosting '{hosting}', and no default "
+        "is known for it. Set one with `local-operator config edit model_name "
+        "<model>` or the --model flag (e.g. gpt-4o, claude-3-5-sonnet-latest, "
+        "deepseek-chat)."
+    )
+
+
 def resolve_hosting_model(
     agent: AgentData | None, args: argparse.Namespace, config_manager: ConfigManager
 ) -> tuple[str, str]:
@@ -250,7 +266,15 @@ def resolve_hosting_model(
     if not hosting:
         raise ValueError("Hosting platform is not configured.")
     if not model_name:
-        raise ValueError("Model name is not configured.")
+        # A hosting with no model is not a dead end: every mainstream provider
+        # has a reasonable default, so resolve to it rather than raising. Only
+        # a provider with no known default (a custom/unregistered hosting) still
+        # errors, and its message now names current models to choose from.
+        from local_operator.model.defaults import default_model_for
+
+        model_name = default_model_for(hosting)
+        if not model_name:
+            raise ValueError(_no_model_message(hosting))
     return hosting, model_name
 
 

--- a/local_operator/skills/index.py
+++ b/local_operator/skills/index.py
@@ -59,6 +59,40 @@ _TOKEN_STRIP = "\"'`()[]{}<>,;:"
 _FILENAME_RE = re.compile(r"^[A-Za-z0-9_+.~\-]+\.[A-Za-z0-9]+$")
 
 
+#: Markers of an authentication failure in an embedding backend's exception.
+#: Matched against the exception's class name + text because the embedding
+#: backends raise their own types (httpx errors, provider-specific wrappers),
+#: and importing the provider stack to classify one degraded lookup would put
+#: that whole graph on the skill-index path. Deliberately narrow: only the
+#: unambiguous 401/invalid-key wordings, so a transient 5xx or a timeout still
+#: surfaces its warning to the user.
+_AUTH_FAILURE_MARKERS = (
+    "401",
+    "unauthorized",
+    "invalid api key",
+    "invalid api-key",
+    "invalid x-api-key",
+    "authentication",
+    "no api key",
+    "missing api key",
+)
+
+
+def _looks_like_auth_failure(exc: BaseException) -> bool:
+    """Best-effort: did ``exc`` come from a rejected/absent credential?
+
+    Used only to decide whether the "embedding backend failed" warning belongs
+    in the log rather than in front of the user (the credential problem is
+    already reported elsewhere). Being wrong is cheap in both directions: a
+    false positive hides one redundant warning, a false negative shows it.
+    """
+    haystack = f"{type(exc).__name__}: {exc}".lower()
+    status = getattr(exc, "status_code", None) or getattr(exc, "status", None)
+    if status in (401, 403):
+        return True
+    return any(marker in haystack for marker in _AUTH_FAILURE_MARKERS)
+
+
 def _path_suffixes(path: str) -> Sequence[str]:
     """A path plus every component-suffix of it: ``a/b/c`` → ``a/b/c``,
     ``b/c``, ``c``.
@@ -279,6 +313,11 @@ class SkillIndex:
         self._backend_failed = False  # memoize primary-backend failure
         self.backend_failures = 0  # count of primary-backend failures seen
         self._local_fallback: LocalEmbedder | None = None  # one stable instance
+        #: Whether the most recent backend failure looked like an auth error
+        #: (401/invalid key). Used to route the "backend failed" warning to the
+        #: log instead of the user when the cause is the credential problem the
+        #: app already reports — see the fallback branch in :meth:`select`.
+        self._last_backend_auth_failure = False
 
     @property
     def warnings(self) -> list[str]:
@@ -461,10 +500,22 @@ class SkillIndex:
             if not self._backend_failed:
                 self._backend_failed = True
                 self.backend_failures += 1
-                self._warnings.append(
+                note = (
                     f"Embedding backend failed ({self.backend_failures}x); "
                     "falling back to the local embedder"
                 )
+                # When the cause is the SAME missing/invalid credential the app
+                # already warns about elsewhere (a 401 from the embedding
+                # provider), surfacing a second "embedding backend failed"
+                # warning is noise proportional to nothing — the user has one
+                # credential problem, not two — and it accuses a subsystem that
+                # is working exactly as designed (it degraded to the local
+                # embedder). Downgrade that specific case to the log file; every
+                # other backend failure still surfaces.
+                if self._last_backend_auth_failure:
+                    logger.info("%s (cause: provider authentication)", note)
+                else:
+                    self._warnings.append(note)
             if self._local_fallback is None:
                 self._local_fallback = LocalEmbedder()
             picked = await self._select_with_backend(self._local_fallback, query, k, threshold, cwd)
@@ -495,6 +546,13 @@ class SkillIndex:
             scores = self._scores(query_vec)
             scores = _hybrid_scores(query, self.skills, scores, cwd)
         except Exception as exc:  # noqa: BLE001 — degradation is the contract
+            # Remember whether THIS failure was an auth error, so the caller can
+            # decide the "backend failed" warning belongs in the log rather than
+            # in front of the user (see the fallback branch in select). Read
+            # best-effort — the embedding backends raise their own exception
+            # types, so classify from status/text markers without importing the
+            # provider stack onto this path.
+            self._last_backend_auth_failure = _looks_like_auth_failure(exc)
             logger.warning("Skill selection failed: %s", exc)
             return None
 

--- a/local_operator/tui/__init__.py
+++ b/local_operator/tui/__init__.py
@@ -18,6 +18,7 @@ async def run_tui(
     theme_name: str = "dark",
     provider_controller: Any | None = None,
     resume_factory: Callable[[str | None], Awaitable[SessionProtocol]] | None = None,
+    on_config_changed: Callable[[], None] | None = None,
 ) -> int:
     """Run the full-screen TUI to completion; return a process exit code.
 
@@ -43,6 +44,7 @@ async def run_tui(
             theme_name=theme_name,
             provider_controller=provider_controller,
             resume_factory=resume_factory,
+            on_config_changed=on_config_changed,
         )
         try:
             await app.run_async()

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -987,6 +987,7 @@ class OperatorApp(App[None]):
         theme_name: str = "dark",
         provider_controller: Any | None = None,
         resume_factory: Callable[[str | None], Awaitable[SessionProtocol]] | None = None,
+        on_config_changed: Callable[[], None] | None = None,
     ) -> None:
         super().__init__()
         # Dark is the product's island night and the fallback: `theme_name`
@@ -1013,6 +1014,16 @@ class OperatorApp(App[None]):
         # commands; ``None`` degrades /provider /usage /model-switch to
         # pointer notices when it is absent.
         self._providers = provider_controller
+        #: True between a first-run "no hosting configured" boot failure and the
+        #: `/login` that resolves it. While set, a successful login reloads the
+        #: session (there is none yet) rather than only re-polling the splash.
+        self._setup_state = False
+        #: Invoked before a post-login session rebuild so the launch-time config
+        #: manager (captured by the session factory closure) re-reads the
+        #: hosting/model that `/login` just wrote to disk. ``None`` outside the
+        #: CLI path (tests build the app directly), where the factory reads
+        #: config live and no reconciliation is needed.
+        self._on_config_changed = on_config_changed
         #: The real theme while a ``/theme`` list preview repaints the screen
         #: in a candidate ramp; ``None`` when no preview is standing. Stashed
         #: on the first highlight and spent on close-or-commit, so however the
@@ -2247,6 +2258,19 @@ class OperatorApp(App[None]):
         user what to do next at exactly the moment they need it, leaving a single
         red line over an empty screen.
         """
+        # First-run setup state (item A1/U1): the ONE construction "failure" that
+        # is not an error is "no hosting configured at all". The CLI let the app
+        # open precisely so the user can `/login` from here, so this reports the
+        # guided next step in the app's own warning voice rather than a red
+        # "session failed to start" that reads like a crash. The splash's
+        # `/login` affordance and the `/model` / `/provider` surfaces are the
+        # setup UI — no separate wizard. Imported lazily beside every other
+        # session_factory reference in this module.
+        from local_operator.session_factory import HostingNotConfiguredError
+
+        if isinstance(error, HostingNotConfiguredError):
+            self._enter_setup_state()
+            return
         self._system_notice(f"session failed to start: {error}", "error")
         assert self._status is not None
         # `model_name` goes with the label it belongs to. Leaving it set is not
@@ -2255,6 +2279,33 @@ class OperatorApp(App[None]):
         # `MoonshotAI: Kimi K2` — has nothing to collide with, so it would be
         # accepted and painted where the app meant to say "session error".
         self._status.update(model_label="session error", model_name="", streaming=False)
+
+    def _enter_setup_state(self) -> None:
+        """First-run setup: guide the user to `/login` with no session yet.
+
+        Reached when the session could not be built because NOTHING is
+        configured (see :meth:`_on_boot_failed`). No parallel wizard: the splash
+        already owns the empty-state real estate and carries a notice row, so the
+        guidance lives there, the status band says "setup" instead of a model
+        name, and the existing `/login` / `/model` / `/provider` commands do the
+        work. A successful `/login` sets hosting + a default model and reloads
+        the session (see :meth:`_login_flow`), which lands the user in a normal
+        working app.
+        """
+        self._setup_state = True
+        # A notice, not a red error: the splash paints this in the warning voice
+        # beside its `/login` hint, which is exactly the affordance the user
+        # needs. Toast headline included so it is noticed on a busy first frame.
+        self._announce_on_splash(
+            "welcome — no provider configured yet. Run /login <provider> "
+            "(e.g. /login openai) to set one up, or /provider to see the list.",
+            "warning",
+        )
+        if self._status is not None:
+            # "setup" rather than a model name: there is no model until the user
+            # picks a provider, and leaving MODEL_PENDING up would read as a
+            # session still booting rather than one waiting on the user.
+            self._status.update(model_label="setup", model_name="", streaming=False)
 
     async def _reload_session(self, *, keep_context: bool = False) -> None:
         """Dispose the current session, boot its replacement, and rebuild the
@@ -10268,6 +10319,36 @@ class OperatorApp(App[None]):
             if self._key_prompt is block:
                 self._key_prompt = None
 
+    def _apply_login_defaults(self, provider: str) -> str | None:
+        """Adopt a just-logged-in provider as hosting when none is set.
+
+        Returns a one-line receipt naming what was written, or ``None`` when
+        hosting was already configured (nothing changed, nothing to say). The
+        provider id is the credential's storage id \u2014 an OAuth flavour like
+        ``xai-oauth`` stores under ``xai``, and that is the hosting the app
+        should point at. Config-write failure is reported but never fatal: the
+        login itself already succeeded.
+        """
+        try:
+            from local_operator.config import ConfigManager
+            from local_operator.model.defaults import default_model_for
+            from local_operator.paths import config_dir
+            from local_operator.providers.registry import credential_provider_id
+
+            manager = ConfigManager(config_dir())
+            if manager.get_config_value("hosting"):
+                return None
+            hosting = credential_provider_id(provider)
+            manager.set_config_value("hosting", hosting)
+            model = default_model_for(hosting) or ""
+            receipt = f"set default hosting to '{hosting}'"
+            if model and not manager.get_config_value("model_name"):
+                manager.set_config_value("model_name", model)
+                receipt += f", model to '{model}'"
+            return receipt
+        except Exception as error:  # noqa: BLE001 — never fail a completed login
+            return f"logged in, but could not save default hosting/model: {error}"
+
     async def _login_flow(self, provider: str) -> None:
         """Run the login on the event loop, reporting into the transcript.
 
@@ -10296,10 +10377,31 @@ class OperatorApp(App[None]):
             self._providers.set_login_callbacks(self._login_callbacks)
             message = await self._providers.login(provider)
             await notice(message, "success")
-            # Nothing else needs poking: the splash re-polls its credential
-            # warning whenever it becomes visible again (`set_visible(True)`
-            # calls `_poll`), and it is hidden right now because the notice
-            # above is a transcript block.
+            # Make the fresh login usable as the boot default when nothing is
+            # configured yet: set hosting to this provider and model_name to its
+            # default. Without this, `/login` stored the credential but left
+            # hosting empty, so a first-run user logged in and still had no
+            # session — the same dead end the setup state exists to end. When
+            # hosting is already set we touch nothing (the user is adding a
+            # second provider, not changing their default).
+            set_msg = self._apply_login_defaults(provider)
+            if set_msg:
+                await notice(set_msg, "info")
+            # In the first-run setup state there is no session yet, so a
+            # successful login has to BUILD one — re-polling the splash would
+            # leave the user staring at a configured-but-not-started app. Outside
+            # setup, the splash re-polls its credential warning whenever it
+            # becomes visible again (`set_visible(True)` calls `_poll`), and it
+            # is hidden right now because the notice above is a transcript block.
+            if self._setup_state:
+                self._setup_state = False
+                # Reconcile the launch-time config manager with what
+                # `_apply_login_defaults` just wrote, or the rebuild resolves the
+                # same empty config and drops back into setup.
+                if self._on_config_changed is not None:
+                    self._on_config_changed()
+                await notice("starting session…", "info")
+                await self._reload_session()
         except LoginCancelledError:
             # A cancel is an OUTCOME, not a failure. Reported as a red "login
             # failed: … cancelled" it told the user their own Escape had broken
@@ -10934,7 +11036,23 @@ class OperatorApp(App[None]):
             cost=cost_text,
         )
         if message.error:
-            self._append_block(NoticeBlock(message.error, "error"))
+            # Append the local recovery to an auth-classified failure: the
+            # provider's own "invalid api-key" says what happened but not what
+            # the user can do from here, and `/login`/`credential update` are
+            # exactly that. No-op for every other error kind (a quota 403 reads
+            # differently and a login cannot fix it). The provider is the first
+            # segment of the model label, the same convention /model uses.
+            from local_operator.providers.failover import append_auth_recovery
+
+            provider = ""
+            if self._session is not None:
+                try:
+                    provider = (self._session.model_label or "").partition("/")[0]
+                except Exception:
+                    provider = ""
+            self._append_block(
+                NoticeBlock(append_auth_recovery(message.error, provider or None), "error")
+            )
         elif message.aborted and not self._interrupted_cards:
             # Only when NOTHING was in flight. A stopped turn already says so on
             # each card it stopped (`⊘ interrupted`), and that per-card mark is

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -1468,7 +1468,10 @@ class OperatorApp(App[None]):
         with self._transcript:
             yield WelcomeView(
                 lambda: session_welcome_info(
-                    self._session, self._providers, notice=self._splash_notice
+                    self._session,
+                    self._providers,
+                    notice=self._splash_notice,
+                    setup=self._setup_state,
                 )
             )
         # The dock band: subagent task list + todo list, sitting between the
@@ -2296,9 +2299,14 @@ class OperatorApp(App[None]):
         # A notice, not a red error: the splash paints this in the warning voice
         # beside its `/login` hint, which is exactly the affordance the user
         # needs. Toast headline included so it is noticed on a busy first frame.
+        # Action-first word order: on a narrow terminal the splash line is
+        # truncated from the right, so the command the user must run has to come
+        # BEFORE the diagnosis or it is what drops (D2). The band and toast
+        # already carry "no provider configured", so leading with the remedy
+        # spends the scarce columns on the one thing they do not.
         self._announce_on_splash(
-            "welcome — no provider configured yet. Run /login <provider> "
-            "(e.g. /login openai) to set one up, or /provider to see the list.",
+            "Run /login <provider> to get started (e.g. /login openai) "
+            "— no provider configured yet, or /provider to see the list.",
             "warning",
         )
         if self._status is not None:
@@ -12322,6 +12330,13 @@ def _splash_toast_headline(text: str) -> str:
         target = body[index + len(marker) :].strip()
         if target:
             return f"Fell back to {target}"
+    # The first-run notice leads with the REMEDY (D2), but the toast's job is
+    # the glance — the state, not the command. A blind 35-cell cut of that
+    # sentence lands mid-word ("…configured ye…") and repeats the greeting the
+    # splash already owns (D5), so the setup notice gets its own clean headline
+    # naming the condition rather than a truncated slice of the action line.
+    if "no provider configured" in body.lower():
+        return "No provider configured"
     # One clause, no wrap: the toast sits over the lockup, and a second
     # row is what buried the mark. 36 cells is comfortably inside the
     # right-hand gutter of a 80-col boot frame.

--- a/local_operator/tui/widgets/welcome.py
+++ b/local_operator/tui/widgets/welcome.py
@@ -226,10 +226,33 @@ def mark_pulse_color(phase: float) -> str:
 #: the same word for the same state, so the two never disagree on screen.
 MODEL_PENDING = "connecting…"
 
+#: The model row's word in the first-run SETUP state — no session, no model,
+#: the app parked waiting on the user's `/login`. This is the same word the
+#: status band shows in setup state (app._enter_setup_state sets
+#: `model_label="setup"`), and that agreement is the whole point: leaving the
+#: `MODEL_PENDING` sentinel up here made the splash read `connecting…` while
+#: the band read `setup`, so the first screen a new user sees told them "it's
+#: busy, wait" (the opposite of "you need to act") and looked hung (D1). The
+#: two MUST answer "what state is this" with the same word.
+MODEL_SETUP = "setup"
+
 #: The few affordances a first-time user actually needs. ``/`` and ``/help``
 #: are kept separate on purpose: one is the inline picker, the other prints the
 #: full two-column list — a user who has met neither cannot infer the other.
 HINTS: tuple[tuple[str, str], ...] = (
+    ("/", "command picker"),
+    ("/help", "all commands"),
+    ("ctrl+d", "quit"),
+)
+
+#: The affordance table in the first-run SETUP state. `/login` leads because it
+#: is the one command this state exists to teach, and the fixed key/description
+#: table is where the eye scans for "what can I type" — the orange notice line
+#: that also names `/login` is exactly the line that truncates first (D2/D3), so
+#: relying on it alone left a scanning user pointed at the picker and quit but
+#: never at the action that unblocks them.
+HINTS_SETUP: tuple[tuple[str, str], ...] = (
+    ("/login", "set up a provider"),
     ("/", "command picker"),
     ("/help", "all commands"),
     ("ctrl+d", "quit"),
@@ -279,6 +302,15 @@ TIPS: tuple[str, ...] = (
     "/goal sets the objective that /loop iterates toward",
 )
 
+#: The tip the SETUP state opens on, in place of the pinned ``TIPS[0]``. The
+#: rotation normally pins its first entry to ``/resume`` on the argument that
+#: resumption is the question a RETURNING user arrives with (see the pool doc
+#: above) — but the setup state is the definitional non-returning user, with no
+#: prior sessions to resume, so the most-read row would advertise a command that
+#: does nothing for them (D4). Once a session exists the rotation resumes into
+#: the normal ring, so this only replaces the opening frame.
+TIP_SETUP = "/login <provider> sets up a provider (e.g. /login openai)"
+
 #: The tip's prefix: the app's own `info` glyph, the mark every quiet one-line
 #: receipt in the transcript already carries (D14). A word — `tip:` — would cost
 #: five cells of the sentence to label a line whose tone already says what it is,
@@ -313,7 +345,7 @@ TIP_ROTATE_INTERVAL_S = 12.0
 #: exists to refuse, and a number that silently went stale the first time a tip
 #: was reworded. Measured against the LONGEST entry, so the widest tip in the
 #: pool is the one that decides, and the invariant holds by construction.
-TIP_MIN_WIDTH = max(cell_len(f"{TIP_GLYPH} {tip}") for tip in TIPS)
+TIP_MIN_WIDTH = max(cell_len(f"{TIP_GLYPH} {tip}") for tip in (*TIPS, TIP_SETUP))
 
 #: Warning body without its remedy, for widths that cannot hold the full
 #: `— /login <provider>` tail. A half-printed command is worse than none: the
@@ -360,6 +392,12 @@ class WelcomeInfo:
     #: stacking would shove the lockup the way a transcript notice already
     #: does. ``None`` when nothing has been announced.
     notice: str | None = None
+    #: First-run SETUP state: the app opened with nothing configured so the user
+    #: can `/login` from here (see ``app._enter_setup_state``). It changes what
+    #: the empty splash SAYS — the model row's idle word, the affordance the
+    #: hint table leads with, and which tip opens the rotation — so the screen
+    #: reads as "you need to act" rather than "a session is still booting".
+    setup: bool = False
 
 
 def app_version() -> str:
@@ -380,6 +418,7 @@ def session_welcome_info(
     providers: Any | None,
     *,
     notice: str | None = None,
+    setup: bool = False,
 ) -> WelcomeInfo:
     """Snapshot the facts the welcome view shows.
 
@@ -429,6 +468,7 @@ def session_welcome_info(
         cwd=os.getcwd(),
         missing_credential=missing,
         notice=notice or None,
+        setup=setup,
     )
 
 
@@ -566,11 +606,17 @@ def _status_rows(info: WelcomeInfo, width: int) -> list[tuple[int, Text]]:
     # `deepseek-chat-v3.1`, so one app answered "which model" with opposite
     # halves of the same string (D10). A display name in the band beside a raw
     # selector here would be that defect again.
-    label = (
-        format_model_label(info.model_label, short=False, name=info.model_name)
-        if info.model_label
-        else MODEL_PENDING
-    )
+    # With no model resolved yet the word depends on WHY there is no model. In
+    # the first-run setup state the app is deliberately parked waiting on the
+    # user, so the row says `setup` (the same word the band shows) rather than
+    # `connecting…`, which would claim a session is being awaited when none is
+    # (D1). Only outside setup is `connecting…` the truth.
+    if info.model_label:
+        label = format_model_label(info.model_label, short=False, name=info.model_name)
+    elif info.setup:
+        label = MODEL_SETUP
+    else:
+        label = MODEL_PENDING
     # Guarded on `info.model_label`, not on the width alone: with no session yet
     # `label` is the `MODEL_PENDING` sentinel while `info.model_label` is "", and
     # shortening "" returns "" — so below 11 columns (`cell_len("connecting…")`)
@@ -606,11 +652,15 @@ def _status_rows(info: WelcomeInfo, width: int) -> list[tuple[int, Text]]:
     return rows
 
 
-def _hint_lines(width: int) -> list[Text]:
+def _hint_lines(width: int, *, setup: bool = False) -> list[Text]:
     """Hint rows, left-aligned to a shared key column, block-centered.
 
     Centering each row independently would ragged the key column; the rows are
     a table, so the TABLE is what gets centered.
+
+    ``setup`` swaps in the first-run table (:data:`HINTS_SETUP`), whose leading
+    row teaches ``/login`` — the one command the setup state exists to teach and
+    the affordance the notice line drops first at narrow widths (D3).
 
     Three width tiers, because the alternative — letting the final truncation
     pass eat the descriptions — turns "command picker" into "command pi…",
@@ -620,6 +670,7 @@ def _hint_lines(width: int) -> list[Text]:
     2. the tight key column (longest key plus one space),
     3. keys only, which still names every affordance the user can try.
     """
+    hints = HINTS_SETUP if setup else HINTS
     # The same tint pair the PICKER uses for name/description (fg over muted),
     # not a step quieter. These rows are a preview of the picker — one of them
     # literally says "/  command picker" — and rendering the identical
@@ -630,7 +681,7 @@ def _hint_lines(width: int) -> list[Text]:
 
     key_column = 0
     for candidate in (HINT_KEY_WIDTH, HINT_KEY_WIDTH_TIGHT):
-        block = max(candidate + cell_len(desc) for _, desc in HINTS)
+        block = max(candidate + cell_len(desc) for _, desc in hints)
         if block <= width:
             key_column = candidate
             break
@@ -641,10 +692,10 @@ def _hint_lines(width: int) -> list[Text]:
     # the same ragged-edge effect that was removed from inside the status stack,
     # surviving one level up.
     if not key_column:
-        return [Text(key, style=key_style, no_wrap=True) for key, _ in HINTS]
+        return [Text(key, style=key_style, no_wrap=True) for key, _ in hints]
 
     lines: list[Text] = []
-    for key, desc in HINTS:
+    for key, desc in hints:
         line = Text(no_wrap=True)
         line.append(key.ljust(key_column), style=key_style)
         line.append(desc, style=desc_style)
@@ -652,7 +703,7 @@ def _hint_lines(width: int) -> list[Text]:
     return lines
 
 
-def _tip_lines(width: int, index: int) -> list[Text]:
+def _tip_lines(width: int, index: int, *, setup: bool = False) -> list[Text]:
     """The tip at ``index``, as ONE row — or no row at all when ``width`` is tight.
 
     The row count is a function of ``width`` alone. That is the contract the
@@ -664,6 +715,10 @@ def _tip_lines(width: int, index: int) -> list[Text]:
     width threshold rather than a per-tip length test.
 
     ``index`` is taken modulo the pool so callers can keep a monotonic counter.
+    ``setup`` swaps the OPENING tip (the pinned ``index == 0`` frame every launch
+    lands on) for :data:`TIP_SETUP`, so a first-run user is not pitched
+    ``/resume`` with nothing to resume (D4). Later rotation frames keep the
+    normal ring — by the time the row has turned over there is a session.
     """
     if width < TIP_MIN_WIDTH:
         return []
@@ -675,9 +730,10 @@ def _tip_lines(width: int, index: int) -> list[Text]:
     # at, which is the one failure mode that would make a rotating row annoying.
     glyph_style = Style(color=theme_mod.semantic_color("faint"))
     body_style = Style(color=theme_mod.semantic_color("dim"))
+    body = TIP_SETUP if (setup and index % len(TIPS) == 0) else TIPS[index % len(TIPS)]
     line = Text(no_wrap=True)
     line.append(f"{TIP_GLYPH} ", style=glyph_style)
-    line.append(TIPS[index % len(TIPS)], style=body_style)
+    line.append(body, style=body_style)
     return [line]
 
 
@@ -748,8 +804,8 @@ def build_welcome_lines(
     # actionable login warning last.
     status_without_version = [row for row in status_full if row[0] != _PRIORITY_VERSION]
     status = list(status_without_version)
-    hints = _hint_lines(width)
-    tip = _tip_lines(width, tip_index)
+    hints = _hint_lines(width, setup=info.setup)
+    tip = _tip_lines(width, tip_index, setup=info.setup)
     show_hints = False
     show_tip = False
     show_wordmark = False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.21.0"
+version = "0.22.0"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@radienthq.com" }]

--- a/tests/unit/providers/test_failover.py
+++ b/tests/unit/providers/test_failover.py
@@ -3418,3 +3418,32 @@ async def test_primary_success_with_a_pinned_route_settles_the_recovery() -> Non
     ]
     assert edges == [None]
     assert state.active is None
+
+
+# --- Auth recovery hints (item 9) -------------------------------------------
+
+
+def test_append_auth_recovery_adds_hint_to_auth_error() -> None:
+    from local_operator.providers.failover import append_auth_recovery
+
+    rendered = "authentication failed (HTTP 401): invalid x-api-key"
+    out = append_auth_recovery(rendered, "openai")
+    assert rendered in out
+    assert "/login openai" in out
+    assert "credential update <OPENAI_API_KEY>" in out
+
+
+def test_append_auth_recovery_ignores_non_auth_errors() -> None:
+    from local_operator.providers.failover import append_auth_recovery
+
+    rendered = "rate limit or quota exceeded (HTTP 429): slow down"
+    # A quota error is left alone — a login cannot fix it.
+    assert append_auth_recovery(rendered, "openai") == rendered
+
+
+def test_append_auth_recovery_generic_without_provider() -> None:
+    from local_operator.providers.failover import append_auth_recovery
+
+    rendered = "authentication failed (HTTP 401): bad key"
+    out = append_auth_recovery(rendered, None)
+    assert "/login <provider>" in out

--- a/tests/unit/providers/test_login_defaults.py
+++ b/tests/unit/providers/test_login_defaults.py
@@ -1,0 +1,107 @@
+"""Login-sets-default-hosting behaviour and default-model resolution.
+
+Covers item 2 (login adopts hosting/model when config is empty) and item 3
+(per-provider default model fallback).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from local_operator.config import ConfigManager
+from local_operator.model.defaults import DEFAULT_MODEL_NAMES, default_model_for
+
+
+def test_default_model_for_known_provider() -> None:
+    assert default_model_for("deepseek") == "deepseek-chat"
+    assert default_model_for("zai") == "glm-5.3"
+    # noop aliases to test, which has no default.
+    assert default_model_for("noop") is None
+
+
+def test_default_model_for_unknown_provider() -> None:
+    assert default_model_for("some-custom-host") is None
+
+
+def test_default_model_names_map_reexported_from_configure() -> None:
+    # configure.DEFAULT_MODEL_NAMES must be the SAME object as defaults' — one
+    # map, imported cheaply on the startup path (item 3).
+    from local_operator.model import configure
+
+    assert configure.DEFAULT_MODEL_NAMES is DEFAULT_MODEL_NAMES
+
+
+def test_apply_login_defaults_sets_hosting_and_model_when_empty(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from local_operator.paths import CONFIG_DIR_ENV
+    from local_operator.providers import auth_cli
+
+    monkeypatch.setenv(CONFIG_DIR_ENV, str(tmp_path))
+    auth_cli._apply_login_defaults("deepseek")
+
+    manager = ConfigManager(tmp_path)
+    assert manager.get_config_value("hosting") == "deepseek"
+    assert manager.get_config_value("model_name") == "deepseek-chat"
+
+
+def test_apply_login_defaults_leaves_existing_hosting_untouched(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from local_operator.paths import CONFIG_DIR_ENV
+    from local_operator.providers import auth_cli
+
+    monkeypatch.setenv(CONFIG_DIR_ENV, str(tmp_path))
+    manager = ConfigManager(tmp_path)
+    manager.set_config_value("hosting", "openai")
+    manager.set_config_value("model_name", "gpt-4o")
+
+    # Logging into a second provider must not repoint an existing default.
+    auth_cli._apply_login_defaults("deepseek")
+
+    reloaded = ConfigManager(tmp_path)
+    assert reloaded.get_config_value("hosting") == "openai"
+    assert reloaded.get_config_value("model_name") == "gpt-4o"
+
+
+def test_resolve_hosting_model_falls_back_to_default_model(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Hosting set, model empty: resolves the provider default rather than
+    raising 'Model name is not configured' (item 3)."""
+    import argparse
+
+    from local_operator.paths import CONFIG_DIR_ENV
+    from local_operator.session_factory import resolve_hosting_model
+
+    monkeypatch.setenv(CONFIG_DIR_ENV, str(tmp_path))
+    manager = ConfigManager(tmp_path)
+    manager.set_config_value("hosting", "deepseek")
+    manager.set_config_value("model_name", "")
+
+    args = argparse.Namespace(hosting=None, model=None)
+    hosting, model = resolve_hosting_model(None, args, manager)
+    assert hosting == "deepseek"
+    assert model == "deepseek-chat"
+
+
+def test_resolve_hosting_model_no_hosting_raises_hosting_error(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """No hosting at all raises the dedicated HostingNotConfiguredError so the
+    setup-state gate can classify it (item 1)."""
+    import argparse
+
+    from local_operator.paths import CONFIG_DIR_ENV
+    from local_operator.session_factory import (
+        HostingNotConfiguredError,
+        resolve_hosting_model,
+    )
+
+    monkeypatch.setenv(CONFIG_DIR_ENV, str(tmp_path))
+    manager = ConfigManager(tmp_path)
+    args = argparse.Namespace(hosting=None, model=None)
+    with pytest.raises(HostingNotConfiguredError):
+        resolve_hosting_model(None, args, manager)

--- a/tests/unit/test_cli_new.py
+++ b/tests/unit/test_cli_new.py
@@ -400,6 +400,64 @@ def test_credential_delete_command(tmp_home: Path) -> None:
     manager.set_credential.assert_called_once_with("TEST_API_KEY", "")
 
 
+def test_credential_update_ctrl_c_exits_130(tmp_home: Path, capsys) -> None:
+    """Ctrl-C at the prompt is a cancel, not a crash: exit 130 (SIGINT
+    convention), one quiet line, no stack-trace panel (item 4)."""
+    manager = MagicMock()
+    manager.prompt_for_credential.side_effect = KeyboardInterrupt
+    with patch("local_operator.cli.CredentialManager", return_value=manager):
+        args = argparse.Namespace(key="OPENAI_API_KEY")
+        assert credential_update_command(args) == 130
+    err = capsys.readouterr().err
+    assert "Cancelled." in err
+    assert "Traceback" not in err
+
+
+def test_credential_update_empty_input_exits_1_plain(tmp_home: Path, capsys) -> None:
+    """Empty/EOF input exits 1 with one plain line, ANSI stripped (item 4)."""
+    manager = MagicMock()
+    manager.prompt_for_credential.side_effect = ValueError(
+        "\033[1;31mOPENAI_API_KEY is required for this step.\033[0m"
+    )
+    with patch("local_operator.cli.CredentialManager", return_value=manager):
+        args = argparse.Namespace(key="OPENAI_API_KEY")
+        assert credential_update_command(args) == 1
+    err = capsys.readouterr().err
+    assert "is required for this step" in err
+    # The nested escape from the exception message is stripped.
+    assert "\033[1;31m" not in err
+
+
+def test_credential_update_unknown_key_warns(tmp_home: Path, capsys) -> None:
+    """A key the registry does not know gets a difflib suggestion but is still
+    stored (custom providers are legitimate) (item 8)."""
+    manager = MagicMock()
+    with patch("local_operator.cli.CredentialManager", return_value=manager):
+        args = argparse.Namespace(key="OPENAI_API_KY")  # typo
+        assert credential_update_command(args) == 0
+    err = capsys.readouterr().err
+    assert "not a known provider key" in err
+    assert "OPENAI_API_KEY" in err  # the suggestion
+
+
+def test_config_edit_rejects_unknown_key(tmp_home: Path, capsys) -> None:
+    """`config edit` validates against the defaults and rejects a typo with a
+    suggestion + exit 1, instead of silently writing junk (item 7)."""
+    args = argparse.Namespace(key="hostng", value="openai")
+    assert cli.config_edit_command(args) == 1
+    err = capsys.readouterr().err
+    assert "unknown configuration key" in err
+    assert "hosting" in err  # the suggestion
+
+
+def test_config_edit_accepts_known_key(tmp_home: Path) -> None:
+    manager = MagicMock()
+    with patch("local_operator.cli.ConfigManager", return_value=manager):
+        args = argparse.Namespace(key="hosting", value="openai")
+        assert cli.config_edit_command(args) == 0
+    manager.update_config.assert_called_once()
+
+
 def test_config_create_command(tmp_home: Path) -> None:
     manager = MagicMock()
     with patch("local_operator.cli.ConfigManager", return_value=manager):

--- a/tests/unit/test_cli_new.py
+++ b/tests/unit/test_cli_new.py
@@ -491,7 +491,7 @@ def test_agents_delete_command_not_found() -> None:
     registry = MagicMock()
     registry.list_agents.return_value = []
     args = argparse.Namespace(name="Ghost", agent_id=None)
-    assert agents_delete_command(args, registry, Path(".")) == -1
+    assert agents_delete_command(args, registry, Path(".")) == 1
     registry.delete_agent.assert_not_called()
 
 
@@ -660,10 +660,10 @@ def test_main_management_command_dispatch(
 
 
 def test_main_exception_banner(tmp_home: Path, quiet_env: None, capsys) -> None:
-    """Red-banner handling survives: any exception -> message + exit -1."""
+    """Red-banner handling survives: any exception -> message + exit 1."""
     with patch("local_operator.cli.ConfigManager", side_effect=Exception("Test error")):
         with patch("sys.argv", ["program"]):
-            assert main() == -1
+            assert main() == 1
     # STDERR: main() wraps the exec dispatch, so its error presenter must not
     # write to the `exec --json` data channel. Asserting the stream is the
     # point of the test now, not incidental.
@@ -817,7 +817,7 @@ def test_main_preflight_missing_hosting(
     monkeypatch.setattr("local_operator.agents.AgentRegistry", MagicMock())
 
     with patch("sys.argv", ["program"]):
-        assert main() == -1
+        assert main() == 1
     # stderr, matching its sibling _preflight_api_key: an error message belongs
     # on the diagnostic channel regardless of which front end asked for it.
     err = capsys.readouterr().err
@@ -886,7 +886,7 @@ def test_preflight_api_key_fatal_by_default(
     somewhere harder to read.
     """
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-    assert cli._preflight_api_key("openai", _bare_credential_manager()) == -1
+    assert cli._preflight_api_key("openai", _bare_credential_manager()) == 1
     err = capsys.readouterr().err
     assert "OPENAI_API_KEY" in err and "Error" in err
 

--- a/tests/unit/test_cli_new.py
+++ b/tests/unit/test_cli_new.py
@@ -694,6 +694,7 @@ def test_main_interactive_tty_uses_tui(
         theme_name: str = "dark",
         provider_controller=None,
         resume_factory=None,
+        on_config_changed=None,
     ) -> int:
         seen["theme"] = theme_name
         seen["session"] = await session_factory()
@@ -799,11 +800,17 @@ def test_yolo_parses_on_every_subcommand(parser: argparse.ArgumentParser, argv: 
 # --- CL-06: startup preflight ---------------------------------------------------
 
 
-def test_main_preflight_missing_hosting(
+def test_main_preflight_missing_hosting_headless(
     tmp_home: Path, quiet_env: None, monkeypatch: pytest.MonkeyPatch, capsys
 ) -> None:
-    """Interactive startup with no hosting configured prints the legacy
-    message shape and exits -1 BEFORE any turn (no session factory call)."""
+    """Non-tty startup with nothing configured prints the COMPLETE first-run
+    quickstart (hosting + model + key + commands) and exits 1 BEFORE any turn.
+
+    Item A1/U1: the fail-fast paths (non-tty, headless, exec) no longer die at
+    the first missing field with just "Hosting platform is not configured" —
+    they name everything missing at once so a scripted user fixes it in one
+    pass. The interactive TUI path takes the setup state instead (see
+    ``test_main_preflight_missing_hosting_tty_enters_setup``)."""
     called: dict[str, bool] = {"factory": False}
 
     async def fake_create_session(*args, **kwargs):
@@ -811,7 +818,8 @@ def test_main_preflight_missing_hosting(
         return MagicMock()
 
     monkeypatch.setattr("local_operator.cli.create_session", fake_create_session)
-    monkeypatch.setattr(sys.stdout, "isatty", lambda: True)
+    # Non-tty: no setup state is possible, so this stays fail-fast.
+    monkeypatch.setattr(sys.stdout, "isatty", lambda: False)
     monkeypatch.setattr("local_operator.cli.ConfigManager", _fake_config_manager)
     monkeypatch.setattr("local_operator.cli.CredentialManager", MagicMock())
     monkeypatch.setattr("local_operator.agents.AgentRegistry", MagicMock())
@@ -821,8 +829,59 @@ def test_main_preflight_missing_hosting(
     # stderr, matching its sibling _preflight_api_key: an error message belongs
     # on the diagnostic channel regardless of which front end asked for it.
     err = capsys.readouterr().err
-    assert "Hosting platform is not configured." in err
+    assert "not configured yet" in err
+    # Every remedy named at once, not one field at a time.
+    assert "login <provider>" in err
+    assert "config edit hosting" in err
+    assert "config edit model_name" in err
+    assert "credential update" in err
     assert called["factory"] is False
+
+
+def test_main_preflight_missing_hosting_tty_enters_setup(
+    tmp_home: Path, quiet_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """tty + importable TUI + nothing configured -> the app OPENS (setup state)
+    instead of failing at preflight (item A1/U1 headline).
+
+    The session factory is still called: the TUI boots, the factory raises
+    HostingNotConfiguredError inside it, and the app's boot-failure handler
+    turns that into the guided setup state. What matters here is that main()
+    reached the TUI launch (return 0) rather than returning a preflight error."""
+    seen: dict[str, Any] = {}
+
+    async def fake_create_session(*args, **kwargs):
+        # The real factory would raise here; the app handles that. The point of
+        # this test is that main() got PAST preflight to the launch.
+        seen["factory_called"] = True
+        return object()
+
+    monkeypatch.setattr("local_operator.cli.create_session", fake_create_session)
+
+    fake_tui = types.ModuleType("local_operator.tui")
+
+    async def fake_run_tui(
+        session_factory,
+        theme_name: str = "dark",
+        provider_controller=None,
+        resume_factory=None,
+        on_config_changed=None,
+    ) -> int:
+        # Prove the setup-state plumbing reached the app: the reconciliation
+        # hook is wired so a first-run /login can take effect.
+        seen["on_config_changed"] = on_config_changed
+        return 0
+
+    setattr(fake_tui, "run_tui", fake_run_tui)
+    monkeypatch.setitem(sys.modules, "local_operator.tui", fake_tui)
+    monkeypatch.setattr(sys.stdout, "isatty", lambda: True)
+    monkeypatch.setattr("local_operator.cli.ConfigManager", _fake_config_manager)
+    monkeypatch.setattr("local_operator.cli.CredentialManager", MagicMock())
+    monkeypatch.setattr("local_operator.agents.AgentRegistry", MagicMock())
+
+    with patch("sys.argv", ["program"]):
+        assert main() == 0
+    assert seen.get("on_config_changed") is not None
 
 
 def test_main_interactive_missing_api_key_warns_and_starts(
@@ -853,6 +912,7 @@ def test_main_interactive_missing_api_key_warns_and_starts(
         theme_name="dark",
         provider_controller=None,
         resume_factory=None,
+        on_config_changed=None,
     ) -> int:
         await session_factory()
         return 0
@@ -941,6 +1001,7 @@ def test_main_preflight_env_key_passes(
         theme_name="dark",
         provider_controller=None,
         resume_factory=None,
+        on_config_changed=None,
     ) -> int:
         seen.setdefault("provider_controller", provider_controller)
         await session_factory()
@@ -977,6 +1038,7 @@ def test_tui_flag_forces_tui_on_non_tty(
         theme_name="dark",
         provider_controller=None,
         resume_factory=None,
+        on_config_changed=None,
     ) -> int:
         seen.setdefault("provider_controller", provider_controller)
         seen["ran"] = True

--- a/tests/unit/test_cli_style.py
+++ b/tests/unit/test_cli_style.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import io
+from typing import IO, cast
 
 from local_operator import cli_style
 
@@ -55,10 +56,10 @@ class _EncStream:
 
 
 def test_can_encode_detects_ascii_only_stream():
-    ascii_stream = _EncStream("ascii")
+    ascii_stream = cast(IO[str], _EncStream("ascii"))
     assert cli_style.can_encode("plain", ascii_stream) is True
     assert cli_style.can_encode("box ─╭", ascii_stream) is False
 
 
 def test_can_encode_treats_unknown_encoding_as_capable():
-    assert cli_style.can_encode("box ─╭", _EncStream("")) is True
+    assert cli_style.can_encode("box ─╭", cast(IO[str], _EncStream(""))) is True

--- a/tests/unit/test_cli_style.py
+++ b/tests/unit/test_cli_style.py
@@ -1,0 +1,64 @@
+"""Tests for the plain-print styling/encoding helper (item 15)."""
+
+from __future__ import annotations
+
+import io
+
+from local_operator import cli_style
+
+
+class _Tty(io.StringIO):
+    encoding = "utf-8"
+
+    def isatty(self) -> bool:
+        return True
+
+
+class _Pipe(io.StringIO):
+    encoding = "utf-8"
+
+    def isatty(self) -> bool:
+        return False
+
+
+def test_colour_disabled_when_no_color_set(monkeypatch):
+    monkeypatch.setenv("NO_COLOR", "1")
+    assert cli_style.colour_enabled(_Tty()) is False
+    # And paint returns the text untouched.
+    assert cli_style.paint("x", cli_style.ERROR, stream=_Tty()) == "x"
+
+
+def test_colour_disabled_on_non_tty(monkeypatch):
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    assert cli_style.colour_enabled(_Pipe()) is False
+
+
+def test_colour_disabled_on_dumb_term(monkeypatch):
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    monkeypatch.setenv("TERM", "dumb")
+    assert cli_style.colour_enabled(_Tty()) is False
+
+
+def test_colour_enabled_on_real_terminal(monkeypatch):
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    monkeypatch.setenv("TERM", "xterm-256color")
+    assert cli_style.colour_enabled(_Tty()) is True
+    painted = cli_style.paint("x", cli_style.ERROR, stream=_Tty())
+    assert painted.startswith("\033[") and painted.endswith("\033[0m")
+
+
+class _EncStream:
+    """A stream stand-in with a settable ``encoding`` (StringIO's is read-only)."""
+
+    def __init__(self, encoding: str) -> None:
+        self.encoding = encoding
+
+
+def test_can_encode_detects_ascii_only_stream():
+    ascii_stream = _EncStream("ascii")
+    assert cli_style.can_encode("plain", ascii_stream) is True
+    assert cli_style.can_encode("box ─╭", ascii_stream) is False
+
+
+def test_can_encode_treats_unknown_encoding_as_capable():
+    assert cli_style.can_encode("box ─╭", _EncStream("")) is True

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -332,3 +332,16 @@ def test_config_manager_non_mapping_top_level_backs_up(temp_config_dir, capsys):
     assert (temp_config_dir / "config.yml.bad").exists()
     err = capsys.readouterr().err
     assert "not a valid configuration mapping" in err
+
+
+def test_config_dir_created_0700(tmp_path):
+    """A config dir the manager CREATES is 0700 (item 17) — never chmod an
+    existing one."""
+    import os
+
+    if os.name != "posix":
+        pytest.skip("permission test is Unix-only")
+    fresh = tmp_path / "made"
+    manager = ConfigManager(fresh)
+    manager._write_config(vars(manager.config))
+    assert fresh.stat().st_mode & 0o077 == 0

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -317,7 +317,10 @@ def test_config_manager_malformed_yaml_backs_up_and_defaults(temp_config_dir, ca
     manager = ConfigManager(temp_config_dir)
     # Degraded to defaults rather than crashing.
     assert manager.get_config_value("hosting") == ""
-    assert (temp_config_dir / "config.yml.bad").exists()
+    # Backup name is `config.yml.bad.<timestamp>` so a second bad edit cannot
+    # clobber the first (round-1 CR-MINOR-3), hence the glob rather than an
+    # exact-name check.
+    assert list(temp_config_dir.glob("config.yml.bad.*"))
     err = capsys.readouterr().err
     assert "could not parse" in err
 
@@ -329,7 +332,7 @@ def test_config_manager_non_mapping_top_level_backs_up(temp_config_dir, capsys):
     config_file.write_text("- just\n- a\n- list\n")
     manager = ConfigManager(temp_config_dir)
     assert manager.get_config_value("hosting") == ""
-    assert (temp_config_dir / "config.yml.bad").exists()
+    assert list(temp_config_dir.glob("config.yml.bad.*"))
     err = capsys.readouterr().err
     assert "not a valid configuration mapping" in err
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -304,3 +304,31 @@ def test_version_ordering(left, right, newer) -> None:
     from local_operator.config import _version_tuple
 
     assert (_version_tuple(left) > _version_tuple(right)) is newer
+
+
+# --- Malformed config handling (item 6) -------------------------------------
+
+
+def test_config_manager_malformed_yaml_backs_up_and_defaults(temp_config_dir, capsys):
+    """A YAML syntax error backs the file up to config.yml.bad and starts with
+    defaults instead of a raw traceback (item 6)."""
+    config_file = temp_config_dir / "config.yml"
+    config_file.write_text(": : not valid yaml [")
+    manager = ConfigManager(temp_config_dir)
+    # Degraded to defaults rather than crashing.
+    assert manager.get_config_value("hosting") == ""
+    assert (temp_config_dir / "config.yml.bad").exists()
+    err = capsys.readouterr().err
+    assert "could not parse" in err
+
+
+def test_config_manager_non_mapping_top_level_backs_up(temp_config_dir, capsys):
+    """A config whose top level is a list/scalar is rejected the same way as a
+    parse error (item 6)."""
+    config_file = temp_config_dir / "config.yml"
+    config_file.write_text("- just\n- a\n- list\n")
+    manager = ConfigManager(temp_config_dir)
+    assert manager.get_config_value("hosting") == ""
+    assert (temp_config_dir / "config.yml.bad").exists()
+    err = capsys.readouterr().err
+    assert "not a valid configuration mapping" in err

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -172,3 +172,93 @@ def test_windows_prompt_for_credential(temp_config, monkeypatch):
     with open(temp_config, "r") as f:
         content = f.read()
     assert "NEW_API_KEY=new_test_key" in content
+
+
+# --- First-run hardening (items 4, 13, 14, 16) ------------------------------
+
+
+def test_set_credential_rejects_control_chars(temp_config):
+    """A newline in a value would split the flat key=value store into a bogus
+    second entry, so it is rejected at the boundary (item 16)."""
+    manager = CredentialManager(config_dir=temp_config.parent)
+    with pytest.raises(ValueError, match="control characters"):
+        manager.set_credential("BAD_KEY", "line1\nline2")
+    with pytest.raises(ValueError, match="control characters"):
+        manager.set_credential("BAD_KEY", "has\x00nul")
+
+
+def test_write_to_file_is_atomic_and_leaves_no_temp(temp_config):
+    """Writes go temp-then-replace, so a crash cannot lose every key, and no
+    stray temp file is left behind (item 16)."""
+    manager = CredentialManager(config_dir=temp_config.parent)
+    manager.set_credential("K1", "v1")
+    manager.set_credential("K2", "v2")
+    content = temp_config.read_text()
+    assert "K1=v1" in content and "K2=v2" in content
+    # No leftover .credentials-*.tmp files in the config dir.
+    leftovers = list(temp_config.parent.glob(".credentials-*.tmp"))
+    assert leftovers == [], leftovers
+
+
+def test_loose_credentials_file_is_retightened(temp_config):
+    """A pre-existing world-readable credentials file is tightened to 0600 on
+    load, but only the file — never chmod the directory (item 17)."""
+    if os.name != "posix":
+        pytest.skip("permission test is Unix-only")
+    temp_config.parent.mkdir(parents=True, exist_ok=True)
+    temp_config.touch()
+    temp_config.chmod(0o644)
+    CredentialManager(config_dir=temp_config.parent)
+    assert temp_config.stat().st_mode & 0o077 == 0
+
+
+def test_prompt_reads_from_piped_stdin_without_getpass(temp_config, monkeypatch):
+    """Non-tty stdin: the value is read as one line (the automation contract),
+    NOT through getpass's echo fallback (item 13)."""
+    import io
+
+    manager = CredentialManager(config_dir=temp_config.parent)
+    monkeypatch.setattr("sys.stdin", io.StringIO("piped-key-value\n"))
+    # getpass must NOT be called on the non-tty path.
+    monkeypatch.setattr(
+        "getpass.getpass",
+        lambda *_a, **_k: pytest.fail("getpass used on non-tty stdin"),
+    )
+    monkeypatch.setattr("builtins.print", lambda *a, **k: None)
+    cred = manager.prompt_for_credential("PIPED_KEY")
+    assert cred.get_secret_value() == "piped-key-value"
+
+
+def test_prompt_empty_piped_stdin_raises_eof(temp_config, monkeypatch):
+    """A closed/empty pipe raises EOFError, which the command handler turns into
+    one plain line + exit 1 (item 4/13)."""
+    import io
+
+    manager = CredentialManager(config_dir=temp_config.parent)
+    monkeypatch.setattr("sys.stdin", io.StringIO(""))
+    monkeypatch.setattr("builtins.print", lambda *a, **k: None)
+    with pytest.raises(EOFError):
+        manager.prompt_for_credential("PIPED_KEY")
+
+
+def test_prompt_ascii_banner_when_stdout_cannot_encode(temp_config, monkeypatch, capsys):
+    """PYTHONIOENCODING=ascii (or a legacy code page) cannot encode the box
+    drawing, so the banner falls back to ASCII rather than crashing (item 14)."""
+    manager = CredentialManager(config_dir=temp_config.parent)
+    # Force the encoding check to report an ASCII-only stdout. Patched in the
+    # credentials module namespace (it imports the name directly), not on
+    # cli_style, or the already-bound reference would win.
+    monkeypatch.setattr("local_operator.credentials.can_encode", lambda *a, **k: False)
+    monkeypatch.setattr("getpass.getpass", lambda *_a, **_k: "k")
+    monkeypatch.setattr("sys.stdin", _TtyStub())
+    manager.prompt_for_credential("ASCII_KEY")
+    out = capsys.readouterr().out
+    assert "─" not in out and "╭" not in out
+    assert "+" in out  # ASCII border corner
+
+
+class _TtyStub:
+    """A stdin stand-in that claims to be a tty (so getpass is used)."""
+
+    def isatty(self) -> bool:
+        return True

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -255,6 +255,10 @@ def test_prompt_ascii_banner_when_stdout_cannot_encode(temp_config, monkeypatch,
     out = capsys.readouterr().out
     assert "─" not in out and "╭" not in out
     assert "+" in out  # ASCII border corner
+    # The success glyph also falls back — a stdout that cannot encode the box
+    # cannot encode ✓ either, and crashing after the key is saved is the worst
+    # place to fail.
+    assert "✓" not in out and "[ok]" in out
 
 
 class _TtyStub:

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -77,6 +77,11 @@ def test_prompt_for_credential(temp_config, monkeypatch):
     """Test prompting for and saving a new credential."""
     manager = CredentialManager(config_dir=temp_config.parent)
 
+    # Pin the interactive branch: prompt_for_credential now reads a line from
+    # stdin when stdin is NOT a tty (the scripted-automation contract). Under
+    # pytest in CI stdin is not a tty, so without forcing isatty True this test
+    # would silently exercise the pipe path and ignore the getpass mock below.
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
     # Mock getpass and print statements
     monkeypatch.setattr("getpass.getpass", lambda _: "new_test_key")
     monkeypatch.setattr("builtins.print", lambda *args, **kwargs: None)
@@ -95,6 +100,11 @@ def test_missing_credential_raises_error(temp_config, monkeypatch):
     """Test that missing credential raises ValueError."""
     manager = CredentialManager(config_dir=temp_config.parent)
 
+    # Pin the interactive branch (see test_prompt_for_credential): this case
+    # asserts the empty-INTERACTIVE-input ValueError. The non-tty pipe path
+    # raises EOFError instead (covered separately by
+    # test_prompt_empty_piped_stdin_raises_eof), so force a tty here.
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
     # Mock empty getpass input
     monkeypatch.setattr("getpass.getpass", lambda _: "")
     monkeypatch.setattr("builtins.print", lambda *args, **kwargs: None)

--- a/tests/unit/test_exec_mode.py
+++ b/tests/unit/test_exec_mode.py
@@ -635,6 +635,32 @@ def test_run_exec_background_spawn(monkeypatch: pytest.MonkeyPatch, tmp_path: Pa
     assert len(lines) == 2
 
 
+def test_spawn_background_unconfigured_hosting_returns_one(
+    monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    """Item 18 contract: the ``exec --background`` preflight failure exits 1.
+
+    Pins the exact regression that round-1 review MAJOR 1 caught — the sites
+    returned ``-1``, which ``exit(main())`` maps to process exit 255, exactly
+    the wrapped-negative outcome item 18 exists to eliminate. A dry-run that
+    raises ``ValueError`` (nothing configured) must surface as a clean ``1`` and
+    must NOT reach ``subprocess.Popen``: a preflight failure never spawns.
+    """
+    monkeypatch.setattr(
+        exec_mode,
+        "resolve_hosting_model_dry",
+        lambda args: (_ for _ in ()).throw(ValueError("Hosting platform is not configured.")),
+    )
+    popen_mock = MagicMock()
+    monkeypatch.setattr("local_operator.exec_mode.subprocess.Popen", popen_mock)
+
+    code = exec_mode.run_exec("do a thing", ExecArgs(background=True))
+
+    assert code == 1  # not -1 / 255
+    popen_mock.assert_not_called()
+    assert "Hosting platform is not configured." in capsys.readouterr().err
+
+
 def test_ledger_reader_tolerates_partial_line(tmp_path: Path, monkeypatch) -> None:
     """CL-11: a truncated trailing line (crash mid-write) never breaks reads."""
     logs_dir = tmp_path / "logs"

--- a/tests/unit/test_paths.py
+++ b/tests/unit/test_paths.py
@@ -127,3 +127,49 @@ def test_ensure_log_dir_returns_none_when_uncreatable(
     monkeypatch.setenv(CONFIG_DIR_ENV, str(blocked))
 
     assert ensure_log_dir() is None
+
+
+# --- Agent home dir (item 12) -----------------------------------------------
+
+
+def test_agent_home_dir_default(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    from local_operator.paths import AGENT_HOME_ENV, agent_home_dir
+
+    monkeypatch.delenv(AGENT_HOME_ENV, raising=False)
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    assert agent_home_dir() == tmp_path / "local-operator-home"
+
+
+def test_agent_home_dir_honours_override(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    from local_operator.paths import AGENT_HOME_ENV, agent_home_dir
+
+    monkeypatch.setenv(AGENT_HOME_ENV, str(tmp_path / "custom"))
+    assert agent_home_dir() == tmp_path / "custom"
+
+
+def test_default_agent_cwd_portable_without_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    from local_operator.paths import AGENT_HOME_ENV, default_agent_cwd
+
+    monkeypatch.delenv(AGENT_HOME_ENV, raising=False)
+    # Portable ~/-relative string when no override, so an exported agent record
+    # replicates on another machine.
+    assert default_agent_cwd() == "~/local-operator-home"
+
+
+def test_default_agent_cwd_absolute_with_override(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from local_operator.paths import AGENT_HOME_ENV, default_agent_cwd
+
+    monkeypatch.setenv(AGENT_HOME_ENV, str(tmp_path / "custom"))
+    # Absolute override so the stored cwd cannot diverge from the created dir.
+    assert default_agent_cwd() == str(tmp_path / "custom")
+
+
+def test_ensure_agent_home_dir_creates(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    from local_operator.paths import AGENT_HOME_ENV, ensure_agent_home_dir
+
+    target = tmp_path / "made" / "home"
+    monkeypatch.setenv(AGENT_HOME_ENV, str(target))
+    result = ensure_agent_home_dir()
+    assert result == target and target.is_dir()

--- a/tests/unit/test_session_factory.py
+++ b/tests/unit/test_session_factory.py
@@ -167,11 +167,25 @@ def test_resolve_precedence_config_fallback() -> None:
 
 
 def test_resolve_missing_values_raise_legacy_messages() -> None:
+    from local_operator.session_factory import HostingNotConfiguredError
+
     config = cast("ConfigManager", FakeConfigManager({}))
-    with pytest.raises(ValueError, match="Hosting platform is not configured."):
+    # No hosting at all still raises the legacy message shape, now as the
+    # dedicated HostingNotConfiguredError subclass so the first-run setup-state
+    # gate can classify it (item 1). It is still a ValueError.
+    with pytest.raises(HostingNotConfiguredError, match="Hosting platform is not configured."):
         resolve_hosting_model(None, _args(), config)
-    with pytest.raises(ValueError, match="Model name is not configured."):
-        resolve_hosting_model(None, _args(hosting="openai"), config)
+    # A hosting with a KNOWN default model no longer errors on the missing
+    # model — it resolves to that default (item 3).
+    assert resolve_hosting_model(None, _args(hosting="openai"), config) == ("openai", "gpt-4o")
+
+
+def test_resolve_unknown_hosting_no_default_still_raises_for_model() -> None:
+    """A provider with NO known default still errors on a missing model, now
+    naming current models to choose from (item 3)."""
+    config = cast("ConfigManager", FakeConfigManager({}))
+    with pytest.raises(ValueError, match="no default is known"):
+        resolve_hosting_model(None, _args(hosting="some-custom-host"), config)
 
 
 # --- Compaction coercion (CL-01) --------------------------------------------------

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -443,6 +443,34 @@ async def test_boot_typing_sends_prompt() -> None:
         assert len(transcript.blocks()) == 1
 
 
+@pytest.mark.asyncio
+async def test_first_run_setup_state_when_hosting_unconfigured() -> None:
+    """A boot that fails with HostingNotConfiguredError enters the guided setup
+    state (splash notice + 'setup' band), NOT a red 'session failed' (item 1)."""
+    from local_operator.session_factory import HostingNotConfiguredError
+
+    async def _no_hosting_factory():
+        raise HostingNotConfiguredError("Hosting platform is not configured.")
+
+    app = OperatorApp(_no_hosting_factory, provider_controller=FakeProviderController())
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        for _ in range(6):
+            await pilot.pause()
+        await asyncio.sleep(0.2)
+        await pilot.pause()
+        # The setup flag is set and the band says "setup", not a model or error.
+        assert app._setup_state is True
+        assert app._status is not None
+        assert app._status._model_label == "setup"
+        # The splash carries the guided /login notice, not a failure.
+        assert app._splash_notice is not None
+        assert "/login" in app._splash_notice
+        assert "no provider configured" in app._splash_notice
+        # The splash was NOT retired: it is still the empty-state block.
+        assert app._welcome_visible is True
+
+
 def test_splash_toast_headline_names_the_fallback_target() -> None:
     """The toast is a glance; the splash row keeps the reason."""
     assert (

--- a/tests/unit/tui/test_welcome.py
+++ b/tests/unit/tui/test_welcome.py
@@ -48,6 +48,7 @@ from local_operator.tui.widgets.welcome import (
     TIP_GLYPH,
     TIP_MIN_WIDTH,
     TIP_ROTATE_INTERVAL_S,
+    TIP_SETUP,
     TIPS,
     WORDMARK,
     WORDMARK_SPACED,
@@ -1320,7 +1321,10 @@ def test_no_width_the_row_is_drawn_at_ever_truncates_a_tip() -> None:
 def test_the_threshold_is_the_width_the_pool_actually_needs() -> None:
     """The constant is DERIVED, so rewording a tip cannot leave it stale — which
     is how it came to admit a row 24 cells narrower than its longest entry."""
-    assert TIP_MIN_WIDTH == max(cell_len(f"{TIP_GLYPH} {tip}") for tip in TIPS)
+    # The setup-state opening tip (TIP_SETUP) is drawn at the same row, so the
+    # threshold must clear the WIDEST of the pool AND that tip, or the setup
+    # notice would truncate at a width the constant swore was safe.
+    assert TIP_MIN_WIDTH == max(cell_len(f"{TIP_GLYPH} {tip}") for tip in (*TIPS, TIP_SETUP))
     # One cell under it there is no row at all, rather than a fragment of one.
     assert not _tip_rows(_lines(_info(), TIP_MIN_WIDTH - 1, 99))
 


### PR DESCRIPTION
## Summary of Changes

New feature + hardening. A brand-new user on a fresh machine hit a wall: the very first `local-operator` launch printed a bare `Error: Hosting platform is not configured.` and exited 255 — no next step, no command named, and the TUI (which owns the `/login` affordance) never opened. Fixing that one error by hand surfaced two more one-line dead-ends in sequence (model, then key), and the escape hatches themselves were broken (`login` stored a key but never closed the loop; Ctrl-C at the credential prompt dumped a traceback). This PR makes first-run followable.

Two independent audits (an architecture pass and a real fresh-`HOME` UX walkthrough) produced a 20-item findings list; this PR addresses all 20 in one branch.

**Headline — interactive keyless launch now enters the TUI in a setup state instead of dying at preflight.** `resolve_hosting_model` raises a new `HostingNotConfiguredError` (a `ValueError` subclass so existing handlers still catch it); the CLI preflight passes it through **only** when the full-screen TUI will actually run (`allow_setup_state`, gated strictly on `stdout.isatty()` + the TUI path), and `OperatorApp` routes it to a setup state that reuses the existing welcome splash + `/login` + `/model` surfaces — no parallel wizard subsystem. The splash's warning row becomes `! welcome — no provider configured yet. Run /login <provider> …` and the status band reads `setup`. Headless / `exec` / non-tty keep fail-fast, but now print a complete quickstart that names hosting **and** model **and** the credential command at once (exit 1, not 255).

**The rest, by finding:**
- **login closes the loop** — `login <provider>` (CLI and TUI) now sets `hosting` + a per-provider default model when config is empty, so the tool's own recommended recovery actually starts the app.
- **default model fallback** — hosting set + model empty resolves a sensible default (`model/defaults.py`) instead of erroring; stale `--model` help examples refreshed.
- **credential prompt hardened** — Ctrl-C → exit 130 quietly; empty/EOF → one plain line, exit 1; ANSI stripped from exception text; non-tty stdin read as one line (documented automation contract); unknown key names warn with a closest-match suggestion; ASCII banner fallback when stdout can't encode box-drawing (legacy Windows codepages); atomic 0600 writes via temp-file + `os.replace`, control chars rejected.
- **Anthropic (callable env-key resolver)** no longer suggests the invalid `credential update API key` — it names `login` when the env var isn't a fixed string.
- **malformed config.yml** → one-line parse error + the file backed up to `config.yml.bad` + defaults, instead of a raw traceback.
- **`config edit`** rejects unknown keys with a difflib suggestion (the old `except KeyError` was dead code).
- **auth-classified stream errors** append the local recovery (`/login` / `login` / `credential update`); the knowledge-embedding 401 fallback warning is downgraded to the log when its cause is the same missing key.
- **headless REPL** raises library loggers to WARNING so INFO/httpx lines don't leak before the first prompt.
- **`~/local-operator-home`** is no longer created unconditionally in `main()` on every invocation and no longer ignores the config-dir override: `paths.agent_home_dir()` honours `LOCAL_OPERATOR_HOME`, creation is lazy at session start, and all readers (agents, server schemas) were migrated together.
- **config + credentials dirs** created 0700 (matching the log dir; transcripts are the same sensitivity class) — at creation only, never chmod'ing an existing dir on upgrade.
- **exit codes** `-1` → `1` on failure paths (255 collided with xargs/ssh sentinels and contradicted the `exec` contract).
- **`config open`** falls back to `$VISUAL`/`$EDITOR` on a headless/SSH box with no GUI opener.
- **shell-env priming** (`$SHELL -l -c` PATH harvest) gated to the subcommands that actually spawn subprocesses, off the `config`/`credential` paths.
- **NO_COLOR / TERM=dumb / non-tty** respected on the first-run and error/warn paths via a small stdlib styling helper (`cli_style.py`), gated on the stream actually written (stderr at the error sites). Note: a handful of other CLI listings (`config list`, `agents`, `teams`) still emit raw escapes and are out of scope for this PR. README corrected (`credentials.env`, angle-bracket examples, first-run description).

Change class: **C2 (feature + cross-platform hardening, pre-authorized)** — user-facing first-run flow plus independent small hardening fixes, each revertible on its own commit; no schema, migration, or auth-contract surface (the new agent-home override defaults to the existing location).

## Related Issue(s)

- Related: none filed (surfaced by a first-run UX audit).

## Impact

- **Behaviour changes worth calling out:** (1) an interactive keyless launch now opens the TUI in a setup state rather than exiting — headless/exec is unchanged in its fail-fast contract, only its message improved; (2) failure exit codes move from 255 to 1 — a script matching on 255 would need updating; (3) `login` now writes `hosting`/`model_name` when they're empty. All three are the intended fixes, not side effects.
- No breaking API/schema changes. The agent-home override defaults to `~/local-operator-home`, so existing installs see the same location; only *when* it's created and *how* the path resolves changed. Dir-perm tightening applies at creation only.
- No dependency updates. The styling/default-model helpers are stdlib-only and kept off the startup import path (the import-graph guard still passes).
- Security: credentials now written atomically at 0600 with control-char rejection; config/credential dirs created 0700; no secrets added to any transcript or log.

## Testing Details

Testing evidence is proof the change works, not a green suite — every fixed dead-end was exercised against a **real fresh `HOME` + `LOCAL_OPERATOR_CONFIG_DIR`**, run from the worktree so the new code (not the installed build) executed. Full transcript with commands and actual responses is attached below; highlights:

**Headline setup state (rendered and viewed, not just asserted):**
- Keyless boot → TUI setup state: splash `! welcome — no provider configured yet. Run /login <provider> …`, band `setup`, splash not retired. Two consecutive frames byte-identical after id-normalisation → no post-paint reflow. Screenshots below.

**Fixed dead-ends (fresh HOME, real execution):**
- Headless keyless launch → complete quickstart naming hosting+model+key+commands, **exit 1** (was a bare one-liner, exit 255).
- `login deepseek` with a fake key → `Stored API key … Set default hosting to 'deepseek' and model to 'deepseek-chat'`, config.yml written, **exit 0** — the loop closes.
- `credential update` Ctrl-C via a real pty → **exit 130**, no traceback; empty piped stdin → `… is required for this step.`, **exit 1**; piped value → stored as one line; typo'd key → `Did you mean OPENAI_API_KEY?` warning; `PYTHONIOENCODING=ascii` → ASCII `+---+` banner, no crash.
- Malformed `config.yml` → one-line parse error + moved to `config.yml.bad` + defaults.
- `config edit hostng radient` → `unknown configuration key: 'hostng'. Did you mean 'hosting'?`, **exit 1**.
- Atomic write: 0600 perms, no `.tmp` leftover; app-created config dir → `drwx------`.
- `config list` does **not** create the agent home (lazy); `LOCAL_OPERATOR_HOME` honoured.
- Auth 401 stream error → local recovery appended; 429 quota text unchanged.
- `config open` with `$EDITOR=cat` and no GUI opener → opens via `$EDITOR`.
- Headless REPL → httpx logger at WARNING, no INFO leak before the first prompt.

**Gates** (rebased onto current `main`, PR head is the tip of `dev-first-run-ux`):
- `flake8` / `black --check` / `isort --check-only` / `pyright` — clean (0 errors).
- `pytest` — non-heavy subset 3005 passed; `session`/`mcp`/`server` 665 passed; `tui` 2210 passed, 4 skipped. New/extended tests cover preflight tty gating + setup-state entry, login-sets-defaults, default-model fallback, config-edit key validation, credential interrupt/EOF/unknown-key/atomic-write, YAML error handling, agent-home override, exit codes, and the NO_COLOR helper.
- One unrelated failure, `test_eval_tool::test_background_streams_output_while_it_runs`, is a **pre-existing timing flake confirmed failing identically on untouched `main`** (verified in a throwaway worktree at the merge-base); it touches none of the files in this PR.

**Note for reviewers:** the second screenshot's `provider controller unavailable — run: local-operator login` hint is a **test-harness artifact** — the `FakeSession` used to render the frame has no live `ProviderController`. The real `/login` path is validated separately by the CLI `login deepseek` evidence above; a reviewer standing up a live session should confirm `/login` end-to-end in the TUI.

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my changes work as intended.
- [x] All new and existing tests pass (one pre-existing unrelated flake noted).
- [x] I have run formatting (black/isort), linting (flake8), and type checks (pyright), and they pass.
- [x] I have updated the documentation when required (README first-run text; in-code why/constraint comments throughout).
- [x] Security considerations are addressed (atomic 0600 credential writes, 0700 dirs, no secrets logged).
- [x] I have linked all related issues.

## Screenshots

Rendered from the real `OperatorApp` (`run_test` + `save_screenshot`, from the worktree so the new code paints) and viewed as PNGs. Two states captured:

1. **First-run setup state (keyless boot)** — splash reads `! welcome — no provider configured yet. Run /login <provider> (e.g. /login openai) to set one up`, status band reads `setup` (not a model, not "session error"), splash is not retired. This is what a brand-new user now sees instead of `Error: Hosting platform is not configured.` + a dead shell.
2. **Guided step — `/login openai` typed in the composer**, band still `setup`.

SVG + PNG artifacts are attached in the review thread (they render from `run_test`, and consecutive frames are byte-identical after id-normalisation — no post-paint reflow). A design-review round with re-captured frames follows on this PR before merge.
