### PR TITLE
feat(tui): run slash commands inline, mid-draft, splicing the token out

### DIFF
--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -145,6 +145,7 @@ from local_operator.tui.widgets.editor import (
     EditorCopyStale,
     EditorQuit,
     EditorSubmitted,
+    InlineCommandRequested,
     InterruptRequested,
     ModelQueryOpened,
     RefreshArgumentChoices,
@@ -441,7 +442,7 @@ SLASH_COMMANDS: list[SlashCommand] = [
     # than being paraphrased into a system notice. `_cmd_goal` writes that row
     # itself, only on the branch that actually stored something — the flag is
     # the permission, not the trigger.
-    SlashCommand("goal", "Show, set, or clear the session goal", echo=True),
+    SlashCommand("goal", "Show, set, or clear the session goal", echo=True, consumes_prompt=True),
     # Not an exception: LOOP_PROMPT is app-authored, not the user's words, and
     # `_loop_worker` already labels every iteration it starts (`· loop 1/3`), so
     # no agent output here is left unattributed. `echo=False` suppresses the
@@ -450,7 +451,7 @@ SLASH_COMMANDS: list[SlashCommand] = [
     # session's user MessageStartEvent is consumed silently rather than
     # painted — two different receipts for two different events (the typed
     # command, and the prompt the turn later announces).
-    SlashCommand("loop", "Iterate autonomously toward the goal"),
+    SlashCommand("loop", "Iterate autonomously toward the goal", consumes_prompt=True),
     # NOT an exception, and the reason IS the feature. The question does reach
     # the model, but only for one off-the-record request that never joins the
     # conversation (`SessionProtocol.complete_aside`) — so a user row in the
@@ -458,7 +459,7 @@ SLASH_COMMANDS: list[SlashCommand] = [
     # still be sitting there after Esc claimed to have thrown the exchange
     # away. The card is the receipt; `^f` inside it is how an exchange gets a
     # row, as a real turn rather than an echo.
-    SlashCommand("btw", "Ask a side question off the record (esc closes it)"),
+    SlashCommand("btw", "Ask a side question off the record (esc closes it)", consumes_prompt=True),
     # NOT an echo, and the receipt is the reason. The pass narrates itself
     # through the same `compacting context…` / `context compacted · 128.4k →
     # 21.9k tokens` notices the automatic one emits, and a refusal says why it
@@ -514,6 +515,10 @@ SLASH_COMMANDS: list[SlashCommand] = [
         "List teams, or send a request to a team's manager",
         aliases=("teams",),
         arguments=ArgumentMode.OPTIONAL,
+        # The request AFTER the team name is a prompt the manager is given, so an
+        # inline `/team` reassembles to the front (name from the autofill, the
+        # draft as the request) rather than eating the draft as the name.
+        consumes_prompt=True,
     ),
     # Same echo reasoning as `/team`, which this command mirrors surface for
     # surface: bare `/agent` is a listing (the listing is the receipt), a
@@ -529,6 +534,9 @@ SLASH_COMMANDS: list[SlashCommand] = [
         "List agents, or speak to this session as one",
         aliases=("agents",),
         arguments=ArgumentMode.OPTIONAL,
+        # The message AFTER the agent name is a prompt the persona is given, so
+        # an inline `/agent` reassembles to the front like `/team`.
+        consumes_prompt=True,
     ),
 ]
 
@@ -3902,6 +3910,37 @@ class OperatorApp(App[None]):
             self._run_slash_command(text)
             return
         self._submit_prompt(text, images, message.attachments)
+
+    def on_inline_command_requested(self, message: InlineCommandRequested) -> None:
+        """Run a slash command spliced out of the MIDDLE of a draft.
+
+        The editor has already removed the ``/command`` token from the buffer and
+        kept the surrounding message; all that remains is to DISPATCH the command,
+        which is the same synchronous slash handling a start-of-line command gets
+        — minus the prompt submission, because there is no prompt here: the draft
+        the user is still composing stays in the composer.
+
+        The aside owns the composer while it is up, and an inline command can only
+        be produced by the main composer (the aside's own key path never reaches
+        the slash picker), so no aside guard is needed here — but the session-gate
+        and unknown-command reporting inside ``_run_slash_command`` still apply
+        exactly as they do for a typed command.
+
+        Attaching a team or agent this way is the whole point of the mid-draft
+        gesture: ``/team ops`` stamps the roster onto this session's volatile
+        prompt tail, so the message the user then sends with Enter runs under the
+        team manager. See ``_cmd_team`` / ``_cmd_agent`` and
+        ``session_factory``'s per-turn prompt provider, which re-reads that tail.
+        """
+        command_text = message.command_text.strip()
+        if not command_text.startswith("/"):
+            return
+        if self._aside_is_open():
+            # Defensive only — see the docstring. Route to the aside rather than
+            # silently dispatching a command the user cannot see they issued.
+            self._ask_aside(command_text)
+            return
+        self._run_slash_command(command_text)
 
     def on_editor_quit(self, message: EditorQuit) -> None:
         self.exit()
@@ -10634,7 +10673,12 @@ class OperatorApp(App[None]):
         from local_operator.mcp.auth import mcp_logged_out_servers, oauth_server_names
         from local_operator.tui.widgets.command_picker import slash_argument
 
-        argument = slash_argument(editor.text, editor._argument_commands)
+        argument = slash_argument(
+            editor.text,
+            editor._argument_commands,
+            editor._caret_offset(),
+            editor._command_names,
+        )
         if argument is None:
             return []
         sub, _space, _rest = argument.partition(" ")

--- a/local_operator/tui/autocomplete.py
+++ b/local_operator/tui/autocomplete.py
@@ -105,6 +105,23 @@ class SlashCommand:
     #: that changes nothing. Free typing is unaffected in every mode — the list
     #: ranks what is typed, it never filters what may be submitted.
     arguments: ArgumentMode = field(default=ArgumentMode.NONE, kw_only=True)
+    #: Whether this command's argument is FREE-TEXT that becomes a prompt the
+    #: model is given — the goal text, a loop instruction, a team/agent request,
+    #: an aside question. These are the "start of the composer" commands: their
+    #: whole point is to prefix a message, so engaging one INLINE (mid-draft)
+    #: does not splice-and-run — it REASSEMBLES the command to the front of the
+    #: composer with the rest of the draft as its argument, staged for the user
+    #: to review and submit. That is what makes "type the message, then remember
+    #: to route it" safe: nothing the user typed is ever consumed as a name or
+    #: silently dropped (the D1 data-loss the naive end-of-line argument caused).
+    #:
+    #: Keyword-only, defaulting to FALSE for the same reason ``echo`` and
+    #: ``arguments`` do: a command that has not opted in keeps the simple
+    #: splice-and-run inline behaviour (``/usage``, ``/model``), which is right
+    #: for every command whose argument is a SELECTOR rather than a message.
+    #: ``SLASH_COMMANDS`` is pinned entry-by-entry in ``test_slash_echo.py`` so a
+    #: new command must state this choice.
+    consumes_prompt: bool = field(default=False, kw_only=True)
 
     @property
     def names(self) -> tuple[str, ...]:

--- a/local_operator/tui/widgets/command_picker.py
+++ b/local_operator/tui/widgets/command_picker.py
@@ -179,44 +179,211 @@ class _RowStyles(NamedTuple):
 
 
 class SlashContext(NamedTuple):
-    """Where the command word starts, and the word typed so far.
+    """Where the active command word sits, and the word typed so far.
 
-    ``start`` indexes the ``/`` itself so a completion can rebuild the buffer
-    without discarding whatever whitespace the user typed in front of it.
+    ``start`` indexes the ``/`` itself and ``end`` the first cell past the word,
+    so a completion can rebuild JUST that span and leave the rest of the draft
+    untouched. Before inline detection the word always ran to the end of the
+    buffer, so a completion could splice from ``start`` to the end; now the word
+    can have a message typed after it (``fix this /team``, or ``/team\\nfix
+    this``), and only ``[start, end)`` is the command — everything outside it is
+    the user's prose and must survive the completion verbatim.
     """
 
     start: int
     query: str
+    end: int
 
 
-def slash_context(text: str) -> SlashContext | None:
-    """The command word being typed, or ``None`` when the picker must hide.
+#: A slash opens a command only at a WORD BOUNDARY: the buffer start, or right
+#: after whitespace. This is what keeps ``src/foo`` and ``and/or`` from opening
+#: the picker — the ``/`` there is glued to a preceding non-space character, so
+#: it is punctuation inside a word, not the start of a command. The rule is the
+#: same one a shell or an editor command palette uses to tell a path apart from
+#: a command, and it is the ONE thing that makes inline detection safe to run on
+#: every keystroke of ordinary prose.
+def _is_boundary(line: str, index: int) -> bool:
+    """Whether ``line[index]`` (a ``/``) begins a fresh token."""
+    return index == 0 or line[index - 1].isspace()
 
-    The picker is for choosing a command, so it shows only while the command
-    WORD is still open: ``/`` first on the first non-blank line, and no
-    whitespace yet terminating the token. Once the user types
-    ``/model `` they have chosen ``model`` and are typing its argument — a
-    list of commands there is stale advice covering the transcript.
+
+def _line_of_cursor(text: str, cursor: int | None) -> tuple[str, int, int]:
+    """The line the cursor sits on, as ``(line, line_start_offset, column)``.
+
+    ``cursor`` is a whole-buffer offset; ``None`` means "the end of the buffer",
+    which is where a user typing at the end of their draft is. Clamped into
+    range so a stale caret (a resync racing a delete) cannot index out of the
+    text. Offsets are measured the same way ``Editor._offset_at`` does, so a
+    caret computed there indexes correctly here. Lines are split on ``\\n`` and
+    a trailing ``\\r`` from a CRLF buffer is stripped below, so every consumer of
+    the returned line agrees on the word regardless of the paste's line endings.
     """
-    lines = text.split("\n")
-    first = next((index for index, line in enumerate(lines) if line.strip()), None)
-    if first is None:
-        return None
-    if len(lines) > first + 1:
-        # A newline after the word terminates it exactly like a space does.
-        return None
-    line = lines[first]
-    stripped = line.lstrip()
-    if not stripped.startswith("/"):
-        return None
-    if any(char.isspace() for char in stripped):
-        return None
-    start = sum(len(other) + 1 for other in lines[:first]) + (len(line) - len(stripped))
-    return SlashContext(start, stripped[1:])
+    if cursor is None or cursor > len(text):
+        cursor = len(text)
+    if cursor < 0:
+        cursor = 0
+    line_start = text.rfind("\n", 0, cursor) + 1  # 0 when no newline precedes
+    line_end = text.find("\n", cursor)
+    if line_end == -1:
+        line_end = len(text)
+    line = text[line_start:line_end]
+    # A CRLF buffer — which a draft/held-prompt restore can carry in, since
+    # ``load_text`` does not normalise — leaves a trailing ``\r`` on every line
+    # split on ``\n``. ``slash_context`` tolerated it (``\r`` is whitespace, so
+    # it terminated the word), but ``slash_word``/``slash_argument_context`` use
+    # ``.partition(" ")``, which does NOT treat ``\r`` as a separator: the word
+    # came back as ``"team\r"`` (matching no command) and argument values
+    # carried the ``\r`` into dispatch. Stripping it here fixes every consumer at
+    # once, because they all read the line through this one helper. The column is
+    # unaffected: the ``\r`` sits at the END of the line, past any caret the
+    # parsers care about (review round 1, minor-1).
+    if line.endswith("\r"):
+        line = line[:-1]
+    return line, line_start, cursor - line_start
 
 
-def slash_argument(text: str, commands: tuple[str, ...]) -> str | None:
-    """The ARGUMENT being typed after one of ``commands``, else ``None``.
+def _boundary_slashes(line: str) -> list[int]:
+    """Indices of every boundary ``/`` on ``line`` (buffer start / after space)."""
+    return [i for i, ch in enumerate(line) if ch == "/" and _is_boundary(line, i)]
+
+
+def _active_slash(line: str, column: int, commands: frozenset[str] = frozenset()) -> int | None:
+    """Index within ``line`` of the boundary ``/`` the cursor is editing.
+
+    Normally the active token is the LAST boundary ``/`` at or before the cursor:
+    a user typing ``a /foo /ba|`` (caret at ``|``) is editing ``/ba``, not
+    ``/foo``. Returns ``None`` when the cursor is not inside any boundary slash
+    token — before every slash on the line, or on a ``/`` glued to a word.
+
+    ``commands`` closes the "already inside a command" case: once the line holds
+    a RECOGNISED command that has been TERMINATED by a space (``/team security
+    …``), that command owns the rest of its line as its argument, so a second
+    ``/team`` typed INSIDE the request ("improve the /team command") is plain
+    argument text — not a new command to highlight or re-open the picker for.
+    The earliest such command on the line wins and claims everything after it;
+    only when no earlier recognised command has claimed the caret's position does
+    the last-slash-before-caret rule apply. Empty ``commands`` (the pure-parser
+    default) disables claiming and keeps the simple behaviour.
+    """
+    slashes = _boundary_slashes(line)
+    candidate: int | None = None
+    for index in slashes:
+        word, sep, _ = line[index + 1 :].partition(" ")
+        if sep and commands and word.lower() in commands:
+            # A recognised, terminated command. Its argument runs to the end of
+            # the line, so if the caret is anywhere past this slash it is inside
+            # THIS command — return it and stop, ignoring every later slash.
+            if column > index:
+                return index
+            # Caret is before this command entirely; nothing earlier can claim.
+            return candidate
+        if index <= column:
+            candidate = index
+    return candidate
+
+
+def slash_context(
+    text: str, cursor: int | None = None, commands: frozenset[str] = frozenset()
+) -> SlashContext | None:
+    """The command word being typed at the cursor, or ``None`` to hide the list.
+
+    Inline and caret-aware, unlike the original first-line-only rule: the picker
+    shows whenever the caret is inside a boundary-slash token whose word is not
+    yet terminated by whitespace, WHEREVER that token is in the draft. This is
+    what lets a user who has typed a message remember to route it — appending
+    ``/team`` at the caret, or dropping it on its own line — and still get the
+    menu. ``src/foo`` never triggers because its ``/`` is not at a boundary.
+
+    Command-WORD phase only: the instant a space terminates the word the user is
+    typing an ARGUMENT (``/model gpt``), which :func:`slash_argument` owns — a
+    command list there is stale advice. ``cursor`` defaults to the end of the
+    buffer, the common "typing at the end" case.
+
+    ``commands`` is the recognised command vocabulary; passing it makes a slash
+    typed INSIDE an already-engaged command's argument (``/team a /team b``) read
+    as plain text rather than a nested command (see :func:`_active_slash`).
+    """
+    line, line_start, column = _line_of_cursor(text, cursor)
+    slash = _active_slash(line, column, commands)
+    if slash is None:
+        return None
+    # The word runs from the slash to the first whitespace after it. A space
+    # BETWEEN the slash and the caret means the word is already terminated and
+    # the caret is out in argument (or message) territory — not the command.
+    word_end = slash + 1
+    while word_end < len(line) and not line[word_end].isspace():
+        word_end += 1
+    if column > word_end:
+        return None
+    return SlashContext(
+        line_start + slash,
+        line[slash + 1 : word_end],
+        line_start + word_end,
+    )
+
+
+def slash_token_span(
+    text: str, cursor: int | None = None, commands: frozenset[str] = frozenset()
+) -> tuple[int, int] | None:
+    """The ``[start, end)`` offsets of the whole slash TOKEN at the caret.
+
+    ``start`` is the ``/`` and ``end`` is the end of its line — the command word
+    plus its inline argument, which by the inline contract runs to the line end.
+    Returns ``None`` when the caret is not on a boundary-slash token. This is the
+    span a RUN splices out of an inline draft, exposed so the editor never has to
+    reach for the module-private tokenizer. ``commands`` is the recognised
+    vocabulary, so a nested slash inside an engaged command's argument is ignored.
+    """
+    line, line_start, column = _line_of_cursor(text, cursor)
+    slash = _active_slash(line, column, commands)
+    if slash is None:
+        return None
+    return line_start + slash, line_start + len(line)
+
+
+def slash_word(
+    text: str, cursor: int | None = None, commands: frozenset[str] = frozenset()
+) -> str | None:
+    """The lower-cased command word of the slash token AT THE CARET, or ``None``.
+
+    The word regardless of PHASE — whether it is still being typed or already
+    terminated by a space — so a caller that needs to know "which command is the
+    caret on" (the editor deciding which argument list to fill) gets one answer
+    whether the buffer reads ``/team`` or ``/team ops``. :func:`slash_context`
+    and :func:`slash_argument` answer the narrower phase-specific questions.
+    ``commands`` is the recognised vocabulary for the nested-slash rule.
+    """
+    line, _, column = _line_of_cursor(text, cursor)
+    slash = _active_slash(line, column, commands)
+    if slash is None:
+        return None
+    return line[slash + 1 :].partition(" ")[0].lower()
+
+
+class SlashArgument(NamedTuple):
+    """The argument being typed, and the spans it occupies in the buffer.
+
+    ``start`` and ``end`` are whole-buffer offsets bracketing the argument text,
+    so a completion can replace JUST the argument and leave a trailing inline
+    message intact — the argument-phase twin of :class:`SlashContext`.
+    ``token_start`` indexes the ``/`` that opens the whole construct, so a RUN
+    can splice the entire ``/cmd arg`` out of an inline draft (not just its
+    argument). ``value`` is the argument text (possibly ``""``).
+    """
+
+    value: str
+    start: int
+    end: int
+    token_start: int
+
+
+def slash_argument_context(
+    text: str,
+    commands: tuple[str, ...],
+    cursor: int | None = None,
+    known: frozenset[str] = frozenset(),
+) -> SlashArgument | None:
+    """The ARGUMENT being typed after one of ``commands``, with its span.
 
     The mirror image of :func:`slash_context`: that one is live while the command
     word is still open, this one takes over the instant the word is terminated by
@@ -225,24 +392,53 @@ def slash_argument(text: str, commands: tuple[str, ...]) -> str | None:
     offers models, and the handover happens on the space the user was going to
     type anyway.
 
-    Returns the argument text, which may be ``""`` (the command word is complete
-    but nothing has been typed after it — the state that should show the whole
-    catalogue). ``None`` means this is not one of ``commands``.
+    Caret-aware and inline like :func:`slash_context`: the argument is the text
+    from the word-terminating space to the END OF THE LINE the command is on.
+    End-of-line, not end-of-buffer, is what makes a command droppable on its own
+    line above a multi-line draft — the line below is the message, not the
+    argument. On the command's own line the argument runs to the line end, so a
+    trailing message on the SAME line (``/team ops ship it``) is read as part of
+    the argument; putting the command last, or on its own line, is how a user
+    keeps the two apart (documented as the inline contract).
 
-    Single-line only, matching ``slash_context``: a newline means the user is
-    composing a message, not picking from a list.
+    ``None`` when the caret is not in the argument phase of one of ``commands``.
+    ``known`` is the FULL recognised vocabulary (a superset of ``commands``) used
+    only for the nested-slash rule: a slash inside an engaged command's argument
+    is not a new token. It defaults to ``commands`` when omitted.
     """
-    lines = text.split("\n")
-    first = next((index for index, line in enumerate(lines) if line.strip()), None)
-    if first is None or len(lines) > first + 1:
+    line, line_start, column = _line_of_cursor(text, cursor)
+    slash = _active_slash(line, column, known or frozenset(commands))
+    if slash is None:
         return None
-    stripped = lines[first].lstrip()
-    if not stripped.startswith("/"):
-        return None
-    word, sep, argument = stripped[1:].partition(" ")
+    word, sep, argument = line[slash + 1 :].partition(" ")
     if not sep or word.lower() not in commands:
         return None
-    return argument
+    # The caret must be in the ARGUMENT, i.e. past the terminating space; while
+    # it is still on the word itself that is command-word phase, which
+    # ``slash_context`` owns. ``slash + 1 + len(word)`` is the space's column.
+    space_column = slash + 1 + len(word)
+    if column <= space_column:
+        return None
+    arg_start = line_start + space_column + 1
+    return SlashArgument(argument, arg_start, line_start + len(line), line_start + slash)
+
+
+def slash_argument(
+    text: str,
+    commands: tuple[str, ...],
+    cursor: int | None = None,
+    known: frozenset[str] = frozenset(),
+) -> str | None:
+    """The argument text being typed after one of ``commands``, else ``None``.
+
+    A thin projection of :func:`slash_argument_context` onto just the text, for
+    the many callers that only rank against the argument and never need to
+    rewrite the span. Returns ``""`` when the command word is complete but
+    nothing has been typed after it (the whole-catalogue state). ``known`` is the
+    full vocabulary for the nested-slash rule.
+    """
+    context = slash_argument_context(text, commands, cursor, known)
+    return None if context is None else context.value
 
 
 #: Below this many typed characters the fuzzy tail is suppressed. A one- or
@@ -355,6 +551,7 @@ class CommandPicker(Static):
         #: row-0 state must not reach the observer (see ``set_choices``).
         self._suppress_report = False
         self._commands: list[SlashCommand] = []
+        self._command_names: frozenset[str] = frozenset()
         self._choices: list[ArgumentChoice] = []
         self._mode = PickerMode.COMMAND
         self._matches: list[_Suggestion] = []
@@ -379,6 +576,13 @@ class CommandPicker(Static):
     def set_commands(self, commands: list[SlashCommand]) -> None:
         """Replace the offered command registry."""
         self._commands = list(commands)
+        # Full recognised vocabulary (primaries AND aliases), lower-cased, for the
+        # nested-slash rule: a slash typed inside an engaged command's argument is
+        # plain text, and the tokenizer needs the vocabulary to know a command has
+        # claimed the rest of the line. Cached so it is not rebuilt per keystroke.
+        self._command_names = frozenset(
+            name.lower() for command in commands for name in command.names
+        )
 
     def set_choices(self, choices: list[ArgumentChoice], highlight: str | None = None) -> None:
         """Replace the values offered for the current command's ARGUMENT.
@@ -510,9 +714,14 @@ class CommandPicker(Static):
         end = min(total, self._window_start + self._row_budget())
         return self._window_start, end, total
 
-    def sync(self, text: str) -> None:
-        """Re-derive the COMMAND suggestions from the editor's current ``text``."""
-        context = slash_context(text)
+    def sync(self, text: str, cursor: int | None = None) -> None:
+        """Re-derive the COMMAND suggestions from the editor's current ``text``.
+
+        ``cursor`` is a whole-buffer offset locating the active slash token, so
+        an inline ``/team`` typed in the middle of a draft opens the list; the
+        editor passes its caret offset. ``None`` means the end of the buffer.
+        """
+        context = slash_context(text, cursor, self._command_names)
         if context is None:
             # Left slash context entirely: forget the dismissal, so the next
             # `/` opens a fresh picker.

--- a/local_operator/tui/widgets/editor.py
+++ b/local_operator/tui/widgets/editor.py
@@ -93,7 +93,10 @@ from local_operator.tui.widgets.command_picker import (
     CommandPicker,
     PickerMode,
     slash_argument,
+    slash_argument_context,
     slash_context,
+    slash_token_span,
+    slash_word,
 )
 from local_operator.tui.widgets.model_picker import ModelPicker, ModelRow
 
@@ -452,6 +455,28 @@ class EditorQuit(Message):
         super().__init__()
 
 
+class InlineCommandRequested(Message):
+    """Posted when an INLINE slash command is run out of the middle of a draft.
+
+    A command typed at the start of the buffer runs through the ordinary submit
+    path (``EditorSubmitted`` with a slash-shaped ``text``): the whole buffer IS
+    the command, so submitting and clearing is exactly right. An INLINE command
+    is different — the user typed a message and then remembered to route it, so
+    the ``/command`` token is spliced OUT of the draft and the rest of the
+    message is left in the composer untouched. This message carries just the
+    command text (``/team ops``) for the app to dispatch, while the editor keeps
+    ownership of the surviving draft.
+
+    Split from ``EditorSubmitted`` deliberately: a submit clears the buffer and
+    records history, neither of which an inline run wants — the draft is still
+    unsent, and the command is not a prompt the user would page back to.
+    """
+
+    def __init__(self, command_text: str) -> None:
+        super().__init__()
+        self.command_text = command_text
+
+
 class ModelQueryOpened(Message):
     """Posted when the buffer enters ``/model …`` and the model list appears.
 
@@ -646,13 +671,19 @@ class Editor(TextArea):
         self._argument_commands: tuple[str, ...] = ()
         self._required_argument_commands: tuple[str, ...] = ()
         # Every registered command word (primaries AND aliases), lower-cased,
-        # for the highlighter's "is this leading /word a real command?" oracle.
-        # Derived from the registry in :meth:`set_commands` — the render pass
-        # must not import the app (which owns ``slash_command_for``): editor.py
-        # is imported BY app.py, so the dependency only goes one way. The same
-        # name-in-``names`` membership ``slash_command_for`` uses is reproduced
-        # here so the highlight cannot claim a command the dispatch would reject.
+        # for the highlighter's "is this leading /word a real command?" oracle,
+        # AND for the inline tokenizer's nested-slash rule (a slash inside an
+        # engaged command's argument is plain text). Derived from the registry in
+        # :meth:`set_commands` — the render pass must not import the app (which
+        # owns ``slash_command_for``): editor.py is imported BY app.py, so the
+        # dependency only goes one way. The same name-in-``names`` membership
+        # ``slash_command_for`` uses is reproduced here so the highlight cannot
+        # claim a command the dispatch would reject.
         self._command_names: frozenset[str] = frozenset()
+        # Commands whose argument is a prompt (goal/loop/team/agent/btw). Same
+        # derive-from-registry reason as the tuples above; read during the
+        # inline run to decide reassemble-to-front vs splice-and-run.
+        self._prompt_commands: tuple[str, ...] = ()
         # The team/agent NAMES the open argument list is offering, pushed by the
         # app in ``on_argument_query_opened`` (see :meth:`set_name_choices`).
         # A frozenset so the render pass tests membership in O(1): the render
@@ -673,6 +704,11 @@ class Editor(TextArea):
         self._slash_runs_cache: (
             tuple[tuple[object, ...], tuple[int, list[tuple[int, int, str]]] | None] | None
         ) = None
+        # Guards the picker resync inside ``load_text`` so ``_set_text_and_caret``
+        # can move the caret first and sync ONCE at the final position (D5). Set
+        # BEFORE ``super().__init__`` because TextArea's constructor loads the
+        # initial document through ``load_text`` → ``_sync_picker``.
+        self._suspend_picker_sync = False
         # tab_behavior="indent": Tab NEVER moves focus (TUI-013). Command
         # completion consumes the key first; otherwise it indents.
         super().__init__(placeholder=placeholder, soft_wrap=True, tab_behavior="indent")
@@ -975,8 +1011,20 @@ class Editor(TextArea):
             if command.arguments is ArgumentMode.REQUIRED
             for name in command.names
         )
-        # Lower-cased so the highlighter's membership test matches the
-        # case-insensitive way ``slash_command_for`` resolves a typed word.
+        # Commands whose argument is a PROMPT (goal/loop/team/agent/btw). Engaging
+        # one inline reassembles it to the FRONT of the composer with the draft as
+        # its argument, rather than splicing-and-running — see
+        # :meth:`_reassemble_prompt_command`. Derived from the registry (aliases
+        # included) so the set cannot drift from the flag it reads.
+        self._prompt_commands = tuple(
+            name for command in commands if command.consumes_prompt for name in command.names
+        )
+        # Lower-cased vocabulary (primaries AND aliases), shared by the
+        # highlighter's "is this a real command?" oracle and the inline
+        # tokenizer's nested-slash rule (a slash inside an engaged command's
+        # argument is plain text). Matches the case-insensitive way
+        # ``slash_command_for`` resolves a typed word, so the highlight cannot
+        # claim a command the dispatch would reject.
         self._command_names = frozenset(
             name.lower() for command in commands for name in command.names
         )
@@ -1115,8 +1163,12 @@ class Editor(TextArea):
         buffer is what decides which picker is open, so anything that opens one has
         to go through the buffer or be undone by the next resync.
         """
-        self.text = "/model "
-        self.move_cursor(self._end_of_buffer())
+        # Through the shared helper so the picker is re-derived with the caret at
+        # the end (in the argument slot), not at the origin the ``text`` setter
+        # leaves it at. Caret-anchored detection means a sync at the origin would
+        # read ``/model `` as the command WORD and never post ``ModelQueryOpened``,
+        # so the list would stay empty until the next keystroke.
+        self._set_text_and_caret("/model ", len("/model "))
         self._history_index = None
 
     # -- key interception ---------------------------------------------------
@@ -1258,8 +1310,14 @@ class Editor(TextArea):
                         # the transcript, cleared the buffer, and made the app put
                         # the query back to reopen a list the keystroke had already
                         # opened. One keystroke, one outcome.
+                        #
+                        # Runs through the shared run path so an inline command is
+                        # spliced out and its draft kept, exactly like the
+                        # argument phase — `_apply_command` moved the caret to the
+                        # end of the completed word, so the run path re-parses at
+                        # that caret and finds this token.
                         if key == "enter" and not self.opens_a_list(name):
-                            self._submit()
+                            self._run_command_from_buffer()
                     elif key == "tab":
                         # Tab never sends, so it can safely take the highlighted
                         # row: that is the whole point of a completion key.
@@ -2468,7 +2526,99 @@ class Editor(TextArea):
         self._copy_gesture = False
         self._copied_selection = None
         super().load_text(text)
+        # Suppressed by :meth:`_set_text_and_caret`, which moves the caret AFTER
+        # this returns and then syncs ONCE at the final position. Without the
+        # guard this sync runs with the caret still at the origin: for a
+        # completion that leaves an argument (``/team security ``) it sees no
+        # active command there, NULLS ``_argument_command``, and the later
+        # caret-anchored sync then re-posts ``ArgumentQueryOpened`` — whose app
+        # handler calls ``set_notice("")`` and erases the U1/U2 parked-caret hint
+        # the editor set for /team·/agent (design review round 3, D5). One sync at
+        # the right place is both correct and cheaper.
+        if not self._suspend_picker_sync:
+            self._sync_picker()
+
+    def _caret_offset(self) -> int:
+        """The caret as a whole-buffer offset, for the slash parsers.
+
+        Inline detection keys on WHERE the caret is: which slash token the user
+        is editing depends on it, so every parse the picker runs is anchored
+        here rather than at the end of the buffer. Reuses the same
+        ``_offset_at`` the attachment chips measure with, so a CRLF buffer a
+        paste carried in is counted the same way in both places.
+        """
+        row, column = self.selection.end
+        return self._offset_at(row, column)
+
+    def _set_text_and_caret(self, text: str, caret_offset: int) -> None:
+        """Replace the buffer and park the caret, then re-derive the pickers.
+
+        The ``text`` setter re-syncs the picker BEFORE the caret has moved (it
+        runs inside ``load_text``, and ``move_cursor`` comes after), so with
+        caret-anchored detection that sync reads the OLD caret position — for a
+        completion, the origin, which names the wrong token or none. Every
+        completion therefore has to re-sync once the caret is where the
+        completion put it; funnelling that through one helper is what keeps the
+        rule from being forgotten at one of the several completion sites.
+
+        The setter's own sync is SUPPRESSED (not merely repeated): a stray
+        origin-anchored sync does not just waste work, it nulls
+        ``_argument_command`` and makes the final sync look like a fresh argument
+        opening, which re-fires ``ArgumentQueryOpened`` and wipes an editor-set
+        notice (D5). So exactly one sync runs, at the final caret.
+        """
+        self._suspend_picker_sync = True
+        try:
+            self.text = text
+            self.move_cursor(self._location_at_offset(caret_offset))
+        finally:
+            self._suspend_picker_sync = False
         self._sync_picker()
+
+    def _location_at_offset(self, offset: int) -> tuple[int, int]:
+        """A whole-buffer ``offset`` as a ``(row, column)`` document location.
+
+        The inverse of :meth:`_offset_at`, so a completion that computed WHERE to
+        put the caret as an offset (the splice point of an inline command) can
+        hand it back to ``move_cursor``. Walks lines counting the document's own
+        separator, matching ``_offset_at`` exactly, so the two agree on a CRLF
+        buffer a paste carried in. Clamped so a stale offset lands at the buffer
+        end rather than raising.
+        """
+        separator = len(self.document.newline)
+        remaining = max(0, offset)
+        for row in range(self.document.line_count):
+            length = len(self.document.get_line(row))
+            if remaining <= length:
+                return row, remaining
+            remaining -= length + separator
+        return self._end_of_buffer()
+
+    def _splice_command(self, token_start: int, token_end: int) -> None:
+        """Remove the ``[token_start, token_end)`` command token from the draft.
+
+        The heart of "a command run mid-text is removed from the text where it
+        was entered": the user typed a message and then a ``/command`` to route
+        it, so once the command runs the token has done its job and must not be
+        left sitting in the prose that is about to be sent. One adjoining
+        whitespace character is removed with it — the space or newline the user
+        typed to set the command apart from the message — so ``fix this /team``
+        becomes ``fix this`` rather than ``fix this ``, ``/team fix this``
+        becomes ``fix this`` rather than `` fix this``, and a command on its OWN
+        line above a draft collapses that line away instead of leaving a blank
+        one. The PRECEDING separator is preferred (that is the one the inline
+        gesture adds — a space before an appended command, a newline above a
+        message); the following one is taken only when the token opened the
+        buffer.
+        """
+        text = self.text
+        start, end = token_start, token_end
+        if start > 0 and text[start - 1] in " \t\n":
+            start -= 1
+        elif end < len(text) and text[end] in " \t\n":
+            end += 1
+        self.text = f"{text[:start]}{text[end:]}"
+        self.move_cursor(self._location_at_offset(start))
 
     def _sync_picker(self) -> None:
         """Re-derive EVERY list from the buffer.
@@ -2480,8 +2630,15 @@ class Editor(TextArea):
         have to cooperate on. The command picker serves both the word and a
         provider argument, so the branch below is which LIST it derives, not which
         widget is visible.
+
+        Every parse is anchored at the CARET (:meth:`_caret_offset`): inline
+        detection means "which slash token is active" is a question about where
+        the caret sits, not just what the buffer contains.
         """
-        list_argument = slash_argument(self.text, self._argument_commands)
+        cursor = self._caret_offset()
+        list_argument = slash_argument(
+            self.text, self._argument_commands, cursor, self._command_names
+        )
         if list_argument is None:
             self._argument_command = None
             self._argument_subcommand = None
@@ -2489,7 +2646,7 @@ class Editor(TextArea):
             # a highlight can never outlive the list that filled it (e.g. the
             # command word was deleted back to `/tea`).
             self._name_choices = frozenset()
-            self._picker.sync(self.text)
+            self._picker.sync(self.text, cursor)
         else:
             command = self._command_word()
             if command != self._argument_command:
@@ -2546,7 +2703,7 @@ class Editor(TextArea):
             # always sets the notice to "", so the hint owns the channel cleanly.
             if self._is_name_argument_command(self._argument_command):
                 self._picker.set_notice(self._name_switch_hint(list_argument) or "")
-        argument = slash_argument(self.text, self.MODEL_COMMANDS)
+        argument = slash_argument(self.text, self.MODEL_COMMANDS, cursor, self._command_names)
         if argument is None:
             if self._model_picker.is_open():
                 self._model_picker.close()
@@ -2571,34 +2728,69 @@ class Editor(TextArea):
         self.post_message(ArgumentHighlightChanged(command or "", name if command else None))
 
     def _command_word(self) -> str | None:
-        """The lower-cased command word on the buffer's first non-blank line."""
-        line = next((line for line in self.text.split("\n") if line.strip()), "")
-        stripped = line.lstrip()
-        if not stripped.startswith("/"):
-            return None
-        return stripped[1:].partition(" ")[0].lower()
+        """The lower-cased command word of the slash token AT THE CARET.
+
+        Caret-anchored to match every other parse: with inline detection the
+        active command is wherever the caret is, so reading the first non-blank
+        line would name the wrong token for ``fix this /model`` or a command
+        dropped on a later line. Both the word phase and the argument phase
+        resolve through :func:`slash_argument`'s companion by sharing the same
+        line/slash split.
+        """
+        return slash_word(self.text, self._caret_offset(), self._command_names)
 
     def _complete_model(self, row: ModelRow) -> None:
-        """Put ``row``'s selector in the buffer without acting on it.
+        """Put ``row``'s selector in the ``/model`` argument without acting on it.
 
         No trailing space, unlike a command completion: the selector IS the whole
         argument, and a trailing space would terminate it and close the list — so
         Tab would appear to both fill the field and give up on it.
+
+        Splices only the argument span so an inline ``/model`` keeps any trailing
+        message; falls back to rewriting the whole buffer when the parse cannot
+        locate the argument (the caret raced a delete), which is the pre-inline
+        behaviour and still correct for the common start-of-buffer case.
         """
-        self.text = f"/model {row.selector}"
-        self.move_cursor(self._end_of_buffer())
+        context = slash_argument_context(
+            self.text, self.MODEL_COMMANDS, self._caret_offset(), self._command_names
+        )
+        if context is None:
+            self.text = f"/model {row.selector}"
+            self.move_cursor(self._end_of_buffer())
+            return
+        text = self.text
+        self._set_text_and_caret(
+            f"{text[: context.start]}{row.selector}{text[context.end :]}",
+            context.start + len(row.selector),
+        )
 
     def _apply_model(self, row: ModelRow) -> None:
-        """Hand a chosen row to the app and clear the buffer.
+        """Hand a chosen row to the app and clear (or splice) the buffer.
 
-        The buffer is cleared HERE rather than by the handler because the command
+        The buffer is emptied HERE rather than by the handler because the command
         never reaches the submit path: choosing from the list is the whole
         interaction, so leaving `/model anthropic/claude-opus-5` behind would
         invite a second Enter that ran the switch again.
+
+        Inline, only the ``/model <selector>`` token is spliced out and the rest
+        of the draft is kept — the same rule every other inline command follows,
+        so choosing a model to switch to mid-draft does not throw the message
+        away. Whole-buffer (the ordinary case) still clears completely.
         """
         self._model_picker.close()
         handler = self._on_model_chosen
-        self.clear_content()
+        context = slash_argument_context(
+            self.text, self.MODEL_COMMANDS, self._caret_offset(), self._command_names
+        )
+        surviving = (
+            (self.text[: context.token_start] + self.text[context.end :]).strip()
+            if context is not None
+            else ""
+        )
+        if context is not None and surviving:
+            self._splice_command(context.token_start, context.end)
+        else:
+            self.clear_content()
         if handler is not None:
             handler(row)
 
@@ -2658,9 +2850,10 @@ class Editor(TextArea):
         case each protects (`/lo` reaching `loop`, `/logout an` reaching a stored
         credential) cannot drift apart.
         """
+        cursor = self._caret_offset()
         if self._picker.mode is PickerMode.ARGUMENT:
-            return slash_argument(self.text, self._argument_commands)
-        context = slash_context(self.text)
+            return slash_argument(self.text, self._argument_commands, cursor, self._command_names)
+        context = slash_context(self.text, cursor, self._command_names)
         return None if context is None else context.query
 
     def _apply_command(self, name: str) -> None:
@@ -2698,13 +2891,19 @@ class Editor(TextArea):
                 return
             self._run_argument(name)
             return
-        context = slash_context(self.text)
+        context = slash_context(self.text, self._caret_offset(), self._command_names)
         if context is None:
             return
-        # Everything from the slash onward IS the command word (that is what
-        # makes it a command word), so the prefix is all that must survive.
-        self.text = f"{self.text[: context.start]}/{name} "
-        self.move_cursor(self._end_of_buffer())
+        # Replace ONLY the command token ``[start, end)`` with ``/name ``. The
+        # word used to run to the end of the buffer, so a completion could splice
+        # to the end; inline detection means a message may follow the token
+        # (``fix this /te|`` or ``/te| ship it``), and that suffix is the user's
+        # prose — it must survive verbatim. The trailing space is load-bearing:
+        # it terminates the word (closing the command list) and, for a
+        # list-taking command, opens the argument list.
+        text = self.text
+        completed = f"{text[: context.start]}/{name} {text[context.end :]}"
+        self._set_text_and_caret(completed, context.start + len(name) + 2)
 
     def _resolve_argument(self, name: str, key: str, unambiguous: bool) -> None:
         """Tab/Enter on an argument row: complete it, or run it.
@@ -2735,24 +2934,140 @@ class Editor(TextArea):
         space terminates the argument, so the matcher would stop matching and Tab
         would appear to fill the field and abandon it in one keystroke.
         """
-        argument = slash_argument(self.text, self._argument_commands)
-        if argument is None:
+        context = slash_argument_context(
+            self.text, self._argument_commands, self._caret_offset(), self._command_names
+        )
+        if context is None:
             return
-        # The argument is by construction the TAIL of the buffer (everything after
-        # the command word's space, on the only non-blank line), so trimming its
-        # length off the end leaves exactly `…/logout ` to append onto.
-        self.text = f"{self.text[: len(self.text) - len(argument)]}{name}"
-        self.move_cursor(self._end_of_buffer())
+        # Replace the argument SPAN ``[start, end)`` rather than the buffer tail:
+        # inline detection means the command may not be the last thing in the
+        # draft, so trimming the argument's length off the end would corrupt a
+        # trailing message. ``end`` is the end of the command's line, which is
+        # the whole argument by construction.
+        text = self.text
+        self._set_text_and_caret(
+            f"{text[: context.start]}{name}{text[context.end :]}", context.start + len(name)
+        )
 
     def _run_argument(self, name: str) -> None:
-        """Complete ``name`` and submit, so the command's own handler runs it.
+        """Complete ``name`` and run, so the command's own handler runs it.
 
-        Submitting the finished text rather than calling a callback keeps ONE
+        Dispatching the finished text rather than calling a callback keeps ONE
         implementation of what `/login anthropic` means: the app's slash dispatch.
         A second path would be a second place for the login flow to drift.
         """
         self._complete_argument(name)
-        self._submit()
+        self._run_command_from_buffer()
+
+    def _run_command_from_buffer(self) -> None:
+        """Run the slash command the caret is on — inline-splice or whole-buffer.
+
+        The ONE run path both the word phase and the argument phase funnel into,
+        so "how a command runs" is decided in one place regardless of which list
+        chose it. Two shapes, told apart by whether ANY of the draft survives
+        once the command token is removed:
+
+        * whole-buffer — the command is all the user typed (``/usage``,
+          ``/logout anthropic``). Goes through :meth:`_submit`, which clears the
+          buffer and records history, exactly as a start-of-line command always
+          has. The app dispatches the slash-shaped ``EditorSubmitted.text``.
+
+        * inline — the user typed a message and then a command to route it
+          (``fix this /team ops``). The token is spliced OUT (see
+          :meth:`_splice_command`), the surviving message is LEFT in the
+          composer, and the command is dispatched through
+          :class:`InlineCommandRequested`. No clear, no history entry: the draft
+          is still unsent, and the command was not a prompt to page back to.
+
+        The command's argument, by the inline contract, is everything from the
+        word to the END OF ITS LINE (see :func:`slash_argument_context`), so a
+        message kept apart from the command sits before the slash or on another
+        line.
+        """
+        span = slash_token_span(self.text, self._caret_offset(), self._command_names)
+        if span is None:
+            # No command token at the caret — nothing to extract. Fall back to a
+            # plain submit so a stray call still does the least surprising thing.
+            self._submit()
+            return
+        token_start, token_end = span
+        command_text = self.text[token_start:token_end].strip()
+        remainder = self.text[:token_start] + self.text[token_end:]
+        if not remainder.strip():
+            # Whole-buffer command: the command IS the draft. Ordinary submit.
+            self._submit()
+            return
+        # Inline. A PROMPT command (goal/loop/team/agent/btw) reassembles to the
+        # front with the draft as its argument and STAGES — never auto-runs —
+        # because its argument is free text the user is still writing, and
+        # treating the trailing draft as a name/request would silently consume it
+        # (the D1 data-loss). A non-prompt command (a selector or a listing, like
+        # `/usage`) splices out and runs, keeping the surrounding draft.
+        word, _, typed_argument = command_text[1:].partition(" ")
+        word = word.lower()
+        if word in self._prompt_commands:
+            # A prompt command with an ARGUMENT LIST (``/team``/``/agent``) and no
+            # name chosen yet does not reassemble on the word alone — the name is
+            # picked from the autofill first. `_apply_command` already completed
+            # the word to ``/team `` and opened that list; leaving it open is the
+            # whole interaction. Reassembly happens when the NAME row is chosen
+            # (see :meth:`_resolve_argument`). A prompt command with no list
+            # (``/goal``/``/loop``/``/btw``) reassembles now: the draft is its
+            # argument directly.
+            if word in self._argument_commands and not typed_argument.strip():
+                return
+            self._reassemble_prompt_command(token_start, token_end)
+            return
+        self._picker.close()
+        self._splice_command(token_start, token_end)
+        self.post_message(InlineCommandRequested(command_text))
+
+    def _reassemble_prompt_command(self, token_start: int, token_end: int) -> None:
+        """Move an inline PROMPT command to the front, draft as its argument.
+
+        The safe resolution of "a message typed, then a command to route it" for
+        commands whose argument is FREE TEXT (``/goal``, ``/loop``, ``/team``,
+        ``/agent``, ``/btw``). Rather than guess which trailing words are a name
+        and which are the message — the guess that silently ate a user's request
+        when ``/team`` treated ``and then ship it`` as a team name (D1) — the
+        composer is rewritten to ``/<command> <the rest of the draft>`` and left
+        STAGED: nothing is submitted, the caret lands at the end, and the command
+        word paints as recognised (the resync below). The user reads the
+        assembled line and presses Enter when it is right.
+
+        These commands are "start of the composer" commands by nature; this is
+        the affordance that lets them be reached by typing anywhere and then
+        assembled, without losing a keystroke of the draft.
+        """
+        text = self.text
+        # ``command`` is the whole token — ``/goal`` when no argument was typed,
+        # or ``/team ops`` when the user hand-typed one before engaging. In the
+        # intended flow (word engaged, name picked from the autofill) there is no
+        # typed argument, so ``command`` is just ``/<word>`` and the draft becomes
+        # its argument cleanly. If a user DID hand-type an argument and then
+        # engage inline, the draft is appended AFTER it (``/team ops`` + ``review
+        # this`` -> ``/team ops review this``): the two read in the opposite order
+        # to how they were typed, but the result still parses (name ``ops``,
+        # request ``review this``) and is STAGED not run, so the user sees and can
+        # fix it before sending — deliberately preferred over guessing which
+        # typed words to reorder (review round 2, minor-1).
+        command = text[token_start:token_end].strip()
+        # The rest of the draft, with the command token and one adjoining
+        # separator removed, is what becomes the command's argument. Reuse the
+        # same separator rule the splice uses so ``msg /goal`` and ``/goal\nmsg``
+        # both collapse to just ``msg``.
+        start, end = token_start, token_end
+        if start > 0 and text[start - 1] in " \t\n":
+            start -= 1
+        elif end < len(text) and text[end] in " \t\n":
+            end += 1
+        rest = (text[:start] + text[end:]).strip()
+        assembled = f"{command} {rest}" if rest else f"{command} "
+        # Staged, not submitted: the user reviews the assembled prompt and sends
+        # it themselves. ``_set_text_and_caret`` re-derives the pickers so the
+        # command word at the front is recognised and, for a list-taking command
+        # with no argument yet, its argument list opens.
+        self._set_text_and_caret(assembled, len(assembled))
 
     def _complete_name_argument(self, name: str) -> None:
         """Fill a team/agent NAME and a trailing space, WITHOUT submitting.
@@ -2769,17 +3084,42 @@ class Editor(TextArea):
         for a NAME+message command "the name is chosen" is not "run it", it is
         "ready for the message" — see :attr:`NAME_ARGUMENT_COMMANDS`.
 
-        Setting ``self.text`` funnels through ``load_text`` → ``_sync_picker``,
-        which re-derives the picker as an argument list with no matches, so the
-        list closes on the same keystroke that completed the name.
+        Setting the buffer funnels through ``_set_text_and_caret`` →
+        ``_sync_picker``, which re-derives the picker as an argument list with no
+        matches, so the list closes on the same keystroke that completed the name.
+
+        INLINE (a draft typed before the command) reassembles instead: the whole
+        ``/<cmd> <name>`` construct moves to the FRONT with the surviving draft as
+        its message, so ``review this /team`` + picking ``frontend-guild`` becomes
+        ``/team frontend-guild review this`` staged — the same safe reassembly
+        every prompt command uses, never consuming the draft as a name.
         """
-        argument = slash_argument(self.text, self._argument_commands)
-        if argument is None:
+        context = slash_argument_context(
+            self.text, self._argument_commands, self._caret_offset(), self._command_names
+        )
+        if context is None:
             return
-        # The argument is by construction the tail of the buffer, so trimming its
-        # length off the end leaves exactly `…/team ` to append the name+space.
-        self.text = f"{self.text[: len(self.text) - len(argument)]}{name} "
-        self.move_cursor(self._end_of_buffer())
+        # Fill the name+space into the argument SPAN (not the buffer tail), so a
+        # trailing inline message would survive. ``context.end`` is the end of the
+        # command's line, the whole argument by construction.
+        text = self.text
+        filled = f"{text[: context.start]}{name} {text[context.end :]}"
+        caret = context.start + len(name) + 1
+        # If a draft survives outside the command token, this is an INLINE engage:
+        # reassemble to the front rather than leaving the command mid-draft. The
+        # name is already filled, so the token now reads ``/team <name>``; the
+        # reassembly moves it to the front with the rest of the draft appended.
+        outside = (text[: context.token_start] + text[context.end :]).strip()
+        if outside:
+            # Recompute the token span on the FILLED text (the name changed its
+            # length) and reassemble from there.
+            self.text = filled
+            self.move_cursor(self._location_at_offset(caret))
+            span = slash_token_span(self.text, caret, self._command_names)
+            if span is not None:
+                self._reassemble_prompt_command(*span)
+            return
+        self._set_text_and_caret(filled, caret)
 
     def _extend_to_common_prefix(self) -> None:
         """Grow the typed word to the matches' longest common prefix, no further.
@@ -2790,7 +3130,7 @@ class Editor(TextArea):
         already the common prefix — the honest outcome, since there is no
         keystroke-free way to tell the candidates apart at that point.
         """
-        context = slash_context(self.text)
+        context = slash_context(self.text, self._caret_offset(), self._command_names)
         if context is None:
             return
         names = [name for name, _ in self._picker.suggestions()]
@@ -2807,9 +3147,14 @@ class Editor(TextArea):
                 return
         if len(shared) <= len(context.query):
             return
-        self.text = f"{self.text[: context.start]}/{shared}"
-        self.move_cursor(self._end_of_buffer())
-        self._sync_picker()
+        # Grow only the word SPAN ``[start, end)``; a trailing inline message
+        # survives untouched, and the caret lands at the new end of the word so
+        # the user keeps narrowing where they were typing.
+        text = self.text
+        self._set_text_and_caret(
+            f"{text[: context.start]}/{shared}{text[context.end :]}",
+            context.start + len(shared) + 1,
+        )
 
     # -- history ------------------------------------------------------------
     def _caret_row(self) -> int:

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -56,6 +56,21 @@ from local_operator.tui.widgets.welcome import WelcomeView
 from tests.unit.tui.conftest import caret_cells, chevron_colour, composer_cells
 
 
+def _set_editor_line(editor, text: str) -> None:
+    """Set the buffer AND park the caret at the end, as typing it would.
+
+    ``editor.text = x`` leaves the caret at ``(0, 0)``; a user who typed ``x``
+    has it at the end, and the slash pickers are caret-anchored (inline
+    detection: which slash token is live depends on where the caret is). A test
+    that sets the text without moving the caret asserts about a state the UI
+    never produces — the caret sitting before the slash, where no command is
+    being edited. This is the faithful shortcut for "the user typed this line".
+    """
+    editor.text = text
+    editor.move_cursor(editor._end_of_buffer())
+    editor._sync_picker()
+
+
 class _FakeJobs:
     """The slice of ``AsyncJobManager`` the app reads: ``list()`` of rows.
 
@@ -1438,7 +1453,7 @@ async def test_login_list_reports_all_three_credential_states() -> None:
         await pilot.pause()
         app.query_one(Editor).focus()
         await pilot.pause()
-        app.query_one(Editor).text = "/login "
+        _set_editor_line(app.query_one(Editor), "/login ")
         await pilot.pause()
         assert _provider_rows(app) == [
             ("openrouter", "logged in"),
@@ -1455,7 +1470,7 @@ async def test_a_search_alias_reaches_the_provider_it_names() -> None:
         await pilot.pause()
         app.query_one(Editor).focus()
         await pilot.pause()
-        app.query_one(Editor).text = "/login grok"
+        _set_editor_line(app.query_one(Editor), "/login grok")
         await pilot.pause()
         assert [name for name, _ in _provider_rows(app)] == ["xai-oauth"]
 
@@ -1474,7 +1489,7 @@ async def test_logout_rows_name_the_credential_they_will_remove() -> None:
         await pilot.pause()
         app.query_one(Editor).focus()
         await pilot.pause()
-        app.query_one(Editor).text = "/logout "
+        _set_editor_line(app.query_one(Editor), "/logout ")
         await pilot.pause()
         assert _provider_rows(app) == [("openrouter", "remove api key")]
 
@@ -1501,7 +1516,7 @@ async def test_logout_with_nothing_stored_says_so_where_the_list_would_have_been
         await pilot.pause()
         app.query_one(Editor).focus()
         await pilot.pause()
-        app.query_one(Editor).text = "/logout "
+        _set_editor_line(app.query_one(Editor), "/logout ")
         await pilot.pause()
         picker = app.query_one(Editor).picker
         assert not picker.is_open(), "a sentence is not a suggestion"
@@ -1540,9 +1555,9 @@ async def test_re_entering_an_empty_argument_state_leaves_the_transcript_alone()
         await pilot.pause()
         transcript = app.query_one(TranscriptView)
         for _ in range(10):
-            editor.text = "/logout"
+            _set_editor_line(editor, "/logout")
             await pilot.pause()
-            editor.text = "/logout "
+            _set_editor_line(editor, "/logout ")
             await pilot.pause()
             await pilot.pause()
             assert transcript.blocks() == []
@@ -1567,7 +1582,7 @@ async def test_an_unreadable_credential_store_says_that_instead() -> None:
         await pilot.pause()
         app.query_one(Editor).focus()
         await pilot.pause()
-        app.query_one(Editor).text = "/logout "
+        _set_editor_line(app.query_one(Editor), "/logout ")
         await pilot.pause()
         rendered = app.query_one(Editor).picker.render_text(80).plain
         assert "unreadable" in rendered
@@ -1589,7 +1604,7 @@ async def test_choosing_a_row_runs_the_existing_logout_path() -> None:
         await pilot.pause()
         app.query_one(Editor).focus()
         await pilot.pause()
-        app.query_one(Editor).text = "/logout "
+        _set_editor_line(app.query_one(Editor), "/logout ")
         await pilot.pause()
         assert len(app.query_one(Editor).picker.suggestions()) == 1, "premise: one match"
         await pilot.press("enter")
@@ -1610,7 +1625,7 @@ async def test_choosing_a_row_runs_the_existing_login_path() -> None:
         await pilot.pause()
         app.query_one(Editor).focus()
         await pilot.pause()
-        app.query_one(Editor).text = "/login deepseek"
+        _set_editor_line(app.query_one(Editor), "/login deepseek")
         await pilot.pause()
         await pilot.press("enter")
         await pilot.pause()
@@ -1634,7 +1649,7 @@ async def test_login_still_lists_every_provider_when_the_store_cannot_be_read() 
         await pilot.pause()
         app.query_one(Editor).focus()
         await pilot.pause()
-        app.query_one(Editor).text = "/login "
+        _set_editor_line(app.query_one(Editor), "/login ")
         await pilot.pause()
         assert app.is_running, "a locked credential store must not take the app down"
         assert _provider_rows(app) == [
@@ -1654,7 +1669,7 @@ async def test_logout_says_the_store_is_unreadable_rather_than_claiming_it_is_em
         await pilot.pause()
         app.query_one(Editor).focus()
         await pilot.pause()
-        app.query_one(Editor).text = "/logout "
+        _set_editor_line(app.query_one(Editor), "/logout ")
         await pilot.pause()
         assert app.is_running
         assert _provider_rows(app) == []
@@ -1677,11 +1692,11 @@ async def test_logout_offers_one_row_per_credential_not_per_provider() -> None:
         await pilot.pause()
         app.query_one(Editor).focus()
         await pilot.pause()
-        app.query_one(Editor).text = "/logout "
+        _set_editor_line(app.query_one(Editor), "/logout ")
         await pilot.pause()
         assert _provider_rows(app) == [("openai", "remove oauth")]
 
-        app.query_one(Editor).text = "/login "
+        _set_editor_line(app.query_one(Editor), "/login ")
         await pilot.pause()
         assert [name for name, _ in _provider_rows(app)] == ["openai", "openai-device"]
 
@@ -1702,7 +1717,7 @@ async def test_a_provider_row_describes_what_its_id_does_not_already_say() -> No
         await pilot.pause()
         app.query_one(Editor).focus()
         await pilot.pause()
-        app.query_one(Editor).text = "/login "
+        _set_editor_line(app.query_one(Editor), "/login ")
         await pilot.pause()
         described = {
             name: choice.description for name, choice in app.query_one(Editor).picker.suggestions()
@@ -1736,7 +1751,7 @@ async def test_a_provider_query_the_user_typed_over_is_not_answered() -> None:
         app.query_one(Editor).focus()
         await pilot.pause()
         editor = app.query_one(Editor)
-        editor.text = "/logout "
+        _set_editor_line(editor, "/logout ")
         editor.text = "how do I write a parser?"
         await pilot.pause()
         await pilot.pause()
@@ -1841,7 +1856,7 @@ def test_completion_matches_alias() -> None:
     """TUI-014: the collapsed exit/quit command still completes via alias —
     the alias wins the ranking slot, so the inserted word is the alias."""
     editor = Editor(commands=[SlashCommand("exit", "Quit", aliases=("quit",))])
-    editor.text = "/q"
+    _set_editor_line(editor, "/q")
     assert editor.picker.highlighted_name() == "quit"
     editor.picker.choose(0)  # the mouse path: select row 0 and complete
     assert editor.text == "/quit "
@@ -2513,7 +2528,7 @@ async def test_provider_and_the_login_list_report_credentials_in_the_same_words(
         await pilot.pause()
         app.query_one(Editor).focus()
         await pilot.pause()
-        app.query_one(Editor).text = "/provider"
+        _set_editor_line(app.query_one(Editor), "/provider")
         await pilot.press("enter")
         await pilot.pause()
         await pilot.pause()
@@ -2522,7 +2537,7 @@ async def test_provider_and_the_login_list_report_credentials_in_the_same_words(
             for line in _transcript_text(app).split("\n")
             if "deepseek" in line or "xai-oauth" in line
         ]
-        app.query_one(Editor).text = "/login "
+        _set_editor_line(app.query_one(Editor), "/login ")
         await pilot.pause()
         states = dict(_provider_rows(app))
 
@@ -3244,13 +3259,13 @@ async def test_mcp_argument_list_offers_subcommands_then_servers() -> None:
             "local_operator.mcp.config.load_all_mcp_configs",
             return_value=(configs, {}),
         ):
-            editor.load_text("/mcp ")
+            _set_editor_line(editor, "/mcp ")
             for _ in range(6):
                 await pilot.pause()
             verb_rows = [name for name, _ in editor.picker.suggestions()]
             assert verb_rows == ["login", "logout", "reauth"], verb_rows
 
-            editor.load_text("/mcp login ")
+            _set_editor_line(editor, "/mcp login ")
             for _ in range(6):
                 await pilot.pause()
             server_rows = [name for name, _ in editor.picker.suggestions()]
@@ -3259,7 +3274,7 @@ async def test_mcp_argument_list_offers_subcommands_then_servers() -> None:
             # Narrowing still matches against the WHOLE argument: `login lin`
             # must keep offering the compound row, or the row the user is
             # looking at would vanish the moment they filtered to it.
-            editor.load_text("/mcp login lin")
+            _set_editor_line(editor, "/mcp login lin")
             for _ in range(6):
                 await pilot.pause()
             assert [name for name, _ in editor.picker.suggestions()] == ["login linear"]
@@ -3298,7 +3313,7 @@ async def test_mcp_logout_list_offers_only_servers_holding_a_credential() -> Non
                 return_value={"https://mcp.linear.app/mcp"},
             ),
         ):
-            editor.load_text("/mcp logout ")
+            _set_editor_line(editor, "/mcp logout ")
             for _ in range(6):
                 await pilot.pause()
             assert [name for name, _ in editor.picker.suggestions()] == ["logout linear"]
@@ -3763,7 +3778,7 @@ async def test_a_hidden_model_is_still_reachable_by_typing_its_selector() -> Non
         await pilot.pause()
         editor = app.query_one(Editor)
         editor.focus()
-        editor.text = "/model anthropic/claude-opus-5"
+        _set_editor_line(editor, "/model anthropic/claude-opus-5")
         await pilot.pause()
         assert editor.model_picker.suggestions() == [], "premise: the row is hidden"
         await pilot.press("enter")
@@ -3835,7 +3850,7 @@ async def test_chatgpt_oauth_offers_the_live_gpt_5_family() -> None:
         await pilot.pause()
         picker = await _open_model_picker(app, pilot)
         editor = app.query_one(Editor)
-        editor.text = "/model gpt-5.6"
+        _set_editor_line(editor, "/model gpt-5.6")
         await pilot.pause()
         offered = {row.model_id for row in picker.suggestions()}
         chrome = picker.render_text(90).plain
@@ -4414,7 +4429,7 @@ async def test_an_entered_rejected_model_command_keeps_the_boot_composition() ->
     async with app.run_test(size=(100, 30)) as pilot:
         await pilot.pause()
         editor = app.query_one(Editor)
-        editor.text = "/model missing-slash"
+        _set_editor_line(editor, "/model missing-slash")
         await pilot.press("enter")
         await pilot.pause()
         await pilot.pause()

--- a/tests/unit/tui/test_approvals_ux.py
+++ b/tests/unit/tui/test_approvals_ux.py
@@ -70,8 +70,16 @@ async def _type(pilot, app: OperatorApp, text: str) -> None:
     mutation through ``edit()``/``load_text()`` into the same ``_sync_picker``,
     so the list state is identical and the test does not spend a second on
     keystrokes. The tests that are ABOUT keystrokes press real keys.
+
+    The caret is parked at the end and the pickers re-derived, because the
+    ``text`` setter syncs with the caret still at the origin and the slash
+    detection is caret-anchored (inline detection) — a text-set that left the
+    caret before the slash would sit in no command at all.
     """
-    app.query_one(Editor).text = text
+    editor = app.query_one(Editor)
+    editor.text = text
+    editor.move_cursor(editor._end_of_buffer())
+    editor._sync_picker()
     await pilot.pause()
     await pilot.pause()
 

--- a/tests/unit/tui/test_command_picker.py
+++ b/tests/unit/tui/test_command_picker.py
@@ -34,6 +34,7 @@ from local_operator.tui.widgets.editor import (
     ArgumentQueryOpened,
     Editor,
     EditorSubmitted,
+    InlineCommandRequested,
 )
 from tests.unit.tui.conftest import TCSS_PATH
 
@@ -103,6 +104,27 @@ class PickerHarnessApp(App[None]):
         super().__init__()
         self.submissions: list[str] = []
         self.provider_queries: list[str] = []
+        #: Inline slash commands the editor spliced out of a draft (the
+        #: ``InlineCommandRequested`` path), captured to prove a mid-text run
+        #: dispatches without submitting the surviving draft.
+        self.inline_commands: list[str] = []
+
+    def set_editor_text(self, text: str) -> None:
+        """Set the buffer AND park the caret at the end, as typing would.
+
+        ``editor.text = x`` leaves the caret at ``(0, 0)``; a user who typed
+        ``x`` has it at the end. Slash detection is caret-anchored — which slash
+        token is active depends on where the caret is — so a test that sets the
+        text without moving the caret is asserting about a state the UI never
+        produces. This is the faithful shortcut for "the user typed this".
+        """
+        self.editor.text = text
+        self.editor.move_cursor(self.editor._end_of_buffer())
+        # The ``text`` setter re-syncs the picker with the caret still at the
+        # origin (Textual moves it after load), so the sync above saw no active
+        # token. Re-sync now that the caret sits where a typist left it — this
+        # is the resync a real keystroke does on every press.
+        self.editor._sync_picker()
 
     def get_css_variables(self) -> dict[str, str]:
         variables = super().get_css_variables()
@@ -120,6 +142,9 @@ class PickerHarnessApp(App[None]):
 
     def on_editor_submitted(self, message: EditorSubmitted) -> None:
         self.submissions.append(message.text)
+
+    def on_inline_command_requested(self, message: InlineCommandRequested) -> None:
+        self.inline_commands.append(message.command_text)
 
     def on_argument_query_opened(self, message: ArgumentQueryOpened) -> None:
         # Stands in for the app's controller-backed answer. The harness keeps the
@@ -147,19 +172,25 @@ class PickerHarnessApp(App[None]):
     "text, expected",
     [
         # Bare slash opens the full menu.
-        ("/", (0, "")),
+        ("/", (0, "", 1)),
         # A word being typed.
-        ("/mo", (0, "mo")),
+        ("/mo", (0, "mo", 3)),
         # Leading whitespace is fine: the first NON-BLANK line counts, and
         # the completion must not discard that whitespace (start=2).
-        ("  /mo", (2, "mo")),
-        ("\n\n  /x", (4, "x")),
+        ("  /mo", (2, "mo", 5)),
+        ("\n\n  /x", (4, "x", 6)),
+        # INLINE: a command typed after a message, at a word boundary, opens the
+        # list too — the whole point of the feature. ``start`` indexes the slash,
+        # ``end`` the cell past the word, so a completion rebuilds only that span.
+        ("fix this /mo", (9, "mo", 12)),
+        # INLINE on a later line — a command dropped under a multi-line draft.
+        ("line one\n/te", (9, "te", 12)),
     ],
 )
-def test_trigger_cases(text: str, expected: tuple[int, str]) -> None:
+def test_trigger_cases(text: str, expected: tuple[int, str, int]) -> None:
     context = slash_context(text)
     assert context is not None
-    assert (context.start, context.query) == expected
+    assert (context.start, context.query, context.end) == expected
 
 
 @pytest.mark.parametrize(
@@ -167,15 +198,77 @@ def test_trigger_cases(text: str, expected: tuple[int, str]) -> None:
     [
         "",  # nothing typed
         "hello",  # not a slash
-        "hello /mo",  # text before the slash on the first non-blank line
         "/model ",  # whitespace terminates the command word
         "/model gpt",  # an argument means the command is already chosen
-        "/mo\nrest",  # a newline terminates the word exactly like a space
+        "/mo\nrest",  # the caret defaults to the buffer end, on the second line
         "/mo\n",
+        "src/foo",  # a glued slash is punctuation inside a word, not a command
+        "and/or",
     ],
 )
 def test_non_trigger_cases(text: str) -> None:
     assert slash_context(text) is None
+
+
+@pytest.mark.parametrize(
+    "text, cursor, expected",
+    [
+        # Caret still on the first line's command word: the picker shows for the
+        # command even though a message follows on the next line.
+        ("/te\nfix this", 3, (0, "te", 3)),
+        # Caret between two inline slash tokens picks the one it is editing.
+        ("a /foo /ba", 10, (7, "ba", 10)),
+        ("a /foo /ba", 6, (2, "foo", 6)),
+    ],
+)
+def test_caret_anchored_trigger_cases(
+    text: str, cursor: int, expected: tuple[int, str, int]
+) -> None:
+    context = slash_context(text, cursor)
+    assert context is not None
+    assert (context.start, context.query, context.end) == expected
+
+
+@pytest.mark.parametrize(
+    "text, cursor",
+    [
+        # Caret out on the message line: the command word above is terminated.
+        ("/te\nfix this", 8),
+        # Caret before every slash on the line: nothing is being edited yet.
+        ("a /foo", 1),
+    ],
+)
+def test_caret_anchored_non_trigger_cases(text: str, cursor: int) -> None:
+    assert slash_context(text, cursor) is None
+
+
+def test_a_nested_slash_inside_an_engaged_command_is_plain_text() -> None:
+    """Once a recognised command owns the line (``/team a …``), a second slash
+    inside its argument is plain text — the command claims to the line end, so
+    the nested ``/team`` never becomes an active token to highlight or run."""
+    known = frozenset({"team", "teams", "goal"})
+    text = "/team alpha improve the /team command"
+    # Caret right after the nested "/team" (index 29).
+    assert slash_context(text, 29, known) is None
+    # Without the vocabulary the pure parser cannot know a command claimed the
+    # line, so the nested slash is the active token — which is exactly why the
+    # editor threads its command set in.
+    assert slash_context(text, 29) is not None
+    # The first command word is still recognised at its own position.
+    ctx = slash_context(text, 5, known)
+    assert ctx is not None and ctx.query == "team"
+
+
+def test_a_crlf_buffer_does_not_leak_a_carriage_return_into_the_word() -> None:
+    """A draft restored with CRLF line endings must still parse: the trailing
+    ``\\r`` on a non-final line is stripped so the word matches the command set
+    and an argument value never carries the control character (round 1, minor-1)."""
+    from local_operator.tui.widgets.command_picker import slash_argument, slash_word
+
+    # Caret at the end of "/team" on the first CRLF line (index 5).
+    assert slash_word("/team\r\nfix", 5, frozenset({"team"})) == "team"
+    # And the argument value on a CRLF line carries no trailing "\r".
+    assert slash_argument("/team ops\r\nmsg", ("team",), 9) == "ops"
 
 
 def test_bare_slash_suggests_the_full_registry_in_order() -> None:
@@ -378,14 +471,22 @@ async def test_completed_word_closes_the_picker() -> None:
 
 
 @pytest.mark.asyncio
-async def test_text_before_the_slash_keeps_it_hidden() -> None:
+async def test_text_before_the_slash_now_opens_it_inline() -> None:
+    """The reported gesture: text typed, then a command remembered mid-draft.
+
+    This USED to assert the picker stayed hidden — the old rule was "the slash
+    must be the first character of the first non-blank line". Inline detection is
+    exactly the reversal of that rule: a boundary slash anywhere in the draft
+    opens the list.
+    """
     app = PickerHarnessApp()
     async with app.run_test(size=(100, 30)) as pilot:
         app.editor.focus()
         await pilot.pause()
         await pilot.press("h", "i", "space", "slash", "m", "o")
         await pilot.pause()
-        assert not app.editor.picker.is_open()
+        assert app.editor.picker.is_open()
+        assert app.editor.text == "hi /mo"
 
 
 @pytest.mark.asyncio
@@ -400,6 +501,165 @@ async def test_escape_dismisses_without_touching_the_text() -> None:
         await pilot.pause()
         assert not app.editor.picker.is_open()
         assert app.editor.text == "/mo"  # the typed text survives
+
+
+@pytest.mark.asyncio
+async def test_inline_command_opens_the_picker_mid_draft() -> None:
+    """The reported gesture: a message typed, then a command remembered."""
+    app = PickerHarnessApp()
+    async with app.run_test(size=(100, 30)) as pilot:
+        app.editor.focus()
+        await pilot.pause()
+        for char in "fix this ":
+            await pilot.press("space" if char == " " else char)
+        await pilot.press("slash", "t", "e")
+        await pilot.pause()
+        assert app.editor.picker.is_open(), "an inline /te must open the list"
+        assert app.editor.text == "fix this /te"
+
+
+@pytest.mark.asyncio
+async def test_a_glued_slash_never_opens_the_picker() -> None:
+    """``src/foo`` is a path; its slash is not at a word boundary."""
+    app = PickerHarnessApp()
+    async with app.run_test(size=(100, 30)) as pilot:
+        app.editor.focus()
+        await pilot.pause()
+        for char in "src":
+            await pilot.press(char)
+        await pilot.press("slash", "f", "o", "o")
+        await pilot.pause()
+        assert not app.editor.picker.is_open()
+
+
+@pytest.mark.asyncio
+async def test_inline_command_runs_and_is_spliced_out_keeping_the_draft() -> None:
+    """The whole reported gesture end to end: type a message, append a command,
+    run it — the command leaves the buffer, the message stays, and the command is
+    dispatched through the inline path (not submitted as a prompt)."""
+    app = PickerHarnessApp()
+    async with app.run_test(size=(100, 30)) as pilot:
+        app.editor.focus()
+        await pilot.pause()
+        for char in "fix the bug ":
+            await pilot.press("space" if char == " " else char)
+        await pilot.press("slash", "u", "s", "a", "g", "e")
+        await pilot.pause()
+        assert app.editor.picker.highlighted_name() == "usage"
+        await pilot.press("enter")
+        await pilot.pause()
+        # The command ran through the inline path, not the submit path.
+        assert app.inline_commands == ["/usage"]
+        assert app.submissions == []
+        # The token is gone and the message survives, with the trailing space the
+        # inline gesture added removed too.
+        assert app.editor.text == "fix the bug"
+        assert app.editor.picker.is_open() is False
+
+
+@pytest.mark.asyncio
+async def test_inline_command_on_its_own_line_keeps_the_message_below() -> None:
+    """A command dropped on its OWN line above a multi-line draft runs and is
+    spliced out, leaving the message. This is the unambiguous way to route a
+    draft whose message should stay when the command comes first — the command's
+    argument runs to its line end, so nothing on the next line is absorbed."""
+    app = PickerHarnessApp()
+    async with app.run_test(size=(100, 30)) as pilot:
+        app.editor.focus()
+        await pilot.pause()
+        await pilot.press("slash", "u", "s", "a", "g", "e")
+        # A hard newline, then the message on the line below.
+        await pilot.press("shift+enter")
+        for char in "and then this":
+            await pilot.press("space" if char == " " else char)
+        # Run the command on line one: move the caret back onto its word.
+        app.editor.move_cursor(app.editor._location_at_offset(6))
+        app.editor._sync_picker()
+        await pilot.pause()
+        assert app.editor.picker.is_open()
+        await pilot.press("enter")
+        await pilot.pause()
+        assert app.inline_commands == ["/usage"]
+        assert app.editor.text == "and then this"
+
+
+@pytest.mark.asyncio
+async def test_a_prompt_command_reassembles_to_the_front_staged_not_run() -> None:
+    """A PROMPT command (``/goal``) engaged inline moves to the front with the
+    draft as its argument and is STAGED — never auto-run, so the draft is never
+    consumed as a name (the D1 data-loss the naive end-of-line argument caused)."""
+    app = PickerHarnessApp()
+    async with app.run_test(size=(100, 30)) as pilot:
+        app.editor.focus()
+        await pilot.pause()
+        for char in "land the oauth fix ":
+            await pilot.press("space" if char == " " else char)
+        for char in "/goal":
+            await pilot.press("slash" if char == "/" else char)
+        await pilot.pause()
+        await pilot.press("enter")
+        await pilot.pause()
+        # Reassembled to the front, staged. Nothing ran or submitted.
+        assert app.editor.text == "/goal land the oauth fix"
+        assert app.inline_commands == []
+        assert app.submissions == []
+
+
+@pytest.mark.asyncio
+async def test_a_whole_buffer_command_still_submits_not_inline() -> None:
+    """A command that IS the whole draft goes through the ordinary submit path —
+    inline splicing is only for a command sharing the buffer with a message."""
+    app = PickerHarnessApp()
+    async with app.run_test(size=(100, 30)) as pilot:
+        app.editor.focus()
+        await pilot.pause()
+        await pilot.press("slash", "u", "s", "a", "g", "e")
+        await pilot.press("enter")
+        await pilot.pause()
+        assert app.submissions == ["/usage "]
+        assert app.inline_commands == []
+
+
+@pytest.mark.asyncio
+async def test_type_through_dismiss_leaves_the_text_when_the_word_stops_matching() -> None:
+    """Typing PAST a command word that no longer matches anything closes the list
+    but keeps every character — the draft is never touched by a dismissal."""
+    app = PickerHarnessApp()
+    async with app.run_test(size=(100, 30)) as pilot:
+        app.editor.focus()
+        await pilot.pause()
+        # `/zzz` matches no command, so the list closes; the text is still there.
+        await pilot.press("slash", "z", "z", "z")
+        await pilot.pause()
+        assert not app.editor.picker.is_open()
+        assert app.editor.text == "/zzz"
+        # Terminating the word with a space also dismisses and keeps the text —
+        # the user typed on past the command into a message.
+        await pilot.press("space", "h", "i")
+        await pilot.pause()
+        assert not app.editor.picker.is_open()
+        assert app.editor.text == "/zzz hi"
+
+
+@pytest.mark.asyncio
+async def test_esc_dismiss_leaves_an_inline_command_in_the_text() -> None:
+    """Esc on the picker leaves the text exactly as typed, even inline and even
+    when it matches — the same 'not now' the start-of-line list already honours."""
+    app = PickerHarnessApp()
+    async with app.run_test(size=(100, 30)) as pilot:
+        app.editor.focus()
+        await pilot.pause()
+        for char in "ship it ":
+            await pilot.press("space" if char == " " else char)
+        await pilot.press("slash", "u", "s")
+        await pilot.pause()
+        assert app.editor.picker.is_open()
+        await pilot.press("escape")
+        await pilot.pause()
+        assert not app.editor.picker.is_open()
+        assert app.editor.text == "ship it /us"
+        assert app.inline_commands == []
+        assert app.submissions == []
 
 
 def test_esc_stays_dismissed_for_the_same_word_until_it_changes() -> None:
@@ -982,12 +1242,12 @@ async def test_switching_between_login_and_logout_reasks_for_the_rows() -> None:
     async with app.run_test(size=(100, 30)) as pilot:
         app.editor.focus()
         await pilot.pause()
-        app.editor.text = "/login "
+        app.set_editor_text("/login ")
         await pilot.pause()
         assert [name for name, _ in app.editor.picker.suggestions()] == [
             c.name for c in PROVIDER_CHOICES
         ]
-        app.editor.text = "/logout "
+        app.set_editor_text("/logout ")
         await pilot.pause()
         assert app.provider_queries == ["login", "logout"]
         assert [name for name, _ in app.editor.picker.suggestions()] == ["anthropic", "alibaba"]
@@ -999,7 +1259,7 @@ async def test_tab_completes_the_provider_id_without_running_it() -> None:
     async with app.run_test(size=(100, 30)) as pilot:
         app.editor.focus()
         await pilot.pause()
-        app.editor.text = "/login clau"
+        app.set_editor_text("/login clau")
         await pilot.pause()
         await pilot.press("tab")
         await pilot.pause()
@@ -1016,7 +1276,7 @@ async def test_enter_runs_an_unambiguous_provider() -> None:
     async with app.run_test(size=(100, 30)) as pilot:
         app.editor.focus()
         await pilot.pause()
-        app.editor.text = "/logout anthropic"
+        app.set_editor_text("/logout anthropic")
         await pilot.pause()
         assert len(app.editor.picker.suggestions()) == 1, "premise: one match"
         await pilot.press("enter")
@@ -1034,7 +1294,7 @@ async def test_an_ambiguous_enter_never_logs_anyone_out() -> None:
     async with app.run_test(size=(100, 30)) as pilot:
         app.editor.focus()
         await pilot.pause()
-        app.editor.text = "/logout a"
+        app.set_editor_text("/logout a")
         await pilot.pause()
         assert len(app.editor.picker.suggestions()) > 1, "premise: /logout a is ambiguous"
 
@@ -1056,7 +1316,7 @@ async def test_arrowing_onto_a_provider_lets_enter_run_it() -> None:
     async with app.run_test(size=(100, 30)) as pilot:
         app.editor.focus()
         await pilot.pause()
-        app.editor.text = "/logout a"
+        app.set_editor_text("/logout a")
         await pilot.pause()
         await pilot.press("down")
         await pilot.pause()
@@ -1072,7 +1332,7 @@ async def test_arrows_move_the_provider_highlight() -> None:
     async with app.run_test(size=(100, 30)) as pilot:
         app.editor.focus()
         await pilot.pause()
-        app.editor.text = "/login "
+        app.set_editor_text("/login ")
         await pilot.pause()
         picker = app.editor.picker
         assert picker.selected_index == 0
@@ -1091,7 +1351,7 @@ async def test_escape_closes_the_provider_list_and_leaves_the_text() -> None:
     async with app.run_test(size=(100, 30)) as pilot:
         app.editor.focus()
         await pilot.pause()
-        app.editor.text = "/login clau"
+        app.set_editor_text("/login clau")
         await pilot.pause()
         assert app.editor.picker.is_open()
         await pilot.press("escape")
@@ -1109,7 +1369,7 @@ async def test_clicking_a_login_row_runs_it() -> None:
     async with app.run_test(size=(100, 30)) as pilot:
         app.editor.focus()
         await pilot.pause()
-        app.editor.text = "/login "
+        app.set_editor_text("/login ")
         await pilot.pause()
         await pilot.click(CommandPicker, offset=(4, 1))
         await pilot.pause()
@@ -1130,7 +1390,7 @@ async def test_clicking_a_logout_row_fills_the_field_and_waits_for_enter() -> No
     async with app.run_test(size=(100, 30)) as pilot:
         app.editor.focus()
         await pilot.pause()
-        app.editor.text = "/logout "
+        app.set_editor_text("/logout ")
         await pilot.pause()
         await pilot.click(CommandPicker, offset=(4, 1))
         await pilot.pause()
@@ -1278,7 +1538,7 @@ async def test_a_single_fuzzy_survivor_never_removes_a_credential(query: str, ro
     async with app.run_test(size=(100, 30)) as pilot:
         app.editor.focus()
         await pilot.pause()
-        app.editor.text = f"/logout {query}"
+        app.set_editor_text(f"/logout {query}")
         await pilot.pause()
         assert [name for name, _ in app.editor.picker.suggestions()] == [row], "premise: one match"
 
@@ -1300,7 +1560,7 @@ async def test_a_single_fuzzy_survivor_still_runs_on_a_login_list() -> None:
     async with app.run_test(size=(100, 30)) as pilot:
         app.editor.focus()
         await pilot.pause()
-        app.editor.text = "/login aib"
+        app.set_editor_text("/login aib")
         await pilot.pause()
         assert [name for name, _ in app.editor.picker.suggestions()] == ["alibaba"]
         await pilot.press("enter")
@@ -1323,7 +1583,7 @@ async def test_arrowing_onto_a_logout_row_still_runs_it_on_one_enter() -> None:
     async with app.run_test(size=(100, 30)) as pilot:
         app.editor.focus()
         await pilot.pause()
-        app.editor.text = "/logout "
+        app.set_editor_text("/logout ")
         await pilot.pause()
         await pilot.press("down")
         await pilot.pause()
@@ -1349,7 +1609,7 @@ async def test_escape_lands_in_the_tick_before_the_rows_arrive() -> None:
     async with app.run_test(size=(100, 30)) as pilot:
         app.editor.focus()
         await pilot.pause()
-        app.editor.text = "/logout "
+        app.set_editor_text("/logout ")
         picker = app.editor.picker
         assert not picker.is_open(), "premise: the rows have not arrived yet"
         assert picker.is_pending()
@@ -1385,7 +1645,7 @@ async def test_an_argument_list_is_budgeted_from_the_rows_available(
     async with app.run_test(size=(100, height)) as pilot:
         app.editor.focus()
         await pilot.pause()
-        app.editor.text = "/login "
+        app.set_editor_text("/login ")
         await pilot.pause()
         # AFTER the buffer opened the list: the harness answers the opening
         # message with its own four rows, so a set made before would be replaced.
@@ -1406,7 +1666,7 @@ async def test_the_command_list_keeps_its_own_smaller_budget() -> None:
     async with app.run_test(size=(100, 28)) as pilot:
         app.editor.focus()
         await pilot.pause()
-        app.editor.text = "/"
+        app.set_editor_text("/")
         await pilot.pause()
         start, end, total = app.editor.picker.visible_window()
         assert (start, end) == (0, MAX_VISIBLE_ROWS)
@@ -1425,7 +1685,7 @@ async def test_the_names_align_with_the_text_the_editor_is_completing() -> None:
     async with app.run_test(size=(100, 30)) as pilot:
         app.editor.focus()
         await pilot.pause()
-        app.editor.text = "/login "
+        app.set_editor_text("/login ")
         await pilot.pause()
         await pilot.pause()
         lines = [
@@ -1531,7 +1791,7 @@ async def test_enter_on_a_team_row_fills_the_name_and_a_space_without_submitting
     async with app.run_test(size=(100, 30)) as pilot:
         app.editor.focus()
         await pilot.pause()
-        app.editor.text = "/team frontend-guild"
+        app.set_editor_text("/team frontend-guild")
         await pilot.pause()
         assert app.editor.picker.highlighted_name() == "frontend-guild"
         await pilot.press("enter")
@@ -1549,7 +1809,7 @@ async def test_tab_on_a_team_row_fills_name_and_space() -> None:
     async with app.run_test(size=(100, 30)) as pilot:
         app.editor.focus()
         await pilot.pause()
-        app.editor.text = "/team front"
+        app.set_editor_text("/team front")
         await pilot.pause()
         await pilot.press("tab")
         await pilot.pause()
@@ -1565,7 +1825,7 @@ async def test_click_on_a_team_row_fills_name_and_space_without_submitting() -> 
     async with app.run_test(size=(100, 30)) as pilot:
         app.editor.focus()
         await pilot.pause()
-        app.editor.text = "/team "
+        app.set_editor_text("/team ")
         await pilot.pause()
         await pilot.click(CommandPicker, offset=(4, 0))
         await pilot.pause()
@@ -1582,7 +1842,7 @@ async def test_arrowing_onto_a_team_row_still_does_not_submit() -> None:
     async with app.run_test(size=(100, 30)) as pilot:
         app.editor.focus()
         await pilot.pause()
-        app.editor.text = "/team "
+        app.set_editor_text("/team ")
         await pilot.pause()
         await pilot.press("down")  # arrow onto row 1 — an explicit move
         await pilot.pause()
@@ -1602,7 +1862,7 @@ async def test_blank_enter_after_a_completed_team_name_submits_attach_only() -> 
     async with app.run_test(size=(100, 30)) as pilot:
         app.editor.focus()
         await pilot.pause()
-        app.editor.text = "/team frontend-guild "
+        app.set_editor_text("/team frontend-guild ")
         await pilot.pause()
         assert not app.editor.picker.is_open()
         await pilot.press("enter")
@@ -1618,7 +1878,7 @@ async def test_typing_a_message_then_enter_sends_the_whole_line() -> None:
     async with app.run_test(size=(100, 30)) as pilot:
         app.editor.focus()
         await pilot.pause()
-        app.editor.text = "/team frontend-guild fix the flaky test"
+        app.set_editor_text("/team frontend-guild fix the flaky test")
         await pilot.pause()
         assert not app.editor.picker.is_open()
         await pilot.press("enter")
@@ -1633,7 +1893,7 @@ async def test_agent_row_behaves_like_team() -> None:
     async with app.run_test(size=(100, 30)) as pilot:
         app.editor.focus()
         await pilot.pause()
-        app.editor.text = "/agent audit"
+        app.set_editor_text("/agent audit")
         await pilot.pause()
         assert app.editor.picker.highlighted_name() == "auditor"
         await pilot.press("enter")
@@ -1650,7 +1910,7 @@ async def test_enum_tail_login_row_still_runs_on_enter() -> None:
     async with app.run_test(size=(100, 30)) as pilot:
         app.editor.focus()
         await pilot.pause()
-        app.editor.text = "/login anthropic"
+        app.set_editor_text("/login anthropic")
         await pilot.pause()
         assert len(app.editor.picker.suggestions()) == 1
         await pilot.press("enter")
@@ -1673,7 +1933,7 @@ async def test_autofill_shows_the_switch_or_send_hint() -> None:
     async with app.run_test(size=(100, 30)) as pilot:
         app.editor.focus()
         await pilot.pause()
-        app.editor.text = "/team frontend-guild"
+        app.set_editor_text("/team frontend-guild")
         await pilot.pause()
         await pilot.press("enter")
         await pilot.pause()
@@ -1691,7 +1951,7 @@ async def test_the_hint_is_withdrawn_once_a_message_is_typed() -> None:
     async with app.run_test(size=(100, 30)) as pilot:
         app.editor.focus()
         await pilot.pause()
-        app.editor.text = "/team frontend-guild "
+        app.set_editor_text("/team frontend-guild ")
         app.editor.move_cursor(app.editor._end_of_buffer())  # as the autofill leaves it
         await pilot.pause()
         assert app.editor.picker._notice == Editor.NAME_SWITCH_HINT
@@ -1709,7 +1969,7 @@ async def test_a_bare_name_list_shows_no_hint() -> None:
     async with app.run_test(size=(100, 30)) as pilot:
         app.editor.focus()
         await pilot.pause()
-        app.editor.text = "/team "
+        app.set_editor_text("/team ")
         await pilot.pause()
         assert app.editor.picker.is_open()  # rows are showing
         assert app.editor.picker._notice == ""
@@ -1723,7 +1983,7 @@ async def test_enum_tail_completion_shows_no_switch_hint() -> None:
     async with app.run_test(size=(100, 30)) as pilot:
         app.editor.focus()
         await pilot.pause()
-        app.editor.text = "/login anthropic "
+        app.set_editor_text("/login anthropic ")
         await pilot.pause()
         assert app.editor.picker._notice == ""
 
@@ -1759,13 +2019,16 @@ async def test_app_owned_notice_survives_a_same_command_keystroke(
         # command-word change (the harness does not model the empty-list case,
         # so we set it directly — the regression is purely in the editor's
         # per-keystroke resync, not in how the notice first arrives).
-        app.editor.text = f"/{command} "
+        app.set_editor_text(f"/{command} ")
         await pilot.pause()
         app.editor.picker.set_notice(notice)
         await pilot.pause()
         assert app.editor.picker._notice == notice, "premise: the notice is shown"
         # Type a query character on the SAME command — this re-runs _sync_picker.
-        app.editor.text = f"/{command} x"
+        # A real same-command keystroke (the caret is already parked at the end
+        # of `/<command> `), which is the per-keystroke resync the CR4 fix is
+        # about — not a whole-buffer reset.
+        await pilot.press("x")
         await pilot.pause()
         assert (
             app.editor.picker._notice == notice
@@ -1862,8 +2125,13 @@ async def test_recognized_team_name_gets_the_argument_style() -> None:
     async with app.run_test(size=(100, 30)) as pilot:
         app.editor.focus()
         await pilot.pause()
-        # Open the list so the app pushes the name snapshot, then type a message.
+        # The highlighter is caret-independent (it parses the first content
+        # line), so this sets the text directly and pushes the name snapshot the
+        # highlight reads — mirroring the app's "list opens, then names arrive"
+        # without depending on where the caret lands.
         app.editor.text = "/team frontend-guild fix it"
+        await pilot.pause()
+        app.editor.set_name_choices(frozenset({"frontend-guild"}))
         await pilot.pause()
         cells = _slash_ink(app.editor)
         signal = theme_mod.semantic_color("signal").lower()

--- a/tests/unit/tui/test_effort.py
+++ b/tests/unit/tui/test_effort.py
@@ -420,6 +420,8 @@ async def test_cycling_is_inert_while_a_completion_list_is_open() -> None:
         await _boot(pilot, app)
         editor = app.query_one(Editor)
         editor.text = "/eff"
+        editor.move_cursor(editor._end_of_buffer())
+        editor._sync_picker()
         await pilot.pause()
         assert editor._picker.is_open()
         await pilot.press("shift+tab")

--- a/tests/unit/tui/test_model_picker.py
+++ b/tests/unit/tui/test_model_picker.py
@@ -398,14 +398,21 @@ def test_an_empty_result_says_so_rather_than_rendering_nothing() -> None:
         ("/model", None),  # the command WORD is still open — that is the other picker
         ("/mo", None),
         ("/help ", None),
-        ("hello /model x", None),  # not a command line at all
-        ("/model x\nmore", None),  # a newline means a message, not a pick
+        # INLINE: a `/model` typed after a message is a real argument now — the
+        # caret defaults to the buffer end, which is inside the selector.
+        ("hello /model x", "x"),
+        # A newline after the argument leaves the caret on the MESSAGE line, so
+        # the argument list is not live there.
+        ("/model x\nmore", None),
     ],
 )
 def test_slash_argument_hands_over_on_the_terminating_space(text: str, expected) -> None:
     """The handover is what lets one buffer drive two lists without either widget
     knowing about the other: `slash_context` is live while the word is open, this
-    takes over the instant a space terminates it."""
+    takes over the instant a space terminates it.
+
+    Inline and caret-aware now: an argument typed mid-draft counts, and the caret
+    (defaulting to the buffer end) decides which line's command is live."""
     assert slash_argument(text, MODEL_COMMANDS) == expected
 
 

--- a/tests/unit/tui/test_slash_echo.py
+++ b/tests/unit/tui/test_slash_echo.py
@@ -87,6 +87,50 @@ ECHO_POLICY = {
 }
 
 
+#: Which commands CONSUME the rest of the composer as a prompt when engaged
+#: inline (``SlashCommand.consumes_prompt``). True for the free-text commands
+#: whose argument becomes a message the model is given — engaging one mid-draft
+#: reassembles it to the FRONT with the draft as its argument rather than
+#: splicing-and-running, so a plausible mid-sentence gesture cannot silently eat
+#: the user's text. Pinned entry-by-entry for the same reason ``ECHO_POLICY`` is:
+#: a new command must state whether its argument is a prompt.
+PROMPT_POLICY = {
+    "help": False,
+    "exit": False,
+    "clear": False,
+    "new": False,
+    "reload": False,
+    "resume": False,
+    "rename": False,
+    "model": False,
+    "effort": False,
+    "theme": False,
+    "provider": False,
+    "search": False,
+    "accounts": False,
+    "usage": False,
+    # A view selector, not a prompt: `/analytics [view]` names which screen to
+    # open, so it splices-and-runs inline like `/usage` rather than reassembling.
+    "analytics": False,
+    # Free text the model is given (the objective / a loop instruction / a side
+    # question), so an inline engage reassembles to the front.
+    "goal": True,
+    "loop": True,
+    "btw": True,
+    "compact": False,
+    "context": False,
+    "approvals": False,
+    "skills": False,
+    "mcp": False,
+    "login": False,
+    "logout": False,
+    "credential": False,
+    # The request after the name is a prompt the manager / persona is given.
+    "team": True,
+    "agent": True,
+}
+
+
 def _user_rows(app: OperatorApp) -> list[str]:
     return [
         block.text()
@@ -161,6 +205,9 @@ def test_every_registered_command_states_an_echo_policy() -> None:
     """A new command must land in the table above, with a reason beside its
     registry entry. Without this, the field's default silently decides."""
     assert {command.name: command.echo for command in SLASH_COMMANDS} == ECHO_POLICY
+    # The same forcing function for the inline-prompt choice: a new command must
+    # state whether its argument is a prompt consumed on an inline engage.
+    assert {c.name: c.consumes_prompt for c in SLASH_COMMANDS} == PROMPT_POLICY
 
 
 def test_no_two_registry_entries_claim_the_same_word() -> None:
@@ -293,6 +340,154 @@ async def test_team_request_attaches_and_sends() -> None:
     assert rows == ["ship the dashboard"], rows
     # U2: the band names the active roster after the attach.
     assert "feature-release" in band, band
+
+
+@pytest.mark.asyncio
+async def test_inline_team_reassembles_to_the_front_and_then_sends_under_the_manager() -> None:
+    """The end-to-end mid-trajectory gesture the user asked to confirm.
+
+    A user types a message, remembers to route it to a team, appends ``/team``
+    and picks the team from the autofill. ``/team`` is a PROMPT command (its
+    request is free text the manager is given), so it does NOT auto-run and eat
+    the draft as a name — it REASSEMBLES to the front as ``/team <name> <the
+    draft>``, STAGED. The user reads the assembled line and presses Enter, which
+    attaches the team and sends the message as the request — under the manager,
+    because the roster rides the session's volatile prompt tail (see
+    ``session_factory``'s per-turn provider).
+    """
+    from local_operator.teams import TeamEditFields, TeamMember, TeamRegistry
+
+    session = FakeSession()
+    registry = TeamRegistry(Path(tempfile.mkdtemp()))
+    registry.create_team(
+        TeamEditFields(
+            name="feature-release",
+            manager="manager",
+            members=[TeamMember(role="coder")],
+        )
+    )
+    session.team_registry = registry
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _boot(pilot, app)
+        editor = app.query_one(Editor)
+        editor.focus()
+        # Type the message, then the inline command at the caret.
+        for char in "ship the dashboard ":
+            await pilot.press("space" if char == " " else char)
+        for char in "/team":
+            await pilot.press("slash" if char == "/" else char)
+        await pilot.pause()
+        # Word complete: Enter opens the team list rather than running (the name
+        # is picked from the autofill, not guessed from the draft).
+        await pilot.press("enter")
+        await pilot.pause()
+        assert editor.picker.is_open(), "the team argument list must open"
+        # Pick the team by name.
+        for char in "feature-release":
+            await pilot.press(char)
+        await pilot.pause()
+        await pilot.press("enter")
+        await pilot.pause()
+        await pilot.pause()
+        # Reassembled to the front, STAGED — nothing attached or sent yet, and
+        # the draft is preserved verbatim as the request.
+        assert editor.text == "/team feature-release ship the dashboard", editor.text
+        assert session.attached_teams == [], "reassembly must not attach yet"
+        assert session.prompts == [], "reassembly must not send yet"
+        # The user reviews the assembled line and submits it.
+        if editor.picker.is_open():
+            await pilot.press("escape")
+            await pilot.pause()
+        await pilot.press("enter")
+        await pilot.pause()
+        await pilot.pause()
+        assert session.attached_teams, "the team attaches on the staged submit"
+        assert session.attached_teams[0].name == "feature-release"
+        assert session.prompts == ["ship the dashboard"], session.prompts
+
+
+@pytest.mark.asyncio
+async def test_completing_a_team_name_keeps_the_parked_hint_in_the_real_app() -> None:
+    """D5 regression (design review round 3), asserted against the REAL app.
+
+    Picking a team name at the START of the buffer fills ``/team <name> `` and
+    parks the caret, and the picker shows the switch/send hint. The hint is set
+    by the editor and cleared by the app's ``on_argument_query_opened`` — so a
+    stray extra picker resync (which nulls ``_argument_command`` and re-fires the
+    query) wipes it. The bespoke harness's ``on_argument_query_opened`` does not
+    clear the notice, so this is only observable against ``OperatorApp``: exactly
+    the "green tests aren't the rendered frame" gap the round-3 review named.
+    """
+    from local_operator.teams import TeamEditFields, TeamMember, TeamRegistry
+
+    session = FakeSession()
+    registry = TeamRegistry(Path(tempfile.mkdtemp()))
+    registry.create_team(
+        TeamEditFields(name="security", manager="manager", members=[TeamMember(role="coder")])
+    )
+    session.team_registry = registry
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _boot(pilot, app)
+        editor = app.query_one(Editor)
+        editor.focus()
+        # Start-of-line /team, open the list, then fill the single team with Tab.
+        for char in "/team ":
+            await pilot.press("slash" if char == "/" else ("space" if char == " " else char))
+        await pilot.pause()
+        assert editor.picker.is_open(), "the team list must open"
+        await pilot.press("tab")
+        await pilot.pause()
+        await pilot.pause()
+        # Name filled, caret parked, and the switch/send hint survives the app's
+        # own argument-query handling — the D5 fix.
+        assert editor.text == "/team security ", editor.text
+        assert (
+            "switch" in editor.picker._notice and "send" in editor.picker._notice
+        ), editor.picker._notice
+
+
+@pytest.mark.asyncio
+async def test_a_second_inline_command_of_the_same_kind_is_plain_argument_text() -> None:
+    """Once a prompt command is engaged at the front, a second occurrence of the
+    same command inside its argument is plain text — no picker, no re-engagement.
+
+    Reported: composing ``/team a improve the /team command`` must treat the
+    second ``/team`` as part of the request, not a nested command to highlight or
+    run.
+    """
+    from local_operator.teams import TeamEditFields, TeamMember, TeamRegistry
+
+    session = FakeSession()
+    registry = TeamRegistry(Path(tempfile.mkdtemp()))
+    registry.create_team(
+        TeamEditFields(name="alpha", manager="manager", members=[TeamMember(role="coder")])
+    )
+    session.team_registry = registry
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _boot(pilot, app)
+        editor = app.query_one(Editor)
+        editor.focus()
+        for char in "/team alpha improve the ":
+            await pilot.press("slash" if char == "/" else ("space" if char == " " else char))
+        # Now type a nested "/team" inside the request.
+        for char in "/team":
+            await pilot.press("slash" if char == "/" else char)
+        for char in " command":
+            await pilot.press("space" if char == " " else char)
+        await pilot.pause()
+        # The picker must be closed: the caret is inside the first /team's
+        # argument, and the nested /team is plain text.
+        assert not editor.picker.is_open(), "a nested /team must not open the picker"
+        assert editor.text == "/team alpha improve the /team command"
+        # Submitting sends the whole request verbatim to the manager.
+        await pilot.press("enter")
+        await pilot.pause()
+        await pilot.pause()
+        assert session.attached_teams and session.attached_teams[0].name == "alpha"
+        assert session.prompts == ["improve the /team command"], session.prompts
 
 
 def _agent_registry(tmp: str):

--- a/tests/unit/tui/test_theme_command.py
+++ b/tests/unit/tui/test_theme_command.py
@@ -47,7 +47,13 @@ async def _boot(pilot, app: OperatorApp) -> None:
 
 
 async def _type(pilot, app: OperatorApp, text: str) -> None:
-    app.query_one(Editor).text = text
+    # Set the line AND park the caret at the end, as typing it would: the slash
+    # pickers are caret-anchored (inline detection), so a text-set that leaves
+    # the caret at the origin sits before the slash where no command is live.
+    editor = app.query_one(Editor)
+    editor.text = text
+    editor.move_cursor(editor._end_of_buffer())
+    editor._sync_picker()
     await pilot.pause()
     await pilot.pause()
 
@@ -272,6 +278,8 @@ async def test_preview_defers_offscreen_reink_to_the_settle(config_dir: Path) ->
         # is the assertion that actually binds — the offscreen block can only
         # carry that ink if the full sweep ran.
         editor.text = "/theme monokai"
+        editor.move_cursor(editor._end_of_buffer())
+        editor._sync_picker()
         await pilot.pause()
         await pilot.press("enter")
         await pilot.pause()


### PR DESCRIPTION
## Summary of Changes

Feature. The slash-command picker only opened when the `/` was the **first character of the first non-blank line**. A user who had started typing a message and then remembered they should route it to a team or an agent — appending `/team` at the caret — got no menu, because the parse was anchored to the buffer start rather than to where the caret actually was.

This makes slash detection **inline and caret-anchored**, and adds a run path that keeps the user's draft safe.

Key design points:

- **Caret-anchored, boundary-gated detection.** `slash_context` / `slash_argument` now key on the caret's whole-buffer offset and open the list for a boundary `/` token **anywhere** in the draft — at the buffer start, right after whitespace, or on its own line above a multi-line draft. A `/` glued to a preceding non-space character (`src/foo`, `and/or`) never triggers; that boundary rule — the same one a shell or editor command palette uses — is what makes running the parse on every keystroke of ordinary prose safe. To engage mid-text the slash must be preceded by a space (or be at the start) and the word terminated by a space or accepted from the picker, so it never fires while the user is still mid-token.

- **Prompt commands reassemble to the front; others splice-and-run.** Free-text commands whose argument is a message the model is given (`/goal`, `/loop`, `/btw`, `/team`, `/agent` — flagged `consumes_prompt` on the registry) are "start of the composer" commands by nature. Engaging one INLINE does **not** run it against the trailing draft — that guesses which words are a name vs the message, and silently ate the request when `/team` read `and then ship it` as a team name (**design review D1, fixed**). Instead it **reassembles** the composer to `/command [name] <the rest of the draft>` and **stages** it: nothing is submitted, and the user reviews the assembled prompt and presses Enter. `/team`/`/agent` reassemble when the name is picked from the autofill (the draft becomes the request); `/goal`/`/loop`/`/btw` reassemble on word completion (the draft becomes the argument). A non-prompt command (a selector or a listing, `/usage`) instead splices just its `/command` token out and runs it via a new `InlineCommandRequested` message, leaving the surrounding draft; a whole-buffer command still goes through the ordinary submit path.

- **Nested slashes are plain text.** Once a recognised command owns its line (`/team a improve the /team command`), a second occurrence of a slash command inside its argument is plain argument text — no picker, no highlight, no re-engagement. The tokenizer is command-aware: a terminated recognised command claims the rest of its line.

- **Type-through and Esc dismiss, both keeping the text.** Terminating the word with a space, or typing on into a word that matches nothing, closes the list without touching the buffer; Esc's per-word "not now" dismissal works inline too. The text is always left exactly as typed.

- **Pairs with the existing mid-session attach.** Reassembling and submitting `/team <name> <request>` (or `/agent <name> <message>`) mid-trajectory stamps the team roster / agent persona onto the session's **volatile prompt tail** (`goal_state.team_brief` / `agent_brief`), which `session_factory`'s prompt provider re-reads on **every** turn — so the message runs under the team manager or that agent. This half already worked; the inline gesture is what makes it reachable without abandoning a half-typed message.

Change class: **C1 (standard, pre-authorized)** — a scoped, additive TUI feature with a clear rollback (revert the branch's commits), no contract, schema, auth, or migration surface.

## Related Issue(s)

- Related: none filed (requested directly).

## Impact

- No breaking changes. Start-of-line commands behave exactly as before; the new behaviour is purely additive for a `/` that is not the first character.
- New registry field `SlashCommand.consumes_prompt`; new public helpers on `command_picker` (`slash_word`, `slash_token_span`, `slash_argument_context`, `SlashArgument`); new `InlineCommandRequested` editor message; `SlashContext`/`SlashArgument` carry span offsets; the parsers take an optional recognised-command set for the nested-slash rule.
- No dependency updates. No security implications — the parser only classifies composer text; dispatch and the attach paths are unchanged.

## Testing Details

Proof the feature works, exercised through the **real editor and app** (key presses, not internal calls):

**Inline detection, reassembly & run (`tests/unit/tui/test_command_picker.py`)** — new tests drive real keystrokes:
- `test_inline_command_opens_the_picker_mid_draft` — `fix this ` then `/te` opens the list, buffer intact.
- `test_a_glued_slash_never_opens_the_picker` — `src/foo` stays closed.
- `test_a_prompt_command_reassembles_to_the_front_staged_not_run` — `land the oauth fix /goal` + Enter → `/goal land the oauth fix`, staged (not run, not submitted).
- `test_inline_command_runs_and_is_spliced_out_keeping_the_draft` — a non-prompt `/usage` splices out and runs, `submissions == []`, buffer left as `fix the bug`.
- `test_inline_command_on_its_own_line_keeps_the_message_below`, `test_a_whole_buffer_command_still_submits_not_inline`.
- `test_type_through_dismiss_leaves_the_text_when_the_word_stops_matching`, `test_esc_dismiss_leaves_an_inline_command_in_the_text`.
- `test_a_nested_slash_inside_an_engaged_command_is_plain_text`, `test_a_crlf_buffer_does_not_leak_a_carriage_return_into_the_word`, plus caret-anchored trigger/non-trigger parametrizations.

**End-to-end mid-trajectory attach (`tests/unit/tui/test_slash_echo.py`)** —
- `test_inline_team_reassembles_to_the_front_and_then_sends_under_the_manager`: `ship the dashboard /team` → pick `feature-release` → reassembles to `/team feature-release ship the dashboard`, **staged** (nothing attached/sent); Enter then attaches the team and sends `ship the dashboard` as the request under the manager.
- `test_a_second_inline_command_of_the_same_kind_is_plain_argument_text`: `/team alpha improve the /team command` keeps the nested `/team` as plain text and submits it verbatim.
- `PROMPT_POLICY` pin mirrors `ECHO_POLICY` so every registered command states whether its argument is a prompt.

**Live UI validation** (real `OperatorApp` rendered to SVG, viewed as a frame):

- **Inline picker** — composer holding `fix the auth bug /team` with the caret after `/team` shows the `/team /teams` row. The old rule would have kept the list hidden because the `/` is not the first character.

  ![Inline slash picker mid-draft](https://raw.githubusercontent.com/damianvtran/local-operator/f3d8e759c605a329d1615eb730aed998d11ad1ee/pr250/inline-picker.png)

- **After reassembly** — typing `review the auth flow /team` and picking `security` reassembles the composer to `/team security review the auth flow`, staged for the user to submit: the draft is preserved verbatim as the request, nothing was consumed as a name.

  ![After reassembling the inline prompt command](https://raw.githubusercontent.com/damianvtran/local-operator/f3d8e759c605a329d1615eb730aed998d11ad1ee/pr250/after-run.png)

**Regression fixed by this PR:** `Editor.begin_model_query` set the buffer but never re-synced at the moved caret, so with caret-anchored detection the model list would not populate on a dispatched `/model`. Fixed to re-derive at the caret; covered by the existing model-default tests.

**Gates** (PR head `b75213b2`):
- `flake8` / `black --check` / `isort --check-only` / `pyright` — clean on all changed files.
- `pytest tests/unit/tui` — **2229 passed, 4 skipped**.

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my changes work as intended.
- [x] All new and existing tests pass.
- [x] I have run formatting (black/isort), linting (flake8), and type checks (pyright), and they pass.
- [x] I have updated the documentation when required (in-code why/constraint comments added; no user doc surface).
- [x] Security considerations are addressed (parser only classifies composer text; dispatch/attach unchanged).
- [x] I have linked all related issues.
