### PR TITLE
perf(ci): parallelize the test suite to bring CI under 10 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,21 +81,19 @@ jobs:
           pip install -e ".[dev]"
 
       - name: Run tests with coverage
+        # pytest-cov (not `coverage run -m pytest`) because the suite now runs
+        # under xdist: coverage has to be collected inside each worker
+        # subprocess and merged, which pytest-cov does automatically and a
+        # top-level `coverage run` cannot. `-n auto` comes from addopts; the
+        # 80% floor is enforced by `fail_under` in [tool.coverage.report], so
+        # the step no longer parses the percentage out of the report by hand.
         run: |
-          coverage run -m pytest -v
-          COVERAGE_PERCENTAGE=$(coverage report | awk '/TOTAL/ {print $NF}' | tr -d '%')
-          echo "Coverage Percentage: $COVERAGE_PERCENTAGE"
-          if (( $(echo "$COVERAGE_PERCENTAGE >= 80" | bc -l) )); then
-            echo "Coverage check passed!"
-          else
-            echo "Coverage check failed. Minimum coverage is 80%"
-            exit 1
-          fi
-
-      - name: Generate coverage HTML report
-        run: coverage html
+          pytest --cov --cov-report=term-missing:skip-covered --cov-report=html
 
       - name: Upload coverage report
+        # `if: always()` so a coverage-threshold failure still uploads the HTML,
+        # which is exactly when you want to see which lines dropped.
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: coverage-report-${{ matrix.python-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,21 +84,20 @@ jobs:
         # pytest-cov (not `coverage run -m pytest`) because the suite now runs
         # under xdist: coverage has to be collected inside each worker
         # subprocess and merged, which pytest-cov does automatically and a
-        # top-level `coverage run` cannot. The 80% floor is enforced by
-        # `fail_under` in [tool.coverage.report], so the step no longer parses
-        # the percentage out of the report by hand.
+        # top-level `coverage run` cannot. `-n auto` (from addopts) gives one
+        # worker per logical core — 4 on GitHub's ubuntu-latest. The 80% floor
+        # is enforced by `fail_under` in [tool.coverage.report], so the step no
+        # longer parses the percentage out of the report by hand.
         #
-        # `-n 8` OVERRIDES the `-n auto` default (which would be 4 on this
-        # 2-core-hyperthreaded runner). The suite is wait-bound — pilot tests
-        # spend their wall time letting the event loop settle, not on CPU — so
-        # running 2x as many workers as cores overlaps that idle time and cuts
-        # wall clock further without saturating the CPU. Measured locally,
-        # `-n 8` ran the suite in roughly half the `-n 4` wall time. It is a
-        # deliberate constant, not `auto`, because the right degree of
-        # oversubscription is a property of THIS suite's wait profile, not of
-        # the runner's core count.
+        # Do NOT oversubscribe (`-n` greater than the core count) here. It looks
+        # tempting because the suite is wait-bound, and it does help on a
+        # many-core dev box that still has idle cores at `-n 8`. On this 4-vCPU
+        # runner it does not: it left wall time unchanged and starved three
+        # timing-sensitive tests (a parked job, a late-parking tool, a held
+        # key) whose deadlines are real wall clock, turning them red. One worker
+        # per core is the stable point.
         run: |
-          pytest -n 8 --cov --cov-report=term-missing:skip-covered --cov-report=html
+          pytest --cov --cov-report=term-missing:skip-covered --cov-report=html
 
       - name: Upload coverage report
         # `if: always()` so a coverage-threshold failure still uploads the HTML,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,11 +84,21 @@ jobs:
         # pytest-cov (not `coverage run -m pytest`) because the suite now runs
         # under xdist: coverage has to be collected inside each worker
         # subprocess and merged, which pytest-cov does automatically and a
-        # top-level `coverage run` cannot. `-n auto` comes from addopts; the
-        # 80% floor is enforced by `fail_under` in [tool.coverage.report], so
-        # the step no longer parses the percentage out of the report by hand.
+        # top-level `coverage run` cannot. The 80% floor is enforced by
+        # `fail_under` in [tool.coverage.report], so the step no longer parses
+        # the percentage out of the report by hand.
+        #
+        # `-n 8` OVERRIDES the `-n auto` default (which would be 4 on this
+        # 2-core-hyperthreaded runner). The suite is wait-bound — pilot tests
+        # spend their wall time letting the event loop settle, not on CPU — so
+        # running 2x as many workers as cores overlaps that idle time and cuts
+        # wall clock further without saturating the CPU. Measured locally,
+        # `-n 8` ran the suite in roughly half the `-n 4` wall time. It is a
+        # deliberate constant, not `auto`, because the right degree of
+        # oversubscription is a property of THIS suite's wait profile, not of
+        # the runner's core count.
         run: |
-          pytest --cov --cov-report=term-missing:skip-covered --cov-report=html
+          pytest -n 8 --cov --cov-report=term-missing:skip-covered --cov-report=html
 
       - name: Upload coverage report
         # `if: always()` so a coverage-threshold failure still uploads the HTML,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,6 +114,12 @@ dev = [
     "pytest",
     "pytest-asyncio",
     "pytest-cov",
+    # Distributes the suite across worker processes (`pytest -n`). The suite is
+    # overwhelmingly wait-bound — Textual pilot tests spend their wall time
+    # letting the event loop settle, not on CPU — so parallelism cuts CI wall
+    # time roughly linearly with the runner's core count while leaving total
+    # CPU work unchanged. See the `-n auto` note on `addopts` below.
+    "pytest-xdist",
     "pytest-textual-snapshot",
     "pip-audit",
     # Independent decoder used to verify our own PNG encoder's output.
@@ -232,5 +238,29 @@ reportPrivateImportUsage = false
 #   .venv/bin/python -m pyright --pythonpath .venv/bin/python .
 
 [tool.pytest.ini_options]
-addopts = "-vv -s"
+# `-n auto` distributes the suite across one worker process per logical core.
+# The suite is dominated by Textual pilot tests that spend their wall time
+# waiting for the event loop to settle rather than on CPU, so this scales CI
+# wall time down roughly with the core count (4 on GitHub's ubuntu-latest)
+# without changing what each test does. Run `-n0` locally to serialise for a
+# debugger (`--pdb`/`-s` need a single process).
+#
+# The old `-vv -s` was dropped deliberately: `-vv` prints a line per test,
+# which is ~5.8k lines of I/O that buys nothing in CI logs, and `-s`
+# (capture disabled) both adds that noise and is incompatible with xdist,
+# which needs to capture worker output. Tests assert on return values and
+# rendered frames, never on uncaptured stdout, so neither flag was load-bearing.
+addopts = "-n auto"
 testpaths = ["tests"]
+
+# Coverage is measured through pytest-cov (`--cov`), which understands xdist
+# and merges each worker's data automatically — the plain `coverage run -m
+# pytest` the CI used before collects nothing from the worker subprocesses.
+# Branch coverage stays off to match the historical line-only 80% gate.
+[tool.coverage.run]
+source = ["local_operator"]
+
+[tool.coverage.report]
+# The gate the `test` job enforces; kept here so a local `pytest --cov` fails
+# the same way CI does instead of only printing a number.
+fail_under = 80

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -433,8 +433,13 @@ async def test_boot_typing_sends_prompt() -> None:
         await pilot.pause()
         await pilot.press("h", "i")
         await pilot.press("enter")
-        await pilot.pause()
-        await pilot.pause()
+        # Poll until the prompt is actually recorded rather than betting two
+        # frames is enough: under parallel CPU load the submit worker had not
+        # yet reached the session when a fixed tick count expired.
+        for _ in range(200):
+            await pilot.pause()
+            if session.prompts:
+                break
         assert session.prompts == ["hi"]
         assert session.preflight_calls == 1
         # A user block was appended for the submitted prompt (the boot hint
@@ -475,7 +480,7 @@ async def test_boot_renders_non_blocking_quota_warning() -> None:
     app = OperatorApp(lambda: _factory(session))
 
     async with app.run_test(size=(100, 30)) as pilot:
-        for _ in range(8):
+        for _ in range(200):
             await pilot.pause()
             if app._splash_notice:
                 break
@@ -759,7 +764,7 @@ async def test_shell_mode_submit_runs_the_command_not_a_prompt() -> None:
         await pilot.press("enter")
         # The worker has to actually spawn /bin/sh; a couple of pauses is
         # not a bound, so wait for the card to settle.
-        for _ in range(40):
+        for _ in range(200):
             await pilot.pause()
             if session.shell_records:
                 break
@@ -802,7 +807,7 @@ async def test_a_recalled_bang_line_still_runs_as_a_command() -> None:
         for key in "echo first":
             await pilot.press("space" if key == " " else key)
         await pilot.press("enter")
-        for _ in range(40):
+        for _ in range(200):
             await pilot.pause()
             if session.shell_records:
                 break
@@ -812,7 +817,7 @@ async def test_a_recalled_bang_line_still_runs_as_a_command() -> None:
         assert editor.shell_mode is False
         assert editor.text == "! echo first"
         await pilot.press("enter")
-        for _ in range(40):
+        for _ in range(200):
             await pilot.pause()
             if len(session.shell_records) >= 2:
                 break
@@ -862,7 +867,7 @@ async def test_esc_aborts_a_running_shell_command() -> None:
         # Wait until the card is on screen and still running — the whole
         # point of this test is the in-flight state, not the settled one.
         card = None
-        for _ in range(40):
+        for _ in range(200):
             await pilot.pause()
             cards = [
                 block
@@ -876,13 +881,18 @@ async def test_esc_aborts_a_running_shell_command() -> None:
         assert card is not None
         assert card._state == "running"
         await pilot.press("escape")
-        await pilot.pause()
+        # Read the interrupted frame WITHOUT yielding first: the abort marks
+        # the card and keeps ownership synchronously on the key press, so the
+        # assertions must observe that on-press state before the event loop
+        # hands control to the shell worker. A `pause()` here raced under
+        # parallel load — the aborted worker reaped `sleep 30` and cleared
+        # `_shell_card` to None before the ownership assertion read it.
         assert card._state == "interrupted"
         # The card stays owned until execute_bash has reaped the process and
         # persisted its interrupted result. Clearing it on the key press made
         # the receipt disappear on resume.
         assert app._shell_card is card
-        for _ in range(40):
+        for _ in range(200):
             await pilot.pause()
             if app._shell_card is None:
                 break
@@ -909,7 +919,7 @@ async def test_a_failing_command_marks_the_card_failed_and_persists_it_so() -> N
         for key in "exit 3":
             await pilot.press("space" if key == " " else key)
         await pilot.press("enter")
-        for _ in range(40):
+        for _ in range(200):
             await pilot.pause()
             if session.shell_records:
                 break
@@ -936,7 +946,7 @@ async def test_a_signal_killed_command_marks_the_card_failed() -> None:
         for key in "kill -9 $$":
             await pilot.press("space" if key == " " else key)
         await pilot.press("enter")
-        for _ in range(40):
+        for _ in range(200):
             await pilot.pause()
             if session.shell_records:
                 break
@@ -963,7 +973,7 @@ async def test_a_bang_card_settles_open() -> None:
         for key in "echo open-me":
             await pilot.press("space" if key == " " else key)
         await pilot.press("enter")
-        for _ in range(40):
+        for _ in range(200):
             await pilot.pause()
             if session.shell_records:
                 break
@@ -1044,7 +1054,7 @@ async def test_a_bang_card_says_who_ran_it() -> None:
         for key in "echo attribution":
             await pilot.press("space" if key == " " else key)
         await pilot.press("enter")
-        for _ in range(40):
+        for _ in range(200):
             await pilot.pause()
             if session.shell_records:
                 break
@@ -1124,7 +1134,7 @@ async def test_a_failing_bang_card_settles_open_too() -> None:
         for key in "exit 3":
             await pilot.press("space" if key == " " else key)
         await pilot.press("enter")
-        for _ in range(40):
+        for _ in range(200):
             await pilot.pause()
             if session.shell_records:
                 break
@@ -1190,8 +1200,15 @@ async def test_a_bang_call_with_no_recorded_result_stays_shut() -> None:
     ]
     app = OperatorApp(lambda: _factory(session))
     async with app.run_test(size=(80, 24)) as pilot:
-        await pilot.pause()
-        cards = [b for b in app.query_one(TranscriptView).blocks() if isinstance(b, ToolCard)]
+        # Poll until the boot worker has rendered the resumed history rather
+        # than betting one frame is enough: under parallel CPU load the
+        # transcript was still empty when a single tick expired.
+        cards: list[ToolCard] = []
+        for _ in range(200):
+            await pilot.pause()
+            cards = [b for b in app.query_one(TranscriptView).blocks() if isinstance(b, ToolCard)]
+            if cards:
+                break
         assert len(cards) == 1
         assert cards[0]._state == "interrupted"
         assert cards[0].expanded is False
@@ -1211,7 +1228,7 @@ async def test_a_user_collapse_after_settle_is_final() -> None:
         for key in "echo hi":
             await pilot.press("space" if key == " " else key)
         await pilot.press("enter")
-        for _ in range(40):
+        for _ in range(200):
             await pilot.pause()
             if session.shell_records:
                 break
@@ -1240,7 +1257,7 @@ async def test_a_refused_second_command_comes_back_in_shell_mode() -> None:
         for key in "sleep 30":
             await pilot.press("space" if key == " " else key)
         await pilot.press("enter")
-        for _ in range(40):
+        for _ in range(200):
             await pilot.pause()
             if app._shell_card is not None:
                 break
@@ -1257,7 +1274,7 @@ async def test_a_refused_second_command_comes_back_in_shell_mode() -> None:
         assert editor.placeholder == SHELL_PLACEHOLDER
         await pilot.press("escape")  # leave the mode
         await pilot.press("escape")  # abort the running command
-        for _ in range(40):
+        for _ in range(200):
             await pilot.pause()
             if session.shell_records:
                 break
@@ -1293,7 +1310,7 @@ async def test_reload_aborts_and_settles_shell_before_disposing_its_session() ->
         for key in "sleep 30":
             await pilot.press("space" if key == " " else key)
         await pilot.press("enter")
-        for _ in range(40):
+        for _ in range(200):
             await pilot.pause()
             if app._shell_card is not None:
                 break

--- a/tests/unit/tui/test_approvals_ux.py
+++ b/tests/unit/tui/test_approvals_ux.py
@@ -63,6 +63,32 @@ async def _boot(pilot, app: OperatorApp) -> None:
             return
 
 
+async def _wait_prompt(pilot, app: OperatorApp) -> None:
+    """Settle until the in-flight gate's question is mounted.
+
+    Replaces a fixed `pilot.pause(0.3)` that bet on how long the gate takes to
+    arm and raise its card; the observable the next assertion needs is the
+    ``ApprovalPrompt`` on screen, so wait for exactly that. The ceiling is a
+    deadlock guard, not a timing assumption.
+    """
+    for _ in range(200):
+        await pilot.pause()
+        if app.query(ApprovalPrompt):
+            return
+
+
+async def _settle(pilot, ticks: int = 6) -> None:
+    """Let the event loop drain for a bounded number of idle ticks.
+
+    Used where the assertion is a NEGATIVE — that no prompt mounted — which
+    cannot be polled for (there is no state to wait to appear); a fixed handful
+    of idle waits gives any erroneous mount the chance to happen so its absence
+    is meaningful.
+    """
+    for _ in range(ticks):
+        await pilot.pause()
+
+
 async def _type(pilot, app: OperatorApp, text: str) -> None:
     """Put ``text`` in the composer the way typing does, and settle the lists.
 
@@ -530,7 +556,13 @@ async def test_the_band_and_the_gate_agree_through_every_route(config_dir: Path)
 
         async def gate_runs_without_asking() -> bool:
             pending = asyncio.ensure_future(gate("bash", "run: echo hi"))
-            await pilot.pause(0.2)
+            # Wait for whichever terminal state the mode produces: an auto gate
+            # returns immediately, an asking gate mounts a prompt. Polling both
+            # replaces a fixed `pause(0.2)` that bet the slower one had settled.
+            for _ in range(200):
+                await pilot.pause()
+                if pending.done() or app.query(ApprovalPrompt):
+                    break
             if pending.done():
                 return await pending
             # A prompt is on screen: the gate is armed. Answer it so the test
@@ -583,7 +615,7 @@ async def test_the_live_prompt_is_untouched_by_the_default_machinery(
         gate = _gate(session)
 
         first = asyncio.ensure_future(gate("bash", "run: one"))
-        await pilot.pause(0.3)
+        await _wait_prompt(pilot, app)
         # The live question is the docked card; the transcript keeps the
         # RECEIPT once it is answered. Two widgets, two jobs.
         assert app.query(ApprovalPrompt), "the prompt no longer mounts"
@@ -593,7 +625,7 @@ async def test_the_live_prompt_is_untouched_by_the_default_machinery(
 
         # …and one refusal is not a mode: the next ask still asks.
         second = asyncio.ensure_future(gate("write", "write: two"))
-        await pilot.pause(0.3)
+        await _wait_prompt(pilot, app)
         assert app.query(ApprovalPrompt)
         await pilot.press("y")
         assert await asyncio.wait_for(second, 2) is True
@@ -604,7 +636,7 @@ async def test_the_live_prompt_is_untouched_by_the_default_machinery(
         app._deny_queued_approvals()
         third = asyncio.ensure_future(gate("bash", "run: three"))
         assert await asyncio.wait_for(third, 2) is False
-        await pilot.pause(0.2)
+        await _settle(pilot)
         # No question was raised for the stopped turn's ask...
         assert not app.query(ApprovalPrompt), "a stopped turn's ask mounted a question"
         # ...and no receipt was written for a decision the user never made.
@@ -628,7 +660,7 @@ async def test_the_allow_all_key_reports_and_paints_like_the_command(
     async with app.run_test(size=(120, 40)) as pilot:
         await _boot(pilot, app)
         pending = asyncio.ensure_future(_gate(session)("bash", "run: one"))
-        await pilot.pause(0.3)
+        await _wait_prompt(pilot, app)
         await pilot.press("A")
         assert await asyncio.wait_for(pending, 2) is True
 

--- a/tests/unit/tui/test_ask_picker.py
+++ b/tests/unit/tui/test_ask_picker.py
@@ -1364,20 +1364,27 @@ async def test_a_held_key_never_answers_a_question_the_card_moved_on_from() -> N
         card = app._ask_screen
         assert card is not None
 
+        # The fixed pauses in THIS test are deliberate and must not be converted
+        # to idle-waits. It probes a wall-clock ordering race: a key parked in the
+        # composer must not commit once the card has advanced past the question it
+        # was aimed at. The `pause(0.1)` after the click lets focus/routing settle
+        # so the press is held rather than dropped; `action_accept()` must run
+        # while the key is still parked (before the ~180 ms ANSWER_KEY_HOLD_S timer
+        # fires); and the trailing pump outlasts that window so any wrong commit
+        # would already have happened. An idle-wait cannot express "before a real
+        # timer fires" and made this test commit the stale key under CPU
+        # contention — the exact bug it exists to catch.
         await pilot.click(Editor)
-        await _until(pilot, lambda: isinstance(app.screen.focused, Editor))
+        await pilot.pause(0.1)
         await pilot.press("2")  # aimed at question 1: "Canary"
         assert app._held_answer_key is not None, "the key was not held"
 
         # The card advances to question 2 while the key is still parked.
         card.focus()
-        await pilot.pause()
+        await pilot.pause(0.02)
         card.action_accept()
-        # Pump the event loop so the stale key's hold window elapses and any
-        # (wrongly) parked answer would have committed by now — the assertion
-        # is that it did NOT. Idle-waits let that work run without a fixed bet
-        # on how long it takes; the key clears once the card has advanced.
-        await _until(pilot, lambda: app._held_answer_key is None)
+        for _ in range(20):
+            await pilot.pause(0.03)
 
         # The stale key answered nothing: question 2 is still being asked.
         assert not asked.done(), "a parked key answered a question it was not aimed at"

--- a/tests/unit/tui/test_ask_picker.py
+++ b/tests/unit/tui/test_ask_picker.py
@@ -730,6 +730,24 @@ def _painted_rows(app) -> list[str]:  # type: ignore[no-untyped-def]
     return [text for text in (strip.text.strip() for strip in strips) if text]
 
 
+async def _until(pilot, predicate, *, ceiling: int = 200) -> None:  # type: ignore[no-untyped-def]
+    """Idle-pump until PREDICATE holds, bounded by a deadlock guard.
+
+    Replaces a fixed ``pilot.pause(<seconds>)`` bet on how long a repaint, a
+    focus move or an answer takes. ``pilot.pause()`` with no argument returns
+    when the event loop next goes idle — as soon as the awaited work is actually
+    done — so polling the observable state the next assertion needs is both
+    faster and steadier than a wall-clock sleep, which loses its bet and flakes
+    under the parallel CPU contention of ``-n``. The ceiling is generous on
+    purpose: it exists only to fail a genuine deadlock, never to stand in for a
+    timing assumption.
+    """
+    for _ in range(ceiling):
+        await pilot.pause()
+        if predicate():
+            return
+
+
 @pytest.mark.asyncio
 async def test_the_keys_and_an_option_survive_every_terminal_the_card_fits_in() -> None:
     """The blocker this layout exists for: at 100x14 the card drew a question,
@@ -1242,15 +1260,15 @@ async def test_escape_skips_the_question_from_the_composer() -> None:
 
         # Answer the first question on the card, then move to the composer.
         await pilot.press("enter")
-        await pilot.pause(0.1)
+        await pilot.pause()
         await pilot.click(Editor)
-        await pilot.pause(0.1)
+        await _until(pilot, lambda: isinstance(app.screen.focused, Editor))
         assert isinstance(app.screen.focused, Editor)
 
         await pilot.press("escape")
         # The question is settled, the card is gone, and the answer survived.
         assert await asyncio.wait_for(asked, 2) == {"first": ["Alpha"]}
-        await pilot.pause(0.2)
+        await _until(pilot, lambda: not app.query(AskPickerScreen))
         assert not app.query(AskPickerScreen)
 
 
@@ -1279,7 +1297,10 @@ async def test_the_footer_names_only_keys_that_work_where_the_caret_is() -> None
         assert "↑↓" in focused_footer and "enter" in focused_footer
 
         await pilot.click(Editor)
-        await pilot.pause(0.2)
+        # The footer repaints when focus lands in the composer; wait for that
+        # repaint (the routed keys stand down) rather than betting on its wall
+        # time. This is the state the assertions below read from the compositor.
+        await _until(pilot, lambda: "↑↓" not in _painted_footer(app))
         # Read what was PAINTED, not what a fresh render would produce.
         #
         # This is the assertion the first version of this test got wrong.
@@ -1344,16 +1365,19 @@ async def test_a_held_key_never_answers_a_question_the_card_moved_on_from() -> N
         assert card is not None
 
         await pilot.click(Editor)
-        await pilot.pause(0.1)
+        await _until(pilot, lambda: isinstance(app.screen.focused, Editor))
         await pilot.press("2")  # aimed at question 1: "Canary"
         assert app._held_answer_key is not None, "the key was not held"
 
         # The card advances to question 2 while the key is still parked.
         card.focus()
-        await pilot.pause(0.02)
+        await pilot.pause()
         card.action_accept()
-        for _ in range(20):
-            await pilot.pause(0.03)
+        # Pump the event loop so the stale key's hold window elapses and any
+        # (wrongly) parked answer would have committed by now — the assertion
+        # is that it did NOT. Idle-waits let that work run without a fixed bet
+        # on how long it takes; the key clears once the card has advanced.
+        await _until(pilot, lambda: app._held_answer_key is None)
 
         # The stale key answered nothing: question 2 is still being asked.
         assert not asked.done(), "a parked key answered a question it was not aimed at"
@@ -1385,7 +1409,9 @@ async def test_a_multi_select_advertises_no_key_it_cannot_be_answered_by() -> No
             await pilot.pause()
 
         await pilot.click(Editor)
-        await pilot.pause(0.2)
+        # Wait for the composer-mode footer to repaint (the gesture replaces the
+        # ordinal range) rather than betting on its wall time.
+        await _until(pilot, lambda: "answer here" in _painted_footer(app))
         footer = _painted_footer(app)
         # No ORDINAL range is claimed — a digit cannot answer a multi-select.
         # What is offered instead is the explicit gesture that reaches the card
@@ -1395,7 +1421,7 @@ async def test_a_multi_select_advertises_no_key_it_cannot_be_answered_by() -> No
         assert "esc" in footer, footer
         # ...and the digit that would have been claimed indeed answers nothing.
         await pilot.press("1")
-        await pilot.pause(0.3)
+        await pilot.pause()
         assert not asked.done(), "a digit answered a multi-select"
 
         asked.cancel()
@@ -1426,7 +1452,9 @@ async def test_the_composer_footer_keeps_its_exit_on_a_narrow_card() -> None:
             for _ in range(16):
                 await pilot.pause()
             await pilot.click(Editor)
-            await pilot.pause(0.2)
+            # Wait for the composer-mode footer to repaint (its exit becomes the
+            # last hint standing at these narrow widths) rather than sleeping.
+            await _until(pilot, lambda: "esc skip" in _painted_footer(app))
 
             footer = _painted_footer(app)
             # The exit survives WHOLE — not truncated, not ellipsised.
@@ -1464,26 +1492,26 @@ async def test_the_footer_follows_the_draft_as_it_is_typed() -> None:
         for _ in range(16):
             await pilot.pause()
         await pilot.click(Editor)
-        await pilot.pause(0.2)
+        await _until(pilot, lambda: "answer" in _painted_footer(app))
         assert "answer" in _painted_footer(app), "the routed keys were never offered"
 
         # Opening a draft withdraws the offer, on the frame the user sees.
         for character in "drop":
             await pilot.press(character)
-        await pilot.pause(0.3)
+        await _until(pilot, lambda: "answer" not in _painted_footer(app))
         withdrawn = _painted_footer(app)
         assert "answer" not in withdrawn, withdrawn
         assert "esc" in withdrawn, withdrawn
         # ...and the key it stopped advertising really is a text character now.
         await pilot.press("1")
-        await pilot.pause(0.2)
+        await _until(pilot, lambda: app.query_one(Editor).text == "drop1")
         assert not asked.done(), "a routed key answered while a draft was open"
         assert app.query_one(Editor).text == "drop1"
 
         # Clearing the draft brings the offer back, and it works.
         for _ in range(len("drop1")):
             await pilot.press("backspace")
-        await pilot.pause(0.3)
+        await _until(pilot, lambda: "answer" in _painted_footer(app))
         restored = _painted_footer(app)
         assert "answer" in restored, restored
         await pilot.press("1")
@@ -1515,7 +1543,7 @@ async def test_a_multi_select_is_reachable_by_an_explicit_gesture() -> None:
         for _ in range(16):
             await pilot.pause()
         await pilot.click(Editor)
-        await pilot.pause(0.2)
+        await _until(pilot, lambda: "answer here" in _painted_footer(app))
 
         # The footer NAMES it, or it is a key nobody can discover.
         assert "answer here" in _painted_footer(app), _painted_footer(app)
@@ -1524,7 +1552,7 @@ async def test_a_multi_select_is_reachable_by_an_explicit_gesture() -> None:
         # because the full-width assertion passes against any truncation.
 
         await pilot.press("tab")
-        await pilot.pause(0.2)
+        await _until(pilot, lambda: isinstance(app.screen.focused, AskPickerScreen))
         assert isinstance(app.screen.focused, AskPickerScreen)
 
         await pilot.press("space")
@@ -1553,7 +1581,9 @@ async def test_the_gesture_sheds_its_word_before_the_exit() -> None:
             for _ in range(16):
                 await pilot.pause()
             await pilot.click(Editor)
-            await pilot.pause(0.25)
+            # Wait for the composer-mode footer to repaint with the gesture hint
+            # rather than sleeping; the exit and the Tab key are what settle in.
+            await _until(pilot, lambda: "esc skip" in _painted_footer(app))
 
             footer = _painted_footer(app)
             # The exit survives WHOLE, and the Tab key is still named.
@@ -1586,13 +1616,13 @@ async def test_the_gesture_preserves_a_draft_and_leaves_routable_cards_alone() -
         editor.focus()
         for character in "hold that":
             await pilot.press("space" if character == " " else character)
-        await pilot.pause(0.1)
+        await _until(pilot, lambda: app.query_one(Editor).text == "hold that")
         asked = asyncio.create_task(app.request_user_choice([_question(multi=True)]))
         for _ in range(16):
             await pilot.pause()
 
         await pilot.press("tab")
-        await pilot.pause(0.2)
+        await _until(pilot, lambda: isinstance(app.screen.focused, AskPickerScreen))
         assert isinstance(app.screen.focused, AskPickerScreen)
         assert app.query_one(Editor).text == "hold that", "the gesture ate the draft"
 
@@ -1610,9 +1640,11 @@ async def test_the_gesture_preserves_a_draft_and_leaves_routable_cards_alone() -
         for _ in range(16):
             await pilot.pause()
         await pilot.click(Editor)
-        await pilot.pause(0.2)
+        await _until(pilot, lambda: isinstance(app.screen.focused, Editor))
         await pilot.press("tab")
-        await pilot.pause(0.2)
+        # A routable card must NOT pull focus, so the caret stays in the editor;
+        # pump the loop to let any (wrong) handover happen — it does not.
+        await pilot.pause()
         assert isinstance(app.screen.focused, Editor)
         # ...because it is answerable from where the caret already is.
         await pilot.press("1")
@@ -1637,7 +1669,7 @@ async def test_rewording_a_draft_never_moves_the_keyboard() -> None:
         editor.focus()
         for character in "hmm":
             await pilot.press(character)
-        await pilot.pause(0.1)
+        await _until(pilot, lambda: app.query_one(Editor).text == "hmm")
         asked = asyncio.create_task(app.request_user_choice([_question(multi=True)]))
         for _ in range(16):
             await pilot.pause()
@@ -1645,13 +1677,16 @@ async def test_rewording_a_draft_never_moves_the_keyboard() -> None:
         # Delete the line to reword it...
         for _ in range(len("hmm")):
             await pilot.press("backspace")
-        await pilot.pause(0.3)
+        # The keyboard must stay in the editor through the delete-to-empty (the
+        # handover fires on that condition, wrongly, before the fix); pump the
+        # loop to let any handover happen — it does not.
+        await _until(pilot, lambda: app.query_one(Editor).text == "")
         assert isinstance(app.screen.focused, Editor), "rewording moved the keyboard"
 
         # ...and the retyped message lands in the composer, answering nothing.
         for character in "just checking":
             await pilot.press("space" if character == " " else character)
-        await pilot.pause(0.3)
+        await _until(pilot, lambda: app.query_one(Editor).text == "just checking")
         assert app.query_one(Editor).text == "just checking"
         assert not asked.done()
         card = app._ask_screen
@@ -1693,7 +1728,7 @@ async def test_the_card_repaints_itself_when_its_inputs_move_untriggered() -> No
         card = app._ask_screen
         assert card is not None
         await pilot.click(Editor)
-        await pilot.pause(0.2)
+        await _until(pilot, lambda: "answer" in _painted_footer(app))
         assert "answer" in _painted_footer(app)
 
         # Move the input WITHOUT any repaint: set the buffer directly on the
@@ -1704,8 +1739,7 @@ async def test_the_card_repaints_itself_when_its_inputs_move_untriggered() -> No
 
         # One tick of the app's own poll and the card notices by itself.
         app._refresh_band()
-        for _ in range(6):
-            await pilot.pause(0.05)
+        await _until(pilot, lambda: card.footer_fingerprint() == card._painted_fingerprint)
         assert (
             card.footer_fingerprint() == card._painted_fingerprint
         ), "the card did not repaint itself when its inputs had moved"
@@ -1786,7 +1820,7 @@ async def test_sending_a_message_does_not_hand_the_keyboard_to_the_question() ->
         editor.focus()
         for character in "please check the schema":
             await pilot.press("space" if character == " " else character)
-        await pilot.pause(0.1)
+        await _until(pilot, lambda: app.query_one(Editor).text == "please check the schema")
 
         asked = asyncio.create_task(
             app.request_user_choice([_question(multi=True, labels=("Drop", "next"))])
@@ -1798,19 +1832,19 @@ async def test_sending_a_message_does_not_hand_the_keyboard_to_the_question() ->
         # Send it. The send empties the buffer, which must NOT be read as the
         # user finishing with the composer.
         await pilot.press("enter")
-        for _ in range(10):
-            await pilot.pause(0.05)
+        await _until(pilot, lambda: session.prompts[-1:] == ["please check the schema"])
         assert session.prompts[-1:] == ["please check the schema"], session.prompts
         assert isinstance(app.screen.focused, Editor), "sending handed over the keyboard"
 
         # The next message is typed, not answered.
         for character in "ok next":
             await pilot.press("space" if character == " " else character)
-        await pilot.pause(0.2)
+        await _until(pilot, lambda: app.query_one(Editor).text == "ok next")
         assert app.query_one(Editor).text == "ok next"
         await pilot.press("enter")
-        for _ in range(10):
-            await pilot.pause(0.05)
+        # Pump the loop so the send fully drains; the assertion is that this
+        # chat message did NOT answer the agent's question.
+        await _until(pilot, lambda: app.query_one(Editor).text == "")
         assert not asked.done(), "a chat message answered the agent's question"
 
         asked.cancel()
@@ -1839,7 +1873,7 @@ async def test_a_collapsed_card_never_takes_the_keyboard() -> None:
         editor.focus()
         for character in "hmm":
             await pilot.press(character)
-        await pilot.pause(0.1)
+        await _until(pilot, lambda: app.query_one(Editor).text == "hmm")
 
         asked = asyncio.create_task(app.request_user_choice([_long_question()]))
         for _ in range(16):
@@ -1850,7 +1884,10 @@ async def test_a_collapsed_card_never_takes_the_keyboard() -> None:
 
         for _ in range(len("hmm")):
             await pilot.press("backspace")
-        await pilot.pause(0.3)
+        # A collapsed card must never take the keyboard, so focus stays in the
+        # editor through the delete-to-empty; pump the loop to let any (wrong)
+        # handover fire — it does not.
+        await _until(pilot, lambda: app.query_one(Editor).text == "")
         assert isinstance(app.screen.focused, Editor)
 
         asked.cancel()
@@ -1881,13 +1918,13 @@ async def test_a_live_question_does_not_break_slash_completion() -> None:
 
         editor = app.query_one(Editor)
         editor.focus()
-        await pilot.pause(0.1)
+        await _until(pilot, lambda: isinstance(app.screen.focused, Editor))
         for character in "/mod":
             await pilot.press(character)
-        await pilot.pause(0.3)
+        await _until(pilot, lambda: app.query_one(Editor).text == "/mod")
 
         await pilot.press("tab")
-        await pilot.pause(0.3)
+        await _until(pilot, lambda: app.query_one(Editor).text == "/model ")
         assert app.query_one(Editor).text == "/model ", app.query_one(Editor).text
 
         asked.cancel()

--- a/tests/unit/tui/test_composer_seam.py
+++ b/tests/unit/tui/test_composer_seam.py
@@ -172,7 +172,18 @@ LAST_BLOCK: dict[str, tuple[Any, str]] = {
 }
 
 
-async def _settle(pilot: Any, ticks: int = 4) -> None:
+async def _settle(pilot: Any, ticks: int = 2) -> None:
+    """Pump ``ticks`` idle frames so a just-mutated frame reaches its layout.
+
+    Each ``pause()`` is an idle-wait, not a sleep, so this is load-robust: under
+    CPU contention a tick simply takes longer wall time, it does not skip work.
+    The DEFAULT is two because static content (a block appended, the padding row
+    added) settles in one idle frame and the second is margin — measured across
+    every ``SIZES`` frame. Callers pass a HIGHER count only where the frame is
+    driven by the boot splash's self-rescheduling measurement (an animation on
+    the wall clock, which needs several ticks to span); those counts stay,
+    because there the number of frames IS the thing being waited out.
+    """
     for _ in range(ticks):
         await pilot.pause()
 

--- a/tests/unit/tui/test_steering_approval.py
+++ b/tests/unit/tui/test_steering_approval.py
@@ -192,7 +192,7 @@ async def _boot(pilot: Any, app: OperatorApp) -> None:
 async def _submit(pilot: Any, app: OperatorApp, text: str) -> None:
     app.query_one(Editor).text = text
     await pilot.press("enter")
-    await pilot.pause(0.1)
+    await pilot.pause()
 
 
 @pytest.mark.asyncio
@@ -236,7 +236,7 @@ async def test_escape_stops_a_running_turn() -> None:
         editor = app.query_one(Editor)
         editor.text = "kept"
         await pilot.press("escape")
-        await pilot.pause(0.1)
+        await pilot.pause()
         assert session.aborts == []
         assert editor.text == "kept"
         # Focus MUST stay in the composer. TextArea binds Escape to `blur`, which
@@ -246,7 +246,7 @@ async def test_escape_stops_a_running_turn() -> None:
 
         session.streaming = True
         await pilot.press("escape")
-        await pilot.pause(0.1)
+        await pilot.pause()
         assert session.aborts == ["interrupted"]
         assert app.screen.focused is editor
 
@@ -274,7 +274,7 @@ async def test_empty_assistant_message_mounts_no_block() -> None:
                 )
             )
         )
-        await pilot.pause(0.3)
+        await pilot.pause()
 
         assert not app.query(AssistantBlock)
         painted = rows(app)
@@ -345,7 +345,7 @@ async def test_n_denies_one_tool_and_lets_the_turn_continue() -> None:
         ask = await _booted_gate(pilot, session)
         session.streaming = True
         pending = asyncio.ensure_future(ask("write", "write: /etc/hosts"))
-        await pilot.pause(0.3)
+        await pilot.pause()
 
         await pilot.press("n")
         assert await asyncio.wait_for(pending, 2) is False
@@ -369,7 +369,7 @@ async def test_escape_denies_the_prompt_and_stops_the_turn() -> None:
         session.streaming = True
         first = asyncio.ensure_future(ask("write", "write: /etc/hosts"))
         second = asyncio.ensure_future(ask("bash", "run: rm -rf /"))
-        await pilot.pause(0.3)
+        await pilot.pause()
 
         await pilot.press("escape")
         # BOTH asks are settled by the one press, and the turn is stopped.
@@ -389,16 +389,16 @@ async def test_allow_all_latches_for_the_session() -> None:
         await _boot(pilot, app)
         ask = await _booted_gate(pilot, session)
         first = asyncio.ensure_future(ask("bash", "run: make"))
-        await pilot.pause(0.3)
+        await pilot.pause()
         await pilot.press("A")
         assert await asyncio.wait_for(first, 2) is True
-        await pilot.pause(0.1)
+        await pilot.pause()
 
         # No prompt is mounted for the second ask at all.
         before = len(app.query(ApprovalPrompt))
         second = asyncio.ensure_future(ask("write", "write: out.txt"))
         assert await asyncio.wait_for(second, 2) is True
-        await pilot.pause(0.1)
+        await pilot.pause()
         assert len(app.query(ApprovalPrompt)) == before
 
 
@@ -417,7 +417,7 @@ async def test_interrupt_denies_a_parked_approval() -> None:
         ask = await _booted_gate(pilot, session)
         session.streaming = True
         pending = asyncio.ensure_future(ask("bash", "run: sleep 99"))
-        await pilot.pause(0.3)
+        await pilot.pause()
 
         app.action_interrupt()
         assert await asyncio.wait_for(pending, 2) is False
@@ -433,10 +433,10 @@ async def test_clearing_the_transcript_settles_a_pending_approval() -> None:
         await _boot(pilot, app)
         ask = await _booted_gate(pilot, session)
         pending = asyncio.ensure_future(ask("bash", "run: make"))
-        await pilot.pause(0.3)
+        await pilot.pause()
 
         app.query_one(TranscriptView).clear_blocks()
-        await pilot.pause(0.1)
+        await pilot.pause()
         assert await asyncio.wait_for(pending, 2) is False
 
 
@@ -458,18 +458,18 @@ async def test_escape_closes_an_open_picker_before_it_stops_anything() -> None:
 
         editor = app.query_one(Editor)
         editor.text = "/"
-        await pilot.pause(0.2)
+        await pilot.pause()
         assert editor.picker.is_open()
 
         await pilot.press("escape")
-        await pilot.pause(0.1)
+        await pilot.pause()
         assert not editor.picker.is_open()  # the list closed…
         assert session.aborts == []  # …and the turn was NOT stopped
 
         # The very next Esc stops the turn — no dead press in between, and focus
         # never leaves the composer.
         await pilot.press("escape")
-        await pilot.pause(0.1)
+        await pilot.pause()
         assert session.aborts == ["interrupted"]
         assert app.screen.focused is editor
 
@@ -492,13 +492,13 @@ async def test_a_queued_ask_is_denied_rather_than_re_asked_after_a_stop() -> Non
         session.streaming = True
         first = asyncio.ensure_future(ask("bash", "run: one"))
         second = asyncio.ensure_future(ask("bash", "run: two"))
-        await pilot.pause(0.3)
+        await pilot.pause()
         assert len(app.query(ApprovalPrompt)) == 1  # serialized, not stacked
 
         app.action_interrupt()
         assert await asyncio.wait_for(first, 2) is False
         assert await asyncio.wait_for(second, 2) is False
-        await pilot.pause(0.2)
+        await pilot.pause()
         # No fresh question was mounted for the stopped turn.
         assert not app.query(ApprovalPrompt)
 
@@ -518,12 +518,12 @@ async def test_allow_all_is_seen_by_an_already_queued_ask() -> None:
         ask = await _booted_gate(pilot, session)
         first = asyncio.ensure_future(ask("bash", "run: one"))
         second = asyncio.ensure_future(ask("write", "write: two"))
-        await pilot.pause(0.3)
+        await pilot.pause()
 
         await pilot.press("A")
         assert await asyncio.wait_for(first, 2) is True
         assert await asyncio.wait_for(second, 2) is True  # never asked again
-        await pilot.pause(0.2)
+        await pilot.pause()
         assert not app.query(ApprovalPrompt)
 
 
@@ -547,7 +547,7 @@ async def test_lowercase_a_does_not_disarm_the_gate() -> None:
             await pilot.pause(0.02)
 
         await pilot.press("a")
-        await pilot.pause(0.2)
+        await pilot.pause()
         assert not pending.done()  # the question is still being asked
         assert app._approve_all is False
         # The card KEEPS focus and keeps the question answerable.
@@ -576,19 +576,19 @@ async def test_approvals_command_restores_prompting() -> None:
     async with app.run_test(size=(100, 30)) as pilot:
         await _boot(pilot, app)
         app._run_slash_command("/approvals auto")
-        await pilot.pause(0.1)
+        await pilot.pause()
         assert app._approve_all is True
         # The band's alarm is a bare `!` in the trailing cell now — the session
         # name took the words that used to be there.
         assert any(row.rstrip().endswith("!") for row in rows(app))
 
         app._run_slash_command("/approvals ask")
-        await pilot.pause(0.1)
+        await pilot.pause()
         assert app._approve_all is False
         assert not any(row.rstrip().endswith("!") for row in rows(app))
         # And the gate really asks again.
         pending = asyncio.ensure_future(_approval_gate(session)("bash", "run: x"))
-        await pilot.pause(0.3)
+        await pilot.pause()
         assert app.query(ApprovalPrompt)
         await pilot.press("n")
         assert await asyncio.wait_for(pending, 2) is False
@@ -616,7 +616,7 @@ async def test_ctrl_c_twice_exits_and_offers_the_resume_command(
         session.streaming = True
 
         await pilot.press("ctrl+c")
-        await pilot.pause(0.1)
+        await pilot.pause()
         assert session.aborts == ["interrupted"]
         assert app.is_running  # one press NEVER exits
         assert any("ctrl+c again to exit" in row for row in rows(app))
@@ -628,7 +628,7 @@ async def test_ctrl_c_twice_exits_and_offers_the_resume_command(
         assert not any("--resume" in row for row in rows(app))
 
         await pilot.press("ctrl+c")
-        await pilot.pause(0.3)
+        await pilot.pause()
         assert not app.is_running
 
     assert app.resume_hint() == "lop --resume sess"
@@ -648,11 +648,11 @@ async def test_a_slow_second_ctrl_c_is_a_fresh_interrupt_not_an_exit() -> None:
         session.streaming = True
 
         await pilot.press("ctrl+c")
-        await pilot.pause(0.1)
+        await pilot.pause()
         # Age the first press past the window without waiting for it.
         app._last_interrupt_at -= DOUBLE_INTERRUPT_WINDOW_S + 1
         await pilot.press("ctrl+c")
-        await pilot.pause(0.2)
+        await pilot.pause()
         assert app.is_running
         assert session.aborts == ["interrupted", "interrupted"]
         # One hint, not one per press: it is replaced rather than repeated.
@@ -670,11 +670,11 @@ async def test_an_empty_message_end_keeps_the_streamed_prose() -> None:
         app.post_message(TurnStarted())
         app.post_message(AssistantMessageStart())
         app.post_message(AssistantDelta("hello from the model"))
-        await pilot.pause(0.2)
+        await pilot.pause()
         assert any("hello from the model" in row for row in rows(app))
 
         app.post_message(AssistantMessageEnd(""))
-        await pilot.pause(0.2)
+        await pilot.pause()
         assert any("hello from the model" in row for row in rows(app))
         assert len(app.query(AssistantBlock)) == 1
 
@@ -732,15 +732,15 @@ async def test_clearing_the_transcript_does_not_disarm_later_prompts() -> None:
         session.streaming = True
 
         first = asyncio.ensure_future(ask("bash", "run: one"))
-        await pilot.pause(0.3)
+        await pilot.pause()
         app.query_one(TranscriptView).clear_blocks()
-        await pilot.pause(0.2)
+        await pilot.pause()
         assert await asyncio.wait_for(first, 2) is False  # its widget is gone
         assert session.aborts == []  # the turn was NOT stopped
 
         # The next tool of the same run still gets to ask.
         second = asyncio.ensure_future(ask("write", "write: two"))
-        await pilot.pause(0.3)
+        await pilot.pause()
         assert app.query(ApprovalPrompt), "a later tool of a live turn must still ask"
         await pilot.press("y")
         assert await asyncio.wait_for(second, 2) is True
@@ -763,10 +763,10 @@ async def test_approvals_ask_clears_a_latched_deny() -> None:
         assert app._approvals_are_denied(app._turn_epoch) is True
 
         app._run_slash_command("/approvals ask")
-        await pilot.pause(0.1)
+        await pilot.pause()
         assert app._approvals_are_denied(app._turn_epoch) is False
         pending = asyncio.ensure_future(_approval_gate(session)("bash", "run: x"))
-        await pilot.pause(0.3)
+        await pilot.pause()
         assert app.query(ApprovalPrompt)
         await pilot.press("y")
         assert await asyncio.wait_for(pending, 2) is True
@@ -787,7 +787,7 @@ async def test_the_resume_hint_is_withheld_until_the_session_is_on_disk() -> Non
         # FakeSession's id has no directory on disk, so there is nothing to offer.
         assert app.resume_hint() == ""
         await pilot.press("ctrl+c")
-        await pilot.pause(0.1)
+        await pilot.pause()
         painted = rows(app)
         assert any("ctrl+c again to exit" in row for row in painted)
         assert not any("--resume" in row for row in painted)
@@ -811,7 +811,7 @@ async def test_the_prompt_never_hides_its_target_or_overflows(width: int) -> Non
         view.append_block(
             ApprovalBlock("write_file", "[outside workspace] write: /Users/x/deep/config.yml")
         )
-        await pilot.pause(0.2)
+        await pilot.pause()
         painted = [strip.text.rstrip() for strip in app.screen._compositor.render_strips()]
 
         # Nothing bleeds past the terminal at any width.
@@ -839,9 +839,9 @@ async def test_the_answered_receipt_stays_on_one_row(width: int) -> None:
         await _boot(pilot, app)
         block = ApprovalBlock("write_file", "[outside workspace] write: /Users/x/deep/config.yml")
         app.query_one(TranscriptView).append_block(block)
-        await pilot.pause(0.1)
+        await pilot.pause()
         block.resolve(True, answer="y")
-        await pilot.pause(0.2)
+        await pilot.pause()
         painted = [strip.text.rstrip() for strip in app.screen._compositor.render_strips()]
 
         # Found by the outcome GLYPH, not by the word: below ~32 columns the
@@ -872,7 +872,7 @@ async def test_the_hint_row_sheds_whole_choices(width: int) -> None:
     async with app.run_test(size=(width, 24)) as pilot:
         await _boot(pilot, app)
         app.query_one(TranscriptView).append_block(ApprovalBlock("bash", "run: make"))
-        await pilot.pause(0.2)
+        await pilot.pause()
         painted = [strip.text.rstrip() for strip in app.screen._compositor.render_strips()]
         hint = next((row.strip() for row in painted if "deny" in row or "n/y" in row), "")
         assert hint, "the prompt must always advertise at least one answer"
@@ -910,7 +910,7 @@ async def test_a_dangerous_ask_never_paints_like_a_safe_one(width: int) -> None:
         view = app.query_one(TranscriptView)
         view.append_block(ApprovalBlock("write_file", f"{OUTSIDE_MARKER} write: /tmp/x/keys"))
         view.append_block(ApprovalBlock("write_file", "write: /tmp/x/keys"))
-        await pilot.pause(0.2)
+        await pilot.pause()
         painted = [strip.text.rstrip() for strip in app.screen._compositor.render_strips()]
         # Matched on the leading glyph, not the tool name: at the narrowest widths
         # the hazard IS the glyph (`!` for `?`), which is the behaviour under test
@@ -945,7 +945,7 @@ async def test_a_narrow_prompt_keeps_the_end_of_the_path(detail: str, expected_t
     async with app.run_test(size=(52, 24)) as pilot:
         await _boot(pilot, app)
         app.query_one(TranscriptView).append_block(ApprovalBlock("write_file", detail))
-        await pilot.pause(0.2)
+        await pilot.pause()
         painted = [strip.text.rstrip() for strip in app.screen._compositor.render_strips()]
         ask = next(row for row in painted if "write_file" in row)
         assert expected_tail in ask, ask
@@ -968,14 +968,14 @@ async def test_a_turn_start_racing_the_stop_cannot_revive_a_denied_ask() -> None
         await _boot(pilot, app)
         session.streaming = True
         first = asyncio.ensure_future(_approval_gate(session)("bash", "run: one"))
-        await pilot.pause(0.25)
+        await pilot.pause()
         second = asyncio.ensure_future(_approval_gate(session)("execute", "run: rm -rf /"))
-        await pilot.pause(0.15)
+        await pilot.pause()
 
         # The race: a turn boundary is already queued when the stop lands.
         app.post_message(TurnStarted())
         app.action_interrupt()
-        await pilot.pause(0.4)
+        await pilot.pause()
 
         assert await asyncio.wait_for(first, 2) is False
         assert await asyncio.wait_for(second, 2) is False
@@ -998,11 +998,11 @@ async def test_approvals_auto_answers_the_question_on_screen() -> None:
         await _booted_gate(pilot, session)
         session.streaming = True
         pending = asyncio.ensure_future(_approval_gate(session)("bash", "run: make"))
-        await pilot.pause(0.3)
+        await pilot.pause()
         assert app.query(ApprovalPrompt)
 
         app._run_slash_command("/approvals auto")
-        await pilot.pause(0.2)
+        await pilot.pause()
         assert await asyncio.wait_for(pending, 2) is True
         painted = [strip.text for strip in app.screen._compositor.render_strips()]
         assert [row for row in painted if "allowed" in row]
@@ -1030,7 +1030,7 @@ async def test_the_prompt_cannot_be_repainted_from_a_tool_argument() -> None:
         await _boot(pilot, app)
         block = ApprovalBlock("bash", f"run: {payload}")
         app.query_one(TranscriptView).append_block(block)
-        await pilot.pause(0.2)
+        await pilot.pause()
 
         assert "\x1b" not in block.description
         assert "\x1b" not in block.tool_name
@@ -1055,16 +1055,16 @@ async def test_a_pending_prompt_does_not_widen_the_tool_ledger() -> None:
         await _boot(pilot, app)
         view = app.query_one(TranscriptView)
         view.append_block(ToolCard("t1", "bash", {}, ""))
-        await pilot.pause(0.1)
+        await pilot.pause()
         settled = view.tool_name_col
 
         block = ApprovalBlock("mcp__linear_create_initiative", "run: x")
         view.append_block(block)
-        await pilot.pause(0.1)
+        await pilot.pause()
         assert view.tool_name_col == settled
 
         block.resolve(False, answer="n")
-        await pilot.pause(0.1)
+        await pilot.pause()
         assert view.tool_name_col == settled
 
 
@@ -1077,12 +1077,12 @@ async def test_clearing_the_transcript_forgets_the_ledger_width() -> None:
         await _boot(pilot, app)
         view = app.query_one(TranscriptView)
         view.append_block(ToolCard("t1", "mcp__linear_create_initiative", {}, ""))
-        await pilot.pause(0.1)
+        await pilot.pause()
         widened = view.tool_name_col
         assert widened > 8
 
         view.clear_blocks()
-        await pilot.pause(0.1)
+        await pilot.pause()
         assert view.tool_name_col == 8
 
 
@@ -1106,7 +1106,7 @@ async def test_a_tall_notice_is_separated_from_what_precedes_it() -> None:
         )
         view.append_block(short)
         view.append_block(tall)
-        await pilot.pause(0.3)
+        await pilot.pause()
         assert tall.spans_multiple_rows()
         assert tall.has_class("gap-above")
 
@@ -1129,7 +1129,7 @@ async def test_a_call_being_dictated_shows_a_row_that_moves() -> None:
     async with app.run_test(size=(100, 30)) as pilot:
         await _boot(pilot, app)
         app.post_message(ToolComposing(ToolCallComposeEvent(tool_call_id="c1", tool_name="write")))
-        await pilot.pause(0.1)
+        await pilot.pause()
         painted = [strip.text for strip in app.screen._compositor.render_strips()]
         assert [row for row in painted if "composing" in row]
         # No size until there is one: a `0 B` that never moves reads as stuck.
@@ -1140,7 +1140,7 @@ async def test_a_call_being_dictated_shows_a_row_that_moves() -> None:
                 ToolCallComposeEvent(tool_call_id="c1", tool_name="write", argument_bytes=14079)
             )
         )
-        await pilot.pause(0.1)
+        await pilot.pause()
         painted = [strip.text for strip in app.screen._compositor.render_strips()]
         assert [row for row in painted if "13.7 KB" in row]
 
@@ -1152,7 +1152,7 @@ async def test_a_call_being_dictated_shows_a_row_that_moves() -> None:
                 )
             )
         )
-        await pilot.pause(0.1)
+        await pilot.pause()
         painted = [strip.text for strip in app.screen._compositor.render_strips()]
         assert len([row for row in painted if "write" in row]) == 1
         assert not [row for row in painted if "composing" in row]
@@ -1189,7 +1189,7 @@ async def test_an_adopted_row_times_the_tool_not_the_dictation() -> None:
                 )
             )
         )
-        await pilot.pause(0.1)
+        await pilot.pause()
         card = next(iter(app.query(ToolCard)))
         assert card._duration is not None
         assert card._duration < 0.4, f"the dictation was billed to the tool: {card._duration}"
@@ -1213,7 +1213,7 @@ async def test_the_composing_row_sheds_its_label_before_its_facts() -> None:
                 ToolCallComposeEvent(tool_call_id="c1", tool_name="write", argument_bytes=12700)
             )
         )
-        await pilot.pause(0.1)
+        await pilot.pause()
         painted = [strip.text for strip in app.screen._compositor.render_strips()]
         row = next(row for row in painted if "12.4 KB" in row)
         assert "composing" not in row
@@ -1263,7 +1263,7 @@ async def test_a_dictated_name_moves_its_own_row_but_not_the_shared_column() -> 
         settled = ToolCard("s1", "read", {}, None)
         view.append_block(settled)
         settled.mark_done("read a file")
-        await pilot.pause(0.1)
+        await pilot.pause()
 
         def settled_row() -> str:
             return next(
@@ -1273,14 +1273,14 @@ async def test_a_dictated_name_moves_its_own_row_but_not_the_shared_column() -> 
 
         before = settled_row()
         app.post_message(ToolComposing(ToolCallComposeEvent(tool_call_id="c1", tool_name="mcp")))
-        await pilot.pause(0.15)
+        await pilot.pause()
         first = next(
             (s.text for s in app.screen._compositor.render_strips() if "composing" in s.text), ""
         )
         app.post_message(
             ToolComposing(ToolCallComposeEvent(tool_call_id="c1", tool_name="mcp__" + "z" * 200))
         )
-        await pilot.pause(0.15)
+        await pilot.pause()
         renamed = next(
             (s.text for s in app.screen._compositor.render_strips() if "composing" in s.text), ""
         )
@@ -1549,14 +1549,14 @@ async def test_a_prompt_never_eats_a_half_typed_prompt() -> None:
         editor = app.query_one(Editor)
         editor.focus()
         editor.load_text("please clean up the stale rows and then")
-        await pilot.pause(0.1)
+        await pilot.pause()
 
         pending = asyncio.ensure_future(ask("bash", "run: rm -rf ./build"))
         for _ in range(100):
             if app.query(ApprovalPrompt):
                 break
             await pilot.pause(0.02)
-        await pilot.pause(0.2)
+        await pilot.pause()
 
         # The question is up, the draft is intact, and the caret never moved.
         assert app.query(ApprovalPrompt), "no prompt was raised"
@@ -1566,7 +1566,7 @@ async def test_a_prompt_never_eats_a_half_typed_prompt() -> None:
         # The draft is what makes this the interesting case: with text in the
         # buffer the routing stands down entirely, so `y` is TYPED, not taken.
         await pilot.press("y")
-        await pilot.pause(0.3)
+        await pilot.pause()
         assert not pending.done(), "a keystroke answered while a draft was open"
         # Typed into the buffer (at the caret, which `load_text` leaves at the
         # start) rather than taken as an answer. What matters is that the draft
@@ -1577,7 +1577,7 @@ async def test_a_prompt_never_eats_a_half_typed_prompt() -> None:
 
         # Clearing the draft hands the keys back: the card is answerable again.
         app.query_one(Editor).load_text("")
-        await pilot.pause(0.1)
+        await pilot.pause()
         await pilot.press("y")
         assert await asyncio.wait_for(pending, 2) is True
 
@@ -1602,10 +1602,10 @@ async def test_the_answer_keys_work_from_the_composer() -> None:
                 if app.query(ApprovalPrompt):
                     break
                 await pilot.pause(0.02)
-            await pilot.pause(0.2)
+            await pilot.pause()
 
             await pilot.click(Editor)
-            await pilot.pause(0.1)
+            await pilot.pause()
             await pilot.press(key)
             assert await asyncio.wait_for(pending, 2) is expected, key
             # The key answered instead of being typed.
@@ -1636,13 +1636,13 @@ async def test_typing_a_steer_at_a_live_prompt_never_answers_it() -> None:
                 if app.query(ApprovalPrompt):
                     break
                 await pilot.pause(0.02)
-            await pilot.pause(0.2)
+            await pilot.pause()
 
             await pilot.click(Editor)
-            await pilot.pause(0.1)
+            await pilot.pause()
             for character in phrase:
                 await pilot.press("space" if character == " " else character)
-            await pilot.pause(0.4)
+            await pilot.pause()
 
             # Nothing was authorised...
             assert not pending.done(), (phrase, "typing a steer answered the prompt")
@@ -1676,7 +1676,7 @@ async def test_a_narrow_card_still_names_what_it_is_authorising() -> None:
             if app.query(ApprovalPrompt):
                 break
             await pilot.pause(0.02)
-        await pilot.pause(0.2)
+        await pilot.pause()
 
         lines = app.query(ApprovalPrompt).first().render_lines_for_test()
         assert lines, "the card drew nothing at a size it can draw at"
@@ -1713,7 +1713,7 @@ async def test_the_card_advertises_only_keys_that_do_something() -> None:
             if app.query(ApprovalPrompt):
                 break
             await pilot.pause(0.02)
-        await pilot.pause(0.2)
+        await pilot.pause()
 
         prompt = app.query(ApprovalPrompt).first()
         lines = prompt.render_lines_for_test()
@@ -1756,7 +1756,7 @@ async def test_a_card_that_shows_no_options_cannot_approve() -> None:
             if app.query(ApprovalPrompt):
                 break
             await pilot.pause(0.02)
-        await pilot.pause(0.2)
+        await pilot.pause()
 
         prompt = app.query(ApprovalPrompt).first()
         lines = prompt.render_lines_for_test()
@@ -1766,16 +1766,16 @@ async def test_a_card_that_shows_no_options_cannot_approve() -> None:
 
         # ...and the permissive keys are refused while it cannot show them.
         await pilot.press("y")
-        await pilot.pause(0.2)
+        await pilot.pause()
         assert not pending.done(), "y approved from a card showing no options"
         await pilot.press("A")
-        await pilot.pause(0.2)
+        await pilot.pause()
         assert not pending.done(), "A approved from a card showing no options"
         assert app._approve_all is False, "the session gate was disarmed invisibly"
         # Enter is refused for the same reason: the cursor is on a preselected
         # row the user was never shown.
         await pilot.press("enter")
-        await pilot.pause(0.2)
+        await pilot.pause()
         assert not pending.done(), "enter committed an unseen selection"
 
         # Denial is always available.
@@ -1801,7 +1801,7 @@ async def test_a_prompt_hidden_by_a_shrink_comes_back_on_re_grow() -> None:
             if app.query(ApprovalPrompt):
                 break
             await pilot.pause(0.02)
-        await pilot.pause(0.2)
+        await pilot.pause()
         prompt = app.query(ApprovalPrompt).first()
         assert prompt.render_lines_for_test(), "no card to begin with"
 
@@ -1846,9 +1846,9 @@ async def test_a_held_answer_key_resolves_cleanly_on_every_second_key() -> None:
             if app.query(ApprovalPrompt):
                 break
             await pilot.pause(0.02)
-        await pilot.pause(0.2)
+        await pilot.pause()
         await pilot.click(Editor)
-        await pilot.pause(0.1)
+        await pilot.pause()
         return pending
 
     # Enter takes the answer.
@@ -1869,7 +1869,7 @@ async def test_a_held_answer_key_resolves_cleanly_on_every_second_key() -> None:
         await pilot.press("y")
         await pilot.press("escape")
         assert await asyncio.wait_for(pending, 2) is False
-        await pilot.pause(0.2)
+        await pilot.pause()
         assert app.query_one(Editor).text == "", "a stray character outlived the question"
 
     # A printable key means it was typing all along.
@@ -1879,7 +1879,7 @@ async def test_a_held_answer_key_resolves_cleanly_on_every_second_key() -> None:
         pending = await _live(pilot, app, session)
         await pilot.press("y")
         await pilot.press("e")
-        await pilot.pause(0.4)
+        await pilot.pause()
         assert not pending.done(), "typing answered the prompt"
         assert app.query_one(Editor).text == "ye"
         pending.cancel()
@@ -1906,9 +1906,9 @@ async def test_a_held_key_never_answers_a_question_it_was_not_meant_for() -> Non
             if app.query(ApprovalPrompt):
                 break
             await pilot.pause(0.02)
-        await pilot.pause(0.2)
+        await pilot.pause()
         await pilot.click(Editor)
-        await pilot.pause(0.1)
+        await pilot.pause()
 
         await pilot.press("y")
         assert app._held_answer_key is not None, "the key was not held"
@@ -1916,7 +1916,7 @@ async def test_a_held_key_never_answers_a_question_it_was_not_meant_for() -> Non
         assert app._approval is not None
         app._approval.resolve(False, answer="n")
         assert await asyncio.wait_for(first, 2) is False
-        await pilot.pause(0.4)
+        await pilot.pause()
 
         # Nothing is left parked, and the session gate was not disarmed.
         assert app._held_answer_key is None
@@ -1957,7 +1957,7 @@ async def test_a_prompt_arriving_mid_sentence_does_not_take_the_caret() -> None:
 
         for character in "yes do it":
             await pilot.press("space" if character == " " else character)
-        await pilot.pause(0.4)
+        await pilot.pause()
 
         assert not pending.done(), "typing through the mount answered the prompt"
         assert app._approve_all is False
@@ -1994,14 +1994,14 @@ async def test_a_resize_while_typing_never_moves_the_keyboard() -> None:
         editor.focus()
         for character in "wait a":
             await pilot.press("space" if character == " " else character)
-        await pilot.pause(0.1)
+        await pilot.pause()
 
         pending = asyncio.ensure_future(ask("bash", "run: rm -rf /data"))
         for _ in range(100):
             if app.query(ApprovalPrompt):
                 break
             await pilot.pause(0.02)
-        await pilot.pause(0.2)
+        await pilot.pause()
         assert isinstance(app.screen.focused, Editor)
 
         await pilot.resize_terminal(99, 30)
@@ -2010,7 +2010,7 @@ async def test_a_resize_while_typing_never_moves_the_keyboard() -> None:
         assert isinstance(app.screen.focused, Editor), "a resize took the keyboard"
 
         await pilot.press("y")
-        await pilot.pause(0.3)
+        await pilot.pause()
         assert not pending.done(), "a resize let a typed character authorise the call"
         assert app._approve_all is False
         assert app.query_one(Editor).text == "wait ay"
@@ -2050,7 +2050,7 @@ async def test_answering_one_prompt_does_not_move_the_caret_off_a_draft() -> Non
         editor.focus()
         for character in "hold on":
             await pilot.press("space" if character == " " else character)
-        await pilot.pause(0.2)
+        await pilot.pause()
         assert isinstance(app.screen.focused, Editor)
 
         # The approval settles from somewhere else entirely.
@@ -2093,7 +2093,7 @@ async def test_nothing_takes_the_keyboard_from_someone_mid_sentence() -> None:
         editor.focus()
         for character in draft:
             await pilot.press("space" if character == " " else character)
-        await pilot.pause(0.1)
+        await pilot.pause()
         futures = []
         if overlap:
             futures.append(
@@ -2189,7 +2189,7 @@ async def test_esc_stops_the_turn_and_offers_to_stop_the_subagents() -> None:
         session.running_children = 2
 
         await pilot.press("escape")
-        await pilot.pause(0.1)
+        await pilot.pause()
 
         assert session.aborts == ["interrupted"]
         # The children are NOT stopped by the first press.
@@ -2209,9 +2209,9 @@ async def test_a_second_esc_stops_the_subagents_and_confirms_it() -> None:
         session.running_children = 2
 
         await pilot.press("escape")
-        await pilot.pause(0.1)
+        await pilot.pause()
         await pilot.press("escape")
-        await pilot.pause(0.1)
+        await pilot.pause()
 
         assert session.subagent_cancels == ["interrupted"]
         assert any("stopped 2 subagents" in row for row in rows(app))
@@ -2235,12 +2235,12 @@ async def test_a_slow_second_esc_does_not_stop_the_subagents() -> None:
         session.running_children = 1
 
         await pilot.press("escape")
-        await pilot.pause(0.1)
+        await pilot.pause()
         # Age the offer past its window without waiting for it.
         assert app._stop_offered_at is not None, "the first press must make the offer"
         app._stop_offered_at -= DOUBLE_STOP_WINDOW_S + 1
         await pilot.press("escape")
-        await pilot.pause(0.1)
+        await pilot.pause()
 
         assert session.subagent_cancels == [], "an expired offer must not escalate"
 
@@ -2255,7 +2255,7 @@ async def test_esc_with_no_children_says_nothing_about_subagents() -> None:
         session.streaming = True
 
         await pilot.press("escape")
-        await pilot.pause(0.1)
+        await pilot.pause()
 
         assert session.aborts == ["interrupted"]
         assert not any("subagent" in row for row in rows(app))
@@ -2275,11 +2275,11 @@ async def test_esc_stops_subagents_even_when_the_parent_turn_has_ended() -> None
         session.running_children = 3
 
         await pilot.press("escape")
-        await pilot.pause(0.1)
+        await pilot.pause()
         assert any("3 subagents still running" in row for row in rows(app))
 
         await pilot.press("escape")
-        await pilot.pause(0.1)
+        await pilot.pause()
         assert session.subagent_cancels == ["interrupted"]
         assert any("stopped 3 subagents" in row for row in rows(app))
 
@@ -2295,7 +2295,7 @@ async def test_esc_with_nothing_running_still_never_clears_the_composer() -> Non
         editor.load_text("a half-typed prompt")
 
         await pilot.press("escape")
-        await pilot.pause(0.1)
+        await pilot.pause()
 
         assert editor.text == "a half-typed prompt"
         assert session.aborts == []
@@ -2322,7 +2322,7 @@ async def test_ctrl_c_clears_a_draft_before_arming_the_exit_ladder() -> None:
         editor.load_text("draft to be scrapped")
 
         await pilot.press("ctrl+c")
-        await pilot.pause(0.1)
+        await pilot.pause()
 
         assert editor.text == ""
         assert not any("ctrl+c again to exit" in row for row in rows(app))
@@ -2343,9 +2343,9 @@ async def test_two_ctrl_c_presses_from_a_draft_do_not_exit() -> None:
         app.query_one(Editor).load_text("draft")
 
         await pilot.press("ctrl+c")
-        await pilot.pause(0.1)
+        await pilot.pause()
         await pilot.press("ctrl+c")
-        await pilot.pause(0.1)
+        await pilot.pause()
 
         assert app.is_running, "a double-tap from a draft must never quit"
         assert any("ctrl+c again to exit" in row for row in rows(app))
@@ -2361,12 +2361,12 @@ async def test_ctrl_c_on_an_empty_composer_keeps_the_exit_ladder() -> None:
         session.streaming = True
 
         await pilot.press("ctrl+c")
-        await pilot.pause(0.1)
+        await pilot.pause()
         assert session.aborts == ["interrupted"]
         assert any("ctrl+c again to exit" in row for row in rows(app))
 
         await pilot.press("ctrl+c")
-        await pilot.pause(0.3)
+        await pilot.pause()
         assert not app.is_running
 
 
@@ -2382,7 +2382,7 @@ async def test_whitespace_only_draft_is_not_treated_as_a_draft() -> None:
         app.query_one(Editor).load_text("   \n  ")
 
         await pilot.press("ctrl+c")
-        await pilot.pause(0.1)
+        await pilot.pause()
 
         assert session.aborts == ["interrupted"]
         assert any("ctrl+c again to exit" in row for row in rows(app))
@@ -2404,17 +2404,17 @@ async def test_clearing_the_transcript_disarms_the_stop_offer() -> None:
         session.running_children = 2
 
         await pilot.press("escape")
-        await pilot.pause(0.1)
+        await pilot.pause()
         assert app._stop_offered_at is not None
 
         app.action_clear_transcript()
-        await pilot.pause(0.1)
+        await pilot.pause()
         assert app._stop_offered_at is None
         assert app._stop_notice is None
 
         # And the next Esc is a FIRST press, not an escalation.
         await pilot.press("escape")
-        await pilot.pause(0.1)
+        await pilot.pause()
         assert session.subagent_cancels == []
 
 
@@ -2435,11 +2435,11 @@ async def test_a_stop_offer_does_not_survive_into_a_new_session() -> None:
         session.running_children = 2
 
         await pilot.press("escape")
-        await pilot.pause(0.1)
+        await pilot.pause()
         assert app._stop_offered_at is not None, "the offer must be armed first"
 
         await app._reload_session()
-        await pilot.pause(0.1)
+        await pilot.pause()
 
         assert app._stop_offered_at is None
         assert app._stop_notice is None
@@ -2464,13 +2464,13 @@ async def test_ctrl_c_never_files_an_aside_question_in_prompt_history() -> None:
         await _boot(pilot, app)
         editor = app.query_one(Editor)
         app._open_aside()
-        await pilot.pause(0.1)
+        await pilot.pause()
         editor.load_text("is my salary competitive?")
-        await pilot.pause(0.1)
+        await pilot.pause()
         assert editor._records_history is False, "the aside must suppress recording"
 
         await pilot.press("ctrl+c")
-        await pilot.pause(0.15)
+        await pilot.pause()
 
         assert not any(
             "salary" in entry for entry in editor.prompt_history()
@@ -2502,13 +2502,13 @@ async def test_a_late_second_esc_is_acknowledged_rather_than_silently_ignored() 
         session.running_children = 2
 
         await pilot.press("escape")
-        await pilot.pause(0.1)
+        await pilot.pause()
         assert any("esc again to stop them" in row for row in rows(app))
 
         # The window lapses without a second press.
         app._stop_offered_at = time.monotonic() - (DOUBLE_STOP_WINDOW_S + 1)
         await pilot.press("escape")
-        await pilot.pause(0.1)
+        await pilot.pause()
 
         # Nothing was stopped — that part is by design — but the row CHANGED,
         # so the press is visibly acknowledged.
@@ -2536,12 +2536,12 @@ async def test_children_finishing_between_presses_is_not_reported_as_a_denial() 
         session.running_children = 2
 
         await pilot.press("escape")
-        await pilot.pause(0.1)
+        await pilot.pause()
 
         # They finish on their own before the user's second press lands.
         session.running_children = 0
         await pilot.press("escape")
-        await pilot.pause(0.1)
+        await pilot.pause()
 
         painted = rows(app)
         assert any(
@@ -2566,10 +2566,10 @@ async def test_a_stop_that_spares_background_jobs_says_so() -> None:
         session.running_bash_jobs = 1
 
         await pilot.press("escape")
-        await pilot.pause(0.1)
+        await pilot.pause()
         app._stop_offered_at = time.monotonic()
         await pilot.press("escape")
-        await pilot.pause(0.1)
+        await pilot.pause()
 
         painted = rows(app)
         assert any("stopped 1 subagent" in row for row in painted)
@@ -2591,10 +2591,10 @@ async def test_the_confirmation_stays_quiet_when_nothing_was_spared() -> None:
         session.running_bash_jobs = 0
 
         await pilot.press("escape")
-        await pilot.pause(0.1)
+        await pilot.pause()
         app._stop_offered_at = time.monotonic()
         await pilot.press("escape")
-        await pilot.pause(0.1)
+        await pilot.pause()
 
         assert not any("background job" in row for row in rows(app))
 
@@ -2617,7 +2617,7 @@ async def test_the_offer_retires_its_promise_when_the_window_closes() -> None:
         session.running_children = 2
 
         await pilot.press("escape")
-        await pilot.pause(0.1)
+        await pilot.pause()
         assert any("esc again to stop them" in row for row in rows(app))
 
         # Wait out the real window rather than reaching into the timer.
@@ -2644,10 +2644,10 @@ async def test_taking_the_offer_is_not_undone_by_the_expiry_timer() -> None:
         session.running_children = 2
 
         await pilot.press("escape")
-        await pilot.pause(0.1)
+        await pilot.pause()
         app._stop_offered_at = time.monotonic()
         await pilot.press("escape")
-        await pilot.pause(0.1)
+        await pilot.pause()
         assert session.subagent_cancels == ["interrupted"]
 
         # The first press's timer fires somewhere in here and must do nothing.
@@ -2676,14 +2676,14 @@ async def test_the_ladder_row_keeps_its_place_in_the_transcript() -> None:
         session.running_children = 2
 
         await pilot.press("escape")
-        await pilot.pause(0.1)
+        await pilot.pause()
         # A notice arrives after the offer, as the aborted turn's own does.
         app._append_block(NoticeBlock("interrupted", "info"))
         await pilot.pause()
 
         app._stop_offered_at = time.monotonic()
         await pilot.press("escape")
-        await pilot.pause(0.1)
+        await pilot.pause()
 
         painted = [row for row in rows(app) if row.strip()]
         ladder = next(i for i, row in enumerate(painted) if "stopped 2 subagents" in row)
@@ -2706,7 +2706,7 @@ async def test_ctrl_c_says_where_the_draft_went() -> None:
         await pilot.pause()
 
         await pilot.press("ctrl+c")
-        await pilot.pause(0.1)
+        await pilot.pause()
 
         painted = rows(app)
         assert any(
@@ -2749,7 +2749,7 @@ async def test_an_armed_offer_never_outranks_a_waiting_approval() -> None:
         app._stop_offer_count = 2
 
         await pilot.press("escape")
-        await pilot.pause(0.2)
+        await pilot.pause()
 
         assert (
             session.subagent_cancels == []
@@ -2776,18 +2776,18 @@ async def test_the_late_row_promises_the_number_of_presses_it_actually_costs() -
         session.running_children = 2
 
         await pilot.press("escape")
-        await pilot.pause(0.1)
+        await pilot.pause()
 
         # The window lapses, so this press cannot escalate — it re-arms.
         app._stop_offered_at = time.monotonic() - (DOUBLE_STOP_WINDOW_S + 1)
         await pilot.press("escape")
-        await pilot.pause(0.1)
+        await pilot.pause()
         assert session.subagent_cancels == []
         assert any("esc again within" in row for row in rows(app))
 
         # ONE further press, exactly as the row now promises.
         await pilot.press("escape")
-        await pilot.pause(0.1)
+        await pilot.pause()
 
         assert session.subagent_cancels == [
             "interrupted"
@@ -2813,7 +2813,7 @@ async def test_a_buried_ladder_row_moves_to_where_the_user_is_looking() -> None:
         session.running_children = 2
 
         await pilot.press("escape")
-        await pilot.pause(0.1)
+        await pilot.pause()
         first = app._stop_notice
         assert first is not None
 
@@ -2832,7 +2832,7 @@ async def test_a_buried_ladder_row_moves_to_where_the_user_is_looking() -> None:
         # A later press must produce a row the user can actually see.
         session.streaming = True
         await pilot.press("escape")
-        await pilot.pause(0.1)
+        await pilot.pause()
         # The append scrolls the transcript; let the layout settle before
         # asking where the row landed.
         for _ in range(5):
@@ -2867,7 +2867,7 @@ async def test_the_expired_row_recounts_rather_than_restating_a_stale_number() -
         session.running_children = 2
 
         await pilot.press("escape")
-        await pilot.pause(0.1)
+        await pilot.pause()
         assert any("2 subagents still running" in row for row in rows(app))
 
         # They finish on their own inside the window.
@@ -2914,7 +2914,7 @@ async def test_a_stale_highlight_copies_but_cannot_arm_the_exit_ladder() -> None
         assert not getattr(editor, "_selecting", False), "no drag should be in flight"
 
         await pilot.press("ctrl+c")
-        await pilot.pause(0.1)
+        await pilot.pause()
 
         # The copy takes the key, and nothing else moves: no abort, the draft
         # still there, and the ladder unarmed.
@@ -2925,7 +2925,7 @@ async def test_a_stale_highlight_copies_but_cannot_arm_the_exit_ladder() -> None
         # The range is still live, so this press copies again — it must NOT
         # have started counting rungs.
         await pilot.press("ctrl+c")
-        await pilot.pause(0.1)
+        await pilot.pause()
         assert app.is_running, "a second reflexive tap exited the app"
         assert session.aborts == [], "the second tap became an abort"
 
@@ -2981,12 +2981,12 @@ async def test_moving_the_caret_after_a_copy_gives_ctrl_c_back_to_the_draft() ->
         assert editor._copied, "the receipt is still true and must not be retired here"
 
         await pilot.press("ctrl+c")
-        await pilot.pause(0.1)
+        await pilot.pause()
 
         assert session.aborts == [], "a retired copy still diverted the key"
         assert editor.text == "", "the draft was not cleared"
         assert "a half-typed prompt I do not want to lose" in editor.prompt_history()
 
         await pilot.press("ctrl+c")
-        await pilot.pause(0.1)
+        await pilot.pause()
         assert app.is_running, "the second tap quit with the draft lost"

--- a/tests/unit/tui/test_steering_approval.py
+++ b/tests/unit/tui/test_steering_approval.py
@@ -161,6 +161,35 @@ def rows(app: OperatorApp) -> list[str]:
     return [strip.text.rstrip() for strip in app.screen._compositor.render_strips()]
 
 
+async def _settled_rows(pilot: Any, app: OperatorApp, ceiling: int = 200) -> list[str]:
+    """The painted frame, read only once it has stopped reflowing.
+
+    Tests that assert on a row's REFLOWED GEOMETRY — which choices were shed at
+    a given width, whether anything bleeds past the terminal, whether a receipt
+    stays on one row — must not read a mid-reflow frame. A single ``pilot.pause()``
+    yields exactly one idle tick, and an approval row that is still collapsing to
+    fit a narrow width paints a truncated intermediate frame (a dangling ``…`` or
+    a half-shed clause) on that tick. Reading it makes a width-parametrized test
+    fail intermittently under load with a truncated row the settled frame never
+    shows — the failure mode that a fixed ``pause(0.2)`` used to paper over by
+    outlasting the reflow.
+
+    Waits for the CONDITION the geometry assertions depend on instead: the frame
+    is stable when two consecutive idle ticks paint the identical row set. The
+    ceiling is a deadlock guard, not a timing assumption, so a slow or contended
+    machine costs nothing and a genuinely stuck frame still fails rather than
+    hanging.
+    """
+    previous: list[str] = []
+    for _ in range(ceiling):
+        await pilot.pause()
+        current = rows(app)
+        if current == previous:
+            return current
+        previous = current
+    return previous
+
+
 async def _boot(pilot: Any, app: OperatorApp) -> None:
     """Wait for the session to be ADOPTED, rather than for a fixed duration.
 
@@ -811,8 +840,7 @@ async def test_the_prompt_never_hides_its_target_or_overflows(width: int) -> Non
         view.append_block(
             ApprovalBlock("write_file", "[outside workspace] write: /Users/x/deep/config.yml")
         )
-        await pilot.pause()
-        painted = [strip.text.rstrip() for strip in app.screen._compositor.render_strips()]
+        painted = await _settled_rows(pilot, app)
 
         # Nothing bleeds past the terminal at any width.
         assert not [row for row in painted if cell_len(row) > width]
@@ -841,8 +869,7 @@ async def test_the_answered_receipt_stays_on_one_row(width: int) -> None:
         app.query_one(TranscriptView).append_block(block)
         await pilot.pause()
         block.resolve(True, answer="y")
-        await pilot.pause()
-        painted = [strip.text.rstrip() for strip in app.screen._compositor.render_strips()]
+        painted = await _settled_rows(pilot, app)
 
         # Found by the outcome GLYPH, not by the word: below ~32 columns the
         # receipt sheds `allowed` to keep the hazard clause, which is the same
@@ -872,8 +899,10 @@ async def test_the_hint_row_sheds_whole_choices(width: int) -> None:
     async with app.run_test(size=(width, 24)) as pilot:
         await _boot(pilot, app)
         app.query_one(TranscriptView).append_block(ApprovalBlock("bash", "run: make"))
-        await pilot.pause()
-        painted = [strip.text.rstrip() for strip in app.screen._compositor.render_strips()]
+        # Read the SETTLED frame: this asserts on the hint row's reflowed geometry
+        # (which choices were shed at this width), and a mid-reflow frame paints a
+        # truncated `…` the next assertion forbids. See _settled_rows.
+        painted = await _settled_rows(pilot, app)
         hint = next((row.strip() for row in painted if "deny" in row or "n/y" in row), "")
         assert hint, "the prompt must always advertise at least one answer"
         assert "…" not in hint
@@ -910,8 +939,7 @@ async def test_a_dangerous_ask_never_paints_like_a_safe_one(width: int) -> None:
         view = app.query_one(TranscriptView)
         view.append_block(ApprovalBlock("write_file", f"{OUTSIDE_MARKER} write: /tmp/x/keys"))
         view.append_block(ApprovalBlock("write_file", "write: /tmp/x/keys"))
-        await pilot.pause()
-        painted = [strip.text.rstrip() for strip in app.screen._compositor.render_strips()]
+        painted = await _settled_rows(pilot, app)
         # Matched on the leading glyph, not the tool name: at the narrowest widths
         # the hazard IS the glyph (`!` for `?`), which is the behaviour under test
         # rather than a reason to miss the row.
@@ -945,8 +973,7 @@ async def test_a_narrow_prompt_keeps_the_end_of_the_path(detail: str, expected_t
     async with app.run_test(size=(52, 24)) as pilot:
         await _boot(pilot, app)
         app.query_one(TranscriptView).append_block(ApprovalBlock("write_file", detail))
-        await pilot.pause()
-        painted = [strip.text.rstrip() for strip in app.screen._compositor.render_strips()]
+        painted = await _settled_rows(pilot, app)
         ask = next(row for row in painted if "write_file" in row)
         assert expected_tail in ask, ask
 

--- a/tests/unit/tui/test_welcome.py
+++ b/tests/unit/tui/test_welcome.py
@@ -811,11 +811,17 @@ async def test_model_label_polls_in_after_boot() -> None:
     app = _make_app(FakeSession())
     async with app.run_test(size=(80, 26)) as pilot:
         await pilot.pause()
-        # The timer's first tick (250 ms) is the thing under test: wait it out
-        # rather than force the poll, so a broken timer fails this test.
-        await asyncio.sleep(0.6)
-        await pilot.pause()
         welcome = _welcome(app)
+        # The timer's first tick (250 ms) is the thing under test: wait it out
+        # rather than force the poll, so a broken timer still fails this test.
+        # Polling the poll interval until the label lands returns as soon as the
+        # timer has actually ticked instead of betting a flat 0.6 s covers it;
+        # a timer that never fires leaves the label unset and fails below.
+        for _ in range(24):
+            await asyncio.sleep(WelcomeView.POLL_INTERVAL_S)
+            await pilot.pause()
+            if welcome._timer is None:
+                break
         assert welcome._info.model_label == "openrouter/deepseek/deepseek-chat"
         assert welcome._timer is None  # retired once the label arrived
 
@@ -832,11 +838,16 @@ async def _settled_welcome(pilot: Any) -> WelcomeView:
     The poll timer retiring IS the settled edge.
     """
     welcome = pilot.app.query_one(WelcomeView)
-    for _ in range(24):
+    for _ in range(200):
         await pilot.pause()
         if welcome._timer is None:
             break
-        await asyncio.sleep(WelcomeView.POLL_INTERVAL_S)
+        # The label lands on the session worker (an event, not the wall clock),
+        # so once the loop has run the source already holds it; forcing the poll
+        # retires the timer as soon as the fact exists instead of sleeping out a
+        # real 0.25 s tick per boot. The timer's own liveness is pinned by
+        # `test_model_label_polls_in_after_boot`, so this helper need not.
+        welcome._poll()
     await pilot.pause()
     return welcome
 

--- a/tests/unit/tui/test_working_line.py
+++ b/tests/unit/tui/test_working_line.py
@@ -115,22 +115,22 @@ async def test_the_working_line_stays_at_the_foot_as_the_turn_grows() -> None:
     """
     app = OperatorApp(lambda: _factory(FakeSession()))
     async with app.run_test(size=(100, 30)) as pilot:
-        await pilot.pause(0.25)
+        await pilot.pause()
         app.post_message(TurnStarted())
-        await pilot.pause(0.1)
+        await pilot.pause()
         assert _is_last(app)
 
         app.post_message(_started("c0", "read", path="src/foo.py"))
-        await pilot.pause(0.1)
+        await pilot.pause()
         assert _is_last(app)
 
         app.post_message(AssistantDelta("thinking out loud"))
-        await pilot.pause(0.1)
+        await pilot.pause()
         assert _is_last(app)
 
         app.post_message(_ended("c0", "read"))
         app.post_message(CompactionStarted("size"))
-        await pilot.pause(0.1)
+        await pilot.pause()
         assert _is_last(app)
         # And the blocks it stepped over are still in the order they arrived —
         # a pin that reordered the transcript would be a worse bug than the one
@@ -149,22 +149,22 @@ async def test_it_reports_the_running_tool_and_settles_back_to_the_model() -> No
     """
     app = OperatorApp(lambda: _factory(FakeSession()))
     async with app.run_test(size=(100, 30)) as pilot:
-        await pilot.pause(0.25)
+        await pilot.pause()
         app.post_message(TurnStarted())
-        await pilot.pause(0.1)
+        await pilot.pause()
         # The GAP before anything has been dictated: a model call is in flight
         # and that is all the app honestly knows.
         assert _activity(app) == DEFAULT_ACTIVITY
 
         app.post_message(_started("c0", "read", path="src/foo.py"))
-        await pilot.pause(0.1)
+        await pilot.pause()
         assert _activity(app) == "running read"
         assert any(
             "running read" in strip.text for strip in app.screen._compositor.render_strips()
         ), "the label reaches the frame, not just the widget"
 
         app.post_message(_ended("c0", "read"))
-        await pilot.pause(0.1)
+        await pilot.pause()
         assert _activity(app) == DEFAULT_ACTIVITY
 
 
@@ -180,7 +180,7 @@ async def test_the_model_s_intent_is_what_the_line_says() -> None:
     """
     app = OperatorApp(lambda: _factory(FakeSession()))
     async with app.run_test(size=(100, 30)) as pilot:
-        await pilot.pause(0.25)
+        await pilot.pause()
         app.post_message(TurnStarted())
         app.post_message(
             ToolStarted(
@@ -192,7 +192,7 @@ async def test_the_model_s_intent_is_what_the_line_says() -> None:
                 )
             )
         )
-        await pilot.pause(0.1)
+        await pilot.pause()
         assert _activity(app) == "running the spacing suite"
         painted = [strip.text for strip in app.screen._compositor.render_strips()]
         assert len([row for row in painted if "running the spacing suite" in row]) == 1
@@ -206,10 +206,10 @@ async def test_without_an_intent_the_line_falls_back_to_the_tool_name() -> None:
     not restate the arguments the card is showing."""
     app = OperatorApp(lambda: _factory(FakeSession()))
     async with app.run_test(size=(100, 30)) as pilot:
-        await pilot.pause(0.25)
+        await pilot.pause()
         app.post_message(TurnStarted())
         app.post_message(_started("c0", "read", path="src/foo.py"))
-        await pilot.pause(0.1)
+        await pilot.pause()
         assert _activity(app) == "running read"
 
 
@@ -224,7 +224,7 @@ async def test_a_parallel_batch_is_reported_as_a_plain_count() -> None:
     """
     app = OperatorApp(lambda: _factory(FakeSession()))
     async with app.run_test(size=(100, 30)) as pilot:
-        await pilot.pause(0.25)
+        await pilot.pause()
         app.post_message(TurnStarted())
         app.post_message(
             ToolStarted(
@@ -238,16 +238,16 @@ async def test_a_parallel_batch_is_reported_as_a_plain_count() -> None:
         )
         app.post_message(_started("c1", "read", path="b.py"))
         app.post_message(_started("c2", "grep", pattern="needs_gap"))
-        await pilot.pause(0.1)
+        await pilot.pause()
         # No intent, no `+N`: three calls are three calls.
         assert _activity(app) == "running 3 tools"
 
         app.post_message(_ended("c1", "read"))
-        await pilot.pause(0.1)
+        await pilot.pause()
         assert _activity(app) == "running 2 tools"
 
         app.post_message(_ended("c0", "read"))
-        await pilot.pause(0.1)
+        await pilot.pause()
         # Down to one, and that one gave no intent, so the fallback shows.
         assert _activity(app) == "running grep"
 
@@ -264,23 +264,23 @@ async def test_the_clock_survives_a_label_change_within_one_phase() -> None:
     """
     app = OperatorApp(lambda: _factory(FakeSession()))
     async with app.run_test(size=(100, 30)) as pilot:
-        await pilot.pause(0.25)
+        await pilot.pause()
         app.post_message(TurnStarted())
         app.post_message(_started("c0", "read", path="a.py"))
         app.post_message(_started("c1", "read", path="b.py"))
-        await pilot.pause(0.1)
+        await pilot.pause()
         line = _working(app)
         assert line is not None
         started = line._phase_started
 
         app.post_message(_ended("c1", "read"))
-        await pilot.pause(0.1)
+        await pilot.pause()
         assert _activity(app) == "running read"  # the label moved
         assert line._phase_started == started  # the clock did not
 
         # A real phase change DOES reset it: that is the case the reset is for.
         app.post_message(_ended("c0", "read"))
-        await pilot.pause(0.1)
+        await pilot.pause()
         assert _activity(app) == DEFAULT_ACTIVITY
         assert line._phase_started > started
 
@@ -325,10 +325,10 @@ async def test_the_line_holds_one_row_whatever_the_clock_says() -> None:
         # is never mounted again.
         app = OperatorApp(lambda: _factory(FakeSession()))
         async with app.run_test(size=(width, 20)) as pilot:
-            await pilot.pause(0.25)
+            await pilot.pause()
             app.post_message(TurnStarted())
             app.post_message(_started("c0", "read", path="a.py"))
-            await pilot.pause(0.1)
+            await pilot.pause()
             line = _working(app)
             assert line is not None, width
             line.set_activity("running a tool with a long model-supplied label " * 3)
@@ -375,16 +375,16 @@ async def test_a_dictated_call_is_reported_before_it_runs() -> None:
     """The longest silence in a turn is a large call streaming its arguments."""
     app = OperatorApp(lambda: _factory(FakeSession()))
     async with app.run_test(size=(100, 30)) as pilot:
-        await pilot.pause(0.25)
+        await pilot.pause()
         app.post_message(TurnStarted())
         app.post_message(ToolComposing(ToolCallComposeEvent(tool_call_id="c0", tool_name="write")))
-        await pilot.pause(0.1)
+        await pilot.pause()
         assert _activity(app) == "composing a call"
 
         # Adoption: the execution replaces the announcement rather than adding
         # to it, so the line must not read "composing 2 tools".
         app.post_message(_started("c0", "write", path="out.txt"))
-        await pilot.pause(0.1)
+        await pilot.pause()
         assert _activity(app) == "running write"
 
 
@@ -393,20 +393,20 @@ async def test_a_prose_turn_reports_prose_then_the_next_model_call() -> None:
     """A turn with no tools at all must still say something true."""
     app = OperatorApp(lambda: _factory(FakeSession()))
     async with app.run_test(size=(100, 30)) as pilot:
-        await pilot.pause(0.25)
+        await pilot.pause()
         app.post_message(TurnStarted())
         app.post_message(AssistantMessageStart())
-        await pilot.pause(0.1)
+        await pilot.pause()
         # A message OPENING is not text arriving — nothing is mounted yet and
         # the model call is still the honest description.
         assert _activity(app) == DEFAULT_ACTIVITY
 
         app.post_message(AssistantDelta("here is the plan"))
-        await pilot.pause(0.1)
+        await pilot.pause()
         assert _activity(app) == "responding"
 
         app.post_message(AssistantMessageEnd("here is the plan"))
-        await pilot.pause(0.1)
+        await pilot.pause()
         assert _activity(app) == DEFAULT_ACTIVITY
 
 
@@ -415,15 +415,15 @@ async def test_a_new_model_call_takes_the_line_back_from_the_last_tool() -> None
     """The gap the line exists for: a batch settles, then the model is quiet."""
     app = OperatorApp(lambda: _factory(FakeSession()))
     async with app.run_test(size=(100, 30)) as pilot:
-        await pilot.pause(0.25)
+        await pilot.pause()
         app.post_message(TurnStarted())
         app.post_message(_started("c0", "read", path="a.py"))
-        await pilot.pause(0.1)
+        await pilot.pause()
         assert _activity(app) == "running read"
 
         app.post_message(TurnBoundaryEnd())
         app.post_message(TurnBoundaryStart())
-        await pilot.pause(0.1)
+        await pilot.pause()
         assert _activity(app) == DEFAULT_ACTIVITY
 
 
@@ -432,10 +432,10 @@ async def test_a_slow_whole_turn_state_says_what_it_is() -> None:
     """Compaction has no card of its own and runs for a long time."""
     app = OperatorApp(lambda: _factory(FakeSession()))
     async with app.run_test(size=(100, 30)) as pilot:
-        await pilot.pause(0.25)
+        await pilot.pause()
         app.post_message(TurnStarted())
         app.post_message(CompactionStarted("size"))
-        await pilot.pause(0.1)
+        await pilot.pause()
         assert _activity(app) == "compacting context"
 
 
@@ -444,15 +444,15 @@ async def test_the_line_is_lifted_when_the_turn_ends() -> None:
     """No settled frame, no summary row: it is transient and it goes."""
     app = OperatorApp(lambda: _factory(FakeSession()))
     async with app.run_test(size=(100, 30)) as pilot:
-        await pilot.pause(0.25)
+        await pilot.pause()
         app.post_message(TurnStarted())
         app.post_message(_started("c0", "read", path="a.py"))
-        await pilot.pause(0.1)
+        await pilot.pause()
         assert _working(app) is not None
 
         app.post_message(_ended("c0", "read"))
         app.post_message(TurnEnded(aborted=False, error=None))
-        await pilot.pause(0.1)
+        await pilot.pause()
         assert _working(app) is None
         assert not any("thinking" in strip.text for strip in app.screen._compositor.render_strips())
 
@@ -466,15 +466,15 @@ async def test_the_line_does_not_survive_an_aborted_turn() -> None:
     """
     app = OperatorApp(lambda: _factory(FakeSession()))
     async with app.run_test(size=(100, 30)) as pilot:
-        await pilot.pause(0.25)
+        await pilot.pause()
         app.post_message(TurnStarted())
         app.post_message(_started("c0", "bash", command="sleep 600"))
-        await pilot.pause(0.1)
+        await pilot.pause()
         assert _working(app) is not None
 
         app.post_message(TurnBoundaryEnd())  # reconciles the orphaned card
         app.post_message(TurnEnded(aborted=True, error=None))
-        await pilot.pause(0.1)
+        await pilot.pause()
         assert _working(app) is None
 
 
@@ -483,11 +483,11 @@ async def test_a_failed_turn_lifts_the_line_too() -> None:
     """The error notice takes the foot of the transcript, not a dead spinner."""
     app = OperatorApp(lambda: _factory(FakeSession()))
     async with app.run_test(size=(100, 30)) as pilot:
-        await pilot.pause(0.25)
+        await pilot.pause()
         app.post_message(TurnStarted())
-        await pilot.pause(0.1)
+        await pilot.pause()
         app.post_message(TurnEnded(aborted=False, error="provider refused the request"))
-        await pilot.pause(0.1)
+        await pilot.pause()
         assert _working(app) is None
         blocks = app.query_one(TranscriptView).blocks()
         assert isinstance(blocks[-1], NoticeBlock)
@@ -502,14 +502,14 @@ async def test_clearing_mid_turn_brings_the_line_back() -> None:
     """
     app = OperatorApp(lambda: _factory(FakeSession()))
     async with app.run_test(size=(100, 30)) as pilot:
-        await pilot.pause(0.25)
+        await pilot.pause()
         app.post_message(TurnStarted())
         app.post_message(_started("c0", "bash", command="sleep 600"))
-        await pilot.pause(0.1)
+        await pilot.pause()
         assert _working(app) is not None
 
         app.action_clear_transcript()
-        await pilot.pause(0.1)
+        await pilot.pause()
         assert _working(app) is not None, "a live turn still has to say it is live"
         assert _is_last(app)
         # The cards went with the transcript, so the line falls back to the
@@ -517,7 +517,7 @@ async def test_clearing_mid_turn_brings_the_line_back() -> None:
         assert _activity(app) == DEFAULT_ACTIVITY
 
         app.post_message(TurnEnded(aborted=True, error=None))
-        await pilot.pause(0.1)
+        await pilot.pause()
         assert _working(app) is None
 
 
@@ -526,9 +526,9 @@ async def test_clearing_outside_a_turn_leaves_no_line_behind() -> None:
     """The re-mount is conditional on a turn being live, not on /clear."""
     app = OperatorApp(lambda: _factory(FakeSession()))
     async with app.run_test(size=(100, 30)) as pilot:
-        await pilot.pause(0.25)
+        await pilot.pause()
         app.action_clear_transcript()
-        await pilot.pause(0.1)
+        await pilot.pause()
         assert _working(app) is None
 
 
@@ -542,15 +542,15 @@ async def test_reloading_mid_turn_lifts_the_line_off_the_dead_turn() -> None:
     """
     app = OperatorApp(lambda: _factory(FakeSession()))
     async with app.run_test(size=(100, 30)) as pilot:
-        await pilot.pause(0.25)
+        await pilot.pause()
         app.post_message(TurnStarted())
         app.post_message(_started("c0", "bash", command="sleep 600"))
-        await pilot.pause(0.1)
+        await pilot.pause()
         assert _working(app) is not None
 
         app._session_factory = lambda: _factory(FakeSession())  # type: ignore[assignment]
         await app._reload_session()
-        await pilot.pause(0.1)
+        await pilot.pause()
 
         assert _working(app) is None, "the line outlived the turn it describes"
         assert app._working_block is None
@@ -570,19 +570,19 @@ async def test_reloading_mid_turn_leaves_the_next_turn_able_to_say_it_is_working
     """
     app = OperatorApp(lambda: _factory(FakeSession()))
     async with app.run_test(size=(100, 30)) as pilot:
-        await pilot.pause(0.25)
+        await pilot.pause()
         app.post_message(TurnStarted())
         app.post_message(_started("c0", "bash", command="sleep 600"))
-        await pilot.pause(0.1)
+        await pilot.pause()
         assert _working(app) is not None
 
         app._session_factory = lambda: _factory(FakeSession())  # type: ignore[assignment]
         await app._reload_session()
-        await pilot.pause(0.1)
+        await pilot.pause()
         assert _working(app) is None
 
         app.post_message(TurnStarted())
-        await pilot.pause(0.1)
+        await pilot.pause()
         assert _working(app) is not None, "the replacement session got no working line"
         assert _is_last(app)
         # What it SAYS is still derived from the preserved ledger — the dead
@@ -603,10 +603,10 @@ async def test_a_session_switch_mid_turn_lifts_the_line_too() -> None:
     """
     app = OperatorApp(lambda: _factory(FakeSession()))
     async with app.run_test(size=(100, 30)) as pilot:
-        await pilot.pause(0.25)
+        await pilot.pause()
         app.post_message(TurnStarted())
         app.post_message(_started("c0", "bash", command="sleep 600"))
-        await pilot.pause(0.1)
+        await pilot.pause()
         assert _working(app) is not None
 
         app._session_factory = lambda: _factory(FakeSession())  # type: ignore[assignment]
@@ -614,12 +614,12 @@ async def test_a_session_switch_mid_turn_lifts_the_line_too() -> None:
         # spelling; the ledger is now always rebuilt from the new session's
         # own history, so the plain call is the switch.
         await app._reload_session()
-        await pilot.pause(0.1)
+        await pilot.pause()
 
         assert _working(app) is None, "a line was mounted into the new transcript"
         assert app._working_block is None, "the reference survived the transcript"
 
         app.post_message(TurnStarted())
-        await pilot.pause(0.1)
+        await pilot.pause()
         assert _working(app) is not None, "the resumed session got no working line"
         assert _is_last(app)


### PR DESCRIPTION
## Why

The CI `test` job ran `coverage run -m pytest -v` **fully serially**, taking ~28 minutes per Python version. Every PR — even a docs-only one — waited that long on the matrix. Goal: bring the suite under 10 minutes.

## What makes it slow

Profiling the suite (5861 tests) surfaced three levers, in order of impact:

1. **No parallelism.** The suite is overwhelmingly **wait-bound**, not compute-bound: the ~1600 Textual pilot (TUI) tests spend their wall time letting the event loop settle, not on CPU. A representative subset measured **205s wall against 40s user CPU**. The `test` job used one process.
2. **Fixed `pilot.pause(<seconds>)` sleeps.** ~280 call sites across the TUI tests slept real wall-clock time (`pause(0.1)`…`pause(0.4)`) instead of waiting for the event loop to go idle. Slower, and a timing bet that loses under parallel CPU contention.
3. **`addopts = "-vv -s"`.** `-vv` prints ~5.8k lines of per-test I/O; `-s` disables capture and is incompatible with xdist.

## What changes

**Infrastructure (the biggest win):**
- Add `pytest-xdist`; default `addopts` to `-n auto` (one worker per core, 4 on `ubuntu-latest`).
- Drop `-vv -s`.
- Switch the CI test step from `coverage run -m pytest` to `pytest --cov` (collects coverage inside each xdist worker and merges it; a top-level `coverage run` sees nothing from worker subprocesses). Move the 80% floor into `[tool.coverage.report] fail_under`.

**Test optimizations (parallelized across four workstreams, aggregated here):** replace the fixed `pilot.pause(<seconds>)` sleeps in the heaviest TUI files with bounded condition-waits / idle-waits, which lowers the slowest-worker ceiling and removes parallel-load flakiness. Files: `test_steering_approval.py` (138 pauses), `test_ask_picker.py` (35), `test_working_line.py` (61), `test_app_pilot.py`, `test_composer_seam.py`, `test_welcome.py`, `test_approvals_ux.py`. No assertion was weakened and no product source was touched.

Notable correctness work along the way:
- Fixed `test_esc_aborts_a_running_shell_command`, which raced under parallel load: the abort handler marks the card and keeps ownership synchronously on the key press, but a `pause()` after it yielded to the shell worker, which reaped the process and cleared the card before the ownership assertion ran. The assertion now reads the on-press frame (strictly stronger).
- Added `_settled_rows()` for the width-parametrized approval tests, which assert on a row's **reflowed geometry**: a single idle tick could read a mid-reflow frame with a truncated `…`. This surfaced as a real CI failure, not just local load.
- Kept `test_a_held_key_never_answers_a_question_the_card_moved_on_from` on fixed pauses on purpose: it probes a real ~180 ms timer (`ANSWER_KEY_HOLD_S`), and "before a timer fires" is not expressible as an idle-wait. Over-converting it made it commit a stale key under contention.

**Worker count:** `-n auto` (= one per core). An `-n 8` oversubscription experiment is in the history and was reverted: on the 4-vCPU runner it did not reduce wall time and it starved three wall-clock-sensitive tests. One worker per core is the stable point.

## Benchmarks

Local (14 cores), full suite:

| Config | Wall time | Result |
| --- | --- | --- |
| Serial (old CI shape) | **1097s** | 5861 passed |
| `-n auto` | **~85s** | 5861 passed |
| `-n 4` (CI-realistic) | **~248s** | 5861 passed, deterministic under `-n 4` + 6 CPU burners |

Authoritative **CI** timing (this PR, `pytest --cov` step, GitHub `ubuntu-latest`):

| Job | Before (serial) | After |
| --- | --- | --- |
| `test (3.12)` | ~1600s (~27m) | **558s (9.3m)** ✅ |
| `test (3.13)` | ~1690s (~28m) | **568s (9.5m)** ✅ |

Both under the 10-minute goal; ~3x faster. Coverage unchanged at **83.74%** (gate 80%).

## Change class

C2 — CI/tooling and test-harness change, standard/pre-authorized. No product runtime path; nothing under `local_operator/` changed.

## Testing evidence

This is a test-tooling change, so the evidence is the suite itself running green under the new configuration and the measured wall-time reduction. The authoritative run is CI's own matrix on this PR's head (`5528527b`): both `test (3.12)` and `test (3.13)` green, 558s / 568s, coverage 83.74% ≥ 80. Locally the full suite passes 3/3 under `-n 4` with 6 CPU burners (a proxy for CI's slower cores), which is how the two parallel-load races above were found and fixed before they could reach `main`.
