### PR TITLE
feat(prompt): harness self-awareness and eval digest-pipeline guidance

### DIFF
--- a/local_operator/prompts_md/system.md
+++ b/local_operator/prompts_md/system.md
@@ -4,6 +4,16 @@ files, searching the workspace, tracking tasks, and scheduling follow-ups. Use
 them before answering whenever the answer depends on the machine's state — a
 real result beats a guess every time.
 
+Local Operator is the harness you are running in — the agent runtime itself, not
+just a persona. Users start it with the `lop` command (the standard way to run
+it; `local-operator` is the full name and `lo` an alias), so when someone asks
+about "lop", "local-operator", "this harness", "this agent", or "yourself" —
+your configuration, prompts, tools, skills, MCP servers, subagents, or how to
+run or update you — they mean this runtime, and you should answer about it rather
+than treating it as an unknown third-party tool. When such a question maps to a
+listed guide, read it first per the guide rule below; the source of truth for
+runtime behaviour is the code and guides in this project, not your assumptions.
+
 ## Working principles
 
 - **Use tools before answering.** Verify with a tool rather than assuming: run
@@ -90,6 +100,18 @@ respect the project's ignore files. Reading a Python file whole returns its
 declaration outline with line ranges — re-read the exact ranges you need
 instead of the whole file. `wake` schedules follow-ups when the user asks to
 be reminded or something should happen later.
+
+`eval` runs Python in a persistent per-session kernel: state (imports, variables,
+functions) survives across calls, so build on earlier work instead of recomputing
+it. Prefer one `eval` call that does a whole multi-step data or file job and
+prints a compact digest over many separate tool calls whose intermediate results
+each land in context. Reading ten files, filtering them, and summarizing is one
+`eval` that prints the summary — not ten `read` calls. Large output the tool
+elides is not lost: it is written to a `spill://` handle you expand on demand with
+`read spill://…` (add `?q=<regex>` to search within it), so keep the printed
+result compact and fetch the full detail only when a step needs inspecting. This
+keeps the token cost of a pipeline near its final answer while every intermediate
+stays one `read` away for debugging.
 
 Keep the todo list honest. When a new requirement arrives mid-turn, `add` it
 instead of rewriting the list, and mark items `done` as you finish them rather

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.22.0"
+version = "0.23.0"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/test_prompts_api.py
+++ b/tests/unit/test_prompts_api.py
@@ -144,6 +144,29 @@ def test_system_md_loads_and_renders() -> None:
     assert "Local Operator" in text
 
 
+def test_system_md_states_harness_identity() -> None:
+    """The prompt must tell the agent it IS the local-operator harness, run as
+    ``lop``, so a question about the harness/itself is answered rather than
+    treated as an unknown third-party tool. Asserts the behaviour contract, not
+    exact wording — reword freely, but keep the identity and the command name.
+    """
+    text = render_template("system.md", {})
+    assert "harness" in text
+    # The standard command name must be named so the agent can tell a user how
+    # to run/update it.
+    assert "`lop`" in text
+
+
+def test_system_md_teaches_eval_digest_pipeline() -> None:
+    """The prompt must steer multi-step work into one ``eval`` that prints a
+    compact digest, with full output kept fetchable via ``spill://`` — the
+    token-efficiency guidance. Contract, not wording.
+    """
+    text = render_template("system.md", {})
+    assert "eval" in text
+    assert "spill://" in text
+
+
 def test_compaction_summary_renders_optional_sections() -> None:
     full = render_template(
         "compaction_summary.md",


### PR DESCRIPTION
## Summary of Changes

Two optimizations to the system prompt (`local_operator/prompts_md/system.md`), both about how an agent understands and uses the runtime it lives in.

**1. Harness self-awareness.** The prompt established the "Local Operator" persona but never tied it to the runtime or the `lop` command that starts it, so a question about "lop" / "local-operator" / "this harness" / "yourself" could read as an unknown third-party tool. The prompt now states plainly that Local Operator **is** the harness, run as `lop` (full name `local-operator`, alias `lo`), and that such questions are about this runtime and should be answered from its code and guides.

**2. `eval` digest-pipeline guidance.** Teaches the agent to collapse a multi-step data/file job into one `eval` call that prints a compact digest, instead of many tool calls whose intermediate results each land in context. Full output stays fetchable via the existing `spill://` handle, so token cost sits near the final answer while every intermediate is one `read` away for debugging. This is the cheap ~90% of the PTC token-efficiency win, with no code change.

- Change class: **C1 (standard, pre-authorized)** — prompt text + a test.

## Impact

- No breaking changes, no dependency updates. Changes model-facing prompt text; no API or interface change.
- Slight, deliberate increase in the fixed prompt size (two paragraphs) — justified: it prevents an agent misclassifying self-questions and steers pipelines toward lower total token cost.

## Testing Details

This changes prompt **content**, whose runtime path is "does the rendered system prompt actually carry the new guidance." Exercised the real render path (`render_template("system.md", {})`) and confirmed both blocks are present in the rendered output:

**Harness identity (rendered):**
```
Local Operator is the harness you are running in — the agent runtime itself, not
just a persona. Users start it with the `lop` command (the standard way to run
it; `local-operator` is the full name and `lo` an alias) ...
```

**eval digest guidance (rendered):**
```
Prefer one `eval` call that does a whole multi-step data or file job and prints a
compact digest over many separate tool calls whose intermediate results each land
in context ... written to a `spill://` handle you expand on demand with
`read spill://…` ...
```

Added two behaviour-contract tests in `tests/unit/test_prompts_api.py`:
- `test_system_md_states_harness_identity` — asserts `harness` and the command name `` `lop` `` are present (reword-tolerant, drop-intolerant).
- `test_system_md_teaches_eval_digest_pipeline` — asserts the `eval`/`spill://` guidance is present.

Gate output:
```
pytest tests/unit/test_prompts_api.py  → 33 passed
black --check (26.1.0)                  → 2 files unchanged
isort --check-only --profile black     → clean
flake8                                 → clean
pyright --pythonpath .venv/bin/python  → 0 errors, 0 warnings
```

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my changes work as intended.
- [x] All new and existing tests pass.
- [x] I have run formatting (black/isort), linting (flake8), and type checks (pyright), and they pass.
- [x] I have updated the documentation when required (prompt is the surface changed).
- [x] Security considerations are addressed: prompt-only; no code-execution surface touched.
