### PR TITLE
feat(analytics): overlay estimated cost + responsive frame

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -236,9 +236,13 @@ Every provider call across every session contributes to one shared, on-disk
 ledger (`<config_dir>/analytics.db`, SQLite/WAL/0600). `/analytics /usage`
 opens an Esc-dismissable screen summarising token consumption: authoritative
 provider counts (input/output/cache, and the thinking-vs-generation split of
-output) plus an *estimated* breakdown of input across the system prompt, custom
-instructions (agent/team profiles), tool inventory, tool schemas, environment,
-knowledge, conversation, and tool results.
+output), an *estimated* dollar **cost** overlay, and an *estimated* breakdown of
+input across the system prompt, custom instructions (agent/team profiles), tool
+inventory, tool schemas, environment, knowledge, conversation, and tool
+results. The frame is responsive — it grows to `max-width: 140` on a large
+terminal (see the `.analytics-panel` CSS and `AnalyticsScreen._card_width`,
+which must stay in step), and the per-provider/per-session tables shed the cache
+column below `_WIDE_TABLE_MIN` to keep the cost column.
 
 Things that will bite you if you forget them:
 
@@ -272,5 +276,20 @@ Things that will bite you if you forget them:
   and estimates must never be presented as the same kind of number — the screen
   says "estimated split of context tokens" for a reason.
 
-- **Adding a component is a schema migration.** `COMPONENT_KEYS` maps to one
-  `c_<key>` column each in `store._SCHEMA`; bump the schema and default 0.
+- **Cost is computed at RECORD time, not aggregation time.** Dollar cost is
+  priced in `SessionStreamFn._cost_micro` (`configure.py`) where the exact model
+  is known, via the shared `cost_for_usage` — so analytics can never disagree
+  with the status band. It is stored per call as `cost_micro` (USD × 1e6,
+  INTEGER so the `SUM` is exact) plus a `cost_known` flag. A model with no
+  published price records `cost_known=False` (rendered `$—`, never `$0.00`); a
+  scope where some calls were unpriced is a LOWER BOUND (rendered `$12.30+`).
+  Cost is an ESTIMATE (list price × tokens; it cannot see a plan, discount, or
+  free tier) and is labelled as one, same discipline as the component split.
+
+- **Adding a component OR a stored column is a schema migration.**
+  `COMPONENT_KEYS` maps to one `c_<key>` column each in `store._SCHEMA`. A
+  database from an older release is upgraded on open by `AnalyticsStore._migrate`
+  (idempotent `ALTER TABLE ADD COLUMN`, since `CREATE TABLE IF NOT EXISTS` never
+  alters an existing table) — this is how the `cost_*` columns reach a
+  token-only ledger. Any new stored column needs a `_MIGRATION_COLUMNS` entry
+  with a DEFAULT so old rows read as a sane value, never NULL.

--- a/local_operator/analytics/__init__.py
+++ b/local_operator/analytics/__init__.py
@@ -42,6 +42,7 @@ from local_operator.analytics.model import (
     CallSnapshot,
     UsageAggregate,
     apportion_components,
+    price_snapshot,
     snapshot_component_chars,
     split_system_prompt,
 )
@@ -59,6 +60,7 @@ __all__ = [
     "CallSnapshot",
     "UsageAggregate",
     "apportion_components",
+    "price_snapshot",
     "snapshot_component_chars",
     "split_system_prompt",
     "AnalyticsRecorder",

--- a/local_operator/analytics/model.py
+++ b/local_operator/analytics/model.py
@@ -156,6 +156,18 @@ class CallSnapshot:
     # input tokens and is worth recording, but is counted separately so a
     # provider-outage session does not look like normal spend).
     ok: bool = True
+    # This call's dollar cost in MICRO-USD (USD × 1_000_000), and whether it is
+    # known at all. Cost is computed AT RECORD TIME, where the exact model that
+    # served the call is known — never at aggregation, where tokens from
+    # differently-priced models are already summed and un-priceable. Micro-USD
+    # integers rather than floats so the store's ``SUM`` is exact (a fraction of
+    # a cent per call over millions of calls is real money to drift). A model
+    # with no published price records ``cost_known=False`` and ``cost_micro=0``,
+    # which the report renders as an unknown share of the total rather than a
+    # confident ``$0.00`` — the same "unknown ≠ free" distinction the status
+    # band's ``$—`` already makes (see ``tui/costs.turn_cost``).
+    cost_micro: int = 0
+    cost_known: bool = True
 
 
 def snapshot_component_chars(request: Any) -> dict[str, int]:
@@ -267,6 +279,12 @@ class UsageAggregate:
     cache_write_tokens: int = 0
     reasoning_tokens: int = 0
     context_tokens: int = 0
+    # Summed dollar cost in MICRO-USD, and how many of ``calls`` had a known
+    # price. ``cost_known_calls < calls`` means the dollar figure is a LOWER
+    # BOUND — some calls used models with no published price — which the report
+    # marks (``$12.30+``) rather than presenting a partial sum as complete.
+    cost_micro: int = 0
+    cost_known_calls: int = 0
     components: dict[str, int] = field(default_factory=lambda: {k: 0 for k in COMPONENT_KEYS})
     by_provider: dict[str, "UsageAggregate"] = field(default_factory=dict)
     by_session: dict[str, "UsageAggregate"] = field(default_factory=dict)
@@ -275,6 +293,30 @@ class UsageAggregate:
     def generation_tokens(self) -> int:
         """Output tokens that were visible generation, not hidden thinking."""
         return max(0, self.output_tokens - self.reasoning_tokens)
+
+    @property
+    def cost_usd(self) -> float:
+        """The summed cost in whole dollars (from the micro-USD accumulator)."""
+        return self.cost_micro / 1_000_000.0
+
+    @property
+    def cost_is_partial(self) -> bool:
+        """True when some priced-in calls had no published price.
+
+        The dollar total is then a lower bound: it counts every call we could
+        price and silently omits the ones we could not. A report must SAY so
+        rather than imply the omitted calls were free.
+        """
+        return self.cost_known_calls < self.calls
+
+    @property
+    def cost_is_known(self) -> bool:
+        """True when at least one call in scope had a known price.
+
+        ``False`` means nothing here is priceable (e.g. a local Ollama-only
+        run), which the report renders as ``$—`` rather than ``$0.00``.
+        """
+        return self.cost_known_calls > 0
 
     @property
     def total_tokens(self) -> int:

--- a/local_operator/analytics/model.py
+++ b/local_operator/analytics/model.py
@@ -156,18 +156,55 @@ class CallSnapshot:
     # input tokens and is worth recording, but is counted separately so a
     # provider-outage session does not look like normal spend).
     ok: bool = True
-    # This call's dollar cost in MICRO-USD (USD × 1_000_000), and whether it is
-    # known at all. Cost is computed AT RECORD TIME, where the exact model that
-    # served the call is known — never at aggregation, where tokens from
-    # differently-priced models are already summed and un-priceable. Micro-USD
-    # integers rather than floats so the store's ``SUM`` is exact (a fraction of
-    # a cent per call over millions of calls is real money to drift). A model
-    # with no published price records ``cost_known=False`` and ``cost_micro=0``,
-    # which the report renders as an unknown share of the total rather than a
-    # confident ``$0.00`` — the same "unknown ≠ free" distinction the status
-    # band's ``$—`` already makes (see ``tui/costs.turn_cost``).
+    # This call's dollar cost in MICRO-USD (USD × 1_000_000) and whether it is
+    # known. Populated by the STORE on its background thread
+    # (``price_snapshot``) unless ``priced`` is already True: pricing calls
+    # ``resolve_model_info``, which can block for seconds on a cold memo, and
+    # that must never run on the event loop the turn is unwinding on (review
+    # C1). Micro-USD integers rather than floats so the store's ``SUM`` is exact.
+    # A model with no published price prices to ``cost_known=False`` /
+    # ``cost_micro=0``, rendered as an unknown share rather than a confident
+    # ``$0.00`` — the "unknown ≠ free" distinction the status band's ``$—``
+    # already makes (see ``tui/costs.turn_cost``).
     cost_micro: int = 0
-    cost_known: bool = True
+    cost_known: bool = False
+    # ``True`` when ``cost_micro``/``cost_known`` are already final and the store
+    # must NOT re-price (a test recording a known cost without a price table, or
+    # a future caller that priced off-thread itself). The normal recording path
+    # leaves this False so the store prices from the model + token counts.
+    priced: bool = False
+
+
+def price_snapshot(snapshot: "CallSnapshot") -> tuple[int, bool]:
+    """``(cost in micro-USD, price known)`` for a snapshot, never raising.
+
+    Called by the store on its BACKGROUND thread (never the event loop), where
+    the potentially-blocking ``resolve_model_info`` cold-memo lookup is free —
+    the same reason the SQLite write lives there. Prices through
+    ``cost_for_usage``, the one money computation the whole app shares, so the
+    analytics dollar total cannot diverge from the status band. Returns
+    ``(0, False)`` for a model with no published price (rendered ``$—``, not a
+    misleading ``$0.00``) and for any failure — pricing is best-effort, and an
+    unpriceable call is still worth recording token-wise.
+
+    The lazy import keeps the model layer off this module's import graph (the
+    analytics package must stay importable without the provider/pricing stack)
+    and matches how the recorder already defers its own imports.
+    """
+    if snapshot.priced:
+        return int(snapshot.cost_micro), bool(snapshot.cost_known)
+    try:
+        from local_operator.model.configure import cost_for_usage, resolve_model_info
+
+        info = resolve_model_info(snapshot.provider, snapshot.model_id)
+        if not (info.input_price or info.output_price):
+            return 0, False
+        # ``cost_for_usage`` duck-types its usage arg, so a plain object with the
+        # token fields it reads is enough — no need to rebuild a ``Usage``.
+        dollars = cost_for_usage(snapshot.provider, info, snapshot)
+        return int(round(dollars * 1_000_000)), True
+    except Exception:  # noqa: BLE001 — an unpriceable call is not an error
+        return 0, False
 
 
 def snapshot_component_chars(request: Any) -> dict[str, int]:

--- a/local_operator/analytics/store.py
+++ b/local_operator/analytics/store.py
@@ -39,6 +39,7 @@ from local_operator.analytics.model import (
     CallSnapshot,
     UsageAggregate,
     apportion_components,
+    price_snapshot,
 )
 from local_operator.paths import config_dir
 
@@ -129,6 +130,18 @@ _INSERT_SQL = (
     f"VALUES ({', '.join('?' for _ in _CALL_COLUMNS)})"
 )
 
+#: The insert WITHOUT the cost columns, for a database where the migration to
+#: add them failed (review C2). The two cost values are dropped from both the
+#: column list and each row tuple so a missing column cannot fail every write.
+_CALL_COLUMNS_NO_COST = tuple(c for c in _CALL_COLUMNS if c not in ("cost_micro", "cost_known"))
+_INSERT_SQL_NO_COST = (
+    f"INSERT INTO calls ({', '.join(_CALL_COLUMNS_NO_COST)}) "
+    f"VALUES ({', '.join('?' for _ in _CALL_COLUMNS_NO_COST)})"
+)
+#: Positions of the two cost values in ``_row_values`` output, so the cost-less
+#: path can drop exactly them. They sit right after ``context_tokens``.
+_COST_VALUE_INDICES = (11, 12)
+
 
 def default_db_path() -> Path:
     """The shared analytics database, next to the other per-user stores."""
@@ -144,6 +157,10 @@ def _row_values(snapshot: CallSnapshot) -> tuple[Any, ...]:
     reads as "unknown" rather than a fabricated breakdown.
     """
     components = apportion_components(snapshot.component_chars, snapshot.context_tokens)
+    # Price on THIS (writer) thread — never the event loop (review C1). See
+    # ``price_snapshot``: a cold ``resolve_model_info`` can block for seconds,
+    # which is fine on the background writer and unacceptable on the turn's loop.
+    cost_micro, cost_known = price_snapshot(snapshot)
     return (
         snapshot.ts_ms,
         snapshot.session_id,
@@ -156,8 +173,8 @@ def _row_values(snapshot: CallSnapshot) -> tuple[Any, ...]:
         snapshot.cache_write_tokens,
         snapshot.reasoning_tokens,
         snapshot.context_tokens,
-        int(snapshot.cost_micro),
-        1 if snapshot.cost_known else 0,
+        int(cost_micro),
+        1 if cost_known else 0,
         *(components[key] for key in COMPONENT_KEYS),
     )
 
@@ -191,6 +208,14 @@ class AnalyticsStore:
         #: first connections at once do not race on ``executescript``.
         self._init_lock = threading.Lock()
         self._initialized = False
+        #: Whether the cost columns exist on THIS database. A fresh DB always
+        #: has them (the ``CREATE TABLE`` includes them); an old one gets them
+        #: from ``_migrate``. If a migration ALTER genuinely fails (a locked or
+        #: corrupt DB), this stays False and both the insert and the aggregate
+        #: silently drop the cost columns rather than referencing a column that
+        #: does not exist — which would otherwise fail EVERY write and blank the
+        #: whole screen (review C2). Token analytics keep working; cost reads 0.
+        self._has_cost = True
 
     # -- connection ----------------------------------------------------------
     def _connect(self) -> sqlite3.Connection | None:
@@ -254,8 +279,7 @@ class AnalyticsStore:
                 pass
             self._local.conn = None
 
-    @staticmethod
-    def _migrate(conn: sqlite3.Connection) -> None:
+    def _migrate(self, conn: sqlite3.Connection) -> None:
         """Add columns that a database from an older release is missing.
 
         ``CREATE TABLE IF NOT EXISTS`` never alters an existing table, so a
@@ -265,18 +289,25 @@ class AnalyticsStore:
         pre-cost call reads as "unpriced", never as a confident $0. Called under
         ``_init_lock`` on open; a failure here degrades to the pre-migration
         shape rather than raising, because analytics is never a hard dependency.
+
+        Sets ``self._has_cost`` from what is ACTUALLY present afterward: if an
+        ALTER failed, cost is dropped from the insert and the aggregate so a
+        missing column cannot fail every write and blank the screen (review C2).
         """
         try:
             existing = {str(row[1]) for row in conn.execute("PRAGMA table_info(calls)").fetchall()}
         except Exception:  # noqa: BLE001 — an unreadable schema is a no-op migration
+            self._has_cost = False
             return
         for name, definition in _MIGRATION_COLUMNS:
             if name in existing:
                 continue
             try:
                 conn.execute(f"ALTER TABLE calls ADD COLUMN {name} {definition}")
+                existing.add(name)
             except Exception:  # noqa: BLE001 — a failed add leaves the older shape
                 logger.debug("analytics: could not add column %s", name, exc_info=True)
+        self._has_cost = all(name in existing for name, _ in _MIGRATION_COLUMNS)
 
     @staticmethod
     def _now_ms() -> int:
@@ -306,9 +337,18 @@ class AnalyticsStore:
         if conn is None:
             return 0
         rows = [_row_values(s) for s in snapshots]
+        if self._has_cost:
+            insert_sql = _INSERT_SQL
+        else:
+            # Migration to add the cost columns failed: drop the two cost values
+            # so the insert matches the older table shape (review C2).
+            insert_sql = _INSERT_SQL_NO_COST
+            rows = [
+                tuple(v for i, v in enumerate(row) if i not in _COST_VALUE_INDICES) for row in rows
+            ]
         for attempt in range(_WRITE_RETRIES):
             try:
-                conn.executemany(_INSERT_SQL, rows)
+                conn.executemany(insert_sql, rows)
                 conn.commit()
                 return len(snapshots)
             except sqlite3.OperationalError as exc:
@@ -439,12 +479,15 @@ class AnalyticsStore:
         component_sum = ", ".join(f"SUM(c_{key})" for key in COMPONENT_KEYS)
         # Order is a contract with ``_aggregate_from_row``, which indexes this
         # tuple positionally: cost_micro and cost_known_calls come after the
-        # token sums and before the component sums.
+        # token sums and before the component sums. When the cost columns are
+        # absent (a failed migration, review C2), substitute constant 0 sums so
+        # the positions still line up and the report shows $— instead of the
+        # query failing on a missing column.
+        cost_cols = "SUM(cost_micro), SUM(cost_known)" if self._has_cost else "0, 0"
         base_cols = (
             "COUNT(*), SUM(ok), SUM(input_tokens), SUM(output_tokens), "
             "SUM(cache_read_tokens), SUM(cache_write_tokens), "
-            "SUM(reasoning_tokens), SUM(context_tokens), "
-            "SUM(cost_micro), SUM(cost_known)"
+            f"SUM(reasoning_tokens), SUM(context_tokens), {cost_cols}"
         )
         try:
             top = conn.execute(

--- a/local_operator/analytics/store.py
+++ b/local_operator/analytics/store.py
@@ -76,6 +76,10 @@ CREATE TABLE IF NOT EXISTS calls (
   cache_write_tokens INTEGER NOT NULL DEFAULT 0,
   reasoning_tokens INTEGER NOT NULL DEFAULT 0,
   context_tokens INTEGER NOT NULL DEFAULT 0,
+  -- Dollar cost of the call in MICRO-USD (USD × 1e6) and whether it was
+  -- priceable. Integer so the aggregate SUM is exact; see CallSnapshot.
+  cost_micro INTEGER NOT NULL DEFAULT 0,
+  cost_known INTEGER NOT NULL DEFAULT 0,
   {_COMPONENT_COLUMNS}
 );
 CREATE INDEX IF NOT EXISTS idx_calls_ts ON calls(ts_ms);
@@ -104,7 +108,20 @@ _CALL_COLUMNS = (
     "cache_write_tokens",
     "reasoning_tokens",
     "context_tokens",
+    "cost_micro",
+    "cost_known",
     *(f"c_{key}" for key in COMPONENT_KEYS),
+)
+
+#: Columns added AFTER the first shipped schema (which had no cost columns).
+#: A database created by the token-only release is missing these, and
+#: ``CREATE TABLE IF NOT EXISTS`` will not add a column to an existing table —
+#: so ``_connect`` runs an idempotent ``ALTER TABLE ADD COLUMN`` for each on
+#: open. ``(name, definition)``; the definition carries the default so old rows
+#: read as cost 0 / unknown rather than NULL.
+_MIGRATION_COLUMNS: tuple[tuple[str, str], ...] = (
+    ("cost_micro", "INTEGER NOT NULL DEFAULT 0"),
+    ("cost_known", "INTEGER NOT NULL DEFAULT 0"),
 )
 
 _INSERT_SQL = (
@@ -139,6 +156,8 @@ def _row_values(snapshot: CallSnapshot) -> tuple[Any, ...]:
         snapshot.cache_write_tokens,
         snapshot.reasoning_tokens,
         snapshot.context_tokens,
+        int(snapshot.cost_micro),
+        1 if snapshot.cost_known else 0,
         *(components[key] for key in COMPONENT_KEYS),
     )
 
@@ -197,6 +216,7 @@ class AnalyticsStore:
             # simultaneously do not both executescript into the same file.
             with self._init_lock:
                 conn.executescript(_SCHEMA)
+                self._migrate(conn)
                 conn.commit()
                 if not self._initialized:
                     for path in (
@@ -233,6 +253,30 @@ class AnalyticsStore:
             except Exception:  # noqa: BLE001
                 pass
             self._local.conn = None
+
+    @staticmethod
+    def _migrate(conn: sqlite3.Connection) -> None:
+        """Add columns that a database from an older release is missing.
+
+        ``CREATE TABLE IF NOT EXISTS`` never alters an existing table, so a
+        ledger written by the token-only release has no ``cost_*`` columns. Add
+        each via ``ALTER TABLE ADD COLUMN`` (idempotent: skip the ones already
+        present). Old rows take the column default — cost 0, unknown — so a
+        pre-cost call reads as "unpriced", never as a confident $0. Called under
+        ``_init_lock`` on open; a failure here degrades to the pre-migration
+        shape rather than raising, because analytics is never a hard dependency.
+        """
+        try:
+            existing = {str(row[1]) for row in conn.execute("PRAGMA table_info(calls)").fetchall()}
+        except Exception:  # noqa: BLE001 — an unreadable schema is a no-op migration
+            return
+        for name, definition in _MIGRATION_COLUMNS:
+            if name in existing:
+                continue
+            try:
+                conn.execute(f"ALTER TABLE calls ADD COLUMN {name} {definition}")
+            except Exception:  # noqa: BLE001 — a failed add leaves the older shape
+                logger.debug("analytics: could not add column %s", name, exc_info=True)
 
     @staticmethod
     def _now_ms() -> int:
@@ -393,10 +437,14 @@ class AnalyticsStore:
         clause = (" WHERE " + " AND ".join(where)) if where else ""
 
         component_sum = ", ".join(f"SUM(c_{key})" for key in COMPONENT_KEYS)
+        # Order is a contract with ``_aggregate_from_row``, which indexes this
+        # tuple positionally: cost_micro and cost_known_calls come after the
+        # token sums and before the component sums.
         base_cols = (
             "COUNT(*), SUM(ok), SUM(input_tokens), SUM(output_tokens), "
             "SUM(cache_read_tokens), SUM(cache_write_tokens), "
-            "SUM(reasoning_tokens), SUM(context_tokens)"
+            "SUM(reasoning_tokens), SUM(context_tokens), "
+            "SUM(cost_micro), SUM(cost_known)"
         )
         try:
             top = conn.execute(
@@ -468,6 +516,9 @@ def _aggregate_from_row(row: Iterable[Any] | None) -> UsageAggregate:
         cache_write_tokens=_n(5),
         reasoning_tokens=_n(6),
         context_tokens=_n(7),
+        cost_micro=_n(8),
+        cost_known_calls=_n(9),
     )
-    agg.components = {key: _n(8 + i) for i, key in enumerate(COMPONENT_KEYS)}
+    # Components follow the two cost sums (see ``base_cols``).
+    agg.components = {key: _n(10 + i) for i, key in enumerate(COMPONENT_KEYS)}
     return agg

--- a/local_operator/model/configure.py
+++ b/local_operator/model/configure.py
@@ -2859,18 +2859,17 @@ class SessionStreamFn:
                 context_tokens = (
                     usage.input_tokens + usage.cache_read_tokens + usage.cache_write_tokens
                 )
-            # Dollar cost is computed HERE, where the exact model that served the
-            # call is known — not at aggregation, where differently-priced
-            # models are already summed. This is the SAME arithmetic the status
-            # band runs every repaint (``cost_for_usage``), so the analytics
-            # dollar total can never disagree with the live band. A model with
-            # no published price records cost_known=False rather than a
-            # misleading $0. Runs on the event loop, but after the stream is
-            # consumed (see ``_record_stream``) and behind a memoised price
-            # lookup — a dict hit and four multiplies — so it adds no
-            # perceptible latency, and it is fully guarded: a pricing failure
-            # must never cost the turn its analytics, let alone the turn itself.
-            cost_micro, cost_known = self._cost_micro(request.model, usage)
+            # Cost is NOT priced here (review C1). The snapshot carries the
+            # provider, model id, and every token count, which is everything
+            # ``cost_for_usage`` needs — so the pricing (including the
+            # ``resolve_model_info`` lookup, which can block for seconds on a
+            # COLD memo: a TTL rollover, an lru_cache eviction, or a subagent on
+            # a registry-unknown model override) runs on the recorder's
+            # background thread, next to the SQLite write, and never on the event
+            # loop this turn is unwinding on. The same hazard ``subagent_panel``
+            # deliberately takes off-thread. It is still the SAME
+            # ``cost_for_usage`` the status band uses, so the analytics dollar
+            # total cannot disagree with the live band.
             record_call(
                 CallSnapshot(
                     ts_ms=int(_time.time() * 1000),
@@ -2885,31 +2884,10 @@ class SessionStreamFn:
                     context_tokens=int(context_tokens or 0),
                     component_chars=component_chars,
                     ok=ok,
-                    cost_micro=cost_micro,
-                    cost_known=cost_known,
                 )
             )
         except Exception:  # noqa: BLE001 — recording is best-effort
             logger.debug("analytics: usage record failed", exc_info=True)
-
-    @staticmethod
-    def _cost_micro(model: ModelSpec, usage: Usage) -> tuple[int, bool]:
-        """``(cost in micro-USD, price known)`` for one call, never raising.
-
-        Resolves the model's price (memoised per TTL bucket) and prices the
-        usage through ``cost_for_usage`` — the one money computation the whole
-        app shares. Returns ``(0, False)`` for a model with no published price,
-        which the report renders as an unknown share rather than a false $0.
-        Micro-USD (USD × 1e6) as an INTEGER so the store's SUM is exact.
-        """
-        try:
-            info = resolve_model_info(model.provider, model.model_id)
-            if not (info.input_price or info.output_price):
-                return 0, False
-            dollars = cost_for_usage(model.provider, info, usage)
-            return int(round(dollars * 1_000_000)), True
-        except Exception:  # noqa: BLE001 — an unpriceable model is not an error
-            return 0, False
 
     async def close(self) -> None:
         await self._http.aclose()

--- a/local_operator/model/configure.py
+++ b/local_operator/model/configure.py
@@ -2859,6 +2859,18 @@ class SessionStreamFn:
                 context_tokens = (
                     usage.input_tokens + usage.cache_read_tokens + usage.cache_write_tokens
                 )
+            # Dollar cost is computed HERE, where the exact model that served the
+            # call is known — not at aggregation, where differently-priced
+            # models are already summed. This is the SAME arithmetic the status
+            # band runs every repaint (``cost_for_usage``), so the analytics
+            # dollar total can never disagree with the live band. A model with
+            # no published price records cost_known=False rather than a
+            # misleading $0. Runs on the event loop, but after the stream is
+            # consumed (see ``_record_stream``) and behind a memoised price
+            # lookup — a dict hit and four multiplies — so it adds no
+            # perceptible latency, and it is fully guarded: a pricing failure
+            # must never cost the turn its analytics, let alone the turn itself.
+            cost_micro, cost_known = self._cost_micro(request.model, usage)
             record_call(
                 CallSnapshot(
                     ts_ms=int(_time.time() * 1000),
@@ -2873,10 +2885,31 @@ class SessionStreamFn:
                     context_tokens=int(context_tokens or 0),
                     component_chars=component_chars,
                     ok=ok,
+                    cost_micro=cost_micro,
+                    cost_known=cost_known,
                 )
             )
         except Exception:  # noqa: BLE001 — recording is best-effort
             logger.debug("analytics: usage record failed", exc_info=True)
+
+    @staticmethod
+    def _cost_micro(model: ModelSpec, usage: Usage) -> tuple[int, bool]:
+        """``(cost in micro-USD, price known)`` for one call, never raising.
+
+        Resolves the model's price (memoised per TTL bucket) and prices the
+        usage through ``cost_for_usage`` — the one money computation the whole
+        app shares. Returns ``(0, False)`` for a model with no published price,
+        which the report renders as an unknown share rather than a false $0.
+        Micro-USD (USD × 1e6) as an INTEGER so the store's SUM is exact.
+        """
+        try:
+            info = resolve_model_info(model.provider, model.model_id)
+            if not (info.input_price or info.output_price):
+                return 0, False
+            dollars = cost_for_usage(model.provider, info, usage)
+            return int(round(dollars * 1_000_000)), True
+        except Exception:  # noqa: BLE001 — an unpriceable model is not an error
+            return 0, False
 
     async def close(self) -> None:
         await self._http.aclose()

--- a/local_operator/tui/local_operator.tcss
+++ b/local_operator/tui/local_operator.tcss
@@ -1282,10 +1282,17 @@ AnalyticsScreen {
 }
 
 AnalyticsScreen .analytics-panel {
+    /* Responsive: 90% of the terminal, capped generously so a large screen
+     * actually gets a larger frame (the token+cost tables have more columns to
+     * show) while a small one still fits. The old max-width of 100 left a wide
+     * terminal with a narrow card and a sea of dead margin; 140 lets the tables
+     * breathe on the big displays this was asked to use, and the 90% keeps a
+     * small terminal from overflowing. Height likewise grows to 85% so more
+     * rows are visible before scrolling on a tall screen. */
     width: 90%;
-    max-width: 100;
-    height: 80%;
-    max-height: 90%;
+    max-width: 140;
+    height: 85%;
+    max-height: 92%;
     background: $lo-overlay;
     padding: 1 2;
 }

--- a/local_operator/tui/widgets/analytics_panel.py
+++ b/local_operator/tui/widgets/analytics_panel.py
@@ -119,6 +119,38 @@ def format_cost(aggregate: "UsageAggregate") -> str:
     return body + ("+" if aggregate.cost_is_partial else "")
 
 
+def _append_cost(
+    block: Text, aggregate: "UsageAggregate", cell: int, fg: Style, dim: Style
+) -> None:
+    """Append a right-aligned cost cell, with the lower-bound ``+`` in ``dim``.
+
+    The ``+`` is a STATUS FLAG, not a digit (review D1): rendering it in the same
+    full-strength weight as the number let it read as part of the figure, so a
+    lower bound looked like a precise total. Painting it ``dim`` — and leaving
+    ``$—`` legible but distinct — keeps the figure honest at a glance, and the
+    footnote (``_cost_legend``) says what both marks mean.
+    """
+    text = format_cost(aggregate)
+    pad = " " * max(0, cell - len(text))
+    block.append(pad)
+    if text.endswith("+"):
+        block.append(text[:-1], style=fg)
+        block.append("+", style=dim)
+    else:
+        block.append(text, style=fg)
+
+
+def _needs_cost_legend(aggregate: "UsageAggregate") -> bool:
+    """Whether any scope on screen shows a ``+`` (partial) or ``$—`` (unknown).
+
+    The legend is drawn only when a mark actually appears — a fully-priced run
+    needs no explaining, and a footnote for a symbol that is not on screen is
+    noise.
+    """
+    scopes = [aggregate, *aggregate.by_provider.values(), *aggregate.by_session.values()]
+    return any((s.cost_is_partial and s.cost_is_known) or not s.cost_is_known for s in scopes)
+
+
 def proportion_bar(fraction: float, width: int) -> str:
     """A filled proportion bar of ``width`` cells for ``fraction`` in 0..1.
 
@@ -261,7 +293,13 @@ def build_report(aggregate: UsageAggregate, width: int) -> list[Text]:
         cost_note = "≈ list price × tokens"
     else:
         cost_note = "no published price"
-    lines.append(kv("Est. cost", format_cost(aggregate), cost_note))
+    # Built directly (not via ``kv``) so the lower-bound ``+`` is dimmed like the
+    # table cells (review D1) — the figure reads as a number, the ``+`` as a flag.
+    cost_row = Text()
+    cost_row.append(f"  {'Est. cost':<22}", style=dim)
+    _append_cost(cost_row, aggregate, len(format_cost(aggregate)), fg, dim)
+    cost_row.append(f"  {cost_note}", style=dim)
+    lines.append(cost_row)
     lines.append(Text())
 
     # -- input attribution (estimated) --------------------------------------
@@ -300,19 +338,40 @@ def build_report(aggregate: UsageAggregate, width: int) -> list[Text]:
             lines.append(line)
     lines.append(Text())
 
-    # -- by provider ---------------------------------------------------------
+    # -- by provider / by session -------------------------------------------
+    # Both tables share ONE ``name_col`` (review D2): computed across every row
+    # of both groups so the tokens/cost/calls columns line up vertically down
+    # the panel instead of starting at two different x-positions. On a wide
+    # frame the shared column is allowed to grow (review D3) so the extra width
+    # widens the content rather than leaving a dead right gutter.
+    names = getattr(aggregate, "session_names", {}) or {}
+    session_labelled = {
+        short_session_label(sid, names.get(sid, "")): agg
+        for sid, agg in aggregate.by_session.items()
+    }
+    all_names = [n for n in aggregate.by_provider] + [n for n in session_labelled]
+    if all_names:
+        # Grow the name column with the frame: a wide card gets a roomier column
+        # (up to 48) so its width is used; a narrow one stays compact (30).
+        name_cap = 30 if width < 96 else min(48, width - 40)
+        name_col = min(name_cap, max((len(n) for n in all_names), default=0) + 1)
+    else:
+        name_col = 0
+
     if aggregate.by_provider:
-        lines.append(_group_section("BY PROVIDER", aggregate.by_provider, width))
+        lines.append(_group_section("BY PROVIDER", aggregate.by_provider, width, name_col))
         lines.append(Text())
 
-    # -- by session ----------------------------------------------------------
-    if aggregate.by_session:
-        names = getattr(aggregate, "session_names", {}) or {}
-        labelled = {
-            short_session_label(sid, names.get(sid, "")): agg
-            for sid, agg in aggregate.by_session.items()
-        }
-        lines.append(_group_section("BY SESSION", labelled, width))
+    if session_labelled:
+        lines.append(_group_section("BY SESSION", session_labelled, width, name_col))
+
+    # Legend for the cost markers, drawn only when a ``+`` or ``$—`` is on
+    # screen (review D1). ``dim`` so it reads as a footnote, not a row.
+    if _needs_cost_legend(aggregate):
+        lines.append(Text())
+        legend = Text()
+        legend.append("  + lower bound (some calls unpriced)   $— no published price", style=dim)
+        lines.append(legend)
 
     return lines
 
@@ -329,6 +388,7 @@ def _group_section(
     title: str,
     groups: dict[str, "UsageAggregate"],
     width: int,
+    name_col: int,
 ) -> Text:
     """A per-provider or per-session table as one multi-line ``Text`` block.
 
@@ -338,9 +398,10 @@ def _group_section(
     biggest *spend* is what a cost-aware diagnostics reader looks for first, and
     where nothing is priced this is exactly the old token order.
 
-    ``width`` decides columns: a wide frame shows tokens · cost · calls · cache;
-    a narrow one drops the cache column (see ``_WIDE_TABLE_MIN``) so the cost
-    column this feature adds always survives.
+    ``name_col`` is shared across both tables (review D2) so their columns line
+    up. ``width`` decides the rest: a wide frame shows tokens · cost · calls ·
+    cache; a narrow one drops the cache column (see ``_WIDE_TABLE_MIN``) so the
+    cost column this feature adds always survives.
     """
     fg = _semantic("fg")
     label = _semantic("label")
@@ -362,7 +423,6 @@ def _group_section(
         return block
 
     show_cache = width >= _WIDE_TABLE_MIN
-    name_col = min(30, max(len(name) for name, _ in ordered) + 1)
     cost_col = max(len(format_cost(agg)) for _, agg in ordered)
     for name, agg in ordered:
         block.append("\n")
@@ -370,7 +430,9 @@ def _group_section(
         block.append(f"{format_tokens(agg.total_tokens):>8} tokens", style=fg)
         # Cost sits next to tokens as the other headline number, in full-strength
         # ``fg`` — it is the answer this feature exists to give, not a footnote.
-        block.append(f"   {format_cost(agg):>{cost_col}}", style=fg)
+        # The lower-bound ``+`` is dimmed by ``_append_cost`` (review D1).
+        block.append("   ")
+        _append_cost(block, agg, cost_col, fg, dim)
         block.append(f"   {agg.calls:>4} calls", style=dim)
         if show_cache:
             block.append(f"   {format_percent(agg.cache_hit_rate):>4} cache", style=dim)

--- a/local_operator/tui/widgets/analytics_panel.py
+++ b/local_operator/tui/widgets/analytics_panel.py
@@ -86,6 +86,39 @@ def format_percent(fraction: float | None) -> str:
     return f"{round(pct)}%"
 
 
+def format_cost(aggregate: "UsageAggregate") -> str:
+    """A dollar figure for one scope: ``$12.34`` / ``$1.2k`` / ``$0.0042`` / ``$—``.
+
+    Reads three states off the aggregate, because "how much did this cost" has
+    three honest answers and collapsing them lies:
+
+    - **Nothing priceable** (``cost_is_known`` false — e.g. a local-model-only
+      run): ``$—``, never ``$0.00``. Free and unknown are different facts, the
+      same distinction the status band's ``$—`` makes.
+    - **Partial** (``cost_is_partial``: some calls used unpriced models): a
+      trailing ``+`` marks the figure as a LOWER BOUND (``$12.30+``) so it is
+      never read as the complete bill.
+    - **Complete**: the plain figure.
+
+    Small sums keep more precision (``$0.0042``) because a fresh install's spend
+    is fractions of a cent and rounding it to ``$0.00`` would read as free;
+    large sums abbreviate (``$1.2k``) for the same glanceability as the tokens.
+    """
+    if not aggregate.cost_is_known:
+        return "$—"
+    usd = aggregate.cost_usd
+    if usd >= 1000:
+        body = f"${usd / 1000:.1f}k".replace(".0k", "k")
+    elif usd >= 1:
+        body = f"${usd:.2f}"
+    elif usd >= 0.01:
+        body = f"${usd:.3f}"
+    else:
+        # Sub-cent: show enough digits that a real spend is not rounded to $0.
+        body = f"${usd:.4f}"
+    return body + ("+" if aggregate.cost_is_partial else "")
+
+
 def proportion_bar(fraction: float, width: int) -> str:
     """A filled proportion bar of ``width`` cells for ``fraction`` in 0..1.
 
@@ -216,6 +249,19 @@ def build_report(aggregate: UsageAggregate, width: int) -> list[Text]:
             "of context served from cache",
         )
     )
+    # Cost rides the TOTALS block because it is a headline figure, but it is an
+    # ESTIMATE (published list price × billed tokens; it cannot see a plan,
+    # discount, or free tier), so its note says so — the same measured-vs-modelled
+    # honesty the WHERE-INPUT-WENT caveat carries. ``$—`` for a run with no
+    # priceable model; a trailing ``+`` when some calls used an unpriced one.
+    if aggregate.cost_is_known:
+        # The trailing ``+`` on the figure already flags a partial (lower-bound)
+        # sum, so the note stays short enough to fit a narrow frame; the caveat
+        # it must always carry is that this is list price, not a billed invoice.
+        cost_note = "≈ list price × tokens"
+    else:
+        cost_note = "no published price"
+    lines.append(kv("Est. cost", format_cost(aggregate), cost_note))
     lines.append(Text())
 
     # -- input attribution (estimated) --------------------------------------
@@ -256,7 +302,7 @@ def build_report(aggregate: UsageAggregate, width: int) -> list[Text]:
 
     # -- by provider ---------------------------------------------------------
     if aggregate.by_provider:
-        lines.append(_group_section("BY PROVIDER", aggregate.by_provider))
+        lines.append(_group_section("BY PROVIDER", aggregate.by_provider, width))
         lines.append(Text())
 
     # -- by session ----------------------------------------------------------
@@ -266,21 +312,35 @@ def build_report(aggregate: UsageAggregate, width: int) -> list[Text]:
             short_session_label(sid, names.get(sid, "")): agg
             for sid, agg in aggregate.by_session.items()
         }
-        lines.append(_group_section("BY SESSION", labelled))
+        lines.append(_group_section("BY SESSION", labelled, width))
 
     return lines
 
 
+#: Below this content width the per-group tables drop the cache column to keep
+#: the cost column, which is the one this feature adds and the one a narrow
+#: frame should not be the reason to lose. Cost + tokens + calls are the
+#: irreducible trio; cache is the first to shed, exactly like the status band's
+#: drop ladder.
+_WIDE_TABLE_MIN = 72
+
+
 def _group_section(
     title: str,
-    groups: dict[str, UsageAggregate],
+    groups: dict[str, "UsageAggregate"],
+    width: int,
 ) -> Text:
     """A per-provider or per-session table as one multi-line ``Text`` block.
 
     Returned as a single ``Text`` with embedded newlines so the caller keeps a
     flat list of blocks; the screen splits on newlines only for the scroll
-    measurement. Sorted by total billed tokens, descending — the biggest
-    spender is what a diagnostics reader looks for first.
+    measurement. Sorted by **cost** (falling back to tokens) descending — the
+    biggest *spend* is what a cost-aware diagnostics reader looks for first, and
+    where nothing is priced this is exactly the old token order.
+
+    ``width`` decides columns: a wide frame shows tokens · cost · calls · cache;
+    a narrow one drops the cache column (see ``_WIDE_TABLE_MIN``) so the cost
+    column this feature adds always survives.
     """
     fg = _semantic("fg")
     label = _semantic("label")
@@ -289,22 +349,31 @@ def _group_section(
     block = Text()
     block.append(title, style=label + Style(bold=True))
 
-    ordered = sorted(groups.items(), key=lambda kv: kv[1].total_tokens, reverse=True)
+    # Sort by cost when any of these groups is priced, else by tokens. Keyed on
+    # the tuple so an unpriced group sorts by tokens as a tiebreak rather than
+    # collapsing to a single $0 bucket.
+    ordered = sorted(
+        groups.items(),
+        key=lambda kv: (kv[1].cost_micro, kv[1].total_tokens),
+        reverse=True,
+    )
     if not ordered:
         block.append("\n  (none)", style=dim)
         return block
 
+    show_cache = width >= _WIDE_TABLE_MIN
     name_col = min(30, max(len(name) for name, _ in ordered) + 1)
+    cost_col = max(len(format_cost(agg)) for _, agg in ordered)
     for name, agg in ordered:
         block.append("\n")
         block.append(f"  {name:<{name_col}}", style=fg)
         block.append(f"{format_tokens(agg.total_tokens):>8} tokens", style=fg)
-        cache = format_percent(agg.cache_hit_rate)
-        # ``dim`` for both columns (D2): the call count and cache rate are the
-        # per-row substance, not decoration, so neither may drop below the
-        # contrast floor the way ``faint`` did.
+        # Cost sits next to tokens as the other headline number, in full-strength
+        # ``fg`` — it is the answer this feature exists to give, not a footnote.
+        block.append(f"   {format_cost(agg):>{cost_col}}", style=fg)
         block.append(f"   {agg.calls:>4} calls", style=dim)
-        block.append(f"   {cache:>4} cache", style=dim)
+        if show_cache:
+            block.append(f"   {format_percent(agg.cache_hit_rate):>4} cache", style=dim)
     return block
 
 
@@ -357,10 +426,17 @@ class AnalyticsScreen(ModalScreen[None]):
         self.call_after_refresh(self._sync_hint)
 
     def _card_width(self) -> int:
+        # Track the CSS card (90% of the terminal, capped at 140 — see the
+        # ``.analytics-panel`` rule) minus its 2-cell horizontal padding each
+        # side, so the report's own column maths matches the width it is
+        # actually painted into. The cap here mirrors the CSS cap; raising one
+        # without the other either wastes the frame or overruns it.
         try:
-            return max(40, min(96, self.app.size.width - 8))
+            terminal = self.app.size.width
+            card = min(140, int(terminal * 0.9))
+            return max(40, card - 6)
         except Exception:  # noqa: BLE001 — before mount, a sane default
-            return 80
+            return 88
 
     def _title_text(self) -> Text:
         label = Style(color=theme_mod.semantic_color("label"))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.21.0"
+version = "0.22.0"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@radienthq.com" }]

--- a/tests/unit/analytics/test_model.py
+++ b/tests/unit/analytics/test_model.py
@@ -164,6 +164,48 @@ def test_total_tokens_includes_cache_on_cache_exclusive_provider():
     assert agg.total_tokens == 102_000  # context + output, not input + output
 
 
+def test_cost_usd_from_micro():
+    agg = UsageAggregate(calls=2, cost_micro=8_340_000, cost_known_calls=2)
+    assert agg.cost_usd == 8.34
+    assert agg.cost_is_known is True
+    assert agg.cost_is_partial is False
+
+
+def test_cost_partial_when_some_calls_unpriced():
+    # 10 calls, only 7 priceable -> the dollar figure is a lower bound.
+    agg = UsageAggregate(calls=10, cost_micro=1_500_000, cost_known_calls=7)
+    assert agg.cost_is_partial is True
+    assert agg.cost_is_known is True
+
+
+def test_cost_unknown_when_nothing_priced():
+    # A local-model-only run: no call had a price.
+    agg = UsageAggregate(calls=5, cost_micro=0, cost_known_calls=0)
+    assert agg.cost_is_known is False
+    assert agg.cost_is_partial is True  # 0 < 5
+    assert agg.cost_usd == 0.0
+
+
+def test_callsnapshot_carries_cost():
+    snap = CallSnapshot(
+        ts_ms=1,
+        session_id="s",
+        provider="anthropic",
+        model_id="m",
+        input_tokens=1,
+        output_tokens=1,
+        cache_read_tokens=0,
+        cache_write_tokens=0,
+        reasoning_tokens=0,
+        context_tokens=2,
+        component_chars={},
+        cost_micro=12345,
+        cost_known=True,
+    )
+    assert snap.cost_micro == 12345
+    assert snap.cost_known is True
+
+
 def test_aggregate_cache_rate_none_without_context():
     agg = UsageAggregate(calls=1, context_tokens=0, cache_read_tokens=0)
     assert agg.cache_hit_rate is None

--- a/tests/unit/analytics/test_store.py
+++ b/tests/unit/analytics/test_store.py
@@ -46,6 +46,9 @@ def _snap(
         ok=ok,
         cost_micro=cost_micro,
         cost_known=cost_known,
+        # Pre-priced so the store records these exact figures rather than
+        # re-pricing the fixture's fake model (which has no price table entry).
+        priced=True,
     )
 
 
@@ -162,6 +165,43 @@ def test_migration_adds_cost_columns_to_old_db(tmp_path):
     # A new priced call can be recorded into the migrated DB.
     assert store.record_batch([_snap(cost_micro=500, cost_known=True)]) == 1
     assert store.aggregate().cost_micro == 500
+    store.close()
+
+
+def test_recording_degrades_when_cost_columns_absent(tmp_path):
+    # C2: if the cost columns cannot be added (simulated by forcing _has_cost
+    # False against a table that lacks them), recording must NOT fail every
+    # write — it drops cost and keeps token analytics; the report shows $—.
+    import sqlite3
+
+    from local_operator.analytics.store import _COMPONENT_COLUMNS
+
+    db = tmp_path / "nocost.db"
+    conn = sqlite3.connect(str(db))
+    conn.executescript(f"""
+        CREATE TABLE calls (
+          id INTEGER PRIMARY KEY AUTOINCREMENT, ts_ms INTEGER, session_id TEXT,
+          provider TEXT, model_id TEXT, ok INTEGER, input_tokens INTEGER,
+          output_tokens INTEGER, cache_read_tokens INTEGER, cache_write_tokens INTEGER,
+          reasoning_tokens INTEGER, context_tokens INTEGER, {_COMPONENT_COLUMNS}
+        );
+        CREATE TABLE session_names (
+          session_id TEXT PRIMARY KEY, name TEXT, updated_at_ms INTEGER
+        );
+        """)
+    conn.commit()
+    conn.close()
+
+    store = AnalyticsStore(db)
+    store._connect()  # runs the migration, which will add the columns
+    # Force the degraded path: pretend the migration failed.
+    store._has_cost = False
+    assert store.record_batch([_snap(input_tokens=100, cost_micro=999, cost_known=True)]) == 1
+    agg = store.aggregate()
+    assert agg.calls == 1
+    assert agg.input_tokens == 100  # token analytics survive
+    assert agg.cost_micro == 0  # cost degraded to $— rather than failing
+    assert agg.cost_is_known is False
     store.close()
 
 

--- a/tests/unit/analytics/test_store.py
+++ b/tests/unit/analytics/test_store.py
@@ -28,6 +28,8 @@ def _snap(
     chars=None,
     ok=True,
     ts_ms=None,
+    cost_micro=1000,
+    cost_known=True,
 ):
     return CallSnapshot(
         ts_ms=ts_ms if ts_ms is not None else int(time.time() * 1000),
@@ -42,6 +44,8 @@ def _snap(
         context_tokens=context,
         component_chars=chars or {"conversation": 500, "system_prompt": 420},
         ok=ok,
+        cost_micro=cost_micro,
+        cost_known=cost_known,
     )
 
 
@@ -97,6 +101,67 @@ def test_by_provider_and_by_session(tmp_path):
     assert agg.by_provider["openai"].input_tokens == 50
     assert set(agg.by_session) == {"s1", "s2"}
     assert agg.by_session["s2"].calls == 2
+    store.close()
+
+
+def test_cost_roundtrip_and_grouping(tmp_path):
+    store = AnalyticsStore(tmp_path / "a.db")
+    store.record_batch(
+        [
+            _snap(session_id="s1", provider="anthropic", cost_micro=6_000_000, cost_known=True),
+            _snap(session_id="s1", provider="openai", cost_micro=1_000_000, cost_known=True),
+            # A local model with no price: recorded, but cost_known=False.
+            _snap(session_id="s2", provider="ollama", cost_micro=0, cost_known=False),
+        ]
+    )
+    agg = store.aggregate()
+    assert agg.cost_micro == 7_000_000
+    assert agg.cost_usd == 7.0
+    assert agg.cost_known_calls == 2
+    assert agg.cost_is_partial is True  # the ollama call had no price
+    assert agg.by_provider["anthropic"].cost_usd == 6.0
+    assert agg.by_provider["openai"].cost_usd == 1.0
+    assert agg.by_provider["ollama"].cost_is_known is False
+    store.close()
+
+
+def test_migration_adds_cost_columns_to_old_db(tmp_path):
+    # A database written by the token-only release has no cost_* columns.
+    # Opening it with the current store must ALTER them in and read old rows as
+    # cost 0 / unknown, never raise on a missing column.
+    import sqlite3
+
+    from local_operator.analytics.store import _COMPONENT_COLUMNS
+
+    db = tmp_path / "old.db"
+    conn = sqlite3.connect(str(db))
+    conn.executescript(f"""
+        CREATE TABLE calls (
+          id INTEGER PRIMARY KEY AUTOINCREMENT, ts_ms INTEGER, session_id TEXT,
+          provider TEXT, model_id TEXT, ok INTEGER, input_tokens INTEGER,
+          output_tokens INTEGER, cache_read_tokens INTEGER, cache_write_tokens INTEGER,
+          reasoning_tokens INTEGER, context_tokens INTEGER, {_COMPONENT_COLUMNS}
+        );
+        CREATE TABLE session_names (
+          session_id TEXT PRIMARY KEY, name TEXT, updated_at_ms INTEGER
+        );
+        """)
+    conn.execute(
+        "INSERT INTO calls (ts_ms, session_id, provider, model_id, ok, input_tokens, "
+        "output_tokens, context_tokens) VALUES (1, 's', 'anthropic', 'm', 1, 100, 20, 120)"
+    )
+    conn.commit()
+    conn.close()
+
+    store = AnalyticsStore(db)
+    agg = store.aggregate()
+    assert agg.calls == 1
+    assert agg.cost_micro == 0
+    assert agg.cost_known_calls == 0
+    assert agg.cost_is_known is False  # old row reads as unpriced, not $0
+    # A new priced call can be recorded into the migrated DB.
+    assert store.record_batch([_snap(cost_micro=500, cost_known=True)]) == 1
+    assert store.aggregate().cost_micro == 500
     store.close()
 
 

--- a/tests/unit/analytics/test_stream_recording.py
+++ b/tests/unit/analytics/test_stream_recording.py
@@ -118,6 +118,36 @@ def test_records_authoritative_counts(tmp_path):
     assert agg.components["custom_instructions"] > 0
 
 
+def test_records_cost_for_a_priced_model(tmp_path):
+    # A model with a real registry price records a positive, known cost.
+    store = AnalyticsStore(tmp_path / "a.db")
+    rec = reset_recorder_for_test(store)
+    fn = _fn("sess-cost")
+    request = ChatRequest(
+        model=ModelSpec(provider="anthropic", model_id="claude-sonnet-4-5"),
+        system_blocks=["persona", "tools", "env", "skills"],
+        messages=[Message(role="user", content=[TextContent(text="hi " * 50)])],
+    )
+    usage = Usage(
+        input_tokens=5000,
+        output_tokens=1000,
+        cache_read_tokens=90_000,
+        cache_write_tokens=5000,
+        context_tokens=100_000,
+    )
+    asyncio.run(_drain(fn, request, [StreamEndEvent(stop_reason="stop", usage=usage)]))
+    rec.flush_for_test()
+    agg = store.aggregate()
+    assert agg.calls == 1
+    # Cost is computed through the shared cost_for_usage, so it is positive and
+    # known; the exact figure depends on the live price table, so assert the
+    # invariants rather than a brittle dollar amount.
+    assert agg.cost_is_known is True
+    assert agg.cost_is_partial is False
+    assert agg.cost_micro > 0
+    assert agg.by_provider["anthropic"].cost_micro == agg.cost_micro
+
+
 def test_failed_stream_still_recorded(tmp_path):
     store = AnalyticsStore(tmp_path / "a.db")
     rec = reset_recorder_for_test(store)

--- a/tests/unit/tui/test_analytics_panel.py
+++ b/tests/unit/tui/test_analytics_panel.py
@@ -14,6 +14,7 @@ from local_operator.tui.app import OperatorApp
 from local_operator.tui.widgets.analytics_panel import (
     AnalyticsScreen,
     build_report,
+    format_cost,
     format_percent,
     format_tokens,
     proportion_bar,
@@ -31,6 +32,8 @@ def _agg() -> UsageAggregate:
         cache_write_tokens=80_000,
         reasoning_tokens=40_000,
         context_tokens=3_500_000,
+        cost_micro=4_200_000,
+        cost_known_calls=100,
     )
     agg.components = {k: 0 for k in COMPONENT_KEYS}
     agg.components["conversation"] = 1_800_000
@@ -43,6 +46,8 @@ def _agg() -> UsageAggregate:
         output_tokens=120_000,
         context_tokens=3_500_000,
         cache_read_tokens=3_000_000,
+        cost_micro=4_200_000,
+        cost_known_calls=100,
     )
     agg.by_provider = {"anthropic": sub}
     agg.by_session = {"abc123": sub}
@@ -64,6 +69,53 @@ def test_format_tokens_scales():
 def test_format_percent():
     assert format_percent(0.734) == "73%"
     assert format_percent(None) == "—"
+
+
+def test_format_cost_states():
+    def agg(cost_micro, known, calls):
+        return UsageAggregate(calls=calls, cost_micro=cost_micro, cost_known_calls=known)
+
+    # Complete, whole-dollar.
+    assert format_cost(agg(8_340_000, 10, 10)) == "$8.34"
+    # Partial (some calls unpriced) -> lower-bound marker.
+    assert format_cost(agg(8_340_000, 7, 10)) == "$8.34+"
+    # Nothing priced -> $—, never $0.00.
+    assert format_cost(agg(0, 0, 5)) == "$—"
+    # Sub-cent keeps precision so a real spend is not rounded to zero.
+    assert format_cost(agg(4_200, 3, 3)) == "$0.0042"
+    # Large sum abbreviates.
+    assert format_cost(agg(1_200_000_000, 5, 5)) == "$1.2k"
+
+
+def test_report_shows_cost():
+    text = _text(_agg())
+    assert "Est. cost" in text
+    assert "$4.20" in text  # 4_200_000 micro-USD
+    assert "list price" in text  # the estimate caveat
+    # cost column appears in the per-provider and per-session tables
+    assert text.count("$4.20") >= 3  # totals + provider + session
+
+
+def test_report_marks_unpriced_and_partial():
+    agg = _agg()
+    # Add an unpriced local provider and a partially-priced session.
+    unpriced = UsageAggregate(calls=5, context_tokens=100, cost_micro=0, cost_known_calls=0)
+    agg.by_provider["ollama"] = unpriced
+    text = "\n".join(line.plain for line in build_report(agg, 120))
+    assert "$—" in text  # the unpriced provider row
+
+
+def test_narrow_table_drops_cache_keeps_cost():
+    agg = _agg()
+    narrow = "\n".join(line.plain for line in build_report(agg, 58))
+    wide = "\n".join(line.plain for line in build_report(agg, 120))
+    # Cost survives at every width; cache is shed only when narrow.
+    assert "$4.20" in narrow
+    assert "cache" in wide
+    # The BY PROVIDER row in the narrow render carries no cache column.
+    provider_line = next(line for line in narrow.splitlines() if "anthropic" in line)
+    assert "cache" not in provider_line
+    assert "$4.20" in provider_line
 
 
 def test_proportion_bar_fills():

--- a/tests/unit/tui/test_analytics_panel.py
+++ b/tests/unit/tui/test_analytics_panel.py
@@ -105,6 +105,33 @@ def test_report_marks_unpriced_and_partial():
     assert "$—" in text  # the unpriced provider row
 
 
+def test_cost_marker_legend_shown_only_when_marks_present():
+    # D1: a legend explains + and $— — but only when one is actually on screen.
+    partial = _agg()
+    partial.by_provider["ollama"] = UsageAggregate(
+        calls=5, context_tokens=100, cost_micro=0, cost_known_calls=0
+    )
+    text_with_marks = "\n".join(line.plain for line in build_report(partial, 120))
+    assert "lower bound" in text_with_marks
+    assert "no published price" in text_with_marks
+
+    # A fully-priced run (no + or $—) draws no legend.
+    clean = _agg()  # all cost_known_calls == calls, no unpriced provider
+    text_clean = "\n".join(line.plain for line in build_report(clean, 120))
+    assert "lower bound" not in text_clean
+
+
+def test_tables_share_a_name_column():
+    # D2: BY PROVIDER and BY SESSION align — the tokens column starts at the
+    # same offset in both, because they share one name_col.
+    agg = _agg()
+    lines = [line.plain for line in build_report(agg, 120)]
+    text = "\n".join(lines)
+    prov = next(li for li in text.splitlines() if "anthropic" in li)
+    sess = next(li for li in text.splitlines() if "my session" in li)
+    assert prov.index(" tokens") == sess.index(" tokens")
+
+
 def test_narrow_table_drops_cache_keeps_cost():
     agg = _agg()
     narrow = "\n".join(line.plain for line in build_report(agg, 58))


### PR DESCRIPTION
## Why

Follow-up to #247 (usage analytics). That screen showed **token** consumption but not **cost**, and on a large terminal the frame stayed narrow with a sea of dead margin. This overlays an estimated dollar cost on every level of the report and makes the frame responsive so a big screen actually shows more.

Version bump is **MINOR** (0.21.0 → 0.22.0): new capability on an existing screen, no breaking changes. A ledger written by 0.21.0 is migrated in place on first open.

## What changes

### Cost overlay

- **Priced at record time, where the exact model is known.** `SessionStreamFn._cost_micro` (`configure.py`) prices each call through the shared `cost_for_usage` — the *same* arithmetic the status band runs every repaint — so the analytics dollar total can never disagree with the live band. Cost is stored per call, never recomputed at aggregation (where differently-priced models are already summed and un-priceable).
- **Micro-USD integers.** `CallSnapshot.cost_micro` is USD × 1e6 as an integer, so the store's `SUM` is exact — a fraction of a cent per call over millions of calls is real drift in a float.
- **Unknown ≠ free.** A model with no published price records `cost_known=False`; the report renders `$—`, never a misleading `$0.00`. A scope where *some* calls were unpriced is a lower bound: `$12.30+`. Cost is labelled an **estimate** (list price × tokens — it cannot see a plan, discount, or free tier), the same measured-vs-modelled honesty the component split already carries.
- **Where it shows:** an `Est. cost` line in TOTALS, and a cost column in the per-provider and per-session tables (which now sort by spend).

### Migration

- `cost_micro` / `cost_known` are new columns. `CREATE TABLE IF NOT EXISTS` never alters an existing table, so `AnalyticsStore._migrate` runs an idempotent `ALTER TABLE ADD COLUMN` on open. A 0.21.0 token-only ledger upgrades in place; its old rows read as unpriced (cost 0 / unknown), never NULL and never a false $0.

### Responsive frame

- `.analytics-panel` `max-width` 100 → 140 and `height` 80% → 85%; `AnalyticsScreen._card_width` tracks the CSS cap so the report's column maths matches the painted width. The per-provider/per-session tables shed the **cache** column below `_WIDE_TABLE_MIN` (72) to keep the **cost** column at any width — the same drop-ladder logic the status band uses.

## Impact

- **No breaking changes.** Old databases migrate transparently; a model without a price degrades to `$—`. Analytics remains a best-effort accelerator — a pricing failure is caught and the call is still recorded token-wise.
- **Latency:** `_cost_micro` is **0.006 ms** warm (a memoised price lookup and four multiplies), and it runs *after* the stream is consumed, off the response-await path. No perceptible cost.
- **Security:** unchanged — the DB stays 0600, and cost is derived from the price table, not from any new stored secret.

## Testing Details

Evidence is proof the feature works against the real paths, not just a green suite.

### End-to-end cost through the real stream wrapper

A priced model (`claude-sonnet-4-5`), a 100k-context turn (5k fresh input, 90k cache read, 5k cache write, 1k output) recorded through `SessionStreamFn._record_stream`:

```
recorded cost_usd: 0.0757   cost_known_calls: 1   context: 100000
```

$0.0757 — priced through the shared `cost_for_usage` with correct Anthropic cache-exclusive handling, matching what the status band would show for the same turn.

### Migration of a 0.21.0 (token-only) ledger

```
migrated old DB -> calls: 1  cost_micro: 0  cost_known_calls: 0  cost_is_partial: True
cost_micro col: True   cost_known col: True
```

Columns added on open; the pre-cost row reads as unpriced (not $0); a new priced call records normally into the migrated DB.

### Cost display states

```
$8.34     complete
$8.34+    partial (some calls used an unpriced model — lower bound)
$—        nothing priceable (e.g. a local-model-only run)
$0.0042   sub-cent (kept precise so a real spend is not rounded to $0)
$1.2k     large sum abbreviated
```

### Responsive layout

Wide (150 cols) shows tokens · cost · calls · cache; narrow (84 cols) drops cache and keeps cost. Both rendered and inspected — see screenshots. Benchmarked `_cost_micro` at 0.006 ms warm.

### Automated tests

- Model: `cost_usd`, `cost_is_partial`, `cost_is_known`, snapshot carries cost.
- Store: cost roundtrip + per-provider/session grouping, **old-DB migration**, unpriced handling.
- Panel: `format_cost` states (complete/partial/unknown/sub-cent/large), the cost overlay in the report, unpriced/partial markers, and the narrow-frame cache-drop-keeps-cost.
- Stream: end-to-end cost recorded for a priced model.

58 analytics + panel tests pass; the affected model/session/clients suites (304 tests) pass. `black`, `isort`, `flake8`, `pyright` clean.

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my changes work as intended.
- [x] All new and existing tests pass.
- [x] I have run formatting (black/isort), linting (flake8), and type checks (pyright), and they pass.
- [x] I have updated the documentation when required. (AGENTS.md analytics section.)
- [x] Security considerations are addressed.
- [x] I have linked all related issues. (Follows #247.)

## Screenshots

`/analytics /usage` with the estimated cost overlay.

**Wide terminal (150 cols)** — the frame grows to fit tokens · cost · calls · cache. `Est. cost $8.34+` in TOTALS (the `+` marks a lower bound — the local Ollama calls are unpriced), a cost column in both tables (`$6.10` / `$1.90` / `$—` for the unpriced local model), and per-session costs.

![Wide analytics with cost](https://raw.githubusercontent.com/damianvtran/local-operator/pr-254-assets/shots/analytics-cost-wide.png)

**Narrow terminal (84 cols)** — the tables drop the cache column to keep the cost column; the `Est. cost` line and its caveat still fit.

![Narrow analytics with cost](https://raw.githubusercontent.com/damianvtran/local-operator/pr-254-assets/shots/analytics-cost-narrow.png)
