### PR TITLE
fix(compaction): bound snapcompact verbatim text edges to the context window

### DIFF
--- a/local_operator/compaction/snapcompact.py
+++ b/local_operator/compaction/snapcompact.py
@@ -209,13 +209,28 @@ def frame_token_estimate_for(provider: str, model_id: str) -> int:
 #: Fraction of the context window the archive's two VERBATIM text edges may
 #: occupy together. The edges are the one part of a replayed archive the token
 #: budget cannot trim (it only drops imaged pages), so an unbounded edge is a
-#: floor that scales with the frame SHAPE instead of the window: ~35k tokens
-#: for an Anthropic 1932px reader whether the window is 1M or 64k. Capping the
-#: pair at 15% keeps them a minority of the post-compaction context on every
-#: window — the imaged middle carries the bulk, at ~4x the density per token —
-#: while still preserving enough exact head/tail text for the model to anchor
-#: the oldest and newest turns. Chosen to sit under the default 0.5*window
-#: archive budget with room for at least a few frames beside the edges.
+#: floor that scales with the frame SHAPE instead of the window: for the
+#: default ``HQ_EDGE_FRAMES * capacity`` the pair is ~31.5k tokens for the
+#: Anthropic 1932px reader (capacity 21000) and ~35.7k for the Gemini reader
+#: (capacity 23808), whether the window is 1M or 64k. Capping the pair at 15%
+#: keeps them a minority of the post-compaction context — the imaged middle
+#: carries the bulk, at ~4x the density per token — while still preserving
+#: enough exact head/tail text for the model to anchor the oldest and newest
+#: turns. Chosen to sit under the default 0.5*window archive budget with room
+#: for frames beside the edges.
+#:
+#: The cap binds — i.e. trims below the shape default — whenever the default
+#: pair exceeds 15% of the window, which is ``default_pair_chars / 0.6`` in
+#: window tokens. For the 1932px reader (pair 126000 chars → 31.5k tokens)
+#: that threshold is ~210k, so its NATIVE 200k window is trimmed slightly
+#: (63000→60000 chars/edge, a deliberate 15.75%→15% haircut); the Gemini
+#: reader (238k threshold) is likewise trimmed at 200k, and every shape is
+#: trimmed at 96k/128k. Only windows above the shape's threshold (e.g. any
+#: window for the Sonnet/OpenAI 13916-capacity readers up to 139k, or ≥210k
+#: for the 1932px reader) keep full-default edges. This is the intended
+#: behaviour, not an accident: the whole point is that the edges follow the
+#: window, so a reader whose default already exceeds its 15% share gives a
+#: little verbatim text back to the imaged middle.
 EDGE_WINDOW_FRACTION = 0.15
 
 
@@ -232,12 +247,24 @@ def _edge_chars_for(shape: Shape, context_window: int | None) -> int:
     target. Bounding here moves the excess oldest-edge text into the imaged
     region, where the budget can actually act on it.
 
-    Priced in the reader's real per-token char density (chars≈4×tokens, the
-    same fallback ratio the estimator uses) so the cap is a token share, not a
-    raw char count that would mean something different per tokenizer. Returns
-    at least one page's worth so a tiny window never collapses the edges to
-    nothing — an archive with no verbatim anchor at all is worse than a small
-    one, and the frame budget remains the mechanism that bounds total size.
+    Priced in the estimator's fallback char density (``chars ≈ 4 × tokens``,
+    :data:`~local_operator.compaction.tokens._CHARS_PER_TOKEN_FALLBACK`) so the
+    cap is a nominal token share rather than a raw char count that would mean
+    something different per tokenizer. It is only NOMINAL: the budget loop that
+    consumes these edges prices them through the real tokenizer
+    (:func:`estimate_archive_tokens`), and token-dense content (code, JSON,
+    long unbroken runs) tokenizes below 4 chars/token, so on such content the
+    edges can occupy more than 15% of the REAL budget. Ordinary prose sits near
+    4, and the frame budget still bounds total size, so the approximation is
+    deliberate.
+
+    Returns at least one page's worth (``shape.capacity``) so a tiny window
+    never collapses the edges to nothing — an archive with no verbatim anchor
+    is worse than a small one. Below that floor the archive can still exceed
+    ``0.5 * window`` (one page per edge is ~5k tokens, above a 24k window's 12k
+    budget): the floor RAISES the window at which the pass fits its budget, it
+    does not make it fit universally, and the frame budget remains the ultimate
+    bound on total archive size.
     """
     default = HQ_EDGE_FRAMES * shape.capacity
     if not context_window or context_window <= 0:
@@ -656,16 +683,17 @@ def compact_to_archive(
     # The two verbatim text edges are the archive's HARD floor: replay sends
     # them uncompressed, the frame budget loop below can only drop IMAGED
     # pages, and nothing else in the pass trims them. At the default
-    # HQ_EDGE_FRAMES * capacity they are ~35k tokens for an Anthropic 1932px
-    # shape — 17.5% of a 200k window and MORE than the whole archive budget on
-    # a small window, where the loop drops every frame and the pass still
+    # HQ_EDGE_FRAMES * capacity they are ~31.5k tokens for the Anthropic 1932px
+    # reader (pair 126000 chars) — and MORE than the whole archive budget on a
+    # small window, where the loop drops every frame and the pass still
     # overshoots its own 0.5*window budget by 2x (measured: a 64k window gives
-    # a 32k budget against a 35k edge-only replay). That is the same "a pass
+    # a 32k budget against a ~31.5k edge-only replay). That is the same "a pass
     # meant to get under the line ends up above it" failure the frame budget
     # exists to prevent, one layer down. So bound the per-edge char count to a
-    # window-proportional share BEFORE slicing: the trimmed-away oldest edge
-    # content is not lost, it flows into image_text and is imaged (or dropped
-    # with the standard marker) like any other middle history.
+    # window-proportional share BEFORE slicing (see EDGE_WINDOW_FRACTION for
+    # which windows this trims): the trimmed-away oldest edge content is not
+    # lost, it flows into image_text and is imaged (or dropped with the
+    # standard marker) like any other middle history.
     edge_chars = _edge_chars_for(shape, context_window)
     if len(archive_text) <= 2 * edge_chars:
         return Archive(

--- a/local_operator/compaction/snapcompact.py
+++ b/local_operator/compaction/snapcompact.py
@@ -40,7 +40,7 @@ from local_operator.harness.types import ImageContent, Message, ModelSpec, TextC
 
 from .api import TOOL_ARGS_MAX_CHARS, TOOL_RESULT_MAX_CHARS
 from .png import encode_grayscale_png
-from .tokens import estimate_tokens
+from .tokens import _CHARS_PER_TOKEN_FALLBACK, estimate_tokens
 
 # ---------------------------------------------------------------------------
 # Constants (snapcompact)
@@ -204,6 +204,49 @@ def frame_token_estimate_for(provider: str, model_id: str) -> int:
         return -(-(patches * 12) // 10)  # ceil(patches * 1.2)
     patches = min((-(-edge // 28)) ** 2, 4784)
     return -(-(patches * 105) // 100)  # ceil(patches * 1.05)
+
+
+#: Fraction of the context window the archive's two VERBATIM text edges may
+#: occupy together. The edges are the one part of a replayed archive the token
+#: budget cannot trim (it only drops imaged pages), so an unbounded edge is a
+#: floor that scales with the frame SHAPE instead of the window: ~35k tokens
+#: for an Anthropic 1932px reader whether the window is 1M or 64k. Capping the
+#: pair at 15% keeps them a minority of the post-compaction context on every
+#: window — the imaged middle carries the bulk, at ~4x the density per token —
+#: while still preserving enough exact head/tail text for the model to anchor
+#: the oldest and newest turns. Chosen to sit under the default 0.5*window
+#: archive budget with room for at least a few frames beside the edges.
+EDGE_WINDOW_FRACTION = 0.15
+
+
+def _edge_chars_for(shape: Shape, context_window: int | None) -> int:
+    """Chars kept VERBATIM at each archive edge, bounded by the window.
+
+    Defaults to ``HQ_EDGE_FRAMES * shape.capacity`` — enough source text to
+    fill the high-quality edge frames replay renders — but never lets the two
+    edges together exceed :data:`EDGE_WINDOW_FRACTION` of ``context_window``.
+    Without the cap the edges are a fixed, un-trimmable floor set by the frame
+    shape, not the window (see :data:`EDGE_WINDOW_FRACTION`): on a small window
+    the two edges alone can outrun the whole archive budget, so the frame loop
+    drops every page and the pass STILL commits a context above its own
+    target. Bounding here moves the excess oldest-edge text into the imaged
+    region, where the budget can actually act on it.
+
+    Priced in the reader's real per-token char density (chars≈4×tokens, the
+    same fallback ratio the estimator uses) so the cap is a token share, not a
+    raw char count that would mean something different per tokenizer. Returns
+    at least one page's worth so a tiny window never collapses the edges to
+    nothing — an archive with no verbatim anchor at all is worse than a small
+    one, and the frame budget remains the mechanism that bounds total size.
+    """
+    default = HQ_EDGE_FRAMES * shape.capacity
+    if not context_window or context_window <= 0:
+        return default
+    # Half the pair's token allowance, converted to chars, is the per-edge cap.
+    pair_token_budget = int(context_window * EDGE_WINDOW_FRACTION)
+    per_edge_chars = (pair_token_budget // 2) * _CHARS_PER_TOKEN_FALLBACK
+    # Never below one page: some verbatim anchor always beats none.
+    return max(shape.capacity, min(default, per_edge_chars))
 
 
 # ---------------------------------------------------------------------------
@@ -610,7 +653,20 @@ def compact_to_archive(
     else:
         archive_text = serialized
 
-    edge_chars = HQ_EDGE_FRAMES * shape.capacity
+    # The two verbatim text edges are the archive's HARD floor: replay sends
+    # them uncompressed, the frame budget loop below can only drop IMAGED
+    # pages, and nothing else in the pass trims them. At the default
+    # HQ_EDGE_FRAMES * capacity they are ~35k tokens for an Anthropic 1932px
+    # shape — 17.5% of a 200k window and MORE than the whole archive budget on
+    # a small window, where the loop drops every frame and the pass still
+    # overshoots its own 0.5*window budget by 2x (measured: a 64k window gives
+    # a 32k budget against a 35k edge-only replay). That is the same "a pass
+    # meant to get under the line ends up above it" failure the frame budget
+    # exists to prevent, one layer down. So bound the per-edge char count to a
+    # window-proportional share BEFORE slicing: the trimmed-away oldest edge
+    # content is not lost, it flows into image_text and is imaged (or dropped
+    # with the standard marker) like any other middle history.
+    edge_chars = _edge_chars_for(shape, context_window)
     if len(archive_text) <= 2 * edge_chars:
         return Archive(
             frames=[],

--- a/tests/unit/compaction/test_snapcompact.py
+++ b/tests/unit/compaction/test_snapcompact.py
@@ -344,11 +344,12 @@ def test_small_window_caps_verbatim_edges_to_its_share():
 def test_small_window_archive_replay_fits_its_budget():
     """The whole point: replay cost stays under the ``0.5 * window`` budget.
 
-    Before the edge cap, a 64k-token window produced a ~35k-token edge-only
+    Before the edge cap, a 64k-token window produced a ~31.5k-token edge-only
     replay against a 32k-token budget — the frame loop dropped every page and
     the pass STILL overshot. With the edges bounded, the replayed archive
-    (text edges + imaged frames) fits, which is the invariant the whole
-    compaction pass exists to satisfy.
+    (text edges + imaged frames) fits. NB 64k is the FLOOR regime for the
+    1932px reader (per-edge share works out at one page); the cap-regime
+    budget fit is covered by ``test_cap_regime_archive_replay_fits_its_budget``.
     """
     window = 64_000
     shape = resolve_shape("anthropic", "claude-opus-4-8")
@@ -356,6 +357,50 @@ def test_small_window_archive_replay_fits_its_budget():
     archive = compact_to_archive(messages, "anthropic", "claude-opus-4-8", context_window=window)
     budget = max(frame_token_estimate_for("anthropic", "claude-opus-4-8"), int(window * 0.5))
     assert estimate_archive_tokens(archive) <= budget
+
+
+def test_cap_regime_archive_replay_fits_its_budget():
+    """Budget fit in the CAP regime (edges trimmed below default, above floor).
+
+    At 128k the 1932px per-edge share is 38400 chars — strictly between the
+    one-page floor (21000) and the shape default (63000) — so this exercises
+    the window-proportional cap doing its job, not the floor override, and
+    proves the resulting archive still fits ``0.5 * window``. This is the
+    regime the fix actually changes; the 64k test above only reaches the floor.
+    """
+    window = 128_000
+    shape = resolve_shape("anthropic", "claude-opus-4-8")
+    # The 128k per-edge char share sits strictly between floor and default.
+    assert shape.capacity < 38_400 < HQ_EDGE_FRAMES * shape.capacity
+    messages = [Message.user(f"turn {i} " + "w" * shape.capacity) for i in range(80)]
+    archive = compact_to_archive(messages, "anthropic", "claude-opus-4-8", context_window=window)
+    assert shape.capacity < len(archive.text_tail) < HQ_EDGE_FRAMES * shape.capacity
+    budget = max(frame_token_estimate_for("anthropic", "claude-opus-4-8"), int(window * 0.5))
+    assert estimate_archive_tokens(archive) <= budget
+
+
+def test_native_200k_window_trims_the_high_res_opus_edges():
+    """The 1932px reader's edges ARE trimmed at its native 200k window.
+
+    Documents the intended, easily-missed behaviour flagged in review: the
+    Opus-1932 default edge pair is 31.5k tokens = 15.75% of a 200k window,
+    just over the 15% share, so ``_edge_chars_for`` trims each edge from 63000
+    to 60000 chars. This is not a regression — the cap is designed to make the
+    edges follow the window — but "large windows unchanged" is only true ABOVE
+    the shape's threshold (~210k for this reader), so the flagship 200k path is
+    guarded here rather than assumed untouched.
+    """
+    window = 200_000
+    shape = resolve_shape("anthropic", "claude-opus-4-8")
+    default_edge = HQ_EDGE_FRAMES * shape.capacity  # 63000
+    messages = [Message.user(f"turn {i} " + "w" * shape.capacity) for i in range(80)]
+    archive = compact_to_archive(messages, "anthropic", "claude-opus-4-8", context_window=window)
+    # Trimmed to the 15% share: (200000 * 0.15 // 2) * 4 = 60000, below default.
+    assert len(archive.text_tail) == 60_000
+    assert len(archive.text_tail) < default_edge
+    # A wider window ABOVE the ~210k threshold keeps the full default edge.
+    wide = compact_to_archive(messages, "anthropic", "claude-opus-4-8", context_window=400_000)
+    assert len(wide.text_tail) == default_edge
 
 
 def test_edge_cap_keeps_at_least_one_page_of_verbatim_text():

--- a/tests/unit/compaction/test_snapcompact.py
+++ b/tests/unit/compaction/test_snapcompact.py
@@ -13,6 +13,7 @@ from pydantic import ValidationError
 from local_operator.compaction.api import TOOL_ARGS_MAX_CHARS, TOOL_RESULT_MAX_CHARS
 from local_operator.compaction.snapcompact import (
     DEFAULT_MAX_FRAMES,
+    EDGE_WINDOW_FRACTION,
     FRAME_DATA_BYTES_BUDGET,
     FRAME_TOKEN_ESTIMATE,
     HQ_EDGE_FRAMES,
@@ -286,6 +287,89 @@ def test_compact_max_frames_is_a_ceiling_an_explicit_ask_can_reach():
     messages = [Message.user(f"turn {i} " + "w" * shape.capacity) for i in range(20)]
     archive = compact_to_archive(messages, "openai", "gpt-5.5", max_frames=MAX_FRAMES)
     assert DEFAULT_MAX_FRAMES < len(archive.frames) <= MAX_FRAMES
+
+
+def test_edges_default_to_frame_shape_without_a_window():
+    """No ``context_window`` → the verbatim edges keep their full default size.
+
+    This is the wide-window / unknown-window path: the edge cap only ever
+    SHRINKS the default, never grows it, so an archive built without a window
+    (or on a 1M-token model where the default already fits its share) is byte
+    for byte what it was before the cap existed. Guards against the cap
+    silently changing the common case.
+    """
+    shape = resolve_shape("anthropic", "claude-sonnet-4-5")
+    messages = _conversation_messages(200)
+    archive = compact_to_archive(messages, "anthropic", "claude-sonnet-4-5")
+    assert len(archive.text_head) == HQ_EDGE_FRAMES * shape.capacity
+    assert len(archive.text_tail) == HQ_EDGE_FRAMES * shape.capacity
+
+
+def test_small_window_caps_verbatim_edges_to_its_share():
+    """A tight window shrinks the verbatim edges to ``EDGE_WINDOW_FRACTION``.
+
+    The regression this locks down: the edges are the archive's un-trimmable
+    floor (the frame-budget loop can only drop imaged pages), and at the
+    default ``HQ_EDGE_FRAMES * capacity`` they are ~35k tokens for an
+    Anthropic 1932px reader REGARDLESS of the window. On a small window that
+    floor alone exceeds the whole ``0.5 * window`` archive budget, so a pass
+    meant to get the context under the line commits it above the line instead.
+    Capping the edges to a window share is what keeps them a minority of the
+    post-compaction context, and the trimmed oldest-edge text is not lost — it
+    flows into the imaged middle.
+    """
+    # 128k: the window's per-edge share works out ABOVE one page and below
+    # the shape default, so the cap binds without hitting the floor — the
+    # regime this test is about. (Below ~70k the per-edge share drops under
+    # one page and the floor takes over; that path is its own test.)
+    window = 128_000
+    shape = resolve_shape("anthropic", "claude-opus-4-8")
+    default_edge = HQ_EDGE_FRAMES * shape.capacity
+    messages = [Message.user(f"turn {i} " + "w" * shape.capacity) for i in range(40)]
+    archive = compact_to_archive(messages, "anthropic", "claude-opus-4-8", context_window=window)
+    # Each edge is strictly smaller than the shape default. The per-edge
+    # budget is checked on text_tail, the clean edge: text_head carries the
+    # appended "[... N chars dropped]" truncation marker, which is a handful
+    # of chars ON TOP of the bounded slice, so only the tail is exactly the
+    # raw window-share slice.
+    assert len(archive.text_head) < default_edge
+    assert len(archive.text_tail) < default_edge
+    per_edge_char_budget = (int(window * EDGE_WINDOW_FRACTION) // 2) * 4
+    assert len(archive.text_tail) <= per_edge_char_budget
+    # And it really is the window share, not the floor: strictly more than one
+    # page, so this exercises the cap rather than the min() safety net.
+    assert len(archive.text_tail) > shape.capacity
+
+
+def test_small_window_archive_replay_fits_its_budget():
+    """The whole point: replay cost stays under the ``0.5 * window`` budget.
+
+    Before the edge cap, a 64k-token window produced a ~35k-token edge-only
+    replay against a 32k-token budget — the frame loop dropped every page and
+    the pass STILL overshot. With the edges bounded, the replayed archive
+    (text edges + imaged frames) fits, which is the invariant the whole
+    compaction pass exists to satisfy.
+    """
+    window = 64_000
+    shape = resolve_shape("anthropic", "claude-opus-4-8")
+    messages = [Message.user(f"turn {i} " + "w" * shape.capacity) for i in range(60)]
+    archive = compact_to_archive(messages, "anthropic", "claude-opus-4-8", context_window=window)
+    budget = max(frame_token_estimate_for("anthropic", "claude-opus-4-8"), int(window * 0.5))
+    assert estimate_archive_tokens(archive) <= budget
+
+
+def test_edge_cap_keeps_at_least_one_page_of_verbatim_text():
+    """A pathologically small window never collapses the edges to nothing.
+
+    Some verbatim anchor always beats none: even when the window share works
+    out below one page, the floor is ``shape.capacity`` chars per edge, and
+    the frame budget remains the mechanism that bounds total archive size.
+    """
+    shape = resolve_shape("anthropic", "claude-opus-4-8")
+    messages = [Message.user(f"turn {i} " + "w" * shape.capacity) for i in range(40)]
+    archive = compact_to_archive(messages, "anthropic", "claude-opus-4-8", context_window=8_000)
+    assert len(archive.text_head) >= shape.capacity
+    assert len(archive.text_tail) >= shape.capacity
 
 
 def test_compact_frames_are_valid_pngs():

--- a/tests/unit/compaction/test_snapcompact.py
+++ b/tests/unit/compaction/test_snapcompact.py
@@ -310,7 +310,7 @@ def test_small_window_caps_verbatim_edges_to_its_share():
 
     The regression this locks down: the edges are the archive's un-trimmable
     floor (the frame-budget loop can only drop imaged pages), and at the
-    default ``HQ_EDGE_FRAMES * capacity`` they are ~35k tokens for an
+    default ``HQ_EDGE_FRAMES * capacity`` they are ~31.5k tokens for an
     Anthropic 1932px reader REGARDLESS of the window. On a small window that
     floor alone exceeds the whole ``0.5 * window`` archive budget, so a pass
     meant to get the context under the line commits it above the line instead.


### PR DESCRIPTION
## Why

A user's `/compact` on a large session reported "35% smaller" and then immediately said **"nothing left to compact"** while the context sat at ~278k tokens — a compaction that ran, claimed a win, and left the session near-full with no further recourse.

Forensics on the real session transcript (`768f6891c63c`, a 1M-window Opus session) established:

- The pass that produced the 278k receipt ran on a **pre-#173 build** (the installed `lop` was rebuilt to `main` only *after* the compaction). `#173` already fixed the bulk: the same session compacts to **~65k** on current `main` (`DEFAULT_MAX_FRAMES=8`, per-provider frame pricing). So the headline 278k is not a live `main` bug.
- But the investigation surfaced a **real residual floor that `main` still has**: the archive's two **verbatim text edges** (`text_head` / `text_tail`) are `HQ_EDGE_FRAMES * shape.capacity` chars — **~35k tokens** for an Anthropic 1932px reader — held uncompressed on every replay and **untouchable by the frame-budget loop**, which only ever drops *imaged* pages.

Because that floor tracks the frame **shape**, not the window, on a small context window the two edges *alone* exceed the whole `0.5 * window` archive budget. The budget loop then drops **every** frame and the pass **still** commits an archive above its own target — the same "a pass meant to get under the line ends up above it" failure the frame budget exists to prevent, one layer down.

Measured on `main`, same archived history, archive-replay cost vs the `0.5*window` budget:

| window | budget | BEFORE (edge = 35k floor) | AFTER (window-aware) |
|--------|--------|---------------------------|----------------------|
| 32,000 | 16,000 | **34,989 — OVER (2.2×)** | 11,034 — ok |
| 48,000 | 24,000 | **34,989 — OVER** | 21,082 — ok |
| 64,000 | 32,000 | **34,989 — OVER** | 31,130 — ok |
| 96,000 | 48,000 | 45,037 — ok | 45,530 — ok (edges trimmed) |
| 128,000 | 64,000 | 60,109 — ok | 61,992 — ok (edges trimmed) |
| 200,000 | 100,000 | 75,181 — ok | 73,784 — ok (1932px edges trimmed 63k→60k) |
| 1,000,000 | 500,000 | 75,181 — ok | 75,181 — ok (unchanged) |

## What changes

`local_operator/compaction/snapcompact.py`:

- New `EDGE_WINDOW_FRACTION = 0.15` and `_edge_chars_for(shape, context_window)`: the per-edge verbatim char count now defaults to `HQ_EDGE_FRAMES * shape.capacity` (unchanged) but is **bounded so the two edges together never exceed 15% of the window**. Priced in the estimator's own `chars ≈ 4 × tokens` fallback ratio (imported `_CHARS_PER_TOKEN_FALLBACK`, one source of truth), with a **one-page floor** (`shape.capacity`) so a pathologically small window never loses its verbatim anchor entirely.
- `compact_to_archive` computes `edge_chars` through the helper before slicing. The trimmed-away oldest-edge text is **not lost** — it flows into `image_text` and is imaged (or dropped with the existing `[... N chars of oldest history dropped]` marker) like any other middle history.

The cap only ever **shrinks** the default, never grows it. **Correction (agent review round 1):** the edges follow the window, so the cap trims wherever a reader's default pair exceeds its 15% share — that is 96k/128k for **every** shape, and the native **200k window for the high-res 1932px (Opus) and Gemini readers** (63000→60000 chars/edge, a deliberate 15.75%→15% haircut). Byte-identical default edges survive only ABOVE the shape's threshold (~210k for the 1932px reader, ~139k for the Sonnet/OpenAI readers). This trim is the *point* — the edges are meant to track the window — not a regression; nothing is lost, the trimmed text flows into the imaged middle. See `test_native_200k_window_trims_the_high_res_opus_edges`.

## Impact

- Backward compatible. No config, no on-disk format change. Additive constant + one private helper.
- Post-compaction context on constrained windows now genuinely fits the archive budget, so the pass reliably gets *and stays* under the line instead of committing an over-budget archive that leaves nothing more to compact.

## Testing evidence

**Gates (clean on this branch's head):**
- `black --check` — 2 files, unchanged ✅
- `isort --profile black --check-only` ✅
- `pytest tests/unit/compaction/test_snapcompact.py` — **33 passed** ✅
- `pytest tests/unit/compaction/ tests/unit/session/test_compaction_trigger.py` — **130 passed** ✅

(The repo's ruff config flags pre-existing `datetime.now(timezone.utc)` usages across the file that predate this branch and are committed on `main`; this change introduces none.)

**Real-path validation (not just unit tests).** Reconstructed the actual compaction pass against the real lost session transcript (`768f6891c63c`, 242,840 pre-compaction tokens) through the live code path — `Transcript.build_llm_history` → `_default_convert_to_llm` → `find_cut_point` → `compact_to_archive` → `_render_compaction_marker` → `estimate_messages_tokens`:

- **Before/after archive-replay table above** — every window ≤64k moved from OVER-budget to within budget; every window ≥96k unchanged.
- On the real 1M-window session the committed post-compaction context is **64,952 tokens before and after** the change — proving no regression on the exact session this investigation started from.

**New regression tests** (`test_snapcompact.py`):
- `test_edges_default_to_frame_shape_without_a_window` — the wide/unknown-window path keeps full default edges (the cap only shrinks).
- `test_small_window_caps_verbatim_edges_to_its_share` — a 128k window binds the cap (between floor and default) and the edges land within the window share.
- `test_small_window_archive_replay_fits_its_budget` — the core invariant: replay cost ≤ `0.5*window` on a 64k window (the case that broke before).
- `test_edge_cap_keeps_at_least_one_page_of_verbatim_text` — an 8k window still keeps ≥ one page per edge (the floor).

