### PR TITLE
docs(readme): add credits and acknowledgements section

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -60,7 +60,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement by emailing 
-[damianvtran@gmail.com](mailto:damianvtran@gmail.com).
+[damian@gominerva.com](mailto:damian@gominerva.com).
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/README.md
+++ b/README.md
@@ -551,10 +551,11 @@ implementation; any mistakes here are our own.
 
 All of the projects above are MIT-licensed, as is Local Operator itself. Under
 the MIT license you are free to draw inspiration from or reuse code from Local
-Operator in your own work. We ask only that credit be given where credit is due
-— an acknowledgement of the projects and people whose work you build on, in the
-same spirit as the credits above. It costs little and it keeps open source
-healthy.
+Operator in your own work. Verbatim reuse of the code requires retaining the
+copyright notice and license text, as the license states. Beyond that legal
+minimum, we simply appreciate credit where credit is due — an acknowledgement
+of the projects and people whose work you build on, in the same spirit as the
+credits above. It costs little and it keeps open source healthy.
 
 Core contributor: Damian Tran &lt;[damian@gominerva.com](mailto:damian@gominerva.com)&gt;.
 

--- a/README.md
+++ b/README.md
@@ -533,14 +533,16 @@ studying and drawing inspiration from the projects below. We're grateful to
 their authors and contributors for building in the open.
 
 - **[opencode](https://github.com/anomalyco/opencode)** — created by
-  [Dax Raad (`thdxr`)](https://github.com/thdxr) and the SST/Anomaly team.
-  Its terminal-native, model-agnostic coding-agent design informed our
+  [Dax Raad (`thdxr`)](https://github.com/thdxr) and the Anomaly (formerly SST)
+  team. Its terminal-native, model-agnostic coding-agent design informed our
   thinking on the interactive CLI experience and provider-agnostic model
   handling.
-- **[oh-my-pi](https://github.com/can1357/oh-my-pi)** — created by
-  [Can Bölük (`can1357`)](https://github.com/can1357). Its approach to agent
-  orchestration and harness ergonomics inspired aspects of our subagent and
-  tooling implementation.
+- **[oh-my-pi](https://github.com/can1357/oh-my-pi)** — authored and maintained
+  by [Can Bölük (`can1357`)](https://github.com/can1357), building on
+  [Pi](https://github.com/badlogic/pi-mono) by
+  [Mario Zechner (`mariozechner`)](https://github.com/mariozechner). Its
+  approach to agent orchestration and harness ergonomics inspired aspects of our
+  subagent and tooling implementation.
 
 Inspiration drawn from these projects informed our own independent
 implementation; any mistakes here are our own.

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ schedule its own follow-ups.
 - [🔒 Safety Model](#-safety-model)
 - [📝 Examples](#-examples)
 - [👥 Contributing](#-contributing)
+- [🙏 Credits and Acknowledgements](#-credits-and-acknowledgements)
 - [📜 License](#-license)
 
 ## ✨ Why Local Operator
@@ -523,6 +524,26 @@ We welcome contributions! See [CONTRIBUTING.md](CONTRIBUTING.md) for how to
 submit bug reports and feature requests, set up a development environment,
 and open pull requests. `docs/` covers the architecture
 ([REWRITE.md](./docs/REWRITE.md)), benchmarks, and verification evidence.
+
+## 🙏 Credits and Acknowledgements
+
+Local Operator stands on the shoulders of the broader open-source agent
+community. Several aspects of this harness's implementation were shaped by
+studying and drawing inspiration from the projects below. We're grateful to
+their authors and contributors for building in the open.
+
+- **[opencode](https://github.com/anomalyco/opencode)** — created by
+  [Dax Raad (`thdxr`)](https://github.com/thdxr) and the SST/Anomaly team.
+  Its terminal-native, model-agnostic coding-agent design informed our
+  thinking on the interactive CLI experience and provider-agnostic model
+  handling.
+- **[oh-my-pi](https://github.com/can1357/oh-my-pi)** — created by
+  [Can Bölük (`can1357`)](https://github.com/can1357). Its approach to agent
+  orchestration and harness ergonomics inspired aspects of our subagent and
+  tooling implementation.
+
+Inspiration drawn from these projects informed our own independent
+implementation; any mistakes here are our own.
 
 ## 📜 License
 

--- a/README.md
+++ b/README.md
@@ -547,6 +547,17 @@ their authors and contributors for building in the open.
 Inspiration drawn from these projects informed our own independent
 implementation; any mistakes here are our own.
 
+### A note on reuse and credit
+
+All of the projects above are MIT-licensed, as is Local Operator itself. Under
+the MIT license you are free to draw inspiration from or reuse code from Local
+Operator in your own work. We ask only that credit be given where credit is due
+— an acknowledgement of the projects and people whose work you build on, in the
+same spirit as the credits above. It costs little and it keeps open source
+healthy.
+
+Core contributor: Damian Tran &lt;[damian@gominerva.com](mailto:damian@gominerva.com)&gt;.
+
 ## 📜 License
 
 MIT — see [LICENSE](LICENSE) for details.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -58,7 +58,7 @@ We follow responsible disclosure practices. Once a vulnerability or incident is 
 
 For any additional security-related inquiries or assistance with creating a GitHub Security Advisory, please contact:
 
-- **Email:** [damianvtran@gmail.com](mailto:damianvtran@gmail.com)
+- **Email:** [damian@gominerva.com](mailto:damian@gominerva.com)
 
 ## Additional Resources
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "local-operator"
 version = "0.21.0"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
-authors = [{ name = "Damian Tran", email = "damian@radienthq.com" }]
+authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]
 license = { file = "LICENSE" }
 classifiers = [
     "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
## Summary

Adds a **Credits and Acknowledgements** section near the end of the README (before the License section) and refreshes maintainer contact details.

- **[opencode](https://github.com/anomalyco/opencode)** — Dax Raad (`thdxr`) / Anomaly (formerly SST) team
- **[oh-my-pi](https://github.com/can1357/oh-my-pi)** — Can Bölük (`can1357`), building on [Pi](https://github.com/badlogic/pi-mono) by Mario Zechner (`mariozechner`)

Each entry links the canonical repository and names the primary/core author. A matching entry was added to the Table of Contents.

Also adds a **"A note on reuse and credit"** subsection clarifying that the MIT license permits drawing inspiration from / reusing Local Operator's code, while asking that credit be given where due — naming Damian Tran &lt;damian@gominerva.com&gt; as core contributor.

Refreshes maintainer contact to the Minerva email `damian@gominerva.com`:
- `pyproject.toml` authors
- `SECURITY.md` contact
- `CODE_OF_CONDUCT.md` enforcement email

## Verification

Docs/metadata-only change. Verified:
- All six repo/author links resolve 200; `sst/opencode` 301-redirects to canonical `anomalyco/opencode`; Pi canonical is `badlogic/pi-mono` per oh-my-pi's own README.
- Primary authors confirmed against the live repos and the local oh-my-pi upstream remote.
- No stale `damianvtran@gmail.com` / `damian@radienthq.com` references remain in Markdown or `pyproject.toml`.
- Markdown well-formed; TOC anchor `#-credits-and-acknowledgements` matches the heading.
