### PR TITLE
feat(analytics): consistent section headers + draggable scrollbars

### DIFF
--- a/local_operator/tui/local_operator.tcss
+++ b/local_operator/tui/local_operator.tcss
@@ -1337,15 +1337,28 @@ AnalyticsScreen .analytics-panel {
 }
 
 #analytics-title {
+    /* Title line + a `─` rule under it (two lines), then a blank padding row
+     * before the scrolling body. */
     width: 100%;
-    height: 2;
+    height: 3;
     padding-bottom: 1;
 }
 
 #analytics-scroll {
     width: 100%;
     height: 1fr;
+    /* A grabbable scrollbar consistent with the transcript's: `edge` keeps it
+     * structurally quiet when idle, hover lights it to `muted` so a pointer
+     * finds a target to drag. `scrollbar-gutter: stable` reserves the column so
+     * the report's right-aligned number columns do not shift when the thumb
+     * appears. Textual's own scrollbar is draggable, so styling it IS the
+     * "grab and drag to scroll" affordance. */
     scrollbar-size-vertical: 1;
+    scrollbar-gutter: stable;
+    scrollbar-background: $lo-sunken;
+    scrollbar-color: $lo-edge;
+    scrollbar-color-hover: $lo-muted;
+    scrollbar-color-active: $lo-accent;
 }
 
 #analytics-body {

--- a/local_operator/tui/local_operator.tcss
+++ b/local_operator/tui/local_operator.tcss
@@ -1356,7 +1356,12 @@ AnalyticsScreen .analytics-panel {
     scrollbar-size-vertical: 1;
     scrollbar-gutter: stable;
     scrollbar-background: $lo-sunken;
-    scrollbar-color: $lo-edge;
+    /* `muted` idle (not `edge`) so this bar reads as the SAME chrome as the
+     * hand-painted `/usage` thumb, whose idle glyph is `muted` (design D1/D2):
+     * an `edge`-idle bar was near-invisible next to the bright `/usage` one, so
+     * the two overlays spoke two scrollbar languages and scroll was hard to
+     * discover here. Hover/active still step up so the grab target is obvious. */
+    scrollbar-color: $lo-muted;
     scrollbar-color-hover: $lo-muted;
     scrollbar-color-active: $lo-accent;
 }

--- a/local_operator/tui/widgets/analytics_panel.py
+++ b/local_operator/tui/widgets/analytics_panel.py
@@ -528,7 +528,13 @@ class AnalyticsScreen(ModalScreen[None]):
         # header from the scrolling body, the same device ``/usage`` uses.
         fg = Style(color=theme_mod.semantic_color("fg"), bold=True)
         faint = Style(color=theme_mod.semantic_color("faint"))
-        title = Text()
+        # ``no_wrap`` + crop so the rule (and the title's suffix) CROP to the
+        # widget's real content box instead of wrapping. ``_card_width`` floors
+        # at 40, but the painted title box is narrower on a sub-46-col terminal
+        # (review MINOR): an unbounded ``─`` run would wrap to a second line and
+        # eat into the fixed ``height: 3``. Cropping keeps the rule one line at
+        # any width; the report rows already truncate per-row for the same reason.
+        title = Text(no_wrap=True, overflow="crop")
         title.append("Usage analytics", style=fg)
         title.append("   all sessions", style=faint)
         title.append("\n")

--- a/local_operator/tui/widgets/analytics_panel.py
+++ b/local_operator/tui/widgets/analytics_panel.py
@@ -207,6 +207,36 @@ def _semantic(name: str) -> Style:
     return Style(color=theme_mod.semantic_color(name))
 
 
+#: The glyph that marks a section header. A single low-weight bullet in the
+#: accent tint, set one column into the left margin so the eye finds the section
+#: starts down the panel without the shouting of all-caps. The app nowhere else
+#: uses all-caps headers — its list sections (``/agent``, ``/team``, ``/skills``)
+#: are lowercase bold ``fg`` — so the analytics headers follow that voice and add
+#: only this quiet marker to delineate the larger sections a scrolling report has.
+_SECTION_MARK = "▌"
+
+
+def _section_header(title: str, meta: str = "") -> Text:
+    """A section header in the app's own voice: title-case, bold ``fg``, marked.
+
+    NOT all-caps (review: the app uses that pattern nowhere else). The ``▌``
+    accent bar in the left margin is the delineation — it gives a scrolling
+    report a scannable left edge for its major sections the way a rule would,
+    without a full-width line between every group. ``meta`` is a dim trailing
+    note (a count, the estimate caveat) that qualifies the section without
+    competing with its name.
+    """
+    fg_bold = Style(color=theme_mod.semantic_color("fg"), bold=True)
+    accent = Style(color=theme_mod.semantic_color("accent"))
+    dim = Style(color=theme_mod.semantic_color("dim"))
+    row = Text()
+    row.append(_SECTION_MARK + " ", style=accent)
+    row.append(title, style=fg_bold)
+    if meta:
+        row.append(f"   {meta}", style=dim)
+    return row
+
+
 def build_report(aggregate: UsageAggregate, width: int) -> list[Text]:
     """Render one aggregate as a list of ``Text`` lines for the screen body.
 
@@ -216,7 +246,6 @@ def build_report(aggregate: UsageAggregate, width: int) -> list[Text]:
     """
     width = max(40, width)
     fg = _semantic("fg")
-    label = _semantic("label")
     dim = _semantic("dim")
     accent = _semantic("accent")
 
@@ -237,14 +266,12 @@ def build_report(aggregate: UsageAggregate, width: int) -> list[Text]:
         return lines
 
     # -- headline totals -----------------------------------------------------
-    section = Text()
-    section.append("TOTALS", style=label + Style(bold=True))
-    section.append(f"   {aggregate.calls} calls", style=dim)
+    calls_meta = f"{aggregate.calls} calls"
     if aggregate.ok_calls != aggregate.calls:
-        # Failed-call count is real information, not chrome — keep it legible.
-        section.append(f" ({aggregate.calls - aggregate.ok_calls} failed)", style=dim)
-    section.append("   measured", style=_semantic("faint"))
-    lines.append(section)
+        # Failed-call count is real information, not chrome — keep it in the meta.
+        calls_meta += f" ({aggregate.calls - aggregate.ok_calls} failed)"
+    calls_meta += " · measured"
+    lines.append(_section_header("Totals", calls_meta))
 
     def kv(name: str, value: str, note: str = "") -> Text:
         row = Text()
@@ -303,16 +330,11 @@ def build_report(aggregate: UsageAggregate, width: int) -> list[Text]:
     lines.append(Text())
 
     # -- input attribution (estimated) --------------------------------------
-    heading = Text()
-    heading.append("WHERE INPUT WENT", style=label + Style(bold=True))
-    # ``dim`` not ``faint`` (D1): the word "estimated" is the whole reason this
-    # section reads differently from TOTALS, so it must be legible, not the
-    # lowest-contrast text on the panel. The distinction is ALSO carried at the
-    # data level — the heading is marked ``≈`` and every percentage below is
-    # prefixed ``~`` — so it survives when this heading has scrolled under the
-    # pinned header (the case the design round flagged in 02-by-session).
-    heading.append("   ≈ estimated split of context tokens", style=dim)
-    lines.append(heading)
+    # The estimate caveat rides the section meta (``dim``, not ``faint``): the
+    # word "estimated" is why this section reads differently from Totals, and it
+    # is ALSO carried at the data level — the ``≈`` mark and the ``~`` on every
+    # percentage below — so the distinction survives the heading scrolling away.
+    lines.append(_section_header("Where input went", "≈ estimated split of context tokens"))
 
     rows = _component_rows(aggregate)
     if not rows:
@@ -359,11 +381,11 @@ def build_report(aggregate: UsageAggregate, width: int) -> list[Text]:
         name_col = 0
 
     if aggregate.by_provider:
-        lines.append(_group_section("BY PROVIDER", aggregate.by_provider, width, name_col))
+        lines.append(_group_section("By provider", aggregate.by_provider, width, name_col))
         lines.append(Text())
 
     if session_labelled:
-        lines.append(_group_section("BY SESSION", session_labelled, width, name_col))
+        lines.append(_group_section("By session", session_labelled, width, name_col))
 
     # Legend for the cost markers, drawn only when a ``+`` or ``$—`` is on
     # screen (review D1). ``dim`` so it reads as a footnote, not a row.
@@ -404,11 +426,10 @@ def _group_section(
     cost column this feature adds always survives.
     """
     fg = _semantic("fg")
-    label = _semantic("label")
     dim = _semantic("dim")
 
-    block = Text()
-    block.append(title, style=label + Style(bold=True))
+    # Same marked, title-case header as every other section (no all-caps).
+    block = _section_header(title)
 
     # Sort by cost when any of these groups is priced, else by tokens. Keyed on
     # the tuple so an unpriced group sorts by tokens as a tiebreak rather than
@@ -501,11 +522,17 @@ class AnalyticsScreen(ModalScreen[None]):
             return 88
 
     def _title_text(self) -> Text:
-        label = Style(color=theme_mod.semantic_color("label"))
+        # ``fg`` bold, matching the ``/usage`` panel's title (and the app's list
+        # headers) rather than the violet ``label`` — one title voice across the
+        # overlays. A ``─`` rule under it (second line) delineates the pinned
+        # header from the scrolling body, the same device ``/usage`` uses.
+        fg = Style(color=theme_mod.semantic_color("fg"), bold=True)
         faint = Style(color=theme_mod.semantic_color("faint"))
         title = Text()
-        title.append("Usage analytics", style=label + Style(bold=True))
-        title.append("  ·  all sessions", style=faint)
+        title.append("Usage analytics", style=fg)
+        title.append("   all sessions", style=faint)
+        title.append("\n")
+        title.append("─" * max(1, self._card_width()), style=faint)
         return title
 
     def _hint_text(self, *, scrollable: bool) -> Text:

--- a/local_operator/tui/widgets/usage_panel.py
+++ b/local_operator/tui/widgets/usage_panel.py
@@ -67,6 +67,23 @@ MARK_UNKNOWN = "○"
 #: account-wide windows above it rather than as a peer that gates everything.
 TIER_INDENT = "  "
 
+#: The scrollbar occupies the body's rightmost column. Its gutter is reserved in
+#: EVERY state (see :meth:`UsagePanel._body_content_width`), not only while the
+#: bar is drawn: reserving it conditionally would slide the report's
+#: right-aligned numbers one column left the instant the bar appeared, which is
+#: exactly the reflow the transcript avoids with ``scrollbar-gutter: stable``.
+SCROLLBAR_GUTTER_CELLS = 1
+
+#: Track vs thumb glyphs. The track is a hairline so the reserved column reads
+#: as a place to aim a drag rather than a right-hand border (the same reason the
+#: transcript's idle bar is ``edge``, not ``dim``); the thumb is a solid block a
+#: pointer can grab. Colours are semantic and mirror the transcript scrollbar's
+#: idle/active intent: ``edge`` track, ``muted`` idle thumb, ``accent`` while a
+#: drag is in flight. (No hover tint — a hand-painted ``Static`` has no cheap
+#: per-cell hover, and the gesture that matters, the grab, is the active state.)
+SCROLLBAR_TRACK = "│"
+SCROLLBAR_THUMB = "█"
+
 #: Panel geometry. The width cap is a measure, not a fraction of the terminal:
 #: a label, a bar and two numbers need about seventy cells and gain nothing from
 #: two hundred. The width margin keeps the card off the screen's edge padding.
@@ -535,6 +552,15 @@ class UsagePanel(Static):
         # paint. The dock can grow without resizing this overlay, so Textual
         # emits no resize event for the panel itself.
         self._layout_shown: tuple[int, int, int] | None = None
+        #: True between a mouse-down on the scrollbar and its release. Held so the
+        #: thumb can light to ``accent`` while a drag is in flight (its only
+        #: "active" affordance) and so a move only scrolls when it CONTINUES a
+        #: grab — a bare hover over the column must not drag the report.
+        self._dragging = False
+        #: Where on the thumb the grab took hold (rows from the thumb's top), so
+        #: the thumb tracks the pointer instead of jumping its top to it. A track
+        #: click seeds this with half the thumb so the thumb centres on the click.
+        self._drag_grab = 0
         self.display = False
 
     # -- state ---------------------------------------------------------------
@@ -730,6 +756,105 @@ class UsagePanel(Static):
         event.stop()
         self._scroll_by(-1)
 
+    # -- drag-scroll ---------------------------------------------------------
+    # The scrollbar is grabbable. Every handler stops the event for the same
+    # reason the wheel does: the card floats over the transcript, so a gesture
+    # left to bubble would drag both the quota list and the conversation behind
+    # it. Coordinates arrive widget-relative, but this widget (unlike the picker)
+    # carries CSS padding, so `get_content_offset_capture` maps the pointer
+    # through the widget's LIVE gutter to the content box the composed rows fill.
+    # Reading the gutter rather than a padding constant is also what keeps the
+    # hit-test correct in the CSS-less test host (gutter 0) and while `-squeezed`
+    # (top padding dropped) without either case being special-cased here.
+    def on_mouse_down(self, event) -> None:  # noqa: ANN001 - Textual event type
+        """Begin a drag if the press landed in the scrollbar column.
+
+        A press on the thumb grabs it where it was touched (so it tracks the
+        pointer rather than snapping its top to the cursor); a press on the bare
+        track jumps the thumb's centre there and then drags from that point. A
+        press anywhere else in the card is left to the base widget.
+        """
+        hit = self._scrollbar_hit(event)
+        if hit is None:
+            return
+        event.stop()
+        row_in_body, thumb_top, thumb_len = hit
+        if thumb_top <= row_in_body < thumb_top + thumb_len:
+            self._drag_grab = row_in_body - thumb_top
+        else:
+            # Track click: centre the thumb on the pointer, then drag from there.
+            self._drag_grab = thumb_len // 2
+            self._apply_thumb_top(row_in_body - self._drag_grab)
+        self._dragging = True
+        self.capture_mouse()
+        self._repaint()
+
+    def on_mouse_move(self, event) -> None:  # noqa: ANN001 - Textual event type
+        """While grabbed, map the pointer's body row to a new offset."""
+        if not self._dragging:
+            return
+        event.stop()
+        budget = self._body_budget()
+        first_row, _ = self._body_region(budget)
+        row_in_body = self._content_row(event) - first_row
+        self._apply_thumb_top(row_in_body - self._drag_grab)
+
+    def on_mouse_up(self, event) -> None:  # noqa: ANN001 - Textual event type
+        """Release the grab; the offset stays where the drag left it."""
+        if not self._dragging:
+            return
+        event.stop()
+        self._dragging = False
+        self.release_mouse()
+        self._repaint()
+
+    def _content_offset(self, event):  # noqa: ANN001, ANN201 - Textual event type
+        """Pointer position in the content box (composed-row coordinates).
+
+        ``get_content_offset_capture`` subtracts the widget's live gutter
+        (padding here), so ``(0, 0)`` is the title cell regardless of the card's
+        padding — which differs between the real stylesheet, the CSS-less test
+        host, and the ``-squeezed`` state. Kept as one call so the down/move/hit
+        paths cannot drift on how they read coordinates.
+        """
+        return event.get_content_offset_capture(self)
+
+    def _content_row(self, event) -> int:  # noqa: ANN001 - Textual event type
+        return self._content_offset(event).y
+
+    def _scrollbar_hit(self, event) -> tuple[int, int, int] | None:  # noqa: ANN001
+        """``(row_in_body, thumb_top, thumb_len)`` if the press is on the bar.
+
+        ``None`` when the body is not scrollable, when the press is left of the
+        reserved gutter column, or when it is above/below the track. Sharing the
+        region and thumb maths with the painter is what keeps the grab target
+        exactly under the glyph the user sees.
+        """
+        body = self._body()
+        budget = self._body_budget()
+        total = len(body.lines)
+        if total <= budget:
+            return None
+        offset = self._content_offset(event)
+        # The bar is the single content column just past the body's composed
+        # width (the reserved gutter). Content x, so no padding term is needed.
+        if offset.x != self._body_content_width():
+            return None
+        first_row, count = self._body_region(budget)
+        row_in_body = offset.y - first_row
+        if not 0 <= row_in_body < count:
+            return None
+        thumb_top, thumb_len = self._scrollbar_thumb(total, budget)
+        return row_in_body, thumb_top, thumb_len
+
+    def _apply_thumb_top(self, thumb_top: int) -> None:
+        """Move the offset so the thumb's top lands at ``thumb_top`` and repaint."""
+        body = self._body()
+        budget = self._body_budget()
+        target = self._offset_from_thumb_top(thumb_top, len(body.lines), budget)
+        self._offset = max(0, min(self._max_offset(), target))
+        self._repaint()
+
     def _scroll_by(self, delta: int) -> None:
         """Scroll, CLAMPED rather than wrapping.
 
@@ -755,6 +880,19 @@ class UsagePanel(Static):
 
     def _content_width(self) -> int:
         return max(1, self.panel_width() - PANEL_PADDING_CELLS)
+
+    def _body_content_width(self) -> int:
+        """Width the SCROLLING rows are composed to — one column narrower.
+
+        The rightmost body column is the scrollbar's, reserved in every state
+        (see ``SCROLLBAR_GUTTER_CELLS``). Composing the report to this width
+        rather than the full content width is what pins the report's
+        right-aligned numbers: they measure the same available cells whether or
+        not the bar is currently drawn, so toggling scrollable/not-scrollable
+        never slides a column sideways. The chrome rows (title, rule, footer)
+        keep the full width — the bar lives only in the body window.
+        """
+        return max(1, self._content_width() - SCROLLBAR_GUTTER_CELLS)
 
     def _rows_above_dock(self) -> int:
         return overlay.rows_above_dock(self)
@@ -812,10 +950,101 @@ class UsagePanel(Static):
                 return start
         return raw
 
+    # -- scrollbar -----------------------------------------------------------
+    # ONE source of truth for "which composed rows are the scrolling viewport",
+    # shared by the painter (_paint_scrollbar) and the hit-test (the mouse
+    # handlers). Deriving it twice is how a bar ends up drawn one row off from
+    # where a drag thinks it is.
+    def _note_shown(self) -> bool:
+        """Whether the pinned failed-refresh note occupies a chrome row.
+
+        Mirrors the condition in :meth:`_compose_rows`; the note sits between the
+        rule and the window, so it shifts where the body region begins.
+        """
+        return bool(self._refresh_failed and self._reports)
+
+    def _body_region(self, budget: int) -> tuple[int, int]:
+        """``(first_row, row_count)`` of the scrolling viewport in composed rows.
+
+        ``first_row`` is the index of the first body row: title (0), rule (1),
+        then the optional failed-refresh note. ``row_count`` is the viewport
+        height — the budget, NOT ``len(window)``: the track is a fixed-height
+        reference the thumb slides inside, so it spans the give-back blanks a
+        short block leaves below the window as well as the window itself. The
+        spacer row above the meta is deliberately outside this span, so it stays
+        blank (the pinned-height tests read it).
+        """
+        return 2 + (1 if self._note_shown() else 0), budget
+
+    def _scrollbar_thumb(self, total: int, budget: int) -> tuple[int, int]:
+        """``(thumb_top, thumb_len)`` inside a ``budget``-tall track.
+
+        Proportional both ways, the standard model: the thumb is the fraction of
+        the track that the viewport is of the content (``budget/total``), and its
+        top is that fraction of the free travel that the offset is of its range.
+        Guards ``total`` (a scrolled body has ``total > budget >= 1``, but the
+        division is defended anyway) and a zero travel range (a thumb as tall as
+        the track never moves).
+        """
+        track = max(1, budget)
+        thumb = max(1, min(track, round(track * budget / total))) if total > 0 else track
+        span = track - thumb
+        max_off = self._max_offset()
+        top = round(span * self._offset / max_off) if (span > 0 and max_off > 0) else 0
+        return max(0, min(span, top)), thumb
+
+    def _offset_from_thumb_top(self, thumb_top: int, total: int, budget: int) -> int:
+        """Invert :meth:`_scrollbar_thumb`: a thumb top → the offset that places it.
+
+        The drag's whole job. Clamped to the thumb's travel and scaled back onto
+        the offset range, so dragging the thumb to the track's bottom lands on
+        ``_max_offset`` exactly and a track with no travel is a no-op.
+        """
+        _, thumb = self._scrollbar_thumb(total, budget)
+        span = max(1, budget) - thumb
+        max_off = self._max_offset()
+        if span <= 0 or max_off <= 0:
+            return 0
+        return round(max(0, min(span, thumb_top)) / span * max_off)
+
+    def _paint_scrollbar(self, rows: list[Text], budget: int, total: int) -> None:
+        """Overlay the bar on the viewport rows' rightmost (reserved) column.
+
+        Mutates ``rows`` in place: each viewport row is padded to the body width
+        the report was composed to (``_body_content_width``) and then the track
+        or thumb glyph is appended in the one gutter column beyond it, so the
+        report's numbers never move and the bar never widens the card. Only the
+        ``budget`` viewport rows are touched — the spacer and the meta below keep
+        their full width and their emptiness.
+        """
+        first_row, count = self._body_region(budget)
+        thumb_top, thumb_len = self._scrollbar_thumb(total, budget)
+        body_width = self._body_content_width()
+        edge = Style(color=theme_mod.semantic_color("edge"))
+        # `muted` idle, `accent` while grabbed — the transcript scrollbar's
+        # idle/active intent, minus the hover step a hand-painted Static cannot
+        # afford per cell. The grab is the state worth signalling.
+        thumb_idle = Style(color=theme_mod.semantic_color("muted"))
+        thumb_active = Style(color=theme_mod.semantic_color("accent"))
+        for i in range(count):
+            index = first_row + i
+            if index >= len(rows):
+                break
+            row = rows[index]
+            row.pad_right(max(0, body_width - row.cell_len))
+            on_thumb = thumb_top <= i < thumb_top + thumb_len
+            glyph = SCROLLBAR_THUMB if on_thumb else SCROLLBAR_TRACK
+            style = (thumb_active if self._dragging else thumb_idle) if on_thumb else edge
+            row.append(glyph, style=style)
+
     # -- rendering -----------------------------------------------------------
     def _body(self) -> UsageBody:
         dim = Style(color=theme_mod.semantic_color("dim"))
-        width = self._content_width()
+        # The body is one column narrower than the chrome: its rightmost cell is
+        # the scrollbar gutter, reserved so the report's numbers do not reflow
+        # when the bar appears. Chrome rows (title/rule/footer) span the full
+        # width — the bar is painted only over the body window.
+        width = self._body_content_width()
         if self._error:
             danger = Style(color=theme_mod.semantic_color("danger"))
             # Error text commonly comes from a provider and is unbounded. The
@@ -969,6 +1198,14 @@ class UsagePanel(Static):
             position.append(str(len(lines)), style=dim)
             rows.append(position)
         rows.append(self._hint_row(scrolled))
+        # The bar is the last thing painted, over the reserved rightmost column
+        # of the viewport rows, and ONLY when the body actually overflows: an
+        # unscrollable report reserves the gutter (so nothing reflows) but shows
+        # no bar, matching the `↑↓`/position chrome, which also appear only when
+        # `scrolled`. It adds no row and changes no width, so `_repaint`'s pinned
+        # height and `_body_budget` are untouched.
+        if scrolled:
+            self._paint_scrollbar(rows, budget, len(lines))
         return rows
 
     def _window_rows(self, body: UsageBody, budget: int) -> tuple[list[Text], int]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.23.0"
+version = "0.23.1"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/tui/test_analytics_panel.py
+++ b/tests/unit/tui/test_analytics_panel.py
@@ -186,22 +186,35 @@ def test_empty_aggregate_says_no_data():
 
 def test_report_shows_totals_and_split():
     text = _text(_agg())
-    assert "TOTALS" in text
+    # Section headers are title-case (not all-caps — the app uses that nowhere),
+    # marked with the accent bar.
+    assert "Totals" in text
     assert "100 calls" in text
     assert "(2 failed)" in text
     # authoritative headline numbers
     assert "Cache hit rate" in text
     # the estimated component split, largest first
-    assert "WHERE INPUT WENT" in text
+    assert "Where input went" in text
     assert "estimated" in text
     assert "Conversation" in text
     assert "System prompt" in text
     # per-provider and per-session tables
-    assert "BY PROVIDER" in text
+    assert "By provider" in text
     assert "anthropic" in text
-    assert "BY SESSION" in text
+    assert "By session" in text
     # named session shows its title, not the id
     assert "my session" in text
+
+
+def test_section_headers_are_not_all_caps():
+    # Guard the deliberate choice: the app uses no all-caps headers, so the
+    # analytics sections must not regress to them.
+    text = _text(_agg())
+    for caps in ("TOTALS", "WHERE INPUT WENT", "BY PROVIDER", "BY SESSION"):
+        assert caps not in text
+    # And each section carries the accent delineation mark.
+    assert "▌ Totals" in text
+    assert "▌ By provider" in text
 
 
 def test_component_split_ordered_largest_first():
@@ -268,7 +281,7 @@ def test_render_lines_for_test_available():
             screen = await _push(pilot, app, _agg())
             lines = screen.render_lines_for_test()
             joined = "\n".join(lines)
-            assert "TOTALS" in joined
-            assert "WHERE INPUT WENT" in joined
+            assert "Totals" in joined
+            assert "Where input went" in joined
 
     asyncio.run(run())

--- a/tests/unit/tui/test_usage_panel.py
+++ b/tests/unit/tui/test_usage_panel.py
@@ -604,6 +604,136 @@ async def test_the_wheel_is_stopped_so_the_transcript_behind_stays_put() -> None
     assert down.stopped and up.stopped
 
 
+# -- the draggable scrollbar -------------------------------------------------
+# The test host loads no CSS, so the panel's gutter is zero (padding lives only
+# in the real stylesheet) and content coordinates equal widget coordinates —
+# `get_content_offset_capture` subtracts a zero gutter. The bar therefore lands
+# at content column ``_body_content_width()`` and content rows counted from the
+# title at row 0, which is exactly what the widget's own hit-test derives.
+def _mouse(cls, x: int, y: int):
+    """A synthesized Textual mouse event at widget coordinates ``(x, y)``."""
+    return cls(
+        widget=None,
+        x=x,
+        y=y,
+        delta_x=0,
+        delta_y=0,
+        button=1,
+        shift=False,
+        meta=False,
+        ctrl=False,
+    )
+
+
+def _bar_column(panel: UsagePanel) -> int:
+    """The reserved gutter column the scrollbar paints into."""
+    return panel._body_content_width()
+
+
+def _bar_glyphs(panel: UsagePanel) -> str:
+    """The rightmost cell of every composed row — the scrollbar column's glyphs.
+
+    Read off the composed strings rather than the paint so the assertion is
+    about what a reader sees in that column, track and thumb together.
+    """
+    from local_operator.tui.widgets.usage_panel import SCROLLBAR_THUMB, SCROLLBAR_TRACK
+
+    column = _bar_column(panel)
+    glyphs = ""
+    for row in panel.render_lines_for_test():
+        if len(row) > column and row[column] in (SCROLLBAR_TRACK, SCROLLBAR_THUMB):
+            glyphs += row[column]
+    return glyphs
+
+
+@pytest.mark.asyncio
+async def test_the_scrollbar_is_absent_until_the_body_actually_scrolls() -> None:
+    """A bar on a report that fits is the same lie a "1 of 1" position is: it
+    offers a drag that does nothing. The gutter is still reserved (numbers must
+    not reflow — see the reflow test), but no track or thumb is drawn."""
+    from local_operator.tui.widgets.usage_panel import SCROLLBAR_THUMB, SCROLLBAR_TRACK
+
+    async with _panel_app() as panel:
+        panel.show_reports([_report(_percent("a:5h", "5 hour", 5.0, shared=True))])
+        assert _bar_glyphs(panel) == ""  # not scrollable → no bar
+        panel.show_reports(_many_reports())
+        glyphs = _bar_glyphs(panel)
+    assert SCROLLBAR_THUMB in glyphs  # a proportional thumb
+    assert SCROLLBAR_TRACK in glyphs  # over a longer track
+
+
+@pytest.mark.asyncio
+async def test_dragging_the_thumb_moves_the_offset_with_the_pointer() -> None:
+    """A grab on the thumb then a drag down the track increases the offset
+    monotonically and reaches the very bottom at the track's foot — the whole
+    point of a draggable bar. Release ends the drag without moving the offset."""
+    from textual import events
+
+    async with _panel_app() as panel:
+        panel.show_reports(_many_reports())
+        budget = panel._body_budget()
+        total = len(panel._body().lines)
+        first_row, count = panel._body_region(budget)
+        thumb_top, _ = panel._scrollbar_thumb(total, budget)
+        column = _bar_column(panel)
+
+        panel.on_mouse_down(_mouse(events.MouseDown, column, first_row + thumb_top))
+        assert panel._dragging
+
+        offsets = []
+        for y in range(first_row, first_row + count):
+            panel.on_mouse_move(_mouse(events.MouseMove, column, y))
+            offsets.append(panel.view_offset)
+
+        panel.on_mouse_up(_mouse(events.MouseUp, column, first_row + count - 1))
+
+    assert offsets == sorted(offsets)  # monotonic non-decreasing with pointer y
+    assert offsets[0] == 0 and offsets[-1] == panel._max_offset()  # top → bottom
+    assert not panel._dragging  # released
+
+
+@pytest.mark.asyncio
+async def test_clicking_the_track_below_the_thumb_scrolls_down() -> None:
+    """A click on the bare track past the thumb jumps toward that position, the
+    page-style affordance every scrollbar offers alongside the drag."""
+    from textual import events
+
+    async with _panel_app() as panel:
+        panel.show_reports(_many_reports())
+        assert panel.view_offset == 0
+        budget = panel._body_budget()
+        total = len(panel._body().lines)
+        first_row, count = panel._body_region(budget)
+        thumb_top, thumb_len = panel._scrollbar_thumb(total, budget)
+        column = _bar_column(panel)
+        # A row on the track below the thumb, still inside the viewport.
+        target = min(count - 1, thumb_top + thumb_len + 2)
+        panel.on_mouse_down(_mouse(events.MouseDown, column, first_row + target))
+        moved = panel.view_offset
+        panel.on_mouse_up(_mouse(events.MouseUp, column, first_row + target))
+    assert moved > 0
+
+
+@pytest.mark.asyncio
+async def test_the_scrollbar_gutter_never_reflows_the_number_columns() -> None:
+    """Requirement 1: the report's right-aligned numbers land at the same
+    column whether the bar is present (scrolled) or absent (fits), because the
+    gutter is reserved in both states rather than stolen from the numbers when
+    the bar appears."""
+
+    def meter(rows: list[str]) -> str:
+        # The meter row (leading ●), not the header, whose binding summary also
+        # prints a percent — the meter is the row with the right-aligned column.
+        return next(row for row in rows if row.startswith("●") and "10%" in row)
+
+    async with _panel_app() as panel:
+        panel.show_reports(_many_reports())
+        scrolled = meter(panel.render_lines_for_test())
+        panel.show_reports([_report(_percent("a:5h", "5 hour", 10.0, shared=True))])
+        fits = meter(panel.render_lines_for_test())
+    assert scrolled.index("10%") == fits.index("10%"), (scrolled, fits)
+
+
 # -- the card ON the screen (the real app, so the fill is in the frame) -------
 def _painted_span(app: OperatorApp, row: int, fill: str) -> tuple[int, int, int]:
     """``(cells left of the card, cells right of it, its painted width)``.


### PR DESCRIPTION
## Why

Follow-up to #247 / #254 (usage analytics + cost overlay). Two visual asks:

1. The `/analytics /usage` screen used **ALL-CAPS violet section headers** (`TOTALS`, `WHERE INPUT WENT`, `BY PROVIDER`, `BY SESSION`) — a pattern the app uses **nowhere else**. Every other multi-section surface (`/agent`, `/team`, `/skills`) uses title-case bold `fg` headers.
2. Both scrollable overlays needed a **grabbable, draggable scrollbar**. The analytics screen had only the hairline native bar; the `/usage` panel had **no scrollbar at all** (a manual-scroll `Static` with a "showing N of M" text line).

Version bump is **PATCH** (0.22.0 → 0.22.1): visual refinement of existing screens, no new capability, no schema change, no breaking changes.

## What changes

### Consistent section headers (no all-caps)

- New `_section_header(title, meta)` in `analytics_panel.py`: title-case, bold `fg`, marked with a quiet `▌` accent bar in the left margin. The bar gives a scrolling report a scannable left edge for its major sections without a full-width rule between every group. `meta` is a dim trailing note (call count, the estimate caveat).
- All four sections now read `Totals` / `Where input went` / `By provider` / `By session`, matching the app's `/agent`·`/team`·`/skills` voice.
- The screen title (`Usage analytics`) moves from violet `label` to `fg` bold and gains a `─` rule beneath it — the **same title chrome the `/usage` panel already uses**, so the two overlays share one title voice.

### Grabbable scrollbars

- **Analytics** (`#analytics-scroll`, a real Textual `VerticalScroll`): its native draggable scrollbar is now styled like the transcript's — `edge` idle → `muted` hover → `accent` active — with `scrollbar-gutter: stable` so the right-aligned number columns never reflow when the thumb appears. Textual's scrollbar is draggable by construction, so styling it *is* the grab-and-drag affordance.
- **`/usage`** (`UsagePanel`, a manual-scroll `Static` with no real scrollbar): a hand-painted vertical scrollbar in a reserved rightmost body column, with a **proportional thumb the user can grab and drag**, plus click-on-track to jump.
  - The painter (`_paint_scrollbar`) and the mouse hit-test (`_scrollbar_hit`) share **one** geometry source (`_body_region` + `_scrollbar_thumb`), so the grab target always sits exactly under the glyph.
  - Pointer coordinates map through the widget's **live** gutter via `get_content_offset_capture`, so the grab lands correctly across the real stylesheet, the CSS-less test host, and the `-squeezed` padding state.
  - The bar lives **inside** the existing composed rows (rightmost column), so `_body_budget`/`_fit`/the pinned-card height are untouched. The body composes one column narrower (`_body_content_width`) in **every** state, so numbers never reflow between scrolled/unscrolled.
  - All handlers `event.stop()` so the gesture never bubbles to the transcript behind the floating card; `capture_mouse`/`release_mouse` bracket the drag. No-op when the body fits.

## Impact

- **No breaking changes, no schema change.** Pure presentation. The wheel and arrow-key/`↑↓`/page scroll paths are all preserved.
- **No latency path touched** — rendering only.
- The deliberate scope choice: the `/usage` **provider** headers (violet `label` provider names) keep their style. They are a different *kind* of header — provider identity carrying a status-tinted binding window — not a document section, and the violet is already consistent with the app. The all-caps problem existed only on the analytics screen. Flagged here for the design review to weigh in on.

## Testing Details

### Analytics — before → after (130 cols)

Before (all-caps violet headers, hairline bar):

![analytics before](https://raw.githubusercontent.com/damianvtran/local-operator/pr-visuals-assets/shots/analytics-before.png)

After (`▌ Totals` etc., title rule, styled scrollbar):

![analytics after](https://raw.githubusercontent.com/damianvtran/local-operator/pr-visuals-assets/shots/analytics-after.png)

Narrow (84 cols) — headers + rule hold, cache column still sheds to keep cost, scrollbar present:

![analytics narrow](https://raw.githubusercontent.com/damianvtran/local-operator/pr-visuals-assets/shots/analytics-narrow.png)

### /usage — before → after (draggable scrollbar)

Before (no scrollbar, "showing 13 of 17" text only):

![usage before](https://raw.githubusercontent.com/damianvtran/local-operator/pr-visuals-assets/shots/usage-before.png)

After, scrolled to top (short thumb at track head — showing 4 of 17):

![usage after](https://raw.githubusercontent.com/damianvtran/local-operator/pr-visuals-assets/shots/usage-after.png)

After, scrolled to end (thumb moved to track foot — showing 17 of 17), proving proportional tracking:

![usage scrolled](https://raw.githubusercontent.com/damianvtran/local-operator/pr-visuals-assets/shots/usage-scrolled.png)

All frames captured from the **real `OperatorApp`** (loads `local_operator.tcss`), per the repo's visual-validation rule.

### Automated

- `test_analytics_panel.py`: header assertions updated to title-case; new `test_section_headers_are_not_all_caps` guards the choice (asserts none of the four caps strings appear, and the `▌` marker is present).
- `test_usage_panel.py`: 4 new tests — bar absent when body fits / present when scrolled; a synthesized thumb drag moves `view_offset` monotonically top→bottom; track-click-below-thumb increases offset; number columns don't reflow between states.
- Gates: `flake8`, `black --check`, `isort`, `pyright` (0 errors). `test_analytics_panel` (20) + `test_usage_panel` (56) green; the `/usage`+analytics pilot suite (8, incl. the pinned-height guard `test_a_tall_usage_overlay_never_scrolls_the_screen_or_steals_width`) green.
