### PR TITLE
fix(tui): keep slash highlight on multi-line name commands

### DIFF
--- a/local_operator/tui/widgets/editor.py
+++ b/local_operator/tui/widgets/editor.py
@@ -692,6 +692,15 @@ class Editor(TextArea):
         # list has opened at least once; a name hand-typed in full before the
         # list ever filled goes un-highlighted, an accepted affordance gap.
         self._name_choices: frozenset[str] = frozenset()
+        # Which command FAMILY (`team` vs `agent`) the snapshot above was filled
+        # for. The two families offer disjoint rosters, so a snapshot is only
+        # valid to paint against the family it came from. Tracked because the
+        # multiline branch of ``_sync_picker`` preserves the snapshot across a
+        # newline, and an atomic word-swap `/team <name>\n…` → `/agent <name>\n…`
+        # while already multiline would otherwise keep the team roster in place
+        # and paint a team name green under `/agent` (a name that is not a valid
+        # agent). ``None`` until a list has filled the snapshot.
+        self._name_choices_family: str | None = None
         # Per-render-pass memo for :meth:`_slash_runs` (CR1). ``render_line`` is
         # called once per visible screen row and the runs are identical for every
         # row of a frame; this caches the parse against a key of every input it
@@ -1054,6 +1063,42 @@ class Editor(TextArea):
         """
         return (name or "").lower() in self.NAME_ARGUMENT_COMMANDS
 
+    @staticmethod
+    def _name_command_family(name: str | None) -> str | None:
+        """The roster FAMILY a NAME+message command word belongs to.
+
+        ``team``/``teams`` share the team roster and ``agent``/``agents`` share
+        the agent roster, but the two rosters are disjoint — a team name is not a
+        valid agent and vice versa. The highlighter's name snapshot is therefore
+        only valid to paint against the family it was filled for, so both the
+        snapshot and the buffer's LEADING command word are reduced to a family
+        key and compared. ``None`` for anything that is not a NAME+message
+        command (its argument is not a roster name at all).
+        """
+        lowered = (name or "").lower()
+        if lowered in ("team", "teams"):
+            return "team"
+        if lowered in ("agent", "agents"):
+            return "agent"
+        return None
+
+    def _leading_command_word(self) -> str | None:
+        """The lower-cased command word on the buffer's FIRST non-blank line.
+
+        Distinct from :meth:`_command_word`, which #250 made caret-anchored (it
+        answers "which slash token is the caret on", for the inline mid-draft
+        picker). The highlighter and its snapshot preservation are about the
+        LEADING command — the one on ``first`` that owns a multi-line body — so
+        they must read that line regardless of where the caret sits (on the
+        message body the caret-anchored word would be ``None`` and the name would
+        wrongly go dark). Mirrors the parse in :meth:`_compute_slash_runs`.
+        """
+        line = next((line for line in self.text.split("\n") if line.strip()), "")
+        stripped = line.lstrip()
+        if not stripped.startswith("/"):
+            return None
+        return stripped[1:].partition(" ")[0].lower()
+
     def _name_switch_hint(self, list_argument: str) -> str | None:
         """The U1/U2 hint, or ``None`` when it must not show.
 
@@ -1112,9 +1157,15 @@ class Editor(TextArea):
         refresh the name would only light up on the NEXT keystroke, a visible
         lag. Gated on a real change so an unchanged re-push is not a repaint.
         """
-        if names == self._name_choices:
+        # The family the snapshot is valid for: the command whose argument list
+        # is open right now. Recorded alongside the names so the multiline
+        # preservation in ``_sync_picker`` can reject a snapshot inherited across
+        # a family switch (see :attr:`_name_choices_family`).
+        family = self._name_command_family(self._argument_command)
+        if names == self._name_choices and family == self._name_choices_family:
             return
         self._name_choices = names
+        self._name_choices_family = family
         self.refresh()
 
     @property
@@ -1958,11 +2009,6 @@ class Editor(TextArea):
         first = next((i for i, line in enumerate(lines) if line.strip()), None)
         if first is None:
             return None
-        # Single content-line discipline, identical to ``slash_context`` — once a
-        # newline follows the command line the buffer is a message body, and a
-        # stray command highlight there would contradict "this is prose".
-        if len(lines) > first + 1:
-            return None
         line = lines[first]
         indent = len(line) - len(line.lstrip())
         rest = line[indent:]
@@ -1972,13 +2018,38 @@ class Editor(TextArea):
         word_end = next((i for i, ch in enumerate(rest) if i > 0 and ch.isspace()), len(rest))
         cmd_start, cmd_end = indent, indent + word_end
         word = rest[1:word_end].lower()
+        # Single content-line discipline, identical to ``slash_context`` — once a
+        # newline follows the command line the buffer is a message body, and a
+        # stray command highlight there would contradict "this is prose".
+        #
+        # EXCEPT for the NAME+message commands. ``/team``·``/agent`` are DEFINED as
+        # ``/<cmd> <name> <free-text message>`` where the message is expected to
+        # span lines, and the command on the FIRST content line still dispatches
+        # as that command across the newline (``slash_command_for`` splits on
+        # ``maxsplit=1``, so ``/team lopdev\n…`` is still ``/team``). The command
+        # is therefore still live, so its command and name tokens must keep their
+        # highlight over a multi-line body — otherwise every token goes dark the
+        # instant the user adds a newline, which is exactly the reported bug.
+        # Only these commands are exempt; every ordinary command still goes dark
+        # on the newline that turns it into abandoned-command prose. This is a
+        # LEADING-command rule (the command on ``first``): #250's inline
+        # mid-draft commands are a separate, caret-anchored concern that the
+        # highlighter has never painted and this change does not touch.
+        multiline = len(lines) > first + 1
+        if multiline and not self._is_name_argument_command(word):
+            return None
         runs: list[tuple[int, int, str]] = []
         if word in self._command_names:
             runs.append((cmd_start, cmd_end, "text-area--slash-command"))
         else:
             # Suppress the "unknown" flash while the word is still being picked:
             # a prefix under an open command list is in progress, not wrong. The
-            # recognized and name highlights are unaffected by this gate.
+            # recognized and name highlights are unaffected by this gate. On a
+            # multi-line buffer the picker is already closed (``slash_context``
+            # returns None once a newline follows the leading word), so
+            # ``picking`` is naturally False — and an unknown word never reaches
+            # here on multiline anyway, since only recognized NAME+message words
+            # clear the guard above.
             picking = self._picker.mode is PickerMode.COMMAND and (
                 self._picker.is_open() or self._picker.is_pending()
             )
@@ -1986,19 +2057,23 @@ class Editor(TextArea):
                 runs.append((cmd_start, cmd_end, "text-area--slash-unknown"))
         # The NAME token, only for /team·/agent and only when the typed name is a
         # known team/agent (an exact snapshot hit — a half-typed name stays prose
-        # rather than flickering). ``slash_argument`` hands back everything after
-        # the command word's first space, so the name is its first token. The
-        # single-content-line guard above has already excluded any newline in the
-        # buffer, so the name is a plain whitespace-delimited token (CR3: no
-        # second newline split is needed after that guard).
+        # rather than flickering). The name is the first whitespace-delimited
+        # token of the command line's argument, read straight from the command
+        # line (``rest``) rather than through ``slash_argument``: that helper is
+        # caret-anchored and single-line (#250) and returns None both on the
+        # multi-line body these commands carry AND whenever the caret sits on the
+        # message rather than the name. Deriving from the first content line is
+        # byte-for-byte identical to the old single-line ``slash_argument`` path
+        # on a single-line buffer (that line IS the whole command there) and
+        # keeps painting the name once the message wraps or moves the caret away.
         if self._is_name_argument_command(word):
-            argument = slash_argument(self.text, self._argument_commands)
-            if argument is not None:
+            _, sep, argument = rest[1:].partition(" ")
+            if sep:
                 lead = len(argument) - len(argument.lstrip())
                 name = argument[lead:].split(" ", 1)[0]
                 if name and name.lower() in self._name_choices:
                     # The argument tail begins one cell past the command token
-                    # (the terminating space), then any extra spaces the user
+                    # (its terminating space), then any extra spaces the user
                     # typed before the name.
                     name_start = cmd_end + 1 + lead
                     runs.append((name_start, name_start + len(name), "text-area--slash-argument"))
@@ -2650,10 +2725,37 @@ class Editor(TextArea):
         if list_argument is None:
             self._argument_command = None
             self._argument_subcommand = None
-            # No argument list is open, so the name snapshot is stale: drop it so
-            # a highlight can never outlive the list that filled it (e.g. the
-            # command word was deleted back to `/tea`).
-            self._name_choices = frozenset()
+            # No argument list is open, so the name snapshot is ordinarily stale:
+            # drop it so a highlight can never outlive the list that filled it
+            # (e.g. the command word was deleted back to `/tea`).
+            #
+            # EXCEPT for a multi-line LEADING NAME+message command WHOSE FAMILY
+            # MATCHES the snapshot. `slash_argument` is single-line and (post
+            # #250) caret-anchored, so it returns None the instant the user adds
+            # a newline to `/team <name> <message>` — but that command's body is
+            # DEFINED to span lines and the leading command still dispatches, so
+            # its command and name tokens must stay highlighted. Clearing the
+            # snapshot here would blank the name token on the first newline (the
+            # reported bug), so keep it while the buffer is a live multi-line name
+            # command of the SAME family the snapshot was filled for.
+            #
+            # The family gate is what makes the within-family "cannot mispaint"
+            # guarantee hold across a family switch: an atomic word-swap
+            # `/team <team-name>\n…` → `/agent <team-name>\n…` while already
+            # multiline never re-opens a list (multiline suppresses it), so
+            # without this the team roster would survive and paint a team name
+            # green under `/agent`. Dropping the snapshot on a family mismatch
+            # falls the name token back to prose, which is correct: the name is
+            # not a valid member of the new family, and no list is open to
+            # re-derive the right roster until the buffer returns to a single
+            # line. Uses the LEADING word, not the caret-anchored one, because the
+            # caret is normally down in the message body.
+            keep = self._is_multiline_name_command() and (
+                self._name_choices_family == self._name_command_family(self._leading_command_word())
+            )
+            if not keep:
+                self._name_choices = frozenset()
+                self._name_choices_family = None
             self._picker.sync(self.text, cursor)
         else:
             command = self._command_word()
@@ -2670,6 +2772,7 @@ class Editor(TextArea):
                 # the previous command's names would highlight `/agent frontend`
                 # against team names.
                 self._name_choices = frozenset()
+                self._name_choices_family = None
                 self.post_message(ArgumentQueryOpened(command or ""))
             elif command in ("mcp", "team", "teams"):
                 # `/mcp` and `/team` are two-level: `/mcp` reserves verbs in the
@@ -2784,6 +2887,26 @@ class Editor(TextArea):
         line/slash split.
         """
         return slash_word(self.text, self._caret_offset(), self._command_names)
+
+    def _is_multiline_name_command(self) -> bool:
+        """Whether the buffer is a LEADING NAME+message command with a body.
+
+        The one state where the name snapshot must survive `_sync_picker`'s
+        "no argument list is open" branch: `/team <name>` (or `/agent …`) on the
+        first content line, followed by a newline and a message. `slash_argument`
+        reports no list on multiline (and #250 also anchors it at the caret), but
+        the leading command is still live and its name token must stay painted,
+        so recognition of the typed name has to keep the snapshot the list left
+        behind. Reads the LEADING word (:meth:`_leading_command_word`), not the
+        caret-anchored one, because the caret is usually down in the message
+        body. Ordinary commands never reach this — only the NAME+message ones
+        carry a multi-line body by design.
+        """
+        lines = self.text.split("\n")
+        first = next((i for i, line in enumerate(lines) if line.strip()), None)
+        if first is None or len(lines) <= first + 1:
+            return False
+        return self._is_name_argument_command(self._leading_command_word())
 
     def _complete_model(self, row: ModelRow) -> None:
         """Put ``row``'s selector in the ``/model`` argument without acting on it.

--- a/local_operator/tui/widgets/editor.py
+++ b/local_operator/tui/widgets/editor.py
@@ -2071,7 +2071,21 @@ class Editor(TextArea):
             if sep:
                 lead = len(argument) - len(argument.lstrip())
                 name = argument[lead:].split(" ", 1)[0]
-                if name and name.lower() in self._name_choices:
+                # ``/team chart`` is #258's two-level form: ``chart`` is a
+                # RESERVED subcommand in the first argument slot (the team name
+                # the chart wants lives in the SECOND slot, after ``chart ``), so
+                # the first token is never a roster name to paint. Guarding it
+                # here — mirroring the same reserved-word exclusion in
+                # :meth:`_name_switch_hint` — keeps the highlight correct even if
+                # a team were literally registered as ``chart`` (talked to as
+                # ``/team =chart``, whose first token is ``=chart`` not ``chart``)
+                # and, more importantly, means a future change that widened the
+                # snapshot or read the second-slot token could not resurrect a
+                # ``chart`` mispaint. The first-token rule already makes the
+                # realistic case correct (``chart`` is not in the roster); this
+                # makes it correct by construction.
+                reserved = word in ("team", "teams") and name.lower() == "chart"
+                if name and not reserved and name.lower() in self._name_choices:
                     # The argument tail begins one cell past the command token
                     # (its terminating space), then any extra spaces the user
                     # typed before the name.
@@ -2749,12 +2763,9 @@ class Editor(TextArea):
             # not a valid member of the new family, and no list is open to
             # re-derive the right roster until the buffer returns to a single
             # line. Uses the LEADING word, not the caret-anchored one, because the
-            # caret is normally down in the message body.
-            # Keep the snapshot only for a live multi-line LEADING name command
-            # whose family still matches what the snapshot was filled for (see
-            # the family-gate rationale above). The leading family is named out
-            # so the guard reads as the two conditions it is: "still a multi-line
-            # name command" AND "same roster family".
+            # caret is normally down in the message body. The leading family is
+            # named out so the guard below reads as its two conditions: "still a
+            # multi-line name command" AND "same roster family".
             leading_family = self._name_command_family(self._leading_command_word())
             keep = self._is_multiline_name_command() and (
                 self._name_choices_family == leading_family

--- a/local_operator/tui/widgets/editor.py
+++ b/local_operator/tui/widgets/editor.py
@@ -2750,8 +2750,14 @@ class Editor(TextArea):
             # re-derive the right roster until the buffer returns to a single
             # line. Uses the LEADING word, not the caret-anchored one, because the
             # caret is normally down in the message body.
+            # Keep the snapshot only for a live multi-line LEADING name command
+            # whose family still matches what the snapshot was filled for (see
+            # the family-gate rationale above). The leading family is named out
+            # so the guard reads as the two conditions it is: "still a multi-line
+            # name command" AND "same roster family".
+            leading_family = self._name_command_family(self._leading_command_word())
             keep = self._is_multiline_name_command() and (
-                self._name_choices_family == self._name_command_family(self._leading_command_word())
+                self._name_choices_family == leading_family
             )
             if not keep:
                 self._name_choices = frozenset()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.24.1"
+version = "0.24.2"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/tui/test_command_picker.py
+++ b/tests/unit/tui/test_command_picker.py
@@ -2355,3 +2355,40 @@ async def test_name_token_soft_wraps_across_rows_on_a_multiline_body() -> None:
                 if fg == green:
                     painted += text
         assert painted == long_name
+
+
+@pytest.mark.asyncio
+async def test_team_chart_subcommand_never_paints_a_name() -> None:
+    """`/team chart <name>` paints ONLY the `/team` token — never `chart`, never
+    the name (single-line AND multiline).
+
+    Guards the #258 integration: `/team` is two-level — `chart` is a reserved
+    SUBCOMMAND in the first argument slot, and the team NAME the chart wants
+    lives in the SECOND slot after `chart `. The highlighter reads the name as
+    the FIRST argument token, which for a chart request is `chart` — not a roster
+    member — so no name run is emitted and `chart` stays prose. The test injects
+    `chart` AND the second-slot name into `_name_choices` adversarially: even if
+    both were roster members, the first-token rule must keep the whole argument
+    prose, so a future refactor that reads the name via a caret-anchored helper
+    (which would resolve the second-slot token) is caught here.
+    """
+    app = PickerHarnessApp()
+    async with app.run_test(size=(100, 30)) as pilot:
+        app.editor.focus()
+        await pilot.pause()
+        signal = theme_mod.semantic_color("signal").lower()
+        green = theme_mod.semantic_color("string").lower()
+        # Adversarial snapshot: both the reserved subcommand word and the
+        # second-slot name are present, so only the first-token rule prevents a
+        # mispaint.
+        adversarial = frozenset({"chart", "frontend-guild"})
+        for text in ("/team chart frontend-guild", "/team chart frontend-guild\nbody text"):
+            app.set_editor_text(text)
+            app.editor.set_name_choices(adversarial)
+            await pilot.pause()
+            cells = _slash_ink(app.editor)
+            # `/team` command token is lit...
+            assert _ink_of(cells, "/team") == signal
+            # ...and nothing on the row is painted with the argument-name colour:
+            # neither `chart` nor the second-slot name is highlighted.
+            assert all(fg != green for _, fg in cells)

--- a/tests/unit/tui/test_command_picker.py
+++ b/tests/unit/tui/test_command_picker.py
@@ -2198,19 +2198,160 @@ async def test_partial_name_is_not_highlighted() -> None:
 
 
 @pytest.mark.asyncio
-async def test_multiline_buffer_does_not_highlight_a_second_line() -> None:
-    """The command lives on line 0 only; a newline makes the rest a message
-    body, and no command highlight may leak onto it."""
+async def test_ordinary_command_highlight_dies_on_a_newline() -> None:
+    """An ordinary command lives on line 0 only; a newline makes the rest a
+    message body and the user has abandoned the command, so no command highlight
+    may leak onto either row."""
     app = PickerHarnessApp()
     async with app.run_test(size=(100, 30)) as pilot:
         app.editor.focus()
         await pilot.pause()
-        app.editor.text = "/team frontend-guild\nmore text"
+        # `/usage` is not a NAME+message command, so the single-line discipline
+        # still applies: the newline turns it into prose and the highlight dies.
+        app.set_editor_text("/usage some\nmore text")
         await pilot.pause()
-        # A newline after the command word means neither token is a live list
-        # surface: nothing is highlighted on either row.
         signal = theme_mod.semantic_color("signal").lower()
+        green = theme_mod.semantic_color("string").lower()
+        dim = theme_mod.semantic_color("dim").lower()
+        for y in (0, 1):
+            cells = _slash_ink(app.editor, y)
+            assert all(fg not in (signal, green, dim) for _, fg in cells)
+
+
+@pytest.mark.asyncio
+async def test_name_command_keeps_highlight_across_a_multiline_message() -> None:
+    """The reported bug: `/team <known-name>` highlights the command and name
+    tokens on a single line, then loses ALL highlight the instant a newline is
+    added to the message.
+
+    NAME+message commands (`/team`, `/agent`) are DEFINED as
+    ``/<cmd> <name> <free-text message>`` where the message is expected to span
+    lines, and the leading command still dispatches as that command across the
+    newline. So the command and name tokens must stay lit over a multi-line body,
+    while the message tail — on line 0 or the wrapped lines — stays prose.
+    """
+    app = PickerHarnessApp()
+    async with app.run_test(size=(100, 30)) as pilot:
+        app.editor.focus()
+        await pilot.pause()
+        # Open the list on a single line so the app pushes the name snapshot...
+        app.set_editor_text("/team frontend-guild fix it")
+        app.editor.set_name_choices(frozenset({"frontend-guild"}))
+        await pilot.pause()
+        signal = theme_mod.semantic_color("signal").lower()
+        green = theme_mod.semantic_color("string").lower()
+        # ``set_editor_text`` parks the caret at the end, so the command renders
+        # as one ``/team`` segment (not a split ``/`` + ``team``).
+        single = _slash_ink(app.editor)
+        assert _ink_of(single, "/team") == signal
+        assert _ink_of(single, "frontend-guild") == green
+        # ...now add a newline and keep typing the message. BEFORE the fix every
+        # token went dark here; the command and name must stay lit.
+        app.set_editor_text("/team frontend-guild\nfix it across\nmany lines")
+        await pilot.pause()
+        row0 = _slash_ink(app.editor, 0)
+        assert _ink_of(row0, "/team") == signal
+        assert _ink_of(row0, "frontend-guild") == green
+        # The message body lines carry no command/name highlight — they are prose.
+        for y in (1, 2):
+            body = _slash_ink(app.editor, y)
+            assert all(c not in (signal, green) for _, c in body)
+
+
+@pytest.mark.asyncio
+async def test_multiline_name_command_with_partial_name_stays_prose() -> None:
+    """A half-typed name is in-progress state even on a multi-line body: only an
+    exact snapshot hit paints the name, so a newline must not suddenly light up
+    an unrecognized name."""
+    app = PickerHarnessApp()
+    async with app.run_test(size=(100, 30)) as pilot:
+        app.editor.focus()
+        await pilot.pause()
+        # Open the list so the snapshot is pushed, then break the name and go
+        # multi-line: `front` is not a known team.
+        app.set_editor_text("/team front")
+        app.editor.set_name_choices(frozenset({"frontend-guild"}))
+        await pilot.pause()
+        app.set_editor_text("/team front\nmore")
+        await pilot.pause()
         green = theme_mod.semantic_color("string").lower()
         for y in (0, 1):
             cells = _slash_ink(app.editor, y)
-            assert all(fg not in (signal, green) for _, fg in cells)
+            assert all(fg != green for _, fg in cells)
+
+
+@pytest.mark.asyncio
+async def test_cross_family_word_swap_while_multiline_drops_the_name() -> None:
+    """A team name must NOT paint under `/agent` after an atomic word-swap.
+
+    The rosters are disjoint, so a name valid for one family is prose for the
+    other. Because a multi-line buffer never re-opens the argument list (the
+    picker is suppressed once a newline follows the leading word), an atomic
+    replacement `/team <team-name>\\n…` -> `/agent <team-name>\\n…` cannot rely on
+    the list re-deriving the right roster — the preserved snapshot has to be
+    rejected on the family switch or the team name paints green under `/agent`.
+    This locks that: the command word still highlights (it is a recognized
+    command), but the inherited team name falls back to prose.
+    """
+    app = PickerHarnessApp()
+    async with app.run_test(size=(100, 30)) as pilot:
+        app.editor.focus()
+        await pilot.pause()
+        # Fill the TEAM snapshot on a single line, then go multi-line so it is
+        # preserved across the newline.
+        app.set_editor_text("/team frontend-guild fix it")
+        app.editor.set_name_choices(frozenset({"frontend-guild"}))
+        await pilot.pause()
+        app.set_editor_text("/team frontend-guild\nfix it")
+        await pilot.pause()
+        signal = theme_mod.semantic_color("signal").lower()
+        green = theme_mod.semantic_color("string").lower()
+        row0 = _slash_ink(app.editor)
+        assert _ink_of(row0, "frontend-guild") == green  # premise: it paints here
+        # Atomic word-swap to /agent while STILL multiline (no list re-opens).
+        app.set_editor_text("/agent frontend-guild\nfix it")
+        await pilot.pause()
+        row0 = _slash_ink(app.editor)
+        # The command word is recognized and still highlighted (one ``/agent``
+        # segment, caret parked at the end by ``set_editor_text``)...
+        assert _ink_of(row0, "/agent") == signal
+        # ...but the inherited team name must NOT paint under the wrong family.
+        assert all(fg != green for _, fg in row0)
+
+
+@pytest.mark.asyncio
+async def test_name_token_soft_wraps_across_rows_on_a_multiline_body() -> None:
+    """The soft-wrap row mapping (`_slash_cells`) must place the name token on
+    the right SCREEN rows even when the buffer also has a multi-line message.
+
+    The single-row multiline tests never exercise the wrap-boundary math, and
+    the pre-existing soft-wrap test uses a single-line buffer. This is the
+    intersection: a name long enough to wrap AND a newline-terminated body, so
+    the command line's own wrapped rows carry the tokens while the body lines
+    below are left untouched.
+    """
+    app = PickerHarnessApp()
+    async with app.run_test(size=(24, 20)) as pilot:
+        app.editor.focus()
+        await pilot.pause()
+        long_name = "frontend-platform-guild-alpha"
+        # Make the message multi-line first, THEN push the bespoke snapshot: on a
+        # multi-line buffer ``_sync_picker`` does not re-open the argument list
+        # (so the harness's ``on_argument_query_opened`` will not overwrite the
+        # snapshot with its fixed rows), and the family gate keeps a snapshot
+        # whose family matches the leading ``/team``. This mirrors the app's real
+        # ordering deterministically for a name not in the fixed roster.
+        app.set_editor_text(f"/team {long_name}\nsecond line\nthird line")
+        app.editor.set_name_choices(frozenset({long_name}))
+        await pilot.pause()
+        wrapped = app.editor.wrapped_document
+        assert len(wrapped.get_offsets(0)) >= 2, "premise: the name itself wraps"
+        green = theme_mod.semantic_color("string").lower()
+        # Gather every green run across ALL wrapped rows of the buffer: the whole
+        # name is painted, contiguously, and nothing on the body lines is.
+        painted = ""
+        for y in range(wrapped.height):
+            for text, fg in _slash_ink(app.editor, y):
+                if fg == green:
+                    painted += text
+        assert painted == long_name


### PR DESCRIPTION
## Why

In the composer, a slash command like `/team lopdev <message>` highlights the `/team` command token and the `lopdev` name token correctly **while the message is a single line**. The moment the user adds a newline and keeps typing the message, **all highlighting disappears** — the command and the name go back to plain text.

The slash highlighter `Editor._compute_slash_runs` enforced a single-content-line discipline: the instant a newline followed the command line it returned no runs and every token went dark. That is correct for ordinary commands (`/model …`, `/login …`) — a newline there means the user abandoned the command and is writing prose. But it is **wrong** for the NAME+message commands (`Editor.NAME_ARGUMENT_COMMANDS = ("team", "teams", "agent", "agents")`), which are defined as `/<cmd> <name> <free-text message>` with a body that is *expected* to span lines. The app still dispatches the whole multi-line buffer as that command — `slash_command_for` splits on `maxsplit=1`, so `/team lopdev\n…` still dispatches as `/team` — so the command was still live while its tokens were being blanked.

## What changes

`local_operator/tui/widgets/editor.py`:

- **`_compute_slash_runs`** — the single-content-line guard is relaxed **only** for NAME+message commands. Their `/command` token and known `<name>` token keep the highlight over a multi-line body; the message tail stays prose exactly as on a single line; every ordinary command still goes dark on the newline. The name token is now derived from the first content line directly, because `slash_argument` shares the single-line discipline and returns `None` on a multi-line body — the derivation is byte-identical to the old `slash_argument` path on a single-line buffer, so single-line behaviour is unchanged. The exact-snapshot-membership gate (`name in _name_choices`) is preserved, so a half-typed name still stays prose.
- **`_sync_picker`** — no longer clears `_name_choices` while the buffer is a live multi-line name command (new helper `_is_multiline_name_command`). `slash_argument` reports no open list on multiline, which previously dropped the name snapshot the highlighter tests against — so the name token would blank on the first newline even with the guard relaxed. The snapshot now survives; because the highlighter still paints only an exact snapshot member, a preserved snapshot cannot mispaint.

Comments record the *why*: NAME+message commands intentionally carry a multi-line body and are therefore exempt from the single-line highlight discipline that ordinary commands follow.

Patch bump `0.22.0 → 0.22.1` (fix).

## Testing evidence

### Real-path visual validation (rendered frames, not just tests)

Drove the real `PickerHarnessApp` (loads `local_operator.tcss`), put the composer in each state, `save_screenshot` to SVG, rendered and looked. Before-frames captured from a throwaway detached worktree at clean `origin/main`.

| state | before | after |
|-------|--------|-------|
| single-line `/team frontend-guild fix the thing` | `/team` blue, name green, tail prose | **identical** (SVGs byte-for-byte equal) |
| multi-line `/team frontend-guild\nfix the thing across\nseveral lines` | **all plain text — bug** | `/team` blue, `frontend-guild` green, message body prose |

- BEFORE multi-line: `/tmp/slashshots/render_before_multi.png` — every token plain.
- AFTER multi-line: `/tmp/slashshots/render_after_multi.png` — command + name lit, body prose.
- AFTER single-line: `/tmp/slashshots/render_after_single.png` — unchanged from before.

Runtime state probe (`_compute_slash_runs` output) confirms the fix at the data layer:

```
SINGLE runs: (0, [(0, 5, 'text-area--slash-command'), (6, 20, 'text-area--slash-argument')])
MULTI  runs (before fix): None            # everything dark
MULTI  runs (after fix):  (0, [(0, 5, 'text-area--slash-command'), (6, 20, 'text-area--slash-argument')])
```

### Unit tests (`tests/unit/tui/test_command_picker.py`)

- `test_name_command_keeps_highlight_across_a_multiline_message` — **new**, reproduces the bug: single-line highlighted → add newlines → command+name tokens still lit on row 0, message body lines carry no command/name highlight.
- `test_multiline_name_command_with_partial_name_stays_prose` — **new**, an unrecognized name stays prose across a newline.
- `test_ordinary_command_highlight_dies_on_a_newline` — **new** (replaces the old `test_multiline_buffer_does_not_highlight_a_second_line`, which encoded the buggy behaviour for a name command): `/usage some\nmore` goes dark on the newline, proving ordinary-command behaviour is unchanged.
- Existing single-line coverage unchanged: `test_recognized_team_name_gets_the_argument_style`, `test_a_name_token_that_soft_wraps_is_highlighted_across_both_rows`, `test_partial_name_is_not_highlighted`, `test_recognized_command_word_gets_the_slash_command_style`, `test_unknown_command_word_gets_the_unknown_style_when_picker_closed`, `test_command_word_is_not_flagged_unknown_while_the_picker_is_open`.

**Suites run (worktree venv, `env -u NO_COLOR TERM=xterm-256color`):**
- `test_command_picker.py` — **240 passed**
- `test_command_picker.py + test_slash_echo.py + test_model_picker.py + test_ask_picker.py + test_paste_images.py` — **450 passed**
- `test_app_pilot.py + test_boot_layout.py + test_slash_echo.py` — **238 passed**

**Gates (clean):**
- `flake8 local_operator tests` ✅
- `black==26.1.0 --check local_operator tests` — 443 files unchanged ✅
- `isort --check-only --profile black local_operator tests` ✅
- `pyright .` — 0 errors, 0 warnings ✅

## Impact

Backward compatible. No config or on-disk format change. The behaviour change is strictly additive: multi-line NAME+message commands now keep the highlight that single-line ones already had; ordinary commands and single-line name commands are byte-for-byte unchanged.
