### PR TITLE
feat(session): make the running model visible to the model, and announce switches

### DIFF
--- a/local_operator/harness/subagent.py
+++ b/local_operator/harness/subagent.py
@@ -912,7 +912,13 @@ async def _build_child_session(
     if mcp is not None and not restricted:
         tools = tools + mcp.tools
 
-    def system_blocks_provider() -> list[str]:
+    def system_blocks_provider(model_label: str = "") -> list[str]:
+        # ``model_label`` is passed by the child Session each turn (its own
+        # ``model_label``), which for a subagent is the resolved effort-tier
+        # override or the parent's model. Surfacing it lets a delegated
+        # reviewer/designer name the model it actually ran on in its byline
+        # instead of guessing.
+        #
         # Standard block layout. The lazy-knowledge tail carries the MCP
         # catalogue and nothing else: re-running semantic skill selection per
         # one-shot child would add cost without giving the parent a new durable
@@ -941,6 +947,7 @@ async def _build_child_session(
             goal=parent_session.goal,
             user_instructions=user_instructions,
             credentials=names,
+            model_label=model_label,
         )
 
     child = Session(

--- a/local_operator/incidents.py
+++ b/local_operator/incidents.py
@@ -27,6 +27,14 @@ from dataclasses import dataclass
 #: resumed replay see the same incident.
 SESSION_INCIDENT_MESSAGE_TYPE = "session_incident"
 
+#: Custom-message type journaled by the session when the running model changes
+#: (a deliberate ``set_model``, or a failover fallback to another model).
+#: Rendered to a user message the same way as an incident, so the model NOTICES
+#: it is now answering as a different model rather than only seeing a changed
+#: static "Model:" line in the system prompt. Persisted, so a resumed session
+#: replays the switch history too.
+SESSION_MODEL_SWITCH_MESSAGE_TYPE = "session_model_switch"
+
 #: Ordered (category, patterns) rules. First category whose pattern matches
 #: (case-insensitive) wins; order is specificity, not severity.
 _RULES: list[tuple[str, tuple[str, ...]]] = [
@@ -176,3 +184,44 @@ def classify_incident(raw: str, provider: str = "", model: str = "") -> Incident
 def format_incident_message(raw: str, provider: str = "", model: str = "") -> str:
     """One-call formatter for the rendered user-visible text."""
     return classify_incident(raw, provider, model).render()
+
+
+def format_model_switch_message(
+    new_label: str,
+    previous_label: str = "",
+    *,
+    reason: str = "",
+    transient: bool = False,
+) -> str:
+    """Render the model-switch text injected into the model's context.
+
+    ``new_label`` / ``previous_label`` are ``provider/model_id`` strings (the
+    same vocabulary the status band and the system-prompt ``Model:`` line use,
+    so two names for one object never read as two models). ``transient`` marks
+    a per-request failover fallback that may return to the primary at the next
+    boundary, as opposed to a deliberate switch that persists; ``reason``
+    carries the failover cause when there is one.
+
+    The message is phrased as present-tense state ("You are now running as X")
+    rather than a command, so the model treats it as context for the turns that
+    follow rather than an instruction to acknowledge.
+    """
+    if previous_label and previous_label != new_label:
+        head = f"[model switch] You are now running as {new_label} (was {previous_label})."
+    else:
+        head = f"[model switch] You are now running as {new_label}."
+    lines = [head]
+    if reason.strip():
+        lines.append(f"Reason: {reason.strip()[:200]}")
+    if transient:
+        lines.append(
+            "This is a temporary fallback for the current request; the session "
+            "may return to its primary model at a later turn. Capabilities and "
+            "context window may differ from the primary."
+        )
+    else:
+        lines.append(
+            "This applies from now on. Capabilities, context window, and tone "
+            "may differ from the previous model; act as the model you now are."
+        )
+    return "\n".join(lines)

--- a/local_operator/prompts_api.py
+++ b/local_operator/prompts_api.py
@@ -272,6 +272,7 @@ def build_system_blocks(
     credentials: Sequence[str] | None = None,
     team_brief: str = "",
     agent_brief: str = "",
+    model_label: str = "",
 ) -> list[str]:
     """Build the system prompt blocks; see the module docstring.
 
@@ -335,6 +336,18 @@ def build_system_blocks(
     env_block = f"Today is {date_str}."
     if env_details:
         env_block = f"{env_block}\n\n{env_details}"
+    if model_label.strip():
+        # The running model, so the assistant knows which model it currently is
+        # rather than guessing (a subagent naming itself in a review byline, a
+        # model reasoning about its own context window or capabilities). This
+        # rides the byte-stable env HEAD block, not the volatile tail, because
+        # within one turn-loop the model does not change: a deliberate
+        # ``set_model`` or a failover fallback takes effect at the NEXT turn
+        # boundary, which re-renders this block from the session's live model,
+        # and the switch itself is separately announced as a
+        # ``session_model_switch`` message so the model notices the change
+        # rather than only seeing a different static line.
+        env_block = f"{env_block}\n\nModel: {model_label.strip()}"
 
     tail = skills_block or "<skills/>"
     if goal:

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -112,7 +112,10 @@ from local_operator.harness.wake import (
     format_wake_delivery_text,
 )
 from local_operator.imaging import rebound_oversize_image
-from local_operator.incidents import SESSION_INCIDENT_MESSAGE_TYPE
+from local_operator.incidents import (
+    SESSION_INCIDENT_MESSAGE_TYPE,
+    SESSION_MODEL_SWITCH_MESSAGE_TYPE,
+)
 from local_operator.session.goal import GoalState
 from local_operator.session.mcp_status import McpStartupOutcome
 from local_operator.session.naming import (
@@ -331,6 +334,32 @@ def _archive_to_json(archive: Any) -> dict[str, Any]:
     return archive.model_dump(mode="json")
 
 
+def _callable_accepts_one_positional(func: Callable[..., Any]) -> tuple[bool, bool]:
+    """``(accepts_one_positional, certain)`` for ``func``.
+
+    Used to decide whether the system-blocks provider takes the live
+    ``model_label`` (the factory and subagent providers do; a legacy zero-arg
+    callable does not). When the signature can be read the answer is certain;
+    when it cannot (a builtin, a C callable, some mocks) the answer is ``True``
+    but ``certain`` is ``False``, so the caller tries the labelled call and may
+    fall back once. Distinguishing the two matters: a TypeError raised INSIDE a
+    provider whose signature was read as one-arg is a real bug that must surface,
+    not be swallowed by a zero-arg retry.
+    """
+    try:
+        signature = inspect.signature(func)
+    except (TypeError, ValueError):
+        return True, False
+    for parameter in signature.parameters.values():
+        if parameter.kind in (
+            inspect.Parameter.VAR_POSITIONAL,
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            inspect.Parameter.POSITIONAL_ONLY,
+        ):
+            return True, True
+    return False, True
+
+
 def _default_convert_to_llm(messages: list[AgentMessage]) -> list[Message]:
     """Default transcript→LLM rendering.
 
@@ -364,11 +393,17 @@ def _default_convert_to_llm(messages: list[AgentMessage]) -> list[Message]:
             # compaction cut landing on a rendered marker can still locate
             # ``first_kept_entry_id`` on replay.
             out.append(_render_compaction_marker(message, entry_id=message.id))
-        elif message.custom_type == SESSION_INCIDENT_MESSAGE_TYPE:
+        elif message.custom_type in (
+            SESSION_INCIDENT_MESSAGE_TYPE,
+            SESSION_MODEL_SWITCH_MESSAGE_TYPE,
+        ):
             # An incident rides the sender's preformatted text (the classifier
             # already wrote category + suggested action), exactly like a wake
             # delivery: it must reach the model as a user turn or the session
-            # stays blind to why its last run died.
+            # stays blind to why its last run died. A model-switch record uses
+            # the same path so the model becomes aware it is now answering as a
+            # different model (a deliberate switch or a failover fallback),
+            # rather than only seeing a changed static "Model:" system line.
             out.append(
                 Message(
                     role="user",
@@ -457,7 +492,9 @@ def _is_todo_reminder(message: AgentMessage) -> TypeGuard[CustomMessage]:
 #: time as a message replays a superseded summary back into context beside the
 #: live one. A deny-list enumerating the ephemeral types cannot see a type that
 #: does not exist yet; this one excludes it by default.
-_PERSISTABLE_CUSTOM_TYPES: frozenset[str] = frozenset({SESSION_INCIDENT_MESSAGE_TYPE})
+_PERSISTABLE_CUSTOM_TYPES: frozenset[str] = frozenset(
+    {SESSION_INCIDENT_MESSAGE_TYPE, SESSION_MODEL_SWITCH_MESSAGE_TYPE}
+)
 
 
 def _paired_prefix(messages: Sequence[AgentMessage]) -> list[AgentMessage]:
@@ -937,7 +974,11 @@ class Session:
         #: tool is not advertised.
         team_registry: Any | None = None,
         conversation_name: ConversationName | None = None,
-        system_blocks_provider: Callable[[], list[str]] | Callable[[], Awaitable[list[str]]],
+        # Called each turn with the session's live ``model_label`` so the env
+        # block names the running model; accepts it positionally (``...``) and
+        # may return sync or async. A provider that ignores the argument is
+        # still valid — the label is additive.
+        system_blocks_provider: Callable[..., list[str]] | Callable[..., Awaitable[list[str]]],
     ) -> None:
         self._model = model
         self._stream_fn = stream_fn
@@ -1007,6 +1048,16 @@ class Session:
         #: this task instead — see :meth:`_spawn_selected_model_write`.
         self._selected_model_task: "asyncio.Future[None] | None" = None
         self._system_blocks_provider = system_blocks_provider
+        # Whether the block provider accepts the live ``model_label`` argument.
+        # Computed once here rather than per call: the factory and subagent
+        # providers do, a bare zero-arg callable (some hosts, most tests) does
+        # not, and the label is additive either way. A provider whose signature
+        # cannot be inspected (a C callable, a mock) is assumed to take it and
+        # falls back at the call site only if that assumption is wrong.
+        (
+            self._blocks_provider_takes_label,
+            self._blocks_provider_arity_certain,
+        ) = _callable_accepts_one_positional(system_blocks_provider)
         self._convert_to_llm = convert_to_llm or _default_convert_to_llm
         #: Set once a provider refuses a request because of an image block, and
         #: never cleared: from then on this session renders its history without
@@ -1150,6 +1201,10 @@ class Session:
         # Error text from the run just ended, journalled as a session incident
         # once persistence finishes (see _run_turn / journal_incident).
         self._pending_incident: str | None = None
+        # (new_label, transient) of the last model switch made model-visible, so
+        # the two edges that can both fire for one change (``set_model`` and a
+        # route-settled event) do not double-announce. See journal_model_switch.
+        self._last_model_switch_announced: tuple[str, bool] | None = None
         self._turn_task: asyncio.Task[None] | None = None  # in-flight turn (wake deliveries)
 
         # on_job_complete: settled model-owned jobs auto-deliver back into the
@@ -1620,6 +1675,34 @@ class Session:
     def model_label(self) -> str:
         return f"{self._model.provider}/{self._model.model_id}"
 
+    def _system_blocks(self) -> list[str] | Awaitable[list[str]]:
+        """Invoke the block provider with the live model label.
+
+        The provider gained an optional ``model_label`` argument so the env
+        block can name the running model (see ``build_system_blocks``). A
+        provider that predates the argument — a bare zero-arg callable a host or
+        a test supplies — is still valid: its arity is inspected once (not
+        probed by catching ``TypeError``, which would mask a genuine TypeError
+        raised INSIDE a one-arg provider and re-invoke it) and it is called with
+        no argument. The label is therefore strictly additive: no caller is
+        forced to grow a parameter it does not use.
+        """
+        if not self._blocks_provider_takes_label:
+            return self._system_blocks_provider()
+        if self._blocks_provider_arity_certain:
+            # Signature was readable and takes the label: any TypeError from here
+            # is a genuine bug inside the provider and must surface, not be
+            # swallowed by a zero-arg retry.
+            return self._system_blocks_provider(self.model_label)
+        try:
+            return self._system_blocks_provider(self.model_label)
+        except TypeError:
+            # Unreadable signature guessed one-arg and guessed wrong: this
+            # provider is genuinely zero-arg. Remember it and call the
+            # compatible way from now on.
+            self._blocks_provider_takes_label = False
+            return self._system_blocks_provider()
+
     @property
     def model(self) -> ModelSpec:
         """The spec every provider call is built from."""
@@ -1827,6 +1910,19 @@ class Session:
         notify = getattr(self._stream_fn, "on_model_changed", None)
         if callable(notify):
             notify(model)
+        # Make the deliberate switch visible to the MODEL, not just the host's
+        # band. A same-pair knob change never reaches here (it took an early
+        # return above), so this fires once per genuine switch. Background
+        # because ``set_model`` is sync and runs on the UI loop; the record
+        # lands before the next turn reads context.
+        self._spawn_background(
+            self.journal_model_switch(
+                f"{model.provider}/{model.model_id}",
+                f"{previous.provider}/{previous.model_id}",
+                reason="model switched",
+                transient=False,
+            )
+        )
 
     def _journal_effort_if_selection_in_force(self, previous: ModelSpec, model: ModelSpec) -> None:
         """Re-journal the selection when a knob change moves the effort on a
@@ -2799,7 +2895,7 @@ class Session:
           the ~0.15 ms the hop itself takes. This runs on the boot path a
           sibling commit cleared of exactly this kind of stall.
         """
-        blocks = self._system_blocks_provider()
+        blocks = self._system_blocks()
         if inspect.isawaitable(blocks):
             blocks = await blocks
         resolved = list(blocks)
@@ -2907,6 +3003,14 @@ class Session:
                     context_window=int(self._model.context_window),
                 )
             )
+            # Tell the model it is back on its primary. Not transient: the
+            # session has returned to its selected model for the foreseeable
+            # future, unlike the outbound fallback below.
+            await self.journal_model_switch(
+                f"{self._model.provider}/{self._model.model_id}",
+                reason=reason or "returned to primary model",
+                transient=False,
+            )
             return
         selector = str(target.selector)
         target_effort = getattr(target, "effort", None)
@@ -2928,6 +3032,16 @@ class Session:
                 is_fallback=True,
                 context_window=int(spec.context_window),
             )
+        )
+        # Tell the model it is now answering on a FALLBACK. Transient: the
+        # session may return to its primary at a later boundary (the target=None
+        # branch above), and the model should know the change may not persist so
+        # it does not, for example, record the fallback as its identity.
+        await self.journal_model_switch(
+            f"{spec.provider}/{spec.model_id}",
+            f"{self._model.provider}/{self._model.model_id}",
+            reason=reason,
+            transient=True,
         )
 
     def _spec_for_route(self, selector: str, effort: str | None) -> ModelSpec | None:
@@ -3076,7 +3190,7 @@ class Session:
                 ):
                     await self._emit(MessageStartEvent(message=message))
 
-            blocks = self._system_blocks_provider()
+            blocks = self._system_blocks()
             if inspect.isawaitable(blocks):
                 blocks = await blocks
             self._context.system_blocks = list(blocks)
@@ -3426,6 +3540,58 @@ class Session:
             self._context.messages.append(message)
         except OSError:
             logger.warning("could not journal session incident", exc_info=True)
+
+    async def journal_model_switch(
+        self,
+        new_label: str,
+        previous_label: str = "",
+        *,
+        reason: str = "",
+        transient: bool = False,
+    ) -> None:
+        """Make a model change visible to the MODEL, not just the UI.
+
+        A deliberate ``/model`` switch and a failover fallback both already
+        emit a ``ModelChangeEvent`` the front end repaints from, and the
+        selection is journalled as ``SELECTED_MODEL_CUSTOM_TYPE`` so a resume
+        restores it — but none of that reaches the model's own context. Without
+        this, a model that has just been switched onto (or a subagent whose run
+        failed over to a different model) keeps reasoning as though it were the
+        previous model: it can misreport which model it is, assume the wrong
+        context window, or name the wrong model in a byline. This appends a
+        ``session_model_switch`` message to the live context so the very next
+        turn sees the change, and persists it so a resumed session replays it.
+
+        Deduplicated against the last switch record so the two edges that can
+        both fire for one change (``set_model`` and a route-settled event) do
+        not double-announce: a repeat naming the same ``new_label`` with the
+        same ``transient`` flag is dropped.
+        """
+        from local_operator.incidents import format_model_switch_message
+
+        if self._disposed or not new_label:
+            return
+        if (new_label, transient) == self._last_model_switch_announced:
+            return
+        self._last_model_switch_announced = (new_label, transient)
+        text = format_model_switch_message(
+            new_label, previous_label, reason=reason, transient=transient
+        )
+        message = CustomMessage(
+            custom_type=SESSION_MODEL_SWITCH_MESSAGE_TYPE,
+            attribution="system",
+            details={
+                "text": text,
+                "new_label": new_label,
+                "previous_label": previous_label,
+                "transient": transient,
+            },
+        )
+        try:
+            await self._transcript.append_message(message)
+            self._context.messages.append(message)
+        except OSError:
+            logger.warning("could not journal model switch", exc_info=True)
 
     def _on_mcp_incident(self, server: str, reason: str) -> None:
         """MCP manager hook (breaker trips): journal without blocking the
@@ -4440,7 +4606,7 @@ class Session:
         Safe to call mid-turn, and the pairing below is what makes that true —
         see :meth:`_wire_legal_snapshot`.
         """
-        blocks = self._system_blocks_provider()
+        blocks = self._system_blocks()
         if inspect.isawaitable(blocks):
             blocks = await blocks
         request = ChatRequest(

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -568,8 +568,20 @@ def _is_persistable_message(message: AgentMessage) -> bool:
     which is exactly where both of those live: after a pass the context is
     ``[marker, *kept]``, so the very next boundary would otherwise persist the
     marker.
+
+    A TRANSIENT model-switch record (a per-request failover fallback) is a
+    special case: it belongs in the live context so the running model knows it
+    is on a fallback, but it must NOT be persisted. A transient fallback that
+    outlives the process is stale by definition — a resumed session boots on its
+    selected model, so replaying "you are now on fallback B (temporary)" with no
+    matching recovery would contradict the authoritative ``Model:`` line
+    (review R1).
     """
     if isinstance(message, CustomMessage):
+        if message.custom_type == SESSION_MODEL_SWITCH_MESSAGE_TYPE and bool(
+            message.details.get("transient")
+        ):
+            return False
         return message.custom_type in _PERSISTABLE_CUSTOM_TYPES
     return True
 
@@ -1913,13 +1925,15 @@ class Session:
         # Make the deliberate switch visible to the MODEL, not just the host's
         # band. A same-pair knob change never reaches here (it took an early
         # return above), so this fires once per genuine switch. Background
-        # because ``set_model`` is sync and runs on the UI loop; the record
-        # lands before the next turn reads context.
+        # because ``set_model`` is sync and runs on the UI loop; the env-block
+        # ``Model:`` line keeps identity correct even if this notice slips a
+        # turn (see journal_model_switch). No ``reason``: the head already reads
+        # "now running as X (was Y)", so a "Reason: model switched" line would
+        # only repeat it. ``reason`` is reserved for failover causes (R3).
         self._spawn_background(
             self.journal_model_switch(
                 f"{model.provider}/{model.model_id}",
                 f"{previous.provider}/{previous.model_id}",
-                reason="model switched",
                 transient=False,
             )
         )
@@ -3559,13 +3573,22 @@ class Session:
         failed over to a different model) keeps reasoning as though it were the
         previous model: it can misreport which model it is, assume the wrong
         context window, or name the wrong model in a byline. This appends a
-        ``session_model_switch`` message to the live context so the very next
-        turn sees the change, and persists it so a resumed session replays it.
+        ``session_model_switch`` message to the live context so the next turn
+        sees the change. A non-transient (deliberate, or return-to-primary)
+        record is also persisted so a resumed session replays it; a TRANSIENT
+        fallback record is live-only, because a fallback that outlives the
+        process is stale on resume (see ``_is_persistable_message``, review R1).
 
         Deduplicated against the last switch record so the two edges that can
         both fire for one change (``set_model`` and a route-settled event) do
         not double-announce: a repeat naming the same ``new_label`` with the
         same ``transient`` flag is dropped.
+
+        Called on the loop, but not synchronously ordered against the next turn:
+        ``set_model`` spawns this in the background. The env-block ``Model:``
+        line already carries the live identity, so the worst case is that the
+        "you just switched" NOTICE lands one turn late, never that the model's
+        identity is wrong (review R2).
         """
         from local_operator.incidents import format_model_switch_message
 
@@ -3588,7 +3611,10 @@ class Session:
             },
         )
         try:
-            await self._transcript.append_message(message)
+            # Persist only when the record should survive a resume; a transient
+            # fallback is live-context-only (see _is_persistable_message).
+            if _is_persistable_message(message):
+                await self._transcript.append_message(message)
             self._context.messages.append(message)
         except OSError:
             logger.warning("could not journal model switch", exc_info=True)

--- a/local_operator/session_factory.py
+++ b/local_operator/session_factory.py
@@ -854,7 +854,7 @@ class _SessionPlan:
     """
 
     session_kwargs: dict[str, Any]
-    system_blocks_provider: Callable[[], Awaitable[list[str]]]
+    system_blocks_provider: Callable[..., Awaitable[list[str]]]
     knowledge_hooks: _KnowledgeHooks
     auth_store: AuthStore | None = None
 
@@ -868,7 +868,7 @@ def _make_system_blocks_provider(
     user_instructions: str = "",
     repo_guidance: str = "",
     variable_store: "VariableStore | None" = None,
-) -> Callable[[], Awaitable[list[str]]]:
+) -> Callable[..., Awaitable[list[str]]]:
     """Build the per-turn system-prompt closure.
 
     Session awaits the result (committed tolerance for awaitable providers),
@@ -892,7 +892,12 @@ def _make_system_blocks_provider(
     the next session, which is also what makes a session's prompt reproducible.
     """
 
-    async def provider() -> list[str]:
+    async def provider(model_label: str = "") -> list[str]:
+        # ``model_label`` is passed live by the Session each turn (its own
+        # ``model_label``), so a deliberate ``set_model`` or a failover fallback
+        # that changed the model is reflected in the env block on the next turn
+        # without rebuilding this closure. The benchmark/preflight caller passes
+        # the spec label directly; both keep the block byte-stable within a turn.
         from local_operator.prompts_api import build_system_blocks
 
         query = _latest_user_query(transcript)
@@ -925,6 +930,7 @@ def _make_system_blocks_provider(
             credentials=names,
             team_brief=team_brief,
             agent_brief=agent_brief,
+            model_label=model_label,
         )
 
     return provider
@@ -1539,9 +1545,13 @@ async def build_initial_blocks(
     """
     plan = await _prepare(args, config_manager, credential_manager, agent_registry, has_ui=False)
     # No session facade is built on this path, so the store's lifetime ends
-    # here: close it directly (CL-08) to release the SQLite lock.
+    # here: close it directly (CL-08) to release the SQLite lock. Pass the
+    # spec's label so the measured startup prompt includes the model line the
+    # real session will carry (the benchmark budget must not under-count it).
+    spec = plan.session_kwargs.get("model")
+    model_label = f"{spec.provider}/{spec.model_id}" if spec is not None else ""
     try:
-        return await plan.system_blocks_provider()
+        return await plan.system_blocks_provider(model_label)
     finally:
         if plan.auth_store is not None:
             try:

--- a/tests/unit/session/test_session.py
+++ b/tests/unit/session/test_session.py
@@ -45,6 +45,7 @@ from local_operator.session.session import (
     SESSION_MODEL_SWITCH_MESSAGE_TYPE,
     Session,
     _callable_accepts_one_positional,
+    _is_persistable_message,
     _paired_prefix,
 )
 from local_operator.session.transcript import Transcript
@@ -1175,6 +1176,35 @@ async def test_failover_route_settled_journals_a_transient_switch(tmp_path):
     assert "You are now running as zai/glm-5.3" in text
     assert "temporary fallback" in text
     assert switches[-1].details["transient"] is True
+
+    # R1: a transient fallback record is live-context-only — it must NOT be
+    # persisted, or a resume would replay a stale fallback the session is no
+    # longer on.
+    dumped = "\n".join(
+        __import__("json").dumps(e.payload, default=str) for e in session._transcript.entries()
+    )
+    assert SESSION_MODEL_SWITCH_MESSAGE_TYPE not in dumped
+    assert not _is_persistable_message(switches[-1])
+    await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_a_deliberate_switch_is_persisted_for_resume(tmp_path):
+    """R1 boundary: a non-transient switch (a deliberate /model change) IS
+    persisted, so a resumed session replays which model it ended up on."""
+    session = make_session(tmp_path, ScriptedStream([]))
+    await session.journal_model_switch("zai/glm-5.3", "test/m", transient=False)
+    switches = [
+        m
+        for m in session._context.messages
+        if isinstance(m, CustomMessage) and m.custom_type == SESSION_MODEL_SWITCH_MESSAGE_TYPE
+    ]
+    assert len(switches) == 1
+    assert _is_persistable_message(switches[-1])
+    dumped = "\n".join(
+        __import__("json").dumps(e.payload, default=str) for e in session._transcript.entries()
+    )
+    assert SESSION_MODEL_SWITCH_MESSAGE_TYPE in dumped
     await session.dispose()
 
 

--- a/tests/unit/session/test_session.py
+++ b/tests/unit/session/test_session.py
@@ -42,7 +42,9 @@ from local_operator.session.session import (
     IMAGE_DROPPED_NOTICE,
     IMAGE_OMITTED_TEXT_ONLY_NOTICE,
     SESSION_INCIDENT_MESSAGE_TYPE,
+    SESSION_MODEL_SWITCH_MESSAGE_TYPE,
     Session,
+    _callable_accepts_one_positional,
     _paired_prefix,
 )
 from local_operator.session.transcript import Transcript
@@ -1033,6 +1035,146 @@ async def test_model_label_and_ids(tmp_path):
     assert session.session_id == "sess-42"
     assert session.agent_id == "Sub"
     assert session.model_label == "test/m"
+    await session.dispose()
+
+
+def test_callable_accepts_one_positional_classifies_arity() -> None:
+    # A one-arg provider is certain; a zero-arg one is certainly not.
+    assert _callable_accepts_one_positional(lambda label="": []) == (True, True)
+    assert _callable_accepts_one_positional(lambda: []) == (False, True)
+
+    # *args counts as accepting one positional.
+    assert _callable_accepts_one_positional(lambda *a: [])[0] is True
+
+    # A signature that cannot be read (str raises ValueError under
+    # inspect.signature) defaults to "assume it takes it", uncertain.
+    assert _callable_accepts_one_positional(str) == (True, False)
+
+
+@pytest.mark.asyncio
+async def test_live_model_label_reaches_a_label_aware_provider(tmp_path):
+    """A provider that accepts the label is handed the session's LIVE model, so
+    the env block names the running model and follows a mid-session switch."""
+    seen: list[str] = []
+
+    def provider(model_label: str = "") -> list[str]:
+        seen.append(model_label)
+        return [f"Model: {model_label}"]
+
+    stream = ScriptedStream([[StreamEndEvent(stop_reason="stop")]])
+    session = make_session(tmp_path, stream, system_blocks_provider=provider)
+    await session.prompt("hi")
+    assert seen[-1] == "test/m"
+    assert stream.requests[0].system_blocks == ["Model: test/m"]
+    await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_zero_arg_provider_still_works_after_the_label_addition(tmp_path):
+    """A legacy zero-arg provider (some hosts, most tests) must keep working:
+    the label is additive, not a required parameter."""
+    stream = ScriptedStream([[StreamEndEvent(stop_reason="stop")]])
+    session = make_session(tmp_path, stream, system_blocks_provider=lambda: ["stable", "env"])
+    assert session._blocks_provider_takes_label is False
+    await session.prompt("hi")
+    assert stream.requests[0].system_blocks == ["stable", "env"]
+    await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_set_model_journals_a_model_visible_switch(tmp_path):
+    """A deliberate switch appends a model-visible record so the NEXT turn knows
+    it is now a different model — not just the UI band."""
+    stream = ScriptedStream([[StreamEndEvent(stop_reason="stop")]])
+    session = make_session(tmp_path, stream)
+    OTHER = ModelSpec(provider="zai", model_id="glm-5.3", context_window=100_000)
+    session.set_model(OTHER, explicit=True)
+    await wait_for(
+        lambda: any(
+            isinstance(m, CustomMessage) and m.custom_type == SESSION_MODEL_SWITCH_MESSAGE_TYPE
+            for m in session._context.messages
+        )
+    )
+    switches = [
+        m
+        for m in session._context.messages
+        if isinstance(m, CustomMessage) and m.custom_type == SESSION_MODEL_SWITCH_MESSAGE_TYPE
+    ]
+    assert len(switches) == 1
+    text = switches[-1].details["text"]
+    assert "You are now running as zai/glm-5.3" in text
+    assert "was test/m" in text
+
+    # It renders into the request the provider sees on the next turn.
+    await session.prompt("continue")
+    rendered = "\n".join(getattr(m, "text", "") for m in stream.requests[0].messages)
+    assert "[model switch]" in rendered and "zai/glm-5.3" in rendered
+    await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_a_knob_only_change_does_not_journal_a_switch(tmp_path):
+    """Same provider/model_id with a different effort is not a model switch and
+    must not append a switch record (which would be one row per keystroke)."""
+    stream = ScriptedStream([])
+    session = make_session(tmp_path, stream)
+    same_pair = MODEL.model_copy(update={"reasoning_effort": "hi"})
+    session.set_model(same_pair)
+    await asyncio.sleep(0.01)
+    switches = [
+        m
+        for m in session._context.messages
+        if isinstance(m, CustomMessage) and m.custom_type == SESSION_MODEL_SWITCH_MESSAGE_TYPE
+    ]
+    assert switches == []
+    await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_model_switch_record_deduplicates(tmp_path):
+    """The two edges that can fire for one change (set_model and a route event)
+    must not double-announce the same target."""
+    session = make_session(tmp_path, ScriptedStream([]))
+    await session.journal_model_switch("zai/glm-5.3", "test/m", transient=True)
+    await session.journal_model_switch("zai/glm-5.3", "test/m", transient=True)
+    switches = [
+        m
+        for m in session._context.messages
+        if isinstance(m, CustomMessage) and m.custom_type == SESSION_MODEL_SWITCH_MESSAGE_TYPE
+    ]
+    assert len(switches) == 1
+    # A genuinely different target is not suppressed.
+    await session.journal_model_switch("kimi/k3", "zai/glm-5.3", transient=True)
+    switches = [
+        m
+        for m in session._context.messages
+        if isinstance(m, CustomMessage) and m.custom_type == SESSION_MODEL_SWITCH_MESSAGE_TYPE
+    ]
+    assert len(switches) == 2
+    await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_failover_route_settled_journals_a_transient_switch(tmp_path):
+    """A failover fallback tells the model it is now on a fallback, marked
+    transient so it does not adopt the fallback as its identity."""
+    session = make_session(tmp_path, ScriptedStream([]))
+
+    class _Target:
+        selector = "zai/glm-5.3"
+        effort = None
+
+    await session._on_route_settled(_Target(), "test/m 429 — falling back")
+    switches = [
+        m
+        for m in session._context.messages
+        if isinstance(m, CustomMessage) and m.custom_type == SESSION_MODEL_SWITCH_MESSAGE_TYPE
+    ]
+    assert len(switches) == 1
+    text = switches[-1].details["text"]
+    assert "You are now running as zai/glm-5.3" in text
+    assert "temporary fallback" in text
+    assert switches[-1].details["transient"] is True
     await session.dispose()
 
 

--- a/tests/unit/test_incidents.py
+++ b/tests/unit/test_incidents.py
@@ -6,8 +6,10 @@ import pytest
 
 from local_operator.incidents import (
     SESSION_INCIDENT_MESSAGE_TYPE,
+    SESSION_MODEL_SWITCH_MESSAGE_TYPE,
     classify_incident,
     format_incident_message,
+    format_model_switch_message,
 )
 
 
@@ -53,3 +55,41 @@ def test_unknown_has_no_invented_hint():
 def test_message_type_constant_is_stable():
     # Persisted into transcripts; renaming it would orphan old sessions' replay.
     assert SESSION_INCIDENT_MESSAGE_TYPE == "session_incident"
+
+
+def test_model_switch_deliberate_names_old_and_new_and_persists():
+    text = format_model_switch_message(
+        "anthropic/claude-opus-4-8",
+        "zai/glm-5.3",
+        reason="model switched",
+    )
+    assert text.startswith("[model switch] You are now running as anthropic/claude-opus-4-8")
+    assert "was zai/glm-5.3" in text
+    assert "applies from now on" in text
+    # A deliberate switch is not transient, so it must not carry the fallback caveat.
+    assert "temporary fallback" not in text
+
+
+def test_model_switch_transient_fallback_is_marked_temporary():
+    text = format_model_switch_message(
+        "kimi/k3",
+        "anthropic/claude-opus-4-8",
+        reason="anthropic 429 — falling back",
+        transient=True,
+    )
+    assert "You are now running as kimi/k3" in text
+    assert "temporary fallback" in text
+    assert "Reason: anthropic 429 — falling back" in text
+    assert "applies from now on" not in text
+
+
+def test_model_switch_without_previous_label_reads_cleanly():
+    # The return-to-primary edge passes no previous label.
+    text = format_model_switch_message("anthropic/claude-opus-4-8")
+    assert text.startswith("[model switch] You are now running as anthropic/claude-opus-4-8.")
+    assert "(was" not in text
+
+
+def test_model_switch_message_type_constant_is_stable():
+    # Persisted into transcripts; renaming it would orphan replay of old sessions.
+    assert SESSION_MODEL_SWITCH_MESSAGE_TYPE == "session_model_switch"

--- a/tests/unit/test_prompts_api.py
+++ b/tests/unit/test_prompts_api.py
@@ -214,6 +214,38 @@ def test_the_system_prompt_names_user_run_bang_receipts() -> None:
     assert skills == SKILLS
 
 
+def test_model_label_rides_the_env_block_not_the_stable_head() -> None:
+    # The running-model line must be visible to the model, and it belongs in the
+    # env block (index 2) rather than the byte-stable head, because it can change
+    # mid-session (a /model switch, a failover fallback) and must not invalidate
+    # the cached conversation prefix.
+    blocks = build_system_blocks(TOOLS, SKILLS, ENV, DATE, model_label="anthropic/claude-opus-4-8")
+    instructions, inventory, env_block, _skills = blocks
+    assert "Model: anthropic/claude-opus-4-8" in env_block
+    # Not in the stable head/inventory — those must stay model-agnostic.
+    assert "claude-opus-4-8" not in instructions
+    assert "claude-opus-4-8" not in inventory
+
+
+def test_model_label_absent_by_default_and_when_blank() -> None:
+    # Sessions/hosts that pass no label (or a blank one) must not grow a dangling
+    # "Model:" line — the feature is additive.
+    for label in ("", "   "):
+        blocks = build_system_blocks(TOOLS, SKILLS, ENV, DATE, model_label=label)
+        assert "Model:" not in blocks[2]
+    assert "Model:" not in build_system_blocks(TOOLS, SKILLS, ENV, DATE)[2]
+
+
+def test_model_label_does_not_perturb_the_stable_prefix() -> None:
+    # Two different model labels must leave blocks 0 and 1 byte-identical, so a
+    # switch never busts the prompt-cache prefix.
+    a = build_system_blocks(TOOLS, SKILLS, ENV, DATE, model_label="anthropic/x")
+    b = build_system_blocks(TOOLS, SKILLS, ENV, DATE, model_label="zai/y")
+    assert a[:2] == b[:2]
+    # Arity is still fixed with the label present.
+    assert len(a) == 4
+
+
 def test_no_skills_keeps_fixed_arity_with_placeholder() -> None:
     # The block list is fixed-arity: an empty selection emits the constant
     # placeholder, never drops the block (breakpoint derivation counts


### PR DESCRIPTION
## What & why

The model never knew **which model it was**. Two gaps:

1. **No model identity in context.** The system prompt carried no model name, so a session — or a delegated subagent naming itself in a review byline — could only guess which model it was running as. (This is the concrete thing that made a reviewer subagent write "Claude Opus 4.6" in its `Reviewer:` line when it was almost certainly on 4.8.)
2. **Model switches were invisible to the model.** A deliberate `/model` switch and a failover fallback both reached the UI band and the resume journal, but never the model's own context. So after a switch the model kept reasoning as the previous model: wrong self-identification, wrong assumed context window.

Both fixes apply to **top-level user sessions and subagent sessions** (reviewers, designers, scouts), since both render through `build_system_blocks`.

## Changes

**1. Model visible at session start** — `build_system_blocks` gains an optional `model_label`, rendered in the **env block** (`Model: <provider>/<model_id>`). It rides the byte-stable head rather than the volatile tail because the model does not change within a turn-loop; the Session passes its **live** `model_label` each turn, so a later switch is reflected next turn without rebuilding the closure. The provider argument is **additive**: a legacy zero-arg provider is detected by arity (`_callable_accepts_one_positional`) and still called with no argument, so no host or test is forced to grow a parameter.

**2. Switch announced into context** — a new `session_model_switch` custom message is rendered to the model as a user turn (same path as `session_incident`) and persisted so a resume replays it. Emitted from:
- `set_model` on a genuine `provider/model_id` change — **not** knob-only `/effort` or sampling changes, which take the same-pair early return;
- `_on_route_settled` on a failover fallback (marked **transient**, so the model does not adopt a temporary fallback as its identity) and on the return to primary.

Deduplicated (`_last_model_switch_announced`) so the two edges that can fire for one change do not double-announce.

## Files

- `local_operator/prompts_api.py` — `model_label` param + env-block line
- `local_operator/session_factory.py` — thread the live label through the factory provider; `build_initial_blocks` passes the spec label
- `local_operator/harness/subagent.py` — same for the subagent provider
- `local_operator/incidents.py` — `SESSION_MODEL_SWITCH_MESSAGE_TYPE` + `format_model_switch_message`
- `local_operator/session/session.py` — arity-adaptive `_system_blocks()`, `journal_model_switch`, render in `_default_convert_to_llm`, persist allow-list, emit hooks in `set_model` and `_on_route_settled`

## Testing evidence

Unit (`test_prompts_api.py`, `test_incidents.py`, `tests/unit/session/test_session.py`):
- env-block label present / absent-when-blank / does-not-perturb-the-cache-prefix
- switch formatter: deliberate (names old+new, "applies from now on"), transient fallback ("temporary fallback" + reason), no-previous-label
- arity detection (`_callable_accepts_one_positional`): one-arg certain, zero-arg certain, `*args`, unreadable-signature uncertain
- session paths: live label reaches the request's `system_blocks`; zero-arg provider still works; `set_model` journals exactly one switch and renders into the next request; a knob-only change journals nothing; dedup; failover route-settled journals a transient switch

Gates: `flake8`, `black==26.1.0 --check`, `isort --profile black`, `pyright` all clean on the changed files. Touched-area suites green: **1721 passed** across `tests/unit/{session,harness,model,providers}` + `test_prompts_api` + `test_incidents` + `test_session_factory`; `tests/unit/tui/test_status_line.py` 78 passed.

End-to-end: rendered a real session's initial blocks through `build_initial_blocks` (the factory path) and confirmed the env block carries `Model: anthropic/claude-opus-4-8`.

> Note on the full suite: `tests/unit` as a whole and `tests/unit/tui` timed out under concurrent-agent machine contention (not failures); one analytics multiprocess test (`test_parallel_processes_write_atomically`, untouched by this PR) is flaky under that contention and passes on isolated re-run. Change class: standard.
