### PR TITLE
fix(mobile): unstick phone session state — done turns and newest transcript rows

### DIFF
--- a/local_operator/mobile/owned.py
+++ b/local_operator/mobile/owned.py
@@ -419,12 +419,13 @@ class OwnedSessionHandle(SessionHandle):
         )
 
     def _reconcile_streaming(self) -> None:
-        """Align ``streaming`` with ``is_streaming`` at the two safe moments:
-        initial attach and command boundaries. NEVER from the per-event
-        handler -- the terminal AgentEndEvent fires while ``is_streaming`` is
-        still True (it clears in the turn's ``finally``), so a reconcile there
-        would re-stick the projection to True permanently."""
-        self._fold.set_state(streaming=bool(getattr(self._session, "is_streaming", False)))
+        """Seed/align ``streaming`` from the session flag at attach and command
+        boundaries, delegating the safety rule to ``ProjectionFold`` (which
+        ignores the flag once it has folded a turn-terminal event -- see
+        ``ProjectionFold.reconcile_streaming``). NEVER called from the
+        per-event handler: the fold's lifecycle events own ``streaming``
+        there."""
+        self._fold.reconcile_streaming(bool(getattr(self._session, "is_streaming", False)))
 
     def _refresh_todos(self) -> None:
         try:

--- a/local_operator/mobile/owned.py
+++ b/local_operator/mobile/owned.py
@@ -219,6 +219,10 @@ class OwnedSessionHandle(SessionHandle):
             self._fold.fold_history(self._session.history())
         except Exception:  # noqa: BLE001 — history is a convenience, not a gate
             logger.debug("owned session history fold failed", exc_info=True)
+        # Seed the live flag ONCE at attach (a phone subscribing mid-turn never
+        # saw the AgentStartEvent). After this the fold's own lifecycle events
+        # own ``streaming`` — see ``_reconcile_streaming``.
+        self._reconcile_streaming()
         return unsubscribe
 
     async def prompt(self, text: str, images: list[dict[str, str]] | None = None) -> str:
@@ -380,6 +384,9 @@ class OwnedSessionHandle(SessionHandle):
     async def refresh(self) -> None:
         self._refresh_state()
         self._refresh_todos()
+        # Command boundary: safe to reconcile from the session flag (no
+        # terminal event is mid-flight here, unlike the per-event path).
+        self._reconcile_streaming()
 
     # -- internals ----------------------------------------------------------------
 
@@ -401,8 +408,23 @@ class OwnedSessionHandle(SessionHandle):
             effort=_current_effort(self._session),
             effort_ladder=_ladder(self._session),
             conversation_name=getattr(self._session, "conversation_name", "") or None,
-            streaming=bool(getattr(self._session, "is_streaming", False)),
+            # NOTE: ``streaming`` is deliberately NOT set here. This runs after
+            # every folded event, and the session clears ``is_streaming`` only
+            # in the turn's ``finally`` -- AFTER the AgentEndEvent has been
+            # emitted and folded. Reading the still-True flag on that terminal
+            # event re-stuck the projection to True with no later event to fix
+            # it, pinning the phone to "in progress" forever. The fold's own
+            # lifecycle events are authoritative; ``_reconcile_streaming``
+            # covers attach and command boundaries.
         )
+
+    def _reconcile_streaming(self) -> None:
+        """Align ``streaming`` with ``is_streaming`` at the two safe moments:
+        initial attach and command boundaries. NEVER from the per-event
+        handler -- the terminal AgentEndEvent fires while ``is_streaming`` is
+        still True (it clears in the turn's ``finally``), so a reconcile there
+        would re-stick the projection to True permanently."""
+        self._fold.set_state(streaming=bool(getattr(self._session, "is_streaming", False)))
 
     def _refresh_todos(self) -> None:
         try:

--- a/local_operator/mobile/projection.py
+++ b/local_operator/mobile/projection.py
@@ -243,6 +243,15 @@ class ProjectionFold:
         self._subagent_started_at: dict[str, float] = {}
         # The working line's clock origin and the label's current source.
         self._activity_started_at: float | None = None
+        # Whether the fold has folded a turn-terminal event (agent_end /
+        # turn_end) that no later agent_start has superseded. This is what
+        # makes ``reconcile_streaming`` safe on the abort/error path: there the
+        # session emits AgentEndEvent INLINE while its ``is_streaming`` flag is
+        # still True (the flag clears several awaits later, in the turn's
+        # ``finally``), so a mobile command landing in that window must not be
+        # allowed to raise ``streaming`` back to True over the fold's correct
+        # False. Seeded False so a mid-turn attach can still seed streaming up.
+        self._streaming_ended = False
         # Approval/ask requests waiting on the user, FIFO. Owned sessions can
         # have several at once (a parallel tool batch); the phone renders the
         # front one and a "1 of N" badge. See push_pending/pop_pending.
@@ -330,8 +339,10 @@ class ProjectionFold:
         p = self.projection
         if isinstance(event, AgentStartEvent):
             p.streaming = True
+            self._streaming_ended = False
         elif isinstance(event, AgentEndEvent):
             p.streaming = False
+            self._streaming_ended = True
             p.queued_count = 0
             p.stop_reason = "aborted" if event.aborted else "completed"
             self._close_open_message()
@@ -343,6 +354,7 @@ class ProjectionFold:
                 )
         elif isinstance(event, TurnEndEvent):
             p.streaming = False
+            self._streaming_ended = True
         elif isinstance(event, MessageStartEvent):
             if isinstance(event.message, Message) and event.message.role == "assistant":
                 entry = TranscriptEntry(
@@ -626,6 +638,30 @@ class ProjectionFold:
         self.projection.pending = self._pending_queue[0] if self._pending_queue else None
         self.projection.pending_count = len(self._pending_queue)
         self._bump()
+
+    def reconcile_streaming(self, is_streaming: bool) -> None:
+        """Align ``streaming`` with the session's own ``is_streaming`` flag at
+        the moments the fold cannot derive it from events alone: initial attach
+        (a phone subscribing mid-turn never witnessed the ``agent_start``) and
+        command boundaries (a prompt/abort/new/resume just changed turn state).
+
+        Once the fold has folded a turn-terminal event (``_streaming_ended``),
+        the fold is authoritative and reconcile does nothing: the session's
+        ``is_streaming`` is briefly, lyingly still True on the abort/error path
+        (it emits ``agent_end`` INLINE and clears the flag several awaits later,
+        in the turn's ``finally``), so honouring the flag in that window is the
+        exact bug this guard prevents — a command landing there would re-stick
+        the phone on "in progress" with no later event to correct it. Before any
+        terminal — a fresh attach that missed ``agent_start`` mid-turn, or a
+        turn whose end the fold has not observed — the flag is the only truth
+        there is, so reconcile trusts it in both directions. A later
+        ``agent_start`` clears the latch so the next turn reconciles normally.
+        """
+        if self._streaming_ended:
+            return
+        if self.projection.streaming != bool(is_streaming):
+            self.projection.streaming = bool(is_streaming)
+            self._bump()
 
     def set_state(
         self,

--- a/local_operator/mobile/projection.py
+++ b/local_operator/mobile/projection.py
@@ -712,8 +712,16 @@ class ProjectionFold:
         tail = entries[-PROJECTION_TRANSCRIPT_LIMIT:]
         first_user = next((e for e in entries if e.kind == "user"), None)
         if first_user is not None and first_user not in tail:
-            # One pinned row + LIMIT-1 tail rows keeps the same bounded size.
-            return [first_user, *tail[:-1]]
+            # Pin the opener and make room by dropping the OLDEST tail row
+            # (``tail[1:]``), never the newest (``tail[:-1]``). ``_cap_tail``
+            # runs on EVERY append, so dropping ``tail[-1]`` here discarded the
+            # row just appended — and did so on each subsequent append, which
+            # froze the transcript: past the cap, no new tool call or message
+            # ever reached the phone (the field report's "last several tool
+            # calls I can't see"). Dropping the oldest keeps the bound (one
+            # pinned + LIMIT-1 newest = LIMIT) while the newest row always
+            # survives. Older rows page back in on scroll via the history API.
+            return [first_user, *tail[1:]]
         return tail
 
     def _find(self, entry_id: str | None) -> TranscriptEntry | None:

--- a/local_operator/mobile/projection.py
+++ b/local_operator/mobile/projection.py
@@ -353,8 +353,19 @@ class ProjectionFold:
                     )
                 )
         elif isinstance(event, TurnEndEvent):
-            p.streaming = False
-            self._streaming_ended = True
+            # NOT a streaming terminal. TurnEndEvent fires after EVERY model
+            # turn within a run (harness.loop yields it whenever the assistant
+            # produced tool calls and the run will continue — loop.py ~589), so
+            # a multi-batch turn emits several before the run ends. The session
+            # keeps ``is_streaming`` True across them and clears it only after
+            # AgentEndEvent, and the TUI's working line stays up the same way,
+            # so the phone must too. Flipping streaming False here (and, worse,
+            # latching ``_streaming_ended``) blanked the working line mid-run
+            # and pinned it off. This branch previously set streaming False and
+            # was harmless ONLY because the removed per-event is_streaming
+            # re-read overwrote it every time; with the fold now authoritative
+            # it must leave streaming alone. AgentEndEvent is the sole terminal.
+            pass
         elif isinstance(event, MessageStartEvent):
             if isinstance(event.message, Message) and event.message.role == "assistant":
                 entry = TranscriptEntry(
@@ -559,10 +570,20 @@ class ProjectionFold:
             self._activity_started_at = time.monotonic()
             self._set_activity("thinking")
             return
-        if isinstance(event, (AgentEndEvent, TurnEndEvent)):
+        if isinstance(event, AgentEndEvent):
+            # The one true terminal: the run is over, clear the working line.
             p.activity = ""
             p.activity_started_s = 0.0
             self._activity_started_at = None
+            return
+        if isinstance(event, TurnEndEvent):
+            # A per-model-turn boundary, NOT the end of the run (loop.py ~589
+            # yields it after every assistant turn that made tool calls). The
+            # run is now waiting on the next model call, exactly like the gap
+            # after a tool finishes — show "thinking", restart the clock for the
+            # wait. Clearing it here blanked the working line mid-run; only
+            # AgentEndEvent settles the turn.
+            self._set_activity("thinking", restart_clock=True)
             return
         if not p.streaming:
             return

--- a/local_operator/mobile/tui_handle.py
+++ b/local_operator/mobile/tui_handle.py
@@ -282,22 +282,19 @@ class TuiSessionHandle(SessionHandle):
         )
 
     def _reconcile_streaming(self) -> None:
-        """Align ``streaming`` with the session's ``is_streaming`` flag at the
-        two moments the fold cannot be trusted on its own: initial attach (the
-        AgentStartEvent may predate the subscription) and command boundaries
-        (a prompt/abort/new/resume just changed turn state).
+        """Seed/align ``streaming`` from the session flag at attach and command
+        boundaries, delegating the safety rule to ``ProjectionFold`` (which
+        owns lifecycle authority and ignores the flag once it has folded a
+        turn-terminal event -- see ``ProjectionFold.reconcile_streaming``).
 
-        Crucially this is NOT called from the per-event handler. There the
-        terminal ``AgentEndEvent`` fires while ``is_streaming`` is still True
-        (the flag clears in the turn's ``finally``), so a reconcile there would
-        re-stick the projection to True with no later event to fix it -- the
-        exact bug this method's absence from the hot path prevents.
+        Deliberately NOT called from the per-event handler: the fold's own
+        lifecycle events own ``streaming`` there.
         """
         try:
             session = self._session()
         except RuntimeError:
             return
-        self._fold.set_state(streaming=bool(getattr(session, "is_streaming", False)))
+        self._fold.reconcile_streaming(bool(getattr(session, "is_streaming", False)))
 
     def _refresh_todos(self) -> None:
         try:

--- a/local_operator/mobile/tui_handle.py
+++ b/local_operator/mobile/tui_handle.py
@@ -122,6 +122,12 @@ class TuiSessionHandle(SessionHandle):
             self._fold.fold_history(session.history())
         except Exception:  # noqa: BLE001
             logger.debug("mobile history fold failed", exc_info=True)
+        # Seed the live flag ONCE at attach: a phone that subscribes mid-turn
+        # never witnessed the AgentStartEvent, so the fold alone would start on
+        # a stale ``streaming=False``. After this the fold's own lifecycle
+        # events (start/end/turn-end) are the sole authority — see
+        # ``_reconcile_streaming`` for why per-event reads are poison.
+        self._reconcile_streaming()
         self._unsubscribe = unsubscribe
         return unsubscribe
 
@@ -214,6 +220,11 @@ class TuiSessionHandle(SessionHandle):
         )
         self._refresh_state()
         self._refresh_todos()
+        # A command may have started or stopped a turn (prompt, abort, /new,
+        # /resume). Command boundaries are safe to reconcile from the session
+        # flag: no terminal event is mid-flight here, unlike the per-event
+        # path. See ``_reconcile_streaming``.
+        self._reconcile_streaming()
 
     # -- pending-prompt mirroring ----------------------------------------------------
 
@@ -258,8 +269,35 @@ class TuiSessionHandle(SessionHandle):
             # the phone on "untitled" forever. Cheap attribute read; the fold
             # already bumps the epoch only when something actually changed.
             conversation_name=getattr(session, "conversation_name", "") or None,
-            streaming=bool(getattr(session, "is_streaming", False)),
+            # NOTE: ``streaming`` is deliberately NOT set here. This runs after
+            # EVERY folded event, and the session flips ``is_streaming`` to
+            # False only in the turn's ``finally`` block -- AFTER the
+            # ``AgentEndEvent`` has already been emitted and folded. Reading
+            # the still-True flag on that terminal event overwrote the fold's
+            # correct ``streaming=False`` with True, and because the end event
+            # is the last event of the turn, no later push ever corrected it:
+            # the phone stayed pinned to "in progress" forever. The fold's own
+            # lifecycle events are authoritative for ``streaming``;
+            # ``_reconcile_streaming`` covers attach and command boundaries.
         )
+
+    def _reconcile_streaming(self) -> None:
+        """Align ``streaming`` with the session's ``is_streaming`` flag at the
+        two moments the fold cannot be trusted on its own: initial attach (the
+        AgentStartEvent may predate the subscription) and command boundaries
+        (a prompt/abort/new/resume just changed turn state).
+
+        Crucially this is NOT called from the per-event handler. There the
+        terminal ``AgentEndEvent`` fires while ``is_streaming`` is still True
+        (the flag clears in the turn's ``finally``), so a reconcile there would
+        re-stick the projection to True with no later event to fix it -- the
+        exact bug this method's absence from the hot path prevents.
+        """
+        try:
+            session = self._session()
+        except RuntimeError:
+            return
+        self._fold.set_state(streaming=bool(getattr(session, "is_streaming", False)))
 
     def _refresh_todos(self) -> None:
         try:

--- a/tests/unit/mobile/test_owned.py
+++ b/tests/unit/mobile/test_owned.py
@@ -201,6 +201,40 @@ async def test_agent_end_clears_streaming_despite_stale_is_streaming() -> None:
 
 
 @pytest.mark.asyncio
+async def test_command_boundary_reconcile_cannot_restick_after_abort() -> None:
+    """F1 regression: on the abort/error path the session emits AgentEndEvent
+    INLINE while its ``is_streaming`` flag is still True (it clears several
+    awaits later, in the turn's ``finally``). A mobile command landing in that
+    window runs ``refresh`` → ``_reconcile_streaming`` with the stale True. The
+    fold must ignore it because it has already folded a terminal event, so the
+    projection stays ``streaming=False`` instead of re-sticking to "in
+    progress" with no later event to correct it.
+    """
+    from local_operator.harness.types import AgentEndEvent, AgentStartEvent
+
+    handle, session = make_handle()
+    handle.subscribe(lambda: None)
+
+    session.is_streaming = True
+    session.emit(AgentStartEvent(generation=1))
+    # Aborted turn: end event folded, but the session flag has NOT cleared yet.
+    session.emit(AgentEndEvent(aborted=True, generation=1))
+    assert handle._fold.projection.streaming is False
+
+    # A command lands before the finally clears is_streaming: reconcile sees
+    # the stale True and must NOT raise streaming back up.
+    await handle.refresh()
+    assert handle._fold.projection.streaming is False, (
+        "command-boundary reconcile re-stuck streaming=True from the stale "
+        "is_streaming flag on the abort path"
+    )
+
+    # A genuine next turn still reconciles up normally (latch cleared on start).
+    session.emit(AgentStartEvent(generation=2))
+    assert handle._fold.projection.streaming is True
+
+
+@pytest.mark.asyncio
 async def test_attach_seeds_streaming_from_flag_for_mid_turn_subscriber() -> None:
     """A phone that subscribes mid-turn never saw the AgentStartEvent, so the
     fold alone would open on a stale ``streaming=False``. Attach seeds the live

--- a/tests/unit/mobile/test_owned.py
+++ b/tests/unit/mobile/test_owned.py
@@ -26,6 +26,7 @@ class FakeSession:
         self.model = None
         self.conversation_name = ""
         self.is_streaming = False
+        self._handlers: list = []
         self._named: list[tuple[str, bool]] = []
         self._complete_calls: list[tuple[str, str]] = []
         # The naming call's reply must be wrapped in the <title> tag the
@@ -51,8 +52,20 @@ class FakeSession:
         self._ask_handler = handler
 
     # -- subscribe/selectors the handle reads at construction ------------------
-    def subscribe(self, handler):  # pragma: no cover - not exercised here
-        return lambda: None
+    def subscribe(self, handler):
+        # Capture the handler so a test can drive the fold with real events,
+        # the way the live session's event stream does.
+        self._handlers.append(handler)
+
+        def _unsub() -> None:
+            if handler in self._handlers:
+                self._handlers.remove(handler)
+
+        return _unsub
+
+    def emit(self, event) -> None:
+        for handler in list(getattr(self, "_handlers", [])):
+            handler(event)
 
     def history(self):  # pragma: no cover - not exercised here
         return []
@@ -148,3 +161,51 @@ async def test_naming_worker_stores_a_title_once() -> None:
     for _ in range(5):
         await asyncio.sleep(0)
     assert session._named == [("A Neat Title", False)]
+
+
+@pytest.mark.asyncio
+async def test_agent_end_clears_streaming_despite_stale_is_streaming() -> None:
+    """Regression: the phone stayed pinned to "in progress" after a turn ended.
+
+    The session emits ``AgentEndEvent`` while its ``is_streaming`` flag is
+    STILL True — the flag clears only in the turn's ``finally`` block, after
+    the event has been emitted and folded. The per-event ``_refresh_state``
+    used to re-read that stale True and overwrite the fold's correct
+    ``streaming=False``; because the end event is the turn's last event, no
+    later push ever corrected it and the session list shimmered forever.
+
+    This drives the real handler wiring (subscribe → emit) and asserts the
+    projection settles to ``streaming=False`` even though ``is_streaming`` is
+    left True, exactly as the live session leaves it at the emit point.
+    """
+    from local_operator.harness.types import AgentEndEvent, AgentStartEvent
+
+    handle, session = make_handle()
+    handle.subscribe(lambda: None)
+
+    # Turn starts: the session marks itself streaming and emits the start.
+    session.is_streaming = True
+    session.emit(AgentStartEvent(generation=1))
+    assert handle._fold.projection.streaming is True
+
+    # Turn ends: the session emits AgentEndEvent BEFORE clearing the flag,
+    # reproducing the real ordering (is_streaming still True at emit time).
+    session.emit(AgentEndEvent(aborted=False, generation=1))
+
+    assert handle._fold.projection.streaming is False, (
+        "projection stuck streaming=True after AgentEndEvent — the per-event "
+        "refresh clobbered the fold with the not-yet-cleared is_streaming flag"
+    )
+    assert handle._fold.projection.stop_reason == "completed"
+    assert handle._fold.projection.activity == ""
+
+
+@pytest.mark.asyncio
+async def test_attach_seeds_streaming_from_flag_for_mid_turn_subscriber() -> None:
+    """A phone that subscribes mid-turn never saw the AgentStartEvent, so the
+    fold alone would open on a stale ``streaming=False``. Attach seeds the live
+    flag once from the session so the working line paints immediately."""
+    handle, session = make_handle()
+    session.is_streaming = True
+    handle.subscribe(lambda: None)
+    assert handle._fold.projection.streaming is True

--- a/tests/unit/mobile/test_owned.py
+++ b/tests/unit/mobile/test_owned.py
@@ -11,6 +11,7 @@ tests stay off the real provider and event loop machinery.
 from __future__ import annotations
 
 import asyncio
+from typing import Any
 
 import pytest
 
@@ -26,7 +27,7 @@ class FakeSession:
         self.model = None
         self.conversation_name = ""
         self.is_streaming = False
-        self._handlers: list = []
+        self._handlers: list[Any] = []
         self._named: list[tuple[str, bool]] = []
         self._complete_calls: list[tuple[str, str]] = []
         # The naming call's reply must be wrapped in the <title> tag the

--- a/tests/unit/mobile/test_projection.py
+++ b/tests/unit/mobile/test_projection.py
@@ -22,6 +22,7 @@ from local_operator.harness.types import (
     ToolExecutionEndEvent,
     ToolExecutionStartEvent,
     ToolResult,
+    TurnEndEvent,
 )
 from local_operator.mobile.projection import (
     ProjectionFold,
@@ -151,6 +152,50 @@ def test_transcript_is_capped_from_the_front() -> None:
     # The OLDEST rows dropped: the tail is what a phone renders.
     assert fold.projection.transcript[-1].text == f"note {PROJECTION_TRANSCRIPT_LIMIT + 24}"
     assert fold.projection.transcript[0].text == "note 25"
+
+
+def test_mid_run_turn_end_does_not_settle_streaming() -> None:
+    """Regression: a multi-batch turn must stay "in progress" across the
+    per-model-turn boundaries inside it.
+
+    ``TurnEndEvent`` fires after every assistant turn that made tool calls and
+    the run will continue (harness.loop ~589), so a turn with several tool
+    batches emits several TurnEndEvents before its single AgentEndEvent. The
+    session keeps ``is_streaming`` True across them and the TUI working line
+    stays up; the phone must match. Folding TurnEndEvent as a streaming
+    terminal blanked the working line mid-run and (with the reconcile latch)
+    pinned it off. Only AgentEndEvent settles the turn.
+    """
+    fold = make_fold()
+    fold.fold_event(AgentStartEvent(generation=1))
+
+    # Batch 1: a tool runs, then a mid-run TurnEndEvent (more work to come).
+    fold.fold_event(
+        ToolExecutionStartEvent(tool_call_id="c1", tool_name="bash", args={}, intent="step 1")
+    )
+    fold.fold_event(
+        ToolExecutionEndEvent(
+            tool_call_id="c1",
+            tool_name="bash",
+            result=ToolResult(tool_call_id="c1", text="ok", is_error=False),
+        )
+    )
+    fold.fold_event(TurnEndEvent(message=Message.assistant()))
+
+    # Still streaming; the working line shows the model-wait, not blank.
+    assert fold.projection.streaming is True
+    assert fold.projection.activity == "thinking"
+
+    # Batch 2 continues normally, then the run's single terminal settles it.
+    fold.fold_event(
+        ToolExecutionStartEvent(tool_call_id="c2", tool_name="bash", args={}, intent="step 2")
+    )
+    assert fold.projection.streaming is True
+    assert fold.projection.activity == "step 2"
+    fold.fold_event(AgentEndEvent(generation=1))
+    assert fold.projection.streaming is False
+    assert fold.projection.activity == ""
+    assert fold.projection.stop_reason == "completed"
 
 
 def test_pinned_opener_never_costs_the_newest_row() -> None:

--- a/tests/unit/mobile/test_projection.py
+++ b/tests/unit/mobile/test_projection.py
@@ -177,7 +177,7 @@ def test_mid_run_turn_end_does_not_settle_streaming() -> None:
         ToolExecutionEndEvent(
             tool_call_id="c1",
             tool_name="bash",
-            result=ToolResult(tool_call_id="c1", text="ok", is_error=False),
+            result=ToolResult(tool_call_id="c1", content=[TextContent(text="ok")], is_error=False),
         )
     )
     fold.fold_event(TurnEndEvent(message=Message.assistant()))

--- a/tests/unit/mobile/test_projection.py
+++ b/tests/unit/mobile/test_projection.py
@@ -153,6 +153,38 @@ def test_transcript_is_capped_from_the_front() -> None:
     assert fold.projection.transcript[0].text == "note 25"
 
 
+def test_pinned_opener_never_costs_the_newest_row() -> None:
+    """Regression: once the transcript passed the cap WITH the opening user
+    message pinned at the head, the newest row stopped reaching the phone.
+
+    ``_cap_tail`` pins the first user message and fills the rest from the tail.
+    It used to make room by dropping ``tail[-1]`` — the row JUST appended — and
+    because the cap runs on every append, the transcript froze: past the cap no
+    new tool call or notice ever appeared (the field report's missing "last
+    several tool calls"). The pin must cost the OLDEST tail row, never the
+    newest, and the tail must keep advancing.
+    """
+    fold = make_fold()
+    fold.note_user_message("the opening ask — this names the whole conversation")
+    for i in range(PROJECTION_TRANSCRIPT_LIMIT + 40):
+        fold.fold_event(NoticeEvent(text=f"note {i}"))
+
+    transcript = fold.projection.transcript
+    assert len(transcript) == PROJECTION_TRANSCRIPT_LIMIT
+    # Opener stays pinned at the head so the phone always knows the topic.
+    assert transcript[0].kind == "user"
+    assert transcript[0].text.startswith("the opening ask")
+    # The single newest row is present — the whole point of the fix.
+    assert transcript[-1].text == f"note {PROJECTION_TRANSCRIPT_LIMIT + 39}"
+
+    # The tail keeps advancing on further appends (it used to be frozen).
+    fold.fold_event(NoticeEvent(text="the very latest"))
+    transcript = fold.projection.transcript
+    assert len(transcript) == PROJECTION_TRANSCRIPT_LIMIT
+    assert transcript[0].kind == "user"
+    assert transcript[-1].text == "the very latest"
+
+
 def test_todo_refresh_replaces_wholesale() -> None:
     fold = make_fold()
     fold.set_todos([{"text": "a", "status": "pending"}, {"text": "b", "status": "done"}])


### PR DESCRIPTION
## Summary of Changes

Two independent mobile session-sync bugs the phone surfaces, both fixed here. Reported symptoms: (1) sessions shown as "in progress" on the phone that are done on the backend, and (2) the newest tool-call rows never appearing on the phone once a conversation gets long.

### 1. Sessions stuck "in progress" after a turn ends

The phone's session list renders a session as in-progress from `streaming && !ended`. The session emits `AgentEndEvent` while its `is_streaming` flag is **still True** — the flag clears only in the turn's `finally` block, *after* the event generator drains (`session.py`). Both mobile session handles (the TUI mirror `tui_handle.py` and the daemon-owned `owned.py`) run `_refresh_state()` after **every** folded event, and that method re-read `session.is_streaming` and wrote it onto the projection. On the terminal `AgentEndEvent`, the fold correctly set `streaming=False`, then `_refresh_state()` immediately clobbered it back to `True` from the not-yet-cleared flag. Because `AgentEndEvent` is the turn's last event, **no later push ever corrected it** — the phone stayed pinned to "in progress" forever, and the stale `streaming=True` also let later stray events re-derive a stale working-line `activity` (the derive guard is `if not p.streaming`).

Confirmed against the live daemon: sessions with `stop_reason` ∈ {`completed`,`aborted`} — set **only** inside the `AgentEndEvent` fold branch — yet reporting `streaming=1`.

**Fix:** the fold's own lifecycle events (`agent_start`/`agent_end`/`turn_end`) are the sole authority for `streaming` on the per-event hot path. `_refresh_state` no longer touches `streaming`. A new `_reconcile_streaming` reads `is_streaming` only at the two safe moments — initial attach (a phone subscribing mid-turn never witnessed the start event) and command boundaries (prompt/abort/new/resume, where no terminal event is mid-flight) — and is deliberately kept **out** of the per-event handler.

### 2. Newest transcript rows never reach the phone past the cap

`ProjectionFold._cap_tail` pins the conversation's opening user message at the head once the transcript passes the 80-row cap, filling the rest from the tail. To make room for the pinned opener it returned `[first_user, *tail[:-1]]` — dropping `tail[-1]`, **the row just appended**. Because `_cap_tail` runs on every append, this discarded the newest row on each append and **froze the transcript**: past the cap, no new tool call or message ever reached the phone. This is the reported "last several tool calls I can't see."

**Fix:** drop the **oldest** tail row (`tail[1:]`) instead of the newest, preserving the bound (one pinned opener + LIMIT-1 newest = LIMIT) while the newest row always survives and the tail keeps advancing. Older rows still page back on scroll via the history API (unchanged). The web client's own windowing (`transcript.tsx`, `slice(-windowSize)`) was already correct — the bug was purely server-side.

- Change class: **C1 (standard, pre-authorized)** — two bug-class correctness fixes with a clean rollback (revert the commits).

## Related Issue(s)

- Related: none (reported directly).

## Impact

- No breaking changes, no dependency updates, no wire-format change. `SessionProjection` fields are unchanged; only how `streaming` and the transcript tail are computed changed.
- Behaviour is strictly corrective: idle sessions now report `streaming=False`, and the newest transcript rows are no longer dropped.

## Testing Details

**Reproduced both bugs first, then showed the fixes.**

Bug 1 — regression test drives the real `subscribe`→`emit` wiring through `OwnedSessionHandle` and asserts the projection settles to `streaming=False` on `AgentEndEvent` even while `is_streaming` is left `True`. Proven to fail on pre-fix code by temporarily reintroducing the clobber:

```
# WITH the clobber (pre-fix behaviour):
tests/unit/mobile/test_owned.py::test_agent_end_clears_streaming_despite_stale_is_streaming FAILED
E   AssertionError: projection stuck streaming=True after AgentEndEvent — the per-event refresh clobbered the fold with the not-yet-cleared is_streaming flag
# WITH the fix:
55 passed
```

Bug 2 — reproduced directly against the fold:

```
# PRE-FIX _cap_tail: append opener + 120 tool rows
newest tc-119 present? False   # newest row dropped; transcript frozen
# POST-FIX:
newest tc-119 present? True    opener pinned? True   rows=80
after one more append -> tail advances to tc-120, opener still pinned
```

New/updated tests:
- `test_owned.py::test_agent_end_clears_streaming_despite_stale_is_streaming` — the streaming regression, real handler wiring.
- `test_owned.py::test_attach_seeds_streaming_from_flag_for_mid_turn_subscriber` — a mid-turn subscriber still seeds `streaming=True` at attach.
- `test_projection.py::test_pinned_opener_never_costs_the_newest_row` — overflow the cap with a pinned opener; assert opener pinned, newest row present, tail keeps advancing.

**End-to-end validation** through the real handle+fold path (simulated 90-tool turn ending with `is_streaming` still True, as the live session leaves it at emit time):

```
streaming after end: False (expect False)
stop_reason: completed   activity: ''
rows: 80   newest: tc-c89 (expect tc-c89)   newest tool call visible?: True
```

Gate output (branch head, off `origin/main` `1422d741`):
```
pytest tests/unit/mobile                         → 55 passed
flake8 local_operator/mobile tests/unit/mobile   → clean
black --check (26.1.0)                            → clean
isort --check-only --profile black                → clean
pyright (changed files) --pythonpath .venv        → 0 errors, 0 warnings
```

No UI/visual change (the phone renders the same fields; only their computed values are corrected), so no design round or screenshots apply.

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my changes work as intended.
- [x] All new and existing tests pass.
- [x] I have run formatting (black/isort), linting (flake8), and type checks (pyright), and they pass.
- [x] Security considerations are addressed (no security-relevant surface; loopback-only daemon unchanged).
