### PR TITLE
fix(mobile): surface TUI ask prompts to the phone and let it answer them

### DIFF
--- a/local_operator/mobile/daemon.py
+++ b/local_operator/mobile/daemon.py
@@ -250,6 +250,7 @@ def _projection_from_json(data: dict[str, Any], record: SessionRecord) -> Sessio
     from dataclasses import fields
 
     from local_operator.mobile.types import (
+        AskOptionWire,
         PendingRequest,
         SubagentRow,
         TodoItem,
@@ -286,13 +287,28 @@ def _projection_from_json(data: dict[str, Any], record: SessionRecord) -> Sessio
     ]
     projection.subagents = build(SubagentRow, data.get("subagents", []))
     pending = data.get("pending")
-    projection.pending = (
-        PendingRequest(
-            **{k: v for k, v in pending.items() if k in {f.name for f in fields(PendingRequest)}}
-        )
-        if isinstance(pending, dict)
-        else None
-    )
+    if isinstance(pending, dict):
+        known_pending = {f.name for f in fields(PendingRequest)}
+        pending_kwargs = {k: v for k, v in pending.items() if k in known_pending}
+        # ``options`` crosses the wire as a list of {label, description} dicts;
+        # rebuild the dataclass so downstream code (and to_json round-trips) see
+        # AskOptionWire, not bare dicts. Tolerant of the label-only shape a
+        # rolling upgrade mid-push could still send.
+        raw_options = pending_kwargs.get("options") or []
+        pending_kwargs["options"] = [
+            (
+                AskOptionWire(
+                    label=str(opt.get("label", "")),
+                    description=str(opt.get("description", "")),
+                )
+                if isinstance(opt, dict)
+                else AskOptionWire(label=str(opt))
+            )
+            for opt in raw_options
+        ]
+        projection.pending = PendingRequest(**pending_kwargs)
+    else:
+        projection.pending = None
     return projection
 
 

--- a/local_operator/mobile/owned.py
+++ b/local_operator/mobile/owned.py
@@ -32,7 +32,11 @@ if TYPE_CHECKING:
 from local_operator.mobile.projection import ProjectionFold
 from local_operator.mobile.registrant import SessionHandle
 from local_operator.mobile.registrant import image_blocks as _image_blocks
-from local_operator.mobile.types import PendingRequest, SessionProjection
+from local_operator.mobile.types import (
+    PendingRequest,
+    SessionProjection,
+    ask_pending_request,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -144,53 +148,57 @@ class OwnedSessionHandle(SessionHandle):
                 # Nothing to ask: answer NOTHING (the harness's "user escaped"
                 # signal) rather than parking a card with no question on it.
                 return None
-            request_id = secrets.token_hex(8)
-            future: asyncio.Future[dict[str, list[str]] | None] = self._loop.create_future()
-            self._pending_futures[request_id] = future
-            first = questions[0]
-            # The answer map is keyed by the QUESTION'S id, not our request id
-            # — AskUserFn's contract answers ``question.id -> choices``, and
-            # the harness validates the keys it gets back. Stash the mapping
-            # so ask_answer resolves with the right key.
-            self._pending_question_ids[request_id] = (
-                getattr(first, "id", "") if first is not None else ""
-            )
-            if len(questions) > 1:
+            total = len(questions)
+            if total > 1:
                 logger.info(
-                    "mobile ask gate: %d questions, projecting the first only",
-                    len(questions),
+                    "mobile ask gate: %d questions, projecting question-by-question",
+                    total,
                 )
-            self._fold.push_pending(
-                PendingRequest(
-                    request_id=request_id,
-                    kind="ask",
-                    title=getattr(first, "question", "the agent is asking")
-                    or "the agent is asking",
-                    detail="",
-                    # Option LABELS, not AskOption objects: PendingRequest goes
-                    # over the wire as JSON (to_json -> asdict -> json.dumps),
-                    # and AskOption is a pydantic model that asdict leaves as an
-                    # object json.dumps cannot serialize — an options ask would
-                    # crash the projection push. The label is also exactly what
-                    # the web card renders and hands back in ask_answer, so a
-                    # bare string is the right wire shape (matches the TUI path
-                    # in tui_handle.note_ask_pending and options: list[str]).
-                    options=[
-                        getattr(option, "label", str(option))
-                        for option in (getattr(first, "options", []) or [])
-                    ],
+            # Answer the questions one at a time on the SAME card so a
+            # multi-question ask is answerable end to end from the phone rather
+            # than the first answer resolving the whole set and dropping the
+            # rest (U1). Each question parks its own future; the phone's
+            # ask_answer resolves the FRONT one, and we advance to the next.
+            answers: dict[str, list[str]] = {}
+            for index, question in enumerate(questions):
+                request_id = secrets.token_hex(8)
+                future: asyncio.Future[dict[str, list[str]] | None] = self._loop.create_future()
+                self._pending_futures[request_id] = future
+                # The answer map is keyed by the QUESTION'S id, not our request
+                # id — AskUserFn's contract answers ``question.id -> choices``.
+                self._pending_question_ids[request_id] = getattr(question, "id", "") or ""
+                # Built through the shared seam so this projection carries option
+                # descriptions (U3), the secret flag (D1/U2, never the value),
+                # and the "N of M" position (U1) identically to the TUI path.
+                self._fold.push_pending(
+                    ask_pending_request(
+                        request_id,
+                        question,
+                        question_index=index,
+                        question_total=total,
+                    )
                 )
-            )
-            self._notify()
-            try:
-                return await asyncio.wait_for(future, timeout=PENDING_REQUEST_TIMEOUT_S)
-            except TimeoutError:
-                return None
-            finally:
-                self._pending_futures.pop(request_id, None)
-                self._pending_question_ids.pop(request_id, None)
-                self._fold.pop_pending(request_id)
                 self._notify()
+                try:
+                    answer = await asyncio.wait_for(future, timeout=PENDING_REQUEST_TIMEOUT_S)
+                except TimeoutError:
+                    # A timed-out question ends the whole ask: report whatever
+                    # earlier questions collected (partial, like the terminal's
+                    # Escape) rather than blocking forever on the next one.
+                    return answers or None
+                finally:
+                    self._pending_futures.pop(request_id, None)
+                    self._pending_question_ids.pop(request_id, None)
+                    self._fold.pop_pending(request_id)
+                    self._notify()
+                if not answer:
+                    # The user answered nothing on this question. On the FIRST
+                    # question that is "escaped" — fall back to the model's
+                    # recommendation (None). Past it, keep the partial map, the
+                    # same rule the terminal picker follows on Escape.
+                    return answers or None
+                answers.update(answer)
+            return answers or None
 
         # Kept as attributes as well as registered on the session: the handle
         # is the single owner of the gate behaviour, and holding the reference
@@ -389,7 +397,16 @@ class OwnedSessionHandle(SessionHandle):
         # Resolve with the QUESTION id the harness asked under — never our
         # request id, which the harness never saw.
         question_id = self._pending_question_ids.get(request_id, request_id)
-        self._resolve_pending(request_id, {question_id: [value]} if value else None)
+        future = self._pending_futures.get(request_id)
+        if future is None or future.done():
+            # Human, reconciling copy (U4): a stale tap means this question
+            # already settled elsewhere — say so rather than the developer-
+            # worded "no longer waiting", so the phone user learns their tap
+            # lost a race instead of the card silently vanishing.
+            raise ValueError("that question was already answered")
+        self._loop.call_soon_threadsafe(
+            future.set_result, {question_id: [value]} if value else None
+        )
         return "answered"
 
     async def refresh(self) -> None:

--- a/local_operator/mobile/owned.py
+++ b/local_operator/mobile/owned.py
@@ -393,7 +393,15 @@ class OwnedSessionHandle(SessionHandle):
         self._resolve_pending(request_id, approved)
         return "approved" if approved else "denied"
 
-    async def ask_answer(self, request_id: str, value: str) -> str:
+    async def ask_answer(
+        self, request_id: str, value: str, question_index: int | None = None
+    ) -> str:
+        # ``question_index`` is accepted for protocol parity with the TUI handle
+        # (U8 guard). An owned session assigns a DISTINCT request_id per question
+        # (the gate loops one future per question), so the request_id is already
+        # the per-question identity: a stale tap targets an id whose future is
+        # gone and is rejected below. No separate index check is needed here.
+        del question_index
         # Resolve with the QUESTION id the harness asked under — never our
         # request id, which the harness never saw.
         question_id = self._pending_question_ids.get(request_id, request_id)

--- a/local_operator/mobile/owned.py
+++ b/local_operator/mobile/owned.py
@@ -167,7 +167,18 @@ class OwnedSessionHandle(SessionHandle):
                     title=getattr(first, "question", "the agent is asking")
                     or "the agent is asking",
                     detail="",
-                    options=list(getattr(first, "options", []) or []),
+                    # Option LABELS, not AskOption objects: PendingRequest goes
+                    # over the wire as JSON (to_json -> asdict -> json.dumps),
+                    # and AskOption is a pydantic model that asdict leaves as an
+                    # object json.dumps cannot serialize — an options ask would
+                    # crash the projection push. The label is also exactly what
+                    # the web card renders and hands back in ask_answer, so a
+                    # bare string is the right wire shape (matches the TUI path
+                    # in tui_handle.note_ask_pending and options: list[str]).
+                    options=[
+                        getattr(option, "label", str(option))
+                        for option in (getattr(first, "options", []) or [])
+                    ],
                 )
             )
             self._notify()

--- a/local_operator/mobile/registrant.py
+++ b/local_operator/mobile/registrant.py
@@ -114,7 +114,9 @@ class SessionHandle(Protocol):
     async def new_conversation(self) -> str: ...
     async def resume_session(self, session_id: str) -> str: ...
     async def approval_answer(self, request_id: str, approved: bool, remember: bool) -> str: ...
-    async def ask_answer(self, request_id: str, value: str) -> str: ...
+    async def ask_answer(  # noqa: E301
+        self, request_id: str, value: str, question_index: int | None = None
+    ) -> str: ...
 
     async def refresh(self) -> None:
         """Re-read session state into the projection (post-resume, rename,
@@ -385,7 +387,18 @@ class Registrant:
                 bool(frame.get("remember")),
             )
         if op == "ask_answer":
-            return await h.ask_answer(str(frame.get("request_id", "")), str(frame.get("value", "")))
+            # ``question_index`` is the question the phone was DISPLAYING when
+            # the user tapped (U8 guard): the handle rejects the answer if the
+            # picker has since advanced past it. Optional — an older client that
+            # omits it falls back to answering the current question, the
+            # pre-guard behaviour.
+            raw_index = frame.get("question_index")
+            question_index = int(raw_index) if isinstance(raw_index, (int, float)) else None
+            return await h.ask_answer(
+                str(frame.get("request_id", "")),
+                str(frame.get("value", "")),
+                question_index=question_index,
+            )
         raise ValueError(f"unknown op: {op!r}")
 
     # -- pushes ----------------------------------------------------------------

--- a/local_operator/mobile/tui_handle.py
+++ b/local_operator/mobile/tui_handle.py
@@ -39,7 +39,10 @@ from typing import TYPE_CHECKING, Any, Callable
 
 from local_operator.mobile.projection import ProjectionFold
 from local_operator.mobile.registrant import SessionHandle, image_blocks
-from local_operator.mobile.types import PendingRequest, SessionProjection
+from local_operator.mobile.types import (
+    SessionProjection,
+    ask_pending_request,
+)
 
 if TYPE_CHECKING:
     from local_operator.tui.app import OperatorApp
@@ -72,17 +75,18 @@ class TuiSessionHandle(SessionHandle):
         self._fold = ProjectionFold(self._projection)
         self._on_projection: Callable[[], None] | None = None
         self._unsubscribe: Callable[[], None] | None = None
-        # request_id -> (live AskPickerScreen, AskQuestion.id) for every ask
-        # picker this handle has projected to the phone. Keyed by a token_hex
-        # request id (owned.py's scheme) because the phone answers by request
-        # id and never sees the widget; the question id is stashed alongside so
-        # ``ask_answer`` resolves with the key AskUserFn expects
-        # (question.id -> choices). ``ask`` is ``exclusive`` so this normally
-        # holds at most one entry, but a dict keeps pop-by-id honest either
-        # way. Mutated ONLY on the Textual loop (mount/settle) and read there
+        # request_id -> the live AskPickerScreen for every ask picker this
+        # handle has projected to the phone. Keyed by a token_hex request id
+        # (owned.py's scheme) because the phone answers by request id and never
+        # sees the widget. The current question (and thus the answer key) is
+        # read LIVE off ``card.question`` on each answer, because a
+        # multi-question picker advances between phone answers (U1) — a stashed
+        # id would resolve every answer under Q0's key. ``ask`` is ``exclusive``
+        # so this normally holds at most one entry, but a dict keeps pop-by-id
+        # honest. Mutated ONLY on the Textual loop (mount/settle) and read there
         # too (``ask_answer`` hops onto it before touching this), so the
         # single-winner race is decided by one owner, not by dict atomicity.
-        self._ask_pending: dict[str, tuple[Any, str]] = {}
+        self._ask_pending: dict[str, Any] = {}
 
     def _session(self) -> Any:
         """The app's current session. A property method (not cached) because
@@ -235,42 +239,52 @@ class TuiSessionHandle(SessionHandle):
         raise ValueError("this approval is on the terminal — answer it there")
 
     async def ask_answer(self, request_id: str, value: str) -> str:
-        """Answer a live TUI ask picker from the phone.
+        """Answer the CURRENT question of a live TUI ask picker from the phone.
 
         Called on the registrant/daemon loop, so the whole resolve hops ONTO
         the Textual loop via :meth:`_on_app`: the pending-map read, the
-        single-winner guard, and the picker settle all run there, against the
-        one owner that also mounts and settles the card. That is what makes the
-        race safe without locking — by the time this callback runs, either the
-        picker is still live (settle it) or the terminal already answered
-        (``settled`` is set / the entry is gone) and we report "no longer
-        waiting", matching owned.py's :meth:`_resolve_pending` text.
+        single-winner guard, and the picker advance/settle all run there,
+        against the one owner that also mounts and settles the card. That is
+        what makes the race safe without locking — by the time this callback
+        runs, either the picker is still live (answer it) or the terminal
+        already answered (``settled`` is set / the entry is gone).
 
-        Resolution goes through the picker's OWN ``settle`` — the same path the
-        terminal's Enter drives — never a parallel answer channel: settling
-        resolves the very future ``request_user_choice`` awaits, and the app's
-        finally block then unmounts the card AND calls
-        :meth:`note_ask_settled` to clear the phone. So a phone answer takes
-        the terminal screen down too, and the tool call returns
-        ``{question.id: [value]}`` exactly as a terminal answer would.
+        Multi-question asks advance question-by-question (U1). A phone answer
+        drives the picker's own :meth:`AskPickerScreen.answer_current`, the
+        external-answer twin of the terminal's Enter: it records this question's
+        answer and either advances the SAME picker to the next question — in
+        which case we RE-PROJECT the new current question so the phone shows it
+        — or, on the last question, settles the whole card. Settling resolves
+        the very future ``request_user_choice`` awaits, so the terminal screen
+        also comes down and the tool call returns the full answer map.
+
+        Race message (U4): if the terminal (or a stop/teardown) already settled
+        this card, report that it was "already answered on the terminal" — a
+        human, reconciling message rather than the developer-worded "no longer
+        waiting", so the phone user learns a different answer won rather than
+        seeing the card silently vanish.
         """
 
         def resolve() -> str:
-            entry = self._ask_pending.get(request_id)
-            if entry is None:
-                raise ValueError("that question is no longer waiting")
-            card, question_id = entry
-            # The terminal (or a stop/teardown) may have settled this card in
-            # the window before its unmount cleared our mapping. ``settle`` is
-            # idempotent, but a second call would still report "answered" to
-            # the phone for an answer the terminal actually gave — so refuse on
-            # an already-settled card and let the phone show the real outcome.
+            card = self._ask_pending.get(request_id)
+            if card is None:
+                raise ValueError("that question was already answered on the terminal")
+            # The terminal may have settled this card in the window before its
+            # unmount cleared our mapping. ``settle`` is idempotent, but a
+            # second answer must not report success for a choice the terminal
+            # actually made — refuse and let the phone show the real outcome.
             if getattr(card, "settled", False):
-                raise ValueError("that question is no longer waiting")
-            # An empty value is "the user answered nothing" (owned.py parity):
-            # settle with None so the tool falls back to its own recommendation
-            # rather than recording a chosen-but-empty answer.
-            card.settle({question_id: [value]} if value else None)
+                raise ValueError("that question was already answered on the terminal")
+            # answer_current takes the chosen text for the CURRENT question:
+            # for options that is the tapped label, for free-text/secret the
+            # typed value. An empty value means "nothing chosen" (settles with
+            # None on Q0, keeps partials past it) — parity with owned.py.
+            settled = card.answer_current([value] if value else [])
+            if settled:
+                return "answered"
+            # The picker advanced to the next question; project it so the phone
+            # follows the terminal to Q2..Qn instead of thinking it is done.
+            self._project_ask_question(request_id, card)
             return "answered"
 
         return await self._on_app(resolve)
@@ -298,40 +312,73 @@ class TuiSessionHandle(SessionHandle):
         answerable card.
 
         Called on the Textual loop from ``OperatorApp.request_user_choice``
-        immediately after the picker mounts, so the card still sits on question
-        0 and ``card.question`` IS the first question. Touching ``_fold`` here
-        is safe: fold mutations are synchronous and only ``_notify`` crosses
-        threads (the registrant coalesces the push onto its own loop).
+        immediately after the picker mounts, so the card sits on its first
+        question. Touching ``_fold`` here is safe: fold mutations are
+        synchronous and only ``_notify`` crosses threads (the registrant
+        coalesces the push onto its own loop).
 
-        Mirrors owned.py's ask gate exactly: a ``token_hex`` request id, the
-        FIRST question projected and keyed by its ``question.id`` (AskUserFn's
-        contract answers ``question.id -> choices``), and option LABELS as tap
-        targets. A secret question carries no options, so it projects with an
-        empty list — the phone shows a paste field — and the pasted value is
-        never echoed into the projection or a log line.
+        A ``token_hex`` request id (owned.py's scheme); the card's CURRENT
+        question is what gets projected — with its options + descriptions (U3),
+        the ``secret`` flag (D1/U2, never the value), and the question position
+        for the "N of M" header (U1). A multi-question ask re-projects its next
+        question from :meth:`ask_answer` as the picker advances.
         """
-        questions = getattr(card, "_questions", None) or []
-        if not questions:
+        # Public property, not the private ``_questions`` list (UX minor-2): at
+        # mount ``card.question`` IS the first question, and reading through the
+        # property keeps this bridge off the widget's internals.
+        if getattr(card, "question", None) is None:
             return
-        first = questions[0]
         request_id = secrets.token_hex(8)
-        self._ask_pending[request_id] = (card, getattr(first, "id", "") or "")
-        self._fold.push_pending(
-            PendingRequest(
-                request_id=request_id,
-                kind="ask",
-                title=getattr(first, "question", "the agent is asking") or "the agent is asking",
-                detail="",
-                # Labels, not AskOption objects: the wire is JSON (AskOption is
-                # not serializable) and the phone renders/returns strings. A
-                # secret question has no options -> empty list -> paste field.
-                options=[
-                    getattr(option, "label", "") for option in (getattr(first, "options", []) or [])
-                ],
-            )
-        )
+        self._ask_pending[request_id] = card
+        # Parity with owned.py's gate: log when more than one question rides a
+        # single card, so the operator can see a multi-part ask went to the
+        # phone (UX minor-1).
+        total = self._question_total(card)
+        if total > 1:
+            logger.info("mobile tui ask: %d questions, projecting question-by-question", total)
+        self._push_current_question(request_id, card)
         if self._on_projection is not None:
             self._on_projection()
+
+    def _project_ask_question(self, request_id: str, card: Any) -> None:
+        """Re-project the picker's now-current question after it advanced.
+
+        The push model is snapshot/repaint, so replacing the pending card with
+        the next question is all it takes for the phone to follow the terminal
+        from Q1 to Q2..Qn (U1). Same-id push (``set_pending`` semantics via
+        pop+push) so the card updates in place rather than stacking."""
+        self._fold.pop_pending(request_id)
+        self._push_current_question(request_id, card)
+        if self._on_projection is not None:
+            self._on_projection()
+
+    def _push_current_question(self, request_id: str, card: Any) -> None:
+        """Push the card's CURRENT question onto the fold as the pending ask.
+
+        The one construction seam, shared by the mount and the advance, built
+        through :func:`ask_pending_request` so the TUI and owned projections
+        cannot drift."""
+        self._fold.push_pending(
+            ask_pending_request(
+                request_id,
+                card.question,
+                question_index=self._question_index(card),
+                question_total=self._question_total(card),
+            )
+        )
+
+    @staticmethod
+    def _question_index(card: Any) -> int:
+        return int(getattr(card, "question_index", 0) or 0)
+
+    @staticmethod
+    def _question_total(card: Any) -> int:
+        # ``_questions`` is the only source of the count; the public surface
+        # exposes the current index but not the total. Fall back to 1 so a
+        # duck-typed test stand-in still projects a coherent single-question
+        # header.
+        questions = getattr(card, "_questions", None)
+        return len(questions) if questions else 1
 
     def note_ask_settled(self, card: Any) -> None:
         """Clear the phone card for a TUI ask picker that just came down.
@@ -351,7 +398,7 @@ class TuiSessionHandle(SessionHandle):
             self._on_projection()
 
     def _request_id_for_card(self, card: Any) -> str | None:
-        for request_id, (pending_card, _question_id) in self._ask_pending.items():
+        for request_id, pending_card in self._ask_pending.items():
             if pending_card is card:
                 return request_id
         return None

--- a/local_operator/mobile/tui_handle.py
+++ b/local_operator/mobile/tui_handle.py
@@ -39,10 +39,7 @@ from typing import TYPE_CHECKING, Any, Callable
 
 from local_operator.mobile.projection import ProjectionFold
 from local_operator.mobile.registrant import SessionHandle, image_blocks
-from local_operator.mobile.types import (
-    SessionProjection,
-    ask_pending_request,
-)
+from local_operator.mobile.types import SessionProjection, ask_pending_request
 
 if TYPE_CHECKING:
     from local_operator.tui.app import OperatorApp

--- a/local_operator/mobile/tui_handle.py
+++ b/local_operator/mobile/tui_handle.py
@@ -15,18 +15,26 @@ Two rules shape everything here:
   so the terminal screen reflects everything the phone did — the user walking
   back to their desk sees the turn they started from the phone, mid-stream.
 
-Approval/ask prompts on the phone are v1-simple: when the TUI's own card is
-up, the projection carries it (via :meth:`note_pending`) so the phone shows
-"waiting in terminal"; phone-answering a TUI-mounted card is a later round,
-because racing two front ends over one modal needs a resolution protocol the
-TUI's card does not yet have. Daemon-owned sessions already answer from the
-phone; the terminal-first session degrades to "see it, go to the desk".
+Ask prompts are answerable from the phone. When the TUI mounts an ``ask``
+picker, the app calls :meth:`note_ask_pending`, which projects the first
+question as a ``kind="ask"`` :class:`PendingRequest` (mirroring the daemon's
+:mod:`owned` ask gate); the phone renders the card and can answer it via the
+``ask_answer`` control op. :meth:`ask_answer` resolves the LIVE picker through
+its own ``settle`` path on the Textual loop, so the terminal screen comes down
+too and exactly one answer wins whichever front end got there first. When the
+picker settles by any route, :meth:`note_ask_settled` clears the phone card.
+
+Approvals on a TUI session are NOT answerable from the phone: the TUI boots in
+auto-approve, so it never parks an approval card the phone would need to reach
+(:meth:`approval_answer` stays a terminal-only stub). Answering approvals over
+mobile is a daemon-owned-session capability today (see :mod:`owned`).
 """
 
 from __future__ import annotations
 
 import asyncio
 import logging
+import secrets
 from typing import TYPE_CHECKING, Any, Callable
 
 from local_operator.mobile.projection import ProjectionFold
@@ -64,6 +72,17 @@ class TuiSessionHandle(SessionHandle):
         self._fold = ProjectionFold(self._projection)
         self._on_projection: Callable[[], None] | None = None
         self._unsubscribe: Callable[[], None] | None = None
+        # request_id -> (live AskPickerScreen, AskQuestion.id) for every ask
+        # picker this handle has projected to the phone. Keyed by a token_hex
+        # request id (owned.py's scheme) because the phone answers by request
+        # id and never sees the widget; the question id is stashed alongside so
+        # ``ask_answer`` resolves with the key AskUserFn expects
+        # (question.id -> choices). ``ask`` is ``exclusive`` so this normally
+        # holds at most one entry, but a dict keeps pop-by-id honest either
+        # way. Mutated ONLY on the Textual loop (mount/settle) and read there
+        # too (``ask_answer`` hops onto it before touching this), so the
+        # single-winner race is decided by one owner, not by dict atomicity.
+        self._ask_pending: dict[str, tuple[Any, str]] = {}
 
     def _session(self) -> Any:
         """The app's current session. A property method (not cached) because
@@ -91,6 +110,10 @@ class TuiSessionHandle(SessionHandle):
         self._projection.subagents.clear()
         self._projection.pending = None
         self._fold = ProjectionFold(self._projection)
+        # A /new or /resume mid-ask abandons the old picker; drop its mapping
+        # so a late phone answer for a question that no longer exists reports
+        # "no longer waiting" instead of settling into the new conversation.
+        self._ask_pending.clear()
         if self._on_projection is not None:
             self.subscribe(self._on_projection)
 
@@ -205,10 +228,52 @@ class TuiSessionHandle(SessionHandle):
         return f"resumed {session_id}"
 
     async def approval_answer(self, request_id: str, approved: bool, remember: bool) -> str:
+        # A TUI session boots in auto-approve (OperatorApp._load_approvals_default),
+        # so it never parks an approval card the phone could reach. Answering
+        # approvals over mobile is a daemon-owned-session capability (owned.py);
+        # keep the honest terminal-only stub rather than pretend otherwise.
         raise ValueError("this approval is on the terminal — answer it there")
 
     async def ask_answer(self, request_id: str, value: str) -> str:
-        raise ValueError("this question is on the terminal — answer it there")
+        """Answer a live TUI ask picker from the phone.
+
+        Called on the registrant/daemon loop, so the whole resolve hops ONTO
+        the Textual loop via :meth:`_on_app`: the pending-map read, the
+        single-winner guard, and the picker settle all run there, against the
+        one owner that also mounts and settles the card. That is what makes the
+        race safe without locking — by the time this callback runs, either the
+        picker is still live (settle it) or the terminal already answered
+        (``settled`` is set / the entry is gone) and we report "no longer
+        waiting", matching owned.py's :meth:`_resolve_pending` text.
+
+        Resolution goes through the picker's OWN ``settle`` — the same path the
+        terminal's Enter drives — never a parallel answer channel: settling
+        resolves the very future ``request_user_choice`` awaits, and the app's
+        finally block then unmounts the card AND calls
+        :meth:`note_ask_settled` to clear the phone. So a phone answer takes
+        the terminal screen down too, and the tool call returns
+        ``{question.id: [value]}`` exactly as a terminal answer would.
+        """
+
+        def resolve() -> str:
+            entry = self._ask_pending.get(request_id)
+            if entry is None:
+                raise ValueError("that question is no longer waiting")
+            card, question_id = entry
+            # The terminal (or a stop/teardown) may have settled this card in
+            # the window before its unmount cleared our mapping. ``settle`` is
+            # idempotent, but a second call would still report "answered" to
+            # the phone for an answer the terminal actually gave — so refuse on
+            # an already-settled card and let the phone show the real outcome.
+            if getattr(card, "settled", False):
+                raise ValueError("that question is no longer waiting")
+            # An empty value is "the user answered nothing" (owned.py parity):
+            # settle with None so the tool falls back to its own recommendation
+            # rather than recording a chosen-but-empty answer.
+            card.settle({question_id: [value]} if value else None)
+            return "answered"
+
+        return await self._on_app(resolve)
 
     async def refresh(self) -> None:
         """Re-seed identity fields after /new, /resume, /model, /rename."""
@@ -226,14 +291,70 @@ class TuiSessionHandle(SessionHandle):
         # path. See ``_reconcile_streaming``.
         self._reconcile_streaming()
 
-    # -- pending-prompt mirroring ----------------------------------------------------
+    # -- ask-picker mirroring ----------------------------------------------------
 
-    def note_pending(self, pending: PendingRequest | None) -> None:
-        """The TUI calls this when its own approval/ask card mounts or
-        resolves, so the phone shows the wait (and who must answer it)."""
-        self._fold.set_pending(pending)
+    def note_ask_pending(self, card: Any) -> None:
+        """Project a freshly mounted TUI ask picker to the phone as an
+        answerable card.
+
+        Called on the Textual loop from ``OperatorApp.request_user_choice``
+        immediately after the picker mounts, so the card still sits on question
+        0 and ``card.question`` IS the first question. Touching ``_fold`` here
+        is safe: fold mutations are synchronous and only ``_notify`` crosses
+        threads (the registrant coalesces the push onto its own loop).
+
+        Mirrors owned.py's ask gate exactly: a ``token_hex`` request id, the
+        FIRST question projected and keyed by its ``question.id`` (AskUserFn's
+        contract answers ``question.id -> choices``), and option LABELS as tap
+        targets. A secret question carries no options, so it projects with an
+        empty list — the phone shows a paste field — and the pasted value is
+        never echoed into the projection or a log line.
+        """
+        questions = getattr(card, "_questions", None) or []
+        if not questions:
+            return
+        first = questions[0]
+        request_id = secrets.token_hex(8)
+        self._ask_pending[request_id] = (card, getattr(first, "id", "") or "")
+        self._fold.push_pending(
+            PendingRequest(
+                request_id=request_id,
+                kind="ask",
+                title=getattr(first, "question", "the agent is asking") or "the agent is asking",
+                detail="",
+                # Labels, not AskOption objects: the wire is JSON (AskOption is
+                # not serializable) and the phone renders/returns strings. A
+                # secret question has no options -> empty list -> paste field.
+                options=[
+                    getattr(option, "label", "") for option in (getattr(first, "options", []) or [])
+                ],
+            )
+        )
         if self._on_projection is not None:
             self._on_projection()
+
+    def note_ask_settled(self, card: Any) -> None:
+        """Clear the phone card for a TUI ask picker that just came down.
+
+        Called on the Textual loop from ``request_user_choice``'s finally block,
+        so it covers EVERY settle route — a terminal answer, Escape, a
+        cancelled tool call, and teardown — with one seam. Card-scoped and
+        idempotent: it pops exactly the request this card was projected under,
+        so a settle can never clear a sibling and a second call is a no-op.
+        """
+        request_id = self._request_id_for_card(card)
+        if request_id is None:
+            return
+        self._ask_pending.pop(request_id, None)
+        self._fold.pop_pending(request_id)
+        if self._on_projection is not None:
+            self._on_projection()
+
+    def _request_id_for_card(self, card: Any) -> str | None:
+        for request_id, (pending_card, _question_id) in self._ask_pending.items():
+            if pending_card is card:
+                return request_id
+        return None
 
     # -- internals ---------------------------------------------------------------------
 

--- a/local_operator/mobile/tui_handle.py
+++ b/local_operator/mobile/tui_handle.py
@@ -238,7 +238,9 @@ class TuiSessionHandle(SessionHandle):
         # keep the honest terminal-only stub rather than pretend otherwise.
         raise ValueError("this approval is on the terminal — answer it there")
 
-    async def ask_answer(self, request_id: str, value: str) -> str:
+    async def ask_answer(
+        self, request_id: str, value: str, question_index: int | None = None
+    ) -> str:
         """Answer the CURRENT question of a live TUI ask picker from the phone.
 
         Called on the registrant/daemon loop, so the whole resolve hops ONTO
@@ -258,6 +260,17 @@ class TuiSessionHandle(SessionHandle):
         the very future ``request_user_choice`` awaits, so the terminal screen
         also comes down and the tool call returns the full answer map.
 
+        ``question_index`` is the question the phone was DISPLAYING when the user
+        tapped. It is the U8 guard, mirroring the composer path's
+        ``_HeldAnswerKey.question_index``: a multi-question picker advances (and
+        the phone re-projects) between answers, so a tap already in flight when
+        a terminal advance lands must NOT be recorded against the question that
+        moved into its place. We refuse when it no longer matches the picker's
+        live index rather than misattribute the value; the phone then repaints
+        to the current question from the re-projection. ``None`` (an older
+        client) skips the check and answers the current question, the pre-guard
+        behaviour.
+
         Race message (U4): if the terminal (or a stop/teardown) already settled
         this card, report that it was "already answered on the terminal" — a
         human, reconciling message rather than the developer-worded "no longer
@@ -275,6 +288,15 @@ class TuiSessionHandle(SessionHandle):
             # actually made — refuse and let the phone show the real outcome.
             if getattr(card, "settled", False):
                 raise ValueError("that question was already answered on the terminal")
+            # U8 guard: the phone answered whatever question it was showing, but
+            # the terminal may have advanced the card since. Answering against a
+            # moved-on question would key the value to the WRONG question, so
+            # refuse and let the re-projection repaint the phone to the current
+            # one.
+            if question_index is not None:
+                live_index = int(getattr(card, "question_index", 0) or 0)
+                if live_index != question_index:
+                    raise ValueError("that question moved on — here is the current one")
             # answer_current takes the chosen text for the CURRENT question:
             # for options that is the tapped label, for free-text/secret the
             # typed value. An empty value means "nothing chosen" (settles with
@@ -283,7 +305,10 @@ class TuiSessionHandle(SessionHandle):
             if settled:
                 return "answered"
             # The picker advanced to the next question; project it so the phone
-            # follows the terminal to Q2..Qn instead of thinking it is done.
+            # follows to Q2..Qn instead of thinking it is done. (The picker also
+            # posts QuestionAdvanced, which re-projects too — this is the
+            # immediate, deterministic path; the message is belt-and-suspenders
+            # for terminal-driven advances.)
             self._project_ask_question(request_id, card)
             return "answered"
 
@@ -340,13 +365,30 @@ class TuiSessionHandle(SessionHandle):
         if self._on_projection is not None:
             self._on_projection()
 
+    def note_ask_advanced(self, card: Any) -> None:
+        """Re-project a picker that advanced to its next question, by ANY route.
+
+        Called on the Textual loop from ``OperatorApp`` when the picker posts
+        ``QuestionAdvanced`` — a terminal Enter as well as a phone-routed
+        answer. Re-projecting on the TERMINAL advance is what closes U8: without
+        it the phone kept showing the previous question after the terminal
+        moved on, and a tap there resolved against the question the terminal had
+        advanced to. Card-scoped and idempotent: a card the handle never
+        projected (or one already settled/popped) is a no-op.
+        """
+        request_id = self._request_id_for_card(card)
+        if request_id is None:
+            return
+        self._project_ask_question(request_id, card)
+
     def _project_ask_question(self, request_id: str, card: Any) -> None:
         """Re-project the picker's now-current question after it advanced.
 
         The push model is snapshot/repaint, so replacing the pending card with
-        the next question is all it takes for the phone to follow the terminal
-        from Q1 to Q2..Qn (U1). Same-id push (``set_pending`` semantics via
-        pop+push) so the card updates in place rather than stacking."""
+        the current question is all it takes for the phone to follow from Q1 to
+        Q2..Qn (U1/U8). Same-id push (``set_pending`` semantics via pop+push) so
+        the card updates in place rather than stacking, and a mid-ask reconnect
+        snapshots the CURRENT question because the fold now holds it."""
         self._fold.pop_pending(request_id)
         self._push_current_question(request_id, card)
         if self._on_projection is not None:

--- a/local_operator/mobile/types.py
+++ b/local_operator/mobile/types.py
@@ -227,6 +227,27 @@ class SubagentRow:
 
 
 @dataclass
+class AskOptionWire:
+    """One selectable answer on an ``ask`` question, as it crosses the wire.
+
+    The phone needs the SAME information the terminal picker shows: the label
+    AND the one-line consequence under it (``AskOption.description``), because
+    ``ask`` exists for consequential either/or decisions and dropping the
+    description makes the remote user answer a materially thinner question
+    (UX round 1, U3). A dataclass rather than a bare string so ``asdict``
+    serializes it to ``{"label", "description"}`` — JSON-serializable, unlike
+    the pydantic ``AskOption`` the harness uses (which ``asdict`` would leave
+    as an object ``json.dumps`` cannot encode; that crash is what the label-only
+    projection originally worked around)."""
+
+    label: str
+    description: str = ""
+
+    def to_json(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
 class PendingRequest:
     """An approval gate or ask dialog waiting on the user — the phone's
     highest-priority render (branding.md §7: a question for the user is the
@@ -236,10 +257,63 @@ class PendingRequest:
     kind: Literal["approval", "ask"]
     title: str
     detail: str = ""
-    options: list[str] = field(default_factory=list)  # ask pickers; empty = free text
+    # Ask pickers; empty means a free-text/secret paste field. Objects, not
+    # bare labels, so the phone can render each option's consequence line the
+    # same way the terminal does (U3).
+    options: list[AskOptionWire] = field(default_factory=list)
+    # True when this ask requests a credential (``AskQuestion.secret``): the
+    # phone must render a MASKED paste field with a "not stored in transcript"
+    # affordance rather than a plain text box (D1/U2). The secret VALUE still
+    # never rides the projection — only this flag does.
+    secret: bool = False
+    # Position of the CURRENT question within a multi-question ask, so the phone
+    # can show "Question 1 of 2" the way the terminal header does and the user
+    # knows more questions follow (U1). ``question_total`` is 1 for the common
+    # single-question ask.
+    question_index: int = 0
+    question_total: int = 1
 
     def to_json(self) -> dict[str, Any]:
         return asdict(self)
+
+
+def ask_pending_request(
+    request_id: str,
+    question: Any,
+    *,
+    question_index: int = 0,
+    question_total: int = 1,
+) -> PendingRequest:
+    """Build the phone's ask card from an ``AskQuestion`` (harness type).
+
+    The single seam both projection sites use — the TUI bridge
+    (:mod:`.tui_handle`) and the daemon-owned gate (:mod:`.owned`) — so the two
+    surfaces cannot drift in what they carry to the phone (was UX nit-1: one
+    site used a ``str(option)`` fallback, the other ``""``). Reading through
+    ``getattr`` keeps this decoupled from the pydantic model and lets tests pass
+    a duck-typed stand-in.
+
+    Carries the option consequence lines (U3), the ``secret`` flag so the card
+    can mask the paste field (D1/U2) — never the secret value, which lives only
+    in the picker's future — and the question position for the "N of M" header
+    (U1)."""
+    options = [
+        AskOptionWire(
+            label=str(getattr(option, "label", "")),
+            description=str(getattr(option, "description", "") or ""),
+        )
+        for option in (getattr(question, "options", []) or [])
+    ]
+    return PendingRequest(
+        request_id=request_id,
+        kind="ask",
+        title=str(getattr(question, "question", "") or "the agent is asking"),
+        detail="",
+        options=options,
+        secret=bool(getattr(question, "secret", False)),
+        question_index=question_index,
+        question_total=question_total,
+    )
 
 
 @dataclass

--- a/local_operator/mobile/web/src/components/pending-card.tsx
+++ b/local_operator/mobile/web/src/components/pending-card.tsx
@@ -4,13 +4,38 @@
  * the only thing that needs a decision, and it must be unmissable).
  *
  * Approval: tool name + detail + Approve/Deny (+ remember). Ask: the
- * question plus options as tap targets, or a free-text input when the
- * daemon offered no options.
+ * question plus options as tap targets (each with its consequence line, U3),
+ * or a paste field — masked when the ask is a secret credential (D1/U2) —
+ * when the daemon offered no options. A multi-question ask shows a
+ * "Question N of M" header and re-renders the next question after each answer
+ * (U1); the card keys off `request_id`+`question_index` so React remounts the
+ * input between questions rather than carrying a stale draft forward.
  */
 import { useState } from "react";
 import { sendCommand } from "../api";
 import { cn } from "../lib/cn";
 import type { PendingRequest } from "../types";
+
+/** Turn a raw command error into copy a phone user can act on. The daemon and
+    registrant speak in developer terms (HTTP status strings, "session not
+    connected"); a person staring at a phone needs the human version (U4/U7). */
+function humanizeError(message: string): string {
+	const m = message.toLowerCase();
+	if (m.includes("already answered")) {
+		/* Stale tap: the question settled on another surface first (U4). */
+		return "Already answered — this question was settled on the terminal.";
+	}
+	if (m.includes("no longer waiting")) {
+		return "Already answered — this question is no longer waiting.";
+	}
+	if (m.includes("not connected") || m.includes("409")) {
+		return "The terminal session went away — reopen it to answer.";
+	}
+	if (m.includes("did not answer") || m.includes("504")) {
+		return "The session didn’t respond in time — try again.";
+	}
+	return message;
+}
 
 export function PendingCard({
 	pid,
@@ -37,7 +62,7 @@ export function PendingCard({
 		try {
 			await fn();
 		} catch (e) {
-			setError(String((e as Error).message ?? e));
+			setError(humanizeError(String((e as Error).message ?? e)));
 			setBusy(false);
 		}
 		/* On success the next projection repaint clears `pending`, which
@@ -63,6 +88,10 @@ export function PendingCard({
 			}),
 		);
 
+	/* A multi-question ask advances one question at a time (U1): show which
+	   question this is so the user knows the card is not the whole prompt. */
+	const multiQuestion = pending.question_total > 1;
+
 	return (
 		<div className="border-accent bg-accent-wash mx-2 flex flex-col gap-2 rounded-md border p-2.5">
 			<div className="flex flex-col gap-0.5">
@@ -70,9 +99,16 @@ export function PendingCard({
 					<span>
 						{pending.kind === "approval"
 							? "approval needed"
-							: "question"}
+							: pending.secret
+								? "secret requested"
+								: "question"}
 					</span>
-					{count > 1 ? (
+					{multiQuestion ? (
+						<span className="font-mono text-mono-sm text-ink-dim">
+							Question {pending.question_index + 1} of{" "}
+							{pending.question_total}
+						</span>
+					) : count > 1 ? (
 						<span className="font-mono text-mono-sm text-ink-dim">
 							1 of {count}
 						</span>
@@ -102,52 +138,80 @@ export function PendingCard({
 							type="button"
 							disabled={busy}
 							onClick={() => approve(true)}
-							className="flex min-h-11 flex-1 items-center justify-center rounded-sm bg-accent text-body-sm font-medium text-on-accent active:bg-accent-active"
+							className="flex min-h-11 flex-1 items-center justify-center rounded-sm bg-accent text-body-sm font-medium text-on-accent active:bg-accent-active disabled:opacity-50"
 						>
-							approve
+							{busy ? "…" : "approve"}
 						</button>
 						<button
 							type="button"
 							disabled={busy}
 							onClick={() => approve(false)}
-							className="flex min-h-11 flex-1 items-center justify-center rounded-sm border border-danger-border bg-danger-wash text-body-sm text-danger active:bg-danger-wash"
+							className="flex min-h-11 flex-1 items-center justify-center rounded-sm border border-danger-border bg-danger-wash text-body-sm text-danger active:bg-danger-wash disabled:opacity-50"
 						>
-							deny
+							{busy ? "…" : "deny"}
 						</button>
 					</div>
 				</>
 			) : pending.options.length > 0 ? (
-				<div className="flex flex-col gap-1">
+				<div className="flex flex-col gap-2">
 					{pending.options.map((opt) => (
 						<button
-							key={opt}
+							key={opt.label}
 							type="button"
 							disabled={busy}
-							onClick={() => answerAsk(opt)}
+							onClick={() => answerAsk(opt.label)}
+							/* Accent-tinted left edge + elevated fill so an option
+							   reads as a tap target, not a static label or a text
+							   field (D2). Disabled dims (D3/D4). */
 							className={cn(
-								"flex min-h-11 items-center rounded-sm border border-control bg-surface px-3 text-left text-body-sm text-ink active:bg-elevated",
+								"flex min-h-11 flex-col justify-center rounded-sm border border-l-2 border-control border-l-accent bg-elevated px-3 py-2 text-left active:bg-accent-wash disabled:opacity-50",
 							)}
 						>
-							{opt}
+							<span className="text-body-sm font-medium text-ink">
+								{opt.label}
+							</span>
+							{opt.description ? (
+								<span className="text-body-sm text-ink-muted">
+									{opt.description}
+								</span>
+							) : null}
 						</button>
 					))}
 				</div>
 			) : (
-				<div className="flex gap-2">
-					<input
-						value={freeText}
-						onChange={(e) => setFreeText(e.target.value)}
-						placeholder="your answer"
-						className="min-h-11 min-w-0 flex-1 rounded-sm border border-control bg-surface px-3 text-body text-ink outline-none placeholder:text-ink-dim"
-					/>
-					<button
-						type="button"
-						disabled={busy || !freeText.trim()}
-						onClick={() => answerAsk(freeText.trim())}
-						className="flex min-h-11 items-center justify-center rounded-sm bg-accent px-4 text-body-sm font-medium text-on-accent active:bg-accent-active"
-					>
-						send
-					</button>
+				<div className="flex flex-col gap-1">
+					<div className="flex gap-2">
+						<input
+							/* Remount the field between questions of a multi-part
+							   ask so a typed draft never carries forward (U1). */
+							key={`${pending.request_id}:${pending.question_index}`}
+							value={freeText}
+							onChange={(e) => setFreeText(e.target.value)}
+							/* Secret asks are credentials: mask the value on screen
+							   and suppress the keyboard's learn/suggest so a token is
+							   not shoulder-surfable or captured (D1/U2). */
+							type={pending.secret ? "password" : "text"}
+							autoComplete={pending.secret ? "off" : undefined}
+							autoCapitalize={pending.secret ? "none" : undefined}
+							autoCorrect={pending.secret ? "off" : undefined}
+							spellCheck={pending.secret ? false : undefined}
+							placeholder={pending.secret ? "paste secret" : "your answer"}
+							className="min-h-11 min-w-0 flex-1 rounded-sm border border-control bg-surface px-3 text-body text-ink outline-none placeholder:text-ink-dim"
+						/>
+						<button
+							type="button"
+							disabled={busy || !freeText.trim()}
+							onClick={() => answerAsk(freeText.trim())}
+							className="flex min-h-11 items-center justify-center rounded-sm bg-accent px-4 text-body-sm font-medium text-on-accent active:bg-accent-active disabled:opacity-50"
+						>
+							{busy ? "…" : "send"}
+						</button>
+					</div>
+					{pending.secret ? (
+						<p className="text-meta text-ink-dim">
+							secret — sent directly, not shown in the transcript
+						</p>
+					) : null}
 				</div>
 			)}
 

--- a/local_operator/mobile/web/src/components/pending-card.tsx
+++ b/local_operator/mobile/web/src/components/pending-card.tsx
@@ -21,6 +21,12 @@ import type { PendingRequest } from "../types";
     connected"); a person staring at a phone needs the human version (U4/U7). */
 function humanizeError(message: string): string {
 	const m = message.toLowerCase();
+	if (m.includes("moved on")) {
+		/* The picker advanced (usually a terminal answer to this question)
+		   while the tap was in flight; the card is about to repaint to the
+		   current question (U8/U9) — distinct from "already answered". */
+		return "That question moved on — showing the current one.";
+	}
 	if (m.includes("already answered")) {
 		/* Stale tap: the question settled on another surface first (U4). */
 		return "Already answered — this question was settled on the terminal.";
@@ -85,12 +91,21 @@ export function PendingCard({
 				op: "ask_answer",
 				request_id: pending.request_id,
 				value,
+				/* The question this card is currently showing. The daemon
+				   rejects the answer if the picker advanced past it (U8). */
+				question_index: pending.question_index,
 			}),
 		);
 
 	/* A multi-question ask advances one question at a time (U1): show which
 	   question this is so the user knows the card is not the whole prompt. */
 	const multiQuestion = pending.question_total > 1;
+
+	/* When an answer is rejected as stale/moved-on, the card is either about to
+	   unmount (terminal settled it) or repaint to a new question. Until that
+	   repaint lands, its options must stop reading as tappable — otherwise the
+	   error line sits under buttons that still look live (D7). */
+	const inert = busy || error !== "";
 
 	return (
 		<div className="border-accent bg-accent-wash mx-2 flex flex-col gap-2 rounded-md border p-2.5">
@@ -158,11 +173,13 @@ export function PendingCard({
 						<button
 							key={opt.label}
 							type="button"
-							disabled={busy}
+							disabled={inert}
 							onClick={() => answerAsk(opt.label)}
 							/* Accent-tinted left edge + elevated fill so an option
 							   reads as a tap target, not a static label or a text
-							   field (D2). Disabled dims (D3/D4). */
+							   field (D2). Disabled dims (D3/D4) — including while an
+							   error is shown, so a stale option stops reading as
+							   live under the message (D7). */
 							className={cn(
 								"flex min-h-11 flex-col justify-center rounded-sm border border-l-2 border-control border-l-accent bg-elevated px-3 py-2 text-left active:bg-accent-wash disabled:opacity-50",
 							)}
@@ -200,7 +217,7 @@ export function PendingCard({
 						/>
 						<button
 							type="button"
-							disabled={busy || !freeText.trim()}
+							disabled={inert || !freeText.trim()}
 							onClick={() => answerAsk(freeText.trim())}
 							className="flex min-h-11 items-center justify-center rounded-sm bg-accent px-4 text-body-sm font-medium text-on-accent active:bg-accent-active disabled:opacity-50"
 						>

--- a/local_operator/mobile/web/src/types.ts
+++ b/local_operator/mobile/web/src/types.ts
@@ -236,5 +236,14 @@ export type CommandOp =
 	| { op: "new_conversation" }
 	| { op: "resume_session"; session_id: string }
 	| { op: "approval_answer"; request_id: string; approved: boolean; remember: boolean }
-	| { op: "ask_answer"; request_id: string; value: string }
+	| {
+			op: "ask_answer";
+			request_id: string;
+			value: string;
+			/** The question the card was showing when the user answered. The
+			    daemon rejects the answer if the picker has advanced past it
+			    (U8), so a tap in flight during a terminal advance is never
+			    recorded against the wrong question. */
+			question_index: number;
+	  }
 	| { op: "snapshot" };

--- a/local_operator/mobile/web/src/types.ts
+++ b/local_operator/mobile/web/src/types.ts
@@ -104,13 +104,28 @@ export interface SubagentRow {
 	error_text: string;
 }
 
+/** One selectable answer on an ask question. Carries the consequence line the
+    terminal shows under each option so the phone user decides with the same
+    information (U3). */
+export interface AskOption {
+	label: string;
+	description: string;
+}
+
 export interface PendingRequest {
 	request_id: string;
 	kind: "approval" | "ask";
 	title: string;
 	detail: string;
-	/** Ask pickers; empty means free text. */
-	options: string[];
+	/** Ask pickers; empty means a free-text / secret paste field. */
+	options: AskOption[];
+	/** True when this ask requests a credential: the paste field is masked and
+	    labelled as a secret (D1/U2). The value never rides the projection. */
+	secret: boolean;
+	/** Position of the current question within a multi-question ask, so the card
+	    can show "Question 1 of 2" and the user knows more follow (U1). */
+	question_index: number;
+	question_total: number;
 }
 
 export interface SessionProjection {

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -5220,6 +5220,10 @@ class OperatorApp(App[None]):
         self._ask_screen = card
         self._ask_pending = future
         self._mount_prompt(card)
+        # Project the question to the phone as an ANSWERABLE card. Guarded and
+        # best-effort, exactly like _mobile_adopted/_mobile_teardown: a phone
+        # bridge that is absent or throwing must never break the terminal ask.
+        self._notify_mobile_ask_pending(card)
         # The turn is parked on the user, and the working line and terminal
         # title say so — the same treatment an unanswered approval gets, for the
         # same reason: a spinner over a wait the agent is not responsible for is
@@ -5247,7 +5251,38 @@ class OperatorApp(App[None]):
             # first (above) so the focus guard does not bounce focus back onto
             # the card being removed.
             self._unmount_prompt(card)
+            # Clear the phone card by whatever route we left the ask — a
+            # terminal answer, Escape, a cancelled tool call, or teardown all
+            # pass through this finally. Card-scoped so it cannot clear a card
+            # a later ask already mounted.
+            self._notify_mobile_ask_settled(card)
             self._refresh_working_activity()
+
+    def _notify_mobile_ask_pending(self, card: AskPickerScreen) -> None:
+        """Tell the mobile bridge an ask picker went up, if one is attached.
+
+        Lazy (`_mobile_handle` is None until a phone bridge starts) and
+        swallow-all: a mobile-notify failure is logged and dropped so the
+        terminal ask proceeds regardless — the same contract
+        _mobile_adopted/_mobile_teardown keep.
+        """
+        handle = self._mobile_handle
+        if handle is None:
+            return
+        try:
+            handle.note_ask_pending(card)
+        except Exception:  # noqa: BLE001 - a phone bridge must never break the ask
+            logger.debug("mobile ask-pending notify failed", exc_info=True)
+
+    def _notify_mobile_ask_settled(self, card: AskPickerScreen) -> None:
+        """Tell the mobile bridge an ask picker came down; see the pending twin."""
+        handle = self._mobile_handle
+        if handle is None:
+            return
+        try:
+            handle.note_ask_settled(card)
+        except Exception:  # noqa: BLE001 - a phone bridge must never break the ask
+            logger.debug("mobile ask-settled notify failed", exc_info=True)
 
     def _settle_ask_picker(self) -> None:
         """Take down a live ``ask`` picker, answering with whatever was chosen.

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -5284,6 +5284,21 @@ class OperatorApp(App[None]):
         except Exception:  # noqa: BLE001 - a phone bridge must never break the ask
             logger.debug("mobile ask-settled notify failed", exc_info=True)
 
+    def _notify_mobile_ask_advanced(self, card: AskPickerScreen) -> None:
+        """Tell the mobile bridge an ask picker advanced to a new question.
+
+        Re-projects the current question so the phone follows a terminal-driven
+        advance (U8). Same lazy, swallow-all contract as the pending/settled
+        twins — the terminal ask proceeds regardless of the phone bridge.
+        """
+        handle = self._mobile_handle
+        if handle is None:
+            return
+        try:
+            handle.note_ask_advanced(card)
+        except Exception:  # noqa: BLE001 - a phone bridge must never break the ask
+            logger.debug("mobile ask-advanced notify failed", exc_info=True)
+
     def _settle_ask_picker(self) -> None:
         """Take down a live ``ask`` picker, answering with whatever was chosen.
 
@@ -5350,6 +5365,21 @@ class OperatorApp(App[None]):
         """
         message.stop()
         self._sync_prompt_host()
+
+    def on_ask_picker_screen_question_advanced(
+        self, message: AskPickerScreen.QuestionAdvanced
+    ) -> None:
+        """The ask card moved to a new question; re-project it to the phone.
+
+        Fires for a terminal Enter as well as a phone-routed answer, so the
+        phone always follows the terminal to Q2..Qn instead of being left on
+        the previous question — the cross-surface desync that let a phone tap
+        be recorded against the wrong question (U8). Guarded/best-effort like
+        the mount and settle notifications: a mobile-notify failure must never
+        break the terminal ask.
+        """
+        message.stop()
+        self._notify_mobile_ask_advanced(message.card)
 
     def _sync_prompt_host(self) -> None:
         """Hide the prompt host when what it holds cannot be drawn.

--- a/local_operator/tui/widgets/ask_picker.py
+++ b/local_operator/tui/widgets/ask_picker.py
@@ -319,6 +319,22 @@ class AskPickerScreen(Container):
             super().__init__()
             self.card = card
 
+    class QuestionAdvanced(Message):
+        """The card moved to a NEW question within a multi-question ask.
+
+        Raised whenever ``_index`` advances, by ANY route — the terminal's
+        Enter (:meth:`action_accept`) and the phone's routed answer
+        (:meth:`answer_current`) both post it. The host relays it to the mobile
+        bridge so the phone re-projects the now-current question and follows the
+        terminal to Q2..Qn (UX round 2, U8): without it, a terminal advance left
+        the phone showing the previous question and a phone tap there was
+        recorded against the question the terminal had moved to.
+        """
+
+        def __init__(self, card: "AskPickerScreen") -> None:
+            super().__init__()
+            self.card = card
+
     BINDINGS = [
         Binding("escape", "cancel", "Cancel", show=False),
         Binding("enter", "accept", "Answer", show=False),
@@ -640,6 +656,10 @@ class AskPickerScreen(Container):
         self._offset = 0
         self._hovered = None
         self._repaint()
+        # Tell the host the card moved to a new question so the phone follows
+        # the terminal to it (U8). Posted AFTER _index advances so the handler
+        # projects the now-current question, not the one just answered.
+        self._notify_advanced()
 
     def answer_current(self, values: list[str]) -> bool:
         """Answer the CURRENT question with ``values`` and advance, or settle.
@@ -684,7 +704,26 @@ class AskPickerScreen(Container):
         self._hovered = None
         self._rejected = False
         self._repaint()
+        # Same re-projection seam as the terminal Enter path: the phone that
+        # DIDN'T drive this advance (or reconnects mid-ask) must still be
+        # shown the current question (U8).
+        self._notify_advanced()
         return False
+
+    def _notify_advanced(self) -> None:
+        """Announce that the card advanced to a new question.
+
+        Posted from every ``_index`` advance so the host can re-project the
+        current question to the phone regardless of which surface drove the
+        move (U8). Guarded because a widget detached from the DOM (a card torn
+        down as it settled) has no message pump; the advance still happened for
+        the terminal, and a failed notify must never break it — the same
+        best-effort contract the app's mobile-notify helpers keep.
+        """
+        try:
+            self.post_message(self.QuestionAdvanced(self))
+        except Exception:  # noqa: BLE001 - a detached card cannot post; harmless
+            pass
 
     def _rejection(self) -> str:
         """What the footer says instead of the keys, or ``""`` to keep them.

--- a/local_operator/tui/widgets/ask_picker.py
+++ b/local_operator/tui/widgets/ask_picker.py
@@ -641,6 +641,51 @@ class AskPickerScreen(Container):
         self._hovered = None
         self._repaint()
 
+    def answer_current(self, values: list[str]) -> bool:
+        """Answer the CURRENT question with ``values`` and advance, or settle.
+
+        The external-answer twin of :meth:`action_accept`: a phone answer routed
+        in over the mobile bridge records this question's answer and moves the
+        SAME picker to the next question, only settling after the last one. This
+        is what makes a multi-question ask answerable question-by-question from
+        the phone instead of the whole card resolving on the first answer and
+        silently discarding the rest (UX round 1, U1).
+
+        Returns True when this answer settled the card (it was the last
+        question), False when the picker advanced and is now waiting on the next
+        question — the caller re-projects the new current question on False.
+
+        ``values`` is already the chosen text (labels for options, the typed
+        string for free-text/secret); an empty list means "nothing chosen",
+        which settles with None on the FIRST question (the harness's "user did
+        not answer" signal) rather than recording an empty answer. On a later
+        question an empty answer keeps whatever earlier questions collected, the
+        same partial-report rule Escape follows.
+        """
+        # Guarded like action_accept: never commit an answer for a question the
+        # card could not even draw.
+        if self.settled:
+            return True
+        if not values:
+            # Nothing chosen. On Q0 this is "the user answered nothing" — settle
+            # with None so the tool falls back to its recommendation. Past Q0,
+            # keep the partial map (Escape's rule) rather than throwing away the
+            # answers already given.
+            self.settle(self._answers or None)
+            return True
+        self._answers[self.question.id] = values
+        if self._index + 1 >= len(self._questions):
+            self.settle(self._answers)
+            return True
+        # Advance the live picker so a terminal user watching sees the next
+        # question too, exactly as Enter would move it.
+        self._index += 1
+        self._offset = 0
+        self._hovered = None
+        self._rejected = False
+        self._repaint()
+        return False
+
     def _rejection(self) -> str:
         """What the footer says instead of the keys, or ``""`` to keep them.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.24.2"
+version = "0.24.3"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/mobile/test_daemon.py
+++ b/tests/unit/mobile/test_daemon.py
@@ -69,7 +69,7 @@ class FakeHandle:
     async def approval_answer(self, request_id, approved, remember):  # noqa: ANN001, ANN202
         return await self._record("approval_answer", request_id, approved, remember)
 
-    async def ask_answer(self, request_id, value):  # noqa: ANN001, ANN202
+    async def ask_answer(self, request_id, value, question_index=None):  # noqa: ANN001, ANN202
         return await self._record("ask_answer", request_id, value)
 
     async def refresh(self) -> None:

--- a/tests/unit/mobile/test_owned.py
+++ b/tests/unit/mobile/test_owned.py
@@ -11,10 +11,12 @@ tests stay off the real provider and event loop machinery.
 from __future__ import annotations
 
 import asyncio
+import json
 from typing import Any
 
 import pytest
 
+from local_operator.harness.types import AskOption, AskQuestion
 from local_operator.mobile.owned import OwnedSessionHandle
 
 
@@ -137,6 +139,50 @@ async def test_ask_mode_parks_a_card_then_resolves() -> None:
     assert await second is False
     await asyncio.sleep(0)
     assert handle._fold.projection.pending is None
+
+
+@pytest.mark.asyncio
+async def test_ask_gate_projects_serializable_option_labels() -> None:
+    """An owned ask WITH options must project a JSON-serializable card.
+
+    Regression: the gate used to push ``options=list(first.options)`` \u2014 raw
+    AskOption pydantic models \u2014 into PendingRequest, whose ``to_json`` is
+    ``asdict`` and leaves those models as objects ``json.dumps`` cannot encode.
+    A daemon-owned session that asked a question with options therefore crashed
+    the very projection push meant to show the card on the phone. The gate now
+    projects option LABELS (strings), which is also what the web card renders
+    and hands back in ask_answer. This test fails on the old code (the
+    ``json.dumps`` below raises ``TypeError: Object of type AskOption is not
+    JSON serializable``) and passes now.
+    """
+    handle, _ = make_handle(auto_approve=False)
+    gate = handle._ask_gate
+
+    question = AskQuestion(
+        id="stale",
+        question="What should happen to the stale rows?",
+        options=[
+            AskOption(label="Drop them", description="nothing reads the column"),
+            AskOption(label="Backfill", description="slower, keeps history"),
+        ],
+    )
+    asked = asyncio.ensure_future(gate([question]))
+    await asyncio.sleep(0)  # let the gate enqueue its card
+
+    pending = handle._fold.projection.pending
+    assert pending is not None
+    assert pending.kind == "ask"
+    assert pending.options == ["Drop them", "Backfill"]
+
+    # The whole point: the projection round-trips over the wire. This is the
+    # line that raised before the fix.
+    wire = json.dumps(handle._fold.projection.to_json())
+    assert '"Drop them"' in wire and '"Backfill"' in wire
+
+    # Answer it back with a label, exactly as the phone does, so the parked
+    # gate resolves under the question's id and the test leaves nothing hanging.
+    await handle.ask_answer(pending.request_id, "Backfill")
+    assert await asyncio.wait_for(asked, 1) == {"stale": ["Backfill"]}
 
 
 @pytest.mark.asyncio

--- a/tests/unit/mobile/test_owned.py
+++ b/tests/unit/mobile/test_owned.py
@@ -142,18 +142,16 @@ async def test_ask_mode_parks_a_card_then_resolves() -> None:
 
 
 @pytest.mark.asyncio
-async def test_ask_gate_projects_serializable_option_labels() -> None:
-    """An owned ask WITH options must project a JSON-serializable card.
+async def test_ask_gate_projects_serializable_options_with_descriptions() -> None:
+    """An owned ask WITH options must project a JSON-serializable card that
+    carries each option's consequence line (U3).
 
-    Regression: the gate used to push ``options=list(first.options)`` \u2014 raw
-    AskOption pydantic models \u2014 into PendingRequest, whose ``to_json`` is
-    ``asdict`` and leaves those models as objects ``json.dumps`` cannot encode.
-    A daemon-owned session that asked a question with options therefore crashed
-    the very projection push meant to show the card on the phone. The gate now
-    projects option LABELS (strings), which is also what the web card renders
-    and hands back in ask_answer. This test fails on the old code (the
-    ``json.dumps`` below raises ``TypeError: Object of type AskOption is not
-    JSON serializable``) and passes now.
+    Regression origin: the gate once pushed raw AskOption pydantic models into
+    PendingRequest, whose ``to_json`` is ``asdict`` and leaves those models as
+    objects ``json.dumps`` cannot encode — crashing the projection push. The
+    wire now carries {label, description} dicts (still JSON-serializable), and
+    the phone renders both. The ``json.dumps`` below is what raised on the old
+    object-valued shape.
     """
     handle, _ = make_handle(auto_approve=False)
     gate = handle._ask_gate
@@ -172,17 +170,91 @@ async def test_ask_gate_projects_serializable_option_labels() -> None:
     pending = handle._fold.projection.pending
     assert pending is not None
     assert pending.kind == "ask"
-    assert pending.options == ["Drop them", "Backfill"]
+    assert [o.label for o in pending.options] == ["Drop them", "Backfill"]
+    assert [o.description for o in pending.options] == [
+        "nothing reads the column",
+        "slower, keeps history",
+    ]
+    assert pending.secret is False
+    assert (pending.question_index, pending.question_total) == (0, 1)
 
     # The whole point: the projection round-trips over the wire. This is the
-    # line that raised before the fix.
+    # line that raised on the old object-valued shape.
     wire = json.dumps(handle._fold.projection.to_json())
-    assert '"Drop them"' in wire and '"Backfill"' in wire
+    assert '"Drop them"' in wire and '"nothing reads the column"' in wire
 
     # Answer it back with a label, exactly as the phone does, so the parked
     # gate resolves under the question's id and the test leaves nothing hanging.
     await handle.ask_answer(pending.request_id, "Backfill")
     assert await asyncio.wait_for(asked, 1) == {"stale": ["Backfill"]}
+
+
+@pytest.mark.asyncio
+async def test_ask_gate_projects_secret_flag_without_the_value() -> None:
+    """D1/U2: a secret ask projects secret=True and no options (paste field),
+    and the pasted value never rides the projection or the wire."""
+    handle, _ = make_handle(auto_approve=False)
+    gate = handle._ask_gate
+
+    question = AskQuestion(id="OPENAI_API_KEY", question="Paste your key", secret=True)
+    asked = asyncio.ensure_future(gate([question]))
+    await asyncio.sleep(0)
+
+    pending = handle._fold.projection.pending
+    assert pending is not None
+    assert pending.secret is True
+    assert pending.options == []
+
+    await handle.ask_answer(pending.request_id, "sk-topsecret")
+    # The value never appeared on the wire while the card was live or after.
+    assert "sk-topsecret" not in json.dumps(handle._fold.projection.to_json())
+    assert await asyncio.wait_for(asked, 1) == {"OPENAI_API_KEY": ["sk-topsecret"]}
+
+
+@pytest.mark.asyncio
+async def test_ask_gate_asks_multiple_questions_one_at_a_time() -> None:
+    """U1: an owned multi-question ask projects and resolves question by
+    question — answering Q1 advances to Q2 rather than settling the whole set,
+    and the gate returns BOTH answers only after the last is answered."""
+    handle, _ = make_handle(auto_approve=False)
+    gate = handle._ask_gate
+
+    q1 = AskQuestion(
+        id="env",
+        question="Which environment?",
+        options=[AskOption(label="prod"), AskOption(label="staging")],
+    )
+    q2 = AskQuestion(
+        id="confirm",
+        question="Confirm?",
+        options=[AskOption(label="yes"), AskOption(label="no")],
+    )
+    asked = asyncio.ensure_future(gate([q1, q2]))
+    await asyncio.sleep(0)
+
+    first = handle._fold.projection.pending
+    assert first is not None
+    assert first.title == "Which environment?"
+    assert (first.question_index, first.question_total) == (0, 2)
+
+    await handle.ask_answer(first.request_id, "prod")
+    # The answer resolves via call_soon_threadsafe; let the gate resume, pop Q1,
+    # and push Q2 across a few loop turns before inspecting the new front card.
+    for _ in range(5):
+        await asyncio.sleep(0)
+    assert not asked.done(), "the gate resolved after only Q1 (U1 truncation)"
+
+    second = handle._fold.projection.pending
+    assert second is not None
+    assert second.title == "Confirm?"
+    assert (second.question_index, second.question_total) == (1, 2)
+    # A distinct request id per question: Q1's stale request must no longer
+    # resolve anything.
+    assert second.request_id != first.request_id
+
+    await handle.ask_answer(second.request_id, "yes")
+    assert await asyncio.wait_for(asked, 1) == {"env": ["prod"], "confirm": ["yes"]}
+    assert handle._fold.projection.pending is None
 
 
 @pytest.mark.asyncio

--- a/tests/unit/mobile/test_tui_ask.py
+++ b/tests/unit/mobile/test_tui_ask.py
@@ -1,0 +1,294 @@
+"""A TUI ``ask`` picker is answerable from the phone.
+
+The TUI-side bridge used to project no ask card and refuse every remote answer
+(``TuiSessionHandle.ask_answer`` was a stub). These tests pin the fixed
+contract against a REAL ``OperatorApp`` running under Textual ``run_test`` with
+its live mobile handle attached:
+
+- mounting an ``ask`` picker projects a ``kind="ask"`` PendingRequest carrying
+  the first question's prompt + option labels (:meth:`note_ask_pending`);
+- a phone ``ask_answer`` resolves the LIVE picker's future through its own
+  settle path, takes the terminal card down, and returns ``{question.id:
+  [value]}`` to the parked tool call;
+- exactly one answer wins each race: phone-first takes the terminal card down,
+  terminal-first makes a late phone answer report "no longer waiting" \u2014 never
+  a double-resolve;
+- when the picker settles by any route the phone card clears
+  (:meth:`note_ask_settled`).
+
+``ask_answer`` is contracted to run on the REGISTRANT's own loop/thread and hop
+onto Textual via ``call_from_thread`` \u2014 which refuses a same-thread call \u2014 so
+the answer is driven through the real loopback control socket exactly as the
+daemon does (the shape ``test_tui_bridge`` uses), not by calling the handle on
+the app's own thread. That also makes these tests true end-to-end evidence:
+projection SSE-equivalent snapshot in, ``ask_answer`` control op out.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from local_operator.harness.types import AskOption, AskQuestion
+from local_operator.mobile.tui_handle import TuiSessionHandle
+from local_operator.tui.app import OperatorApp
+from tests.unit.tui.test_app_pilot import FakeSession, _factory
+
+
+def _question(secret: bool = False) -> AskQuestion:
+    if secret:
+        return AskQuestion(
+            id="OPENAI_API_KEY",
+            question="Paste your OpenAI API key",
+            secret=True,
+        )
+    return AskQuestion(
+        id="stale",
+        question="What should happen to the stale rows?",
+        options=[
+            AskOption(label="Drop them", description="nothing reads the column"),
+            AskOption(label="Backfill", description="slower, keeps history"),
+        ],
+    )
+
+
+async def _wait_for_handle(app: OperatorApp, pilot) -> TuiSessionHandle:
+    """The mobile bridge starts a few pilot ticks after adoption; wait for it."""
+    for _ in range(50):
+        handle = app._mobile_handle
+        if isinstance(handle, TuiSessionHandle):
+            return handle
+        await pilot.pause(0.05)
+    raise AssertionError("mobile handle never attached")
+
+
+async def _mount_ask(
+    app: OperatorApp, pilot, question: AskQuestion
+) -> "asyncio.Task[dict[str, list[str]] | None]":
+    asked = asyncio.create_task(app.request_user_choice([question]))
+    for _ in range(4):
+        await pilot.pause()
+    assert app._ask_screen is not None, "ask picker never mounted"
+    return asked
+
+
+def _pending_request_id(handle: TuiSessionHandle) -> str:
+    pending = handle._fold.projection.pending
+    assert pending is not None, "no pending ask projected"
+    return pending.request_id
+
+
+class _Control:
+    """An authenticated control connection to the TUI's registrant socket \u2014 a
+    stand-in for the daemon, on its OWN thread's loop the way the real client
+    runs (so ``ask_answer`` hops back onto Textual as designed)."""
+
+    def __init__(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        self._reader = reader
+        self._writer = writer
+        self._req = 0
+
+    @classmethod
+    async def connect(cls, control_port: int, control_key: str) -> "_Control":
+        reader, writer = await asyncio.open_connection("127.0.0.1", control_port)
+        writer.write(json.dumps({"key": control_key}).encode() + b"\n")
+        await writer.drain()
+        return cls(reader, writer)
+
+    async def read_frame(self, timeout: float = 5.0) -> dict[str, object]:
+        line = await asyncio.wait_for(self._reader.readline(), timeout=timeout)
+        return json.loads(line)
+
+    async def latest_projection(self, timeout: float = 5.0) -> dict[str, object]:
+        """Drain to the most recent projection frame available right now."""
+        data: dict[str, object] | None = None
+        while True:
+            try:
+                frame = await asyncio.wait_for(self._reader.readline(), timeout=timeout)
+            except asyncio.TimeoutError:
+                break
+            parsed = json.loads(frame)
+            if parsed.get("op") == "projection":
+                data = parsed["data"]
+                timeout = 0.3  # keep draining any already-queued repaints, briefly
+        assert data is not None, "no projection frame arrived"
+        return data
+
+    async def send(self, op: str, **fields) -> dict[str, object]:
+        self._req += 1
+        req = self._req
+        self._writer.write(json.dumps({"op": op, "req": req, **fields}).encode() + b"\n")
+        await self._writer.drain()
+        # The registrant answers with ack|error for our req, interleaved with
+        # projection pushes; skip the pushes and return the reply for this req.
+        for _ in range(20):
+            frame = await self.read_frame()
+            if frame.get("req") == req and frame.get("op") in ("ack", "error"):
+                return frame
+        raise AssertionError(f"no ack/error for {op}")
+
+    def close(self) -> None:
+        self._writer.close()
+
+
+async def _control_for(app: OperatorApp, pilot) -> _Control:
+    for _ in range(50):
+        if app._mobile_registrant is not None:
+            break
+        await pilot.pause(0.05)
+    assert app._mobile_registrant is not None, "mobile registrant never started"
+    from local_operator.mobile import registry
+
+    records = registry.scan()
+    assert records, "no discovery record published"
+    record, _state = records[0]
+    return await _Control.connect(record.control_port, record.control_key)
+
+
+@pytest.mark.asyncio
+async def test_tui_ask_projects_a_pending_ask_to_the_phone() -> None:
+    """Mounting the picker pushes a kind=ask card carrying the question and its
+    option labels \u2014 the projection JSON the phone renders from."""
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(90, 30)) as pilot:
+        await pilot.pause()
+        handle = await _wait_for_handle(app, pilot)
+        asked = await _mount_ask(app, pilot, _question())
+
+        projection = handle._fold.projection
+        pending = projection.pending
+        assert pending is not None
+        assert pending.kind == "ask"
+        assert pending.title == "What should happen to the stale rows?"
+        assert pending.options == ["Drop them", "Backfill"]
+        # The wire is JSON; option labels are strings, not AskOption objects.
+        assert pending.to_json()["options"] == ["Drop them", "Backfill"]
+
+        # Clean up the parked call.
+        app._settle_ask_picker()
+        for _ in range(4):
+            await pilot.pause()
+        await asyncio.wait_for(asked, 2)
+
+
+@pytest.mark.asyncio
+async def test_phone_answer_resolves_the_picker_and_clears_pending() -> None:
+    """A phone ask_answer (over the real control socket) settles the LIVE
+    picker: the tool call returns the chosen value keyed by question.id, the
+    terminal card comes down, and the projection clears its pending card."""
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(90, 30)) as pilot:
+        await pilot.pause()
+        handle = await _wait_for_handle(app, pilot)
+        control = await _control_for(app, pilot)
+        try:
+            asked = await _mount_ask(app, pilot, _question())
+            picker = app._ask_screen
+            request_id = _pending_request_id(handle)
+
+            reply = await control.send("ask_answer", request_id=request_id, value="Backfill")
+            assert reply["op"] == "ack" and reply["detail"] == "answered"
+            for _ in range(4):
+                await pilot.pause()
+
+            answer = await asyncio.wait_for(asked, 2)
+            assert answer == {"stale": ["Backfill"]}
+            assert picker is not None and not picker.is_attached
+            assert handle._fold.projection.pending is None
+        finally:
+            control.close()
+
+
+@pytest.mark.asyncio
+async def test_terminal_answer_first_makes_a_late_phone_answer_fail() -> None:
+    """Terminal wins the race: once the picker settles from the terminal, a late
+    phone answer reports "no longer waiting" rather than double-resolving."""
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(90, 30)) as pilot:
+        await pilot.pause()
+        handle = await _wait_for_handle(app, pilot)
+        control = await _control_for(app, pilot)
+        try:
+            asked = await _mount_ask(app, pilot, _question())
+            request_id = _pending_request_id(handle)
+
+            # The terminal answers: settle the picker exactly as the app's Enter
+            # path does, on the Textual thread.
+            picker = app._ask_screen
+            assert picker is not None
+            picker.settle({"stale": ["Drop them"]})
+            for _ in range(4):
+                await pilot.pause()
+            answer = await asyncio.wait_for(asked, 2)
+            assert answer == {"stale": ["Drop them"]}
+            assert handle._fold.projection.pending is None
+
+            # A phone answer arriving now must not double-resolve: the socket
+            # returns an error frame carrying the "no longer waiting" message.
+            reply = await control.send("ask_answer", request_id=request_id, value="Backfill")
+            assert reply["op"] == "error"
+            assert "no longer waiting" in str(reply["message"])
+        finally:
+            control.close()
+
+
+@pytest.mark.asyncio
+async def test_phone_answer_first_takes_the_terminal_card_down() -> None:
+    """Phone wins the race: the terminal picker comes down because the phone
+    answer resolves the very future the terminal awaits, and a second phone
+    answer for the same request then fails."""
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(90, 30)) as pilot:
+        await pilot.pause()
+        handle = await _wait_for_handle(app, pilot)
+        control = await _control_for(app, pilot)
+        try:
+            asked = await _mount_ask(app, pilot, _question())
+            picker = app._ask_screen
+            request_id = _pending_request_id(handle)
+
+            reply = await control.send("ask_answer", request_id=request_id, value="Drop them")
+            assert reply["op"] == "ack"
+            for _ in range(4):
+                await pilot.pause()
+            answer = await asyncio.wait_for(asked, 2)
+            assert answer == {"stale": ["Drop them"]}
+            assert picker is not None and not picker.is_attached
+
+            reply = await control.send("ask_answer", request_id=request_id, value="Backfill")
+            assert reply["op"] == "error" and "no longer waiting" in str(reply["message"])
+        finally:
+            control.close()
+
+
+@pytest.mark.asyncio
+async def test_secret_ask_projects_a_free_text_card_without_leaking_the_value() -> None:
+    """A secret question has no options, so it projects with an empty option
+    list (the phone shows a paste field); the pasted value resolves the picker
+    and never appears in the projection."""
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(90, 30)) as pilot:
+        await pilot.pause()
+        handle = await _wait_for_handle(app, pilot)
+        control = await _control_for(app, pilot)
+        try:
+            asked = await _mount_ask(app, pilot, _question(secret=True))
+
+            pending = handle._fold.projection.pending
+            assert pending is not None
+            assert pending.kind == "ask"
+            assert pending.options == []
+            request_id = pending.request_id
+
+            reply = await control.send("ask_answer", request_id=request_id, value="sk-supersecret")
+            assert reply["op"] == "ack"
+            for _ in range(4):
+                await pilot.pause()
+            answer = await asyncio.wait_for(asked, 2)
+            assert answer == {"OPENAI_API_KEY": ["sk-supersecret"]}
+            # The secret never rode the projection.
+            assert handle._fold.projection.pending is None
+        finally:
+            control.close()

--- a/tests/unit/mobile/test_tui_ask.py
+++ b/tests/unit/mobile/test_tui_ask.py
@@ -377,3 +377,87 @@ async def test_multi_question_ask_advances_instead_of_truncating() -> None:
             assert handle._fold.projection.pending is None
         finally:
             control.close()
+
+
+@pytest.mark.asyncio
+async def test_terminal_advance_reprojects_and_stale_phone_tap_is_safe() -> None:
+    """U8: when the TERMINAL advances a multi-question ask, the phone must be
+    re-projected to the new question, and a phone tap carrying the OLD question
+    index must never be recorded against the question the terminal moved to.
+
+    Reproduces the corruption on the pre-fix code (a phone answer against the
+    stale question was silently keyed to the advanced question) and proves it is
+    now closed by BOTH halves: re-projection on terminal advance, and the
+    question-index guard on ask_answer.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(90, 30)) as pilot:
+        await pilot.pause()
+        handle = await _wait_for_handle(app, pilot)
+        control = await _control_for(app, pilot)
+        try:
+            q1 = AskQuestion(
+                id="env",
+                question="Which environment?",
+                options=[
+                    AskOption(label="prod", description="the live one"),
+                    AskOption(label="staging", description="safe to break"),
+                ],
+            )
+            q2 = AskQuestion(
+                id="confirm",
+                question="Confirm the deploy?",
+                options=[AskOption(label="yes"), AskOption(label="no")],
+            )
+            asked = asyncio.create_task(app.request_user_choice([q1, q2]))
+            for _ in range(4):
+                await pilot.pause()
+
+            pending = handle._fold.projection.pending
+            assert pending is not None
+            assert pending.title == "Which environment?"
+            assert pending.question_index == 0
+            request_id = pending.request_id
+
+            # The TERMINAL answers Q1 by pressing Enter on the selected option
+            # (prod is index 0 and preselected). This advances the picker to Q2.
+            picker = app._ask_screen
+            assert picker is not None
+            await pilot.press("enter")
+            for _ in range(6):
+                await pilot.pause()
+            assert picker.question_index == 1, "terminal Enter did not advance the picker"
+
+            # Part 1 (re-project on terminal advance): the phone now shows Q2,
+            # not the stale Q1 — the desync U8 described is gone.
+            pending = handle._fold.projection.pending
+            assert pending is not None
+            assert pending.title == "Confirm the deploy?"
+            assert pending.question_index == 1
+            assert pending.request_id == request_id
+
+            # Part 2 (index guard): a phone tap that still carries the OLD index
+            # (0) — a tap in flight before the re-projection landed — must be
+            # REJECTED, never recorded against Q2. This is the exact corruption
+            # from the U8 repro: tapping 'staging' (a Q1 option) must not become
+            # the answer to 'Confirm the deploy?'.
+            reply = await control.send(
+                "ask_answer", request_id=request_id, value="staging", question_index=0
+            )
+            assert reply["op"] == "error"
+            assert "moved on" in str(reply["message"])
+            assert not asked.done(), "a stale-index tap must not settle the card"
+
+            # A correctly-indexed phone answer to the CURRENT question lands.
+            reply = await control.send(
+                "ask_answer", request_id=request_id, value="yes", question_index=1
+            )
+            assert reply["op"] == "ack"
+            for _ in range(4):
+                await pilot.pause()
+            answer = await asyncio.wait_for(asked, 2)
+            # Each value keyed to the RIGHT question: prod->env (terminal),
+            # yes->confirm (phone). 'staging' never entered the map.
+            assert answer == {"env": ["prod"], "confirm": ["yes"]}
+        finally:
+            control.close()

--- a/tests/unit/mobile/test_tui_ask.py
+++ b/tests/unit/mobile/test_tui_ask.py
@@ -162,9 +162,23 @@ async def test_tui_ask_projects_a_pending_ask_to_the_phone() -> None:
         assert pending is not None
         assert pending.kind == "ask"
         assert pending.title == "What should happen to the stale rows?"
-        assert pending.options == ["Drop them", "Backfill"]
-        # The wire is JSON; option labels are strings, not AskOption objects.
-        assert pending.to_json()["options"] == ["Drop them", "Backfill"]
+        assert [o.label for o in pending.options] == ["Drop them", "Backfill"]
+        # U3: option consequence lines ride the wire so the phone user decides
+        # with the same information the terminal shows.
+        assert [o.description for o in pending.options] == [
+            "nothing reads the column",
+            "slower, keeps history",
+        ]
+        assert pending.secret is False
+        assert (pending.question_index, pending.question_total) == (0, 1)
+        # The whole card must be JSON-serializable (asdict -> dict).
+        wire = pending.to_json()
+        assert wire["options"] == [
+            {"label": "Drop them", "description": "nothing reads the column"},
+            {"label": "Backfill", "description": "slower, keeps history"},
+        ]
+        assert wire["secret"] is False
+        json.dumps(projection.to_json())
 
         # Clean up the parked call.
         app._settle_ask_picker()
@@ -226,10 +240,10 @@ async def test_terminal_answer_first_makes_a_late_phone_answer_fail() -> None:
             assert handle._fold.projection.pending is None
 
             # A phone answer arriving now must not double-resolve: the socket
-            # returns an error frame carrying the "no longer waiting" message.
+            # returns an error frame with the human "already answered" message (U4).
             reply = await control.send("ask_answer", request_id=request_id, value="Backfill")
             assert reply["op"] == "error"
-            assert "no longer waiting" in str(reply["message"])
+            assert "already answered" in str(reply["message"])
         finally:
             control.close()
 
@@ -258,7 +272,7 @@ async def test_phone_answer_first_takes_the_terminal_card_down() -> None:
             assert picker is not None and not picker.is_attached
 
             reply = await control.send("ask_answer", request_id=request_id, value="Backfill")
-            assert reply["op"] == "error" and "no longer waiting" in str(reply["message"])
+            assert reply["op"] == "error" and "already answered" in str(reply["message"])
         finally:
             control.close()
 
@@ -280,6 +294,12 @@ async def test_secret_ask_projects_a_free_text_card_without_leaking_the_value() 
             assert pending is not None
             assert pending.kind == "ask"
             assert pending.options == []
+            # D1/U2: the secret flag rides the wire so the phone masks the
+            # paste field — but the VALUE never does.
+            assert pending.secret is True
+            wire = handle._fold.projection.to_json()
+            assert wire["pending"]["secret"] is True
+            assert "sk-" not in json.dumps(wire)
             request_id = pending.request_id
 
             reply = await control.send("ask_answer", request_id=request_id, value="sk-supersecret")
@@ -289,6 +309,71 @@ async def test_secret_ask_projects_a_free_text_card_without_leaking_the_value() 
             answer = await asyncio.wait_for(asked, 2)
             assert answer == {"OPENAI_API_KEY": ["sk-supersecret"]}
             # The secret never rode the projection.
+            assert handle._fold.projection.pending is None
+        finally:
+            control.close()
+
+
+@pytest.mark.asyncio
+async def test_multi_question_ask_advances_instead_of_truncating() -> None:
+    """U1: a phone answer to Q1 of a two-question ask must advance the picker
+    to Q2 (re-projecting it) rather than settling the whole card and dropping
+    Q2. Only after the last question is answered does the tool call resolve,
+    and it resolves with BOTH answers."""
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(90, 30)) as pilot:
+        await pilot.pause()
+        handle = await _wait_for_handle(app, pilot)
+        control = await _control_for(app, pilot)
+        try:
+            q1 = AskQuestion(
+                id="env",
+                question="Which environment?",
+                options=[
+                    AskOption(label="prod", description="the live one"),
+                    AskOption(label="staging", description="safe to break"),
+                ],
+            )
+            q2 = AskQuestion(
+                id="confirm",
+                question="Confirm the deploy?",
+                options=[
+                    AskOption(label="yes", description="ship it"),
+                    AskOption(label="no", description="hold"),
+                ],
+            )
+            asked = asyncio.create_task(app.request_user_choice([q1, q2]))
+            for _ in range(4):
+                await pilot.pause()
+
+            # Q1 is up, with the "1 of 2" position on the wire.
+            pending = handle._fold.projection.pending
+            assert pending is not None
+            assert pending.title == "Which environment?"
+            assert (pending.question_index, pending.question_total) == (0, 2)
+            request_id = pending.request_id
+
+            # Answer Q1 from the phone: the card must NOT settle — it advances.
+            reply = await control.send("ask_answer", request_id=request_id, value="prod")
+            assert reply["op"] == "ack"
+            for _ in range(4):
+                await pilot.pause()
+            assert not asked.done(), "the tool call settled after only Q1 (U1 truncation)"
+
+            # Q2 is now projected under the SAME request id, position 2 of 2.
+            pending = handle._fold.projection.pending
+            assert pending is not None
+            assert pending.title == "Confirm the deploy?"
+            assert (pending.question_index, pending.question_total) == (1, 2)
+            assert pending.request_id == request_id
+
+            # Answer Q2: now the whole card settles with both answers.
+            reply = await control.send("ask_answer", request_id=request_id, value="yes")
+            assert reply["op"] == "ack"
+            for _ in range(4):
+                await pilot.pause()
+            answer = await asyncio.wait_for(asked, 2)
+            assert answer == {"env": ["prod"], "confirm": ["yes"]}
             assert handle._fold.projection.pending is None
         finally:
             control.close()


### PR DESCRIPTION
## Why

A TUI `lop` session parked on the **`ask` tool** — waiting for the user to choose an option — showed the phone **nothing but a "thinking" spinner**, and the question could not be answered from the phone. The turn sat blocked on a decision the phone could see was needed but had no way to make.

Root cause was a single unwired seam, not a missing transport. Daemon-**owned** sessions already answered `ask` from the phone (`owned.py`'s ask gate pushed a `kind="ask"` PendingRequest and resolved it from `ask_answer`), and the mobile web UI already rendered `kind="ask"` cards and posted an `ask_answer` control op. But the **TUI bridge** had `TuiSessionHandle.note_pending` defined and **never called**, and `ask_answer` was a **stub that raised** `"answer it there"`. So a terminal `ask` never projected to the phone.

Version bump is **PATCH** (0.24.3 — next patch above main's 0.24.2 after rebase): a bug fix wiring an existing surface, no new capability, no breaking change.

## What changes

### TUI `ask` now projects to the phone and is answerable from it
- **`tui/app.py`** — `request_user_choice` notifies the mobile handle when the picker **mounts** (`_notify_mobile_ask_pending`), **advances** (`_notify_mobile_ask_advanced` via a new `AskPickerScreen.QuestionAdvanced` message), and **settles by any route** (`_notify_mobile_ask_settled` in its `finally`). All guarded/best-effort — a phone-bridge failure can never break the terminal ask.
- **`mobile/tui_handle.py`** — implemented `ask_answer`; a phone answer hops onto the Textual loop and drives the picker's **own** idempotent `answer_current`/`settle`, so the terminal screen stays in lockstep and exactly **one answer wins**.
- **`tui/widgets/ask_picker.py`** — `answer_current()` (the external-answer twin of Enter) and a `QuestionAdvanced` message posted on every `_index` advance, by terminal Enter **or** phone.

### Multi-question asks answer one at a time (no truncation)
The projection carries the **current** question plus `question_index`/`question_total` ("Question N of M"); a phone answer advances the picker to the next question and only settles after the last, resolving with **all** answers. An advance by **either** surface re-projects the current question, and `ask_answer` is **question-identified**: a tap carrying a stale `question_index` is rejected ("that question moved on — here is the current one") rather than misattributed.

### Secret asks are masked; option consequences carried
- `PendingRequest.secret` on the wire → the web card renders a masked `type="password"` field with a "secret — sent directly, not shown in the transcript" affordance; the value **never** rides the projection or logs.
- `options` is now `list[{label, description}]` → the phone shows each option's consequence line, matching the terminal.

### Fixes to the owned/daemon path (same feature)
- `owned.py` previously projected non-JSON-serializable `AskOption` **objects** into `PendingRequest.options` — a daemon-owned session with an options ask **crashed** on projection serialize. Now projects the structured `AskOptionWire` shape; daemon reconstruction handles it.

## Impact
- No breaking changes, no schema change to existing fields. `secret` asks never leak their value. Approvals stay terminal-only (the TUI boots auto-approve) — deliberately scoped to `ask`.
- Rebased onto current main; coexists with #260 (phased todos) and #263 (phone-session-state) — disjoint fold state, verified at the merge seam.

## Testing Details

### Real control-socket round-trip
A real `OperatorApp` under Textual `run_test` with its live mobile registrant + loopback control socket; a phone `ask_answer` POSTed over the socket exactly as the daemon does. The ask projects as `{kind:"ask", options:[{label,description}], secret, question_index, question_total}`; a **phone** answer resolves the parked tool call with `{question.id:[value]}`, takes the terminal picker down, and clears `pending`; a **terminal** answer clears the phone's `pending` live; a **terminal advance** re-projects the next question to the phone; a **stale-index** phone tap is rejected, not misattributed (final map keys each value to the right question).

### Phone web card (real `PendingCard`)

![tui ask mobile card](https://raw.githubusercontent.com/damianvtran/local-operator/pr-tui-ask-assets/shots/ask-card-phone-r2.png)

Options with consequence lines + accent tap targets; multi-question "Question 1 of 2"; masked secret field + affordance; and the "Already answered — this question was settled on the terminal" state for a stale tap.

### Automated
- `tests/unit/mobile/test_tui_ask.py` — ask projection; phone answer resolves + clears; terminal-first stale rejection; phone-first terminal-down; **multi-question advance (no truncation)**; **terminal-advance re-projects + stale tap safe (U8)**; secret flag on wire with value never leaked.
- `tests/unit/mobile/test_owned.py` — question-by-question owned gate; serializable option labels+descriptions (red-then-green on the old crash); secret flag without value.
- Gates whole-tree: flake8, black==26.1.0, isort, pyright (0 errors), web `tsc -b --noEmit`. `tests/unit/mobile` **70 passed**; `tests/unit/tui` **2357 passed, 4 skipped**.

## Review history
Full agent review gate: code review (3 rounds → clean), design review (4 rounds → clean, secret-masking + tap-target + stale-inert fixes), UX review (5 rounds → clean, multi-question-truncation blocker U1 and terminal-advance-desync blocker U8 fixed and re-verified live). All axes clean, fresh, and independent against the current head.
