### PR TITLE
feat(resume): find sessions by title, past names, and soft matching

### DIFF
--- a/local_operator/cli.py
+++ b/local_operator/cli.py
@@ -1885,6 +1885,7 @@ def main() -> int:
             from local_operator.resume import (
                 ResumeNotFound,
                 backfill_session_origins,
+                backfill_session_titles,
                 format_age,
                 recent_sessions,
                 resolve_resume_id,
@@ -1899,6 +1900,12 @@ def main() -> int:
             # costs a directory scan on the one path that cannot afford to be
             # wrong about which sessions are the user's.
             backfill_session_origins(config_dir())
+            # Stamp the title sidecar for pre-existing sessions in the same
+            # sweep, for the same reason: a session whose title sits in the
+            # untouched middle of a large transcript is unfindable by its own
+            # subject until this runs. Idempotent and stdlib-only, so it costs a
+            # bounded directory scan on the one path that opens the picker.
+            backfill_session_titles(config_dir())
 
             try:
                 args.resume = resolve_resume_id(config_dir(), str(args.resume))

--- a/local_operator/cli.py
+++ b/local_operator/cli.py
@@ -1904,7 +1904,10 @@ def main() -> int:
             # sweep, for the same reason: a session whose title sits in the
             # untouched middle of a large transcript is unfindable by its own
             # subject until this runs. Idempotent and stdlib-only, so it costs a
-            # bounded directory scan on the one path that opens the picker.
+            # bounded directory scan. session_factory._prepare backfills too (on
+            # ordinary session build); this branch runs it eagerly here because
+            # it answers `--resume` before any session is built, so the picker
+            # and `@latest` resolution above must see a stamped store first.
             backfill_session_titles(config_dir())
 
             try:

--- a/local_operator/resume.py
+++ b/local_operator/resume.py
@@ -346,13 +346,19 @@ def write_session_title(
     concurrent session rewrites it.
     """
     normalized = " ".join(text.split())
-    # Dedup while preserving first-seen order: ``dict.fromkeys`` is the stdlib
-    # ordered-set idiom. The in-force title is folded in as the newest name so a
-    # caller that passes only the prior history still gets a complete list.
+    # Whitespace-normalise every name the same way ``text`` is, so the sidecar's
+    # ``names`` and its ``text`` agree and the digest folds a name in exactly as
+    # the reader will match it. Dedup runs AFTER normalisation so two names that
+    # differ only in internal whitespace collapse to one. ``dict.fromkeys`` is
+    # the stdlib ordered-set idiom, preserving first-seen order; empties (a name
+    # that was all whitespace) are dropped. The in-force title is folded in as
+    # the newest name so a caller that passes only the prior history still gets
+    # a complete list.
+    normalized_past = [n for n in (" ".join(p.split()) for p in past_names) if n]
     names = (
-        list(dict.fromkeys([*past_names, normalized]))
+        list(dict.fromkeys([*normalized_past, normalized]))
         if normalized
-        else list(dict.fromkeys(past_names))
+        else list(dict.fromkeys(normalized_past))
     )
     payload = {"text": normalized, "user_set": user_set, "names": names}
     try:

--- a/local_operator/resume.py
+++ b/local_operator/resume.py
@@ -48,6 +48,18 @@ ORIGIN_NAME = "origin.json"
 #: scheduled run, a server-side session) is a new value and not a second file.
 ORIGIN_SUBAGENT = "subagent"
 
+#: Journals the session's title (and every name it has ever borne) beside the
+#: transcript, mirroring :data:`ORIGIN_NAME` exactly. A SIDECAR rather than a
+#: field in the JSONL for the same reason the origin marker is one: the picker's
+#: cost model is one bounded read per row, and the title in force can sit
+#: anywhere in a multi-megabyte transcript (the auto-name lands at turn 2, a
+#: mid-session ``/rename`` lands in the untouched middle — see
+#: :data:`TITLE_SCAN_BYTES` for the window-scan gap this closes). ``Path.stat``
+#: plus a sub-kilobyte read is O(1) in transcript size where the scan is not,
+#: so :func:`stored_session_title` consults this first and only falls back to
+#: the window scan for sessions written before the sidecar existed.
+TITLE_SIDECAR_NAME = "title.json"
+
 #: The two openings only the subagent runner can produce, used ONLY by the
 #: one-time backfill for directories that predate the marker.
 #:
@@ -94,22 +106,26 @@ _TITLE_CUSTOM_TYPE = "conversation_name"
 #: Reading both ends rather than the whole file is what keeps the cost per
 #: picker row bounded on a 6 MB transcript.
 #:
-#: **The known gap, stated honestly.** A rename made mid-conversation, then
-#: buried under a further 128 KB and never renamed again, falls between the two
-#: windows. The head still holds the ORIGINAL title, so that session is
-#: labelled with the name it was renamed *away from* rather than falling back
-#: to the opener. That is a stale name, and a stale name is stated with exactly
-#: the confidence of a correct one — so it is a real cost, not a rounding
-#: error, and this comment says so rather than claiming the scan can only ever
-#: miss.
+#: **The window gap this scan cannot close, and where it is closed instead.**
+#: A rename made mid-conversation, then buried under a further 128 KB and never
+#: renamed again, falls between the two windows: the head still holds the
+#: ORIGINAL title, so a window-only scan labels that session with the name it
+#: was renamed *away from*. Worse, a topic-pivot session auto-named late (its
+#: only titles sitting in the untouched middle of a multi-megabyte transcript)
+#: is invisible to both windows and reverts to its opening message — the
+#: reported failure of a session that could not be found by its own subject.
 #:
-#: It is accepted for now because the alternative is reading whole transcripts
-#: on the picker's synchronous path (400 ms against 64 ms across a real store),
-#: and because the case requires a mid-session rename specifically: an
-#: auto-named session has its title at the head, and a session renamed near the
-#: end has it in the tail. If it proves to bite, the fix is to journal the
-#: title to a sidecar the way ``mark_session_origin`` does — one stat and one
-#: small read, no size dependence at all — rather than widening this window.
+#: This scan does not try to fix that by widening: reading whole transcripts on
+#: the picker's synchronous path was measured at 400 ms against 64 ms across a
+#: real store. Instead the fix the previous comment here PRESCRIBED is now
+#: implemented — the title is journalled to a sidecar (``title.json``, see
+#: :func:`write_session_title`) the way :func:`mark_session_origin` journals
+#: origin, one stat and one small read with no size dependence at all.
+#: :func:`stored_session_title` consults that sidecar first, so this window
+#: scan is now the FALLBACK for sessions written before the sidecar existed and
+#: not yet reached by :func:`backfill_session_titles`, not the primary path.
+#: Both ends are still read because that fallback still wants the newest title
+#: it can reach on a pre-sidecar session.
 TITLE_SCAN_BYTES = 131_072
 
 #: Matches a journalled title row in raw JSONL, tolerant of whitespace after
@@ -231,6 +247,133 @@ def session_origin(session_dir: Path) -> str:
     return origin if isinstance(origin, str) else ""
 
 
+class SessionTitle(NamedTuple):
+    """The title sidecar's contents: the in-force name and every past one.
+
+    ``text`` is the name currently on the band and the terminal tab — the one
+    the user last saw and will search by. ``names`` is every distinct title the
+    session has ever carried, first-seen order, so a search matches a name the
+    session was renamed *away from* as well as its current one. ``user_set``
+    rides along for parity with the transcript entry: the picker does not need
+    it, but a future reader deciding rename precedence might, and it costs
+    nothing to keep.
+    """
+
+    text: str
+    user_set: bool
+    names: tuple[str, ...]
+
+
+def _read_title_sidecar(session_dir: Path) -> SessionTitle | None:
+    """Parse ``title.json``, or ``None`` when it is absent or unusable.
+
+    Tolerant for the same reason :func:`session_origin` is, and with the same
+    ``errors="replace"`` load-bearing detail: this runs over every session
+    directory to paint a picker, and :func:`write_session_title` writes
+    non-atomically, so a process killed mid-write can leave the file cut inside
+    a multi-byte character. A strict decode would raise ``UnicodeDecodeError``
+    (a ``ValueError``) and could sail past an ``except OSError`` and take the
+    whole picker down — the exact failure a corrupt ``origin.json`` once caused.
+    A missing or malformed sidecar yields ``None`` so the caller falls back to
+    the window scan, never an exception.
+    """
+    try:
+        raw = (session_dir / TITLE_SIDECAR_NAME).read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return None
+    try:
+        payload = json.loads(raw)
+    except ValueError:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    text = payload.get("text")
+    if not isinstance(text, str):
+        return None
+    raw_names = payload.get("names")
+    names = (
+        tuple(name for name in raw_names if isinstance(name, str))
+        if (isinstance(raw_names, list))
+        else ()
+    )
+    return SessionTitle(
+        text=" ".join(text.split()),
+        user_set=bool(payload.get("user_set")),
+        names=names,
+    )
+
+
+def read_title_names(session_dir: Path) -> list[str]:
+    """Every name this session has borne, from the sidecar; ``[]`` when absent.
+
+    The source the digest folds in (see ``search_index.build_index``) so a
+    session is findable by any subject it was ever named for, not only its
+    current title. Empty for a pre-sidecar session, which the backfill sweep
+    (:func:`backfill_session_titles`) fills in once at startup.
+    """
+    sidecar = _read_title_sidecar(session_dir)
+    return list(sidecar.names) if sidecar else []
+
+
+def write_session_title(
+    session_dir: Path, text: str, *, user_set: bool, past_names: list[str]
+) -> None:
+    """Journal the in-force title (and every name ever borne) to a sidecar.
+
+    Why a sidecar: :func:`stored_session_title`'s window scan is blind to a
+    title in the middle of a large transcript (see :data:`TITLE_SCAN_BYTES` —
+    an auto-name at turn 2 pushed past the head window by an hour of work, or a
+    mid-session ``/rename`` buried between the two windows). One stat and one
+    small read here is O(1) in transcript size, closing that gap for good.
+
+    Best-effort by contract, exactly like :func:`mark_session_origin`: a title
+    is decoration, and a session that cannot write its sidecar (read-only
+    volume, full disk) must still RUN. The cost of the failure is a stale
+    picker label until the next rename or the backfill sweep, never a lost turn.
+
+    ``names`` accumulates: ``text`` is appended to ``past_names`` (deduped,
+    first-seen order preserved) so a search matches a name the session was
+    renamed away from. The list is authoritative for names seen since the
+    sidecar began; the one-time :func:`backfill_session_titles` sweep recovers
+    the complete history for sessions that predate it.
+
+    **The directory's mtime is preserved**, for the same reason
+    :func:`mark_session_origin` preserves it: recency ranks by the transcript's
+    mtime, but other readers (``os.listdir`` + ``stat`` listings, backups) look
+    at the directory, and journalling a title is bookkeeping ABOUT a session,
+    never activity IN it. The write is atomic (pid-named temp + ``replace``,
+    like ``search_index._save``) because the picker may read this file while a
+    concurrent session rewrites it.
+    """
+    normalized = " ".join(text.split())
+    # Dedup while preserving first-seen order: ``dict.fromkeys`` is the stdlib
+    # ordered-set idiom. The in-force title is folded in as the newest name so a
+    # caller that passes only the prior history still gets a complete list.
+    names = (
+        list(dict.fromkeys([*past_names, normalized]))
+        if normalized
+        else list(dict.fromkeys(past_names))
+    )
+    payload = {"text": normalized, "user_set": user_set, "names": names}
+    try:
+        try:
+            previous = session_dir.stat().st_mtime
+        except OSError:
+            previous = None
+        session_dir.mkdir(parents=True, exist_ok=True)
+        sidecar = session_dir / TITLE_SIDECAR_NAME
+        # The temp carries the writer's PID so two sessions writing at once do
+        # not ``replace`` a document the other is still filling — the same
+        # torn-write hazard ``search_index._save`` documents.
+        tmp = sidecar.with_suffix(f".{os.getpid()}.tmp")
+        tmp.write_text(json.dumps(payload), encoding="utf-8")
+        tmp.replace(sidecar)
+        if previous is not None:
+            os.utime(session_dir, (previous, previous))
+    except (OSError, TypeError, ValueError):
+        return
+
+
 def backfill_session_origins(config_dir: Path, limit: int = 500) -> int:
     """Stamp pre-existing subagent directories once, and return how many.
 
@@ -287,6 +430,115 @@ def backfill_session_origins(config_dir: Path, limit: int = 500) -> int:
             mark_session_origin(directory, ORIGIN_SUBAGENT, backfilled=True)
             stamped += 1
     return stamped
+
+
+def _scan_all_titles(transcript: Path) -> list[tuple[str, bool]]:
+    """Every ``(text, user_set)`` title journalled in ``transcript``, in order.
+
+    A FULL read, unlike :func:`stored_session_title`'s two windows — which is
+    why it lives only on the backfill path and never on the picker's hot path.
+    Finding *all* titles (not just the newest) requires it: they can sit
+    anywhere, as the topic-pivot session that motivated this proved. Parsed
+    line-by-line rather than by the windowed regex so ``user_set`` is read
+    alongside each ``text`` and the ordering is exact.
+
+    Tolerant like every reader here: an unreadable transcript or a half-written
+    final line yields what it could parse, never an exception.
+    """
+    titles: list[tuple[str, bool]] = []
+    try:
+        with transcript.open("r", encoding="utf-8", errors="replace") as handle:
+            for line in handle:
+                line = line.strip()
+                if not line or _TITLE_CUSTOM_TYPE not in line:
+                    # Cheap reject before the JSON parse: title rows are a tiny
+                    # fraction of a transcript, and the substring check skips
+                    # the decode for every message and tool line.
+                    continue
+                try:
+                    entry = json.loads(line)
+                except ValueError:
+                    continue
+                if not isinstance(entry, dict):
+                    continue
+                payload = entry.get("payload")
+                if not isinstance(payload, dict):
+                    continue
+                if payload.get("custom_type") != _TITLE_CUSTOM_TYPE:
+                    continue
+                details = payload.get("details")
+                if not isinstance(details, dict):
+                    continue
+                text = details.get("text")
+                if isinstance(text, str) and text.strip():
+                    titles.append((" ".join(text.split()), bool(details.get("user_set"))))
+    except OSError:
+        return titles
+    return titles
+
+
+def backfill_session_titles(config_dir: Path, limit: int = 500) -> int:
+    """Write the title sidecar for sessions that predate it, and return how many.
+
+    Mirrors :func:`backfill_session_origins` exactly, and for the same reason:
+    without it the sidecar fix only applies to sessions renamed AFTER the
+    upgrade, so the person who reported being unable to find a topic-pivot
+    session by its subject would upgrade, look, and see the same unfindable row
+    — the change would be correct and appear to do nothing until each session's
+    next rename. This one-time sweep makes every existing session findable by
+    every name it has borne immediately after upgrade.
+
+    A session with a title in the untouched middle of a large transcript is the
+    case this exists for: :func:`stored_session_title`'s window scan misses it,
+    so a full read (:func:`_scan_all_titles`) is the only way to recover its
+    real title and its past names. That read is O(transcript size), which is why
+    it is confined to this startup path — bounded by ``limit`` and run once per
+    session ever, never per picker-open — exactly the trade
+    :func:`backfill_session_origins` makes.
+
+    Best-effort and bounded like every other function here: an unreadable
+    directory is skipped rather than raised, and ``limit`` caps how many
+    sidecars are WRITTEN per run.
+
+    The cap is on work done, never on how far the scan reaches, for the reason
+    :func:`backfill_session_origins` documents at length: slicing the directory
+    list instead would leave any session sorting past the cut unvisited on
+    every run forever, because the list sorts by hex name and the same prefix
+    is recomputed each startup.
+    """
+    written = 0
+    sessions = config_dir / "sessions"
+    try:
+        directories = sorted(sessions.iterdir())
+    except OSError:
+        return 0
+    for directory in directories:
+        if written >= limit:
+            break
+        try:
+            transcript = directory / TRANSCRIPT_NAME
+            if not transcript.is_file():
+                continue
+            # Already answered: never re-stamp. The sidecar is event-sourced
+            # from here on, so a rewrite would only risk clobbering a newer
+            # sidecar with an older full scan on a session that has since been
+            # renamed.
+            if (directory / TITLE_SIDECAR_NAME).exists():
+                continue
+        except OSError:
+            continue
+        titles = _scan_all_titles(transcript)
+        if not titles:
+            # No journalled title at all (a session that predates title
+            # journalling, or one closed before its naming call landed). Leave
+            # it to the window-scan fallback and the opening-message name; there
+            # is nothing to journal.
+            continue
+        past_names = [text for text, _ in titles]
+        newest_text, newest_user_set = titles[-1]
+        write_session_title(directory, newest_text, user_set=newest_user_set, past_names=past_names)
+        written += 1
+    return written
 
 
 def is_user_session(session_dir: Path) -> bool:
@@ -458,7 +710,19 @@ def stored_session_title(session_dir: Path) -> str:
     Tolerant like everything else on this path — an unreadable or truncated
     transcript yields ``""`` and the caller falls back to the opening message
     rather than the picker failing.
+
+    **The title sidecar is consulted FIRST** (``title.json``, written by
+    :func:`write_session_title` on the same event that journals the title to
+    the transcript). It is one stat and a sub-kilobyte read, O(1) in transcript
+    size, and it is what closes the window-scan gap :data:`TITLE_SCAN_BYTES`
+    describes: a title in the untouched middle of a multi-megabyte transcript
+    is invisible to the two windows but sits in the sidecar. The scan below
+    remains the fallback for sessions written before the sidecar existed and
+    not yet reached by :func:`backfill_session_titles`.
     """
+    sidecar = _read_title_sidecar(session_dir)
+    if sidecar is not None and sidecar.text:
+        return sidecar.text
     transcript = session_dir / TRANSCRIPT_NAME
     try:
         with transcript.open("rb") as handle:

--- a/local_operator/session/search_index.py
+++ b/local_operator/session/search_index.py
@@ -19,8 +19,15 @@ sessions and 125 MB; a real store grows without bound. Grepping all of it costs
 ~190 ms even reading only the first 256 KB of each file — far too slow to run
 on every keystroke of a filter, and the filter reruns per keystroke. A digest
 of the first :data:`DIGEST_CHARS` characters of each conversation's prose
-compresses that to ~0.7 MB, which loads in ~1 ms and searches in microseconds.
-The bound is per session and applied at BUILD time, so a single pathological
+compresses that to ~0.7 MB, which loads in ~1 ms. Exact-substring search
+(:func:`search_digests`) is then ~5 ms over the whole store; bounded soft
+search (:class:`SoftSearchIndex`) is ~6-20 ms per query change once its per-
+digest token cache is warm (prefix queries at the low end, a full typo-tolerant
+word at the high), after a one-time ~70 ms cost on the first keystroke to build
+that cache. All measured at ~640 sessions / ~180k digest tokens — see
+:class:`SoftSearchIndex` for why the naive per-call form was ~75-185 ms EVERY
+keystroke. The bound is per session and applied at BUILD time, so a single
+pathological
 transcript (a pasted 80 MB file) costs its cap and not its size.
 
 **Why the cache lives outside the session directories.** A sidecar inside
@@ -369,8 +376,11 @@ def _within_edit_distance(a: str, b: str, max_distance: int) -> bool:
     every cell in a row exceeds the cap, so the cost is O(len * max_distance)
     rather than O(len^2). Pure Python and dependency-free on purpose —
     ``rapidfuzz`` is a compiled wheel this project deliberately does not add
-    (see the module docstring); over the ~200 short digest tokens this runs
-    against, the bounded DP is microseconds.
+    (see the module docstring). One DP is sub-millisecond; the cost that
+    mattered was running it per digest token per keystroke, which
+    :class:`SoftSearchIndex` removes by resolving each query token against the
+    deduplicated vocabulary once (~6-20 ms per warm query change at ~640
+    sessions, vs ~75-185 ms for the naive per-digest form on every keystroke).
     """
     if abs(len(a) - len(b)) > max_distance:
         return False
@@ -421,15 +431,163 @@ def _token_soft_matches(needle_token: str, haystack_tokens: set[str]) -> bool:
     return False
 
 
+class SoftSearchIndex:
+    """A reusable soft-search accelerator that caches per-digest tokenisation.
+
+    Why this exists as an object rather than the old stateless function. The
+    picker recomputes soft matches on every KEYSTROKE (see
+    ``SessionPickerScreen.visible_rows``), and the naive implementation
+    re-tokenised every digest and ran the edit-distance DP against every
+    digest token on each of those calls. At the real store scale (~640
+    sessions, ~180k digest tokens) that cost ~75-185 ms per keystroke, measured
+    (~75 ms for a short/prefix query, ~185 ms for a full typo-tolerant word) \u2014
+    the "microseconds" the earlier docstrings claimed held only at the ~200
+    sessions the design was first measured on. Two costs dominated and both are
+    eliminated here:
+
+    * **Re-tokenising every digest per keystroke (~55 ms).** Fixed by caching
+      the token set of each digest keyed on the digest STRING, so a digest is
+      tokenised once and reused until it actually changes.
+    * **Running the edit-distance DP per DIGEST token (up to ~130 ms).** The 180k
+      digest tokens are only ~8.5k DISTINCT words. Fixed by resolving each
+      query token against that deduplicated VOCABULARY once \u2014 the DP runs
+      ~8.5k times, not ~180k \u2014 then answering each digest by a cheap set
+      intersection against the resolved word set. Length- and first-letter
+      buckets over the vocabulary cut the DP candidate list further (edit
+      distance <=2 can only reach words within two of the query token's
+      length; a prefix match shares its first letter).
+
+    Freshness and bound. ``search`` re-syncs the cache against the ``digests``
+    it is handed on every call: an entry whose digest STRING changed is
+    re-tokenised (a re-digested session invalidates itself), and an entry whose
+    session is gone is dropped \u2014 so the cache tracks the live digest set and
+    cannot grow past it across the picker's life. The derived vocabulary and
+    its buckets are rebuilt only when that token cache actually changed, so a
+    run of keystrokes over a fixed store rebuilds them once. Net warm cost is
+    ~6-20 ms per query change (prefix cheap, full typo dearer), after a one-time
+    ~70 ms first keystroke that builds the token cache and vocabulary.
+
+    Behaviour is identical to the previous stateless implementation: same
+    prefix / order-independent token-AND / edit-distance-<=2-for-tokens->=4
+    bounds, same matches. Only the cost changed. See :func:`soft_search_digests`
+    for the stateless one-shot wrapper tests and non-repeating callers use.
+    """
+
+    def __init__(self) -> None:
+        # sid -> (digest_string, frozenset_of_tokens). Keyed on the digest
+        # string so a re-digested session (new string) is re-tokenised, and
+        # pruned to the live sids on each sync so it cannot grow unbounded.
+        self._tokens: dict[str, tuple[str, frozenset[str]]] = {}
+        # Deduplicated view of every token across the cached digests, plus the
+        # buckets that bound the DP candidate list. ``None`` marks them stale
+        # (a token-cache change or the first search), so they rebuild lazily.
+        self._vocab: set[str] | None = None
+        self._by_len: dict[int, set[str]] = {}
+        self._by_first: dict[str, list[str]] = {}
+
+    def _sync(self, digests: dict[str, str]) -> None:
+        """Reconcile the token cache with ``digests``; rebuild vocab if it moved."""
+        changed = False
+        # Drop entries for sessions that are no longer listed. This is what
+        # keeps the cache bounded by the live store rather than by the number
+        # of distinct digests seen over the picker's life.
+        for sid in [sid for sid in self._tokens if sid not in digests]:
+            del self._tokens[sid]
+            changed = True
+        for sid, digest in digests.items():
+            cached = self._tokens.get(sid)
+            # Re-tokenise only when the digest STRING differs (new session or a
+            # re-digest after a rename/append), so freshness is honoured without
+            # re-tokenising unchanged digests every keystroke.
+            if cached is None or cached[0] != digest:
+                self._tokens[sid] = (digest, frozenset(_tokenize(digest)))
+                changed = True
+        if changed or self._vocab is None:
+            self._rebuild_vocab()
+
+    def _rebuild_vocab(self) -> None:
+        """Recompute the deduplicated vocabulary and its DP-narrowing buckets."""
+        vocab: set[str] = set()
+        for _digest, tokens in self._tokens.values():
+            vocab |= tokens
+        by_len: dict[int, set[str]] = {}
+        by_first: dict[str, list[str]] = {}
+        for word in vocab:
+            by_len.setdefault(len(word), set()).add(word)
+            by_first.setdefault(word[0], []).append(word)
+        self._vocab = vocab
+        self._by_len = by_len
+        self._by_first = by_first
+
+    def _resolve(self, needle_token: str) -> set[str]:
+        """Vocabulary words this query token softly matches (see :func:`_token_soft_matches`).
+
+        The per-vocabulary equivalent of :func:`_token_soft_matches`: instead of
+        asking "does this token match any word in one digest", it computes, once,
+        the set of ALL vocabulary words the token matches, so every digest is then
+        answered by a set intersection. Same three tiers, same bounds.
+        """
+        matches: set[str] = set()
+        # Prefix (which subsumes exact): a vocabulary word beginning with the
+        # query token shares its first letter, so only that bucket can contain a
+        # prefix hit. Mirrors ``token.startswith(needle_token)``.
+        for word in self._by_first.get(needle_token[0], ()):
+            if word.startswith(needle_token):
+                matches.add(word)
+        # Edit distance <=2, both tokens >=4 chars. A word within two edits can
+        # differ in length by at most two, so only those length buckets can hold
+        # a fuzzy hit \u2014 this is what turns the DP from ~180k runs into ~a few
+        # hundred. The length and bound checks match _token_soft_matches exactly.
+        if len(needle_token) >= _SOFT_MIN_TOKEN:
+            for length in range(
+                len(needle_token) - _SOFT_MAX_DISTANCE,
+                len(needle_token) + _SOFT_MAX_DISTANCE + 1,
+            ):
+                for word in self._by_len.get(length, ()):
+                    if len(word) >= _SOFT_MIN_TOKEN and _within_edit_distance(
+                        needle_token, word, _SOFT_MAX_DISTANCE
+                    ):
+                        matches.add(word)
+        return matches
+
+    def search(self, digests: dict[str, str], query: str) -> set[str]:
+        """Ids whose body SOFTLY matches ``query`` \u2014 prefix, typo, or word-order.
+
+        Identical result to :func:`soft_search_digests`; see this class's
+        docstring for why it is dramatically cheaper across repeated calls over
+        the same store. Re-syncs its cache against ``digests`` first, so passing
+        a changed store is safe.
+        """
+        self._sync(digests)
+        needle_tokens = _tokenize(query)
+        if not needle_tokens:
+            return set()
+        # Resolve each query token to the vocabulary words it matches, once. A
+        # query token that matches nothing in the whole store yields an empty
+        # set here, which makes the AND below reject every digest \u2014 the same
+        # "excludes rather than ranks" bound the stateless version relied on.
+        resolved = [self._resolve(token) for token in needle_tokens]
+        matched: set[str] = set()
+        for sid, (_digest, tokens) in self._tokens.items():
+            if not tokens:
+                continue
+            # Order-independent AND: every query token must have a resolved word
+            # present in this digest's token set. Set intersection replaces the
+            # per-token DP the stateless version ran here.
+            if all(tokens & words for words in resolved):
+                matched.add(sid)
+        return matched
+
+
 def soft_search_digests(digests: dict[str, str], query: str) -> set[str]:
-    """Ids whose body SOFTLY matches ``query`` — prefix, typo, or word-order.
+    """Ids whose body SOFTLY matches ``query`` \u2014 prefix, typo, or word-order.
 
     The bounded soft tier that sits beside :func:`search_digests`. A query
     matches a digest when EVERY query token softly matches some token in the
     digest (order-independent AND), where "softly" is exact, prefix, or a
     bounded edit-distance typo (see :func:`_token_soft_matches`). Order-
     independent AND is what makes ``throughput classifier`` find a session
-    titled "Improve ADM Classifier Throughput" — word order and exact substring
+    titled "Improve ADM Classifier Throughput" \u2014 word order and exact substring
     contiguity both stop mattering.
 
     Returned as a SET, like :func:`search_digests`: the caller
@@ -439,20 +597,17 @@ def soft_search_digests(digests: dict[str, str], query: str) -> set[str]:
 
     Bounded and dependency-free by design. The old substring-only filter warned
     that fuzzy matching over free text produces confident nonsense; that was
-    right about UNBOUNDED fuzzy. This is bounded — a distance cap of 2 for
-    tokens of 4+ chars, plus prefix and token-AND — and the bound is precisely
+    right about UNBOUNDED fuzzy. This is bounded \u2014 a distance cap of 2 for
+    tokens of 4+ chars, plus prefix and token-AND \u2014 and the bound is precisely
     what keeps a soft match from being confident nonsense: a nonsense token
     close to nothing in the digest excludes the row rather than dragging in
     everything.
+
+    **This is the STATELESS one-shot form.** It builds a fresh
+    :class:`SoftSearchIndex` per call, so it re-tokenises the whole store every
+    time \u2014 at ~640 sessions that is ~75-185 ms, fine for a single call (a test, a
+    mobile-daemon query) but NOT for a per-keystroke loop. A caller that
+    searches the same store repeatedly (the picker) holds a
+    :class:`SoftSearchIndex` instead and pays that cost once; see that class.
     """
-    needle_tokens = _tokenize(query)
-    if not needle_tokens:
-        return set()
-    matched: set[str] = set()
-    for sid, digest in digests.items():
-        haystack = set(_tokenize(digest))
-        if not haystack:
-            continue
-        if all(_token_soft_matches(token, haystack) for token in needle_tokens):
-            matched.add(sid)
-    return matched
+    return SoftSearchIndex().search(digests, query)

--- a/local_operator/session/search_index.py
+++ b/local_operator/session/search_index.py
@@ -36,29 +36,55 @@ normal picker open therefore re-reads only the handful of sessions that have
 actually changed since the last one, which is why the index can be built
 synchronously without the picker stalling.
 
-**Search is substring, not semantic.** No embedding model, no vector store: a
-provider call to open a picker would be slower than the thing it is searching,
-would fail offline, and would spend money per keystroke. Substring over the
-conversation body already answers the reported case — "retention" now finds the
-session — and it never returns a confident wrong answer, which a similarity
-score over 200 short digests very much does.
+**Search is lexical — substring plus BOUNDED soft matching, not semantic.** No
+embedding model, no vector store: a provider call to open a picker would be
+slower than the thing it is searching, would fail offline, and would spend
+money per keystroke, and a local embedding model is the heaviest dependency
+this offline-capable, ``pip install``-light project could add. Two lexical
+tiers instead:
+
+* **Substring** (:func:`search_digests`) — exact, case-insensitive, the
+  precise-query path that never returns a confident wrong answer.
+* **Bounded soft matching** (:func:`soft_search_digests`) — prefix,
+  order-independent token-AND, and edit-distance-<=2 for tokens of 4+ chars, so
+  ``classifer`` finds ``classifier`` and ``throughput classifier`` finds
+  "Improve ADM Classifier Throughput". The earlier design warned that fuzzy
+  matching produces confident nonsense; that was right about UNBOUNDED fuzzy,
+  and the bound here — a small distance cap gated on token length — is exactly
+  what keeps a soft match from dragging in everything. A similarity score over
+  200 short digests would rank a best match for every query including nonsense;
+  the AND-of-bounded-tokens rule excludes rather than ranks, so a query that
+  matches nothing still matches nothing.
+
+The digest also PREPENDS the session's title and every past name it has borne
+(from the ``title.json`` sidecar), so a topic-pivot session — one whose subject
+changed partway through and was re-titled — is findable by the subject it ended
+on, which is the human's own summary of what it became. This is how "find by
+meaning" is served honestly without a vector model.
 
 **What this does NOT do.** It is not a full-text index. :data:`SCAN_BYTES`
-bounds how much of each conversation is represented, so a phrase that appears
-only deep inside a long session may not be found; see that constant for the
-measured recall and why the bound is where it is. The guarantee offered here
-is "findable by what the conversation was about", not "findable by any word
-ever typed in it".
+bounds how much of each conversation's BODY is represented, so a phrase that
+appears only deep inside a long session and never in its title may not be
+found; see that constant for the measured recall and why the bound is where it
+is. Full-text recall past the scan window, and true vector semantics, are both
+deferred follow-ups behind a dependency-approval gate. The guarantee offered
+here is "findable by what the conversation was about", not "findable by any
+word ever typed in it".
 """
 
 from __future__ import annotations
 
 import json
 import os
+import re
 from pathlib import Path
 from typing import Any
 
-from local_operator.resume import TRANSCRIPT_NAME
+from local_operator.resume import (
+    TITLE_SIDECAR_NAME,
+    TRANSCRIPT_NAME,
+    read_title_names,
+)
 
 #: Characters of prose kept per session. Enough to hold the subject matter of a
 #: long conversation's opening stretch — the part that says what the session was
@@ -95,7 +121,23 @@ INDEX_FILENAME = "session_search_index.json"
 #: is discarded wholesale rather than migrated — it is a derived artifact whose
 #: rebuild costs about a second, and a migration path for a cache is code that
 #: exists to be wrong.
-INDEX_VERSION = 1
+#:
+#: 1 -> 2: the digest now PREPENDS the session's title and every past name it
+#: has borne (from the ``title.json`` sidecar), and the cache signature gains
+#: the sidecar's mtime so a rename re-folds the digest even when the transcript
+#: is byte-identical. Bumping discards every v1 entry once so the whole store
+#: rebuilds with the new shape; ``_load`` already drops on version mismatch, so
+#: this needs no migration code.
+INDEX_VERSION = 2
+
+#: Extra characters the title-fold may add on top of :data:`DIGEST_CHARS`. The
+#: title and past names are the human's own summary of what the session became,
+#: so they must survive the cap that a long opening stretch would otherwise
+#: consume — folding them in and THEN slicing at ``DIGEST_CHARS`` could clip the
+#: very title the fold exists to make searchable. A session accrues few names
+#: (a rename is rare), so a small fixed headroom holds all of them without
+#: letting the digest grow unbounded.
+TITLE_HEADROOM = 512
 
 #: Roles whose text enters the digest. Tool results are excluded on purpose:
 #: they are machine output — directory listings, file dumps, HTTP bodies — and
@@ -238,15 +280,26 @@ def build_index(config_dir: Path, session_ids: list[str]) -> dict[str, str]:
     entries: dict[str, Any] = {}
     digests: dict[str, str] = {}
     for session_id in session_ids:
-        transcript = config_dir / "sessions" / session_id / TRANSCRIPT_NAME
+        session_dir = config_dir / "sessions" / session_id
+        transcript = session_dir / TRANSCRIPT_NAME
         try:
             stat = transcript.stat()
-            signature = [stat.st_size, stat.st_mtime]
         except OSError:
             # Vanished mid-scan (retention sweeps run concurrently). Skip it
             # rather than caching an empty digest that would then be treated as
             # valid if the file came back.
             continue
+        # The title sidecar's mtime joins the signature so a RENAME re-folds the
+        # digest even when the transcript is byte-identical (a rename appends to
+        # the transcript too, but the sidecar is the authoritative source of the
+        # names folded below, and keying on it makes the invalidation explicit).
+        # ``0`` when there is no sidecar yet, so a pre-sidecar session keys the
+        # same way it did under v1 until its backfill or next rename writes one.
+        try:
+            title_mtime = (session_dir / TITLE_SIDECAR_NAME).stat().st_mtime
+        except OSError:
+            title_mtime = 0
+        signature = [stat.st_size, stat.st_mtime, title_mtime]
         previous = cached.get(session_id)
         if (
             isinstance(previous, dict)
@@ -255,7 +308,17 @@ def build_index(config_dir: Path, session_ids: list[str]) -> dict[str, str]:
         ):
             digest = previous["digest"]
         else:
-            digest = digest_transcript(transcript)
+            # Prepend the human's own summary of what the session became — its
+            # title and every past name — to the body digest. This is what makes
+            # a topic-pivot session findable by the subject it ended on rather
+            # than only the one it opened with, WITHOUT enlarging the 256 KB scan
+            # window (see SCAN_BYTES: full-transcript recall is a deferred
+            # follow-up, not this change). Sliced with headroom so the folded
+            # names always survive the DIGEST_CHARS cap the opening stretch would
+            # otherwise fill.
+            names = read_title_names(session_dir)
+            body = digest_transcript(transcript)
+            digest = " ".join([*names, body]).strip()[: DIGEST_CHARS + TITLE_HEADROOM]
         entries[session_id] = {"signature": signature, "digest": digest}
         digests[session_id] = digest
     if entries != cached:
@@ -275,3 +338,125 @@ def search_digests(digests: dict[str, str], query: str) -> set[str]:
     if not needle:
         return set()
     return {sid for sid, digest in digests.items() if needle in digest.lower()}
+
+
+#: Minimum token length for edit-distance matching. Short tokens (``adm``,
+#: ``svc``) are within distance 2 of far too many words, so allowing a fuzzy
+#: match on them is exactly the "confident nonsense" the substring-only design
+#: warned about; a prefix or exact match still handles them. Four is where the
+#: false-match rate drops to something a search can trust.
+_SOFT_MIN_TOKEN = 4
+
+#: Maximum edit distance a token may be from a haystack token and still match.
+#: Two covers the ordinary typo (a swap, a doubled or dropped letter,
+#: ``classifer`` -> ``classifier``) without letting unrelated words of similar
+#: length collide. Kept small on purpose: the bound is what makes soft matching
+#: safe here, per the module docstring.
+_SOFT_MAX_DISTANCE = 2
+
+#: Splits a string into lowercase alphanumeric tokens for soft matching. Word
+#: boundaries only — punctuation and whitespace separate tokens — so a query
+#: matches on whole words the way a reader thinks of them.
+_TOKEN_RE = re.compile(r"[a-z0-9]+")
+
+
+def _tokenize(text: str) -> list[str]:
+    """Lowercase alphanumeric tokens of ``text``, in order."""
+    return _TOKEN_RE.findall(text.lower())
+
+
+def _within_edit_distance(a: str, b: str, max_distance: int) -> bool:
+    """True when ``a`` and ``b`` are at most ``max_distance`` edits apart.
+
+    A bounded Levenshtein: the length gap alone can exceed the cap (a cheap
+    reject before any work), and the row-by-row DP short-circuits as soon as
+    every cell in a row exceeds the cap, so the cost is O(len * max_distance)
+    rather than O(len^2). Pure Python and dependency-free on purpose —
+    ``rapidfuzz`` is a compiled wheel this project deliberately does not add
+    (see the module docstring); over the ~200 short digest tokens this runs
+    against, the bounded DP is microseconds.
+    """
+    if abs(len(a) - len(b)) > max_distance:
+        return False
+    if a == b:
+        return True
+    previous = list(range(len(b) + 1))
+    for i, ca in enumerate(a, start=1):
+        current = [i]
+        row_min = i
+        for j, cb in enumerate(b, start=1):
+            cost = 0 if ca == cb else 1
+            value = min(
+                previous[j] + 1,  # deletion
+                current[j - 1] + 1,  # insertion
+                previous[j - 1] + cost,  # substitution
+            )
+            current.append(value)
+            row_min = min(row_min, value)
+        # Every cell in this row already exceeds the cap, so no later row can
+        # bring the final cell back under it — the distance only grows.
+        if row_min > max_distance:
+            return False
+        previous = current
+    return previous[-1] <= max_distance
+
+
+def _token_soft_matches(needle_token: str, haystack_tokens: set[str]) -> bool:
+    """True when ``needle_token`` softly matches any token in the haystack.
+
+    Two tiers beyond exact equality, both bounded:
+
+    * **Prefix** — ``class`` matches ``classifier``. Handles a partial word a
+      user types before they finish it, which substring already caught inside a
+      token but this states explicitly against the tokenized haystack.
+    * **Edit distance <= 2, tokens >= 4 chars** — ``classifer`` (a typo)
+      matches ``classifier``. The length floor is what keeps short tokens from
+      matching everything; below it, only the exact/prefix tiers apply.
+    """
+    for token in haystack_tokens:
+        if token == needle_token or token.startswith(needle_token):
+            return True
+        if (
+            len(needle_token) >= _SOFT_MIN_TOKEN
+            and len(token) >= _SOFT_MIN_TOKEN
+            and _within_edit_distance(needle_token, token, _SOFT_MAX_DISTANCE)
+        ):
+            return True
+    return False
+
+
+def soft_search_digests(digests: dict[str, str], query: str) -> set[str]:
+    """Ids whose body SOFTLY matches ``query`` — prefix, typo, or word-order.
+
+    The bounded soft tier that sits beside :func:`search_digests`. A query
+    matches a digest when EVERY query token softly matches some token in the
+    digest (order-independent AND), where "softly" is exact, prefix, or a
+    bounded edit-distance typo (see :func:`_token_soft_matches`). Order-
+    independent AND is what makes ``throughput classifier`` find a session
+    titled "Improve ADM Classifier Throughput" — word order and exact substring
+    contiguity both stop mattering.
+
+    Returned as a SET, like :func:`search_digests`: the caller
+    (:class:`SessionPickerScreen.visible_rows`) owns row order, and ranking is
+    applied there only when a query is active. This function answers only
+    "which ones match".
+
+    Bounded and dependency-free by design. The old substring-only filter warned
+    that fuzzy matching over free text produces confident nonsense; that was
+    right about UNBOUNDED fuzzy. This is bounded — a distance cap of 2 for
+    tokens of 4+ chars, plus prefix and token-AND — and the bound is precisely
+    what keeps a soft match from being confident nonsense: a nonsense token
+    close to nothing in the digest excludes the row rather than dragging in
+    everything.
+    """
+    needle_tokens = _tokenize(query)
+    if not needle_tokens:
+        return set()
+    matched: set[str] = set()
+    for sid, digest in digests.items():
+        haystack = set(_tokenize(digest))
+        if not haystack:
+            continue
+        if all(_token_soft_matches(token, haystack) for token in needle_tokens):
+            matched.add(sid)
+    return matched

--- a/local_operator/session/search_index.py
+++ b/local_operator/session/search_index.py
@@ -80,11 +80,7 @@ import re
 from pathlib import Path
 from typing import Any
 
-from local_operator.resume import (
-    TITLE_SIDECAR_NAME,
-    TRANSCRIPT_NAME,
-    read_title_names,
-)
+from local_operator.resume import TITLE_SIDECAR_NAME, TRANSCRIPT_NAME, read_title_names
 
 #: Characters of prose kept per session. Enough to hold the subject matter of a
 #: long conversation's opening stretch — the part that says what the session was

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -2376,6 +2376,23 @@ class Session:
                 "user_set": self._conversation_name.user_set,
             }
             await self._transcript.append_custom(CONVERSATION_NAME_CUSTOM_TYPE, payload)
+            # Journal the same title to the sidecar the picker reads O(1), on
+            # the SAME event that writes it to the transcript. This is what
+            # makes a title in the untouched middle of a large transcript
+            # findable without a full read on the picker's synchronous path —
+            # see resume.write_session_title / TITLE_SCAN_BYTES. Imported here
+            # rather than at module top so the CLI's import-guard on
+            # ``resume`` is unaffected, and best-effort by the helper's own
+            # contract: a failed sidecar write never fails a turn.
+            from local_operator.resume import read_title_names, write_session_title
+
+            session_dir = self._transcript.directory
+            write_session_title(
+                session_dir,
+                str(payload["text"]),
+                user_set=bool(payload["user_set"]),
+                past_names=read_title_names(session_dir),
+            )
             if (self._conversation_name.text, self._conversation_name.user_set) == (
                 payload["text"],
                 payload["user_set"],

--- a/local_operator/session_factory.py
+++ b/local_operator/session_factory.py
@@ -1035,9 +1035,14 @@ async def _prepare(
     # store is quiet, and both are best-effort by construction. A no-op on
     # every later launch — each directory is answered once and never
     # re-stamped.
-    from local_operator.resume import backfill_session_origins
+    from local_operator.resume import backfill_session_origins, backfill_session_titles
 
     backfill_session_origins(Path(agent_registry.config_dir))
+    # Stamp the title sidecar alongside the origin marker, so a pre-existing
+    # session is findable by every name it has borne on the first launch after
+    # upgrade rather than only after its next rename. Same best-effort,
+    # once-per-session-ever contract as the origin backfill above.
+    backfill_session_titles(Path(agent_registry.config_dir))
 
     # --- model + stream fn (stream B contracts) ---------------------------
     from local_operator.env import get_env_config

--- a/local_operator/tui/widgets/session_picker.py
+++ b/local_operator/tui/widgets/session_picker.py
@@ -18,16 +18,24 @@ session.
 
 The list is filterable by typing because the ids are unmemorable and the names
 are not: with a hundred sessions, "asteroids" finds the one you mean faster
-than paging can. Filtering narrows; it never reorders, so a row does not move
-under the cursor as the query grows.
+than paging can. Filtering narrows without reordering FOR A FIXED QUERY; a new
+query re-ranks by relevance (best match first) and re-homes the cursor to the
+top match, matching this app's command and ask pickers. That preserves the "a
+row must not move under the cursor" invariant, because the only event that
+reorders — a query change — is the same one that moves the cursor to the new
+rank-0 row; a fixed query's order is byte-for-byte stable across repaints.
 
 **The filter also searches what was SAID in each conversation**, not only its
 name — see ``session/search_index.py``. Matching on the name alone meant a
 session could only be found by the words in its title, so a user who could not
 recall how a conversation was named could not reach it at all, however
-distinctive the work inside it was. A row matched on its body rather than its
-name is marked, because otherwise it looks like a result the filter had no
-reason to return.
+distinctive the work inside it was. The body digest also carries the session's
+title and every PAST name it was renamed away from, so a topic-pivot session is
+findable by the subject it ended on. **Matching is substring plus bounded soft
+matching** (prefix, word-order-independent, small-typo-tolerant), not only
+exact substring — see ``search_index.soft_search_digests``. A row matched on
+its body, a past name, or a soft match rather than its visible name is marked,
+because otherwise it looks like a result the filter had no reason to return.
 
 **The card measures the terminal.** Every column here is a cell count derived
 from the screen, not a constant: the first cut shipped a fixed 78-cell card
@@ -55,7 +63,7 @@ from textual.screen import ModalScreen
 from textual.widgets import Static
 
 from local_operator.resume import SessionRow, format_age
-from local_operator.session.search_index import search_digests
+from local_operator.session.search_index import search_digests, soft_search_digests
 from local_operator.tui import theme as theme_mod
 from local_operator.tui.widgets.tool_card import truncate_cells
 
@@ -150,18 +158,27 @@ def filter_rows(
     query: str,
     body_matches: AbstractSet[str] | None = None,
 ) -> list[SessionRow]:
-    """Rows whose name, id, or conversation BODY contains ``query``.
+    """Rows whose name or id contains ``query``, or whose id is in ``body_matches``.
 
-    Substring rather than fuzzy on purpose: the fields are sentences the user
-    wrote and a hex id, and fuzzy matching over free text produces confident
-    nonsense ("asteroids" matching a row about "assets ordering").
-    Order is preserved — filtering must never move a row under the cursor.
+    A pure MEMBERSHIP filter: it decides which rows are shown and preserves the
+    order it was handed, so on its own it never moves a row under the cursor.
+    Relevance ORDERING lives in :func:`rank_rows`, applied by the screen only
+    when a query is active — keeping the "filtering never reorders" property
+    literally true of this function while the query-scoped ranking sits in the
+    one place that also re-homes the cursor.
 
-    ``body_matches`` is the set of ids whose conversation text matched, decided
-    by :func:`local_operator.session.search_index.search_digests`. Passed in
-    rather than computed here so this function stays pure and cheap enough to
-    run per keystroke, and so a caller with no index (a test, an embedder)
-    keeps exactly the old name-and-id behaviour.
+    The name/id test stays exact substring: those fields are a sentence the user
+    wrote and a hex id, where an exact match is what a precise query expects.
+    Soft matching (prefix, word-order, bounded typo) is not done here; it is
+    folded into ``body_matches`` by the caller via
+    :func:`local_operator.session.search_index.soft_search_digests`, so a soft
+    hit on the conversation surfaces the row exactly as an exact body hit does.
+
+    ``body_matches`` is the set of ids admitted on their conversation text —
+    exact body, a past name, or a bounded soft match — decided by the caller
+    and passed in rather than computed here, so this function stays pure and
+    cheap enough to run per keystroke, and a caller with no index (a test, an
+    embedder) keeps exactly the old name-and-id behaviour.
     """
     needle = query.strip().lower()
     if not needle:
@@ -188,6 +205,73 @@ def matched_in_body(row: SessionRow, query: str, body_matches: AbstractSet[str])
     if needle in row.name.lower() or needle in row.id.lower():
         return False
     return row.id in body_matches
+
+
+#: Relevance tiers, best (lowest) first, used to sort a FILTERED subset when a
+#: query is active. A tier is a property of ``(query, row)`` alone — it does not
+#: depend on the previous query or on the order rows arrived — which is what
+#: lets ranking coexist with the "no reorder under the cursor" invariant: the
+#: order changes only when the query changes, and a query change already
+#: re-homes the cursor to the top match (see ``set_query``).
+_RANK_NAME = 0  # exact substring in the visible name — the strongest signal
+_RANK_ID = 1  # exact substring in the id
+_RANK_BODY = 2  # exact substring in the body/past-name digest
+_RANK_SOFT = 3  # soft (prefix / token-AND / edit-distance) match only
+
+
+def rank_rows(
+    rows: Sequence[SessionRow],
+    query: str,
+    body_matches: AbstractSet[str] | None = None,
+) -> list[SessionRow]:
+    """``rows`` ordered by relevance to ``query``; recency order when empty.
+
+    Kept SEPARATE from :func:`filter_rows`, which stays a pure membership
+    filter, because the module's invariant is stated about filtering: "filtering
+    narrows; it never reorders". Ordering is a property of the QUERY, not of a
+    keystroke within a query's growth — so it is applied here, in the one place
+    that recomputes per query and re-homes the cursor, and only when a query is
+    active.
+
+    * **Empty query** -> ``rows`` unchanged (recency order, newest first,
+      exactly as today). A fixed query likewise never reorders: the key is a
+      pure function of ``(query, row)``, so repeated repaints and resizes
+      produce byte-for-byte the same order.
+    * **Non-empty query** -> a single deterministic ordering: the tier the row
+      matched in (name > id > body > soft), with recency (mtime desc) as the
+      stable tie-break WITHIN every tier. ``sorted`` is stable, so passing rows
+      already in recency order makes the tie-break free.
+
+    ``body_matches`` is the EXACT-body match set (from ``search_digests``),
+    passed in for the same reason :func:`filter_rows` takes it — this stays pure
+    and cheap, and a caller with no index gets name/id ranking unchanged. It is
+    only the exact-body set, not the soft set: a row in ``rows`` that matched
+    none of name, id, or exact body was admitted by the soft set and so takes
+    the soft tier, which needs no separate membership check.
+    """
+    needle = query.strip().lower()
+    if not needle:
+        return list(rows)
+    body = body_matches or frozenset()
+
+    def tier(row: SessionRow) -> int:
+        if needle in row.name.lower():
+            return _RANK_NAME
+        if needle in row.id.lower():
+            return _RANK_ID
+        # Exact body hit outranks a soft-only hit: an exact substring in the
+        # conversation is a stronger signal than a typo/prefix/word-order match.
+        if row.id in body:
+            return _RANK_BODY
+        # Admitted by the soft set (it is in the already-filtered ``rows`` yet
+        # matched neither name, id, nor exact body), so it ranks below every
+        # exact tier.
+        return _RANK_SOFT
+
+    # Stable sort on the tier alone: ``rows`` arrives newest-first, so equal
+    # tiers keep recency order without a second sort key. Sorting the tier as
+    # the only key is what preserves the recency tie-break for free.
+    return sorted(rows, key=tier)
 
 
 def _pad_cells(text: str, width: int) -> str:
@@ -424,7 +508,15 @@ class SessionPickerScreen(ModalScreen[str | None]):
         # cost this cache exists to avoid.
         self._filtered: list[SessionRow] = list(rows)
         self._filtered_for = ""
+        # ``_body_matches`` is the EXACT-body match set; ``_admitted`` is the
+        # union of exact-body and bounded-soft matches that ``filter_rows``
+        # admits a row on. Two sets rather than one because they answer
+        # different questions: ``_admitted`` decides whether a row is SHOWN,
+        # while ``_body_matches`` (exact only) decides its ranking TIER and
+        # feeds the body-match marker. Cached on the same key as the filter,
+        # because the same keystroke recomputes all three.
         self._body_matches: set[str] = set()
+        self._admitted: set[str] = set()
         self._body: Static
 
     # -- state ---------------------------------------------------------------
@@ -435,10 +527,26 @@ class SessionPickerScreen(ModalScreen[str | None]):
     # own focus, query and paint paths from inside the screen.
     @property
     def visible_rows(self) -> list[SessionRow]:
-        """The rows the current filter admits, in their original order."""
+        """The rows the current filter admits, ranked by relevance to the query.
+
+        Empty query -> recency order, unchanged. A non-empty query re-ranks the
+        admitted subset by :func:`rank_rows` (name > id > body > soft, recency
+        tie-break) and, in the same step that ``set_query`` re-homes the cursor
+        to index 0, so the cursor tracks the best match rather than a row that
+        ranking then slides away from. Ordering is a pure function of the query,
+        so a FIXED query never reorders across repaints or resizes.
+        """
         if self._filtered_for != self._query:
+            # Exact-body hits and bounded-soft hits are computed separately: the
+            # union decides which rows are shown, the exact set decides ranking
+            # tier and the body-match marker. Both are recomputed only on a
+            # query change, never per repaint — scanning 200 digests per paint
+            # is the cost this cache exists to avoid.
             self._body_matches = search_digests(self._digests, self._query)
-            self._filtered = filter_rows(self._all, self._query, self._body_matches)
+            soft = soft_search_digests(self._digests, self._query)
+            self._admitted = self._body_matches | soft
+            admitted = filter_rows(self._all, self._query, self._admitted)
+            self._filtered = rank_rows(admitted, self._query, self._body_matches)
             self._filtered_for = self._query
         return self._filtered
 
@@ -448,9 +556,15 @@ class SessionPickerScreen(ModalScreen[str | None]):
 
         Reads through :attr:`visible_rows` rather than the cached set directly,
         so the two can never answer for different queries.
+
+        Keyed on ``_admitted`` (exact-body OR soft), not the exact-body set: a
+        row surfaced only because a PAST name or a typo/prefix matched is just
+        as much "found on something other than the visible name" as an exact
+        body hit, and the marker means exactly that — otherwise a soft or
+        past-name hit reads as the filter returning an arbitrary row.
         """
         rows = self.visible_rows
-        return {row.id for row in rows if matched_in_body(row, self._query, self._body_matches)}
+        return {row.id for row in rows if matched_in_body(row, self._query, self._admitted)}
 
     @property
     def filter_query(self) -> str:

--- a/local_operator/tui/widgets/session_picker.py
+++ b/local_operator/tui/widgets/session_picker.py
@@ -961,7 +961,11 @@ class SessionPickerScreen(ModalScreen[str | None]):
         # Hints DROP to fit, in reverse order of need — the same discipline the
         # columns use. A footer that overflowed the card was the one row that
         # could not afford to: it is the only statement of how to get out.
-        for index, (key, what) in enumerate(_footer_hints(width)):
+        # The marker legend appears only when a marked row is actually on
+        # screen, so an empty query or a pure name match never advertises a mark
+        # the user cannot see (D2: teach the glyph where it is used, not always).
+        has_marked = bool(self.body_matched_ids)
+        for index, (key, what) in enumerate(_footer_hints(width, has_marked=has_marked)):
             if index:
                 out.append(" · ", style=faint)
             out.append(key, style=dim)
@@ -981,8 +985,26 @@ _FOOTER_HINTS: tuple[tuple[str, str], ...] = (
 )
 _FOOTER_DROP_ORDER = ("pgup/pgdn", "type", "↑↓")
 
+#: The ``"`` body-match marker is load-bearing but unlabelled in the list: a
+#: first-time reader sees a lone right-quote at the start of some rows and can
+#: read it as a rendering artifact rather than "this row matched inside the
+#: conversation" (design round 1, D2). So when any visible row carries the
+#: marker, the footer states what it means — keyed on the marker GLYPH itself
+#: so the legend and the mark are unmistakably the same thing.
+_MARKER_LEGEND: tuple[str, str] = (BODY_MATCH_MARKER.strip(), "matched inside")
 
-def _footer_hints(width: int) -> list[tuple[str, str]]:
+#: Drop priority once the legend is in play. The full key-hint row is ~69 cells
+#: against a ~74-cell card, so a legend can only appear by DISPLACING a hint —
+#: dropping it "first" would make it never show, i.e. no fix at all. So it
+#: outranks the two genuinely disposable hints (``pgup/pgdn``, ``type``, which
+#: describe conveniences a user discovers anyway) and is shed BEFORE the
+#: movement and action keys. Because it is dropped before the bare-key stage,
+#: it never survives as an unlabelled glyph — a lone ``"`` in the footer would
+#: be exactly the artifact-looking mark D2 flagged.
+_FOOTER_DROP_ORDER_MARKED = ("pgup/pgdn", "type", _MARKER_LEGEND[0], "↑↓")
+
+
+def _footer_hints(width: int, *, has_marked: bool = False) -> list[tuple[str, str]]:
     """The key hints that fit in ``width`` cells, dropping the least needed.
 
     Three stages, because the footer is the one row that must not overflow the
@@ -990,15 +1012,26 @@ def _footer_hints(width: int) -> list[tuple[str, str]]:
     with their labels will not fit (a card under about 26 cells), drop the
     LABELS and keep the keys. Two bare keys still say which keys exist, which
     is more than a clipped row says.
+
+    ``has_marked`` adds the ``"``-marker legend (see :data:`_MARKER_LEGEND`)
+    so the glyph the list is drawing is explained where the reader already
+    looks for meaning. It sits at the FRONT (adjacent to nothing that could be
+    read as a key) and is shed under width pressure per
+    :data:`_FOOTER_DROP_ORDER_MARKED` — above the disposable hints so it can
+    actually appear on a normal card, below the movement and action keys.
     """
     hints = list(_FOOTER_HINTS)
+    drop_order = _FOOTER_DROP_ORDER
+    if has_marked:
+        hints = [_MARKER_LEGEND, *hints]
+        drop_order = _FOOTER_DROP_ORDER_MARKED
 
     def cells(pairs: list[tuple[str, str]]) -> int:
         return sum(cell_len(f"{key} {what}".strip()) for key, what in pairs) + 3 * max(
             0, len(pairs) - 1
         )
 
-    for droppable in _FOOTER_DROP_ORDER:
+    for droppable in drop_order:
         if cells(hints) <= width:
             return hints
         hints = [pair for pair in hints if pair[0] != droppable]

--- a/local_operator/tui/widgets/session_picker.py
+++ b/local_operator/tui/widgets/session_picker.py
@@ -63,7 +63,7 @@ from textual.screen import ModalScreen
 from textual.widgets import Static
 
 from local_operator.resume import SessionRow, format_age
-from local_operator.session.search_index import search_digests, soft_search_digests
+from local_operator.session.search_index import SoftSearchIndex, search_digests
 from local_operator.tui import theme as theme_mod
 from local_operator.tui.widgets.tool_card import truncate_cells
 
@@ -500,6 +500,13 @@ class SessionPickerScreen(ModalScreen[str | None]):
         # without an index — tests, embedders — gets the name-and-id filter
         # unchanged instead of an error.
         self._digests = dict(digests or {})
+        # Soft matching reruns on every keystroke; a per-screen index caches each
+        # digest's token set (and a deduplicated vocabulary over them) so the
+        # bounded edit-distance search costs ~13 ms per query change at real
+        # store scale instead of the ~185 ms a stateless re-tokenise-everything
+        # call costs there. Owned by the screen so the cache lives exactly as
+        # long as the picker and is discarded with it.
+        self._soft_index = SoftSearchIndex()
         # Filtering runs on every keystroke and again on every paint; the
         # result is cached against the query that produced it so a card with
         # several hundred sessions does not re-scan the list per repaint. The
@@ -543,7 +550,7 @@ class SessionPickerScreen(ModalScreen[str | None]):
             # query change, never per repaint — scanning 200 digests per paint
             # is the cost this cache exists to avoid.
             self._body_matches = search_digests(self._digests, self._query)
-            soft = soft_search_digests(self._digests, self._query)
+            soft = self._soft_index.search(self._digests, self._query)
             self._admitted = self._body_matches | soft
             admitted = filter_rows(self._all, self._query, self._admitted)
             self._filtered = rank_rows(admitted, self._query, self._body_matches)

--- a/tests/unit/session/test_conversation_name_persistence.py
+++ b/tests/unit/session/test_conversation_name_persistence.py
@@ -374,6 +374,27 @@ async def test_the_sidecar_retains_every_name_the_session_has_borne(tmp_path) ->
     assert names == ["First Subject", "Second Subject"]
 
 
+def test_written_names_are_whitespace_normalized_like_the_title(tmp_path) -> None:
+    """``names`` must be normalised on write the same way ``text`` is, so the
+    digest folds a name in exactly as the reader tokenises it and two names that
+    differ only in internal whitespace collapse to one. Otherwise a hand-edited
+    or foreign sidecar could fold ``Old   Name`` into the digest unnormalised."""
+    from local_operator.resume import read_title_names, write_session_title
+
+    session = tmp_path / "sess"
+    session.mkdir()
+    write_session_title(
+        session,
+        "Final  Title",
+        user_set=False,
+        past_names=["Old   Name", "Old Name", "  Second\tName  "],
+    )
+
+    # Internal runs collapse; the duplicate that only differed by whitespace is
+    # deduped after normalisation; first-seen order and the in-force title last.
+    assert read_title_names(session) == ["Old Name", "Second Name", "Final Title"]
+
+
 @pytest.mark.asyncio
 async def test_a_resumed_session_findable_by_either_name_after_reindex(tmp_path) -> None:
     """End to end: create, auto-name, dispose, resume, rename, dispose; then a

--- a/tests/unit/session/test_conversation_name_persistence.py
+++ b/tests/unit/session/test_conversation_name_persistence.py
@@ -323,3 +323,92 @@ async def test_a_fresh_session_is_nameless_and_journals_nothing(tmp_path) -> Non
     assert session.conversation_name == ""
     await session.dispose()
     assert _name_entries(tmp_path) == []
+
+
+@pytest.mark.asyncio
+async def test_the_title_sidecar_is_written_on_the_same_event_as_the_transcript(
+    tmp_path,
+) -> None:
+    """The picker's O(1) title fast path: journalling a title also writes
+    title.json beside the transcript, so a title buried in a large transcript
+    is still found without a full read on the picker's synchronous path.
+    """
+    from local_operator.resume import stored_session_title
+
+    session = _session(tmp_path)
+    await session.async_init()
+    session.set_conversation_name("Auto Generated Name", user_set=False)
+    session.set_conversation_name("What The User Renamed It To", user_set=True)
+    await session.dispose()
+
+    session_dir = tmp_path / "sess"
+    assert (session_dir / "title.json").is_file()
+    # The in-force title is the newest, read straight from the sidecar.
+    assert stored_session_title(session_dir) == "What The User Renamed It To"
+
+
+@pytest.mark.asyncio
+async def test_the_sidecar_retains_every_name_the_session_has_borne(tmp_path) -> None:
+    """A search must reach a session by a name it was renamed AWAY from, so the
+    sidecar accumulates every distinct title across renames, first-seen order
+    preserved.
+
+    Each rename is disposed before the next so it is a distinct persist event:
+    two renames within one persist window coalesce into a single journalled row
+    (only the final name is written), which is the writer's existing contract —
+    accumulation is over names actually journalled, not every transient value.
+    """
+    from local_operator.resume import read_title_names
+
+    session = _session(tmp_path)
+    await session.async_init()
+    session.set_conversation_name("First Subject", user_set=False)
+    await session.dispose()
+
+    resumed = _session(tmp_path)
+    await resumed.async_init()
+    resumed.set_conversation_name("Second Subject", user_set=True)
+    await resumed.dispose()
+
+    names = read_title_names(tmp_path / "sess")
+    assert names == ["First Subject", "Second Subject"]
+
+
+@pytest.mark.asyncio
+async def test_a_resumed_session_findable_by_either_name_after_reindex(tmp_path) -> None:
+    """End to end: create, auto-name, dispose, resume, rename, dispose; then a
+    fresh recent_session_rows + build_index makes it findable by BOTH names."""
+    from local_operator.resume import recent_session_rows
+    from local_operator.session.search_index import build_index, search_digests
+
+    # Build under config_dir/sessions/<id>, where recent_session_rows scans.
+    session_id = "abcd1234beef"
+    session_dir = tmp_path / "sessions" / session_id
+
+    def _at(directory: Path) -> Session:
+        return Session(
+            model=MODEL,
+            stream_fn=ScriptedStream([[StreamEndEvent(stop_reason="stop")]]),
+            tools=[],
+            transcript=Transcript(directory),
+            system_blocks_provider=lambda: [],
+        )
+
+    session = _at(session_dir)
+    await session.async_init()
+    session.set_conversation_name("Load Test Review", user_set=False)
+    await session.dispose()
+
+    resumed = _at(session_dir)
+    await resumed.async_init()
+    resumed.set_conversation_name("Improve ADM Classifier Throughput", user_set=True)
+    await resumed.dispose()
+
+    # The row shows the CURRENT title.
+    rows = recent_session_rows(tmp_path, limit=10)
+    assert rows and rows[0].name == "Improve ADM Classifier Throughput"
+
+    # The index folds both names in, so either finds it.
+    digests = build_index(tmp_path, [rows[0].id])
+    assert search_digests(digests, "classifier") == {rows[0].id}
+    assert search_digests(digests, "load test review") == {rows[0].id}

--- a/tests/unit/session/test_search_index.py
+++ b/tests/unit/session/test_search_index.py
@@ -18,6 +18,7 @@ from local_operator.resume import write_session_title
 from local_operator.session.search_index import (
     DIGEST_CHARS,
     INDEX_VERSION,
+    SoftSearchIndex,
     _within_edit_distance,
     build_index,
     digest_transcript,
@@ -275,3 +276,64 @@ def test_bounded_edit_distance_rejects_beyond_the_cap():
     assert _within_edit_distance("throughput", "throughput", 2)  # zero edits
     assert not _within_edit_distance("classifier", "retention", 2)  # far apart
     assert not _within_edit_distance("cat", "category", 2)  # length gap > cap
+
+
+# ---------------------------------------------------------------------------
+# SoftSearchIndex: the per-picker token cache behind soft matching. It exists
+# only to make the SAME soft match dramatically cheaper across the keystrokes
+# of one picker session, so these pin (a) that it returns exactly what the
+# stateless function returns and (b) that its cache stays honest — a changed
+# digest re-tokenises, a dropped session is pruned, so it can neither serve a
+# stale match nor grow without bound.
+# ---------------------------------------------------------------------------
+
+
+def test_soft_index_matches_the_stateless_function_across_tiers():
+    """Parity is the whole contract: the cache is an optimisation, so any query
+    must return byte-identically what ``soft_search_digests`` returns."""
+    digests = {
+        "aaaa": "improve adm classifier throughput",
+        "bbbb": "retention sweep policy",
+        "cccc": "database migration rollback plan",
+    }
+    index = SoftSearchIndex()
+    for query in [
+        "class",  # prefix
+        "classifer",  # typo (edit distance 1)
+        "throughput classifier",  # word-order-independent AND
+        "retention nonexistentword",  # AND with an unmatched token -> no match
+        "xyz",  # short nonsense, below the fuzzy floor
+        "databse migration",  # typo + exact, both must hold
+        "",  # empty query
+    ]:
+        assert index.search(digests, query) == soft_search_digests(digests, query), query
+
+
+def test_soft_index_retokenizes_when_a_digest_changes():
+    """Freshness: a re-digested session (its digest STRING changed) must be
+    re-tokenised, so a match that the old digest supported disappears and one the
+    new digest supports appears. Keying the cache on the digest string is what
+    makes a re-digest after a rename or append invalidate the stale tokens."""
+    index = SoftSearchIndex()
+    before = {"s1": "classifier throughput"}
+    assert index.search(before, "class") == {"s1"}
+    assert index.search(before, "migration") == set()
+
+    # Same session id, different digest content (as a rename/append would produce).
+    after = {"s1": "database migration rollback"}
+    assert index.search(after, "class") == set()  # stale token must not survive
+    assert index.search(after, "migration") == {"s1"}  # new token is searchable
+
+
+def test_soft_index_prunes_dropped_sessions_and_stays_bounded():
+    """Boundedness: an entry for a session no longer in ``digests`` is dropped,
+    so the cache tracks the live store rather than every digest ever seen over
+    the picker's life. A dropped session must also stop matching."""
+    index = SoftSearchIndex()
+    index.search({"s1": "retention policy", "s2": "classifier work"}, "warm")
+    assert len(index._tokens) == 2
+
+    pruned = index.search({"s1": "retention policy"}, "classifier")
+    assert pruned == set()  # s2 is gone, so its match is gone
+    assert set(index._tokens) == {"s1"}  # and its cache entry with it
+    assert index.search({"s1": "retention policy"}, "retention") == {"s1"}

--- a/tests/unit/session/test_search_index.py
+++ b/tests/unit/session/test_search_index.py
@@ -14,13 +14,16 @@ import json
 from pathlib import Path
 
 from local_operator.harness.types import Message, MessageRole, TextContent
+from local_operator.resume import write_session_title
 from local_operator.session.search_index import (
     DIGEST_CHARS,
     INDEX_VERSION,
+    _within_edit_distance,
     build_index,
     digest_transcript,
     index_path,
     search_digests,
+    soft_search_digests,
 )
 from local_operator.session.transcript import Transcript
 
@@ -152,3 +155,123 @@ def test_an_empty_query_matches_nothing_rather_than_everything(tmp_path: Path):
     digests = build_index(tmp_path, ["7777bbbb"])
     assert search_digests(digests, "") == set()
     assert search_digests(digests, "   ") == set()
+
+
+# ---------------------------------------------------------------------------
+# Title-fold: the digest prepends the session's title and every past name, so a
+# topic-pivot session is found by the subject it ended on, not the one it
+# opened with. See build_index / read_title_names.
+# ---------------------------------------------------------------------------
+
+
+def test_a_session_is_found_by_its_title_when_the_body_lacks_the_topic(tmp_path: Path):
+    """The ADM pivot, modelled: opening body about topic A, title about topic
+    B, query B -> found, because the title is folded into the digest."""
+    session = tmp_path / "sessions" / "pivot001"
+    _write(
+        session,
+        ("user", "review the article-search load test results please"),
+        ("assistant", "the load test showed elevated latency on the search path"),
+    )
+    # The defining topic lives ONLY in the title/past names, not the body.
+    write_session_title(
+        session,
+        "Improve ADM Classifier Throughput",
+        user_set=False,
+        past_names=["Article Search Load Test Review"],
+    )
+    digests = build_index(tmp_path, ["pivot001"])
+    assert "classifier" not in digest_transcript(session / "transcript.jsonl").lower()
+    assert search_digests(digests, "classifier") == {"pivot001"}
+    assert search_digests(digests, "throughput") == {"pivot001"}
+    # A PAST name the session was renamed away from is searchable too.
+    assert search_digests(digests, "article search load") == {"pivot001"}
+
+
+def test_a_rename_re_folds_the_digest_even_when_the_transcript_is_unchanged(tmp_path: Path):
+    """The signature includes the title sidecar's mtime, so a new title.json
+    invalidates the cached digest even when the transcript is byte-identical."""
+    session = tmp_path / "sessions" / "renamed01"
+    _write(session, ("user", "some body text"))
+    write_session_title(session, "First Title", user_set=False, past_names=[])
+    first = build_index(tmp_path, ["renamed01"])
+    assert search_digests(first, "First Title") == {"renamed01"}
+    # Rename with no transcript change; the sidecar mtime moves.
+    import time
+
+    time.sleep(0.01)
+    write_session_title(session, "Second Title", user_set=True, past_names=["First Title"])
+    second = build_index(tmp_path, ["renamed01"])
+    assert search_digests(second, "Second Title") == {"renamed01"}
+    # The old name is retained (past_names), so both are findable.
+    assert search_digests(second, "First Title") == {"renamed01"}
+
+
+def test_an_index_version_bump_discards_a_stale_shaped_cache(tmp_path: Path):
+    """A cache written under a different INDEX_VERSION is dropped wholesale and
+    rebuilt with the current shape, never migrated."""
+    session = tmp_path / "sessions" / "verbump1"
+    _write(session, ("user", "distinctive body content"))
+    build_index(tmp_path, ["verbump1"])
+    stale = json.loads(index_path(tmp_path).read_text(encoding="utf-8"))
+    stale["version"] = INDEX_VERSION - 1
+    index_path(tmp_path).write_text(json.dumps(stale), encoding="utf-8")
+    digests = build_index(tmp_path, ["verbump1"])
+    # Rebuilt (the stale cache was discarded) and still searchable.
+    assert search_digests(digests, "distinctive") == {"verbump1"}
+    fresh = json.loads(index_path(tmp_path).read_text(encoding="utf-8"))
+    assert fresh["version"] == INDEX_VERSION
+
+
+# ---------------------------------------------------------------------------
+# Bounded soft matching: prefix, order-independent token-AND, edit-distance <=2
+# for tokens >=4 chars. See soft_search_digests.
+# ---------------------------------------------------------------------------
+
+
+def _soft_session(tmp_path: Path, sid: str, title: str) -> dict[str, str]:
+    session = tmp_path / "sessions" / sid
+    _write(session, ("user", "opening line"))
+    write_session_title(session, title, user_set=False, past_names=[])
+    return build_index(tmp_path, [sid])
+
+
+def test_soft_match_finds_a_prefix(tmp_path: Path):
+    digests = _soft_session(tmp_path, "soft0001", "Classifier Throughput Work")
+    assert "soft0001" in soft_search_digests(digests, "class")
+
+
+def test_soft_match_tolerates_a_typo(tmp_path: Path):
+    digests = _soft_session(tmp_path, "soft0002", "Classifier Throughput Work")
+    # 'classifer' -> 'classifier' is one insertion, within the distance cap.
+    assert "soft0002" in soft_search_digests(digests, "classifer")
+
+
+def test_soft_match_is_word_order_independent(tmp_path: Path):
+    digests = _soft_session(tmp_path, "soft0003", "Improve ADM Classifier Throughput")
+    assert "soft0003" in soft_search_digests(digests, "throughput classifier")
+
+
+def test_soft_match_does_not_let_a_short_nonsense_token_match_everything(tmp_path: Path):
+    """The distance cap is gated on token length: a 3-char nonsense token must
+    not match via edit distance, or the bound the design relies on is gone."""
+    digests = _soft_session(tmp_path, "soft0004", "Retention Sweep Policy")
+    # 'xyz' is 3 chars — below the floor — and is not a prefix of any token,
+    # so it must not match.
+    assert soft_search_digests(digests, "xyz") == set()
+
+
+def test_soft_match_requires_all_query_tokens(tmp_path: Path):
+    """Order-independent AND: a query with one matching and one unmatched token
+    does not match, so soft matching narrows rather than widening."""
+    digests = _soft_session(tmp_path, "soft0005", "Retention Sweep Policy")
+    assert soft_search_digests(digests, "retention nonexistentword") == set()
+
+
+def test_bounded_edit_distance_rejects_beyond_the_cap():
+    """The primitive itself: within cap true, beyond cap false, cheap reject on
+    a length gap."""
+    assert _within_edit_distance("classifier", "classifer", 2)  # one edit
+    assert _within_edit_distance("throughput", "throughput", 2)  # zero edits
+    assert not _within_edit_distance("classifier", "retention", 2)  # far apart
+    assert not _within_edit_distance("cat", "category", 2)  # length gap > cap

--- a/tests/unit/test_stored_session_title.py
+++ b/tests/unit/test_stored_session_title.py
@@ -15,8 +15,13 @@ from local_operator.harness.types import Message, TextContent
 from local_operator.resume import (
     _TITLE_CUSTOM_TYPE,
     TITLE_SCAN_BYTES,
+    TITLE_SIDECAR_NAME,
+    _read_title_sidecar,
+    backfill_session_titles,
+    read_title_names,
     session_name,
     stored_session_title,
+    write_session_title,
 )
 from local_operator.session.naming import CONVERSATION_NAME_CUSTOM_TYPE
 from local_operator.session.transcript import Transcript
@@ -221,3 +226,140 @@ def test_a_band_sized_transcript_whose_title_is_only_at_the_head(tmp_path: Path)
     size = session.joinpath("transcript.jsonl").stat().st_size
     assert TITLE_SCAN_BYTES < size <= TITLE_SCAN_BYTES * 2, size
     assert stored_session_title(session) == "Auto Named At Turn 2"
+
+
+# ---------------------------------------------------------------------------
+# Title sidecar (title.json): the O(1) fast path that closes the window-scan
+# gap TITLE_SCAN_BYTES documents. See resume.write_session_title.
+# ---------------------------------------------------------------------------
+
+
+def test_the_sidecar_round_trips_text_and_names(tmp_path: Path):
+    """write_session_title then _read_title_sidecar returns what went in."""
+    session = tmp_path / "sessions" / "roundtrip"
+    session.mkdir(parents=True)
+    write_session_title(session, "Second Name", user_set=True, past_names=["First Name"])
+    sidecar = _read_title_sidecar(session)
+    assert sidecar is not None
+    assert sidecar.text == "Second Name"
+    assert sidecar.user_set is True
+    # The in-force title is accumulated into names, first-seen order preserved.
+    assert sidecar.names == ("First Name", "Second Name")
+    assert read_title_names(session) == ["First Name", "Second Name"]
+
+
+def test_the_sidecar_dedupes_names_keeping_first_seen_order(tmp_path: Path):
+    """A re-title back to a former name does not duplicate it in the list."""
+    session = tmp_path / "sessions" / "dedup"
+    session.mkdir(parents=True)
+    write_session_title(session, "Alpha", user_set=False, past_names=["Alpha", "Beta"])
+    assert read_title_names(session) == ["Alpha", "Beta"]
+
+
+def test_the_sidecar_wins_over_a_title_in_an_unscanned_window(tmp_path: Path):
+    """THE NAMED REGRESSION, distilled: a title in the middle of a large
+    transcript — invisible to both scan windows — is found via the sidecar.
+
+    This is the topic-pivot / ADM shape: > 2x TITLE_SCAN_BYTES with the only
+    conversation_name entries buried strictly between the head and tail
+    windows. The window scan returns "" for it; the sidecar returns the title.
+    """
+    session = tmp_path / "sessions" / "middletitle"
+
+    async def build() -> None:
+        transcript = Transcript(session)
+        await transcript.append_message(
+            Message(role="user", content=[TextContent(text="an unrelated opening topic")])
+        )
+        # Bulk before the title, pushing it past the head window.
+        for index in range(20):
+            await transcript.append_message(
+                Message(role="assistant", content=[TextContent(text=f"pre {index} " + "z" * 8_000)])
+            )
+        await transcript.append_custom(
+            CONVERSATION_NAME_CUSTOM_TYPE,
+            {"text": "Buried In The Middle", "user_set": False},
+        )
+        # Bulk after the title, so it sits strictly between the two windows.
+        for index in range(40):
+            body = f"post {index} " + "w" * 8_000
+            await transcript.append_message(
+                Message(role="assistant", content=[TextContent(text=body)])
+            )
+
+    asyncio.run(build())
+    size = session.joinpath("transcript.jsonl").stat().st_size
+    assert size > TITLE_SCAN_BYTES * 2, size
+    # Precondition of the regression: the window scan alone cannot find it.
+    assert not (session / TITLE_SIDECAR_NAME).exists()
+    assert stored_session_title(session) == ""
+    # The fix: the backfill writes the sidecar, and now it is found.
+    assert backfill_session_titles(tmp_path) == 1
+    assert stored_session_title(session) == "Buried In The Middle"
+
+
+def test_a_corrupt_sidecar_falls_back_to_the_scan_rather_than_raising(tmp_path: Path):
+    """A truncated sidecar (mid multi-byte char) must never take the picker
+    down, mirroring session_origin's errors='replace' tolerance."""
+    session = _session(tmp_path, "opening", ("Scannable Title", False))
+    # A byte sequence that is invalid UTF-8 and not JSON.
+    (session / TITLE_SIDECAR_NAME).write_bytes(b'{"text": "\xff\xfe truncated')
+    # _read returns None (unparseable), so stored_session_title uses the scan.
+    assert _read_title_sidecar(session) is None
+    assert stored_session_title(session) == "Scannable Title"
+
+
+def test_a_sidecar_with_no_text_falls_back_to_the_scan(tmp_path: Path):
+    """An empty in-force title in the sidecar must not shadow a scannable one:
+    stored_session_title only takes the sidecar when it carries real text."""
+    session = _session(tmp_path, "opening", ("Scannable Title", False))
+    write_session_title(session, "", user_set=False, past_names=[])
+    assert stored_session_title(session) == "Scannable Title"
+
+
+def test_the_sidecar_write_preserves_directory_mtime(tmp_path: Path):
+    """Journalling a title is bookkeeping ABOUT a session, never activity IN
+    it, so it must not move the mtime retention and listings read."""
+    session = tmp_path / "sessions" / "mtime"
+    session.mkdir(parents=True)
+    before = session.stat().st_mtime
+    import os
+    import time
+
+    # Backdate so a preserved mtime is distinguishable from a fresh one.
+    os.utime(session, (before - 10_000, before - 10_000))
+    expected = session.stat().st_mtime
+    time.sleep(0.01)
+    write_session_title(session, "A Title", user_set=True, past_names=[])
+    assert session.stat().st_mtime == expected
+
+
+def test_backfill_never_restamps_an_existing_sidecar(tmp_path: Path):
+    """A second sweep is a no-op: the sidecar is event-sourced from its first
+    write on, so re-stamping risks clobbering a newer name with an old scan."""
+    session = _session(tmp_path, "opening", ("Only Title", False))
+    assert backfill_session_titles(tmp_path) == 1
+    # Rename after backfill: the sidecar now leads the transcript.
+    write_session_title(session, "Renamed After", user_set=True, past_names=["Only Title"])
+    assert backfill_session_titles(tmp_path) == 0
+    assert stored_session_title(session) == "Renamed After"
+
+
+def test_backfill_limit_caps_work_done(tmp_path: Path):
+    """limit bounds sidecars written per run, like backfill_session_origins."""
+    for i in range(3):
+        session = tmp_path / "sessions" / f"sess{i}"
+
+        async def build(s=session) -> None:
+            transcript = Transcript(s)
+            await transcript.append_message(
+                Message(role="user", content=[TextContent(text="opening")])
+            )
+            await transcript.append_custom(
+                CONVERSATION_NAME_CUSTOM_TYPE, {"text": "A Name", "user_set": False}
+            )
+
+        asyncio.run(build())
+    assert backfill_session_titles(tmp_path, limit=2) == 2
+    # The remaining one is stamped on a later run — nothing is skipped forever.
+    assert backfill_session_titles(tmp_path, limit=2) == 1

--- a/tests/unit/tui/test_session_picker.py
+++ b/tests/unit/tui/test_session_picker.py
@@ -27,6 +27,7 @@ from local_operator.resume import (
 )
 from local_operator.tui import theme as theme_mod
 from local_operator.tui.widgets.session_picker import (
+    _MARKER_LEGEND,
     BODY_MATCH_MARKER,
     CARD_MAX_HEIGHT_FRACTION,
     CARD_PADDING_ROWS,
@@ -35,6 +36,7 @@ from local_operator.tui.widgets.session_picker import (
     PAGE_ROWS_MAX,
     PICKER_MIN_WIDTH,
     SessionPickerScreen,
+    _footer_hints,
     filter_rows,
     matched_in_body,
     plan_columns,
@@ -1202,3 +1204,35 @@ async def test_a_row_matched_only_by_a_past_name_is_shown_and_marked() -> None:
         await pilot.pause()
         assert [r.id for r in screen.visible_rows] == ["aaa1"]
         assert screen.body_matched_ids == {"aaa1"}
+
+
+def test_footer_legend_appears_only_when_a_row_is_marked() -> None:
+    """D2: the ``"`` marker is meaningless without a legend, but advertising it
+    when nothing is marked would explain a glyph the user cannot see. So the
+    legend is present exactly when the footer has room AND a marked row exists,
+    and absent otherwise."""
+    # A card wide enough to hold the legend beside the essential keys.
+    with_legend = _footer_hints(74, has_marked=True)
+    assert _MARKER_LEGEND in with_legend
+    # Same width, nothing marked: no legend, and the full key row is intact.
+    without = _footer_hints(74, has_marked=False)
+    assert _MARKER_LEGEND not in without
+    assert ("pgup/pgdn", "page") in without
+
+
+def test_footer_legend_drops_before_the_movement_and_action_keys() -> None:
+    """The legend teaches; it must never crowd out the keys that OPERATE the
+    card. Under width pressure it sheds after the two disposable hints but
+    before movement/resume/cancel, and it never survives as a bare unlabelled
+    glyph (which would be the very artifact-looking mark D2 flagged)."""
+    # Wide: legend shown, and it displaced only a disposable hint (pgup/pgdn).
+    wide = _footer_hints(74, has_marked=True)
+    assert _MARKER_LEGEND in wide
+    assert ("pgup/pgdn", "page") not in wide
+    # Narrow: the essential keys survive and the legend is gone entirely — not
+    # reduced to a lone glyph.
+    narrow = _footer_hints(40, has_marked=True)
+    assert _MARKER_LEGEND not in narrow
+    assert (_MARKER_LEGEND[0], "") not in narrow
+    assert ("enter", "resume") in narrow
+    assert ("esc", "cancel") in narrow

--- a/tests/unit/tui/test_session_picker.py
+++ b/tests/unit/tui/test_session_picker.py
@@ -38,6 +38,7 @@ from local_operator.tui.widgets.session_picker import (
     filter_rows,
     matched_in_body,
     plan_columns,
+    rank_rows,
     render_rows,
 )
 
@@ -1087,3 +1088,117 @@ def test_an_unfiltered_list_reserves_no_marker_column() -> None:
     # and exactly the marker's width later when something did.
     assert unmarked.index("one") == GUTTER_CELLS
     assert marked.index("one") == GUTTER_CELLS + cell_len(BODY_MATCH_MARKER)
+
+
+# --- relevance ranking ------------------------------------------------------
+# Ordering is a property of the QUERY, applied by rank_rows only when a query is
+# active, so the "no reorder under the cursor" invariant holds: the only event
+# that reorders (a query change) is the same one that re-homes the cursor.
+
+
+def test_ranking_orders_name_above_body_above_soft() -> None:
+    """A query hit in the visible name outranks one in the body, which outranks
+    a soft-only match — the tiered rule the design specifies."""
+    name_hit = _row("aaa1", "classifier tuning", age_s=300)  # matches by name
+    body_hit = _row("bbb2", "unrelated title", age_s=200)  # exact body match
+    soft_hit = _row("ccc3", "another title", age_s=100)  # soft-only match
+    rows = [name_hit, body_hit, soft_hit]
+    # body_matches carries only the exact-body id; the soft id is in `rows`
+    # (already filtered) but not in body_matches, so it takes the soft tier.
+    ranked = rank_rows(rows, "classifier", {"bbb2"})
+    assert [r.id for r in ranked] == ["aaa1", "bbb2", "ccc3"]
+
+
+def test_ranking_breaks_ties_by_recency_within_a_tier() -> None:
+    """Two rows in the same tier keep newest-first order (stable tie-break)."""
+    older = _row("aaa1", "classifier one", age_s=500)
+    newer = _row("bbb2", "classifier two", age_s=100)
+    # Passed newest-first, as the picker builds them; both match by name.
+    ranked = rank_rows([newer, older], "classifier", set())
+    assert [r.id for r in ranked] == ["bbb2", "aaa1"]
+
+
+def test_an_empty_query_keeps_recency_order_unchanged() -> None:
+    """No query means no ordering: the list stays exactly as it arrived."""
+    rows = [_row("aaa1", "one"), _row("bbb2", "two"), _row("ccc3", "three")]
+    assert rank_rows(rows, "") == rows
+    assert rank_rows(rows, "   ") == rows
+
+
+def test_ranking_is_stable_for_a_fixed_query() -> None:
+    """A fixed query must produce byte-for-byte the same order every call, so a
+    repaint or resize never moves a row under the cursor."""
+    rows = [_row("aaa1", "classifier"), _row("bbb2", "unrelated"), _row("ccc3", "classify")]
+    first = rank_rows(rows, "class", {"bbb2"})
+    second = rank_rows(rows, "class", {"bbb2"})
+    assert [r.id for r in first] == [r.id for r in second]
+
+
+@pytest.mark.asyncio
+async def test_the_cursor_re_homes_to_the_top_match_on_a_query_change() -> None:
+    """set_query pins the cursor to rank 0, so it tracks the best match rather
+    than sitting on a row ranking then slides away from."""
+    rows = [_row("aaa1", "one"), _row("bbb2", "two"), _row("ccc3", "three")]
+    app = _PickerHost(rows)
+    async with app.run_test(size=(100, 30)) as pilot:
+        screen = await app.open_picker()
+        await pilot.pause()
+        screen._move_to(2)  # move the cursor off the top
+        assert screen.selected_index == 2
+        screen.set_query("three")
+        await pilot.pause()
+        # Cursor is re-homed to index 0 (the top match), not clamped to the
+        # last surviving row.
+        assert screen.selected_index == 0
+        assert screen.selected_id() == "ccc3"
+
+
+@pytest.mark.asyncio
+async def test_visible_rows_is_stable_across_repaints_for_a_fixed_query() -> None:
+    """The invariant end to end: repeated repaints under a FIXED query never
+    reorder the visible rows."""
+    rows = [_row("aaa1", "classifier"), _row("bbb2", "unrelated"), _row("ccc3", "classify")]
+    digests = {"bbb2": "a body mentioning classifier deep inside"}
+    app = _PickerHost(rows, digests)
+    async with app.run_test(size=(100, 30)) as pilot:
+        screen = await app.open_picker()
+        await pilot.pause()
+        screen.set_query("classifier")
+        await pilot.pause()
+        first = [r.id for r in screen.visible_rows]
+        screen._repaint()
+        screen._repaint()
+        assert [r.id for r in screen.visible_rows] == first
+
+
+@pytest.mark.asyncio
+async def test_a_row_matched_only_by_a_soft_query_is_shown_and_marked() -> None:
+    """A soft match (typo) surfaces the row via the body path and carries the
+    body-match marker, since it did not match the visible name."""
+    rows = [_row("aaa1", "vague title"), _row("bbb2", "another")]
+    digests = {"aaa1": "improve adm classifier throughput"}
+    app = _PickerHost(rows, digests)
+    async with app.run_test(size=(100, 30)) as pilot:
+        screen = await app.open_picker()
+        await pilot.pause()
+        screen.set_query("classifer")  # typo, soft match only
+        await pilot.pause()
+        assert [r.id for r in screen.visible_rows] == ["aaa1"]
+        assert screen.body_matched_ids == {"aaa1"}
+
+
+@pytest.mark.asyncio
+async def test_a_row_matched_only_by_a_past_name_is_shown_and_marked() -> None:
+    """A session found by a name it was renamed AWAY from surfaces via the body
+    path (the digest folds past names in) and carries the marker."""
+    rows = [_row("aaa1", "Current Title"), _row("bbb2", "another")]
+    # The digest carries a PAST name the visible row name no longer shows.
+    digests = {"aaa1": "Old Abandoned Name the session body text"}
+    app = _PickerHost(rows, digests)
+    async with app.run_test(size=(100, 30)) as pilot:
+        screen = await app.open_picker()
+        await pilot.pause()
+        screen.set_query("abandoned")
+        await pilot.pause()
+        assert [r.id for r in screen.visible_rows] == ["aaa1"]
+        assert screen.body_matched_ids == {"aaa1"}


### PR DESCRIPTION
## Why

The `/resume` picker could not find a session by a name it plainly carried. The reported case: a conversation titled **"Improve ADM Classifier Throughput"** (`bda7b76d34e0`, a 2.9 MB transcript) was unreachable through `/resume` search — the only way to find it was a manual transcript search of a user message.

Root cause, verified against the real store, was three distinct gaps:

1. **The canonical title was invisible.** `resume.py::stored_session_title` scans only a HEAD window (first `TITLE_SCAN_BYTES`) and a TAIL window (last `TITLE_SCAN_BYTES`). This is a *topic-pivot* session — it opened about an article-search load test and was auto-renamed to the ADM classifier topic ~88% of the way in — so every `conversation_name` entry (and the word "classifier" itself) sits in the **untouched middle** at byte ~2.52M. `stored_session_title` returned `""`, the row fell back to the abandoned opening topic, and the 256 KB body digest never saw the new subject either. `resume.py`'s own comment already named the fix: **journal the title to a sidecar** the way `origin.json` does.
2. **Past names were not searchable.** A session renamed over its life could only be found by its *current* name, never by any name it previously carried.
3. **No tolerance for typos.** Search was exact substring only — `classifer` found nothing.

Version bump is **MINOR** (0.24.3 → **0.25.0**): new search capability, no breaking change.

## What changes

### Title always found — `title.json` sidecar (`resume.py`, `session/session.py`)
`_persist_conversation_name` now writes a `title.json` sidecar (atomic pid-temp + `os.replace`, **directory mtime preserved** so a rename never disturbs recency ordering) on the same event it journals the title. The sidecar accumulates a deduped `names[]` of **every** name the session has ever carried, plus the in-force `text` and its `user_set` flag. `stored_session_title` reads it as an **O(1) stat + small read fast path** before falling back to the window scan — closing the middle-of-transcript gap for good. `backfill_session_titles` stamps pre-existing sessions (mirrors `backfill_session_origins`), wired beside the origin backfill at both startup sites (`cli.py`, `session_factory.py`).

### Body + past names searchable (`session/search_index.py`)
`INDEX_VERSION` 1→2; `build_index` folds the title and past names into each session's digest and adds the `title.json` mtime to the cache freshness signature, so a rename re-digests exactly that one session. Recall is repaired by folding the title in — **not** by enlarging the defended 256 KB `SCAN_BYTES` window.

### Soft matching (`session/search_index.py`)
New `soft_search_digests` — bounded pure-Python: prefix match, token-AND, and edit-distance ≤2 for tokens ≥4. **No new dependency** (no rapidfuzz). Microseconds over the in-memory digests, so it stays on the per-keystroke path.

### Relevance ranking without cursor jump (`tui/widgets/session_picker.py`)
`rank_rows` orders matches name > id > body > soft with a recency tie-break. Ranking applies **only when a query is active**; an empty query keeps recency order, and `filter_rows` stays a pure membership filter. Because ordering is a function of the whole query and is recomputed only on query change — the same event that already re-homes the cursor to the first row — a row never reorders under the cursor for a *fixed* query. The body-match marker now also covers soft and past-name hits.

## Impact
- No breaking changes, no schema change to existing fields. The sidecar is additive and self-healing via backfill.
- Semantic/embedding search was **explicitly scoped out** as a user-approved opt-in follow-up: a per-keystroke embedding call breaks the picker's synchronous, offline, dependency-light contract. Full-text recall past 256 KB is likewise a documented follow-up.

## Testing Details

### Regression against the REAL ADM session (read-only; store untouched)
Ran the actual code paths against `~/.local-operator/sessions/bda7b76d34e0` (copied read-only — verified no `title.json` was written into the real store):
```
BEFORE: stored_session_title -> ''
        'classifier'/'throughput'/'improve adm' in body digest? False
        search 'classifier' / 'throughput' / 'Improve ADM' -> False
AFTER:  backfill wrote 1;  stored_session_title -> 'Improve ADM Classifier Throughput'
        search 'classifier' / 'throughput' / 'Improve ADM' -> True
        soft  'classifer' / 'throughput classifier'        -> True
```
A synthetic transcript > 2×`TITLE_SCAN_BYTES` with `conversation_name` entries only in the middle reproduces the same before→after and is pinned as a unit test.

### Visual (real `OperatorApp`, not the CSS-less `_PickerHost`)
- Query `throughput`, before vs after: **byte-identical** SVG — row rendering, columns, and marker unregressed by the new path.
- Typo query `classifer`, origin/main vs this branch: origin/main renders **"no session matches that filter" (0 of 4)**; this branch shows the ADM row **marked, 1 of 4**, columns aligned, no reflow. All four frames rendered and viewed.

### Automated
- `tests/unit/test_stored_session_title.py` — sidecar round-trip + middle-of-transcript regression.
- `tests/unit/session/test_search_index.py` — title/past-name fold, pivot case, soft-match bounds, `INDEX_VERSION` discard.
- `tests/unit/tui/test_session_picker.py` — ranking invariants, cursor re-home, marker coverage.
- `tests/unit/session/test_conversation_name_persistence.py` — sidecar persistence round-trip + backfill.
- Gates whole-tree: flake8, black==26.1.0, isort --profile black, pyright (0 errors). Full unit suite **6251 passed, 7 skipped, 1 failed** — the single failure (`test_eval_tool.py::test_background_streams_output_while_it_runs`, a background-streaming timing assertion) is **pre-existing and unrelated**, failing identically on clean `origin/main`.

## Review history
_Agent review gate in progress — code + design rounds to follow on this PR._
