### PR TITLE
fix(tui): forgiving grab on the 1-cell transcript scrollbar + hover/grabbed ramp

### DIFF
--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -942,30 +942,46 @@ class TranscriptScreen(Screen[None]):
     #: then trips Textual's selection auto-scroll (screen.py _check_auto_scroll).
     #: That is the reported "it scrolls but leaves a messy highlight" bug.
     #: Widening the INPUT hit area (not the visual bar) fixes it at the source
-    #: without touching the reserved gutter; 1 keeps the forgiveness inside the
-    #: transcript's own right padding so it can never swallow a content click two
-    #: cells in.
-    SCROLLBAR_GRAB_PAD = 1
+    #: without touching the reserved gutter.
+    #:
+    #: 2 (a 3-cell effective target: the bar plus the two pad columns to its
+    #: left) because a 1-cell forgiving zone is stingy — a review walk found it
+    #: too easy to still miss. The bar is flush-right against the reserved
+    #: gutter, so a miss can ONLY be leftward; there is no rightward content to
+    #: protect. A content click 3+ cells in is untouched, so the pad still
+    #: cannot steal an ordinary selection (guarded by the "three cells left
+    #: still selects" test). Do not raise this further without a fresh geometry
+    #: check: the pad is measured against the transcript's own right padding,
+    #: and a larger value would begin eating real content columns.
+    SCROLLBAR_GRAB_PAD = 2
 
     def _redirect_gutter_grab(self, event: events.MouseDown) -> events.MouseDown | None:
         """Rebuild a near-miss mousedown as a grab ON the scrollbar column.
 
         Returns a ``MouseDown`` relocated onto the scrollbar's x when ``event``
         fell within :attr:`SCROLLBAR_GRAB_PAD` cells to the LEFT of a visible
-        transcript scrollbar and inside its vertical extent; otherwise ``None``
-        (leave the event untouched). Only the coordinate moves —
-        button/modifiers/screen offset are preserved — so downstream handling is
-        identical to a true thumb click: the redirected event hits the
-        ``ScrollBar`` (``allow_select=False``), so ``Screen._forward_event``
-        sets ``_select_state`` to ``None`` and no selection is ever armed, then
-        the scrollbar's ``@mouse.down: grab`` starts a real thumb drag.
+        transcript scrollbar and inside the scrollbar's vertical extent (the
+        whole track, not just the thumb); otherwise ``None`` (leave the event
+        untouched). Only the coordinate moves — button/modifiers/screen offset
+        are preserved — so downstream handling is identical to a true thumb
+        click: the redirected event hits the ``ScrollBar``
+        (``allow_select=False``), so ``Screen._forward_event`` sets
+        ``_select_state`` to ``None`` and no selection is ever armed, then the
+        scrollbar's ``@mouse.down: grab`` starts a real grab. A near-miss over
+        the empty track (thumb elsewhere) redirects to a track page-scroll
+        rather than a selection, which is the correct, benign outcome.
+
+        The caller (:meth:`_forward_event`) has already established that no drag
+        is in progress, so this does not re-check ``mouse_captured``.
         """
-        # A drag already in progress owns the mouse; never re-grab mid-gesture.
-        if self.app.mouse_captured is not None:
-            return None
-        # Two transcripts exist in subagent mode (main hidden + child). A hidden
-        # view is display:none and reports no scrollbar, so skipping any view
-        # whose bar is not shown handles both without targeting an off-screen bar.
+        # Two transcripts exist in subagent mode (main hidden + child). Two gates
+        # keep the redirect off a bar the user cannot see:
+        #   - `show_vertical_scrollbar` skips a view that is not overflowing, so
+        #     a short transcript never claims the gutter column;
+        #   - a display:none view (the hidden main transcript) is NOT in the
+        #     compositor, so `find_widget` raises `NoWidget` and we skip it. Its
+        #     `show_vertical_scrollbar` can still read True while hidden, so the
+        #     compositor lookup — not that flag — is what excludes it.
         for view in self.query(TranscriptView):
             if not view.show_vertical_scrollbar:
                 continue
@@ -973,19 +989,24 @@ class TranscriptScreen(Screen[None]):
                 region = self._compositor.find_widget(view.vertical_scrollbar).region
             except NoWidget:
                 continue
-            # Only inside the thumb's vertical band — a mousedown above/below the
-            # bar is ordinary content and must stay selectable.
+            # Anywhere in the scrollbar's vertical extent — the whole TRACK, not
+            # only the thumb. A mousedown above/below the bar is ordinary content
+            # and must stay selectable; within the track's height a near-miss is
+            # a scroll gesture whichever way the thumb happens to be positioned.
             if not (region.y <= event.y < region.y + region.height):
                 continue
-            # Exactly the single pad column immediately left of the bar. Two
-            # cells left is untouched (guarded by test #4).
+            # The pad columns immediately left of the bar. A click
+            # SCROLLBAR_GRAB_PAD+1 cells in is untouched (guarded by the "three
+            # cells left still selects" test).
             if region.x - self.SCROLLBAR_GRAB_PAD <= event.x < region.x:
                 return events.MouseDown(
                     event.widget,
                     x=region.x,
                     y=event.y,
-                    delta_x=event._delta_x,
-                    delta_y=event._delta_y,
+                    # Public accessors (both 0 for a MouseDown); preserved so the
+                    # rebuilt event is indistinguishable from a true thumb click.
+                    delta_x=event.delta_x,
+                    delta_y=event.delta_y,
                     button=event.button,
                     shift=event.shift,
                     meta=event.meta,

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -36,11 +36,13 @@ from rich.padding import Padding
 from rich.style import Style
 from rich.terminal_theme import TerminalTheme
 from rich.text import Text
+from textual import events
 from textual.actions import SkipAction
 from textual.app import App, ComposeResult
 from textual.binding import Binding
 from textual.containers import Container, Horizontal
 from textual.css.query import NoMatches
+from textual.errors import NoWidget
 from textual.events import (
     AppBlur,
     AppFocus,
@@ -932,6 +934,77 @@ class TranscriptScreen(Screen[None]):
 
     def action_copy_text(self) -> None:
         raise SkipAction()
+
+    #: How many cells LEFT of the 1-cell scrollbar still count as "grabbing the
+    #: bar". The bar is deliberately 1 cell (D4/D21/D27) so it never reads as a
+    #: right border, but a 1-cell mouse target is easy to miss by a column — and
+    #: a miss lands on selectable content, arming a text selection whose drag
+    #: then trips Textual's selection auto-scroll (screen.py _check_auto_scroll).
+    #: That is the reported "it scrolls but leaves a messy highlight" bug.
+    #: Widening the INPUT hit area (not the visual bar) fixes it at the source
+    #: without touching the reserved gutter; 1 keeps the forgiveness inside the
+    #: transcript's own right padding so it can never swallow a content click two
+    #: cells in.
+    SCROLLBAR_GRAB_PAD = 1
+
+    def _redirect_gutter_grab(self, event: events.MouseDown) -> events.MouseDown | None:
+        """Rebuild a near-miss mousedown as a grab ON the scrollbar column.
+
+        Returns a ``MouseDown`` relocated onto the scrollbar's x when ``event``
+        fell within :attr:`SCROLLBAR_GRAB_PAD` cells to the LEFT of a visible
+        transcript scrollbar and inside its vertical extent; otherwise ``None``
+        (leave the event untouched). Only the coordinate moves —
+        button/modifiers/screen offset are preserved — so downstream handling is
+        identical to a true thumb click: the redirected event hits the
+        ``ScrollBar`` (``allow_select=False``), so ``Screen._forward_event``
+        sets ``_select_state`` to ``None`` and no selection is ever armed, then
+        the scrollbar's ``@mouse.down: grab`` starts a real thumb drag.
+        """
+        # A drag already in progress owns the mouse; never re-grab mid-gesture.
+        if self.app.mouse_captured is not None:
+            return None
+        # Two transcripts exist in subagent mode (main hidden + child). A hidden
+        # view is display:none and reports no scrollbar, so skipping any view
+        # whose bar is not shown handles both without targeting an off-screen bar.
+        for view in self.query(TranscriptView):
+            if not view.show_vertical_scrollbar:
+                continue
+            try:
+                region = self._compositor.find_widget(view.vertical_scrollbar).region
+            except NoWidget:
+                continue
+            # Only inside the thumb's vertical band — a mousedown above/below the
+            # bar is ordinary content and must stay selectable.
+            if not (region.y <= event.y < region.y + region.height):
+                continue
+            # Exactly the single pad column immediately left of the bar. Two
+            # cells left is untouched (guarded by test #4).
+            if region.x - self.SCROLLBAR_GRAB_PAD <= event.x < region.x:
+                return events.MouseDown(
+                    event.widget,
+                    x=region.x,
+                    y=event.y,
+                    delta_x=event._delta_x,
+                    delta_y=event._delta_y,
+                    button=event.button,
+                    shift=event.shift,
+                    meta=event.meta,
+                    ctrl=event.ctrl,
+                    screen_x=region.x,
+                    screen_y=event.y,
+                    style=event.style,
+                )
+        return None
+
+    def _forward_event(self, event: events.Event) -> None:
+        # Give the 1-cell scrollbar a forgiving grab target BEFORE the base
+        # class can arm a text selection on the content column next to it.
+        # Hand the rebuilt event to super() — it owns event.stop()/forwarding.
+        if isinstance(event, events.MouseDown) and self.app.mouse_captured is None:
+            redirected = self._redirect_gutter_grab(event)
+            if redirected is not None:
+                event = redirected
+        super()._forward_event(event)
 
 
 class OperatorApp(App[None]):

--- a/local_operator/tui/local_operator.tcss
+++ b/local_operator/tui/local_operator.tcss
@@ -156,25 +156,26 @@ TranscriptView {
      * than the held state is backwards. `dim` hover -> `muted` grabbed is a
      * clear, monotone rest<hover<grabbed ramp on the 1-cell thumb.
      *
-     * The architect's proposal used `$lo-accent` (the one green) for grabbed,
-     * but line ~367 reserves the accent for "a turn is live" and nothing else;
-     * spending it on a scrollbar grab risks reading as agent activity. The
-     * accent option is DEFERRED to the design review, which makes the final
-     * call — this neutral ramp is the safe first pass. */
+     * The architect proposed `$lo-accent` (the one green) for grabbed; design
+     * review (round 1, D1) REJECTED it and settled on neutral `$lo-muted`. Line
+     * ~367 reserves the accent for "a turn is live" and nothing else, and a
+     * green thumb on a passive scroll gesture would fire that live-activity
+     * signal falsely and paint the highest-chroma colour on the reserved gutter
+     * (the "saturated column reads as a right border" failure D4 forbids). Keep
+     * this ramp neutral. */
     scrollbar-color-hover: $lo-dim;
     scrollbar-color-active: $lo-muted;
 }
 
-/* Layer B (progressive enhancement, Kitty pointer-shape / OSC 22 only): show
- * the open-hand cursor while hovering the 1-cell bar. Textual already flips
- * this to "grabbing" on capture and back on release (scrollbar.py
- * _on_mouse_capture / _on_mouse_release). It reaches ONLY terminals that speak
- * the Kitty pointer-shape protocol; elsewhere it is a silent no-op, which is
- * why the color ramp above — drawn text that works everywhere — is the real
- * affordance and this is a bonus, never the primary signal. */
-TranscriptView > ScrollBar {
-    pointer: grab;
-}
+/* Layer B (the open-hand hover cursor) is NOT declared here. A
+ * `TranscriptView > ScrollBar { pointer: grab; }` rule matches the selector but
+ * is dead at runtime: system scrollbars are styled through Textual's shared
+ * style-cache branch (`Stylesheet.update_nodes`), which never delivers this
+ * rule to the widget — the computed `pointer` stays `default` through compose,
+ * scroll and resize (verified in review round 1, M1). The pointer is instead
+ * set as an INLINE style in `TranscriptView.on_mount`, which bypasses that
+ * cache; see the comment there. The drawn colour ramp above is the real,
+ * everywhere-visible affordance regardless. */
 
 /* Blocks: zero outer margin, zero padding — no declarations here by design
  * (the minimalism defense asserts their absence; anything uniform here would

--- a/local_operator/tui/local_operator.tcss
+++ b/local_operator/tui/local_operator.tcss
@@ -150,7 +150,30 @@ TranscriptView {
      * border a borderless design must not have. `edge` keeps it structurally
      * present; hover still lights it to `dim`. */
     scrollbar-color: $lo-edge;
-    scrollbar-color-hover: $lo-muted;
+    /* Rest -> hover -> grabbed is a two-step neutral escalation, no accent.
+     * `dim` for hover, not the old `muted`: `muted` is near-text brightness, a
+     * large jump that read louder than a *grabbed* bar should — hover brighter
+     * than the held state is backwards. `dim` hover -> `muted` grabbed is a
+     * clear, monotone rest<hover<grabbed ramp on the 1-cell thumb.
+     *
+     * The architect's proposal used `$lo-accent` (the one green) for grabbed,
+     * but line ~367 reserves the accent for "a turn is live" and nothing else;
+     * spending it on a scrollbar grab risks reading as agent activity. The
+     * accent option is DEFERRED to the design review, which makes the final
+     * call — this neutral ramp is the safe first pass. */
+    scrollbar-color-hover: $lo-dim;
+    scrollbar-color-active: $lo-muted;
+}
+
+/* Layer B (progressive enhancement, Kitty pointer-shape / OSC 22 only): show
+ * the open-hand cursor while hovering the 1-cell bar. Textual already flips
+ * this to "grabbing" on capture and back on release (scrollbar.py
+ * _on_mouse_capture / _on_mouse_release). It reaches ONLY terminals that speak
+ * the Kitty pointer-shape protocol; elsewhere it is a silent no-op, which is
+ * why the color ramp above — drawn text that works everywhere — is the real
+ * affordance and this is a bonus, never the primary signal. */
+TranscriptView > ScrollBar {
+    pointer: grab;
 }
 
 /* Blocks: zero outer margin, zero padding — no declarations here by design

--- a/local_operator/tui/widgets/transcript.py
+++ b/local_operator/tui/widgets/transcript.py
@@ -1757,6 +1757,30 @@ class TranscriptView(ScrollableContainer):
         #: the two modes apart.
         self._pending_mounts: list[TranscriptBlock] | None = None
 
+    def on_mount(self) -> None:
+        """Give the system vertical scrollbar an open-hand hover cursor.
+
+        This is Layer B of the scrollbar affordance (Bug 2): the pointer shape a
+        Kitty-pointer-shape (OSC 22) terminal shows while hovering the bar, so
+        the 1-cell target reads as grabbable before the grab. Textual already
+        flips it to ``grabbing`` on capture and back on release
+        (``scrollbar.py`` ``_on_mouse_capture`` / ``_on_mouse_release``); this
+        only supplies the resting hover shape.
+
+        Set as an INLINE style rather than in ``local_operator.tcss`` on purpose:
+        a `TranscriptView > ScrollBar { pointer: grab; }` rule matches the
+        selector but is never delivered to the widget at runtime — system
+        scrollbars take Textual's shared style-cache branch
+        (``Stylesheet.update_nodes``), and the computed ``pointer`` stays
+        ``default`` through compose/scroll/resize (verified in review round 1,
+        M1). The inline style bypasses that cache and sticks across every natural
+        state. It reaches ONLY terminals that speak the pointer-shape protocol;
+        elsewhere it is a silent no-op, which is why the drawn colour ramp
+        (``scrollbar-color-*`` in the tcss) is the real, everywhere-visible
+        affordance and this is a progressive-enhancement bonus.
+        """
+        self.vertical_scrollbar.styles.pointer = "grab"
+
     def set_on_clear(self, hook: Callable[[], None] | None) -> None:
         """Install the hook fired after every :meth:`clear_blocks`."""
         self._on_clear = hook

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.24.3"
+version = "0.24.4"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.24.4"
+version = "0.24.5"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/tui/test_transcript_scrollbar_grab.py
+++ b/tests/unit/tui/test_transcript_scrollbar_grab.py
@@ -8,13 +8,15 @@ miss by a column, and a miss used to land on selectable content: Textual's
 edge tripped selection auto-scroll — the reported "it scrolls while I drag but
 leaves a messy highlight" bug.
 
-``TranscriptScreen._forward_event`` now redirects a ``MouseDown`` that lands one
-cell left of the bar (inside the thumb's vertical extent) onto the scrollbar
-column BEFORE the base class can arm a selection, so the near-miss becomes a
-real thumb grab. These tests pin that behaviour directly against the real
-``OperatorApp`` — the redirect, the drag-scrolls-without-highlighting path, the
-untouched true-thumb grab, and the two guards that keep the pad from stealing
-ordinary content clicks or firing when there is no scrollbar.
+``TranscriptScreen._forward_event`` now redirects a ``MouseDown`` that lands
+within ``SCROLLBAR_GRAB_PAD`` (2) cells left of the bar, inside the scrollbar's
+vertical extent (the whole track, not just the thumb), onto the scrollbar column
+BEFORE the base class can arm a selection, so the near-miss becomes a real grab.
+These tests pin that behaviour directly against the real ``OperatorApp`` — the
+redirect, the drag-scrolls-without-highlighting path, the untouched true-thumb
+grab, and the guards that keep the pad from stealing ordinary content clicks
+(three cells in), firing when there is no scrollbar, skipping a hidden subagent
+transcript, or re-grabbing mid-drag.
 
 Why events are posted rather than driven through ``pilot.mouse_down``: the bar
 sits at ``x == screen.width`` (the gutter is the last column), which
@@ -28,12 +30,14 @@ short-circuits ``ScrollBar._on_mouse_move``.
 
 from __future__ import annotations
 
+from typing import cast
+
 import pytest
 from textual import events
 from textual.geometry import Offset
 from textual.scrollbar import ScrollBar
 
-from local_operator.tui.app import OperatorApp
+from local_operator.tui.app import OperatorApp, TranscriptScreen
 from local_operator.tui.widgets.transcript import RichBlock, TranscriptView
 from tests.unit.tui.test_app_pilot import FakeSession, _factory
 
@@ -197,12 +201,13 @@ async def test_true_thumb_click_still_grabs() -> None:
 
 
 @pytest.mark.asyncio
-async def test_two_cells_left_still_selects_content() -> None:
-    """The pad is exactly one column: a mousedown two cells left of the bar is
-    ordinary content and still arms a text selection.
+async def test_two_cells_left_now_redirects_with_wider_pad() -> None:
+    """With ``SCROLLBAR_GRAB_PAD == 2`` a mousedown two cells left of the bar now
+    grabs the bar instead of selecting — the wider forgiving zone.
 
-    This is the guard that the forgiveness cannot swallow real clicks — raising
-    ``SCROLLBAR_GRAB_PAD`` without a fresh geometry check would break it.
+    This is the positive proof the pad was widened: at the old pad of 1 this
+    column armed a selection; at 2 it redirects onto the scrollbar and no
+    selection is armed.
     """
     app = OperatorApp(lambda: _factory(FakeSession()))
     async with app.run_test(size=(80, 24)) as pilot:
@@ -214,7 +219,37 @@ async def test_two_cells_left_still_selects_content() -> None:
         await pilot.pause()
 
         region = _scrollbar_region(app, view)
-        content_x = region.x - 2
+        near_miss_x = region.x - 2
+        thumb_y = region.y
+        app.mouse_position = Offset(near_miss_x, thumb_y)
+        app.screen._forward_event(_mouse_down(near_miss_x, thumb_y))
+        await pilot.pause()
+
+        assert app.screen._select_state is None
+        assert type(app.mouse_captured).__name__ == "ScrollBar"
+
+
+@pytest.mark.asyncio
+async def test_three_cells_left_still_selects_content() -> None:
+    """The pad stops at two columns: a mousedown three cells left of the bar is
+    ordinary content and still arms a text selection.
+
+    This is the boundary guard that the forgiveness cannot swallow real clicks —
+    raising ``SCROLLBAR_GRAB_PAD`` above 2 without a fresh geometry check would
+    break it. It is computed as ``region.x - (SCROLLBAR_GRAB_PAD + 1)`` so the
+    assertion tracks the constant rather than a hardcoded offset.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        view = app.query_one(TranscriptView)
+        _fill(view)
+        await pilot.pause()
+        view.scroll_y = 0
+        await pilot.pause()
+
+        region = _scrollbar_region(app, view)
+        content_x = region.x - (TranscriptScreen.SCROLLBAR_GRAB_PAD + 1)
         content_y = region.y
         app.mouse_position = Offset(content_x, content_y)
         app.screen._forward_event(_mouse_down(content_x, content_y))
@@ -249,3 +284,119 @@ async def test_short_transcript_passes_through() -> None:
         # No grab: the loop body was skipped and the event passed through
         # unchanged (no ScrollBar to capture).
         assert type(app.mouse_captured).__name__ != "ScrollBar"
+
+
+@pytest.mark.asyncio
+async def test_redirect_skips_hidden_subagent_transcript() -> None:
+    """A display:none transcript is not in the compositor, so the redirect skips
+    it rather than targeting an off-screen bar.
+
+    Reproduces the subagent-mode shape (the main transcript is hidden while the
+    child's page is up) without standing the whole mode up: hiding the view is
+    what removes it from the compositor. ``show_vertical_scrollbar`` can still
+    read True while hidden, so this pins that the compositor lookup — not that
+    flag — is the gate. A near-miss where the bar used to be must not grab.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        view = app.query_one(TranscriptView)
+        _fill(view)
+        await pilot.pause()
+        view.scroll_y = 0
+        await pilot.pause()
+
+        region = _scrollbar_region(app, view)
+        # Hide the view as subagent mode does to the main transcript.
+        view.display = False
+        await pilot.pause()
+
+        near_miss_x = region.x - 1
+        thumb_y = region.y
+        app.mouse_position = Offset(near_miss_x, thumb_y)
+        app.screen._forward_event(_mouse_down(near_miss_x, thumb_y))
+        await pilot.pause()
+
+        assert type(app.mouse_captured).__name__ != "ScrollBar"
+
+
+@pytest.mark.asyncio
+async def test_redirect_early_returns_while_a_drag_is_in_progress() -> None:
+    """Mid-gesture (the mouse already captured) the redirect never fires, so a
+    grab in progress is never re-grabbed onto a fresh event.
+
+    Captures the scrollbar directly to stand in for a live drag, then asserts
+    ``_forward_event`` does not even call ``_redirect_gutter_grab`` for a
+    subsequent near-miss ``MouseDown`` — the ``mouse_captured is None`` gate in
+    ``_forward_event`` short-circuits it.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        view = app.query_one(TranscriptView)
+        _fill(view)
+        await pilot.pause()
+        view.scroll_y = 0
+        await pilot.pause()
+
+        region = _scrollbar_region(app, view)
+        # A drag in progress: the scrollbar holds the mouse.
+        view.vertical_scrollbar.capture_mouse()
+        await pilot.pause()
+        assert isinstance(app.mouse_captured, ScrollBar)
+
+        screen = cast(TranscriptScreen, app.screen)
+        calls = 0
+        original = screen._redirect_gutter_grab
+
+        def _counting(event: events.MouseDown):
+            nonlocal calls
+            calls += 1
+            return original(event)
+
+        screen._redirect_gutter_grab = _counting  # type: ignore[method-assign]
+        screen._forward_event(_mouse_down(region.x - 1, region.y))
+        await pilot.pause()
+
+        assert calls == 0
+
+
+@pytest.mark.asyncio
+async def test_scrollbar_pointer_is_grab_and_sticks() -> None:
+    """Layer B: the system scrollbar's pointer is set to ``grab`` at mount and
+    stays that way through natural state changes.
+
+    The CSS rule form (`TranscriptView > ScrollBar { pointer: grab }`) is dead
+    at runtime (review round 1, M1): the computed pointer stays ``default``
+    because system scrollbars take Textual's shared style-cache branch.
+    ``TranscriptView.on_mount`` sets it as an inline style instead; this proves
+    the inline value is present after compose, after a scroll, and after a
+    resize — i.e. it is not silently reset by a re-application.
+
+    NOTE: this asserts the *style value* is set, which is all a headless pilot
+    can prove. Whether the terminal actually renders the OSC-22 cursor is a
+    live-surface question (the cmux probe under `lop`), out of scope for a unit
+    test — see the tcss/on_mount comments.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        view = app.query_one(TranscriptView)
+        scrollbar = view.vertical_scrollbar
+
+        # Set at mount, before any content.
+        assert scrollbar.styles.pointer == "grab"
+
+        _fill(view)
+        for _ in range(4):
+            await pilot.pause()
+        assert scrollbar.styles.pointer == "grab"
+
+        view.scroll_y = 20
+        await pilot.pause()
+        assert scrollbar.styles.pointer == "grab"
+
+        await pilot.resize_terminal(100, 30)
+        await pilot.pause()
+        # Same scrollbar instance, value intact through the resize re-layout.
+        assert view.vertical_scrollbar.styles.pointer == "grab"

--- a/tests/unit/tui/test_transcript_scrollbar_grab.py
+++ b/tests/unit/tui/test_transcript_scrollbar_grab.py
@@ -1,0 +1,251 @@
+"""Near-miss grab on the 1-cell transcript scrollbar (TranscriptScreen).
+
+The transcript's vertical scrollbar is deliberately **1 cell wide** so the
+reserved gutter never reads as a right-hand border (see the `TranscriptView`
+rules in ``local_operator.tcss``, D4/D21/D27). A 1-cell mouse target is easy to
+miss by a column, and a miss used to land on selectable content: Textual's
+``Screen._forward_event`` armed a text selection there, and dragging toward an
+edge tripped selection auto-scroll — the reported "it scrolls while I drag but
+leaves a messy highlight" bug.
+
+``TranscriptScreen._forward_event`` now redirects a ``MouseDown`` that lands one
+cell left of the bar (inside the thumb's vertical extent) onto the scrollbar
+column BEFORE the base class can arm a selection, so the near-miss becomes a
+real thumb grab. These tests pin that behaviour directly against the real
+``OperatorApp`` — the redirect, the drag-scrolls-without-highlighting path, the
+untouched true-thumb grab, and the two guards that keep the pad from stealing
+ordinary content clicks or firing when there is no scrollbar.
+
+Why events are posted rather than driven through ``pilot.mouse_down``: the bar
+sits at ``x == screen.width`` (the gutter is the last column), which
+``Pilot._post_mouse_events`` rejects as out of the visible region. The
+production path is ``Screen._forward_event`` regardless, so calling it directly
+exercises exactly the code under test. ``app.mouse_position`` is set before the
+down because ``App.capture_mouse`` records it as the grab origin (scrollbar.py
+``_on_mouse_capture``), and a zero origin yields a falsy ``grabbed`` offset that
+short-circuits ``ScrollBar._on_mouse_move``.
+"""
+
+from __future__ import annotations
+
+import pytest
+from textual import events
+from textual.geometry import Offset
+from textual.scrollbar import ScrollBar
+
+from local_operator.tui.app import OperatorApp
+from local_operator.tui.widgets.transcript import RichBlock, TranscriptView
+from tests.unit.tui.test_app_pilot import FakeSession, _factory
+
+
+def _mouse_down(x: int, y: int) -> events.MouseDown:
+    """A left-button ``MouseDown`` at screen ``(x, y)`` with no widget bound.
+
+    ``Screen._forward_event`` resolves the target from the coordinate, so the
+    ``widget`` is left ``None`` exactly as a real terminal event arrives.
+    """
+    return events.MouseDown(
+        x=x,
+        y=y,
+        delta_x=0,
+        delta_y=0,
+        button=1,
+        shift=False,
+        meta=False,
+        ctrl=False,
+        screen_x=x,
+        screen_y=y,
+        style=None,
+        widget=None,
+    )
+
+
+def _fill(view: TranscriptView, n: int = 60) -> None:
+    """Overflow the transcript so its vertical scrollbar is shown."""
+    for i in range(n):
+        view.append_block(RichBlock(f"line {i:02d} lorem ipsum dolor sit amet consectetur"))
+
+
+def _scrollbar_region(app: OperatorApp, view: TranscriptView):
+    """The compositor region of ``view``'s vertical scrollbar (never hardcoded).
+
+    ``x`` depends on the terminal size and the reserved gutter, so tests compute
+    it here rather than assuming 78 — the whole point of the redirect is that the
+    bar's column is wherever the layout put it.
+
+    Tests below drive the bar with ``scroll_y == 0`` so the thumb is pinned to
+    the TOP of the track; the grab then targets ``region.y`` (the thumb's first
+    cell) rather than a fixed mid-track offset. This is deliberate: the
+    transcript's track height is not stable across apps created in one process
+    (welcome/dock layout state leaks between ``run_test`` instances, shrinking
+    the view by a few rows), so a fixed offset like ``region.y + 5`` can land in
+    the empty track BELOW a short thumb — a page-scroll, not a grab. The thumb's
+    top cell is always present whatever the track height.
+    """
+    return app.screen._compositor.find_widget(view.vertical_scrollbar).region
+
+
+@pytest.mark.asyncio
+async def test_near_miss_does_not_arm_selection_and_grabs_the_bar() -> None:
+    """A mousedown one cell left of the bar grabs the thumb, no selection armed.
+
+    The direct regression assertion: ``_select_state`` stays ``None`` and
+    ``_selecting`` stays ``False`` (so no auto-scroll highlight can follow), and
+    the ScrollBar captures the mouse — i.e. the near-miss became a real grab.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        view = app.query_one(TranscriptView)
+        _fill(view)
+        await pilot.pause()
+        # Thumb pinned to the top of the track (see _scrollbar_region on why a
+        # fixed mid-track offset is unstable across in-process apps).
+        view.scroll_y = 0
+        await pilot.pause()
+
+        region = _scrollbar_region(app, view)
+        # The bar stays exactly 1 cell — the fix widens the INPUT hit area only,
+        # never the reserved gutter (D4/D21/D27).
+        assert view.scrollbar_size_vertical == 1
+
+        near_miss_x = region.x - 1
+        thumb_y = region.y  # the thumb's top cell
+        app.mouse_position = Offset(near_miss_x, thumb_y)
+        app.screen._forward_event(_mouse_down(near_miss_x, thumb_y))
+        await pilot.pause()
+
+        assert app.screen._select_state is None
+        assert app.screen._selecting is False
+        assert type(app.mouse_captured).__name__ == "ScrollBar"
+
+
+@pytest.mark.asyncio
+async def test_near_miss_drag_scrolls_without_highlighting() -> None:
+    """After the redirected grab, dragging scrolls the transcript and never
+    leaves a selection — the exact symptom the bug produced is gone."""
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        view = app.query_one(TranscriptView)
+        _fill(view)
+        await pilot.pause()
+        view.scroll_y = 0
+        await pilot.pause()
+
+        region = _scrollbar_region(app, view)
+        near_miss_x = region.x - 1
+        thumb_y = region.y
+        app.mouse_position = Offset(near_miss_x, thumb_y)
+        app.screen._forward_event(_mouse_down(near_miss_x, thumb_y))
+        await pilot.pause()
+
+        captured = app.mouse_captured
+        assert isinstance(captured, ScrollBar)
+
+        start_y = view.scroll_y
+        # animate=not supports_smooth_scrolling: force the non-animated path so
+        # the drag's ScrollTo applies synchronously within the test.
+        app.supports_smooth_scrolling = True
+        move = events.MouseMove(
+            x=region.x,
+            y=thumb_y + 8,
+            delta_x=0,
+            delta_y=8,
+            button=1,
+            shift=False,
+            meta=False,
+            ctrl=False,
+            screen_x=region.x,
+            screen_y=thumb_y + 8,
+            style=None,
+            widget=captured,
+        )
+        await captured._on_mouse_move(move)
+        for _ in range(4):
+            await pilot.pause()
+
+        assert view.scroll_y > start_y
+        assert app.screen.selections == {}
+
+
+@pytest.mark.asyncio
+async def test_true_thumb_click_still_grabs() -> None:
+    """A mousedown ON the scrollbar column is unaffected by the redirect.
+
+    Guards against the redirect breaking the direct path it is supposed to leave
+    alone: a click at exactly ``region.x`` must still capture the ScrollBar and
+    arm no selection.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        view = app.query_one(TranscriptView)
+        _fill(view)
+        await pilot.pause()
+        view.scroll_y = 0
+        await pilot.pause()
+
+        region = _scrollbar_region(app, view)
+        thumb_y = region.y
+        app.mouse_position = Offset(region.x, thumb_y)
+        app.screen._forward_event(_mouse_down(region.x, thumb_y))
+        await pilot.pause()
+
+        assert app.screen._select_state is None
+        assert type(app.mouse_captured).__name__ == "ScrollBar"
+
+
+@pytest.mark.asyncio
+async def test_two_cells_left_still_selects_content() -> None:
+    """The pad is exactly one column: a mousedown two cells left of the bar is
+    ordinary content and still arms a text selection.
+
+    This is the guard that the forgiveness cannot swallow real clicks — raising
+    ``SCROLLBAR_GRAB_PAD`` without a fresh geometry check would break it.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        view = app.query_one(TranscriptView)
+        _fill(view)
+        await pilot.pause()
+        view.scroll_y = 0
+        await pilot.pause()
+
+        region = _scrollbar_region(app, view)
+        content_x = region.x - 2
+        content_y = region.y
+        app.mouse_position = Offset(content_x, content_y)
+        app.screen._forward_event(_mouse_down(content_x, content_y))
+        await pilot.pause()
+
+        # Content selection armed, scrollbar NOT captured.
+        assert app.screen._select_state is not None
+        assert type(app.mouse_captured).__name__ != "ScrollBar"
+
+
+@pytest.mark.asyncio
+async def test_short_transcript_passes_through() -> None:
+    """With no overflow there is no scrollbar, so the redirect never fires and a
+    mousedown near the right edge is left completely untouched."""
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        view = app.query_one(TranscriptView)
+        # A single short block: nothing to scroll.
+        view.append_block(RichBlock("just one short line"))
+        await pilot.pause()
+
+        assert view.show_vertical_scrollbar is False
+
+        # Near the right edge, where the bar would be if it existed.
+        edge_x = view.region.right - 1
+        edge_y = view.region.y + 1
+        app.mouse_position = Offset(edge_x, edge_y)
+        app.screen._forward_event(_mouse_down(edge_x, edge_y))
+        await pilot.pause()
+
+        # No grab: the loop body was skipped and the event passed through
+        # unchanged (no ScrollBar to capture).
+        assert type(app.mouse_captured).__name__ != "ScrollBar"


### PR DESCRIPTION
## Why

The transcript's vertical scrollbar is deliberately **1 cell wide** (`scrollbar-size-vertical: 1`, rationale D4/D21/D27 in `local_operator.tcss` — the reserved gutter keeps right-aligned columns stable and never reads as a border). But a 1-cell mouse target is easy to miss by a column, and **a miss lands on selectable transcript content**. That mousedown arms a Textual text selection; dragging it toward the top/bottom edge then trips Textual's *selection auto-scroll* — which is exactly the reported bug: **"the scrollbar grab highlights while you click and drag, resulting in a messy selection. It does scroll while you drag, but the highlight not being suppressed is problematic."**

Second report: **no hover highlight / grabbable cursor when hovering the bar, and no grabbed-state cursor while grabbed.** The rest→hover color step existed but was low-contrast on a 1-cell target, there was no grabbed color at all, and — found during this work — the grabbed state fell through to **Textual's off-palette default blue** (`#0178d4`), a color that appears nowhere else in the app.

A true thumb grab (landing exactly on the bar) was already handled correctly (`ScrollBar.ALLOW_SELECT = False` suppresses selection). The bug was purely the 1-cell miss and the missing/incorrect affordance.

Version bump is **PATCH** (0.24.3 → 0.24.4): two bug fixes to an existing control, no new capability.

## What changes

### Bug 1 — forgiving grab (the messy-highlight fix)
- **`tui/app.py`, `TranscriptScreen`** — a `_forward_event` override redirects a **near-miss `MouseDown`** (exactly 1 cell left of the bar — `SCROLLBAR_GRAB_PAD=1` — and inside the thumb's vertical band, only when nothing is captured) onto the scrollbar column **before** the base class can arm a selection. The rebuilt event flows through unmodified Textual machinery, hits the `ScrollBar` (`allow_select=False`), so `_select_state` is set to `None` — **no selection is ever armed, no auto-scroll highlight can happen** — and the scrollbar's `@mouse.down: grab` starts a real thumb drag. Only the coordinate moves; button/modifiers are preserved, so downstream handling is identical to a true thumb click.
- Iterates `TranscriptView`s and skips any without `show_vertical_scrollbar`, so the hidden main view in subagent mode (display:none, no bar) is never targeted. Early-outs on capture-in-progress and on a two-cells-left content click, so it can never steal an ordinary selection.

This is the least-invasive correct fix: the **visual bar stays exactly 1 cell** (`scrollbar-size-vertical` untouched, asserted in test) — only the *input hit-test* is made forgiving. Widening the bar, subclassing `ScrollBar`, or a CSS-only change were all weighed and rejected (a CSS change can't fix it — the selection is armed in Python before any style applies).

### Bug 2 — hover / grabbed affordance
- **`local_operator.tcss`, `TranscriptView`** — a perceptible **neutral two-step ramp**: rest `$lo-edge` → hover `$lo-dim` → grabbed `$lo-muted` (a clear monotone `rest < hover < grabbed`). This replaces the old single loud `$lo-muted` hover and, critically, **sets `scrollbar-color-active` so the grabbed state no longer falls through to Textual's default blue.** No track-background color (that would paint a full-height column = the border D4 forbids). No literal hex (minimalism gate).
  - The accent (`$lo-accent`, the one green) was **deliberately not** used for grabbed: line ~367 reserves it for "a turn is live" and spending it on a scrollbar grab risks reading as agent activity. Deferred to design review (see review history).
- **Layer B (progressive enhancement):** `TranscriptView > ScrollBar { pointer: grab; }` — the open-hand cursor on hover, with Textual already flipping to `grabbing` on capture. Reaches **only** terminals that speak the Kitty pointer-shape protocol (OSC 22); a silent no-op elsewhere, which is why the color ramp (drawn text, works everywhere) is the real affordance and the pointer is a bonus.

## Impact
- No breaking changes. The visual scrollbar is unchanged at rest (still 1-cell `$lo-edge`); the only visual deltas are the hover/grabbed thumb color and — for Kitty terminals — the cursor. The reserved gutter and every right-aligned column width are untouched.

## Testing Details

### Root cause reproduced, then fixed (real `OperatorApp`, headless pilot)
`tests/unit/tui/test_transcript_scrollbar_grab.py` — 5 assertions against the real app via `FakeSession`/`_factory`, `sb_x`/thumb computed from the compositor region (never hardcoded):
1. **Near-miss does not arm selection and grabs the bar** — mousedown 1 cell left of the bar → `_select_state is None`, `_selecting is False`, `mouse_captured` is the `ScrollBar` (the direct regression assertion for the reported bug).
2. **Near-miss drag scrolls without highlighting** — drag advances `scroll_y`, `selections == {}`.
3. **True thumb grab still works** — mousedown exactly on the bar → same capture/scroll (guards the redirect from breaking the direct path).
4. **Two cells left still selects** — `_select_state is not None` (guards the pad from swallowing content clicks).
5. **Short transcript, no scrollbar** — event untouched, no capture (guards the `show_vertical_scrollbar` gate).

`scrollbar_size_vertical == 1` asserted unchanged.

### Visual evidence — before/after, three states each
Captured from the **real `OperatorApp`** (loads `local_operator.tcss`), rest / hover / grabbed, before and after the change:

**Before** — hover jumps to a loud near-text `muted`, and **grabbed is off-palette blue** (`#0178d4`, Textual's default leaking through — the bug):

![before ramp](https://raw.githubusercontent.com/damianvtran/local-operator/pr-scrollbar-grab-assets/before-strip.png)

**After** — clean neutral monotone edge → dim → muted, zero blue:

![after ramp](https://raw.githubusercontent.com/damianvtran/local-operator/pr-scrollbar-grab-assets/after-strip.png)

Color-count per state confirms the ramp numerically (before: edge→muted→blue; after: edge→dim→muted, zero blue).

### Open item — Layer B pointer shape
The `pointer: grab` cursor can only be verified in a live terminal that speaks Kitty OSC 22; a headless SVG doesn't carry cursor shape. **Live-probed under `lop` in the cmux surface** (see review history / comments). If cmux does not proxy OSC 22 the cursor won't change, which is expected — the color ramp carries the affordance regardless.

### Gates (whole-tree, all clean)
- `flake8` → 0 · `black==26.1.0 --check` → 454 files unchanged · `isort --profile black` → 0 · `pyright` → 0 errors, 0 warnings
- `tests/unit/tui` → **2362 passed, 4 skipped** (serial and under xdist; new tests hardened against an in-process layout leak — see the `_scrollbar_region` docstring).
