### PR TITLE
fix(tui): carry pasted images through /team and /agent to the model

### DIFF
--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -3114,6 +3114,29 @@ class OperatorApp(App[None]):
         rows.append(Text("Send: /team <name> <message>", style=body))
         return RichBlock(Group(*rows))
 
+    def _submit_command_prompt(
+        self, request: str, attachments: Mapping[int, Attachment] | None
+    ) -> None:
+        """Send a prompt-carrying slash command's argument as a real user turn.
+
+        The shared tail of ``/team <name> <request>`` and ``/agent <name>
+        <message>``: both attach something to the session and then hand the
+        argument to the model. The images the argument cites are resolved from
+        the text itself (``resolve_markers``) — the same authority the composer
+        uses, so a marker the request no longer cites drops its image and order
+        follows the text — and both the resolved list and the raw index→image
+        map go to ``_submit_prompt`` so a held draft (steer/compaction) can
+        rebuild its pixels exactly as a plain prompt would.
+
+        Extracted so the resolve-then-submit pair lives in ONE place: it was
+        copied into three call sites (``/team``, ``/agent`` with and without a
+        layered persona), and three copies of "which text resolves the markers"
+        is exactly the kind of drift the composer's single ``resolve_markers``
+        walk exists to prevent.
+        """
+        images = resolve_markers(request, attachments or {})
+        self._submit_prompt(request, images, attachments)
+
     def _cmd_team(
         self,
         arg: str,
@@ -3217,16 +3240,12 @@ class OperatorApp(App[None]):
         # second row restating `/team name …` would be the duplication
         # the echo policy exists to prevent.
         #
-        # ``resolve_markers`` against the REQUEST, not the whole slash line: the
-        # marker sits in the request tail the user typed around, and resolving
-        # from the text is the same authority the composer uses — a marker the
-        # request no longer cites (deleted before sending) drops its image, and
-        # order follows the text. Passing the map through both arguments lets
-        # ``_submit_prompt`` render the image blocks and hold the pixels across
-        # a steer/compaction exactly as a plain prompt does.
+        # ``_submit_command_prompt`` resolves the request's own image markers
+        # and sends them — the marker sits in the request tail the user typed
+        # around, so a pasted screenshot reaches the manager as pixels, not a
+        # dead ``[Image #N]`` marker.
         notice(f"sending to {team.name}. {team.manager} is coordinating.")
-        images = resolve_markers(request, attachments or {})
-        self._submit_prompt(request, images, attachments)
+        self._submit_command_prompt(request, attachments)
 
     def _cmd_team_chart(self, name: str, registry: Any, notice: NoticeFn) -> None:
         """``/team chart [name]`` — open the org-chart mode for a team.
@@ -3516,8 +3535,7 @@ class OperatorApp(App[None]):
                 # message's own image markers are resolved and sent, same as the
                 # instruction-carrying path below.
                 notice(f"agent {resolved} has no instructions; sending your message as-is.")
-                images = resolve_markers(request, attachments or {})
-                self._submit_prompt(request, images, attachments)
+                self._submit_command_prompt(request, attachments)
             else:
                 notice(
                     f"agent {resolved} resolved but carries no instructions, "
@@ -3542,8 +3560,7 @@ class OperatorApp(App[None]):
         # markers are resolved from the text, the same authority the composer
         # uses, so a cited screenshot reaches the persona as pixels.
         notice(f"agent {resolved} now governs this session's replies.")
-        images = resolve_markers(request, attachments or {})
-        self._submit_prompt(request, images, attachments)
+        self._submit_command_prompt(request, attachments)
 
     # -- MCP status ---------------------------------------------------------
     def _wire_mcp_status(self, session: SessionProtocol) -> None:

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -3114,13 +3114,23 @@ class OperatorApp(App[None]):
         rows.append(Text("Send: /team <name> <message>", style=body))
         return RichBlock(Group(*rows))
 
-    def _cmd_team(self, arg: str, notice: NoticeFn) -> None:
+    def _cmd_team(
+        self,
+        arg: str,
+        notice: NoticeFn,
+        attachments: Mapping[int, Attachment] | None = None,
+    ) -> None:
         """``/team`` — list; ``/team <name> <request>`` — talk to the manager.
 
         Bare ``/team`` is a listing, so it does not echo. A named team with a
         request attaches that team to this session (stamping the roster and
         briefs onto the manager) and sends the request as a real user turn —
         the one case besides ``/goal`` whose argument reaches the model.
+
+        ``attachments`` is the composer's image map at submit time. Only the
+        markers the REQUEST still cites are resolved and sent, so a screenshot
+        pasted before the user typed ``/team ops <request about it>`` reaches
+        the manager as pixels rather than a dead ``[Image #N]`` marker.
         """
         session = self._session
         if session is None:
@@ -3206,8 +3216,17 @@ class OperatorApp(App[None]):
         # not echoed: the request text is the transcript subject, and a
         # second row restating `/team name …` would be the duplication
         # the echo policy exists to prevent.
+        #
+        # ``resolve_markers`` against the REQUEST, not the whole slash line: the
+        # marker sits in the request tail the user typed around, and resolving
+        # from the text is the same authority the composer uses — a marker the
+        # request no longer cites (deleted before sending) drops its image, and
+        # order follows the text. Passing the map through both arguments lets
+        # ``_submit_prompt`` render the image blocks and hold the pixels across
+        # a steer/compaction exactly as a plain prompt does.
         notice(f"sending to {team.name}. {team.manager} is coordinating.")
-        self._submit_prompt(request)
+        images = resolve_markers(request, attachments or {})
+        self._submit_prompt(request, images, attachments)
 
     def _cmd_team_chart(self, name: str, registry: Any, notice: NoticeFn) -> None:
         """``/team chart [name]`` — open the org-chart mode for a team.
@@ -3395,7 +3414,12 @@ class OperatorApp(App[None]):
             return
         self._status.update(team=str(getattr(self._session, "active_team_name", "") or ""))
 
-    def _cmd_agent(self, arg: str, notice: NoticeFn) -> None:
+    def _cmd_agent(
+        self,
+        arg: str,
+        notice: NoticeFn,
+        attachments: Mapping[int, Attachment] | None = None,
+    ) -> None:
         """``/agent`` — list; ``/agent <name> [<message>]`` — adopt a profile.
 
         Mirrors ``_cmd_team`` surface for surface. Bare ``/agent`` is a
@@ -3404,6 +3428,10 @@ class OperatorApp(App[None]):
         ``Session.attach_agent_profile``); with a message the message is then
         sent as a real user turn, the same one-command-two-acts shape as
         ``/team <name> <request>``.
+
+        ``attachments`` mirrors ``_cmd_team``: the composer's image map, so a
+        screenshot the MESSAGE cites reaches the attached persona as pixels
+        rather than a bare ``[Image #N]`` marker.
 
         The NAME is the first whitespace-delimited token, exactly like
         `/team`'s parse. Role/specialist names may in principle contain spaces
@@ -3484,9 +3512,12 @@ class OperatorApp(App[None]):
         if not layered:
             if request:
                 # The message is still worth sending — the user asked for a
-                # turn — but say plainly no persona was applied to it.
+                # turn — but say plainly no persona was applied to it. The
+                # message's own image markers are resolved and sent, same as the
+                # instruction-carrying path below.
                 notice(f"agent {resolved} has no instructions; sending your message as-is.")
-                self._submit_prompt(request)
+                images = resolve_markers(request, attachments or {})
+                self._submit_prompt(request, images, attachments)
             else:
                 notice(
                     f"agent {resolved} resolved but carries no instructions, "
@@ -3507,9 +3538,12 @@ class OperatorApp(App[None]):
         # attached profile is told) and starts the turn — same non-echo
         # reasoning as `_cmd_team`: the message text is the transcript
         # subject, and a second row restating `/agent name …` would be the
-        # duplication the echo policy exists to prevent.
+        # duplication the echo policy exists to prevent. The message's image
+        # markers are resolved from the text, the same authority the composer
+        # uses, so a cited screenshot reaches the persona as pixels.
         notice(f"agent {resolved} now governs this session's replies.")
-        self._submit_prompt(request)
+        images = resolve_markers(request, attachments or {})
+        self._submit_prompt(request, images, attachments)
 
     # -- MCP status ---------------------------------------------------------
     def _wire_mcp_status(self, session: SessionProtocol) -> None:
@@ -4249,7 +4283,17 @@ class OperatorApp(App[None]):
             # below it always appended. Without that, it would retire the splash
             # for a command that draws nothing into the transcript — a
             # ``/usage`` panel over a screen with no splash and no ledger.
-            self._run_slash_command(text)
+            #
+            # The attachments ride along: the two ``consumes_prompt`` commands
+            # that send their argument to the model (``/team <name> <request>``,
+            # ``/agent <name> <message>``) need the pasted screenshot the request
+            # cites, or the ``[Image #N]`` marker reaches the model as bare text
+            # with no pixels — the exact bug where attaching an image and then
+            # routing it through ``/team`` silently dropped the image. Handed as
+            # the index→attachment MAP (not the pre-resolved ``images`` list),
+            # because the handler submits only the REQUEST tail and must resolve
+            # the markers THAT text still cites, not the whole slash line's.
+            self._run_slash_command(text, message.attachments)
             return
         self._submit_prompt(text, images, message.attachments)
 
@@ -7897,8 +7941,17 @@ class OperatorApp(App[None]):
         """The input editor. Queried rather than held: Textual owns the widget."""
         return self.query_one(Editor)
 
-    def _run_slash_command(self, text: str) -> None:
+    def _run_slash_command(
+        self, text: str, attachments: Mapping[int, Attachment] | None = None
+    ) -> None:
         """Dispatch a typed slash command (with arguments) to its handler.
+
+        ``attachments`` is the composer's index→image map at submit time, passed
+        through so the two prompt-sending commands (``/team``/``/agent``) can
+        forward the pixels their request cites to the model. It defaults to
+        ``None`` because most commands take no prompt and the mid-draft inline
+        path (:meth:`on_inline_command_requested`) leaves the draft — images and
+        all — in the composer rather than submitting it.
 
         The typed word is resolved to its registry PRIMARY name first, so the
         branches below only ever have to know one spelling. They used to match
@@ -7984,9 +8037,9 @@ class OperatorApp(App[None]):
         elif command == "/credential":
             self._cmd_credential(arg, notice)
         elif command == "/team":
-            self._cmd_team(arg, notice)
+            self._cmd_team(arg, notice, attachments)
         elif command == "/agent":
-            self._cmd_agent(arg, notice)
+            self._cmd_agent(arg, notice, attachments)
         else:
             # ``parts[0]``, not the lowered ``command``: with the echo gone this
             # line is the ONLY place the mistyped word appears, so it has to

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.25.0"
+version = "0.25.1"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -105,6 +105,10 @@ class FakeSession:
 
     def __init__(self) -> None:
         self.prompts: list[str] = []
+        #: The images each prompt carried, index-aligned with ``prompts``. Kept
+        #: so a test can prove a screenshot reached the model through a command
+        #: that submits a prompt (``/team``/``/agent``), not just the text.
+        self.prompt_images: list[list[Any]] = []
         self.aborts: list[str] = []
         #: Bang-mode commands this fake was asked to persist. A list of
         #: ``(command, result)`` so a test can say the TUI recorded what ran
@@ -288,6 +292,10 @@ class FakeSession:
 
     async def prompt(self, text: str, images: Sequence[ImageContent] | None = None) -> None:
         self.prompts.append(text)
+        # Parallel to ``prompts``: the pixels the turn carried, so a test can
+        # assert an image survived a route (e.g. `/team <name> <request>` with
+        # a pasted screenshot) rather than only that the words did.
+        self.prompt_images.append(list(images or []))
 
     async def record_shell(self, command: str, result: Any) -> None:
         self.shell_records.append((command, result))

--- a/tests/unit/tui/test_slash_command_images.py
+++ b/tests/unit/tui/test_slash_command_images.py
@@ -160,6 +160,82 @@ async def test_team_without_a_request_sends_nothing(tmp_path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_team_request_carries_multiple_images_in_text_order(tmp_path) -> None:
+    """Two images, and the order/subset the REQUEST text cites is what is sent.
+
+    Locks the resolve-from-text contract the fix leans on: markers are keys, not
+    positions, so citing only ``#2`` (the user deleted ``#1`` before sending)
+    must send exactly one image — the ``#2`` pixels — and citing both in the
+    reverse order must send them in that order. Distinct sizes make each image
+    identifiable by its decoded dimensions.
+    """
+    first = _png(tmp_path / "a.png", 40, 20)
+    second = _png(tmp_path / "b.png", 80, 60)
+    session = FakeSession()
+    reg = TeamRegistry(Path(tempfile.mkdtemp()))
+    reg.create_team(
+        TeamEditFields(name="ops", manager="manager", members=[TeamMember(role="coder")])
+    )
+    session.team_registry = reg
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _boot(pilot, app)
+        editor = app.query_one(Editor)
+        editor.focus()
+        await pilot.pause()
+        await _paste(app, pilot, first)
+        await _paste(app, pilot, second)
+        # Both markers are now in the composer, `#1` then `#2`.
+        assert editor.text == "[Image #1, 40x20] [Image #2, 80x60] "
+
+        # Cite ONLY #2 in the request — the user kept the second screenshot and
+        # dropped the first before routing it.
+        editor.load_text("/team ops just this one [Image #2, 80x60]")
+        await pilot.press("enter")
+        await pilot.pause()
+
+        (sent,) = session.prompt_images[0]
+        kept = Image.open(io.BytesIO(base64.b64decode(sent.data)))
+        assert kept.size == (80, 60), "the wrong (or extra) image was sent"
+
+
+@pytest.mark.asyncio
+async def test_team_marker_in_the_name_position_is_not_an_image(tmp_path) -> None:
+    """F2: an image marker where the NAME goes resolves nothing and finds no team.
+
+    Pins the (correct, but silent) behaviour that only the request TAIL carries
+    images: ``/team [Image #1] …`` treats the bracketed marker as a team name,
+    which no team matches, so it is an error rather than a smuggled image. Keeps
+    a future refactor from quietly making the name position image-bearing.
+    """
+    path = _png(tmp_path / "shot.png")
+    session = FakeSession()
+    reg = TeamRegistry(Path(tempfile.mkdtemp()))
+    reg.create_team(
+        TeamEditFields(name="ops", manager="manager", members=[TeamMember(role="coder")])
+    )
+    session.team_registry = reg
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _boot(pilot, app)
+        editor = app.query_one(Editor)
+        editor.focus()
+        await pilot.pause()
+        await _paste(app, pilot, path)
+        marker = editor.text.strip()
+        # Marker in the NAME slot, not the request tail.
+        editor.load_text(f"/team {marker} describe it")
+        await pilot.press("enter")
+        await pilot.pause()
+
+        # No team matched a bracket-shaped name, so nothing was attached and no
+        # turn (and no image) was sent.
+        assert session.attached_teams == []
+        assert session.prompts == []
+        assert session.prompt_images == []
+
+
+@pytest.mark.asyncio
 async def test_agent_message_carries_the_pasted_image(tmp_path) -> None:
     """`/agent <name> <message>` sends the screenshot the message cites."""
     path = _png(tmp_path / "shot.png", 1568, 410)

--- a/tests/unit/tui/test_slash_command_images.py
+++ b/tests/unit/tui/test_slash_command_images.py
@@ -161,13 +161,15 @@ async def test_team_without_a_request_sends_nothing(tmp_path) -> None:
 
 @pytest.mark.asyncio
 async def test_team_request_carries_multiple_images_in_text_order(tmp_path) -> None:
-    """Two images, and the order/subset the REQUEST text cites is what is sent.
+    """Two images, but only the one the REQUEST text still cites is sent.
 
     Locks the resolve-from-text contract the fix leans on: markers are keys, not
     positions, so citing only ``#2`` (the user deleted ``#1`` before sending)
-    must send exactly one image — the ``#2`` pixels — and citing both in the
-    reverse order must send them in that order. Distinct sizes make each image
-    identifiable by its decoded dimensions.
+    must send exactly one image — the ``#2`` pixels, not ``#1`` and not both.
+    Distinct sizes make the surviving image identifiable by its decoded
+    dimensions. (Ordering across several surviving markers is already pinned by
+    ``resolve_markers``'s own tests in ``test_paste_images``; this guards the
+    slash-command seam that used to drop the pixels entirely.)
     """
     first = _png(tmp_path / "a.png", 40, 20)
     second = _png(tmp_path / "b.png", 80, 60)

--- a/tests/unit/tui/test_slash_command_images.py
+++ b/tests/unit/tui/test_slash_command_images.py
@@ -1,0 +1,185 @@
+"""A pasted image survives a prompt-sending slash command.
+
+The bug: attach an image, then route it to a team or persona with
+``/team <name> <request>`` or ``/agent <name> <message>``, and the screenshot
+was silently dropped — the model received the bare ``[Image #N]`` marker as
+text with no pixels behind it. ``on_editor_submitted`` handed slash-shaped
+lines to ``_run_slash_command(text)`` and discarded ``message.attachments``,
+and the two commands whose argument reaches the model (``_cmd_team`` /
+``_cmd_agent``) called ``_submit_prompt(request)`` with no images.
+
+These are end-to-end pilot tests, not editor unit tests: the whole point is
+that the attachment survives the SUBMIT path from composer to session, which is
+exactly the seam that dropped it. The image is pasted from a real PNG so the
+marker the app writes is the same one a user's paste produces, and the
+assertion reads the pixels off ``FakeSession.prompt_images`` — proof the bytes
+travelled, not merely that a marker did.
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+import tempfile
+from pathlib import Path
+
+import pytest
+from PIL import Image
+from textual import events
+
+from local_operator.agents import AgentEditFields, AgentRegistry
+from local_operator.teams import TeamEditFields, TeamMember, TeamRegistry
+from local_operator.tui.app import OperatorApp
+from local_operator.tui.widgets.editor import Editor
+from tests.unit.tui.test_app_pilot import FakeSession, _factory
+
+
+def _agent_registry(tmp: Path) -> AgentRegistry:
+    """A registry with one role that carries real instructions.
+
+    Mirrors ``test_slash_echo._agent_registry`` but minimal: ``/agent auditor``
+    resolves to a role whose non-empty system prompt makes the attach layer a
+    persona (the ``agent_brief`` path), so the message-carrying branch — the one
+    that must forward the image — is the branch this test exercises.
+    """
+    registry = AgentRegistry(tmp)
+    # AgentEditFields requires every field spelled out (no defaults), so build a
+    # None-filled base and override only what this fixture needs — the same
+    # shape ``test_slash_echo`` uses for its registry.
+    base = dict(
+        name=None,
+        security_prompt=None,
+        hosting=None,
+        model=None,
+        description=None,
+        tags=None,
+        categories=None,
+        last_message=None,
+        temperature=None,
+        top_p=None,
+        top_k=None,
+        max_tokens=None,
+        stop=None,
+        frequency_penalty=None,
+        presence_penalty=None,
+        seed=None,
+        current_working_directory=None,
+    )
+    role = registry.create_agent(
+        AgentEditFields(**{**base, "name": "auditor", "description": "Audit", "tags": ["role"]})
+    )
+    registry.set_agent_system_prompt(role.id, "You audit changes.")
+    return registry
+
+
+def _png(path: Path, width: int = 1568, height: int = 200) -> str:
+    Image.new("RGB", (width, height), (30, 30, 40)).save(path)
+    return str(path)
+
+
+async def _boot(pilot, app: OperatorApp) -> None:
+    for _ in range(40):
+        await pilot.pause()
+        if app._session is not None:
+            return
+
+
+async def _paste(app: OperatorApp, pilot, text: str) -> None:
+    app.post_message(events.Paste(text))
+    await pilot.pause()
+    await pilot.pause()
+
+
+@pytest.mark.asyncio
+async def test_team_request_carries_the_pasted_image(tmp_path) -> None:
+    """`/team <name> <request>` sends the screenshot the request cites."""
+    path = _png(tmp_path / "shot.png", 1568, 410)
+    session = FakeSession()
+    reg = TeamRegistry(Path(tempfile.mkdtemp()))
+    reg.create_team(
+        TeamEditFields(name="ops", manager="manager", members=[TeamMember(role="coder")])
+    )
+    session.team_registry = reg
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _boot(pilot, app)
+        editor = app.query_one(Editor)
+        editor.focus()
+        await pilot.pause()
+
+        # Attach the image FIRST — the exact order the bug report describes:
+        # image on the composer, then a slash command typed around it.
+        await _paste(app, pilot, path)
+        assert editor.referenced_images(), "the image was not attached to the composer"
+        # The composer now holds `[Image #1, …] ` — type the command around it,
+        # mirroring `/team ops <request about the image>`.
+        marker = editor.text.strip()
+        editor.load_text(f"/team ops look at {marker} and fix it")
+        await pilot.press("enter")
+        await pilot.pause()
+
+        assert [t.name for t in session.attached_teams] == ["ops"]
+        assert session.prompts == ["look at [Image #1, 1568x410] and fix it"]
+        # The crux: one image, and it is the pixels that were pasted.
+        (sent,) = session.prompt_images[0]
+        decoded = Image.open(io.BytesIO(base64.b64decode(sent.data)))
+        assert decoded.size[0] > 0 and decoded.size[1] > 0
+
+
+@pytest.mark.asyncio
+async def test_team_without_a_request_sends_nothing(tmp_path) -> None:
+    """A bare attach (`/team ops` with no request) sends no turn, no image.
+
+    Guards the resolve-from-text rule from the other side: the image marker
+    lives in the request tail, so an attach with no tail cites nothing and must
+    not smuggle the composer's leftover attachment into a turn that never runs.
+    """
+    path = _png(tmp_path / "shot.png")
+    session = FakeSession()
+    reg = TeamRegistry(Path(tempfile.mkdtemp()))
+    reg.create_team(
+        TeamEditFields(name="ops", manager="manager", members=[TeamMember(role="coder")])
+    )
+    session.team_registry = reg
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _boot(pilot, app)
+        editor = app.query_one(Editor)
+        editor.focus()
+        await pilot.pause()
+        await _paste(app, pilot, path)
+        # Attach only — the image marker is present but the command has no
+        # request tail citing it.
+        editor.load_text("/team ops")
+        await pilot.press("enter")
+        await pilot.pause()
+
+        assert [t.name for t in session.attached_teams] == ["ops"]
+        assert session.prompts == []
+        assert session.prompt_images == []
+
+
+@pytest.mark.asyncio
+async def test_agent_message_carries_the_pasted_image(tmp_path) -> None:
+    """`/agent <name> <message>` sends the screenshot the message cites."""
+    path = _png(tmp_path / "shot.png", 1568, 410)
+    session = FakeSession()
+    session.agent_registry = _agent_registry(Path(tempfile.mkdtemp()))
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _boot(pilot, app)
+        editor = app.query_one(Editor)
+        editor.focus()
+        await pilot.pause()
+        await _paste(app, pilot, path)
+        assert editor.referenced_images(), "the image was not attached to the composer"
+        marker = editor.text.strip()
+        editor.load_text(f"/agent auditor what do you make of {marker}")
+        await pilot.press("enter")
+        await pilot.pause()
+
+        assert session.attached_agents == ["auditor"]
+        assert session.prompts == ["what do you make of [Image #1, 1568x410]"]
+        (sent,) = session.prompt_images[0]
+        decoded = Image.open(io.BytesIO(base64.b64decode(sent.data)))
+        assert decoded.size[0] > 0 and decoded.size[1] > 0


### PR DESCRIPTION
## Why

Attaching an image and then adding team/persona context with a slash command **silently dropped the image**. The reported flow: paste a screenshot into the composer, then route it with `/team <name> <request about the image>` (or `/agent <name> <message>`), and the model receives the bare `[Image #N]` marker as *text with no pixels behind it*. The user's workaround was to re-attach the image after the command — the symptom in the bug report.

Root cause is a single dropped argument on the submit path:

- `on_editor_submitted` routes any slash-shaped line to `_run_slash_command(text)` and **discards `message.images` / `message.attachments`** (the non-slash branch right below it passes them to `_submit_prompt`).
- The two commands whose argument actually reaches the model — `/team <name> <request>` and `/agent <name> <message>`, both `consumes_prompt=True` — then call `_submit_prompt(request)` with **no images**.

Every other slash command takes no model-bound prompt (`/goal` stores text, `/loop` iterates, `/btw` opens the text-only aside), so only these two are affected. The composer's attachment map was fully intact at submit — it just never got handed to the command handlers.

Version bump is **PATCH** (0.25.0 → 0.25.1): one behavioural bug fix, no new capability.

## What changes

- **`tui/app.py`, `on_editor_submitted`** — the slash-dispatch call now passes `message.attachments` through: `self._run_slash_command(text, message.attachments)`. Handed as the index→attachment **map**, not the pre-resolved `images` list, because the handler submits only the *request tail* and must resolve the markers **that** text cites, not the whole slash line's.
- **`_run_slash_command`** — gains an optional `attachments` parameter (defaults `None`; the mid-draft `on_inline_command_requested` path still leaves the draft in the composer, so it passes nothing), forwarded to `/team` and `/agent`.
- **`_cmd_team` / `_cmd_agent`** — before `_submit_prompt`, resolve `images = resolve_markers(request, attachments or {})` and pass both `images` and the `attachments` map. Using `resolve_markers` against the **request** keeps the composer's text-is-authority rule: a marker the request no longer cites drops its image, order follows the text, and the map riding through `_submit_prompt` lets the pixels survive a steer/compaction hold exactly as a plain prompt does. A bare attach (`/team ops` with no request) cites nothing and sends no turn.

## Testing

### Automated — new end-to-end regression tests (`tests/unit/tui/test_slash_command_images.py`)

These drive the **real `OperatorApp`** through the actual submit path (paste a real PNG → type the command around the marker → press Enter), and read the pixels back off the session — proof the bytes travelled, not merely a marker.

```
$ env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest \
    tests/unit/tui/test_slash_command_images.py -q
...                                                                      [100%]
3 passed, 28 warnings in 2.43s
```

- `test_team_request_carries_the_pasted_image` — `/team ops look at [Image #1, 1568x410] and fix it` → `session.prompts == ["look at [Image #1, 1568x410] and fix it"]` **and** `session.prompt_images[0]` decodes to a real image.
- `test_agent_message_carries_the_pasted_image` — same for `/agent auditor …`.
- `test_team_without_a_request_sends_nothing` — a bare attach cites nothing: `session.prompts == []`, `session.prompt_images == []` (guards against smuggling a leftover attachment into a turn that never runs).

### The test catches the bug (mutation check)

Reverting `_cmd_team` to the old `self._submit_prompt(request)` makes the new test fail on exactly the dropped image:

```
FAILED test_team_request_carries_the_pasted_image
  - ValueError: not enough values to unpack (expected 1, got 0)   # no image reached the session
```

Restoring the fix → green.

### No regressions

```
$ env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit/tui -q
2400 passed, 4 skipped, 28 warnings in 78.40s
```

### Gates

```
flake8 .                                  # clean
black==26.1.0 --check local_operator tests  # All done ✨ 455 files unchanged
isort --check-only --profile black         # clean
pyright                                    # 0 errors
```

## Notes

No visual or interaction-flow change: the command surface, picker, and echo policy are all identical — only the payload routing behind them changed. So this is a code-review-only change (no design/UX round).
