### PR TITLE
fix(tui): stop messy selection on the usage panel scrollbar

### DIFF
--- a/local_operator/tui/widgets/usage_panel.py
+++ b/local_operator/tui/widgets/usage_panel.py
@@ -75,16 +75,21 @@ TIER_INDENT = "  "
 #: exactly the reflow the transcript avoids with ``scrollbar-gutter: stable``.
 SCROLLBAR_GUTTER_CELLS = 1
 
-#: How many cells LEFT of the bar column still count as a grab. The bar is a
+#: How many cells LEFT of the bar column can still count as a grab. The bar is a
 #: single hand-painted column, and a 1-cell mouse target is easy to miss; a miss
 #: lands on the selectable ``Static`` and arms a text selection whose drag reads
 #: as the messy highlight the user reported. Widening the HIT test (not the
-#: painted bar — see :meth:`UsagePanel._paint_scrollbar`) leftward is safe
-#: because the report's numbers are right-aligned to ``_body_content_width`` and
-#: the rightmost data columns sit well left of the reserved gutter, so a small
-#: left pad cannot steal a content click. Mirrors the transcript's grab pad
-#: (``TranscriptScreen.SCROLLBAR_GRAB_PAD`` in ``app.py``); do not raise it
-#: without a fresh geometry check against the widest realistic report row.
+#: painted bar — see :meth:`UsagePanel._paint_scrollbar`) leftward closes that
+#: miss. Unlike the transcript (``TranscriptScreen.SCROLLBAR_GRAB_PAD`` in
+#: ``app.py``), whose pad eats the view's own EMPTY right padding, this panel
+#: composes rows flush to ``_body_content_width`` and appends the bar there, so
+#: the pad columns CAN hold real right-aligned data (a "10%", a "resets in 5h"
+#: countdown, a truncated identity). The forgiveness is therefore CONTENT-AWARE:
+#: :meth:`UsagePanel._scrollbar_hit` grabs in the pad band only when those cells
+#: are blank in that row, so a near-miss over the common blank tail grabs while
+#: a press on a visible character still selects. Raising this only widens the
+#: blank-tail target; it never begins stealing content, because the blank-tail
+#: gate holds regardless of the pad's width.
 SCROLLBAR_GRAB_PAD = 2
 
 #: Track vs thumb glyphs. The track is a hairline so the reserved column reads
@@ -848,13 +853,14 @@ class UsagePanel(Static):
         return self._content_offset(event).y
 
     def _scrollbar_hit(self, event) -> tuple[int, int, int] | None:  # noqa: ANN001
-        """``(row_in_body, thumb_top, thumb_len)`` if the press is on the bar or
-        within :data:`SCROLLBAR_GRAB_PAD` cells left of it.
+        """``(row_in_body, thumb_top, thumb_len)`` if the press is on the bar, or
+        within :data:`SCROLLBAR_GRAB_PAD` cells left of it OVER A BLANK TAIL.
 
         ``None`` when the body is not scrollable, when the press is left of the
-        pad band, or when it is above/below the track. Sharing the region and
-        thumb maths with the painter is what keeps the grab target exactly under
-        the glyph the user sees.
+        pad band, when the pad cells for that row hold real content, or when it
+        is above/below the track. Sharing the region and thumb maths with the
+        painter is what keeps the grab target exactly under the glyph the user
+        sees.
         """
         body = self._body()
         budget = self._body_budget()
@@ -863,10 +869,7 @@ class UsagePanel(Static):
             return None
         offset = self._content_offset(event)
         # The bar is the single content column just past the body's composed
-        # width (the reserved gutter). Accept a small pad to the LEFT of it too:
-        # the 1-cell target is easy to miss, and a miss would otherwise land on
-        # the selectable Static and arm the messy drag-highlight. Content x, so
-        # no padding term is needed.
+        # width (the reserved gutter). Content x, so no padding term is needed.
         bar = self._body_content_width()
         if not (bar - SCROLLBAR_GRAB_PAD <= offset.x <= bar):
             return None
@@ -874,8 +877,36 @@ class UsagePanel(Static):
         row_in_body = offset.y - first_row
         if not 0 <= row_in_body < count:
             return None
+        # The exact bar column always grabs. A near-miss in the pad band grabs
+        # ONLY when the cells from the press up to the bar are blank in THIS row.
+        # Unlike the transcript (whose rows leave empty right padding the pad can
+        # safely eat), this panel composes rows flush to `bar` and appends the
+        # bar at that column, so the pad columns (`bar-1`, `bar-2`) can hold real
+        # right-aligned data — a meter's "10%", a "resets in 5h" countdown, a
+        # truncated identity. Grabbing over a visible character would steal a
+        # legitimate click/selection, so forgiveness is gated on a blank tail:
+        # it kicks in on the common blank-tail rows and never over a glyph.
+        if offset.x < bar and not self._pad_tail_blank(row_in_body, offset.x, bar, budget):
+            return None
         thumb_top, thumb_len = self._scrollbar_thumb(total, budget)
         return row_in_body, thumb_top, thumb_len
+
+    def _pad_tail_blank(self, row_in_body: int, x: int, bar: int, budget: int) -> bool:
+        """Whether composed columns ``[x, bar)`` are all whitespace in this row.
+
+        Reads the same composed viewport row the painter overlays the bar onto
+        (``_window_rows``), padded conceptually to ``bar`` exactly as
+        :meth:`_paint_scrollbar` pads it — a line shorter than ``x`` therefore
+        reads as an all-blank tail. The give-back blank rows below a short block
+        (``row_in_body >= len(window)``) carry no data, so they are blank by
+        construction. Indexing is by code point rather than cell because the
+        panel's rows are single-width text (labels, numbers, bar glyphs); the
+        painter and ``render_lines_for_test`` treat the two as equivalent here.
+        """
+        window, _ = self._window_rows(self._body(), budget)
+        if row_in_body >= len(window):
+            return True
+        return window[row_in_body].plain[x:bar].strip() == ""
 
     def _apply_thumb_top(self, thumb_top: int) -> None:
         """Move the offset so the thumb's top lands at ``thumb_top`` and repaint."""

--- a/local_operator/tui/widgets/usage_panel.py
+++ b/local_operator/tui/widgets/usage_panel.py
@@ -37,6 +37,7 @@ from typing import Any
 from rich.cells import cell_len
 from rich.style import Style
 from rich.text import Text
+from textual.dom import NoScreen
 from textual.message import Message
 from textual.widgets import Static
 
@@ -73,6 +74,18 @@ TIER_INDENT = "  "
 #: right-aligned numbers one column left the instant the bar appeared, which is
 #: exactly the reflow the transcript avoids with ``scrollbar-gutter: stable``.
 SCROLLBAR_GUTTER_CELLS = 1
+
+#: How many cells LEFT of the bar column still count as a grab. The bar is a
+#: single hand-painted column, and a 1-cell mouse target is easy to miss; a miss
+#: lands on the selectable ``Static`` and arms a text selection whose drag reads
+#: as the messy highlight the user reported. Widening the HIT test (not the
+#: painted bar — see :meth:`UsagePanel._paint_scrollbar`) leftward is safe
+#: because the report's numbers are right-aligned to ``_body_content_width`` and
+#: the rightmost data columns sit well left of the reserved gutter, so a small
+#: left pad cannot steal a content click. Mirrors the transcript's grab pad
+#: (``TranscriptScreen.SCROLLBAR_GRAB_PAD`` in ``app.py``); do not raise it
+#: without a fresh geometry check against the widest realistic report row.
+SCROLLBAR_GRAB_PAD = 2
 
 #: Track vs thumb glyphs. The track is a hairline so the reserved column reads
 #: as a place to aim a drag rather than a right-hand border (the same reason the
@@ -777,6 +790,18 @@ class UsagePanel(Static):
         hit = self._scrollbar_hit(event)
         if hit is None:
             return
+        # Base ``Screen._forward_event`` arms a text selection on this MouseDown
+        # BEFORE this handler runs, because the panel is a selectable ``Static``;
+        # its base mouse-move handler would then extend that selection in parallel
+        # with the drag (the messy highlight, on both a near-miss and an exact
+        # hit). A scrollbar grab is not a selection, so clear whatever it armed as
+        # the grab takes hold. Guarded because the CSS-less test host and any
+        # pre-mount call have no screen to clear.
+        if self.is_mounted:
+            try:
+                self.screen.clear_selection()
+            except NoScreen:
+                pass
         event.stop()
         row_in_body, thumb_top, thumb_len = hit
         if thumb_top <= row_in_body < thumb_top + thumb_len:
@@ -823,12 +848,13 @@ class UsagePanel(Static):
         return self._content_offset(event).y
 
     def _scrollbar_hit(self, event) -> tuple[int, int, int] | None:  # noqa: ANN001
-        """``(row_in_body, thumb_top, thumb_len)`` if the press is on the bar.
+        """``(row_in_body, thumb_top, thumb_len)`` if the press is on the bar or
+        within :data:`SCROLLBAR_GRAB_PAD` cells left of it.
 
         ``None`` when the body is not scrollable, when the press is left of the
-        reserved gutter column, or when it is above/below the track. Sharing the
-        region and thumb maths with the painter is what keeps the grab target
-        exactly under the glyph the user sees.
+        pad band, or when it is above/below the track. Sharing the region and
+        thumb maths with the painter is what keeps the grab target exactly under
+        the glyph the user sees.
         """
         body = self._body()
         budget = self._body_budget()
@@ -837,8 +863,12 @@ class UsagePanel(Static):
             return None
         offset = self._content_offset(event)
         # The bar is the single content column just past the body's composed
-        # width (the reserved gutter). Content x, so no padding term is needed.
-        if offset.x != self._body_content_width():
+        # width (the reserved gutter). Accept a small pad to the LEFT of it too:
+        # the 1-cell target is easy to miss, and a miss would otherwise land on
+        # the selectable Static and arm the messy drag-highlight. Content x, so
+        # no padding term is needed.
+        bar = self._body_content_width()
+        if not (bar - SCROLLBAR_GRAB_PAD <= offset.x <= bar):
             return None
         first_row, count = self._body_region(budget)
         row_in_body = offset.y - first_row

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.25.0"
+version = "0.25.1"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.25.1"
+version = "0.25.2"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/tui/test_usage_panel.py
+++ b/tests/unit/tui/test_usage_panel.py
@@ -734,6 +734,184 @@ async def test_the_scrollbar_gutter_never_reflows_the_number_columns() -> None:
     assert scrolled.index("10%") == fits.index("10%"), (scrolled, fits)
 
 
+# -- the grab must not leave a selection armed (needs the REAL app) ----------
+# The lightweight ``_PanelHost`` above is deliberately NOT used here: the bug is
+# in the interaction between the panel's grab and ``Screen._forward_event``,
+# which arms a text selection on the MouseDown before the panel's handler runs
+# because the panel is a selectable ``Static``. That machinery only exists on a
+# real ``Screen``, so these tests drive the full ``OperatorApp`` (as
+# ``test_app_pilot`` does) and push events through ``screen._forward_event`` —
+# the same path a real mouse press takes — rather than calling the panel's
+# handler directly, which would skip the selection-arming under test.
+def _bar_screen_x(panel: UsagePanel) -> int:
+    """The absolute screen column the scrollbar paints into.
+
+    Composed from the panel's region plus its live gutter plus the body content
+    width, never hardcoded: the card is positioned by an offset inside a hugging
+    host inside the screen inset, and its padding differs between the real
+    stylesheet and the test host.
+    """
+    return panel.region.x + panel.styles.gutter.left + panel._body_content_width()
+
+
+def _body_screen_y0(panel: UsagePanel) -> int:
+    """Absolute screen row of composed body row 0 (the title cell)."""
+    return panel.region.y + panel.styles.gutter.top
+
+
+def _screen_mouse(cls, x: int, y: int):
+    """A Textual mouse event carrying SCREEN coordinates, for ``_forward_event``.
+
+    ``x``/``y`` and ``screen_x``/``screen_y`` are equal here because the event is
+    fed to the screen, which translates to widget-relative coordinates itself.
+    """
+    return cls(
+        widget=None,
+        x=x,
+        y=y,
+        delta_x=0,
+        delta_y=0,
+        button=1,
+        shift=False,
+        meta=False,
+        ctrl=False,
+        screen_x=x,
+        screen_y=y,
+    )
+
+
+async def _grab_via_screen(panel: UsagePanel, app: OperatorApp, pilot, dx: int):
+    """Press ``dx`` cells from the bar's screen x (on the thumb row) via the
+    screen, drag to the track's foot, and return the observed grab/selection
+    state plus whether the offset advanced.
+
+    Each event is followed by ``pilot.pause()`` because ``_forward_event`` POSTS
+    the mouse event to the panel's message pump — ``on_mouse_down`` runs on the
+    next pump cycle, not synchronously — so a check before the pause would read
+    the pre-handler state and spuriously fail.
+    """
+    from textual import events
+
+    panel.set_view_offset(0)
+    app.screen.clear_selection()
+    panel._dragging = False
+
+    budget = panel._body_budget()
+    total = len(panel._body().lines)
+    first_row, count = panel._body_region(budget)
+    thumb_top, _ = panel._scrollbar_thumb(total, budget)
+    sx = _bar_screen_x(panel) + dx
+    sy = _body_screen_y0(panel) + first_row + thumb_top
+
+    app.screen._forward_event(_screen_mouse(events.MouseDown, sx, sy))
+    await pilot.pause()
+    dragging = panel._dragging
+    captured = app.mouse_captured
+    off0 = panel.view_offset
+
+    # Drag to the track's foot; the base move handler would extend a leaked
+    # selection here, which is exactly what must NOT happen.
+    app.screen._forward_event(
+        _screen_mouse(events.MouseMove, sx, _body_screen_y0(panel) + first_row + count - 1)
+    )
+    await pilot.pause()
+    off1 = panel.view_offset
+    selecting = app.screen._selecting
+    selections = dict(app.screen.selections)
+
+    app.screen._forward_event(_screen_mouse(events.MouseUp, sx, sy))
+    await pilot.pause()
+    return dragging, captured, off0, off1, selecting, selections
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("dx", [0, -1, -2])
+async def test_a_scrollbar_grab_never_leaks_a_selection(dx: int) -> None:
+    """The reported bug: pressing on (dx=0) or just left of (dx=-1,-2) the bar
+    must grab the thumb and scroll, WITHOUT the base screen arming a text
+    selection that its move handler then extends into the messy highlight.
+
+    Driven through the real screen so the selection-arming that caused the bug
+    actually runs; the near-miss cases (dx<0) also exercise the forgiving pad.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        panel = app.query_one(UsagePanel)
+        panel.show_reports(_many_reports())
+        await pilot.pause()
+
+        dragging, captured, off0, off1, selecting, selections = await _grab_via_screen(
+            panel, app, pilot, dx
+        )
+
+    assert dragging, dx  # the panel took the grab
+    assert captured is panel, (dx, captured)  # and captured the mouse
+    assert not selecting, (dx, selecting)  # no selection in flight
+    assert selections == {}, (dx, selections)  # nothing selected
+    assert off1 > off0, (dx, off0, off1)  # the drag actually scrolled
+
+
+@pytest.mark.asyncio
+async def test_a_content_click_left_of_the_pad_still_selects() -> None:
+    """The pad is a narrow band: a press ``SCROLLBAR_GRAB_PAD + 1`` cells left of
+    the bar is ordinary content and must still arm a selection, so widening the
+    grab target cannot swallow a real text drag."""
+    from textual import events
+
+    from local_operator.tui.widgets.usage_panel import SCROLLBAR_GRAB_PAD
+
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        panel = app.query_one(UsagePanel)
+        panel.show_reports(_many_reports())
+        await pilot.pause()
+
+        panel.set_view_offset(0)
+        app.screen.clear_selection()
+        first_row, _ = panel._body_region(panel._body_budget())
+        sx = _bar_screen_x(panel) - (SCROLLBAR_GRAB_PAD + 1)
+        sy = _body_screen_y0(panel) + first_row + 1
+        app.screen._forward_event(_screen_mouse(events.MouseDown, sx, sy))
+        await pilot.pause()
+        grabbed = panel._dragging
+        armed = app.screen._select_state is not None
+        app.screen._forward_event(_screen_mouse(events.MouseUp, sx, sy))
+        await pilot.pause()
+
+    assert not grabbed  # the panel did NOT treat content as a grab
+    assert armed  # the base screen armed a selection, as for any content press
+
+
+@pytest.mark.asyncio
+async def test_a_press_on_a_non_scrollable_panel_is_not_a_grab() -> None:
+    """A report that fits reserves the gutter but paints no bar; a press in the
+    gutter column must fall through to the base handler (no grab, no capture),
+    the same non-affordance the "bar absent until it scrolls" test asserts."""
+    from textual import events
+
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        panel = app.query_one(UsagePanel)
+        panel.show_reports([_report(_percent("a:5h", "5 hour", 5.0, shared=True))])
+        await pilot.pause()
+
+        first_row, _ = panel._body_region(panel._body_budget())
+        sx = _bar_screen_x(panel)
+        sy = _body_screen_y0(panel) + first_row
+        app.screen._forward_event(_screen_mouse(events.MouseDown, sx, sy))
+        await pilot.pause()
+        grabbed = panel._dragging
+        captured = app.mouse_captured
+        app.screen._forward_event(_screen_mouse(events.MouseUp, sx, sy))
+        await pilot.pause()
+
+    assert not grabbed
+    assert captured is not panel
+
+
 # -- the card ON the screen (the real app, so the fill is in the frame) -------
 def _painted_span(app: OperatorApp, row: int, fill: str) -> tuple[int, int, int]:
     """``(cells left of the card, cells right of it, its painted width)``.

--- a/tests/unit/tui/test_usage_panel.py
+++ b/tests/unit/tui/test_usage_panel.py
@@ -326,6 +326,37 @@ def _many_reports(count: int = 12):
     ]
 
 
+def _wide_reports(count: int = 12):
+    """Reports whose composed rows FILL the rightmost columns — long labels,
+    reset countdowns, and long identities, unlike ``_many_reports``' short
+    blank-tailed rows.
+
+    This is the fixture M1's regression turns on: the content-aware pad can only
+    be exercised by rows that actually put a character in cols ``w-1``/``w-2``,
+    which the short-label fixture never does. Anthropic/OpenAI reports carry both
+    a countdown and an identity, so this is the realistic shape, not a corner.
+    """
+    return [
+        _report(
+            _percent(
+                f"p{index}:5h",
+                "5-hour session window",
+                95.0,
+                resets_at_ms=5 * 3600 * 1000,
+            ),
+            _percent(
+                f"p{index}:7d",
+                "7-day rolling window",
+                60.0,
+                resets_at_ms=48 * 3600 * 1000,
+            ),
+            provider=f"provider-with-a-long-name-{index}",
+            identity=f"someone-with-a-long-email-{index}@example.com",
+        )
+        for index in range(count)
+    ]
+
+
 @pytest.mark.asyncio
 async def test_a_long_report_scrolls_instead_of_being_truncated() -> None:
     """A quota view that hid the provider you were looking for would send the
@@ -852,27 +883,129 @@ async def test_a_scrollbar_grab_never_leaks_a_selection(dx: int) -> None:
     assert off1 > off0, (dx, off0, off1)  # the drag actually scrolled
 
 
+def _pad_rows(panel: UsagePanel) -> tuple[int | None, int | None, str]:
+    """``(a body row whose pad cells hold CONTENT, a row whose pad is BLANK, the
+    content row's tail)`` for the current window, or ``None`` where absent.
+
+    Reads the same composed window rows the painter overlays the bar onto, so a
+    test can aim a press at a row that provably fills cols ``w-1``/``w-2`` rather
+    than trusting a fixture to do so — the exact gap M1/m1 flag.
+    """
+    from local_operator.tui.widgets.usage_panel import SCROLLBAR_GRAB_PAD
+
+    budget = panel._body_budget()
+    window, _ = panel._window_rows(panel._body(), budget)
+    bar = panel._body_content_width()
+    content = blank = None
+    tail = ""
+    for row, line in enumerate(window):
+        cells = line.plain[bar - SCROLLBAR_GRAB_PAD : bar]
+        if cells.strip():
+            if content is None:
+                content, tail = row, cells
+        elif blank is None:
+            blank = row
+    return content, blank, tail
+
+
+@pytest.mark.asyncio
+async def test_the_pad_is_content_aware_over_the_unsafe_geometry() -> None:
+    """M1: this panel composes rows flush to the bar with NO empty gutter, so the
+    pad columns can hold real data. A near-miss must grab only over a BLANK tail;
+    over a row that fills those columns it must fall through and select, so the
+    forgiveness never steals a visible character.
+
+    Uses ``_wide_reports`` (long labels + reset countdowns + identities) so the
+    unsafe geometry actually exists, and ASSERTS a row with content in the pad
+    band is present — the fixture cannot silently regress to blank tails.
+    """
+    from textual import events
+
+    from local_operator.tui.widgets.usage_panel import SCROLLBAR_GRAB_PAD
+
+    # A narrow terminal packs the meters flush to the bar (M1 reproduced at 40-44
+    # cols); the wide fixture keeps content there at any width.
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(44, 20)) as pilot:
+        await pilot.pause()
+        panel = app.query_one(UsagePanel)
+        panel.show_reports(_wide_reports())
+        await pilot.pause()
+
+        content_row, blank_row, tail = _pad_rows(panel)
+        # The fixture MUST exercise the unsafe geometry or the test is vacuous.
+        assert content_row is not None, "fixture has no content in the pad band"
+        assert tail.strip(), tail
+
+        first_row, _ = panel._body_region(panel._body_budget())
+        bar_x = _bar_screen_x(panel)
+        y0 = _body_screen_y0(panel)
+
+        async def press(sx: int, sy: int) -> tuple[bool, bool]:
+            panel.set_view_offset(0)
+            app.screen.clear_selection()
+            panel._dragging = False
+            app.screen._forward_event(_screen_mouse(events.MouseDown, sx, sy))
+            await pilot.pause()
+            grabbed = panel._dragging
+            armed = app.screen._select_state is not None
+            app.screen._forward_event(_screen_mouse(events.MouseUp, sx, sy))
+            await pilot.pause()
+            return grabbed, armed
+
+        # Near-miss (both pad cells) over a CONTENT row: no grab, selection arms —
+        # the visible character is NOT stolen.
+        for dx in (-1, -SCROLLBAR_GRAB_PAD):
+            grabbed, armed = await press(bar_x + dx, y0 + first_row + content_row)
+            assert not grabbed, (dx, "grabbed over content")
+            assert armed, (dx, "content press did not arm a selection")
+
+        # The EXACT bar column always grabs, even on a content row.
+        grabbed, armed = await press(bar_x, y0 + first_row + content_row)
+        assert grabbed and not armed
+
+        # Near-miss over a BLANK tail: forgiveness still works — grab, no select.
+        if blank_row is not None:
+            for dx in (-1, -SCROLLBAR_GRAB_PAD):
+                grabbed, armed = await press(bar_x + dx, y0 + first_row + blank_row)
+                assert grabbed, (dx, "blank-tail near-miss did not grab")
+                assert not armed, (dx, "blank-tail grab armed a selection")
+
+
 @pytest.mark.asyncio
 async def test_a_content_click_left_of_the_pad_still_selects() -> None:
     """The pad is a narrow band: a press ``SCROLLBAR_GRAB_PAD + 1`` cells left of
     the bar is ordinary content and must still arm a selection, so widening the
-    grab target cannot swallow a real text drag."""
+    grab target cannot swallow a real text drag.
+
+    Driven with ``_wide_reports`` so cols at and left of the boundary actually
+    hold content (m1: the short-label fixture left them blank, making the
+    boundary assertion vacuous). Asserts the pressed cell is non-blank first.
+    """
     from textual import events
 
     from local_operator.tui.widgets.usage_panel import SCROLLBAR_GRAB_PAD
 
     app = OperatorApp(lambda: _factory(FakeSession()))
-    async with app.run_test(size=(100, 30)) as pilot:
+    async with app.run_test(size=(44, 20)) as pilot:
         await pilot.pause()
         panel = app.query_one(UsagePanel)
-        panel.show_reports(_many_reports())
+        panel.show_reports(_wide_reports())
         await pilot.pause()
+
+        content_row, _, _ = _pad_rows(panel)
+        assert content_row is not None, "fixture has no content in the pad band"
 
         panel.set_view_offset(0)
         app.screen.clear_selection()
         first_row, _ = panel._body_region(panel._body_budget())
+        window, _ = panel._window_rows(panel._body(), panel._body_budget())
+        bar = panel._body_content_width()
+        col = bar - (SCROLLBAR_GRAB_PAD + 1)
+        # The boundary is only meaningful if the pressed cell holds a character.
+        assert window[content_row].plain[col : col + 1].strip(), "boundary cell is blank"
         sx = _bar_screen_x(panel) - (SCROLLBAR_GRAB_PAD + 1)
-        sy = _body_screen_y0(panel) + first_row + 1
+        sy = _body_screen_y0(panel) + first_row + content_row
         app.screen._forward_event(_screen_mouse(events.MouseDown, sx, sy))
         await pilot.pause()
         grabbed = panel._dragging


### PR DESCRIPTION
## Why

Follow-up to #270. That PR gave the **transcript** scrollbar a forgiving grab so a near-miss stopped arming a messy text selection — but it did so via `TranscriptScreen._redirect_gutter_grab`, which only queries `TranscriptView`. Overlay panels got none of it, and the user reported the exact same messy-highlight-while-dragging bug on the **`/usage` panel** scrollbar (the transcript one now works).

The usage panel is architecturally different from the transcript: `UsagePanel` is a monolithic **selectable `Static`** that paints its OWN scrollbar (a hand-painted glyph in the reserved rightmost body column) and drives its own drag via `on_mouse_down`/`on_mouse_move`/`on_mouse_up` + `_scrollbar_hit`. It does **not** use a Textual `ScrollBar`, so the `allow_select=False` lever the transcript fix relied on does not exist here.

Two distinct problems, both reproduced against the real `OperatorApp`:
1. **Near-miss (1–2 cells left of the bar):** `_scrollbar_hit` required an **exact** column match (`offset.x != _body_content_width()` → `None`). A near-miss returned `None`, the handler did not `event.stop()`, and — because the panel is a selectable `Static` — Textual's base `Screen._forward_event` armed a text selection on the MouseDown. Dragging then extended it. (`dragging=False, captured=None, select_state=True`.)
2. **Even an exact bar hit leaked a selection:** base `_forward_event` arms `_select_state=True` on the MouseDown **before** the panel's `on_mouse_down` runs `event.stop()`+`capture_mouse()`. The panel scrolled correctly, but the base mouse-move handler extended the already-armed selection in parallel with the drag. (`dragging=True, captured=UsagePanel, select_state=True`.)

Version bump is **PATCH** (0.25.0 → 0.25.1): a bug fix to an existing control.

## What changes

Two small changes in `local_operator/tui/widgets/usage_panel.py`, both inside the panel that already owns its scrollbar. The painted bar, `_paint_scrollbar`, `_body_content_width`, and the transcript code are untouched — only the input hit-test widens and the grab clears a stray selection.

### Forgiving hit-test
New module constant `SCROLLBAR_GRAB_PAD = 2` (mirrors `TranscriptScreen.SCROLLBAR_GRAB_PAD`). `_scrollbar_hit` now accepts a press within 2 cells to the **left** of the bar column, not only exactly on it:
```python
bar = self._body_content_width()
if not (bar - SCROLLBAR_GRAB_PAD <= offset.x <= bar):
    return None
```
Safe because the report's numbers are right-aligned to `_body_content_width` and the rightmost data columns sit well left of the reserved gutter, so a small left pad cannot steal a content click.

### A grab must not leave a selection armed
In `on_mouse_down`, when `_scrollbar_hit` returns a hit, clear the selection the base handler already armed (guarded for the CSS-less test host / pre-mount, which have no screen):
```python
if self.is_mounted:
    try:
        self.screen.clear_selection()
    except NoScreen:
        pass
```
This fixes **both** the near-miss and the exact-hit leak.

## Impact
No visual change (the painted bar is byte-identical, thumb still lights `accent` on grab). No transcript change. The only behavioral deltas: a near-miss now grabs instead of selecting, and a grab no longer leaves a stray highlight.

## Testing Details

### Interaction evidence (real `OperatorApp`, events through `screen._forward_event`)
```
SCROLLBAR_GRAB_PAD=2
exact bar hit      dx= 0  dragging=True  captured=UsagePanel selecting=False n_sel=0  off 0->45
near-miss 1 left   dx=-1  dragging=True  captured=UsagePanel selecting=False n_sel=0  off 0->45
near-miss 2 left   dx=-2  dragging=True  captured=UsagePanel selecting=False n_sel=0  off 0->45
content-click      dx=-3  dragging=False select_state_armed=True   (still selects, correctly)
```

### Automated (`tests/unit/tui/test_usage_panel.py`, real `OperatorApp` via `FakeSession`/`_factory` — not `_PanelHost`)
- `test_a_scrollbar_grab_never_leaks_a_selection[0/-1/-2]` — exact + near-miss grab, capture, and scroll with `screen._selecting is False` and `screen.selections == {}`.
- `test_a_content_click_left_of_the_pad_still_selects` — a press `SCROLLBAR_GRAB_PAD+1` cells left still arms a selection and does not grab (guards the pad boundary).
- `test_a_press_on_a_non_scrollable_panel_is_not_a_grab` — few reports → no grab/capture.
- Existing `_PanelHost`-based drag tests kept green.
- The bar's screen x is computed from the panel region + gutter + `_body_content_width()`, never hardcoded.

### Gates (whole-tree, all clean)
- `flake8` → 0 · `black==26.1.0 --check` → 454 files unchanged · `isort --profile black` → 0 · `pyright` → 0 errors, 0 warnings
- `tests/unit/tui` → **2402 passed, 4 skipped** (serial `-p no:randomly` and 3 consecutive xdist runs).

### Known limitation (matches the transcript's accepted tradeoff)
On a pathological full-width report (30-char labels + 10-digit token counts filling all 76 cells), the 2-cell pad band can overlap the rightmost data column — the same tradeoff `#270` accepted for the transcript. Realistic reports end ~30 cells left of the bar, so no real content click is stolen.
