### PR TITLE
fix(usage): announce quota state once per transition, not every message

### DIFF
--- a/local_operator/model/configure.py
+++ b/local_operator/model/configure.py
@@ -1538,6 +1538,19 @@ class SessionStreamFn:
         self._primary_selector: str | None = None
         self._usage_checked_selector: str | None = None
         self._usage_checked_at = 0.0
+        # Quota is re-probed at EVERY user-message boundary, but the user only
+        # needs to hear about a CHANGE in quota standing — not the same "quota
+        # low"/"quota exhausted" line echoed on every message they send while
+        # the condition simply persists. This latch remembers, per
+        # ``provider/model_id`` selector, the last quota ``health.state`` we
+        # actually announced ("reserve" for low, "depleted" for exhausted) so a
+        # steady state stays silent and only a genuine transition
+        # (none->low, low->exhausted, or a recurrence after recovery) speaks.
+        # The key is cleared the moment the selector reads "healthy" again, so a
+        # later re-entry into low/exhausted counts as a real new transition and
+        # re-announces. Account ROTATION churn is not tracked here at all — it
+        # is suppressed outright as an internal implementation detail.
+        self._last_quota_state: dict[str, str] = {}
 
     def _client_for(self, spec: ModelSpec) -> WireClient:
         from local_operator.providers.clients import client_for_spec
@@ -1735,6 +1748,33 @@ class SessionStreamFn:
         result = self._notice_handler(text, kind)
         if inspect.isawaitable(result):
             await result
+
+    async def _announce_quota_change(
+        self, selector: str, state: str, text: str, kind: str = "warning"
+    ) -> None:
+        """Emit a quota notice only on a genuine state TRANSITION for ``selector``.
+
+        The preflight runs on every user-message boundary, so a persistent
+        low/exhausted verdict recurs on every message the user sends — but the
+        user only needs to hear about the CHANGE, not the same line echoed
+        forever. ``self._last_quota_state`` remembers the ``health.state`` last
+        announced for this ``provider/model_id``; we speak only when the new
+        state differs (none->low, low->exhausted, or a recurrence after a
+        healthy edge cleared the latch), then record it. Steady state is silent.
+        """
+        if self._last_quota_state.get(selector) == state:
+            return
+        self._last_quota_state[selector] = state
+        await self._notice(text, kind)
+
+    def _clear_quota_latch(self, selector: str) -> None:
+        """Drop the last-announced quota state so a real recurrence re-announces.
+
+        Called on the healthy edge: once quota recovers, the next slide back into
+        low/exhausted is a genuinely new transition the user should hear about,
+        not a duplicate of a verdict we already announced before the recovery.
+        """
+        self._last_quota_state.pop(selector, None)
 
     async def _on_route_change(self, target: Any, reason: str) -> None:
         effort = f" ({target.effort} effort)" if target.effort else ""
@@ -2163,9 +2203,16 @@ class SessionStreamFn:
             if health.state == "healthy":
                 # Settled for the same reason as the auth-only path above: this
                 # clear is the moment a pinned fallback stops serving requests.
+                # Also drop the quota-notice latch: recovery means the next
+                # slide back to low/exhausted is a real new transition to
+                # announce, not a duplicate of what we said before recovery.
+                self._clear_quota_latch(selector)
                 await self._route_state.clear_settled("primary model recovered")
                 return
             if health.state == "unknown":
+                # Fail-open, indeterminate: NOT a transition. Leave the latch as
+                # it stands so an unreadable probe between two low readings does
+                # not reset the dedup and let the next low reading re-announce.
                 return
 
             shared_remaining, tier_binding = shared_tier_saturation(
@@ -2274,16 +2321,21 @@ class SessionStreamFn:
                         self._auth_store.deprioritize_credential(
                             model.provider, access.credential_id
                         )
-                    await self._notice(
-                        f"{model.provider} {condition}{remaining} for {model.model_id} "
-                        f"— trying another {model.provider} account before provider fallback"
-                    )
+                    # Rotating to another same-provider account is an internal
+                    # implementation detail — the user's request is still being
+                    # served on this provider, just on a different login. It
+                    # used to emit a notice per rotation, which spammed the
+                    # transcript on every boundary. Rotate silently.
                     continue
                 if health.state == "reserve":
                     # Last account, still holding this model's quota. Same
                     # rule as the account-scope path: reserve is not a
-                    # licence to leave the provider.
-                    await self._notice(
+                    # licence to leave the provider. Deduped by state: "quota
+                    # low, continuing" is worth one line on the transition, not
+                    # one per message for as long as the account stays low.
+                    await self._announce_quota_change(
+                        selector,
+                        health.state,
                         f"{model.provider} {condition}{remaining} for {model.model_id} "
                         f"— continuing until {model.provider} quota is exhausted",
                         "info",
@@ -2295,9 +2347,15 @@ class SessionStreamFn:
                     reserve_percent=retry.usage_reserve_percent,
                 )
                 if fallback is None:
-                    await self._notice(
+                    # Deduped by state: the quota is spent and nothing can take
+                    # over, but the user only needs that told once per
+                    # transition — not on every message while the condition
+                    # holds and no fallback appears.
+                    await self._announce_quota_change(
+                        selector,
+                        health.state,
                         f"{model.provider} {condition}{remaining} for {model.model_id}; "
-                        "no configured model fallback is available"
+                        "no configured model fallback is available",
                     )
                     return
                 await self._route_state.activate(
@@ -2351,6 +2409,11 @@ class SessionStreamFn:
         """
         from local_operator.providers.failover import parse_selector
 
+        # Same dedup key the boundary check uses: quota notices out of this
+        # method latch on ``provider/model_id`` so a persistent verdict is
+        # announced once per transition, not once per message (see
+        # ``_announce_quota_change``).
+        selector = f"{model.provider}/{model.model_id}"
         threshold = min(100.0, max(0.0, float(retry.usage_reserve_percent))) / 100.0
         # ``None`` means no shared window carried a number — indeterminate, not
         # headroom, so the tier-cap guard stays off and the cautious rotate /
@@ -2397,7 +2460,9 @@ class SessionStreamFn:
                         quota=True,
                     )
                     return False
-            await self._notice(
+            await self._announce_quota_change(
+                selector,
+                health.state,
                 f"{model.provider} {condition}{remaining} — continuing until "
                 f"{model.provider} quota is exhausted",
                 "info",
@@ -2467,8 +2532,13 @@ class SessionStreamFn:
                 )
 
         if not siblings and fallback is None:
-            await self._notice(
-                f"{model.provider} {condition}{remaining}; no configured fallback is available"
+            # Deduped by state: spent with nowhere to fall back is worth one
+            # line on the transition, not a repeat on every subsequent message
+            # while the account stays spent.
+            await self._announce_quota_change(
+                selector,
+                health.state,
+                f"{model.provider} {condition}{remaining}; no configured fallback is available",
             )
             return False
 
@@ -2529,10 +2599,10 @@ class SessionStreamFn:
 
         if siblings:
             take_out_of_rotation(access.credential_id)
-            await self._notice(
-                f"{model.provider} {condition}{remaining} — trying another "
-                f"{model.provider} account before provider fallback"
-            )
+            # Silent: rotating to another same-provider account is an internal
+            # implementation detail. The request is still served on the same
+            # provider, so the per-rotation notice this used to emit was pure
+            # churn on the transcript (once per boundary while quota was low).
             return True
 
         assert fallback is not None
@@ -2657,6 +2727,11 @@ class SessionStreamFn:
                 reserve_percent=retry.usage_reserve_percent,
             )
             if health.state == "healthy":
+                # A recovered account is a healthy edge like the boundary
+                # probe's: drop the quota latch so a later re-entry into
+                # low/exhausted announces afresh rather than being deduped
+                # against the pre-recovery verdict.
+                self._clear_quota_latch(f"{model.provider}/{model.model_id}")
                 await self._notice(
                     f"{model.provider} account quota recovered — resuming {model.provider}",
                     "info",

--- a/local_operator/model/configure.py
+++ b/local_operator/model/configure.py
@@ -1542,15 +1542,28 @@ class SessionStreamFn:
         # needs to hear about a CHANGE in quota standing — not the same "quota
         # low"/"quota exhausted" line echoed on every message they send while
         # the condition simply persists. This latch remembers, per
-        # ``provider/model_id`` selector, the last quota ``health.state`` we
-        # actually announced ("reserve" for low, "depleted" for exhausted) so a
-        # steady state stays silent and only a genuine transition
+        # ``provider/model_id`` selector, WHICH quota conditions we have already
+        # announced so a steady state stays silent and only a genuine transition
         # (none->low, low->exhausted, or a recurrence after recovery) speaks.
-        # The key is cleared the moment the selector reads "healthy" again, so a
-        # later re-entry into low/exhausted counts as a real new transition and
-        # re-announces. Account ROTATION churn is not tracked here at all — it
-        # is suppressed outright as an internal implementation detail.
-        self._last_quota_state: dict[str, str] = {}
+        # The whole selector entry is cleared the moment the selector reads
+        # "healthy" again, so a later re-entry into low/exhausted counts as a
+        # real new transition and re-announces. Account ROTATION churn is not
+        # tracked here at all — it is suppressed outright as an internal
+        # implementation detail.
+        #
+        # The value is a SET of announced condition TOKENS, not a single state
+        # string. A single selector can be under more than one distinct quota
+        # condition at different times — account-scope low/exhausted
+        # (``account:<state>``), model/tier-scope low/exhausted
+        # (``model:<state>``), and the tier-cap-spent-but-shared-remains notice
+        # (``tier-spent:<state>``) all key on the SAME ``provider/model_id``.
+        # If they shared one remembered state string they would alias: announcing
+        # one would overwrite another's memory, so a still-holding condition could
+        # wrongly re-announce or a genuinely new one be wrongly suppressed. A set
+        # per selector lets each condition dedup against ITSELF only, while the
+        # healthy edge still resets all of them together (recovery is a fresh
+        # start for every condition on that selector).
+        self._last_quota_state: dict[str, set[str]] = {}
 
     def _client_for(self, spec: ModelSpec) -> WireClient:
         from local_operator.providers.clients import client_for_spec
@@ -1750,29 +1763,45 @@ class SessionStreamFn:
             await result
 
     async def _announce_quota_change(
-        self, selector: str, state: str, text: str, kind: str = "warning"
+        self, selector: str, token: str, text: str, kind: str = "warning"
     ) -> None:
-        """Emit a quota notice only on a genuine state TRANSITION for ``selector``.
+        """Emit a quota notice once per distinct CONDITION for ``selector``.
 
         The preflight runs on every user-message boundary, so a persistent
         low/exhausted verdict recurs on every message the user sends — but the
         user only needs to hear about the CHANGE, not the same line echoed
-        forever. ``self._last_quota_state`` remembers the ``health.state`` last
-        announced for this ``provider/model_id``; we speak only when the new
-        state differs (none->low, low->exhausted, or a recurrence after a
-        healthy edge cleared the latch), then record it. Steady state is silent.
+        forever. ``self._last_quota_state`` remembers the SET of condition
+        ``token``s already announced for this ``provider/model_id``; we speak
+        only when ``token`` is not yet in that set (a genuinely new condition,
+        or a recurrence after a healthy edge cleared the whole selector entry),
+        then record it. Steady state is silent.
+
+        ``token`` must be distinct per CONDITION, not merely per state: several
+        different conditions (account-scope low/exhausted, model-tier-scope
+        low/exhausted, tier-cap-spent-but-shared-remains) key on the same
+        selector, and a token that only encoded ``health.state`` would alias
+        them — one overwriting another's memory. Callers pass a scoped token
+        (``account:<state>``, ``model:<state>``, ``tier-spent:<state>``) so each
+        condition dedups against itself alone.
         """
-        if self._last_quota_state.get(selector) == state:
+        announced = self._last_quota_state.get(selector)
+        if announced is not None and token in announced:
             return
-        self._last_quota_state[selector] = state
+        if announced is None:
+            announced = set()
+            self._last_quota_state[selector] = announced
+        announced.add(token)
         await self._notice(text, kind)
 
     def _clear_quota_latch(self, selector: str) -> None:
-        """Drop the last-announced quota state so a real recurrence re-announces.
+        """Drop every announced quota condition so a real recurrence re-announces.
 
         Called on the healthy edge: once quota recovers, the next slide back into
-        low/exhausted is a genuinely new transition the user should hear about,
-        not a duplicate of a verdict we already announced before the recovery.
+        ANY low/exhausted condition is a genuinely new transition the user should
+        hear about, not a duplicate of a verdict we already announced before the
+        recovery. Recovery resets all conditions on this selector together —
+        dropping the whole entry — because a healthy reading clears the account
+        as a whole, so every prior condition on it starts fresh.
         """
         self._last_quota_state.pop(selector, None)
 
@@ -2330,12 +2359,16 @@ class SessionStreamFn:
                 if health.state == "reserve":
                     # Last account, still holding this model's quota. Same
                     # rule as the account-scope path: reserve is not a
-                    # licence to leave the provider. Deduped by state: "quota
-                    # low, continuing" is worth one line on the transition, not
-                    # one per message for as long as the account stays low.
+                    # licence to leave the provider. Deduped per condition:
+                    # "quota low, continuing" is worth one line on the
+                    # transition, not one per message for as long as the account
+                    # stays low. ``model:`` scope token — this is the model-tier
+                    # branch, and its token must stay distinct from the
+                    # account-scope branch's ``account:`` token so the two
+                    # conditions cannot alias on this shared selector.
                     await self._announce_quota_change(
                         selector,
-                        health.state,
+                        f"model:{health.state}",
                         f"{model.provider} {condition}{remaining} for {model.model_id} "
                         f"— continuing until {model.provider} quota is exhausted",
                         "info",
@@ -2347,13 +2380,14 @@ class SessionStreamFn:
                     reserve_percent=retry.usage_reserve_percent,
                 )
                 if fallback is None:
-                    # Deduped by state: the quota is spent and nothing can take
-                    # over, but the user only needs that told once per
+                    # Deduped per condition: the quota is spent and nothing can
+                    # take over, but the user only needs that told once per
                     # transition — not on every message while the condition
-                    # holds and no fallback appears.
+                    # holds and no fallback appears. ``model:`` scope token,
+                    # distinct from the account-scope ``account:`` token.
                     await self._announce_quota_change(
                         selector,
-                        health.state,
+                        f"model:{health.state}",
                         f"{model.provider} {condition}{remaining} for {model.model_id}; "
                         "no configured model fallback is available",
                     )
@@ -2460,9 +2494,12 @@ class SessionStreamFn:
                         quota=True,
                     )
                     return False
+            # ``account:`` scope token: this is the account-scope path, and its
+            # condition must dedup separately from the model-tier branch that
+            # shares this selector.
             await self._announce_quota_change(
                 selector,
-                health.state,
+                f"account:{health.state}",
                 f"{model.provider} {condition}{remaining} — continuing until "
                 f"{model.provider} quota is exhausted",
                 "info",
@@ -2532,12 +2569,13 @@ class SessionStreamFn:
                 )
 
         if not siblings and fallback is None:
-            # Deduped by state: spent with nowhere to fall back is worth one
-            # line on the transition, not a repeat on every subsequent message
-            # while the account stays spent.
+            # Deduped per condition: spent with nowhere to fall back is worth
+            # one line on the transition, not a repeat on every subsequent
+            # message while the account stays spent. ``account:`` scope token,
+            # distinct from the model-tier branch's ``model:`` token.
             await self._announce_quota_change(
                 selector,
-                health.state,
+                f"account:{health.state}",
                 f"{model.provider} {condition}{remaining}; no configured fallback is available",
             )
             return False
@@ -2549,7 +2587,20 @@ class SessionStreamFn:
             # headroom down to zero instead of rotating or failing over on a
             # cap that does not gate this request.
             binding = "/".join(health.binding_labels) or "a model-tier window"
-            await self._notice(
+            # Route through the dedup helper, not a raw ``_notice``: preflight
+            # runs on every message boundary, so a tier cap that stays spent
+            # while shared quota holds would echo this "continuing…" line on
+            # every message — the exact per-boundary spam this latch exists to
+            # kill. The ``tier-spent:`` token must be DISTINCT from the plain
+            # ``account:``/``model:`` state tokens: this is a separate condition
+            # (tier cap spent but shared remains) that can hold at the same time
+            # as, and on the same selector as, a plain low/exhausted verdict, so
+            # sharing a token would let the two conditions alias — one masking
+            # the other. A distinct token dedups this condition against itself
+            # alone.
+            await self._announce_quota_change(
+                selector,
+                f"tier-spent:{health.state}",
                 f"{model.provider} {binding} spent; shared quota remains{remaining} "
                 "— continuing until shared windows are exhausted",
                 "info",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.25.2"
+version = "0.25.3"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/model/test_configure.py
+++ b/tests/unit/model/test_configure.py
@@ -416,6 +416,44 @@ def _anthropic_tier_spent_shared_remains(extra_used: float, shared_used: float) 
     )
 
 
+def _anthropic_model_tier_reserve() -> UsageReport:
+    """A MODEL-scope reserve verdict: the tier cap that gates this exact model
+    is in reserve while the shared pool is healthy.
+
+    ``usage_health("claude-opus-5")`` keeps only the shared windows plus the
+    tier windows whose name appears in the model id, so the Opus weekly (5%
+    remaining, in reserve) is the binding limit and — being ``tier`` and not
+    ``shared`` — makes ``scope == "model"``. The shared 5-hour window sits at
+    10% used (healthy) so it never binds. Paired with
+    ``_anthropic_tier_spent_shared_remains`` this yields TWO ``reserve`` verdicts
+    on one selector that differ ONLY in scope (``model`` vs ``account``): the
+    exact same-state/different-scope case the scoped-token widening exists to
+    keep separate. A state-only latch token would collapse both to ``reserve``
+    and suppress the second."""
+    return UsageReport(
+        provider="anthropic",
+        limits=[
+            UsageLimit(
+                id="anthropic:5h",
+                label="5 hour",
+                amount=UsageAmount(used=10.0, limit=100.0, unit="percent"),
+                window="5h",
+                shared=True,
+                resets_at_ms=10**15,
+            ),
+            UsageLimit(
+                id="anthropic:7d:opus",
+                label="7 day (Opus)",
+                amount=UsageAmount(used=95.0, limit=100.0, unit="percent"),
+                window="7d",
+                shared=False,
+                tier="opus",
+                resets_at_ms=10**15,
+            ),
+        ],
+    )
+
+
 @pytest.mark.asyncio
 async def test_usage_preflight_rotates_accounts_before_providers(tmp_path) -> None:
     store = AuthStore(tmp_path / "auth.db")
@@ -1143,19 +1181,34 @@ async def test_tier_spent_shared_remains_notice_is_deduped_across_boundaries(tmp
 
 @pytest.mark.asyncio
 async def test_distinct_quota_conditions_on_one_selector_do_not_alias(tmp_path) -> None:
-    """Two DIFFERENT quota conditions on the same provider/model each get their
+    """Two quota conditions that share a STATE but differ in SCOPE each get their
     own single announcement rather than masking each other.
 
-    The latch is keyed per selector, so before it was widened to a SET of
-    condition tokens a second condition would overwrite the first's remembered
-    state — one wrongly suppressing the other. Here the account first hits the
-    tier-cap-spent-but-shared-remains condition (``tier-spent:``), then, when
-    the shared window itself runs out, the plain account-exhausted condition
-    (``account:``). Both must be heard: distinct conditions, distinct tokens,
-    two lines. Two same-provider accounts skip the ``not siblings`` guards so
-    the tier-spent branch (which sits past them) is reachable, and with no
-    configured cross-provider fallback the exhausted path still lands on the
-    account-scope "no configured fallback" line."""
+    This is the guard for the scoped-token widening specifically, so the two
+    conditions are chosen to be indistinguishable to the PRE-fix state-only
+    latch: BOTH read ``health.state == "reserve"``, and differ ONLY in scope.
+
+    - Phase 1 (``tier-spent``): a spent extra-usage window drives an
+      ACCOUNT-scope reserve verdict while the shared 5-hour window still has
+      headroom → the ``tier-spent:reserve`` "continuing until shared windows are
+      exhausted" line.
+    - Phase 2 (``model-reserve``): the Opus weekly tier cap that gates this exact
+      model is in reserve while the shared pool is healthy → a MODEL-scope reserve
+      verdict and the ``model:reserve`` "for <model> — continuing until anthropic
+      quota is exhausted" line.
+
+    Under the fix both are announced once (tokens ``tier-spent:reserve`` and
+    ``model:reserve`` are distinct). Under the bug — a token that encoded only
+    ``health.state`` — both would collapse to a single ``"reserve"`` entry and the
+    SECOND would be wrongly suppressed. A regression guard whose two conditions
+    differed in state (as an earlier version of this test did) stays green even
+    against that bug, so it proved nothing; keeping the state fixed is the whole
+    point. See ``test_state_only_quota_token_would_alias_distinct_scopes`` for the
+    companion that pins the bug direction by forcing a state-only token.
+
+    Two same-provider accounts are configured so the walk rotates siblings
+    silently before the last account lands on the scoped reserve announce (the
+    model-tier branch), and so the account-scope tier-spent branch is reachable."""
     store = AuthStore(tmp_path / "auth.db")
     store.upsert_credential("anthropic", _oauth("oauth-a", "account-a"))
     store.upsert_credential("anthropic", _oauth("oauth-b", "account-b"))
@@ -1169,26 +1222,27 @@ async def test_distinct_quota_conditions_on_one_selector_do_not_alias(tmp_path) 
     model = ModelSpec(provider="anthropic", model_id="claude-opus-5")
 
     # A knob the mocked endpoint reads so each boundary presents a different
-    # quota shape: first tier-spent-with-shared-headroom, then shared spent.
+    # quota shape. Both shapes read ``reserve`` — only the SCOPE differs.
     phase = {"value": "tier-spent"}
 
     def report_for_phase(*_a, **_k):
         if phase["value"] == "tier-spent":
-            # Extra window in reserve (account-scope reserve) while the shared
-            # 5-hour window still holds headroom → tier-spent branch.
+            # Extra window spent (account-scope reserve) while the shared 5-hour
+            # window still holds headroom → the account-scope tier-spent branch.
             return _anthropic_tier_spent_shared_remains(95.0, 50.0)
-        # Shared 5-hour window itself exhausted → plain account-exhausted.
-        return _anthropic_tier_spent_shared_remains(100.0, 100.0)
+        # Opus weekly cap in reserve, shared pool healthy → model-scope reserve.
+        return _anthropic_model_tier_reserve()
 
     async def boundary() -> None:
         stream.begin_message()
         stream._usage_checked_at = 0.0
 
     tier_spent_line = "continuing until shared windows are exhausted"
-    exhausted_line = "no configured fallback is available"
+    model_reserve_line = "for claude-opus-5 — continuing until anthropic quota is exhausted"
     try:
         with patch("local_operator.providers.usage.fetch_usage", side_effect=report_for_phase):
-            # 1) Tier-spent condition announces once and stays quiet.
+            # 1) The account-scope (tier-spent) reserve condition announces once
+            #    and stays quiet across a second identical boundary.
             phase["value"] = "tier-spent"
             await boundary()
             await stream.preflight_usage(model)
@@ -1196,15 +1250,87 @@ async def test_distinct_quota_conditions_on_one_selector_do_not_alias(tmp_path) 
             await stream.preflight_usage(model)
             assert sum(tier_spent_line in n for n in notices) == 1
 
-            # 2) A DIFFERENT condition (shared exhausted) on the same selector
-            #    is announced too — the widened latch keeps the two conditions
-            #    from aliasing on the shared selector key.
-            phase["value"] = "exhausted"
+            # 2) A DIFFERENT-SCOPE reserve condition (model-tier) on the SAME
+            #    selector and the SAME state is announced too — the scoped tokens
+            #    keep the two conditions from aliasing where a state-only token
+            #    (``reserve``) would have suppressed this second line.
+            phase["value"] = "model-reserve"
             await boundary()
             await stream.preflight_usage(model)
-            assert sum(exhausted_line in n for n in notices) == 1
+            assert sum(model_reserve_line in n for n in notices) == 1
             # The earlier condition's single announcement is untouched.
             assert sum(tier_spent_line in n for n in notices) == 1
+    finally:
+        await stream.close()
+        store.close()
+
+
+@pytest.mark.asyncio
+async def test_state_only_quota_token_would_alias_distinct_scopes(tmp_path) -> None:
+    """Pins the DIRECTION of the aliasing bug the scoped tokens fix.
+
+    Same two same-state/different-scope reserve conditions as
+    ``test_distinct_quota_conditions_on_one_selector_do_not_alias``, but the
+    latch's per-condition ``token`` is monkeypatched back to a bare
+    ``health.state`` — the PRE-fix behaviour. With that collapse the second
+    condition (model-scope reserve) shares the first's ``"reserve"`` entry and is
+    wrongly suppressed, so only ONE line is heard. This is the failure the
+    strengthened guard above must be able to catch: if the production code ever
+    regresses to a state-only token, the guard flips red instead of staying
+    green. Together the two tests bracket the bug — one proves the fix announces
+    both, this one proves the bug would silence the second."""
+    store = AuthStore(tmp_path / "auth.db")
+    store.upsert_credential("anthropic", _oauth("oauth-a", "account-a"))
+    store.upsert_credential("anthropic", _oauth("oauth-b", "account-b"))
+    stream = create_stream_fn(
+        store,
+        {"retry": {"usageAwareFallback": True, "usageReservePercent": 10}},
+        session_id="session-a",
+    )
+    notices: list[str] = []
+    stream.set_notice_handler(lambda text, kind: notices.append(text))
+    model = ModelSpec(provider="anthropic", model_id="claude-opus-5")
+
+    # Re-derive the state-only token from the announcement text so the shim needs
+    # no access to ``health`` here: both conditions in this scenario are reserve,
+    # so a state-only latch keys every one of them on the single token "reserve".
+    original = stream._announce_quota_change
+
+    async def state_only_token(selector, token, text, kind="warning"):
+        # The bug: collapse the scoped token (``tier-spent:reserve`` /
+        # ``model:reserve``) back to the state alone, so distinct conditions on
+        # one selector alias onto a single latch entry.
+        return await original(selector, "reserve", text, kind)
+
+    stream._announce_quota_change = state_only_token  # type: ignore[method-assign]
+
+    phase = {"value": "tier-spent"}
+
+    def report_for_phase(*_a, **_k):
+        if phase["value"] == "tier-spent":
+            return _anthropic_tier_spent_shared_remains(95.0, 50.0)
+        return _anthropic_model_tier_reserve()
+
+    async def boundary() -> None:
+        stream.begin_message()
+        stream._usage_checked_at = 0.0
+
+    tier_spent_line = "continuing until shared windows are exhausted"
+    model_reserve_line = "for claude-opus-5 — continuing until anthropic quota is exhausted"
+    try:
+        with patch("local_operator.providers.usage.fetch_usage", side_effect=report_for_phase):
+            phase["value"] = "tier-spent"
+            await boundary()
+            await stream.preflight_usage(model)
+            assert sum(tier_spent_line in n for n in notices) == 1
+
+            phase["value"] = "model-reserve"
+            await boundary()
+            await stream.preflight_usage(model)
+            # The bug in action: same "reserve" token as phase 1, so the
+            # model-scope line is swallowed. This assertion documents the wrong
+            # behaviour the scoped tokens prevent.
+            assert sum(model_reserve_line in n for n in notices) == 0
     finally:
         await stream.close()
         store.close()

--- a/tests/unit/model/test_configure.py
+++ b/tests/unit/model/test_configure.py
@@ -405,7 +405,9 @@ async def test_usage_preflight_rotates_accounts_before_providers(tmp_path) -> No
         selected = await store.get_oauth_access("anthropic", "session-a")
         assert selected is not None and selected.credential_id == second.id
         assert stream._route_state.active is None
-        assert any("trying another anthropic account" in notice for notice in notices)
+        # Rotating to a sibling account is an internal detail and is now silent:
+        # the user still gets served on anthropic, so no notice should fire.
+        assert not any("trying another anthropic account" in notice for notice in notices)
     finally:
         await stream.close()
         store.close()
@@ -913,7 +915,8 @@ async def test_model_tier_cap_rotates_siblings_before_leaving_the_provider(tmp_p
         opus = await store.get_oauth_access("anthropic", session, model_id="claude-opus-4-8")
         assert opus is not None  # the family-blocked account still serves opus
         assert stream._route_state.active is None
-        assert any("trying another anthropic account" in notice for notice in notices)
+        # Sibling rotation is silent now — an internal detail, not a transcript event.
+        assert not any("trying another anthropic account" in notice for notice in notices)
     finally:
         await stream.close()
         store.close()
@@ -965,6 +968,87 @@ async def test_last_account_in_reserve_stays_on_the_provider(tmp_path) -> None:
         selected = await store.get_oauth_access("anthropic", "session-a")
         assert selected is not None and selected.credential_id == account.id
         assert any("continuing until anthropic quota is exhausted" in n for n in notices)
+    finally:
+        await stream.close()
+        store.close()
+
+
+@pytest.mark.asyncio
+async def test_quota_notice_is_deduped_to_one_per_state_transition(tmp_path) -> None:
+    """The user hears about a quota CHANGE, not the same line every message.
+
+    Preflight runs on every user-message boundary, so a persistent low/exhausted
+    verdict recurs on every message the user sends. Before the dedup latch that
+    echoed the identical "quota low"/"quota exhausted" line forever. The
+    contract now: announce once per state TRANSITION per provider/model —
+    silent while a state holds, a fresh line when it changes, and a fresh line
+    again after a recovery resets the latch. This is the real-execution evidence
+    for that behaviour, driving successive boundaries through the account-scope
+    ``_apply_account_health`` path (single account, no configured fallback)."""
+    store = AuthStore(tmp_path / "auth.db")
+    account = store.upsert_credential("anthropic", _oauth("oauth-a", "account-a"))
+    stream = create_stream_fn(
+        store,
+        {"retry": {"usageAwareFallback": True, "usageReservePercent": 10}},
+        session_id="session-a",
+    )
+    notices: list[str] = []
+    stream.set_notice_handler(lambda text, kind: notices.append(text))
+    model = ModelSpec(provider="anthropic", model_id="claude-opus-5")
+
+    # A knob the mocked usage endpoint reads, so each boundary can present a
+    # different quota shape without re-patching.
+    used_percent = {"value": 95.0}
+
+    async def usage_for_access(_client, _provider, *, access_token=None, **_kwargs):
+        return _anthropic_usage(used_percent["value"])
+
+    async def boundary() -> None:
+        # Simulate a fresh user message far enough apart that the 60s TTL memo
+        # (which only dedupes the several requests ONE message makes) does not
+        # itself swallow the check — resetting the memo clock is what a real
+        # inter-message gap does.
+        stream.begin_message()
+        stream._usage_checked_at = 0.0
+
+    reserve_line = "continuing until anthropic quota is exhausted"
+    depleted_line = "no configured fallback is available"
+    recovered_line = "account quota recovered"
+
+    try:
+        with patch("local_operator.providers.usage.fetch_usage", side_effect=usage_for_access):
+            # 1) First slide to low (reserve, 5% remaining): one notice.
+            used_percent["value"] = 95.0
+            await boundary()
+            await stream.preflight_usage(model)
+            assert sum(reserve_line in n for n in notices) == 1
+
+            # 2) Still low on the next boundary: silent — no duplicate line.
+            await boundary()
+            await stream.preflight_usage(model)
+            assert sum(reserve_line in n for n in notices) == 1
+
+            # 3) low -> exhausted is a real transition: a second, different line.
+            used_percent["value"] = 100.0
+            await boundary()
+            await stream.preflight_usage(model)
+            assert sum(depleted_line in n for n in notices) == 1
+            assert store.is_blocked(account.id, "anthropic")
+
+            # 4) Recovery (healthy) clears the latch via the blocked-account
+            #    re-probe, so the exhausted verdict is no longer "already said".
+            used_percent["value"] = 0.0
+            await boundary()
+            await stream.preflight_usage(model)
+            assert sum(recovered_line in n for n in notices) == 1
+            assert not store.is_blocked(account.id, "anthropic")
+
+            # 5) Sliding back to low AFTER recovery is a genuine new transition:
+            #    it re-announces rather than being deduped against step 1.
+            used_percent["value"] = 95.0
+            await boundary()
+            await stream.preflight_usage(model)
+            assert sum(reserve_line in n for n in notices) == 2
     finally:
         await stream.close()
         store.close()

--- a/tests/unit/model/test_configure.py
+++ b/tests/unit/model/test_configure.py
@@ -372,6 +372,50 @@ def _anthropic_tier_capped_usage(five_hour_used: float, fable_used: float) -> Us
     )
 
 
+def _anthropic_tier_spent_shared_remains(extra_used: float, shared_used: float) -> UsageReport:
+    """A spent per-tier cap that leaves the account under an ACCOUNT-scope
+    verdict while shared quota still remains.
+
+    ``usage_health`` reads the paid extra-usage window (non-shared, non-tier)
+    as an ACCOUNT-scope binding, so a high ``extra_used`` drives the account to
+    reserve/depleted; but ``shared_tier_saturation`` re-reads the report and
+    still sees the shared 5-hour window with headroom. That is the exact
+    combination that reaches the ``tier_binding and shared_above_reserve``
+    branch inside ``_apply_account_health`` — the "continuing until shared
+    windows are exhausted" notice this test exercises. The spent Fable tier
+    row supplies ``tier_binding``."""
+    return UsageReport(
+        provider="anthropic",
+        limits=[
+            UsageLimit(
+                id="anthropic:5h",
+                label="5 hour",
+                amount=UsageAmount(used=shared_used, limit=100.0, unit="percent"),
+                window="5h",
+                shared=True,
+                resets_at_ms=10**15,
+            ),
+            UsageLimit(
+                id="anthropic:5h:extra",
+                label="5 hour (extra)",
+                amount=UsageAmount(used=extra_used, limit=100.0, unit="percent"),
+                window="5h",
+                shared=False,
+                resets_at_ms=10**15,
+            ),
+            UsageLimit(
+                id="anthropic:7d:fable",
+                label="7 day (Fable)",
+                amount=UsageAmount(used=100.0, limit=100.0, unit="percent"),
+                window="7d",
+                shared=False,
+                tier="fable",
+                resets_at_ms=10**15,
+            ),
+        ],
+    )
+
+
 @pytest.mark.asyncio
 async def test_usage_preflight_rotates_accounts_before_providers(tmp_path) -> None:
     store = AuthStore(tmp_path / "auth.db")
@@ -1049,6 +1093,118 @@ async def test_quota_notice_is_deduped_to_one_per_state_transition(tmp_path) -> 
             await boundary()
             await stream.preflight_usage(model)
             assert sum(reserve_line in n for n in notices) == 2
+    finally:
+        await stream.close()
+        store.close()
+
+
+@pytest.mark.asyncio
+async def test_tier_spent_shared_remains_notice_is_deduped_across_boundaries(tmp_path) -> None:
+    """The "continuing until shared windows are exhausted" line is announced
+    once, then silent while the condition holds.
+
+    ``_apply_account_health`` reaches this branch when a per-tier cap is spent
+    (Fable at 100%) but the shared window still has headroom. Preflight runs on
+    every message boundary, so before the dedup this notice recurred on every
+    message — the per-boundary spam this PR eliminates. Two same-provider
+    accounts skip the ``not siblings`` guards so the tier-spent branch is the
+    one that fires. Real execution: repeated boundaries, one notice."""
+    store = AuthStore(tmp_path / "auth.db")
+    store.upsert_credential("anthropic", _oauth("oauth-a", "account-a"))
+    store.upsert_credential("anthropic", _oauth("oauth-b", "account-b"))
+    stream = create_stream_fn(
+        store,
+        {"retry": {"usageAwareFallback": True, "usageReservePercent": 10}},
+        session_id="session-a",
+    )
+    notices: list[str] = []
+    stream.set_notice_handler(lambda text, kind: notices.append(text))
+    model = ModelSpec(provider="anthropic", model_id="claude-opus-5")
+
+    async def boundary() -> None:
+        stream.begin_message()
+        stream._usage_checked_at = 0.0
+
+    tier_spent_line = "continuing until shared windows are exhausted"
+    try:
+        with patch(
+            "local_operator.providers.usage.fetch_usage",
+            side_effect=lambda *_a, **_k: _anthropic_tier_spent_shared_remains(95.0, 50.0),
+        ):
+            for _ in range(4):
+                await boundary()
+                await stream.preflight_usage(model)
+        # One line on the first boundary, silent on the three that follow.
+        assert sum(tier_spent_line in n for n in notices) == 1
+    finally:
+        await stream.close()
+        store.close()
+
+
+@pytest.mark.asyncio
+async def test_distinct_quota_conditions_on_one_selector_do_not_alias(tmp_path) -> None:
+    """Two DIFFERENT quota conditions on the same provider/model each get their
+    own single announcement rather than masking each other.
+
+    The latch is keyed per selector, so before it was widened to a SET of
+    condition tokens a second condition would overwrite the first's remembered
+    state — one wrongly suppressing the other. Here the account first hits the
+    tier-cap-spent-but-shared-remains condition (``tier-spent:``), then, when
+    the shared window itself runs out, the plain account-exhausted condition
+    (``account:``). Both must be heard: distinct conditions, distinct tokens,
+    two lines. Two same-provider accounts skip the ``not siblings`` guards so
+    the tier-spent branch (which sits past them) is reachable, and with no
+    configured cross-provider fallback the exhausted path still lands on the
+    account-scope "no configured fallback" line."""
+    store = AuthStore(tmp_path / "auth.db")
+    store.upsert_credential("anthropic", _oauth("oauth-a", "account-a"))
+    store.upsert_credential("anthropic", _oauth("oauth-b", "account-b"))
+    stream = create_stream_fn(
+        store,
+        {"retry": {"usageAwareFallback": True, "usageReservePercent": 10}},
+        session_id="session-a",
+    )
+    notices: list[str] = []
+    stream.set_notice_handler(lambda text, kind: notices.append(text))
+    model = ModelSpec(provider="anthropic", model_id="claude-opus-5")
+
+    # A knob the mocked endpoint reads so each boundary presents a different
+    # quota shape: first tier-spent-with-shared-headroom, then shared spent.
+    phase = {"value": "tier-spent"}
+
+    def report_for_phase(*_a, **_k):
+        if phase["value"] == "tier-spent":
+            # Extra window in reserve (account-scope reserve) while the shared
+            # 5-hour window still holds headroom → tier-spent branch.
+            return _anthropic_tier_spent_shared_remains(95.0, 50.0)
+        # Shared 5-hour window itself exhausted → plain account-exhausted.
+        return _anthropic_tier_spent_shared_remains(100.0, 100.0)
+
+    async def boundary() -> None:
+        stream.begin_message()
+        stream._usage_checked_at = 0.0
+
+    tier_spent_line = "continuing until shared windows are exhausted"
+    exhausted_line = "no configured fallback is available"
+    try:
+        with patch("local_operator.providers.usage.fetch_usage", side_effect=report_for_phase):
+            # 1) Tier-spent condition announces once and stays quiet.
+            phase["value"] = "tier-spent"
+            await boundary()
+            await stream.preflight_usage(model)
+            await boundary()
+            await stream.preflight_usage(model)
+            assert sum(tier_spent_line in n for n in notices) == 1
+
+            # 2) A DIFFERENT condition (shared exhausted) on the same selector
+            #    is announced too — the widened latch keeps the two conditions
+            #    from aliasing on the shared selector key.
+            phase["value"] = "exhausted"
+            await boundary()
+            await stream.preflight_usage(model)
+            assert sum(exhausted_line in n for n in notices) == 1
+            # The earlier condition's single announcement is untouched.
+            assert sum(tier_spent_line in n for n in notices) == 1
     finally:
         await stream.close()
         store.close()


### PR DESCRIPTION
## Why

Every user-message boundary runs an OAuth quota preflight (`SessionStreamFn.preflight_usage`), and its notices were emitted **unconditionally on each boundary**. A user whose provider sat at low/exhausted quota saw the same lines echoed on **every single message they sent**:

```
! anthropic quota low (9% remaining) — trying another anthropic account before provider fallback
! anthropic quota exhausted (0% remaining) — trying another anthropic account before provider fallback
! anthropic quota exhausted (0% remaining) — trying another anthropic account before provider fallback
```

Two separate defects:
1. **No dedup across boundaries** — a *persistent* quota state re-announced on every message, though the user only needs to hear about a **change** in standing.
2. **Per-rotation churn** — the account-rotation loop emitted "trying another … account before provider fallback" **once per sibling account** it silently rotated through, producing the duplicated lines. Rotating to another same-provider account is an internal detail; the request is still served on the same provider.

Reported by the operator: quota-low noise on every message, redundant duplicate lines.

Version bump is **PATCH** (0.25.0 → **0.25.1**): behavioural fix, no new capability, no breaking change.

## What changes

`local_operator/model/configure.py` only.

### Announce once per state transition
A per-session latch `self._last_quota_state: dict[str, str]` keyed by `provider/model_id` remembers the last `health.state` actually announced (`reserve` = low, `depleted` = exhausted). A new `_announce_quota_change(selector, state, text, kind)` helper routes all four surviving quota notices and speaks **only when the state differs** from what was last announced for that selector. A steady low/exhausted verdict is now silent after the first line; a genuine transition (none→low, low→exhausted, or a recurrence after recovery) still speaks once.

### Latch cleared on the healthy edge
`_clear_quota_latch(selector)` is called on **both** healthy edges — the boundary probe recovering and `_recover_blocked_accounts` reviving an account — so a later slide back into low/exhausted counts as a real new transition and re-announces. The `unknown` fail-open branch leaves the latch untouched (indeterminate is not a transition).

### Rotation churn suppressed
Both "trying another … account before provider fallback" notices (tier-scope in `preflight_usage`, account-scope in `_apply_account_health`) are removed — the rotation now `continue`s silently. **Block/rotation/selection logic is untouched**; only the transcript notice is dropped.

Fallback-activation notices (`_on_route_change` / `RouteState.activate`) are deliberately left alone — a fallback firing is a real event worth one line.

## Impact
- No schema, config, or API change. Purely reduces redundant transcript output.
- Quota standing is still surfaced on genuine transitions, and `/usage` remains the on-demand source of truth.

## Testing Details

### New unit test — real execution
`tests/unit/model/test_configure.py::test_quota_notice_is_deduped_to_one_per_state_transition` drives five successive message boundaries through the real `preflight_usage` path with a mocked usage fetch, asserting exact notice counts:

```
boundary 1  low        -> 1 notice   (none -> low: announce)
boundary 2  low        -> 0 notices  (steady: silent)
boundary 3  exhausted  -> 1 notice   (low -> depleted: announce)
boundary 4  healthy    -> latch cleared
boundary 5  low again  -> 1 notice   (recurrence after recovery: announce)
```
`1 passed in 1.19s`.

Two existing tests (`…rotates_accounts_before_providers`, family-block rotation) updated to assert the rotation is now **silent** while still asserting the block/select behaviour is unchanged.

### Gates (all clean, from a fresh worktree off origin/main with `.venv/bin/python`)
```
flake8 .                                  clean
black --check (26.1.0)                     clean
isort --check-only --profile black         clean
pyright --pythonpath .venv/bin/python      0 errors, 0 warnings, 0 informations
pytest tests/unit/model                     394 passed
pytest test_session + test_active_route     113 passed
```

## Notes
Not visual — this removes transcript noise rather than changing widget rendering, so no SVG frames apply. The evidence is the notice-count assertions above, which exercise the real boundary path.
