### PR TITLE
fix(providers): cap credential blocks, soonest-reset keying, and stop the primary request-400 storm

### DIFF
--- a/local_operator/providers/auth_store.py
+++ b/local_operator/providers/auth_store.py
@@ -57,6 +57,17 @@ logger = logging.getLogger("local_operator.providers.auth_store")
 OAUTH_REFRESH_SKEW_MS = 60_000  # pre-emptive refresh trigger
 DEFAULT_BLOCK_MS = 60_000  # rate-limit / 401 backoff
 
+#: Hard ceiling on ANY credential block, whatever computed it (a usage
+#: reset estimate, a provider Retry-After header, a caller's block_ms). A
+#: block is a cost-avoidance backoff, not a correctness gate -- every message
+#: boundary re-probes usage and the cascade re-checks blocked rows -- so no
+#: reading, however large or however hostile the header, may strand an
+#: account for more than this. An hour outlives a working session's need to
+#: stop re-hitting a spent account, and is short enough that a wrong estimate
+#: self-heals on the next boundary. Guards the days-long block a raw weekly
+#: reset or a Retry-After: 604800 would otherwise write.
+MAX_CREDENTIAL_BLOCK_MS = 60 * 60 * 1000  # 1 hour
+
 #: How long a provider-fault demotion keeps a credential at the back of the pool
 #: (see ``AuthStore.deprioritize_credential``). Deliberately short: the mark says
 #: "this account was failing a moment ago", which stops being useful information
@@ -500,7 +511,15 @@ class AuthStore:
         credential = self.get_credential(credential_id)
         provider = self._storage_id(provider)
         provider_key = f"{provider}:{credential.credential_type if credential else 'api_key'}"
-        until = self._now_ms() + max(1000, int(block_ms))
+        # Floor keeps a 0/negative block from being a no-op; the ceiling
+        # (MAX_CREDENTIAL_BLOCK_MS) guarantees no reading -- a multi-day usage
+        # reset, a hostile Retry-After -- can strand an account past the point
+        # where re-probing is cheaper than waiting. This is the single choke
+        # point every block passes through (preflight AND reactive
+        # rotate_sibling AND any future caller), so the cap protects them all
+        # from a rogue provider header for free. See the constant's docstring.
+        block_ms = max(1000, min(int(block_ms), MAX_CREDENTIAL_BLOCK_MS))
+        until = self._now_ms() + block_ms
         self._conn.execute(
             "INSERT INTO auth_credential_blocks (credential_id, provider_key, block_scope,"
             " blocked_until_ms, updated_at) VALUES (?, ?, ?, ?, ?)"

--- a/local_operator/providers/failover.py
+++ b/local_operator/providers/failover.py
@@ -1894,6 +1894,29 @@ async def stream_with_failover(
                     # resolve_next_key owns the decision (PR-04/05).
                     error = exc
                     continue
+                # A request the provider READ and refused (kind=="request": a
+                # 4xx that is not auth/quota/timeout) is DETERMINISTIC in its
+                # bytes — the same request fails identically on every other
+                # provider. Walking the fallback chain on it is the storm this
+                # guard stops: one malformed Anthropic 400 marched through
+                # z.ai/kimi/etc, each 400ing on the same messages. When it is
+                # the PRIMARY (the user's own model) that refused, abort the
+                # turn now and surface its 400 rather than the last fallback's —
+                # the user needs the words of the model they chose. Image
+                # rejections take this path too: their recovery is the session's
+                # _degrade_if_image_rejected (fired from the turn end event,
+                # independent of this walk) plus a resend, NOT the chain, so
+                # stopping the walk costs the image path nothing. A request-kind
+                # error on a FALLBACK is left to fall through to the next
+                # target: it can mean that one fallback rejected a field (an
+                # effort rung its ladder lacks) the primary accepted, a
+                # per-target defect the walk should route around. record() at
+                # L1837 already stored this exc, so raising it surfaces the same
+                # frame the reported slot holds. Gate strictly on kind=="request"
+                # (not "unknown": a bare-status gateway failure may be transient
+                # and a fallback can survive it).
+                if exc.kind == "request" and is_primary:
+                    raise exc
                 break  # non-retryable for this provider
             except Exception as exc:  # network errors et al.
                 wrapped = wrap_transport_error(exc)

--- a/local_operator/providers/usage.py
+++ b/local_operator/providers/usage.py
@@ -372,7 +372,15 @@ def usage_health(
         ):
             return QuotaHealth("unknown")
         zero_balance = balances
-        reset_after = max(
+        # This branch is unconditionally a depleted verdict (every balance is
+        # zeroed), and a depleted account is usable again the moment ANY spent
+        # window reopens -- a request needs only one window with headroom -- so
+        # the honest "try again at" is the SOONEST reset among the zeroed
+        # windows, not the latest. A two-zeroed-window DeepSeek/Kimi account
+        # reopens at the earliest of its resets; keying to the latest would pin
+        # a days-long block to the slowest window. The cap in block_credential
+        # is the backstop; this is the estimate.
+        reset_after = min(
             (
                 value
                 for value in (limit.resets_in_ms(now_ms) for limit in zero_balance)
@@ -418,7 +426,19 @@ def usage_health(
     else:
         horizon = binding
     horizon_resets = [limit.resets_in_ms(now_ms) for limit in horizon]
-    reset_after = max((value for value in horizon_resets if value is not None), default=None)
+    present = [value for value in horizon_resets if value is not None]
+    if state == "depleted":
+        # The account is usable again the moment ANY spent window reopens -- a
+        # request needs only one window with headroom -- so the honest "try
+        # again at" is the SOONEST reset among fully-spent windows, not the
+        # latest. Keying to the latest (the old max) pinned a block to the
+        # 7-day window when the 5-hour window reopened first. The cap in
+        # block_credential is the backstop; this is the estimate. The reserve
+        # (else) branch keeps max: for a low-but-usable account the display
+        # wants "when does the binding window recover", i.e. the latest.
+        reset_after = min(present, default=None)
+    else:
+        reset_after = max(present, default=None)
     if not binding:
         scope: Literal["account", "model", "unknown"] = "unknown"
     elif all(limit.tier and not limit.shared for limit in binding):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.25.1"
+version = "0.25.2"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/providers/test_auth_store.py
+++ b/tests/unit/providers/test_auth_store.py
@@ -216,6 +216,70 @@ async def test_a_blocked_row_returns_to_service_when_its_window_passes(
     assert await store.get_api_key("openai") == "k1"
 
 
+async def test_block_credential_caps_at_max(store: AuthStore, monkeypatch: Any) -> None:
+    """A multi-day block request is clamped to MAX_CREDENTIAL_BLOCK_MS.
+
+    A genuinely full-week-depleted account keys its block to the weekly
+    reset (days out); the cap guarantees no reading -- a usage reset estimate
+    or a hostile Retry-After -- strands an account past the point where
+    re-probing is cheaper than waiting. This is the single choke point the cap
+    lives at, so it protects every caller (preflight AND rotate_sibling)."""
+    from local_operator.providers.auth_store import MAX_CREDENTIAL_BLOCK_MS
+
+    clock = {"now": 1_000_000}
+    monkeypatch.setattr(AuthStore, "_now_ms", staticmethod(lambda: clock["now"]))
+    row = store.upsert_credential("openai", {"key": "k1", "type": "api_key"})
+    # A seven-day block request -- the shape a raw weekly usage reset writes.
+    store.block_credential(row.id, "openai", block_ms=7 * 86_400_000)
+    stored = store._conn.execute(
+        "SELECT blocked_until_ms FROM auth_credential_blocks WHERE credential_id = ?",
+        (row.id,),
+    ).fetchone()
+    assert stored is not None
+    # Capped: the stored horizon is at most one hour out, not seven days.
+    assert stored[0] - clock["now"] == MAX_CREDENTIAL_BLOCK_MS
+
+
+async def test_block_credential_floor_still_applies(store: AuthStore, monkeypatch: Any) -> None:
+    """A 0/negative block still floors at 1000 ms (the cap did not remove it)."""
+    clock = {"now": 1_000_000}
+    monkeypatch.setattr(AuthStore, "_now_ms", staticmethod(lambda: clock["now"]))
+    row = store.upsert_credential("openai", {"key": "k1", "type": "api_key"})
+    store.block_credential(row.id, "openai", block_ms=0)
+    stored = store._conn.execute(
+        "SELECT blocked_until_ms FROM auth_credential_blocks WHERE credential_id = ?",
+        (row.id,),
+    ).fetchone()
+    assert stored is not None
+    assert stored[0] - clock["now"] == 1000
+
+
+async def test_rotate_sibling_retry_after_is_capped(store: AuthStore, monkeypatch: Any) -> None:
+    """The reactive rotation path inherits the cap for free.
+
+    ``rotate_sibling`` writes ``block_ms=max(block_ms, retry_after or 0)``, so
+    a provider that answers a quota 429 with ``Retry-After: 604800`` (a week)
+    would, uncapped, strand the account for a week. The cap lives in
+    ``block_credential`` -- the single choke point -- so this site needs no
+    inline clamp and still cannot write a multi-day block."""
+    from local_operator.providers.auth_store import MAX_CREDENTIAL_BLOCK_MS
+    from local_operator.providers.failover import ProviderError
+
+    clock = {"now": 1_000_000}
+    monkeypatch.setattr(AuthStore, "_now_ms", staticmethod(lambda: clock["now"]))
+    row = store.upsert_credential("openai", {"key": "k1", "type": "api_key"})
+    store.upsert_credential("openai", {"key": "k2", "type": "api_key"})
+    # A hostile week-long Retry-After on a usage-limit 429.
+    hostile = ProviderError(429, "rate limit reached", retryable=True, retry_after_ms=604_800_000)
+    store.rotate_sibling("openai", None, hostile, api_key="k1")
+    stored = store._conn.execute(
+        "SELECT blocked_until_ms FROM auth_credential_blocks WHERE credential_id = ?",
+        (row.id,),
+    ).fetchone()
+    assert stored is not None
+    assert stored[0] - clock["now"] == MAX_CREDENTIAL_BLOCK_MS
+
+
 async def test_rotate_sibling_blocks_failing_and_reports_remaining(store: AuthStore) -> None:
     store.upsert_credential("openai", {"key": "k1", "type": "api_key"})
     row2 = store.upsert_credential("openai", {"key": "k2", "type": "api_key"})

--- a/tests/unit/providers/test_failover.py
+++ b/tests/unit/providers/test_failover.py
@@ -483,7 +483,13 @@ async def test_fallback_chain_deduplicates_current_model_and_effort() -> None:
     async def client_for(spec: ModelSpec) -> Any:
         specs_seen.append(f"{spec.provider}/{spec.model_id}/{spec.reasoning_effort}")
         if spec.provider == "openai":
-            return ScriptedClient(ProviderError(400, "unavailable"))
+            # A generic "primary is down, walk to the fallback" trigger. Uses an
+            # UNKNOWN-kind failure (status=None) rather than a request-shape 400:
+            # a primary kind=="request" 400 now ABORTS the turn (the storm guard),
+            # so a 400 here would no longer walk. status=None takes the identical
+            # non-retryable break->walk path without being classified "request",
+            # which keeps this test about fallback dedup, not the abort policy.
+            return ScriptedClient(ProviderError(None, "unavailable"))
         return ScriptedClient([StreamEndEvent(stop_reason="stop")])
 
     request = _request()
@@ -520,7 +526,10 @@ async def test_successful_fallback_stays_pinned_for_same_message() -> None:
     async def client_for(spec: ModelSpec) -> Any:
         specs_seen.append(f"{spec.provider}/{spec.model_id}")
         if spec.provider == "openai":
-            return ScriptedClient(ProviderError(400, "model unavailable"))
+            # Unknown-kind (status=None) "primary down" trigger, not a 400: a
+            # primary request-shape 400 now aborts the turn rather than walking.
+            # See test_primary_request_400_aborts_without_walking_chain.
+            return ScriptedClient(ProviderError(None, "model unavailable"))
         return ScriptedClient([StreamEndEvent(stop_reason="stop")])
 
     settings = {
@@ -615,7 +624,10 @@ async def test_exhausted_fallback_is_benched_for_the_next_walk(monkeypatch) -> N
     async def client_for(spec: ModelSpec) -> Any:
         specs_seen.append(f"{spec.provider}/{spec.model_id}")
         if spec.provider in ("openai", "anthropic"):
-            return ScriptedClient(ProviderError(400, "model unavailable"))
+            # Unknown-kind (status=None) "target down" trigger, not a 400: a
+            # primary request-shape 400 now aborts instead of walking. status=None
+            # keeps the identical break->walk path for this bench-mechanics test.
+            return ScriptedClient(ProviderError(None, "model unavailable"))
         return ScriptedClient([StreamEndEvent(stop_reason="stop")])
 
     settings = {
@@ -678,7 +690,10 @@ async def test_bench_never_strands_a_turn_when_every_fallback_is_benched(monkeyp
     async def client_for(spec: ModelSpec) -> Any:
         specs_seen.append(f"{spec.provider}/{spec.model_id}")
         if spec.provider == "openai":
-            return ScriptedClient(ProviderError(400, "model unavailable"))
+            # Unknown-kind (status=None) "primary down" trigger, not a 400: a
+            # primary request-shape 400 now aborts instead of walking. status=None
+            # keeps the identical break->walk path for this all-benched test.
+            return ScriptedClient(ProviderError(None, "model unavailable"))
         return ScriptedClient([StreamEndEvent(stop_reason="stop")])
 
     settings = {"retry": {"baseDelayMs": 1, "fallbackChains": {"default": ["groq/llama-x"]}}}
@@ -767,10 +782,18 @@ async def test_stream_exhaustion_raises_last_error() -> None:
     assert excinfo.value.status == 500
 
 
-async def test_stream_non_retryable_stops_provider_immediately() -> None:
-    """A non-retryable 400 abandons the provider after one call and walks
-    the fallback chain instead of re-trying the same key."""
+async def test_primary_request_400_aborts_without_walking_chain() -> None:
+    """A PRIMARY request-shape 400 aborts the turn instead of walking the chain.
+
+    ``kind=="request"`` is a 4xx the provider READ and refused: the same bytes
+    fail identically on every other provider, so walking the fallback chain is
+    a storm — one malformed Anthropic 400 marched through z.ai/kimi/etc, each
+    400ing on the same messages. When the PRIMARY (the user's own model)
+    refuses, the turn now raises its 400 immediately and never touches the
+    fallback. (Was: this test asserted the anthropic fallback served "b" — the
+    behaviour the storm-stopper corrects.)"""
     calls = {"n": 0}
+    anthropic = ScriptedClient([StreamTextDelta(delta="b"), StreamEndEvent(stop_reason="stop")])
 
     def fail(
         request: ChatRequest, api_key: str | None, oauth_access: Any = None
@@ -780,18 +803,108 @@ async def test_stream_non_retryable_stops_provider_immediately() -> None:
 
     async def client_for(spec: ModelSpec) -> Any:
         if spec.provider == "anthropic":
-            return ScriptedClient([StreamTextDelta(delta="b"), StreamEndEvent(stop_reason="stop")])
+            return anthropic
         return _FnClient(fail)
 
     settings = {"retry": {"baseDelayMs": 1, "fallbackChains": {"default": ["anthropic/claude-x"]}}}
-    got = [
-        event
-        async for event in stream_with_failover(
+    with pytest.raises(ProviderError) as excinfo:
+        async for _ in stream_with_failover(
             _request(), FakeAuth({"openai": ["k"], "anthropic": ["k2"]}), settings, client_for
-        )
-    ]
+        ):
+            pass
+    # The primary's own 400 surfaces, not a fallback's error.
+    assert excinfo.value.status == 400
+    assert excinfo.value.kind == "request"
     assert calls["n"] == 1  # 400 is not retried on the same provider
-    assert any(isinstance(e, StreamTextDelta) and e.delta == "b" for e in got)
+    assert anthropic.calls == 0  # the fallback chain was never walked
+
+
+async def test_fallback_request_400_still_walks() -> None:
+    """A request-shape 400 on a FALLBACK target still walks to the next target.
+
+    The abort is gated on ``is_primary``: a ``kind=="request"`` failure on a
+    fallback can mean that one fallback rejected a field the primary accepted
+    (an effort rung its ladder lacks) — a per-target defect the walk should
+    route around, NOT a request-shape defect. So a fallback 400 keeps walking
+    to a later target that can serve."""
+    served = ScriptedClient([StreamTextDelta(delta="c"), StreamEndEvent(stop_reason="stop")])
+
+    async def client_for(spec: ModelSpec) -> Any:
+        if spec.provider == "openai":  # the primary — hand off with a provider fault
+            return ScriptedClient(ProviderError(500, "boom", retryable=True))
+        if spec.provider == "anthropic":  # first fallback — request-shape 400
+            return ScriptedClient(ProviderError(400, "bad request", retryable=False))
+        return served  # zai — the later target that serves
+
+    settings = {
+        "retry": {
+            "baseDelayMs": 1,
+            "maxRetries": 1,
+            "fallbackChains": {"default": ["anthropic/claude-x", "zai/glm-x"]},
+        }
+    }
+    auth = FakeAuth({"openai": ["k"], "anthropic": ["k2"], "zai": ["k3"]})
+    got = [event async for event in stream_with_failover(_request(), auth, settings, client_for)]
+    # The walk continued PAST the fallback 400 to the later target.
+    assert any(isinstance(e, StreamTextDelta) and e.delta == "c" for e in got)
+    assert served.calls == 1
+
+
+async def test_primary_image_rejection_400_aborts_turn() -> None:
+    """A PRIMARY image-rejection 400 aborts too, and keeps its image marker.
+
+    Image rejections are ``kind=="request"`` (a plain 400 on the provider's own
+    wording). Their recovery is the session's ``_degrade_if_image_rejected``,
+    fired from the turn end event INDEPENDENT of this walk, plus a resend — not
+    the fallback chain (a poisoned image 400s everywhere too). So aborting the
+    walk costs the image path nothing, and the raised error must still satisfy
+    ``is_image_rejection`` so the session's degrade fires."""
+    anthropic = ScriptedClient([StreamTextDelta(delta="b"), StreamEndEvent(stop_reason="stop")])
+
+    async def client_for(spec: ModelSpec) -> Any:
+        if spec.provider == "anthropic":
+            return anthropic
+        return ScriptedClient(ProviderError(400, "could not process image", retryable=False))
+
+    settings = {"retry": {"baseDelayMs": 1, "fallbackChains": {"default": ["anthropic/claude-x"]}}}
+    with pytest.raises(ProviderError) as excinfo:
+        async for _ in stream_with_failover(
+            _request(), FakeAuth({"openai": ["k"], "anthropic": ["k2"]}), settings, client_for
+        ):
+            pass
+    assert excinfo.value.status == 400
+    # The error object still carries the image marker, so the session degrade fires.
+    assert is_image_rejection(excinfo.value)
+    assert anthropic.calls == 0  # aborted, not walked
+
+
+async def test_primary_unknown_400_style_not_aborted_if_not_request_kind() -> None:
+    """An ``unknown``-kind failure still walks — the abort is request-only.
+
+    An empty-bodied gateway failure classifies as ``unknown`` (not ``request``)
+    and may be a transient edge a fallback survives, so the guard is gated
+    strictly on ``kind=="request"``. This pins that a primary ``unknown``
+    failure does NOT abort but walks to a serving fallback (guards against
+    over-broad aborting)."""
+    served = ScriptedClient([StreamTextDelta(delta="ok"), StreamEndEvent(stop_reason="stop")])
+
+    async def client_for(spec: ModelSpec) -> Any:
+        if spec.provider == "anthropic":
+            return served
+        # status=None, non-retryable, no auth/timeout markers -> kind "unknown".
+        return ScriptedClient(ProviderError(None, "gateway boom", retryable=False))
+
+    settings = {
+        "retry": {
+            "baseDelayMs": 1,
+            "maxRetries": 1,
+            "fallbackChains": {"default": ["anthropic/claude-x"]},
+        }
+    }
+    auth = FakeAuth({"openai": ["k"], "anthropic": ["k2"]})
+    got = [event async for event in stream_with_failover(_request(), auth, settings, client_for)]
+    assert any(isinstance(e, StreamTextDelta) and e.delta == "ok" for e in got)
+    assert served.calls == 1
 
 
 async def test_transport_retries_honor_budget_same_key_first() -> None:
@@ -3367,7 +3480,10 @@ async def test_route_edges_reach_the_settle_handler_in_both_directions() -> None
 
     async def client_for(spec: ModelSpec) -> Any:
         if spec.provider == "openai" and not primary_healthy:
-            return ScriptedClient(ProviderError(400, "model unavailable"))
+            # Unknown-kind (status=None) "primary down" trigger, not a 400: a
+            # primary request-shape 400 now aborts instead of walking, so it
+            # would never reach the settle-handler pin this test asserts.
+            return ScriptedClient(ProviderError(None, "model unavailable"))
         return ScriptedClient([StreamEndEvent(stop_reason="stop")])
 
     settings = {"retry": {"fallbackChains": {"default": ["anthropic/claude-opus-5"]}}}

--- a/tests/unit/providers/test_usage.py
+++ b/tests/unit/providers/test_usage.py
@@ -209,6 +209,75 @@ def test_usage_health_depleted_reset_ignores_windows_merely_in_reserve() -> None
     assert health.reset_after_ms == 2 * 3_600_000
 
 
+def test_usage_health_depleted_reset_keys_to_soonest_spent_window() -> None:
+    """With SEVERAL fully-spent windows the block keys to the earliest reset.
+
+    A depleted account is usable again the moment ANY spent binding window
+    reopens (a request needs only one window with headroom), so the honest
+    "try again at" is the SOONEST reset among the fully-spent windows, not the
+    latest. Keying to the latest (the old ``max``) pinned a two-hour block to
+    the 7-day window's five-day reset. This is the new-behaviour twin of
+    ``test_usage_health_depleted_reset_ignores_windows_merely_in_reserve``:
+    that test keeps passing because its 7d window sits at 91% (not spent), so
+    its depleted horizon has one member and min==max; here BOTH windows are
+    spent, so the direction is observable."""
+    report = UsageReport(
+        provider="anthropic",
+        limits=[
+            UsageLimit(
+                id="anthropic:5h",
+                label="5 hour",
+                amount=UsageAmount(used_fraction=1.0),
+                shared=True,
+                resets_at_ms=2 * 3_600_000,
+            ),
+            UsageLimit(
+                id="anthropic:7d",
+                label="7 day",
+                amount=UsageAmount(used_fraction=1.0),
+                shared=True,
+                resets_at_ms=5 * 86_400_000,
+            ),
+        ],
+    )
+    health = usage_health(report, "claude-opus-5", reserve_percent=10, now_ms=0)
+    assert health.state == "depleted"
+    # The SOONEST reset (5-hour window), not the weekly.
+    assert health.reset_after_ms == 2 * 3_600_000
+
+
+def test_usage_health_balance_only_depleted_keys_to_soonest() -> None:
+    """The balance-only (Kimi/DeepSeek) depleted path keys to the soonest reset.
+
+    Two zeroed balance windows with different resets: the account reopens at
+    the earliest of them, so ``reset_after_ms`` is the sooner reset. Covers the
+    ``max``->``min`` change on the balance-only branch, which is always a
+    depleted verdict."""
+    report = UsageReport(
+        provider="deepseek",
+        limits=[
+            UsageLimit(
+                id="deepseek:usd",
+                label="USD",
+                amount=UsageAmount(remaining=0.0, unit="usd"),
+                shared=True,
+                resets_at_ms=3 * 3_600_000,
+            ),
+            UsageLimit(
+                id="deepseek:cny",
+                label="CNY",
+                amount=UsageAmount(remaining=0.0, unit="cny"),
+                shared=True,
+                resets_at_ms=9 * 3_600_000,
+            ),
+        ],
+    )
+    health = usage_health(report, "deepseek-chat", reserve_percent=10, now_ms=0)
+    assert health.state == "depleted"
+    # The SOONEST reset (3-hour window), not the 9-hour one.
+    assert health.reset_after_ms == 3 * 3_600_000
+
+
 def test_usage_health_ignores_unrelated_model_tier() -> None:
     report = UsageReport(
         provider="anthropic",


### PR DESCRIPTION
## Why

Three defects in provider auth/failover let a **usable** account look dropped and let one malformed request storm the whole provider pool. Root-caused against `origin/main` (= the live `lop` runtime, verified via `.lop-source`) using the operator's real `auth.db` and runtime logs.

**1. A credential block has no upper bound.** `block_credential` applies its `block_ms` raw. A legitimately *depleted* Anthropic account keys its block to a window reset that can be days away (the 7-day window), and `rotate_sibling` writes `max(block_ms, retry_after)` — so a large or hostile `Retry-After` header can strand an account for days. A block is a cost-avoidance backoff, not a correctness gate (every message boundary re-probes usage and the cascade re-checks blocked rows), so nothing justifies a multi-day strand. Observed live: two enabled accounts carried blocks until Aug 24 / Aug 25 (2.5–3.4 days) from a single low reading.

**2. A depleted block keys to the *latest* spent window, not the soonest.** `usage_health` computed `reset_after_ms` as `max(...)` over the depleted horizon. An account is usable again the moment **any** spent window reopens — a request needs only one window with headroom — so keying to the latest reset pins a block to the 7-day window when the 5-hour window reopens first.

**3. A primary request-shape 400 walks the entire fallback chain.** In `stream_with_failover`, a `kind=="request"` failure (a 4xx the provider *read* and refused) is deterministic in its bytes — the same request 400s on every other provider. The driver walked the whole chain anyway. Observed live: one malformed Anthropic 400 marched through z.ai → kimi → alibaba → xai → chatgpt, each rejecting the same `messages` payload, producing a confusing "all accounts/providers exhausted" cascade for what was a single bad request. The final reported error was already correct (the primary's 400), so this is a resilience/cost fix, not a wrong-answer fix.

Version bump is **PATCH** (0.25.1 → **0.25.2**): three bug fixes, no new user-facing feature, no schema change. (0.25.1 was taken by #271 upstream while this branch was in flight.)

## What changes

### Cap every credential block at 1h — `providers/auth_store.py`
New `MAX_CREDENTIAL_BLOCK_MS = 60*60*1000`, clamped in `block_credential`: `block_ms = max(1000, min(int(block_ms), MAX_CREDENTIAL_BLOCK_MS))`. One choke point, so it protects **every** caller (preflight usage block *and* reactive `rotate_sibling` backoff) from a rogue reset estimate or a hostile header, with no per-caller duplicate ceiling that could drift. The **read side (`is_blocked`) is unchanged** — a row written by an older build with a multi-day `blocked_until_ms` is still honoured as written; only new writes are capped (and old long blocks self-heal via the cascade's blocked-row recovery probes).

### Key a depleted block to the soonest spent window — `providers/usage.py`
The depleted horizon's `reset_after` flips `max`→`min` at **both** the measured path and the balance-only (`zero_balance`) branch. The `reserve`/else branch keeps `max` (its job is "when does the binding window recover" for display). `None` resets are filtered before `min`, exactly as the old `max` did, so an unknown reset still falls back to `DEFAULT_USAGE_BLOCK_MS`.

### Abort a primary request-shape 400 instead of walking — `providers/failover.py`
At the `break  # non-retryable for this provider` site, a guard: `if exc.kind == "request" and is_primary: raise exc`. Gated strictly on `kind=="request"` **and** `is_primary`:
- A **fallback** request-400 still walks — it can mean one fallback rejected a field the primary accepted (an effort rung its ladder lacks), a per-target defect the walk should route around.
- An `unknown`-kind failure (empty-bodied gateway) still walks — it may be a transient edge a fallback survives.
- The **image-rejection** path is unaffected: an image 400 aborts here too, but its recovery is the session's `_degrade_if_image_rejected` (fired from the turn end event, independent of this walk) plus a resend — never the chain — so aborting costs it nothing, and the raised error still satisfies `is_image_rejection` so the degrade fires.

## Impact
- No breaking changes, no schema change. Existing block rows honoured as written; only new writes are capped.
- **Same error reaches the user** on a primary 400 (primary rank already dominated the reported slot) — minus the wasted fallback attempts and their log noise.
- **Deferred to a follow-up PR (BUG 3):** route the preflight's usage reads through the existing shared cross-process cache (`usage_cache.py` + leases) to collapse the per-boundary, per-process usage fan-out against Anthropic's 429ing endpoint. The infra already exists; the gap is `preflight_usage` calling `usage.fetch_usage` raw at 4 sites. Split out deliberately — it roughly doubles the PR surface (lazy-controller plumbing, cache-identity matching, ~30 preflight tests that patch `usage.fetch_usage`) and wants its own focused review. `configure.py`/`controller.py` are untouched here, a clean base for it.

## Testing Details

### BUG 1 — block cap, real sqlite `auth.db` (not a mock)
```
requested block: 604800000 ms (7.0 days)
MAX_CREDENTIAL_BLOCK_MS: 3600000 ms (1.0h)
actual stored block: ~3600000 ms (1.00h)
CAPPED TO 1H: True
```
Unit tests added: a 7-day request clamps to 1h; a hostile `Retry-After` via `rotate_sibling` clamps; a two-fully-spent-window report keys `reset_after_ms` to the soonest (2h), not the latest (120h).

### BUG 3-adjacent live cleanup
The operator's two spuriously-blocked accounts (stale multi-day rows written by the pre-fix build) were cleared from the live store as part of the investigation; they return to rotation immediately and cannot be re-written that long under this change.

### BUG 2 — request-400 abort, real `stream_with_failover` (reproduce-before / passing-after)
With the guard **disabled**, both storm-stopper tests fail — the driver walks the chain:
```
FAILED test_primary_request_400_aborts_without_walking_chain - DID NOT RAISE ProviderError
FAILED test_primary_image_rejection_400_aborts_turn         - DID NOT RAISE ProviderError
```
With the guard **restored**, both pass: a primary 400 raises after touching **only** the primary (`anthropic.calls == 0` — the fallback chain never walked), surfacing the primary's own 400. Companion tests pin that a **fallback** request-400 still walks to a serving target, an `unknown`-kind primary failure still walks, and a primary image-rejection 400 aborts **and** keeps `is_image_rejection(err) == True` so the session degrade still fires.

### Test maintenance
`test_stream_non_retryable_stops_provider_immediately` split into primary-aborts + fallback-still-walks. 5 existing bench/pin/dedup tests used a primary `ProviderError(400)` purely as a generic "primary down → walk" trigger; under the new policy that aborts, so they were repointed to an `unknown`-kind (`status=None`) failure — byte-identical break→walk path, just not classified `request` — each with a comment explaining why.

### Gates (whole tree, rebased onto current `origin/main`)
- `flake8` ✓ · `black==26.1.0 --check` ✓ · `isort --profile black --check-only` ✓ · `pyright` **0 errors, 0 warnings**
- **Full unit suite: 6335 passed, 7 skipped.** Provider+model subset: 1001 passed.

🤖 Generated with local-operator (lopdev team)
