### PR TITLE
fix(usage): route preflight quota probes through the shared cache to end the per-process 429 storm

### DIFF
--- a/local_operator/model/configure.py
+++ b/local_operator/model/configure.py
@@ -63,6 +63,8 @@ if TYPE_CHECKING:
     from local_operator.env import EnvConfig
     from local_operator.providers.auth_store import AuthStore
     from local_operator.providers.clients import WireClient
+    from local_operator.providers.usage import UsageReport
+    from local_operator.providers.usage_cache import UsageCacheStore
 
     #: Either provider's ``list_models()`` payload. The two schemas are
     #: structurally identical (``data`` of items with ``id``/``description``/
@@ -1564,6 +1566,14 @@ class SessionStreamFn:
         # healthy edge still resets all of them together (recovery is a fresh
         # start for every condition on that selector).
         self._last_quota_state: dict[str, set[str]] = {}
+        # Shared cross-process usage cache for preflight probes, built lazily on
+        # the first routing check and reused for the session's lifetime. Its
+        # sole job here is to collapse a concurrent PEER process's duplicate
+        # fetch of the same account (the per-source-IP 429 storm this fixes) —
+        # it never suppresses this process's own per-boundary re-probe. None
+        # until first use, and stays None whenever the cache cannot open (a
+        # permanent live-fetch miss, never an error). See ``_usage_cache_store``.
+        self._usage_cache: "UsageCacheStore | None" = None
 
     def _client_for(self, spec: ModelSpec) -> WireClient:
         from local_operator.providers.clients import client_for_spec
@@ -1883,6 +1893,7 @@ class SessionStreamFn:
             usage_health,
             usage_supported,
         )
+        from local_operator.providers.usage_cache import fingerprint_secret
 
         if not usage_supported(provider):
             cache[cache_key] = "unknown"
@@ -1908,12 +1919,16 @@ class SessionStreamFn:
 
         for access in accesses:
             try:
-                report = await fetch_usage(
-                    self._http,
+                report = await self._cached_account_usage(
                     provider,
-                    access_token=access.access_token,
-                    account_id=access.account_id,
-                    oauth_creds=access.raw,
+                    access.email or access.account_id or f"cred:{access.credential_id}",
+                    lambda a=access: fetch_usage(
+                        self._http,
+                        provider,
+                        access_token=a.access_token,
+                        account_id=a.account_id,
+                        oauth_creds=a.raw,
+                    ),
                 )
             except Exception:
                 saw_unknown = True
@@ -1943,7 +1958,11 @@ class SessionStreamFn:
             saw_unknown = True
         if selected is not None and selected.kind == "api_key":
             try:
-                report = await fetch_usage(self._http, provider, api_key=selected.access_token)
+                report = await self._cached_account_usage(
+                    provider,
+                    fingerprint_secret(selected.access_token),
+                    lambda: fetch_usage(self._http, provider, api_key=selected.access_token),
+                )
             except Exception:
                 report = None
             if report is None:
@@ -2040,6 +2059,42 @@ class SessionStreamFn:
         from local_operator.providers.registry import credential_provider_id
 
         return credential_provider_id(provider)
+
+    def _usage_cache_store(self) -> "UsageCacheStore | None":
+        """The shared usage cache, built lazily. A cache that cannot open is a
+        permanent miss (live fetch), never an error — same contract as the warmer's."""
+        if self._usage_cache is None:
+            try:
+                from local_operator.providers.usage_cache import UsageCacheStore
+
+                self._usage_cache = UsageCacheStore()
+            except Exception:  # noqa: BLE001 — no cache = live fetch, never fatal
+                return None
+        return self._usage_cache
+
+    async def _cached_account_usage(
+        self,
+        provider: str,
+        account_identity: str,
+        fetch: "Callable[[], Awaitable[UsageReport | None]]",
+    ) -> "UsageReport | None":
+        """Route one preflight usage probe through the shared cross-process cache.
+
+        Collapses a concurrent peer's duplicate fetch of the SAME account (the 429
+        storm this fixes) while keeping every boundary free to re-probe live —
+        ``leased_account_usage`` never serves a fresh row on the fast path. Fails open
+        to a live fetch when the cache is unavailable, so routing can never be made
+        WORSE than the pre-cache behaviour. See docs/specs/preflight-usage-cache.md.
+        """
+        from local_operator.providers.usage_cache import (
+            account_preflight_key,
+            leased_account_usage,
+        )
+
+        storage = self._storage_provider(provider)
+        store = self._usage_cache_store()
+        key = account_preflight_key(storage, account_identity)
+        return await leased_account_usage(store, key, storage, fetch)
 
     async def _primary_has_auth(self, model: ModelSpec) -> bool:
         from local_operator.providers.failover import FallbackTarget
@@ -2216,11 +2271,15 @@ class SessionStreamFn:
                 usage_health,
             )
 
-            report = await fetch_usage(
-                self._http,
+            report = await self._cached_account_usage(
                 model.provider,
-                access_token=access.access_token,
-                account_id=access.account_id,
+                access.email or access.account_id or f"cred:{access.credential_id}",
+                lambda a=access: fetch_usage(
+                    self._http,
+                    model.provider,
+                    access_token=a.access_token,
+                    account_id=a.account_id,
+                ),
             )
             if report is None:
                 return
@@ -2744,11 +2803,15 @@ class SessionStreamFn:
             token = key_fn(creds) if key_fn else creds.get("access")
             if not token:
                 continue
-            report = await fetch_usage(
-                self._http,
+            report = await self._cached_account_usage(
                 model.provider,
-                access_token=token,
-                account_id=creds.get("account_id"),
+                creds.get("email") or creds.get("account_id") or f"cred:{row.id}",
+                lambda t=token, c=creds: fetch_usage(
+                    self._http,
+                    model.provider,
+                    access_token=t,
+                    account_id=c.get("account_id"),
+                ),
             )
             if report is None:
                 continue  # unreachable quota endpoint: keep the block, move on
@@ -3010,6 +3073,13 @@ class SessionStreamFn:
 
     async def close(self) -> None:
         await self._http.aclose()
+        if self._usage_cache is not None:
+            try:
+                self._usage_cache.close()
+            except Exception:  # noqa: BLE001 — teardown, never fatal
+                self._usage_cache = None
+            else:
+                self._usage_cache = None
 
 
 def create_stream_fn(

--- a/local_operator/providers/usage_cache.py
+++ b/local_operator/providers/usage_cache.py
@@ -506,9 +506,6 @@ async def leased_account_usage(
     if store is None:
         return await fetch()
 
-    stale = store.get(key, include_expired=True)
-    stale_report = stale[0] if stale else None
-
     # The lease is contended only when a peer is mid-fetch. A free lease (the common
     # case, and ALWAYS the case in a single-process test) means: this process fetches.
     if not store.try_lease(key):
@@ -516,6 +513,14 @@ async def leased_account_usage(
         # next boundary. Serve what we have rather than doubling the network hit. With
         # nothing on hand (cold start) we cannot serve nothing — fetch live, matching
         # the controller's "the lease only protects a stale value" rule.
+        #
+        # The stale read lives HERE, not before the lease check, on purpose: the
+        # free-lease fast path (the overwhelming majority of calls) never consumes
+        # ``stale_report``, so reading it up front spent one SQLite query per probe
+        # for nothing. Deferring it to the contended branch also reads a marginally
+        # fresher row — any write the peer landed between here and the lease check.
+        stale = store.get(key, include_expired=True)
+        stale_report = stale[0] if stale else None
         return stale_report if stale_report is not None else await fetch()
 
     try:

--- a/local_operator/providers/usage_cache.py
+++ b/local_operator/providers/usage_cache.py
@@ -55,6 +55,7 @@ import os
 import sqlite3
 import time
 import uuid
+from collections.abc import Awaitable, Callable
 from dataclasses import asdict
 from pathlib import Path
 from typing import Any
@@ -195,6 +196,26 @@ def fingerprint_secret(secret: str) -> str:
     cache-hit purposes.
     """
     return "key:" + hashlib.sha256(secret.encode("utf-8", "replace")).hexdigest()[:16]
+
+
+def account_preflight_key(storage_id: str, account_identity: str) -> str:
+    """Cache key for ONE account's preflight usage probe.
+
+    A namespace disjoint from the warmer's per-provider-set keys: the ``:pf:``
+    segment appears in no ``provider_cache_key`` output, so a preflight row can
+    never collide with a warmer row even when a provider has exactly one account
+    (where ``fingerprint_accounts([id])`` would otherwise match). Kept separate on
+    purpose — see the module note in the spec: the two subsystems cache different
+    shapes (one account vs the full set) with different freshness policies, and the
+    raw preflight fetch does not backfill ``UsageReport.identity``, so the warmer's
+    set-row cannot be reliably sliced per account anyway.
+
+    ``account_identity`` is a NON-SECRET stable identifier (email, account id, or a
+    ``fingerprint_secret`` digest for the API-key route — never a raw key or a
+    rotating OAuth token). It is hashed again here so no identity string sits in
+    the row's primary key, matching the warmer's discipline.
+    """
+    return f"{storage_id}:pf:{fingerprint_accounts([account_identity])}"
 
 
 class UsageCacheStore:
@@ -458,3 +479,59 @@ class UsageCacheStore:
                 )
         except Exception:  # noqa: BLE001
             logger.debug("usage cache: lease release failed", exc_info=True)
+
+
+async def leased_account_usage(
+    store: "UsageCacheStore | None",
+    key: str,
+    provider: str,
+    fetch: Callable[[], Awaitable["UsageReport | None"]],
+) -> "UsageReport | None":
+    """One account's usage for a ROUTING decision: fetch live, but collapse a
+    concurrent peer's duplicate fetch.
+
+    Unlike the display read-through (:meth:`ProviderController._refresh_provider_usage`)
+    this NEVER serves a fresh cached value on the fast path — a routing probe must be
+    free to notice recovery/depletion on its own next boundary. The cache does exactly
+    one job here: when a PEER process already holds the fetch lease for this account,
+    this process serves the peer's last-good value instead of crossing the network for
+    the identical answer (Anthropic/OpenAI rate-limit the usage endpoint per source IP,
+    so a synchronized fan-out is how a routing check earns its own 429).
+
+    Degrades to the pre-cache behaviour whenever coordination is unavailable: no store,
+    or a lease it could not take with nothing on hand, means fetch live. ``fetch``
+    returning ``None`` (transport/HTTP failure OR no quota) is passed through unchanged,
+    so the caller's fail-open path is preserved exactly.
+    """
+    if store is None:
+        return await fetch()
+
+    stale = store.get(key, include_expired=True)
+    stale_report = stale[0] if stale else None
+
+    # The lease is contended only when a peer is mid-fetch. A free lease (the common
+    # case, and ALWAYS the case in a single-process test) means: this process fetches.
+    if not store.try_lease(key):
+        # A peer owns the in-flight fetch; its result lands in this same row for the
+        # next boundary. Serve what we have rather than doubling the network hit. With
+        # nothing on hand (cold start) we cannot serve nothing — fetch live, matching
+        # the controller's "the lease only protects a stale value" rule.
+        return stale_report if stale_report is not None else await fetch()
+
+    try:
+        report = await fetch()
+        if report is not None:
+            store.set(
+                key,
+                provider,
+                [report],
+                expires_at_ms=store._now_ms() + USAGE_REPORT_TTL_MS,
+            )
+            return report
+        # None = failure or genuinely-empty. Keep the last-good value servable to a
+        # concurrent lease-loser under the short failure cool-down; return None so the
+        # ROUTING caller fails open exactly as it does today.
+        store.write_failure(key, provider)
+        return None
+    finally:
+        store.release_lease(key)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.26.0"
+version = "0.26.1"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/model/test_configure.py
+++ b/tests/unit/model/test_configure.py
@@ -2714,3 +2714,64 @@ async def test_quota_pinned_fallback_is_reprobed_at_the_next_boundary(tmp_path) 
     finally:
         await stream.close()
         store.close()
+
+
+@pytest.mark.asyncio
+async def test_preflight_reuses_stale_row_when_a_peer_holds_the_lease(tmp_path) -> None:
+    """Cross-process fan-out collapse, through the real configure→helper wiring.
+
+    Two sessions share one HOME (hence one ``usage_cache.db``). Session A holds
+    the account's preflight fetch lease, standing in for a peer mid-fetch. Session
+    B's ``preflight_usage`` must reach a real verdict off A's last-good row WITHOUT
+    the patched fetcher ever being invoked for that account — proving the ``:pf:``
+    lease diverts the duplicate network hit that earned the endpoint its 429 storm
+    (BUG 3). This exercises the whole path (``_cached_account_usage`` →
+    ``account_preflight_key`` → ``leased_account_usage``), not the helper alone."""
+    from local_operator.providers.usage_cache import account_preflight_key
+
+    store = AuthStore(tmp_path / "auth.db")
+    account = store.upsert_credential("anthropic", _oauth("oauth-a", "account-a"))
+    store.upsert_credential("zai", {"key": "sk-zai", "source": "login"})
+    settings = {
+        "retry": {
+            "usageAwareFallback": True,
+            "usageReservePercent": 10,
+            "fallbackChains": {"default": ["zai/glm-5.3"]},
+        }
+    }
+    stream_a = create_stream_fn(store, settings, session_id="session-a")
+    stream_b = create_stream_fn(store, settings, session_id="session-b")
+    model = ModelSpec(provider="anthropic", model_id="claude-opus-4-8")
+    # The reactive probe keys on ``access.account_id`` here (``_oauth`` sets no
+    # email), so this is the exact row site 2150 will read for account-a.
+    key = account_preflight_key("anthropic", "account-a")
+
+    calls: list[dict[str, Any]] = []
+
+    async def recorder(*_args, **kwargs):
+        # If the lease-loser ever crossed the network this would fire (and, being
+        # a depleted 99% report, would flip the verdict) — so an empty ``calls``
+        # is a two-sided proof the network was NOT crossed.
+        calls.append(kwargs)
+        return _anthropic_usage(99.0)
+
+    try:
+        # A seeds a healthy last-good row and holds the lease (peer mid-fetch).
+        cache_a = stream_a._usage_cache_store()
+        assert cache_a is not None
+        cache_a.set(key, "anthropic", [_anthropic_usage(20.0)], expires_at_ms=cache_a._now_ms() - 1)
+        assert cache_a.try_lease(key) is True
+
+        with patch("local_operator.providers.usage.fetch_usage", side_effect=recorder):
+            stream_b.begin_message()
+            await stream_b.preflight_usage(model)
+
+        # Verdict reached off the stale healthy row: account stays in service, no
+        # fallback pinned — and the patched fetcher was never called for account-a.
+        assert calls == []
+        assert stream_b._route_state.active is None
+        assert not store.is_blocked(account.id, "anthropic")
+    finally:
+        await stream_a.close()
+        await stream_b.close()
+        store.close()

--- a/tests/unit/providers/test_usage_cache.py
+++ b/tests/unit/providers/test_usage_cache.py
@@ -17,8 +17,10 @@ from local_operator.providers.usage_cache import (
     USAGE_FAILURE_BACKOFF_MS,
     USAGE_LAST_GOOD_RETENTION_MS,
     UsageCacheStore,
+    account_preflight_key,
     fingerprint_accounts,
     fingerprint_secret,
+    leased_account_usage,
     provider_cache_key,
     report_from_dict,
     report_to_dict,
@@ -228,3 +230,185 @@ def test_a_write_leaves_no_open_transaction_behind(cache) -> None:
         assert other.get("k3") is not None, "peer write was silently lost"
     finally:
         other.close()
+
+
+# -- preflight read-through (leased_account_usage) ----------------------------
+# The routing helper is deliberately NOT the display read-through: it fetches
+# live on every fast path (so a boundary can notice recovery/depletion) and only
+# uses the lease to divert a concurrent PEER process that would otherwise
+# duplicate the same account's fetch and earn the endpoint a per-source-IP 429.
+# These tests pin exactly that contract. See docs/specs/preflight-usage-cache.md.
+
+
+@pytest.mark.asyncio
+async def test_preflight_lease_loser_serves_stale_without_a_network_fetch(tmp_path) -> None:
+    """Fan-out collapse (the headline proof): 2 processes, 2 preflights, 1 fetch.
+
+    Process A holds the account's fetch lease (mid-fetch). Process B's preflight
+    must serve A's last-good row instead of crossing the network for the identical
+    answer — the whole point of the ``:pf:`` lease.
+    """
+    db = tmp_path / "usage_cache.db"
+    store_a = UsageCacheStore(db)
+    store_b = UsageCacheStore(db)
+    key = account_preflight_key("anthropic", "account-a")
+    report_a = _report(percent=10.0)
+    report_b = _report(percent=90.0)
+    calls: list[str] = []
+
+    async def fetch():
+        calls.append("net")
+        return report_b
+
+    try:
+        # A stale row A already wrote, and A holding the lease (mid-fetch).
+        store_a.set(key, "anthropic", [report_a], expires_at_ms=store_a._now_ms() - 1)
+        assert store_a.try_lease(key) is True
+
+        served = await leased_account_usage(store_b, key, "anthropic", fetch)
+
+        assert served is not None
+        assert served.limits[0].amount.used == report_a.limits[0].amount.used  # stale served
+        assert calls == []  # network NOT crossed by the lease-loser
+    finally:
+        store_a.close()
+        store_b.close()
+
+
+@pytest.mark.asyncio
+async def test_preflight_free_lease_fetches_writes_and_releases(tmp_path) -> None:
+    """The common (single-process) case: a free lease always fetches live, caches
+    the result, and releases the lease so the next boundary can re-probe."""
+    store = UsageCacheStore(tmp_path / "usage_cache.db")
+    key = account_preflight_key("anthropic", "account-a")
+    report = _report(percent=42.0)
+    calls: list[str] = []
+
+    async def fetch():
+        calls.append("net")
+        return report
+
+    try:
+        served = await leased_account_usage(store, key, "anthropic", fetch)
+
+        assert served is report
+        assert calls == ["net"]
+        cached = store.get(key)
+        assert cached is not None and cached[0].limits[0].amount.used == 42.0
+        # Lease was released, not left to expire — the next boundary can fetch.
+        assert store.try_lease(key) is True
+    finally:
+        store.close()
+
+
+@pytest.mark.asyncio
+async def test_preflight_keys_isolate_accounts_and_avoid_the_warmer_namespace(
+    tmp_path,
+) -> None:
+    """Per-account isolation: two accounts get disjoint ``:pf:`` keys, each
+    returning its OWN report — the namespace, not ``UsageReport.identity`` (which
+    the raw preflight fetch never backfills), is what separates accounts. And the
+    keys never collide with the warmer's per-provider-set rows."""
+    db = tmp_path / "usage_cache.db"
+    holder = UsageCacheStore(db)  # holds each account's lease → forces stale serving
+    reader = UsageCacheStore(db)
+    key_a = account_preflight_key("anthropic", "account-a")
+    key_b = account_preflight_key("anthropic", "account-b")
+    report_a = _report(percent=11.0)
+    report_b = _report(percent=22.0)
+
+    async def _fail():  # must never run: both are lease-losers with stale on hand
+        raise AssertionError("lease-loser crossed the network")
+
+    try:
+        # Distinct namespace: contains ":pf:" and differs from the warmer's key.
+        assert ":pf:" in key_a and ":pf:" in key_b
+        assert key_a != key_b
+        warmer_key = provider_cache_key("anthropic", fingerprint_accounts(["account-a"]))
+        assert key_a != warmer_key
+
+        reader.set(key_a, "anthropic", [report_a], expires_at_ms=reader._now_ms() - 1)
+        reader.set(key_b, "anthropic", [report_b], expires_at_ms=reader._now_ms() - 1)
+        assert holder.try_lease(key_a) is True
+        assert holder.try_lease(key_b) is True
+
+        served_a = await leased_account_usage(reader, key_a, "anthropic", _fail)
+        served_b = await leased_account_usage(reader, key_b, "anthropic", _fail)
+
+        assert served_a is not None and served_a.limits[0].amount.used == 11.0
+        assert served_b is not None and served_b.limits[0].amount.used == 22.0
+    finally:
+        holder.close()
+        reader.close()
+
+
+@pytest.mark.asyncio
+async def test_preflight_lease_loser_with_no_stale_fetches_live(tmp_path) -> None:
+    """A cold start: the lease is held by a peer but no row exists. The loser
+    cannot serve nothing, so it fetches live — matching the pre-cache behaviour."""
+    db = tmp_path / "usage_cache.db"
+    holder = UsageCacheStore(db)
+    loser = UsageCacheStore(db)
+    key = account_preflight_key("anthropic", "account-a")
+    report = _report(percent=7.0)
+    calls: list[str] = []
+
+    async def fetch():
+        calls.append("net")
+        return report
+
+    try:
+        assert holder.try_lease(key) is True  # peer mid-fetch, nothing cached yet
+        served = await leased_account_usage(loser, key, "anthropic", fetch)
+
+        assert served is report
+        assert calls == ["net"]
+    finally:
+        holder.close()
+        loser.close()
+
+
+@pytest.mark.asyncio
+async def test_preflight_fails_open_when_the_cache_is_unavailable() -> None:
+    """No store means the pre-cache behaviour: fetch live and pass the result
+    through unchanged, including a ``None`` the routing caller fails open on."""
+    calls: list[str] = []
+
+    async def fetch_ok():
+        calls.append("net")
+        return _report(percent=3.0)
+
+    async def fetch_none():
+        calls.append("net")
+        return None
+
+    served = await leased_account_usage(None, "k", "anthropic", fetch_ok)
+    assert served is not None and served.limits[0].amount.used == 3.0
+
+    served_none = await leased_account_usage(None, "k", "anthropic", fetch_none)
+    assert served_none is None
+    assert calls == ["net", "net"]
+
+
+@pytest.mark.asyncio
+async def test_preflight_none_result_preserves_last_good_and_fails_open(tmp_path) -> None:
+    """A ``None`` fetch (transport failure OR genuinely-empty) returns ``None`` so
+    the routing caller fails open, while the last-good row stays servable to a
+    concurrent lease-loser under the write_failure cool-down."""
+    store = UsageCacheStore(tmp_path / "usage_cache.db")
+    key = account_preflight_key("anthropic", "account-a")
+    good = _report(percent=50.0)
+
+    async def fetch_none():
+        return None
+
+    try:
+        store.set(key, "anthropic", [good], expires_at_ms=store._now_ms() + 60_000)
+        served = await leased_account_usage(store, key, "anthropic", fetch_none)
+
+        assert served is None  # caller fails open
+        # Last-good survives (write_failure re-wrote it under the short cool-down).
+        retained = store.get(key, include_expired=True)
+        assert retained is not None and retained[0].limits[0].amount.used == 50.0
+    finally:
+        store.close()


### PR DESCRIPTION
## Why

The follow-up deferred from #274. The usage **preflight** — the per-message-boundary quota check that decides routing — calls `usage.fetch_usage` **raw** at four sites in `SessionStreamFn` (`configure.py`), bypassing the shared cross-process usage cache that the `/usage` panel and its background warmer already use. So every user-message boundary, in **every** concurrent `lop` process, fetches every account's usage fresh from Anthropic's `/api/oauth/usage` — an endpoint that rate-limits **per source IP**. N sessions × M accounts × every boundary is how that endpoint earns a 429 of its own, which was a contributing factor in the brittleness investigated in #274 (the usage check itself getting throttled, then feeding block/deprioritize decisions).

The four raw sites:
- `_provider_quota_availability` — the per-OAuth-account enumeration loop, and the selected-API-key probe.
- `preflight_usage` — the reactive per-boundary primary probe.
- `_recover_blocked_accounts` — the blocked-account recovery walk.

Version bump is **PATCH** (0.25.4 → **0.25.5**): a fix, no new user-facing feature, no schema change.

## What changes

### A routing-shaped read-through, not a display cache — `providers/usage_cache.py`
New `leased_account_usage(store, key, provider, fetch)` plus `account_preflight_key(storage_id, account_identity)`.

The key insight: **the fan-out worth collapsing is cross-*process* concurrency, not one process's sequential boundaries.** A single process re-probing on its next boundary is *intended* — that is how routing notices a quota recovering or depleting (and the suite enforces it: `test_quota_pinned_fallback_is_reprobed_at_the_next_boundary` mutates the report between two boundaries and asserts the second sees it). So this helper is deliberately **not** the warmer's read-through:

- It **never serves a fresh cached value on the fast path** — it fetches live every boundary, so per-boundary re-probing is untouched.
- It takes `try_lease` **only to divert a concurrent peer**: when another process already holds the in-flight lease for this account, this process serves the peer's last-good value instead of crossing the network for the identical answer. That single difference from the warmer's `force_refresh` path (which skips the lease) is the whole design.
- It **fails open**: no cache, or a cache that can't open, means live fetch — routing can never be made *worse* than the pre-cache behaviour. `fetch` returning `None` (transport failure *or* no-quota) is passed through unchanged, preserving the preflight's existing `saw_unknown` fail-open.

The preflight uses a **deliberately separate `:pf:` key namespace**, disjoint from the warmer's per-provider-**set** rows. Reasons: the shapes differ (one account vs the full set); `UsageReport.identity` is only backfilled on the controller's fetch path, so the warmer's set-row can't be reliably sliced per account on the raw preflight path; and the two want different freshness policies. Accepted cost: a warmer refresh and a preflight probe for the same account may each cross the network once — fine, the warmer was never the storm.

### Wire the preflight through it — `model/configure.py`
`SessionStreamFn` gains a lazily-built `_usage_cache` (a cache that can't open is a permanent live-fetch miss, never an error), a thin `_cached_account_usage(provider, account_identity, fetch)` wrapper, and a `close()` that releases the handle. Each of the four sites is rewritten to call it with the account's identity and an immediate closure over the still-**function-local** `fetch_usage`. Keeping that import function-local (and the closures immediate, default-binding loop vars) is what preserves the tests' patch point — `usage_cache`'s helper never references `fetch_usage`; it takes the fetcher as a callable.

The blocked-account recovery walk's per-row termination guarantee is untouched: it records `attempted_ids` **before** the probe, independent of whether the network was crossed.

## Impact
- No breaking change, no schema change. `controller.py` (the warmer's read-through) is deliberately left alone — its fresh-within-TTL, per-provider-set, empty-over-data semantics are correct for a *display* panel and wrong for a *routing* probe.
- **Watched behaviour change:** a lease-loser now acts on last-good data (≤ `USAGE_FETCH_LEASE_MS` = 30s + one boundary old) instead of failing open on a self-inflicted 429. Strictly better than the storm, but the recovery-latency ceiling is on the record.

## Testing Details

### Fan-out collapse — real cross-process proof (two stores, one on-disk cache db)
```
preflight key: anthropic:pf:c7d735069d2a1faa
  contains ':pf:':          True
  disjoint from warmer key: True

seed fetch crossed network: 1  (expect 1)
peer B while A holds lease — network calls added: 0  (expect 0: served stale)
peer B still got a usable report: True
```
Two independent `UsageCacheStore` handles on one db = two processes. While process A holds the account's fetch lease, process B's `leased_account_usage` adds **zero** network calls (serves last-good) yet still returns a usable report. This is the storm collapse, demonstrated end to end.

### Unit tests — `tests/unit/providers/test_usage_cache.py` (+6)
Fan-out collapse; free-lease fetches/writes/releases; per-account isolation (two accounts → disjoint `:pf:` keys, each returns its own report, both differ from the warmer's `provider_cache_key`); lease-loser-with-no-stale fetches live; fail-open on `store=None` (incl. `None` result); `None`-result preserves last-good and fails open.

### Integration — `tests/unit/model/test_configure.py` (+1)
Two `SessionStreamFn` on one `HOME`/db: A holds the account lease, and B's `preflight_usage` reaches its verdict off the stale healthy row **without the patched fetcher being called** for that account (`calls == []`). Two-sided: the seeded fetcher would have returned a depleted 99% report that flips the verdict, so a wrong wiring would fail loudly.

### The ~30 existing preflight tests stayed green with ZERO changes
This is the regression proof. Every `test_configure.py` test that reaches a preflight fetch patches `local_operator.providers.usage.fetch_usage` and runs single-process under the autouse isolated-`HOME` fixture → a fresh empty cache db → `try_lease` always free → live fetch every time → the patched fetcher is called exactly as often as before. The two count-sensitive assertions (`assert_not_called` / `assert_called`) both still hold.

### Gates (whole tree, rebased onto current `origin/main` @ 0.25.4 — which included #273's heavy `preflight_usage` rewrite)
- `flake8` ✓ · `black==26.1.0 --check` ✓ · `isort --profile black` ✓ · `pyright` **0 errors, 0 warnings**
- `test_configure.py` + `test_usage_cache.py`: **121 passed**. Full `tests/unit/providers tests/unit/model`: **1012 passed**.

🤖 Generated with local-operator (lopdev team)
