### PR TITLE
feat(analytics): nest billed-input breakdown and split image tokens

### DIFF
--- a/local_operator/analytics/model.py
+++ b/local_operator/analytics/model.py
@@ -49,9 +49,11 @@ from typing import Any, Mapping
 #: region and splitting them further would be a guess. ``system_prompt`` is the
 #: packaged persona plus repo guidance (AGENTS.md/CLAUDE.md), which share block
 #: 0's stable head with the persona and carry no wire delimiter of their own.
-#: ``images`` is APPENDED, never inserted, so every existing ``c_*`` rollup
-#: column keeps its position — a stored DB indexes these by ordinal, so a mid-
-#: list insert would silently re-map old columns onto the wrong component.
+#: ``images`` is APPENDED, never inserted, so the CREATE TABLE / docs /
+#: ``_COMPONENT_COLUMNS`` order stays a stable contract. Inserts and the
+#: aggregate SELECT address named ``c_*`` columns, so a mid-list insert would
+#: not silently remap an existing DB — appending is still right, just not
+#: for the ordinal-remap reason an earlier comment claimed.
 COMPONENT_KEYS: tuple[str, ...] = (
     "system_prompt",
     "custom_instructions",
@@ -397,6 +399,20 @@ class UsageAggregate:
         not a zero-token turn, but it is the only number we can stand behind.
         """
         return self.context_tokens + self.output_tokens
+
+    @property
+    def fresh_tokens(self) -> int:
+        """Uncached input tokens, independent of how the provider reports input.
+
+        Providers disagree on whether ``input_tokens`` already includes cache:
+        Anthropic reports input EXCLUDING cache (so ``input == context - read
+        - write``), while OpenAI-shaped usage folds cache into input (so
+        ``context == input`` and a naive Fresh=input would show the FULL
+        context). Subtracting cache from the normalised ``context_tokens`` is
+        the one definition that is the uncached slice on every provider, and
+        it is linear so computing it on the aggregate equals summing per-call.
+        """
+        return max(0, self.context_tokens - self.cache_read_tokens - self.cache_write_tokens)
 
     @property
     def cache_hit_rate(self) -> float | None:

--- a/local_operator/analytics/model.py
+++ b/local_operator/analytics/model.py
@@ -49,6 +49,9 @@ from typing import Any, Mapping
 #: region and splitting them further would be a guess. ``system_prompt`` is the
 #: packaged persona plus repo guidance (AGENTS.md/CLAUDE.md), which share block
 #: 0's stable head with the persona and carry no wire delimiter of their own.
+#: ``images`` is APPENDED, never inserted, so every existing ``c_*`` rollup
+#: column keeps its position — a stored DB indexes these by ordinal, so a mid-
+#: list insert would silently re-map old columns onto the wrong component.
 COMPONENT_KEYS: tuple[str, ...] = (
     "system_prompt",
     "custom_instructions",
@@ -58,6 +61,7 @@ COMPONENT_KEYS: tuple[str, ...] = (
     "knowledge",
     "conversation",
     "tool_results",
+    "images",
 )
 
 #: Human labels for each component key, for the ``/analytics /usage`` screen.
@@ -70,6 +74,9 @@ COMPONENT_LABELS: dict[str, str] = {
     "knowledge": "Knowledge / skills",
     "conversation": "Conversation",
     "tool_results": "Tool results",
+    # "(est.)" because image tokens are a flat char proxy, not a measured
+    # per-image count — the honesty label the rest of the split already carries.
+    "images": "Images (est.)",
 }
 
 #: Marks the operator's custom-instructions section inside system block 0. Kept
@@ -102,28 +109,35 @@ def split_system_prompt(block0: str) -> tuple[int, int]:
     return idx, len(block0) - idx
 
 
-def _content_chars(message: Any) -> int:
-    """Total character length of a message's text content.
+#: Flat per-image char proxy (~4 chars/token * IMAGE_TOKEN_ESTIMATE). Kept as a
+#: module constant, not an import, so the tokeniser module stays off this hot
+#: snapshot path; it matches ``compaction.tokens.IMAGE_TOKEN_ESTIMATE`` scaled
+#: back to chars so the two estimators tell the same story.
+_IMAGE_CHAR_PROXY = 4 * 1200
 
-    Images are counted as a flat proxy so an image-heavy turn does not read as
-    near-zero input: they cost real context tokens the provider billed, and
-    leaving them at zero would push their share onto text components. The proxy
-    matches ``compaction.tokens.IMAGE_TOKEN_ESTIMATE`` scaled back to chars so
-    the two estimators tell the same story.
+
+def _content_chars(message: Any) -> tuple[int, int]:
+    """A message's content length as ``(text_chars, image_chars)``.
+
+    The two are returned SEPARATELY so image consumption can be attributed to
+    its own ``images`` component instead of inflating whichever text bucket the
+    message happens to sit in (conversation or tool_results). Images still cost
+    real context tokens the provider billed, and leaving them at zero would push
+    their share onto text; but folding them INTO the text total would over-weight
+    that text bucket in the proportional apportionment (see
+    ``snapshot_component_chars``). Splitting here keeps both honest.
     """
-    total = 0
+    text_chars = 0
+    image_chars = 0
     content = getattr(message, "content", None) or []
     for part in content:
         text = getattr(part, "text", None)
         if isinstance(text, str):
-            total += len(text)
+            text_chars += len(text)
             continue
-        # Non-text (image) block: a flat char proxy (~4 chars/token *
-        # IMAGE_TOKEN_ESTIMATE). Kept local rather than imported to avoid
-        # pulling the tokeniser module onto this hot snapshot path.
         if getattr(part, "type", "") == "image":
-            total += 4 * 1200
-    return total
+            image_chars += _IMAGE_CHAR_PROXY
+    return text_chars, image_chars
 
 
 @dataclass(frozen=True)
@@ -244,13 +258,21 @@ def snapshot_component_chars(request: Any) -> dict[str, int]:
 
     conversation_chars = 0
     tool_result_chars = 0
+    image_chars = 0
     for message in getattr(request, "messages", []) or []:
         role = getattr(message, "role", "")
-        chars = _content_chars(message)
+        text_chars, msg_image_chars = _content_chars(message)
+        # CRITICAL: image chars are pulled OUT of the text buckets and summed
+        # into ``images``, NEVER added alongside. Apportionment splits the fixed
+        # ``context_tokens`` proportionally to total chars, so counting an
+        # image's chars in both its text bucket AND ``images`` would double its
+        # weight and over-attribute the shared total to conversation/tool_results.
+        # Images from BOTH conversation and tool messages accumulate here.
+        image_chars += msg_image_chars
         if role == "tool":
-            tool_result_chars += chars
+            tool_result_chars += text_chars
         else:
-            conversation_chars += chars
+            conversation_chars += text_chars
 
     return {
         "system_prompt": system_prompt_chars,
@@ -261,6 +283,7 @@ def snapshot_component_chars(request: Any) -> dict[str, int]:
         "knowledge": len(blocks[3]),
         "conversation": conversation_chars,
         "tool_results": tool_result_chars,
+        "images": image_chars,
     }
 
 

--- a/local_operator/analytics/store.py
+++ b/local_operator/analytics/store.py
@@ -187,33 +187,43 @@ _CALL_COLUMNS = (
     *(f"c_{key}" for key in COMPONENT_KEYS),
 )
 
-#: Columns added AFTER the first shipped schema (which had no cost columns).
-#: A database created by the token-only release is missing these, and
-#: ``CREATE TABLE IF NOT EXISTS`` will not add a column to an existing table —
-#: so ``_connect`` runs an idempotent ``ALTER TABLE ADD COLUMN`` for each on
-#: open. ``(name, definition)``; the definition carries the default so old rows
-#: read as cost 0 / unknown rather than NULL.
+#: Columns added AFTER the first shipped schema. A database created by an older
+#: release is missing these, and ``CREATE TABLE IF NOT EXISTS`` will not add a
+#: column to an existing table — so ``_connect`` runs an idempotent
+#: ``ALTER TABLE ADD COLUMN`` for each on open. ``(name, definition)``; the
+#: definition carries the default so old rows read as 0 rather than NULL.
+#:
+#: This is the SINGLE registry of optional columns (review C2, Option A): the
+#: first release had cost absent, and now ``c_images`` (the 9th component) is
+#: absent on any DB written before it. Rather than a bespoke ``_NO_COST`` insert
+#: variant per absent column — which multiplies combinatorially with the next
+#: component added — ``_migrate`` records which of THESE are actually present and
+#: the insert/aggregate paths are driven by that set. A column that is in this
+#: tuple but missing from the table is simply dropped from the insert and read
+#: as 0 in the aggregate, giving every optional column the same "analytics must
+#: never break a turn" guarantee the cost columns already had.
 _MIGRATION_COLUMNS: tuple[tuple[str, str], ...] = (
     ("cost_micro", "INTEGER NOT NULL DEFAULT 0"),
     ("cost_known", "INTEGER NOT NULL DEFAULT 0"),
+    # Old rows keep their image tokens baked into the conversation/tool_results
+    # estimates they were recorded with (forward-fill, same philosophy as the
+    # rollup tables). After this ALTER they read ``c_images=0`` rather than
+    # being re-apportioned — we cannot honestly unbake a historical estimate.
+    ("c_images", "INTEGER NOT NULL DEFAULT 0"),
 )
 
+#: The names in ``_MIGRATION_COLUMNS`` as a set, for the "is this column optional
+#: (i.e. possibly absent on an old DB)?" test. A column NOT in here — the base
+#: token columns and the original eight ``c_*`` components — is present on every
+#: DB that has ever existed and is never dropped from a query.
+_OPTIONAL_COLUMN_NAMES: frozenset[str] = frozenset(name for name, _ in _MIGRATION_COLUMNS)
+
+#: The all-columns insert, used when the DB has every optional column (a fresh DB
+#: always does). ``_migrate`` narrows this to the present columns per DB.
 _INSERT_SQL = (
     f"INSERT INTO calls ({', '.join(_CALL_COLUMNS)}) "
     f"VALUES ({', '.join('?' for _ in _CALL_COLUMNS)})"
 )
-
-#: The insert WITHOUT the cost columns, for a database where the migration to
-#: add them failed (review C2). The two cost values are dropped from both the
-#: column list and each row tuple so a missing column cannot fail every write.
-_CALL_COLUMNS_NO_COST = tuple(c for c in _CALL_COLUMNS if c not in ("cost_micro", "cost_known"))
-_INSERT_SQL_NO_COST = (
-    f"INSERT INTO calls ({', '.join(_CALL_COLUMNS_NO_COST)}) "
-    f"VALUES ({', '.join('?' for _ in _CALL_COLUMNS_NO_COST)})"
-)
-#: Positions of the two cost values in ``_row_values`` output, so the cost-less
-#: path can drop exactly them. They sit right after ``context_tokens``.
-_COST_VALUE_INDICES = (11, 12)
 
 #: The measure columns a rollup row accumulates. Every one is summed on
 #: conflict, so an upsert is a pure ``x = x + excluded.x`` accumulate and N
@@ -398,14 +408,26 @@ class AnalyticsStore:
         #: first connections at once do not race on ``executescript``.
         self._init_lock = threading.Lock()
         self._initialized = False
-        #: Whether the cost columns exist on THIS database. A fresh DB always
-        #: has them (the ``CREATE TABLE`` includes them); an old one gets them
-        #: from ``_migrate``. If a migration ALTER genuinely fails (a locked or
-        #: corrupt DB), this stays False and both the insert and the aggregate
-        #: silently drop the cost columns rather than referencing a column that
-        #: does not exist — which would otherwise fail EVERY write and blank the
-        #: whole screen (review C2). Token analytics keep working; cost reads 0.
+        #: Whether the cost columns exist on THIS database, scoped EXPLICITLY to
+        #: ``cost_micro``/``cost_known`` (not "all optional columns present"):
+        #: once ``c_images`` joined ``_MIGRATION_COLUMNS`` a blanket check would
+        #: conflate "cost present" with "images present" and mislabel a
+        #: cost-capable DB. The report reads this to choose ``$—`` vs a real sum.
         self._has_cost = True
+        #: Which OPTIONAL columns (``_MIGRATION_COLUMNS``) actually exist on this
+        #: DB. A fresh DB has all of them (the ``CREATE TABLE`` includes them); an
+        #: old one gets them from ``_migrate``. If a migration ALTER genuinely
+        #: fails (a locked/corrupt DB), the absent column is dropped from every
+        #: insert and read as 0 in the aggregate rather than being referenced and
+        #: failing EVERY write — the generalised C2 "never break a turn" path.
+        #: Defaults to all-present; ``_migrate`` narrows it to the truth per DB.
+        self._present_optional: frozenset[str] = _OPTIONAL_COLUMN_NAMES
+        #: The insert column list + SQL for THIS DB, derived from
+        #: ``_present_optional`` in ``_migrate``. ``_insert_indices`` selects the
+        #: matching values out of ``_row_values``' full (``_CALL_COLUMNS``-order)
+        #: tuple so a missing column is dropped from both the SQL and the row.
+        self._insert_indices: tuple[int, ...] = tuple(range(len(_CALL_COLUMNS)))
+        self._insert_sql: str = _INSERT_SQL
 
     # -- connection ----------------------------------------------------------
     def _connect(self) -> sqlite3.Connection | None:
@@ -480,14 +502,21 @@ class AnalyticsStore:
         ``_init_lock`` on open; a failure here degrades to the pre-migration
         shape rather than raising, because analytics is never a hard dependency.
 
-        Sets ``self._has_cost`` from what is ACTUALLY present afterward: if an
-        ALTER failed, cost is dropped from the insert and the aggregate so a
-        missing column cannot fail every write and blank the screen (review C2).
+        Records which OPTIONAL columns are ACTUALLY present afterward
+        (``self._present_optional``) and rebuilds the per-DB insert plan from it:
+        if an ALTER failed, that column is dropped from the insert AND read as 0
+        in the aggregate, so a missing column cannot fail every write and blank
+        the screen (review C2, generalised to every optional column via Option A).
+        ``self._has_cost`` is scoped EXPLICITLY to the two cost columns so adding
+        ``c_images`` to ``_MIGRATION_COLUMNS`` does not conflate "cost present"
+        with "images present".
         """
         try:
             existing = {str(row[1]) for row in conn.execute("PRAGMA table_info(calls)").fetchall()}
         except Exception:  # noqa: BLE001 — an unreadable schema is a no-op migration
             self._has_cost = False
+            self._present_optional = frozenset()
+            self._rebuild_insert_plan()
             return
         for name, definition in _MIGRATION_COLUMNS:
             if name in existing:
@@ -497,7 +526,37 @@ class AnalyticsStore:
                 existing.add(name)
             except Exception:  # noqa: BLE001 — a failed add leaves the older shape
                 logger.debug("analytics: could not add column %s", name, exc_info=True)
-        self._has_cost = all(name in existing for name, _ in _MIGRATION_COLUMNS)
+        # Scope cost to the cost columns only (NOT "all optional present"): with
+        # c_images now in _MIGRATION_COLUMNS an all-present check would flip cost
+        # off on a cost-capable DB that merely lacks images.
+        self._has_cost = all(n in existing for n in ("cost_micro", "cost_known"))
+        self._present_optional = frozenset(
+            name for name, _ in _MIGRATION_COLUMNS if name in existing
+        )
+        self._rebuild_insert_plan()
+
+    def _rebuild_insert_plan(self) -> None:
+        """Recompute the insert SQL + value selector from ``_present_optional``.
+
+        The insert columns are ``_CALL_COLUMNS`` minus any optional column absent
+        on this DB, in the SAME order; ``_insert_indices`` picks the matching
+        values out of ``_row_values``' full tuple so the row and the column list
+        stay aligned. One selector drives the general degraded path — no bespoke
+        ``_NO_COST``/``_NO_IMAGES`` variant per column, which is the whole point
+        of Option A.
+        """
+
+        # A column is KEPT when it is not optional (always present) or it is an
+        # optional column that this DB actually has.
+        def _keep(col: str) -> bool:
+            return col not in _OPTIONAL_COLUMN_NAMES or col in self._present_optional
+
+        self._insert_indices = tuple(i for i, c in enumerate(_CALL_COLUMNS) if _keep(c))
+        columns = [_CALL_COLUMNS[i] for i in self._insert_indices]
+        self._insert_sql = (
+            f"INSERT INTO calls ({', '.join(columns)}) "
+            f"VALUES ({', '.join('?' for _ in columns)})"
+        )
 
     @staticmethod
     def _now_ms() -> int:
@@ -544,15 +603,14 @@ class AnalyticsStore:
             day, month = _local_day_month(int(snap.ts_ms))
             daily_rows.append(_rollup_row_values(snap, day, cm, ck))
             monthly_rows.append(_rollup_row_values(snap, month, cm, ck))
-        if self._has_cost:
-            insert_sql = _INSERT_SQL
-        else:
-            # Migration to add the cost columns failed: drop the two cost values
-            # so the insert matches the older table shape (review C2).
-            insert_sql = _INSERT_SQL_NO_COST
-            rows = [
-                tuple(v for i, v in enumerate(row) if i not in _COST_VALUE_INDICES) for row in rows
-            ]
+        # Option A: the insert SQL and the value selector were computed once in
+        # ``_migrate`` from the columns this DB actually has. Select exactly the
+        # present columns' values out of each full row tuple, so an absent
+        # optional column (failed cost or images migration) is dropped from both
+        # the SQL and the row rather than referenced and failing every write.
+        insert_sql = self._insert_sql
+        if len(self._insert_indices) != len(_CALL_COLUMNS):
+            rows = [tuple(row[i] for i in self._insert_indices) for row in rows]
         for attempt in range(_WRITE_RETRIES):
             try:
                 conn.executemany(insert_sql, rows)
@@ -740,7 +798,17 @@ class AnalyticsStore:
             params.append(session_id)
         clause = (" WHERE " + " AND ".join(where)) if where else ""
 
-        component_sum = ", ".join(f"SUM(c_{key})" for key in COMPONENT_KEYS)
+        # Substitute a constant 0 for any optional component column this DB lacks
+        # (a failed/old-DB migration, review C2 generalised): an absent ``c_*``
+        # reads as 0 rather than failing the whole query on a missing column. The
+        # base ``c_*`` columns (the original eight) are not optional and always
+        # summed. Positions stay a contract with ``_aggregate_from_row``.
+        def _component_expr(key: str) -> str:
+            col = f"c_{key}"
+            present = col not in _OPTIONAL_COLUMN_NAMES or col in self._present_optional
+            return f"SUM({col})" if present else "0"
+
+        component_sum = ", ".join(_component_expr(key) for key in COMPONENT_KEYS)
         # Order is a contract with ``_aggregate_from_row``, which indexes this
         # tuple positionally: cost_micro and cost_known_calls come after the
         # token sums and before the component sums. When the cost columns are

--- a/local_operator/tui/widgets/analytics_panel.py
+++ b/local_operator/tui/widgets/analytics_panel.py
@@ -467,10 +467,15 @@ def build_report(
     calls_meta += " · measured"
     lines.append(_section_header("Totals", calls_meta))
 
+    # Value cells share a gutter so notes line up even when compact figures
+    # differ in width (``3M`` vs ``387k``). 11 cells matches the existing
+    # ``3.7M tokens`` / ``$18.40`` slot; a longer value just grows the cell.
+    _VALUE_CELL = 11
+
     def kv(name: str, value: str, note: str = "") -> Text:
         row = Text()
         row.append(f"  {name:<22}", style=dim)
-        row.append(value, style=fg)
+        row.append(f"{value:<{_VALUE_CELL}}", style=fg)
         if note:
             # ``dim`` not ``faint`` (D2): the note carries the actual cache and
             # thinking/generation breakdown — the substance a diagnostics reader
@@ -497,31 +502,43 @@ def build_report(
     # it as user messages would be wrong. ``kv`` pads the name to 22 uniformly,
     # so the leading space + tree glyph on the sub-rows indents them while the
     # values stay column-aligned.
+    #
+    # Fresh is ``aggregate.fresh_tokens`` (context − cache_read − cache_write),
+    # not ``input_tokens``: providers disagree on whether input already includes
+    # cache, so binding Fresh to input would show the FULL context on OpenAI-
+    # shaped usage. The three children partition the parent on every provider.
+    # The Context-read note restates that composition so compact formatting
+    # (387k + 3M + 113k all printing as 3.5M / 3M) cannot hide the sum.
+    fresh = aggregate.fresh_tokens
+    cache_read = aggregate.cache_read_tokens
+    cache_write = aggregate.cache_write_tokens
     lines.append(
         kv(
             "Context read",
             format_tokens(aggregate.context_tokens),
-            "full input read, all calls summed",
+            f"{format_tokens(fresh)} fresh · "
+            f"{format_tokens(cache_read)} cached · "
+            f"{format_tokens(cache_write)} written",
         )
     )
     lines.append(
         kv(
             " ├ Fresh (uncached)",
-            format_tokens(aggregate.input_tokens),
+            format_tokens(fresh),
             "new input, billed at full rate",
         )
     )
     lines.append(
         kv(
             " ├ Cache read",
-            format_tokens(aggregate.cache_read_tokens),
+            format_tokens(cache_read),
             "input served from cache",
         )
     )
     lines.append(
         kv(
             " └ Cache write",
-            format_tokens(aggregate.cache_write_tokens),
+            format_tokens(cache_write),
             "new input written to cache",
         )
     )
@@ -554,9 +571,14 @@ def build_report(
         cost_note = "no published price"
     # Built directly (not via ``kv``) so the lower-bound ``+`` is dimmed like the
     # table cells (review D1) — the figure reads as a number, the ``+`` as a flag.
+    # ``_append_cost`` right-aligns (table cells); here we pass the figure's own
+    # width so it left-aligns with the token values, then pad out to
+    # ``_VALUE_CELL`` so the cost note shares the gutter (D2).
+    cost_text = format_cost(aggregate)
     cost_row = Text()
     cost_row.append(f"  {'Est. cost':<22}", style=dim)
-    _append_cost(cost_row, aggregate, len(format_cost(aggregate)), fg, dim)
+    _append_cost(cost_row, aggregate, len(cost_text), fg, dim)
+    cost_row.append(" " * max(0, _VALUE_CELL - len(cost_text)))
     cost_row.append(f"  {cost_note}", style=dim)
     lines.append(cost_row)
     lines.append(Text())

--- a/local_operator/tui/widgets/analytics_panel.py
+++ b/local_operator/tui/widgets/analytics_panel.py
@@ -478,13 +478,51 @@ def build_report(
             row.append(f"  {note}", style=dim)
         return row
 
-    lines.append(kv("Total billed", format_tokens(aggregate.total_tokens) + " tokens"))
     lines.append(
         kv(
-            "Input",
+            "Total billed",
+            format_tokens(aggregate.total_tokens) + " tokens",
+            f"{format_tokens(aggregate.context_tokens)} in · "
+            f"{format_tokens(aggregate.output_tokens)} out",
+        )
+    )
+    # NESTED input breakdown. The old flat "Input NNN" row read as "total input"
+    # and, at a 97% cache-hit rate, showed a tiny number (only the fresh/uncached
+    # slice) that looked like a bug. All three sub-values are AUTHORITATIVE
+    # provider counts (not estimates), so the tree makes explicit that the small
+    # "Fresh (uncached)" figure sits UNDER the full "Context read" total, with
+    # cache reads/writes as its siblings. The wording is deliberate: "Fresh
+    # (uncached)" is ALL uncached input (new user turns plus freshly-added tool
+    # results/reads/system content not yet cached), NOT "user input" — labelling
+    # it as user messages would be wrong. ``kv`` pads the name to 22 uniformly,
+    # so the leading space + tree glyph on the sub-rows indents them while the
+    # values stay column-aligned.
+    lines.append(
+        kv(
+            "Context read",
+            format_tokens(aggregate.context_tokens),
+            "full input read, all calls summed",
+        )
+    )
+    lines.append(
+        kv(
+            " ├ Fresh (uncached)",
             format_tokens(aggregate.input_tokens),
-            f"+{format_tokens(aggregate.cache_read_tokens)} cache read, "
-            f"{format_tokens(aggregate.cache_write_tokens)} cache write",
+            "new input, billed at full rate",
+        )
+    )
+    lines.append(
+        kv(
+            " ├ Cache read",
+            format_tokens(aggregate.cache_read_tokens),
+            "input served from cache",
+        )
+    )
+    lines.append(
+        kv(
+            " └ Cache write",
+            format_tokens(aggregate.cache_write_tokens),
+            "new input written to cache",
         )
     )
     lines.append(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.26.0"
+version = "0.27.0"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/analytics/test_model.py
+++ b/tests/unit/analytics/test_model.py
@@ -262,6 +262,33 @@ def test_aggregate_generation_never_negative():
     assert agg.generation_tokens == 0
 
 
+def test_fresh_tokens_independent_of_provider_input_shape():
+    # Anthropic: input already excludes cache, so fresh == input.
+    anthropic = UsageAggregate(
+        input_tokens=5_000,
+        cache_read_tokens=90_000,
+        cache_write_tokens=5_000,
+        context_tokens=100_000,
+    )
+    assert anthropic.fresh_tokens == 5_000
+    # OpenAI: input already includes cache, so fresh is the remainder.
+    openai = UsageAggregate(
+        input_tokens=100_000,
+        cache_read_tokens=80_000,
+        cache_write_tokens=0,
+        context_tokens=100_000,
+    )
+    assert openai.fresh_tokens == 20_000
+    # Never negative even if a provider over-reports cache against context.
+    over = UsageAggregate(
+        input_tokens=10,
+        cache_read_tokens=80,
+        cache_write_tokens=30,
+        context_tokens=100,
+    )
+    assert over.fresh_tokens == 0
+
+
 def test_callsnapshot_is_frozen_scalars():
     # The snapshot is handed to a background thread; it must be a plain value.
     snap = CallSnapshot(

--- a/tests/unit/analytics/test_model.py
+++ b/tests/unit/analytics/test_model.py
@@ -20,6 +20,7 @@ from local_operator.analytics.model import (
 from local_operator.harness.types import (
     AgentTool,
     ChatRequest,
+    ImageContent,
     Message,
     ModelSpec,
     TextContent,
@@ -126,6 +127,49 @@ def test_snapshot_component_chars_separates_regions():
     assert chars["tool_results"] == len("command output")
     # Tool schema is name + description + compact params JSON, and is nonzero.
     assert chars["tool_schemas"] > len("bash") + len("run a shell command")
+    # No image blocks here, so the images bucket is empty.
+    assert chars["images"] == 0
+
+
+def test_snapshot_component_chars_splits_images_from_text():
+    # An image block in a message must attribute to ``images``, NOT to the text
+    # bucket the message sits in — and the text chars beside it must stay in
+    # that text bucket. This is the double-counting guard: apportionment splits
+    # a fixed total by chars, so an image counted in both would over-weight its
+    # text bucket. Images come from BOTH conversation and tool messages.
+    request = ChatRequest(
+        model=ModelSpec(provider="anthropic", model_id="m"),
+        system_blocks=["", "", "", ""],
+        messages=[
+            Message(
+                role="user",
+                content=[
+                    TextContent(text="look at this"),
+                    ImageContent(data="deadbeef", mime_type="image/png"),
+                ],
+            ),
+            Message(
+                role="tool",
+                tool_call_id="t1",
+                tool_name="screenshot",
+                content=[
+                    TextContent(text="captured"),
+                    ImageContent(data="cafe", mime_type="image/png"),
+                ],
+            ),
+        ],
+        tools=[],
+    )
+    chars = snapshot_component_chars(request)
+    # Text chars stay in their own buckets, unaffected by the images beside them.
+    assert chars["conversation"] == len("look at this")
+    assert chars["tool_results"] == len("captured")
+    # Two image blocks (one conversation, one tool) sum into ``images`` and
+    # nowhere else — the flat char proxy per image, so a positive multiple of 2.
+    assert chars["images"] > 0
+    assert chars["images"] % 2 == 0
+    # The image chars are NOT also folded into the text buckets (the guard).
+    assert chars["conversation"] + chars["tool_results"] == len("look at this") + len("captured")
 
 
 def test_aggregate_generation_and_cache_rate():

--- a/tests/unit/analytics/test_store.py
+++ b/tests/unit/analytics/test_store.py
@@ -267,8 +267,14 @@ def test_recording_degrades_when_component_column_absent(tmp_path):
 
     store = AnalyticsStore(db)
     store._connect()  # runs the migration, which would normally add c_images
-    # Force the degraded path: pretend the c_images ALTER failed. Rebuild the
-    # insert plan from the narrowed set, exactly as _migrate would on a failure.
+    # Drop the column the migration just added so the insert actually hits a
+    # table that lacks it. Flipping ``_present_optional`` alone left the
+    # column in place, so a broken insert plan that still named ``c_images``
+    # would still return record_batch == 1.
+    conn = store._connect()
+    assert conn is not None
+    conn.execute("ALTER TABLE calls DROP COLUMN c_images")
+    conn.commit()
     from local_operator.analytics.store import _OPTIONAL_COLUMN_NAMES
 
     store._present_optional = _OPTIONAL_COLUMN_NAMES - {"c_images"}
@@ -312,10 +318,15 @@ def test_recording_degrades_when_cost_columns_absent(tmp_path):
 
     store = AnalyticsStore(db)
     store._connect()  # runs the migration, which will add the columns
-    # Force the Option A degraded path: pretend the cost ALTERs failed. Rebuild
-    # the insert plan from the narrowed set so the write drops cost columns
-    # rather than referencing them (the old `_has_cost` flag only steers the
-    # aggregate's 0-substitute now).
+    # Drop the cost columns the migration just added so the insert actually
+    # hits a table that lacks them. Flipping ``_has_cost`` / ``_present_optional``
+    # alone left the columns in place, so a broken insert plan that still
+    # named them would still return record_batch == 1.
+    conn = store._connect()
+    assert conn is not None
+    conn.execute("ALTER TABLE calls DROP COLUMN cost_micro")
+    conn.execute("ALTER TABLE calls DROP COLUMN cost_known")
+    conn.commit()
     from local_operator.analytics.store import _OPTIONAL_COLUMN_NAMES
 
     store._has_cost = False

--- a/tests/unit/analytics/test_store.py
+++ b/tests/unit/analytics/test_store.py
@@ -66,6 +66,14 @@ def test_record_and_aggregate_roundtrip(tmp_path):
     # Component split was apportioned against context at write time and sums
     # back to the context total.
     assert sum(agg.components.values()) == agg.context_tokens
+    # Images is a first-class component in the roundtrip: image chars apportion
+    # to it and read back non-zero.
+    store2 = AnalyticsStore(tmp_path / "img.db")
+    assert (
+        store2.record_batch([_snap(context=1000, chars={"conversation": 500, "images": 500})]) == 1
+    )
+    assert store2.aggregate().components["images"] > 0
+    store2.close()
     store.close()
 
 
@@ -168,6 +176,116 @@ def test_migration_adds_cost_columns_to_old_db(tmp_path):
     store.close()
 
 
+#: The eight component columns a pre-``images`` DB had, so a migration test can
+#: build a genuinely old schema (``_COMPONENT_COLUMNS`` now includes c_images and
+#: would not reproduce the missing-column case). Order matches the original
+#: COMPONENT_KEYS before ``images`` was appended.
+_PRE_IMAGES_COMPONENT_COLUMNS = ",\n  ".join(
+    f"c_{key} INTEGER NOT NULL DEFAULT 0"
+    for key in (
+        "system_prompt",
+        "custom_instructions",
+        "tool_inventory",
+        "tool_schemas",
+        "environment",
+        "knowledge",
+        "conversation",
+        "tool_results",
+    )
+)
+
+
+def test_migration_adds_images_column_to_old_db(tmp_path):
+    # A DB written before the images component existed has c_* columns for the
+    # original eight only. Opening it must ALTER c_images in, read old rows as
+    # images 0, and record new calls WITH an images estimate — never raise on a
+    # missing column.
+    import sqlite3
+
+    db = tmp_path / "preimages.db"
+    conn = sqlite3.connect(str(db))
+    conn.executescript(f"""
+        CREATE TABLE calls (
+          id INTEGER PRIMARY KEY AUTOINCREMENT, ts_ms INTEGER, session_id TEXT,
+          provider TEXT, model_id TEXT, ok INTEGER, input_tokens INTEGER,
+          output_tokens INTEGER, cache_read_tokens INTEGER, cache_write_tokens INTEGER,
+          reasoning_tokens INTEGER, context_tokens INTEGER,
+          cost_micro INTEGER NOT NULL DEFAULT 0, cost_known INTEGER NOT NULL DEFAULT 0,
+          {_PRE_IMAGES_COMPONENT_COLUMNS}
+        );
+        CREATE TABLE session_names (
+          session_id TEXT PRIMARY KEY, name TEXT, updated_at_ms INTEGER
+        );
+        """)
+    # An old row: its image tokens (if any) stayed baked into the text-bucket
+    # estimates it was recorded with; it reads images 0 after migration.
+    conn.execute(
+        "INSERT INTO calls (ts_ms, session_id, provider, model_id, ok, input_tokens, "
+        "output_tokens, context_tokens, c_conversation) "
+        "VALUES (1, 's', 'anthropic', 'm', 1, 100, 20, 120, 120)"
+    )
+    conn.commit()
+    conn.close()
+
+    store = AnalyticsStore(db)
+    agg = store.aggregate()
+    assert agg.calls == 1
+    assert agg.components["images"] == 0  # old row forward-fills to images 0
+    # A new call carrying image chars records a non-zero images estimate into the
+    # migrated column.
+    assert (
+        store.record_batch([_snap(context=1000, chars={"conversation": 500, "images": 500})]) == 1
+    )
+    assert store.aggregate().components["images"] > 0
+    store.close()
+
+
+def test_recording_degrades_when_component_column_absent(tmp_path):
+    # Option A: a missing OPTIONAL component column (here c_images) must degrade
+    # the same way a missing cost column does — the column is dropped from the
+    # insert and read as 0 in the aggregate, never failing the write. Simulated
+    # by pretending the images migration failed while the rest is present.
+    import sqlite3
+
+    db = tmp_path / "noimages.db"
+    conn = sqlite3.connect(str(db))
+    conn.executescript(f"""
+        CREATE TABLE calls (
+          id INTEGER PRIMARY KEY AUTOINCREMENT, ts_ms INTEGER, session_id TEXT,
+          provider TEXT, model_id TEXT, ok INTEGER, input_tokens INTEGER,
+          output_tokens INTEGER, cache_read_tokens INTEGER, cache_write_tokens INTEGER,
+          reasoning_tokens INTEGER, context_tokens INTEGER,
+          cost_micro INTEGER NOT NULL DEFAULT 0, cost_known INTEGER NOT NULL DEFAULT 0,
+          {_PRE_IMAGES_COMPONENT_COLUMNS}
+        );
+        CREATE TABLE session_names (
+          session_id TEXT PRIMARY KEY, name TEXT, updated_at_ms INTEGER
+        );
+        """)
+    conn.commit()
+    conn.close()
+
+    store = AnalyticsStore(db)
+    store._connect()  # runs the migration, which would normally add c_images
+    # Force the degraded path: pretend the c_images ALTER failed. Rebuild the
+    # insert plan from the narrowed set, exactly as _migrate would on a failure.
+    from local_operator.analytics.store import _OPTIONAL_COLUMN_NAMES
+
+    store._present_optional = _OPTIONAL_COLUMN_NAMES - {"c_images"}
+    store._rebuild_insert_plan()
+    # A call with image chars still records — images just degrade to 0.
+    assert (
+        store.record_batch([_snap(context=1000, chars={"conversation": 500, "images": 500})]) == 1
+    )
+    agg = store.aggregate()
+    assert agg.calls == 1
+    assert agg.context_tokens == 1000  # token analytics survive
+    assert agg.components["images"] == 0  # images degraded to 0, not a crash
+    # Cost is unaffected: only the images column was dropped.
+    assert agg.cost_is_known is True
+    store.close()
+
+
 def test_recording_degrades_when_cost_columns_absent(tmp_path):
     # C2: if the cost columns cannot be added (simulated by forcing _has_cost
     # False against a table that lacks them), recording must NOT fail every
@@ -194,8 +312,15 @@ def test_recording_degrades_when_cost_columns_absent(tmp_path):
 
     store = AnalyticsStore(db)
     store._connect()  # runs the migration, which will add the columns
-    # Force the degraded path: pretend the migration failed.
+    # Force the Option A degraded path: pretend the cost ALTERs failed. Rebuild
+    # the insert plan from the narrowed set so the write drops cost columns
+    # rather than referencing them (the old `_has_cost` flag only steers the
+    # aggregate's 0-substitute now).
+    from local_operator.analytics.store import _OPTIONAL_COLUMN_NAMES
+
     store._has_cost = False
+    store._present_optional = _OPTIONAL_COLUMN_NAMES - {"cost_micro", "cost_known"}
+    store._rebuild_insert_plan()
     assert store.record_batch([_snap(input_tokens=100, cost_micro=999, cost_known=True)]) == 1
     agg = store.aggregate()
     assert agg.calls == 1

--- a/tests/unit/tui/test_analytics_panel.py
+++ b/tests/unit/tui/test_analytics_panel.py
@@ -247,6 +247,78 @@ def test_thinking_generation_split_shown():
     assert "generation" in text and "thinking" in text
 
 
+def test_fresh_is_uncached_slice_on_openai_shaped_usage():
+    # OpenAI-shaped: cache is already folded into input, so context == input.
+    # Fresh must be context − cache_read − cache_write (20k), NOT input (100k).
+    agg = UsageAggregate(
+        calls=10,
+        ok_calls=10,
+        input_tokens=100_000,
+        output_tokens=5_000,
+        cache_read_tokens=80_000,
+        cache_write_tokens=0,
+        context_tokens=100_000,
+        cost_micro=1_000_000,
+        cost_known_calls=10,
+    )
+    assert agg.fresh_tokens == 20_000
+    text = _text(agg)
+    assert "20k" in text
+    # The Fresh row itself must not show the full 100k as its value.
+    fresh_line = next(line for line in text.splitlines() if "Fresh (uncached)" in line)
+    assert "20k" in fresh_line
+    assert "100k" not in fresh_line
+    # The three children partition Context read (20k + 80k + 0 == 100k).
+    assert agg.fresh_tokens + agg.cache_read_tokens + agg.cache_write_tokens == (agg.context_tokens)
+    context_line = next(line for line in text.splitlines() if "Context read" in line)
+    assert "20k fresh" in context_line
+    assert "80k cached" in context_line
+    assert "0 written" in context_line
+
+
+def test_fresh_equals_input_on_anthropic_shaped_usage():
+    # Anthropic: context = input + cache_read + cache_write, so fresh == input.
+    # The shared ``_agg()`` fixture is close but does not partition (500k + 3M
+    # + 80k ≠ 3.5M), so this case is built to actually sum.
+    agg = UsageAggregate(
+        calls=100,
+        ok_calls=100,
+        input_tokens=387_000,
+        output_tokens=210_000,
+        cache_read_tokens=3_000_000,
+        cache_write_tokens=113_000,
+        context_tokens=3_500_000,
+        cost_micro=1_000_000,
+        cost_known_calls=100,
+    )
+    assert agg.fresh_tokens == agg.input_tokens == 387_000
+    assert agg.fresh_tokens + agg.cache_read_tokens + agg.cache_write_tokens == agg.context_tokens
+    text = _text(agg)
+    fresh_line = next(line for line in text.splitlines() if "Fresh (uncached)" in line)
+    assert "387k" in fresh_line
+    context_line = next(line for line in text.splitlines() if "Context read" in line)
+    assert "387k fresh" in context_line
+    assert "3M cached" in context_line
+    assert "113k written" in context_line
+
+
+def test_totals_value_cells_share_a_note_gutter():
+    # D2: a short value (``3M``) must not pull its note left of a longer
+    # sibling (``387k`` / ``500k``). Notes share one column after the pad.
+    text = _text(_agg())
+    rows = [
+        next(line for line in text.splitlines() if needle in line)
+        for needle in ("Fresh (uncached)", "Cache read", "Cache write")
+    ]
+    notes = (
+        "new input, billed at full rate",
+        "input served from cache",
+        "new input written to cache",
+    )
+    starts = [row.index(note) for row, note in zip(rows, notes)]
+    assert len(set(starts)) == 1, rows
+
+
 async def _push(pilot, app, agg, *, daily=None, monthly=None):
     await pilot.pause()
     screen = AnalyticsScreen(agg, daily=daily, monthly=monthly)

--- a/tests/unit/tui/test_analytics_panel.py
+++ b/tests/unit/tui/test_analytics_panel.py
@@ -42,6 +42,7 @@ def _agg() -> UsageAggregate:
     agg.components["tool_results"] = 900_000
     agg.components["system_prompt"] = 500_000
     agg.components["tool_schemas"] = 300_000
+    agg.components["images"] = 400_000
     sub = UsageAggregate(
         calls=100,
         input_tokens=500_000,
@@ -195,11 +196,23 @@ def test_report_shows_totals_and_split():
     assert "(2 failed)" in text
     # authoritative headline numbers
     assert "Cache hit rate" in text
+    # NESTED input breakdown: the flat "Input" row is gone; the full context
+    # read is the parent and fresh/cache-read/cache-write are its sub-rows. The
+    # small "Fresh (uncached)" figure must be unmistakably the uncached slice,
+    # never labelled as "Input" (which read as a total) or "user input".
+    assert "Context read" in text
+    assert "Fresh (uncached)" in text
+    assert "Cache read" in text
+    assert "Cache write" in text
+    # The old flat label must not survive as a standalone Totals row.
+    assert not any(line.strip().startswith("Input ") for line in text.splitlines())
     # the estimated component split, largest first
     assert "Where input went" in text
     assert "estimated" in text
     assert "Conversation" in text
     assert "System prompt" in text
+    # image-vs-text split surfaces once image tokens are present
+    assert "Images (est.)" in text
     # per-provider and per-session tables
     assert "By provider" in text
     assert "anthropic" in text


### PR DESCRIPTION
## Why

The Totals block showed `Input 38.7k` on a 97% cache-hit run and looked like a calc bug. It is not: `input_tokens` is the FRESH/uncached slice, and almost everything else is `cache_read`. The label just read as "total input." The operator asked to (1) relabel so the small number is unmistakably fresh/uncached — **not** "user input", it is all uncached input — (2) make reads/cached-reads/output first-class, (3) split image-vs-text token consumption, (4) keep more granular breakdowns so it is obvious where tokens go.

## What changes

**Totals block (nested layout).** Replaces the flat `Input` row. All three sub-values are authoritative provider counts; `· measured` stays in the section meta.

- `Total billed` → `N tokens` with `Xin · Yout`
- `Context read` → full input read, all calls summed
- ` ├ Fresh (uncached)` → new input, billed at full rate
- ` ├ Cache read` → input served from cache
- ` └ Cache write` → new input written to cache
- `Output` / `Cache hit rate` / `Est. cost` unchanged

**Image-vs-text split.** `images` is a 9th component, **appended** so existing `c_*` column positions stay stable. Image chars are pulled OUT of the conversation/tool_results text buckets (apportionment splits a fixed `context_tokens` by total chars — double-counting would over-weight those buckets). Old rows read `c_images=0`; their image tokens stay baked into the historical text estimates (forward-fill).

**Store migration (Option A).** `c_images` is ALTERed onto existing DBs. `_has_cost` is scoped to `cost_micro`/`cost_known` so adding `c_images` to `_MIGRATION_COLUMNS` cannot conflate "cost present" with "images present". The cost-specific `_INSERT_SQL_NO_COST` path is replaced by a column-set-driven insert: `_migrate` records which optional columns are actually present; `record_batch`/`aggregate` drop or 0-substitute any that are missing. Same C2 "analytics must never break a turn" guarantee, no `_NO_COST × _NO_IMAGES` variant explosion. Rollup tables are untouched (they carry no `c_*` columns).

Version bump is **MINOR** (0.26.0 → 0.27.0): new first-class breakdowns on an existing surface. 0.26.0 is already taken by #276.

## Impact

- Existing DBs migrate in place; old rows keep their baked-in text estimates and show `Images (est.)` only once new image-bearing calls are recorded.
- A failed ALTER on any optional column degrades that column to 0 rather than failing every write.
- `_component_rows` is unchanged — `Images (est.)` appears automatically when `components["images"] > 0`.

## Testing Details

### Rendered `/analytics /usage` (real `OperatorApp`, `run_test` + `save_screenshot`)

High cache-hit aggregate (Fresh 387k under Context read 3.5M) **and** image tokens present so `Images (est.)` shows in the split. Geometry: `screen.size == virtual_size` (118×42), `vscroll=False` — no clip, no scrollbar.

**Before** — flat `Input 387k` reads as a total:

![before](https://raw.githubusercontent.com/damianvtran/local-operator/pr-analytics-breakdown-assets/assets/lop-before-view.png)

**After** — nested tree, values column-aligned, `Images (est.)` in the split:

![after](https://raw.githubusercontent.com/damianvtran/local-operator/pr-analytics-breakdown-assets/assets/lop-after-view.png)

SVG stills (same frames): [`lop-before.svg`](https://raw.githubusercontent.com/damianvtran/local-operator/pr-analytics-breakdown-assets/assets/lop-before.svg) · [`lop-after.svg`](https://raw.githubusercontent.com/damianvtran/local-operator/pr-analytics-breakdown-assets/assets/lop-after.svg)

### New / updated tests

- `test_model.py`: apportion still sums to context (now includes `images`); new test — an `image` content block attributes to `images`, not conversation/tool_results; text chars stay in their bucket.
- `test_store.py`: `c_images` is ALTERed into an old DB and old rows read `images==0`; roundtrip includes images; Option A degraded path covers an absent component column **and** absent cost columns.
- `test_analytics_panel.py`: Totals asserts `Context read` / `Fresh (uncached)` / `Cache read` / `Cache write`; the old standalone `Input` row is gone; `Images (est.)` appears when `components["images"]>0`.

### Gates (worktree, all clean)

- `flake8` → 0
- `black==26.1.0 --check` → 455 files unchanged
- `isort --check-only --profile black` → 0
- `pyright` → 0 errors, 0 warnings
- `tests/unit/analytics` → **56 passed**
- `tests/unit/tui/test_analytics_panel.py` → **33 passed** (`env -u NO_COLOR TERM=xterm-256color`)
- focused re-run after Option A cost-degrade tightening → **76 passed**

Do not merge — review gate + release are the manager's.
