### PR TITLE
feat(tui): title the session theme, not the newest message

### DIFF
--- a/local_operator/session/naming.py
+++ b/local_operator/session/naming.py
@@ -26,12 +26,22 @@ because the obvious implementation gets it wrong:
   :func:`provisional_title` names the conversation from the opener the instant
   it is submitted — no network at all — and the model's title now lands a
   second or two later, concurrently with the turn, rather than after it.
-- **A conversation drifts, so a title has to be allowed to.**
-  :func:`generate_retitle` gives the model the current title and a new message
-  and lets IT judge whether the subject or the goals have materially moved.
-  That judgement is not expressible as a keyword rule, and a title still
-  naming the first of five subjects misidentifies the session rather than
-  merely under-describing it.
+- **A conversation drifts, so a title has to be allowed to — toward the THEME,
+  not the newest message.** :func:`generate_retitle` gives the model a sampled
+  ``<chat>`` of the whole trajectory (the opening turns, which state the
+  subject, plus a recent tail) anchored on the CURRENT title, and lets IT judge
+  whether the body of work has genuinely moved on. That judgement is not
+  expressible as a keyword rule. The earlier design showed the model only the
+  single newest message, so an IN-GOAL step read as a brand-new subject: a
+  session building a web-fetch tool got renamed to "Find Port Credit
+  restaurants" the moment the user exercised the tool, then again on the next
+  follow-up, each pivot compounding because the next check anchored on the
+  already-drifted title. Titling the whole trajectory against the current-title
+  anchor is what keeps a drifting session named after what it is actually
+  about. The three parts that make this work — whole-trajectory context, the
+  current-title anchor, and the caller's growth-gated refresh schedule — each
+  fail alone; see :func:`build_theme_context`, :data:`THEME_SYSTEM_PROMPT`,
+  and :func:`should_refresh_theme`.
 
 The holder (:class:`ConversationName`) mirrors ``GoalState``: a small mutable
 object the session and its host share, so a name that lands asynchronously is
@@ -46,6 +56,18 @@ from __future__ import annotations
 import asyncio
 import re
 from dataclasses import dataclass
+from typing import Any, Sequence
+
+#: A history entry as the theme sampler reads it. Deliberately ``Any`` and
+#: duck-typed via ``getattr`` rather than a ``Protocol`` or an import of the
+#: harness ``AgentMessage`` union: the sampler only ever needs ``.role`` and
+#: ``.text``, and a ``CustomMessage`` in that union legitimately carries no
+#: ``role`` at all (it is filtered out here, not type-excluded). Typing this as
+#: the real union would either drag a harness dependency into what is meant to
+#: be a leaf module or fail to describe the role-less custom entries; reading
+#: the two attributes defensively is both honest and keeps naming standalone.
+_Turn = Any
+
 
 #: Hard caps on a stored title. Both are enforced as REJECTION, not
 #: truncation: see the module docstring.
@@ -99,20 +121,66 @@ TITLE_SYSTEM_PROMPT = (
     "No quotes, no trailing punctuation."
 )
 
-#: The system block for a RE-titling call. It carries the current title and
-#: asks the model — not a keyword heuristic here — whether the subject or the
-#: goals have materially moved. Keeping the sentinel as "no change" makes the
-#: common answer the cheapest one to produce and the cheapest one to parse:
-#: `parse_title` already reads `<title/>` as "no title from this call".
-RETITLE_SYSTEM_PROMPT = (
-    "A conversation is titled: {current}\n"
-    "Given the user's new message, decide if the SUBJECT or GOALS have "
-    "materially changed.\n"
-    "Unchanged, or a follow-up on the same subject: reply exactly <title/>.\n"
-    "Materially changed: reply with only <title>3 to 7 words</title> naming "
-    "the new subject.\n"
-    "No quotes, no trailing punctuation."
+#: The system block for a RE-titling call, ported from the omp coding-agent's
+#: proven ``title-theme-system`` prompt. It titles the WHOLE body of work rather
+#: than the newest message, which is the fix for the drift the old prompt
+#: caused: shown only the latest message, the model read every in-goal step as a
+#: new subject. The user message that rides beside this block is a sampled
+#: ``<chat>`` trajectory (see :func:`build_theme_context`) that already carries a
+#: ``<current-title>`` anchor, so the anchor lives in the DATA, not here — the
+#: system block only has to teach the model what the scaffolding means and to
+#: repeat the anchor verbatim unless the subject genuinely moved. Keeping the
+#: ``<title/>`` sentinel as "no change" makes the common answer the cheapest one
+#: to produce and to parse: `parse_title` already reads it as "no title from
+#: this call", and `generate_retitle` also folds a verbatim restatement of the
+#: current title back onto that sentinel.
+THEME_SYSTEM_PROMPT = (
+    "Write a 3 to 7 word title for the overall theme of the conversation in "
+    "<chat>. Title the whole body of work, not the most recent message.\n"
+    "<current-title> is the name this conversation already has. Repeat it "
+    "verbatim unless the work has moved to a different subject. A new step, "
+    "file, question, or tool call inside the same body of work is NOT a "
+    "different subject.\n"
+    "The earliest turns establish the subject; later turns only refine it. "
+    "<elided/> marks turns left out.\n"
+    "Never title one file, error, or tool call the conversation happened to "
+    "touch.\n"
+    "Reply with only <title>3 to 7 words</title>. No task, just small talk: "
+    "reply exactly <title/>.\n"
+    "Capitalize only the first word and names. No quotes, no trailing "
+    "punctuation."
 )
+
+#: How many turns to sample from each end of the trajectory for the theme
+#: context, ported from omp's ``THEME_CONTEXT_HEAD_TURNS`` / ``_TAIL_TURNS``.
+#: The HEAD is what states the subject — the opening request is the only turn
+#: that says what the session is FOR rather than a step inside it — so it is
+#: kept larger relative to the tail, which merely refines the theme or shows a
+#: genuine change of subject. A tail-only window is precisely why the old design
+#: chased the newest message: by turn 40 the opener had scrolled out entirely,
+#: leaving the model to name whatever the last message touched.
+THEME_HEAD_TURNS = 3
+THEME_TAIL_TURNS = 4
+
+#: Per-turn character budget inside the sampled ``<chat>``. The whole point of
+#: the retitle call staying cheap is that it never grows with the conversation:
+#: a handful of turns, each trimmed to a sentence or two, is enough to state a
+#: theme, and an unbounded sample would put a pasted log back into the call
+#: `MAX_PROMPT_CHARS` exists to keep out. Bounded PER TURN, not on the assembled
+#: envelope, so the head turns the sampler exists to preserve are never the ones
+#: cut (they are usually the long ones).
+THEME_TURN_CHARS = 240
+
+#: Longest ``<current-title>`` embedded in the context. A stored title is capped
+#: at `MAX_TITLE_CHARS` (80) but a `user_set` rename can reach it, so the anchor
+#: is bounded like any other body rather than trusted to be short.
+THEME_CURRENT_TITLE_CHARS = 120
+
+#: The self-closing marker standing in for the turns dropped between the head
+#: and the tail. Two disjoint fragments presented as adjacent read as an abrupt
+#: topic switch and invite exactly the drift this sampler exists to prevent, so
+#: the gap is always marked when anything falls between the two halves.
+_ELIDED_MARKER = "<elided/>"
 
 #: How much of a message the naming call sees. Was 2000, which made the cheap
 #: call the expensive one on exactly the input most likely to be pasted: a log.
@@ -418,6 +486,129 @@ def _errand_prompt(text: str) -> str:
     return " ".join((text or "").split())[:MAX_PROMPT_CHARS]
 
 
+#: Growth-gated refresh schedule, ported from omp's ``session-titling``. These
+#: three numbers together produce a geometric spacing: with the transcript
+#: turn-count stamped at each titling, a session is titled at turn 1, then
+#: eligible to refresh at >=6, >=16, >=36, >=76, >=156, then never. The spacing
+#: is deliberate — an early session is still deciding what it is about and
+#: should re-title cheaply, while a long-running one has an established identity
+#: and its name must stop tracking the cursor. See :func:`should_refresh_theme`.
+#:
+#: - MAX caps refreshes per session: past it the name is final, because the
+#:   growth gate alone would still permit a rename after a long enough run.
+#: - GROWTH_FACTOR requires the transcript to be a multiple of its length at the
+#:   last titling. Growth, not elapsed turns, is the signal: doubling the
+#:   conversation is roughly the point at which the earlier sample can no longer
+#:   represent it, which is exactly when a fresh sample is worth paying for.
+#: - MIN_TURNS is an absolute floor added to the growth requirement; it also
+#:   carries the never-titled case (``last_titled_turn_count`` 0), where the
+#:   gate reduces to four turns — enough for a request plus a reply to have
+#:   established a subject.
+THEME_REFRESH_MAX = 5
+THEME_REFRESH_GROWTH_FACTOR = 2
+THEME_REFRESH_MIN_TURNS = 4
+
+
+def should_refresh_theme(turn_count: int, last_titled_turn_count: int, refresh_count: int) -> bool:
+    """Whether the conversation's auto title may be regenerated now.
+
+    Pure and side-effect free so the caller stays dumb: it counts turns and
+    asks, rather than carrying its own idea of "enough has changed". This is
+    the PRIMARY gate that replaced the wall-time-only throttle — a long session
+    used to keep re-titling indefinitely because the only bound was 120 seconds
+    between checks, so every in-goal follow-up an hour in was still eligible to
+    pivot the name. Gating on transcript GROWTH instead bounds re-titles to a
+    handful over the life of a session and concentrates them early, when the
+    subject is still settling. A small time floor may still sit in front of this
+    in the caller as a churn guard, but growth is what makes the schedule finite.
+    """
+    if refresh_count >= THEME_REFRESH_MAX:
+        return False
+    return (
+        turn_count >= last_titled_turn_count * THEME_REFRESH_GROWTH_FACTOR + THEME_REFRESH_MIN_TURNS
+    )
+
+
+def _theme_turns(turns: Sequence[_Turn], newest: str) -> list[tuple[str, str]]:
+    """Collect ``(role, text)`` pairs the theme sampler titles from.
+
+    Only ``user``/``assistant`` turns with rendered text count: tool results
+    and host-authored custom entries (which carry no ``role``) are noise for a
+    THEME judgement, and a blank turn contributes nothing but scaffolding. The
+    newest message is appended as a trailing user turn when it is not already
+    the last one, because the retitle call fires at SUBMIT — before the turn has
+    run — so ``session.history()`` does not yet contain it, and the tail is
+    exactly where a genuine change of subject shows up.
+    """
+    collected: list[tuple[str, str]] = []
+    for turn in turns:
+        role = getattr(turn, "role", "")
+        if role not in ("user", "assistant"):
+            continue
+        text = " ".join((getattr(turn, "text", "") or "").split())
+        if not text:
+            continue
+        collected.append((role, text))
+    newest_clean = " ".join((newest or "").split())
+    if newest_clean and (not collected or collected[-1] != ("user", newest_clean)):
+        collected.append(("user", newest_clean))
+    return collected
+
+
+def build_theme_context(
+    turns: Sequence[_Turn], newest: str = "", *, current_title: str = ""
+) -> str:
+    """A sampled ``<chat>`` of the whole trajectory for the theme titling call.
+
+    Samples the head and the tail instead of the last N turns, which is the
+    heart of the drift fix: a tail-only window is precisely why the old design
+    chased the newest message, because by turn 40 the opening request — the one
+    turn that states what the session is FOR — had scrolled out of the window
+    entirely, leaving the model to name whatever the last message touched. The
+    head states the subject; the tail refines it or shows a genuine pivot.
+
+    The ``<current-title>`` anchor leads the envelope so the model reads the
+    name it is being asked to keep before it reads the turns. When turns fall
+    between the head and the tail the gap is marked with ``<elided/>``: two
+    disjoint fragments presented as adjacent read as an abrupt topic switch and
+    invite exactly the drift this sampler exists to prevent.
+
+    Returns ``""`` when there is nothing titleable, which the caller reads the
+    same way it reads a low-signal message: spend no call.
+    """
+    collected = _theme_turns(turns, newest)
+    if not collected:
+        return ""
+    head_end = min(THEME_HEAD_TURNS, len(collected))
+    tail_start = max(head_end, len(collected) - THEME_TAIL_TURNS)
+    sampled = collected[:head_end] + collected[tail_start:]
+    # Index into ``sampled`` where the tail begins; the marker is emitted once,
+    # immediately before it, and only when turns were actually dropped between
+    # the two halves. Placed before the following turn rather than after the
+    # preceding one so it never lands in the trailing position, where it would
+    # read as "the conversation continues" instead of "turns were skipped here".
+    elided_before = head_end if tail_start > head_end else None
+
+    parts: list[str] = []
+    header = ""
+    title_clean = " ".join((current_title or "").split())
+    if title_clean:
+        header = (
+            f"<current-title>\n{cut_on_a_word(title_clean, THEME_CURRENT_TITLE_CHARS)}\n"
+            "</current-title>\n\n"
+        )
+    for index, (role, text) in enumerate(sampled):
+        if elided_before is not None and index == elided_before:
+            parts.append(_ELIDED_MARKER)
+        # Bounded PER TURN, not on the assembled envelope: budgeting the whole
+        # string would spend its allowance on the long head turns the sampler
+        # exists to preserve and cut them mid-tag. `cut_on_a_word` keeps the cut
+        # legible, and the tag scaffolding it sits inside stays intact.
+        body = cut_on_a_word(text, THEME_TURN_CHARS)
+        parts.append(f"<{role}>\n{body}\n</{role}>")
+    return f"<chat>\n{header}" + "\n\n".join(parts) + "\n</chat>"
+
+
 async def generate_title(
     text: str,
     complete_fn,
@@ -443,32 +634,47 @@ async def generate_retitle(
     text: str,
     complete_fn,
     *,
+    turns: Sequence[_Turn] | None = None,
     timeout: float = TITLE_TIMEOUT_S,
 ) -> str | None:
-    """A REPLACEMENT title when ``text`` has moved the subject; else ``None``.
+    """A REPLACEMENT title when the THEME has moved; else ``None``.
 
     A long conversation drifts. It opens as "Fix the login redirect loop" and
     four messages later it is about the billing importer, and a title that
     still names the first thing is worse than one that names nothing — it
     actively misidentifies the session in a tab bar of five.
 
-    The DECISION belongs to the model, and that is deliberate rather than
+    But the earlier design over-corrected: given only ``current`` and the single
+    newest ``text``, the model read every IN-GOAL step as a new subject. A
+    session building a web-fetch tool got renamed the instant the user exercised
+    it ("find Port Credit restaurants"), then again on the next follow-up. The
+    fix is to title the WHOLE body of work: ``turns`` is the session's history
+    (``session.history()``), from which :func:`build_theme_context` samples a
+    ``<chat>`` of the opening turns (which state the subject) plus a recent tail,
+    anchored on ``current``. The model keeps the anchor verbatim unless the
+    subject genuinely moved — which a new step inside the same work is not.
+
+    The DECISION still belongs to the model, and that is deliberate rather than
     convenient. "The subject has materially changed" is a judgement about
     meaning: any keyword rule written here would fire on "actually, forget the
-    parser" and miss "right, and now the same thing for invoices". So the model
-    is given the current title and the new message and answers with the
-    sentinel to keep what it has. ``None`` therefore means BOTH "no change" and
-    "the call failed", which are the same instruction to the caller: leave the
-    title alone.
+    parser" and miss "right, and now the same thing for invoices". The model
+    answers with the ``<title/>`` sentinel to keep what it has, so ``None`` means
+    BOTH "no change" and "the call failed" — the same instruction to the caller:
+    leave the title alone.
 
     Same cost and the same isolation as :func:`generate_title` — one bounded,
     single-attempt, tools-free call. What keeps it cheap in aggregate is the
-    CALLER's throttle, not this function: see the TUI's re-title policy.
+    CALLER's growth-gated schedule (:func:`should_refresh_theme`), not this
+    function. ``turns`` defaults to ``None`` for callers with no history handy;
+    the newest ``text`` alone is then the whole trajectory, which is the old
+    behaviour and still correct for a two-message session.
     """
     if not current or is_low_signal(text):
         return None
-    system = RETITLE_SYSTEM_PROMPT.format(current=current)
-    title = await _ask_for_title(system, _errand_prompt(text), complete_fn, timeout)
+    context = build_theme_context(turns or (), text, current_title=current)
+    if not context:
+        return None
+    title = await _ask_for_title(THEME_SYSTEM_PROMPT, context, complete_fn, timeout)
     if title is None:
         return None
     # A model that "changes" the title to the one it already has has answered

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -606,17 +606,18 @@ USAGE_WARM_INTERVAL_S = 60.0
 #: headroom under the worst draw while still refreshing only ~twice per TTL.
 USAGE_WARM_STALE_AFTER_S = 150.0
 
-#: Minimum seconds between two re-title CHECKS on one conversation. The check
-#: is a provider call (the model, not a keyword rule, judges whether the
-#: subject moved — see :meth:`OperatorApp._maybe_retitle_conversation`), so
-#: unthrottled it would bill once per follow-up. Measured against
-#: anthropic/claude-opus-5 at its lowest effort, one check is 167 input + 18
-#: output tokens — real money at Opus rates on a chatty session, but the
-#: sharper cost is CHURN: a tab label that can change every twenty seconds is
-#: one nobody can read. Two minutes is longer than a burst of follow-ups on
-#: one subject (which then costs exactly one check) and much shorter than the
-#: time it takes a session to genuinely move on to something else.
-RETITLE_MIN_GAP_S = 120.0
+#: Minimum seconds between two re-title CHECKS on one conversation — now a
+#: SECONDARY churn guard behind the growth gate (:func:`naming.should_refresh_theme`),
+#: not the whole throttle. The growth gate bounds re-titles to a handful over the
+#: life of a session and concentrates them early; this floor only stops a rapid
+#: burst of substantive messages from spending two checks within seconds of each
+#: other, since transcript growth alone would let the second through the instant
+#: it crossed the threshold. Kept because the check is a provider call (measured
+#: against anthropic/claude-opus-5 at its lowest effort, ~167 input + 18 output
+#: tokens) and because a tab label that changes twice in one breath is one nobody
+#: can read. Shorter than the old 120 s: the growth gate does the real work of
+#: keeping the schedule finite, so this only has to smooth a same-second burst.
+RETITLE_MIN_GAP_S = 30.0
 
 #: TUI diagnostics go to the log FILE, never the terminal — stderr belongs to
 #: the rendered app (see ``local_operator.logger.file_logging``).
@@ -1400,9 +1401,24 @@ class OperatorApp(App[None]):
         self._name_generation: int = 0
         # Monotonic stamp of the last moment a title was DECIDED — either
         # stored, or checked against a new message and left alone. The re-title
-        # throttle measures its gap from here; see
+        # throttle's SECONDARY time floor measures its gap from here; see
         # :meth:`_maybe_retitle_conversation` for why the gap exists.
         self._retitle_checked_at: float = 0.0
+        # The growth-gated re-title schedule's two counters, mirroring omp's
+        # `lastTitledTurnCount`/`refreshCount`. `_last_titled_turn_count` is the
+        # transcript turn-count at the moment the title in force was set (0 until
+        # the first title lands); `_theme_refresh_count` is how many automatic
+        # RE-titles have been spent. Together they feed
+        # `naming.should_refresh_theme`, which is the PRIMARY gate that replaced
+        # the wall-time-only throttle: a long session used to keep re-titling
+        # indefinitely because 120 s between checks was the only bound, so every
+        # in-goal follow-up an hour in was still eligible to pivot the name.
+        # Held here on the host, beside `_retitle_checked_at`, because the title
+        # holder (`ConversationName`) is shared with the session and persisted,
+        # while these are display-schedule bookkeeping for the live host — the
+        # same split `_provisional_name` already makes.
+        self._last_titled_turn_count: int = 0
+        self._theme_refresh_count: int = 0
         # A turn holds this for its whole provider round trip, and `_dispose`
         # waits on it so a session is never torn down under a live request.
         # Naming does NOT take it: the title call is `isolated` (see
@@ -2702,6 +2718,14 @@ class OperatorApp(App[None]):
         # inside the window would make the new conversation's first follow-up
         # unable to correct a title generated from an opener it never had.
         self._retitle_checked_at = 0.0
+        # The growth-gate counters describe the dead conversation's title
+        # schedule too. Reset so the replacement session starts from the
+        # never-titled floor rather than inheriting a spend budget or a turn
+        # baseline it never earned — the same argument as `_retitle_checked_at`,
+        # one gate over. A `/reload` onto the same conversation re-derives them
+        # from the first title it lands, so nothing is lost that mattered.
+        self._last_titled_turn_count = 0
+        self._theme_refresh_count = 0
         # The spend ledger is the dead conversation's — unless the reload lands
         # back on the SAME conversation, which `/reload` now does. Reset it here
         # so `/new` and `/resume` cannot inherit a figure they did not spend,
@@ -6865,14 +6889,26 @@ class OperatorApp(App[None]):
         """
         return time.monotonic()
 
+    def _theme_turn_count(self, session: SessionProtocol) -> int:
+        """User/assistant turns in the transcript, the unit the growth gate counts.
+
+        Tool results and host-authored custom entries carry no ``role`` in the
+        ("user", "assistant") set and are noise for a THEME judgement, so the
+        count matches exactly what :func:`naming.build_theme_context` samples
+        from. Mirrors omp's ``#titleTurnCount``.
+        """
+        history = session.history() if hasattr(session, "history") else []
+        return sum(1 for turn in history if getattr(turn, "role", "") in ("user", "assistant"))
+
     def _maybe_retitle_conversation(self, text: str) -> None:
-        """Ask whether ``text`` has moved the subject, at most once per window.
+        """Ask whether ``text`` has moved the THEME, on a growth-gated schedule.
 
         A long session drifts. It opens as "Fix the login redirect loop" and an
         hour later it is about the billing importer, and a tab still naming the
         first subject actively misidentifies the session rather than merely
         under-describing it. So a named conversation keeps asking — but the
-        asking has to stay cheap, and three gates do that:
+        asking has to stay cheap AND the answer has to track the whole body of
+        work, not the newest message. Four gates do that:
 
         * **The user renamed it.** ``user_set`` outranks everything, forever.
           Checked HERE as well as at the store, so an explicitly named
@@ -6880,24 +6916,44 @@ class OperatorApp(App[None]):
         * **Low signal.** Already filtered by the caller; "ok", "thanks" and
           "continue" are most follow-ups in a long session and none of them
           can have moved a subject.
-        * **A minimum gap.** ``RETITLE_MIN_GAP_S`` since the title in force was
-          last decided — stamped when a check is DISPATCHED (below) and again
-          by :meth:`_store_title` when a title actually lands. Unthrottled, a
-          40-message session would spend 40 checks; measured on
-          anthropic/claude-opus-5, one check is 167 input + 18 output tokens.
-          The cap is as much about CHURN as money — a tab label that can
-          change every twenty seconds is one nobody can read. A burst of
-          follow-ups on one subject costs exactly one check.
+        * **Growth gating (the PRIMARY gate).** ``naming.should_refresh_theme``
+          allows a re-title only once the transcript has grown substantially
+          since the last title (geometric: eligible at turn >=6, >=16, >=36,
+          >=76, >=156) and at most five times per session. This is what replaced
+          the wall-time-only throttle, which let a long session re-title
+          indefinitely: every in-goal follow-up an hour in was still eligible to
+          pivot the name, and shown only that one message the model read the
+          in-goal step as a new subject. Growth gating concentrates re-titles
+          early, when the subject is still settling, and stops them once the
+          session has an established identity.
+        * **A minimum time floor (a SECONDARY churn guard).**
+          ``RETITLE_MIN_GAP_S`` since the title in force was last decided —
+          stamped when a check is DISPATCHED (below) and again by
+          :meth:`_store_title` when one lands. The growth gate does the heavy
+          lifting; this only stops a rapid burst of substantive messages from
+          spending two checks within seconds of each other, since transcript
+          growth alone would admit the second the instant it crossed a
+          threshold. A tab label that changes twice in one breath is unreadable.
 
-        The decision itself is the MODEL's (see ``naming.generate_retitle``):
-        "the subject has materially changed" is a judgement about meaning, and
-        any keyword rule here would fire on "actually, forget the parser" and
-        miss "right, now the same thing for invoices".
+        The decision itself is the MODEL's (see ``naming.generate_retitle``),
+        and it now judges the WHOLE trajectory: the worker hands it
+        ``session.history()``, from which the theme sampler keeps the opening
+        turns (which state the subject) plus a recent tail, anchored on the
+        current title. "The subject has materially changed" is a judgement about
+        meaning that any keyword rule here would get wrong.
         """
         session = self._session
         if session is None or self._status is None:
             return
         if session.conversation_name_state.user_set:
+            return
+        # The primary gate: has the transcript grown enough since the last
+        # title, and are there refreshes left? Counted from history so an
+        # in-goal follow-up on a settled session never even reaches the call.
+        turn_count = self._theme_turn_count(session)
+        if not naming.should_refresh_theme(
+            turn_count, self._last_titled_turn_count, self._theme_refresh_count
+        ):
             return
         now = self._clock()
         if now - self._retitle_checked_at < RETITLE_MIN_GAP_S:
@@ -6908,14 +6964,28 @@ class OperatorApp(App[None]):
         self._retitle_checked_at = now
         self._name_generation += 1
         generation = self._name_generation
+        # A snapshot of the trajectory taken NOW, on the UI thread, so the
+        # worker titles the conversation as it stood when the message was
+        # submitted rather than as it may look after the turn it kicked off has
+        # written more history. `history()` returns the live list; a shallow
+        # copy is enough because the sampler only reads role/text off each entry.
+        turns = list(session.history()) if hasattr(session, "history") else []
         self.run_worker(
-            self._retitle_conversation_worker(session, session.conversation_name, text, generation),
+            self._retitle_conversation_worker(
+                session, session.conversation_name, text, generation, turns, turn_count
+            ),
             thread=False,
             group="naming",
         )
 
     async def _retitle_conversation_worker(
-        self, session: SessionProtocol, current: str, text: str, generation: int
+        self,
+        session: SessionProtocol,
+        current: str,
+        text: str,
+        generation: int,
+        turns: list[AgentMessage],
+        turn_count: int,
     ) -> None:
         """One isolated re-title call; ``None`` from it means "leave it alone".
 
@@ -6924,21 +6994,44 @@ class OperatorApp(App[None]):
         resolves to "no change" rather than to a notice. The band therefore
         never flickers on a failed check — nothing repaints unless a genuinely
         different title came back.
+
+        ``turns`` is the trajectory snapshot the theme sampler titles from; the
+        model sees the whole body of work anchored on ``current``, not just the
+        newest message. ``turn_count`` is the transcript length at DISPATCH,
+        carried through so a landed title stamps the growth gate's baseline from
+        the same count the gate measured — see :meth:`_store_title`.
+
+        A re-title check is charged against the growth budget whether or not it
+        produces a new name (mirroring omp's ``#refreshSessionTheme``): the
+        budget bounds MODEL CALLS, not renames, and re-asking the same question
+        on the next follow-up would put the drift back on a faster clock. The
+        charge is applied at the store when a title lands, and here when the
+        model answered "no change" — both spend one refresh.
         """
         try:
-            title = await naming.generate_retitle(current, text, session.complete_once)
+            title = await naming.generate_retitle(current, text, session.complete_once, turns=turns)
         except asyncio.CancelledError:
             return
-        if not title:
-            return  # unchanged subject, or the call failed: same instruction
+        # A generation/session mismatch means this attempt was superseded (a
+        # reload) or belongs to a session no longer on screen: it must touch
+        # neither the title nor the shared growth budget.
         if generation != self._name_generation or session is not self._session:
+            return
+        if not title:
+            # Unchanged subject, or the call failed: leave the title alone, but
+            # STILL spend a refresh on a genuine "no change" answer so the
+            # growth schedule advances. A failed call is indistinguishable here
+            # from "no change" (both are None), and charging it is the safe
+            # direction — it slows re-titling, never speeds it — while leaving
+            # the never-titled baseline untouched.
+            self._charge_theme_refresh(session, turn_count)
             return
         # Re-read rather than trusting `current`: a rename or a reload may have
         # landed during the call, and both outrank a check made against a title
         # that is no longer in force.
         if session.conversation_name != current:
             return
-        self._store_title(session, title)
+        self._store_title(session, title, turn_count=turn_count)
 
     async def _name_conversation_worker(
         self, session: SessionProtocol, text: str, generation: int
@@ -6996,7 +7089,28 @@ class OperatorApp(App[None]):
             return
         self._store_title(session, title)
 
-    def _store_title(self, session: SessionProtocol, title: str) -> str:
+    def _charge_theme_refresh(self, session: SessionProtocol, turn_count: int) -> None:
+        """Spend one growth-budget refresh without changing the title.
+
+        The "no change" (and, indistinguishably, the failed-call) branch of a
+        re-title check. The budget bounds MODEL CALLS, not renames: a check that
+        answered "same subject" has done its job and must advance the schedule,
+        or the next substantive message re-asks the identical question the
+        instant transcript growth crosses the threshold again — putting the
+        drift the growth gate exists to slow back on a faster clock. Advancing
+        the baseline to ``turn_count`` pushes the next eligibility out by another
+        doubling; incrementing the count walks toward the per-session cap.
+        Stamped from the same DISPATCH count the gate measured so the schedule
+        stays geometric regardless of how much history the concurrent turn wrote
+        while the call was in flight.
+        """
+        self._last_titled_turn_count = turn_count
+        self._theme_refresh_count += 1
+        self._retitle_checked_at = self._clock()
+
+    def _store_title(
+        self, session: SessionProtocol, title: str, *, turn_count: int | None = None
+    ) -> str:
         """Store a generated title and put it on both surfaces.
 
         One writer for the first title and for every later re-title, so the
@@ -7004,8 +7118,35 @@ class OperatorApp(App[None]):
         store itself owns precedence: ``user_set=False`` means an explicit
         rename always wins, including one that landed while this call was in
         flight, so this may store nothing and return the name already there.
+
+        ``turn_count`` distinguishes the two callers and drives the growth
+        gate's counters. ``None`` is the FIRST title (the naming path): the
+        session's identity starts here, so the baseline is seeded from the
+        transcript's current turn count and the refresh budget is (re)set to
+        zero — this is where omp's ``lastTitledTurnCount``/``refreshCount`` are
+        initialised. An int is a RE-title: the baseline moves to the count the
+        check was dispatched at and one refresh is spent, so the next re-title
+        needs another doubling of the transcript.
         """
         stored = session.set_conversation_name(title, user_set=False)
+        if turn_count is None:
+            # First title: this conversation's identity — and therefore its
+            # refresh schedule — begins now. Seed the baseline from the live
+            # transcript so the first re-title is gated on growth from HERE, and
+            # reset the spend so a resumed-then-reopened conversation does not
+            # inherit a budget it never had. Floor at 1: the first title fires
+            # at SUBMIT, before the opener is in history, so a raw count of 0
+            # would make the next refresh eligible at four turns instead of the
+            # documented "titled at 1, refresh at >=6" schedule.
+            self._last_titled_turn_count = max(1, self._theme_turn_count(session))
+            self._theme_refresh_count = 0
+        else:
+            # A re-title landed: advance the baseline to the dispatch count and
+            # spend one refresh, exactly as `_charge_theme_refresh` does for the
+            # no-change branch — a rename and a "same subject" answer cost the
+            # same one call against the budget.
+            self._last_titled_turn_count = turn_count
+            self._theme_refresh_count += 1
         # A title just took effect, so the re-title window restarts from here
         # rather than from whenever the last CHECK was dispatched. Without
         # this, a title landing at the tail of an open window would be eligible

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.26.1"
+version = "0.27.0"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/tui/test_conversation_naming.py
+++ b/tests/unit/tui/test_conversation_naming.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -74,6 +75,25 @@ class _GatedSession(FakeSession):
                 self.timeline.append("name:cancel")
                 raise
         return self.title
+
+    def grow_transcript(self, turns: int) -> None:
+        """Stand in for a conversation that has accumulated ``turns`` messages.
+
+        The growth-gated re-title schedule counts user/assistant turns off
+        ``session.history()``, so a test that wants the gate OPEN has to present
+        a transcript long enough to clear it. The real ``prompt`` on this fake
+        never builds history (it only records the text), so this seeds it
+        directly with alternating user/assistant entries carrying the role and
+        text the theme sampler reads — enough shape for both the turn count and
+        the ``<chat>`` sample, nothing more.
+        """
+        self._history = [
+            SimpleNamespace(
+                role="user" if index % 2 == 0 else "assistant",
+                text=f"message {index}",
+            )
+            for index in range(turns)
+        ]
 
 
 async def _settle() -> None:
@@ -407,9 +427,19 @@ async def _named(app: OperatorApp, session: _GatedSession, opener: str) -> list[
 
 
 async def _named_a_while_ago(app: OperatorApp, session: _GatedSession, opener: str) -> list[float]:
-    """:func:`_named`, then far enough past ``RETITLE_MIN_GAP_S`` to ask again."""
+    """:func:`_named`, then into a state where the next message may re-title.
+
+    Two gates guard the re-title now, and this opens both. It advances the fake
+    clock past ``RETITLE_MIN_GAP_S`` (the secondary churn floor) AND grows the
+    transcript past the growth gate: the first title seeds
+    ``_last_titled_turn_count`` from the transcript, which the fake leaves at 0,
+    so ``should_refresh_theme`` needs the history to reach ``THEME_REFRESH_MIN_TURNS``
+    (4) before a re-title is eligible. Six turns clears it with margin and is the
+    length the geometric schedule's first refresh lands at anyway.
+    """
     now = await _named(app, session, opener)
     now[0] += RETITLE_MIN_GAP_S + 1
+    session.grow_transcript(6)
     return now
 
 
@@ -440,7 +470,15 @@ async def test_a_material_change_of_subject_retitles_both_surfaces() -> None:
         await _settle()
 
         assert len(session.completions) == 2, "no re-title check was made"
-        assert session.completions[1][0].startswith("A conversation is titled: Fix the login flow")
+        # The re-title call now carries the theme prompt, and the current title
+        # rides the DATA as the `<current-title>` anchor rather than the system
+        # block — the whole point of titling the trajectory, not the message.
+        retitle_system, retitle_data = session.completions[1]
+        assert retitle_system == naming.THEME_SYSTEM_PROMPT
+        assert "<current-title>\nFix the login flow\n</current-title>" in retitle_data
+        assert retitle_data.startswith("<chat>")
+        # The newest message reaches the model as the tail of the trajectory.
+        assert "forget that, rewrite the billing importer instead" in retitle_data
         assert session.conversation_name == "Billing importer rewrite"
         assert app._status._conversation_name == "Billing importer rewrite"
         assert "Billing importer rewrite" in title.current
@@ -490,6 +528,62 @@ async def test_a_human_rename_is_never_overwritten_by_a_retitle() -> None:
 
         assert session.conversation_name == "Ledger reconciliation"
         assert len(session.completions) == 1, "a renamed conversation spent a re-title call"
+
+
+@pytest.mark.asyncio
+async def test_a_settled_session_does_not_even_spend_a_check_on_an_in_goal_step() -> None:
+    """The growth gate at the host level: an in-goal step on a long, settled
+    session spends NO provider call at all.
+
+    This is the drift the whole change exists to stop, defended one layer up
+    from the sampler. The conversation was named at turn 1 and has since grown —
+    but not doubled — so ``should_refresh_theme`` declines before any call is
+    dispatched. Under the old wall-time-only throttle this same message an hour
+    in would have spent a check and, shown only itself, pivoted the title.
+    """
+    app, session = await _boot(title="<title>Fix the login flow</title>")
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _ready(pilot, app)
+        now = await _named(app, session, "fix the login redirect loop")
+        # Past the time floor, so only the growth gate can decline this. The
+        # title landed with the transcript at length 0, so the baseline is 0 and
+        # the floor is four turns; three turns is short of it.
+        now[0] += RETITLE_MIN_GAP_S + 1
+        session.grow_transcript(3)
+
+        session.title = "<title>Find Port Credit restaurants</title>"
+        app._submit_prompt("now find me some good Port Credit restaurants to try it out")
+        await _settle()
+
+        assert len(session.completions) == 1, "a settled session spent a re-title check"
+        assert session.conversation_name == "Fix the login flow"
+
+
+@pytest.mark.asyncio
+async def test_the_refresh_budget_stops_re_titling_after_the_cap() -> None:
+    """Growth alone would keep re-titling a long session; the cap makes it stop.
+
+    Five automatic re-titles are the ceiling. Here the budget is driven to the
+    cap directly, then a transcript grown far past any growth threshold is shown
+    an unmistakable change of subject — and it is declined without a call,
+    because a session with an established identity must stop tracking the cursor.
+    """
+    app, session = await _boot(title="<title>Fix the login flow</title>")
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _ready(pilot, app)
+        now = await _named(app, session, "fix the login redirect loop")
+        now[0] += RETITLE_MIN_GAP_S + 1
+        # The budget is spent: five refreshes already charged.
+        app._theme_refresh_count = 5
+        app._last_titled_turn_count = 1
+        session.grow_transcript(500)
+
+        session.title = "<title>Billing importer rewrite</title>"
+        app._submit_prompt("forget all that, rewrite the billing importer instead")
+        await _settle()
+
+        assert len(session.completions) == 1, "a capped session spent a re-title check"
+        assert session.conversation_name == "Fix the login flow"
 
 
 # -- `/rename`: the human's title ---------------------------------------------
@@ -646,7 +740,16 @@ async def test_a_chatty_follow_up_makes_no_call_at_all() -> None:
 
 @pytest.mark.asyncio
 async def test_a_burst_of_substantive_follow_ups_costs_exactly_one_check() -> None:
-    """The throttle. Unthrottled this is one provider call per message."""
+    """A burst on one subject costs exactly one check.
+
+    Two gates cooperate to make this so. The FIRST follow-up clears the growth
+    gate (the transcript grew to six turns) and the secondary time floor, so it
+    spends a check; the model answers "no change", which charges one refresh and
+    advances ``_last_titled_turn_count`` to six. The next two follow-ups arrive
+    against an unchanged transcript, so the growth gate now demands sixteen
+    turns and declines them without a call. Unthrottled this was one provider
+    call per message.
+    """
     app, session = await _boot(title="<title>Fix the login flow</title>")
     async with app.run_test(size=(100, 30)) as pilot:
         await _ready(pilot, app)
@@ -665,19 +768,22 @@ async def test_a_burst_of_substantive_follow_ups_costs_exactly_one_check() -> No
 
 
 @pytest.mark.asyncio
-async def test_a_landed_title_starts_the_re_title_window() -> None:
-    """The window is measured from when the title took EFFECT.
+async def test_the_time_floor_defends_against_a_same_breath_burst() -> None:
+    """The SECONDARY churn guard, isolated with the growth gate held open.
 
-    The first title comes from the naming path, which stamps nothing on its way
-    out — only ``_store_title`` does, and only when a title actually lands.
-    Without that stamp the window is still sitting at its initial zero when the
-    conversation gets its name, so the very next message would be allowed to
-    replace a title the user has had on screen for one second.
+    With the transcript already past the growth threshold, growth alone would
+    admit a re-title the instant a message arrives. The time floor is what stops
+    two checks landing within seconds of each other: the first title stamps
+    ``_retitle_checked_at`` at the store, so a message one second later is
+    declined, and only once the clock crosses ``RETITLE_MIN_GAP_S`` does the
+    model get asked. A tab label that changes twice in one breath is unreadable.
     """
     app, session = await _boot(title="<title>Fix the login flow</title>")
     async with app.run_test(size=(100, 30)) as pilot:
         await _ready(pilot, app)
         now = await _named(app, session, "fix the login redirect loop")
+        # Growth gate held OPEN so the only guard left is the time floor.
+        session.grow_transcript(6)
 
         session.title = "<title>Billing importer rewrite</title>"
         app._submit_prompt("forget that, rewrite the billing importer instead")
@@ -685,7 +791,7 @@ async def test_a_landed_title_starts_the_re_title_window() -> None:
         assert len(session.completions) == 1, "a one-second-old title was up for replacement"
         assert session.conversation_name == "Fix the login flow"
 
-        # Past the window the model does get asked, and its answer is taken.
+        # Past the floor the model does get asked, and its answer is taken.
         now[0] += RETITLE_MIN_GAP_S + 1
         app._submit_prompt("forget that, rewrite the billing importer instead")
         await _settle()
@@ -737,6 +843,120 @@ async def test_generate_retitle_swallows_a_provider_failure_as_no_change() -> No
         raise RuntimeError("429 rate limited")
 
     assert await naming.generate_retitle("Fix the login flow", "rewrite the importer", boom) is None
+
+
+# -- the theme sampler and the drift regression it fixes ----------------------
+
+
+def _turn(role: str, text: str) -> SimpleNamespace:
+    """A minimal history entry — the theme sampler only reads .role and .text."""
+    return SimpleNamespace(role=role, text=text)
+
+
+@pytest.mark.asyncio
+async def test_an_in_goal_step_does_not_pivot_the_title() -> None:
+    """THE regression: an in-goal step must not read as a new subject.
+
+    The reported failure — a "build a web fetch tool" session renamed to "Find
+    Port Credit restaurants" the moment the user exercised the tool — was caused
+    by the model seeing ONLY the newest message. Here a model that titles from
+    what it is shown keeps the theme, because the whole trajectory (opener plus
+    tail, anchored on the current title) is what it now receives: the in-goal
+    step is plainly a step inside the same body of work, not a pivot.
+    """
+    seen: list[str] = []
+
+    async def titles_from_context(system: str, prompt: str) -> str:
+        seen.append(prompt)
+        # The opener is in the trajectory, so the theme is obvious: keep it.
+        if "web fetch" in prompt.lower():
+            return "<title/>"
+        # Shown only the in-goal step, the same model would pivot — the bug.
+        return "<title>Find Port Credit restaurants</title>"
+
+    trajectory = [
+        _turn("user", "help me build a web fetch tool for the agent"),
+        _turn("assistant", "I'll add a fetch tool that GETs a URL."),
+        _turn("user", "wire it into the tool registry"),
+        _turn("assistant", "Done — registered and callable."),
+    ]
+    result = await naming.generate_retitle(
+        "Build a web fetch tool",
+        "now find me some good Port Credit restaurants to try it out",
+        titles_from_context,
+        turns=trajectory,
+    )
+    assert result is None, "an in-goal step pivoted the title"
+    # And the reason it held: the model saw the opener, not just the newest line.
+    assert "web fetch tool" in seen[0]
+
+
+def test_build_theme_context_samples_head_and_tail_with_an_elision_marker() -> None:
+    """The whole trajectory reaches the model: opener + tail, gap marked.
+
+    A tail-only window is why the old design chased the newest message; the
+    sampler keeps the opening turns (which state the subject) and a recent tail,
+    and marks the turns dropped between them so two fragments never read as an
+    abrupt switch.
+    """
+    turns = [_turn("user" if i % 2 == 0 else "assistant", f"turn {i}") for i in range(12)]
+    context = naming.build_theme_context(turns, "the newest thing", current_title="Old title")
+
+    # The anchor leads the envelope.
+    assert context.startswith("<chat>\n<current-title>\nOld title\n</current-title>")
+    # The opening turns are present (the head states the subject)...
+    assert "turn 0" in context and "turn 1" in context and "turn 2" in context
+    # ...a middle turn is dropped...
+    assert "turn 6" not in context
+    # ...the gap is marked...
+    assert "<elided/>" in context
+    # ...and the newest message rides the tail.
+    assert "the newest thing" in context.rsplit("<elided/>", 1)[-1]
+
+
+def test_build_theme_context_appends_the_newest_message_as_the_tail() -> None:
+    """The retitle fires at SUBMIT, so history lacks the newest message yet.
+
+    The sampler appends it as a trailing user turn — without it the tail, where
+    a genuine change of subject shows up, would be a message stale by one.
+    """
+    turns = [_turn("user", "opener"), _turn("assistant", "reply")]
+    context = naming.build_theme_context(turns, "brand new subject", current_title="T")
+    assert context.rstrip().endswith("brand new subject\n</user>\n</chat>")
+
+
+def test_build_theme_context_ignores_non_conversational_entries() -> None:
+    """Tool results and role-less custom entries are noise for a THEME."""
+    turns = [
+        _turn("user", "opener"),
+        _turn("tool", "a large tool result"),
+        SimpleNamespace(text="a custom entry with no role"),  # no .role
+        _turn("assistant", "reply"),
+    ]
+    context = naming.build_theme_context(turns, "", current_title="T")
+    assert "a large tool result" not in context
+    assert "a custom entry with no role" not in context
+    assert "opener" in context and "reply" in context
+
+
+def test_build_theme_context_is_empty_when_there_is_nothing_to_title() -> None:
+    """No turns and no newest message ⇒ no context ⇒ the caller spends no call."""
+    assert naming.build_theme_context([], "", current_title="T") == ""
+
+
+def test_should_refresh_theme_follows_the_geometric_schedule() -> None:
+    """Titled at turn 1, then eligible at >=6, >=16, >=36, capped at five."""
+    # Never titled (baseline 0): the gate reduces to the four-turn floor.
+    assert not naming.should_refresh_theme(3, last_titled_turn_count=0, refresh_count=0)
+    assert naming.should_refresh_theme(4, last_titled_turn_count=0, refresh_count=0)
+    # Titled at turn 1: next eligibility at 1*2 + 4 = 6.
+    assert not naming.should_refresh_theme(5, last_titled_turn_count=1, refresh_count=0)
+    assert naming.should_refresh_theme(6, last_titled_turn_count=1, refresh_count=0)
+    # Titled again at turn 6: next at 6*2 + 4 = 16.
+    assert not naming.should_refresh_theme(15, last_titled_turn_count=6, refresh_count=1)
+    assert naming.should_refresh_theme(16, last_titled_turn_count=6, refresh_count=1)
+    # The cap is final regardless of how much the transcript has grown.
+    assert not naming.should_refresh_theme(10_000, last_titled_turn_count=1, refresh_count=5)
 
 
 # -- the opener-derived label itself -----------------------------------------


### PR DESCRIPTION
## Why

A session whose goal was **build a web fetch tool** got auto-renamed to **"Find Port Credit restaurants"** the moment the user exercised the tool, then again to **"Include Findings in Release"** on the next follow-up. Each pivot compounded because the next check anchored on the already-drifted title. The title should have stayed on the session's *theme* — work on a web fetch tool — so a glance at the tab or `/resume` picker still identifies the conversation.

Root cause, verified against the live path on `origin/main`:

- `generate_retitle` sent the model **only the current title + the single newest user message** (`_errand_prompt`, 320 chars) and asked "did the SUBJECT or GOALS materially change?"
- An in-goal step ("test the tool by finding Port Credit restaurants") looks, in isolation, like a brand-new subject.
- The throttle was **wall-time only** (`RETITLE_MIN_GAP_S = 120s`), so a long session kept re-titling indefinitely instead of settling.

This ports the omp fork's proven `feat/session-theme-titling` design into lop's Python idiom. Version bump **0.26.0 → 0.27.0** (minor — 0.26.0 was already taken by `web_fetch` #276).

## What changes

Three parts, none of which works alone:

1. **Whole-trajectory context** (`naming.build_theme_context`) — the re-title call now sees a sampled `<chat>` of the opening turns (which *state* the subject) plus a recent tail, with `<elided/>` marking the gap. Bounded per turn so a pasted log cannot blow the cheap call.
2. **Current-title anchor + theme prompt** (`THEME_SYSTEM_PROMPT`) — "Title the whole body of work, not the most recent message. Repeat `<current-title>` verbatim unless the work has moved to a different subject. A new step, file, question, or tool call inside the same body of work is NOT a different subject."
3. **Growth-gated hysteresis** (`naming.should_refresh_theme`) — replace the 120s-only throttle with transcript-growth doubling (eligible at turn ≥6, ≥16, ≥36, ≥76, ≥156) capped at five refreshes. A 30s time floor stays as a secondary burst guard. Counters live on the TUI host (not `ConversationName` — that holder is persisted/shared).

Preserved: `user_set` (`/rename`) outranks everything forever and spends no call; low-signal messages spend nothing; the call stays isolated / single-attempt and swallows all failures to `None`; `<title/>` means no change; the provisional opener path is unchanged.

## Testing

### Behavioural — the reported sequence, old vs new

Same opener, same in-goal follow-up, same model policy ("if you only see the newest message, title it; if you see the opener, keep the theme"):

```
=== OLD prompt (newest message only) ===
now find me some good Port Credit restaurants to try it out
OLD title produced: 'Find Port Credit restaurants'

=== NEW prompt (theme context) ===
<chat>
<current-title>
Build a web fetch tool
</current-title>

<user>
help me build a web fetch tool for the agent
</user>

<assistant>
I'll add a fetch tool that GETs a URL.
</assistant>

<user>
wire it into the tool registry
</user>

<assistant>
Done — registered and callable.
</assistant>

<user>
now find me some good Port Credit restaurants to try it out
</user>
</chat>
NEW title produced: None  (None = keep current theme)
```

Growth schedule (unit-checked): titled at turn 1, next refresh at ≥6, then ≥16, ≥36, ≥76, ≥156, then never.

### Automated

`tests/unit/tui/test_conversation_naming.py` — 37 passed, including:

- `test_an_in_goal_step_does_not_pivot_the_title` — the reported regression.
- `test_build_theme_context_samples_head_and_tail_with_an_elision_marker`
- `test_should_refresh_theme_follows_the_geometric_schedule`
- `test_the_refresh_budget_stops_re_titling_after_the_cap`
- `test_the_time_floor_defends_against_a_same_breath_burst`
- All prior invariants: human `/rename` never overwritten, low-signal spends nothing, sentinel = no change, restatement = no change, provider failure swallowed.

```
$ env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit/tui/test_conversation_naming.py -q
37 passed in 4.53s
```

### Gates

```
flake8 / black==26.1.0 / isort --profile black / pyright  — clean (0 errors)
```

A first full `tests/unit/tui tests/unit/session` run showed 3 pre-existing flakes (theme-color snapshot `#1e1a14` vs `#14110c`, composing-row label timing) that passed on re-run and fail identically on clean `origin/main`. Not this change.

## Review history
_Agent review gate in progress — code round to follow on this PR._
