### PR TITLE
fix(analytics): record spend under the serving model

### DIFF
--- a/local_operator/analytics/model.py
+++ b/local_operator/analytics/model.py
@@ -27,6 +27,7 @@ tokeniser touch — happens on the recorder's background thread.
 from __future__ import annotations
 
 import json
+import math
 import re
 from dataclasses import dataclass, field
 from typing import Any, Mapping
@@ -189,6 +190,13 @@ class CallSnapshot:
     # a future caller that priced off-thread itself). The normal recording path
     # leaves this False so the store prices from the model + token counts.
     priced: bool = False
+    # Provider-reported dollar cost for this call (OpenRouter ``usage.cost``,
+    # any compat provider that precomputes billing). Copied off ``Usage.usd_cost``
+    # at record time so ``price_snapshot`` can prefer it over the registry table
+    # — without this field the ledger silently re-estimated every reported bill.
+    # ``None`` is "not reported"; a real ``0.0`` is billed-as-free and must
+    # survive as a known $0, not collapse into ``$—``.
+    usd_cost: float | None = None
 
 
 def price_snapshot(snapshot: "CallSnapshot") -> tuple[int, bool]:
@@ -213,6 +221,23 @@ def price_snapshot(snapshot: "CallSnapshot") -> tuple[int, bool]:
         from local_operator.model.configure import cost_for_usage, resolve_model_info
 
         info = resolve_model_info(snapshot.provider, snapshot.model_id)
+        # A provider-reported dollar is ground truth even when the registry has
+        # no row for this id (OpenRouter, a brand-new SKU). Asking the table
+        # first used to drop that figure and store the call as unpriced.
+        # Malformed reports (negative, non-finite) are "not reported" — the
+        # same rule ``cost_for_usage`` uses — so we fall through to the table
+        # rather than marking a garbage figure as known.
+        reported = snapshot.usd_cost
+        if reported is not None:
+            try:
+                cost = float(reported)
+            except (TypeError, ValueError):
+                cost = None
+            else:
+                if not (math.isfinite(cost) and cost >= 0):
+                    cost = None
+            if cost is not None:
+                return int(round(cost * 1_000_000)), True
         if not (info.input_price or info.output_price):
             return 0, False
         # ``cost_for_usage`` duck-types its usage arg, so a plain object with the

--- a/local_operator/harness/types.py
+++ b/local_operator/harness/types.py
@@ -240,6 +240,18 @@ class Usage(BaseModel):
     # the provider billed as free) — the same three-way split the TUI's
     # ``None``-vs-``$0.0000`` contract already draws.
     usd_cost: float | None = None
+    # Serving identity, stamped by the failover layer from the on-the-wire
+    # ``ChatRequest`` (the spec that actually went out). The analytics recorder
+    # used to read ``request.model`` off the ORIGINAL ChatRequest, which still
+    # names the session primary after ``stream_with_failover`` rewrites the
+    # request to a fallback — every Grok call then landed under
+    # ``anthropic/claude-opus-4-8`` and was priced at Opus rates. These fields
+    # are the honest channel: a primary success, an isolated/naming call
+    # (``route_state`` is None), and a mid-turn failover all carry the spec
+    # that served THIS attempt. ``None`` means "not stamped"; the recorder
+    # then falls back to ``request.model``.
+    provider: str | None = None
+    model_id: str | None = None
 
     @property
     def total_tokens(self) -> int:

--- a/local_operator/model/configure.py
+++ b/local_operator/model/configure.py
@@ -3052,12 +3052,29 @@ class SessionStreamFn:
             # deliberately takes off-thread. It is still the SAME
             # ``cost_for_usage`` the status band uses, so the analytics dollar
             # total cannot disagree with the live band.
+            # Serving identity comes off the usage event the failover layer
+            # stamped from the on-the-wire request. Falling back to
+            # ``request.model`` would reintroduce the bug this exists to
+            # close: after a primary→fallback walk the original ChatRequest
+            # still names the session primary, so every Grok call was stored
+            # as anthropic and priced at Opus rates. Isolated/naming calls
+            # disable ``route_state``, so that pin is not an honest source
+            # either. Unstamped usage (a test drain, a client that never
+            # went through failover) still has ``request.model``.
+            serving_provider = getattr(usage, "provider", None) or request.model.provider
+            serving_model = getattr(usage, "model_id", None) or request.model.model_id
+            from local_operator.providers.registry import credential_provider_id
+
+            # Login flavours (``xai-oauth``, ``openai-device``) are the same
+            # billable provider as their storage id. Canonicalize at record
+            # time so By-provider does not split one vendor into two rows.
+            serving_provider = credential_provider_id(serving_provider)
             record_call(
                 CallSnapshot(
                     ts_ms=int(_time.time() * 1000),
                     session_id=self._session_id or "",
-                    provider=request.model.provider,
-                    model_id=request.model.model_id,
+                    provider=serving_provider,
+                    model_id=serving_model,
                     input_tokens=int(usage.input_tokens),
                     output_tokens=int(usage.output_tokens),
                     cache_read_tokens=int(usage.cache_read_tokens),
@@ -3066,6 +3083,7 @@ class SessionStreamFn:
                     context_tokens=int(context_tokens or 0),
                     component_chars=component_chars,
                     ok=ok,
+                    usd_cost=getattr(usage, "usd_cost", None),
                 )
             )
         except Exception:  # noqa: BLE001 — recording is best-effort

--- a/local_operator/model/registry.py
+++ b/local_operator/model/registry.py
@@ -915,6 +915,27 @@ def anthropic_family_model_info(model_id: str) -> Optional[ModelInfo]:
 
 
 openai_models: Dict[str, ModelInfo] = {
+    # GPT-5.6 Sol. Official list from
+    # https://developers.openai.com/api/docs/models/gpt-5.6-sol (read
+    # 2026-08-23): $4 / $0.40 cached / $20 per million, 1,050,000 context,
+    # 128k max output. Promotional rate through at least 2026-11-21; the
+    # page also notes a 2x/1.5x long-context surcharge above 272k input,
+    # which we do not invent a blended rate for (same convention as grok-4.6).
+    "gpt-5.6-sol": ModelInfo(
+        id="gpt-5.6-sol",
+        name="GPT-5.6 Sol",
+        input_price=4.0,
+        output_price=20.0,
+        cache_writes_price=5.0,  # 1.25x uncached input, per the same page
+        cache_reads_price=0.40,
+        max_tokens=128_000,
+        context_window=1_050_000,
+        supports_images=True,
+        supports_prompt_cache=True,
+        supports_responses_api=True,
+        description="OpenAI GPT-5.6 Sol: frontier model for complex professional work.",
+        recommended=True,
+    ),
     "gpt-4o": ModelInfo(
         id="gpt-4o",
         name="GPT-4o",
@@ -1863,10 +1884,80 @@ kimi_models: Dict[str, ModelInfo] = {
         description="Multimodal model with 128K context",
         recommended=False,
     ),
+    # Kimi K3. Official list price from
+    # https://platform.kimi.ai/docs/pricing/chat-k3 (read 2026-08-23):
+    # $3.00 cache-miss / $0.30 cache-hit / $15.00 output per million tokens,
+    # 1,048,576 context, flat (no long-context surcharge). The coding-plan
+    # host serves this as the bare id ``k3`` (and ``k3-256k``); the mainland
+    # listing uses ``kimi-k3``. Both spellings must resolve or a failover
+    # onto ``kimi/k3`` prices as unknown.
+    "k3": ModelInfo(
+        id="k3",
+        name="Kimi K3",
+        max_tokens=131_072,
+        context_window=1_048_576,
+        supports_images=True,
+        supports_prompt_cache=True,
+        input_price=3.00,
+        output_price=15.00,
+        cache_writes_price=3.00,
+        cache_reads_price=0.30,
+        description="Moonshot Kimi K3 flagship: 1M context, flat per-token pricing.",
+        recommended=True,
+    ),
 }
 
 # X.AI Grok models and pricing
 xai_models: Dict[str, ModelInfo] = {
+    # Current-generation Grok 4 family. Prices and windows transcribed from
+    # https://docs.x.ai/developers/models (read 2026-08-23). The page quotes
+    # two tiers per id: the <200k-prompt rate and a 2x long-context surcharge
+    # once the prompt reaches 200k. We carry the <200k rate because that is
+    # the list price of a typical agent turn; a 200k+ prompt is still billed
+    # (and still appears in By provider) but the estimate understates it
+    # rather than inventing a blended rate the table cannot express.
+    "grok-4.6": ModelInfo(
+        id="grok-4.6",
+        name="Grok 4.6",
+        max_tokens=131_072,
+        context_window=500_000,
+        supports_images=True,
+        supports_prompt_cache=True,
+        input_price=2.00,  # $2 / MTok (<200k prompt); $4 ≥200k
+        output_price=6.00,  # $6 / MTok (<200k prompt); $12 ≥200k
+        cache_writes_price=2.00,
+        cache_reads_price=0.50,  # $0.50 / MTok (<200k); $1.00 ≥200k
+        description="xAI Grok 4.6: frontier coding/agent model, 500k context.",
+        recommended=True,
+    ),
+    "grok-4.5": ModelInfo(
+        id="grok-4.5",
+        name="Grok 4.5",
+        max_tokens=131_072,
+        context_window=500_000,
+        supports_images=True,
+        supports_prompt_cache=True,
+        input_price=2.00,
+        output_price=6.00,
+        cache_writes_price=2.00,
+        cache_reads_price=0.30,
+        description="xAI Grok 4.5: previous-generation frontier, 500k context.",
+        recommended=False,
+    ),
+    "grok-4.3": ModelInfo(
+        id="grok-4.3",
+        name="Grok 4.3",
+        max_tokens=131_072,
+        context_window=1_000_000,
+        supports_images=True,
+        supports_prompt_cache=True,
+        input_price=1.25,
+        output_price=2.50,
+        cache_writes_price=1.25,
+        cache_reads_price=0.20,
+        description="xAI Grok 4.3: 1M-context Grok 4 family model.",
+        recommended=False,
+    ),
     # grok-3-beta, grok-3, grok-3-latest
     "grok-3-beta": ModelInfo(
         id="grok-3-beta",

--- a/local_operator/providers/failover.py
+++ b/local_operator/providers/failover.py
@@ -1431,6 +1431,28 @@ def wrap_transport_error(exc: BaseException) -> ProviderError:
     )
 
 
+def _stamp_serving_spec(event: StreamEvent, spec: ModelSpec) -> StreamEvent:
+    """Copy the on-the-wire serving spec onto a usage-bearing event.
+
+    ``stream_with_failover`` rewrites ``current_request.model`` to the fallback
+    that actually served, but the recorder used to read the ORIGINAL
+    ``ChatRequest`` and therefore stored every failover success under the
+    session primary. Stamping here is the honest channel: a primary success,
+    an isolated/naming call (``route_state`` is None), and a mid-turn failover
+    all carry the spec that went on the wire for THIS attempt. Events without
+    a ``usage`` pass through unchanged so the stream stays byte-for-byte for
+    everything the turn actually consumes.
+    """
+    usage = getattr(event, "usage", None)
+    if usage is None:
+        return event
+    try:
+        stamped = usage.model_copy(update={"provider": spec.provider, "model_id": spec.model_id})
+        return event.model_copy(update={"usage": stamped})
+    except Exception:  # noqa: BLE001 — a stamp failure must not drop the event
+        return event
+
+
 async def stream_with_failover(
     request: ChatRequest,
     auth: FailoverAuthStore,
@@ -1799,11 +1821,12 @@ async def stream_with_failover(
             buffered: list[StreamEvent] | None = [] if current_request.replayable else None
             try:
                 async for event in client.stream(current_request, key, oauth_access=access):
+                    stamped = _stamp_serving_spec(event, spec)
                     if buffered is not None:
-                        buffered.append(event)
+                        buffered.append(stamped)
                         continue
                     forwarded_any = True
-                    yield event
+                    yield stamped
                 if route_state is not None and target == primary_target:
                     # Settled, not silent: while a fallback was pinned the front
                     # end has been displaying THAT model, so the primary serving

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.27.1"
+version = "0.27.2"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/analytics/test_model.py
+++ b/tests/unit/analytics/test_model.py
@@ -14,6 +14,7 @@ from local_operator.analytics.model import (
     CallSnapshot,
     UsageAggregate,
     apportion_components,
+    price_snapshot,
     snapshot_component_chars,
     split_system_prompt,
 )
@@ -313,3 +314,49 @@ def test_callsnapshot_is_frozen_scalars():
     except Exception:
         raised = True
     assert raised
+
+
+def test_price_snapshot_prefers_provider_reported_usd_cost():
+    """A snapshot with ``usd_cost`` stores that figure even when the table differs.
+
+    OpenRouter (and any compat provider that reports ``usage.cost``) used to be
+    silently re-estimated because ``CallSnapshot`` had no field for the reported
+    dollar and ``price_snapshot`` only consulted the registry. $0.0075 must
+    become 7500 micro-USD, not Opus-or-whatever list math on 2M tokens.
+    """
+    snap = CallSnapshot(
+        ts_ms=1,
+        session_id="s",
+        provider="openrouter",
+        model_id="anthropic/claude-opus-4-8",
+        input_tokens=1_000_000,
+        output_tokens=1_000_000,
+        cache_read_tokens=0,
+        cache_write_tokens=0,
+        reasoning_tokens=0,
+        context_tokens=1_000_000,
+        usd_cost=0.0075,
+    )
+    cost_micro, known = price_snapshot(snap)
+    assert known is True
+    assert cost_micro == 7500
+
+
+def test_price_snapshot_reported_zero_is_known_free():
+    """A real billed-as-free ``0.0`` must not collapse into ``$—``."""
+    snap = CallSnapshot(
+        ts_ms=1,
+        session_id="s",
+        provider="openrouter",
+        model_id="free/sku",
+        input_tokens=10,
+        output_tokens=10,
+        cache_read_tokens=0,
+        cache_write_tokens=0,
+        reasoning_tokens=0,
+        context_tokens=10,
+        usd_cost=0.0,
+    )
+    cost_micro, known = price_snapshot(snap)
+    assert known is True
+    assert cost_micro == 0

--- a/tests/unit/analytics/test_stream_recording.py
+++ b/tests/unit/analytics/test_stream_recording.py
@@ -203,3 +203,112 @@ def test_analytics_failure_never_breaks_turn(tmp_path, monkeypatch):
     out = asyncio.run(_drain(fn, _request(), [StreamEndEvent(stop_reason="stop", usage=usage)]))
     # The turn's event still came through; the analytics failure was swallowed.
     assert [type(e).__name__ for e in out] == ["StreamEndEvent"]
+
+
+def test_records_serving_model_not_session_primary(tmp_path):
+    """A primary→xai failover must land under xai/grok-4.6, not anthropic.
+
+    ``stream_with_failover`` rewrites the on-the-wire request but used to leave
+    the recorder reading the ORIGINAL ChatRequest. After Anthropic failed over
+    to Grok every successful call was stored as ``anthropic/claude-opus-4-8``
+    and priced at Opus rates — which is why By provider showed only anthropic.
+    The failover layer now stamps the serving spec onto Usage; this is the
+    contract the recorder must honour.
+    """
+    store = AnalyticsStore(tmp_path / "a.db")
+    rec = reset_recorder_for_test(store)
+    fn = _fn("sess-failover")
+    request = _request()  # anthropic/claude-opus-5
+    usage = Usage(
+        input_tokens=1000,
+        output_tokens=200,
+        context_tokens=1000,
+        provider="xai",
+        model_id="grok-4.6",
+    )
+    asyncio.run(_drain(fn, request, [StreamEndEvent(stop_reason="stop", usage=usage)]))
+    rec.flush_for_test()
+    agg = store.aggregate()
+    assert agg.calls == 1
+    assert "xai" in agg.by_provider
+    assert "anthropic" not in agg.by_provider
+    rec.close()
+    store.close()
+
+
+def test_records_primary_success_under_primary(tmp_path):
+    """A call that never failed over must still attribute to the session primary.
+
+    The serving-spec stamp is how failover is honest; it must not invent a
+    fallback on a primary success (or an isolated naming call that never
+    walked the chain).
+    """
+    store = AnalyticsStore(tmp_path / "a.db")
+    rec = reset_recorder_for_test(store)
+    fn = _fn()
+    usage = Usage(
+        input_tokens=100,
+        output_tokens=20,
+        context_tokens=100,
+        provider="anthropic",
+        model_id="claude-opus-5",
+    )
+    asyncio.run(_drain(fn, _request(), [StreamEndEvent(stop_reason="stop", usage=usage)]))
+    rec.flush_for_test()
+    assert set(store.aggregate().by_provider) == {"anthropic"}
+    rec.close()
+    store.close()
+
+
+def test_canonicalizes_login_flavour_to_storage_id(tmp_path):
+    """``xai-oauth`` spend must roll up under ``xai``, not a second row.
+
+    The login flavour is the same billable vendor as the API-key id. Splitting
+    them in By provider was the other half of "I am on grok and analytics
+    still shows only anthropic" once the serving-spec stamp landed.
+    """
+    store = AnalyticsStore(tmp_path / "a.db")
+    rec = reset_recorder_for_test(store)
+    fn = _fn()
+    request = ChatRequest(
+        model=ModelSpec(provider="xai-oauth", model_id="grok-4.6"),
+        system_blocks=["persona", "tools", "env", "skills"],
+        messages=[Message(role="user", content=[TextContent(text="hi " * 50)])],
+    )
+    usage = Usage(input_tokens=100, output_tokens=20, context_tokens=100)
+    asyncio.run(_drain(fn, request, [StreamEndEvent(stop_reason="stop", usage=usage)]))
+    rec.flush_for_test()
+    assert set(store.aggregate().by_provider) == {"xai"}
+    rec.close()
+    store.close()
+
+
+def test_provider_reported_usd_cost_survives_into_the_ledger(tmp_path):
+    """OpenRouter's ``usage.cost`` must become ``cost_micro``, not a table estimate.
+
+    ``CallSnapshot`` used to drop ``usd_cost``, so ``price_snapshot`` always
+    re-estimated from the registry. A reported $0.0075 on a model whose table
+    price is wildly different must store 7500 micro-USD.
+    """
+    store = AnalyticsStore(tmp_path / "a.db")
+    rec = reset_recorder_for_test(store)
+    fn = _fn()
+    request = ChatRequest(
+        model=ModelSpec(provider="openrouter", model_id="some/unpriced-sku"),
+        system_blocks=["persona", "tools", "env", "skills"],
+        messages=[Message(role="user", content=[TextContent(text="hi " * 50)])],
+    )
+    usage = Usage(
+        input_tokens=1_000_000,
+        output_tokens=1_000_000,
+        context_tokens=1_000_000,
+        usd_cost=0.0075,
+    )
+    asyncio.run(_drain(fn, request, [StreamEndEvent(stop_reason="stop", usage=usage)]))
+    rec.flush_for_test()
+    agg = store.aggregate()
+    assert agg.calls == 1
+    assert agg.cost_is_known is True
+    assert agg.cost_micro == 7500
+    rec.close()
+    store.close()

--- a/tests/unit/model/test_catalogue.py
+++ b/tests/unit/model/test_catalogue.py
@@ -1220,7 +1220,7 @@ def test_an_unshipped_xai_id_does_not_keep_the_unknown_placeholder_name(monkeypa
     from local_operator.model.discovery import DiscoveredModel
     from local_operator.model.registry import unknown_model_info, xai_models
 
-    model_id = "grok-4.6"
+    model_id = "grok-4.20"
     assert model_id not in xai_models, "the id this test treats as unshipped now ships"
 
     _stub_discovery(
@@ -1237,7 +1237,7 @@ def test_an_unshipped_xai_id_does_not_keep_the_unknown_placeholder_name(monkeypa
     assert info.name != "Unknown"
     assert info.context_window == 500_000
     # The id wearing a name's clothes is refused by the band (see naming.py),
-    # so the operator sees ``grok-4.6`` rather than the placeholder word.
+    # so the operator sees ``grok-4.20`` rather than the placeholder word.
     assert spec.display_name in ("", model_id)
     assert spec.display_name != "Unknown"
     assert spec.context_window == 500_000

--- a/tests/unit/model/test_naming.py
+++ b/tests/unit/model/test_naming.py
@@ -290,10 +290,10 @@ def test_the_unknown_placeholder_name_is_not_a_display_name() -> None:
     """``Unknown`` is the shipped fallback's identity, not a model. Promoting it
     is how a nameless xAI listing painted the status band ``Unknown`` for a
     running Grok 4.6 session."""
-    info = ModelInfo(id="grok-4.6", name="Unknown", description="Unknown model")
-    assert build_model_spec("xai", "grok-4.6", info).display_name == ""
-    assert model_label("xai", "grok-4.6", "Unknown").full == "xai/grok-4.6"
-    assert model_label("xai", "grok-4.6", "Unknown").compact == "grok-4.6"
+    info = ModelInfo(id="grok-4.20", name="Unknown", description="Unknown model")
+    assert build_model_spec("xai", "grok-4.20", info).display_name == ""
+    assert model_label("xai", "grok-4.20", "Unknown").full == "xai/grok-4.20"
+    assert model_label("xai", "grok-4.20", "Unknown").compact == "grok-4.20"
 
 
 def test_a_normalised_id_still_supplies_its_name() -> None:

--- a/tests/unit/model/test_registry.py
+++ b/tests/unit/model/test_registry.py
@@ -116,6 +116,36 @@ def test_get_model_info() -> None:
         get_model_info("unknown", "any")
 
 
+def test_current_fallback_chain_models_have_first_class_prices() -> None:
+    """The operator's default fallback chain must price without discovery.
+
+    ``price_snapshot`` returns ``(0, False)`` — rendered ``$—`` — when both
+    input and output prices are missing. After the serving-model fix, an xAI
+    row that still had no registry price would appear in By provider with
+    tokens and no dollars. These are the ids on the live default chain
+    (plus grok-4.6, the one the operator is on right now).
+    """
+    grok = get_model_info("xai", "grok-4.6")
+    assert grok.input_price == 2.00
+    assert grok.output_price == 6.00
+    assert grok.cache_reads_price == 0.50
+    assert grok.context_window == 500_000
+
+    k3 = get_model_info("kimi", "k3")
+    assert k3.input_price == 3.00
+    assert k3.output_price == 15.00
+    assert k3.cache_reads_price == 0.30
+
+    sol = get_model_info("openai", "gpt-5.6-sol")
+    assert sol.input_price == 4.0
+    assert sol.output_price == 20.0
+    assert sol.cache_reads_price == 0.40
+
+    glm = get_model_info("zai", "glm-5.3")
+    assert glm.input_price == 1.4
+    assert glm.output_price == 4.4
+
+
 # -- QwenCloud Token Plan -----------------------------------------------------
 #
 # The Token Plan gateway's `/models` listing carries ONLY ids (checked live,

--- a/tests/unit/providers/test_failover.py
+++ b/tests/unit/providers/test_failover.py
@@ -20,6 +20,8 @@ from local_operator.harness.types import (
     ModelSpec,
     StreamEndEvent,
     StreamTextDelta,
+    StreamUsageEvent,
+    Usage,
 )
 from local_operator.model.configure import build_model_spec
 from local_operator.providers import failover as failover_module
@@ -475,6 +477,73 @@ async def test_stream_fallback_chain_walks_to_next_model() -> None:
     got = [event async for event in stream_with_failover(_request(), auth, settings, client_for)]
     assert [s.model_id for s in specs_seen] == ["gpt-4o", "claude-x"]
     assert any(isinstance(e, StreamTextDelta) and e.delta == "fallback" for e in got)
+
+
+async def test_failover_stamps_serving_spec_on_usage() -> None:
+    """After a primary→xai walk the usage event names xai, not the primary.
+
+    The analytics recorder reads serving identity off Usage. Without this stamp
+    it would keep attributing the successful Grok call to anthropic — the
+    missing-provider bug. A primary success is covered by the same helper
+    (it stamps whatever ``current_request.model`` is) so this cannot
+    mis-attribute a call that never left the primary.
+    """
+    usage = Usage(input_tokens=10, output_tokens=4)
+
+    async def client_for(spec: ModelSpec) -> Any:
+        if spec.provider == "anthropic":
+            return ScriptedClient(ProviderError(500, "boom", retryable=True))
+        return ScriptedClient(
+            [
+                StreamTextDelta(delta="ok"),
+                StreamUsageEvent(usage=usage),
+                StreamEndEvent(stop_reason="stop", usage=usage),
+            ]
+        )
+
+    settings = {
+        "retry": {
+            "baseDelayMs": 1,
+            "fallbackChains": {"default": ["xai/grok-4.6"]},
+        }
+    }
+    auth = FakeAuth({"anthropic": ["k1"], "xai": ["k2"]})
+    got = [
+        event
+        async for event in stream_with_failover(
+            _request("anthropic", "claude-opus-4-8"), auth, settings, client_for
+        )
+    ]
+    usage_events = [e for e in got if isinstance(e, StreamUsageEvent)]
+    end_events = [e for e in got if isinstance(e, StreamEndEvent)]
+    assert usage_events and usage_events[0].usage.provider == "xai"
+    assert usage_events[0].usage.model_id == "grok-4.6"
+    assert end_events and end_events[0].usage is not None
+    assert end_events[0].usage.provider == "xai"
+    assert end_events[0].usage.model_id == "grok-4.6"
+
+
+async def test_primary_success_stamps_primary_spec() -> None:
+    """A call that never failed over must still name the session primary."""
+    usage = Usage(input_tokens=3, output_tokens=1)
+
+    async def client_for(spec: ModelSpec) -> Any:
+        return ScriptedClient(
+            [StreamUsageEvent(usage=usage), StreamEndEvent(stop_reason="stop", usage=usage)]
+        )
+
+    got = [
+        event
+        async for event in stream_with_failover(
+            _request("anthropic", "claude-opus-4-8"),
+            FakeAuth({"anthropic": ["k"]}),
+            None,
+            client_for,
+        )
+    ]
+    stamped = next(e for e in got if isinstance(e, StreamUsageEvent)).usage
+    assert stamped.provider == "anthropic"
+    assert stamped.model_id == "claude-opus-4-8"
 
 
 async def test_fallback_chain_deduplicates_current_model_and_effort() -> None:

--- a/tests/unit/tui/test_status_line.py
+++ b/tests/unit/tui/test_status_line.py
@@ -263,8 +263,8 @@ def test_a_listing_name_reaches_the_band_for_a_model_no_registry_row_covers() ->
 def test_the_unknown_placeholder_does_not_reach_the_band() -> None:
     """The word the shared fallback is named, not a model. A nameless listing
     used to keep it and paint it on the band for every unshipped id."""
-    assert format_model_label("xai/grok-4.6", short=False, name="Unknown") == "xai/grok-4.6"
-    assert format_model_label("xai/grok-4.6", short=True, name="Unknown") == "grok-4.6"
+    assert format_model_label("xai/grok-4.20", short=False, name="Unknown") == "xai/grok-4.20"
+    assert format_model_label("xai/grok-4.20", short=True, name="Unknown") == "grok-4.20"
 
 
 def test_a_resold_model_keeps_its_selector_however_the_reseller_names_it() -> None:


### PR DESCRIPTION
## Why

Live `analytics.db` has 17k+ rows and they are ALL `anthropic` / `claude-opus-4-8`. The operator is on `xai/grok-4.6` right now (primary Anthropic failed over down the default chain). `/analytics` still showed only anthropic, and Est. cost was Opus list rates on Grok tokens.

Three bugs, stacked:

1. **Serving model discarded.** `stream_with_failover` rewrites the on-the-wire request to the fallback spec (`current_request = request.model_copy(update={"model": spec})`) but `_record_usage` read `request.model` off the ORIGINAL ChatRequest. After Anthropic walked to xAI, every successful Grok call was stored as `anthropic/claude-opus-4-8`.
2. **Provider-reported cost dropped.** `Usage.usd_cost` (OpenRouter `usage.cost`) never reached `CallSnapshot`, so `price_snapshot` always re-estimated from the registry table.
3. **Current-generation models unpriced.** Static `xai_models` stopped at grok-3 / grok-2. `price_snapshot` returns `(0, False)` when both prices are missing, so even after (1) an xAI row would have rendered `$—`. Same hole for `kimi/k3` and `openai/gpt-5.6-sol` on the default fallback chain.

Historical rows are left alone. Past failover spend is already stored as anthropic and cannot be recovered. New calls must be correct.

## What changes

- Failover stamps the on-the-wire serving spec onto `Usage.provider` / `Usage.model_id`. The recorder prefers that stamp, then falls back to `request.model` for unstamped paths (tests, isolated drains). Isolated/naming calls disable `route_state`, so the pin is not an honest source — the stamp is.
- Login flavours (`xai-oauth`, `openai-device`) canonicalize to their storage id at record time so By provider does not split one vendor into two rows.
- `CallSnapshot.usd_cost` carries the provider-reported dollar. `price_snapshot` prefers a finite non-negative report even when the registry has no row for the id.
- First-class registry prices, transcribed from first-party docs on 2026-08-23:
  - `xai/grok-4.6` $2 / $6 / $0.50 cached (https://docs.x.ai/developers/models; <200k-prompt tier)
  - `xai/grok-4.5`, `xai/grok-4.3` (same page)
  - `kimi/k3` $3 / $15 / $0.30 cached (https://platform.kimi.ai/docs/pricing/chat-k3)
  - `openai/gpt-5.6-sol` $4 / $20 / $0.40 cached (https://developers.openai.com/api/docs/models/gpt-5.6-sol)
- Patch bump 0.27.1 → 0.27.2. 0.27.1 shipped #280 (last-known OAuth usage numbers) while this PR was in review, so this branch was rebased onto that tag and bumped again.

No `/analytics` interaction change. Existing By-provider UI just starts showing the other providers.

## Impact

- Existing DBs are untouched. New calls attribute to the model that actually served and price from that model's table (or the provider's own `usage.cost`).
- An unpriceable model still appears in By provider with tokens + `$—` (unknown ≠ missing).
- Long-context surcharges (grok ≥200k, gpt-5.6-sol >272k) are not blended into the table; the estimate uses the typical-turn rate rather than inventing one.

## Testing Details

### Automated

- flake8 clean · black==26.1.0 --check clean · isort --profile black clean · pyright 0 errors / 0 warnings.
- New / updated tests (fail on unfixed code, pass after):
  - `test_failover_stamps_serving_spec_on_usage` — primary anthropic → xai/grok-4.6 stamps `provider="xai"`.
  - `test_primary_success_stamps_primary_spec` — a call that never left the primary still names anthropic.
  - `test_records_serving_model_not_session_primary` — recorder stores the stamp, not the original ChatRequest.
  - `test_canonicalizes_login_flavour_to_storage_id` — `xai-oauth` rolls up under `xai`.
  - `test_provider_reported_usd_cost_survives_into_the_ledger` / `test_price_snapshot_prefers_provider_reported_usd_cost` — a reported $0.0075 stores as 7500 micro-USD even when the table would differ.
  - `test_current_fallback_chain_models_have_first_class_prices` — grok-4.6 / k3 / gpt-5.6-sol / glm-5.3 have real input/output prices.
- `pytest tests/unit` → 6452 passed, 7 skipped. Two failures are pre-existing flakes (`test_eval_tool.py::test_background_streams_output_while_it_runs`, `test_ask_picker.py::test_a_held_key_never_answers_a_question_the_card_moved_on_from`) — they fail identically on clean origin/main and are unrelated.
- `env -u NO_COLOR TERM=xterm-256color pytest tests/unit/tui tests/unit/analytics` → 2490 passed, 4 skipped (same eval-tool flake when included).

### Rendered `/analytics` (real OperatorApp, run_test + save_screenshot)

Fixture store with anthropic + xai + openai (priced) and ollama (unpriced → `$—`). Geometry: `screen.size == virtual_size` (116×40), `vscroll=False` — no clip, no unexpected scrollbar. This is a data-path fix, not a layout change, so before and after frames are identical: the existing By-provider table already rendered multiple providers correctly once the ledger told the truth.

**Before / after** (same frame; the UI already knew how to show this):

![before](https://raw.githubusercontent.com/damianvtran/local-operator/pr-analytics-providers-assets/assets/lop-analytics-before-view.png)

![after](https://raw.githubusercontent.com/damianvtran/local-operator/pr-analytics-providers-assets/assets/lop-analytics-after-view.png)

SVG stills: [before.svg](https://raw.githubusercontent.com/damianvtran/local-operator/pr-analytics-providers-assets/assets/lop-analytics-before.svg) · [after.svg](https://raw.githubusercontent.com/damianvtran/local-operator/pr-analytics-providers-assets/assets/lop-analytics-after.svg)

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my changes work as intended.
- [x] All new and existing tests pass (pre-existing flakes noted above).
- [x] I have run formatting (black/isort), linting (flake8), and type checks (pyright), and they pass.
- [x] I have updated the documentation when required.
- [x] Security considerations are addressed (especially for code execution features).
- [ ] I have linked all related issues.

