### PR TITLE
feat(update): add PyPI upgrade and process relaunch

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,9 @@ pip install local-operator     # pipx install local-operator on Linux (PEP 668)
 ```
 
 The install provides both `local-operator` and its short alias `lop` — the
-rest of this page uses `lop`.
+rest of this page uses `lop`. `lop update` upgrades that install from PyPI;
+`lop-update` (hyphen) is the developer script that rebuilds the global
+runtime from a local git checkout.
 
 Sign in to a provider (or skip this — on an interactive terminal `lop` opens
 in a setup state and walks you through `/login`; a headless or piped run prints

--- a/README.md
+++ b/README.md
@@ -182,7 +182,8 @@ current session's cost live).
 | `/effort` | Show or set reasoning effort (`shift+tab` cycles) |
 | `/approvals` | Set whether tools ask first (`ask`/`auto`; add `default` to keep it) |
 | `/resume` | Pick a past conversation and continue it |
-| `/new`, `/clear`, `/reload` | Fresh conversation · wipe the screen · reboot the session in place |
+| `/new`, `/clear`, `/reload` | Fresh conversation · wipe the screen · relaunch this conversation on the current install |
+| `/update` | Install the latest version from PyPI and relaunch |
 | `/goal`, `/loop` | Set an objective, then iterate autonomously toward it |
 | `/btw` | Ask a side question off the record — it never joins the conversation |
 | `/compact` | Compact the context now (it also happens automatically) |

--- a/local_operator/cli.py
+++ b/local_operator/cli.py
@@ -401,6 +401,22 @@ def build_cli_parser() -> argparse.ArgumentParser:
     serve_mobile_parser.add_argument("--port", type=int, default=4098)
 
     # Exec command for single execution mode
+    # PyPI upgrade. Not ``lop-update`` (hyphen), which archives local git
+    # ``main`` into the uv-tool env — opposite audience, never invoked here.
+    update_parser = subparsers.add_parser(
+        "update",
+        help=(
+            "Upgrade this install from PyPI. Not the lop-update script, "
+            "which rebuilds the global runtime from a local git checkout."
+        ),
+        parents=[parent_parser],
+    )
+    update_parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Print installed vs PyPI; do not install",
+    )
+
     exec_parser = subparsers.add_parser(
         "exec",
         help="Execute a single command without starting interactive mode",
@@ -2086,6 +2102,12 @@ def main() -> int:
             if invalid is not None:
                 return invalid
             return mcp_command(args)
+        elif args.subcommand == "update":
+            # Lazy: ``update`` imports httpx. ``import local_operator.cli``
+            # must not (``tests/unit/test_import_graph.py``).
+            from local_operator.update import update_command
+
+            return update_command(check=bool(getattr(args, "check", False)))
         elif args.subcommand == "exec":
             # Single-execution mode: headless one-shot (README contract —
             # exit 0 on success, non-zero on error). Working-directory
@@ -2350,13 +2372,23 @@ def main() -> int:
                 # which must keep its console output, so the wrapping goes on
                 # this call site rather than inside it.
                 with file_logging():
-                    return asyncio.run(
+                    tui_code = asyncio.run(
                         _run_with_scheduler(
                             tui_entry,
                             session_factory,
                             theme_name,
                         )
                     )
+                # 75: the TUI asked to be replaced after a clean teardown.
+                # ``replace_self`` does not return; a missing plan is a bug.
+                from local_operator.reexec import REEXEC_CODE, replace_self, take_plan
+
+                if tui_code == REEXEC_CODE:
+                    plan = take_plan()
+                    if plan is None:
+                        return 1
+                    replace_self(plan)
+                return tui_code
             finally:
                 try:
                     tui_controller.close()

--- a/local_operator/reexec.py
+++ b/local_operator/reexec.py
@@ -1,0 +1,164 @@
+"""Replace this process with a fresh launch of the same install.
+
+WHY THIS EXISTS
+---------------
+``/reload`` used to reboot MCP/credentials/model inside the *old*
+interpreter. After ``lop update`` (or any other package replace) that
+cannot pick up the new wheel. ``/update`` and ``/reload`` therefore share
+one helper that ends the TUI cleanly and then replaces the process.
+
+WHY NOT ``os.execv`` FROM INSIDE THE TUI
+----------------------------------------
+Textual owns the alternate screen. Exec-ing over a live ``OperatorApp``
+leaves the terminal half-raw. ``run_tui`` already returns
+``app.return_code`` after ``run_async()`` and restores the terminal in
+that teardown — that is the seam. The handler stashes a :class:`RestartPlan`,
+exits with :data:`REEXEC_CODE`, and ``cli.main`` calls :func:`replace_self`
+only after the TUI has released the tty.
+
+``75`` is ``EX_TEMPFAIL``: not 0/1/130, which ``run_tui`` already uses
+for success, error, and Ctrl-C.
+
+POSIX uses ``os.execvpe`` so the same PID comes back with cwd/env
+preserved by definition. Windows console shims make ``os.execv``
+unreliable, so that backend is ``Popen`` + ``os._exit(0)``. One helper,
+two OS backends — no detached babysitter unless a file-lock on
+``uv tool upgrade`` later forces it.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+
+#: Private exit from the TUI that means "replace this process", not "the
+#: user quit". ``run_tui`` suppresses the ``session ended — resume with:``
+#: hint on this code: that line is for a human staying in the shell.
+REEXEC_CODE = 75
+
+
+@dataclass(frozen=True)
+class RestartPlan:
+    """What the next process should look like.
+
+    ``argv`` is the rewritten launch line. ``resume_id`` is recorded so
+    tests (and a future Windows helper) can see the session the plan
+    targeted without re-parsing argv.
+    """
+
+    argv: list[str]
+    resume_id: str | None = None
+
+
+def _drop_flag(argv: list[str], name: str) -> list[str]:
+    """Remove ``name`` and, when it takes a value, the following token."""
+    out: list[str] = []
+    skip = False
+    for token in argv:
+        if skip:
+            skip = False
+            continue
+        if token == name:
+            skip = True
+            continue
+        if token.startswith(f"{name}="):
+            continue
+        out.append(token)
+    return out
+
+
+def plan_argv(
+    original: list[str] | None = None,
+    *,
+    resume_id: str | None = None,
+) -> list[str]:
+    """``sys.argv`` as launched, with ``--resume`` rewritten.
+
+    A transcript on disk (the same id ``resume_hint()`` advertises) is
+    injected so the new process reopens this conversation. No transcript
+    yet — first turn never persisted — strips any ``--resume`` so the new
+    process is a cold launch, matching what today's in-process ``/reload``
+    already accepts when it cannot rebind.
+
+    A previous ``--resume`` is dropped before the new one is written so
+    the flag cannot appear twice. ``--hosting`` / ``--model`` / ``--agent``
+    / ``--tui`` / ``--debug`` / ``--train`` ride along because they were
+    already on the launch line; we do not invent them.
+    """
+    launched = list(original if original is not None else sys.argv)
+    if not launched:
+        launched = [sys.argv[0] if sys.argv else "lop"]
+
+    rewritten = _drop_flag(launched, "--resume")
+    if resume_id:
+        rewritten.extend(["--resume", resume_id])
+    return rewritten
+
+
+def make_plan(
+    original: list[str] | None = None,
+    *,
+    resume_id: str | None = None,
+) -> RestartPlan:
+    return RestartPlan(argv=plan_argv(original, resume_id=resume_id), resume_id=resume_id)
+
+
+_pending: RestartPlan | None = None
+
+
+def stash_plan(plan: RestartPlan) -> None:
+    """Park a plan for ``cli.main`` to consume after the TUI has torn down.
+
+    The handler cannot ``exec`` from inside Textual (alternate screen). It
+    exits 75 and leaves the plan here so ``replace_self`` runs only after
+    ``run_tui`` has restored the terminal.
+    """
+    global _pending
+    _pending = plan
+
+
+def take_plan() -> RestartPlan | None:
+    """Return and clear the parked plan (``None`` if the TUI never stashed)."""
+    global _pending
+    plan = _pending
+    _pending = None
+    return plan
+
+
+def _on_windows() -> bool:
+    """Indirection so tests can flip the backend without patching ``sys``."""
+    return sys.platform == "win32"
+
+
+def _replace_windows(argv: list[str], env: dict[str, str]) -> None:
+    """Spawn a sibling then exit. ``os.execv`` on Windows console shims is unreliable."""
+    flags = 0
+    create_new = getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
+    if isinstance(create_new, int):
+        flags = create_new
+    subprocess.Popen(  # noqa: S603 — relaunch of our own argv
+        argv,
+        cwd=os.getcwd(),
+        env=env,
+        close_fds=True,
+        creationflags=flags,
+    )
+    os._exit(0)
+
+
+def _replace_posix(argv: list[str], env: dict[str, str]) -> None:
+    os.execvpe(argv[0], argv, env)
+
+
+def replace_self(plan: RestartPlan) -> None:
+    """Never returns on success. POSIX execs; Windows spawns then exits."""
+    argv = list(plan.argv)
+    if not argv:
+        raise RuntimeError("RestartPlan.argv is empty")
+    env = os.environ.copy()
+    if _on_windows():
+        _replace_windows(argv, env)
+        return
+    _replace_posix(argv, env)

--- a/local_operator/tui/__init__.py
+++ b/local_operator/tui/__init__.py
@@ -55,7 +55,12 @@ async def run_tui(
             # user's scrollback where it can be copied — printing it from inside
             # the app would put it in a frame that is being torn down. In the
             # `finally` so it survives the exit paths as well as the clean one.
-            hint = app.resume_hint()
-            if hint:
-                print(f"\nsession ended — resume with:\n  {hint}\n")
+            from local_operator.reexec import REEXEC_CODE
+
+            # A relaunch is about to replace this process; the hint is for a
+            # human who is staying in the shell.
+            if app.return_code != REEXEC_CODE:
+                hint = app.resume_hint()
+                if hint:
+                    print(f"\nsession ended — resume with:\n  {hint}\n")
         return int(app.return_code or 0)

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import sys
 import time
 from collections.abc import Mapping
 from dataclasses import dataclass
@@ -367,9 +368,14 @@ SLASH_COMMANDS: list[SlashCommand] = [
     SlashCommand("clear", "Clear the transcript (history is untouched)"),
     # Replaces the transcript; a row describing the old one would not survive.
     SlashCommand("new", "Start a new conversation"),
-    # "reloading session…" while it runs; `_reconcile_reload` posts the receipt
-    # that survives the ledger being rebuilt, and it names what came back.
-    SlashCommand("reload", "Reboot the session, keeping this conversation"),
+    # In-process reboot cannot load a replaced wheel; this command exists so
+    # ``/update`` is not the only way to pick up new code. Same relaunch
+    # helper as ``/update`` — the conversation comes back via ``--resume``.
+    SlashCommand("reload", "Relaunch this conversation on the current install"),
+    # The notice (or the relaunch) is the receipt. echo=False is the default;
+    # pin it in ECHO_POLICY so a later flip cannot sneak a user row onto an
+    # empty splash that ``/update`` is required to leave standing.
+    SlashCommand("update", "Install the latest version from PyPI and relaunch"),
     # The picker (or "resuming session <id>…") is the receipt, and a resume
     # replaces the transcript anyway.
     SlashCommand(
@@ -1254,6 +1260,14 @@ class OperatorApp(App[None]):
         #: one only: the splash is one row. Cleared on a session swap
         #: because it describes the session that just died.
         self._splash_notice: str | None = None
+        #: PyPI version strictly newer than this install, filled by the
+        #: one-shot mount worker. ``None`` until then AND when current —
+        #: the splash does not reserve the row.
+        self._update_available: str | None = None
+        #: Stashed so ``cli.main`` can ``replace_self`` after ``run_tui``
+        #: has restored the terminal. ``None`` unless ``/update`` or
+        #: ``/reload`` asked to relaunch.
+        self._restart_plan: Any | None = None
         # Whatever held focus when the usage panel opened, so closing it returns
         # the user to the composer they were typing in rather than to nothing.
         # The approval card follows the same discipline for the same reason.
@@ -1621,6 +1635,7 @@ class OperatorApp(App[None]):
                     self._providers,
                     notice=self._splash_notice,
                     setup=self._setup_state,
+                    update_available=self._update_available,
                 )
             )
         # The dock band: subagent task list + todo list, sitting between the
@@ -1777,6 +1792,13 @@ class OperatorApp(App[None]):
 
         # Await the session in a worker so the app paints first.
         self.run_worker(self._boot_session(), thread=False, group="session")
+        # After first paint, not on the welcome poll timer (that one only
+        # waits for the model label). Deferred so this thread worker cannot
+        # steal the first tick from boot. Network failure is silent.
+        self.call_after_refresh(self._start_update_check)
+
+    def _start_update_check(self) -> None:
+        self.run_worker(self._check_for_update, thread=True, group="update-check")
 
     @staticmethod
     async def _warm_session_imports() -> None:
@@ -2871,35 +2893,93 @@ class OperatorApp(App[None]):
         )
 
     def _cmd_reload(self, notice: NoticeFn) -> None:
-        """``/reload`` — re-run boot against the SAME conversation.
+        """``/reload`` — relaunch this conversation on the current install.
 
-        What a reload is FOR is the boot: MCP servers reconnected, credentials
-        re-read, the model re-resolved. The conversation is not what went
-        wrong, and with ``/new`` standing as the explicit fresh start there is
-        no reason for this to discard it. It discarded it anyway: the launch
-        factory is ``create_session`` bound to the args the app started with,
-        which name no session to resume, so every ``/reload`` minted a NEW
-        transcript directory. The model lost the conversation while the screen
-        went on showing it.
-
-        So rebind to this conversation's id first, exactly as
-        :meth:`_resume_session` does — a reload IS a resume of the session
-        already open, and ``Session`` seeds its context from the transcript it
-        is pointed at. Gated on that transcript being on disk, because
-        ``resume_dir`` refuses an id it cannot find: a reload before the first
-        turn persisted would otherwise fail to boot at all. The same gate keeps
-        the command's original purpose intact — a session that never
-        constructed has no id to rebind to, so it retries the launch factory
-        exactly as it always did.
+        In-process reboot cannot load a replaced wheel; this command exists
+        so ``/update`` is not the only way to pick up new code. ``/new`` and
+        ``/resume`` stay in-process — they swap conversations, not binaries.
         """
-        resume_id = self._resumable_session_id()
-        if resume_id and self._resume_factory is not None:
-            self._session_factory = lambda: self._resume_factory(resume_id)  # type: ignore[misc]
-        # Transient by design: the reload rebuilds the ledger from the session
-        # it boots, so this line is the acknowledgement WHILE that happens and
-        # `_reconcile_reload`'s receipt is what the user is left holding.
-        notice("reloading session…")
-        self.run_worker(self._reload_session(keep_context=True), thread=False, group="session")
+        del notice
+        self._request_relaunch()
+
+    def _turn_is_live(self) -> bool:
+        """A mid-turn exec would drop work the user can still abort with esc."""
+        session = self._session
+        streaming = session is not None and bool(getattr(session, "is_streaming", False))
+        return bool(streaming or self._loop_running or self._streaming_block is not None)
+
+    def _request_relaunch(self) -> None:
+        """Stash a :class:`RestartPlan` and exit 75 so ``cli.main`` re-execs."""
+        if self._turn_is_live():
+            self._system_notice("esc first — a turn is still running", "warning")
+            return
+        from local_operator.reexec import REEXEC_CODE, make_plan, stash_plan
+
+        resume_id = self._resumable_session_id() or None
+        plan = make_plan(list(sys.argv), resume_id=resume_id)
+        self._restart_plan = plan
+        stash_plan(plan)
+        # Keyword: Textual's first positional is ``result``, not the code.
+        self.exit(return_code=REEXEC_CODE)
+
+    def _check_for_update(self) -> None:
+        """Background splash probe. Any failure stays silent — no toast."""
+        from local_operator.update import check_latest
+
+        try:
+            result = check_latest()
+        except Exception:
+            return
+        if not result.behind or not result.latest:
+            return
+        self._update_available = result.latest
+        welcome = self._welcome
+        if welcome is not None:
+            self.call_from_thread(welcome.refresh_info)
+
+    def _cmd_update(self, notice: NoticeFn) -> None:
+        """``/update`` — live PyPI check, upgrade, then the shared relaunch."""
+        del notice
+        if self._turn_is_live():
+            self._system_notice("esc first — a turn is still running", "warning")
+            return
+        self.run_worker(self._run_update, thread=True, group="update")
+
+    def _run_update(self) -> None:
+        from local_operator.update import (
+            UpdateError,
+            check_latest,
+            perform_upgrade,
+        )
+
+        try:
+            result = check_latest(force=True)
+        except Exception as exc:
+            self.call_from_thread(
+                self._system_notice, f"could not check for updates: {exc}", "warning"
+            )
+            return
+        if result.latest is None:
+            self.call_from_thread(
+                self._system_notice, "could not reach PyPI to learn the latest version", "warning"
+            )
+            return
+        if not result.behind:
+            self.call_from_thread(
+                self._system_notice, f"already on v{result.installed or result.latest}"
+            )
+            return
+        self.call_from_thread(self._notice, f"updating to v{result.latest}…")
+        try:
+            installed = perform_upgrade(target=result.latest)
+        except UpdateError as exc:
+            self.call_from_thread(self._system_notice, str(exc), "warning")
+            return
+        except Exception as exc:
+            self.call_from_thread(self._system_notice, f"update failed: {exc}", "error")
+            return
+        self.call_from_thread(self._notice, f"updated to v{installed} — restarting…")
+        self.call_from_thread(self._request_relaunch)
 
     def _cmd_resume(self, arg: str, notice: NoticeFn) -> None:
         """``/resume`` — pick a conversation; ``/resume <id>`` — resume one.
@@ -8139,6 +8219,8 @@ class OperatorApp(App[None]):
             self._clear_transcript()
         elif command == "/reload":
             self._cmd_reload(notice)
+        elif command == "/update":
+            self._cmd_update(notice)
         elif command == "/new":
             self._cmd_new(notice)
         elif command == "/resume":

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -1268,6 +1268,14 @@ class OperatorApp(App[None]):
         #: has restored the terminal. ``None`` unless ``/update`` or
         #: ``/reload`` asked to relaunch.
         self._restart_plan: Any | None = None
+        #: True from the moment ``/update`` accepts until the process exits
+        #: 75 (or the upgrade is refused). The mutex ``group="update"``
+        #: cannot be: Textual exclusivity CANCELS the running worker, and
+        #: cancelling ``uv tool upgrade`` mid-write leaves a half-replaced
+        #: env. A second ``/update`` and a ``/reload`` both honour this
+        #: instead. Also what keeps the composer locked so a typed-ahead
+        #: turn cannot cancel the relaunch after the wheel is already in.
+        self._update_in_progress: bool = False
         # Whatever held focus when the usage panel opened, so closing it returns
         # the user to the composer they were typing in rather than to nothing.
         # The approval card follows the same discipline for the same reason.
@@ -2500,11 +2508,14 @@ class OperatorApp(App[None]):
         missing history was the smaller half of it — nothing detected or
         reported the divergence, because nothing compared the two surfaces.
 
-        ``keep_context`` states the CALLER'S INTENT — ``/reload`` continues this
-        conversation, ``/new`` and ``/resume`` deliberately do not — and it is
-        verified rather than trusted: a reload that meant to keep the
-        conversation and came back with less of it says so, instead of leaving
-        the user to discover it from an answer that has forgotten everything.
+        ``keep_context`` states the CALLER'S INTENT — an in-process rebuild
+        that meant to continue this conversation (tests, and any future
+        caller that still swaps sessions without re-exec) versus ``/new``
+        and ``/resume``, which deliberately do not. It is verified rather
+        than trusted: a reload that meant to keep the conversation and came
+        back with less of it says so, instead of leaving the user to
+        discover it from an answer that has forgotten everything.
+        ``/reload`` itself no longer calls this path; it re-execs.
         """
         previous_id = self._conversation_id()
         previous_len = self._history_length()
@@ -2849,12 +2860,14 @@ class OperatorApp(App[None]):
         The ledger has already been rebuilt from the new session's own history,
         so the screen cannot disagree with the model by the time this runs. What
         it can be is emptier than the user asked for, and that is what this
-        catches: ``/reload`` is a promise to continue this conversation, and
-        when the replacement comes back with less of it — no resume-capable
-        launcher, a transcript that never reached disk, a boot that failed
-        outright — the promise was not kept. Reporting it is the difference
-        between a user who knows to re-establish context and the one who found
-        out from an answer that had forgotten the question.
+        catches: an in-process rebuild that asked to keep this conversation
+        (``keep_context=True``) is a promise to continue it, and when the
+        replacement comes back with less of it — no resume-capable launcher,
+        a transcript that never reached disk, a boot that failed outright —
+        the promise was not kept. Reporting it is the difference between a
+        user who knows to re-establish context and the one who found out
+        from an answer that had forgotten the question. ``/reload`` no
+        longer uses this path; it re-execs via :meth:`_request_relaunch`.
 
         Spend travels the other way. It was charged to a conversation that is
         still open, so without this the band walks its own total back to zero
@@ -2864,10 +2877,11 @@ class OperatorApp(App[None]):
             total, children, was_floor = carried_spend
             self._total_cost = total
             self._subagent_costs.update(children)
-            # The provenance travels with the money. Without it a `/reload` onto
-            # the same conversation repainted the identical restored floor as a
-            # bare figure — same number, same provenance, honesty mark gone, on
-            # the one command that promises to change nothing.
+            # The provenance travels with the money. Without it an in-process
+            # rebuild onto the same conversation repainted the identical
+            # restored floor as a bare figure — same number, same provenance,
+            # honesty mark gone, on the one path that promises to change
+            # nothing.
             self._spend_is_floor = was_floor
             if self._status is not None:
                 self._status.update(cost=self._spend_text())
@@ -2900,18 +2914,45 @@ class OperatorApp(App[None]):
         ``/resume`` stay in-process — they swap conversations, not binaries.
         """
         del notice
+        if self._update_in_progress:
+            self._system_notice("an update is already running", "warning")
+            return
         self._request_relaunch()
 
     def _turn_is_live(self) -> bool:
-        """A mid-turn exec would drop work the user can still abort with esc."""
+        """A mid-turn exec would drop work the user can still abort with esc.
+
+        Compaction holds the session lock with ``is_streaming`` False (see
+        the hold in :meth:`on_editor_submitted`), so it has to count here
+        too: ``/update`` and ``/reload`` would otherwise tear the process
+        down while history is being rewritten.
+        """
         session = self._session
         streaming = session is not None and bool(getattr(session, "is_streaming", False))
-        return bool(streaming or self._loop_running or self._streaming_block is not None)
+        return bool(
+            streaming or self._loop_running or self._streaming_block is not None or self._compacting
+        )
 
-    def _request_relaunch(self) -> None:
-        """Stash a :class:`RestartPlan` and exit 75 so ``cli.main`` re-execs."""
-        if self._turn_is_live():
-            self._system_notice("esc first — a turn is still running", "warning")
+    def _live_turn_refuse_copy(self) -> str:
+        """Mid-turn refuse for ``/update`` / ``/reload``. Same key, right noun."""
+        if self._loop_running and not (
+            self._streaming_block is not None
+            or self._compacting
+            or (self._session is not None and bool(getattr(self._session, "is_streaming", False)))
+        ):
+            return "esc first — a loop is still running"
+        return "esc first — a turn is still running"
+
+    def _request_relaunch(self, *, force: bool = False) -> None:
+        """Stash a :class:`RestartPlan` and exit 75 so ``cli.main`` re-execs.
+
+        ``force`` is the completed-upgrade path: the wheel is already on
+        disk, so a turn that started during the installer must not cancel
+        the relaunch. The composer is locked for that window; this is the
+        belt if something still looks live.
+        """
+        if not force and self._turn_is_live():
+            self._system_notice(self._live_turn_refuse_copy(), "warning")
             return
         from local_operator.reexec import REEXEC_CODE, make_plan, stash_plan
 
@@ -2919,6 +2960,16 @@ class OperatorApp(App[None]):
         plan = make_plan(list(sys.argv), resume_id=resume_id)
         self._restart_plan = plan
         stash_plan(plan)
+        # Receipt BEFORE exit: ``/reload`` used to vanish with no copy, which
+        # read as a crash — especially on a first-turn splash whose plan
+        # carries no ``--resume`` and comes back as a cold launch. The
+        # completed-upgrade path already painted ``restarting…`` on the
+        # same tick, so it does not get a second line.
+        if not force:
+            if resume_id is None:
+                self._system_notice("relaunching… this will open a new session")
+            else:
+                self._system_notice("relaunching…")
         # Keyword: Textual's first positional is ``result``, not the code.
         self.exit(return_code=REEXEC_CODE)
 
@@ -2940,16 +2991,46 @@ class OperatorApp(App[None]):
     def _cmd_update(self, notice: NoticeFn) -> None:
         """``/update`` — live PyPI check, upgrade, then the shared relaunch."""
         del notice
-        if self._turn_is_live():
-            self._system_notice("esc first — a turn is still running", "warning")
+        if self._update_in_progress:
+            self._system_notice("an update is already running", "warning")
             return
+        if self._turn_is_live():
+            self._system_notice(self._live_turn_refuse_copy(), "warning")
+            return
+        # Armed BEFORE the worker so a second ``/update`` typed while the
+        # first is still scheduling cannot start a second installer. The
+        # composer lock is the other half: a prompt during ``uv tool
+        # upgrade`` used to cancel the relaunch after the wheel was in.
+        self._update_in_progress = True
+        self._set_composer_read_only(True)
+        self._system_notice("checking for updates…")
+        # exclusive left false on purpose: Textual exclusivity CANCELS the
+        # running worker, and cancelling the installer mid-write is worse
+        # than a refused second ``/update``. The flag above is the mutex.
         self.run_worker(self._run_update, thread=True, group="update")
+
+    def _finish_update(self) -> None:
+        """Drop the in-progress lock and give the composer back.
+
+        Only the refusal / already-current paths call this. A successful
+        upgrade keeps the lock through ``exit(75)`` so nothing can start
+        a turn that would cancel the relaunch.
+        """
+        self._update_in_progress = False
+        if self._subagent_view is None and self._org_chart_view is None:
+            self._set_composer_read_only(False)
 
     def _run_update(self) -> None:
         from local_operator.update import (
+            InstallKind,
             UpdateError,
             check_latest,
+            git_snapshot_notice,
+            install_kind,
+            is_git_snapshot,
             perform_upgrade,
+            tui_editable_refusal,
+            tui_installer_failure,
         )
 
         try:
@@ -2958,28 +3039,53 @@ class OperatorApp(App[None]):
             self.call_from_thread(
                 self._system_notice, f"could not check for updates: {exc}", "warning"
             )
+            self.call_from_thread(self._finish_update)
             return
         if result.latest is None:
             self.call_from_thread(
                 self._system_notice, "could not reach PyPI to learn the latest version", "warning"
             )
+            self.call_from_thread(self._finish_update)
             return
         if not result.behind:
             self.call_from_thread(
                 self._system_notice, f"already on v{result.installed or result.latest}"
             )
+            self.call_from_thread(self._finish_update)
             return
-        self.call_from_thread(self._notice, f"updating to v{result.latest}…")
+        kind = install_kind()
+        if is_git_snapshot():
+            # Architect contract: a lop-update snapshot still upgrades from
+            # PyPI after one printed line. CLI already does this; the TUI
+            # used to replace the snapshot silently.
+            self.call_from_thread(self._system_notice, git_snapshot_notice())
+        self.call_from_thread(self._system_notice, f"updating to v{result.latest}…")
         try:
-            installed = perform_upgrade(target=result.latest)
+            installed = perform_upgrade(target=result.latest, kind=kind)
         except UpdateError as exc:
-            self.call_from_thread(self._system_notice, str(exc), "warning")
+            if "repo .venv" in str(exc) or kind is InstallKind.EDITABLE:
+                message = tui_editable_refusal()
+            elif str(exc).startswith("installer exited"):
+                message = tui_installer_failure(kind)
+            else:
+                message = str(exc)
+            self.call_from_thread(self._system_notice, message, "warning")
+            self.call_from_thread(self._finish_update)
             return
         except Exception as exc:
             self.call_from_thread(self._system_notice, f"update failed: {exc}", "error")
+            self.call_from_thread(self._finish_update)
             return
-        self.call_from_thread(self._notice, f"updated to v{installed} — restarting…")
-        self.call_from_thread(self._request_relaunch)
+        # ``restarting…`` only once exit 75 is actually happening — a
+        # typed-ahead turn used to make ``_request_relaunch`` refuse after
+        # this line had already painted. Wrapped so ``call_from_thread``
+        # does not have to forward the keyword.
+
+        def _relaunch_after_upgrade() -> None:
+            self._system_notice(f"updated to v{installed} — restarting…")
+            self._request_relaunch(force=True)
+
+        self.call_from_thread(_relaunch_after_upgrade)
 
     def _cmd_resume(self, arg: str, notice: NoticeFn) -> None:
         """``/resume`` — pick a conversation; ``/resume <id>`` — resume one.
@@ -3066,10 +3172,11 @@ class OperatorApp(App[None]):
         """``/new`` — start a fresh conversation without leaving the app.
 
         There was no way to do this: ``/clear`` wipes the SCREEN and keeps the
-        conversation the model sees, ``/reload`` reboots the SAME conversation,
-        and ``/resume`` moves to a different existing one. Starting genuinely
-        fresh meant quitting and relaunching, which also throws away the
-        terminal state, the MCP connections and the warm imports.
+        conversation the model sees, ``/reload`` relaunches the SAME
+        conversation in a new process, and ``/resume`` moves to a different
+        existing one. Starting genuinely fresh meant quitting and
+        relaunching, which also throws away the terminal state, the MCP
+        connections and the warm imports.
 
         Implemented through the resume factory with ``None`` rather than a
         second factory: ``create_session`` already branches on
@@ -4879,8 +4986,8 @@ class OperatorApp(App[None]):
         guaranteed to reject.
 
         Read by :meth:`resume_hint`, which must not advertise a command that
-        cannot work, and by :meth:`_cmd_reload`, which must not rebind the
-        session factory to an id that would fail to boot.
+        cannot work, and by :meth:`_request_relaunch`, which must not stash
+        a ``--resume`` id that the next process would reject.
         """
         session = self._session
         if session is None:
@@ -9616,8 +9723,8 @@ class OperatorApp(App[None]):
             if command in ("on", "off") and len(words) == 1:
                 set_search_enabled(manager, command == "on")
                 notice(
-                    f"web search {command}; /reload "
-                    f"{'adds' if command == 'on' else 'removes'} the tool"
+                    f"web search {command}; /reload relaunches the app to "
+                    f"{'add' if command == 'on' else 'remove'} the tool"
                 )
                 return
             if command in ("enable", "disable") and len(words) == 2:

--- a/local_operator/tui/widgets/welcome.py
+++ b/local_operator/tui/widgets/welcome.py
@@ -357,12 +357,14 @@ WARNING_SHORT = "not logged in"
 #: only row that changes what the user must DO next — is the last one
 #: standing. A harness notice (quota fallback) is the same KIND of row but
 #: not the same urgency: you can still type, just on a different model, so
-#: it sheds one step before the login warning.
+#: it sheds one step before the login warning. An optional update row is
+#: news, not an action that unblocks typing, so it sheds before both.
 _PRIORITY_VERSION = 0
 _PRIORITY_CWD = 1
 _PRIORITY_MODEL = 2
-_PRIORITY_NOTICE = 3
-_PRIORITY_WARNING = 4
+_PRIORITY_UPDATE = 3
+_PRIORITY_NOTICE = 4
+_PRIORITY_WARNING = 5
 
 
 @dataclass(frozen=True)
@@ -392,6 +394,11 @@ class WelcomeInfo:
     #: stacking would shove the lockup the way a transcript notice already
     #: does. ``None`` when nothing has been announced.
     notice: str | None = None
+    #: PyPI version strictly newer than the installed distribution, or
+    #: ``None``. A new field rather than overwriting ``notice``: that slot
+    #: is the quota fallback, and an update probe must not hide a failover.
+    #: Absent when current — the row is not reserved.
+    update_available: str | None = None
     #: First-run SETUP state: the app opened with nothing configured so the user
     #: can `/login` from here (see ``app._enter_setup_state``). It changes what
     #: the empty splash SAYS — the model row's idle word, the affordance the
@@ -419,6 +426,7 @@ def session_welcome_info(
     *,
     notice: str | None = None,
     setup: bool = False,
+    update_available: str | None = None,
 ) -> WelcomeInfo:
     """Snapshot the facts the welcome view shows.
 
@@ -468,6 +476,7 @@ def session_welcome_info(
         cwd=os.getcwd(),
         missing_credential=missing,
         notice=notice or None,
+        update_available=update_available or None,
         setup=setup,
     )
 
@@ -628,6 +637,15 @@ def _status_rows(info: WelcomeInfo, width: int) -> list[tuple[int, Text]]:
     if info.cwd:
         shown = _fit_tail(_shorten_home(info.cwd), width)
         rows.append((_PRIORITY_CWD, Text(shown, style=dim, no_wrap=True)))
+    if info.update_available:
+        # Same glyph/tint as the other ``!`` rows. The command is dropped
+        # WHOLE when it does not fit — a half-printed ``/upd…`` is an
+        # instruction nobody can follow, same rule as the login warning.
+        glyph = NOTICE_GLYPHS["warning"]
+        body = f"{glyph} latest is v{info.update_available} — /update"
+        if cell_len(body) > width:
+            body = f"{glyph} latest is v{info.update_available}"
+        rows.append((_PRIORITY_UPDATE, Text(body, style=warn, no_wrap=True)))
     if info.notice:
         # Same glyph and tint as the credential warning: both are "something
         # about the harness you should know before you type". Truncated from

--- a/local_operator/update.py
+++ b/local_operator/update.py
@@ -1,0 +1,480 @@
+"""PyPI-facing updater for the installed ``local-operator`` distribution.
+
+WHY THIS EXISTS
+---------------
+End users install from PyPI (``uv tool``, pipx, or pip). They need one
+command that upgrades whatever they actually have, without being pointed at
+``lop-update`` — that script archives local git ``main`` into the uv-tool
+env, which is the opposite audience.
+
+"Latest" is always ``https://pypi.org/pypi/local-operator/json`` →
+``info.version``, compared to ``importlib.metadata.version("local-operator")``.
+That is the same source the splash version row and ``lop --version`` already
+use. A second version channel (git tags, ``lop-update``, a pin file) would
+diverge from what the running process reports.
+
+WHY THE CACHE
+-------------
+The splash paints immediately and a background probe fills an optional ``!``
+row. Hitting PyPI on every launch would stall a flaky network under the first
+frame and turn a quiet check into a toast. Modelled on
+``model/catalogue.py``: fresh cache skips the network, a stale copy is kept
+when the fetch fails, and a total miss is ``None`` — never an error the user
+has to dismiss. The probe is news, not a prerequisite, so it must not compete
+with the credentials-fallback line.
+
+``/update`` and ``lop update`` bypass the TTL (they need a live answer) but
+still rewrite the cache so the next splash is free.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+import time
+from dataclasses import dataclass
+from enum import Enum
+from importlib.metadata import PackageNotFoundError, distribution, version
+from pathlib import Path
+from typing import Any, Callable
+
+#: Same cache root the model catalogue uses, so there is one place to clear.
+_CACHE_DIR = Path("~/.local-operator/cache")
+_CACHE_NAME = "pypi-local-operator.json"
+
+#: Six hours. Shorter re-fetches on every other launch for a number that
+#: moves on the order of days; a day would hide a release the user just
+#: saw announced. The splash worker runs once per process, so the TTL is
+#: for the *next* launch, not for keystrokes.
+TTL_S = 6 * 60 * 60
+
+PYPI_JSON_URL = "https://pypi.org/pypi/local-operator/json"
+
+#: Short enough that a hung PyPI cannot stall a splash worker across the
+#: TUI suite; long enough for a slow but living mirror.
+_FETCH_TIMEOUT_S = 5.0
+
+
+class InstallKind(str, Enum):
+    UV_TOOL = "uv-tool"
+    PIPX = "pipx"
+    PIP = "pip"
+    EDITABLE = "editable"
+    UNKNOWN = "unknown"
+
+
+class UpdateError(Exception):
+    """Refused or failed upgrade; the message is what the CLI/TUI print."""
+
+
+@dataclass(frozen=True)
+class VersionCheck:
+    installed: str
+    latest: str | None
+    behind: bool
+
+
+def installed_version() -> str:
+    """Distribution version, or ``""`` when this interpreter has no install.
+
+    Empty is the source-checkout case: there is nothing to compare to PyPI
+    and :func:`install_kind` will refuse rather than guess.
+    """
+    try:
+        return version("local-operator")
+    except PackageNotFoundError:
+        return ""
+
+
+def parse_version(value: str) -> tuple[int, int, int] | None:
+    """``X.Y.Z`` or ``None``. No ``packaging`` — this project ships that shape.
+
+    An unparseable side (a local ``0.28.0rc1``, a yanked extra) is treated as
+    "not behind" by the caller: a banner we cannot defend is worse than none.
+    """
+    parts = value.strip().split(".")
+    if len(parts) != 3:
+        return None
+    try:
+        return int(parts[0]), int(parts[1]), int(parts[2])
+    except ValueError:
+        return None
+
+
+def is_behind(installed: str, latest: str | None) -> bool:
+    """True only when both sides parse and installed is strictly older."""
+    if not installed or not latest:
+        return False
+    left = parse_version(installed)
+    right = parse_version(latest)
+    if left is None or right is None:
+        return False
+    return left < right
+
+
+def default_cache_dir() -> Path:
+    return _CACHE_DIR.expanduser()
+
+
+def _cache_path(cache_dir: Path | None) -> Path:
+    return (cache_dir or default_cache_dir()) / _CACHE_NAME
+
+
+def _read_cache(path: Path) -> tuple[dict[str, Any] | None, float]:
+    """Return ``(payload, age_seconds)``; ``(None, inf)`` when unusable.
+
+    Corrupt and future-dated documents are missing, not raised: this is an
+    optimisation store. A future timestamp treated as age-zero would pin the
+    document forever after a clock skew (same rule as ``model/catalogue.py``).
+    """
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+        payload = raw["payload"]
+        fetched_at = float(raw["fetched_at"])
+    except (OSError, ValueError, KeyError, TypeError):
+        return None, float("inf")
+    if not isinstance(payload, dict):
+        return None, float("inf")
+    age = time.time() - fetched_at
+    if not (age >= 0):
+        return payload, float("inf")
+    return payload, age
+
+
+def _umask() -> int:
+    current = os.umask(0o022)
+    os.umask(current)
+    return current
+
+
+def _write_cache(path: Path, payload: dict[str, Any]) -> None:
+    """Atomic temp+rename, best-effort. A failed write must not fail the check."""
+    fd: int | None = None
+    tmp: Path | None = None
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        handle, name = tempfile.mkstemp(dir=str(path.parent), prefix=f"{path.name}.", suffix=".tmp")
+        fd, tmp = handle, Path(name)
+        with os.fdopen(fd, "w", encoding="utf-8") as stream:
+            fd = None
+            json.dump({"fetched_at": time.time(), "payload": payload}, stream)
+        os.chmod(tmp, 0o644 & ~_umask())
+        tmp.replace(path)
+        tmp = None
+    except OSError:
+        pass
+    finally:
+        if fd is not None:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+        if tmp is not None:
+            try:
+                tmp.unlink(missing_ok=True)
+            except OSError:
+                pass
+
+
+def _fetch_pypi_version(*, client: Any | None = None) -> str | None:
+    """Live ``info.version``, or ``None`` on any transport/HTTP/JSON error.
+
+    httpx is imported here so ``import local_operator.cli`` (and the splash
+    module) never pay for it. The splash worker already swallows ``None``.
+    """
+    import httpx
+
+    try:
+        if client is None:
+            response = httpx.get(PYPI_JSON_URL, timeout=_FETCH_TIMEOUT_S)
+        else:
+            response = client.get(PYPI_JSON_URL, timeout=_FETCH_TIMEOUT_S)
+        response.raise_for_status()
+        version_s = response.json()["info"]["version"]
+    except Exception:
+        return None
+    if not isinstance(version_s, str) or not version_s.strip():
+        return None
+    return version_s.strip()
+
+
+def check_latest(
+    *,
+    force: bool = False,
+    cache_dir: Path | None = None,
+    client: Any | None = None,
+) -> VersionCheck:
+    """Installed vs PyPI. ``force`` bypasses the TTL but still rewrites the cache.
+
+    Failure mode is silent: ``latest is None`` and ``behind is False``. The
+    splash must not grow a toast or steal ``info.notice`` for a probe.
+    """
+    installed = installed_version()
+    path = _cache_path(cache_dir)
+    payload, age = _read_cache(path)
+    cached: str | None = None
+    if payload is not None:
+        raw = payload.get("version")
+        if isinstance(raw, str) and raw.strip():
+            cached = raw.strip()
+
+    latest: str | None
+    if cached is not None and age < TTL_S and not force:
+        latest = cached
+    else:
+        fetched = _fetch_pypi_version(client=client)
+        if fetched is not None:
+            latest = fetched
+            _write_cache(path, {"version": fetched})
+        else:
+            latest = cached
+
+    return VersionCheck(installed=installed, latest=latest, behind=is_behind(installed, latest))
+
+
+def _direct_url_payload() -> dict[str, Any] | None:
+    try:
+        dist = distribution("local-operator")
+    except PackageNotFoundError:
+        return None
+    text = dist.read_text("direct_url.json")
+    if not text:
+        return None
+    try:
+        data = json.loads(text)
+    except ValueError:
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _is_editable_direct_url() -> bool:
+    """PEP 610 / 660: ``dir_info.editable`` is what pip and uv write for ``-e``."""
+    data = _direct_url_payload()
+    if data is None:
+        return False
+    if data.get("editable") is True:
+        return True
+    dir_info = data.get("dir_info")
+    return isinstance(dir_info, dict) and dir_info.get("editable") is True
+
+
+def _is_uv_tool(prefix: Path) -> bool:
+    """uv tool is the documented end-user path (README + the ``lop`` launcher).
+
+    Two probes because the layout has drifted across uv versions: older
+    installs put ``uv-receipt.toml`` next to ``sys.prefix``; every current
+    one still nests the env under ``…/uv/tools/local-operator``. Either
+    signal is enough — requiring both would miss a valid install.
+    """
+    if (prefix / "uv-receipt.toml").is_file():
+        return True
+    if (prefix.parent / "uv-receipt.toml").is_file():
+        return True
+    parts = prefix.parts
+    try:
+        uv_at = parts.index("uv")
+    except ValueError:
+        return False
+    rest = parts[uv_at + 1 :]
+    return len(rest) >= 2 and rest[0] == "tools" and "local-operator" in rest
+
+
+def _is_pipx(prefix: Path) -> bool:
+    """pipx is the other installer the README already tells people to use.
+
+    ``PIPX_HOME`` first so a relocated pipx (the documented escape hatch on
+    Linux PEP-668 hosts) still matches; the default ``~/.local/pipx`` is
+    what an unconfigured install actually writes.
+    """
+    pipx_home = Path(os.environ.get("PIPX_HOME", Path.home() / ".local" / "pipx"))
+    expected = (pipx_home / "venvs" / "local-operator").resolve()
+    try:
+        resolved = prefix.resolve()
+    except OSError:
+        resolved = prefix
+    if resolved == expected or expected in resolved.parents:
+        return True
+    parts = prefix.parts
+    return "pipx" in parts and "venvs" in parts and "local-operator" in parts
+
+
+def _is_ordinary_pip(prefix: Path) -> bool:
+    """A venv or virtual-env prefix: the remaining README ``pip install`` path."""
+    if (prefix / "pyvenv.cfg").is_file():
+        return True
+    return sys.prefix != getattr(sys, "base_prefix", sys.prefix)
+
+
+def install_kind(
+    *,
+    prefix: str | Path | None = None,
+    executable: str | Path | None = None,
+) -> InstallKind:
+    """How this interpreter was installed. Refuse-don't-guess for the rest.
+
+    ``prefix`` / ``executable`` are test seams so a tmp tree can stand in
+    for ``sys.prefix`` without mutating the running process.
+    """
+    del executable  # reserved: unknown-layout messages print the real one
+    root = Path(prefix) if prefix is not None else Path(sys.prefix)
+
+    # No distribution, or an editable checkout: this is the repo ``.venv``.
+    # ``pip install -U`` into it would either no-op or smash the editable
+    # link. Developers update the *global* runtime with ``lop-update``.
+    try:
+        distribution("local-operator")
+        has_dist = True
+    except PackageNotFoundError:
+        has_dist = False
+    if not has_dist or _is_editable_direct_url():
+        return InstallKind.EDITABLE
+
+    if _is_uv_tool(root):
+        return InstallKind.UV_TOOL
+    if _is_pipx(root):
+        return InstallKind.PIPX
+    if _is_ordinary_pip(root):
+        return InstallKind.PIP
+    return InstallKind.UNKNOWN
+
+
+def is_git_snapshot(prefix: str | Path | None = None) -> bool:
+    """``.lop-source`` marks a ``lop-update`` uv-tool snapshot, not a PyPI wheel.
+
+    Default is still PyPI: the caller prints one line and upgrades. We do
+    not invoke ``lop-update`` — developers who want git ``main`` keep using
+    that script.
+    """
+    root = Path(prefix) if prefix is not None else Path(sys.prefix)
+    return (root / ".lop-source").is_file()
+
+
+def installer_argv(
+    kind: InstallKind,
+    *,
+    executable: str | None = None,
+) -> list[str]:
+    if kind is InstallKind.UV_TOOL:
+        return ["uv", "tool", "upgrade", "local-operator"]
+    if kind is InstallKind.PIPX:
+        return ["pipx", "upgrade", "local-operator"]
+    if kind is InstallKind.PIP:
+        return [executable or sys.executable, "-m", "pip", "install", "-U", "local-operator"]
+    raise UpdateError(f"no installer for {kind.value}")
+
+
+def installer_label(kind: InstallKind) -> str:
+    if kind is InstallKind.UV_TOOL:
+        return "uv tool"
+    if kind is InstallKind.PIPX:
+        return "pipx"
+    if kind is InstallKind.PIP:
+        return "pip"
+    return kind.value
+
+
+def editable_refusal() -> str:
+    return (
+        "this interpreter is the repo .venv, not an installed distribution. "
+        "update the global runtime with lop-update after the change is merged."
+    )
+
+
+def unknown_refusal(
+    *,
+    prefix: str | None = None,
+    executable: str | None = None,
+) -> str:
+    return (
+        "cannot tell how this install was launched\n"
+        f"  sys.prefix: {prefix or sys.prefix}\n"
+        f"  sys.executable: {executable or sys.executable}\n"
+        "supported upgrades:\n"
+        "  uv tool upgrade local-operator\n"
+        "  pipx upgrade local-operator\n"
+        "  python -m pip install -U local-operator"
+    )
+
+
+def git_snapshot_notice() -> str:
+    return "this runtime was built from git; " "lop update will replace it with the PyPI wheel"
+
+
+def _run_installer(argv: list[str]) -> int:
+    import subprocess
+
+    # stderr/stdout pass through: the installer is what the user is watching.
+    completed = subprocess.run(argv, check=False)
+    return int(completed.returncode)
+
+
+def perform_upgrade(
+    *,
+    target: str,
+    kind: InstallKind | None = None,
+    run: Callable[[list[str]], int] | None = None,
+    prefix: str | Path | None = None,
+    executable: str | None = None,
+) -> str:
+    """Run the detected installer. Returns ``target`` (this process cannot re-read it).
+
+    The new wheel is not imported into this interpreter; callers print
+    ``target`` rather than asking :func:`installed_version` again.
+    """
+    detected = kind if kind is not None else install_kind(prefix=prefix, executable=executable)
+    if detected is InstallKind.EDITABLE:
+        raise UpdateError(editable_refusal())
+    if detected is InstallKind.UNKNOWN:
+        raise UpdateError(
+            unknown_refusal(prefix=str(prefix) if prefix else None, executable=executable)
+        )
+    argv = installer_argv(detected, executable=executable)
+    runner = run or _run_installer
+    code = runner(argv)
+    if code != 0:
+        raise UpdateError(f"installer exited {code}")
+    return target
+
+
+def update_command(*, check: bool = False) -> int:
+    """``lop update`` / ``lop update --check``. See the architect table for codes."""
+    result = check_latest(force=True)
+    if result.latest is None:
+        print("could not reach PyPI to learn the latest version", file=sys.stderr)
+        return 1
+
+    if check:
+        if result.behind:
+            print(f"local-operator {result.installed}")
+            print(f"latest on PyPI: {result.latest}")
+            print("run `lop update` to install")
+            return 2
+        print(f"local-operator {result.installed} is the latest")
+        return 0
+
+    if not result.behind:
+        print(f"local-operator {result.installed} is the latest")
+        return 0
+
+    kind = install_kind()
+    if kind is InstallKind.EDITABLE:
+        print(editable_refusal(), file=sys.stderr)
+        return 1
+    if kind is InstallKind.UNKNOWN:
+        print(unknown_refusal(), file=sys.stderr)
+        return 1
+
+    if is_git_snapshot():
+        print(git_snapshot_notice())
+
+    print(f"local-operator {result.installed} (latest is {result.latest})")
+    print(f"upgrading via {installer_label(kind)}…")
+    try:
+        installed = perform_upgrade(target=result.latest, kind=kind)
+    except UpdateError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    print(f"installed {installed}")
+    return 0

--- a/local_operator/update.py
+++ b/local_operator/update.py
@@ -382,6 +382,27 @@ def editable_refusal() -> str:
     )
 
 
+def tui_editable_refusal() -> str:
+    """Same refusal as :func:`editable_refusal`, worded for the person in the TUI.
+
+    The CLI line names ``.venv`` and ``lop-update`` because that is the
+    contributor path. ``/update`` is typed by someone sitting in the app;
+    they need to know this is the checkout, not the installed ``lop``.
+    """
+    return "this is the repo checkout, not the installed lop — run lop-update after merge"
+
+
+def tui_installer_failure(kind: InstallKind) -> str:
+    """User-facing next step after a non-zero installer, keyed by install kind."""
+    if kind is InstallKind.PIPX:
+        hint = "pipx upgrade local-operator"
+    elif kind is InstallKind.PIP:
+        hint = "python -m pip install -U local-operator"
+    else:
+        hint = "uv tool upgrade local-operator"
+    return f"upgrade failed; try `{hint}` in a shell"
+
+
 def unknown_refusal(
     *,
     prefix: str | None = None,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.27.3"
+version = "0.28.0"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/test_reexec.py
+++ b/tests/unit/test_reexec.py
@@ -1,0 +1,93 @@
+"""Process-relaunch helper: argv rewrite and OS backends."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from local_operator.reexec import RestartPlan, make_plan, plan_argv, replace_self
+
+
+def test_plan_argv_no_resume() -> None:
+    assert plan_argv(["lop", "--model", "gpt-4o"]) == ["lop", "--model", "gpt-4o"]
+
+
+def test_plan_argv_injects_resume() -> None:
+    assert plan_argv(["lop"], resume_id="abc123") == ["lop", "--resume", "abc123"]
+
+
+def test_plan_argv_replaces_existing_resume() -> None:
+    assert plan_argv(["lop", "--resume", "old", "--debug"], resume_id="new") == [
+        "lop",
+        "--debug",
+        "--resume",
+        "new",
+    ]
+
+
+def test_plan_argv_strips_resume_when_none() -> None:
+    assert plan_argv(["lop", "--resume", "old", "--tui"]) == ["lop", "--tui"]
+
+
+def test_plan_argv_preserves_model_and_hosting() -> None:
+    argv = ["lop", "--hosting", "anthropic", "--model", "claude", "--train"]
+    assert plan_argv(argv, resume_id="s1") == [
+        "lop",
+        "--hosting",
+        "anthropic",
+        "--model",
+        "claude",
+        "--train",
+        "--resume",
+        "s1",
+    ]
+
+
+def test_plan_argv_equals_form_resume() -> None:
+    assert plan_argv(["lop", "--resume=old"], resume_id="new") == ["lop", "--resume", "new"]
+
+
+def test_make_plan_records_resume_id() -> None:
+    plan = make_plan(["lop"], resume_id="sess")
+    assert plan.resume_id == "sess"
+    assert plan.argv[-2:] == ["--resume", "sess"]
+
+
+def test_replace_self_posix_execs_once() -> None:
+    plan = RestartPlan(argv=["lop", "--resume", "s"], resume_id="s")
+    with (
+        patch("local_operator.reexec.sys.platform", "darwin"),
+        patch("local_operator.reexec.os.execvpe") as execvpe,
+    ):
+        replace_self(plan)
+        execvpe.assert_called_once()
+        args, kwargs = execvpe.call_args
+        assert args[0] == "lop"
+        assert args[1] == ["lop", "--resume", "s"]
+        assert "PATH" in args[2] or args[2] is not None
+
+
+def test_replace_self_windows_popen_then_exit() -> None:
+    from local_operator.reexec import _replace_windows
+
+    with (
+        patch("local_operator.reexec.subprocess.Popen") as popen,
+        patch("local_operator.reexec.os._exit") as exit_,
+    ):
+        popen.return_value = MagicMock()
+        _replace_windows(["lop.exe"], {"PATH": "/bin"})
+        popen.assert_called_once()
+        assert popen.call_args.args[0] == ["lop.exe"]
+        assert popen.call_args.kwargs["close_fds"] is True
+        exit_.assert_called_once_with(0)
+
+
+def test_replace_self_dispatches_windows_backend() -> None:
+    plan = RestartPlan(argv=["lop.exe"], resume_id=None)
+    with (
+        patch("local_operator.reexec._on_windows", return_value=True),
+        patch("local_operator.reexec._replace_windows") as win,
+        patch("local_operator.reexec._replace_posix") as posix,
+    ):
+        replace_self(plan)
+        win.assert_called_once()
+        posix.assert_not_called()

--- a/tests/unit/test_update.py
+++ b/tests/unit/test_update.py
@@ -21,6 +21,8 @@ from local_operator.update import (
     is_behind,
     parse_version,
     perform_upgrade,
+    tui_editable_refusal,
+    tui_installer_failure,
     update_command,
 )
 
@@ -251,6 +253,13 @@ def test_perform_upgrade_nonzero_installer() -> None:
 
 def test_installer_argv_matches_kind() -> None:
     assert installer_argv(InstallKind.UV_TOOL) == ["uv", "tool", "upgrade", "local-operator"]
+
+
+def test_tui_refusal_copy_is_user_facing() -> None:
+    assert "repo checkout" in tui_editable_refusal()
+    assert "lop-update" in tui_editable_refusal()
+    assert "uv tool upgrade local-operator" in tui_installer_failure(InstallKind.UV_TOOL)
+    assert "pipx upgrade local-operator" in tui_installer_failure(InstallKind.PIPX)
 
 
 def _check(installed: str, latest: str | None, behind: bool) -> update_mod.VersionCheck:

--- a/tests/unit/test_update.py
+++ b/tests/unit/test_update.py
@@ -1,0 +1,317 @@
+"""PyPI updater: version compare, cache, install detection, CLI dispatch."""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from local_operator import update as update_mod
+from local_operator.update import (
+    TTL_S,
+    InstallKind,
+    UpdateError,
+    check_latest,
+    install_kind,
+    installer_argv,
+    is_behind,
+    parse_version,
+    perform_upgrade,
+    update_command,
+)
+
+
+def _pypi_transport(
+    status: int = 200, version: str = "0.28.0", delay: float = 0
+) -> httpx.MockTransport:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if delay:
+            raise httpx.TimeoutException("timed out")
+        if status != 200:
+            return httpx.Response(status, text="nope")
+        return httpx.Response(status, json={"info": {"version": version}})
+
+    return httpx.MockTransport(handler)
+
+
+def _client(transport: httpx.MockTransport) -> httpx.Client:
+    return httpx.Client(transport=transport)
+
+
+def test_parse_version_accepts_only_x_y_z() -> None:
+    assert parse_version("0.27.0") == (0, 27, 0)
+    assert parse_version("1.0.0") == (1, 0, 0)
+    assert parse_version("0.28.0rc1") is None
+    assert parse_version("not-a-version") is None
+    assert parse_version("") is None
+
+
+def test_is_behind_is_strict_and_unparseable_is_not() -> None:
+    assert is_behind("0.27.0", "0.28.0") is True
+    assert is_behind("0.28.0", "0.28.0") is False
+    assert is_behind("0.28.0", "0.27.0") is False
+    assert is_behind("0.28.0rc1", "0.28.0") is False
+    assert is_behind("0.27.0", None) is False
+    assert is_behind("", "0.28.0") is False
+
+
+def test_check_latest_newer_same_older(tmp_path: Path) -> None:
+    with patch.object(update_mod, "installed_version", return_value="0.27.0"):
+        newer = check_latest(
+            force=True, cache_dir=tmp_path, client=_client(_pypi_transport(version="0.28.0"))
+        )
+        assert newer.behind is True
+        assert newer.latest == "0.28.0"
+
+        same = check_latest(
+            force=True, cache_dir=tmp_path, client=_client(_pypi_transport(version="0.27.0"))
+        )
+        assert same.behind is False
+        assert same.latest == "0.27.0"
+
+        older = check_latest(
+            force=True, cache_dir=tmp_path, client=_client(_pypi_transport(version="0.26.0"))
+        )
+        assert older.behind is False
+        assert older.latest == "0.26.0"
+
+
+def test_check_latest_500_and_timeout_are_silent(tmp_path: Path) -> None:
+    with patch.object(update_mod, "installed_version", return_value="0.27.0"):
+        failed = check_latest(
+            force=True, cache_dir=tmp_path, client=_client(_pypi_transport(status=500))
+        )
+        assert failed.latest is None
+        assert failed.behind is False
+
+        timed = check_latest(
+            force=True, cache_dir=tmp_path, client=_client(_pypi_transport(delay=1))
+        )
+        assert timed.latest is None
+        assert timed.behind is False
+
+
+def test_corrupt_cache_is_missing(tmp_path: Path) -> None:
+    cache = tmp_path / "pypi-local-operator.json"
+    cache.write_text("not-json", encoding="utf-8")
+    with patch.object(update_mod, "installed_version", return_value="0.27.0"):
+        result = check_latest(cache_dir=tmp_path, client=_client(_pypi_transport(version="0.28.0")))
+    assert result.latest == "0.28.0"
+    assert result.behind is True
+
+
+def test_stale_cache_used_on_failure(tmp_path: Path) -> None:
+    cache = tmp_path / "pypi-local-operator.json"
+    cache.write_text(
+        json.dumps({"fetched_at": time.time() - TTL_S - 10, "payload": {"version": "0.28.0"}}),
+        encoding="utf-8",
+    )
+    with patch.object(update_mod, "installed_version", return_value="0.27.0"):
+        result = check_latest(cache_dir=tmp_path, client=_client(_pypi_transport(status=500)))
+    assert result.latest == "0.28.0"
+    assert result.behind is True
+
+
+def test_fresh_cache_skips_get(tmp_path: Path) -> None:
+    cache = tmp_path / "pypi-local-operator.json"
+    cache.write_text(
+        json.dumps({"fetched_at": time.time(), "payload": {"version": "0.28.0"}}),
+        encoding="utf-8",
+    )
+    hits = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        hits["n"] += 1
+        return httpx.Response(200, json={"info": {"version": "9.9.9"}})
+
+    with patch.object(update_mod, "installed_version", return_value="0.27.0"):
+        result = check_latest(cache_dir=tmp_path, client=_client(httpx.MockTransport(handler)))
+    assert hits["n"] == 0
+    assert result.latest == "0.28.0"
+
+
+def test_force_bypasses_ttl_and_rewrites(tmp_path: Path) -> None:
+    cache = tmp_path / "pypi-local-operator.json"
+    cache.write_text(
+        json.dumps({"fetched_at": time.time(), "payload": {"version": "0.27.0"}}),
+        encoding="utf-8",
+    )
+    with patch.object(update_mod, "installed_version", return_value="0.27.0"):
+        result = check_latest(
+            force=True, cache_dir=tmp_path, client=_client(_pypi_transport(version="0.28.0"))
+        )
+    assert result.latest == "0.28.0"
+    written = json.loads(cache.read_text(encoding="utf-8"))
+    assert written["payload"]["version"] == "0.28.0"
+
+
+def test_install_kind_uv_receipt(tmp_path: Path) -> None:
+    prefix = tmp_path / "uv" / "tools" / "local-operator"
+    prefix.mkdir(parents=True)
+    (prefix / "uv-receipt.toml").write_text("[tool]\n", encoding="utf-8")
+    (prefix / "pyvenv.cfg").write_text("home = /usr\n", encoding="utf-8")
+    with (
+        patch.object(update_mod, "distribution") as dist,
+        patch.object(update_mod, "_is_editable_direct_url", return_value=False),
+    ):
+        dist.return_value = object()
+        assert install_kind(prefix=prefix) is InstallKind.UV_TOOL
+
+
+def test_install_kind_uv_path_without_receipt(tmp_path: Path) -> None:
+    prefix = tmp_path / "share" / "uv" / "tools" / "local-operator"
+    prefix.mkdir(parents=True)
+    (prefix / "pyvenv.cfg").write_text("home = /usr\n", encoding="utf-8")
+    with (
+        patch.object(update_mod, "distribution") as dist,
+        patch.object(update_mod, "_is_editable_direct_url", return_value=False),
+    ):
+        dist.return_value = object()
+        assert install_kind(prefix=prefix) is InstallKind.UV_TOOL
+
+
+def test_install_kind_pipx(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    home = tmp_path / "pipx-home"
+    prefix = home / "venvs" / "local-operator"
+    prefix.mkdir(parents=True)
+    (prefix / "pyvenv.cfg").write_text("home = /usr\n", encoding="utf-8")
+    monkeypatch.setenv("PIPX_HOME", str(home))
+    with (
+        patch.object(update_mod, "distribution") as dist,
+        patch.object(update_mod, "_is_editable_direct_url", return_value=False),
+    ):
+        dist.return_value = object()
+        assert install_kind(prefix=prefix) is InstallKind.PIPX
+
+
+def test_install_kind_editable(tmp_path: Path) -> None:
+    with (
+        patch.object(update_mod, "distribution") as dist,
+        patch.object(update_mod, "_is_editable_direct_url", return_value=True),
+    ):
+        dist.return_value = object()
+        assert install_kind(prefix=tmp_path) is InstallKind.EDITABLE
+
+
+def test_install_kind_no_distribution(tmp_path: Path) -> None:
+    from importlib.metadata import PackageNotFoundError
+
+    with patch.object(
+        update_mod, "distribution", side_effect=PackageNotFoundError("local-operator")
+    ):
+        assert install_kind(prefix=tmp_path) is InstallKind.EDITABLE
+
+
+def test_install_kind_unknown(tmp_path: Path) -> None:
+    with (
+        patch.object(update_mod, "distribution") as dist,
+        patch.object(update_mod, "_is_editable_direct_url", return_value=False),
+        patch.object(update_mod.sys, "prefix", str(tmp_path)),
+        patch.object(update_mod.sys, "base_prefix", str(tmp_path)),
+    ):
+        dist.return_value = object()
+        assert install_kind(prefix=tmp_path) is InstallKind.UNKNOWN
+
+
+def test_perform_upgrade_runs_detected_argv() -> None:
+    seen: list[list[str]] = []
+
+    def run(argv: list[str]) -> int:
+        seen.append(argv)
+        return 0
+
+    out = perform_upgrade(target="0.28.0", kind=InstallKind.UV_TOOL, run=run)
+    assert out == "0.28.0"
+    assert seen == [["uv", "tool", "upgrade", "local-operator"]]
+
+    seen.clear()
+    perform_upgrade(target="0.28.0", kind=InstallKind.PIPX, run=run)
+    assert seen == [["pipx", "upgrade", "local-operator"]]
+
+    seen.clear()
+    perform_upgrade(target="0.28.0", kind=InstallKind.PIP, run=run, executable="/venv/bin/python")
+    assert seen == [["/venv/bin/python", "-m", "pip", "install", "-U", "local-operator"]]
+
+
+def test_perform_upgrade_refuses_editable_and_unknown() -> None:
+    with pytest.raises(UpdateError, match="repo .venv"):
+        perform_upgrade(target="0.28.0", kind=InstallKind.EDITABLE, run=lambda _: 0)
+    with pytest.raises(UpdateError, match="cannot tell"):
+        perform_upgrade(target="0.28.0", kind=InstallKind.UNKNOWN, run=lambda _: 0)
+
+
+def test_perform_upgrade_nonzero_installer() -> None:
+    with pytest.raises(UpdateError, match="exited 9"):
+        perform_upgrade(target="0.28.0", kind=InstallKind.UV_TOOL, run=lambda _: 9)
+
+
+def test_installer_argv_matches_kind() -> None:
+    assert installer_argv(InstallKind.UV_TOOL) == ["uv", "tool", "upgrade", "local-operator"]
+
+
+def _check(installed: str, latest: str | None, behind: bool) -> update_mod.VersionCheck:
+    return update_mod.VersionCheck(installed=installed, latest=latest, behind=behind)
+
+
+def test_update_command_check_behind(capsys: pytest.CaptureFixture[str]) -> None:
+    with patch.object(update_mod, "check_latest", return_value=_check("0.27.0", "0.28.0", True)):
+        assert update_command(check=True) == 2
+    out = capsys.readouterr().out
+    assert "local-operator 0.27.0" in out
+    assert "latest on PyPI: 0.28.0" in out
+    assert "run `lop update` to install" in out
+
+
+def test_update_command_check_current(capsys: pytest.CaptureFixture[str]) -> None:
+    with patch.object(update_mod, "check_latest", return_value=_check("0.27.0", "0.27.0", False)):
+        assert update_command(check=True) == 0
+    assert capsys.readouterr().out.strip() == "local-operator 0.27.0 is the latest"
+
+
+def test_update_command_check_network_error(capsys: pytest.CaptureFixture[str]) -> None:
+    with patch.object(update_mod, "check_latest", return_value=_check("0.27.0", None, False)):
+        assert update_command(check=True) == 1
+    assert "could not reach PyPI" in capsys.readouterr().err
+
+
+def test_update_command_already_latest(capsys: pytest.CaptureFixture[str]) -> None:
+    with patch.object(update_mod, "check_latest", return_value=_check("0.27.0", "0.27.0", False)):
+        assert update_command(check=False) == 0
+    assert capsys.readouterr().out.strip() == "local-operator 0.27.0 is the latest"
+
+
+def test_update_command_upgrades(capsys: pytest.CaptureFixture[str]) -> None:
+    with (
+        patch.object(update_mod, "check_latest", return_value=_check("0.27.0", "0.28.0", True)),
+        patch.object(update_mod, "install_kind", return_value=InstallKind.UV_TOOL),
+        patch.object(update_mod, "is_git_snapshot", return_value=False),
+        patch.object(update_mod, "perform_upgrade", return_value="0.28.0") as upgrade,
+    ):
+        assert update_command(check=False) == 0
+        upgrade.assert_called_once()
+    out = capsys.readouterr().out
+    assert "local-operator 0.27.0 (latest is 0.28.0)" in out
+    assert "upgrading via uv tool…" in out
+    assert "installed 0.28.0" in out
+
+
+def test_main_dispatches_update_check(monkeypatch: pytest.MonkeyPatch) -> None:
+    from local_operator.cli import main
+
+    monkeypatch.setattr("sys.argv", ["lop", "update", "--check"])
+    with patch("local_operator.update.update_command", return_value=2) as cmd:
+        assert main() == 2
+        cmd.assert_called_once_with(check=True)
+
+
+def test_main_dispatches_update(monkeypatch: pytest.MonkeyPatch) -> None:
+    from local_operator.cli import main
+
+    monkeypatch.setattr("sys.argv", ["lop", "update"])
+    with patch("local_operator.update.update_command", return_value=0) as cmd:
+        assert main() == 0
+        cmd.assert_called_once_with(check=False)

--- a/tests/unit/tui/conftest.py
+++ b/tests/unit/tui/conftest.py
@@ -27,6 +27,14 @@ def hermetic_tui_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("NO_COLOR", raising=False)
     monkeypatch.setenv("TERM", "xterm-256color")
     monkeypatch.setenv("LOCAL_OPERATOR_NO_SHIMMER", "1")
+    # The splash starts a one-shot PyPI probe on mount. Unit tests must not
+    # pay a 5 s timeout (or a real GET) for news they are not asserting.
+    # Patch the worker, not ``check_latest``: ``/update`` needs the real
+    # function so its own mocks can drive newer/same/error.
+    monkeypatch.setattr(
+        "local_operator.tui.app.OperatorApp._check_for_update",
+        lambda self: None,
+    )
     # The caret used to be pinned here too: `TextArea.cursor_blink` was patched
     # off for the whole suite because a blinking caret made whether a captured
     # frame contained one a coin flip, and the boot snapshot failed against a

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -1412,8 +1412,14 @@ async def test_boot_failure_posts_error_and_reload_retries() -> None:
 
     app = OperatorApp(flaky_factory)
     async with app.run_test(size=(80, 24)) as pilot:
-        await pilot.pause()
-        await pilot.pause()
+        for _ in range(40):
+            await pilot.pause()
+            transcript = app.query_one(TranscriptView)
+            texts = "\n".join(
+                getattr(getattr(b, "renderable", None), "plain", "") for b in transcript.blocks()
+            )
+            if "provider is down" in texts:
+                break
         # Boot failure surfaces as an error notice + 'session error' status.
         transcript = app.query_one(TranscriptView)
         kinds = [type(b).__name__ for b in transcript.blocks()]
@@ -1430,14 +1436,18 @@ async def test_boot_failure_posts_error_and_reload_retries() -> None:
         # line over an empty screen.
         assert app.query_one(WelcomeView).display is True
         assert app.screen.has_class(BOOT_LAYOUT_CLASS)
-        # /reload re-runs boot and succeeds this time.
+        # /reload now re-execs (exit 75) rather than retrying in-process.
+        # A boot that never constructed still relaunches as a cold start.
         app.query_one(Editor).focus()
         await pilot.pause()
         await pilot.press("slash", "r", "e", "l", "o", "a", "d", "enter")
         await pilot.pause()
         await pilot.pause()
-        assert attempts["n"] == 2
-        assert app._session is session
+        from local_operator.reexec import REEXEC_CODE
+
+        assert app.return_code == REEXEC_CODE
+        assert attempts["n"] == 1
+        assert app._session is None
 
 
 # --- login/logout through the provider controller --------------------------

--- a/tests/unit/tui/test_command_picker.py
+++ b/tests/unit/tui/test_command_picker.py
@@ -829,7 +829,7 @@ async def test_click_on_the_overflow_row_does_nothing() -> None:
 @pytest.mark.parametrize(
     "query,expected",
     [
-        ("u", ["usage"]),
+        ("u", ["update", "usage"]),
         ("g", ["goal"]),
         ("s", ["search", "skills"]),
         ("c", ["clear", "context", "compact", "credential"]),

--- a/tests/unit/tui/test_effort.py
+++ b/tests/unit/tui/test_effort.py
@@ -290,7 +290,9 @@ async def test_the_chosen_level_survives_a_session_rebuild() -> None:
     async with app.run_test(size=(120, 40)) as pilot:
         await _boot(pilot, app)
         await _submit(pilot, app, "/effort low")
-        await _submit(pilot, app, "/reload")
+        # In-process rebuild — ``/reload`` now re-execs the process.
+        app._session_factory = lambda: _factory(sessions.pop(0))  # type: ignore[assignment]
+        await app._reload_session(keep_context=True)
         for _ in range(40):
             await pilot.pause()
             if app._session is not None and not sessions:
@@ -311,7 +313,8 @@ async def test_a_level_the_next_model_cannot_take_is_forgotten_not_hidden() -> N
     async with app.run_test(size=(120, 40)) as pilot:
         await _boot(pilot, app)
         await _submit(pilot, app, "/effort max")
-        await _submit(pilot, app, "/reload")
+        app._session_factory = lambda: _factory(sessions.pop(0))  # type: ignore[assignment]
+        await app._reload_session(keep_context=True)
         for _ in range(40):
             await pilot.pause()
             if app._session is not None and not sessions:

--- a/tests/unit/tui/test_slash_echo.py
+++ b/tests/unit/tui/test_slash_echo.py
@@ -44,6 +44,7 @@ ECHO_POLICY = {
     "clear": False,
     "new": False,
     "reload": False,
+    "update": False,
     "resume": False,
     # The label of the conversation, not words the model is told: the receipt
     # quotes the title that ended up in force, which is more than what was typed.
@@ -100,6 +101,7 @@ PROMPT_POLICY = {
     "clear": False,
     "new": False,
     "reload": False,
+    "update": False,
     "resume": False,
     "rename": False,
     "model": False,
@@ -257,8 +259,10 @@ async def test_every_registered_name_and_alias_actually_runs() -> None:
     async with app.run_test(size=(120, 40)) as pilot:
         await _boot(pilot, app)
         for entry in SLASH_COMMANDS:
-            if entry.name == "exit":
-                continue  # `self.exit()` would end the pilot mid-loop
+            if entry.name in {"exit", "reload", "update"}:
+                # ``exit`` ends the pilot; ``reload``/``update`` now exit 75
+                # to re-exec, which would do the same mid-loop.
+                continue
             for spelling in entry.names:
                 app._transcript_view().clear_blocks()
                 app._run_slash_command(f"/{spelling}")

--- a/tests/unit/tui/test_update_command.py
+++ b/tests/unit/tui/test_update_command.py
@@ -3,14 +3,17 @@
 from __future__ import annotations
 
 from collections.abc import Iterator
+from threading import Event
 from unittest.mock import patch
 
 import pytest
 
 from local_operator.reexec import REEXEC_CODE, RestartPlan
 from local_operator.tui.app import OperatorApp
+from local_operator.tui.widgets.editor import Editor
 from local_operator.tui.widgets.transcript import NoticeBlock, TranscriptView
-from local_operator.update import VersionCheck
+from local_operator.tui.widgets.welcome import WelcomeView
+from local_operator.update import UpdateError, VersionCheck
 from tests.unit.tui.test_app_pilot import FakeSession, _factory, _set_editor_line
 
 
@@ -121,3 +124,318 @@ async def test_live_turn_refuses_update_and_reload() -> None:
         await pilot.pause()
         assert app.return_code != REEXEC_CODE
         assert any("esc first" in text for text in _notices(app))
+
+
+@pytest.mark.asyncio
+async def test_compacting_refuses_update_and_reload() -> None:
+    """M1: compaction holds the session lock with is_streaming False."""
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        for _ in range(40):
+            await pilot.pause()
+            if app._session is not None:
+                break
+        app._compacting = True
+        editor = app.query_one("Editor")
+        editor.focus()
+        _set_editor_line(editor, "/update")
+        await pilot.press("enter")
+        await pilot.pause()
+        assert app.return_code != REEXEC_CODE
+        _set_editor_line(editor, "/reload")
+        await pilot.press("enter")
+        await pilot.pause()
+        assert app.return_code != REEXEC_CODE
+        assert any("esc first" in text for text in _notices(app))
+
+
+@pytest.mark.asyncio
+async def test_loop_refuse_copy_names_the_loop() -> None:
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        for _ in range(40):
+            await pilot.pause()
+            if app._session is not None:
+                break
+        app._loop_running = True
+        editor = app.query_one("Editor")
+        editor.focus()
+        _set_editor_line(editor, "/reload")
+        await pilot.press("enter")
+        await pilot.pause()
+        assert app.return_code != REEXEC_CODE
+        assert any("a loop is still running" in text for text in _notices(app))
+
+
+@pytest.mark.asyncio
+async def test_second_update_is_refused_while_one_is_running() -> None:
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    check = VersionCheck(installed="0.27.0", latest="0.28.0", behind=True)
+    started = Event()
+    released = Event()
+
+    def _slow_upgrade(*, target: str, **_kwargs: object) -> str:
+        started.set()
+        released.wait(timeout=5)
+        return target
+
+    with (
+        patch("local_operator.update.check_latest", return_value=check),
+        patch("local_operator.update.perform_upgrade", side_effect=_slow_upgrade),
+        patch("local_operator.update.install_kind") as kind,
+        patch("local_operator.update.is_git_snapshot", return_value=False),
+    ):
+        from local_operator.update import InstallKind
+
+        kind.return_value = InstallKind.UV_TOOL
+        async with app.run_test(size=(100, 30)) as pilot:
+            await pilot.pause()
+            editor = app.query_one(Editor)
+            editor.focus()
+            _set_editor_line(editor, "/update")
+            await pilot.press("enter")
+            for _ in range(40):
+                await pilot.pause()
+                if started.is_set() or app._update_in_progress:
+                    break
+            assert app._update_in_progress is True
+            assert editor.read_only is True
+            app._cmd_update(app._notice)
+            assert any("already running" in text for text in _notices(app))
+            released.set()
+            for _ in range(60):
+                await pilot.pause()
+                if app.return_code == REEXEC_CODE:
+                    break
+            assert app.return_code == REEXEC_CODE
+
+
+@pytest.mark.asyncio
+async def test_reload_during_in_flight_upgrade_is_refused() -> None:
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    check = VersionCheck(installed="0.27.0", latest="0.28.0", behind=True)
+    released = Event()
+
+    def _slow_upgrade(*, target: str, **_kwargs: object) -> str:
+        released.wait(timeout=5)
+        return target
+
+    with (
+        patch("local_operator.update.check_latest", return_value=check),
+        patch("local_operator.update.perform_upgrade", side_effect=_slow_upgrade),
+        patch("local_operator.update.install_kind") as kind,
+        patch("local_operator.update.is_git_snapshot", return_value=False),
+    ):
+        from local_operator.update import InstallKind
+
+        kind.return_value = InstallKind.UV_TOOL
+        async with app.run_test(size=(100, 30)) as pilot:
+            await pilot.pause()
+            editor = app.query_one(Editor)
+            editor.focus()
+            _set_editor_line(editor, "/update")
+            await pilot.press("enter")
+            for _ in range(40):
+                await pilot.pause()
+                if app._update_in_progress:
+                    break
+            app._cmd_reload(app._notice)
+            await pilot.pause()
+            assert app.return_code != REEXEC_CODE
+            assert any("already running" in text for text in _notices(app))
+            released.set()
+            for _ in range(60):
+                await pilot.pause()
+                if app.return_code == REEXEC_CODE:
+                    break
+            assert app.return_code == REEXEC_CODE
+
+
+@pytest.mark.asyncio
+async def test_composer_is_not_submittable_during_upgrade() -> None:
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    check = VersionCheck(installed="0.27.0", latest="0.28.0", behind=True)
+    released = Event()
+
+    def _slow_upgrade(*, target: str, **_kwargs: object) -> str:
+        released.wait(timeout=5)
+        return target
+
+    with (
+        patch("local_operator.update.check_latest", return_value=check),
+        patch("local_operator.update.perform_upgrade", side_effect=_slow_upgrade),
+        patch("local_operator.update.install_kind") as kind,
+        patch("local_operator.update.is_git_snapshot", return_value=False),
+    ):
+        from local_operator.update import InstallKind
+
+        kind.return_value = InstallKind.UV_TOOL
+        async with app.run_test(size=(100, 30)) as pilot:
+            await pilot.pause()
+            editor = app.query_one(Editor)
+            editor.focus()
+            _set_editor_line(editor, "/update")
+            await pilot.press("enter")
+            for _ in range(40):
+                await pilot.pause()
+                if app._update_in_progress:
+                    break
+            assert editor.read_only is True
+            assert editor.can_focus is False
+            released.set()
+            for _ in range(60):
+                await pilot.pause()
+                if app.return_code == REEXEC_CODE:
+                    break
+            assert app.return_code == REEXEC_CODE
+            # Lock held through relaunch so a late submit cannot cancel it.
+            assert app._update_in_progress is True
+            assert editor.read_only is True
+
+
+@pytest.mark.asyncio
+async def test_successful_upgrade_exits_75_even_if_something_looks_live() -> None:
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    check = VersionCheck(installed="0.27.0", latest="0.28.0", behind=True)
+
+    original = app._request_relaunch
+
+    def _force_looks_live(*, force: bool = False) -> None:
+        app._compacting = True
+        original(force=force)
+
+    with (
+        patch("local_operator.update.check_latest", return_value=check),
+        patch("local_operator.update.perform_upgrade", return_value="0.28.0"),
+        patch("local_operator.update.install_kind") as kind,
+        patch("local_operator.update.is_git_snapshot", return_value=False),
+    ):
+        from local_operator.update import InstallKind
+
+        kind.return_value = InstallKind.UV_TOOL
+        async with app.run_test(size=(100, 30)) as pilot:
+            await pilot.pause()
+            app._request_relaunch = _force_looks_live  # type: ignore[method-assign]
+            editor = app.query_one(Editor)
+            editor.focus()
+            _set_editor_line(editor, "/update")
+            await pilot.press("enter")
+            for _ in range(60):
+                await pilot.pause()
+                if app.return_code == REEXEC_CODE:
+                    break
+            assert app.return_code == REEXEC_CODE
+            assert any("restarting" in text for text in _notices(app))
+
+
+@pytest.mark.asyncio
+async def test_git_snapshot_notice_prints_before_installer() -> None:
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    check = VersionCheck(installed="0.27.0", latest="0.28.0", behind=True)
+    with (
+        patch("local_operator.update.check_latest", return_value=check),
+        patch("local_operator.update.perform_upgrade", return_value="0.28.0"),
+        patch("local_operator.update.install_kind") as kind,
+        patch("local_operator.update.is_git_snapshot", return_value=True),
+    ):
+        from local_operator.update import InstallKind
+
+        kind.return_value = InstallKind.UV_TOOL
+        async with app.run_test(size=(100, 30)) as pilot:
+            await pilot.pause()
+            editor = app.query_one(Editor)
+            editor.focus()
+            _set_editor_line(editor, "/update")
+            await pilot.press("enter")
+            for _ in range(60):
+                await pilot.pause()
+                if app.return_code == REEXEC_CODE:
+                    break
+            notices = _notices(app)
+            assert any("built from git" in text for text in notices)
+            assert any("PyPI wheel" in text for text in notices)
+            assert app.return_code == REEXEC_CODE
+
+
+@pytest.mark.asyncio
+async def test_reload_prints_relaunching_before_exit() -> None:
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        editor = app.query_one(Editor)
+        editor.focus()
+        _set_editor_line(editor, "/reload")
+        await pilot.press("enter")
+        await pilot.pause()
+        assert app.return_code == REEXEC_CODE
+        assert any("relaunching" in text for text in _notices(app))
+        assert any("new session" in text for text in _notices(app))
+
+
+@pytest.mark.asyncio
+async def test_failed_update_from_splash_keeps_empty_state() -> None:
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    check = VersionCheck(installed="0.27.0", latest="0.28.0", behind=True)
+    with (
+        patch("local_operator.update.check_latest", return_value=check),
+        patch(
+            "local_operator.update.perform_upgrade",
+            side_effect=UpdateError("this interpreter is the repo .venv"),
+        ),
+        patch("local_operator.update.install_kind") as kind,
+        patch("local_operator.update.is_git_snapshot", return_value=False),
+    ):
+        from local_operator.update import InstallKind
+
+        kind.return_value = InstallKind.EDITABLE
+        async with app.run_test(size=(100, 30)) as pilot:
+            await pilot.pause()
+            editor = app.query_one(Editor)
+            editor.focus()
+            _set_editor_line(editor, "/update")
+            await pilot.press("enter")
+            for _ in range(40):
+                await pilot.pause()
+                if any("repo checkout" in text for text in _notices(app)):
+                    break
+            notices = _notices(app)
+            assert any("checking for updates" in text for text in notices)
+            assert any("repo checkout" in text for text in notices)
+            assert not any("repo .venv" in text for text in notices)
+            assert app.query_one(WelcomeView).display is True
+            assert app.return_code != REEXEC_CODE
+            assert editor.read_only is False
+
+
+@pytest.mark.asyncio
+async def test_installer_failure_names_a_shell_retry() -> None:
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    check = VersionCheck(installed="0.27.0", latest="0.28.0", behind=True)
+    with (
+        patch("local_operator.update.check_latest", return_value=check),
+        patch(
+            "local_operator.update.perform_upgrade",
+            side_effect=UpdateError("installer exited 1"),
+        ),
+        patch("local_operator.update.install_kind") as kind,
+        patch("local_operator.update.is_git_snapshot", return_value=False),
+    ):
+        from local_operator.update import InstallKind
+
+        kind.return_value = InstallKind.UV_TOOL
+        async with app.run_test(size=(100, 30)) as pilot:
+            await pilot.pause()
+            editor = app.query_one(Editor)
+            editor.focus()
+            _set_editor_line(editor, "/update")
+            await pilot.press("enter")
+            for _ in range(40):
+                await pilot.pause()
+                if any("upgrade failed" in text for text in _notices(app)):
+                    break
+            notices = _notices(app)
+            assert any("uv tool upgrade local-operator" in text for text in notices)
+            assert app.query_one(WelcomeView).display is True
+            assert app.return_code != REEXEC_CODE

--- a/tests/unit/tui/test_update_command.py
+++ b/tests/unit/tui/test_update_command.py
@@ -1,0 +1,123 @@
+"""TUI ``/update`` and the relaunching ``/reload``."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from unittest.mock import patch
+
+import pytest
+
+from local_operator.reexec import REEXEC_CODE, RestartPlan
+from local_operator.tui.app import OperatorApp
+from local_operator.tui.widgets.transcript import NoticeBlock, TranscriptView
+from local_operator.update import VersionCheck
+from tests.unit.tui.test_app_pilot import FakeSession, _factory, _set_editor_line
+
+
+@pytest.fixture(autouse=True)
+def _clear_reexec_plan() -> Iterator[None]:
+    from local_operator.reexec import take_plan
+
+    take_plan()
+    yield
+    take_plan()
+
+
+def _notices(app: OperatorApp) -> list[str]:
+    return [
+        block._text
+        for block in app.query_one(TranscriptView).blocks()
+        if isinstance(block, NoticeBlock)
+    ]
+
+
+@pytest.mark.asyncio
+async def test_update_when_current_does_not_reexec() -> None:
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    check = VersionCheck(installed="0.27.0", latest="0.27.0", behind=False)
+    with patch("local_operator.update.check_latest", return_value=check):
+        async with app.run_test(size=(100, 30)) as pilot:
+            await pilot.pause()
+            editor = app.query_one("Editor")
+            editor.focus()
+            _set_editor_line(editor, "/update")
+            await pilot.press("enter")
+            for _ in range(40):
+                await pilot.pause()
+                if any("already on" in text for text in _notices(app)):
+                    break
+            assert any("already on v0.27.0" in text for text in _notices(app))
+            assert app.return_code != REEXEC_CODE
+            assert app._restart_plan is None
+
+
+@pytest.mark.asyncio
+async def test_update_success_exits_75() -> None:
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    check = VersionCheck(installed="0.27.0", latest="0.28.0", behind=True)
+    with (
+        patch("local_operator.update.check_latest", return_value=check),
+        patch("local_operator.update.perform_upgrade", return_value="0.28.0"),
+    ):
+        async with app.run_test(size=(100, 30)) as pilot:
+            await pilot.pause()
+            editor = app.query_one("Editor")
+            editor.focus()
+            _set_editor_line(editor, "/update")
+            await pilot.press("enter")
+            for _ in range(60):
+                await pilot.pause()
+                if app.return_code == REEXEC_CODE:
+                    break
+            assert app.return_code == REEXEC_CODE
+            assert isinstance(app._restart_plan, RestartPlan)
+
+
+@pytest.mark.asyncio
+async def test_reload_exits_75_with_resumable_id(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    session_dir = tmp_path / "sessions" / "sess"
+    session_dir.mkdir(parents=True)
+    (session_dir / "transcript.jsonl").write_text("{}\n", encoding="utf-8")
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        for _ in range(40):
+            await pilot.pause()
+            if app._session is not None:
+                break
+        editor = app.query_one("Editor")
+        editor.focus()
+        _set_editor_line(editor, "/reload")
+        await pilot.press("enter")
+        await pilot.pause()
+        assert app.return_code == REEXEC_CODE
+        plan = app._restart_plan
+        assert isinstance(plan, RestartPlan)
+        assert plan.resume_id == "sess"
+        assert "--resume" in plan.argv
+        assert "sess" in plan.argv
+
+
+@pytest.mark.asyncio
+async def test_live_turn_refuses_update_and_reload() -> None:
+    session = FakeSession()
+    session.streaming = True
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        for _ in range(40):
+            await pilot.pause()
+            if app._session is not None:
+                break
+        editor = app.query_one("Editor")
+        editor.focus()
+        _set_editor_line(editor, "/update")
+        await pilot.press("enter")
+        await pilot.pause()
+        assert app.return_code != REEXEC_CODE
+        _set_editor_line(editor, "/reload")
+        await pilot.press("enter")
+        await pilot.pause()
+        assert app.return_code != REEXEC_CODE
+        assert any("esc first" in text for text in _notices(app))

--- a/tests/unit/tui/test_welcome.py
+++ b/tests/unit/tui/test_welcome.py
@@ -305,6 +305,55 @@ def test_a_harness_notice_sheds_before_the_credential_warning() -> None:
     assert _warning_body(two)
 
 
+def test_update_row_is_absent_when_none() -> None:
+    """Do not reserve the row. A current install must match today's splash."""
+    info = WelcomeInfo(version="0.27.0", model_label="test/model", cwd="/tmp")
+    rows = plain(build_welcome_lines(info, ROOMY_W, ROOMY_H))
+    assert "latest is" not in rows
+    assert "/update" not in rows
+
+
+def test_update_row_copy_and_narrow_drop() -> None:
+    info = WelcomeInfo(
+        version="0.27.0",
+        model_label="test/model",
+        cwd="/tmp",
+        update_available="0.28.0",
+    )
+    wide = plain(build_welcome_lines(info, ROOMY_W, ROOMY_H))
+    assert "! latest is v0.28.0 — /update" in wide
+    narrow = plain(build_welcome_lines(info, 22, ROOMY_H))
+    assert "latest is v0.28.0" in narrow
+    assert "/update" not in narrow
+    assert "/upd" not in narrow
+
+
+def test_update_sheds_before_harness_notice_and_login() -> None:
+    """Update is optional news. A quota fallback outranks it; login outranks both."""
+    info = WelcomeInfo(
+        version="0.27.0",
+        model_label="anthropic/claude-opus-5",
+        cwd="/tmp",
+        missing_credential="anthropic",
+        notice="anthropic quota low — falling back to zai/glm-5.3",
+        update_available="0.28.0",
+    )
+    one = build_welcome_lines(info, ROOMY_W, 1)
+    assert _warning_body(one)
+    assert "latest is" not in plain(one)
+    assert "quota low" not in plain(one)
+
+    two = build_welcome_lines(info, ROOMY_W, 2)
+    assert "quota low" in plain(two)
+    assert _warning_body(two)
+    assert "latest is" not in plain(two)
+
+    three = build_welcome_lines(info, ROOMY_W, 3)
+    assert "latest is v0.28.0" in plain(three)
+    assert "quota low" in plain(three)
+    assert _warning_body(three)
+
+
 def _warning_body(lines: list[Text]) -> bool:
     return any("not logged in" in line.plain for line in lines)
 
@@ -752,7 +801,10 @@ async def test_no_credential_warning_appears() -> None:
     provider and the command that fixes it."""
     app = _make_app(FakeSession(), FakeProviders(missing={"openrouter": True}))
     async with app.run_test(size=(80, 26)) as pilot:
-        await pilot.pause()
+        for _ in range(40):
+            await pilot.pause()
+            if app._session is not None:
+                break
         welcome = _welcome(app)
         welcome._poll()  # the factory has resolved by now; force one read
         body = plain(build_welcome_lines(welcome._info, welcome.size.width, welcome.size.height))


### PR DESCRIPTION
## Why

There is no in-app way to upgrade a PyPI install or to pick up a replaced wheel. `/reload` rebooted MCP/credentials/model inside the old interpreter, so a just-updated binary never came back. End users were pointed at `lop-update`, which archives local git `main` — the opposite audience.

This is a minor feature. Version **0.27.1 → 0.28.0**.

## What changes

### PyPI updater — `local_operator/update.py`

`lop update` / `/update` upgrade the **installed distribution from PyPI**, not git. Latest is always `https://pypi.org/pypi/local-operator/json` → `info.version`, compared to `importlib.metadata.version("local-operator")` — the same source the splash version row and `lop --version` already use.

Detected install → one command:

| Detected install | Command |
|---|---|
| uv tool (`sys.prefix` under `…/uv/tools/local-operator`, or `uv-receipt.toml`) | `uv tool upgrade local-operator` |
| pipx | `pipx upgrade local-operator` |
| Ordinary venv / pip | `[sys.executable, "-m", "pip", "install", "-U", "local-operator"]` |

Refuse, do not guess: editable / source checkout (repo `.venv`) and unknown layouts exit 1 with how this process was launched. `.lop-source` (developer uv-tool snapshot) still upgrades from PyPI after one printed line; it does **not** call `lop-update`.

`lop update --check` prints installed vs PyPI and exits 0 (current), 2 (behind), or 1 (error). No `--yes`. No prompt. CLI upgrade does not re-exec — the user is in a shell.

Subparser help names the collision:

```
update  Upgrade this install from PyPI. Not the lop-update script,
        which rebuilds the global runtime from a local git checkout.
```

### Shared relaunch — `local_operator/reexec.py`

`/update` and `/reload` stash a `RestartPlan` and `app.exit(return_code=75)`. `run_tui` suppresses the `session ended — resume with:` hint on 75. `cli.main` then `os.execvpe`s (POSIX) or `Popen` + `_exit` (Windows).

`--resume` is rewritten from the on-disk transcript id (same gate as `resume_hint()`). No transcript yet → cold launch. Mid-turn / `/loop` refuses both commands (`esc` first). `/new` and `/resume` stay in-process.

### Splash `!` row

A one-shot mount worker (after first paint, not on the welcome poll timer) calls `check_latest()`. Newer PyPI fills `WelcomeInfo.update_available` and refreshes. Cache shape matches `model/catalogue.py` (`~/.local-operator/cache/pypi-local-operator.json`, TTL 6 hours, stale-used-on-failure, silent on miss). The row is **not reserved** when current.

Copy: `! latest is v0.28.0 — /update` (narrow: drop `/update` whole). Placement: version → model → cwd → **update** → harness notice → login warning. Shed priorities bumped so login still outranks everything.

## Testing Details

### Unit — `tests/unit/test_update.py`, `test_reexec.py`, `tests/unit/tui/test_update_command.py`

- `check_latest` against a fake `httpx` transport: newer / same / older / 500 / timeout / corrupt cache / stale-used-on-failure / TTL hit skips GET.
- `install_kind` with tmp prefixes: uv-receipt, uv path, pipx, editable, no distribution, unknown.
- `perform_upgrade` asserts the argv it would run; subprocess is injected. Does not hit real PyPI install.
- `lop update --check` via `main()` with `sys.argv` patched: exit 0 / 2 / 1 and stdout.
- `plan_argv`: no resume, inject, replace existing, preserve `--model`/`--hosting`/`--train`.
- `replace_self`: POSIX `execvpe` once; Windows backend `Popen` + `_exit(0)`.
- TUI: `/update` when current does not set return_code 75; stubbed successful upgrade exits 75; `/reload` exits 75 with a resumable id stashed; live turn refuses both.
- Echo policy pin (`"update": False`). Splash geometry / shed order / no row when `None`.

### Visual — real `OperatorApp`, 100×30

| Frame | Path | content height | virtual vs size | scrollbar |
|---|---|---|---|---|
| before (origin/main) | `/tmp/before.svg` | 22 | 98×28 == 98×28 | no |
| after, current | `/tmp/after-current.svg` | 22 | 98×28 == 98×28 | no |
| after, `update_available="0.28.0"` | `/tmp/after-available.svg` | 23 | 98×28 == 98×28 | no |

Looked at the rendered PNGs. Current matches today's splash (no reserved row). Available adds one yellow `! latest is v0.28.0 — /update` under cwd, above the hint table. No reflow of the lockup or composer.

### Live PyPI check (this worktree, not the installed `lop`)

```
$ PYTHONPATH=/tmp/lop-update-cmd .venv/bin/python -c "from local_operator.update import update_command; raise SystemExit(update_command(check=True))"
local-operator 0.17.4
latest on PyPI: 0.27.1
run `lop update` to install
EXIT:2
```

The installed `lop` runtime does not yet have the subcommand (`invalid choice: 'update'`), as expected.

### Gates

```
.venv/bin/python -m flake8 .                         # pass
uvx --from black==26.1.0 black --check local_operator tests   # pass
uvx isort --check-only --profile black local_operator tests   # pass
.venv/bin/python -m pyright --pythonpath .venv/bin/python .   # pass (0 errors)
env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit -q
  # 6487 passed, 7 skipped; 3 failures are pre-existing flakes also
  # reproduced (eval stream) or passing (comms, bash cancel, jobs wait)
  # on origin/main. Feature tests: 42/42.
```

## Cannot prove in-unit

A real `uv tool upgrade` + living TUI `exec` was **not** exercised. Do not treat the mocked installer argv or the exit-75 pilot as a published-upgrade.

## Design decisions (not redesigned)

- PyPI, not `lop-update`.
- `/reload` now re-execs; `/new` and `/resume` stay in-process.
- Splash `!` row, not reserved, not `info.notice`.
- No `--from-source`, no `--yes`, no new dependency.
