### PR TITLE
chore(release): bump version to 0.27.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.27.2"
+version = "0.27.3"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
#282 merged as 8477570e with pyproject still at 0.27.2 because #281 had already taken that number (tag v0.27.2 / 40182b2a, session titles on every model). This bump is so the serving-model analytics fix can publish as v0.27.3.