### PR TITLE
fix(mobile): sync titles and serving model across every front end

### DIFF
--- a/local_operator/mobile/owned.py
+++ b/local_operator/mobile/owned.py
@@ -25,7 +25,7 @@ import logging
 import secrets
 from typing import TYPE_CHECKING, Any, Callable
 
-from local_operator.harness.types import AgentEvent
+from local_operator.harness.types import AgentEvent, ModelChangeEvent
 
 if TYPE_CHECKING:
     from local_operator.harness.types import ImageContent
@@ -84,7 +84,7 @@ class OwnedSessionHandle(SessionHandle):
             # the real title lands, instead of a placeholder that never moves.
             conversation_name=getattr(session, "conversation_name", "") or "",
             cwd=cwd,
-            model_label=session.model_label,
+            model_label=_effective_label(session),
             model_selector=_selector(session),
             effort=_current_effort(session),
             effort_ladder=_ladder(session),
@@ -97,6 +97,10 @@ class OwnedSessionHandle(SessionHandle):
         # OperatorApp._name_requested: the first substantive prompt fires ONE
         # background naming call, alongside the turn it decorates.
         self._name_requested = False
+        # Opener of a naming attempt that returned nothing. Isolated naming
+        # often 429s on a dead primary BEFORE the turn pins a fallback; the
+        # route edge re-fires this opener once a serving model exists.
+        self._pending_name_text = ""
         # Strong references to detached background tasks (the naming errand),
         # so the event loop cannot garbage-collect one mid-flight and drop the
         # title silently. Each task removes itself on completion.
@@ -231,6 +235,8 @@ class OwnedSessionHandle(SessionHandle):
             self._fold.fold_event(event)
             self._refresh_state()
             self._refresh_todos()
+            if isinstance(event, ModelChangeEvent):
+                self._retry_naming_after_route_change()
             self._notify()
 
         unsubscribe = self._session.subscribe(handler)
@@ -277,6 +283,13 @@ class OwnedSessionHandle(SessionHandle):
             # Already named (a restored session, or a prior prompt named it).
             self._name_requested = True
             return
+        # Wear the opener on the phone immediately — same stand-in the TUI
+        # band shows — so the list/header are not "untitled" for the whole
+        # first turn (or forever, if the isolated naming call 429s).
+        label = naming.provisional_title(text)
+        if label:
+            self._fold.set_state(conversation_name=label)
+            self._notify()
         self._name_requested = True
         # Hold a strong reference until the task settles: a bare ensure_future
         # is only weakly held by the loop and can be collected before it runs.
@@ -305,7 +318,9 @@ class OwnedSessionHandle(SessionHandle):
             # allow a later substantive prompt to retry only when still unnamed.
             if not getattr(self._session, "conversation_name", ""):
                 self._name_requested = False
+                self._pending_name_text = text
             return
+        self._pending_name_text = ""
         self._session.set_conversation_name(title, user_set=False)
         self._refresh_state()
         self._notify()
@@ -439,7 +454,7 @@ class OwnedSessionHandle(SessionHandle):
 
     def _refresh_state(self) -> None:
         self._fold.set_state(
-            model_label=self._session.model_label,
+            model_label=_effective_label(self._session),
             model_selector=_selector(self._session),
             effort=_current_effort(self._session),
             effort_ladder=_ladder(self._session),
@@ -463,6 +478,19 @@ class OwnedSessionHandle(SessionHandle):
         there."""
         self._fold.reconcile_streaming(bool(getattr(self._session, "is_streaming", False)))
 
+    def _retry_naming_after_route_change(self) -> None:
+        """Re-fire a failed naming attempt once a fallback is actually serving.
+
+        Isolated naming has no fallback chain, so a quota 429 on the primary
+        returns None while the turn is still pinning the rescue route. The
+        opener is stashed; this spends it the moment the serving model exists.
+        """
+        pending = self._pending_name_text
+        if not pending or getattr(self._session, "conversation_name", ""):
+            return
+        self._pending_name_text = ""
+        self._maybe_name_conversation(pending)
+
     def _refresh_todos(self) -> None:
         try:
             from local_operator.tools.builtin import TODO_STORE
@@ -470,6 +498,16 @@ class OwnedSessionHandle(SessionHandle):
             self._fold.set_todos(list(TODO_STORE.get(self._session.session_id, [])))
         except Exception:  # noqa: BLE001 — todos are a panel, never a failure
             logger.debug("todo refresh failed", exc_info=True)
+
+
+def _effective_label(session: Any) -> str:
+    """``provider/model`` of the model actually serving requests.
+
+    A display that reads ``session.model_label`` during a provider fallback
+    names a model that is not answering — the stale composer chip.
+    """
+    label = str(getattr(session, "effective_model_label", "") or "")
+    return label or str(getattr(session, "model_label", "") or "")
 
 
 def _selector(session: Any) -> str:
@@ -482,7 +520,8 @@ def _selector(session: Any) -> str:
 
 def _current_effort(session: Any) -> str:
     try:
-        return session.model.reasoning_effort or ""
+        spec = getattr(session, "effective_model", None) or session.model
+        return spec.reasoning_effort or ""
     except Exception:  # noqa: BLE001
         return ""
 

--- a/local_operator/mobile/projection.py
+++ b/local_operator/mobile/projection.py
@@ -39,6 +39,7 @@ from local_operator.harness.types import (
     MessageEndEvent,
     MessageStartEvent,
     MessageUpdateEvent,
+    ModelChangeEvent,
     NoticeEvent,
     RetryEndEvent,
     RetryStartEvent,
@@ -482,6 +483,14 @@ class ProjectionFold:
             self._append(TranscriptEntry(id=f"rt-{time.time_ns()}", kind="notice", text=note))
         elif isinstance(event, RetryEndEvent):
             pass  # the retry row already reads; success is the next assistant row
+        elif isinstance(event, ModelChangeEvent):
+            # The composer chip and the session-list model must name the
+            # model ACTUALLY answering. A display that kept the selected
+            # primary after a quota fallback is the stale chip the phone
+            # showed while Grok was serving.
+            p.model_label = f"{event.provider}/{event.model_id}"
+            if event.effort:
+                p.effort = event.effort
         # Unknown events are dropped by design: the fold renders a SUBSET of
         # the harness taxonomy (the phone has no use for wake/loop internals),
         # and ``extra="allow"`` on AgentEvent means matching must stay

--- a/local_operator/mobile/tui_handle.py
+++ b/local_operator/mobile/tui_handle.py
@@ -64,7 +64,7 @@ class TuiSessionHandle(SessionHandle):
             kind="tui",
             conversation_name=getattr(session, "conversation_name", "") or "",
             cwd=_session_cwd(session),
-            model_label=session.model_label,
+            model_label=_effective_label(session),
             model_selector=_selector(session),
             effort=_current_effort(session),
             effort_ladder=_ladder(session),
@@ -419,6 +419,18 @@ class TuiSessionHandle(SessionHandle):
         questions = getattr(card, "_questions", None)
         return len(questions) if questions else 1
 
+    def note_title(self, name: str) -> None:
+        """Push a title that landed off the event stream.
+
+        Generated titles and provisional stand-ins never emit an AgentEvent,
+        so the per-event refresh never sees them. The TUI calls this the
+        moment the band updates so the phone's header and list follow.
+        """
+        label = (name or "").strip()
+        self._fold.set_state(conversation_name=label or None)
+        if self._on_projection is not None:
+            self._on_projection()
+
     def note_ask_settled(self, card: Any) -> None:
         """Clear the phone card for a TUI ask picker that just came down.
 
@@ -466,7 +478,7 @@ class TuiSessionHandle(SessionHandle):
     def _refresh_state(self) -> None:
         session = self._session()
         self._fold.set_state(
-            model_label=session.model_label,
+            model_label=_effective_label(session),
             model_selector=_selector(session),
             effort=_current_effort(session),
             effort_ladder=_ladder(session),
@@ -537,6 +549,17 @@ def _session_cwd(session: Any) -> str:
     return os.getcwd()
 
 
+def _effective_label(session: Any) -> str:
+    """``provider/model`` of the model actually serving requests.
+
+    A display that reads ``session.model_label`` (the selection) during a
+    provider fallback names a model that is not answering — the stale
+    composer chip the phone showed after a quota failover.
+    """
+    label = str(getattr(session, "effective_model_label", "") or "")
+    return label or str(getattr(session, "model_label", "") or "")
+
+
 def _selector(session: Any) -> str:
     try:
         spec = session.model
@@ -547,7 +570,8 @@ def _selector(session: Any) -> str:
 
 def _current_effort(session: Any) -> str:
     try:
-        return session.model.reasoning_effort or ""
+        spec = getattr(session, "effective_model", None) or session.model
+        return spec.reasoning_effort or ""
     except Exception:  # noqa: BLE001
         return ""
 

--- a/local_operator/resume.py
+++ b/local_operator/resume.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import sys
 from pathlib import Path
 from typing import NamedTuple
 
@@ -660,6 +661,12 @@ def live_session_owner(config_dir: Path, session_id: str) -> int | None:
         return None
     if pid <= 0:
         return None
+    # Windows has no signal 0 — ``os.kill`` there TERMINATES the target
+    # (see ``session.retention._process_alive``). A parseable marker is
+    # treated as live rather than probed, so a ``/resume`` cannot kill
+    # the phone-started child it is trying to share (F2).
+    if sys.platform == "win32":
+        return pid
     try:
         os.kill(pid, 0)
     except ProcessLookupError:

--- a/local_operator/resume.py
+++ b/local_operator/resume.py
@@ -634,6 +634,43 @@ def resolve_resume_id(config_dir: Path, requested: str) -> str:
     return resume_dir(config_dir, requested).name
 
 
+def live_session_owner(config_dir: Path, session_id: str) -> int | None:
+    """Pid of the process currently hosting ``session_id``, or ``None``.
+
+    Two writers on one transcript is how a TUI ``/resume`` of a phone-started
+    session painted the splash: the second process claimed the directory,
+    replayed a mid-write journal, and left the first process as the only one
+    still appending. The live process already publishes to the phone, so a
+    second front end should attach to THAT process rather than open another
+    writer.
+
+    Consults the session directory's ``.session.pid`` liveness marker — the
+    same file the retention sweep uses. Stdlib-only and import-light: this
+    module must stay off the engine and the mobile package (see the module
+    docstring). A live TUI or phone-started child always writes that marker
+    when it claims the directory.
+    """
+    if session_id in ("", ".", "..") or Path(session_id).name != session_id:
+        return None
+    marker = config_dir / "sessions" / session_id / ".session.pid"
+    try:
+        raw = marker.read_text(encoding="utf-8").strip()
+        pid = int(raw)
+    except (OSError, ValueError):
+        return None
+    if pid <= 0:
+        return None
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return None
+    except PermissionError:
+        return pid
+    except OSError:
+        return pid
+    return pid
+
+
 def recent_sessions(config_dir: Path, limit: int = 10) -> list[tuple[str, float]]:
     """``(id, mtime)`` for the USER's resumable sessions, newest first.
 

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -4610,7 +4610,11 @@ class Session:
         Prefers the operator's ``lo`` tier (``values.subagents.models.lo``),
         which is the same ladder a scout subagent runs on — an operator who has
         already said "this is my cheap model" should not have to say it twice.
-        With no tier configured it falls back to the session's own model.
+        With no tier configured it uses the model ACTUALLY serving requests
+        (the pinned fallback while one is in force, else the selected model).
+        A naming call that stayed on the selected primary after a quota
+        fallback would 429 on the dead route and leave the session untitled
+        while the turn already answered on the fallback.
 
         The clamp is applied to WHICHEVER of the two this returns, and it is not
         only a cost argument. ``ERRAND_MAX_TOKENS`` becomes
@@ -4627,7 +4631,7 @@ class Session:
         unaffected.
         """
         tier = self._resolve_subagent_model("task", "lo")
-        return self._lowest_effort(tier if tier is not None else self._model)
+        return self._lowest_effort(tier if tier is not None else self.effective_model)
 
     @staticmethod
     def _lowest_effort(spec: ModelSpec) -> ModelSpec:

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -3188,21 +3188,23 @@ class OperatorApp(App[None]):
         )
 
         try:
-            concrete = (
-                resume_id
-                if resume_id == RESUME_LATEST
-                else resolve_resume_id(config_dir(), resume_id)
-            )
+            # Resolve ``@latest`` to a concrete id BEFORE the owner check.
+            # Skipping the sentinel left bare ``/resume`` / ``/resume @latest``
+            # on the second-writer path this method exists to close (F1).
+            concrete = resolve_resume_id(config_dir(), resume_id)
         except Exception:
             concrete = resume_id
         if concrete != RESUME_LATEST:
             owner = live_session_owner(config_dir(), concrete)
             if owner is not None and owner != os.getpid():
-                notice(
-                    f"session {concrete} is already live in pid {owner} — "
-                    "watch and steer it from this TUI's phone list, or "
-                    "from the process that owns it; a second writer would "
-                    "open empty"
+                # A refused navigation is not conversation content: keep the
+                # splash, same as the other /resume rejections (D1). Name the
+                # owning process and the next step in user words (D2).
+                self._system_notice(
+                    f"session {concrete} is already open in another process "
+                    f"(pid {owner}) — watch and steer it there, or from the "
+                    "phone session list",
+                    "warning",
                 )
                 return
         self._session_factory = lambda: self._resume_factory(resume_id)  # type: ignore[misc]

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -1441,6 +1441,12 @@ class OperatorApp(App[None]):
         # same split `_provisional_name` already makes.
         self._last_titled_turn_count: int = 0
         self._theme_refresh_count: int = 0
+        # Opener text of a naming attempt that returned nothing. A quota
+        # fallback pins AFTER the isolated naming call has already 429'd on
+        # the dead primary, so the next substantive message is too late —
+        # the phone stays "untitled" for the whole first turn. The route
+        # edge re-fires this opener once a serving model exists.
+        self._pending_name_text: str = ""
         # A turn holds this for its whole provider round trip, and `_dispose`
         # waits on it so a session is never torn down under a live request.
         # Naming does NOT take it: the title call is `isolated` (see
@@ -2759,6 +2765,7 @@ class OperatorApp(App[None]):
         # from the first title it lands, so nothing is lost that mattered.
         self._last_titled_turn_count = 0
         self._theme_refresh_count = 0
+        self._pending_name_text = ""
         # The spend ledger is the dead conversation's — unless the reload lands
         # back on the SAME conversation, which `/reload` now does. Reset it here
         # so `/new` and `/resume` cannot inherit a figure they did not spend,
@@ -3160,10 +3167,44 @@ class OperatorApp(App[None]):
         Shared by the picker and by ``/resume <id>`` so both paths reload
         identically. Failures inside the new factory surface through
         ``_on_boot_failed`` exactly as a bad ``--resume`` does.
+
+        A session that is ALREADY live in another process (a phone-started
+        child, another TUI) is not reopened here. Two writers on one
+        transcript is how a resume of a mobile session painted the splash:
+        the second process claimed the directory, replayed a mid-write
+        journal, and left the first process as the only one still appending.
+        The live process already publishes to the phone; this TUI stays
+        put and names that process so the user can watch and steer from
+        either front end.
         """
         if self._resume_factory is None:
             self._system_notice("resume unavailable: no resume-capable launcher", "warning")
             return
+        from local_operator.paths import config_dir
+        from local_operator.resume import (
+            RESUME_LATEST,
+            live_session_owner,
+            resolve_resume_id,
+        )
+
+        try:
+            concrete = (
+                resume_id
+                if resume_id == RESUME_LATEST
+                else resolve_resume_id(config_dir(), resume_id)
+            )
+        except Exception:
+            concrete = resume_id
+        if concrete != RESUME_LATEST:
+            owner = live_session_owner(config_dir(), concrete)
+            if owner is not None and owner != os.getpid():
+                notice(
+                    f"session {concrete} is already live in pid {owner} — "
+                    "watch and steer it from this TUI's phone list, or "
+                    "from the process that owns it; a second writer would "
+                    "open empty"
+                )
+                return
         self._session_factory = lambda: self._resume_factory(resume_id)  # type: ignore[misc]
         notice(f"resuming session {resume_id}…")
         self.run_worker(self._reload_session(), thread=False, group="session")
@@ -5665,6 +5706,23 @@ class OperatorApp(App[None]):
         except Exception:  # noqa: BLE001 - a phone bridge must never break the ask
             logger.debug("mobile ask-advanced notify failed", exc_info=True)
 
+    def _notify_mobile_title(self, name: str) -> None:
+        """Push a title (generated, renamed, or provisional) to the phone.
+
+        The fold only re-reads ``session.conversation_name`` on an event, and
+        a title lands on a detached worker with no event of its own. A
+        provisional stand-in never even reaches the session store. Without
+        this the phone stays on "untitled" for the whole first turn — and
+        forever if the isolated naming call 429s on a dead primary.
+        """
+        handle = self._mobile_handle
+        if handle is None:
+            return
+        try:
+            handle.note_title(name)
+        except Exception:  # noqa: BLE001 — a phone bridge must never break naming
+            logger.debug("mobile title notify failed", exc_info=True)
+
     def _settle_ask_picker(self) -> None:
         """Take down a live ``ask`` picker, answering with whatever was chosen.
 
@@ -7065,6 +7123,11 @@ class OperatorApp(App[None]):
             return
         self._provisional_name = label
         self._status.update(conversation_name=label)
+        # The band is DISPLAY-only; the phone reads the session store, which
+        # is still empty. Push the stand-in so the list and header name the
+        # conversation the same frame the tab does, instead of "untitled"
+        # until a generated title lands (or forever, if naming 429s).
+        self._notify_mobile_title(label)
 
     def _clock(self) -> float:
         """Monotonic seconds, as one overridable seam.
@@ -7273,7 +7336,12 @@ class OperatorApp(App[None]):
             # that is the point of it being a stand-in and not a placeholder.
             if not session.conversation_name:
                 self._name_requested = False
+                # Remember the opener so a fallback that pins AFTER this
+                # isolated 429 can re-fire naming on the serving model
+                # without waiting for the next user message.
+                self._pending_name_text = text
             return
+        self._pending_name_text = ""
         self._store_title(session, title)
 
     def _charge_theme_refresh(self, session: SessionProtocol, turn_count: int) -> None:
@@ -7348,6 +7416,10 @@ class OperatorApp(App[None]):
             # `StatusLine._sync_terminal_title`), so both surfaces follow from
             # this one call and neither can lag the other by a frame.
             self._status.update(conversation_name=stored)
+        # The title lands on a detached worker AFTER the last turn event, so
+        # the mobile fold never re-reads it on its own. Push now so the
+        # phone's header and list update the same moment the band does.
+        self._notify_mobile_title(stored)
         return stored
 
     def _cmd_rename(self, arg: str, notice: NoticeFn) -> None:
@@ -7396,6 +7468,7 @@ class OperatorApp(App[None]):
             # `StatusLine._sync_terminal_title`), so neither surface can lag the
             # other by a frame.
             self._status.update(conversation_name=stored)
+        self._notify_mobile_title(stored)
         # `stored`, not `arg`: the store collapses whitespace and caps the length
         # (`MAX_TITLE_CHARS`), and the receipt's whole job is to show the title
         # that is actually in force. Truncated rather than REJECTED, unlike a
@@ -12952,6 +13025,13 @@ class OperatorApp(App[None]):
             effort=_effort_label(session) if session is not None else "",
             context_window=_context_window(session) if session is not None else 0,
         )
+        # Naming is isolated (no fallback chain) and often fires BEFORE the
+        # turn pins a fallback. A 429 on the dead primary released the latch
+        # and stashed the opener; now a serving model exists, so retry once.
+        pending = self._pending_name_text
+        if pending and session is not None and not session.conversation_name:
+            self._pending_name_text = ""
+            self._maybe_name_conversation(pending)
 
     def on_retry_started(self, message: RetryStarted) -> None:
         body = f"retry {message.attempt}: {message.error}"

--- a/tests/unit/mobile/test_owned.py
+++ b/tests/unit/mobile/test_owned.py
@@ -26,6 +26,7 @@ class FakeSession:
     def __init__(self) -> None:
         self.session_id = "sess-1"
         self.model_label = "test/model"
+        self.effective_model_label = "test/model"
         self.model = None
         self.conversation_name = ""
         self.is_streaming = False
@@ -279,6 +280,62 @@ async def test_naming_worker_stores_a_title_once() -> None:
     for _ in range(5):
         await asyncio.sleep(0)
     assert session._named == [("A Neat Title", False)]
+
+
+@pytest.mark.asyncio
+async def test_first_prompt_wears_a_provisional_title_before_the_model_answers() -> None:
+    """The phone list must not stay "untitled" for the whole first turn.
+
+    Isolated naming is a round trip (and often a 429 on a dead primary). The
+    opener excerpt is already in hand, so the projection wears it the same
+    frame the prompt is accepted — matching the TUI band.
+    """
+    handle, session = make_handle()
+    session.title_reply = ""  # naming will fail; the stand-in must still land
+
+    handle._maybe_name_conversation("review what regressed in mobile titles")
+    assert handle._fold.projection.conversation_name == "Review what regressed in mobile titles"
+    assert session.conversation_name == ""
+
+    for _ in range(5):
+        await asyncio.sleep(0)
+    # Failure released the latch and stashed the opener for a route-edge retry.
+    assert handle._name_requested is False
+    assert handle._pending_name_text == "review what regressed in mobile titles"
+
+
+@pytest.mark.asyncio
+async def test_a_failed_name_retries_once_a_fallback_pins() -> None:
+    """Quota-exhausted naming is isolated; the turn's fallback must re-fire it."""
+    from local_operator.harness.types import ModelChangeEvent
+
+    handle, session = make_handle()
+    session.title_reply = ""
+    handle.subscribe(lambda: None)
+    handle._maybe_name_conversation("review what regressed in mobile titles")
+    for _ in range(5):
+        await asyncio.sleep(0)
+    assert session.conversation_name == ""
+    assert handle._pending_name_text
+
+    session.title_reply = "<title>Mobile title sync</title>"
+    # The real session updates effective_model BEFORE emitting; _refresh_state
+    # then re-reads that label. A fake that only emits would have the fold
+    # paint the fallback and the refresh clobber it back to the selection.
+    session.effective_model_label = "xai/grok-4.6"
+    session.emit(
+        ModelChangeEvent(
+            provider="xai",
+            model_id="grok-4.6",
+            is_fallback=True,
+            reason="quota exhausted",
+        )
+    )
+    for _ in range(8):
+        await asyncio.sleep(0)
+    assert session.conversation_name == "Mobile title sync"
+    assert handle._pending_name_text == ""
+    assert handle._fold.projection.model_label == "xai/grok-4.6"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/mobile/test_projection.py
+++ b/tests/unit/mobile/test_projection.py
@@ -13,6 +13,7 @@ from local_operator.harness.types import (
     MessageEndEvent,
     MessageStartEvent,
     MessageUpdateEvent,
+    ModelChangeEvent,
     NoticeEvent,
     SubagentEndEvent,
     SubagentProgressEvent,
@@ -39,6 +40,23 @@ from local_operator.mobile.types import (
 
 def make_fold() -> ProjectionFold:
     return ProjectionFold(SessionProjection(session_id="s1", pid=1))
+
+
+def test_model_change_repaints_the_composer_chip() -> None:
+    """A fallback must rename the chip the phone shows, not just the notice."""
+    fold = make_fold()
+    fold.projection.model_label = "anthropic/claude-opus-4-8"
+    fold.fold_event(
+        ModelChangeEvent(
+            provider="xai",
+            model_id="grok-4.6",
+            effort="high",
+            is_fallback=True,
+            reason="quota exhausted",
+        )
+    )
+    assert fold.projection.model_label == "xai/grok-4.6"
+    assert fold.projection.effort == "high"
 
 
 def test_streaming_assistant_row_updates_in_place() -> None:

--- a/tests/unit/session/test_session.py
+++ b/tests/unit/session/test_session.py
@@ -2543,6 +2543,26 @@ async def test_the_errand_model_is_effort_clamped_on_both_routes(tmp_path, monke
 
 
 @pytest.mark.asyncio
+async def test_the_errand_model_follows_a_pinned_fallback(tmp_path, monkeypatch):
+    """Naming must not stay on a quota-exhausted primary.
+
+    Isolated naming has no fallback chain of its own. After the turn pins a
+    rescue route, the errand has to use THAT model or the title 429s forever
+    and the phone stays untitled.
+    """
+    from local_operator.model.configure import build_model_spec
+
+    _config_dir_with(tmp_path, monkeypatch, None)
+    primary = build_model_spec("anthropic", "claude-opus-5")
+    rescue = ModelSpec(provider="xai", model_id="grok-4.6", context_window=100_000)
+    session = make_session(tmp_path, ScriptedStream([]), model=primary)
+    session._active_fallback = rescue
+    errand = session._errand_model()
+    assert (errand.provider, errand.model_id) == ("xai", "grok-4.6")
+    await session.dispose()
+
+
+@pytest.mark.asyncio
 async def test_the_mid_turn_flush_never_persists_a_compaction_marker(tmp_path):
     """F1: the mid-turn flush must not write the compaction summary marker.
 

--- a/tests/unit/test_stored_session_title.py
+++ b/tests/unit/test_stored_session_title.py
@@ -18,6 +18,7 @@ from local_operator.resume import (
     TITLE_SIDECAR_NAME,
     _read_title_sidecar,
     backfill_session_titles,
+    live_session_owner,
     read_title_names,
     session_name,
     stored_session_title,
@@ -40,6 +41,22 @@ def _session(tmp_path: Path, opener: str, *titles: tuple[str, bool]) -> Path:
 
     asyncio.run(build())
     return session
+
+
+def test_a_live_pid_marker_is_the_owner_of_the_session(tmp_path: Path, monkeypatch) -> None:
+    """A second writer must not reopen a conversation another process hosts."""
+    import os
+
+    session = tmp_path / "sessions" / "live00000001"
+    session.mkdir(parents=True)
+    (session / "transcript.jsonl").write_text("{}\n", encoding="utf-8")
+    (session / ".session.pid").write_text(str(os.getpid()), encoding="utf-8")
+    assert live_session_owner(tmp_path, "live00000001") == os.getpid()
+
+    (session / ".session.pid").write_text("2147483646", encoding="utf-8")
+    monkeypatch.setattr(os, "kill", lambda pid, sig: (_ for _ in ()).throw(ProcessLookupError()))
+    assert live_session_owner(tmp_path, "live00000001") is None
+    assert live_session_owner(tmp_path, "missing000001") is None
 
 
 def test_the_journalled_title_type_matches_the_writer():

--- a/tests/unit/test_stored_session_title.py
+++ b/tests/unit/test_stored_session_title.py
@@ -59,6 +59,27 @@ def test_a_live_pid_marker_is_the_owner_of_the_session(tmp_path: Path, monkeypat
     assert live_session_owner(tmp_path, "missing000001") is None
 
 
+def test_a_windows_live_marker_is_trusted_without_os_kill(tmp_path: Path, monkeypatch) -> None:
+    """Windows has no signal 0; probing would terminate the owning child."""
+    import os
+
+    session = tmp_path / "sessions" / "live00000002"
+    session.mkdir(parents=True)
+    (session / "transcript.jsonl").write_text("{}\n", encoding="utf-8")
+    (session / ".session.pid").write_text("4242", encoding="utf-8")
+
+    killed: list[tuple[int, int]] = []
+
+    def _kill(pid: int, sig: int) -> None:
+        killed.append((pid, sig))
+        raise AssertionError("os.kill must not run on win32")
+
+    monkeypatch.setattr("local_operator.resume.sys.platform", "win32")
+    monkeypatch.setattr(os, "kill", _kill)
+    assert live_session_owner(tmp_path, "live00000002") == 4242
+    assert killed == []
+
+
 def test_the_journalled_title_type_matches_the_writer():
     """``resume`` may not import the engine, so it spells the entry type again.
 

--- a/tests/unit/tui/test_conversation_naming.py
+++ b/tests/unit/tui/test_conversation_naming.py
@@ -38,7 +38,7 @@ from local_operator.tui.app import RETITLE_MIN_GAP_S, OperatorApp
 from local_operator.tui.terminal_title import TerminalTitle
 from local_operator.tui.widgets.editor import Editor
 from local_operator.tui.widgets.transcript import NoticeBlock, TranscriptView
-from tests.unit.tui.test_app_pilot import FakeSession, _factory
+from tests.unit.tui.test_app_pilot import FakeSession, _factory, _transcript_text
 
 
 class _GatedSession(FakeSession):
@@ -448,7 +448,23 @@ async def test_resume_of_a_live_session_does_not_open_a_second_writer(
         app._resume_session("live00000001", notice)
         await _settle()
         assert rebuilt["called"] is False
-        assert any("already live" in body for body in notices)
+        # The refuse is a system notice (splash stays), not the slash
+        # receipt callback — look at the transcript, not ``notices``.
+        text = _transcript_text(app)
+        assert "already open" in text
+        assert "pid 4242" in text
+        assert "second writer" not in text
+        assert app._session is session
+        # Splash survives a refused navigation (D1).
+        from local_operator.tui.widgets.welcome import WelcomeView
+
+        assert app.query_one(WelcomeView).display is True
+
+        # F1: ``@latest`` must resolve then refuse, not skip the owner check.
+        rebuilt["called"] = False
+        app._resume_session("@latest", notice)
+        await _settle()
+        assert rebuilt["called"] is False
         assert app._session is session
 
 

--- a/tests/unit/tui/test_conversation_naming.py
+++ b/tests/unit/tui/test_conversation_naming.py
@@ -377,6 +377,81 @@ async def test_a_low_signal_opener_names_nothing_at_all() -> None:
         assert app._status._conversation_name == ""
 
 
+@pytest.mark.asyncio
+async def test_a_dead_naming_call_retries_when_a_fallback_pins() -> None:
+    """Isolated naming 429s on the dead primary; the route edge re-fires it.
+
+    The first turn's naming call races the fallback pin and loses. Without a
+    retry on ``EffectiveModelChanged`` the conversation stays untitled for
+    the whole session — the phone list and header never update.
+    """
+    from local_operator.tui.events import EffectiveModelChanged
+
+    app, session = await _boot(title="")
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _ready(pilot, app)
+        app._submit_prompt("review what regressed in mobile titles")
+        session.gate.set()
+        await _settle()
+        assert session.conversation_name == ""
+        assert app._pending_name_text == "review what regressed in mobile titles"
+
+        session.title = "<title>Mobile title sync</title>"
+        app.on_effective_model_changed(
+            EffectiveModelChanged(
+                provider="xai",
+                model_id="grok-4.6",
+                effort=None,
+                reason="quota exhausted",
+                is_fallback=True,
+            )
+        )
+        await _settle()
+        assert session.conversation_name == "Mobile title sync"
+        assert app._pending_name_text == ""
+        assert app._status is not None
+        assert app._status._conversation_name == "Mobile title sync"
+
+
+@pytest.mark.asyncio
+async def test_resume_of_a_live_session_does_not_open_a_second_writer(
+    tmp_path, monkeypatch
+) -> None:
+    """A phone-started session is already live; /resume must not fork it.
+
+    Two writers on one transcript is how a TUI resume of a mobile session
+    painted the splash: the second process claimed the directory and
+    replayed a mid-write journal.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    live = tmp_path / "sessions" / "live00000001"
+    live.mkdir(parents=True)
+    (live / "transcript.jsonl").write_text("{}\n", encoding="utf-8")
+    (live / ".session.pid").write_text("4242", encoding="utf-8")
+    monkeypatch.setattr("os.kill", lambda pid, sig: None)
+
+    rebuilt = {"called": False}
+
+    async def resume_factory(_resume_id: str | None):
+        rebuilt["called"] = True
+        return FakeSession()
+
+    app, session = await _boot()
+    app._resume_factory = resume_factory
+    notices: list[str] = []
+
+    def notice(body: str, kind: str = "info") -> None:
+        notices.append(body)
+
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _ready(pilot, app)
+        app._resume_session("live00000001", notice)
+        await _settle()
+        assert rebuilt["called"] is False
+        assert any("already live" in body for body in notices)
+        assert app._session is session
+
+
 # -- re-titling a conversation that has drifted -------------------------------
 
 


### PR DESCRIPTION
## Summary of Changes

Phone list/header stayed `untitled` and the composer chip kept the selected model after a quota fallback, for both TUI-started and phone-started sessions. Isolated naming raced the fallback pin, 429'd on the dead primary, and never retried. A TUI `/resume` of a live mobile session opened a second writer and painted the splash.

- Push provisional and generated titles to the phone the moment the TUI band updates (`note_title`), and wear the opener excerpt on phone-started sessions immediately.
- Paint the composer chip and session-list model from the serving model (`effective_model_label`); fold `ModelChangeEvent` so a fallback/recovery updates the chip live.
- Retry a failed naming attempt when a fallback pins; `_errand_model` uses the serving model when no `lo` tier is configured.
- `/resume` of a conversation already live in another process refuses a second writer and names the owning pid, so TUI and phone stay attached to the same session.

## Related Issue(s)

- Related: none (user-reported live regression)

## Impact

- Change class: C2 standard / pre-authorized.
- No breaking API change. Discovery records, control frames, and the phone bundle are unchanged; the projection already carried `conversation_name` and `model_label`.
- A live `/resume` of another process's session no longer forks a second writer. Watch and steer that session from the phone list (or the process that owns it).

## Testing Details

### Automated

- black / isort / flake8 / pyright clean on the changed files (pyright 0 errors / 0 warnings).
- New tests (fail on unfixed code, pass after):
  - `test_first_prompt_wears_a_provisional_title_before_the_model_answers`
  - `test_a_failed_name_retries_once_a_fallback_pins`
  - `test_model_change_repaints_the_composer_chip`
  - `test_a_dead_naming_call_retries_when_a_fallback_pins`
  - `test_resume_of_a_live_session_does_not_open_a_second_writer`
  - `test_a_live_pid_marker_is_the_owner_of_the_session`
  - `test_the_errand_model_follows_a_pinned_fallback`
- `pytest tests/unit/mobile tests/unit/tui/test_conversation_naming.py tests/unit/test_stored_session_title.py tests/unit/session/test_conversation_name_persistence.py tests/unit/tui/test_session_picker.py` → 217 passed.

### Live path (this machine)

Reproduced before the fix:

- Live mobile records for recent TUI sessions had `conversation_name: ""` while the TUI band already showed a provisional/generated title. This session (`e55d96789026`, kind=daemon) had no `title.json` and no `conversation_name` journal row after several user turns.
- Composer chip still read `anthropic/claude-opus-4-8` after the quota-exhausted fallback notice named `xai/grok-4.6`.
- Newest empty session dirs (`3286489eb194`, `a05a2967d5ad`) held only an `active_model_route` custom row — the shape of a TUI resume that claimed a live mobile transcript and painted the splash.

The runtime still serving the phone is the previous `lop` install. After this PR merges and `lop-update` rebuilds the tool, new TUI/phone sessions pick up the sync. Existing untitled live sessions keep their in-memory empty name until a later substantive prompt or a `/rename`.

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my changes work as intended.
- [x] Targeted unit suites pass.
- [x] I have run formatting (black/isort), linting (flake8), and type checks (pyright), and they pass.
- [x] I have updated the documentation when required (docstrings on the new seams).
- [x] Security considerations are addressed (especially for code execution features).
- [ ] I have linked all related issues.