### PR TITLE
fix(update): restart the mobile daemon after a successful upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,8 @@ pip install local-operator     # pipx install local-operator on Linux (PEP 668)
 ```
 
 The install provides both `local-operator` and its short alias `lop` — the
-rest of this page uses `lop`. `lop update` upgrades that install from PyPI;
+rest of this page uses `lop`. `lop update` upgrades that install from PyPI
+and restarts the mobile daemon when the LaunchAgent is installed;
 `lop-update` (hyphen) is the developer script that rebuilds the global
 runtime from a local git checkout.
 

--- a/docs/mobile.md
+++ b/docs/mobile.md
@@ -158,9 +158,11 @@ Screens, following branding.md §7's agent-output hierarchy:
   flips to *ended*, offering resume.
 - **Two daemons**: the LaunchAgent label owns the port; a second `serve`
   fails to bind and exits loudly. No split-brain by construction.
-- **Upgrade**: `lop mobile restart` after `lop-update`; the daemon re-serves
-  the new bundle, phones reload on next open, cookies survive (keyed on the
-  password, not the build).
+- **Upgrade**: `lop update` / `/update` run `lop mobile restart` when the
+  LaunchAgent is installed. The daemon re-serves the new wheel's
+  `mobile/web/dist`; phones reload on next open; cookies survive (keyed on
+  the password, not the build). A developer `lop-update` snapshot still
+  needs a manual `lop mobile restart`.
 - **Approvals on terminal sessions**: a TUI-mounted approval card is answered
   at the terminal (the phone shows the wait and says so); phone-answering
   needs a resolution protocol the TUI card does not yet have. Sessions the

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -3103,8 +3103,12 @@ class OperatorApp(App[None]):
                     "warning",
                 )
             elif mobile.kind == "unsupervised":
+                # No LaunchAgent owns this daemon (foreground `lop mobile
+                # serve`), so `lop mobile restart` is not the fix — tell the
+                # operator to relaunch the process they started.
                 self._system_notice(
-                    "a mobile daemon is running unsupervised; restart it to pick up the new UI",
+                    "a mobile daemon is running unsupervised; stop and relaunch "
+                    "the foreground lop mobile serve process to pick up the new UI",
                     "warning",
                 )
             self._system_notice(f"updated to v{installed} — restarting…")

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -3036,6 +3036,7 @@ class OperatorApp(App[None]):
             install_kind,
             is_git_snapshot,
             perform_upgrade,
+            refresh_mobile_after_upgrade,
             tui_editable_refusal,
             tui_installer_failure,
         )
@@ -3083,12 +3084,29 @@ class OperatorApp(App[None]):
             self.call_from_thread(self._system_notice, f"update failed: {exc}", "error")
             self.call_from_thread(self._finish_update)
             return
+        # Bounce the LaunchAgent *before* the TUI image is replaced so the
+        # new daemon is already scanning when this process comes back.
+        # Failure is a notice, never a rollback: the wheel is already in.
+        mobile = refresh_mobile_after_upgrade()
+
         # ``restarting…`` only once exit 75 is actually happening — a
         # typed-ahead turn used to make ``_request_relaunch`` refuse after
         # this line had already painted. Wrapped so ``call_from_thread``
         # does not have to forward the keyword.
 
         def _relaunch_after_upgrade() -> None:
+            if mobile.kind == "restarted":
+                self._system_notice("mobile daemon restarted — refresh the phone UI")
+            elif mobile.kind == "failed":
+                self._system_notice(
+                    "updated, but the mobile daemon did not restart — run lop mobile restart",
+                    "warning",
+                )
+            elif mobile.kind == "unsupervised":
+                self._system_notice(
+                    "a mobile daemon is running unsupervised; restart it to pick up the new UI",
+                    "warning",
+                )
             self._system_notice(f"updated to v{installed} — restarting…")
             self._request_relaunch(force=True)
 

--- a/local_operator/update.py
+++ b/local_operator/update.py
@@ -510,16 +510,16 @@ def _mobile_restart_argv() -> list[str] | None:
     """Argv for the *new* distribution's ``mobile restart``.
 
     ``sys.executable -m local_operator.cli`` is the post-upgrade
-    interpreter. After ``uv tool upgrade`` that path can vanish; fall
-    back to PATH ``lop`` rather than inventing a third entry point.
+    interpreter — the same interpreter the LaunchAgent's ProgramArguments
+    already name, so its site-packages are the wheel the installer just
+    wrote. There is deliberately NO PATH ``lop`` fallback: a PATH hit can
+    be a *different* installation (another tool env, a brew shim) than
+    the one just upgraded, and restarting that would serve the wrong
+    build while reporting success. If this interpreter is gone after the
+    upgrade, the refresh fails honestly and the copy names the recovery.
     """
-    import shutil
-
     if sys.executable and Path(sys.executable).exists():
         return [sys.executable, "-m", "local_operator.cli", "mobile", "restart"]
-    lop = shutil.which("lop")
-    if lop:
-        return [lop, "mobile", "restart"]
     return None
 
 
@@ -546,7 +546,7 @@ def refresh_mobile_after_upgrade() -> MobileRefresh:
         if argv is None:
             return MobileRefresh(
                 kind="failed",
-                error="sys.executable is gone and lop is not on PATH",
+                error="this interpreter vanished after the upgrade",
             )
         completed = subprocess.run(
             argv,
@@ -572,13 +572,20 @@ def _print_cli_mobile_refresh(result: MobileRefresh) -> None:
     if result.kind == "restarted":
         print("mobile daemon restarted — refresh the phone UI")
     elif result.kind == "failed":
+        # U1: name the recovery, not just the failure — the update itself
+        # succeeded, so the only action left is the bounce the update could
+        # not perform.
         print(
-            f"warning: mobile daemon did not restart: {result.error}",
+            f"warning: mobile daemon did not restart: {result.error}; run lop mobile restart",
             file=sys.stderr,
         )
     elif result.kind == "unsupervised":
+        # U2: no LaunchAgent owns this daemon, so `lop mobile restart` is not
+        # the fix — that path is launchd-only. The operator of a foreground
+        # serve must stop and relaunch the process they started.
         print(
-            "warning: a mobile daemon is running unsupervised; " "restart it to pick up the new UI",
+            "warning: a mobile daemon is running unsupervised; "
+            "stop and relaunch the foreground lop mobile serve process to pick up the new UI",
             file=sys.stderr,
         )
 

--- a/local_operator/update.py
+++ b/local_operator/update.py
@@ -38,7 +38,7 @@ from dataclasses import dataclass
 from enum import Enum
 from importlib.metadata import PackageNotFoundError, distribution, version
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any, Callable, Literal
 
 #: Same cache root the model catalogue uses, so there is one place to clear.
 _CACHE_DIR = Path("~/.local-operator/cache")
@@ -67,6 +67,25 @@ class InstallKind(str, Enum):
 
 class UpdateError(Exception):
     """Refused or failed upgrade; the message is what the CLI/TUI print."""
+
+
+#: Bound the child so a hung ``launchctl kickstart`` cannot stall the
+#: successful-upgrade path. The daemon itself is not waited on.
+_MOBILE_RESTART_TIMEOUT_S = 30.0
+
+#: Default loopback probe used only for the unsupervised warning. Must
+#: match ``mobile.daemon.DEFAULT_PORT``; do not import that module here.
+_MOBILE_HEALTHZ = "http://127.0.0.1:4098/healthz"
+
+MobileRefreshKind = Literal["skipped", "restarted", "failed", "unsupervised"]
+
+
+@dataclass(frozen=True)
+class MobileRefresh:
+    """Outcome of the post-upgrade LaunchAgent bounce. Never an exception."""
+
+    kind: MobileRefreshKind
+    error: str = ""
 
 
 @dataclass(frozen=True)
@@ -459,6 +478,111 @@ def perform_upgrade(
     return target
 
 
+def _mobile_plist_path() -> Path:
+    """Well-known LaunchAgent path. Isolated so tests can patch it.
+
+    Same one-liner as ``install.plist_path`` / ``install.LABEL``
+    (``com.local-operator.mobile.plist``). Duplicated on purpose:
+    ``local_operator.mobile.install`` imports ``daemon`` (Starlette),
+    and folding that into the updater would pull the web stack into
+    every ``lop update`` and every TUI ``/update`` worker.
+    """
+    return Path.home() / "Library" / "LaunchAgents" / "com.local-operator.mobile.plist"
+
+
+def _mobile_healthz_answers() -> bool:
+    """True only when something already answers on the default port.
+
+    Used solely to warn about an unsupervised ``lop mobile serve``. Do
+    not SIGTERM that process: it is not ours to bounce.
+    """
+    import urllib.error
+    import urllib.request
+
+    try:
+        with urllib.request.urlopen(_MOBILE_HEALTHZ, timeout=1.0) as response:
+            return 200 <= int(response.status) < 300
+    except (OSError, urllib.error.URLError, ValueError):
+        return False
+
+
+def _mobile_restart_argv() -> list[str] | None:
+    """Argv for the *new* distribution's ``mobile restart``.
+
+    ``sys.executable -m local_operator.cli`` is the post-upgrade
+    interpreter. After ``uv tool upgrade`` that path can vanish; fall
+    back to PATH ``lop`` rather than inventing a third entry point.
+    """
+    import shutil
+
+    if sys.executable and Path(sys.executable).exists():
+        return [sys.executable, "-m", "local_operator.cli", "mobile", "restart"]
+    lop = shutil.which("lop")
+    if lop:
+        return [lop, "mobile", "restart"]
+    return None
+
+
+def refresh_mobile_after_upgrade() -> MobileRefresh:
+    """Bounce the supervised mobile daemon after a successful wheel install.
+
+    Kept out of :func:`perform_upgrade` so existing installer tests cannot
+    kickstart a real LaunchAgent. Never raises: the package upgrade already
+    succeeded, and a failed bounce must not roll it back.
+
+    ``restart``, not ``install``: the wheel already ships ``mobile/web/dist``,
+    cookies live in the Keychain, and ``install`` would regenerate a
+    password. In-process ``service_action`` would run *this* (old) code
+    and import Starlette into the TUI worker.
+    """
+    import subprocess
+
+    try:
+        if not _mobile_plist_path().exists():
+            if _mobile_healthz_answers():
+                return MobileRefresh(kind="unsupervised")
+            return MobileRefresh(kind="skipped")
+        argv = _mobile_restart_argv()
+        if argv is None:
+            return MobileRefresh(
+                kind="failed",
+                error="sys.executable is gone and lop is not on PATH",
+            )
+        completed = subprocess.run(
+            argv,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=_MOBILE_RESTART_TIMEOUT_S,
+        )
+        if completed.returncode != 0:
+            tail = (completed.stderr or completed.stdout or "").strip()
+            detail = tail.splitlines()[-1][:200] if tail else f"exit {completed.returncode}"
+            return MobileRefresh(kind="failed", error=detail)
+        return MobileRefresh(kind="restarted")
+    except subprocess.TimeoutExpired:
+        return MobileRefresh(kind="failed", error="timed out")
+    except FileNotFoundError as exc:
+        return MobileRefresh(kind="failed", error=str(exc))
+    except Exception as exc:  # noqa: BLE001 — bounce must never fail the update
+        return MobileRefresh(kind="failed", error=str(exc))
+
+
+def _print_cli_mobile_refresh(result: MobileRefresh) -> None:
+    if result.kind == "restarted":
+        print("mobile daemon restarted — refresh the phone UI")
+    elif result.kind == "failed":
+        print(
+            f"warning: mobile daemon did not restart: {result.error}",
+            file=sys.stderr,
+        )
+    elif result.kind == "unsupervised":
+        print(
+            "warning: a mobile daemon is running unsupervised; " "restart it to pick up the new UI",
+            file=sys.stderr,
+        )
+
+
 def update_command(*, check: bool = False) -> int:
     """``lop update`` / ``lop update --check``. See the architect table for codes."""
     result = check_latest(force=True)
@@ -498,4 +622,5 @@ def update_command(*, check: bool = False) -> int:
         print(str(exc), file=sys.stderr)
         return 1
     print(f"installed {installed}")
+    _print_cli_mobile_refresh(refresh_mobile_after_upgrade())
     return 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.28.0"
+version = "0.28.1"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/test_update.py
+++ b/tests/unit/test_update.py
@@ -445,30 +445,36 @@ def test_refresh_failed_timeout() -> None:
     assert result == MobileRefresh(kind="failed", error="timed out")
 
 
-def test_refresh_falls_back_to_path_lop_when_executable_gone() -> None:
+def test_refresh_never_falls_back_to_path_lop() -> None:
+    """M1: PATH ``lop`` is a different install, not this one.
+
+    After ``uv tool upgrade`` the interpreter path can vanish; restarting a
+    PATH ``lop`` would serve whatever build THAT install has while the
+    update reports success. The refresh must fail honestly instead.
+    """
     with (
         patch.object(update_mod, "_mobile_plist_path", return_value=_FakePlist(True)),
         patch.object(update_mod.sys, "executable", "/gone/python"),
         patch.object(Path, "exists", return_value=False),
         patch("shutil.which", return_value="/usr/local/bin/lop"),
-        patch("subprocess.run", return_value=subprocess.CompletedProcess([], 0)) as run,
-    ):
-        result = refresh_mobile_after_upgrade()
-    assert result == MobileRefresh(kind="restarted")
-    assert run.call_args.args[0] == ["/usr/local/bin/lop", "mobile", "restart"]
-
-
-def test_refresh_failed_when_no_executable_and_no_lop() -> None:
-    with (
-        patch.object(update_mod, "_mobile_plist_path", return_value=_FakePlist(True)),
-        patch.object(update_mod.sys, "executable", "/gone/python"),
-        patch.object(Path, "exists", return_value=False),
-        patch("shutil.which", return_value=None),
         patch("subprocess.run") as run,
     ):
         result = refresh_mobile_after_upgrade()
     assert result.kind == "failed"
-    assert "lop is not on PATH" in result.error
+    assert "lop is not on PATH" not in result.error
+    run.assert_not_called()
+
+
+def test_refresh_failed_when_executable_gone() -> None:
+    with (
+        patch.object(update_mod, "_mobile_plist_path", return_value=_FakePlist(True)),
+        patch.object(update_mod.sys, "executable", "/gone/python"),
+        patch.object(Path, "exists", return_value=False),
+        patch("subprocess.run") as run,
+    ):
+        result = refresh_mobile_after_upgrade()
+    assert result.kind == "failed"
+    assert "interpreter vanished" in result.error
     run.assert_not_called()
 
 
@@ -523,7 +529,9 @@ def test_update_command_refresh_fail_still_zero(capsys: pytest.CaptureFixture[st
     captured = capsys.readouterr()
     assert run.call_count == 1
     assert "installed 0.28.0" in captured.out
+    # U1: the failure names the recovery, not just the cause.
     assert "warning: mobile daemon did not restart:" in captured.err
+    assert "run lop mobile restart" in captured.err
     assert "kickstart failed" in captured.err
 
 
@@ -563,6 +571,9 @@ def test_update_command_unsupervised_warns(capsys: pytest.CaptureFixture[str]) -
     run.assert_not_called()
     assert "installed 0.28.0" in captured.out
     assert "warning: a mobile daemon is running unsupervised" in captured.err
+    # U2: `lop mobile restart` is launchd-only and is NOT the fix here.
+    assert "lop mobile serve" in captured.err
+    assert "lop mobile restart" not in captured.err
 
 
 def test_perform_upgrade_does_not_refresh() -> None:

--- a/tests/unit/test_update.py
+++ b/tests/unit/test_update.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 import json
+import subprocess
+import sys
 import time
+from contextlib import contextmanager
 from pathlib import Path
 from unittest.mock import patch
 
@@ -14,6 +17,7 @@ from local_operator import update as update_mod
 from local_operator.update import (
     TTL_S,
     InstallKind,
+    MobileRefresh,
     UpdateError,
     check_latest,
     install_kind,
@@ -21,6 +25,7 @@ from local_operator.update import (
     is_behind,
     parse_version,
     perform_upgrade,
+    refresh_mobile_after_upgrade,
     tui_editable_refusal,
     tui_installer_failure,
     update_command,
@@ -267,29 +272,46 @@ def _check(installed: str, latest: str | None, behind: bool) -> update_mod.Versi
 
 
 def test_update_command_check_behind(capsys: pytest.CaptureFixture[str]) -> None:
-    with patch.object(update_mod, "check_latest", return_value=_check("0.27.0", "0.28.0", True)):
+    with (
+        patch.object(update_mod, "check_latest", return_value=_check("0.27.0", "0.28.0", True)),
+        patch.object(update_mod, "refresh_mobile_after_upgrade") as refresh,
+    ):
         assert update_command(check=True) == 2
+        refresh.assert_not_called()
     out = capsys.readouterr().out
     assert "local-operator 0.27.0" in out
     assert "latest on PyPI: 0.28.0" in out
     assert "run `lop update` to install" in out
+    assert "mobile" not in out.lower()
 
 
 def test_update_command_check_current(capsys: pytest.CaptureFixture[str]) -> None:
-    with patch.object(update_mod, "check_latest", return_value=_check("0.27.0", "0.27.0", False)):
+    with (
+        patch.object(update_mod, "check_latest", return_value=_check("0.27.0", "0.27.0", False)),
+        patch.object(update_mod, "refresh_mobile_after_upgrade") as refresh,
+    ):
         assert update_command(check=True) == 0
+        refresh.assert_not_called()
     assert capsys.readouterr().out.strip() == "local-operator 0.27.0 is the latest"
 
 
 def test_update_command_check_network_error(capsys: pytest.CaptureFixture[str]) -> None:
-    with patch.object(update_mod, "check_latest", return_value=_check("0.27.0", None, False)):
+    with (
+        patch.object(update_mod, "check_latest", return_value=_check("0.27.0", None, False)),
+        patch.object(update_mod, "refresh_mobile_after_upgrade") as refresh,
+    ):
         assert update_command(check=True) == 1
+        refresh.assert_not_called()
     assert "could not reach PyPI" in capsys.readouterr().err
 
 
 def test_update_command_already_latest(capsys: pytest.CaptureFixture[str]) -> None:
-    with patch.object(update_mod, "check_latest", return_value=_check("0.27.0", "0.27.0", False)):
+    with (
+        patch.object(update_mod, "check_latest", return_value=_check("0.27.0", "0.27.0", False)),
+        patch.object(update_mod, "refresh_mobile_after_upgrade") as refresh,
+    ):
         assert update_command(check=False) == 0
+        refresh.assert_not_called()
     assert capsys.readouterr().out.strip() == "local-operator 0.27.0 is the latest"
 
 
@@ -299,13 +321,19 @@ def test_update_command_upgrades(capsys: pytest.CaptureFixture[str]) -> None:
         patch.object(update_mod, "install_kind", return_value=InstallKind.UV_TOOL),
         patch.object(update_mod, "is_git_snapshot", return_value=False),
         patch.object(update_mod, "perform_upgrade", return_value="0.28.0") as upgrade,
+        patch.object(
+            update_mod, "refresh_mobile_after_upgrade", return_value=MobileRefresh(kind="skipped")
+        ) as refresh,
     ):
         assert update_command(check=False) == 0
         upgrade.assert_called_once()
-    out = capsys.readouterr().out
-    assert "local-operator 0.27.0 (latest is 0.28.0)" in out
-    assert "upgrading via uv tool…" in out
-    assert "installed 0.28.0" in out
+        refresh.assert_called_once()
+    captured = capsys.readouterr()
+    assert "local-operator 0.27.0 (latest is 0.28.0)" in captured.out
+    assert "upgrading via uv tool…" in captured.out
+    assert "installed 0.28.0" in captured.out
+    assert "mobile" not in captured.out
+    assert captured.err == ""
 
 
 def test_main_dispatches_update_check(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -324,3 +352,225 @@ def test_main_dispatches_update(monkeypatch: pytest.MonkeyPatch) -> None:
     with patch("local_operator.update.update_command", return_value=0) as cmd:
         assert main() == 0
         cmd.assert_called_once_with(check=False)
+
+
+class _FakePlist:
+    """Reports existence without touching ``~/Library/LaunchAgents``."""
+
+    def __init__(self, exists: bool) -> None:
+        self._exists = exists
+
+    def exists(self) -> bool:
+        return self._exists
+
+
+@contextmanager
+def _upgrade_cmd():
+    """Successful ``update_command`` path with the installer already done."""
+    with (
+        patch.object(update_mod, "check_latest", return_value=_check("0.27.0", "0.28.0", True)),
+        patch.object(update_mod, "install_kind", return_value=InstallKind.UV_TOOL),
+        patch.object(update_mod, "is_git_snapshot", return_value=False),
+        patch.object(update_mod, "perform_upgrade", return_value="0.28.0"),
+    ):
+        yield
+
+
+def test_refresh_skipped_when_plist_absent() -> None:
+    with (
+        patch.object(update_mod, "_mobile_plist_path", return_value=_FakePlist(False)),
+        patch.object(update_mod, "_mobile_healthz_answers", return_value=False),
+        patch("subprocess.run") as run,
+    ):
+        result = refresh_mobile_after_upgrade()
+    assert result == MobileRefresh(kind="skipped")
+    run.assert_not_called()
+
+
+def test_refresh_unsupervised_when_live_without_plist() -> None:
+    with (
+        patch.object(update_mod, "_mobile_plist_path", return_value=_FakePlist(False)),
+        patch.object(update_mod, "_mobile_healthz_answers", return_value=True),
+        patch("subprocess.run") as run,
+    ):
+        result = refresh_mobile_after_upgrade()
+    assert result == MobileRefresh(kind="unsupervised")
+    run.assert_not_called()
+
+
+def test_refresh_restarts_via_new_distribution() -> None:
+    with (
+        patch.object(update_mod, "_mobile_plist_path", return_value=_FakePlist(True)),
+        patch("subprocess.run", return_value=subprocess.CompletedProcess([], 0)) as run,
+    ):
+        result = refresh_mobile_after_upgrade()
+    assert result == MobileRefresh(kind="restarted")
+    run.assert_called_once()
+    assert run.call_args.args[0] == [
+        sys.executable,
+        "-m",
+        "local_operator.cli",
+        "mobile",
+        "restart",
+    ]
+
+
+def test_refresh_failed_child_exit() -> None:
+    completed = subprocess.CompletedProcess([], 1, stdout="", stderr="launchctl: no such service")
+    with (
+        patch.object(update_mod, "_mobile_plist_path", return_value=_FakePlist(True)),
+        patch("subprocess.run", return_value=completed),
+    ):
+        result = refresh_mobile_after_upgrade()
+    assert result.kind == "failed"
+    assert "no such service" in result.error
+
+
+def test_refresh_failed_missing_binary() -> None:
+    with (
+        patch.object(update_mod, "_mobile_plist_path", return_value=_FakePlist(True)),
+        patch("subprocess.run", side_effect=FileNotFoundError("launchctl")),
+    ):
+        result = refresh_mobile_after_upgrade()
+    assert result.kind == "failed"
+    assert "launchctl" in result.error
+
+
+def test_refresh_failed_timeout() -> None:
+    with (
+        patch.object(update_mod, "_mobile_plist_path", return_value=_FakePlist(True)),
+        patch("subprocess.run", side_effect=subprocess.TimeoutExpired(cmd="x", timeout=30)),
+    ):
+        result = refresh_mobile_after_upgrade()
+    assert result == MobileRefresh(kind="failed", error="timed out")
+
+
+def test_refresh_falls_back_to_path_lop_when_executable_gone() -> None:
+    with (
+        patch.object(update_mod, "_mobile_plist_path", return_value=_FakePlist(True)),
+        patch.object(update_mod.sys, "executable", "/gone/python"),
+        patch.object(Path, "exists", return_value=False),
+        patch("shutil.which", return_value="/usr/local/bin/lop"),
+        patch("subprocess.run", return_value=subprocess.CompletedProcess([], 0)) as run,
+    ):
+        result = refresh_mobile_after_upgrade()
+    assert result == MobileRefresh(kind="restarted")
+    assert run.call_args.args[0] == ["/usr/local/bin/lop", "mobile", "restart"]
+
+
+def test_refresh_failed_when_no_executable_and_no_lop() -> None:
+    with (
+        patch.object(update_mod, "_mobile_plist_path", return_value=_FakePlist(True)),
+        patch.object(update_mod.sys, "executable", "/gone/python"),
+        patch.object(Path, "exists", return_value=False),
+        patch("shutil.which", return_value=None),
+        patch("subprocess.run") as run,
+    ):
+        result = refresh_mobile_after_upgrade()
+    assert result.kind == "failed"
+    assert "lop is not on PATH" in result.error
+    run.assert_not_called()
+
+
+def test_update_command_no_plist_prints_only_install_lines(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with (
+        _upgrade_cmd(),
+        patch.object(update_mod, "_mobile_plist_path", return_value=_FakePlist(False)),
+        patch.object(update_mod, "_mobile_healthz_answers", return_value=False),
+        patch("subprocess.run") as run,
+    ):
+        assert update_command(check=False) == 0
+    captured = capsys.readouterr()
+    run.assert_not_called()
+    assert captured.out.splitlines() == [
+        "local-operator 0.27.0 (latest is 0.28.0)",
+        "upgrading via uv tool…",
+        "installed 0.28.0",
+    ]
+    assert captured.err == ""
+
+
+def test_update_command_restarted_prints_phone_line(capsys: pytest.CaptureFixture[str]) -> None:
+    with (
+        _upgrade_cmd(),
+        patch.object(update_mod, "_mobile_plist_path", return_value=_FakePlist(True)),
+        patch("subprocess.run", return_value=subprocess.CompletedProcess([], 0)) as run,
+    ):
+        assert update_command(check=False) == 0
+    captured = capsys.readouterr()
+    assert run.call_args.args[0] == [
+        sys.executable,
+        "-m",
+        "local_operator.cli",
+        "mobile",
+        "restart",
+    ]
+    assert "installed 0.28.0" in captured.out
+    assert "mobile daemon restarted — refresh the phone UI" in captured.out
+    assert captured.err == ""
+
+
+def test_update_command_refresh_fail_still_zero(capsys: pytest.CaptureFixture[str]) -> None:
+    completed = subprocess.CompletedProcess([], 1, stdout="", stderr="kickstart failed")
+    with (
+        _upgrade_cmd(),
+        patch.object(update_mod, "_mobile_plist_path", return_value=_FakePlist(True)),
+        patch("subprocess.run", return_value=completed) as run,
+    ):
+        assert update_command(check=False) == 0
+    captured = capsys.readouterr()
+    assert run.call_count == 1
+    assert "installed 0.28.0" in captured.out
+    assert "warning: mobile daemon did not restart:" in captured.err
+    assert "kickstart failed" in captured.err
+
+
+def test_update_command_refresh_missing_binary_still_zero(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with (
+        _upgrade_cmd(),
+        patch.object(update_mod, "_mobile_plist_path", return_value=_FakePlist(True)),
+        patch("subprocess.run", side_effect=FileNotFoundError("No such file: launchctl")),
+    ):
+        assert update_command(check=False) == 0
+    captured = capsys.readouterr()
+    assert "installed 0.28.0" in captured.out
+    assert "warning: mobile daemon did not restart:" in captured.err
+
+
+def test_update_command_refresh_timeout_still_zero(capsys: pytest.CaptureFixture[str]) -> None:
+    with (
+        _upgrade_cmd(),
+        patch.object(update_mod, "_mobile_plist_path", return_value=_FakePlist(True)),
+        patch("subprocess.run", side_effect=subprocess.TimeoutExpired(cmd="x", timeout=30)),
+    ):
+        assert update_command(check=False) == 0
+    assert "warning: mobile daemon did not restart:" in capsys.readouterr().err
+
+
+def test_update_command_unsupervised_warns(capsys: pytest.CaptureFixture[str]) -> None:
+    with (
+        _upgrade_cmd(),
+        patch.object(update_mod, "_mobile_plist_path", return_value=_FakePlist(False)),
+        patch.object(update_mod, "_mobile_healthz_answers", return_value=True),
+        patch("subprocess.run") as run,
+    ):
+        assert update_command(check=False) == 0
+    captured = capsys.readouterr()
+    run.assert_not_called()
+    assert "installed 0.28.0" in captured.out
+    assert "warning: a mobile daemon is running unsupervised" in captured.err
+
+
+def test_perform_upgrade_does_not_refresh() -> None:
+    with (
+        patch.object(update_mod, "refresh_mobile_after_upgrade") as refresh,
+        patch("subprocess.run") as run,
+    ):
+        out = perform_upgrade(target="0.28.0", kind=InstallKind.UV_TOOL, run=lambda _: 0)
+    assert out == "0.28.0"
+    refresh.assert_not_called()
+    run.assert_not_called()

--- a/tests/unit/tui/test_update_command.py
+++ b/tests/unit/tui/test_update_command.py
@@ -13,7 +13,7 @@ from local_operator.tui.app import OperatorApp
 from local_operator.tui.widgets.editor import Editor
 from local_operator.tui.widgets.transcript import NoticeBlock, TranscriptView
 from local_operator.tui.widgets.welcome import WelcomeView
-from local_operator.update import UpdateError, VersionCheck
+from local_operator.update import MobileRefresh, UpdateError, VersionCheck
 from tests.unit.tui.test_app_pilot import FakeSession, _factory, _set_editor_line
 
 
@@ -26,9 +26,31 @@ def _clear_reexec_plan() -> Iterator[None]:
     take_plan()
 
 
+@pytest.fixture(autouse=True)
+def _no_real_mobile_refresh() -> Iterator[None]:
+    """Existing success paths must not probe the live LaunchAgent.
+
+    Tests that care about the bounce patch this target themselves; the
+    default is a no-op skip so CI never talks to launchctl.
+    """
+    with patch(
+        "local_operator.update.refresh_mobile_after_upgrade",
+        return_value=MobileRefresh(kind="skipped"),
+    ):
+        yield
+
+
 def _notices(app: OperatorApp) -> list[str]:
     return [
         block._text
+        for block in app.query_one(TranscriptView).blocks()
+        if isinstance(block, NoticeBlock)
+    ]
+
+
+def _notice_kinds(app: OperatorApp) -> list[tuple[str, str]]:
+    return [
+        (block._text, block._token)
         for block in app.query_one(TranscriptView).blocks()
         if isinstance(block, NoticeBlock)
     ]
@@ -438,4 +460,107 @@ async def test_installer_failure_names_a_shell_retry() -> None:
             notices = _notices(app)
             assert any("uv tool upgrade local-operator" in text for text in notices)
             assert app.query_one(WelcomeView).display is True
+            assert app.return_code != REEXEC_CODE
+
+
+@pytest.mark.asyncio
+async def test_update_refresh_fail_still_exits_75() -> None:
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    check = VersionCheck(installed="0.27.0", latest="0.28.0", behind=True)
+    with (
+        patch("local_operator.update.check_latest", return_value=check),
+        patch("local_operator.update.perform_upgrade", return_value="0.28.0"),
+        patch("local_operator.update.install_kind") as kind,
+        patch("local_operator.update.is_git_snapshot", return_value=False),
+        patch(
+            "local_operator.update.refresh_mobile_after_upgrade",
+            return_value=MobileRefresh(kind="failed", error="kickstart failed"),
+        ),
+    ):
+        from local_operator.update import InstallKind
+
+        kind.return_value = InstallKind.UV_TOOL
+        async with app.run_test(size=(100, 30)) as pilot:
+            await pilot.pause()
+            editor = app.query_one(Editor)
+            editor.focus()
+            _set_editor_line(editor, "/update")
+            await pilot.press("enter")
+            for _ in range(60):
+                await pilot.pause()
+                if app.return_code == REEXEC_CODE:
+                    break
+            assert app.return_code == REEXEC_CODE
+            assert isinstance(app._restart_plan, RestartPlan)
+            notices = _notices(app)
+            assert any(
+                "updated, but the mobile daemon did not restart — run lop mobile restart" in text
+                for text in notices
+            )
+            assert any("updated to v0.28.0 — restarting…" in text for text in notices)
+            assert app._update_in_progress is True
+            assert editor.read_only is True
+            kinds = {text: token for text, token in _notice_kinds(app)}
+            assert (
+                kinds["updated, but the mobile daemon did not restart — run lop mobile restart"]
+                == "warning"
+            )
+
+
+@pytest.mark.asyncio
+async def test_update_refresh_success_still_exits_75() -> None:
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    check = VersionCheck(installed="0.27.0", latest="0.28.0", behind=True)
+    with (
+        patch("local_operator.update.check_latest", return_value=check),
+        patch("local_operator.update.perform_upgrade", return_value="0.28.0"),
+        patch("local_operator.update.install_kind") as kind,
+        patch("local_operator.update.is_git_snapshot", return_value=False),
+        patch(
+            "local_operator.update.refresh_mobile_after_upgrade",
+            return_value=MobileRefresh(kind="restarted"),
+        ),
+    ):
+        from local_operator.update import InstallKind
+
+        kind.return_value = InstallKind.UV_TOOL
+        async with app.run_test(size=(100, 30)) as pilot:
+            await pilot.pause()
+            editor = app.query_one(Editor)
+            editor.focus()
+            _set_editor_line(editor, "/update")
+            await pilot.press("enter")
+            for _ in range(60):
+                await pilot.pause()
+                if app.return_code == REEXEC_CODE:
+                    break
+            assert app.return_code == REEXEC_CODE
+            assert isinstance(app._restart_plan, RestartPlan)
+            notices = _notices(app)
+            assert any("mobile daemon restarted — refresh the phone UI" in text for text in notices)
+            assert any("updated to v0.28.0 — restarting…" in text for text in notices)
+            kinds = {text: token for text, token in _notice_kinds(app)}
+            assert kinds["mobile daemon restarted — refresh the phone UI"] == "dim"
+
+
+@pytest.mark.asyncio
+async def test_update_when_current_does_not_refresh() -> None:
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    check = VersionCheck(installed="0.27.0", latest="0.27.0", behind=False)
+    with (
+        patch("local_operator.update.check_latest", return_value=check),
+        patch("local_operator.update.refresh_mobile_after_upgrade") as refresh,
+    ):
+        async with app.run_test(size=(100, 30)) as pilot:
+            await pilot.pause()
+            editor = app.query_one("Editor")
+            editor.focus()
+            _set_editor_line(editor, "/update")
+            await pilot.press("enter")
+            for _ in range(40):
+                await pilot.pause()
+                if any("already on" in text for text in _notices(app)):
+                    break
+            assert any("already on v0.27.0" in text for text in _notices(app))
+            refresh.assert_not_called()
             assert app.return_code != REEXEC_CODE


### PR DESCRIPTION
## Why

`lop update` / TUI `/update` in 0.28.0 stop when the package manager returns 0. A recommended-install LaunchAgent keeps running the **old** in-memory process and serving the **old** `web/dist/` it imported at start, so the phone UI does not pick up the new wheel.

This is a patch. Version **0.28.0 → 0.28.1**.

## What changes

After a successful wheel install, if `~/Library/LaunchAgents/com.local-operator.mobile.plist` is on disk, subprocess the **new** distribution:

```
[sys.executable, "-m", "local_operator.cli", "mobile", "restart"]
```

Not PATH `lop` (unless `sys.executable` vanished after `uv tool upgrade`). Not `install`. Not `lop-update`. Not in-process `service_action` (would run old code and import Starlette into the TUI worker).

If the plist is absent: no-op. Do not SIGTERM `:4098`. If something answers `/healthz` without a plist, print the unsupervised warning and leave the process alone.

`refresh_mobile_after_upgrade()` is a new function, called from `update_command` and TUI `_run_update` **after** `perform_upgrade` returns. It never raises. A failed bounce is a warning; the update still exits 0 / REEXEC 75. `--check` and already-latest do not mention mobile.

CLI copy (only after a successful wheel install):

| Result | Stream | Line |
|---|---|---|
| not installed | — | *(nothing)* |
| restarted | stdout | `mobile daemon restarted — refresh the phone UI` |
| restart failed | stderr | `warning: mobile daemon did not restart: {error}` |
| live daemon, no plist | stderr | `warning: a mobile daemon is running unsupervised; restart it to pick up the new UI` |

TUI `/update` emits the matching `_system_notice` before `updated to vX — restarting…`. Failed refresh does not change `REEXEC_CODE` / `RestartPlan`.

## Impact

- No breaking API. No new CLI verb. No plist rewrite. No password generation.
- Cookies survive (keyed on the password, not the build).
- Linux / foreground `lop mobile serve` is not installed and is not touched.

## Testing Details

### Unit (no real launchctl)

`tests/unit/test_update.py`, `tests/unit/tui/test_update_command.py`. Every path that could reach the real home plist patches `_mobile_plist_path` **and** `subprocess.run`. TUI suite autouse-patches `refresh_mobile_after_upgrade` to `skipped`.

```
$ env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest \
    tests/unit/test_update.py tests/unit/tui/test_update_command.py tests/unit/mobile -q
131 passed, 2 warnings in 3.69s
```

Covered:

- No plist → no `subprocess.run`; `update_command` stdout is only the existing install lines.
- Plist present → exactly `[sys.executable, "-m", "local_operator.cli", "mobile", "restart"]`.
- Child exit 1 / `FileNotFoundError` / timeout → `update_command` still returns 0; stderr has `warning: mobile daemon did not restart:`; no second installer argv.
- `perform_upgrade` does **not** invoke refresh.
- TUI: patch refresh to FAILED → still REEXEC_CODE, still RestartPlan, warning notice, composer stays locked through exit.
- TUI: patch refresh to RESTARTED → still REEXEC_CODE; info notice is the exact phone-refresh line.
- `--check` / already-latest: refresh not called.

### Gates (worktree `/tmp/lop-mobile-refresh`)

```
.venv/bin/python -m flake8 .                                          # 0
uvx --from black==26.1.0 black --check local_operator tests           # 474 files unchanged
uvx --from isort==5.13.2 isort --check-only .                         # skipped 1, 0 errors
.venv/bin/python -m pyright --pythonpath .venv/bin/python .           # 0 errors, 0 warnings
```

### Manual (read-only; did **not** bounce the live daemon)

```
$ lop mobile status
installed:    yes
password set: yes
healthy:      yes
auth gate:    closed
sessions:     7
```

CI must not hit real `launchctl`. This PR does not add a live-launchd test.

## Checklist

- [x] Code follows the style guidelines of this project.
- [x] Self-review done.
- [x] Tests prove the change (mocked launchctl / subprocess / plist path).
- [x] Targeted unit tests pass.
- [x] flake8 / black / isort / pyright pass.
- [x] Docs updated (`docs/mobile.md`, `README.md`).
- [x] No secrets, no plist rewrite, no password generation.

Do not merge from this PR until the agent-review round is complete. Do not tag or release.
