### PR TITLE
feat(tui): clarify desktop notification context

### DIFF
--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -6568,16 +6568,17 @@ class OperatorApp(App[None]):
         self._notifier = Notifier(driver.write)
 
     def _notify_label(self) -> str:
-        """The session name a toast carries \u2014 the band's label, or the cwd.
+        """The current session title a toast carries, or the cwd before one exists.
 
-        Same fallback chain the window title uses, and for the same reason: a
-        conversation is named off its first substantive prompt, so a session
-        spends its opening minutes unnamed, and three identically-titled toasts
-        from three sessions identify none of them.
+        The provisional name is the title the status band and terminal tab show
+        while model-generated naming is still in flight (or unavailable), so a
+        notification that skipped it regressed to an unhelpful directory such
+        as ``tmp`` even though every visible session surface already had a useful
+        title. A stored or explicitly renamed title still wins immediately.
         """
         session = self._session
         name = getattr(session, "conversation_name", "") if session is not None else ""
-        return name or cwd_label(os.getcwd())
+        return name or self._provisional_name or cwd_label(os.getcwd())
 
     def _notify(self, kind: str, *, running_children: int | None = None) -> bool:
         """Fire one notification, if this app has a notifier and the event qualifies.

--- a/local_operator/tui/notify.py
+++ b/local_operator/tui/notify.py
@@ -101,15 +101,29 @@ _ENV_DISABLE = "LOCAL_OPERATOR_NO_NOTIFICATIONS"
 #: the two deliberately differ.
 APP_NAME = "Local Operator"
 
-#: Notification body for a finished turn, and for a turn parked on the user.
-#: Fixed strings rather than the model's own words: a notification is delivered
-#: by the OS to a surface this app cannot sanitise twice, and the point of the
-#: toast is the STATE, which the user reads in under a second. The session name
-#: (the title) says which conversation it was.
+#: Notification context and body for a finished turn, and for a turn parked on
+#: the user. Fixed strings rather than the model's own words: a notification is
+#: delivered by the OS to a surface this app cannot sanitise twice, and the
+#: point of the toast is the STATE, which the user reads in under a second. The
+#: session name remains the title so several simultaneous sessions are distinct;
+#: cmux's subtitle carries the action category even when the body is truncated.
+CONTEXT_COMPLETE = "Complete"
+CONTEXT_INPUT_REQUIRED = "Input required"
+CONTEXT_ATTENTION = "Needs attention"
 BODY_COMPLETE = "Task complete"
 BODY_APPROVAL = "Waiting for approval"
 BODY_ASK = "Waiting for your answer"
 BODY_ERROR = "Stopped with an error"
+
+#: Short state categories for notification surfaces with a title/subtitle/body
+#: split. Approval and ask intentionally share the category: both mean the turn
+#: cannot advance until the user returns, while the body says what it needs.
+CONTEXTS: dict[str, str] = {
+    "complete": CONTEXT_COMPLETE,
+    "approval": CONTEXT_INPUT_REQUIRED,
+    "ask": CONTEXT_INPUT_REQUIRED,
+    "error": CONTEXT_ATTENTION,
+}
 
 #: Notification kinds. ``complete`` is an edge the user may ignore; the two
 #: waiting kinds are edges the turn is BLOCKED on, which is why they are
@@ -390,8 +404,8 @@ def argv_safe(value: str) -> str:
     return f" {value}" if value.startswith("-") else value
 
 
-def cmux_command(surface_id: str, title: str, body: str) -> list[str]:
-    """argv delivering one notification to a specific cmux surface.
+def cmux_command(surface_id: str, title: str, subtitle: str, body: str) -> list[str]:
+    """argv delivering one structured notification to a specific cmux surface.
 
     Pure so a test asserts the exact wire shape without spawning anything.
     """
@@ -408,6 +422,8 @@ def cmux_command(surface_id: str, title: str, body: str) -> list[str]:
         # call. The surface id is already UUID-validated by `cmux_surface_id`.
         "--title",
         argv_safe(title or APP_NAME),
+        "--subtitle",
+        argv_safe(subtitle),
         "--body",
         argv_safe(body),
     ]
@@ -626,11 +642,12 @@ class Notifier:
         if self._focused:
             return False
         title = self._label or APP_NAME
+        subtitle = CONTEXTS.get(kind, CONTEXT_COMPLETE)
         body = BODIES.get(kind, BODY_COMPLETE)
 
         surface = cmux_surface_id(self._env)
         if surface is not None:
-            _spawn_detached(cmux_command(surface, title, body))
+            _spawn_detached(cmux_command(surface, title, subtitle, body))
             return True
 
         for chunk in notification_writes(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.28.1"
+version = "0.29.0"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/tui/test_notify.py
+++ b/tests/unit/tui/test_notify.py
@@ -28,6 +28,7 @@ from local_operator.tui.notify import (
     APP_NAME,
     BEL,
     BODIES,
+    CONTEXTS,
     MAX_TITLE_CHARS,
     OSC9_PREFIX,
     OSC99_PREFIX,
@@ -222,15 +223,17 @@ def test_only_a_uuid_surface_identifies_a_pane() -> None:
     assert cmux_surface_id({}) is None
 
 
-def test_the_cmux_command_targets_the_surface_by_uuid() -> None:
+def test_the_cmux_command_targets_the_surface_with_structured_context() -> None:
     surface = "773d5e5e-1111-4222-8333-444455556666"
-    assert cmux_command(surface, "Fix quota reporting", "Task complete") == [
+    assert cmux_command(surface, "Fix quota reporting", "Complete", "Task complete") == [
         "cmux",
         "notify",
         "--surface",
         surface,
         "--title",
         "Fix quota reporting",
+        "--subtitle",
+        "Complete",
         "--body",
         "Task complete",
     ]
@@ -247,7 +250,7 @@ def test_cmux_wins_over_the_in_band_escape(monkeypatch: Any) -> None:
     notifier, sink = unfocused({**GHOSTTY_ENV, "CMUX_SURFACE_ID": surface})
     assert notifier.send("complete") is True
     assert sink.writes == []
-    assert spawned == [cmux_command(surface, APP_NAME, BODIES["complete"])]
+    assert spawned == [cmux_command(surface, APP_NAME, CONTEXTS["complete"], BODIES["complete"])]
 
 
 # -- the Linux D-Bus fallback ------------------------------------------------
@@ -333,9 +336,15 @@ def test_a_parked_turn_notifies_even_with_children_running() -> None:
 
 
 def test_each_kind_says_which_state_it_is() -> None:
-    """Four states, four distinct bodies: a user reads a toast in under a
-    second and 'Local Operator' alone tells them nothing to act on."""
+    """Four states have distinct details and actionable context: completion is
+    unlike a blocked turn, while ask and approval share the need for input."""
     assert len(set(BODIES.values())) == len(BODIES)
+    assert CONTEXTS == {
+        "complete": "Complete",
+        "approval": "Input required",
+        "ask": "Input required",
+        "error": "Needs attention",
+    }
     for kind in ("complete", "approval", "ask", "error"):
         notifier, sink = unfocused()
         notifier.send(kind)  # type: ignore[arg-type]
@@ -437,7 +446,7 @@ def test_a_dash_leading_session_name_cannot_become_a_notify_send_option() -> Non
 
 def test_a_dash_leading_session_name_is_neutralised_for_cmux() -> None:
     surface = "773d5e5e-1111-4222-8333-444455556666"
-    argv = cmux_command(surface, "-u critical", "Task complete")
+    argv = cmux_command(surface, "-u critical", "Complete", "Task complete")
     assert not argv[argv.index("--title") + 1].startswith("-")
 
 

--- a/tests/unit/tui/test_notify_wiring.py
+++ b/tests/unit/tui/test_notify_wiring.py
@@ -293,6 +293,24 @@ async def test_the_toast_is_titled_with_the_conversation_name() -> None:
 
 
 @pytest.mark.asyncio
+async def test_the_toast_uses_the_current_provisional_session_title() -> None:
+    """Naming runs concurrently with the opening turn, so the display title is
+    often still provisional when completion or an ask edge arrives. Falling
+    through to the cwd here produced notifications titled ``tmp`` while the
+    status band and terminal tab already showed the useful session title."""
+    session = JobsSession()
+    app, notifier = await _app_with_notifier(session)
+    async with app.run_test(size=(80, 24)) as pilot:
+        await _boot(pilot, app)
+        app._notifier = notifier  # type: ignore[assignment]
+        app._provisional_name = "Improve notification context"
+        app.on_turn_ended(TurnEnded(aborted=False, error=None))
+        await pilot.pause()
+    assert session.conversation_name == ""
+    assert notifier.labels[-1] == "Improve notification context"
+
+
+@pytest.mark.asyncio
 async def test_focus_changes_reach_the_notifier() -> None:
     """`AppFocus`/`AppBlur` are what make "only when the user is elsewhere"
     true; a notifier that never heard about them would notify always."""


### PR DESCRIPTION
## Summary

Desktop notifications now use the same current session title shown by the status band and terminal tab, including the provisional title available while generated naming is still in flight. They no longer fall back to an unhelpful working-directory basename such as `tmp` when the visible session already has a useful title.

cmux notifications also use its structured subtitle field to make the event immediately scannable:

- `Complete` with `Task complete`
- `Input required` with `Waiting for approval` or `Waiting for your answer`
- `Needs attention` with `Stopped with an error`

The existing title/body behavior remains unchanged for OSC and Linux fallback transports that do not support a separate subtitle.

## Change classification

C2, standard user-visible TUI improvement. This is a narrow notification presentation and title-resolution change with no data migration, authentication, or infrastructure impact. Version bumps from 0.28.1 to 0.29.0 as a minor feature.

## Real-path validation

Exercised the production `Notifier.send()` cmux path through a temporary `cmux` executable that captured the exact detached-process argv without emitting external desktop notifications.

Before (`/tmp/lop-notification-before.txt`):

```text
--title
tmp
--body
Task complete
```

After (`/tmp/lop-notification-after.txt`), all four states captured:

```text
Improve notification context | Complete | Task complete
Improve notification context | Input required | Waiting for approval
Improve notification context | Input required | Waiting for your answer
Improve notification context | Needs attention | Stopped with an error
```

The focused app wiring test also drives the real `OperatorApp` with Textual `run_test`, leaves `session.conversation_name` empty, stages the current provisional title, and proves the notification receives that title instead of the cwd.

## Automated validation

- `env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit -q`: **6572 passed, 7 skipped**
- `.venv/bin/python -m flake8 .`: passed
- `uvx --from black==26.1.0 black --check local_operator tests`: 474 files clean
- `uvx isort --check-only --profile black local_operator tests`: passed
- `.venv/bin/python -m pyright --pythonpath .venv/bin/python .`: 0 errors, 0 warnings
- Focused notification suites: **72 passed**

The first full-suite attempt exposed that a symlinked shared editable `.venv` made eval subprocesses execute the main checkout rather than this worktree. Validation was rerun in a worktree-local editable environment, where the eval streaming reproduction passed and the full suite completed cleanly.

## Evidence artifacts

- Before transport capture: `/tmp/lop-notification-before.txt`
- After transport capture: `/tmp/lop-notification-after.txt`

Desktop notification pixels were not captured because the safe real-path exercise intentionally replaced only the final `cmux` executable to avoid posting disruptive external notifications. The captured argv is the exact structured payload handed to cmux.
