### PR TITLE
fix(providers): fail over on opaque aggregator 400s

### DIFF
--- a/local_operator/providers/clients.py
+++ b/local_operator/providers/clients.py
@@ -302,11 +302,17 @@ def _strip_quote_pair(text: str) -> str:
     The peel LOOPS rather than running once to cover a value that arrives
     already wrapped more than once — e.g. ``'"ERROR"'`` — which costs nothing
     to absorb and keeps the predicate insensitive to how many layers of
-    quoting an aggregator applied. Note this is NOT the JSON double-encoding
-    case: a truly double-encoded ``raw`` arrives backslash-escaped
-    (``"\\"ERROR\\""``), which :func:`_openrouter_upstream_text` has already
-    parsed away by the time this sees it, so that input never reaches the
-    loop.
+    quoting an aggregator applied.
+
+    A JSON-encoded ``raw`` whose inner value is itself a string (the
+    double-encoding case) DOES reach this function. :func:`_openrouter_upstream_text`
+    ``json.loads`` it, then — because the inner is a ``str``, not a
+    ``Mapping`` — returns the original unparsed ``raw`` rather than the
+    decoded inner. The peel then takes matched quote pairs off that original.
+    (A ``Mapping`` inner is unwrapped to its ``message`` instead, and never
+    gets here.) The earlier claim that double-encoding is "parsed away before
+    this sees it" was wrong; the behaviour was always this, only the stated
+    reason was not.
 
     ``_MAX_QUOTE_PEELS`` bounds the loop because slicing copies the string on
     every pass: an adversarial body of a few MB of quotes would otherwise cost

--- a/local_operator/providers/clients.py
+++ b/local_operator/providers/clients.py
@@ -267,6 +267,46 @@ def _openrouter_upstream_text(error: Mapping[str, Any]) -> str:
     return raw.strip()[:500]
 
 
+#: Aggregators answer an UPSTREAM provider failure with an HTTP 400 whose body
+#: names nothing: the outer message is exactly "Provider returned error" and
+#: ``metadata.raw`` holds a bare sentinel instead of the origin provider's
+#: diagnostics. Session e13d092c093c recorded this shape intermittently on a
+#: request that live probes at ~750k tokens answered 200 seconds later — an
+#: upstream blip wearing a 400. Compared case-insensitively because the casing
+#: on the wire ("Provider returned error", raw "ERROR") is the aggregator's,
+#: not part of the signal.
+_OPAQUE_AGGREGATOR_MESSAGE = "provider returned error"
+
+#: Raw bodies short enough to prove nobody tried to say anything. A real
+#: upstream body — "context length exceeded", a JSON error object — is
+#: actionable and must keep its ``request`` classification.
+_OPAQUE_RAW_SENTINELS = frozenset({"error"})
+
+
+def _is_opaque_aggregator_400(error: Mapping[str, Any]) -> bool:
+    """An aggregator 400 carrying NO actionable upstream diagnostics.
+
+    OpenRouter forwards an upstream failure as ``{"message": "Provider
+    returned error", "metadata": {"raw": ...}}``. When ``raw`` holds real
+    diagnostics the composed message names the actual problem and the 400 is
+    an answer — kind ``request``, no retry. When ``raw`` is a bare sentinel
+    (observed: ``"ERROR"``, from a provider named "Stealth"), the body says
+    nothing a caller could fix, and the status line is the aggregator's relay
+    choice rather than evidence the request was wrong. Those are classified
+    transient so the failover cascade runs; the driver's server-fault budget
+    bounds the retries, and a genuinely broken request just burns a little of
+    it before surfacing — strictly better than aborting a turn that rotation
+    or a fallback could have served.
+    """
+    message = _first_text(error.get("message"))
+    if message.lower() != _OPAQUE_AGGREGATOR_MESSAGE:
+        return False
+    upstream = _openrouter_upstream_text(error)
+    # Strip quote pairs too: ``raw`` is defined as a JSON-encoded string, so a
+    # sentinel can arrive as ``"\"ERROR\""`` and parse straight back to quotes.
+    return upstream.strip().strip("\"'").lower() in _OPAQUE_RAW_SENTINELS
+
+
 def _compat_stream_error(chunk: Mapping[str, Any]) -> ProviderError:
     """An in-band mid-stream failure on an OpenAI-compatible stream.
 
@@ -430,6 +470,13 @@ def raise_for_status(response: httpx.Response) -> None:
     # 408/504 are the two "ran out of time" statuses; 429 and 5xx are the
     # classic retryables. Everything else in 4xx is an answer, not a blip.
     retryable = status == 429 or status >= 500 or status in (408, 504)
+    # ...except an aggregator 400 whose body carries no usable diagnostics:
+    # that is an upstream failure relayed under a 400, not a request the
+    # provider read and refused, so it must reach the failover cascade. See
+    # :func:`_is_opaque_aggregator_400` for the shape and the evidence.
+    error = payload.get("error") if isinstance(payload, Mapping) else None
+    if status == 400 and isinstance(error, Mapping) and _is_opaque_aggregator_400(error):
+        retryable = True
     raise ProviderError(
         status,
         _extract_error_message(response, payload),

--- a/local_operator/providers/clients.py
+++ b/local_operator/providers/clients.py
@@ -282,6 +282,12 @@ _OPAQUE_AGGREGATOR_MESSAGE = "provider returned error"
 #: actionable and must keep its ``request`` classification.
 _OPAQUE_RAW_SENTINELS = frozenset({"error"})
 
+#: How many matched quote pairs :func:`_strip_quote_pair` will peel. Real
+#: bodies use at most one or two layers; the cap exists so a body made of
+#: nothing but quotes cannot spend quadratic CPU (each peel copies the string)
+#: on a request that is already failing.
+_MAX_QUOTE_PEELS = 4
+
 
 def _strip_quote_pair(text: str) -> str:
     """Peel MATCHED surrounding quote pairs off ``text``.
@@ -293,11 +299,24 @@ def _strip_quote_pair(text: str) -> str:
     so pairs are peeled one at a time and an unbalanced body keeps its quotes
     and stays ``request``.
 
-    A pair is peeled repeatedly because ``raw`` is a JSON-encoded string that
-    has occasionally been double-encoded upstream (``"\\"ERROR\\""`` parses back
-    to a quoted quote).
+    The peel LOOPS rather than running once to cover a value that arrives
+    already wrapped more than once — e.g. ``'"ERROR"'`` — which costs nothing
+    to absorb and keeps the predicate insensitive to how many layers of
+    quoting an aggregator applied. Note this is NOT the JSON double-encoding
+    case: a truly double-encoded ``raw`` arrives backslash-escaped
+    (``"\\"ERROR\\""``), which :func:`_openrouter_upstream_text` has already
+    parsed away by the time this sees it, so that input never reaches the
+    loop.
+
+    ``_MAX_QUOTE_PEELS`` bounds the loop because slicing copies the string on
+    every pass: an adversarial body of a few MB of quotes would otherwise cost
+    quadratic time on a request that is already failing. Nothing legitimate
+    nests quotes more than a couple of layers deep, so a low cap costs real
+    traffic nothing and denies a hostile aggregator the CPU.
     """
-    while len(text) >= 2 and text[0] == text[-1] and text[0] in "\"'":
+    for _ in range(_MAX_QUOTE_PEELS):
+        if not (len(text) >= 2 and text[0] == text[-1] and text[0] in "\"'"):
+            break
         text = text[1:-1].strip()
     return text
 

--- a/local_operator/providers/clients.py
+++ b/local_operator/providers/clients.py
@@ -283,6 +283,25 @@ _OPAQUE_AGGREGATOR_MESSAGE = "provider returned error"
 _OPAQUE_RAW_SENTINELS = frozenset({"error"})
 
 
+def _strip_quote_pair(text: str) -> str:
+    """Peel MATCHED surrounding quote pairs off ``text``.
+
+    ``str.strip('"\'')`` would take any leading/trailing run of either
+    character, so unbalanced junk like ``\'\'\'ERROR""`` would reduce to the
+    sentinel and be treated as no-information. That only ever widens the match,
+    but the widening should be a decision rather than an accident of the API —
+    so pairs are peeled one at a time and an unbalanced body keeps its quotes
+    and stays ``request``.
+
+    A pair is peeled repeatedly because ``raw`` is a JSON-encoded string that
+    has occasionally been double-encoded upstream (``"\\"ERROR\\""`` parses back
+    to a quoted quote).
+    """
+    while len(text) >= 2 and text[0] == text[-1] and text[0] in "\"'":
+        text = text[1:-1].strip()
+    return text
+
+
 def _is_opaque_aggregator_400(error: Mapping[str, Any]) -> bool:
     """An aggregator 400 carrying NO actionable upstream diagnostics.
 
@@ -293,18 +312,38 @@ def _is_opaque_aggregator_400(error: Mapping[str, Any]) -> bool:
     (observed: ``"ERROR"``, from a provider named "Stealth"), the body says
     nothing a caller could fix, and the status line is the aggregator's relay
     choice rather than evidence the request was wrong. Those are classified
-    transient so the failover cascade runs; the driver's server-fault budget
-    bounds the retries, and a genuinely broken request just burns a little of
-    it before surfacing — strictly better than aborting a turn that rotation
-    or a fallback could have served.
+    transient so the failover cascade runs.
+
+    Two deliberate widenings, both toward "treat no-information as transient":
+
+    - The outer message is matched after trimming and case-folding, so
+      ``"Provider returned error "`` matches too. The casing and padding on the
+      wire are the aggregator's formatting, not part of the signal.
+    - :func:`_openrouter_upstream_text` unwraps a nested ``error`` object, so
+      ``{"error": {"message": "ERROR"}}`` resolves to the same bare sentinel and
+      also matches. A body that structurally tried to say something but whose
+      content is still the word "error" carries no more actionable information
+      than the flat sentinel. This is the case most likely to shadow a real
+      upstream error whose message happens to be that single word; the cost of
+      that collision is bounded retries, and the cost of the opposite mistake
+      is a dead turn.
+
+    The price is latency, not correctness, and it is not small: a genuinely
+    broken request now saturates the driver's server-fault budget (12 requests
+    per target) before surfacing. Measured against the default 500ms base delay
+    and the 8s backoff cap, that is 64-76s of sleep on a single target and
+    roughly 4-5 minutes across a 3-target fallback chain. A user hitting a
+    PERSISTENT aggregator 400 therefore waits minutes for a failure that
+    previously surfaced immediately. That is the accepted trade: this shape is
+    by construction unattributable, so the alternative is killing a turn that
+    rotation or a fallback could have served — but it is a real cost, not the
+    rounding error an earlier draft of this docstring implied.
     """
     message = _first_text(error.get("message"))
     if message.lower() != _OPAQUE_AGGREGATOR_MESSAGE:
         return False
     upstream = _openrouter_upstream_text(error)
-    # Strip quote pairs too: ``raw`` is defined as a JSON-encoded string, so a
-    # sentinel can arrive as ``"\"ERROR\""`` and parse straight back to quotes.
-    return upstream.strip().strip("\"'").lower() in _OPAQUE_RAW_SENTINELS
+    return _strip_quote_pair(upstream.strip()).lower() in _OPAQUE_RAW_SENTINELS
 
 
 def _compat_stream_error(chunk: Mapping[str, Any]) -> ProviderError:
@@ -333,6 +372,7 @@ def _compat_stream_error(chunk: Mapping[str, Any]) -> ProviderError:
     error = chunk.get("error")
     status: int | None = None
     error_type = ""
+    opaque_aggregator_400 = False
     if isinstance(error, Mapping):
         message = _first_text(error.get("message"), error.get("detail"), error.get("msg"))
         upstream = _openrouter_upstream_text(error)
@@ -348,6 +388,13 @@ def _compat_stream_error(chunk: Mapping[str, Any]) -> ProviderError:
         metadata = error.get("metadata")
         if isinstance(metadata, Mapping):
             error_type = str(metadata.get("error_type") or "")
+        # The SAME opaque relay body arrives on this channel whenever the
+        # gateway had already committed HTTP 200 before the upstream failed, so
+        # it has to classify the same way here as in `raise_for_status` -- a
+        # turn must not die on the relay channel the aggregator happened to
+        # pick. Judged on the chunk's `code` rather than a status line, because
+        # in-band that is where the 400 lives.
+        opaque_aggregator_400 = status == 400 and _is_opaque_aggregator_400(error)
     else:
         message = _first_text(error)
     if not message:
@@ -357,7 +404,7 @@ def _compat_stream_error(chunk: Mapping[str, Any]) -> ProviderError:
     return ProviderError(
         status,
         _capped(message),
-        retryable=status is None or status == 429 or status >= 500,
+        retryable=(opaque_aggregator_400 or status is None or status == 429 or status >= 500),
         auth_error=status in (401, 403),
     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.44.5"
+version = "0.44.6"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/providers/test_clients.py
+++ b/tests/unit/providers/test_clients.py
@@ -1388,6 +1388,87 @@ class TestErrorMessageExtraction:
         assert error.kind == "transient"
 
 
+class TestOpaqueAggregator400:
+    """An aggregator relays an UPSTREAM failure as an HTTP 400 whose body names
+    nothing. Session e13d092c093c recorded the shape — ``message`` exactly
+    "Provider returned error", ``metadata.raw`` a bare "ERROR", provider_name
+    "Stealth" — arriving intermittently on a request that live probes at ~750k
+    tokens answered 200 seconds later, and again during the investigation.
+    Classified ``request``, it aborted the turn before rotation or fallback
+    could serve it; these tests pin both sides of the new line: the opaque
+    sentinel is transient/retryable, every 400 with real diagnostics stays an
+    answer."""
+
+    def _error(self, response: httpx.Response) -> ProviderError:
+        with pytest.raises(ProviderError) as excinfo:
+            raise_for_status(response)
+        return excinfo.value
+
+    @staticmethod
+    def _openrouter_body(raw: str, provider: str = "Stealth") -> dict[str, Any]:
+        return {
+            "error": {
+                "message": "Provider returned error",
+                "code": 400,
+                "metadata": {"raw": raw, "provider_name": provider},
+            }
+        }
+
+    def test_the_reported_sentinel_is_transient(self) -> None:
+        """The exact wire body from the session: bare "ERROR" in ``raw``."""
+        error = self._error(httpx.Response(400, json=self._openrouter_body("ERROR")))
+        assert (error.kind, error.retryable) == ("transient", True)
+        # The frame still shows what the wire said — no invented diagnostics.
+        assert error.message == "Provider returned error: ERROR"
+
+    def test_a_quoted_json_string_sentinel_is_transient_too(self) -> None:
+        """``raw`` is defined as JSON-encoded, so the sentinel can arrive as
+        ``\"\\\"ERROR\\\"\"`` and parse straight back to quotes."""
+        error = self._error(httpx.Response(400, json=self._openrouter_body(json.dumps("ERROR"))))
+        assert (error.kind, error.retryable) == ("transient", True)
+
+    def test_actionable_upstream_diagnostics_stay_request(self) -> None:
+        """A ``raw`` holding the origin provider's REAL body is an answer, not
+        weather: the same outer message with real diagnostics keeps kind
+        ``request`` so a genuinely broken request is not retried."""
+        body = self._openrouter_body(
+            json.dumps({"error": {"message": "context length exceeded"}}),
+            provider="Google",
+        )
+        error = self._error(httpx.Response(400, json=body))
+        assert (error.kind, error.retryable) == ("request", False)
+        assert "context length exceeded" in error.message
+
+    def test_real_text_in_raw_stays_request(self) -> None:
+        """A non-JSON ``raw`` that still SAYS something is actionable."""
+        error = self._error(
+            httpx.Response(
+                400,
+                json=self._openrouter_body("This model's maximum context length is 16385 tokens"),
+            )
+        )
+        assert (error.kind, error.retryable) == ("request", False)
+
+    def test_direct_provider_400s_are_untouched(self) -> None:
+        """Only the aggregator's exact outer message qualifies; ordinary 400s
+        keep their classification whatever their metadata holds."""
+        plain = self._error(httpx.Response(400, json={"error": {"message": "bad field"}}))
+        assert (plain.kind, plain.retryable) == ("request", False)
+        other_message = self._error(
+            httpx.Response(
+                400,
+                json={
+                    "error": {
+                        "message": "Provider error",
+                        "code": 400,
+                        "metadata": {"raw": "ERROR", "provider_name": "Stealth"},
+                    }
+                },
+            )
+        )
+        assert (other_message.kind, other_message.retryable) == ("request", False)
+
+
 class TestRetryAfter:
     """ "try again in 40s" is the single most actionable fact in a rate-limit
     error, and providers disagree about where to put it."""

--- a/tests/unit/providers/test_clients.py
+++ b/tests/unit/providers/test_clients.py
@@ -1468,6 +1468,93 @@ class TestOpaqueAggregator400:
         )
         assert (other_message.kind, other_message.retryable) == ("request", False)
 
+    def test_nested_error_object_sentinel_is_transient(self) -> None:
+        """``_openrouter_upstream_text`` unwraps a nested ``error`` object, so a
+        structurally-richer body whose CONTENT is still the bare word carries no
+        more information than the flat sentinel and matches too. Documented as a
+        deliberate widening rather than left to chance."""
+        body = self._openrouter_body(json.dumps({"error": {"message": "ERROR"}}))
+        error = self._error(httpx.Response(400, json=body))
+        assert (error.kind, error.retryable) == ("transient", True)
+
+    def test_unbalanced_quote_runs_stay_request(self) -> None:
+        """Only MATCHED quote pairs are peeled. ``str.strip`` would take any run
+        of either character and reduce this to the sentinel; an unbalanced body
+        is malformed rather than empty, so it keeps its ``request`` answer."""
+        error = self._error(httpx.Response(400, json=self._openrouter_body("'''ERROR\"\"")))
+        assert (error.kind, error.retryable) == ("request", False)
+
+    def test_opaque_5xx_shape_is_unchanged(self) -> None:
+        """The predicate only widens 400s: a 5xx carrying the same opaque body
+        was already retryable by status and must stay that way."""
+        body = self._openrouter_body("ERROR")
+        body["error"]["code"] = 502
+        error = self._error(httpx.Response(502, json=body))
+        assert (error.kind, error.retryable) == ("transient", True)
+
+
+class TestOpaqueAggregator400InBand:
+    """The aggregator's OTHER relay channel for the identical upstream failure.
+
+    Once the gateway has committed HTTP 200 it cannot use the status line, so it
+    delivers the same opaque body as an in-band error chunk (the shape
+    ``test_openai_compat_mid_stream_error_chunk_unwraps_upstream_raw`` pins for a
+    502). Classified from ``code`` alone that body was ``request``/not-retryable
+    and killed the turn, so the fix had to reach both channels: which relay the
+    aggregator picks is not something the caller can influence, and the two must
+    agree."""
+
+    @staticmethod
+    def _chunk(raw: str, code: int = 400) -> dict[str, Any]:
+        return {
+            "id": "gen-1",
+            "error": {
+                "code": code,
+                "message": "Provider returned error",
+                "metadata": {"raw": raw, "provider_name": "Stealth"},
+            },
+            "choices": [{"index": 0, "delta": {"content": ""}, "finish_reason": "error"}],
+        }
+
+    async def _stream_error(self, chunk: dict[str, Any]) -> ProviderError:
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                content=_sse([chunk]),
+                headers={"content-type": "text/event-stream"},
+            )
+
+        client = OpenAICompatClient(
+            "https://api.test.example/v1",
+            http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+        )
+        with pytest.raises(ProviderError) as excinfo:
+            await _collect(
+                client.stream(ChatRequest(model=_spec(), messages=[Message.user("hi")]), "sk-test")
+            )
+        return excinfo.value
+
+    async def test_in_band_sentinel_is_transient(self) -> None:
+        """The reported body, delivered mid-stream instead of pre-stream."""
+        error = await self._stream_error(self._chunk("ERROR"))
+        assert error.status == 400
+        assert (error.kind, error.retryable) == ("transient", True)
+        assert "Provider returned error" in str(error)
+
+    async def test_in_band_actionable_diagnostics_stay_request(self) -> None:
+        """Real upstream diagnostics in-band are still an answer, not weather."""
+        chunk = self._chunk(json.dumps({"error": {"message": "context length exceeded"}}))
+        error = await self._stream_error(chunk)
+        assert (error.kind, error.retryable) == ("request", False)
+        assert "context length exceeded" in str(error)
+
+    async def test_in_band_other_400s_are_untouched(self) -> None:
+        """A different outer message keeps the status-only classification."""
+        chunk = self._chunk("ERROR")
+        chunk["error"]["message"] = "Provider error"
+        error = await self._stream_error(chunk)
+        assert (error.kind, error.retryable) == ("request", False)
+
 
 class TestRetryAfter:
     """ "try again in 40s" is the single most actionable fact in a rate-limit

--- a/tests/unit/providers/test_failover.py
+++ b/tests/unit/providers/test_failover.py
@@ -1009,6 +1009,70 @@ async def test_primary_unknown_400_style_not_aborted_if_not_request_kind() -> No
     assert served.calls == 1
 
 
+async def test_opaque_aggregator_400_fails_over_instead_of_aborting() -> None:
+    """The session e13d092c093c failure, end to end: an aggregator answers the
+    PRIMARY with HTTP 400 / "Provider returned error" / ``metadata.raw``
+    "ERROR" — no actionable diagnostics. Classified ``request`` it aborted the
+    turn before rotation or fallback could serve; classified transient it must
+    consume a same-credential attempt, rotate to the sibling key, and only then
+    walk the chain — all under the driver's existing server-fault budget."""
+    import httpx as _httpx
+
+    from local_operator.providers.clients import raise_for_status
+
+    def _opaque_400() -> ProviderError:
+        # Built through the real wire mapper so the test exercises the exact
+        # body OpenRouter sent, not a hand-stamped classification.
+        try:
+            raise_for_status(
+                _httpx.Response(
+                    400,
+                    json={
+                        "error": {
+                            "message": "Provider returned error",
+                            "code": 400,
+                            "metadata": {"raw": "ERROR", "provider_name": "Stealth"},
+                        }
+                    },
+                )
+            )
+        except ProviderError as exc:
+            return exc
+        raise AssertionError("raise_for_status must raise")
+
+    attempts: list[str | None] = []
+    served = ScriptedClient([StreamTextDelta(delta="ok"), StreamEndEvent(stop_reason="stop")])
+
+    def fail_like_the_session(
+        request: ChatRequest, api_key: str | None, oauth_access: Any = None
+    ) -> AsyncIterator[Any]:
+        attempts.append(api_key)
+        raise _opaque_400()
+
+    async def client_for(spec: ModelSpec) -> Any:
+        if spec.provider == "anthropic":
+            return served
+        return _FnClient(fail_like_the_session)
+
+    settings = {
+        "retry": {
+            "baseDelayMs": 1,
+            "maxRetries": 2,
+            "fallbackChains": {"default": ["anthropic/claude-x"]},
+        }
+    }
+    auth = FakeAuth({"openai": ["k1", "k2"], "anthropic": ["k3"]})
+    got = [event async for event in stream_with_failover(_request(), auth, settings, client_for)]
+    assert any(isinstance(e, StreamTextDelta) and e.delta == "ok" for e in got)
+    assert served.calls == 1
+    # The opaque 400 was retried on the SAME credential first (transient
+    # semantics), then rotated to the sibling before the chain took over.
+    assert len(attempts) >= 2
+    assert attempts[0] == "k1"
+    assert any(k == "k2" for k in attempts[1:])
+    assert auth.rotations, "the sibling rotation must actually have run"
+
+
 async def test_transport_retries_honor_budget_same_key_first() -> None:
     """PR-06: retryable 5xx consumes retry.maxRetries on the SAME key with
     backoff BEFORE any credential rotation."""

--- a/tests/unit/providers/test_failover.py
+++ b/tests/unit/providers/test_failover.py
@@ -1016,8 +1016,6 @@ async def test_opaque_aggregator_400_fails_over_instead_of_aborting() -> None:
     turn before rotation or fallback could serve; classified transient it must
     consume a same-credential attempt, rotate to the sibling key, and only then
     walk the chain — all under the driver's existing server-fault budget."""
-    import httpx as _httpx
-
     from local_operator.providers.clients import raise_for_status
 
     def _opaque_400() -> ProviderError:
@@ -1025,7 +1023,7 @@ async def test_opaque_aggregator_400_fails_over_instead_of_aborting() -> None:
         # body OpenRouter sent, not a hand-stamped classification.
         try:
             raise_for_status(
-                _httpx.Response(
+                httpx.Response(
                     400,
                     json={
                         "error": {
@@ -1071,6 +1069,66 @@ async def test_opaque_aggregator_400_fails_over_instead_of_aborting() -> None:
     assert attempts[0] == "k1"
     assert any(k == "k2" for k in attempts[1:])
     assert auth.rotations, "the sibling rotation must actually have run"
+
+
+async def test_opaque_aggregator_400_in_band_fails_over_instead_of_aborting() -> None:
+    """The same failure on the aggregator's OTHER relay channel.
+
+    When the gateway has already committed HTTP 200 it relays the identical
+    opaque body as an in-band error chunk instead of a status line. That path is
+    mapped by ``_compat_stream_error``, which classified from ``code`` alone and
+    so still aborted the turn with zero fallback calls after the pre-stream path
+    was fixed. Driven end to end through a REAL ``OpenAICompatClient`` over a
+    mock transport, so the chunk travels the actual SSE parser rather than a
+    hand-stamped ProviderError: the cascade must rotate the sibling key and let
+    the chain serve the turn."""
+    body = json.dumps(
+        {
+            "id": "gen-1",
+            "error": {
+                "code": 400,
+                "message": "Provider returned error",
+                "metadata": {"raw": "ERROR", "provider_name": "Stealth"},
+            },
+            "choices": [{"index": 0, "delta": {"content": ""}, "finish_reason": "error"}],
+        }
+    )
+    primary_requests: list[Any] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        primary_requests.append(request)
+        # The error is the FIRST chunk, so nothing has been forwarded yet and
+        # failover is genuinely still possible at that point.
+        return httpx.Response(
+            200,
+            content=f"data: {body}\n\ndata: [DONE]\n\n".encode(),
+            headers={"content-type": "text/event-stream"},
+        )
+
+    primary = OpenAICompatClient(
+        "https://api.test.example/v1",
+        http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+    )
+    served = ScriptedClient([StreamTextDelta(delta="ok"), StreamEndEvent(stop_reason="stop")])
+
+    async def client_for(spec: ModelSpec) -> Any:
+        return served if spec.provider == "anthropic" else primary
+
+    settings = {
+        "retry": {
+            "baseDelayMs": 1,
+            "maxRetries": 2,
+            "fallbackChains": {"default": ["anthropic/claude-x"]},
+        }
+    }
+    auth = FakeAuth({"openai": ["k1", "k2"], "anthropic": ["k3"]})
+    got = [event async for event in stream_with_failover(_request(), auth, settings, client_for)]
+    assert any(isinstance(e, StreamTextDelta) and e.delta == "ok" for e in got)
+    assert served.calls == 1, "the fallback chain must have served the turn"
+    assert auth.rotations, "the sibling rotation must actually have run"
+    # Bounded, not unbounded: the driver's server-fault budget still caps the
+    # in-band path, so the primary is not retried forever before the chain runs.
+    assert len(primary_requests) <= 12
 
 
 async def test_transport_retries_honor_budget_same_key_first() -> None:


### PR DESCRIPTION
## Summary

OpenRouter (and similar aggregators) relay an **upstream provider failure** as an HTTP 400 whose outer message is exactly `Provider returned error`. When `metadata.raw` carries the origin provider's real diagnostics, that body is actionable and the 400 is a genuine answer — kind `request`, correctly not retried.

But session `e13d092c093c` (ts 1787579469.9000828) recorded the same shape with `metadata.raw` holding only a bare sentinel:

```json
{"error":{"message":"Provider returned error","code":400,"metadata":{"raw":"ERROR","provider_name":"Stealth"}}}
```

The failure was intermittent: direct live probes of the same request shape and inputs at ~750k tokens returned 200, and the same model failed again during the investigation, triggering fallbacks. Classified as a refused request (`kind="request", retryable=False`), it hit the driver's primary-400 storm guard and **aborted the turn before credential rotation or model fallback could serve it** — for an upstream blip wearing a 400.

## Change

- `local_operator/providers/clients.py`: new `_is_opaque_aggregator_400()` detects the opaque shape in `raise_for_status()` — outer message exactly "Provider returned error" (case-insensitive) AND `metadata.raw` resolving to a bare sentinel (`ERROR`, also when JSON-quoted). Only that shape flips `retryable=True`; `_classify_fields` then returns `transient` via its existing rule, so no classifier changes were needed.
- The detection lives in `raise_for_status` deliberately: it is the one point where the structured `metadata.raw` is still available — `_classify_fields` only ever sees the composed message string.
- Genuine 400s with actionable upstream diagnostics (`raw` = "context length exceeded", a JSON error object, any substantive text) keep `kind="request"`; all direct-provider 400s are untouched; the same opaque shape arriving on a 5xx keeps its existing transient classification.
- Loop safety: `is_server_side_failure` treats `transient` as provider-side weather, so the error gets the standard small per-bearer allowance, then rotation, then the fallback chain — all bounded by the existing turn-wide `MAX_SERVER_FAULT_REQUESTS_PER_TURN = 12`. A genuinely broken request now burns a little budget before surfacing instead of aborting a turn rotation could have served.

## Testing evidence

Reproduction first (pre-fix, against the session's exact wire body):

```
kind      = request
retryable = False
message   = Provider returned error: ERROR
str       = invalid request (HTTP 400): Provider returned error: ERROR
```

Post-fix classification matrix, run against real wire bodies through `raise_for_status`:

| Body | kind | retryable |
|---|---|---|
| Session body (`raw:"ERROR"`) | `transient` | True |
| Same, `raw` JSON-quoted sentinel | `transient` | True |
| `raw` = real upstream JSON diagnostics | `request` | False |
| `raw` = substantive non-JSON text | `request` | False |
| Different outer message + sentinel raw | `request` | False |
| Direct-provider 400 (`max_tokens too large`) | `request` | False |
| Opaque shape on 502 (unchanged path) | `transient` | True |

End-to-end failover proof (`test_opaque_aggregator_400_fails_over_instead_of_aborting`): the primary raises the session's exact 400 built through the real wire mapper; the test asserts the turn is served by the fallback, the same credential was retried first (`attempts[0] == "k1"`), the sibling key was rotated to, and `rotate_sibling` actually ran. The existing storm-guard tests (`test_primary_request_400_aborts_without_walking_chain`, `test_primary_image_rejection_400_aborts_turn`, `test_primary_unknown_400_style_not_aborted_if_not_request_kind`, `test_fallback_request_400_still_walks`) still pass unchanged, pinning the preserved behavior.

Gates (all clean):
- `flake8 .` — clean
- `black==26.1.0 --check local_operator tests` — clean (after formatting)
- `isort --check-only --profile black` — clean (after fixing import order)
- `pyright` — 0 errors, 0 warnings
- Full unit suite: see CI; focused runs of both touched test files pass (7 new tests).

## Review focus

- The sentinel set is deliberately minimal (`ERROR` only) — it is the one observed value; widening it needs evidence.
- Whether `_OPAQUE_RAW_SENTINELS` should live in config — kept internal until a second aggregator shape shows up.
