### PR TITLE
feat(tui): attach to live sessions across front ends

### DIFF
--- a/local_operator/cli.py
+++ b/local_operator/cli.py
@@ -1946,6 +1946,27 @@ def main() -> int:
                         )
                 return 1
 
+            # Second-writer guard, at the ONLY place the hole starts. Left to
+            # the session factory, `lop --resume <live-id>` claims the
+            # directory and silently becomes a second writer on a transcript
+            # another process is appending to — the exact corruption the
+            # in-app /resume guard exists to prevent, reachable on every cold
+            # boot. Owned by another LIVE pid: attach to that owner (a
+            # follower view over its control socket) when it is reachable,
+            # refuse with the same copy the TUI uses otherwise. The factory
+            # never runs on this path. `exec --resume` refuses outright (a
+            # headless one-shot cannot follow) — see the exec branch below.
+            if args.subcommand is None and getattr(args, "resume", None) is not None:
+                from local_operator.resume import live_session_owner
+
+                owner = live_session_owner(config_dir(), str(args.resume))
+                if owner is not None and owner != os.getpid():
+                    from local_operator.cli_attach import run_owned_resume_attach
+
+                    return run_owned_resume_attach(
+                        config_dir(), str(args.resume), owner
+                    )
+
         os.environ["LOCAL_OPERATOR_DEBUG"] = "true" if args.debug else "false"
         # (CL-12) No env_config binding here: the scheduler wrapper resolves its
         # own env config and the session factory does the same lazily — a
@@ -2115,6 +2136,27 @@ def main() -> int:
             invalid = _apply_run_in(args.run_in)
             if invalid is not None:
                 return invalid
+            # Second-writer guard, same rationale as the interactive branch
+            # above but with no attach escape: exec is headless and one-shot,
+            # following a live session is meaningless, and double-writing a
+            # transcript another process owns is the corruption case. The
+            # refusal IS the feature; no new flag.
+            if getattr(args, "resume", None) is not None:
+                from local_operator.resume import live_session_owner, resolve_resume_id
+
+                try:
+                    exec_resume_id = resolve_resume_id(config_dir(), str(args.resume))
+                except Exception:
+                    exec_resume_id = str(args.resume)
+                exec_owner = live_session_owner(config_dir(), exec_resume_id)
+                if exec_owner is not None and exec_owner != os.getpid():
+                    print(
+                        f"\033[31msession {exec_resume_id} is already open in "
+                        f"another process (pid {exec_owner}) — watch and steer "
+                        "it there, or from the phone session list\033[0m",
+                        file=sys.stderr,
+                    )
+                    return 1
             from local_operator.exec_mode import ExecArgs, run_exec
 
             exec_args = ExecArgs(

--- a/local_operator/cli.py
+++ b/local_operator/cli.py
@@ -1963,9 +1963,7 @@ def main() -> int:
                 if owner is not None and owner != os.getpid():
                     from local_operator.cli_attach import run_owned_resume_attach
 
-                    return run_owned_resume_attach(
-                        config_dir(), str(args.resume), owner
-                    )
+                    return run_owned_resume_attach(config_dir(), str(args.resume), owner)
 
         os.environ["LOCAL_OPERATOR_DEBUG"] = "true" if args.debug else "false"
         # (CL-12) No env_config binding here: the scheduler wrapper resolves its

--- a/local_operator/cli_attach.py
+++ b/local_operator/cli_attach.py
@@ -1,0 +1,63 @@
+"""The CLI's owned-resume branch: attach to a live owner instead of racing it.
+
+``lop --resume <id>`` where another live process owns ``<id>`` used to fall
+through to the session factory, claim the directory, and silently become a
+second writer on a transcript the owner was still appending to — the cold-boot
+half of the corruption hole the TUI's in-app guard already refuses. This module
+is the CLI edge of the attach design: discover the owner's control-socket
+record, and either run the standalone attach app (a follower view; the factory
+never runs) or print the TUI's refusal copy and exit 1 when the owner is not
+attachable (old binary, registrant failure, rebind race).
+
+Kept as its own module (not inline in ``cli.py``) because everything here is
+import-heavy (Textual, the mobile package) and the branch is rare: the CLI's
+startup import-cost guard stays green because none of this loads unless an
+owned resume actually happens. ``local_operator.resume`` stays stdlib-only —
+this module imports it, never the reverse.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+def _refuse(session_id: str, owner: int) -> int:
+    """Today's refusal line, verbatim with the TUI's, plus exit 1."""
+    print(
+        f"\033[31msession {session_id} is already open in another process "
+        f"(pid {owner}) — watch and steer it there, or from the phone "
+        f"session list\033[0m",
+        file=sys.stderr,
+    )
+    return 1
+
+
+def run_owned_resume_attach(config_dir: Path, session_id: str, owner: int) -> int:
+    """Attach to the live owner of ``session_id``, or refuse exactly as before.
+
+    Exit codes: 0 after a clean detach; 75 when the user chose 'resume here'
+    after the owner died mid-attach (the caller relaunches without ``--resume``
+    — by then the claim marker names a dead pid, so the relaunch is the
+    legitimate first writer); 1 when the owner is not attachable.
+    """
+    from local_operator.mobile.attach_client import find_owner_record
+
+    record, found_owner = find_owner_record(config_dir, session_id)
+    if record is None or found_owner != owner:
+        return _refuse(session_id, owner)
+
+    from local_operator.tui.attach_screen import run_attach_app
+
+    code = run_attach_app(record, session_id)
+    if code == 75:
+        # 'resume here': the owner is gone (the attach screen only offers this
+        # after owner death), so re-enter the CLI with the resume flag dropped.
+        # A fresh process is the honest shape: this one already decided NOT to
+        # build a session when it took the attach branch. ``-m local_operator.cli``
+        # because the package has no ``__main__``; the module's own tail runs
+        # ``main()``.
+        import subprocess
+
+        return subprocess.call([sys.executable, "-m", "local_operator.cli"])
+    return code

--- a/local_operator/cli_attach.py
+++ b/local_operator/cli_attach.py
@@ -54,10 +54,12 @@ def run_owned_resume_attach(config_dir: Path, session_id: str, owner: int) -> in
         # 'resume here': the owner is gone (the attach screen only offers this
         # after owner death), so re-enter the CLI with the resume flag dropped.
         # A fresh process is the honest shape: this one already decided NOT to
-        # build a session when it took the attach branch. ``-m local_operator.cli``
-        # because the package has no ``__main__``; the module's own tail runs
-        # ``main()``.
+        # build a session when it took the attach branch. Preserve the session
+        # id: by now the owner is dead, so the fresh guard falls through to the
+        # factory and this process becomes the legitimate first writer. ``-m
+        # local_operator.cli`` because the package has no ``__main__``; the
+        # module's own tail runs ``main()``.
         import subprocess
 
-        return subprocess.call([sys.executable, "-m", "local_operator.cli"])
+        return subprocess.call([sys.executable, "-m", "local_operator.cli", "--resume", session_id])
     return code

--- a/local_operator/mobile/attach_client.py
+++ b/local_operator/mobile/attach_client.py
@@ -31,12 +31,18 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
+import subprocess
+import sys
+import time
+import uuid
 from pathlib import Path
 from typing import Any, Callable
 
 from local_operator.mobile.registry import scan
 from local_operator.mobile.types import (
     PROTOCOL_VERSION,
+    ContinuationCommand,
     SessionProjection,
     SessionRecord,
     _projection_from_json,
@@ -245,8 +251,28 @@ class AttachClient:
             raise RuntimeError(str(reply.get("message", "request failed")))
         return str(reply.get("detail", ""))
 
-    async def prompt(self, text: str) -> str:
-        return await self._request("prompt", text=text)
+    async def prompt(
+        self,
+        text: str,
+        *,
+        command_id: str | None = None,
+        images: list[dict[str, str]] | None = None,
+    ) -> str:
+        return await self._request(
+            "prompt",
+            command_id=command_id or str(uuid.uuid4()),
+            text=text,
+            images=list(images or []),
+        )
+
+    async def send_command(self, command: ContinuationCommand) -> str:
+        if command.session_id != self._session_id:
+            raise ValueError("command belongs to another conversation")
+        return await self.prompt(
+            command.text,
+            command_id=command.command_id,
+            images=command.images,
+        )
 
     async def steer(self, text: str) -> str:
         return await self._request("steer", text=text)
@@ -292,3 +318,57 @@ class AttachClient:
                 self._writer.close()
             except Exception:  # noqa: BLE001
                 pass
+
+
+async def continue_command(
+    config_dir: Path,
+    command: ContinuationCommand,
+    *,
+    deadline_s: float = ACK_TIMEOUT_S,
+    on_projection: Callable[[SessionProjection], None] | None = None,
+) -> tuple[AttachClient, str]:
+    """Deliver one retained command to whichever host wins the session lease.
+
+    Every contender may start a candidate. The atomic transcript lease, never
+    a check before spawning, decides authority. Losing candidates exit and the
+    producer redials the published winner with the unchanged command id.
+    """
+    deadline = time.monotonic() + deadline_s
+    spawned = False
+    delay = 0.1
+    last_error: Exception | None = None
+    while time.monotonic() < deadline:
+        record, _ = await asyncio.to_thread(find_owner_record, config_dir, command.session_id)
+        if record is not None:
+            disconnected = asyncio.Event()
+            client = AttachClient(
+                on_projection or (lambda projection: None),
+                lambda reason: disconnected.set(),
+            )
+            try:
+                await client.connect(record, command.session_id)
+                detail = await client.send_command(command)
+                return client, detail
+            except (ConnectionError, RuntimeError, TimeoutError) as exc:
+                last_error = exc
+                client.close()
+        if not spawned:
+            # Only routing data enters the environment. Prompt text, images and
+            # command identity stay on the authenticated loopback connection.
+            env = dict(os.environ)
+            env["LOP_MOBILE_CHILD_CWD"] = str(Path.home())
+            env["LOP_MOBILE_CHILD_RESUME"] = command.session_id
+            await asyncio.create_subprocess_exec(
+                sys.executable,
+                "-m",
+                "local_operator.mobile.child",
+                env=env,
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                start_new_session=True,
+            )
+            spawned = True
+        await asyncio.sleep(min(delay, max(0.0, deadline - time.monotonic())))
+        delay = min(delay * 1.7, 1.0)
+    raise TimeoutError("Couldn’t continue this conversation. Try again.") from last_error

--- a/local_operator/mobile/attach_client.py
+++ b/local_operator/mobile/attach_client.py
@@ -31,7 +31,6 @@ from __future__ import annotations
 
 import asyncio
 import json
-import secrets
 from pathlib import Path
 from typing import Any, Callable
 
@@ -50,9 +49,7 @@ from local_operator.mobile.types import (
 ACK_TIMEOUT_S = 15.0
 
 
-def find_owner_record(
-    config_dir: Path, session_id: str
-) -> tuple[SessionRecord | None, int | None]:
+def find_owner_record(config_dir: Path, session_id: str) -> tuple[SessionRecord | None, int | None]:
     """Locate the discovery record of the live process hosting ``session_id``.
 
     Returns ``(record, owner_pid)``. The normal case matches a record whose
@@ -130,9 +127,7 @@ class AttachClient:
         retry mechanism, by design.
         """
         if record.protocol < 2:
-            raise ConnectionError(
-                f"owner runs protocol v{record.protocol}; attach needs >= 2"
-            )
+            raise ConnectionError(f"owner runs protocol v{record.protocol}; attach needs >= 2")
         self._session_id = session_id
         try:
             reader, writer = await asyncio.open_connection(
@@ -162,9 +157,7 @@ class AttachClient:
             raise ConnectionError(f"owner replied {frame.get('op')!r}, not its state")
         projection = _projection_from_json(frame.get("data") or {}, record)
         if projection.session_id != session_id:
-            raise ConnectionError(
-                f"owner moved to another conversation ({projection.session_id})"
-            )
+            raise ConnectionError(f"owner moved to another conversation ({projection.session_id})")
         self._connected = True
         self._reader_task = asyncio.get_running_loop().create_task(self._pump())
         # Deliver the welcome synchronously so the host paints before any

--- a/local_operator/mobile/attach_client.py
+++ b/local_operator/mobile/attach_client.py
@@ -265,17 +265,45 @@ class AttachClient:
             images=list(images or []),
         )
 
-    async def send_command(self, command: ContinuationCommand) -> str:
+    async def send_command(self, command: ContinuationCommand, *, streaming: bool = False) -> str:
+        """Submit natural text using the latest owner projection.
+
+        The retained command id rides both paths. If an idle projection races a
+        turn start, the owner's busy rejection is reconciled once as steering;
+        no second prompt is created and reconnect retries keep one identity.
+        """
         if command.session_id != self._session_id:
             raise ValueError("command belongs to another conversation")
-        return await self.prompt(
-            command.text,
-            command_id=command.command_id,
-            images=command.images,
-        )
+        if streaming:
+            return await self.steer(
+                command.text, command_id=command.command_id, images=command.images
+            )
+        try:
+            return await self.prompt(
+                command.text,
+                command_id=command.command_id,
+                images=command.images,
+            )
+        except RuntimeError as exc:
+            if "already streaming" not in str(exc):
+                raise
+            return await self.steer(
+                command.text, command_id=command.command_id, images=command.images
+            )
 
-    async def steer(self, text: str) -> str:
-        return await self._request("steer", text=text)
+    async def steer(
+        self,
+        text: str,
+        *,
+        command_id: str | None = None,
+        images: list[dict[str, str]] | None = None,
+    ) -> str:
+        return await self._request(
+            "steer",
+            command_id=command_id or str(uuid.uuid4()),
+            text=text,
+            images=list(images or []),
+        )
 
     async def abort(self) -> str:
         return await self._request("abort")

--- a/local_operator/mobile/attach_client.py
+++ b/local_operator/mobile/attach_client.py
@@ -1,0 +1,301 @@
+"""The attach client: a follower terminal's half of the control socket.
+
+Every interactive ``lop`` process hosts a :class:`~local_operator.mobile.registrant.Registrant`
+whose loopback socket is the phone's window onto the session. This module is
+the SAME socket seen from a second terminal: ``/resume`` of a session another
+process owns dials that owner and renders its projection repaints, steering
+through the same ops the phone uses. One socket, N front ends — a second
+protocol would drift from the first, so there is none.
+
+Design constraints baked in:
+
+- **No auto-reconnect.** Owner death (socket EOF) is a DECISION POINT for the
+  hosting screen — "resume here / detach" — not something to paper over by
+  redialing a pid that may have been reused. The callback fires once and the
+  client is dead.
+- **Identity over pid trust.** ``live_session_owner`` cannot probe pids on
+  Windows, and a recycled pid anywhere defeats pid trust. After auth the
+  registrant sends a full projection unprompted; the client requires that
+  projection's ``session_id`` to match the one the user asked for before
+  declaring the attach good. A mismatch means the owner rebound away — the
+  caller surfaces the graceful refusal copy.
+- **Protocol gate before dialing.** A v1 registrant treats ANY authenticated
+  dial as THE daemon and evicts the real one; requiring ``record.protocol
+  >= 2`` turns that hazard into the graceful degradation path instead.
+
+Stdlib-only plus the mobile wire types: the CLI imports this lazily on the
+owned-resume branch only, keeping ``resume.py`` and the startup path light.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import secrets
+from pathlib import Path
+from typing import Any, Callable
+
+from local_operator.mobile.registry import scan
+from local_operator.mobile.types import (
+    PROTOCOL_VERSION,
+    SessionProjection,
+    SessionRecord,
+    _projection_from_json,
+)
+
+#: How long to wait for an ack/error matching a request id. Mirrors the
+#: daemon's ``request`` timeout: long enough for a turn-boundary op (prompt
+#: acquires the turn lock) on a busy owner, short enough that a wedged owner
+#: surfaces as an error rather than a hang.
+ACK_TIMEOUT_S = 15.0
+
+
+def find_owner_record(
+    config_dir: Path, session_id: str
+) -> tuple[SessionRecord | None, int | None]:
+    """Locate the discovery record of the live process hosting ``session_id``.
+
+    Returns ``(record, owner_pid)``. The normal case matches a record whose
+    ``session_id`` equals the ask. The rebind-race fallback: the record's
+    session_id is re-stamped only every heartbeat (15s), so when no record
+    matches but the claim marker names a live pid, that pid's record is
+    returned anyway and the welcome projection's identity check (in
+    :meth:`AttachClient.connect`) arbitrates — a stale match costs one refused
+    dial, never a wrong attach.
+
+    ``(None, pid)`` means an owner exists but no usable record does (old
+    binary, registrant failed to start): the caller degrades gracefully.
+    ``(None, None)`` means no owner at all.
+    """
+    from local_operator.resume import live_session_owner
+
+    owner = live_session_owner(config_dir, session_id)
+    if owner is None:
+        return None, None
+    best: SessionRecord | None = None
+    fallback: SessionRecord | None = None
+    try:
+        for record, state in scan(config_dir):
+            if state != "live":
+                continue
+            if record.pid == owner and record.session_id == session_id:
+                best = record
+                break
+            if record.pid == owner:
+                fallback = record
+    except OSError:
+        return None, owner
+    if best is not None and best.protocol >= 2:
+        return best, owner
+    # A v1 record is not dialable (see module docstring) — report the owner so
+    # the caller can print the refusal naming it.
+    if best is not None or fallback is not None:
+        return None, owner
+    return None, owner
+
+
+class AttachClient:
+    """One authenticated ``attach`` connection to a live session's registrant.
+
+    The host (an ``AttachScreen``) supplies two callbacks — both fire on the
+    client's own reader task, so the host must hop to its UI thread. The
+    client is single-use: after ``on_disconnected`` it is dead by design.
+    """
+
+    def __init__(
+        self,
+        on_projection: Callable[[SessionProjection], None],
+        on_disconnected: Callable[[str], None],
+    ) -> None:
+        self._on_projection = on_projection
+        self._on_disconnected = on_disconnected
+        self._reader: asyncio.StreamReader | None = None
+        self._writer: asyncio.StreamWriter | None = None
+        self._reader_task: asyncio.Task[None] | None = None
+        self._pending: dict[Any, asyncio.Future[dict[str, Any]]] = {}
+        self._req_seq = 0
+        self._session_id = ""
+        self._connected = False
+
+    @property
+    def connected(self) -> bool:
+        return self._connected
+
+    async def connect(self, record: SessionRecord, session_id: str) -> None:
+        """Dial, authenticate as an attach client, and verify identity.
+
+        Raises on any failure (dial refused, auth rejected, welcome identity
+        mismatch, protocol too old): the caller collapses every one to the
+        graceful refusal copy — a user re-running the command is the only
+        retry mechanism, by design.
+        """
+        if record.protocol < 2:
+            raise ConnectionError(
+                f"owner runs protocol v{record.protocol}; attach needs >= 2"
+            )
+        self._session_id = session_id
+        try:
+            reader, writer = await asyncio.open_connection(
+                "127.0.0.1", record.control_port, limit=1 << 20
+            )
+        except OSError as exc:
+            raise ConnectionError(f"owner socket unreachable: {exc}") from exc
+        self._reader = reader
+        self._writer = writer
+        auth = {"key": record.control_key, "client": "attach"}
+        writer.write(json.dumps(auth).encode() + b"\n")
+        await writer.drain()
+        # The welcome projection doubles as the identity check: it names the
+        # conversation the OWNER is actually hosting right now, which is the
+        # fact the user cares about and the one a pid cannot prove.
+        try:
+            first = await asyncio.wait_for(reader.readline(), timeout=ACK_TIMEOUT_S)
+        except TimeoutError as exc:
+            raise ConnectionError("owner did not send its state") from exc
+        if not first:
+            raise ConnectionError("owner closed the connection")
+        try:
+            frame = json.loads(first.decode("utf-8", "replace"))
+        except ValueError as exc:
+            raise ConnectionError("owner sent a malformed frame") from exc
+        if frame.get("op") not in ("projection", "welcome"):
+            raise ConnectionError(f"owner replied {frame.get('op')!r}, not its state")
+        projection = _projection_from_json(frame.get("data") or {}, record)
+        if projection.session_id != session_id:
+            raise ConnectionError(
+                f"owner moved to another conversation ({projection.session_id})"
+            )
+        self._connected = True
+        self._reader_task = asyncio.get_running_loop().create_task(self._pump())
+        # Deliver the welcome synchronously so the host paints before any
+        # later repaint can race it.
+        self._on_projection(projection)
+
+    async def _pump(self) -> None:
+        """Read frames until EOF; route projections and match acks by req id."""
+        reader = self._reader
+        assert reader is not None
+        reason = "owner exited"
+        try:
+            while True:
+                line = await reader.readline()
+                if not line:
+                    break
+                try:
+                    frame = json.loads(line.decode("utf-8", "replace"))
+                except ValueError:
+                    continue
+                op = frame.get("op")
+                if op in ("projection", "welcome"):
+                    try:
+                        # pid=0 record: the attach screen keys nothing on the
+                        # record's pid (it reads the projection's own), and
+                        # building a fake record per repaint would imply the
+                        # record carries truth it does not.
+                        self._on_projection(
+                            _projection_from_json(
+                                frame.get("data") or {},
+                                SessionRecord(
+                                    pid=0,
+                                    kind="tui",
+                                    session_id="",
+                                    conversation_name="",
+                                    cwd="",
+                                    model_label="",
+                                    control_port=0,
+                                    control_key="",
+                                    protocol=PROTOCOL_VERSION,
+                                ),
+                            )
+                        )
+                    except Exception:  # noqa: BLE001 — a malformed push must not kill the pump
+                        continue
+                elif op in ("ack", "error"):
+                    future = self._pending.pop(frame.get("req"), None)
+                    if future is not None and not future.done():
+                        future.set_result(frame)
+        except (ConnectionResetError, BrokenPipeError, OSError):
+            reason = "owner connection reset"
+        finally:
+            self._connected = False
+            for future in self._pending.values():
+                if not future.done():
+                    future.set_exception(ConnectionError(reason))
+            self._pending.clear()
+            try:
+                self._writer.close()  # type: ignore[union-attr]
+            except Exception:  # noqa: BLE001
+                pass
+            self._on_disconnected(reason)
+
+    # -- requests ---------------------------------------------------------------
+
+    async def _request(self, op: str, **fields: Any) -> str:
+        """Send one op and await its ack detail (or raise its error message)."""
+        if not self._connected or self._writer is None:
+            raise ConnectionError("not attached")
+        self._req_seq += 1
+        req = self._req_seq
+        future: asyncio.Future[dict[str, Any]] = asyncio.get_running_loop().create_future()
+        self._pending[req] = future
+        frame = {"op": op, "req": req, **fields}
+        try:
+            self._writer.write(json.dumps(frame).encode() + b"\n")
+            await self._writer.drain()
+            reply = await asyncio.wait_for(future, timeout=ACK_TIMEOUT_S)
+        except (ConnectionResetError, BrokenPipeError, OSError) as exc:
+            self._pending.pop(req, None)
+            raise ConnectionError(f"owner connection lost: {exc}") from exc
+        finally:
+            self._pending.pop(req, None)
+        if reply.get("op") == "error":
+            raise RuntimeError(str(reply.get("message", "request failed")))
+        return str(reply.get("detail", ""))
+
+    async def prompt(self, text: str) -> str:
+        return await self._request("prompt", text=text)
+
+    async def steer(self, text: str) -> str:
+        return await self._request("steer", text=text)
+
+    async def abort(self) -> str:
+        return await self._request("abort")
+
+    async def slash(self, command: str, args: str) -> str:
+        return await self._request("slash", command=command, args=args)
+
+    async def set_model(self, provider: str, model_id: str) -> str:
+        return await self._request("set_model", provider=provider, model_id=model_id)
+
+    async def set_effort(self, effort: str) -> str:
+        return await self._request("set_effort", effort=effort)
+
+    async def approval_answer(self, request_id: str, approved: bool) -> str:
+        return await self._request(
+            "approval_answer", request_id=request_id, approved=approved, remember=False
+        )
+
+    async def ask_answer(self, request_id: str, value: str) -> str:
+        return await self._request("ask_answer", request_id=request_id, value=value)
+
+    async def detach(self) -> None:
+        """Close the connection from our side. ``on_disconnected`` still fires
+        (the pump observes EOF) so the host's teardown runs one path."""
+        self._connected = False
+        if self._writer is not None:
+            try:
+                self._writer.close()
+            except Exception:  # noqa: BLE001
+                pass
+
+    def close(self) -> None:
+        """Synchronous teardown for hosts without a loop (app exit paths)."""
+        self._connected = False
+        if self._reader_task is not None:
+            self._reader_task.cancel()
+            self._reader_task = None
+        if self._writer is not None:
+            try:
+                self._writer.close()
+            except Exception:  # noqa: BLE001
+                pass

--- a/local_operator/mobile/child.py
+++ b/local_operator/mobile/child.py
@@ -10,9 +10,9 @@ session its work.
 
 The child builds a session with the CLI's composition root, wraps it in the
 owned-session handle (approval/ask gates resolved from the phone), registers
-it through the normal record + control socket path, and idles until its work
-ends, a signal arrives, or — since the attach/reaping design — no front end
-holds it any longer (see :func:`_reaper`). Environment variables are the
+it through the normal record + control socket path, and idles until a signal
+arrives or its work and pending gates drain long enough for self-reaping (see
+:func:`_reaper`). Environment variables are the
 spawn contract (``LOP_MOBILE_CHILD_CWD``, ``_PROVIDER``, ``_MODEL``) — argv
 would be ps-readable.
 """
@@ -28,17 +28,13 @@ import time
 
 logger = logging.getLogger(__name__)
 
-#: How often the reaper re-evaluates "is anyone still holding this session?".
-#: Short enough that a front end leaving is noticed within the grace budget's
-#: own resolution, long enough that five-second polls cost nothing.
-REAP_CHECK_S = 5.0
+#: Fine polling makes the 3-second drain predictable while remaining cheap for
+#: one event loop. Viewer traffic is deliberately not an input to this loop.
+REAP_CHECK_S = 0.25
 
-#: Default grace before a held-by-nobody session exits, overridable with
-#: ``LOP_SESSION_GRACE_S``. Long enough that a phone screen-lock / tunnel
-#: blip (SSE drop + reconnect) never kills a session the user is coming back
-#: to; short enough that unattended sessions cannot accumulate as live
-#: processes — the buildup this reaper exists to prevent.
-DEFAULT_GRACE_S = 120.0
+#: Idle execution hosts are disposable once their durable session state is
+#: quiescent. This is a drain for newly arriving work, not a reconnect grace.
+DEFAULT_GRACE_S = 3.0
 
 
 def _grace_seconds() -> float:
@@ -51,43 +47,19 @@ def _grace_seconds() -> float:
 
 
 def _should_exit(handle: object, registrant: object) -> bool:
-    """True iff NO front end holds the session and no work is running.
-
-    The mixed-version guard is load-bearing: until the registrant has SEEN a
-    watch/unwatch op (``watch_supported``), phone watchers are UNKNOWN — an
-    old daemon never sends the ops — and unknown must count as present, or a
-    new child under an old daemon would reap a session a phone is actively
-    watching. The latch never resets, so once a watch-capable daemon has
-    spoken, a true zero is trusted forever after.
-    """
-    watchers_known_empty = (
-        bool(getattr(registrant, "watch_supported", False))
-        and getattr(registrant, "phone_watchers", 1) == 0
-    )
-    if not watchers_known_empty:
-        return False
-    if getattr(registrant, "attach_clients", lambda: 0)() > 0:
-        return False
+    """True when the execution host is quiescent, regardless of viewers."""
+    del registrant  # Watchers and replicas observe work; they do not own it.
     is_busy = getattr(handle, "is_busy", None)
-    if is_busy is not None and is_busy():
-        return False
-    return True
+    return not (is_busy is not None and is_busy())
 
 
 async def _clean_exit(handle: object, registrant: object) -> None:
-    """Deny gates, dispose the session (releases the claim), unpublish.
+    """Dispose the quiescent session, then unpublish its owner record.
 
-    Ordering mirrors OperatorApp.on_unmount: the gates are refused BEFORE
-    dispose because dispose awaits teardown and a turn parked on an
-    unanswered card would never reach it; the record is unpublished LAST so
-    a scanner never sees a gone record while the claim is still held.
+    The reaper reaches this only after ordinary gate timeouts and all resumed
+    work have drained, so injecting a shutdown denial here would violate the
+    same no-interruption invariant that selected this state.
     """
-    deny = getattr(handle, "_deny_pending_gates", None)
-    if deny is not None:
-        try:
-            deny()
-        except Exception:  # noqa: BLE001 — shutdown must proceed
-            logger.debug("child gate deny failed", exc_info=True)
     try:
         await handle.dispose()  # type: ignore[attr-defined]
     except Exception:  # noqa: BLE001 — dispose is best-effort at exit
@@ -99,15 +71,10 @@ async def _clean_exit(handle: object, registrant: object) -> None:
 
 
 async def _reaper(handle: object, registrant: object, stop: asyncio.Event) -> None:
-    """Exit the child cleanly once no front end has held it for a grace period.
+    """Exit the disposable execution host after one uninterrupted idle drain.
 
-    The child is the only party with the authoritative liveness facts (its
-    turn, its subagents, its connections), so the child reaps ITSELF — the
-    daemon never kills children. The grace timer starts at the earliest
-    moment all hold conditions are false: a turn mid-flight when the last
-    front end leaves simply defers the start (``is_busy`` gates it), so the
-    grace outlives the turn by construction. Any holder returning mid-grace
-    cancels the countdown.
+    Autonomous work and ordinary pending-gate timeouts are authoritative. Any
+    new activity resets the drain; viewer count intentionally does not.
     """
     grace_s = _grace_seconds()
     while not stop.is_set():
@@ -118,9 +85,9 @@ async def _reaper(handle: object, registrant: object, stop: asyncio.Event) -> No
         while time.monotonic() < deadline:
             await asyncio.sleep(REAP_CHECK_S)
             if stop.is_set() or not _should_exit(handle, registrant):
-                break  # a front end came back (or shutdown began)
+                break  # work arrived (or shutdown began)
         else:
-            logger.info("mobile child: no front end for %.0fs — exiting cleanly", grace_s)
+            logger.info("mobile child: idle for %.1fs; exiting cleanly", grace_s)
             await _clean_exit(handle, registrant)
             stop.set()  # amain's wait() returns; exit code stays 0
             return

--- a/local_operator/mobile/child.py
+++ b/local_operator/mobile/child.py
@@ -10,10 +10,11 @@ session its work.
 
 The child builds a session with the CLI's composition root, wraps it in the
 owned-session handle (approval/ask gates resolved from the phone), registers
-it through the normal record + control socket path, and idles until killed
-or its turn ends the conversation. Environment variables are the spawn
-contract (``LOP_MOBILE_CHILD_CWD``, ``_PROVIDER``, ``_MODEL``) — argv would
-be ps-readable.
+it through the normal record + control socket path, and idles until its work
+ends, a signal arrives, or — since the attach/reaping design — no front end
+holds it any longer (see :func:`_reaper`). Environment variables are the
+spawn contract (``LOP_MOBILE_CHILD_CWD``, ``_PROVIDER``, ``_MODEL``) — argv
+would be ps-readable.
 """
 
 from __future__ import annotations
@@ -23,8 +24,108 @@ import logging
 import os
 import signal
 import sys
+import time
 
 logger = logging.getLogger(__name__)
+
+#: How often the reaper re-evaluates "is anyone still holding this session?".
+#: Short enough that a front end leaving is noticed within the grace budget's
+#: own resolution, long enough that five-second polls cost nothing.
+REAP_CHECK_S = 5.0
+
+#: Default grace before a held-by-nobody session exits, overridable with
+#: ``LOP_SESSION_GRACE_S``. Long enough that a phone screen-lock / tunnel
+#: blip (SSE drop + reconnect) never kills a session the user is coming back
+#: to; short enough that unattended sessions cannot accumulate as live
+#: processes — the buildup this reaper exists to prevent.
+DEFAULT_GRACE_S = 120.0
+
+
+def _grace_seconds() -> float:
+    raw = os.environ.get("LOP_SESSION_GRACE_S", "")
+    try:
+        value = float(raw)
+    except ValueError:
+        return DEFAULT_GRACE_S
+    return value if value > 0 else DEFAULT_GRACE_S
+
+
+def _should_exit(handle: object, registrant: object) -> bool:
+    """True iff NO front end holds the session and no work is running.
+
+    The mixed-version guard is load-bearing: until the registrant has SEEN a
+    watch/unwatch op (``watch_supported``), phone watchers are UNKNOWN — an
+    old daemon never sends the ops — and unknown must count as present, or a
+    new child under an old daemon would reap a session a phone is actively
+    watching. The latch never resets, so once a watch-capable daemon has
+    spoken, a true zero is trusted forever after.
+    """
+    watchers_known_empty = (
+        bool(getattr(registrant, "watch_supported", False))
+        and getattr(registrant, "phone_watchers", 1) == 0
+    )
+    if not watchers_known_empty:
+        return False
+    if getattr(registrant, "attach_clients", lambda: 0)() > 0:
+        return False
+    is_busy = getattr(handle, "is_busy", None)
+    if is_busy is not None and is_busy():
+        return False
+    return True
+
+
+async def _clean_exit(handle: object, registrant: object) -> None:
+    """Deny gates, dispose the session (releases the claim), unpublish.
+
+    Ordering mirrors OperatorApp.on_unmount: the gates are refused BEFORE
+    dispose because dispose awaits teardown and a turn parked on an
+    unanswered card would never reach it; the record is unpublished LAST so
+    a scanner never sees a gone record while the claim is still held.
+    """
+    deny = getattr(handle, "_deny_pending_gates", None)
+    if deny is not None:
+        try:
+            deny()
+        except Exception:  # noqa: BLE001 — shutdown must proceed
+            logger.debug("child gate deny failed", exc_info=True)
+    try:
+        await handle.dispose()  # type: ignore[attr-defined]
+    except Exception:  # noqa: BLE001 — dispose is best-effort at exit
+        logger.warning("child session dispose failed", exc_info=True)
+    try:
+        await registrant.aclose()  # type: ignore[attr-defined]
+    except Exception:  # noqa: BLE001
+        logger.debug("child registrant aclose failed", exc_info=True)
+
+
+async def _reaper(handle: object, registrant: object, stop: asyncio.Event) -> None:
+    """Exit the child cleanly once no front end has held it for a grace period.
+
+    The child is the only party with the authoritative liveness facts (its
+    turn, its subagents, its connections), so the child reaps ITSELF — the
+    daemon never kills children. The grace timer starts at the earliest
+    moment all hold conditions are false: a turn mid-flight when the last
+    front end leaves simply defers the start (``is_busy`` gates it), so the
+    grace outlives the turn by construction. Any holder returning mid-grace
+    cancels the countdown.
+    """
+    grace_s = _grace_seconds()
+    while not stop.is_set():
+        await asyncio.sleep(REAP_CHECK_S)
+        if stop.is_set() or not _should_exit(handle, registrant):
+            continue
+        deadline = time.monotonic() + grace_s
+        while time.monotonic() < deadline:
+            await asyncio.sleep(REAP_CHECK_S)
+            if stop.is_set() or not _should_exit(handle, registrant):
+                break  # a front end came back (or shutdown began)
+        else:
+            logger.info(
+                "mobile child: no front end for %.0fs — exiting cleanly", grace_s
+            )
+            await _clean_exit(handle, registrant)
+            stop.set()  # amain's wait() returns; exit code stays 0
+            return
 
 
 async def amain() -> int:
@@ -51,7 +152,27 @@ async def amain() -> int:
     stop = asyncio.Event()
     for sig in (signal.SIGTERM, signal.SIGINT):
         loop.add_signal_handler(sig, stop.set)
+    # The self-reaper: a phone session nobody watches and nothing runs is a
+    # live process doing nothing, and before this it idled FOREVER. Runs
+    # beside the signal wait; whichever fires first wins.
+    reaper = asyncio.ensure_future(_reaper(handle, registrant, stop))
+    reaper_ran_clean_exit = False
     await stop.wait()
+    if not reaper.done():
+        reaper.cancel()
+    elif reaper.exception() is None:
+        # The reaper completed (not was cancelled): it already ran the clean
+        # ordering. A signal-initiated stop still owes it.
+        reaper_ran_clean_exit = True
+    if not reaper_ran_clean_exit:
+        try:
+            handle._deny_pending_gates()
+        except Exception:  # noqa: BLE001 — shutdown must proceed
+            logger.debug("child gate deny failed", exc_info=True)
+        try:
+            await handle.dispose()
+        except Exception:  # noqa: BLE001
+            logger.warning("child session dispose failed", exc_info=True)
     await registrant.aclose()
     return 0
 

--- a/local_operator/mobile/child.py
+++ b/local_operator/mobile/child.py
@@ -120,9 +120,7 @@ async def _reaper(handle: object, registrant: object, stop: asyncio.Event) -> No
             if stop.is_set() or not _should_exit(handle, registrant):
                 break  # a front end came back (or shutdown began)
         else:
-            logger.info(
-                "mobile child: no front end for %.0fs — exiting cleanly", grace_s
-            )
+            logger.info("mobile child: no front end for %.0fs — exiting cleanly", grace_s)
             await _clean_exit(handle, registrant)
             stop.set()  # amain's wait() returns; exit code stays 0
             return

--- a/local_operator/mobile/command_reservation.py
+++ b/local_operator/mobile/command_reservation.py
@@ -2,61 +2,106 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Callable
 from typing import Any, Literal
 
-_CommandState = Literal["pending", "accepted", "prompt-transfer"]
+MAX_PENDING_STEERS = 32
+
+_CommandState = Literal["prompt", "steer", "prompt-transfer"]
+_CommandKind = Literal["prompt", "steer"]
 
 
 class CommandReservations:
-    """Undurable identities, mutated only on the session owner's loop.
+    """Bounded undurable identities, mutated only on the session owner's loop.
 
-    Durable history remains the long-term authority. Reservations close the gap
-    before queued steers reach it, then disappear once history proves them, so
-    memory tracks the session's pending work rather than the session's lifetime.
+    The transcript's append-only index is the lifetime authority.  This map
+    closes only the pre-append gap, so durable callbacks remove entries without
+    TTLs or eviction that could make an accepted producer identity reusable.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, session: Any) -> None:
+        has_admitted = getattr(session, "has_admitted_command", None)
+        if callable(has_admitted):
+            self._has_admitted: Callable[[str], bool] = lambda command_id: bool(
+                has_admitted(command_id)
+            )
+        else:
+            # Compatibility for test/third-party protocol implementations that
+            # predate the durable seam. Production Session always takes the
+            # transcript-indexed branch above.
+            self._has_admitted = lambda command_id: any(
+                getattr(message, "id", None) == command_id for message in session.history()
+            )
+        self._session = session
         self._commands: dict[str, _CommandState] = {}
+        self._pending_steers = 0
+
+    def subscribe_durable(self) -> Callable[[], None]:
+        subscribe = getattr(self._session, "subscribe_admitted_commands", None)
+        if callable(subscribe):
+            unsubscribe = subscribe(self.mark_durable)
+            if callable(unsubscribe):
+
+                def stop() -> None:
+                    unsubscribe()
+
+                return stop
+        return lambda: None
 
     def reserve(
         self,
         command_id: str,
-        history: Iterable[Any],
         *,
+        kind: _CommandKind,
         prompt_transfer: bool = False,
     ) -> bool:
-        durable_ids = {
-            message_id
-            for message in history
-            if (message_id := getattr(message, "id", None)) is not None
-        }
-        # Once persistence proves an accepted steer, history itself becomes the
-        # reservation. Removing that in-memory copy bounds this set to commands
-        # still pending in the session's own queue.
-        for durable_id in durable_ids:
-            self._commands.pop(durable_id, None)
-        if command_id in durable_ids:
+        if self._has_admitted(command_id):
+            self.mark_durable(command_id)
             return False
         state = self._commands.get(command_id)
         if prompt_transfer and state == "prompt-transfer":
-            # Prompt rejection and steer admission happen in one owner-loop
-            # callback, so no competing retry can slip through this handoff.
-            self._commands[command_id] = "pending"
+            self._reserve_steer_capacity()
+            self._commands[command_id] = "steer"
+            self._pending_steers += 1
             return True
         if state is not None:
             return False
-        self._commands[command_id] = "pending"
+        if kind == "steer":
+            self._reserve_steer_capacity()
+            self._pending_steers += 1
+        self._commands[command_id] = kind
         return True
 
+    def _reserve_steer_capacity(self) -> None:
+        if self._pending_steers >= MAX_PENDING_STEERS:
+            raise RuntimeError(
+                f"steering queue is full ({MAX_PENDING_STEERS}); "
+                "wait for a queued steer to be delivered"
+            )
+
     def accept(self, command_id: str) -> None:
-        self._commands[command_id] = "accepted"
+        # Prompt ACK runs after the append callback, so it must not recreate an
+        # entry already handed to the durable ledger. Steers remain until drain.
+        if self._has_admitted(command_id):
+            self.mark_durable(command_id)
 
     def reject(self, command_id: str, *, transfer_to_steer: bool = False) -> None:
+        state = self._commands.get(command_id)
         if transfer_to_steer:
+            if state == "steer":
+                self._pending_steers -= 1
             self._commands[command_id] = "prompt-transfer"
         else:
-            self._commands.pop(command_id, None)
+            self._remove(command_id)
+
+    def mark_durable(self, command_id: str) -> None:
+        """Hand one reservation to the transcript-backed lifetime ledger."""
+        self._remove(command_id)
+
+    def _remove(self, command_id: str) -> None:
+        if self._commands.pop(command_id, None) == "steer":
+            self._pending_steers -= 1
 
     def clear(self) -> None:
         self._commands.clear()
+        self._pending_steers = 0

--- a/local_operator/mobile/command_reservation.py
+++ b/local_operator/mobile/command_reservation.py
@@ -1,0 +1,62 @@
+"""Owner-loop command identity reservations for mobile continuation input."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any, Literal
+
+_CommandState = Literal["pending", "accepted", "prompt-transfer"]
+
+
+class CommandReservations:
+    """Undurable identities, mutated only on the session owner's loop.
+
+    Durable history remains the long-term authority. Reservations close the gap
+    before queued steers reach it, then disappear once history proves them, so
+    memory tracks the session's pending work rather than the session's lifetime.
+    """
+
+    def __init__(self) -> None:
+        self._commands: dict[str, _CommandState] = {}
+
+    def reserve(
+        self,
+        command_id: str,
+        history: Iterable[Any],
+        *,
+        prompt_transfer: bool = False,
+    ) -> bool:
+        durable_ids = {
+            message_id
+            for message in history
+            if (message_id := getattr(message, "id", None)) is not None
+        }
+        # Once persistence proves an accepted steer, history itself becomes the
+        # reservation. Removing that in-memory copy bounds this set to commands
+        # still pending in the session's own queue.
+        for durable_id in durable_ids:
+            self._commands.pop(durable_id, None)
+        if command_id in durable_ids:
+            return False
+        state = self._commands.get(command_id)
+        if prompt_transfer and state == "prompt-transfer":
+            # Prompt rejection and steer admission happen in one owner-loop
+            # callback, so no competing retry can slip through this handoff.
+            self._commands[command_id] = "pending"
+            return True
+        if state is not None:
+            return False
+        self._commands[command_id] = "pending"
+        return True
+
+    def accept(self, command_id: str) -> None:
+        self._commands[command_id] = "accepted"
+
+    def reject(self, command_id: str, *, transfer_to_steer: bool = False) -> None:
+        if transfer_to_steer:
+            self._commands[command_id] = "prompt-transfer"
+        else:
+            self._commands.pop(command_id, None)
+
+    def clear(self) -> None:
+        self._commands.clear()

--- a/local_operator/mobile/command_reservation.py
+++ b/local_operator/mobile/command_reservation.py
@@ -37,16 +37,26 @@ class CommandReservations:
         self._pending_steers = 0
 
     def subscribe_durable(self) -> Callable[[], None]:
-        subscribe = getattr(self._session, "subscribe_admitted_commands", None)
-        if callable(subscribe):
-            unsubscribe = subscribe(self.mark_durable)
-            if callable(unsubscribe):
+        subscribe_durable = getattr(self._session, "subscribe_admitted_commands", None)
+        unsubscribe_durable = (
+            subscribe_durable(self.mark_durable) if callable(subscribe_durable) else None
+        )
+        subscribe_rejected = getattr(self._session, "subscribe_rejected_steering", None)
+        unsubscribe_rejected = (
+            subscribe_rejected(self._on_steer_rejected) if callable(subscribe_rejected) else None
+        )
 
-                def stop() -> None:
-                    unsubscribe()
+        def stop() -> None:
+            if callable(unsubscribe_durable):
+                unsubscribe_durable()
+            if callable(unsubscribe_rejected):
+                unsubscribe_rejected()
 
-                return stop
-        return lambda: None
+        return stop
+
+    def _on_steer_rejected(self, command_id: str, _reason: str) -> None:
+        """Release the retry identity and its bounded steering capacity."""
+        self.reject(command_id)
 
     def reserve(
         self,

--- a/local_operator/mobile/daemon.py
+++ b/local_operator/mobile/daemon.py
@@ -567,6 +567,32 @@ class MobileDaemon:
 
     # -- control requests ---------------------------------------------------------
 
+    def notify_watch_transition(self, pid: int, *, watching: bool) -> None:
+        """Push watch/unwatch to a session when its phone SSE subscriber
+        count crosses 0 <-> N.
+
+        Scheduled, not awaited: the SSE handshake must not block on a slow
+        (or old, op-rejecting) registrant. The fire-and-forget task rides the
+        daemon's loop; errors are swallowed at the task boundary — an OLD
+        registrant's `error: unknown op` reply arrives as a RuntimeError from
+        ``request`` and is expected during rolling upgrades."""
+
+        async def send() -> None:
+            try:
+                await self.request(pid, "watch" if watching else "unwatch")
+            except (RuntimeError, TimeoutError, KeyError, asyncio.CancelledError):
+                # KeyError: no dial yet (the SSE stream can open before the
+                # control connection is established). RuntimeError: old
+                # registrant or op rejected. Both are fine — the session's
+                # watch_supported latch stays unlatched and its reaper (if
+                # any) stays inert, which is the safe direction.
+                logger.debug("watch push to pid %s skipped (%s)", pid, watching)
+
+        try:
+            asyncio.get_running_loop().create_task(send())
+        except RuntimeError:  # no loop (tests constructing the daemon directly)
+            pass
+
     async def request(self, pid: int, op: str, **fields: Any) -> dict[str, Any]:
         """Send one control frame to a session and await its ack/error."""
         entry = self.table.entries.get(pid)
@@ -794,6 +820,13 @@ def build_app(daemon: MobileDaemon):
             return JSONResponse({"error": "unknown session"}, status_code=404)
         queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue(maxsize=8)
         entry.subscribers.add(queue)
+        # First subscriber = a phone just started watching: tell the session so
+        # its self-reaper (if any) counts this front end and holds the session
+        # in ACTIVE. Fire-and-forget on the already-open dial writer; an OLD
+        # registrant answers `error: unknown op` and that must not 500 the SSE
+        # handshake — RuntimeError/TimeoutError are swallowed by design.
+        if len(entry.subscribers) == 1:
+            daemon.notify_watch_transition(pid, watching=True)
 
         async def stream():
             try:
@@ -806,7 +839,13 @@ def build_app(daemon: MobileDaemon):
                     except TimeoutError:
                         yield ": keepalive\n\n"
             finally:
+                was_last = entry.subscribers == {queue}
                 entry.subscribers.discard(queue)
+                if was_last:
+                    # Last subscriber out = no phone is watching: the session's
+                    # grace timer (if it has one) may now start. Same swallow
+                    # rules as the watch push above.
+                    daemon.notify_watch_transition(pid, watching=False)
 
         return StreamingResponse(
             stream(),

--- a/local_operator/mobile/daemon.py
+++ b/local_operator/mobile/daemon.py
@@ -244,71 +244,13 @@ async def _dial(daemon: "MobileDaemon", entry: SessionEntry) -> None:
 
 
 def _projection_from_json(data: dict[str, Any], record: SessionRecord) -> SessionProjection:
-    """Rebuild a projection from a wire payload. The registrant already
-    serialized dataclasses; here we tolerate missing keys (a rolling upgrade
-    mid-push) by constructing through the dataclass with defaults."""
-    from dataclasses import fields
+    """The daemon's rebuild seam: the shared wire-types rebuild, plus the
+    opening-user-message pin (a DAEMON-side repair for older sessions — see
+    :func:`_pin_opening_user_message`), which no other consumer wants."""
+    from local_operator.mobile.types import _projection_from_json as _rebuild
 
-    from local_operator.mobile.types import (
-        AskOptionWire,
-        PendingRequest,
-        SubagentRow,
-        TodoItem,
-        TodoPhase,
-        TranscriptEntry,
-    )
-
-    def build(cls: type, items: list[dict[str, Any]]) -> list[Any]:
-        known = {f.name for f in fields(cls)}
-        return [cls(**{k: v for k, v in item.items() if k in known}) for item in items]
-
-    known = {f.name for f in fields(SessionProjection)}
-    base = {
-        k: v
-        for k, v in data.items()
-        if k in known and k not in ("transcript", "todos", "subagents", "pending")
-    }
-    projection = SessionProjection(**base)
-    # The fold stamps pid=0 (the registrant does not know its own listen
-    # pid until after the record is published). The discovery record is
-    # the source of truth, and the phone keys drafts and commands on it.
-    projection.pid = record.pid
-    projection.transcript = build(TranscriptEntry, data.get("transcript", []))
+    projection = _rebuild(data, record)
     _pin_opening_user_message(projection, record)
-    # Todos arrive PHASED (``[{"name", "items":[{...}]}]``); rebuild the two
-    # nested dataclass levels, tolerating missing keys the same way ``build``
-    # does for a rolling upgrade mid-push.
-    projection.todos = [
-        TodoPhase(
-            name=str(phase.get("name", "")),
-            items=build(TodoItem, phase.get("items", []) or []),
-        )
-        for phase in data.get("todos", []) or []
-    ]
-    projection.subagents = build(SubagentRow, data.get("subagents", []))
-    pending = data.get("pending")
-    if isinstance(pending, dict):
-        known_pending = {f.name for f in fields(PendingRequest)}
-        pending_kwargs = {k: v for k, v in pending.items() if k in known_pending}
-        # ``options`` crosses the wire as a list of {label, description} dicts;
-        # rebuild the dataclass so downstream code (and to_json round-trips) see
-        # AskOptionWire, not bare dicts. Tolerant of the label-only shape a
-        # rolling upgrade mid-push could still send.
-        raw_options = pending_kwargs.get("options") or []
-        pending_kwargs["options"] = [
-            (
-                AskOptionWire(
-                    label=str(opt.get("label", "")),
-                    description=str(opt.get("description", "")),
-                )
-                if isinstance(opt, dict)
-                else AskOptionWire(label=str(opt))
-            )
-            for opt in raw_options
-        ]
-        projection.pending = PendingRequest(**pending_kwargs)
-    else:
-        projection.pending = None
     return projection
 
 

--- a/local_operator/mobile/daemon.py
+++ b/local_operator/mobile/daemon.py
@@ -125,46 +125,58 @@ class SessionTable:
         self.list_subscribers: set[asyncio.Queue[None]] = set()
 
     def summaries(self) -> list[dict[str, Any]]:
-        """The session-list payload: one summary per session, live first,
-        then wedged, then ended — the order the phone list renders."""
-        out = []
+        """Reconcile live generations with durable conversations by session id."""
+        from local_operator.paths import config_dir
+        from local_operator.resume import recent_session_rows
+
+        durable = {row.id: row for row in recent_session_rows(config_dir(), limit=100)}
+        active: dict[str, SessionEntry] = {}
         for entry in self.entries.values():
-            p = entry.projection
+            if entry.ended:
+                continue
+            prior = active.get(entry.record.session_id)
+            if prior is None or entry.record.heartbeat_at > prior.record.heartbeat_at:
+                active[entry.record.session_id] = entry
+        out: list[dict[str, Any]] = []
+        for session_id in set(durable) | set(active):
+            entry = active.get(session_id)
+            p = entry.projection if entry else None
+            row = durable.get(session_id)
             out.append(
                 {
-                    "pid": entry.record.pid,
-                    "kind": entry.record.kind,
-                    "session_id": entry.record.session_id,
-                    "conversation_name": (
-                        p.conversation_name if p else entry.record.conversation_name
+                    "session_id": session_id,
+                    "section": "active" if entry else "previous",
+                    "conversation_name": (p.conversation_name if p else "")
+                    or (entry.record.conversation_name if entry else "")
+                    or (row.name if row else ""),
+                    "cwd": p.cwd if p else (entry.record.cwd if entry else ""),
+                    "model_label": (
+                        p.model_label if p else (entry.record.model_label if entry else "")
                     ),
-                    "cwd": p.cwd if p else entry.record.cwd,
-                    "model_label": p.model_label if p else entry.record.model_label,
                     "streaming": bool(p and p.streaming),
-                    "ended": entry.ended,
-                    "degraded": entry.degraded,
                     "needs_attention": bool(p and p.pending),
-                    "pending_kind": (p.pending.kind if p and p.pending else ""),
-                    "subagents_running": (
-                        sum(1 for s in p.subagents if s.status == "running") if p else 0
+                    "pending_kind": p.pending.kind if p and p.pending else "",
+                    "subagents_running": sum(
+                        1 for subagent in (p.subagents if p else []) if subagent.status == "running"
                     ),
-                    # Open == not closed (``pending`` or ``blocked``; ``blocked``
-                    # is open work waiting on an answer, mirroring the tool's
-                    # ``open_todos``). Summed across ALL phases so a multi-phase
-                    # plan's badge counts every group, not just the first.
-                    "todos_open": (
-                        sum(
-                            1
-                            for phase in p.todos
-                            for t in phase.items
-                            if t.status in ("pending", "blocked")
-                        )
-                        if p
-                        else 0
+                    "todos_open": sum(
+                        1
+                        for phase in (p.todos if p else [])
+                        for todo in phase.items
+                        if todo.status in ("pending", "blocked")
                     ),
+                    "mtime": row.mtime if row else entry.record.started_at if entry else 0,
                 }
             )
-        out.sort(key=lambda s: (s["ended"], s["degraded"], -s["pid"]))
+        out.sort(
+            key=lambda summary: (
+                summary["section"] != "active",
+                not summary["needs_attention"],
+                not summary["streaming"],
+                -summary["mtime"],
+                summary["session_id"],
+            )
+        )
         return out
 
     def notify_list_changed(self) -> None:
@@ -173,6 +185,41 @@ class SessionTable:
                 queue.put_nowait(None)
             except asyncio.QueueFull:
                 pass
+
+
+def _entry_for_session(daemon: "MobileDaemon", session_id: str) -> SessionEntry | None:
+    """Select the newest live generation without exposing its pid publicly."""
+    candidates = [
+        entry
+        for entry in daemon.table.entries.values()
+        if entry.record.session_id == session_id and not entry.ended
+    ]
+    return max(candidates, key=lambda entry: entry.record.heartbeat_at, default=None)
+
+
+def _durable_projection(session_id: str) -> SessionProjection | None:
+    """Fold a conversation from disk when no execution host exists."""
+    from local_operator.mobile.projection import ProjectionFold
+    from local_operator.paths import config_dir
+    from local_operator.resume import stored_session_title
+    from local_operator.session.transcript import Transcript
+
+    directory = config_dir() / "sessions" / session_id
+    if not (directory / "transcript.jsonl").exists():
+        return None
+    projection = SessionProjection(
+        session_id=session_id,
+        pid=0,
+        kind="daemon",
+        conversation_name=stored_session_title(directory),
+        cwd="",
+        model_label="",
+    )
+    fold = ProjectionFold(projection)
+    fold.fold_history(Transcript(directory).build_llm_history())
+    projection.ended = False
+    projection.degraded = False
+    return projection
 
 
 # ---------------------------------------------------------------------------
@@ -226,8 +273,9 @@ async def _dial(daemon: "MobileDaemon", entry: SessionEntry) -> None:
                     # the NEXT push is a full repaint that repairs the view.
                     logger.debug("mobile daemon: dropping malformed projection", exc_info=True)
                     continue
-                entry.projection.degraded = entry.degraded
-                entry.projection.ended = entry.ended
+                entry.projection.degraded = False
+                entry.projection.ended = False
+                daemon.session_projections[entry.record.session_id] = entry.projection
                 _fan_out(entry)
             # acks/errors are matched by req id in _request's future map.
             pending = daemon._pending_reqs.pop((record.pid, frame.get("req")), None)
@@ -458,6 +506,9 @@ class MobileDaemon:
         # Session id -> pid of a resume spawn already in flight, so a retried
         # resume POST returns the same child instead of forking a second.
         self.resumes_in_flight: dict[str, int] = {}
+        # A session route outlives every process generation. Retain its latest
+        # repaint so an open phone remains a normal conversation while idle.
+        self.session_projections: dict[str, SessionProjection] = {}
 
     # -- scanning --------------------------------------------------------------
 
@@ -756,24 +807,26 @@ def build_app(daemon: MobileDaemon):
         denied = gate(request)
         if denied is not None:
             return denied
-        pid = int(request.path_params["pid"])
-        entry = daemon.table.entries.get(pid)
-        if entry is None:
-            return JSONResponse({"error": "unknown session"}, status_code=404)
+        session_id = str(request.path_params["session_id"])
+        entry = _entry_for_session(daemon, session_id)
         queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue(maxsize=8)
-        entry.subscribers.add(queue)
+        if entry is not None:
+            entry.subscribers.add(queue)
         # First subscriber = a phone just started watching: tell the session so
         # its self-reaper (if any) counts this front end and holds the session
         # in ACTIVE. Fire-and-forget on the already-open dial writer; an OLD
         # registrant answers `error: unknown op` and that must not 500 the SSE
         # handshake — RuntimeError/TimeoutError are swallowed by design.
-        if len(entry.subscribers) == 1:
-            daemon.notify_watch_transition(pid, watching=True)
 
         async def stream():
             try:
-                if entry.projection is not None:
-                    yield _sse("projection", entry.projection.to_json())
+                projection = daemon.session_projections.get(session_id)
+                if projection is None:
+                    projection = await asyncio.to_thread(_durable_projection, session_id)
+                    if projection is not None:
+                        daemon.session_projections[session_id] = projection
+                if projection is not None:
+                    yield _sse("projection", projection.to_json())
                 while True:
                     try:
                         frame = await asyncio.wait_for(queue.get(), timeout=SSE_KEEPALIVE_S)
@@ -781,13 +834,8 @@ def build_app(daemon: MobileDaemon):
                     except TimeoutError:
                         yield ": keepalive\n\n"
             finally:
-                was_last = entry.subscribers == {queue}
-                entry.subscribers.discard(queue)
-                if was_last:
-                    # Last subscriber out = no phone is watching: the session's
-                    # grace timer (if it has one) may now start. Same swallow
-                    # rules as the watch push above.
-                    daemon.notify_watch_transition(pid, watching=False)
+                if entry is not None:
+                    entry.subscribers.discard(queue)
 
         return StreamingResponse(
             stream(),
@@ -840,8 +888,8 @@ def build_app(daemon: MobileDaemon):
         denied = gate(request)
         if denied is not None:
             return denied
-        pid = int(request.path_params["pid"])
-        entry = daemon.table.entries.get(pid)
+        session_id = str(request.path_params["session_id"])
+        entry = _entry_for_session(daemon, session_id)
         if entry is None:
             return JSONResponse({"error": "unknown session"}, status_code=404)
         before = request.query_params.get("before")
@@ -877,8 +925,8 @@ def build_app(daemon: MobileDaemon):
         denied = gate(request)
         if denied is not None:
             return denied
-        pid = int(request.path_params["pid"])
-        entry = daemon.table.entries.get(pid)
+        session_id = str(request.path_params["session_id"])
+        entry = _entry_for_session(daemon, session_id)
         if entry is None:
             return JSONResponse({"error": "unknown session"}, status_code=404)
         entry_id = request.query_params.get("entry", "")
@@ -905,14 +953,29 @@ def build_app(daemon: MobileDaemon):
         denied = gate(request)
         if denied is not None:
             return denied
-        pid = int(request.path_params["pid"])
+        session_id = str(request.path_params["session_id"])
         try:
             body = await request.json()
         except ValueError:
             return JSONResponse({"error": "invalid JSON"}, status_code=400)
         op = str(body.pop("op", ""))
         try:
-            reply = await daemon.request(pid, op, **body)
+            entry = _entry_for_session(daemon, session_id)
+            if op == "prompt" and entry is None:
+                from local_operator.mobile.attach_client import continue_command
+                from local_operator.mobile.types import ContinuationCommand
+
+                command = ContinuationCommand.from_json(
+                    {**body, "session_id": session_id, "images": body.get("images", [])}
+                )
+                from local_operator.paths import config_dir
+
+                client, detail = await continue_command(config_dir(), command)
+                client.close()
+                return JSONResponse({"ok": True, "detail": detail})
+            if entry is None:
+                raise KeyError(session_id)
+            reply = await daemon.request(entry.record.pid, op, **body)
         except KeyError:
             return JSONResponse({"error": "session not connected"}, status_code=409)
         except TimeoutError:
@@ -1076,10 +1139,10 @@ def build_app(daemon: MobileDaemon):
         Route("/api/sessions/past", api_past_sessions),
         Route("/api/sessions/resume", api_resume_session, methods=["POST"]),
         Route("/api/sessions/search", api_search_sessions),
-        Route("/api/sessions/{pid:int}/events", api_session_events),
-        Route("/api/sessions/{pid:int}/history", api_session_history),
-        Route("/api/sessions/{pid:int}/image", api_session_image),
-        Route("/api/sessions/{pid:int}/command", api_command, methods=["POST"]),
+        Route("/api/sessions/{session_id:str}/events", api_session_events),
+        Route("/api/sessions/{session_id:str}/history", api_session_history),
+        Route("/api/sessions/{session_id:str}/image", api_session_image),
+        Route("/api/sessions/{session_id:str}/command", api_command, methods=["POST"]),
         Route("/api/commands", api_commands),
         Route("/api/models", api_models),
         Route("/mark.png", mark_png),

--- a/local_operator/mobile/daemon.py
+++ b/local_operator/mobile/daemon.py
@@ -108,6 +108,9 @@ class SessionEntry:
         self.next_dial_at: float = 0.0
         self.degraded = False
         self.ended = False
+        # SSE ownership is session-level in SessionTable. A process entry is a
+        # replaceable routing generation and must never own a conversation view.
+        # Kept as an alias only for compatibility with focused diagnostics.
         self.subscribers: set[asyncio.Queue[dict[str, Any]]] = set()
         # Monotonic request id for control frames we originate.
         self._req_seq = 0
@@ -123,6 +126,10 @@ class SessionTable:
     def __init__(self) -> None:
         self.entries: dict[int, SessionEntry] = {}  # by pid
         self.list_subscribers: set[asyncio.Queue[None]] = set()
+        # Durable conversation identity owns viewers across zero or many host
+        # generations. Entries route watch commands but never own these queues.
+        self.session_subscribers: dict[str, set[asyncio.Queue[dict[str, Any]]]] = {}
+        self.provisional_active: set[str] = set()
 
     def summaries(self) -> list[dict[str, Any]]:
         """Reconcile live generations with durable conversations by session id."""
@@ -145,7 +152,9 @@ class SessionTable:
             out.append(
                 {
                     "session_id": session_id,
-                    "section": "active" if entry else "previous",
+                    "section": (
+                        "active" if entry or session_id in self.provisional_active else "previous"
+                    ),
                     "conversation_name": (p.conversation_name if p else "")
                     or (entry.record.conversation_name if entry else "")
                     or (row.name if row else ""),
@@ -293,7 +302,9 @@ async def _dial(daemon: "MobileDaemon", entry: SessionEntry) -> None:
                 entry.projection.degraded = False
                 entry.projection.ended = False
                 daemon.session_projections[entry.record.session_id] = entry.projection
-                _fan_out(entry)
+                daemon.table.provisional_active.discard(entry.record.session_id)
+                daemon.table.notify_list_changed()
+                _fan_out(entry, daemon)
             # acks/errors are matched by req id in _request's future map.
             pending = daemon._pending_reqs.pop((record.pid, frame.get("req")), None)
             if pending is not None and not pending.done():
@@ -305,7 +316,7 @@ async def _dial(daemon: "MobileDaemon", entry: SessionEntry) -> None:
             entry.writer = None
         entry.next_dial_at = time.monotonic() + REDIAL_BACKOFF_S
         entry.degraded = not entry.ended
-        _fan_out(entry)
+        _fan_out(entry, daemon)
 
 
 def _projection_from_json(data: dict[str, Any], record: SessionRecord) -> SessionProjection:
@@ -500,15 +511,17 @@ def _image_bytes(record: SessionRecord, entry_id: str, index: int) -> tuple[byte
     return raw, images[index].mime_type or "image/png"
 
 
-def _fan_out(entry: SessionEntry) -> None:
-    """Push the current projection to every open SSE queue for this session.
-    A slow phone's queue fills; repaints supersede, so evict the oldest and
-    retry until the put lands — a repaint must never be silently lost, because
-    the dropped one might be the approval card."""
+def _fan_out(entry: SessionEntry, daemon: "MobileDaemon | None" = None) -> None:
+    """Push a repaint to durable session viewers, never one pid generation."""
     if entry.projection is None:
         return
     frame = entry.projection.to_json()
-    for queue in entry.subscribers:
+    queues = (
+        daemon.table.session_subscribers.get(entry.record.session_id, set())
+        if daemon is not None
+        else entry.subscribers
+    )
+    for queue in queues:
         while True:
             try:
                 queue.put_nowait(frame)
@@ -539,6 +552,7 @@ class MobileDaemon:
         # A session route outlives every process generation. Retain its latest
         # repaint so an open phone remains a normal conversation while idle.
         self.session_projections: dict[str, SessionProjection] = {}
+        self._wake_settle_tasks: dict[str, asyncio.Task[None]] = {}
 
     # -- scanning --------------------------------------------------------------
 
@@ -560,6 +574,11 @@ class MobileDaemon:
                 entry = SessionEntry(record)
                 self.table.entries[record.pid] = entry
                 changed = True
+                # Durable viewers predate this process generation after a
+                # Previous wake. Rebind only the reaper signal to the new host;
+                # the SSE queues remain owned by session_id in the daemon.
+                if self.table.session_subscribers.get(record.session_id):
+                    self.notify_watch_transition(record.pid, watching=True)
             else:
                 # Re-adopt record updates (model label, name, /resume's new
                 # session id) — the socket survives them by design.
@@ -567,6 +586,31 @@ class MobileDaemon:
             if state == "stale":
                 entry.ended = True
                 changed = True
+                # SIGKILL cannot run owner cleanup. Discovery already proved the
+                # record pid dead; the lease helper revalidates generation and
+                # process identity under the recovery lock before removing only
+                # that claim and its pid mirror. Transcript data is untouched.
+                from local_operator.paths import config_dir
+                from local_operator.session_lease import reap_proven_dead_session_claim
+
+                await asyncio.to_thread(
+                    reap_proven_dead_session_claim,
+                    config_dir() / "sessions" / record.session_id,
+                    record.pid,
+                )
+                self.table.provisional_active.discard(record.session_id)
+                projection = await asyncio.to_thread(_durable_projection, record.session_id)
+                if projection is not None:
+                    self.session_projections[record.session_id] = projection
+                    for queue in self.table.session_subscribers.get(record.session_id, set()):
+                        try:
+                            queue.put_nowait(projection.to_json())
+                        except asyncio.QueueFull:
+                            try:
+                                queue.get_nowait()
+                                queue.put_nowait(projection.to_json())
+                            except asyncio.QueueEmpty:
+                                pass
             elif state == "wedged":
                 entry.degraded = True
             # Degraded is precisely "we owe this session a redial" — the only
@@ -585,8 +629,48 @@ class MobileDaemon:
                 if not entry.ended:
                     entry.ended = True
                     changed = True
+                    session_id = entry.record.session_id
+                    self.table.provisional_active.discard(session_id)
+                    projection = await asyncio.to_thread(_durable_projection, session_id)
+                    if projection is not None:
+                        self.session_projections[session_id] = projection
+                        for queue in self.table.session_subscribers.get(session_id, set()):
+                            try:
+                                queue.put_nowait(projection.to_json())
+                            except asyncio.QueueFull:
+                                try:
+                                    queue.get_nowait()
+                                    queue.put_nowait(projection.to_json())
+                                except asyncio.QueueEmpty:
+                                    pass
         if changed:
             self.table.notify_list_changed()
+
+    def retain_provisional_active(self, session_id: str) -> None:
+        """Hold a wake transition until discovery or one scan interval wins."""
+        previous = self._wake_settle_tasks.pop(session_id, None)
+        if previous is not None:
+            previous.cancel()
+
+        async def settle() -> None:
+            try:
+                await asyncio.sleep(SCAN_INTERVAL_S)
+                await self._scan_once()
+                if _entry_for_session(self, session_id) is None:
+                    self.table.provisional_active.discard(session_id)
+                    projection = await asyncio.to_thread(_durable_projection, session_id)
+                    if projection is not None:
+                        self.session_projections[session_id] = projection
+                        for queue in self.table.session_subscribers.get(session_id, set()):
+                            try:
+                                queue.put_nowait(projection.to_json())
+                            except asyncio.QueueFull:
+                                pass
+                    self.table.notify_list_changed()
+            finally:
+                self._wake_settle_tasks.pop(session_id, None)
+
+        self._wake_settle_tasks[session_id] = asyncio.create_task(settle())
 
     # -- control requests ---------------------------------------------------------
 
@@ -840,8 +924,11 @@ def build_app(daemon: MobileDaemon):
         session_id = str(request.path_params["session_id"])
         entry = _entry_for_session(daemon, session_id)
         queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue(maxsize=8)
-        if entry is not None:
-            entry.subscribers.add(queue)
+        subscribers = daemon.table.session_subscribers.setdefault(session_id, set())
+        first_watcher = not subscribers
+        subscribers.add(queue)
+        if entry is not None and first_watcher:
+            daemon.notify_watch_transition(entry.record.pid, watching=True)
         # First subscriber = a phone just started watching: tell the session so
         # its self-reaper (if any) counts this front end and holds the session
         # in ACTIVE. Fire-and-forget on the already-open dial writer; an OLD
@@ -850,7 +937,8 @@ def build_app(daemon: MobileDaemon):
 
         async def stream():
             try:
-                projection = daemon.session_projections.get(session_id)
+                live = _entry_for_session(daemon, session_id)
+                projection = live.projection if live is not None else None
                 if projection is None:
                     projection = await asyncio.to_thread(_durable_projection, session_id)
                     if projection is not None:
@@ -864,8 +952,14 @@ def build_app(daemon: MobileDaemon):
                     except TimeoutError:
                         yield ": keepalive\n\n"
             finally:
-                if entry is not None:
-                    entry.subscribers.discard(queue)
+                current = daemon.table.session_subscribers.get(session_id)
+                if current is not None:
+                    current.discard(queue)
+                    if not current:
+                        daemon.table.session_subscribers.pop(session_id, None)
+                        live = _entry_for_session(daemon, session_id)
+                        if live is not None:
+                            daemon.notify_watch_transition(live.record.pid, watching=False)
 
         return StreamingResponse(
             stream(),
@@ -994,9 +1088,28 @@ def build_app(daemon: MobileDaemon):
             body = await request.json()
         except ValueError:
             return JSONResponse({"error": "invalid JSON"}, status_code=400)
-        op = str(body.pop("op", ""))
+        if not isinstance(body, dict):
+            return JSONResponse({"error": "request body must be an object"}, status_code=400)
+        body = dict(body)
+        op = body.pop("op", None)
+        if not isinstance(op, str) or not op:
+            return JSONResponse({"error": "op must be a non-empty string"}, status_code=422)
         try:
+            from local_operator.mobile.types import (
+                ContinuationCommand,
+                validate_control_frame,
+            )
+
             entry = _entry_for_session(daemon, session_id)
+            if op == "prompt" and entry is None and _durable_user_session_dir(session_id) is None:
+                raise KeyError(session_id)
+            validate_control_frame({"op": op, "session_id": session_id, **body})
+            # HTTP is a reconnectable producer boundary, so prompt/steer identity
+            # is mandatory even though protocol-v2 loopback clients remain valid.
+            if op in ("prompt", "steer"):
+                ContinuationCommand.from_json(
+                    {**body, "session_id": session_id, "images": body.get("images", [])}
+                )
             if op == "prompt" and entry is None:
                 # Only an existing durable user conversation may wake a host.
                 # Besides authorization, this prevents a malformed/unknown id
@@ -1004,15 +1117,34 @@ def build_app(daemon: MobileDaemon):
                 if _durable_user_session_dir(session_id) is None:
                     raise KeyError(session_id)
                 from local_operator.mobile.attach_client import continue_command
-                from local_operator.mobile.types import ContinuationCommand
 
                 command = ContinuationCommand.from_json(
                     {**body, "session_id": session_id, "images": body.get("images", [])}
                 )
                 from local_operator.paths import config_dir
 
-                client, detail = await continue_command(config_dir(), command)
+                # Publish the accepted wake intent before process discovery. It
+                # remains authoritative until a live projection arrives or the
+                # attempt fails, so even a 50 ms worker is observable in list SSE.
+                daemon.table.provisional_active.add(session_id)
+                daemon.table.notify_list_changed()
+                projection = daemon.session_projections.get(session_id) or _durable_projection(
+                    session_id
+                )
+                if projection is not None:
+                    projection.ended = False
+                    projection.degraded = False
+                    daemon.session_projections[session_id] = projection
+                    for target in daemon.table.session_subscribers.get(session_id, set()):
+                        target.put_nowait(projection.to_json())
+                try:
+                    client, detail = await continue_command(config_dir(), command)
+                except BaseException:
+                    daemon.table.provisional_active.discard(session_id)
+                    daemon.table.notify_list_changed()
+                    raise
                 client.close()
+                daemon.retain_provisional_active(session_id)
                 return JSONResponse({"ok": True, "detail": detail})
             if entry is None:
                 raise KeyError(session_id)
@@ -1026,6 +1158,8 @@ def build_app(daemon: MobileDaemon):
             # failures. The web composer maps every non-2xx continuation reply
             # to its stable retry message while retaining the original command.
             return JSONResponse({"error": str(exc)[:200]}, status_code=502)
+        except ValueError as exc:
+            return JSONResponse({"error": str(exc)}, status_code=422)
         except RuntimeError as exc:
             return JSONResponse({"error": str(exc)}, status_code=422)
         return JSONResponse({"ok": True, "detail": reply.get("detail", "")})

--- a/local_operator/mobile/daemon.py
+++ b/local_operator/mobile/daemon.py
@@ -197,15 +197,32 @@ def _entry_for_session(daemon: "MobileDaemon", session_id: str) -> SessionEntry 
     return max(candidates, key=lambda entry: entry.record.heartbeat_at, default=None)
 
 
-def _durable_projection(session_id: str) -> SessionProjection | None:
-    """Fold a conversation from disk when no execution host exists."""
-    from local_operator.mobile.projection import ProjectionFold
+def _durable_user_session_dir(session_id: str) -> Path | None:
+    """Return a strictly addressed durable user conversation, if it exists.
+
+    Mobile routes are public identifiers, not filesystem paths. Checking the
+    name before joining prevents traversal and checking the origin marker keeps
+    subagent/scheduled transcripts out of the human conversation surface.
+    """
     from local_operator.paths import config_dir
+    from local_operator.resume import is_user_session
+
+    if session_id in ("", ".", "..") or Path(session_id).name != session_id:
+        return None
+    directory = config_dir() / "sessions" / session_id
+    if not (directory / "transcript.jsonl").is_file() or not is_user_session(directory):
+        return None
+    return directory
+
+
+def _durable_projection(session_id: str) -> SessionProjection | None:
+    """Fold a user conversation from disk when no execution host exists."""
+    from local_operator.mobile.projection import ProjectionFold
     from local_operator.resume import stored_session_title
     from local_operator.session.transcript import Transcript
 
-    directory = config_dir() / "sessions" / session_id
-    if not (directory / "transcript.jsonl").exists():
+    directory = _durable_user_session_dir(session_id)
+    if directory is None:
         return None
     projection = SessionProjection(
         session_id=session_id,
@@ -382,7 +399,9 @@ def _transcript_entry_json(entry: Any) -> dict[str, Any]:
     return entry.to_json()
 
 
-def _history_page(record: SessionRecord, before: str | None, limit: int) -> tuple[list[Any], bool]:
+def _history_page(
+    session_id: str, before: str | None, limit: int, *, durable_only: bool = True
+) -> tuple[list[Any], bool]:
     """Fold the session's full on-disk transcript and return the page of
     entries immediately OLDER than ``before`` (chronological within the page)
     plus whether more history exists beyond it.
@@ -391,18 +410,29 @@ def _history_page(record: SessionRecord, before: str | None, limit: int) -> tupl
     a long transcript rehydrates every message and is not loop-safe work.
     """
     from local_operator.mobile.projection import fold_messages_to_entries
-    from local_operator.paths import config_dir
     from local_operator.session.transcript import Transcript
 
-    directory = config_dir() / "sessions" / record.session_id
-    if not (directory / "transcript.jsonl").exists():
+    if durable_only:
+        directory = _durable_user_session_dir(session_id)
+    else:
+        # A live SessionEntry already established the route's identity. Keep
+        # the pre-existing live behavior (including non-user hosts) while still
+        # requiring one safe path component before touching disk.
+        from local_operator.paths import config_dir
+
+        directory = (
+            config_dir() / "sessions" / session_id
+            if session_id not in ("", ".", "..") and Path(session_id).name == session_id
+            else None
+        )
+    if directory is None or not (directory / "transcript.jsonl").is_file():
         return [], False
     try:
         transcript = Transcript(directory)
         history = transcript.build_llm_history()
         entries = fold_messages_to_entries(history)
     except Exception:  # noqa: BLE001 — an odd transcript yields no history, not a 500
-        logger.exception("history fold failed for session %s", record.session_id)
+        logger.exception("history fold failed for session %s", session_id)
         return [], False
 
     if before:
@@ -890,14 +920,20 @@ def build_app(daemon: MobileDaemon):
             return denied
         session_id = str(request.path_params["session_id"])
         entry = _entry_for_session(daemon, session_id)
-        if entry is None:
+        # A host generation is optional for reads: Previous conversations keep
+        # the same public route and page directly from their durable transcript.
+        # Live sessions retain the existing eligibility path; durable-only
+        # routes must prove they are user sessions before any filesystem read.
+        if entry is None and _durable_user_session_dir(session_id) is None:
             return JSONResponse({"error": "unknown session"}, status_code=404)
         before = request.query_params.get("before")
         try:
             limit = max(1, min(int(request.query_params.get("limit", "80")), 200))
         except ValueError:
             limit = 80
-        page, has_more = await asyncio.to_thread(_history_page, entry.record, before, limit)
+        page, has_more = await asyncio.to_thread(
+            _history_page, session_id, before, limit, durable_only=entry is None
+        )
         return JSONResponse(
             {
                 "entries": [_transcript_entry_json(e) for e in page],
@@ -962,6 +998,11 @@ def build_app(daemon: MobileDaemon):
         try:
             entry = _entry_for_session(daemon, session_id)
             if op == "prompt" and entry is None:
+                # Only an existing durable user conversation may wake a host.
+                # Besides authorization, this prevents a malformed/unknown id
+                # from spawning a child that can never own a transcript.
+                if _durable_user_session_dir(session_id) is None:
+                    raise KeyError(session_id)
                 from local_operator.mobile.attach_client import continue_command
                 from local_operator.mobile.types import ContinuationCommand
 
@@ -980,6 +1021,11 @@ def build_app(daemon: MobileDaemon):
             return JSONResponse({"error": "session not connected"}, status_code=409)
         except TimeoutError:
             return JSONResponse({"error": "session did not answer"}, status_code=504)
+        except (ConnectionError, OSError) as exc:
+            # Child construction and daemon/socket failures are transport
+            # failures. The web composer maps every non-2xx continuation reply
+            # to its stable retry message while retaining the original command.
+            return JSONResponse({"error": str(exc)[:200]}, status_code=502)
         except RuntimeError as exc:
             return JSONResponse({"error": str(exc)}, status_code=422)
         return JSONResponse({"ok": True, "detail": reply.get("detail", "")})

--- a/local_operator/mobile/owned.py
+++ b/local_operator/mobile/owned.py
@@ -23,6 +23,7 @@ import argparse
 import asyncio
 import logging
 import secrets
+from asyncio import InvalidStateError
 from typing import TYPE_CHECKING, Any, Callable
 
 from local_operator.harness.types import AgentEvent, ModelChangeEvent
@@ -39,6 +40,16 @@ from local_operator.mobile.types import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _resolve_gate_future(future: asyncio.Future[Any], value: Any) -> None:
+    """Set a gate future's result if it can still take one, swallowing the
+    InvalidStateError otherwise. Module-level so ``call_soon_threadsafe``
+    callbacks (which must never raise) can share it."""
+    try:
+        future.set_result(value)
+    except (InvalidStateError, TypeError):
+        pass
 
 #: How long an approval/ask may sit unanswered before the tool is denied and
 #: the turn told why. A phone in a pocket is the common case; an unbounded
@@ -212,6 +223,59 @@ class OwnedSessionHandle(SessionHandle):
         self._ask_gate = ask_gate
         self._session.set_approval_handler(approval_gate)
         self._session.set_ask_handler(ask_gate)
+
+    async def dispose(self) -> None:
+        """Dispose the underlying session (release the claim, flush, abort).
+
+        The child's clean-exit path calls this rather than reaching through
+        to ``self._session`` so the ordering (deny gates first) stays in one
+        place and hosts cannot forget the claim release."""
+        await self._session.dispose()
+
+    def is_busy(self) -> bool:
+        """True while the session holds work a clean exit would destroy.
+
+        The child reaper's WORK signal (design §4.1): a turn under the lock,
+        an on-demand compaction, live subagents, or a gate parked on the
+        user's answer. A parked approval IS a running turn — the tool slot is
+        held and the conversation is mid-flight, so a reaper that counted it
+        idle would kill sessions waiting on a phone that is merely slow.
+
+        Reads private session state (``_turn_lock``, ``_compacting``) the way
+        the session's own prompt guard does; the alternative — exposing each
+        flag — would widen the session's public surface for one caller."""
+        session = self._session
+        if getattr(session, "is_streaming", False):
+            return True
+        if getattr(session, "_compacting", False):
+            return True
+        if getattr(session, "_turn_lock", None) is not None and session._turn_lock.locked():
+            return True
+        try:
+            if session.running_subagents() > 0:
+                return True
+        except Exception:  # noqa: BLE001 — a broken counter must not wedge the reaper
+            return True
+        if self._pending_futures:
+            return True
+        return False
+
+    def _deny_pending_gates(self) -> None:
+        """Refuse every parked approval/ask so teardown cannot hang on them.
+
+        The clean-exit ordering mirror of OperatorApp.on_unmount (deny gates
+        BEFORE dispose): dispose awaits teardown, and a turn parked on an
+        unanswered card would never reach it. Resolving False/None here is
+        the same answer a timeout would eventually deliver, minus the wait."""
+        for request_id, future in list(self._pending_futures.items()):
+            if not future.done():
+                # None answers an ask ("user escaped"); False would be wrong
+                # there, and None is meaningless to an approval future typed
+                # bool — so resolve by the gate the future serves. Both are
+                # the deny answer their timeout would deliver.
+                value = None if request_id in self._pending_question_ids else False
+                self._loop.call_soon_threadsafe(_resolve_gate_future, future, value)
+        self._pending_futures.clear()
 
     def _resolve_pending(self, request_id: str, value: Any) -> None:
         future = self._pending_futures.get(request_id)

--- a/local_operator/mobile/owned.py
+++ b/local_operator/mobile/owned.py
@@ -536,12 +536,13 @@ class OwnedSessionHandle(SessionHandle):
             try:
                 parameters = inspect.signature(self._session.prompt).parameters
                 if "message_id" in parameters:
-                    await self._session.prompt(
-                        command.text,
-                        command.images,
-                        message_id=command.command_id,
-                        admitted=command.admitted,
-                    )
+                    fields: dict[str, Any] = {
+                        "message_id": command.command_id,
+                        "admitted": command.admitted,
+                    }
+                    if "producer_command_id" in parameters:
+                        fields["producer_command_id"] = command.command_id
+                    await self._session.prompt(command.text, command.images, **fields)
                 else:
                     # Legacy tests/third-party handles have no admission seam;
                     # preserve their historical queue-insertion receipt. Real
@@ -603,8 +604,11 @@ class OwnedSessionHandle(SessionHandle):
         # Images ride the steer too. Producer identity follows the queued user
         # row so a reconnect cannot inject the same correction twice.
         fields: dict[str, Any] = {}
-        if "message_id" in inspect.signature(self._session.steer).parameters:
+        parameters = inspect.signature(self._session.steer).parameters
+        if "message_id" in parameters:
             fields["message_id"] = command_id
+        if "producer_command_id" in parameters:
+            fields["producer_command_id"] = command_id
         try:
             self._session.steer(text, _image_blocks(images), **fields)
         except Exception:

--- a/local_operator/mobile/owned.py
+++ b/local_operator/mobile/owned.py
@@ -346,11 +346,26 @@ class OwnedSessionHandle(SessionHandle):
                 self._loop.call_soon_threadsafe(_resolve_gate_future, future, value)
         self._pending_futures.clear()
 
-    def _resolve_pending(self, request_id: str, value: Any) -> None:
-        future = self._pending_futures.get(request_id)
-        if future is None or future.done():
-            raise ValueError("that prompt is no longer waiting")
-        self._loop.call_soon_threadsafe(future.set_result, value)
+    async def _resolve_pending(self, request_id: str, value: Any) -> None:
+        """Atomically reserve and settle one gate on its owning event loop."""
+        import concurrent.futures
+
+        receipt: concurrent.futures.Future[None] = concurrent.futures.Future()
+
+        def settle() -> None:
+            future = self._pending_futures.pop(request_id, None)
+            if future is None or future.done():
+                receipt.set_exception(ValueError("that prompt is no longer waiting"))
+                return
+            try:
+                future.set_result(value)
+            except (InvalidStateError, TypeError):
+                receipt.set_exception(ValueError("that prompt is no longer waiting"))
+                return
+            receipt.set_result(None)
+
+        self._loop.call_soon_threadsafe(settle)
+        await asyncio.wrap_future(receipt)
 
     # -- SessionHandle -----------------------------------------------------------
 
@@ -556,11 +571,23 @@ class OwnedSessionHandle(SessionHandle):
                 self._prompt_queue.popleft()
                 self._prompt_commands.pop(command.command_id, None)
 
-    async def steer(self, text: str, images: list[dict[str, str]] | None = None) -> str:
+    async def steer(
+        self,
+        text: str,
+        images: list[dict[str, str]] | None = None,
+        command_id: str | None = None,
+    ) -> str:
         self._check_loop_thread()
-        # Images ride the steer too — a screenshot sent mid-turn IS the
-        # correction, and session.steer already carries them.
-        self._session.steer(text, _image_blocks(images))
+        if command_id and any(
+            getattr(message, "id", None) == command_id for message in self._session.history()
+        ):
+            return "already admitted"
+        # Images ride the steer too. Producer identity follows the queued user
+        # row so a reconnect cannot inject the same correction twice.
+        fields: dict[str, Any] = {}
+        if "message_id" in inspect.signature(self._session.steer).parameters:
+            fields["message_id"] = command_id
+        self._session.steer(text, _image_blocks(images), **fields)
         self._projection.queued_count += 1
         self._fold.note_user_message(text, steer=True)
         self._notify()
@@ -612,7 +639,7 @@ class OwnedSessionHandle(SessionHandle):
         raise ValueError("pick the session from the session list instead")
 
     async def approval_answer(self, request_id: str, approved: bool, remember: bool) -> str:
-        self._resolve_pending(request_id, approved)
+        await self._resolve_pending(request_id, approved)
         return "approved" if approved else "denied"
 
     async def ask_answer(
@@ -627,16 +654,11 @@ class OwnedSessionHandle(SessionHandle):
         # Resolve with the QUESTION id the harness asked under — never our
         # request id, which the harness never saw.
         question_id = self._pending_question_ids.get(request_id, request_id)
-        future = self._pending_futures.get(request_id)
-        if future is None or future.done():
-            # Human, reconciling copy (U4): a stale tap means this question
-            # already settled elsewhere — say so rather than the developer-
-            # worded "no longer waiting", so the phone user learns their tap
-            # lost a race instead of the card silently vanishing.
-            raise ValueError("that question was already answered")
-        self._loop.call_soon_threadsafe(
-            future.set_result, {question_id: [value]} if value else None
-        )
+        try:
+            await self._resolve_pending(request_id, {question_id: [value]} if value else None)
+        except ValueError as exc:
+            # Human, reconciling copy: a stale tap means another front end won.
+            raise ValueError("that question was already answered") from exc
         return "answered"
 
     async def refresh(self) -> None:

--- a/local_operator/mobile/owned.py
+++ b/local_operator/mobile/owned.py
@@ -261,6 +261,16 @@ class OwnedSessionHandle(SessionHandle):
             # Ordinary gate timeout owns the non-authorizing answer. Keeping the
             # host busy until then prevents the reaper from denying it early.
             return True
+        manager = getattr(session, "jobs", None)
+        if manager is not None:
+            try:
+                # Session.dispose tears down the whole manager, not only task jobs.
+                # Background bash and capacity-queued jobs therefore carry the same
+                # liveness weight as subagents until their manager row settles.
+                if any(getattr(job, "status", None) == "running" for job in manager.list()):
+                    return True
+            except Exception:  # noqa: BLE001 — uncertainty must fail closed
+                return True
         if any(not task.done() for task in self._background_tasks):
             return True
         return False

--- a/local_operator/mobile/owned.py
+++ b/local_operator/mobile/owned.py
@@ -24,6 +24,7 @@ import asyncio
 import logging
 import secrets
 from asyncio import InvalidStateError
+from collections import deque
 from typing import TYPE_CHECKING, Any, Callable
 
 from local_operator.harness.types import AgentEvent, ModelChangeEvent
@@ -56,6 +57,9 @@ def _resolve_gate_future(future: asyncio.Future[Any], value: Any) -> None:
 #: the turn told why. A phone in a pocket is the common case; an unbounded
 #: wait would pin the turn (and its tool slot) forever.
 PENDING_REQUEST_TIMEOUT_S = 30.0
+# Socket admission is intentionally bounded: many front ends may produce input,
+# but an abandoned automation loop must not grow one owner's memory forever.
+MAX_QUEUED_PROMPTS = 32
 
 
 class OwnedSessionHandle(SessionHandle):
@@ -122,6 +126,12 @@ class OwnedSessionHandle(SessionHandle):
         # request_id -> the AskQuestion.id the harness is waiting on (the
         # answer map's key — see ask_gate).
         self._pending_question_ids: dict[str, str] = {}
+        # One owner process, many producers: ordinary prompts enter this FIFO
+        # and exactly one drain invokes Session.prompt at a time. Session itself
+        # deliberately rejects concurrent calls, so serialization belongs at
+        # this control/admission boundary rather than by adding another writer.
+        self._prompt_queue: deque[tuple[str, list["ImageContent"]]] = deque()
+        self._prompt_drain_task: asyncio.Task[None] | None = None
         self._install_gates()
 
     # -- gates -----------------------------------------------------------------
@@ -231,6 +241,11 @@ class OwnedSessionHandle(SessionHandle):
         The child's clean-exit path calls this rather than reaching through
         to ``self._session`` so the ordering (deny gates first) stays in one
         place and hosts cannot forget the claim release."""
+        drain = self._prompt_drain_task
+        if drain is not None and not drain.done():
+            drain.cancel()
+            await asyncio.gather(drain, return_exceptions=True)
+        self._prompt_queue.clear()
         await self._session.dispose()
 
     def is_busy(self) -> bool:
@@ -256,6 +271,10 @@ class OwnedSessionHandle(SessionHandle):
             if session.running_subagents() > 0:
                 return True
         except Exception:  # noqa: BLE001 — a broken counter must not wedge the reaper
+            return True
+        if self._prompt_queue or (
+            self._prompt_drain_task is not None and not self._prompt_drain_task.done()
+        ):
             return True
         if self._pending_futures:
             # Ordinary gate timeout owns the non-authorizing answer. Keeping the
@@ -331,16 +350,16 @@ class OwnedSessionHandle(SessionHandle):
 
     async def prompt(self, text: str, images: list[dict[str, str]] | None = None) -> str:
         self._check_loop_thread()
-        image_blocks = _image_blocks(images)
-        # A rejected prompt must not leave a ghost user row on the phone, so
-        # the echo waits until Session.prompt has ACCEPTED the turn (the lock
-        # is the honest signal) — see _run_turn_task. Check the cheap guard up
-        # front so the common busy case answers immediately without a task.
-        if self._session.is_streaming or getattr(self._session, "_compacting", False):
-            return "not sent: session is busy — steer instead, or retry in a moment"
+        if len(self._prompt_queue) >= MAX_QUEUED_PROMPTS:
+            raise RuntimeError(
+                f"prompt queue is full ({MAX_QUEUED_PROMPTS}); wait for an admitted turn to start"
+            )
         self._maybe_name_conversation(text)
-        self._run_turn_task(text, image_blocks)
-        return "prompt sent"
+        self._prompt_queue.append((text, _image_blocks(images)))
+        position = len(self._prompt_queue)
+        if self._prompt_drain_task is None or self._prompt_drain_task.done():
+            self._prompt_drain_task = asyncio.ensure_future(self._drain_prompt_queue())
+        return "prompt admitted" if position == 1 else f"prompt queued ({position})"
 
     def _maybe_name_conversation(self, text: str) -> None:
         """Name a still-unnamed conversation from its first real prompt.
@@ -404,29 +423,26 @@ class OwnedSessionHandle(SessionHandle):
         self._refresh_state()
         self._notify()
 
-    def _run_turn_task(self, text: str, image_blocks: list["ImageContent"]) -> None:
-        """Run the turn as a background task; a rejection surfaces as a notice,
-        never as a ghost user row.
+    async def _drain_prompt_queue(self) -> None:
+        """Run admitted ordinary prompts in owner order, one safe turn at a time.
 
-        The session emits MessageStartEvent for a user turn only AFTER the
-        turn lock is acquired (see Session._run_turn), so that event IS the
-        acceptance signal — the fold paints the row from it, and there is no
-        optimistic echo to undo. Session.prompt raises RuntimeError when a
-        turn started in the gap between the guard above and the lock; catching
-        it here keeps the un-awaited-future warning out of the log and gives
-        the phone a quiet "not sent" notice instead of a fake sent row.
+        Accepted input remains in memory until its turn reaches Session.prompt;
+        only that call emits the user row and persists it, giving every viewer
+        one shared projection row rather than one optimistic echo per producer.
         """
-
-        async def run() -> None:
+        while self._prompt_queue:
+            text, image_blocks = self._prompt_queue[0]
             try:
                 await self._session.prompt(text, image_blocks)
             except RuntimeError as exc:
+                # Disposal is a terminal rejection. Other RuntimeErrors are
+                # surfaced but cannot make a later accepted FIFO item disappear.
                 self._projection.streaming = self._session.is_streaming
                 self._fold.note_prompt_rejected(str(exc))
                 self._notify()
-                logger.warning("mobile prompt rejected: %s", exc)
-
-        asyncio.ensure_future(run())
+                logger.warning("mobile prompt rejected after admission: %s", exc)
+            finally:
+                self._prompt_queue.popleft()
 
     async def steer(self, text: str, images: list[dict[str, str]] | None = None) -> str:
         self._check_loop_thread()

--- a/local_operator/mobile/owned.py
+++ b/local_operator/mobile/owned.py
@@ -155,7 +155,8 @@ class OwnedSessionHandle(SessionHandle):
         # Prompt and steer share one identity namespace. In particular, an idle
         # projection may race a turn start and transfer the rejected prompt's
         # identity to steer rather than admitting the same producer twice.
-        self._command_reservations = CommandReservations()
+        self._command_reservations = CommandReservations(session)
+        self._unsubscribe_admitted_commands = self._command_reservations.subscribe_durable()
         self._disposing = False
         self._install_gates()
 
@@ -282,6 +283,7 @@ class OwnedSessionHandle(SessionHandle):
                 )
             self._fold.note_prompt_rejected("session closed before the prompt was admitted")
         self._notify()
+        self._unsubscribe_admitted_commands()
         self._command_reservations.clear()
         await self._session.dispose()
 
@@ -419,7 +421,7 @@ class OwnedSessionHandle(SessionHandle):
         if existing is not None:
             await existing.admitted
             return "already admitted"
-        if not self._command_reservations.reserve(command_id, self._session.history()):
+        if not self._command_reservations.reserve(command_id, kind="prompt"):
             return "already admitted"
         if self._disposing:
             self._command_reservations.reject(command_id)
@@ -594,7 +596,7 @@ class OwnedSessionHandle(SessionHandle):
         command_id = command_id or str(uuid.uuid4())
         if not self._command_reservations.reserve(
             command_id,
-            self._session.history(),
+            kind="steer",
             prompt_transfer=True,
         ):
             return "already admitted"

--- a/local_operator/mobile/owned.py
+++ b/local_operator/mobile/owned.py
@@ -21,10 +21,13 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import inspect
 import logging
 import secrets
+import uuid
 from asyncio import InvalidStateError
 from collections import deque
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Callable
 
 from local_operator.harness.types import AgentEvent, ModelChangeEvent
@@ -60,6 +63,19 @@ PENDING_REQUEST_TIMEOUT_S = 30.0
 # Socket admission is intentionally bounded: many front ends may produce input,
 # but an abandoned automation loop must not grow one owner's memory forever.
 MAX_QUEUED_PROMPTS = 32
+
+
+@dataclass
+class _PromptCommand:
+    command_id: str
+    text: str
+    images: list["ImageContent"]
+    admitted: asyncio.Future[None]
+
+    def __iter__(self):  # type: ignore[no-untyped-def]
+        # Tuple compatibility for older diagnostics that inspect the queue.
+        yield self.text
+        yield self.images
 
 
 class OwnedSessionHandle(SessionHandle):
@@ -130,7 +146,10 @@ class OwnedSessionHandle(SessionHandle):
         # and exactly one drain invokes Session.prompt at a time. Session itself
         # deliberately rejects concurrent calls, so serialization belongs at
         # this control/admission boundary rather than by adding another writer.
-        self._prompt_queue: deque[tuple[str, list["ImageContent"]]] = deque()
+        self._prompt_queue: deque[_PromptCommand] = deque()
+        # Pending and running duplicates join the same durable-admission future;
+        # completed duplicates are recognized from transcript-backed history.
+        self._prompt_commands: dict[str, _PromptCommand] = {}
         self._prompt_drain_task: asyncio.Task[None] | None = None
         self._disposing = False
         self._install_gates()
@@ -247,12 +266,16 @@ class OwnedSessionHandle(SessionHandle):
         if drain is not None and not drain.done():
             drain.cancel()
             await asyncio.gather(drain, return_exceptions=True)
-        # Every prompt below was already acknowledged to its producer. Reject
-        # each explicitly in the shared projection instead of silently erasing
-        # admissions that never reached Session.prompt.
+        # Anything still queued has no durable receipt. Wake every producer so
+        # it can retain and retry the same identity rather than hanging forever.
         while self._prompt_queue:
-            self._prompt_queue.popleft()
-            self._fold.note_prompt_rejected("session closed before the admitted prompt could run")
+            command = self._prompt_queue.popleft()
+            self._prompt_commands.pop(command.command_id, None)
+            if not command.admitted.done():
+                command.admitted.set_exception(
+                    RuntimeError("session closed before the prompt was admitted")
+                )
+            self._fold.note_prompt_rejected("session closed before the prompt was admitted")
         self._notify()
         await self._session.dispose()
 
@@ -360,8 +383,23 @@ class OwnedSessionHandle(SessionHandle):
         self._reconcile_streaming()
         return unsubscribe
 
-    async def prompt(self, text: str, images: list[dict[str, str]] | None = None) -> str:
+    async def prompt(
+        self,
+        text: str,
+        images: list[dict[str, str]] | None = None,
+        command_id: str | None = None,
+    ) -> str:
         self._check_loop_thread()
+        if not command_id:
+            # Only old in-process callers omit the v3 field. Minting here keeps
+            # their local submission valid; all wire producers retain their id.
+            command_id = str(uuid.uuid4())
+        existing = self._prompt_commands.get(command_id)
+        if existing is not None:
+            await existing.admitted
+            return "already admitted"
+        if any(getattr(message, "id", None) == command_id for message in self._session.history()):
+            return "already admitted"
         if self._disposing:
             raise RuntimeError("session is closing; prompt was not admitted")
         if len(self._prompt_queue) >= MAX_QUEUED_PROMPTS:
@@ -369,14 +407,25 @@ class OwnedSessionHandle(SessionHandle):
                 f"prompt queue is full ({MAX_QUEUED_PROMPTS}); wait for an admitted turn to start"
             )
         self._maybe_name_conversation(text)
-        self._prompt_queue.append((text, _image_blocks(images)))
-        position = len(self._prompt_queue)
+        admitted: asyncio.Future[None] = self._loop.create_future()
+        command = _PromptCommand(command_id, text, _image_blocks(images), admitted)
+        position = len(self._prompt_queue) + 1
+        legacy_prompt = "message_id" not in inspect.signature(self._session.prompt).parameters
+        # Compatibility-only fake/third-party sessions predate durable
+        # admission. Production Session exposes ``message_id`` and never takes
+        # this early-receipt branch.
+        if legacy_prompt:
+            admitted.set_result(None)
+        self._prompt_commands[command_id] = command
+        self._prompt_queue.append(command)
         if self._prompt_drain_task is None or self._prompt_drain_task.done():
             self._prompt_drain_task = asyncio.ensure_future(self._drain_prompt_queue())
-            # Retrieving an unexpected BaseException prevents a background-task
-            # warning while preserving cancellation/SystemExit semantics.
             self._prompt_drain_task.add_done_callback(self._observe_prompt_drain)
-        return "prompt admitted" if position == 1 else f"prompt queued ({position})"
+        # ACK is the durable transcript append, never insertion into this queue.
+        await admitted
+        if legacy_prompt and position > 1:
+            return f"prompt queued ({position})"
+        return "prompt admitted"
 
     @staticmethod
     def _observe_prompt_drain(task: asyncio.Task[None]) -> None:
@@ -457,10 +506,28 @@ class OwnedSessionHandle(SessionHandle):
         one shared projection row rather than one optimistic echo per producer.
         """
         while self._prompt_queue:
-            text, image_blocks = self._prompt_queue[0]
+            command = self._prompt_queue[0]
             try:
-                await self._session.prompt(text, image_blocks)
+                parameters = inspect.signature(self._session.prompt).parameters
+                if "message_id" in parameters:
+                    await self._session.prompt(
+                        command.text,
+                        command.images,
+                        message_id=command.command_id,
+                        admitted=command.admitted,
+                    )
+                else:
+                    # Legacy tests/third-party handles have no admission seam;
+                    # preserve their historical queue-insertion receipt. Real
+                    # Session implementations always take the durable branch.
+                    if not command.admitted.done():
+                        command.admitted.set_result(None)
+                    await self._session.prompt(command.text, command.images)
             except asyncio.CancelledError:
+                if not command.admitted.done():
+                    command.admitted.set_exception(
+                        RuntimeError("session closed before the prompt was admitted")
+                    )
                 # The in-flight admission is popped by finally, so record its
                 # terminal rejection here; dispose handles only those still queued.
                 self._projection.streaming = False
@@ -471,6 +538,8 @@ class OwnedSessionHandle(SessionHandle):
                 # Cancellation is control flow and must remain cancellation.
                 raise
             except Exception as exc:  # noqa: BLE001 — admitted turns need terminal handling
+                if not command.admitted.done():
+                    command.admitted.set_exception(exc)
                 # Provider, transcript, and tool failures are all terminal for
                 # this one admission. Surface the failure asynchronously, then
                 # continue in FIFO order without retrying the failed head.
@@ -485,6 +554,7 @@ class OwnedSessionHandle(SessionHandle):
                 raise
             finally:
                 self._prompt_queue.popleft()
+                self._prompt_commands.pop(command.command_id, None)
 
     async def steer(self, text: str, images: list[dict[str, str]] | None = None) -> str:
         self._check_loop_thread()

--- a/local_operator/mobile/owned.py
+++ b/local_operator/mobile/owned.py
@@ -132,6 +132,7 @@ class OwnedSessionHandle(SessionHandle):
         # this control/admission boundary rather than by adding another writer.
         self._prompt_queue: deque[tuple[str, list["ImageContent"]]] = deque()
         self._prompt_drain_task: asyncio.Task[None] | None = None
+        self._disposing = False
         self._install_gates()
 
     # -- gates -----------------------------------------------------------------
@@ -241,11 +242,18 @@ class OwnedSessionHandle(SessionHandle):
         The child's clean-exit path calls this rather than reaching through
         to ``self._session`` so the ordering (deny gates first) stays in one
         place and hosts cannot forget the claim release."""
+        self._disposing = True
         drain = self._prompt_drain_task
         if drain is not None and not drain.done():
             drain.cancel()
             await asyncio.gather(drain, return_exceptions=True)
-        self._prompt_queue.clear()
+        # Every prompt below was already acknowledged to its producer. Reject
+        # each explicitly in the shared projection instead of silently erasing
+        # admissions that never reached Session.prompt.
+        while self._prompt_queue:
+            self._prompt_queue.popleft()
+            self._fold.note_prompt_rejected("session closed before the admitted prompt could run")
+        self._notify()
         await self._session.dispose()
 
     def is_busy(self) -> bool:
@@ -260,6 +268,10 @@ class OwnedSessionHandle(SessionHandle):
         Reads private session state (``_turn_lock``, ``_compacting``) the way
         the session's own prompt guard does; the alternative — exposing each
         flag — would widen the session's public surface for one caller."""
+        if self._disposing:
+            # Disposal has explicitly rejected the admission queue and owns
+            # teardown now; stale provider streaming flags must not wedge exit.
+            return False
         session = self._session
         if getattr(session, "is_streaming", False):
             return True
@@ -350,6 +362,8 @@ class OwnedSessionHandle(SessionHandle):
 
     async def prompt(self, text: str, images: list[dict[str, str]] | None = None) -> str:
         self._check_loop_thread()
+        if self._disposing:
+            raise RuntimeError("session is closing; prompt was not admitted")
         if len(self._prompt_queue) >= MAX_QUEUED_PROMPTS:
             raise RuntimeError(
                 f"prompt queue is full ({MAX_QUEUED_PROMPTS}); wait for an admitted turn to start"
@@ -359,7 +373,19 @@ class OwnedSessionHandle(SessionHandle):
         position = len(self._prompt_queue)
         if self._prompt_drain_task is None or self._prompt_drain_task.done():
             self._prompt_drain_task = asyncio.ensure_future(self._drain_prompt_queue())
+            # Retrieving an unexpected BaseException prevents a background-task
+            # warning while preserving cancellation/SystemExit semantics.
+            self._prompt_drain_task.add_done_callback(self._observe_prompt_drain)
         return "prompt admitted" if position == 1 else f"prompt queued ({position})"
+
+    @staticmethod
+    def _observe_prompt_drain(task: asyncio.Task[None]) -> None:
+        if task.cancelled():
+            return
+        try:
+            task.exception()
+        except asyncio.CancelledError:
+            return
 
     def _maybe_name_conversation(self, text: str) -> None:
         """Name a still-unnamed conversation from its first real prompt.
@@ -434,13 +460,29 @@ class OwnedSessionHandle(SessionHandle):
             text, image_blocks = self._prompt_queue[0]
             try:
                 await self._session.prompt(text, image_blocks)
-            except RuntimeError as exc:
-                # Disposal is a terminal rejection. Other RuntimeErrors are
-                # surfaced but cannot make a later accepted FIFO item disappear.
+            except asyncio.CancelledError:
+                # The in-flight admission is popped by finally, so record its
+                # terminal rejection here; dispose handles only those still queued.
+                self._projection.streaming = False
+                self._fold.note_prompt_rejected(
+                    "session closed before the admitted prompt could complete"
+                )
+                self._notify()
+                # Cancellation is control flow and must remain cancellation.
+                raise
+            except Exception as exc:  # noqa: BLE001 — admitted turns need terminal handling
+                # Provider, transcript, and tool failures are all terminal for
+                # this one admission. Surface the failure asynchronously, then
+                # continue in FIFO order without retrying the failed head.
                 self._projection.streaming = self._session.is_streaming
                 self._fold.note_prompt_rejected(str(exc))
                 self._notify()
-                logger.warning("mobile prompt rejected after admission: %s", exc)
+                logger.exception("mobile prompt failed after admission")
+            except BaseException:
+                # KeyboardInterrupt/SystemExit retain their process semantics;
+                # the finally block still removes exactly the failed admission.
+                logger.critical("mobile prompt drain terminated", exc_info=True)
+                raise
             finally:
                 self._prompt_queue.popleft()
 

--- a/local_operator/mobile/owned.py
+++ b/local_operator/mobile/owned.py
@@ -34,6 +34,7 @@ from local_operator.harness.types import AgentEvent, ModelChangeEvent
 
 if TYPE_CHECKING:
     from local_operator.harness.types import ImageContent
+from local_operator.mobile.command_reservation import CommandReservations
 from local_operator.mobile.projection import ProjectionFold
 from local_operator.mobile.registrant import SessionHandle
 from local_operator.mobile.registrant import image_blocks as _image_blocks
@@ -151,6 +152,10 @@ class OwnedSessionHandle(SessionHandle):
         # completed duplicates are recognized from transcript-backed history.
         self._prompt_commands: dict[str, _PromptCommand] = {}
         self._prompt_drain_task: asyncio.Task[None] | None = None
+        # Prompt and steer share one identity namespace. In particular, an idle
+        # projection may race a turn start and transfer the rejected prompt's
+        # identity to steer rather than admitting the same producer twice.
+        self._command_reservations = CommandReservations()
         self._disposing = False
         self._install_gates()
 
@@ -277,6 +282,7 @@ class OwnedSessionHandle(SessionHandle):
                 )
             self._fold.note_prompt_rejected("session closed before the prompt was admitted")
         self._notify()
+        self._command_reservations.clear()
         await self._session.dispose()
 
     def is_busy(self) -> bool:
@@ -413,11 +419,13 @@ class OwnedSessionHandle(SessionHandle):
         if existing is not None:
             await existing.admitted
             return "already admitted"
-        if any(getattr(message, "id", None) == command_id for message in self._session.history()):
+        if not self._command_reservations.reserve(command_id, self._session.history()):
             return "already admitted"
         if self._disposing:
+            self._command_reservations.reject(command_id)
             raise RuntimeError("session is closing; prompt was not admitted")
         if len(self._prompt_queue) >= MAX_QUEUED_PROMPTS:
+            self._command_reservations.reject(command_id)
             raise RuntimeError(
                 f"prompt queue is full ({MAX_QUEUED_PROMPTS}); wait for an admitted turn to start"
             )
@@ -438,6 +446,7 @@ class OwnedSessionHandle(SessionHandle):
             self._prompt_drain_task.add_done_callback(self._observe_prompt_drain)
         # ACK is the durable transcript append, never insertion into this queue.
         await admitted
+        self._command_reservations.accept(command_id)
         if legacy_prompt and position > 1:
             return f"prompt queued ({position})"
         return "prompt admitted"
@@ -554,6 +563,10 @@ class OwnedSessionHandle(SessionHandle):
                 raise
             except Exception as exc:  # noqa: BLE001 — admitted turns need terminal handling
                 if not command.admitted.done():
+                    self._command_reservations.reject(
+                        command.command_id,
+                        transfer_to_steer="already streaming" in str(exc),
+                    )
                     command.admitted.set_exception(exc)
                 # Provider, transcript, and tool failures are all terminal for
                 # this one admission. Surface the failure asynchronously, then
@@ -578,8 +591,11 @@ class OwnedSessionHandle(SessionHandle):
         command_id: str | None = None,
     ) -> str:
         self._check_loop_thread()
-        if command_id and any(
-            getattr(message, "id", None) == command_id for message in self._session.history()
+        command_id = command_id or str(uuid.uuid4())
+        if not self._command_reservations.reserve(
+            command_id,
+            self._session.history(),
+            prompt_transfer=True,
         ):
             return "already admitted"
         # Images ride the steer too. Producer identity follows the queued user
@@ -587,7 +603,14 @@ class OwnedSessionHandle(SessionHandle):
         fields: dict[str, Any] = {}
         if "message_id" in inspect.signature(self._session.steer).parameters:
             fields["message_id"] = command_id
-        self._session.steer(text, _image_blocks(images), **fields)
+        try:
+            self._session.steer(text, _image_blocks(images), **fields)
+        except Exception:
+            # No queue insertion means no durable acceptance exists; the same
+            # producer identity must remain retryable after this terminal reject.
+            self._command_reservations.reject(command_id)
+            raise
+        self._command_reservations.accept(command_id)
         self._projection.queued_count += 1
         self._fold.note_user_message(text, steer=True)
         self._notify()

--- a/local_operator/mobile/owned.py
+++ b/local_operator/mobile/owned.py
@@ -55,7 +55,7 @@ def _resolve_gate_future(future: asyncio.Future[Any], value: Any) -> None:
 #: How long an approval/ask may sit unanswered before the tool is denied and
 #: the turn told why. A phone in a pocket is the common case; an unbounded
 #: wait would pin the turn (and its tool slot) forever.
-PENDING_REQUEST_TIMEOUT_S = 3600.0
+PENDING_REQUEST_TIMEOUT_S = 30.0
 
 
 class OwnedSessionHandle(SessionHandle):
@@ -258,6 +258,10 @@ class OwnedSessionHandle(SessionHandle):
         except Exception:  # noqa: BLE001 — a broken counter must not wedge the reaper
             return True
         if self._pending_futures:
+            # Ordinary gate timeout owns the non-authorizing answer. Keeping the
+            # host busy until then prevents the reaper from denying it early.
+            return True
+        if any(not task.done() for task in self._background_tasks):
             return True
         return False
 

--- a/local_operator/mobile/owned.py
+++ b/local_operator/mobile/owned.py
@@ -51,6 +51,7 @@ def _resolve_gate_future(future: asyncio.Future[Any], value: Any) -> None:
     except (InvalidStateError, TypeError):
         pass
 
+
 #: How long an approval/ask may sit unanswered before the tool is denied and
 #: the turn told why. A phone in a pocket is the common case; an unbounded
 #: wait would pin the turn (and its tool slot) forever.

--- a/local_operator/mobile/registrant.py
+++ b/local_operator/mobile/registrant.py
@@ -35,6 +35,8 @@ import logging
 import os
 import secrets
 import threading
+import time
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Callable, Protocol
 
 if TYPE_CHECKING:
@@ -43,7 +45,9 @@ if TYPE_CHECKING:
 from local_operator.mobile.projection import ProjectionFold
 from local_operator.mobile.registry import RecordPublisher
 from local_operator.mobile.types import (
+    ATTACH_MAX_CLIENTS,
     HEARTBEAT_INTERVAL_S,
+    ClientKind,
     PendingRequest,
     SessionProjection,
     SessionRecord,
@@ -81,6 +85,23 @@ def image_blocks(images: list[dict[str, str]] | None) -> list["ImageContent"]:
 #: A prompt payload past 1 MB is a bug, not a prompt — the line limit the
 #: control socket reader enforces.
 _MAX_LINE_BYTES = 1 << 20
+
+
+@dataclass
+class _ClientConn:
+    """One authenticated control connection in the registrant's registry.
+
+    Multiplexing is already half-there (frames carry caller-chosen ``req``
+    ids), so multi-front-end needs N concurrent connections on the ONE
+    socket rather than a second protocol: the daemon plus up to
+    ``ATTACH_MAX_CLIENTS`` attach terminals. ``last_seen`` is the LRU clock
+    for attach eviction — stamped on every request so the least-recently-ACTIVE
+    follower is the one dropped when the cap is hit.
+    """
+
+    writer: asyncio.StreamWriter
+    kind: ClientKind
+    last_seen: float = field(default_factory=time.monotonic)
 
 
 class SessionHandle(Protocol):
@@ -144,7 +165,11 @@ class Registrant:
         )
         self._publisher: RecordPublisher | None = None
         self._server: asyncio.AbstractServer | None = None
-        self._writer: asyncio.StreamWriter | None = None
+        # N authenticated connections keyed by id(writer): one daemon (a new
+        # daemon dial evicts the old — that IS its reconnect story) plus up to
+        # ATTACH_MAX_CLIENTS attach clients. A single _writer could not carry
+        # the phone bridge and a follower terminal at once.
+        self._clients: dict[int, _ClientConn] = {}
         self._thread: threading.Thread | None = None
         self._loop: asyncio.AbstractEventLoop | None = None
         self._unsubscribe: Callable[[], None] | None = None
@@ -152,6 +177,18 @@ class Registrant:
         self._push_scheduled = False
         self._send_lock: asyncio.Lock | None = None
         self._heartbeat_task: asyncio.Task[None] | None = None
+        # -- front-end accounting (the child reaper's inputs, §4) --------------
+        # Phone SSE watchers, fed by the daemon's watch/unwatch pushes. Floored
+        # at 0: a daemon restart redials without unwatching, and a counter that
+        # went negative would read as "watchers" to an == 0 check forever.
+        self.phone_watchers: int = 0
+        # Latched True on the first watch/unwatch EVER received. Until then
+        # watcher count is UNKNOWN (an old daemon never sends the ops), and
+        # unknown must be treated as "present" — a new child under an old
+        # daemon must not reap a session a phone is actively watching. The
+        # latch never resets: once a watch-capable daemon has spoken, absence
+        # of the op means absence of watchers.
+        self.watch_supported: bool = False
 
     # -- lifecycle -----------------------------------------------------------
 
@@ -256,11 +293,12 @@ class Registrant:
             self._heartbeat_task.cancel()
         if self._server is not None:
             self._server.close()
-        if self._writer is not None:
+        for conn in list(self._clients.values()):
             try:
-                self._writer.close()
+                conn.writer.close()
             except Exception:  # noqa: BLE001
                 pass
+        self._clients.clear()
 
     async def _heartbeat_loop(self) -> None:
         while not self._closed.is_set():
@@ -284,16 +322,19 @@ class Registrant:
     async def _on_connection(
         self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
     ) -> None:
-        """One daemon connection. Auth is the first frame: ``{"key": ...}``
+        """One control connection. Auth is the first frame: ``{"key": ...}``
         within a short deadline, constant-time compared. Anything else closes
         without a reply — an open port that answers wrong keys with errors is
         an oracle, however small.
 
-        One control connection at a time — the daemon is the only legitimate
-        client, and a second one racing it would interleave repaints on the
-        same socket. A new dial REPLACES the old, which is also the reconnect
-        story: the daemon re-dials after any drop and the stale socket is
-        evicted."""
+        Protocol v2 carries N connections: one ``daemon`` plus up to
+        ``ATTACH_MAX_CLIENTS`` ``attach`` followers. A new daemon dial still
+        REPLACES the old one (that is its reconnect story, preserved from the
+        single-writer era); a further attach dial past the cap evicts the
+        least-recently-seen attach client. Connection close is detected by
+        the reader loop's ``finally``; the cap only guards leaked-but-open
+        sockets liveness detection cannot see.
+        """
         peer = writer.get_extra_info("peername")
         try:
             line = await asyncio.wait_for(reader.readline(), timeout=5.0)
@@ -306,47 +347,102 @@ class Registrant:
             logger.warning("mobile control: rejected bad key from %s", peer)
             writer.close()
             return
+        # Absent client field means daemon: an OLD daemon dialing a NEW
+        # registrant must land on the class it always had, or every rolling
+        # upgrade would demote the phone bridge to a follower.
+        raw_kind = frame.get("client", "daemon")
+        kind: ClientKind = "attach" if raw_kind == "attach" else "daemon"
 
-        # Authenticated: this becomes THE daemon connection. A prior one is
-        # evicted — reconnect after a drop is the normal path here.
-        if self._writer is not None:
-            try:
-                self._writer.close()
-            except Exception:  # noqa: BLE001
-                pass
-        self._writer = writer
-        await self._push()  # the welcome: a full projection, unprompted
+        if kind == "daemon":
+            # At most ONE daemon connection — a new dial evicts the old, which
+            # is also the reconnect path after a daemon restart.
+            for other in [
+                c for c in self._clients.values() if c.kind == "daemon" and c.writer is not writer
+            ]:
+                self._drop_client(other)
+        else:
+            # Attach cap with LRU eviction: the least-recently-seen follower
+            # goes. Sending on the evicted socket first (a goodbye) is not
+            # worth the failure modes — its reader loop is still alive and
+            # will observe the close as EOF, which is the attach screen's
+            # owner-death signal minus a corpse.
+            attaches = [c for c in self._clients.values() if c.kind == "attach"]
+            if len(attaches) >= ATTACH_MAX_CLIENTS:
+                victim = min(attaches, key=lambda c: c.last_seen)
+                logger.info("mobile control: evicting attach client %s (cap)", peer)
+                self._drop_client(victim)
+
+        conn = _ClientConn(writer=writer, kind=kind)
+        self._clients[id(writer)] = conn
+        await self._push_to(conn)  # the welcome: a full projection, unprompted
         try:
             while not self._closed.is_set():
                 line = await reader.readline()
                 if not line:
-                    return  # daemon hung up
+                    return  # client hung up
                 try:
                     frame = json.loads(line.decode("utf-8", "replace"))
                 except ValueError:
                     continue
-                await self._on_request(frame)
+                conn.last_seen = time.monotonic()
+                await self._on_request(frame, conn)
         except (ConnectionResetError, BrokenPipeError):
             return
         finally:
-            if self._writer is writer:
-                self._writer = None
-            try:
-                writer.close()
-            except Exception:  # noqa: BLE001
-                pass
+            self._drop_client(conn)
 
-    async def _on_request(self, frame: dict[str, Any]) -> None:
+    def _drop_client(self, conn: _ClientConn) -> None:
+        """Remove one connection from the registry and close its socket.
+
+        The ONLY removal path: reader-loop exit, shutdown, daemon eviction,
+        and attach-cap eviction all funnel here so the registry can never
+        retain an entry whose socket is closed (the reaper counts them)."""
+        self._clients.pop(id(conn.writer), None)
+        try:
+            conn.writer.close()
+        except Exception:  # noqa: BLE001
+            pass
+
+    def attach_clients(self) -> int:
+        """How many attach (follower terminal) connections are live.
+
+        The child reaper's front-end count: an attached TUI is a front end
+        exactly like a phone, so it must hold the child in ACTIVE."""
+        return sum(1 for c in self._clients.values() if c.kind == "attach")
+
+    async def _on_request(self, frame: dict[str, Any], conn: _ClientConn) -> None:
         op = str(frame.get("op") or "")
         req = frame.get("req")
         try:
-            detail = await self._dispatch(op, frame)
-            await self._send({"op": "ack", "req": req, "detail": detail})
-            # Mutations change the projection; push what the phone should see.
-            await self._handle.refresh()
-            await self._push()
+            # Attach clients are followers: rebinding the owner's conversation
+            # from a follower terminal surprises the user AT THAT TERMINAL's
+            # owner. The error frame is the reply — the attach screen surfaces
+            # it like any other rejected op. The daemon keeps both ops (the
+            # phone's resume button rides them).
+            if conn.kind == "attach" and op in ("new_conversation", "resume_session"):
+                raise ValueError(
+                    "attached front ends cannot rebind the session; detach and /resume instead"
+                )
+            if op in ("watch", "unwatch"):
+                # The reaper's phone-watcher signal (§2.8). watch_supported
+                # latches on the FIRST op seen so a mixed-version child never
+                # mistakes silence for zero watchers.
+                self.watch_supported = True
+                if op == "watch":
+                    self.phone_watchers += 1
+                else:
+                    self.phone_watchers = max(0, self.phone_watchers - 1)
+                detail = f"watchers: {self.phone_watchers}"
+            else:
+                detail = await self._dispatch(op, frame)
+            await self._send_to(conn, {"op": "ack", "req": req, "detail": detail})
+            # Mutations change the projection; push what every front end
+            # should see.
+            if op not in ("watch", "unwatch"):
+                await self._handle.refresh()
+                await self._push()
         except Exception as exc:  # noqa: BLE001 — the error IS the reply
-            await self._send({"op": "error", "req": req, "message": str(exc)[:400]})
+            await self._send_to(conn, {"op": "error", "req": req, "message": str(exc)[:400]})
             await self._push()
 
     async def _dispatch(self, op: str, frame: dict[str, Any]) -> str:
@@ -428,17 +524,41 @@ class Registrant:
         await self._push()
 
     async def _push(self) -> None:
-        await self._send({"op": "projection", "data": self._fold.projection.to_json()})
+        """Broadcast a projection repaint to every live connection.
 
-    async def _send(self, frame: dict[str, Any]) -> None:
-        if self._writer is None or self._send_lock is None:
+        Projections are snapshots (no deltas), so every front end wants each
+        one — the daemon fans it to the phone, each attach terminal renders
+        it directly. Sending is per-connection: one dead socket must not
+        block or corrupt the others' frames."""
+        await self._broadcast({"op": "projection", "data": self._fold.projection.to_json()})
+
+    async def _push_to(self, conn: _ClientConn) -> None:
+        """The welcome form of a push: one full projection to one connection."""
+        await self._send_to(conn, {"op": "projection", "data": self._fold.projection.to_json()})
+
+    async def _broadcast(self, frame: dict[str, Any]) -> None:
+        # Copy the registry: a send failure drops its own entry, and mutating
+        # the dict mid-iteration is exactly the failure being handled.
+        for conn in list(self._clients.values()):
+            await self._send_to(conn, frame)
+
+    async def _send_to(self, conn: _ClientConn, frame: dict[str, Any]) -> None:
+        """One frame to one connection. A failed send drops ONLY that client
+        from the registry (never retried — the reader loop will observe the
+        close and its finally is a no-op second removal)."""
+        if self._send_lock is None:
             return
         async with self._send_lock:
             try:
-                self._writer.write(json.dumps(frame).encode() + b"\n")
-                await self._writer.drain()
-            except (ConnectionResetError, BrokenPipeError):
-                self._writer = None
+                conn.writer.write(json.dumps(frame).encode() + b"\n")
+                await conn.writer.drain()
+            except (ConnectionResetError, BrokenPipeError, OSError):
+                self._drop_client(conn)
+
+    async def _send(self, frame: dict[str, Any]) -> None:
+        """Broadcast alias kept for the pre-v2 call shape (tests, hosts that
+        grabbed a reference before the bump)."""
+        await self._broadcast(frame)
 
     # -- host-facing helpers ----------------------------------------------------
 

--- a/local_operator/mobile/registrant.py
+++ b/local_operator/mobile/registrant.py
@@ -85,6 +85,10 @@ def image_blocks(images: list[dict[str, str]] | None) -> list["ImageContent"]:
 #: A prompt payload past 1 MB is a bug, not a prompt — the line limit the
 #: control socket reader enforces.
 _MAX_LINE_BYTES = 1 << 20
+# A projection is replaceable state. If a peer cannot accept one within this
+# bound, dropping that peer is safer than blocking authority-bearing ACKs for
+# every healthy front end.
+_SEND_TIMEOUT_S = 1.0
 
 
 @dataclass
@@ -102,6 +106,9 @@ class _ClientConn:
     writer: asyncio.StreamWriter
     kind: ClientKind
     last_seen: float = field(default_factory=time.monotonic)
+    # Frames on one TCP stream must stay ordered, while unrelated streams must
+    # never queue behind its backpressure.
+    send_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
 
 
 class SessionHandle(Protocol):
@@ -175,7 +182,6 @@ class Registrant:
         self._unsubscribe: Callable[[], None] | None = None
         self._closed = threading.Event()
         self._push_scheduled = False
-        self._send_lock: asyncio.Lock | None = None
         self._heartbeat_task: asyncio.Task[None] | None = None
         # -- front-end accounting (the child reaper's inputs, §4) --------------
         # Phone SSE watchers, fed by the daemon's watch/unwatch pushes. Floored
@@ -208,7 +214,6 @@ class Registrant:
         if self._server is not None:
             return
         self._loop = asyncio.get_running_loop()
-        self._send_lock = asyncio.Lock()
         await self._serve()
 
     def close(self) -> None:
@@ -255,7 +260,6 @@ class Registrant:
     def _run(self) -> None:
         loop = asyncio.new_event_loop()
         self._loop = loop
-        self._send_lock = asyncio.Lock()
         try:
             loop.run_until_complete(self._serve())
         except Exception:  # noqa: BLE001 — a dead registrant must not kill the host
@@ -539,20 +543,17 @@ class Registrant:
     async def _broadcast(self, frame: dict[str, Any]) -> None:
         # Copy the registry: a send failure drops its own entry, and mutating
         # the dict mid-iteration is exactly the failure being handled.
-        for conn in list(self._clients.values()):
-            await self._send_to(conn, frame)
+        await asyncio.gather(*(self._send_to(conn, frame) for conn in list(self._clients.values())))
 
     async def _send_to(self, conn: _ClientConn, frame: dict[str, Any]) -> None:
         """One frame to one connection. A failed send drops ONLY that client
         from the registry (never retried — the reader loop will observe the
         close and its finally is a no-op second removal)."""
-        if self._send_lock is None:
-            return
-        async with self._send_lock:
+        async with conn.send_lock:
             try:
                 conn.writer.write(json.dumps(frame).encode() + b"\n")
-                await conn.writer.drain()
-            except (ConnectionResetError, BrokenPipeError, OSError):
+                await asyncio.wait_for(conn.writer.drain(), timeout=_SEND_TIMEOUT_S)
+            except (TimeoutError, ConnectionResetError, BrokenPipeError, OSError):
                 self._drop_client(conn)
 
     async def _send(self, frame: dict[str, Any]) -> None:

--- a/local_operator/mobile/registrant.py
+++ b/local_operator/mobile/registrant.py
@@ -188,6 +188,10 @@ class Registrant:
         self._unsubscribe: Callable[[], None] | None = None
         self._closed = threading.Event()
         self._push_scheduled = False
+        # The delayed repaint must be owned like the heartbeat. A bare task can
+        # still be sleeping when close tears down the registrant loop, producing
+        # an orphan warning and proving teardown returned before its work ended.
+        self._push_task: asyncio.Task[None] | None = None
         self._heartbeat_task: asyncio.Task[None] | None = None
         # -- front-end accounting (the child reaper's inputs, §4) --------------
         # Phone SSE watchers, fed by the daemon's watch/unwatch pushes. Floored
@@ -256,6 +260,7 @@ class Registrant:
             except Exception:  # noqa: BLE001
                 logger.debug("registrant unsubscribe failed", exc_info=True)
         self._shutdown()
+        await self._await_push_shutdown()
         if self._server is not None:
             await self._server.wait_closed()
         if self._publisher is not None:
@@ -291,6 +296,9 @@ class Registrant:
             # the caller then owns cancelling the heartbeat (close() does).
             await self._closed_wait()
             heartbeat.cancel()
+            if self._push_task is not None:
+                self._push_task.cancel()
+            await self._await_push_shutdown()
             self._server.close()
             await self._server.wait_closed()
 
@@ -301,6 +309,8 @@ class Registrant:
     def _shutdown(self) -> None:
         if self._heartbeat_task is not None:
             self._heartbeat_task.cancel()
+        if self._push_task is not None:
+            self._push_task.cancel()
         if self._server is not None:
             self._server.close()
         for conn in list(self._clients.values()):
@@ -309,6 +319,16 @@ class Registrant:
             except Exception:  # noqa: BLE001
                 pass
         self._clients.clear()
+
+    async def _await_push_shutdown(self) -> None:
+        """Join the coalesced repaint before its owning loop can disappear."""
+        task = self._push_task
+        if task is None:
+            return
+        await asyncio.gather(task, return_exceptions=True)
+        if self._push_task is task:
+            self._push_task = None
+        self._push_scheduled = False
 
     async def _heartbeat_loop(self) -> None:
         while not self._closed.is_set():
@@ -524,16 +544,21 @@ class Registrant:
             pass
 
     def _push_soon(self) -> None:
-        if self._push_scheduled:
+        # A callback may already be queued when close flips the cross-thread
+        # event. Recheck here so shutdown cannot create new work behind itself.
+        if self._closed.is_set() or self._push_scheduled:
             return
         self._push_scheduled = True
-        asyncio.ensure_future(self._push_later())
+        self._push_task = asyncio.create_task(self._push_later())
 
     async def _push_later(self) -> None:
-        # One sleep(0) lets the current event batch fold before the snapshot.
-        await asyncio.sleep(0.05)
-        self._push_scheduled = False
-        await self._push()
+        try:
+            # One short delay lets the current event batch fold before snapshot.
+            await asyncio.sleep(0.05)
+            if not self._closed.is_set():
+                await self._push()
+        finally:
+            self._push_scheduled = False
 
     async def _push(self) -> None:
         """Broadcast a projection repaint to every live connection.

--- a/local_operator/mobile/registrant.py
+++ b/local_operator/mobile/registrant.py
@@ -193,6 +193,10 @@ class Registrant:
         # an orphan warning and proving teardown returned before its work ended.
         self._push_task: asyncio.Task[None] | None = None
         self._heartbeat_task: asyncio.Task[None] | None = None
+        # Shutdown is represented by one owner-loop task so synchronous close,
+        # awaited close, and the thread runner can converge without cancelling
+        # loop-owned objects from whichever thread happened to request teardown.
+        self._shutdown_task: asyncio.Task[None] | None = None
         # -- front-end accounting (the child reaper's inputs, §4) --------------
         # Phone SSE watchers, fed by the daemon's watch/unwatch pushes. Floored
         # at 0: a daemon restart redials without unwatching, and a counter that
@@ -227,9 +231,51 @@ class Registrant:
         await self._serve()
 
     def close(self) -> None:
-        """Unpublish and shut down. Safe from any thread, safe twice. In
-        in-process mode prefer :meth:`aclose` — it awaits the cleanup instead
-        of posting it onto a loop the caller may be about to tear down."""
+        """Unpublish and shut down. Safe from any thread, safe twice.
+
+        Thread-hosted registrants are joined before returning. In-process hosts
+        should prefer :meth:`aclose`; when ``close`` is called on their owning
+        loop it schedules cleanup instead of deadlocking that loop waiting for
+        itself.
+        """
+        self._request_close()
+        loop = self._loop
+        if self._thread is not None:
+            # The thread runner observes the close latch and performs teardown
+            # itself. Joining it is both simpler and race-free when close lands
+            # while the thread is still publishing its loop reference.
+            if threading.current_thread() is not self._thread:
+                self._thread.join(timeout=2.0)
+            return
+        if loop is None or loop.is_closed():
+            return
+        if self._on_owner_loop():
+            self._ensure_shutdown_task()
+            return
+        shutdown = self._shutdown_on_loop()
+        try:
+            asyncio.run_coroutine_threadsafe(shutdown, loop).result(timeout=2.0)
+        except RuntimeError:
+            # run_coroutine_threadsafe does not consume the coroutine when the
+            # loop wins the close race, so close it to avoid a false leak warning.
+            shutdown.close()
+            logger.debug("registrant loop exited during shutdown", exc_info=True)
+        except TimeoutError:
+            logger.debug("registrant shutdown did not finish before timeout", exc_info=True)
+
+    async def aclose(self) -> None:
+        """Await complete teardown on the owning loop.
+
+        Repeated calls still join the original cleanup task; merely observing
+        the cross-thread closed flag is not proof that loop-owned work ended.
+        """
+        self._request_close()
+        if not self._on_owner_loop():
+            raise RuntimeError("Registrant.aclose() must run on its owning event loop")
+        await self._shutdown_on_loop()
+
+    def _request_close(self) -> None:
+        """Latch closure and detach the host feed exactly once."""
         if self._closed.is_set():
             return
         self._closed.set()
@@ -238,33 +284,13 @@ class Registrant:
                 self._unsubscribe()
             except Exception:  # noqa: BLE001 — shutdown must not raise
                 logger.debug("registrant unsubscribe failed", exc_info=True)
-        if self._loop is not None:
-            self._loop.call_soon_threadsafe(self._shutdown)
-        if self._publisher is not None:
-            self._publisher.close()
-        if self._thread is not None:
-            self._thread.join(timeout=2.0)
+            self._unsubscribe = None
 
-    async def aclose(self) -> None:
-        """In-process mode shutdown, awaited on the owning loop: cancel the
-        heartbeat, close the server and the daemon connection, unpublish.
-        Posting this to a loop that is about to close (the child's amain
-        returns right after) is how heartbeats outlive their process — so the
-        child awaits it instead."""
-        if self._closed.is_set():
-            return
-        self._closed.set()
-        if self._unsubscribe is not None:
-            try:
-                self._unsubscribe()
-            except Exception:  # noqa: BLE001
-                logger.debug("registrant unsubscribe failed", exc_info=True)
-        self._shutdown()
-        await self._await_push_shutdown()
-        if self._server is not None:
-            await self._server.wait_closed()
-        if self._publisher is not None:
-            self._publisher.close()
+    def _on_owner_loop(self) -> bool:
+        try:
+            return asyncio.get_running_loop() is self._loop
+        except RuntimeError:
+            return False
 
     # -- the registrant's own loop -------------------------------------------
 
@@ -295,30 +321,50 @@ class Registrant:
             # mode returns so the caller's loop keeps running its own work —
             # the caller then owns cancelling the heartbeat (close() does).
             await self._closed_wait()
-            heartbeat.cancel()
-            if self._push_task is not None:
-                self._push_task.cancel()
-            await self._await_push_shutdown()
-            self._server.close()
-            await self._server.wait_closed()
+            await self._shutdown_on_loop()
 
     async def _closed_wait(self) -> None:
         while not self._closed.is_set():
             await asyncio.sleep(0.2)
 
-    def _shutdown(self) -> None:
+    def _ensure_shutdown_task(self) -> asyncio.Task[None]:
+        """Create the one teardown task; called only on the registrant loop."""
+        task = self._shutdown_task
+        if task is None:
+            task = asyncio.create_task(self._shutdown_impl())
+            self._shutdown_task = task
+        return task
+
+    async def _shutdown_on_loop(self) -> None:
+        """Join idempotent teardown from a coroutine on the registrant loop."""
+        await asyncio.shield(self._ensure_shutdown_task())
+
+    async def _shutdown_impl(self) -> None:
+        """Cancel and join every object owned by the registrant event loop."""
         if self._heartbeat_task is not None:
             self._heartbeat_task.cancel()
         if self._push_task is not None:
             self._push_task.cancel()
         if self._server is not None:
             self._server.close()
-        for conn in list(self._clients.values()):
-            try:
-                conn.writer.close()
-            except Exception:  # noqa: BLE001
-                pass
-        self._clients.clear()
+        clients = list(self._clients.values())
+        for conn in clients:
+            self._drop_client(conn)
+        await self._await_push_shutdown()
+        heartbeat = self._heartbeat_task
+        if heartbeat is not None:
+            await asyncio.gather(heartbeat, return_exceptions=True)
+            self._heartbeat_task = None
+        if self._server is not None:
+            await self._server.wait_closed()
+            self._server = None
+        if clients:
+            await asyncio.gather(
+                *(conn.writer.wait_closed() for conn in clients), return_exceptions=True
+            )
+        if self._publisher is not None:
+            self._publisher.close()
+            self._publisher = None
 
     async def _await_push_shutdown(self) -> None:
         """Join the coalesced repaint before its owning loop can disappear."""

--- a/local_operator/mobile/registrant.py
+++ b/local_operator/mobile/registrant.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 
 import asyncio
 import hmac
+import inspect
 import json
 import logging
 import os
@@ -133,7 +134,12 @@ class SessionHandle(Protocol):
         Returns an unsubscribe callable."""
         ...
 
-    async def prompt(self, text: str, images: list[dict[str, str]] | None = None) -> str: ...
+    async def prompt(
+        self,
+        text: str,
+        images: list[dict[str, str]] | None = None,
+        command_id: str | None = None,
+    ) -> str: ...
     async def steer(self, text: str, images: list[dict[str, str]] | None = None) -> str: ...
     async def abort(self) -> str: ...
     async def set_model(self, provider: str, model_id: str) -> str: ...
@@ -458,10 +464,12 @@ class Registrant:
             return "snapshot sent"
         if op == "prompt":
             images = frame.get("images")
-            return await h.prompt(
-                str(frame.get("text", "")),
-                images=images if isinstance(images, list) else None,
-            )
+            fields: dict[str, Any] = {
+                "images": images if isinstance(images, list) else None,
+            }
+            if "command_id" in inspect.signature(h.prompt).parameters:
+                fields["command_id"] = str(frame.get("command_id", "")) or None
+            return await h.prompt(str(frame.get("text", "")), **fields)
         if op == "steer":
             images = frame.get("images")
             return await h.steer(

--- a/local_operator/mobile/registrant.py
+++ b/local_operator/mobile/registrant.py
@@ -456,6 +456,9 @@ class Registrant:
             await self._push()
 
     async def _dispatch(self, op: str, frame: dict[str, Any]) -> str:
+        from local_operator.mobile.types import validate_control_frame
+
+        validate_control_frame(frame)
         h = self._handle
         if op == "ping":
             return "pong"
@@ -464,18 +467,15 @@ class Registrant:
             return "snapshot sent"
         if op == "prompt":
             images = frame.get("images")
-            fields: dict[str, Any] = {
-                "images": images if isinstance(images, list) else None,
-            }
+            fields: dict[str, Any] = {"images": images}
             if "command_id" in inspect.signature(h.prompt).parameters:
-                fields["command_id"] = str(frame.get("command_id", "")) or None
-            return await h.prompt(str(frame.get("text", "")), **fields)
+                fields["command_id"] = frame.get("command_id")
+            return await h.prompt(frame["text"], **fields)
         if op == "steer":
-            images = frame.get("images")
-            return await h.steer(
-                str(frame.get("text", "")),
-                images=images if isinstance(images, list) else None,
-            )
+            fields = {"images": frame.get("images")}
+            if "command_id" in inspect.signature(h.steer).parameters:
+                fields["command_id"] = frame.get("command_id")
+            return await h.steer(frame["text"], **fields)
         if op == "abort":
             return await h.abort()
         if op == "set_model":
@@ -490,9 +490,9 @@ class Registrant:
             return await h.resume_session(str(frame.get("session_id", "")))
         if op == "approval_answer":
             return await h.approval_answer(
-                str(frame.get("request_id", "")),
-                bool(frame.get("approved")),
-                bool(frame.get("remember")),
+                frame["request_id"],
+                frame["approved"],
+                frame.get("remember", False),
             )
         if op == "ask_answer":
             # ``question_index`` is the question the phone was DISPLAYING when
@@ -503,8 +503,8 @@ class Registrant:
             raw_index = frame.get("question_index")
             question_index = int(raw_index) if isinstance(raw_index, (int, float)) else None
             return await h.ask_answer(
-                str(frame.get("request_id", "")),
-                str(frame.get("value", "")),
+                frame["request_id"],
+                frame["value"],
                 question_index=question_index,
             )
         raise ValueError(f"unknown op: {op!r}")

--- a/local_operator/mobile/tui_handle.py
+++ b/local_operator/mobile/tui_handle.py
@@ -80,7 +80,8 @@ class TuiSessionHandle(SessionHandle):
         self._unsubscribe: Callable[[], None] | None = None
         # Mutated only on Textual's loop, making admission atomic even though
         # several registrant coroutines may cross from its socket thread.
-        self._command_reservations = CommandReservations()
+        self._command_reservations = CommandReservations(session)
+        self._unsubscribe_admitted_commands = self._command_reservations.subscribe_durable()
         # request_id -> the live AskPickerScreen for every ask picker this
         # handle has projected to the phone. Keyed by a token_hex request id
         # (owned.py's scheme) because the phone answers by request id and never
@@ -124,7 +125,10 @@ class TuiSessionHandle(SessionHandle):
         # so a late phone answer for a question that no longer exists reports
         # "no longer waiting" instead of settling into the new conversation.
         self._ask_pending.clear()
+        self._unsubscribe_admitted_commands()
         self._command_reservations.clear()
+        self._command_reservations = CommandReservations(session)
+        self._unsubscribe_admitted_commands = self._command_reservations.subscribe_durable()
         if self._on_projection is not None:
             self.subscribe(self._on_projection)
 
@@ -179,7 +183,7 @@ class TuiSessionHandle(SessionHandle):
 
         def begin_prompt() -> tuple[asyncio.AbstractEventLoop, asyncio.Future[None], Any] | None:
             session = self._session()
-            if not self._command_reservations.reserve(command_id, session.history()):
+            if not self._command_reservations.reserve(command_id, kind="prompt"):
                 return None
             owner_loop = asyncio.get_running_loop()
             admitted: asyncio.Future[None] = owner_loop.create_future()
@@ -231,7 +235,7 @@ class TuiSessionHandle(SessionHandle):
             session = self._session()
             if not self._command_reservations.reserve(
                 command_id,
-                session.history(),
+                kind="steer",
                 prompt_transfer=True,
             ):
                 return False

--- a/local_operator/mobile/tui_handle.py
+++ b/local_operator/mobile/tui_handle.py
@@ -189,11 +189,21 @@ class TuiSessionHandle(SessionHandle):
             raise
         return "prompt admitted"
 
-    async def steer(self, text: str, images: list[dict[str, str]] | None = None) -> str:
+    async def steer(
+        self,
+        text: str,
+        images: list[dict[str, str]] | None = None,
+        command_id: str | None = None,
+    ) -> str:
         image_blocks = _image_blocks(images)
 
         def do_steer() -> None:
-            self._session().steer(text, image_blocks)
+            session = self._session()
+            if command_id and any(
+                getattr(message, "id", None) == command_id for message in session.history()
+            ):
+                return
+            session.steer(text, image_blocks, message_id=command_id)
 
         await self._on_app(do_steer)
         self._fold.note_user_message(text, steer=True)

--- a/local_operator/mobile/tui_handle.py
+++ b/local_operator/mobile/tui_handle.py
@@ -37,6 +37,7 @@ import logging
 import secrets
 from typing import TYPE_CHECKING, Any, Callable
 
+from local_operator.mobile.command_reservation import CommandReservations
 from local_operator.mobile.projection import ProjectionFold
 from local_operator.mobile.registrant import SessionHandle, image_blocks
 from local_operator.mobile.types import SessionProjection, ask_pending_request
@@ -77,6 +78,9 @@ class TuiSessionHandle(SessionHandle):
         self._fold = ProjectionFold(self._projection)
         self._on_projection: Callable[[], None] | None = None
         self._unsubscribe: Callable[[], None] | None = None
+        # Mutated only on Textual's loop, making admission atomic even though
+        # several registrant coroutines may cross from its socket thread.
+        self._command_reservations = CommandReservations()
         # request_id -> the live AskPickerScreen for every ask picker this
         # handle has projected to the phone. Keyed by a token_hex request id
         # (owned.py's scheme) because the phone answers by request id and never
@@ -120,6 +124,7 @@ class TuiSessionHandle(SessionHandle):
         # so a late phone answer for a question that no longer exists reports
         # "no longer waiting" instead of settling into the new conversation.
         self._ask_pending.clear()
+        self._command_reservations.clear()
         if self._on_projection is not None:
             self.subscribe(self._on_projection)
 
@@ -171,15 +176,37 @@ class TuiSessionHandle(SessionHandle):
         if not command_id:
             raise ValueError("command_id is required")
         image_blocks = _image_blocks(images)
-        owner_loop: asyncio.AbstractEventLoop = await self._on_app(asyncio.get_running_loop)
-        session = self._session()
-        if any(getattr(message, "id", None) == command_id for message in session.history()):
+
+        def begin_prompt() -> tuple[asyncio.AbstractEventLoop, asyncio.Future[None], Any] | None:
+            session = self._session()
+            if not self._command_reservations.reserve(command_id, session.history()):
+                return None
+            owner_loop = asyncio.get_running_loop()
+            admitted: asyncio.Future[None] = owner_loop.create_future()
+
+            async def run_turn() -> None:
+                try:
+                    await session.prompt(
+                        text,
+                        image_blocks,
+                        message_id=command_id,
+                        admitted=admitted,
+                    )
+                except BaseException as exc:
+                    if not admitted.done():
+                        self._command_reservations.reject(
+                            command_id,
+                            transfer_to_steer="already streaming" in str(exc),
+                        )
+                        admitted.set_exception(exc)
+                    raise
+
+            return owner_loop, admitted, asyncio.run_coroutine_threadsafe(run_turn(), owner_loop)
+
+        started = await self._on_app(begin_prompt)
+        if started is None:
             return "already admitted"
-        admitted: asyncio.Future[None] = owner_loop.create_future()
-        turn = asyncio.run_coroutine_threadsafe(
-            session.prompt(text, image_blocks, message_id=command_id, admitted=admitted),
-            owner_loop,
-        )
+        owner_loop, admitted, turn = started
         try:
             await asyncio.wrap_future(
                 asyncio.run_coroutine_threadsafe(_await_future(admitted), owner_loop)
@@ -187,6 +214,7 @@ class TuiSessionHandle(SessionHandle):
         except Exception:
             turn.cancel()
             raise
+        await self._on_app(lambda: self._command_reservations.accept(command_id))
         return "prompt admitted"
 
     async def steer(
@@ -195,17 +223,28 @@ class TuiSessionHandle(SessionHandle):
         images: list[dict[str, str]] | None = None,
         command_id: str | None = None,
     ) -> str:
+        if not command_id:
+            raise ValueError("command_id is required")
         image_blocks = _image_blocks(images)
 
-        def do_steer() -> None:
+        def do_steer() -> bool:
             session = self._session()
-            if command_id and any(
-                getattr(message, "id", None) == command_id for message in session.history()
+            if not self._command_reservations.reserve(
+                command_id,
+                session.history(),
+                prompt_transfer=True,
             ):
-                return
-            session.steer(text, image_blocks, message_id=command_id)
+                return False
+            try:
+                session.steer(text, image_blocks, message_id=command_id)
+            except Exception:
+                self._command_reservations.reject(command_id)
+                raise
+            self._command_reservations.accept(command_id)
+            return True
 
-        await self._on_app(do_steer)
+        if not await self._on_app(do_steer):
+            return "already admitted"
         self._fold.note_user_message(text, steer=True)
         if self._on_projection is not None:
             self._on_projection()

--- a/local_operator/mobile/tui_handle.py
+++ b/local_operator/mobile/tui_handle.py
@@ -33,6 +33,7 @@ mobile is a daemon-owned-session capability today (see :mod:`owned`).
 from __future__ import annotations
 
 import asyncio
+import inspect
 import logging
 import secrets
 from typing import TYPE_CHECKING, Any, Callable
@@ -190,12 +191,13 @@ class TuiSessionHandle(SessionHandle):
 
             async def run_turn() -> None:
                 try:
-                    await session.prompt(
-                        text,
-                        image_blocks,
-                        message_id=command_id,
-                        admitted=admitted,
-                    )
+                    fields: dict[str, Any] = {
+                        "message_id": command_id,
+                        "admitted": admitted,
+                    }
+                    if "producer_command_id" in inspect.signature(session.prompt).parameters:
+                        fields["producer_command_id"] = command_id
+                    await session.prompt(text, image_blocks, **fields)
                 except BaseException as exc:
                     if not admitted.done():
                         self._command_reservations.reject(
@@ -240,7 +242,10 @@ class TuiSessionHandle(SessionHandle):
             ):
                 return False
             try:
-                session.steer(text, image_blocks, message_id=command_id)
+                fields: dict[str, Any] = {"message_id": command_id}
+                if "producer_command_id" in inspect.signature(session.steer).parameters:
+                    fields["producer_command_id"] = command_id
+                session.steer(text, image_blocks, **fields)
             except Exception:
                 self._command_reservations.reject(command_id)
                 raise

--- a/local_operator/mobile/tui_handle.py
+++ b/local_operator/mobile/tui_handle.py
@@ -47,6 +47,11 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+async def _await_future(future: asyncio.Future[Any]) -> Any:
+    """Await an owner-loop future from the registrant's bridge coroutine."""
+    return await future
+
+
 # Decode wire images via the shared mobile-contract helper (registrant.py);
 # kept as a module alias so existing call sites stay short.
 _image_blocks = image_blocks
@@ -157,17 +162,32 @@ class TuiSessionHandle(SessionHandle):
 
     # -- mutations: every one hops to the Textual thread ---------------------------
 
-    async def prompt(self, text: str, images: list[dict[str, str]] | None = None) -> str:
+    async def prompt(
+        self,
+        text: str,
+        images: list[dict[str, str]] | None = None,
+        command_id: str | None = None,
+    ) -> str:
+        if not command_id:
+            raise ValueError("command_id is required")
         image_blocks = _image_blocks(images)
-
-        def submit() -> None:
-            self._app._submit_prompt(text, image_blocks, None)
-
-        await self._on_app(submit)
-        self._fold.note_user_message(text)
-        if self._on_projection is not None:
-            self._on_projection()
-        return "prompt sent"
+        owner_loop: asyncio.AbstractEventLoop = await self._on_app(asyncio.get_running_loop)
+        session = self._session()
+        if any(getattr(message, "id", None) == command_id for message in session.history()):
+            return "already admitted"
+        admitted: asyncio.Future[None] = owner_loop.create_future()
+        turn = asyncio.run_coroutine_threadsafe(
+            session.prompt(text, image_blocks, message_id=command_id, admitted=admitted),
+            owner_loop,
+        )
+        try:
+            await asyncio.wrap_future(
+                asyncio.run_coroutine_threadsafe(_await_future(admitted), owner_loop)
+            )
+        except Exception:
+            turn.cancel()
+            raise
+        return "prompt admitted"
 
     async def steer(self, text: str, images: list[dict[str, str]] | None = None) -> str:
         image_blocks = _image_blocks(images)

--- a/local_operator/mobile/types.py
+++ b/local_operator/mobile/types.py
@@ -34,8 +34,51 @@ binary and a stale registrant is re-registered on its next heartbeat.
 from __future__ import annotations
 
 import time
+import uuid
 from dataclasses import asdict, dataclass, field
 from typing import Any, Literal
+
+
+@dataclass(frozen=True)
+class ContinuationCommand:
+    """Producer-owned prompt retained until its transcript row is durable.
+
+    Process discovery and request ids are transport details. This identity is
+    the conversation-level receipt that survives reconnects and host changes.
+    """
+
+    command_id: str
+    session_id: str
+    text: str
+    images: list[dict[str, str]] = field(default_factory=list)
+    submitted_at: float = field(default_factory=time.time)
+
+    @staticmethod
+    def create(
+        session_id: str, text: str, images: list[dict[str, str]] | None = None
+    ) -> "ContinuationCommand":
+        return ContinuationCommand(
+            command_id=str(uuid.uuid4()),
+            session_id=session_id,
+            text=text,
+            images=list(images or []),
+        )
+
+    def to_json(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @staticmethod
+    def from_json(data: dict[str, Any]) -> "ContinuationCommand":
+        command_id = str(data.get("command_id", ""))
+        uuid.UUID(command_id)
+        return ContinuationCommand(
+            command_id=command_id,
+            session_id=str(data.get("session_id", "")),
+            text=str(data.get("text", "")),
+            images=[dict(item) for item in data.get("images", []) if isinstance(item, dict)],
+            submitted_at=float(data.get("submitted_at", time.time())),
+        )
+
 
 #: Bumped on any breaking change to control frames or web payloads. The
 #: registrant and daemon always ship together; the phone UI learns the
@@ -49,7 +92,7 @@ from typing import Any, Literal
 #: rather than silently breaking the owner's phone bridge. The record's
 #: version field is the only pre-dial gate — the socket itself speaks the
 #: same frame shapes either side of the bump.
-PROTOCOL_VERSION = 2
+PROTOCOL_VERSION = 3
 
 #: Which side of the owner relationship a control connection speaks for.
 #: ``daemon`` (the default when the auth frame omits ``client``) may rebind
@@ -125,7 +168,7 @@ class SessionRecord:
 # Requests the daemon may send. Kept as Literal aliases rather than enums so
 # frames stay plain dicts — json.loads output needs no decoding step.
 ControlOp = Literal[
-    "prompt",  # {text, images?} — a full user turn (or queue while streaming)
+    "prompt",  # {command_id, text, images?} — durable idempotent user turn
     "steer",  # {text} — inject mid-turn
     "abort",  # {} — the stop button; never kills the session
     "set_model",  # {provider, model_id} — the model sheet's choice

--- a/local_operator/mobile/types.py
+++ b/local_operator/mobile/types.py
@@ -40,7 +40,30 @@ from typing import Any, Literal
 #: Bumped on any breaking change to control frames or web payloads. The
 #: registrant and daemon always ship together; the phone UI learns the
 #: version in its bootstrap payload and can warn on a stale cached bundle.
-PROTOCOL_VERSION = 1
+#:
+#: v2 (attach + reaping) added the ``watch``/``unwatch`` ops, the auth
+#: frame's optional ``client`` field, and multi-connection registrants. The
+#: bump is load-bearing for ATTACH specifically: an old (v1) registrant
+#: treats any authenticated dial as THE daemon and evicts the real one, so
+#: an attach client must refuse to dial a record whose ``protocol`` is < 2
+#: rather than silently breaking the owner's phone bridge. The record's
+#: version field is the only pre-dial gate — the socket itself speaks the
+#: same frame shapes either side of the bump.
+PROTOCOL_VERSION = 2
+
+#: Which side of the owner relationship a control connection speaks for.
+#: ``daemon`` (the default when the auth frame omits ``client``) may rebind
+#: the owner's conversation; ``attach`` is a follower terminal that may
+#: watch and steer but never rebind. Absent-means-daemon keeps an OLD
+#: daemon dialing a NEW registrant on the same class it always had.
+ClientKind = Literal["daemon", "attach"]
+
+#: How many concurrent attach (follower terminal) connections one registrant
+#: accepts before evicting the least-recently-seen one. Connection close is
+#: detected anyway (the reader loop drops the registry entry); the cap is
+#: defense against leaked-but-open sockets — half-open TCP with no FIN —
+#: which liveness detection cannot see.
+ATTACH_MAX_CLIENTS = 4
 
 
 # ---------------------------------------------------------------------------
@@ -114,6 +137,14 @@ ControlOp = Literal[
     "ask_answer",  # {request_id, value}
     "snapshot",  # {} — ask for a fresh welcome-equivalent projection
     "ping",  # {} — liveness probe; answered with {"op": "ack", ...}
+    # v2 (attach + reaping): phone SSE subscriber transitions, daemon ->
+    # registrant. "watch" = a phone just started following this session;
+    # "unwatch" = the last phone left. The child's self-reaper counts these
+    # to know whether a front end still holds the session. Additive on the
+    # wire: an OLD registrant answers `error: unknown op`, which the daemon
+    # tolerates (fire-and-forget), so a mixed-version machine keeps working.
+    "watch",  # {} — a phone SSE subscriber appeared for this session
+    "unwatch",  # {} — the last phone SSE subscriber left
 ]
 
 # Events the registrant streams to the daemon.

--- a/local_operator/mobile/types.py
+++ b/local_operator/mobile/types.py
@@ -69,15 +69,82 @@ class ContinuationCommand:
 
     @staticmethod
     def from_json(data: dict[str, Any]) -> "ContinuationCommand":
-        command_id = str(data.get("command_id", ""))
-        uuid.UUID(command_id)
+        """Validate an untrusted continuation payload without coercing types.
+
+        This constructor sits on both HTTP and control-socket boundaries. Silent
+        ``str(...)`` coercion turns missing, object, and list fields into model
+        input and lets malformed UUIDs escape as route-level 500s, so invalid
+        producer data is rejected before any owner is spawned or transcript is
+        opened.
+        """
+        if not isinstance(data, dict):
+            raise ValueError("command payload must be an object")
+        command_id = data.get("command_id")
+        if not isinstance(command_id, str) or not command_id:
+            raise ValueError("command_id must be a UUID string")
+        try:
+            uuid.UUID(command_id)
+        except (ValueError, AttributeError) as exc:
+            raise ValueError("command_id must be a valid UUID") from exc
+        session_id = data.get("session_id")
+        if not isinstance(session_id, str) or not session_id:
+            raise ValueError("session_id must be a non-empty string")
+        text = data.get("text")
+        if not isinstance(text, str) or not text.strip():
+            raise ValueError("text must be a non-empty string")
+        images = data.get("images", [])
+        if not isinstance(images, list) or not all(isinstance(item, dict) for item in images):
+            raise ValueError("images must be a list of objects")
+        submitted_at = data.get("submitted_at", time.time())
+        if not isinstance(submitted_at, (int, float)) or isinstance(submitted_at, bool):
+            raise ValueError("submitted_at must be a number")
         return ContinuationCommand(
             command_id=command_id,
-            session_id=str(data.get("session_id", "")),
-            text=str(data.get("text", "")),
-            images=[dict(item) for item in data.get("images", []) if isinstance(item, dict)],
-            submitted_at=float(data.get("submitted_at", time.time())),
+            session_id=session_id,
+            text=text,
+            images=[dict(item) for item in images],
+            submitted_at=float(submitted_at),
         )
+
+
+def validate_control_frame(frame: dict[str, Any]) -> None:
+    """Reject malformed authenticated mutations before dispatch side effects."""
+    if not isinstance(frame, dict):
+        raise ValueError("control frame must be an object")
+    op = frame.get("op")
+    if not isinstance(op, str) or not op:
+        raise ValueError("op must be a non-empty string")
+    if op in ("prompt", "steer"):
+        text = frame.get("text")
+        if not isinstance(text, str) or not text.strip():
+            raise ValueError("text must be a non-empty string")
+        images = frame.get("images", [])
+        if not isinstance(images, list) or not all(isinstance(item, dict) for item in images):
+            raise ValueError("images must be a list of objects")
+        # Protocol-v3 producers send identity on both paths. Older authenticated
+        # loopback clients omitted it, so absence remains compatible; a supplied
+        # id is always validated before reaching transcript or steering state.
+        if "command_id" in frame:
+            ContinuationCommand.from_json(
+                {
+                    "command_id": frame.get("command_id"),
+                    "session_id": frame.get("session_id", "control-session"),
+                    "text": text,
+                    "images": images,
+                }
+            )
+    elif op == "approval_answer":
+        if not isinstance(frame.get("request_id"), str) or not frame["request_id"]:
+            raise ValueError("request_id must be a non-empty string")
+        if not isinstance(frame.get("approved"), bool):
+            raise ValueError("approved must be a boolean")
+        if "remember" in frame and not isinstance(frame.get("remember"), bool):
+            raise ValueError("remember must be a boolean")
+    elif op == "ask_answer":
+        if not isinstance(frame.get("request_id"), str) or not frame["request_id"]:
+            raise ValueError("request_id must be a non-empty string")
+        if not isinstance(frame.get("value"), str):
+            raise ValueError("value must be a string")
 
 
 #: Bumped on any breaking change to control frames or web payloads. The

--- a/local_operator/mobile/types.py
+++ b/local_operator/mobile/types.py
@@ -409,6 +409,70 @@ class SessionProjection:
 PROJECTION_TRANSCRIPT_LIMIT = 80
 
 
+def _projection_from_json(data: dict[str, Any], record: SessionRecord) -> SessionProjection:
+    """Rebuild a projection from a wire payload.
+
+    The registrant already serialized dataclasses; this tolerates missing
+    keys (a rolling upgrade mid-push) by constructing through the dataclass
+    with defaults. Lives in the wire-types module (not the daemon) because
+    BOTH consumers of the socket rebuild projections from the same frames —
+    the daemon for the phone, the attach client for a follower terminal —
+    and a copy in each is exactly how two renderers drift.
+
+    ``record`` supplies the pid: the fold stamps 0 (the registrant does not
+    know its own pid until the record is published), and the discovery record
+    is the source of truth.
+    """
+    from dataclasses import fields
+
+    def build(cls: type, items: list[dict[str, Any]]) -> list[Any]:
+        known = {f.name for f in fields(cls)}
+        return [cls(**{k: v for k, v in item.items() if k in known}) for item in items]
+
+    known = {f.name for f in fields(SessionProjection)}
+    base = {
+        k: v
+        for k, v in data.items()
+        if k in known and k not in ("transcript", "todos", "subagents", "pending")
+    }
+    projection = SessionProjection(**base)
+    projection.pid = record.pid
+    projection.transcript = build(TranscriptEntry, data.get("transcript", []))
+    # Todos arrive PHASED; rebuild the two nested dataclass levels, tolerating
+    # missing keys the same way ``build`` does for a rolling upgrade mid-push.
+    projection.todos = [
+        TodoPhase(
+            name=str(phase.get("name", "")),
+            items=build(TodoItem, phase.get("items", []) or []),
+        )
+        for phase in data.get("todos", []) or []
+    ]
+    projection.subagents = build(SubagentRow, data.get("subagents", []))
+    pending = data.get("pending")
+    if isinstance(pending, dict):
+        known_pending = {f.name for f in fields(PendingRequest)}
+        pending_kwargs = {k: v for k, v in pending.items() if k in known_pending}
+        # ``options`` crosses the wire as a list of {label, description} dicts;
+        # rebuild the dataclass so downstream code (and to_json round-trips)
+        # see AskOptionWire, not bare dicts.
+        raw_options = pending_kwargs.get("options") or []
+        pending_kwargs["options"] = [
+            (
+                AskOptionWire(
+                    label=str(opt.get("label", "")),
+                    description=str(opt.get("description", "")),
+                )
+                if isinstance(opt, dict)
+                else AskOptionWire(label=str(opt))
+            )
+            for opt in raw_options
+        ]
+        projection.pending = PendingRequest(**pending_kwargs)
+    else:
+        projection.pending = None
+    return projection
+
+
 # ---------------------------------------------------------------------------
 # Slash command surface (exported to the phone)
 # ---------------------------------------------------------------------------

--- a/local_operator/mobile/web/src/api.ts
+++ b/local_operator/mobile/web/src/api.ts
@@ -93,10 +93,10 @@ export function startSession(input: {
 }
 
 export function sendCommand(
-	pid: number,
+	sessionId: string,
 	op: CommandOp,
 ): Promise<{ ok: boolean; detail: string }> {
-	return request(`/api/sessions/${pid}/command`, {
+	return request(`/api/sessions/${encodeURIComponent(sessionId)}/command`, {
 		method: "POST",
 		headers: { "content-type": "application/json" },
 		body: JSON.stringify(op),
@@ -108,9 +108,9 @@ export function sendCommand(
     id plus the image-only index the ref emitted. Same-origin, cacheable and
     immutable — a message's attachments never change — so an <img src> can use
     it directly. */
-export function imageUrl(pid: number, entryId: string, index: number): string {
+export function imageUrl(sessionId: string, entryId: string, index: number): string {
 	const q = new URLSearchParams({ entry: entryId, i: String(index) });
-	return `/api/sessions/${pid}/image?${q}`;
+	return `/api/sessions/${encodeURIComponent(sessionId)}/image?${q}`;
 }
 
 /** Older transcript entries for lazy loading. ``before`` is the id of the
@@ -118,11 +118,11 @@ export function imageUrl(pid: number, entryId: string, index: number): string {
     immediately older than it (chronological within the page) plus whether
     more history exists beyond. */
 export function getHistory(
-	pid: number,
+	sessionId: string,
 	before: string | null,
 	limit = 80,
 ): Promise<{ entries: TranscriptEntry[]; has_more: boolean }> {
 	const q = new URLSearchParams({ limit: String(limit) });
 	if (before) q.set("before", before);
-	return request(`/api/sessions/${pid}/history?${q}`);
+	return request(`/api/sessions/${encodeURIComponent(sessionId)}/history?${q}`);
 }

--- a/local_operator/mobile/web/src/app.tsx
+++ b/local_operator/mobile/web/src/app.tsx
@@ -17,7 +17,7 @@ export function App() {
 		case "past":
 			return <PastSessionsScreen />;
 		case "session":
-			return <SessionScreen key={route.pid} pid={route.pid} />;
+			return <SessionScreen key={route.sessionId} sessionId={route.sessionId} />;
 		default:
 			return <SessionListScreen />;
 	}

--- a/local_operator/mobile/web/src/components/composer.tsx
+++ b/local_operator/mobile/web/src/components/composer.tsx
@@ -172,7 +172,7 @@ function EffortSheet({
 }: {
 	open: boolean;
 	onClose: () => void;
-	pid: number;
+	pid: string;
 	projection: SessionProjection;
 }) {
 	const set = async (effort: string) => {
@@ -223,7 +223,7 @@ export function Composer({
 	onCloseEffort,
 }: {
 	/** Route pid — the discovery record's, not the fold's (which stamps 0). */
-	pid: number;
+	pid: string;
 	projection: SessionProjection;
 	onOpenModels: () => void;
 	onOpenEffort: () => void;
@@ -252,7 +252,7 @@ export function Composer({
 		el.style.height = `${Math.min(el.scrollHeight, MAX_TEXTAREA_PX)}px`;
 	}, [text]);
 
-	const disabled = projection.ended;
+	const disabled = false;
 
 	const addFiles = async (files: Iterable<File>) => {
 		for (const f of files) {
@@ -297,13 +297,19 @@ export function Composer({
 			} else {
 				const chosen =
 					op ?? (projection.streaming ? "steer" : "prompt");
-				await sendCommand(pid, {
-					op: chosen,
-					text: trimmed,
-					images: images.length
-						? images.map(({ data_b64, mime_type }) => ({ data_b64, mime_type }))
-						: undefined,
-				});
+				const commandId =
+					localStorage.getItem(`lo-mobile-command:${pid}`) ?? crypto.randomUUID();
+				localStorage.setItem(`lo-mobile-command:${pid}`, commandId);
+				const payloadImages = images.length
+					? images.map(({ data_b64, mime_type }) => ({ data_b64, mime_type }))
+					: undefined;
+				await sendCommand(
+					pid,
+					chosen === "prompt"
+						? { op: "prompt", command_id: commandId, text: trimmed, images: payloadImages }
+						: { op: "steer", text: trimmed, images: payloadImages },
+				);
+				if (chosen === "prompt") localStorage.removeItem(`lo-mobile-command:${pid}`);
 				images.forEach((i) => URL.revokeObjectURL(i.preview));
 				setImages([]);
 			}

--- a/local_operator/mobile/web/src/components/composer.tsx
+++ b/local_operator/mobile/web/src/components/composer.tsx
@@ -213,6 +213,8 @@ function EffortSheet({
 }
 
 const MAX_TEXTAREA_PX = 6 * 22; /* six lines at body line-height */
+const CONTINUATION_ERROR = "Couldn’t continue this conversation. Try again.";
+const COMPOSER_PLACEHOLDER = "Message Local Operator…";
 
 export function Composer({
 	pid,
@@ -315,7 +317,16 @@ export function Composer({
 			}
 			setText("");
 		} catch (e) {
-			setError(String((e as Error).message ?? e));
+			/* Previous conversations can fail at every layer between fetch and
+			   provider construction. Those mechanics are intentionally invisible:
+			   retain the exact draft, images, and command id for a safe retry while
+			   giving every continuation failure one actionable product message. */
+			const continuingPrevious = projection.kind === "daemon" && !projection.streaming;
+			setError(
+				continuingPrevious
+					? CONTINUATION_ERROR
+					: String((e as Error).message ?? e),
+			);
 		} finally {
 			setSending(false);
 		}
@@ -363,7 +374,21 @@ export function Composer({
 				</button>
 			) : null}
 
-			{error ? <p className="text-body-sm text-danger">{error}</p> : null}
+			{sending ? (
+				<p role="status" aria-live="polite" className="text-body-sm text-ink-muted">
+					Connecting…
+				</p>
+			) : null}
+
+			{error ? (
+				<p
+					role="alert"
+					aria-live="assertive"
+					className="rounded-sm border border-danger-border bg-danger-wash px-3 py-2 text-body-sm text-danger"
+				>
+					{error}
+				</p>
+			) : null}
 
 			{images.length > 0 ? (
 				<div className="flex flex-wrap gap-1.5">
@@ -438,13 +463,7 @@ export function Composer({
 								void addFiles(files);
 							}
 						}}
-						placeholder={
-							disabled
-								? "session ended"
-								: projection.streaming
-									? "steer this turn…"
-									: "message…"
-						}
+						placeholder={COMPOSER_PLACEHOLDER}
 						disabled={disabled}
 						rows={1}
 						enterKeyHint="send"
@@ -475,10 +494,10 @@ export function Composer({
 					type="button"
 					onClick={() => void send(text)}
 					disabled={(!text.trim() && images.length === 0) || sending || disabled}
-					aria-label={projection.streaming ? "steer" : "send"}
+					aria-label={sending ? "Connecting" : projection.streaming ? "steer" : "send"}
 					className="flex size-11 shrink-0 items-center justify-center rounded-full bg-accent text-on-accent active:bg-accent-active disabled:bg-sunken disabled:text-ink-disabled"
 				>
-					↑
+					<span aria-hidden>{sending ? "…" : "↑"}</span>
 				</button>
 			</div>
 

--- a/local_operator/mobile/web/src/components/model-sheet.tsx
+++ b/local_operator/mobile/web/src/components/model-sheet.tsx
@@ -18,7 +18,7 @@ export function ModelSheet({
 	open: boolean;
 	onClose: () => void;
 	/** Route pid — the discovery record's, not the fold's (which stamps 0). */
-	pid: number;
+	pid: string;
 	projection: SessionProjection;
 }) {
 	const [models, setModels] = useState<ModelEntry[]>([]);

--- a/local_operator/mobile/web/src/components/pending-card.tsx
+++ b/local_operator/mobile/web/src/components/pending-card.tsx
@@ -48,7 +48,7 @@ export function PendingCard({
 	pending,
 	count = 1,
 }: {
-	pid: number;
+	pid: string;
 	pending: PendingRequest;
 	/** Total requests waiting, including this one. A parallel tool batch can
 	    open several approvals at once; when >1 the card shows a "1 of N" badge

--- a/local_operator/mobile/web/src/components/transcript.tsx
+++ b/local_operator/mobile/web/src/components/transcript.tsx
@@ -201,7 +201,16 @@ export function Transcript({
 	const visible =
 		merged.length > windowSize ? merged.slice(-windowSize) : merged;
 	const hiddenCount = merged.length - visible.length;
-	const oldestId = visible.length > 0 ? visible[0].id : null;
+	/* Long projections pin the opening user row ahead of a disjoint tail. It is
+	   already retained, but it is not the tail's chronological history cursor;
+	   anchor at the next row so the API can return the missing middle. The
+	   merge's id de-dup keeps the opener exactly once when that page reaches it. */
+	const oldestId =
+		older.length === 0 && entries.length === PAGE && entries[0]?.kind === "user"
+			? entries[1]?.id ?? entries[0]?.id ?? null
+			: visible.length > 0
+				? visible[0].id
+				: null;
 
 	/* Follow the tail on new content, but only when already at the bottom. */
 	useEffect(() => {

--- a/local_operator/mobile/web/src/components/transcript.tsx
+++ b/local_operator/mobile/web/src/components/transcript.tsx
@@ -33,7 +33,7 @@ function AttachmentImage({
 	entryId,
 	index,
 }: {
-	pid: number;
+	pid: string;
 	entryId: string;
 	index: number;
 }) {
@@ -80,7 +80,7 @@ function AttachmentImage({
 	);
 }
 
-function Entry({ entry, pid }: { entry: TranscriptEntry; pid: number }) {
+function Entry({ entry, pid }: { entry: TranscriptEntry; pid: string }) {
 	switch (entry.kind) {
 		case "user": {
 			/* The user's own words. Right-aligned like the desktop app's bubble,
@@ -159,7 +159,7 @@ export function Transcript({
 	pid,
 	entries,
 }: {
-	pid: number;
+	pid: string;
 	entries: TranscriptEntry[];
 }) {
 	const [windowSize, setWindowSize] = useState(PAGE);

--- a/local_operator/mobile/web/src/router.ts
+++ b/local_operator/mobile/web/src/router.ts
@@ -9,14 +9,14 @@ export type Route =
 	| { name: "list" }
 	| { name: "new" }
 	| { name: "past" }
-	| { name: "session"; pid: number };
+	| { name: "session"; sessionId: string };
 
 export function parseHash(hash: string): Route {
 	const path = hash.replace(/^#/, "") || "/";
 	if (path === "/new") return { name: "new" };
 	if (path === "/past") return { name: "past" };
-	const session = path.match(/^\/s\/(\d+)/);
-	if (session) return { name: "session", pid: Number(session[1]) };
+	const session = path.match(/^\/s\/([^/]+)/);
+	if (session) return { name: "session", sessionId: decodeURIComponent(session[1]) };
 	return { name: "list" };
 }
 

--- a/local_operator/mobile/web/src/screens/session-list.tsx
+++ b/local_operator/mobile/web/src/screens/session-list.tsx
@@ -30,11 +30,8 @@ function SessionCard({ s, home }: { s: SessionSummary; home: string }) {
 	return (
 		<button
 			type="button"
-			onClick={() => navigate(`/s/${s.pid}`)}
-			className={cn(
-				"flex w-full flex-col gap-0.5 rounded-md px-2 py-1.5 text-left select-none active:bg-elevated",
-				s.ended && "text-ink-disabled",
-			)}
+			onClick={() => navigate(`/s/${encodeURIComponent(s.session_id)}`)}
+			className="flex w-full flex-col gap-0.5 rounded-md px-2 py-1.5 text-left select-none active:bg-elevated"
 		>
 			<div className="flex items-center gap-2">
 				{s.needs_attention && pendingLabel ? (
@@ -43,7 +40,7 @@ function SessionCard({ s, home }: { s: SessionSummary; home: string }) {
 						aria-hidden
 					/>
 				) : null}
-				{s.streaming && !s.ended ? (
+				{s.streaming ? (
 					/* The obvious in-progress mark beside the title: a small loading
 					   wheel, not just the text sweep — the sweep alone was too
 					   subtle to catch at a glance. */
@@ -52,7 +49,7 @@ function SessionCard({ s, home }: { s: SessionSummary; home: string }) {
 				<span
 					className={cn(
 						"min-w-0 flex-1 truncate text-body-sm font-medium",
-						s.streaming && !s.ended && "lo-shimmer",
+						s.streaming && "lo-shimmer",
 					)}
 				>
 					{s.conversation_name || "untitled"}
@@ -73,9 +70,6 @@ function SessionCard({ s, home }: { s: SessionSummary; home: string }) {
 					<span className="shrink-0 font-mono text-mono-sm text-ink-dim">
 						{s.todos_open} todo
 					</span>
-				) : null}
-				{s.ended ? (
-					<span className="shrink-0 text-meta text-ink-dim">ended</span>
 				) : null}
 			</div>
 			<div className="flex items-baseline gap-2">
@@ -139,6 +133,14 @@ export function SessionListScreen() {
 	const { sessions, connected } = useSessions();
 	const [home, setHome] = useState("");
 	const [themeOpen, setThemeOpen] = useState(false);
+	const [query, setQuery] = useState("");
+	const visible = sessions.filter((session) =>
+		`${session.conversation_name} ${session.session_id} ${session.cwd}`
+			.toLowerCase()
+			.includes(query.toLowerCase()),
+	);
+	const active = visible.filter((session) => session.section === "active");
+	const previous = visible.filter((session) => session.section === "previous");
 
 	useEffect(() => retainSessionListStream(), []);
 	useEffect(() => {
@@ -162,7 +164,13 @@ export function SessionListScreen() {
 					local operator
 				</h1>
 			</header>
-			<main className="flex flex-1 flex-col px-1 pb-2">
+			<main className="flex flex-1 flex-col overflow-y-auto px-1 pb-2">
+				<input
+					value={query}
+					onChange={(event) => setQuery(event.target.value)}
+					placeholder="Search conversations…"
+					className="mx-2 mb-2 min-h-10 rounded-sm border border-control bg-surface px-3 text-body text-ink outline-none placeholder:text-ink-dim"
+				/>
 				{sessions.length === 0 ? (
 					<div className="flex flex-1 flex-col items-center justify-center gap-2 px-6 text-center">
 						<p className="text-body text-ink-muted">
@@ -175,10 +183,15 @@ export function SessionListScreen() {
 						</p>
 					</div>
 				) : (
-					<div className="flex flex-col">
-						{sessions.map((s) => (
-							<SessionCard key={s.pid} s={s} home={home} />
-						))}
+					<div className="flex flex-col gap-3">
+						<section>
+							<h2 className="px-2 py-1 text-meta font-medium text-ink-muted">Active Sessions</h2>
+							{active.map((s) => <SessionCard key={s.session_id} s={s} home={home} />)}
+						</section>
+						<section>
+							<h2 className="px-2 py-1 text-meta font-medium text-ink-muted">Previous Sessions</h2>
+							{previous.map((s) => <SessionCard key={s.session_id} s={s} home={home} />)}
+						</section>
 					</div>
 				)}
 			</main>
@@ -189,13 +202,6 @@ export function SessionListScreen() {
 					className="flex min-h-11 flex-1 items-center justify-center rounded-md border border-control bg-surface text-body-sm font-medium text-ink select-none active:bg-elevated"
 				>
 					new session
-				</button>
-				<button
-					type="button"
-					onClick={() => navigate("/past")}
-					className="flex min-h-11 items-center justify-center rounded-md border border-control bg-surface px-4 text-body-sm text-ink select-none active:bg-elevated"
-				>
-					past
 				</button>
 				<button
 					type="button"

--- a/local_operator/mobile/web/src/screens/session-view.tsx
+++ b/local_operator/mobile/web/src/screens/session-view.tsx
@@ -18,7 +18,6 @@ import { SubagentsPanel } from "../components/subagents-panel";
 import { TodosPanel } from "../components/todos-panel";
 import { Transcript } from "../components/transcript";
 import { WorkingLine } from "../components/working-line";
-import { cn } from "../lib/cn";
 import { navigate } from "../router";
 import { retainProjectionStream, useProjection } from "../store";
 import type { SessionProjection } from "../types";
@@ -28,13 +27,6 @@ function Header({
 }: {
 	projection: SessionProjection;
 }) {
-	const status = projection.ended
-		? "bg-ink-disabled"
-		: projection.degraded
-			? "bg-warning"
-			: projection.streaming
-				? "lo-pulse bg-accent"
-				: "bg-success";
 	return (
 		<header className="flex items-center gap-2 border-b border-hairline px-1 py-1 pt-[max(env(safe-area-inset-top),0.25rem)]">
 			<button
@@ -45,10 +37,6 @@ function Header({
 			>
 				‹
 			</button>
-			<span
-				className={cn("size-2 shrink-0 rounded-full", status)}
-				aria-hidden
-			/>
 			<span className="min-w-0 flex-1 truncate text-body-sm font-medium">
 				{projection.conversation_name || "untitled"}
 			</span>
@@ -56,13 +44,13 @@ function Header({
 	);
 }
 
-export function SessionScreen({ pid }: { pid: number }) {
-	const { projection, connected } = useProjection(pid);
+export function SessionScreen({ sessionId }: { sessionId: string }) {
+	const { projection, connected } = useProjection(sessionId);
 	const [modelsOpen, setModelsOpen] = useState(false);
 	const [effortOpen, setEffortOpen] = useState(false);
 	const rootRef = useRef<HTMLDivElement>(null);
 
-	useEffect(() => retainProjectionStream(pid), [pid]);
+	useEffect(() => retainProjectionStream(sessionId), [sessionId]);
 
 	/* Keep the composer above the iOS keyboard: pin the layout column to
 	   the visual viewport's height and offset while the keyboard is open. */
@@ -135,7 +123,7 @@ export function SessionScreen({ pid }: { pid: number }) {
 					</p>
 				</div>
 			) : (
-				<Transcript pid={pid} entries={projection.transcript} />
+				<Transcript pid={sessionId} entries={projection.transcript} />
 			)}
 
 			{/* The aggregate working line — pinned at the foot of the transcript
@@ -156,25 +144,14 @@ export function SessionScreen({ pid }: { pid: number }) {
 
 			{projection.pending ? (
 				<PendingCard
-					pid={pid}
+					pid={sessionId}
 					pending={projection.pending}
 					count={projection.pending_count}
 				/>
 			) : null}
 
-			{projection.degraded && !projection.ended ? (
-				<p className="mx-3 rounded-sm bg-warning-wash px-3 py-2 text-center text-body-sm text-warning">
-					reconnecting to this session…
-				</p>
-			) : null}
-			{projection.ended ? (
-				<p className="mx-3 rounded-sm bg-sunken px-3 py-2 text-center text-body-sm text-ink-dim">
-					this session has ended
-				</p>
-			) : null}
-
 			<Composer
-				pid={pid}
+				pid={sessionId}
 				projection={projection}
 				onOpenModels={() => setModelsOpen(true)}
 				onOpenEffort={() => setEffortOpen(true)}
@@ -185,7 +162,7 @@ export function SessionScreen({ pid }: { pid: number }) {
 			<ModelSheet
 				open={modelsOpen}
 				onClose={() => setModelsOpen(false)}
-				pid={pid}
+				pid={sessionId}
 				projection={projection}
 			/>
 		</div>

--- a/local_operator/mobile/web/src/store.ts
+++ b/local_operator/mobile/web/src/store.ts
@@ -20,7 +20,7 @@ export interface ProjectionSlot {
 
 let sessions: SessionSummary[] = [];
 let sessionsConnected = false;
-const projections = new Map<number, ProjectionSlot>();
+const projections = new Map<string, ProjectionSlot>();
 
 const listeners = new Set<() => void>();
 
@@ -47,11 +47,11 @@ export function useSessions(): {
 	return { sessions: list, connected };
 }
 
-export function useProjection(pid: number): ProjectionSlot {
+export function useProjection(sessionId: string): ProjectionSlot {
 	return useSyncExternalStore(
 		subscribe,
 		() =>
-			projections.get(pid) ?? { projection: null, connected: false },
+			projections.get(sessionId) ?? { projection: null, connected: false },
 	);
 }
 
@@ -149,18 +149,18 @@ export function retainSessionListStream(): () => void {
 /* ------------------------------------------------------------------ */
 
 const projectionStreams = new Map<
-	number,
+	string,
 	{ close: () => void; refs: number }
 >();
 
-export function retainProjectionStream(pid: number): () => void {
-	const existing = projectionStreams.get(pid);
+export function retainProjectionStream(sessionId: string): () => void {
+	const existing = projectionStreams.get(sessionId);
 	if (existing) {
 		existing.refs++;
 	} else {
-		projections.set(pid, { projection: null, connected: false });
+		projections.set(sessionId, { projection: null, connected: false });
 		const close = openEventStream(
-			`/api/sessions/${pid}/events`,
+			`/api/sessions/${encodeURIComponent(sessionId)}/events`,
 			"projection",
 			(data) => {
 				let incoming: SessionProjection;
@@ -169,7 +169,7 @@ export function retainProjectionStream(pid: number): () => void {
 				} catch {
 					return;
 				}
-				const current = projections.get(pid);
+				const current = projections.get(sessionId);
 				/* Drop stale repaints: the daemon's epoch only moves forward. */
 				if (
 					current?.projection &&
@@ -177,27 +177,27 @@ export function retainProjectionStream(pid: number): () => void {
 				) {
 					return;
 				}
-				projections.set(pid, { projection: incoming, connected: true });
+				projections.set(sessionId, { projection: incoming, connected: true });
 				emit();
 			},
 			() => {
-				const cur = projections.get(pid);
+				const cur = projections.get(sessionId);
 				if (cur) {
-					projections.set(pid, { ...cur, connected: true });
+					projections.set(sessionId, { ...cur, connected: true });
 					emit();
 				}
 			},
 		);
-		projectionStreams.set(pid, { close, refs: 1 });
+		projectionStreams.set(sessionId, { close, refs: 1 });
 	}
 	return () => {
-		const entry = projectionStreams.get(pid);
+		const entry = projectionStreams.get(sessionId);
 		if (!entry) return;
 		entry.refs--;
 		if (entry.refs > 0) return;
 		entry.close();
-		projectionStreams.delete(pid);
-		projections.delete(pid);
+		projectionStreams.delete(sessionId);
+		projections.delete(sessionId);
 		emit();
 	};
 }
@@ -208,15 +208,15 @@ export function retainProjectionStream(pid: number): () => void {
 
 const DRAFT_PREFIX = "lo-mobile-draft:";
 
-export function getDraft(pid: number): string {
-	return localStorage.getItem(DRAFT_PREFIX + pid) ?? "";
+export function getDraft(sessionId: string): string {
+	return localStorage.getItem(DRAFT_PREFIX + sessionId) ?? "";
 }
 
-export function setDraft(pid: number, text: string): void {
+export function setDraft(sessionId: string, text: string): void {
 	if (text) {
-		localStorage.setItem(DRAFT_PREFIX + pid, text);
+		localStorage.setItem(DRAFT_PREFIX + sessionId, text);
 	} else {
-		localStorage.removeItem(DRAFT_PREFIX + pid);
+		localStorage.removeItem(DRAFT_PREFIX + sessionId);
 	}
 }
 
@@ -225,16 +225,16 @@ export function setDraft(pid: number, text: string): void {
  * Drafts survive navigation away and back, which is the phone case — the
  * user answers a message mid-compose and returns.
  */
-export function useDraft(pid: number): [string, (t: string) => void] {
-	const [text, setText] = useState(() => getDraft(pid));
+export function useDraft(sessionId: string): [string, (t: string) => void] {
+	const [text, setText] = useState(() => getDraft(sessionId));
 	useEffect(() => {
-		setText(getDraft(pid));
-	}, [pid]);
+		setText(getDraft(sessionId));
+	}, [sessionId]);
 	return [
 		text,
 		(t: string) => {
 			setText(t);
-			setDraft(pid, t);
+			setDraft(sessionId, t);
 		},
 	];
 }

--- a/local_operator/mobile/web/src/types.ts
+++ b/local_operator/mobile/web/src/types.ts
@@ -173,19 +173,17 @@ export interface SessionProjection {
 }
 
 export interface SessionSummary {
-	pid: number;
-	kind: string;
 	session_id: string;
+	section: "active" | "previous";
 	conversation_name: string;
 	cwd: string;
 	model_label: string;
 	streaming: boolean;
-	ended: boolean;
-	degraded: boolean;
 	needs_attention: boolean;
 	pending_kind: "approval" | "ask" | "" | null;
 	subagents_running: number;
-	todos_open: string;
+	todos_open: number;
+	mtime: number;
 }
 
 export interface SlashCommand {
@@ -218,7 +216,7 @@ export interface Directories {
 	tmp?: string;
 }
 
-/* ---- command ops (POST /api/sessions/{pid}/command) ---------------------- */
+/* ---- command ops (POST /api/sessions/{session_id}/command) --------------- */
 
 /** A pasted / dropped image, base64 — the wire form the handles decode. */
 export interface PromptImage {
@@ -227,7 +225,7 @@ export interface PromptImage {
 }
 
 export type CommandOp =
-	| { op: "prompt"; text: string; images?: PromptImage[] }
+	| { op: "prompt"; command_id: string; text: string; images?: PromptImage[] }
 	| { op: "steer"; text: string; images?: PromptImage[] }
 	| { op: "abort" }
 	| { op: "set_model"; provider: string; model_id: string }

--- a/local_operator/session/retention.py
+++ b/local_operator/session/retention.py
@@ -297,6 +297,11 @@ def release_session(session_dir: Path) -> None:
     """
     if not _is_session_store_dir(session_dir):
         return
+    # A leased session releases its compatibility mirror through the lease's
+    # compare-token hook. Unconditional unlink here could erase a successor's
+    # mirror after an in-process generation handoff.
+    if (session_dir / ".execution-lease").exists():
+        return
     try:
         (session_dir / LIVE_MARKER_NAME).unlink()
     except OSError:

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -1106,6 +1106,10 @@ class Session:
         )
         self._handlers: list[EventHandler] = []
         self._steering_queue: asyncio.Queue[AgentMessage] = asyncio.Queue()
+        # Producer identity is transport provenance, not message identity. Keep
+        # it beside queued messages so ordinary callers can still choose ids
+        # without accidentally entering the mobile admission namespace.
+        self._steering_producers: dict[int, str] = {}
         # Count of courtesy wake_prompt messages sitting in the steering
         # queue. The immediate-interrupt poll may cancel a RUNNING tool only
         # for steering the user actually typed (see ``_has_urgent_steering``):
@@ -2507,13 +2511,16 @@ class Session:
         images: Sequence[ImageContent] | None = None,
         *,
         message_id: str | None = None,
+        producer_command_id: str | None = None,
         admitted: asyncio.Future[None] | None = None,
     ) -> None:
         """Run one user turn to completion (awaitable) or raise.
 
-        ``message_id`` and ``admitted`` form the continuation admission seam:
-        the caller receives a receipt only after the user row is on disk, while
-        the model turn may continue afterward. Ordinary local prompts omit both.
+        ``producer_command_id`` and ``admitted`` form the continuation
+        admission seam: the caller receives a receipt only after the explicitly
+        marked user row is on disk, while the model turn may continue afterward.
+        ``message_id`` remains independent conversation identity; ordinary local
+        prompts omit producer provenance even if a host supplies a message id.
 
         ``images`` are attachments the user pasted into their prompt; they
         ride the same message as the text so the model sees them as one
@@ -2571,7 +2578,12 @@ class Session:
                 )
             user = Message.user(text, images, **({"id": message_id} if message_id else {}))
             initial: list[AgentMessage] = [catchup, user] if catchup is not None else [user]
-            await self._run_turn_pipeline(initial, admitted=admitted, admitted_id=user.id)
+            await self._run_turn_pipeline(
+                initial,
+                admitted=admitted,
+                admitted_id=user.id,
+                producer_command_id=producer_command_id,
+            )
         finally:
             self._turn_lock.release()
 
@@ -2603,6 +2615,7 @@ class Session:
         images: Sequence[ImageContent] | None = None,
         *,
         message_id: str | None = None,
+        producer_command_id: str | None = None,
     ) -> None:
         """Inject an identified steering message into the running turn.
 
@@ -2614,6 +2627,8 @@ class Session:
             Message.user(text, images, id=message_id) if message_id else Message.user(text, images)
         )
         self._steering_queue.put_nowait(message)
+        if producer_command_id is not None:
+            self._steering_producers[id(message)] = producer_command_id
 
     def queued_steering(self) -> list[AgentMessage]:
         """A FIFO snapshot of the steering queue, without draining it.
@@ -2681,6 +2696,7 @@ class Session:
             item = self._steering_queue.get_nowait()
             if item is message and not found:
                 found = True
+                self._steering_producers.pop(id(item), None)
                 continue
             remaining.append(item)
         for item in remaining:
@@ -3149,6 +3165,7 @@ class Session:
         *,
         admitted: asyncio.Future[None] | None = None,
         admitted_id: str | None = None,
+        producer_command_id: str | None = None,
     ) -> None:
         """One turn + its auto-continuations. Caller holds ``_turn_lock``.
 
@@ -3173,7 +3190,12 @@ class Session:
             begin_message()
         self._turn_task = asyncio.current_task()
         try:
-            await self._run_turn(initial, admitted=admitted, admitted_id=admitted_id)
+            await self._run_turn(
+                initial,
+                admitted=admitted,
+                admitted_id=admitted_id,
+                producer_command_id=producer_command_id,
+            )
             await self._drain_continuation()
         finally:
             self._turn_task = None
@@ -3203,6 +3225,7 @@ class Session:
         *,
         admitted: asyncio.Future[None] | None = None,
         admitted_id: str | None = None,
+        producer_command_id: str | None = None,
     ) -> None:
         """One loop run + persistence. Caller holds ``_turn_lock``."""
         if self._wake.needs_rearm:
@@ -3222,7 +3245,12 @@ class Session:
             signal.abort("interrupted")
         try:
             for message in initial:
-                await self._transcript.append_message(message)
+                await self._transcript.append_message(
+                    message,
+                    producer_command_id=(
+                        producer_command_id if message.id == admitted_id else None
+                    ),
+                )
                 if admitted is not None and message.id == admitted_id and not admitted.done():
                     # The append completed under Transcript's fsync boundary;
                     # only now may a producer discard its retained command.
@@ -3726,7 +3754,14 @@ class Session:
         messages: list[AgentMessage] = []
         while not self._steering_queue.empty():
             message = self._steering_queue.get_nowait()
-            await self._transcript.append_message(message)
+            producer_command_id = self._steering_producers.get(id(message))
+            try:
+                await self._transcript.append_message(
+                    message,
+                    producer_command_id=producer_command_id,
+                )
+            finally:
+                self._steering_producers.pop(id(message), None)
             messages.append(message)
         # The drain is the ONLY consumer, so every courtesy message queued
         # before this boundary just left with it; anything queued after is a

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -1741,6 +1741,14 @@ class Session:
         spec = self.effective_model
         return f"{spec.provider}/{spec.model_id}"
 
+    def has_admitted_command(self, command_id: str) -> bool:
+        """Return whether a producer command is durably in this transcript."""
+        return self._transcript.has_admitted_command(command_id)
+
+    def subscribe_admitted_commands(self, handler: Callable[[str], None]) -> Callable[[], None]:
+        """Observe command IDs once their transcript append has succeeded."""
+        return self._transcript.subscribe_admitted_commands(handler)
+
     def history(self) -> list[AgentMessage]:
         """The conversation as replayed into LLM context, in order.
 

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -2493,8 +2493,19 @@ class Session:
             await result
 
     # -- driving turns --------------------------------------------------------
-    async def prompt(self, text: str, images: Sequence[ImageContent] | None = None) -> None:
+    async def prompt(
+        self,
+        text: str,
+        images: Sequence[ImageContent] | None = None,
+        *,
+        message_id: str | None = None,
+        admitted: asyncio.Future[None] | None = None,
+    ) -> None:
         """Run one user turn to completion (awaitable) or raise.
+
+        ``message_id`` and ``admitted`` form the continuation admission seam:
+        the caller receives a receipt only after the user row is on disk, while
+        the model turn may continue afterward. Ordinary local prompts omit both.
 
         ``images`` are attachments the user pasted into their prompt; they
         ride the same message as the text so the model sees them as one
@@ -2550,12 +2561,9 @@ class Session:
                         "continue with the user's request that follows" if fresh else None
                     ),
                 )
-            initial: list[AgentMessage] = (
-                [catchup, Message.user(text, images)]
-                if catchup is not None
-                else [Message.user(text, images)]
-            )
-            await self._run_turn_pipeline(initial)
+            user = Message.user(text, images, **({"id": message_id} if message_id else {}))
+            initial: list[AgentMessage] = [catchup, user] if catchup is not None else [user]
+            await self._run_turn_pipeline(initial, admitted=admitted, admitted_id=user.id)
         finally:
             self._turn_lock.release()
 
@@ -3118,7 +3126,13 @@ class Session:
             self._handle_missed_wakes()
             await self._run_turn_pipeline(initial)
 
-    async def _run_turn_pipeline(self, initial: list[AgentMessage]) -> None:
+    async def _run_turn_pipeline(
+        self,
+        initial: list[AgentMessage],
+        *,
+        admitted: asyncio.Future[None] | None = None,
+        admitted_id: str | None = None,
+    ) -> None:
         """One turn + its auto-continuations. Caller holds ``_turn_lock``.
 
         A post-compaction continuation is a CONTINUATION of the same logical
@@ -3142,7 +3156,7 @@ class Session:
             begin_message()
         self._turn_task = asyncio.current_task()
         try:
-            await self._run_turn(initial)
+            await self._run_turn(initial, admitted=admitted, admitted_id=admitted_id)
             await self._drain_continuation()
         finally:
             self._turn_task = None
@@ -3166,7 +3180,13 @@ class Session:
             else held.model_copy(update={"generation": generation})
         )
 
-    async def _run_turn(self, initial: list[AgentMessage]) -> None:
+    async def _run_turn(
+        self,
+        initial: list[AgentMessage],
+        *,
+        admitted: asyncio.Future[None] | None = None,
+        admitted_id: str | None = None,
+    ) -> None:
         """One loop run + persistence. Caller holds ``_turn_lock``."""
         if self._wake.needs_rearm:
             # HC-20: the scheduler could not arm without a running loop at
@@ -3186,6 +3206,10 @@ class Session:
         try:
             for message in initial:
                 await self._transcript.append_message(message)
+                if admitted is not None and message.id == admitted_id and not admitted.done():
+                    # The append completed under Transcript's fsync boundary;
+                    # only now may a producer discard its retained command.
+                    admitted.set_result(None)
                 # Announce USER turns to every subscriber. The loop only emits
                 # MessageStartEvent for ASSISTANT messages, so without this a
                 # user prompt — from any front end — never reaches the other

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -2589,14 +2589,23 @@ class Session:
             await self._transcript.append_message(message)
             self._context.messages.append(message)
 
-    def steer(self, text: str, images: Sequence[ImageContent] | None = None) -> None:
-        """Inject a steering message into the running turn (interrupts tool
-        batches at the next boundary).
+    def steer(
+        self,
+        text: str,
+        images: Sequence[ImageContent] | None = None,
+        *,
+        message_id: str | None = None,
+    ) -> None:
+        """Inject an identified steering message into the running turn.
 
-        Attachments ride along for the same reason they do on ``prompt``:
-        steering mid-turn with a screenshot is the case where the picture
-        IS the correction."""
-        self._steering_queue.put_nowait(Message.user(text, images))
+        Attachments ride along for the same reason they do on ``prompt``. The
+        optional producer identity is persisted when the queue drains, letting
+        reconnecting followers deduplicate the correction like an ordinary turn.
+        """
+        message = (
+            Message.user(text, images, id=message_id) if message_id else Message.user(text, images)
+        )
+        self._steering_queue.put_nowait(message)
 
     def queued_steering(self) -> list[AgentMessage]:
         """A FIFO snapshot of the steering queue, without draining it.

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -1110,6 +1110,11 @@ class Session:
         # it beside queued messages so ordinary callers can still choose ids
         # without accidentally entering the mobile admission namespace.
         self._steering_producers: dict[int, str] = {}
+        # Hosts reserve producer identities before a steer reaches its durable
+        # boundary. A failed append must hand that identity back explicitly;
+        # otherwise one disk error consumes both the retry ID and a bounded
+        # steering slot for the lifetime of the owner.
+        self._steering_rejection_handlers: list[Callable[[str, str], None]] = []
         # Count of courtesy wake_prompt messages sitting in the steering
         # queue. The immediate-interrupt poll may cancel a RUNNING tool only
         # for steering the user actually typed (see ``_has_urgent_steering``):
@@ -1752,6 +1757,20 @@ class Session:
     def subscribe_admitted_commands(self, handler: Callable[[str], None]) -> Callable[[], None]:
         """Observe command IDs once their transcript append has succeeded."""
         return self._transcript.subscribe_admitted_commands(handler)
+
+    def subscribe_rejected_steering(
+        self, handler: Callable[[str, str], None]
+    ) -> Callable[[], None]:
+        """Observe producer steers that failed before durable admission."""
+        self._steering_rejection_handlers.append(handler)
+
+        def unsubscribe() -> None:
+            try:
+                self._steering_rejection_handlers.remove(handler)
+            except ValueError:
+                pass
+
+        return unsubscribe
 
     def history(self) -> list[AgentMessage]:
         """The conversation as replayed into LLM context, in order.
@@ -3737,6 +3756,25 @@ class Session:
         )
         self._spawn_background(self._prompt_messages([message]))
 
+    async def _reject_steering(self, command_id: str, reason: str) -> None:
+        """Terminally reject one accepted-but-undurable producer steer."""
+        for handler in list(self._steering_rejection_handlers):
+            try:
+                handler(command_id, reason)
+            except Exception:  # noqa: BLE001 - one owner cannot hide rejection from others
+                logger.exception("steering rejection handler failed")
+        await self._emit(
+            NoticeEvent(
+                text=(
+                    f"steering command {command_id} was not saved: {reason}; "
+                    "retry with the same command ID"
+                )
+            )
+        )
+        # Mobile projections optimistically count accepted steers. Rejection is
+        # another terminal exit from that queue, even though it was not delivered.
+        await self._emit(SteeringDeliveredEvent(count=1))
+
     async def _drain_steering(self) -> list[AgentMessage]:
         """Consume the steering queue. Steering messages are real injected
         turns, so they are persisted here — the loop never returns them in its
@@ -3760,6 +3798,12 @@ class Session:
                     message,
                     producer_command_id=producer_command_id,
                 )
+            except OSError as exc:
+                if producer_command_id is not None:
+                    await self._reject_steering(producer_command_id, str(exc))
+                else:
+                    logger.warning("could not journal steering message", exc_info=True)
+                continue
             finally:
                 self._steering_producers.pop(id(message), None)
             messages.append(message)
@@ -5697,6 +5741,14 @@ class Session:
         if self._disposed:
             return
         self._disposed = True
+        # No later boundary can drain producer steers once disposal starts.
+        # Reject them while owner callbacks and viewers are still attached so
+        # capacity is released and the producer can safely reuse the same ID.
+        while not self._steering_queue.empty():
+            message = self._steering_queue.get_nowait()
+            command_id = self._steering_producers.pop(id(message), None)
+            if command_id is not None:
+                await self._reject_steering(command_id, "session closed before durable admission")
         # A courtesy wake still queued here was never delivered, so its count
         # must not survive to misclassify a later enqueue on a reused Session.
         self._courtesy_wake_count = 0

--- a/local_operator/session/transcript.py
+++ b/local_operator/session/transcript.py
@@ -42,7 +42,7 @@ import time
 import uuid
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 from local_operator.harness.types import (
     AgentMessage,
@@ -246,6 +246,11 @@ class Transcript:
         self.path = self.directory / TRANSCRIPT_FILENAME
         self._lock = asyncio.Lock()
         self._entries: list[TranscriptEntry] = []
+        # Command identities live beside the append-only rows that prove their
+        # admission.  Replay builds this once; hot-path lookups must not scan a
+        # transcript whose model-facing window may also have been compacted.
+        self._admitted_command_ids: set[str] = set()
+        self._admission_handlers: list[Callable[[str], None]] = []
         #: Shared content-addressed media store. Write path: image payloads
         #: are externalized to it on append. Read path: references are
         #: resolved back to inline base64 on replay, so anything downstream
@@ -259,6 +264,9 @@ class Transcript:
                     entry = TranscriptEntry.from_json(line)
                     if entry is not None:
                         self._entries.append(entry)
+                        command_id = _admitted_command_id(entry)
+                        if command_id is not None:
+                            self._admitted_command_ids.add(command_id)
 
     # -- append -------------------------------------------------------------
 
@@ -395,7 +403,34 @@ class Transcript:
                     for row in self._entries:
                         handle.write(row.to_json() + "\n")
                     handle.flush()
+            command_id = _admitted_command_id(entry)
+            if command_id is not None:
+                # Update only after the append's flush boundary.  A crash after
+                # this point can replay the row; an ACK or callback before it
+                # would claim durability the transcript did not yet have.
+                self._admitted_command_ids.add(command_id)
+                for handler in list(self._admission_handlers):
+                    try:
+                        handler(command_id)
+                    except Exception:  # noqa: BLE001 - observers cannot undo durability
+                        logger.exception("transcript admission handler failed")
         return entry
+
+    def has_admitted_command(self, command_id: str) -> bool:
+        """Return whether an append-only user row already owns ``command_id``."""
+        return command_id in self._admitted_command_ids
+
+    def subscribe_admitted_commands(self, handler: Callable[[str], None]) -> Callable[[], None]:
+        """Observe user command IDs after their durable append boundary."""
+        self._admission_handlers.append(handler)
+
+        def unsubscribe() -> None:
+            try:
+                self._admission_handlers.remove(handler)
+            except ValueError:
+                pass
+
+        return unsubscribe
 
     # -- replay -------------------------------------------------------------
 
@@ -788,6 +823,22 @@ def _shrink_marked(entry: TranscriptEntry) -> TranscriptEntry:
     provider_payload[SHRUNK_KEY] = True
     payload["provider_payload"] = provider_payload
     return TranscriptEntry(id=entry.id, ts=entry.ts, type=entry.type, payload=payload)
+
+
+def _admitted_command_id(entry: TranscriptEntry) -> str | None:
+    """Extract only durable user-message identities from a transcript row.
+
+    Compaction/prune/custom rows also carry IDs, while malformed and legacy
+    fragments may carry incomplete payloads.  None of those are producer
+    commands and therefore none may poison the admission namespace.
+    """
+    if entry.type != ENTRY_MESSAGE:
+        return None
+    payload = entry.payload
+    if payload.get("kind", CUSTOM_KIND_MESSAGE) != CUSTOM_KIND_MESSAGE:
+        return None
+    command_id = entry.id
+    return command_id if command_id and payload.get("role") == "user" else None
 
 
 def _entry_to_message(

--- a/local_operator/session/transcript.py
+++ b/local_operator/session/transcript.py
@@ -879,10 +879,18 @@ def _admitted_command_id(entry: TranscriptEntry) -> str | None:
     if entry.type != ENTRY_MESSAGE:
         return None
     payload = entry.payload
-    if payload.get("kind", CUSTOM_KIND_MESSAGE) != CUSTOM_KIND_MESSAGE:
+    # Producer provenance was introduced with an explicit kind marker. Treating
+    # the legacy missing-kind default as producer-eligible lets imported rows
+    # claim IDs merely by carrying an unknown extra envelope field.
+    if payload.get("kind") != CUSTOM_KIND_MESSAGE:
         return None
     command_id = payload.get("producer_command_id")
-    return command_id if isinstance(command_id, str) and command_id else None
+    if not isinstance(command_id, str) or not command_id.strip():
+        return None
+    message = _entry_to_message(entry)
+    if not isinstance(message, Message) or message.role != "user":
+        return None
+    return command_id
 
 
 def _entry_to_message(
@@ -891,6 +899,10 @@ def _entry_to_message(
     """Rehydrate one message entry; malformed rows are dropped individually."""
     payload = dict(entry.payload)
     kind = payload.pop("kind", CUSTOM_KIND_MESSAGE)
+    # Producer identity belongs to the transcript envelope, never the Message
+    # schema. Leaving it in makes strict Message decoding reject every valid
+    # producer row as an unknown field during both replay and admission checks.
+    payload.pop("producer_command_id", None)
     # The entry id IS the message id for BOTH kinds — the writer passes
     # ``message.id`` as the entry id and the encoder omits it from the
     # payload, so a custom entry that read its id from the payload would come

--- a/local_operator/session/transcript.py
+++ b/local_operator/session/transcript.py
@@ -270,18 +270,32 @@ class Transcript:
 
     # -- append -------------------------------------------------------------
 
-    async def append_message(self, message: Message | CustomMessage) -> TranscriptEntry:
+    async def append_message(
+        self,
+        message: Message | CustomMessage,
+        *,
+        producer_command_id: str | None = None,
+    ) -> TranscriptEntry:
         """Append one LLM-visible message (or a custom transcript message).
 
         BOTH kinds persist the message's own ``id`` as the entry id (never
         mint a new one): compaction's ``first_kept_entry_id`` must be able to
         reference a custom entry that renders into LLM context.
+
+        ``producer_command_id`` is deliberately separate from that message id.
+        Hosts use message ids for several unrelated purposes, so treating every
+        user row as producer admission lets imported or seeded history suppress
+        a later command whose namespace happens to collide. The marker lives on
+        the transcript envelope, where replay preserves it without exposing
+        transport bookkeeping to either model-facing history or the UI.
         """
         kind = CUSTOM_KIND_MESSAGE if isinstance(message, Message) else CUSTOM_KIND_CUSTOM
         payload: dict[str, Any] = {
             "kind": kind,
             **encode_message_payload(message, self._attachments),
         }
+        if producer_command_id is not None:
+            payload["producer_command_id"] = producer_command_id
         return await self._append(ENTRY_MESSAGE, payload, message.id)
 
     async def append_compaction(
@@ -349,7 +363,6 @@ class Transcript:
             payload=payload,
         )
         async with self._lock:
-            self._entries.append(entry)
             # DELIBERATELY SYNCHRONOUS, and not an oversight — do not "fix"
             # this into a to_thread the way :meth:`compact_file` legitimately
             # is. This append has callers that never await it:
@@ -375,9 +388,9 @@ class Transcript:
             # type their first message, and the retention sweep's ``live_dir``
             # only protects the sweeping process's OWN session. Dying on
             # FileNotFoundError here costs the whole session for a directory
-            # one mkdir restores; ``self._entries`` still holds every prior
-            # entry, so the recreated file is rebuilt complete rather than
-            # starting truncated.
+            # one mkdir restores; the candidate joins ``self._entries`` only
+            # after the rebuilt file reaches its durability boundary, so a
+            # failed rebuild cannot resurrect a row on the next append.
             #
             # The FILE alone vanishing (directory intact) is the same wound
             # with a quieter symptom: ``"a"`` mode recreates the file without
@@ -385,24 +398,53 @@ class Transcript:
             # holds one row while memory holds the whole session — a resume
             # would then replay a single message as if the rest never
             # happened. Checked BEFORE the append because that path never
-            # raises; both cases rebuild from ``self._entries`` under the
-            # same lock.
+            # raises; both cases rebuild from the committed rows plus this
+            # unpublished candidate under the same lock.
             rebuild = not self.path.exists()
             if not rebuild:
                 try:
-                    with self.path.open("a", encoding="utf-8") as handle:
-                        handle.write(entry.to_json() + "\n")
-                        handle.flush()
+                    previous_size = self.path.stat().st_size
                 except FileNotFoundError:
-                    # Directory removed between the exists() check and the
-                    # open — the race is real, so the window is too.
                     rebuild = True
+                else:
+                    try:
+                        with self.path.open("a", encoding="utf-8") as handle:
+                            handle.write(entry.to_json() + "\n")
+                            handle.flush()
+                            os.fsync(handle.fileno())
+                    except FileNotFoundError:
+                        # Directory removed between the exists() check and the
+                        # open — the race is real, so the window is too.
+                        rebuild = True
+                    except BaseException:
+                        # write/flush/fsync may raise after changing the file.
+                        # The append-only framing makes its old byte boundary
+                        # the only safe rollback point; the lock prevents a
+                        # successor from being truncated with this candidate.
+                        try:
+                            os.truncate(self.path, previous_size)
+                        except FileNotFoundError:
+                            pass
+                        raise
             if rebuild:
                 self.directory.mkdir(parents=True, exist_ok=True)
-                with self.path.open("w", encoding="utf-8") as handle:
-                    for row in self._entries:
-                        handle.write(row.to_json() + "\n")
-                    handle.flush()
+                try:
+                    with self.path.open("w", encoding="utf-8") as handle:
+                        for row in (*self._entries, entry):
+                            handle.write(row.to_json() + "\n")
+                        handle.flush()
+                        os.fsync(handle.fileno())
+                except BaseException:
+                    # A failed rebuild started from a missing file. Removing
+                    # its partial journal preserves that pre-call state and
+                    # prevents a parseable prefix from becoming admitted after
+                    # restart even though this call failed.
+                    try:
+                        self.path.unlink()
+                    except FileNotFoundError:
+                        pass
+                    raise
+            self._entries.append(entry)
             command_id = _admitted_command_id(entry)
             if command_id is not None:
                 # Update only after the append's flush boundary.  A crash after
@@ -826,19 +868,21 @@ def _shrink_marked(entry: TranscriptEntry) -> TranscriptEntry:
 
 
 def _admitted_command_id(entry: TranscriptEntry) -> str | None:
-    """Extract only durable user-message identities from a transcript row.
+    """Extract an explicitly marked producer identity from a transcript row.
 
-    Compaction/prune/custom rows also carry IDs, while malformed and legacy
-    fragments may carry incomplete payloads.  None of those are producer
-    commands and therefore none may poison the admission namespace.
+    Message IDs belong to the conversation namespace and can collide with
+    seeded, imported, compacted, custom, or locally-authored rows. Only the
+    transport marker proves that a producer command crossed the durable append
+    boundary; released transcripts and malformed fragments have no marker and
+    therefore cannot poison admission.
     """
     if entry.type != ENTRY_MESSAGE:
         return None
     payload = entry.payload
     if payload.get("kind", CUSTOM_KIND_MESSAGE) != CUSTOM_KIND_MESSAGE:
         return None
-    command_id = entry.id
-    return command_id if command_id and payload.get("role") == "user" else None
+    command_id = payload.get("producer_command_id")
+    return command_id if isinstance(command_id, str) and command_id else None
 
 
 def _entry_to_message(

--- a/local_operator/session_factory.py
+++ b/local_operator/session_factory.py
@@ -857,6 +857,9 @@ class _SessionPlan:
     system_blocks_provider: Callable[..., Awaitable[list[str]]]
     knowledge_hooks: _KnowledgeHooks
     auth_store: AuthStore | None = None
+    # Acquired before transcript construction and transferred to Session.dispose;
+    # benchmark-only preparation releases it directly because no Session exists.
+    session_lease: Any | None = None
 
 
 def _make_system_blocks_provider(
@@ -1003,6 +1006,15 @@ async def _prepare(
     transcript_dir, agent_id = _transcript_dir_and_agent_id(agent, args, agent_registry)
 
     from local_operator.session.retention import claim_session, sweep_from_config
+    from local_operator.session_lease import acquire_session_lease
+
+    # Sole-writer ownership is acquired at the shared construction boundary,
+    # before transcript creation. Edge checks remain useful UX, but only O_EXCL
+    # can make two simultaneous cold resumes safe. Agent training directories
+    # retain their established non-session semantics and are not leased here.
+    session_lease = (
+        acquire_session_lease(transcript_dir) if transcript_dir.parent.name == "sessions" else None
+    )
 
     # CLAIM BEFORE creating the directory, and in that order. The claim marker
     # is what tells every OTHER session's startup sweep that this directory
@@ -1212,6 +1224,7 @@ async def _prepare(
         system_blocks_provider=system_blocks_provider,
         knowledge_hooks=hooks,
         auth_store=auth_store,
+        session_lease=session_lease,
     )
 
 
@@ -1522,7 +1535,16 @@ async def create_session(
         has_ui=has_ui,
         cwd=effective_cwd,
     )
-    session = Session(**plan.session_kwargs)
+    try:
+        session = Session(**plan.session_kwargs)
+    except BaseException:
+        # Construction never transferred ownership to Session.dispose, so the
+        # factory must relinquish its generation without touching a successor.
+        if plan.session_lease is not None:
+            plan.session_lease.release()
+        raise
+    if plan.session_lease is not None:
+        session.add_dispose_hook(plan.session_lease.release)
 
     # Auth seam (CL-08): the AuthStore's SQLite connection is owned by this
     # session; fold its close into dispose so every front end releases the
@@ -1564,6 +1586,10 @@ async def build_initial_blocks(
     budget without instantiating the session facade.
     """
     plan = await _prepare(args, config_manager, credential_manager, agent_registry, has_ui=False)
+    # No session facade is built on this path, so the lease and store lifetimes
+    # end here rather than waiting for a Session.dispose that cannot happen.
+    if plan.session_lease is not None:
+        plan.session_lease.release()
     # No session facade is built on this path, so the store's lifetime ends
     # here: close it directly (CL-08) to release the SQLite lock. Pass the
     # spec's label so the measured startup prompt includes the model line the

--- a/local_operator/session_lease.py
+++ b/local_operator/session_lease.py
@@ -163,6 +163,42 @@ class SessionLease:
             pass
 
 
+def reap_proven_dead_session_claim(session_dir: Path, owner_pid: int) -> bool:
+    """Remove only the exact dead owner's lease and compatibility mirror.
+
+    The daemon calls this after discovery proves a record pid is gone. Recovery
+    still revalidates under the same kernel lock used by acquisition, because a
+    successor may claim the durable transcript between the scan and cleanup.
+    Windows remains conservative through ``_pid_state`` and lock acquisition.
+    """
+    if _pid_state(owner_pid) != "dead":
+        return False
+    path = session_dir / LEASE_NAME
+    with _stale_recovery_right(session_dir) as may_recover:
+        if not may_recover:
+            return False
+        generation, current_pid = _read_claim(path)
+        if generation is None or current_pid is None or current_pid != owner_pid:
+            return False
+        if _pid_state(current_pid) != "dead":
+            return False
+        # Re-read immediately before unlink so cleanup is generation-fenced even
+        # if a future platform changes lock semantics around pathname replacement.
+        if _read_claim(path) != (generation, current_pid):
+            return False
+        try:
+            path.unlink()
+        except OSError:
+            return False
+        mirror = session_dir / MIRROR_NAME
+        try:
+            if mirror.read_text(encoding="utf-8").strip() == str(owner_pid):
+                mirror.unlink()
+        except OSError:
+            pass
+        return True
+
+
 def acquire_session_lease(session_dir: Path, pid: int | None = None) -> SessionLease:
     """Atomically acquire sole-writer ownership, recovering proven-dead claims."""
     owner_pid = os.getpid() if pid is None else pid

--- a/local_operator/session_lease.py
+++ b/local_operator/session_lease.py
@@ -1,0 +1,152 @@
+"""Atomic sole-writer leases for durable session transcripts.
+
+The compatibility ``.session.pid`` marker is useful for old readers but cannot
+be authoritative because replacing a text file is not acquisition.  This
+module stays stdlib-only so resume discovery can consult it without importing
+the engine or mobile stack.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import secrets
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+LEASE_NAME = ".execution-lease"
+MIRROR_NAME = ".session.pid"
+
+
+class SessionLeaseHeldError(RuntimeError):
+    """Raised when another live or unverifiable process owns a transcript."""
+
+    def __init__(self, session_dir: Path, pid: int | None) -> None:
+        owner = f"pid {pid}" if pid is not None else "an unverifiable process"
+        super().__init__(
+            f"session {session_dir.name} is already open in {owner}; "
+            "attach to that session or wait for its owner to exit"
+        )
+        self.session_dir = session_dir
+        self.pid = pid
+
+
+def _pid_state(pid: int) -> Literal["live", "dead", "uncertain"]:
+    """Probe only what the platform can prove; uncertainty never permits theft."""
+    if pid <= 0:
+        return "uncertain"
+    if os.name == "nt":
+        # OpenProcess is the Windows liveness primitive. Access denial means the
+        # process may exist under another integrity level, so fail closed.
+        try:
+            import ctypes
+
+            kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+            handle = kernel32.OpenProcess(0x1000, False, pid)  # PROCESS_QUERY_LIMITED_INFORMATION
+            if handle:
+                kernel32.CloseHandle(handle)
+                return "live"
+            error = ctypes.get_last_error()
+            return "dead" if error == 87 else "uncertain"  # ERROR_INVALID_PARAMETER
+        except Exception:
+            return "uncertain"
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return "dead"
+    except PermissionError:
+        return "live"
+    except OSError:
+        return "uncertain"
+    return "live"
+
+
+def _read_claim(path: Path) -> tuple[str | None, int | None]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        token = data.get("generation")
+        pid = data.get("pid")
+        return (str(token) if token else None, int(pid) if isinstance(pid, int) else None)
+    except (OSError, ValueError, TypeError):
+        return None, None
+
+
+@dataclass(frozen=True)
+class SessionLease:
+    """One generation claim; release removes only this exact generation."""
+
+    session_dir: Path
+    generation: str
+    pid: int
+
+    def release(self) -> None:
+        path = self.session_dir / LEASE_NAME
+        token, _ = _read_claim(path)
+        if token != self.generation:
+            return
+        try:
+            path.unlink()
+        except OSError:
+            return
+        # The mirror is never authority. Compare its pid so an old generation
+        # cannot erase the compatibility signal written by a successor.
+        mirror = self.session_dir / MIRROR_NAME
+        try:
+            if mirror.read_text(encoding="utf-8").strip() == str(self.pid):
+                mirror.unlink()
+        except OSError:
+            pass
+
+
+def acquire_session_lease(session_dir: Path, pid: int | None = None) -> SessionLease:
+    """Atomically acquire sole-writer ownership, recovering proven-dead claims."""
+    owner_pid = os.getpid() if pid is None else pid
+    session_dir.mkdir(parents=True, exist_ok=True)
+    path = session_dir / LEASE_NAME
+    mirror = session_dir / MIRROR_NAME
+    # During mixed-version rollout an old writer has only the pid mirror. It is
+    # still authoritative when live or uncertain; otherwise a new binary could
+    # acquire a lease beside an old binary that knows nothing about leases.
+    if not path.exists():
+        try:
+            legacy_pid = int(mirror.read_text(encoding="utf-8").strip())
+        except (OSError, ValueError):
+            legacy_pid = None
+        if legacy_pid is not None and _pid_state(legacy_pid) != "dead":
+            raise SessionLeaseHeldError(session_dir, legacy_pid)
+    generation = secrets.token_hex(16)
+    payload = json.dumps(
+        {"schema": 1, "session_id": session_dir.name, "generation": generation, "pid": owner_pid},
+        separators=(",", ":"),
+    ).encode()
+
+    while True:
+        try:
+            fd = os.open(path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+        except FileExistsError:
+            _, existing_pid = _read_claim(path)
+            if existing_pid is None or _pid_state(existing_pid) != "dead":
+                raise SessionLeaseHeldError(session_dir, existing_pid)
+            tombstone = session_dir / f"{LEASE_NAME}.stale.{secrets.token_hex(8)}"
+            try:
+                os.replace(path, tombstone)
+            except OSError:
+                # Another contender recovered it, or Windows would not permit
+                # the rename. Re-read rather than granting ourselves ownership.
+                continue
+            try:
+                tombstone.unlink()
+            except OSError:
+                pass
+            continue
+        try:
+            os.write(fd, payload)
+            os.fsync(fd)
+        finally:
+            os.close(fd)
+        try:
+            (session_dir / MIRROR_NAME).write_text(str(owner_pid), encoding="utf-8")
+        except OSError:
+            pass
+        return SessionLease(session_dir, generation, owner_pid)

--- a/local_operator/session_lease.py
+++ b/local_operator/session_lease.py
@@ -11,12 +11,14 @@ from __future__ import annotations
 import json
 import os
 import secrets
+from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Literal
+from typing import Iterator, Literal
 
 LEASE_NAME = ".execution-lease"
 MIRROR_NAME = ".session.pid"
+RECOVERY_LOCK_NAME = ".execution-lease.recovery"
 
 
 class SessionLeaseHeldError(RuntimeError):
@@ -72,6 +74,68 @@ def _read_claim(path: Path) -> tuple[str | None, int | None]:
         return None, None
 
 
+@contextmanager
+def _stale_recovery_right(session_dir: Path) -> Iterator[bool]:
+    """Try to serialize stale takeover with a crash-released kernel lock.
+
+    A persistent side file avoids the same pathname replacement race as the
+    lease itself. The kernel lock, not the file's lifetime, is authoritative:
+    process death releases it automatically, so recovery cannot become
+    immortal. Windows lock failures stay closed because access denial and a
+    live contender are intentionally indistinguishable here.
+    """
+    path = session_dir / RECOVERY_LOCK_NAME
+    fd = os.open(path, os.O_CREAT | os.O_RDWR, 0o600)
+    token = secrets.token_hex(16)
+    acquired = False
+    try:
+        if os.name == "nt":
+            import msvcrt
+
+            try:
+                if os.fstat(fd).st_size == 0:
+                    os.write(fd, b"\0")
+                os.lseek(fd, 0, os.SEEK_SET)
+                msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)
+                acquired = True
+            except OSError:
+                yield False
+                return
+        else:
+            import fcntl
+
+            try:
+                fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                acquired = True
+            except OSError:
+                yield False
+                return
+        # Metadata is diagnostic only, but records both process identity and a
+        # per-attempt token so a surviving file is never mistaken for authority.
+        os.ftruncate(fd, 0)
+        os.write(
+            fd,
+            json.dumps({"pid": os.getpid(), "token": token}, separators=(",", ":")).encode(),
+        )
+        os.fsync(fd)
+        yield True
+    finally:
+        if acquired:
+            try:
+                if os.name == "nt":
+                    import msvcrt
+
+                    os.lseek(fd, 0, os.SEEK_SET)
+                    msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
+                else:
+                    import fcntl
+
+                    fcntl.flock(fd, fcntl.LOCK_UN)
+            except OSError:
+                pass
+        os.close(fd)
+
+
 @dataclass(frozen=True)
 class SessionLease:
     """One generation claim; release removes only this exact generation."""
@@ -125,28 +189,45 @@ def acquire_session_lease(session_dir: Path, pid: int | None = None) -> SessionL
         try:
             fd = os.open(path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
         except FileExistsError:
-            _, existing_pid = _read_claim(path)
-            if existing_pid is None or _pid_state(existing_pid) != "dead":
-                raise SessionLeaseHeldError(session_dir, existing_pid)
-            tombstone = session_dir / f"{LEASE_NAME}.stale.{secrets.token_hex(8)}"
-            try:
-                os.replace(path, tombstone)
-            except OSError:
-                # Another contender recovered it, or Windows would not permit
-                # the rename. Re-read rather than granting ourselves ownership.
-                continue
-            try:
-                tombstone.unlink()
-            except OSError:
-                pass
-            continue
+            inspected_generation, inspected_pid = _read_claim(path)
+            if inspected_pid is None or _pid_state(inspected_pid) != "dead":
+                raise SessionLeaseHeldError(session_dir, inspected_pid)
+            with _stale_recovery_right(session_dir) as may_recover:
+                if not may_recover:
+                    # A live recoverer is indistinguishable from ownership until
+                    # it publishes its successor. Fail closed instead of racing it.
+                    _, current_pid = _read_claim(path)
+                    raise SessionLeaseHeldError(session_dir, current_pid)
+                current_generation, current_pid = _read_claim(path)
+                if (
+                    current_generation != inspected_generation
+                    or current_pid != inspected_pid
+                    or current_pid is None
+                    or _pid_state(current_pid) != "dead"
+                ):
+                    # The exact generation/process pair changed, became live, or
+                    # cannot still be proven dead. Never move that successor.
+                    raise SessionLeaseHeldError(session_dir, current_pid)
+                tombstone = session_dir / f"{LEASE_NAME}.stale.{secrets.token_hex(8)}"
+                try:
+                    os.replace(path, tombstone)
+                    fd = os.open(path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+                except OSError:
+                    # Windows rename denial and any unexpected successor both
+                    # stay closed; neither permits speculative ownership.
+                    raise SessionLeaseHeldError(session_dir, current_pid) from None
+                finally:
+                    try:
+                        tombstone.unlink()
+                    except OSError:
+                        pass
         try:
             os.write(fd, payload)
             os.fsync(fd)
         finally:
             os.close(fd)
         try:
-            (session_dir / MIRROR_NAME).write_text(str(owner_pid), encoding="utf-8")
+            mirror.write_text(str(owner_pid), encoding="utf-8")
         except OSError:
             pass
         return SessionLease(session_dir, generation, owner_pid)

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -683,9 +683,10 @@ class _TerminalFrontendReaper:
             if self.gate_since is None:
                 self.gate_since = now
                 return None
-            # The deadline is total answerability time, independent of work,
-            # but settlement waits until it cannot disturb unrelated activity.
-            if now - self.gate_since >= self.gate_timeout_s and not busy:
+            # Settling the front-end future is not an interruption: it is the
+            # only event that lets this gate-owned streaming turn progress. Any
+            # unrelated work remains untouched and is observed after settlement.
+            if now - self.gate_since >= self.gate_timeout_s:
                 self.gate_since = None
                 return "settle"
             return None
@@ -3330,7 +3331,9 @@ class OperatorApp(App[None]):
             from local_operator.tui.attach_screen import AttachScreen
             from local_operator.tui.widgets.toast import TOAST_DEFAULT_MS, Toast
 
-            self.push_screen(AttachScreen(record, concrete))
+            self.push_screen(
+                AttachScreen(record, concrete, on_resume_here=self._resume_attached_here)
+            )
             # The toast replaces the warning the refusal used to print: the
             # user's navigation SUCCEEDED, it just landed on a follower view.
             try:
@@ -3351,6 +3354,24 @@ class OperatorApp(App[None]):
             "phone session list",
             "warning",
         )
+
+    async def _resume_attached_here(self, session_id: str) -> None:
+        """Replace a dead follower with this app's normal writable resume path.
+
+        The factory owns atomic lease arbitration, so a successor that appeared
+        after EOF becomes an actionable boot failure rather than a second writer.
+        Pop first so progress and any failure render in the app's native surface.
+        """
+        if self._resume_factory is None:
+            screen = self.screen
+            pending = getattr(screen, "_pending", None)
+            if pending is not None:
+                pending.update("resume unavailable: no resume-capable launcher")
+            return
+        self.pop_screen()
+        self._session_factory = lambda: self._resume_factory(session_id)  # type: ignore[misc]
+        self._system_notice(f"resuming session {session_id} here…", "info")
+        await self._reload_session()
 
     def _cmd_new(self, notice: NoticeFn) -> None:
         """``/new`` — start a fresh conversation without leaving the app.
@@ -6841,10 +6862,10 @@ class OperatorApp(App[None]):
             return True
         if session is None:
             return self._turn_is_live() and not gate_pending
-        # A gate parks the app's runner, so that flag alone is not autonomous
-        # work while WAITING_INPUT. The session streaming flag still catches an
-        # unrelated model/tool phase that happens to overlap the visible gate.
-        if bool(getattr(session, "is_streaming", False)):
+        # Streaming and the turn task are expected to remain live while their
+        # displayed gate is parked. They matter again immediately after the gate
+        # is settled; before then they must not prevent its hard deadline.
+        if bool(getattr(session, "is_streaming", False)) and not gate_pending:
             return True
         if self._turn_is_live() and not gate_pending:
             return True

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -3329,21 +3329,8 @@ class OperatorApp(App[None]):
         record, found_owner = await asyncio.to_thread(find_owner_record, config_dir, concrete)
         if record is not None and found_owner == owner:
             from local_operator.tui.attach_screen import AttachScreen
-            from local_operator.tui.widgets.toast import TOAST_DEFAULT_MS, Toast
 
-            self.push_screen(
-                AttachScreen(record, concrete, on_resume_here=self._resume_attached_here)
-            )
-            # The toast replaces the warning the refusal used to print: the
-            # user's navigation SUCCEEDED, it just landed on a follower view.
-            try:
-                self.query_one(Toast).show(
-                    f"attached to pid {owner} — /detach to return",
-                    duration_ms=TOAST_DEFAULT_MS,
-                    yield_to_actionable=True,
-                )
-            except Exception:  # noqa: BLE001 — a toast is decoration, never a gate
-                pass
+            self.push_screen(AttachScreen(record, concrete))
             return
         # A refused navigation is not conversation content: keep the
         # splash, same as the other /resume rejections (D1). Name the
@@ -3354,24 +3341,6 @@ class OperatorApp(App[None]):
             "phone session list",
             "warning",
         )
-
-    async def _resume_attached_here(self, session_id: str) -> None:
-        """Replace a dead follower with this app's normal writable resume path.
-
-        The factory owns atomic lease arbitration, so a successor that appeared
-        after EOF becomes an actionable boot failure rather than a second writer.
-        Pop first so progress and any failure render in the app's native surface.
-        """
-        if self._resume_factory is None:
-            screen = self.screen
-            pending = getattr(screen, "_pending", None)
-            if pending is not None:
-                pending.update("resume unavailable: no resume-capable launcher")
-            return
-        self.pop_screen()
-        self._session_factory = lambda: self._resume_factory(session_id)  # type: ignore[misc]
-        self._system_notice(f"resuming session {session_id} here…", "info")
-        await self._reload_session()
 
     def _cmd_new(self, notice: NoticeFn) -> None:
         """``/new`` — start a fresh conversation without leaving the app.

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -3191,13 +3191,14 @@ class OperatorApp(App[None]):
         ``_on_boot_failed`` exactly as a bad ``--resume`` does.
 
         A session that is ALREADY live in another process (a phone-started
-        child, another TUI) is not reopened here. Two writers on one
-        transcript is how a resume of a mobile session painted the splash:
-        the second process claimed the directory, replayed a mid-write
-        journal, and left the first process as the only one still appending.
-        The live process already publishes to the phone; this TUI stays
-        put and names that process so the user can watch and steer from
-        either front end.
+        child, another TUI) is not reopened here — it is ATTACHED to when the
+        owner is reachable over the mobile control socket (see
+        ``_attach_or_refuse``), and refused with today's copy otherwise. Two
+        writers on one transcript is how a resume of a mobile session painted
+        the splash: the second process claimed the directory, replayed a
+        mid-write journal, and left the first process as the only one still
+        appending. The live process already publishes to the phone; this TUI
+        follows and steers that process instead of racing it.
         """
         if self._resume_factory is None:
             self._system_notice("resume unavailable: no resume-capable launcher", "warning")
@@ -3219,19 +3220,61 @@ class OperatorApp(App[None]):
         if concrete != RESUME_LATEST:
             owner = live_session_owner(config_dir(), concrete)
             if owner is not None and owner != os.getpid():
-                # A refused navigation is not conversation content: keep the
-                # splash, same as the other /resume rejections (D1). Name the
-                # owning process and the next step in user words (D2).
-                self._system_notice(
-                    f"session {concrete} is already open in another process "
-                    f"(pid {owner}) — watch and steer it there, or from the "
-                    "phone session list",
-                    "warning",
+                # Discovery scans the filesystem; run it as a worker so the
+                # UI thread never blocks on it, and settle attach-vs-refuse
+                # when the record is in hand.
+                self.run_worker(
+                    self._attach_or_refuse(config_dir(), concrete, owner),
+                    thread=False,
+                    group="session",
                 )
                 return
         self._session_factory = lambda: self._resume_factory(resume_id)  # type: ignore[misc]
         notice(f"resuming session {resume_id}…")
         self.run_worker(self._reload_session(), thread=False, group="session")
+
+    async def _attach_or_refuse(
+        self, config_dir, concrete: str, owner: int
+    ) -> None:
+        """Settle the owned-session branch of ``_resume_session``.
+
+        ATTACH when the owner is reachable over the control socket (record
+        found, protocol >= 2, pid match): push the AttachScreen and toast the
+        new state. Otherwise degrade to TODAY's refusal message verbatim —
+        graceful degradation for old binaries, registrant-start failures, and
+        rebind races. Runs as a worker: ``find_owner_record`` is filesystem
+        I/O.
+        """
+        from local_operator.mobile.attach_client import find_owner_record
+
+        record, found_owner = await asyncio.to_thread(
+            find_owner_record, config_dir, concrete
+        )
+        if record is not None and found_owner == owner:
+            from local_operator.tui.attach_screen import AttachScreen
+            from local_operator.tui.widgets.toast import TOAST_DEFAULT_MS, Toast
+
+            self.push_screen(AttachScreen(record, concrete))
+            # The toast replaces the warning the refusal used to print: the
+            # user's navigation SUCCEEDED, it just landed on a follower view.
+            try:
+                self.query_one(Toast).show(
+                    f"attached to pid {owner} — /detach to return",
+                    duration_ms=TOAST_DEFAULT_MS,
+                    yield_to_actionable=True,
+                )
+            except Exception:  # noqa: BLE001 — a toast is decoration, never a gate
+                pass
+            return
+        # A refused navigation is not conversation content: keep the
+        # splash, same as the other /resume rejections (D1). Name the
+        # owning process and the next step in user words (D2).
+        self._system_notice(
+            f"session {concrete} is already open in another process "
+            f"(pid {owner}) — watch and steer it there, or from the "
+            "phone session list",
+            "warning",
+        )
 
     def _cmd_new(self, notice: NoticeFn) -> None:
         """``/new`` — start a fresh conversation without leaving the app.

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -637,6 +637,51 @@ logger = logging.getLogger("local_operator.tui.app")
 #: resume command — where omp's only clears the editor.)
 DOUBLE_INTERRUPT_WINDOW_S = 1.5
 
+#: Terminal-reader liveness is a lifecycle signal, not an idle timer. Textual's
+#: POSIX input thread exits on tty EOF but does not exit the app, so a closed
+#: terminal can otherwise leave the owning pid and session claim alive forever.
+TERMINAL_LIFECYCLE_CHECK_S = 1.0
+
+
+@dataclass
+class _TerminalFrontendReaper:
+    """Turn terminal-reader death into a bounded, holder-aware app exit.
+
+    ``reader_alive=True`` means a genuinely mounted terminal front end and
+    therefore NEVER starts a countdown, however long it is idle. ``False`` is
+    trusted only after a live reader was observed: drivers without a reader and
+    startup races must not look like terminal loss. Busy work and a remote phone
+    or attach holder both cancel the grace window, so work can finish and a new
+    front end can take over before this process releases the session.
+    """
+
+    grace_s: float
+    reader_seen: bool = False
+    quiescent_since: float | None = None
+
+    def observe(
+        self,
+        *,
+        reader_alive: bool | None,
+        busy: bool,
+        remote_holders: bool,
+        now: float,
+    ) -> bool:
+        if reader_alive is None:
+            return False
+        if reader_alive:
+            self.reader_seen = True
+            self.quiescent_since = None
+            return False
+        if not self.reader_seen or busy or remote_holders:
+            self.quiescent_since = None
+            return False
+        if self.quiescent_since is None:
+            self.quiescent_since = now
+            return False
+        return now - self.quiescent_since >= self.grace_s
+
+
 #: How long a second Esc counts as the "also stop the subagents" press. Longer
 #: than the Ctrl+C window because the two gestures answer different questions.
 #: Ctrl+C's second press QUITS, so its window is deliberately too short to hit
@@ -1531,6 +1576,11 @@ class OperatorApp(App[None]):
         #: first session is adopted; torn down in ``on_unmount``.
         self._mobile_registrant: Any = None
         self._mobile_handle: Any = None
+        # Separate from user inactivity: this watches the OS-backed terminal
+        # reader. A mounted but untouched TUI remains alive indefinitely.
+        from local_operator.mobile.child import _grace_seconds
+
+        self._terminal_frontend_reaper = _TerminalFrontendReaper(_grace_seconds())
         # What a NEW session opens in, read from config at mount and rewritten
         # by `/approvals default <mode>`. Held beside `_approve_all` rather than
         # re-read per use because the two are ONE state to a reader — "is the
@@ -1800,6 +1850,11 @@ class OperatorApp(App[None]):
         editor.focus()
         # The count has no event to hang off (see JOB_POLL_INTERVAL_S).
         self.set_interval(JOB_POLL_INTERVAL_S, self._poll_subagents)
+        self.set_interval(TERMINAL_LIFECYCLE_CHECK_S, self._check_terminal_frontend)
+        # Prime the reader observation while mount still owns a known-live
+        # driver. A tty can EOF before the first interval tick, and requiring a
+        # prior observation is what keeps headless/alternate drivers safe.
+        self._check_terminal_frontend()
         # Keep the active provider's quota warm in the shared cache so `/usage`
         # answers from disk (see USAGE_WARM_INTERVAL_S).
         self.set_interval(USAGE_WARM_INTERVAL_S, self._warm_usage_background)
@@ -6732,6 +6787,64 @@ class OperatorApp(App[None]):
                 logger.debug("mobile registrant close failed", exc_info=True)
             self._mobile_registrant = None
             self._mobile_handle = None
+
+    def _terminal_reader_alive(self) -> bool | None:
+        """Return the Textual tty reader's lifecycle, when the driver has one.
+
+        Textual's POSIX driver exits ``_key_thread`` when ``os.read`` returns
+        EOF. The app loop keeps running, so thread liveness is the normal
+        terminal-loss signal that distinguishes a closed front end from an idle
+        mounted TUI. Headless and alternate drivers expose no such thread and
+        are deliberately outside this policy.
+        """
+        if self.is_headless or self._driver is None:
+            return None
+        reader = getattr(self._driver, "_key_thread", None)
+        if reader is None:
+            return None
+        return bool(reader.is_alive())
+
+    def _remote_frontend_holds_session(self) -> bool:
+        registrant = self._mobile_registrant
+        if registrant is None:
+            return False
+        try:
+            return bool(registrant.phone_watchers) or registrant.attach_clients() > 0
+        except Exception:  # noqa: BLE001 — uncertainty keeps the owner alive
+            logger.debug("mobile holder check failed", exc_info=True)
+            return True
+
+    def _terminal_loss_busy(self) -> bool:
+        session = self._session
+        if self._turn_is_live() or self._compacting:
+            return True
+        if session is None:
+            return False
+        try:
+            return session.running_subagents() > 0
+        except Exception:  # noqa: BLE001 — uncertainty keeps the owner alive
+            return True
+
+    def _check_terminal_frontend(self) -> None:
+        """Reap a TUI whose tty reader is gone, without truncating live work."""
+        reader_alive = self._terminal_reader_alive()
+        remote_holders = self._remote_frontend_holds_session()
+        if reader_alive is False and not remote_holders:
+            # These futures require a front end response. Settling them is not
+            # an agent abort: it lets the parked turn finish normally so busy
+            # work and subagents can drain before the grace window begins.
+            self._deny_queued_approvals()
+            self._settle_ask_picker()
+            self._settle_key_prompt()
+        should_exit = self._terminal_frontend_reaper.observe(
+            reader_alive=reader_alive,
+            busy=self._terminal_loss_busy(),
+            remote_holders=remote_holders,
+            now=time.monotonic(),
+        )
+        if should_exit:
+            logger.info("terminal front end closed; session is quiescent — exiting cleanly")
+            self.exit()
 
     async def on_unmount(self) -> None:
         # Unpublish the discovery record BEFORE anything can block: the mobile

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -3233,9 +3233,7 @@ class OperatorApp(App[None]):
         notice(f"resuming session {resume_id}…")
         self.run_worker(self._reload_session(), thread=False, group="session")
 
-    async def _attach_or_refuse(
-        self, config_dir, concrete: str, owner: int
-    ) -> None:
+    async def _attach_or_refuse(self, config_dir, concrete: str, owner: int) -> None:
         """Settle the owned-session branch of ``_resume_session``.
 
         ATTACH when the owner is reachable over the control socket (record
@@ -3247,9 +3245,7 @@ class OperatorApp(App[None]):
         """
         from local_operator.mobile.attach_client import find_owner_record
 
-        record, found_owner = await asyncio.to_thread(
-            find_owner_record, config_dir, concrete
-        )
+        record, found_owner = await asyncio.to_thread(find_owner_record, config_dir, concrete)
         if record is not None and found_owner == owner:
             from local_operator.tui.attach_screen import AttachScreen
             from local_operator.tui.widgets.toast import TOAST_DEFAULT_MS, Toast

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -637,26 +637,27 @@ logger = logging.getLogger("local_operator.tui.app")
 #: resume command — where omp's only clears the editor.)
 DOUBLE_INTERRUPT_WINDOW_S = 1.5
 
-#: Terminal-reader liveness is a lifecycle signal, not an idle timer. Textual's
-#: POSIX input thread exits on tty EOF but does not exit the app, so a closed
-#: terminal can otherwise leave the owning pid and session claim alive forever.
-TERMINAL_LIFECYCLE_CHECK_S = 1.0
+#: Terminal-reader liveness is a lifecycle signal, not an idle timer. Fine
+#: polling bounds the 3-second drain without turning user inactivity into input.
+TERMINAL_LIFECYCLE_CHECK_S = 0.25
+TERMINAL_GATE_TIMEOUT_S = 30.0
 
 
 @dataclass
 class _TerminalFrontendReaper:
-    """Turn terminal-reader death into a bounded, holder-aware app exit.
+    """Sequence terminal-loss gate settlement and clean exit safely.
 
-    ``reader_alive=True`` means a genuinely mounted terminal front end and
-    therefore NEVER starts a countdown, however long it is idle. ``False`` is
-    trusted only after a live reader was observed: drivers without a reader and
-    startup races must not look like terminal loss. Busy work and a remote phone
-    or attach holder both cancel the grace window, so work can finish and a new
-    front end can take over before this process releases the session.
+    A front-end-only gate gets one grace window for a replacement viewer before
+    it is settled. Work unblocked by that settlement then gets as long as it
+    needs, and clean exit requires a fresh quiescent grace. Keeping those clocks
+    separate prevents terminal EOF from becoming either an immediate denial or
+    an implicit turn cancellation.
     """
 
     grace_s: float
+    gate_timeout_s: float = TERMINAL_GATE_TIMEOUT_S
     reader_seen: bool = False
+    gate_since: float | None = None
     quiescent_since: float | None = None
 
     def observe(
@@ -664,22 +665,46 @@ class _TerminalFrontendReaper:
         *,
         reader_alive: bool | None,
         busy: bool,
+        gate_pending: bool,
         remote_holders: bool,
         now: float,
-    ) -> bool:
+    ) -> str | None:
         if reader_alive is None:
-            return False
+            return None
         if reader_alive:
             self.reader_seen = True
+            self.gate_since = None
             self.quiescent_since = None
-            return False
-        if not self.reader_seen or busy or remote_holders:
+            return None
+        if not self.reader_seen:
+            return None
+        if gate_pending:
             self.quiescent_since = None
-            return False
+            if self.gate_since is None:
+                self.gate_since = now
+                return None
+            # The deadline is total answerability time, independent of work,
+            # but settlement waits until it cannot disturb unrelated activity.
+            if now - self.gate_since >= self.gate_timeout_s and not busy:
+                self.gate_since = None
+                return "settle"
+            return None
+        if busy:
+            self.gate_since = None
+            self.quiescent_since = None
+            return None
+        self.gate_since = None
         if self.quiescent_since is None:
             self.quiescent_since = now
-            return False
-        return now - self.quiescent_since >= self.grace_s
+            return None
+        if now - self.quiescent_since >= self.grace_s:
+            return "exit"
+        return None
+
+    def gates_settled(self) -> None:
+        """Require a fresh grace after settlement, even if callbacks drain inline."""
+        self.gate_since = None
+        self.quiescent_since = None
 
 
 #: How long a second Esc counts as the "also stop the subagents" press. Longer
@@ -6804,22 +6829,25 @@ class OperatorApp(App[None]):
             return None
         return bool(reader.is_alive())
 
-    def _remote_frontend_holds_session(self) -> bool:
-        registrant = self._mobile_registrant
-        if registrant is None:
-            return False
-        try:
-            return bool(registrant.phone_watchers) or registrant.attach_clients() > 0
-        except Exception:  # noqa: BLE001 — uncertainty keeps the owner alive
-            logger.debug("mobile holder check failed", exc_info=True)
-            return True
+    def _terminal_frontend_gate_pending(self) -> bool:
+        approval = self._approval
+        approval_pending = approval is not None and not approval.answered
+        ask_pending = self._ask_pending is not None and not self._ask_pending.done()
+        return approval_pending or ask_pending or self._key_prompt is not None
 
-    def _terminal_loss_busy(self) -> bool:
+    def _terminal_loss_busy(self, *, gate_pending: bool) -> bool:
         session = self._session
-        if self._turn_is_live() or self._compacting:
+        if self._compacting:
             return True
         if session is None:
-            return False
+            return self._turn_is_live() and not gate_pending
+        # A gate parks the app's runner, so that flag alone is not autonomous
+        # work while WAITING_INPUT. The session streaming flag still catches an
+        # unrelated model/tool phase that happens to overlap the visible gate.
+        if bool(getattr(session, "is_streaming", False)):
+            return True
+        if self._turn_is_live() and not gate_pending:
+            return True
         try:
             return session.running_subagents() > 0
         except Exception:  # noqa: BLE001 — uncertainty keeps the owner alive
@@ -6828,21 +6856,23 @@ class OperatorApp(App[None]):
     def _check_terminal_frontend(self) -> None:
         """Reap a TUI whose tty reader is gone, without truncating live work."""
         reader_alive = self._terminal_reader_alive()
-        remote_holders = self._remote_frontend_holds_session()
-        if reader_alive is False and not remote_holders:
-            # These futures require a front end response. Settling them is not
-            # an agent abort: it lets the parked turn finish normally so busy
-            # work and subagents can drain before the grace window begins.
+        gate_pending = self._terminal_frontend_gate_pending()
+        action = self._terminal_frontend_reaper.observe(
+            reader_alive=reader_alive,
+            busy=self._terminal_loss_busy(gate_pending=gate_pending),
+            gate_pending=gate_pending,
+            remote_holders=False,
+            now=time.monotonic(),
+        )
+        if action == "settle":
+            # Only grace expiry makes an unreachable front-end gate disposable.
+            # Its callback may resume real work, which the next observations let
+            # finish before a separate clean-exit grace can begin.
             self._deny_queued_approvals()
             self._settle_ask_picker()
             self._settle_key_prompt()
-        should_exit = self._terminal_frontend_reaper.observe(
-            reader_alive=reader_alive,
-            busy=self._terminal_loss_busy(),
-            remote_holders=remote_holders,
-            now=time.monotonic(),
-        )
-        if should_exit:
+            self._terminal_frontend_reaper.gates_settled()
+        elif action == "exit":
             logger.info("terminal front end closed; session is quiescent — exiting cleanly")
             self.exit()
 

--- a/local_operator/tui/attach_screen.py
+++ b/local_operator/tui/attach_screen.py
@@ -30,14 +30,18 @@ from __future__ import annotations
 import asyncio
 from typing import Any, Awaitable, Callable, Optional
 
-from textual.app import App, ComposeResult
+from textual.app import App
+from textual.binding import Binding
 from textual.containers import Vertical
 from textual.screen import Screen
-from textual.widget import Widget
-from textual.binding import Binding
 from textual.widgets import Input, Static
+
 from local_operator.mobile.attach_client import AttachClient
-from local_operator.mobile.types import SessionProjection, SessionRecord, TranscriptEntry
+from local_operator.mobile.types import (
+    SessionProjection,
+    SessionRecord,
+    TranscriptEntry,
+)
 
 #: Submitted text that starts with this word is a screen command, not a steer.
 #: Only one exists (/detach); parsed by prefix so the composer stays a plain
@@ -162,7 +166,7 @@ class AttachScreen(Screen[None]):  # noqa: D101 — the module docstring is the 
         session_id: str,
         *,
         on_detached: Optional[Callable[[], None]] = None,
-        on_resume_here: Optional[Callable[[str], None]] = None,
+        on_resume_here: Callable[[str], Awaitable[None]] | Callable[[str], None] | None = None,
         standalone: bool = False,
     ) -> None:
         super().__init__()
@@ -208,13 +212,15 @@ class AttachScreen(Screen[None]):  # noqa: D101 — the module docstring is the 
 
     def _on_projection(self, projection: SessionProjection) -> None:
         self._projection = projection
-        self.call_from_thread(self._render_projection, projection) if self.is_running else (
+        if self.is_running:
+            # The client's reader task is not the UI thread; hop over.
+            self.app.call_from_thread(self._render_projection, projection)
+        else:
             self._render_projection(projection)
-        )
 
     def _on_disconnected(self, reason: str) -> None:
         try:
-            self.call_from_thread(self._owner_exited, reason)
+            self.app.call_from_thread(self._owner_exited, reason)
         except Exception:  # noqa: BLE001 — screen may already be unmounting
             pass
 
@@ -287,20 +293,14 @@ class AttachScreen(Screen[None]):  # noqa: D101 — the module docstring is the 
         try:
             if streaming:
                 detail = await client.steer(text)
-                self._transcript.mount(
-                    Static(f"↪ {text}", classes="attach-row attach-steer")
-                )
+                self._transcript.mount(Static(f"↪ {text}", classes="attach-row attach-steer"))
                 self._banner.update(
                     f"attached · pid {self._record.pid} — queued as steering ({detail})"
                 )
             else:
                 detail = await client.prompt(text)
-                self._transcript.mount(
-                    Static(f"❯ {text}", classes="attach-row attach-user")
-                )
-                self._banner.update(
-                    f"attached · pid {self._record.pid} — {detail}"
-                )
+                self._transcript.mount(Static(f"❯ {text}", classes="attach-row attach-user"))
+                self._banner.update(f"attached · pid {self._record.pid} — {detail}")
         except (RuntimeError, ConnectionError) as exc:
             self._banner.update(f"attached · pid {self._record.pid} — {exc}")
 
@@ -376,7 +376,7 @@ class AttachApp(App[None]):
         self,
         record: SessionRecord,
         session_id: str,
-        on_resume_here: Callable[[str], Awaitable[None]] | None = None,
+        on_resume_here: Callable[[str], Awaitable[None]] | Callable[[str], None] | None = None,
     ) -> None:
         super().__init__()
         self._record = record
@@ -406,12 +406,10 @@ class AttachApp(App[None]):
         mission. The standalone host cannot resume in-place (it owns no
         session machinery), so it exits with a sentinel the CLI reads to
         relaunch the real TUI on that transcript."""
-        from local_operator.reexec import REEXEC_CODE, plan_reexec, take_plan  # noqa: F401
-
-        # Simplest correct v1: exit 75 (EX_TEMPFAIL) with the id on stdout;
-        # the CLI wrapper re-runs itself WITHOUT --resume, which now finds the
-        # owner gone and opens normally.
-        self.exit(75, return_code=75)
+        # Exit 75 (EX_TEMPFAIL) is the sentinel the CLI's owned-resume branch
+        # reads as 'relaunch without --resume' — by then the claim marker
+        # names a dead pid, so the relaunch is the legitimate first writer.
+        self.exit(75, return_code=75)  # type: ignore[call-overload]
 
 
 def run_attach_app(record: SessionRecord, session_id: str) -> int:

--- a/local_operator/tui/attach_screen.py
+++ b/local_operator/tui/attach_screen.py
@@ -1,0 +1,426 @@
+"""The attach screen: follow and steer a session another process owns.
+
+``/resume <id>`` of a live session used to refuse — "already open in another
+process" — because two writers on one transcript is the corruption case the
+refusal exists to prevent. But the mobile stack already solved multi-front-end
+for the phone: the owner runs a registrant whose loopback socket carries
+whole-projection repaints and steering ops. This screen is a SECOND TERMINAL's
+window onto that socket: it renders the owner's ``SessionProjection`` and
+routes submits to ``prompt``/``steer``, never opening the transcript directory
+for writing. The owner stays the only writer; this process is a front end.
+
+Deliberately a ``Screen``, not a second ``OperatorApp``: full parity would
+mean inverse-folding projections into AgentEvents — lossy and drift-prone —
+and the projection is already a legitimate render surface (the phone renders
+exactly this shape). The bargain is the phone's: a follower view with a
+banner that says so.
+
+Two hosting modes share the one screen:
+
+- **in-app** — pushed over a running ``OperatorApp`` by
+  ``OperatorApp._resume_session``; ``/detach`` pops back to the user's own
+  conversation, whose claim and registrant were never touched.
+- **standalone** — a minimal Textual app (``run_attach_app``) for cold-boot
+  ``lop --resume <live-id>``, where there is no TUI of the user's own to push
+  onto; ``/detach`` exits.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Awaitable, Callable, Optional
+
+from textual.app import App, ComposeResult
+from textual.containers import Vertical
+from textual.screen import Screen
+from textual.widget import Widget
+from textual.binding import Binding
+from textual.widgets import Input, Static
+from local_operator.mobile.attach_client import AttachClient
+from local_operator.mobile.types import SessionProjection, SessionRecord, TranscriptEntry
+
+#: Submitted text that starts with this word is a screen command, not a steer.
+#: Only one exists (/detach); parsed by prefix so the composer stays a plain
+#: Editor with no slash registry of its own — the owner owns slash commands.
+DETACH_COMMAND = "/detach"
+
+
+def _entry_line(entry: TranscriptEntry) -> str:
+    """One text line for one transcript row, folded like the phone renders it.
+
+    The projection is pre-folded (one line per tool call, notices as text);
+    this only chooses the lead glyph. Kept dumb on purpose: this screen is a
+    follower view, not a second implementation of the TUI's render semantics.
+    """
+    if entry.kind == "user":
+        return f"❯ {entry.text}"
+    if entry.kind == "steer":
+        return f"↪ {entry.text}"
+    if entry.kind == "tool":
+        label = entry.summary or entry.tool_name or "tool"
+        return f"· {label}"
+    if entry.kind == "notice":
+        return f"· {entry.text}"
+    # assistant rows and compaction markers render as their own text
+    return entry.text
+
+
+class _Banner(Static):
+    """The one-line 'you are a follower' band segment.
+
+    Dim on purpose (design §3): 'attached' is the load-bearing word, and a
+    follower signal that outshone the transcript would invert the frame. On a
+    phone-watch-less world this banner is the only persistent reminder that
+    submits here steer a conversation whose owner is elsewhere.
+    """
+
+
+class _Transcript(Vertical):
+    """Read-only rows rendered from the projection's transcript tail."""
+
+    def render_projection(self, projection: SessionProjection) -> None:
+        self.remove_children()
+        for entry in projection.transcript:
+            text = _entry_line(entry)
+            classes = "attach-row"
+            if entry.kind == "user":
+                classes += " attach-user"
+            elif entry.kind == "steer":
+                classes += " attach-steer"
+            elif entry.kind == "tool":
+                classes += " attach-tool"
+            elif entry.kind == "notice":
+                classes += " attach-notice"
+            self.mount(Static(text, classes=classes))
+        # The working line: what the turn is doing right now, when streaming.
+        if projection.streaming:
+            activity = projection.activity or "working"
+            self.mount(Static(f"… {activity}", classes="attach-row attach-working"))
+
+
+class _PendingCard(Static):
+    """The front approval/ask gate, answerable with minimal keys.
+
+    V1 keeps multi-question asks to the owner (the phone/owner terminal);
+    a single-question answer or a y/n approval is fine from a follower.
+    """
+
+
+class AttachScreen(Screen[None]):  # noqa: D101 — the module docstring is the doc
+    CSS = """
+    AttachScreen {
+        layout: vertical;
+    }
+    #attach-banner {
+        height: 1;
+        color: $lo-dim;
+    }
+    #attach-transcript {
+        height: 1fr;
+        overflow-y: auto;
+    }
+    .attach-row {
+        height: auto;
+        color: $lo-fg;
+    }
+    .attach-user {
+        color: $lo-fg;
+        text-style: bold;
+    }
+    .attach-steer {
+        color: $lo-muted;
+    }
+    .attach-tool {
+        color: $lo-muted;
+    }
+    .attach-notice {
+        color: $lo-dim;
+    }
+    .attach-working {
+        color: $lo-dim;
+    }
+    #attach-pending {
+        height: auto;
+        color: $lo-warning;
+    }
+    #attach-composer {
+        dock: bottom;
+        height: 3;
+    }
+    #attach-composer Input {
+        width: 1fr;
+    }
+    """
+
+    BINDINGS = [
+        Binding("escape", "detach", "Detach", show=False),
+    ]
+
+    def __init__(
+        self,
+        record: SessionRecord,
+        session_id: str,
+        *,
+        on_detached: Optional[Callable[[], None]] = None,
+        on_resume_here: Optional[Callable[[str], None]] = None,
+        standalone: bool = False,
+    ) -> None:
+        super().__init__()
+        self._record = record
+        self._session_id = session_id
+        self._standalone = standalone
+        self._on_detached = on_detached
+        self._on_resume_here = on_resume_here
+        self._client: AttachClient | None = None
+        self._projection: SessionProjection | None = None
+        self._owner_dead = False
+
+    # -- lifecycle ---------------------------------------------------------------
+
+    def on_mount(self) -> None:
+        self._banner = _Banner(id="attach-banner")
+        self._transcript = _Transcript(id="attach-transcript")
+        self._pending = _PendingCard(id="attach-pending")
+        self._composer = Input(placeholder="steer the attached session — /detach to leave")
+        self._composer.id = "attach-composer"
+        self.mount(self._banner, self._transcript, self._pending, self._composer)
+        self._set_banner()
+        self._client = AttachClient(
+            on_projection=self._on_projection,
+            on_disconnected=self._on_disconnected,
+        )
+        # The reader task must live on the app's loop; connect() is async and
+        # cheap (loopback), so create_task is right here.
+        self.run_task = asyncio.get_event_loop().create_task(self._connect())
+
+    async def _connect(self) -> None:
+        try:
+            await self._client.connect(self._record, self._session_id)  # type: ignore[union-attr]
+        except Exception:  # noqa: BLE001 — any connect failure is owner-death copy
+            self._on_disconnected("could not attach")
+
+    def on_unmount(self) -> None:
+        if self._client is not None:
+            self._client.close()
+            self._client = None
+
+    # -- socket callbacks (fire on the client's reader task; hop to the UI) -----
+
+    def _on_projection(self, projection: SessionProjection) -> None:
+        self._projection = projection
+        self.call_from_thread(self._render_projection, projection) if self.is_running else (
+            self._render_projection(projection)
+        )
+
+    def _on_disconnected(self, reason: str) -> None:
+        try:
+            self.call_from_thread(self._owner_exited, reason)
+        except Exception:  # noqa: BLE001 — screen may already be unmounting
+            pass
+
+    # -- rendering ----------------------------------------------------------------
+
+    def _set_banner(self, dead: bool = False) -> None:
+        name = (self._projection.conversation_name if self._projection else "") or "untitled"
+        pid = self._record.pid
+        if dead:
+            self._banner.update(f"owner exited (pid {pid}) — r: resume here · esc: detach")
+        else:
+            self._banner.update(f"attached · pid {pid} · {name} — /detach to release")
+
+    def _render_projection(self, projection: SessionProjection) -> None:
+        self._projection = projection
+        self._set_banner()
+        self._transcript.render_projection(projection)
+        pending = projection.pending
+        if pending is None:
+            self._pending.display = False
+        else:
+            if pending.kind == "approval":
+                body = f"{pending.title} — y/n"
+            else:
+                opts = " · ".join(o.label for o in pending.options) or "type an answer"
+                body = f"{pending.title} — {opts}"
+            self._pending.update(body)
+            self._pending.display = True
+
+    def _owner_exited(self, reason: str) -> None:
+        """Owner death: swap the banner and offer the two exits inline.
+
+        No modal (design §3): the transcript stays readable behind the choice.
+        'resume here' re-runs the resume path — by now the claim marker names
+        a dead pid, so this process becomes the legitimate FIRST writer.
+        """
+        if self._owner_dead:
+            return
+        self._owner_dead = True
+        self._set_banner(dead=True)
+        self._pending.update("owner exited — r: resume here · esc: detach")
+        self._pending.display = True
+        self._composer.placeholder = "owner exited — r to resume here, esc to detach"
+
+    # -- input ---------------------------------------------------------------------
+
+    async def on_input_submitted(self, event: Any) -> None:
+        text = str(getattr(event, "value", "")).strip()
+        if not text:
+            return
+        if self._composer is not None:
+            self._composer.value = ""
+        if text.lower() in (DETACH_COMMAND, "esc"):
+            self.action_detach()
+            return
+        if self._owner_dead:
+            # Inputs while dead other than the two commands are meaningless;
+            # the banner restates the choice rather than silently eating keys.
+            self._pending.update("owner exited — r: resume here · esc: detach")
+            return
+        client = self._client
+        if client is None or not client.connected:
+            return
+        # Route by owner state: prompt when idle, steer when streaming. The
+        # alternative — sending prompt and showing the busy error — is what
+        # the owned handle does, but from a follower terminal the busy case IS
+        # the normal case mid-turn, and reading it as a failure teaches the
+        # user the screen is broken when it is working as designed.
+        streaming = bool(self._projection and self._projection.streaming)
+        try:
+            if streaming:
+                detail = await client.steer(text)
+                self._transcript.mount(
+                    Static(f"↪ {text}", classes="attach-row attach-steer")
+                )
+                self._banner.update(
+                    f"attached · pid {self._record.pid} — queued as steering ({detail})"
+                )
+            else:
+                detail = await client.prompt(text)
+                self._transcript.mount(
+                    Static(f"❯ {text}", classes="attach-row attach-user")
+                )
+                self._banner.update(
+                    f"attached · pid {self._record.pid} — {detail}"
+                )
+        except (RuntimeError, ConnectionError) as exc:
+            self._banner.update(f"attached · pid {self._record.pid} — {exc}")
+
+    def on_key(self, event: Any) -> None:
+        """Minimal key answers for the pending gate, plus owner-death actions."""
+        key = str(getattr(event, "key", ""))
+        if self._owner_dead:
+            if key == "r" and self._on_resume_here is not None:
+                event.prevent_default()
+                event.stop()
+                self._on_resume_here(self._session_id)
+            return
+        pending = self._projection.pending if self._projection else None
+        if pending is None or self._composer is None:
+            return
+        if self._composer.has_focus:
+            return  # typing goes to the composer
+        client = self._client
+        if client is None:
+            return
+
+        async def answer() -> None:
+            try:
+                if pending.kind == "approval":
+                    approved = key == "y"
+                    await client.approval_answer(pending.request_id, approved)
+                elif pending.options:
+                    for opt in pending.options:
+                        if opt.label.lower().startswith(key.lower()) and key:
+                            await client.ask_answer(pending.request_id, opt.label)
+                            break
+            except (RuntimeError, ConnectionError):
+                pass
+
+        if pending.kind == "approval" and key in ("y", "n"):
+            event.prevent_default()
+            event.stop()
+            asyncio.get_event_loop().create_task(answer())
+        elif pending.kind == "ask" and pending.options and len(key) == 1:
+            event.prevent_default()
+            event.stop()
+            asyncio.get_event_loop().create_task(answer())
+
+    # -- actions --------------------------------------------------------------------
+
+    def action_detach(self) -> None:
+        """Leave the attach: pop (in-app) or exit (standalone)."""
+        if self._client is not None:
+            try:
+                self._client.close()
+            finally:
+                self._client = None
+        if self._standalone:
+            self.app.exit()
+        else:
+            self.app.pop_screen()
+        if self._on_detached is not None:
+            self._on_detached()
+
+
+class AttachApp(App[None]):
+    """The minimal standalone host for cold-boot ``lop --resume <live-id>``.
+
+    Carries the app-level theme variables (``$lo-*``) so the screen renders in
+    the product's palette rather than Textual defaults — the same seam
+    ``OperatorApp.get_css_variables`` provides, duplicated here because the
+    standalone host deliberately does not boot an OperatorApp (no session, no
+    workers, no claim)."""
+
+    CSS_PATH = "../local_operator.tcss"
+
+    def __init__(
+        self,
+        record: SessionRecord,
+        session_id: str,
+        on_resume_here: Callable[[str], Awaitable[None]] | None = None,
+    ) -> None:
+        super().__init__()
+        self._record = record
+        self._session_id = session_id
+        self._on_resume_here = on_resume_here
+
+    def get_css_variables(self) -> dict[str, str]:
+        from local_operator.tui import theme as theme_mod
+
+        return {
+            **theme_mod.tcss_variable_map(theme_mod.current_theme()),
+            **super().get_css_variables(),
+        }
+
+    def on_mount(self) -> None:
+        self.push_screen(
+            AttachScreen(
+                self._record,
+                self._session_id,
+                standalone=True,
+                on_resume_here=self._resume_here,
+            )
+        )
+
+    async def _resume_here(self, session_id: str) -> None:
+        """Owner died and the user chose to resume: replace this process's
+        mission. The standalone host cannot resume in-place (it owns no
+        session machinery), so it exits with a sentinel the CLI reads to
+        relaunch the real TUI on that transcript."""
+        from local_operator.reexec import REEXEC_CODE, plan_reexec, take_plan  # noqa: F401
+
+        # Simplest correct v1: exit 75 (EX_TEMPFAIL) with the id on stdout;
+        # the CLI wrapper re-runs itself WITHOUT --resume, which now finds the
+        # owner gone and opens normally.
+        self.exit(75, return_code=75)
+
+
+def run_attach_app(record: SessionRecord, session_id: str) -> int:
+    """Run the standalone attach app to completion; return a process code.
+
+    Exit 75 means the user chose 'resume here' after owner death — the caller
+    (the CLI's owned-resume branch) treats it as 'relaunch without --resume'.
+    """
+    app = AttachApp(record, session_id)
+    app.run()
+    code = app.return_code or 0
+    return int(code)

--- a/local_operator/tui/attach_screen.py
+++ b/local_operator/tui/attach_screen.py
@@ -50,6 +50,8 @@ from local_operator.tui.widgets.editor import DEFAULT_PLACEHOLDER
 #: Only one exists (/detach); parsed by prefix so the composer stays a plain
 #: Editor with no slash registry of its own — the owner owns slash commands.
 DETACH_COMMAND = "/detach"
+HELP_COMMAND = "/help"
+ATTACHED_HELP = "/detach  Return to your prior conversation and close this view."
 
 
 def _entry_line(entry: TranscriptEntry) -> str:
@@ -284,6 +286,14 @@ class AttachScreen(Screen[None]):  # noqa: D101 — the module docstring is the 
         if text.lower() in (DETACH_COMMAND, "esc"):
             self.action_detach()
             return
+        if text.lower() == HELP_COMMAND:
+            # Attached help is local navigation, never model input. Keep the
+            # escape route out of persistent chrome while making it discoverable
+            # in the command flow users already know from ordinary conversations.
+            self._pending.update(ATTACHED_HELP)
+            self._pending.display = True
+            self._composer.value = ""
+            return
         command = self._pending_command or ContinuationCommand.create(self._session_id, text)
         self._pending_command = command
         client = self._client
@@ -294,7 +304,18 @@ class AttachScreen(Screen[None]):  # noqa: D101 — the module docstring is the 
         # user the screen is broken when it is working as designed.
         try:
             if client is not None and client.connected:
-                await client.send_command(command)
+                if self._projection is not None and self._projection.streaming:
+                    try:
+                        await client.send_command(command, streaming=True)
+                    except TypeError:
+                        # Compatibility for third-party/test attach clients built
+                        # before natural dispatch accepted the state hint.
+                        await client.steer(command.text)
+                else:
+                    try:
+                        await client.send_command(command, streaming=False)
+                    except TypeError:
+                        await client.send_command(command)
             else:
                 self._pending.update("Connecting…")
                 self._pending.display = True

--- a/local_operator/tui/attach_screen.py
+++ b/local_operator/tui/attach_screen.py
@@ -110,6 +110,21 @@ class _PendingCard(Static):
     """
 
 
+class _AttachComposer(Input):
+    """Composer that lets a displayed authority gate consume its shortcuts.
+
+    Textual's Input handles printable keys before they bubble to the Screen, so
+    screen-only bindings cannot make y/n or ask initials reachable from normal
+    focus. Calling the screen handler here gives a valid gate first refusal;
+    unrecognized keys retain ordinary Input editing.
+    """
+
+    def on_key(self, event: Any) -> None:
+        screen = self.screen
+        if isinstance(screen, AttachScreen):
+            screen._handle_gate_key(event)
+
+
 class AttachScreen(Screen[None]):  # noqa: D101 — the module docstring is the doc
     CSS = """
     AttachScreen {
@@ -179,6 +194,7 @@ class AttachScreen(Screen[None]):  # noqa: D101 — the module docstring is the 
         self._client: AttachClient | None = None
         self._projection: SessionProjection | None = None
         self._owner_dead = False
+        self._answering_request: str | None = None
 
     # -- lifecycle ---------------------------------------------------------------
 
@@ -186,7 +202,9 @@ class AttachScreen(Screen[None]):  # noqa: D101 — the module docstring is the 
         self._banner = _Banner(id="attach-banner")
         self._transcript = _Transcript(id="attach-transcript")
         self._pending = _PendingCard(id="attach-pending")
-        self._composer = Input(placeholder="steer the attached session — /detach to leave")
+        self._composer = _AttachComposer(
+            placeholder="steer the attached session — /detach to leave"
+        )
         self._composer.id = "attach-composer"
         self.mount(self._banner, self._transcript, self._pending, self._composer)
         self._set_banner()
@@ -234,11 +252,15 @@ class AttachScreen(Screen[None]):  # noqa: D101 — the module docstring is the 
         name = (self._projection.conversation_name if self._projection else "") or "untitled"
         pid = self._record.pid
         if dead:
-            self._banner.update(f"owner exited (pid {pid}) — r: resume here · esc: detach")
+            self._banner.update(f"owner exited · pid {pid}")
         else:
             self._banner.update(f"attached · pid {pid} · {name} — /detach to release")
 
     def _render_projection(self, projection: SessionProjection) -> None:
+        # EOF is terminal for this connection. A projection already queued on
+        # the UI tick must not repaint the screen back to "live" afterward.
+        if self._owner_dead:
+            return
         self._projection = projection
         self._set_banner()
         self._transcript.render_projection(projection)
@@ -265,9 +287,9 @@ class AttachScreen(Screen[None]):  # noqa: D101 — the module docstring is the 
             return
         self._owner_dead = True
         self._set_banner(dead=True)
-        self._pending.update("owner exited — r: resume here · esc: detach")
+        self._pending.update("r: resume here · esc: detach")
         self._pending.display = True
-        self._composer.placeholder = "owner exited — r to resume here, esc to detach"
+        self._composer.placeholder = "attached session inactive"
         # Disable the dead composer so printable keys bubble to the Screen's
         # inline actions instead of becoming a draft that can never be sent.
         self._composer.disabled = True
@@ -276,7 +298,9 @@ class AttachScreen(Screen[None]):  # noqa: D101 — the module docstring is the 
 
     def _resume_after_owner_death(self) -> None:
         if self._on_resume_here is None:
+            self._pending.update("resume unavailable here · esc: detach")
             return
+        self._pending.update("resuming here…")
         outcome = self._on_resume_here(self._session_id)
         if asyncio.iscoroutine(outcome):
             asyncio.get_event_loop().create_task(outcome)
@@ -291,9 +315,6 @@ class AttachScreen(Screen[None]):  # noqa: D101 — the module docstring is the 
             self.action_detach()
             return
         if self._owner_dead:
-            # Inputs while dead other than the two commands are meaningless;
-            # the banner restates the choice rather than silently eating keys.
-            self._pending.update("owner exited — r: resume here · esc: detach")
             return
         client = self._client
         if client is None or not client.connected:
@@ -320,6 +341,10 @@ class AttachScreen(Screen[None]):  # noqa: D101 — the module docstring is the 
 
     def on_key(self, event: Any) -> None:
         """Minimal key answers for the pending gate, plus owner-death actions."""
+        self._handle_gate_key(event)
+
+    def _handle_gate_key(self, event: Any) -> None:
+        """Consume only keys that answer the currently displayed state."""
         key = str(getattr(event, "key", ""))
         if self._owner_dead:
             if key == "r":
@@ -330,30 +355,40 @@ class AttachScreen(Screen[None]):  # noqa: D101 — the module docstring is the 
         pending = self._projection.pending if self._projection else None
         if pending is None or self._composer is None:
             return
-        if self._composer.has_focus:
-            return  # typing goes to the composer
         client = self._client
         if client is None:
             return
 
+        option = next(
+            (opt for opt in pending.options if key and opt.label.lower().startswith(key.lower())),
+            None,
+        )
+
         async def answer() -> None:
+            self._answering_request = pending.request_id
+            self._pending.update("answering…")
             try:
                 if pending.kind == "approval":
-                    approved = key == "y"
-                    await client.approval_answer(pending.request_id, approved)
-                elif pending.options:
-                    for opt in pending.options:
-                        if opt.label.lower().startswith(key.lower()) and key:
-                            await client.ask_answer(pending.request_id, opt.label)
-                            break
-            except (RuntimeError, ConnectionError):
-                pass
+                    detail = await client.approval_answer(pending.request_id, key == "y")
+                elif option is not None:
+                    detail = await client.ask_answer(pending.request_id, option.label)
+                else:
+                    return
+                # A projection normally removes the card. This receipt covers
+                # the interval before that repaint and makes stale rejection
+                # visible instead of swallowing the key silently.
+                if self._answering_request == pending.request_id:
+                    self._pending.update(detail or "answer accepted")
+            except (RuntimeError, ConnectionError) as exc:
+                self._pending.update(f"answer not accepted: {exc}")
+            finally:
+                self._answering_request = None
 
         if pending.kind == "approval" and key in ("y", "n"):
             event.prevent_default()
             event.stop()
             asyncio.get_event_loop().create_task(answer())
-        elif pending.kind == "ask" and pending.options and len(key) == 1:
+        elif pending.kind == "ask" and option is not None and len(key) == 1:
             event.prevent_default()
             event.stop()
             asyncio.get_event_loop().create_task(answer())

--- a/local_operator/tui/attach_screen.py
+++ b/local_operator/tui/attach_screen.py
@@ -36,12 +36,15 @@ from textual.containers import Vertical
 from textual.screen import Screen
 from textual.widgets import Input, Static
 
-from local_operator.mobile.attach_client import AttachClient
+from local_operator.mobile.attach_client import AttachClient, continue_command
 from local_operator.mobile.types import (
+    ContinuationCommand,
     SessionProjection,
     SessionRecord,
     TranscriptEntry,
 )
+from local_operator.paths import config_dir
+from local_operator.tui.widgets.editor import DEFAULT_PLACEHOLDER
 
 #: Submitted text that starts with this word is a screen command, not a steer.
 #: Only one exists (/detach); parsed by prefix so the composer stays a plain
@@ -130,10 +133,6 @@ class AttachScreen(Screen[None]):  # noqa: D101 — the module docstring is the 
     AttachScreen {
         layout: vertical;
     }
-    #attach-banner {
-        height: 1;
-        color: $lo-dim;
-    }
     #attach-transcript {
         height: 1fr;
         overflow-y: auto;
@@ -171,10 +170,7 @@ class AttachScreen(Screen[None]):  # noqa: D101 — the module docstring is the 
     }
     """
 
-    BINDINGS = [
-        Binding("escape", "detach", "Detach", show=False),
-        Binding("r", "resume_here", "Resume here", show=False),
-    ]
+    BINDINGS = [Binding("escape", "detach", "Detach", show=False)]
 
     def __init__(
         self,
@@ -195,19 +191,16 @@ class AttachScreen(Screen[None]):  # noqa: D101 — the module docstring is the 
         self._projection: SessionProjection | None = None
         self._owner_dead = False
         self._answering_request: str | None = None
+        self._pending_command: ContinuationCommand | None = None
 
     # -- lifecycle ---------------------------------------------------------------
 
     def on_mount(self) -> None:
-        self._banner = _Banner(id="attach-banner")
         self._transcript = _Transcript(id="attach-transcript")
         self._pending = _PendingCard(id="attach-pending")
-        self._composer = _AttachComposer(
-            placeholder="steer the attached session — /detach to leave"
-        )
+        self._composer = _AttachComposer(placeholder=DEFAULT_PLACEHOLDER)
         self._composer.id = "attach-composer"
-        self.mount(self._banner, self._transcript, self._pending, self._composer)
-        self._set_banner()
+        self.mount(self._transcript, self._pending, self._composer)
         self._client = AttachClient(
             on_projection=self._on_projection,
             on_disconnected=self._on_disconnected,
@@ -248,21 +241,15 @@ class AttachScreen(Screen[None]):  # noqa: D101 — the module docstring is the 
 
     # -- rendering ----------------------------------------------------------------
 
-    def _set_banner(self, dead: bool = False) -> None:
-        name = (self._projection.conversation_name if self._projection else "") or "untitled"
-        pid = self._record.pid
-        if dead:
-            self._banner.update(f"owner exited · pid {pid}")
-        else:
-            self._banner.update(f"attached · pid {pid} · {name} — /detach to release")
-
     def _render_projection(self, projection: SessionProjection) -> None:
         # EOF is terminal for this connection. A projection already queued on
         # the UI tick must not repaint the screen back to "live" afterward.
         if self._owner_dead:
             return
         self._projection = projection
-        self._set_banner()
+        self._owner_dead = False
+        self._composer.disabled = False
+        self._composer.placeholder = DEFAULT_PLACEHOLDER
         self._transcript.render_projection(projection)
         pending = projection.pending
         if pending is None:
@@ -277,67 +264,53 @@ class AttachScreen(Screen[None]):  # noqa: D101 — the module docstring is the 
             self._pending.display = True
 
     def _owner_exited(self, reason: str) -> None:
-        """Owner death: swap the banner and offer the two exits inline.
-
-        No modal (design §3): the transcript stays readable behind the choice.
-        'resume here' re-runs the resume path — by now the claim marker names
-        a dead pid, so this process becomes the legitimate FIRST writer.
-        """
+        """Preserve the conversation projection while its routing disappears."""
         if self._owner_dead:
             return
         self._owner_dead = True
-        self._set_banner(dead=True)
-        self._pending.update("r: resume here · esc: detach")
-        self._pending.display = True
-        self._composer.placeholder = "attached session inactive"
-        # Disable the dead composer so printable keys bubble to the Screen's
-        # inline actions instead of becoming a draft that can never be sent.
-        self._composer.disabled = True
+        # Process loss is invisible plumbing. The retained transcript and
+        # composer remain exactly the same; a submit performs continuation.
+        if self._projection is None or self._projection.pending is None:
+            self._pending.display = False
+        self._composer.placeholder = DEFAULT_PLACEHOLDER
+        self._composer.disabled = False
 
     # -- input ---------------------------------------------------------------------
-
-    def _resume_after_owner_death(self) -> None:
-        if self._on_resume_here is None:
-            self._pending.update("resume unavailable here · esc: detach")
-            return
-        self._pending.update("resuming here…")
-        outcome = self._on_resume_here(self._session_id)
-        if asyncio.iscoroutine(outcome):
-            asyncio.get_event_loop().create_task(outcome)
 
     async def on_input_submitted(self, event: Any) -> None:
         text = str(getattr(event, "value", "")).strip()
         if not text:
             return
-        if self._composer is not None:
-            self._composer.value = ""
         if text.lower() in (DETACH_COMMAND, "esc"):
             self.action_detach()
             return
-        if self._owner_dead:
-            return
+        command = self._pending_command or ContinuationCommand.create(self._session_id, text)
+        self._pending_command = command
         client = self._client
-        if client is None or not client.connected:
-            return
         # Route by owner state: prompt when idle, steer when streaming. The
         # alternative — sending prompt and showing the busy error — is what
         # the owned handle does, but from a follower terminal the busy case IS
         # the normal case mid-turn, and reading it as a failure teaches the
         # user the screen is broken when it is working as designed.
-        streaming = bool(self._projection and self._projection.streaming)
         try:
-            if streaming:
-                detail = await client.steer(text)
-                self._transcript.mount(Static(f"↪ {text}", classes="attach-row attach-steer"))
-                self._banner.update(
-                    f"attached · pid {self._record.pid} — queued as steering ({detail})"
-                )
+            if client is not None and client.connected:
+                await client.send_command(command)
             else:
-                detail = await client.prompt(text)
-                self._transcript.mount(Static(f"❯ {text}", classes="attach-row attach-user"))
-                self._banner.update(f"attached · pid {self._record.pid} — {detail}")
-        except (RuntimeError, ConnectionError) as exc:
-            self._banner.update(f"attached · pid {self._record.pid} — {exc}")
+                self._pending.update("Connecting…")
+                self._pending.display = True
+                client, _ = await continue_command(
+                    config_dir(), command, on_projection=self._on_projection
+                )
+                self._client = client
+            self._pending_command = None
+            self._composer.value = ""
+            if self._projection is None or self._projection.pending is None:
+                self._pending.display = False
+        except (RuntimeError, ConnectionError, TimeoutError) as exc:
+            self._pending.update(str(exc) or "Couldn’t continue this conversation. Try again.")
+            self._pending.display = True
+            # Exact text and attachments remain mounted until durable ACK.
+            self._composer.value = command.text
 
     def on_key(self, event: Any) -> None:
         """Minimal key answers for the pending gate, plus owner-death actions."""
@@ -346,12 +319,6 @@ class AttachScreen(Screen[None]):  # noqa: D101 — the module docstring is the 
     def _handle_gate_key(self, event: Any) -> None:
         """Consume only keys that answer the currently displayed state."""
         key = str(getattr(event, "key", ""))
-        if self._owner_dead:
-            if key == "r":
-                event.prevent_default()
-                event.stop()
-                self._resume_after_owner_death()
-            return
         pending = self._projection.pending if self._projection else None
         if pending is None or self._composer is None:
             return
@@ -394,10 +361,6 @@ class AttachScreen(Screen[None]):  # noqa: D101 — the module docstring is the 
             asyncio.get_event_loop().create_task(answer())
 
     # -- actions --------------------------------------------------------------------
-
-    def action_resume_here(self) -> None:
-        if self._owner_dead:
-            self._resume_after_owner_death()
 
     def action_detach(self) -> None:
         """Leave the attach: pop (in-app) or exit (standalone)."""

--- a/local_operator/tui/attach_screen.py
+++ b/local_operator/tui/attach_screen.py
@@ -158,6 +158,7 @@ class AttachScreen(Screen[None]):  # noqa: D101 — the module docstring is the 
 
     BINDINGS = [
         Binding("escape", "detach", "Detach", show=False),
+        Binding("r", "resume_here", "Resume here", show=False),
     ]
 
     def __init__(
@@ -213,14 +214,17 @@ class AttachScreen(Screen[None]):  # noqa: D101 — the module docstring is the 
     def _on_projection(self, projection: SessionProjection) -> None:
         self._projection = projection
         if self.is_running:
-            # The client's reader task is not the UI thread; hop over.
-            self.app.call_from_thread(self._render_projection, projection)
+            # AttachClient's pump is a task on the Textual loop (not a socket
+            # thread), so schedule on the next UI tick. call_from_thread is
+            # deliberately forbidden from the app's own thread and would turn
+            # the first live repaint into a RuntimeError.
+            self.app.call_later(self._render_projection, projection)
         else:
             self._render_projection(projection)
 
     def _on_disconnected(self, reason: str) -> None:
         try:
-            self.app.call_from_thread(self._owner_exited, reason)
+            self.app.call_later(self._owner_exited, reason)
         except Exception:  # noqa: BLE001 — screen may already be unmounting
             pass
 
@@ -264,8 +268,18 @@ class AttachScreen(Screen[None]):  # noqa: D101 — the module docstring is the 
         self._pending.update("owner exited — r: resume here · esc: detach")
         self._pending.display = True
         self._composer.placeholder = "owner exited — r to resume here, esc to detach"
+        # Disable the dead composer so printable keys bubble to the Screen's
+        # inline actions instead of becoming a draft that can never be sent.
+        self._composer.disabled = True
 
     # -- input ---------------------------------------------------------------------
+
+    def _resume_after_owner_death(self) -> None:
+        if self._on_resume_here is None:
+            return
+        outcome = self._on_resume_here(self._session_id)
+        if asyncio.iscoroutine(outcome):
+            asyncio.get_event_loop().create_task(outcome)
 
     async def on_input_submitted(self, event: Any) -> None:
         text = str(getattr(event, "value", "")).strip()
@@ -308,10 +322,10 @@ class AttachScreen(Screen[None]):  # noqa: D101 — the module docstring is the 
         """Minimal key answers for the pending gate, plus owner-death actions."""
         key = str(getattr(event, "key", ""))
         if self._owner_dead:
-            if key == "r" and self._on_resume_here is not None:
+            if key == "r":
                 event.prevent_default()
                 event.stop()
-                self._on_resume_here(self._session_id)
+                self._resume_after_owner_death()
             return
         pending = self._projection.pending if self._projection else None
         if pending is None or self._composer is None:
@@ -346,6 +360,10 @@ class AttachScreen(Screen[None]):  # noqa: D101 — the module docstring is the 
 
     # -- actions --------------------------------------------------------------------
 
+    def action_resume_here(self) -> None:
+        if self._owner_dead:
+            self._resume_after_owner_death()
+
     def action_detach(self) -> None:
         """Leave the attach: pop (in-app) or exit (standalone)."""
         if self._client is not None:
@@ -370,7 +388,7 @@ class AttachApp(App[None]):
     standalone host deliberately does not boot an OperatorApp (no session, no
     workers, no claim)."""
 
-    CSS_PATH = "../local_operator.tcss"
+    CSS_PATH = "local_operator.tcss"
 
     def __init__(
         self,
@@ -409,7 +427,7 @@ class AttachApp(App[None]):
         # Exit 75 (EX_TEMPFAIL) is the sentinel the CLI's owned-resume branch
         # reads as 'relaunch without --resume' — by then the claim marker
         # names a dead pid, so the relaunch is the legitimate first writer.
-        self.exit(75, return_code=75)  # type: ignore[call-overload]
+        self.exit(return_code=75)
 
 
 def run_attach_app(record: SessionRecord, session_id: str) -> int:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.29.0"
+version = "0.30.0"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/mobile/test_attach_client.py
+++ b/tests/unit/mobile/test_attach_client.py
@@ -1,0 +1,229 @@
+"""The attach client against a real registrant: discovery, gating, identity,
+correlation, and the no-reconnect contract."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from local_operator.mobile import registry
+from local_operator.mobile.attach_client import AttachClient, find_owner_record
+from local_operator.mobile.registrant import Registrant
+from local_operator.mobile.types import SessionProjection, TranscriptEntry
+
+
+class FakeHandle:
+    def __init__(self, session_id: str = "sess-a") -> None:
+        self._projection = SessionProjection(
+            session_id=session_id,
+            pid=0,
+            kind="tui",
+            conversation_name="owner chat",
+            cwd="/tmp",
+            model_label="test/model",
+        )
+
+    @property
+    def session_projection_seed(self) -> SessionProjection:
+        return self._projection
+
+    def subscribe(self, on_projection):  # noqa: ANN001, ANN202
+        return lambda: None
+
+    async def refresh(self) -> None:
+        pass
+
+    async def prompt(self, text, images=None):  # noqa: ANN001, ANN202
+        self._projection.transcript.append(
+            TranscriptEntry(id=f"u{len(self._projection.transcript)}", kind="user", text=text)
+        )
+        return "prompt sent"
+
+    async def steer(self, text, images=None):  # noqa: ANN001, ANN202
+        return "steering queued"
+
+    async def slash(self, command, args):  # noqa: ANN001, ANN202
+        raise ValueError(f"/{command} is terminal-only here")
+
+
+async def _wait_record() -> registry.SessionRecord:
+    deadline = asyncio.get_running_loop().time() + 5
+    while asyncio.get_running_loop().time() < deadline:
+        found = registry.scan()
+        if found and found[0][1] == "live":
+            return found[0][0]
+        await asyncio.sleep(0.05)
+    raise AssertionError("no live record")
+
+
+def _marker(config: Path, session_id: str, pid: int) -> None:
+    d = config / "sessions" / session_id
+    d.mkdir(parents=True, exist_ok=True)
+    (d / ".session.pid").write_text(str(pid))
+
+
+@pytest.fixture
+def config(tmp_path: Path, monkeypatch) -> Path:
+    cfg = tmp_path / ".local-operator"
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(cfg))
+    return cfg
+
+
+@pytest.mark.asyncio
+async def test_discovery_finds_the_live_owner(config: Path) -> None:
+    handle = FakeHandle("sess-a")
+    r = Registrant(handle, kind="tui")
+    r.start()
+    try:
+        record = await _wait_record()
+        _marker(config, "sess-a", os.getpid())
+        found, owner = find_owner_record(config, "sess-a")
+        assert found is not None
+        assert found.pid == record.pid
+        assert owner == os.getpid()
+    finally:
+        r.close()
+
+
+@pytest.mark.asyncio
+async def test_discovery_without_owner_returns_none(config: Path) -> None:
+    found, owner = find_owner_record(config, "never-started")
+    assert found is None
+    assert owner is None
+
+
+@pytest.mark.asyncio
+async def test_discovery_owner_without_record_reports_pid_only(config: Path) -> None:
+    # A live pid holds the claim but publishes nothing (old binary,
+    # registrant failed): the caller needs the pid for the refusal copy.
+    _marker(config, "sess-x", os.getpid())
+    found, owner = find_owner_record(config, "sess-x")
+    assert found is None
+    assert owner == os.getpid()
+
+
+@pytest.mark.asyncio
+async def test_protocol_gate_refuses_v1_records(config: Path) -> None:
+    handle = FakeHandle("sess-old")
+    r = Registrant(handle, kind="tui")
+    r.start()
+    try:
+        record = await _wait_record()
+        _marker(config, "sess-old", os.getpid())
+        # Degrade the published record to protocol 1, as an old binary would.
+        record.protocol = 1
+        registry.publish(record, root=config)
+        found, owner = find_owner_record(config, "sess-old")
+        # The gate reports the owner (refusal copy needs the pid) but no
+        # dialable record.
+        assert found is None
+        assert owner == os.getpid()
+    finally:
+        r.close()
+
+
+@pytest.mark.asyncio
+async def test_connect_rejects_protocol_one_before_dialing(config: Path) -> None:
+    record = registry.SessionRecord(
+        pid=1,
+        kind="tui",
+        session_id="s",
+        conversation_name="",
+        cwd="/tmp",
+        model_label="",
+        control_port=1,
+        control_key="k",
+        protocol=1,
+    )
+    client = AttachClient(lambda p: None, lambda reason: None)
+    with pytest.raises(ConnectionError):
+        await client.connect(record, "s")
+
+
+@pytest.mark.asyncio
+async def test_welcome_identity_mismatch_is_a_connection_error(config: Path) -> None:
+    # The owner is hosting sess-a; the user asked for sess-b (a rebind raced
+    # the heartbeat). The welcome projection must arbitrate against attaching.
+    handle = FakeHandle("sess-a")
+    r = Registrant(handle, kind="tui")
+    r.start()
+    try:
+        record = await _wait_record()
+        client = AttachClient(lambda p: None, lambda reason: None)
+        with pytest.raises(ConnectionError) as excinfo:
+            await client.connect(record, "sess-b")
+        assert "another conversation" in str(excinfo.value)
+    finally:
+        r.close()
+
+
+@pytest.mark.asyncio
+async def test_prompt_ack_and_repaint_flow(config: Path) -> None:
+    handle = FakeHandle("sess-a")
+    r = Registrant(handle, kind="tui")
+    r.start()
+    try:
+        record = await _wait_record()
+        projections: list[SessionProjection] = []
+        disconnected: list[str] = []
+        client = AttachClient(projections.append, disconnected.append)
+        await client.connect(record, "sess-a")
+        assert projections and projections[0].session_id == "sess-a"
+        detail = await client.prompt("hello owner")
+        assert detail == "prompt sent"
+        # The broadcast repaint carries the user row the owner folded.
+        deadline = asyncio.get_running_loop().time() + 5
+        while asyncio.get_running_loop().time() < deadline:
+            if any(e.kind == "user" for e in projections[-1].transcript):
+                break
+            await asyncio.sleep(0.05)
+        assert any(e.kind == "user" and e.text == "hello owner" for e in projections[-1].transcript)
+        await client.detach()
+    finally:
+        r.close()
+
+
+@pytest.mark.asyncio
+async def test_owner_death_fires_on_disconnected_once(config: Path) -> None:
+    handle = FakeHandle("sess-a")
+    r = Registrant(handle, kind="tui")
+    r.start()
+    try:
+        record = await _wait_record()
+        disconnected: list[str] = []
+        client = AttachClient(lambda p: None, disconnected.append)
+        await client.connect(record, "sess-a")
+        # Kill the owner's socket the hard way: close the server.
+        r._shutdown()
+        deadline = asyncio.get_running_loop().time() + 5
+        while asyncio.get_running_loop().time() < deadline:
+            if disconnected:
+                break
+            await asyncio.sleep(0.05)
+        assert len(disconnected) == 1
+        assert not client.connected
+    finally:
+        r.close()
+
+
+@pytest.mark.asyncio
+async def test_request_error_raises_runtime_error(config: Path) -> None:
+    handle = FakeHandle("sess-a")
+    r = Registrant(handle, kind="tui")
+    r.start()
+    try:
+        record = await _wait_record()
+        client = AttachClient(lambda p: None, lambda reason: None)
+        await client.connect(record, "sess-a")
+        with pytest.raises(RuntimeError) as excinfo:
+            # An op the owned-handle rejects for every caller: the error
+            # frame must surface as RuntimeError, not a silent None.
+            await client.slash("nonexistent", "")
+        assert "terminal-only" in str(excinfo.value)
+        await client.detach()
+    finally:
+        r.close()

--- a/tests/unit/mobile/test_attach_client.py
+++ b/tests/unit/mobile/test_attach_client.py
@@ -4,7 +4,6 @@ correlation, and the no-reconnect contract."""
 from __future__ import annotations
 
 import asyncio
-import json
 import os
 from pathlib import Path
 
@@ -48,6 +47,29 @@ class FakeHandle:
 
     async def slash(self, command, args):  # noqa: ANN001, ANN202
         raise ValueError(f"/{command} is terminal-only here")
+
+    # The rest of the SessionHandle surface the registrant's protocol demands;
+    # these tests never drive them, but the protocol check is structural.
+    async def abort(self):  # noqa: ANN202
+        return "stopping"
+
+    async def set_model(self, provider, model_id):  # noqa: ANN001, ANN202
+        return "model"
+
+    async def set_effort(self, effort):  # noqa: ANN001, ANN202
+        return "effort"
+
+    async def new_conversation(self):  # noqa: ANN202
+        raise ValueError("not here")
+
+    async def resume_session(self, session_id):  # noqa: ANN001, ANN202
+        raise ValueError("not here")
+
+    async def approval_answer(self, request_id, approved, remember):  # noqa: ANN001, ANN202
+        return "done"
+
+    async def ask_answer(self, request_id, value, question_index=None):  # noqa: ANN001, ANN202
+        return "done"
 
 
 async def _wait_record() -> registry.SessionRecord:

--- a/tests/unit/mobile/test_attach_client.py
+++ b/tests/unit/mobile/test_attach_client.py
@@ -219,8 +219,11 @@ async def test_owner_death_fires_on_disconnected_once(config: Path) -> None:
         disconnected: list[str] = []
         client = AttachClient(lambda p: None, disconnected.append)
         await client.connect(record, "sess-a")
-        # Kill the owner's socket the hard way: close the server.
-        r._shutdown()
+        # Kill the owner through its public synchronous seam. This call runs
+        # on the attach client's loop, not the registrant thread, preserving
+        # the hard socket-death path while exercising the cross-loop boundary.
+        r.close()
+        r.close()  # repeated host teardown must remain a no-op
         deadline = asyncio.get_running_loop().time() + 5
         while asyncio.get_running_loop().time() < deadline:
             if disconnected:

--- a/tests/unit/mobile/test_attach_client.py
+++ b/tests/unit/mobile/test_attach_client.py
@@ -36,7 +36,7 @@ class FakeHandle:
     async def refresh(self) -> None:
         pass
 
-    async def prompt(self, text, images=None):  # noqa: ANN001, ANN202
+    async def prompt(self, text, images=None, command_id=None):  # noqa: ANN001, ANN202
         self._projection.transcript.append(
             TranscriptEntry(id=f"u{len(self._projection.transcript)}", kind="user", text=text)
         )

--- a/tests/unit/mobile/test_child_reaper.py
+++ b/tests/unit/mobile/test_child_reaper.py
@@ -1,0 +1,167 @@
+"""The child's self-reaper: the truth table, the grace window, and the
+clean-exit ordering."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from local_operator.mobile import child as child_mod
+from local_operator.mobile.child import _clean_exit, _reaper, _should_exit
+
+
+class FakeRegistrant:
+    def __init__(
+        self, *, supported: bool = False, watchers: int = 0, attaches: int = 0
+    ) -> None:
+        self.watch_supported = supported
+        self.phone_watchers = watchers
+        self._attaches = attaches
+        self.closed = False
+
+    def attach_clients(self) -> int:
+        return self._attaches
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+class FakeHandle:
+    def __init__(self, *, busy: bool = False) -> None:
+        self._busy = busy
+        self.disposed = False
+        self.denied = False
+
+    def is_busy(self) -> bool:
+        return self._busy
+
+    def _deny_pending_gates(self) -> None:
+        self.denied = True
+
+    async def dispose(self) -> None:
+        self.disposed = True
+
+
+def test_unknown_watchers_never_exit() -> None:
+    """The mixed-version guard: an old daemon never sends watch/unwatch, so
+    watchers are UNKNOWN and _should_exit must read as present."""
+    reg = FakeRegistrant(supported=False, watchers=0)
+    assert _should_exit(FakeHandle(), reg) is False
+
+
+def test_known_zero_watchers_idle_session_exits() -> None:
+    reg = FakeRegistrant(supported=True, watchers=0)
+    assert _should_exit(FakeHandle(), reg) is True
+
+
+def test_present_watchers_hold() -> None:
+    reg = FakeRegistrant(supported=True, watchers=1)
+    assert _should_exit(FakeHandle(), reg) is False
+
+
+def test_attach_client_holds() -> None:
+    reg = FakeRegistrant(supported=True, watchers=0, attaches=1)
+    assert _should_exit(FakeHandle(), reg) is False
+
+
+def test_busy_session_holds() -> None:
+    reg = FakeRegistrant(supported=True, watchers=0)
+    assert _should_exit(FakeHandle(busy=True), reg) is False
+
+
+def test_latch_never_resets() -> None:
+    """Once watch-capable, silence means zero — but the latch itself must
+    survive a watchers count that rises again (it gates on the flag, not the
+    count's history)."""
+    reg = FakeRegistrant(supported=True, watchers=2)
+    assert _should_exit(FakeHandle(), reg) is False
+    reg.phone_watchers = 0
+    assert _should_exit(FakeHandle(), reg) is True
+
+
+@pytest.mark.asyncio
+async def test_clean_exit_orders_gates_dispose_unpublish(monkeypatch) -> None:
+    order: list[str] = []
+    handle = FakeHandle()
+    reg = FakeRegistrant(supported=True)
+
+    async def dispose() -> None:
+        order.append("dispose")
+
+    async def aclose() -> None:
+        order.append("unpublish")
+
+    handle._deny_pending_gates = lambda: order.append("deny")  # type: ignore[method-assign]
+    handle.dispose = dispose  # type: ignore[method-assign]
+    reg.aclose = aclose  # type: ignore[method-assign]
+    await _clean_exit(handle, reg)
+    assert order == ["deny", "dispose", "unpublish"]
+
+
+@pytest.mark.asyncio
+async def test_grace_elapses_then_clean_exit(monkeypatch) -> None:
+    monkeypatch.setattr(child_mod, "REAP_CHECK_S", 0.05)
+    monkeypatch.setenv("LOP_SESSION_GRACE_S", "0.2")
+    reg = FakeRegistrant(supported=True)
+    handle = FakeHandle()
+    stop = asyncio.Event()
+    task = asyncio.ensure_future(_reaper(handle, reg, stop))
+    deadline = asyncio.get_running_loop().time() + 3
+    while asyncio.get_running_loop().time() < deadline:
+        if stop.is_set():
+            break
+        await asyncio.sleep(0.05)
+    assert stop.is_set()
+    assert handle.disposed and handle.denied and reg.closed
+    await task
+
+
+@pytest.mark.asyncio
+async def test_front_end_returning_mid_grace_cancels(monkeypatch) -> None:
+    monkeypatch.setattr(child_mod, "REAP_CHECK_S", 0.05)
+    monkeypatch.setenv("LOP_SESSION_GRACE_S", "0.5")
+    reg = FakeRegistrant(supported=True)
+    handle = FakeHandle()
+    stop = asyncio.Event()
+    task = asyncio.ensure_future(_reaper(handle, reg, stop))
+    # Inside the grace window, a phone comes back.
+    await asyncio.sleep(0.15)
+    reg.phone_watchers = 1
+    await asyncio.sleep(0.8)  # well past the original grace
+    assert not stop.is_set()
+    assert not handle.disposed
+    task.cancel()
+
+
+@pytest.mark.asyncio
+async def test_busy_session_defers_grace_start(monkeypatch) -> None:
+    """A turn mid-flight when the last front end leaves must NOT start the
+    clock; grace begins at turn end and outlives the turn by construction."""
+    monkeypatch.setattr(child_mod, "REAP_CHECK_S", 0.05)
+    monkeypatch.setenv("LOP_SESSION_GRACE_S", "0.2")
+    reg = FakeRegistrant(supported=True)
+    handle = FakeHandle(busy=True)
+    stop = asyncio.Event()
+    task = asyncio.ensure_future(_reaper(handle, reg, stop))
+    await asyncio.sleep(0.5)  # past the whole grace had it started at t=0
+    assert not stop.is_set()
+    handle._busy = False  # the turn ends NOW
+    deadline = asyncio.get_running_loop().time() + 3
+    while asyncio.get_running_loop().time() < deadline:
+        if stop.is_set():
+            break
+        await asyncio.sleep(0.05)
+    assert stop.is_set()
+    await task
+
+
+def test_grace_env_override_and_defaults(monkeypatch) -> None:
+    monkeypatch.delenv("LOP_SESSION_GRACE_S", raising=False)
+    assert child_mod._grace_seconds() == child_mod.DEFAULT_GRACE_S == 120.0
+    monkeypatch.setenv("LOP_SESSION_GRACE_S", "10")
+    assert child_mod._grace_seconds() == 10.0
+    monkeypatch.setenv("LOP_SESSION_GRACE_S", "not-a-number")
+    assert child_mod._grace_seconds() == 120.0
+    monkeypatch.setenv("LOP_SESSION_GRACE_S", "-5")
+    assert child_mod._grace_seconds() == 120.0

--- a/tests/unit/mobile/test_child_reaper.py
+++ b/tests/unit/mobile/test_child_reaper.py
@@ -30,6 +30,7 @@ class FakeHandle:
         self._busy = busy
         self.disposed = False
         self.denied = False
+        self.dispose_order: list[str] = []
 
     def is_busy(self) -> bool:
         return self._busy
@@ -38,44 +39,24 @@ class FakeHandle:
         self.denied = True
 
     async def dispose(self) -> None:
+        self.dispose_order.append("dispose")
         self.disposed = True
 
 
-def test_unknown_watchers_never_exit() -> None:
-    """The mixed-version guard: an old daemon never sends watch/unwatch, so
-    watchers are UNKNOWN and _should_exit must read as present."""
-    reg = FakeRegistrant(supported=False, watchers=0)
-    assert _should_exit(FakeHandle(), reg) is False
-
-
-def test_known_zero_watchers_idle_session_exits() -> None:
-    reg = FakeRegistrant(supported=True, watchers=0)
+@pytest.mark.parametrize(
+    "reg",
+    [
+        FakeRegistrant(supported=False),
+        FakeRegistrant(supported=True, watchers=1),
+        FakeRegistrant(supported=True, watchers=5, attaches=3),
+    ],
+)
+def test_viewer_counts_never_pin_idle_host(reg: FakeRegistrant) -> None:
     assert _should_exit(FakeHandle(), reg) is True
 
 
-def test_present_watchers_hold() -> None:
-    reg = FakeRegistrant(supported=True, watchers=1)
-    assert _should_exit(FakeHandle(), reg) is False
-
-
-def test_attach_client_holds() -> None:
-    reg = FakeRegistrant(supported=True, watchers=0, attaches=1)
-    assert _should_exit(FakeHandle(), reg) is False
-
-
-def test_busy_session_holds() -> None:
-    reg = FakeRegistrant(supported=True, watchers=0)
-    assert _should_exit(FakeHandle(busy=True), reg) is False
-
-
-def test_latch_never_resets() -> None:
-    """Once watch-capable, silence means zero — but the latch itself must
-    survive a watchers count that rises again (it gates on the flag, not the
-    count's history)."""
-    reg = FakeRegistrant(supported=True, watchers=2)
-    assert _should_exit(FakeHandle(), reg) is False
-    reg.phone_watchers = 0
-    assert _should_exit(FakeHandle(), reg) is True
+def test_active_work_holds() -> None:
+    assert _should_exit(FakeHandle(busy=True), FakeRegistrant()) is False
 
 
 @pytest.mark.asyncio
@@ -94,7 +75,7 @@ async def test_clean_exit_orders_gates_dispose_unpublish(monkeypatch) -> None:
     handle.dispose = dispose  # type: ignore[method-assign]
     reg.aclose = aclose  # type: ignore[method-assign]
     await _clean_exit(handle, reg)
-    assert order == ["deny", "dispose", "unpublish"]
+    assert order == ["dispose", "unpublish"]
 
 
 @pytest.mark.asyncio
@@ -111,25 +92,23 @@ async def test_grace_elapses_then_clean_exit(monkeypatch) -> None:
             break
         await asyncio.sleep(0.05)
     assert stop.is_set()
-    assert handle.disposed and handle.denied and reg.closed
+    assert handle.disposed and not handle.denied and reg.closed
     await task
 
 
 @pytest.mark.asyncio
-async def test_front_end_returning_mid_grace_cancels(monkeypatch) -> None:
-    monkeypatch.setattr(child_mod, "REAP_CHECK_S", 0.05)
-    monkeypatch.setenv("LOP_SESSION_GRACE_S", "0.5")
-    reg = FakeRegistrant(supported=True)
-    handle = FakeHandle()
-    stop = asyncio.Event()
-    task = asyncio.ensure_future(_reaper(handle, reg, stop))
-    # Inside the grace window, a phone comes back.
-    await asyncio.sleep(0.15)
-    reg.phone_watchers = 1
-    await asyncio.sleep(0.8)  # well past the original grace
-    assert not stop.is_set()
-    assert not handle.disposed
-    task.cancel()
+async def test_viewers_do_not_change_idle_timing(monkeypatch) -> None:
+    monkeypatch.setattr(child_mod, "REAP_CHECK_S", 0.01)
+    monkeypatch.setenv("LOP_SESSION_GRACE_S", "0.08")
+    elapsed: list[float] = []
+    for watchers, attaches in ((0, 0), (1, 0), (5, 3)):
+        reg = FakeRegistrant(supported=bool(watchers), watchers=watchers, attaches=attaches)
+        handle = FakeHandle()
+        stop = asyncio.Event()
+        started = asyncio.get_running_loop().time()
+        await _reaper(handle, reg, stop)
+        elapsed.append(asyncio.get_running_loop().time() - started)
+    assert max(elapsed) - min(elapsed) < 0.04
 
 
 @pytest.mark.asyncio
@@ -154,12 +133,30 @@ async def test_busy_session_defers_grace_start(monkeypatch) -> None:
     await task
 
 
+@pytest.mark.asyncio
+async def test_new_activity_resets_idle_drain(monkeypatch) -> None:
+    monkeypatch.setattr(child_mod, "REAP_CHECK_S", 0.02)
+    monkeypatch.setenv("LOP_SESSION_GRACE_S", "0.12")
+    reg = FakeRegistrant(watchers=3, attaches=2)
+    handle = FakeHandle()
+    stop = asyncio.Event()
+    task = asyncio.ensure_future(_reaper(handle, reg, stop))
+    await asyncio.sleep(0.08)
+    handle._busy = True
+    await asyncio.sleep(0.1)
+    handle._busy = False
+    await asyncio.sleep(0.08)
+    assert not stop.is_set()
+    await task
+    assert stop.is_set()
+
+
 def test_grace_env_override_and_defaults(monkeypatch) -> None:
     monkeypatch.delenv("LOP_SESSION_GRACE_S", raising=False)
-    assert child_mod._grace_seconds() == child_mod.DEFAULT_GRACE_S == 120.0
+    assert child_mod._grace_seconds() == child_mod.DEFAULT_GRACE_S == 3.0
     monkeypatch.setenv("LOP_SESSION_GRACE_S", "10")
     assert child_mod._grace_seconds() == 10.0
     monkeypatch.setenv("LOP_SESSION_GRACE_S", "not-a-number")
-    assert child_mod._grace_seconds() == 120.0
+    assert child_mod._grace_seconds() == 3.0
     monkeypatch.setenv("LOP_SESSION_GRACE_S", "-5")
-    assert child_mod._grace_seconds() == 120.0
+    assert child_mod._grace_seconds() == 3.0

--- a/tests/unit/mobile/test_child_reaper.py
+++ b/tests/unit/mobile/test_child_reaper.py
@@ -12,9 +12,7 @@ from local_operator.mobile.child import _clean_exit, _reaper, _should_exit
 
 
 class FakeRegistrant:
-    def __init__(
-        self, *, supported: bool = False, watchers: int = 0, attaches: int = 0
-    ) -> None:
+    def __init__(self, *, supported: bool = False, watchers: int = 0, attaches: int = 0) -> None:
         self.watch_supported = supported
         self.phone_watchers = watchers
         self._attaches = attaches

--- a/tests/unit/mobile/test_command_reservation.py
+++ b/tests/unit/mobile/test_command_reservation.py
@@ -1,0 +1,86 @@
+"""Durable identity and bounded-undelivered-command regressions."""
+
+from __future__ import annotations
+
+import pytest
+
+from local_operator.harness.types import Message
+from local_operator.mobile.command_reservation import (
+    MAX_PENDING_STEERS,
+    CommandReservations,
+)
+from local_operator.session.transcript import Transcript
+
+
+class _SessionAuthority:
+    def __init__(self, transcript: Transcript) -> None:
+        self.transcript = transcript
+
+    def has_admitted_command(self, command_id: str) -> bool:
+        return self.transcript.has_admitted_command(command_id)
+
+    def subscribe_admitted_commands(self, handler):  # noqa: ANN001, ANN202
+        return self.transcript.subscribe_admitted_commands(handler)
+
+
+@pytest.mark.asyncio
+async def test_compacted_command_remains_admitted_after_reconstruction(tmp_path) -> None:
+    directory = tmp_path / "session"
+    transcript = Transcript(directory)
+    command = Message.user("first", id="producer-1")
+    await transcript.append_message(command)
+    kept = await transcript.append_message(Message.assistant("later"))
+    await transcript.append_compaction("summary", kept.id, tokens_before=100)
+
+    assert all(message.id != command.id for message in transcript.build_llm_history())
+    assert transcript.has_admitted_command(command.id)
+    assert Transcript(directory).has_admitted_command(command.id)
+
+
+@pytest.mark.asyncio
+async def test_append_before_ack_hands_reservation_to_durable_authority(tmp_path) -> None:
+    transcript = Transcript(tmp_path / "session")
+    reservations = CommandReservations(_SessionAuthority(transcript))
+    unsubscribe = reservations.subscribe_durable()
+    assert reservations.reserve("crash-boundary", kind="prompt")
+
+    await transcript.append_message(Message.user("persisted", id="crash-boundary"))
+
+    assert "crash-boundary" not in reservations._commands
+    assert not reservations.reserve("crash-boundary", kind="prompt")
+    unsubscribe()
+
+
+@pytest.mark.asyncio
+async def test_pending_steers_are_bounded_without_evicting_accepted_ids(tmp_path) -> None:
+    transcript = Transcript(tmp_path / "session")
+    reservations = CommandReservations(_SessionAuthority(transcript))
+    reservations.subscribe_durable()
+
+    for index in range(MAX_PENDING_STEERS):
+        assert reservations.reserve(f"steer-{index}", kind="steer")
+    assert reservations._pending_steers == MAX_PENDING_STEERS
+    assert len(reservations._commands) == MAX_PENDING_STEERS
+    assert not reservations.reserve("steer-0", kind="steer")
+    with pytest.raises(RuntimeError, match=r"steering queue is full \(32\)"):
+        reservations.reserve("overflow", kind="steer")
+
+    await transcript.append_message(Message.user("delivered", id="steer-0"))
+    assert reservations._pending_steers == MAX_PENDING_STEERS - 1
+    assert reservations.reserve("replacement", kind="steer")
+    assert not reservations.reserve("steer-0", kind="steer")
+
+
+def test_prompt_transfer_consumes_one_steer_slot_and_rejection_releases_it(tmp_path) -> None:
+    reservations = CommandReservations(_SessionAuthority(Transcript(tmp_path / "session")))
+    assert reservations.reserve("race", kind="prompt")
+    reservations.reject("race", transfer_to_steer=True)
+    assert reservations.reserve("race", kind="steer", prompt_transfer=True)
+    assert reservations._pending_steers == 1
+
+    reservations.reject("race")
+    assert reservations._pending_steers == 0
+    assert reservations.reserve("race", kind="steer")
+    reservations.clear()
+    assert reservations._pending_steers == 0
+    assert not reservations._commands

--- a/tests/unit/mobile/test_command_reservation.py
+++ b/tests/unit/mobile/test_command_reservation.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from local_operator.harness.types import Message
+from local_operator.harness.types import CustomMessage, Message
 from local_operator.mobile.command_reservation import (
     MAX_PENDING_STEERS,
     CommandReservations,
@@ -28,7 +28,7 @@ async def test_compacted_command_remains_admitted_after_reconstruction(tmp_path)
     directory = tmp_path / "session"
     transcript = Transcript(directory)
     command = Message.user("first", id="producer-1")
-    await transcript.append_message(command)
+    await transcript.append_message(command, producer_command_id=command.id)
     kept = await transcript.append_message(Message.assistant("later"))
     await transcript.append_compaction("summary", kept.id, tokens_before=100)
 
@@ -38,13 +38,50 @@ async def test_compacted_command_remains_admitted_after_reconstruction(tmp_path)
 
 
 @pytest.mark.asyncio
+async def test_only_explicit_producer_markers_enter_admission_index(tmp_path) -> None:
+    directory = tmp_path / "session"
+    transcript = Transcript(directory)
+    collision = "shared-id"
+
+    await transcript.append_message(Message.user("local", id=collision))
+    await transcript.append_message(Message.assistant("assistant", id=collision))
+    await transcript.append_message(
+        CustomMessage(custom_type="imported", details={"text": "custom"}, id=collision)
+    )
+    await transcript.append_custom("ledger", {"command_id": collision})
+    await transcript.append_compaction("summary", collision, tokens_before=1)
+    with transcript.path.open("a", encoding="utf-8") as handle:
+        handle.write('{"id":"shared-id","type":"message","payload":{"role":"user"\n')
+
+    assert not transcript.has_admitted_command(collision)
+    assert not Transcript(directory).has_admitted_command(collision)
+    reservations = CommandReservations(_SessionAuthority(Transcript(directory)))
+    assert reservations.reserve(collision, kind="prompt")
+
+    await transcript.append_message(
+        Message.user("mobile", id="different-message-id"),
+        producer_command_id=collision,
+    )
+    reopened = Transcript(directory)
+    assert reopened.has_admitted_command(collision)
+    assert not CommandReservations(_SessionAuthority(reopened)).reserve(collision, kind="prompt")
+    marker = reopened.entries()[-1].payload["producer_command_id"]
+    replayed = reopened.build_llm_history()
+    assert marker == collision
+    assert all("producer_command_id" not in message.model_dump() for message in replayed)
+
+
+@pytest.mark.asyncio
 async def test_append_before_ack_hands_reservation_to_durable_authority(tmp_path) -> None:
     transcript = Transcript(tmp_path / "session")
     reservations = CommandReservations(_SessionAuthority(transcript))
     unsubscribe = reservations.subscribe_durable()
     assert reservations.reserve("crash-boundary", kind="prompt")
 
-    await transcript.append_message(Message.user("persisted", id="crash-boundary"))
+    await transcript.append_message(
+        Message.user("persisted", id="crash-boundary"),
+        producer_command_id="crash-boundary",
+    )
 
     assert "crash-boundary" not in reservations._commands
     assert not reservations.reserve("crash-boundary", kind="prompt")
@@ -65,7 +102,10 @@ async def test_pending_steers_are_bounded_without_evicting_accepted_ids(tmp_path
     with pytest.raises(RuntimeError, match=r"steering queue is full \(32\)"):
         reservations.reserve("overflow", kind="steer")
 
-    await transcript.append_message(Message.user("delivered", id="steer-0"))
+    await transcript.append_message(
+        Message.user("delivered", id="steer-0"),
+        producer_command_id="steer-0",
+    )
     assert reservations._pending_steers == MAX_PENDING_STEERS - 1
     assert reservations.reserve("replacement", kind="steer")
     assert not reservations.reserve("steer-0", kind="steer")

--- a/tests/unit/mobile/test_command_reservation.py
+++ b/tests/unit/mobile/test_command_reservation.py
@@ -111,6 +111,34 @@ async def test_pending_steers_are_bounded_without_evicting_accepted_ids(tmp_path
     assert not reservations.reserve("steer-0", kind="steer")
 
 
+def test_async_steer_rejection_releases_identity_and_capacity(tmp_path) -> None:
+    class Session(_SessionAuthority):
+        def __init__(self, transcript):  # noqa: ANN001
+            super().__init__(transcript)
+            self._rejection_handlers = []
+
+        def subscribe_rejected_steering(self, handler):  # noqa: ANN001, ANN202
+            self._rejection_handlers.append(handler)
+            return lambda: self._rejection_handlers.remove(handler)
+
+        def reject(self, command_id: str, reason: str) -> None:
+            for handler in list(self._rejection_handlers):
+                handler(command_id, reason)
+
+    session = Session(Transcript(tmp_path / "session"))
+    reservations = CommandReservations(session)
+    unsubscribe = reservations.subscribe_durable()
+    assert reservations.reserve("retry-id", kind="steer")
+    assert reservations._pending_steers == 1
+
+    session.reject("retry-id", "disk full")
+
+    assert reservations._pending_steers == 0
+    assert not reservations._commands
+    assert reservations.reserve("retry-id", kind="steer")
+    unsubscribe()
+
+
 def test_prompt_transfer_consumes_one_steer_slot_and_rejection_releases_it(tmp_path) -> None:
     reservations = CommandReservations(_SessionAuthority(Transcript(tmp_path / "session")))
     assert reservations.reserve("race", kind="prompt")

--- a/tests/unit/mobile/test_daemon.py
+++ b/tests/unit/mobile/test_daemon.py
@@ -235,6 +235,51 @@ def test_directories_endpoint_offers_tmp(monkeypatch) -> None:
     assert body.get("tmp")
 
 
+def test_previous_command_validation_is_bounded_without_side_effects(tmp_path, monkeypatch) -> None:
+    """Malformed authenticated continuation input never reaches child startup."""
+    import asyncio as _asyncio
+
+    from local_operator.harness.types import Message
+    from local_operator.mobile import attach_client
+    from local_operator.session.transcript import Transcript
+
+    cfg = tmp_path / "config"
+    cfg.mkdir()
+    monkeypatch.setattr("local_operator.paths.config_dir", lambda: cfg)
+    directory = cfg / "sessions" / "previous-invalid"
+    directory.mkdir(parents=True)
+    transcript = Transcript(directory)
+    _asyncio.run(transcript.append_message(Message.user("existing", id="existing")))
+    called = False
+
+    async def should_not_start(*args, **kwargs):  # noqa: ANN002, ANN003, ANN202
+        nonlocal called
+        called = True
+        raise AssertionError("invalid input spawned a continuation")
+
+    monkeypatch.setattr(attach_client, "continue_command", should_not_start)
+    client = TestClient(build_app(MobileDaemon(port=0, password="pw123")))
+    client.post("/login", data={"password": "pw123"})
+    invalid = [
+        {"op": "prompt", "command_id": "not-a-uuid", "text": "hello"},
+        {"op": "prompt", "text": "hello"},
+        {"op": "prompt", "command_id": "12345678-1234-5678-1234-567812345678", "text": []},
+        {
+            "op": "prompt",
+            "command_id": "12345678-1234-5678-1234-567812345678",
+            "text": "hello",
+            "images": {},
+        },
+    ]
+    for payload in invalid:
+        response = client.post("/api/sessions/previous-invalid/command", json=payload)
+        assert response.status_code in (400, 422)
+        assert response.headers["content-type"].startswith("application/json")
+        assert "error" in response.json()
+    assert not called
+    assert [message.id for message in transcript.build_llm_history()] == ["existing"]
+
+
 def test_previous_continuation_transport_failure_is_non_2xx(tmp_path, monkeypatch) -> None:
     """Provider/child/socket failures return an error and never a false ACK."""
     import asyncio as _asyncio

--- a/tests/unit/mobile/test_daemon.py
+++ b/tests/unit/mobile/test_daemon.py
@@ -42,7 +42,7 @@ class FakeHandle:
         self.calls.append((name, args, kwargs))
         return f"{name} ok"
 
-    async def prompt(self, text, images=None):  # noqa: ANN001, ANN202
+    async def prompt(self, text, images=None, command_id=None):  # noqa: ANN001, ANN202
         return await self._record("prompt", text)
 
     async def steer(self, text, images=None):  # noqa: ANN001, ANN202

--- a/tests/unit/mobile/test_daemon.py
+++ b/tests/unit/mobile/test_daemon.py
@@ -14,7 +14,7 @@ from starlette.testclient import TestClient
 from local_operator.mobile import registry
 from local_operator.mobile.daemon import MobileDaemon, SessionEntry, _dial, build_app
 from local_operator.mobile.registrant import Registrant
-from local_operator.mobile.types import SessionProjection
+from local_operator.mobile.types import PROJECTION_TRANSCRIPT_LIMIT, SessionProjection
 
 
 class FakeHandle:
@@ -176,6 +176,14 @@ def test_unknown_session_command_is_a_409() -> None:
     client.post("/login", data={"password": "pw123"})
     reply = client.post("/api/sessions/424242/command", json={"op": "abort"})
     assert reply.status_code == 409
+    # A prompt to an unknown/malformed route must not reach continuation child
+    # construction; only a proven durable user conversation can wake a host.
+    prompt = {"op": "prompt", "command_id": "unknown-1", "text": "hello"}
+    assert client.post("/api/sessions/424242/command", json=prompt).status_code == 409
+    assert client.post("/api/sessions/%2E%2E%2Foutside/command", json=prompt).status_code in (
+        404,
+        409,
+    )
 
 
 def test_spawn_dir_gate_allows_home_and_tmp_only(tmp_path, monkeypatch) -> None:
@@ -225,6 +233,126 @@ def test_directories_endpoint_offers_tmp(monkeypatch) -> None:
     assert "recent" in body
     # /tmp is offered as a scratch start dir beside home.
     assert body.get("tmp")
+
+
+def test_previous_continuation_transport_failure_is_non_2xx(tmp_path, monkeypatch) -> None:
+    """Provider/child/socket failures return an error and never a false ACK."""
+    import asyncio as _asyncio
+
+    from local_operator.harness.types import Message
+    from local_operator.mobile import attach_client
+    from local_operator.session.transcript import Transcript
+
+    cfg = tmp_path / "config"
+    cfg.mkdir()
+    monkeypatch.setattr("local_operator.paths.config_dir", lambda: cfg)
+    directory = cfg / "sessions" / "previous-failure"
+    directory.mkdir(parents=True)
+    transcript = Transcript(directory)
+    _asyncio.run(transcript.append_message(Message.user("existing", id="existing")))
+
+    async def fail(*args, **kwargs):  # noqa: ANN002, ANN003, ANN202
+        raise ConnectionError("daemon restarted")
+
+    monkeypatch.setattr(attach_client, "continue_command", fail)
+    client = TestClient(build_app(MobileDaemon(port=0, password="pw123")))
+    client.post("/login", data={"password": "pw123"})
+    response = client.post(
+        "/api/sessions/previous-failure/command",
+        json={
+            "op": "prompt",
+            "command_id": "12345678-1234-5678-1234-567812345678",
+            "text": "retry me",
+        },
+    )
+    assert response.status_code == 502
+    assert response.json() == {"error": "daemon restarted"}
+    history = transcript.build_llm_history()
+    assert [message.id for message in history] == ["existing"]
+
+
+def test_previous_history_pages_full_durable_transcript_once(tmp_path, monkeypatch) -> None:
+    """A Previous route pages beyond the projection cap without a live host.
+
+    The first request anchors at the retained tail's oldest row, then each
+    cursor walks backwards. Concatenating the pages with that tail must recover
+    every folded row exactly once and in chronological order.
+    """
+    import asyncio as _asyncio
+
+    from local_operator.harness.types import Message
+    from local_operator.mobile.daemon import _durable_projection
+    from local_operator.session.transcript import Transcript
+
+    cfg = tmp_path / "config"
+    cfg.mkdir()
+    monkeypatch.setattr("local_operator.paths.config_dir", lambda: cfg)
+    session_id = "durable-history"
+    directory = cfg / "sessions" / session_id
+    directory.mkdir(parents=True)
+    transcript = Transcript(directory)
+    expected_ids: list[str] = []
+    for turn in range(PROJECTION_TRANSCRIPT_LIMIT + 25):
+        user = Message.user(f"user {turn}", id=f"u-{turn:03d}")
+        assistant = Message.assistant(f"answer {turn}", id=f"a-{turn:03d}")
+        _asyncio.run(transcript.append_message(user))
+        _asyncio.run(transcript.append_message(assistant))
+        expected_ids.extend([user.id, assistant.id])
+
+    daemon = MobileDaemon(port=0, password="pw123")
+    client = TestClient(build_app(daemon), follow_redirects=False)
+    client.post("/login", data={"password": "pw123"})
+    projection = _durable_projection(session_id)
+    assert projection is not None
+    tail_ids = [entry.id for entry in projection.transcript]
+    assert len(tail_ids) == PROJECTION_TRANSCRIPT_LIMIT
+
+    pages: list[list[str]] = []
+    # The projection pins the opener at index 0 and keeps the chronological tail
+    # after it; the web view therefore anchors history at the first tail row.
+    before = tail_ids[1]
+    while True:
+        response = client.get(
+            f"/api/sessions/{session_id}/history", params={"before": before, "limit": 17}
+        )
+        assert response.status_code == 200
+        body = response.json()
+        page = [entry["id"] for entry in body["entries"]]
+        pages.insert(0, page)
+        if not body["has_more"]:
+            break
+        assert page
+        before = page[0]
+
+    recovered = [entry_id for page in pages for entry_id in page] + tail_ids[1:]
+    # The pinned opener overlaps the oldest page and is de-duplicated by the
+    # web merge, exactly as it is here.
+    recovered = list(dict.fromkeys([tail_ids[0], *recovered]))
+    assert recovered == expected_ids
+    assert len(recovered) == len(set(recovered))
+
+
+def test_previous_history_rejects_unknown_traversal_and_subagent(tmp_path, monkeypatch) -> None:
+    """Durability does not broaden the route beyond human-owned sessions."""
+    import asyncio as _asyncio
+
+    from local_operator.harness.types import Message
+    from local_operator.session.transcript import Transcript
+
+    cfg = tmp_path / "config"
+    cfg.mkdir()
+    monkeypatch.setattr("local_operator.paths.config_dir", lambda: cfg)
+    subagent = cfg / "sessions" / "subagent-session"
+    subagent.mkdir(parents=True)
+    _asyncio.run(Transcript(subagent).append_message(Message.user("hidden", id="hidden")))
+    (subagent / "origin.json").write_text('{"origin":"subagent"}')
+
+    client = TestClient(build_app(MobileDaemon(port=0, password="pw123")))
+    client.post("/login", data={"password": "pw123"})
+    assert client.get("/api/sessions/unknown/history").status_code == 404
+    assert client.get("/api/sessions/subagent-session/history").status_code == 404
+    # Encoded slash must never turn the public identifier into a filesystem path.
+    assert client.get("/api/sessions/%2E%2E%2Foutside/history").status_code in (404, 400)
 
 
 def test_image_bytes_reads_attachment_from_transcript(tmp_path, monkeypatch) -> None:

--- a/tests/unit/mobile/test_daemon_watch.py
+++ b/tests/unit/mobile/test_daemon_watch.py
@@ -32,7 +32,7 @@ class FakeHandle:
     def subscribe(self, on_projection):  # noqa: ANN001, ANN202
         return lambda: None
 
-    async def prompt(self, text, images=None):  # noqa: ANN001, ANN202
+    async def prompt(self, text, images=None, command_id=None):  # noqa: ANN001, ANN202
         return "sent"
 
     async def steer(self, text, images=None):  # noqa: ANN001, ANN202

--- a/tests/unit/mobile/test_daemon_watch.py
+++ b/tests/unit/mobile/test_daemon_watch.py
@@ -1,0 +1,125 @@
+"""The daemon's watch/unwatch pushes on SSE subscriber transitions (design
+§2.8): first-in sends watch, last-out sends unwatch, and an old registrant's
+error reply is swallowed rather than 500ing the handshake."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+from starlette.testclient import TestClient
+
+from local_operator.mobile import registry
+from local_operator.mobile.daemon import MobileDaemon, SessionEntry, build_app
+from local_operator.mobile.registrant import Registrant
+from local_operator.mobile.types import SessionProjection
+
+
+class FakeHandle:
+    def __init__(self) -> None:
+        self._projection = SessionProjection(
+            session_id="s1",
+            pid=0,
+            kind="tui",
+            conversation_name="fake",
+            cwd="/tmp",
+            model_label="test/model",
+        )
+
+    @property
+    def session_projection_seed(self) -> SessionProjection:
+        return self._projection
+
+    def subscribe(self, on_projection):  # noqa: ANN001, ANN202
+        return lambda: None
+
+    async def refresh(self) -> None:
+        pass
+
+
+async def _wait_record() -> registry.SessionRecord:
+    deadline = asyncio.get_running_loop().time() + 5
+    while asyncio.get_running_loop().time() < deadline:
+        found = registry.scan()
+        if found and found[0][1] == "live":
+            return found[0][0]
+        await asyncio.sleep(0.05)
+    raise AssertionError("no live record")
+
+
+@pytest.mark.asyncio
+async def test_first_subscriber_sends_watch_and_last_out_sends_unwatch() -> None:
+    handle = FakeHandle()
+    registrant = Registrant(handle, kind="tui")
+    registrant.start()
+    try:
+        record = await _wait_record()
+        # Drive the daemon's notify path directly against the live socket:
+        # the SSE handler's transitions are what call it, and the handler
+        # itself is covered by the TestClient test below.
+        daemon = MobileDaemon(port=0, password="pw")
+        entry = SessionEntry(record)
+        daemon.table.entries[record.pid] = entry
+        dial = asyncio.ensure_future(_dial_and_hold(daemon, entry))
+        try:
+            await _wait_dial(entry)
+            assert registrant.phone_watchers == 0
+            daemon.notify_watch_transition(record.pid, watching=True)
+            deadline = asyncio.get_running_loop().time() + 5
+            while asyncio.get_running_loop().time() < deadline:
+                if registrant.phone_watchers == 1 and registrant.watch_supported:
+                    break
+                await asyncio.sleep(0.05)
+            assert registrant.phone_watchers == 1
+            assert registrant.watch_supported
+            daemon.notify_watch_transition(record.pid, watching=False)
+            deadline = asyncio.get_running_loop().time() + 5
+            while asyncio.get_running_loop().time() < deadline:
+                if registrant.phone_watchers == 0:
+                    break
+                await asyncio.sleep(0.05)
+            assert registrant.phone_watchers == 0
+        finally:
+            dial.cancel()
+    finally:
+        registrant.close()
+
+
+async def _dial_and_hold(daemon, entry) -> None:  # noqa: ANN001
+    from local_operator.mobile.daemon import _dial
+
+    await _dial(daemon, entry)
+
+
+async def _wait_dial(entry) -> None:  # noqa: ANN001
+    deadline = asyncio.get_running_loop().time() + 5
+    while asyncio.get_running_loop().time() < deadline:
+        if entry.writer is not None:
+            return
+        await asyncio.sleep(0.05)
+    raise AssertionError("daemon never dialed")
+
+
+@pytest.mark.asyncio
+async def test_watch_push_to_unknown_session_is_swallowed() -> None:
+    daemon = MobileDaemon(port=0, password="pw")
+    # No entry for the pid: the push must not raise (the SSE stream that
+    # triggered it is already mid-handshake).
+    daemon.notify_watch_transition(999999, watching=True)
+    await asyncio.sleep(0.1)
+
+
+def test_old_registrant_error_reply_is_swallowed() -> None:
+    """An entry whose writer is None (or a registrant that answers
+    `error: unknown op`) must not propagate: notify is fire-and-forget and
+    the RuntimeError path is caught inside the task."""
+    daemon = MobileDaemon(port=0, password="pw")
+
+    async def scenario() -> None:
+        # A request against a not-connected entry raises KeyError inside the
+        # task; the swallow keeps the loop clean.
+        daemon.notify_watch_transition(12345, watching=True)
+        await asyncio.sleep(0.05)
+
+    asyncio.run(scenario())

--- a/tests/unit/mobile/test_daemon_watch.py
+++ b/tests/unit/mobile/test_daemon_watch.py
@@ -5,13 +5,11 @@ error reply is swallowed rather than 500ing the handshake."""
 from __future__ import annotations
 
 import asyncio
-import json
 
 import pytest
-from starlette.testclient import TestClient
 
 from local_operator.mobile import registry
-from local_operator.mobile.daemon import MobileDaemon, SessionEntry, build_app
+from local_operator.mobile.daemon import MobileDaemon, SessionEntry
 from local_operator.mobile.registrant import Registrant
 from local_operator.mobile.types import SessionProjection
 
@@ -33,6 +31,36 @@ class FakeHandle:
 
     def subscribe(self, on_projection):  # noqa: ANN001, ANN202
         return lambda: None
+
+    async def prompt(self, text, images=None):  # noqa: ANN001, ANN202
+        return "sent"
+
+    async def steer(self, text, images=None):  # noqa: ANN001, ANN202
+        return "queued"
+
+    async def abort(self):  # noqa: ANN202
+        return "stopping"
+
+    async def set_model(self, provider, model_id):  # noqa: ANN001, ANN202
+        return "model"
+
+    async def set_effort(self, effort):  # noqa: ANN001, ANN202
+        return "effort"
+
+    async def slash(self, command, args):  # noqa: ANN001, ANN202
+        return "done"
+
+    async def new_conversation(self):  # noqa: ANN202
+        return "done"
+
+    async def resume_session(self, session_id):  # noqa: ANN001, ANN202
+        return "done"
+
+    async def approval_answer(self, request_id, approved, remember):  # noqa: ANN001, ANN202
+        return "done"
+
+    async def ask_answer(self, request_id, value, question_index=None):  # noqa: ANN001, ANN202
+        return "done"
 
     async def refresh(self) -> None:
         pass

--- a/tests/unit/mobile/test_owned.py
+++ b/tests/unit/mobile/test_owned.py
@@ -34,6 +34,9 @@ class FakeSession:
         self._handlers: list[Any] = []
         self._named: list[tuple[str, bool]] = []
         self._complete_calls: list[tuple[str, str]] = []
+        self.prompt_calls: list[str] = []
+        self.steer_calls: list[str] = []
+        self.prompt_release = asyncio.Event()
         # Tagged or a short untagged title both parse; the default stays
         # tagged so these tests stay independent of the untagged heuristics.
         self.title_reply = "<title>A Neat Title</title>"
@@ -79,6 +82,15 @@ class FakeSession:
 
     def running_subagents(self) -> int:
         return 0
+
+    async def prompt(self, text: str, images=None) -> None:  # noqa: ANN001
+        self.prompt_calls.append(text)
+        self.is_streaming = True
+        await self.prompt_release.wait()
+        self.is_streaming = False
+
+    def steer(self, text: str, images=None) -> None:  # noqa: ANN001
+        self.steer_calls.append(text)
 
     @property
     def reasoning_effort(self):  # pragma: no cover
@@ -146,6 +158,42 @@ async def test_ask_mode_parks_a_card_then_resolves() -> None:
     assert await second is False
     await asyncio.sleep(0)
     assert handle._fold.projection.pending is None
+
+
+@pytest.mark.asyncio
+async def test_concurrent_ordinary_prompts_are_admitted_fifo() -> None:
+    handle, session = make_handle()
+    first, second, third = await asyncio.gather(
+        handle.prompt("mobile"),
+        handle.prompt("attach one"),
+        handle.prompt("attach two"),
+    )
+    assert first == "prompt admitted"
+    assert second == "prompt queued (2)"
+    assert third == "prompt queued (3)"
+    await asyncio.sleep(0)
+    assert session.prompt_calls == ["mobile"]
+    assert handle.is_busy() is True
+
+    session.prompt_release.set()
+    deadline = asyncio.get_running_loop().time() + 5
+    while len(session.prompt_calls) < 3:
+        assert asyncio.get_running_loop().time() < deadline
+        await asyncio.sleep(0.01)
+    assert session.prompt_calls == ["mobile", "attach one", "attach two"]
+    assert len(set(session.prompt_calls)) == 3
+
+
+@pytest.mark.asyncio
+async def test_concurrent_explicit_steers_preserve_dispatch_order() -> None:
+    handle, session = make_handle()
+    receipts = await asyncio.gather(
+        handle.steer("mobile steer"),
+        handle.steer("attach steer one"),
+        handle.steer("attach steer two"),
+    )
+    assert receipts == ["steering queued"] * 3
+    assert session.steer_calls == ["mobile steer", "attach steer one", "attach steer two"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/mobile/test_owned.py
+++ b/tests/unit/mobile/test_owned.py
@@ -32,6 +32,8 @@ class FakeSession:
         self.conversation_name = ""
         self.is_streaming = False
         self._handlers: list[Any] = []
+        self._admission_handlers: list[Any] = []
+        self._admitted_ids: set[str] = set()
         self._named: list[tuple[str, bool]] = []
         self._complete_calls: list[tuple[str, str]] = []
         self.prompt_calls: list[str] = []
@@ -79,6 +81,22 @@ class FakeSession:
 
     def history(self):  # pragma: no cover - not exercised here
         return []
+
+    def has_admitted_command(self, command_id: str) -> bool:
+        return command_id in self._admitted_ids
+
+    def subscribe_admitted_commands(self, handler):  # noqa: ANN001, ANN202
+        self._admission_handlers.append(handler)
+
+        def unsubscribe() -> None:
+            self._admission_handlers.remove(handler)
+
+        return unsubscribe
+
+    def admit(self, command_id: str) -> None:
+        self._admitted_ids.add(command_id)
+        for handler in list(self._admission_handlers):
+            handler(command_id)
 
     def running_subagents(self) -> int:
         return 0
@@ -185,6 +203,23 @@ async def test_steer_ack_loss_retry_remains_admitted() -> None:
     assert await handle.steer("once", command_id="lost-ack") == "steering queued"
     assert await handle.steer("once", command_id="lost-ack") == "already admitted"
     assert session.steer_calls == ["once"]
+
+
+@pytest.mark.asyncio
+async def test_stalled_owned_steers_apply_backpressure_and_drain_frees_capacity() -> None:
+    handle, session = make_handle()
+
+    for index in range(32):
+        assert await handle.steer(f"steer {index}", command_id=f"id-{index}") == "steering queued"
+    assert len(session.steer_calls) == 32
+    assert await handle.steer("duplicate", command_id="id-0") == "already admitted"
+    with pytest.raises(RuntimeError, match=r"steering queue is full \(32\)"):
+        await handle.steer("overflow", command_id="overflow")
+    assert len(session.steer_calls) == 32
+
+    session.admit("id-0")
+    assert await handle.steer("replacement", command_id="replacement") == "steering queued"
+    assert await handle.steer("old retry", command_id="id-0") == "already admitted"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/mobile/test_owned.py
+++ b/tests/unit/mobile/test_owned.py
@@ -17,6 +17,7 @@ from typing import Any
 import pytest
 
 from local_operator.harness.types import AskOption, AskQuestion
+from local_operator.mobile import owned as owned_mod
 from local_operator.mobile.owned import OwnedSessionHandle
 
 
@@ -72,6 +73,9 @@ class FakeSession:
 
     def history(self):  # pragma: no cover - not exercised here
         return []
+
+    def running_subagents(self) -> int:
+        return 0
 
     @property
     def reasoning_effort(self):  # pragma: no cover
@@ -139,6 +143,29 @@ async def test_ask_mode_parks_a_card_then_resolves() -> None:
     assert await second is False
     await asyncio.sleep(0)
     assert handle._fold.projection.pending is None
+
+
+@pytest.mark.asyncio
+async def test_pending_gate_is_busy_until_ordinary_timeout(monkeypatch) -> None:
+    """The child drain cannot deny WAITING_INPUT ahead of its 30s policy."""
+    monkeypatch.setattr(owned_mod, "PENDING_REQUEST_TIMEOUT_S", 0.05)
+    handle, _ = make_handle(auto_approve=False)
+    waiting = asyncio.ensure_future(handle._approval_gate("bash", "one"))
+    await asyncio.sleep(0)
+    assert handle.is_busy() is True
+    assert await waiting is False
+    assert handle.is_busy() is False
+    assert owned_mod.PENDING_REQUEST_TIMEOUT_S == 0.05
+
+
+@pytest.mark.asyncio
+async def test_detached_background_work_is_busy_until_done() -> None:
+    handle, _ = make_handle()
+    future: asyncio.Future[None] = asyncio.get_running_loop().create_future()
+    handle._background_tasks.add(future)
+    assert handle.is_busy() is True
+    future.set_result(None)
+    assert handle.is_busy() is False
 
 
 @pytest.mark.asyncio

--- a/tests/unit/mobile/test_owned.py
+++ b/tests/unit/mobile/test_owned.py
@@ -249,6 +249,24 @@ async def test_queue_overflow_rejects_before_admission(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
+async def test_concurrent_gate_answers_have_one_authoritative_winner() -> None:
+    handle, _ = make_handle()
+    gate = asyncio.create_task(handle._approval_gate("bash", "Allow?"))
+    await asyncio.sleep(0)
+    request_id = next(iter(handle._pending_futures))
+    results = await asyncio.gather(
+        handle.approval_answer(request_id, True, False),
+        handle.approval_answer(request_id, False, False),
+        return_exceptions=True,
+    )
+    assert gate.done()
+    assert await gate in (True, False)
+    assert sum(isinstance(result, ValueError) for result in results) == 1
+    assert sum(isinstance(result, str) for result in results) == 1
+    assert request_id not in handle._pending_futures
+
+
+@pytest.mark.asyncio
 async def test_concurrent_explicit_steers_preserve_dispatch_order() -> None:
     handle, session = make_handle()
     receipts = await asyncio.gather(

--- a/tests/unit/mobile/test_owned.py
+++ b/tests/unit/mobile/test_owned.py
@@ -92,6 +92,9 @@ class FakeSession:
     def steer(self, text: str, images=None) -> None:  # noqa: ANN001
         self.steer_calls.append(text)
 
+    async def dispose(self) -> None:
+        self.prompt_release.set()
+
     @property
     def reasoning_effort(self):  # pragma: no cover
         return "auto"
@@ -182,6 +185,67 @@ async def test_concurrent_ordinary_prompts_are_admitted_fifo() -> None:
         await asyncio.sleep(0.01)
     assert session.prompt_calls == ["mobile", "attach one", "attach two"]
     assert len(set(session.prompt_calls)) == 3
+
+
+@pytest.mark.asyncio
+async def test_failed_admitted_prompt_is_visible_and_later_fifo_progresses() -> None:
+    handle, session = make_handle()
+    session.prompt_release.set()
+    calls: list[str] = []
+
+    async def prompt(text: str, images=None) -> None:  # noqa: ANN001
+        calls.append(text)
+        if text == "first":
+            raise ValueError("provider exploded")
+
+    session.prompt = prompt
+    assert await handle.prompt("first") == "prompt admitted"
+    assert await handle.prompt("second") == "prompt queued (2)"
+    drain = handle._prompt_drain_task
+    assert drain is not None
+    await drain
+
+    assert calls == ["first", "second"]
+    assert not handle._prompt_queue
+    assert handle.is_busy() is False
+    notices = [
+        entry.text for entry in handle.session_projection_seed.transcript if entry.kind == "notice"
+    ]
+    assert any("provider exploded" in notice for notice in notices)
+    assert drain.exception() is None
+
+
+@pytest.mark.asyncio
+async def test_dispose_rejects_queued_admissions_without_unhandled_task_error() -> None:
+    handle, session = make_handle()
+    assert await handle.prompt("running") == "prompt admitted"
+    assert await handle.prompt("queued") == "prompt queued (2)"
+    await asyncio.sleep(0)
+
+    await handle.dispose()
+
+    assert not handle._prompt_queue
+    assert handle.is_busy() is False
+    notices = [
+        entry.text for entry in handle.session_projection_seed.transcript if entry.kind == "notice"
+    ]
+    assert sum("session closed" in notice for notice in notices) == 2
+    drain = handle._prompt_drain_task
+    assert drain is not None and drain.cancelled()
+
+
+@pytest.mark.asyncio
+async def test_queue_overflow_rejects_before_admission(monkeypatch) -> None:
+    monkeypatch.setattr(owned_mod, "MAX_QUEUED_PROMPTS", 1)
+    handle, _ = make_handle()
+    assert await handle.prompt("first") == "prompt admitted"
+    with pytest.raises(RuntimeError, match="prompt queue is full"):
+        await handle.prompt("overflow")
+    assert [text for text, _ in handle._prompt_queue] == ["first"]
+    drain = handle._prompt_drain_task
+    assert drain is not None
+    drain.cancel()
+    await asyncio.gather(drain, return_exceptions=True)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/mobile/test_owned.py
+++ b/tests/unit/mobile/test_owned.py
@@ -16,7 +16,12 @@ from typing import Any
 
 import pytest
 
-from local_operator.harness.types import AskOption, AskQuestion
+from local_operator.harness.types import (
+    AskOption,
+    AskQuestion,
+    NoticeEvent,
+    SteeringDeliveredEvent,
+)
 from local_operator.mobile import owned as owned_mod
 from local_operator.mobile.owned import OwnedSessionHandle
 
@@ -33,6 +38,7 @@ class FakeSession:
         self.is_streaming = False
         self._handlers: list[Any] = []
         self._admission_handlers: list[Any] = []
+        self._steer_rejection_handlers: list[Any] = []
         self._admitted_ids: set[str] = set()
         self._named: list[tuple[str, bool]] = []
         self._complete_calls: list[tuple[str, str]] = []
@@ -97,6 +103,27 @@ class FakeSession:
         self._admitted_ids.add(command_id)
         for handler in list(self._admission_handlers):
             handler(command_id)
+
+    def subscribe_rejected_steering(self, handler):  # noqa: ANN001, ANN202
+        self._steer_rejection_handlers.append(handler)
+
+        def unsubscribe() -> None:
+            self._steer_rejection_handlers.remove(handler)
+
+        return unsubscribe
+
+    def reject_steer(self, command_id: str, reason: str) -> None:
+        for handler in list(self._steer_rejection_handlers):
+            handler(command_id, reason)
+        self.emit(
+            NoticeEvent(
+                text=(
+                    f"steering command {command_id} was not saved: {reason}; "
+                    "retry with the same command ID"
+                )
+            )
+        )
+        self.emit(SteeringDeliveredEvent(count=1))
 
     def running_subagents(self) -> int:
         return 0
@@ -194,6 +221,33 @@ async def test_same_id_concurrent_steers_are_admitted_once() -> None:
     assert receipts == ["steering queued", "already admitted"]
     assert session.steer_calls == ["correction"]
     assert [row.text for row in handle._fold.projection.transcript] == ["correction"]
+
+
+@pytest.mark.asyncio
+async def test_async_steer_rejection_releases_owned_slot_and_same_id() -> None:
+    handle, session = make_handle()
+    notified = 0
+
+    def notify() -> None:
+        nonlocal notified
+        notified += 1
+
+    handle.subscribe(notify)
+    assert await handle.steer("first", command_id="retry-id") == "steering queued"
+    assert handle._command_reservations._pending_steers == 1
+    assert handle.session_projection_seed.queued_count == 1
+
+    session.reject_steer("retry-id", "disk full")
+
+    assert handle._command_reservations._pending_steers == 0
+    assert "retry-id" not in handle._command_reservations._commands
+    assert handle.session_projection_seed.queued_count == 0
+    assert handle.session_projection_seed.transcript[-1].text == (
+        "steering command retry-id was not saved: disk full; retry with the same command ID"
+    )
+    assert notified >= 2
+    assert await handle.steer("retry", command_id="retry-id") == "steering queued"
+    assert session.steer_calls == ["first", "retry"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/mobile/test_owned.py
+++ b/tests/unit/mobile/test_owned.py
@@ -164,6 +164,82 @@ async def test_ask_mode_parks_a_card_then_resolves() -> None:
 
 
 @pytest.mark.asyncio
+async def test_same_id_concurrent_steers_are_admitted_once() -> None:
+    handle, session = make_handle()
+    command_id = "same-steer"
+
+    receipts = await asyncio.gather(
+        handle.steer("correction", command_id=command_id),
+        handle.steer("correction", command_id=command_id),
+    )
+
+    assert receipts == ["steering queued", "already admitted"]
+    assert session.steer_calls == ["correction"]
+    assert [row.text for row in handle._fold.projection.transcript] == ["correction"]
+
+
+@pytest.mark.asyncio
+async def test_steer_ack_loss_retry_remains_admitted() -> None:
+    handle, session = make_handle()
+
+    assert await handle.steer("once", command_id="lost-ack") == "steering queued"
+    assert await handle.steer("once", command_id="lost-ack") == "already admitted"
+    assert session.steer_calls == ["once"]
+
+
+@pytest.mark.asyncio
+async def test_terminal_steer_rejection_releases_identity() -> None:
+    handle, session = make_handle()
+    original = session.steer
+    attempts = 0
+
+    def reject_once(text, images=None):  # noqa: ANN001, ANN202
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise RuntimeError("not accepted")
+        original(text, images)
+
+    session.steer = reject_once  # type: ignore[method-assign]
+    with pytest.raises(RuntimeError, match="not accepted"):
+        await handle.steer("retry", command_id="retry-id")
+    assert await handle.steer("retry", command_id="retry-id") == "steering queued"
+    assert session.steer_calls == ["retry"]
+
+
+@pytest.mark.asyncio
+async def test_prompt_streaming_rejection_transfers_identity_to_steer() -> None:
+    handle, session = make_handle()
+
+    async def reject_prompt(  # noqa: ANN202
+        text, images=None, *, message_id=None, admitted=None  # noqa: ANN001
+    ):
+        raise RuntimeError("session is already streaming; use steer() to inject mid-turn")
+
+    session.prompt = reject_prompt  # type: ignore[method-assign]
+    with pytest.raises(RuntimeError, match="already streaming"):
+        await handle.prompt("raced", command_id="fallback-id")
+    assert await handle.steer("raced", command_id="fallback-id") == "steering queued"
+    assert await handle.steer("raced", command_id="fallback-id") == "already admitted"
+    assert session.steer_calls == ["raced"]
+
+
+@pytest.mark.asyncio
+async def test_distinct_concurrent_steers_keep_fifo_order() -> None:
+    handle, session = make_handle()
+
+    receipts = await asyncio.gather(
+        *(
+            handle.steer(text, command_id=f"id-{index}")
+            for index, text in enumerate(["a", "b", "c"])
+        )
+    )
+
+    assert receipts == ["steering queued"] * 3
+    assert session.steer_calls == ["a", "b", "c"]
+
+
+@pytest.mark.asyncio
 async def test_concurrent_ordinary_prompts_are_admitted_fifo() -> None:
     handle, session = make_handle()
     first, second, third = await asyncio.gather(

--- a/tests/unit/mobile/test_owned.py
+++ b/tests/unit/mobile/test_owned.py
@@ -37,6 +37,9 @@ class FakeSession:
         # Tagged or a short untagged title both parse; the default stays
         # tagged so these tests stay independent of the untagged heuristics.
         self.title_reply = "<title>A Neat Title</title>"
+        from local_operator.harness.jobs import AsyncJobManager
+
+        self.jobs = AsyncJobManager()
 
     # -- naming seams ----------------------------------------------------------
     def set_conversation_name(self, text: str, *, user_set: bool = True) -> str:
@@ -156,6 +159,35 @@ async def test_pending_gate_is_busy_until_ordinary_timeout(monkeypatch) -> None:
     assert await waiting is False
     assert handle.is_busy() is False
     assert owned_mod.PENDING_REQUEST_TIMEOUT_S == 0.05
+
+
+@pytest.mark.asyncio
+async def test_real_background_bash_job_is_busy_until_done(tmp_path) -> None:
+    """The reaper reads the real bash job Session.dispose would terminate."""
+    from local_operator.harness.types import ToolContext
+    from local_operator.tools import builtin
+
+    handle, session = make_handle()
+    context = ToolContext(cwd=str(tmp_path), session_id="owned-bash", jobs=session.jobs)
+    tool = builtin.build_bash_tool()
+    result = await tool.execute(  # type: ignore[operator]
+        "call",
+        {"command": "sleep 0.4; echo settled", "background": True, "timeout": 5},
+        None,
+        None,
+        context,
+    )
+    job_id = str((result.details or {})["job_id"])
+    job = session.jobs.get(job_id)
+    assert job is not None and job.type == "bash"
+    assert handle.is_busy() is True
+    deadline = asyncio.get_running_loop().time() + 5
+    while job.status == "running":
+        assert asyncio.get_running_loop().time() < deadline
+        await asyncio.sleep(0.01)
+    assert job.status == "completed"
+    assert handle.is_busy() is False
+    await session.jobs.dispose()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/mobile/test_registrant.py
+++ b/tests/unit/mobile/test_registrant.py
@@ -175,6 +175,33 @@ async def test_broadcast_reaches_every_client() -> None:
 
 
 @pytest.mark.asyncio
+async def test_nonreading_socket_cannot_block_active_ack_and_projection() -> None:
+    """A real authenticated peer that applies backpressure loses only itself."""
+    handle = FakeHandle()
+    # Each repaint is large enough that a handful fill the non-reader's kernel
+    # window, while remaining below the protocol's one-megabyte frame limit.
+    handle._projection.conversation_name = "x" * 700_000
+    registrant = Registrant(handle, kind="tui")
+    registrant.start()
+    try:
+        record = await _wait_record()
+        slow_reader, slow_writer = await _dial(record, client="attach")
+        del slow_reader  # authenticate and consume welcome, then never read again
+        active_reader, active_writer = await _dial(record, client="attach")
+        for req in range(12):
+            active_writer.write(json.dumps({"op": "ping", "req": req}).encode() + b"\n")
+            await active_writer.drain()
+            ack = await asyncio.wait_for(_until(active_reader, "ack", req), timeout=2.5)
+            assert ack["detail"] == "pong"
+            projection = await asyncio.wait_for(_until(active_reader, "projection"), timeout=2.5)
+            assert projection["data"]["session_id"] == "s1"
+        active_writer.close()
+        slow_writer.close()
+    finally:
+        registrant.close()
+
+
+@pytest.mark.asyncio
 async def test_acks_stay_point_to_point_under_concurrent_ops() -> None:
     handle = FakeHandle()
     registrant = Registrant(handle, kind="tui")

--- a/tests/unit/mobile/test_registrant.py
+++ b/tests/unit/mobile/test_registrant.py
@@ -205,6 +205,32 @@ async def test_in_process_close_joins_delayed_projection_push() -> None:
     assert task.done()
     assert registrant._push_task is None
     assert not registrant._push_scheduled
+    assert registrant._heartbeat_task is None
+    assert registrant._server is None
+
+    # A second awaited close must join the completed shutdown rather than
+    # returning early based only on the cross-thread close latch.
+    await registrant.aclose()
+
+
+@pytest.mark.asyncio
+async def test_in_process_sync_close_schedules_cleanup_without_deadlock() -> None:
+    """Legacy synchronous hosts may close from inside the owning loop."""
+    handle = FakeHandle()
+    registrant = Registrant(handle, kind="tui")
+    await registrant.start_in_process()
+    registrant._schedule_push()
+    await asyncio.sleep(0)
+
+    registrant.close()
+    registrant.close()
+    task = registrant._shutdown_task
+    assert task is not None
+    await asyncio.wait_for(asyncio.shield(task), timeout=2)
+
+    assert registrant._heartbeat_task is None
+    assert registrant._push_task is None
+    assert registrant._server is None
 
 
 @pytest.mark.asyncio

--- a/tests/unit/mobile/test_registrant.py
+++ b/tests/unit/mobile/test_registrant.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import asyncio
 import json
-import os
+from typing import Any
 
 import pytest
 
@@ -96,9 +96,7 @@ async def _wait_record() -> registry.SessionRecord:
 
 async def _dial(record: registry.SessionRecord, *, client: str | None = None):
     """Open + auth one connection; consume the welcome projection."""
-    reader, writer = await asyncio.open_connection(
-        "127.0.0.1", record.control_port, limit=1 << 20
-    )
+    reader, writer = await asyncio.open_connection("127.0.0.1", record.control_port, limit=1 << 20)
     auth: dict[str, object] = {"key": record.control_key}
     if client is not None:
         auth["client"] = client
@@ -111,7 +109,7 @@ async def _dial(record: registry.SessionRecord, *, client: str | None = None):
 
 async def _until(
     reader: asyncio.StreamReader, want_op: str, want_req: object = None, n: int = 30
-) -> dict:
+) -> dict[str, Any]:
     """Read until a frame matching (op, req) arrives; skip broadcasts."""
     for _ in range(n):
         raw = await asyncio.wait_for(reader.readline(), timeout=5)
@@ -319,7 +317,7 @@ async def test_watch_unwatch_accounting_and_floor() -> None:
         rd, wd = await _dial(record)
         wd.write(json.dumps({"op": "unwatch", "req": 1}).encode() + b"\n")
         await wd.drain()
-        ack = await _until(rd, "ack", 1)
+        await _until(rd, "ack", 1)
         # The unwatch-before-watch case floors at zero: a daemon restart
         # redials without unwatching and the counter must not go negative.
         assert registrant.phone_watchers == 0

--- a/tests/unit/mobile/test_registrant.py
+++ b/tests/unit/mobile/test_registrant.py
@@ -22,6 +22,7 @@ from local_operator.mobile.types import (
     ATTACH_MAX_CLIENTS,
     PROTOCOL_VERSION,
     SessionProjection,
+    TranscriptEntry,
 )
 
 
@@ -82,6 +83,41 @@ class FakeHandle:
 
     async def refresh(self) -> None:
         pass
+
+
+class ConcurrentHandle(FakeHandle):
+    """Owner-side admission model for real-socket multi-producer tests."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._admission_lock = asyncio.Lock()
+        self._notify = None
+        self.admitted: list[tuple[str, str]] = []
+
+    def subscribe(self, on_projection):  # noqa: ANN001, ANN202
+        self._notify = on_projection
+        return lambda: None
+
+    async def _admit(self, kind: str, text: str) -> str:
+        async with self._admission_lock:
+            self.admitted.append((kind, text))
+            self._projection.transcript.append(
+                TranscriptEntry(
+                    id=f"{kind}-{len(self.admitted)}",
+                    kind="steer" if kind == "steer" else "user",
+                    text=text,
+                )
+            )
+            if self._notify is not None:
+                self._notify()
+            await asyncio.sleep(0)
+            return f"{kind} admitted"
+
+    async def prompt(self, text, images=None):  # noqa: ANN001, ANN202
+        return await self._admit("prompt", text)
+
+    async def steer(self, text, images=None):  # noqa: ANN001, ANN202
+        return await self._admit("steer", text)
 
 
 async def _wait_record() -> registry.SessionRecord:
@@ -170,6 +206,53 @@ async def test_broadcast_reaches_every_client() -> None:
         assert frame["data"]["session_id"] == "s1"
         wd.close()
         wa.close()
+    finally:
+        registrant.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("op", ["prompt", "steer"])
+async def test_concurrent_producers_ack_once_and_converge(op: str) -> None:
+    """Daemon plus two attaches submit together through one transcript owner."""
+    handle = ConcurrentHandle()
+    registrant = Registrant(handle, kind="tui")
+    registrant.start()
+    try:
+        record = await _wait_record()
+        clients = [
+            await _dial(record),
+            await _dial(record, client="attach"),
+            await _dial(record, client="attach"),
+        ]
+        texts = ["from mobile", "from attach one", "from attach two"]
+        for req, ((_, writer), text) in enumerate(zip(clients, texts)):
+            writer.write(json.dumps({"op": op, "req": req, "text": text}).encode() + b"\n")
+        await asyncio.gather(*(writer.drain() for _, writer in clients))
+
+        acks = await asyncio.gather(
+            *(_until(reader, "ack", req) for req, (reader, _) in enumerate(clients))
+        )
+        assert [ack["req"] for ack in acks] == [0, 1, 2]
+        assert sorted(text for kind, text in handle.admitted if kind == op) == sorted(texts)
+        assert len(handle.admitted) == 3
+
+        expected = [(kind, text) for kind, text in handle.admitted]
+
+        async def reconciled(reader: asyncio.StreamReader) -> dict[str, Any]:
+            for _ in range(10):
+                projection = await _until(reader, "projection")
+                if len(projection["data"]["transcript"]) == len(expected):
+                    return projection
+            raise AssertionError("viewer never received the reconciled projection")
+
+        projections = await asyncio.gather(*(reconciled(reader) for reader, _ in clients))
+        for projection in projections:
+            rows = projection["data"]["transcript"]
+            assert [
+                ("steer" if row["kind"] == "steer" else "prompt", row["text"]) for row in rows
+            ] == expected
+        for _, writer in clients:
+            writer.close()
     finally:
         registrant.close()
 

--- a/tests/unit/mobile/test_registrant.py
+++ b/tests/unit/mobile/test_registrant.py
@@ -51,7 +51,7 @@ class FakeHandle:
         self.calls.append((name, args, kwargs))
         return f"{name} ok"
 
-    async def prompt(self, text, images=None):  # noqa: ANN001, ANN202
+    async def prompt(self, text, images=None, command_id=None):  # noqa: ANN001, ANN202
         return await self._record("prompt", text)
 
     async def steer(self, text, images=None):  # noqa: ANN001, ANN202
@@ -113,7 +113,7 @@ class ConcurrentHandle(FakeHandle):
             await asyncio.sleep(0)
             return f"{kind} admitted"
 
-    async def prompt(self, text, images=None):  # noqa: ANN001, ANN202
+    async def prompt(self, text, images=None, command_id=None):  # noqa: ANN001, ANN202
         return await self._admit("prompt", text)
 
     async def steer(self, text, images=None):  # noqa: ANN001, ANN202
@@ -159,8 +159,8 @@ async def _until(
 
 
 @pytest.mark.asyncio
-async def test_protocol_version_is_two_and_cap_constant() -> None:
-    assert PROTOCOL_VERSION == 2
+async def test_protocol_version_is_three_and_cap_constant() -> None:
+    assert PROTOCOL_VERSION == 3
     assert ATTACH_MAX_CLIENTS == 4
 
 

--- a/tests/unit/mobile/test_registrant.py
+++ b/tests/unit/mobile/test_registrant.py
@@ -190,6 +190,24 @@ async def test_daemon_and_attach_clients_coexist() -> None:
 
 
 @pytest.mark.asyncio
+async def test_in_process_close_joins_delayed_projection_push() -> None:
+    """Loop teardown leaves no coalesced repaint task behind."""
+    handle = FakeHandle()
+    registrant = Registrant(handle, kind="tui")
+    await registrant.start_in_process()
+    registrant._schedule_push()
+    await asyncio.sleep(0)
+    task = registrant._push_task
+    assert task is not None and not task.done()
+
+    await registrant.aclose()
+
+    assert task.done()
+    assert registrant._push_task is None
+    assert not registrant._push_scheduled
+
+
+@pytest.mark.asyncio
 async def test_broadcast_reaches_every_client() -> None:
     handle = FakeHandle()
     registrant = Registrant(handle, kind="tui")

--- a/tests/unit/mobile/test_registrant.py
+++ b/tests/unit/mobile/test_registrant.py
@@ -1,0 +1,363 @@
+"""Multi-connection registrant: N authenticated clients on one control socket.
+
+Protocol v2's core contract — the daemon plus up to ATTACH_MAX_CLIENTS attach
+terminals, broadcast pushes, point-to-point acks, watch/unwatch accounting,
+and the attach dispatch restrictions. These run against the REAL socket (a
+FakeHandle), matching test_daemon.py's style, because the failure modes this
+module guards (frame interleaving, eviction, registry leaks) only exist on a
+real connection pair.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+
+import pytest
+
+from local_operator.mobile import registry
+from local_operator.mobile.registrant import Registrant
+from local_operator.mobile.types import (
+    ATTACH_MAX_CLIENTS,
+    PROTOCOL_VERSION,
+    SessionProjection,
+)
+
+
+class FakeHandle:
+    """Static projection; records dispatch calls for assertions."""
+
+    def __init__(self) -> None:
+        self._projection = SessionProjection(
+            session_id="s1",
+            pid=0,
+            kind="tui",
+            conversation_name="fake",
+            cwd="/tmp",
+            model_label="test/model",
+        )
+        self.calls: list[tuple[str, tuple[object, ...], dict[str, object]]] = []
+
+    @property
+    def session_projection_seed(self) -> SessionProjection:
+        return self._projection
+
+    def subscribe(self, on_projection):  # noqa: ANN001, ANN202
+        return lambda: None
+
+    async def _record(self, name: str, *args: object, **kwargs: object) -> str:
+        self.calls.append((name, args, kwargs))
+        return f"{name} ok"
+
+    async def prompt(self, text, images=None):  # noqa: ANN001, ANN202
+        return await self._record("prompt", text)
+
+    async def steer(self, text, images=None):  # noqa: ANN001, ANN202
+        return await self._record("steer", text)
+
+    async def abort(self):  # noqa: ANN202
+        return await self._record("abort")
+
+    async def set_model(self, provider, model_id):  # noqa: ANN001, ANN202
+        return await self._record("set_model", provider, model_id)
+
+    async def set_effort(self, effort):  # noqa: ANN001, ANN202
+        return await self._record("set_effort", effort)
+
+    async def slash(self, command, args):  # noqa: ANN001, ANN202
+        return await self._record("slash", command, args)
+
+    async def new_conversation(self):  # noqa: ANN202
+        return await self._record("new_conversation")
+
+    async def resume_session(self, session_id):  # noqa: ANN001, ANN202
+        return await self._record("resume_session", session_id)
+
+    async def approval_answer(self, request_id, approved, remember):  # noqa: ANN001, ANN202
+        return await self._record("approval_answer", request_id, approved, remember)
+
+    async def ask_answer(self, request_id, value, question_index=None):  # noqa: ANN001, ANN202
+        return await self._record("ask_answer", request_id, value)
+
+    async def refresh(self) -> None:
+        pass
+
+
+async def _wait_record() -> registry.SessionRecord:
+    deadline = asyncio.get_running_loop().time() + 5
+    while asyncio.get_running_loop().time() < deadline:
+        found = registry.scan()
+        if found and found[0][1] == "live":
+            return found[0][0]
+        await asyncio.sleep(0.05)
+    raise AssertionError("registrant never published a live record")
+
+
+async def _dial(record: registry.SessionRecord, *, client: str | None = None):
+    """Open + auth one connection; consume the welcome projection."""
+    reader, writer = await asyncio.open_connection(
+        "127.0.0.1", record.control_port, limit=1 << 20
+    )
+    auth: dict[str, object] = {"key": record.control_key}
+    if client is not None:
+        auth["client"] = client
+    writer.write(json.dumps(auth).encode() + b"\n")
+    await writer.drain()
+    welcome = await asyncio.wait_for(reader.readline(), timeout=5)
+    assert json.loads(welcome)["op"] == "projection"
+    return reader, writer
+
+
+async def _until(
+    reader: asyncio.StreamReader, want_op: str, want_req: object = None, n: int = 30
+) -> dict:
+    """Read until a frame matching (op, req) arrives; skip broadcasts."""
+    for _ in range(n):
+        raw = await asyncio.wait_for(reader.readline(), timeout=5)
+        s = raw.decode("utf-8", "replace").strip()
+        if not s:
+            continue
+        frame = json.loads(s)
+        if frame.get("op") == want_op and (want_req is None or frame.get("req") == want_req):
+            return frame
+    raise AssertionError(f"no {want_op} frame arrived")
+
+
+@pytest.mark.asyncio
+async def test_protocol_version_is_two_and_cap_constant() -> None:
+    assert PROTOCOL_VERSION == 2
+    assert ATTACH_MAX_CLIENTS == 4
+
+
+@pytest.mark.asyncio
+async def test_daemon_and_attach_clients_coexist() -> None:
+    handle = FakeHandle()
+    registrant = Registrant(handle, kind="tui")
+    registrant.start()
+    try:
+        record = await _wait_record()
+        rd, wd = await _dial(record)
+        ra, wa = await _dial(record, client="attach")
+        ra2, wa2 = await _dial(record, client="attach")
+        assert registrant.attach_clients() == 2
+        # All three stay live across traffic from any of them.
+        wa.write(json.dumps({"op": "ping", "req": 1}).encode() + b"\n")
+        await wa.drain()
+        await _until(ra, "ack", 1)
+        wa2.write(json.dumps({"op": "ping", "req": 2}).encode() + b"\n")
+        await wa2.drain()
+        await _until(ra2, "ack", 2)
+        assert registrant.attach_clients() == 2
+        for w in (wd, wa, wa2):
+            w.close()
+    finally:
+        registrant.close()
+
+
+@pytest.mark.asyncio
+async def test_broadcast_reaches_every_client() -> None:
+    handle = FakeHandle()
+    registrant = Registrant(handle, kind="tui")
+    registrant.start()
+    try:
+        record = await _wait_record()
+        rd, wd = await _dial(record)
+        ra, wa = await _dial(record, client="attach")
+        # A mutation from the DAEMON must repaint the ATTACH client too.
+        wd.write(json.dumps({"op": "set_effort", "req": 7, "effort": "high"}).encode() + b"\n")
+        await wd.drain()
+        await _until(rd, "ack", 7)
+        frame = await _until(ra, "projection")
+        assert frame["data"]["session_id"] == "s1"
+        wd.close()
+        wa.close()
+    finally:
+        registrant.close()
+
+
+@pytest.mark.asyncio
+async def test_acks_stay_point_to_point_under_concurrent_ops() -> None:
+    handle = FakeHandle()
+    registrant = Registrant(handle, kind="tui")
+    registrant.start()
+    try:
+        record = await _wait_record()
+        ra, wa = await _dial(record, client="attach")
+        ra2, wa2 = await _dial(record, client="attach")
+        # Two concurrent ops with overlapping req ids from two clients.
+        wa.write(json.dumps({"op": "ping", "req": 1}).encode() + b"\n")
+        wa2.write(json.dumps({"op": "ping", "req": 1}).encode() + b"\n")
+        await wa.drain()
+        await wa2.drain()
+        a1 = await _until(ra, "ack", 1)
+        a2 = await _until(ra2, "ack", 1)
+        # Each client sees exactly its own ack detail; no cross-delivery of
+        # the OTHER client's frames between the two reads is hard to prove
+        # exhaustively, but each reader must never see an ERROR here.
+        assert a1["detail"] == "pong"
+        assert a2["detail"] == "pong"
+        wa.close()
+        wa2.close()
+    finally:
+        registrant.close()
+
+
+@pytest.mark.asyncio
+async def test_new_daemon_dial_evicts_the_old() -> None:
+    handle = FakeHandle()
+    registrant = Registrant(handle, kind="tui")
+    registrant.start()
+    try:
+        record = await _wait_record()
+        rd, wd = await _dial(record)
+        rd2, wd2 = await _dial(record)  # reconnect story
+        # The old socket observes EOF.
+        raw = await asyncio.wait_for(rd.readline(), timeout=5)
+        assert raw == b""
+        # The new one still works.
+        wd2.write(json.dumps({"op": "ping", "req": 3}).encode() + b"\n")
+        await wd2.drain()
+        await _until(rd2, "ack", 3)
+        wd.close()
+        wd2.close()
+    finally:
+        registrant.close()
+
+
+@pytest.mark.asyncio
+async def test_attach_cap_evicts_least_recently_seen() -> None:
+    handle = FakeHandle()
+    registrant = Registrant(handle, kind="tui")
+    registrant.start()
+    try:
+        record = await _wait_record()
+        pairs = [await _dial(record, client="attach") for _ in range(ATTACH_MAX_CLIENTS)]
+        assert registrant.attach_clients() == ATTACH_MAX_CLIENTS
+        # Touch every attach EXCEPT the first (the LRU victim).
+        for i in range(1, ATTACH_MAX_CLIENTS):
+            reader, writer = pairs[i]
+            writer.write(json.dumps({"op": "ping", "req": i}).encode() + b"\n")
+            await writer.drain()
+            await _until(reader, "ack", i)
+            await asyncio.sleep(0.05)
+        # A further dial evicts the untouched first client.
+        rn, wn = await _dial(record, client="attach")
+        victim_reader = pairs[0][0]
+        # The victim's socket still holds the broadcasts queued BEFORE its
+        # eviction; drain until EOF (the eviction itself closes it).
+        raw = b"x"
+        deadline = asyncio.get_running_loop().time() + 5
+        while raw != b"" and asyncio.get_running_loop().time() < deadline:
+            raw = await asyncio.wait_for(victim_reader.readline(), timeout=5)
+        assert raw == b""  # evicted: EOF
+        assert registrant.attach_clients() == ATTACH_MAX_CLIENTS
+        wn.close()
+        for _, w in pairs:
+            w.close()
+    finally:
+        registrant.close()
+
+
+@pytest.mark.asyncio
+async def test_attach_client_cannot_rebind_the_session() -> None:
+    handle = FakeHandle()
+    registrant = Registrant(handle, kind="tui")
+    registrant.start()
+    try:
+        record = await _wait_record()
+        ra, wa = await _dial(record, client="attach")
+        wa.write(json.dumps({"op": "resume_session", "req": 4, "session_id": "x"}).encode() + b"\n")
+        await wa.drain()
+        err = await _until(ra, "error", 4)
+        assert "cannot rebind" in err["message"]
+        wa.write(json.dumps({"op": "new_conversation", "req": 5}).encode() + b"\n")
+        await wa.drain()
+        err = await _until(ra, "error", 5)
+        assert "cannot rebind" in err["message"]
+        # The daemon keeps both ops.
+        rd, wd = await _dial(record)
+        wd.write(json.dumps({"op": "new_conversation", "req": 6}).encode() + b"\n")
+        await wd.drain()
+        ack = await _until(rd, "ack", 6)
+        assert "new_conversation ok" in ack["detail"]
+        wa.close()
+        wd.close()
+    finally:
+        registrant.close()
+
+
+@pytest.mark.asyncio
+async def test_dead_socket_leaves_the_registry() -> None:
+    handle = FakeHandle()
+    registrant = Registrant(handle, kind="tui")
+    registrant.start()
+    try:
+        record = await _wait_record()
+        ra, wa = await _dial(record, client="attach")
+        assert registrant.attach_clients() == 1
+        wa.close()
+        deadline = asyncio.get_running_loop().time() + 5
+        while asyncio.get_running_loop().time() < deadline:
+            if registrant.attach_clients() == 0:
+                break
+            await asyncio.sleep(0.05)
+        assert registrant.attach_clients() == 0
+    finally:
+        registrant.close()
+
+
+@pytest.mark.asyncio
+async def test_watch_unwatch_accounting_and_floor() -> None:
+    handle = FakeHandle()
+    registrant = Registrant(handle, kind="tui")
+    registrant.start()
+    try:
+        record = await _wait_record()
+        assert registrant.phone_watchers == 0
+        assert registrant.watch_supported is False
+        rd, wd = await _dial(record)
+        wd.write(json.dumps({"op": "unwatch", "req": 1}).encode() + b"\n")
+        await wd.drain()
+        ack = await _until(rd, "ack", 1)
+        # The unwatch-before-watch case floors at zero: a daemon restart
+        # redials without unwatching and the counter must not go negative.
+        assert registrant.phone_watchers == 0
+        assert registrant.watch_supported is True
+        wd.write(json.dumps({"op": "watch", "req": 2}).encode() + b"\n")
+        await wd.drain()
+        await _until(rd, "ack", 2)
+        assert registrant.phone_watchers == 1
+        wd.write(json.dumps({"op": "watch", "req": 3}).encode() + b"\n")
+        await wd.drain()
+        await _until(rd, "ack", 3)
+        assert registrant.phone_watchers == 2
+        wd.write(json.dumps({"op": "unwatch", "req": 4}).encode() + b"\n")
+        await wd.drain()
+        await _until(rd, "ack", 4)
+        assert registrant.phone_watchers == 1
+        # The latch never resets.
+        assert registrant.watch_supported is True
+        wd.close()
+    finally:
+        registrant.close()
+
+
+@pytest.mark.asyncio
+async def test_absent_client_field_means_daemon() -> None:
+    """An OLD daemon dialing a NEW registrant keeps the daemon class."""
+    handle = FakeHandle()
+    registrant = Registrant(handle, kind="tui")
+    registrant.start()
+    try:
+        record = await _wait_record()
+        rd, wd = await _dial(record)  # no client field
+        assert registrant.attach_clients() == 0
+        # And a second daemon-class dial still evicts it (reconnect).
+        rd2, wd2 = await _dial(record)
+        raw = await asyncio.wait_for(rd.readline(), timeout=5)
+        assert raw == b""
+        wd.close()
+        wd2.close()
+    finally:
+        registrant.close()

--- a/tests/unit/mobile/test_remediation.py
+++ b/tests/unit/mobile/test_remediation.py
@@ -70,12 +70,37 @@ async def test_f3_fanout_never_drops_a_repaint() -> None:
 
     queue: asyncio.Queue[dict[str, object]] = asyncio.Queue(maxsize=1)
     queue.put_nowait({"stale": True})  # exactly full at entry
-    entry.subscribers.add(queue)
+    daemon = MobileDaemon(port=0, password="pw")
+    daemon.table.session_subscribers.setdefault("s1", set()).add(queue)
 
-    _fan_out(entry)
+    _fan_out(entry, daemon)
     assert queue.qsize() == 1
     frame = queue.get_nowait()
     assert frame.get("session_id") == "s1"  # the NEW frame, not the stale one
+
+
+@pytest.mark.asyncio
+async def test_previous_subscriber_survives_new_process_generation() -> None:
+    """F6/U3: one durable queue receives every future host generation."""
+    from local_operator.mobile.daemon import _fan_out
+    from local_operator.mobile.types import SessionProjection
+
+    daemon = MobileDaemon(port=0, password="pw")
+    queue: asyncio.Queue[dict[str, object]] = asyncio.Queue(maxsize=8)
+    daemon.table.session_subscribers.setdefault("s1", set()).add(queue)
+
+    first = SessionEntry(make_record(port=1))
+    first.record.pid = 101
+    first.projection = SessionProjection(session_id="s1", pid=101, streaming=True)
+    second = SessionEntry(make_record(port=2))
+    second.record.pid = 202
+    second.projection = SessionProjection(session_id="s1", pid=202, streaming=False)
+    _fan_out(first, daemon)
+    first.ended = True
+    _fan_out(second, daemon)
+
+    assert [queue.get_nowait()["pid"], queue.get_nowait()["pid"]] == [101, 202]
+    assert len(daemon.table.session_subscribers["s1"]) == 1
 
 
 def test_f9_password_newlines_rejected() -> None:

--- a/tests/unit/mobile/test_tui_bridge.py
+++ b/tests/unit/mobile/test_tui_bridge.py
@@ -10,7 +10,39 @@ import json
 
 import pytest
 
+from local_operator.mobile.tui_handle import TuiSessionHandle
 from tests.unit.tui.test_app_pilot import FakeSession, _factory
+
+
+@pytest.mark.asyncio
+async def test_tui_same_id_concurrent_steers_cross_thread_once() -> None:
+    class Session(FakeSession):
+        def __init__(self) -> None:
+            super().__init__()
+            self.steer_calls: list[tuple[str, str | None]] = []
+
+        def steer(self, text, images=None, *, message_id=None):  # noqa: ANN001, ANN202
+            self.steer_calls.append((text, message_id))
+
+    class App:
+        def __init__(self, session) -> None:  # noqa: ANN001
+            self._session = session
+
+        def call_from_thread(self, callback) -> None:  # noqa: ANN001
+            # The callback is the Textual loop's atomic admission section. This
+            # fake runs it inline while concurrent bridge tasks contend for it.
+            callback()
+
+    session = Session()
+    handle = TuiSessionHandle(App(session))  # type: ignore[arg-type]
+    receipts = await asyncio.gather(
+        handle.steer("correction", command_id="same-id"),
+        handle.steer("correction", command_id="same-id"),
+    )
+
+    assert receipts == ["steering queued", "already admitted"]
+    assert session.steer_calls == [("correction", "same-id")]
+    assert [row.text for row in handle._fold.projection.transcript] == ["correction"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/mobile/test_tui_bridge.py
+++ b/tests/unit/mobile/test_tui_bridge.py
@@ -46,6 +46,34 @@ async def test_tui_same_id_concurrent_steers_cross_thread_once() -> None:
 
 
 @pytest.mark.asyncio
+async def test_tui_stalled_steers_apply_owner_loop_backpressure() -> None:
+    class Session(FakeSession):
+        def __init__(self) -> None:
+            super().__init__()
+            self.steer_calls: list[str] = []
+
+        def steer(self, text, images=None, *, message_id=None):  # noqa: ANN001, ANN202
+            assert isinstance(message_id, str)
+            self.steer_calls.append(message_id)
+
+    class App:
+        def __init__(self, session) -> None:  # noqa: ANN001
+            self._session = session
+
+        def call_from_thread(self, callback) -> None:  # noqa: ANN001
+            callback()
+
+    session = Session()
+    handle = TuiSessionHandle(App(session))  # type: ignore[arg-type]
+    for index in range(32):
+        assert await handle.steer(str(index), command_id=f"id-{index}") == "steering queued"
+    assert await handle.steer("duplicate", command_id="id-0") == "already admitted"
+    with pytest.raises(RuntimeError, match=r"steering queue is full \(32\)"):
+        await handle.steer("overflow", command_id="overflow")
+    assert len(session.steer_calls) == 32
+
+
+@pytest.mark.asyncio
 async def test_tui_auto_registers_and_answers_control() -> None:
     from local_operator.tui.app import OperatorApp
 

--- a/tests/unit/session/test_session.py
+++ b/tests/unit/session/test_session.py
@@ -179,6 +179,112 @@ async def test_steer_marks_only_explicit_producer_commands(tmp_path):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("failure", ["write", "flush", "fsync"])
+async def test_failed_steer_append_rejects_identity_and_allows_same_id_retry(
+    tmp_path, monkeypatch, failure
+):
+    session = make_session(tmp_path, ScriptedStream([[StreamEndEvent(stop_reason="stop")]]))
+    rejected: list[tuple[str, str]] = []
+    events: list[AgentEvent] = []
+    session.subscribe_rejected_steering(
+        lambda command_id, reason: rejected.append((command_id, reason))
+    )
+    session.subscribe(events.append)
+    command_id = f"retry-{failure}"
+    session.steer("first", message_id="first", producer_command_id=command_id)
+    from pathlib import Path
+
+    real_open = Path.open
+    real_fsync = __import__("os").fsync
+    fail_once = True
+
+    class FailingHandle:
+        def __init__(self, handle):  # noqa: ANN001
+            self._handle = handle
+
+        def __enter__(self):
+            self._handle.__enter__()
+            return self
+
+        def __exit__(self, *args):  # noqa: ANN002, ANN202
+            return self._handle.__exit__(*args)
+
+        def write(self, value):  # noqa: ANN001, ANN201
+            if failure == "write":
+                raise OSError("injected write failure")
+            return self._handle.write(value)
+
+        def flush(self):
+            if failure == "flush":
+                raise OSError("injected flush failure")
+            return self._handle.flush()
+
+        def fileno(self):
+            return self._handle.fileno()
+
+    def failing_open(path, *args, **kwargs):  # noqa: ANN001, ANN002, ANN003, ANN202
+        nonlocal fail_once
+        handle = real_open(path, *args, **kwargs)
+        if fail_once and path == session._transcript.path:
+            fail_once = False
+            return FailingHandle(handle)
+        return handle
+
+    monkeypatch.setattr(Path, "open", failing_open)
+    if failure == "fsync":
+        fsync_failed = False
+
+        def failing_fsync(fd):  # noqa: ANN001, ANN202
+            nonlocal fsync_failed
+            if not fsync_failed:
+                fsync_failed = True
+                raise OSError("injected fsync failure")
+            return real_fsync(fd)
+
+        monkeypatch.setattr("local_operator.session.transcript.os.fsync", failing_fsync)
+
+    assert await session._drain_steering() == []
+    assert rejected == [(command_id, f"injected {failure} failure")]
+    assert not session.has_admitted_command(command_id)
+    assert session.queued_steering() == []
+    assert not session._steering_producers
+    assert any(
+        isinstance(event, NoticeEvent)
+        and command_id in event.text
+        and "retry with the same command ID" in event.text
+        for event in events
+    )
+
+    session.steer("retry", message_id="retry", producer_command_id=command_id)
+    drained = await session._drain_steering()
+    assert [message.text for message in drained if isinstance(message, Message)] == ["retry"]
+    assert session.has_admitted_command(command_id)
+    reopened = Transcript(tmp_path / "sess")
+    assert reopened.has_admitted_command(command_id)
+    assert [
+        message.text for message in reopened.build_llm_history() if isinstance(message, Message)
+    ] == ["retry"]
+    await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_dispose_rejects_queued_producer_steer(tmp_path):
+    session = make_session(tmp_path, ScriptedStream([[StreamEndEvent(stop_reason="stop")]]))
+    rejected: list[tuple[str, str]] = []
+    session.subscribe_rejected_steering(
+        lambda command_id, reason: rejected.append((command_id, reason))
+    )
+    session.steer("queued", producer_command_id="dispose-id")
+
+    await session.dispose()
+
+    assert rejected == [("dispose-id", "session closed before durable admission")]
+    assert session.queued_steering() == []
+    assert not session._steering_producers
+    assert not session.has_admitted_command("dispose-id")
+
+
+@pytest.mark.asyncio
 async def test_prompt_full_turn_events_and_persistence(tmp_path):
     """prompt() drives a text→tool→text turn; handlers see ordered events;
     every produced message lands in the transcript."""

--- a/tests/unit/session/test_session.py
+++ b/tests/unit/session/test_session.py
@@ -131,6 +131,54 @@ def make_session(tmp_path, stream, tools=None, **kwargs) -> Session:
 
 
 @pytest.mark.asyncio
+async def test_prompt_marks_only_explicit_producer_commands(tmp_path):
+    stream = ScriptedStream(
+        [
+            [StreamEndEvent(stop_reason="stop")],
+            [StreamEndEvent(stop_reason="stop")],
+        ]
+    )
+    session = make_session(tmp_path, stream)
+
+    await session.prompt("local", message_id="collision")
+    assert not session.has_admitted_command("collision")
+
+    admitted = asyncio.get_running_loop().create_future()
+    await session.prompt(
+        "mobile",
+        message_id="mobile-message",
+        producer_command_id="collision",
+        admitted=admitted,
+    )
+    assert admitted.done()
+    assert session.has_admitted_command("collision")
+    assert Transcript(tmp_path / "sess").has_admitted_command("collision")
+    await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_steer_marks_only_explicit_producer_commands(tmp_path):
+    session = make_session(tmp_path, ScriptedStream([[StreamEndEvent(stop_reason="stop")]]))
+    session.steer("local", message_id="collision")
+    session.steer(
+        "mobile",
+        message_id="mobile-message",
+        producer_command_id="producer-steer",
+    )
+
+    drained = await session._drain_steering()
+
+    assert [message.text for message in drained if isinstance(message, Message)] == [
+        "local",
+        "mobile",
+    ]
+    assert not session.has_admitted_command("collision")
+    assert session.has_admitted_command("producer-steer")
+    assert Transcript(tmp_path / "sess").has_admitted_command("producer-steer")
+    await session.dispose()
+
+
+@pytest.mark.asyncio
 async def test_prompt_full_turn_events_and_persistence(tmp_path):
     """prompt() drives a text→tool→text turn; handlers see ordered events;
     every produced message lands in the transcript."""

--- a/tests/unit/session/test_transcript.py
+++ b/tests/unit/session/test_transcript.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import shutil
+from pathlib import Path
 
 import pytest
 
@@ -81,6 +82,109 @@ async def test_append_rebuilds_when_only_the_file_vanished(tmp_path):
     assert len(lines) == 3  # rebuilt complete, not restarted at one row
     texts = [json.loads(line)["payload"]["content"][0]["text"] for line in lines]
     assert texts == ["one", "two", "three"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure_point", ["write", "flush"])
+async def test_failed_append_never_enters_memory_index_or_later_rebuild(
+    tmp_path, monkeypatch, failure_point
+):
+    """A rejected producer row must not resurrect through a later rebuild."""
+    directory = tmp_path / "sess"
+    transcript = Transcript(directory)
+    await transcript.append_message(
+        Message.user("admitted", id="admitted"),
+        producer_command_id="admitted",
+    )
+    real_open = Path.open
+    fail_once = True
+
+    class FailingHandle:
+        def __init__(self, handle):  # noqa: ANN001
+            self._handle = handle
+
+        def __enter__(self):
+            self._handle.__enter__()
+            return self
+
+        def __exit__(self, *args):  # noqa: ANN002, ANN202
+            return self._handle.__exit__(*args)
+
+        def write(self, value):  # noqa: ANN001, ANN201
+            if failure_point == "write":
+                self._handle.write(value[: max(1, len(value) // 2)])
+                raise OSError("injected write failure")
+            return self._handle.write(value)
+
+        def flush(self):
+            if failure_point == "flush":
+                raise OSError("injected flush failure")
+            return self._handle.flush()
+
+        def fileno(self):
+            return self._handle.fileno()
+
+    def failing_open(path, *args, **kwargs):  # noqa: ANN001, ANN202
+        nonlocal fail_once
+        handle = real_open(path, *args, **kwargs)
+        if fail_once and path == transcript.path and args and args[0] == "a":
+            fail_once = False
+            return FailingHandle(handle)
+        return handle
+
+    monkeypatch.setattr(Path, "open", failing_open)
+    with pytest.raises(OSError, match=failure_point):
+        await transcript.append_message(
+            Message.user("failed", id="failed"),
+            producer_command_id="failed",
+        )
+
+    assert [entry.id for entry in transcript.entries()] == ["admitted"]
+    assert not transcript.has_admitted_command("failed")
+    assert [entry.id for entry in Transcript(directory).entries()] == ["admitted"]
+
+    transcript.path.unlink()
+    await transcript.append_message(
+        Message.user("later", id="later"),
+        producer_command_id="later",
+    )
+    reopened = Transcript(directory)
+    assert [entry.id for entry in reopened.entries()] == ["admitted", "later"]
+    assert not reopened.has_admitted_command("failed")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("command_kind", ["prompt", "steer"])
+async def test_failed_first_rebuild_is_retryable_without_resurrection(
+    tmp_path, monkeypatch, command_kind
+):
+    """An open failure before the first row leaves no disk or memory claim."""
+    directory = tmp_path / "sess"
+    transcript = Transcript(directory)
+    real_open = Path.open
+    fail_once = True
+
+    def failing_open(path, *args, **kwargs):  # noqa: ANN001, ANN202
+        nonlocal fail_once
+        if fail_once and path == transcript.path and args and args[0] == "w":
+            fail_once = False
+            raise OSError("injected open failure")
+        return real_open(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "open", failing_open)
+    command_id = f"retry-{command_kind}"
+    failed = Message.user("failed", id=command_id)
+    with pytest.raises(OSError, match="open failure"):
+        await transcript.append_message(failed, producer_command_id=command_id)
+
+    assert transcript.entries() == []
+    assert not transcript.path.exists()
+    assert not transcript.has_admitted_command(command_id)
+
+    await transcript.append_message(failed, producer_command_id=command_id)
+    reopened = Transcript(directory)
+    assert [entry.id for entry in reopened.entries()] == [command_id]
+    assert reopened.has_admitted_command(command_id)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/session/test_transcript.py
+++ b/tests/unit/session/test_transcript.py
@@ -187,6 +187,58 @@ async def test_failed_first_rebuild_is_retryable_without_resurrection(
     assert reopened.has_admitted_command(command_id)
 
 
+def test_only_valid_user_message_rows_claim_producer_markers(tmp_path) -> None:
+    directory = tmp_path / "sess"
+    directory.mkdir()
+    valid_payload = {
+        "kind": "message",
+        "role": "user",
+        "content": [{"text": "valid"}],
+        "producer_command_id": "valid",
+    }
+    invalid_payloads = [
+        {**valid_payload, "producer_command_id": "missing-kind", "kind": None},
+        {**valid_payload, "producer_command_id": "custom-kind", "kind": "custom"},
+        {**valid_payload, "producer_command_id": "assistant", "role": "assistant"},
+        {**valid_payload, "producer_command_id": "system", "role": "system"},
+        {**valid_payload, "producer_command_id": "malformed-content", "content": "text"},
+        {**valid_payload, "producer_command_id": "malformed-block", "content": [42]},
+        {**valid_payload, "producer_command_id": "   "},
+    ]
+    entries = [
+        TranscriptEntry(id="valid-row", ts=1, type=ENTRY_MESSAGE, payload=valid_payload),
+        *[
+            TranscriptEntry(
+                id=f"invalid-{index}", ts=2 + index, type=ENTRY_MESSAGE, payload=payload
+            )
+            for index, payload in enumerate(invalid_payloads)
+        ],
+        TranscriptEntry(
+            id="import-collision",
+            ts=20,
+            type="custom",
+            payload={**valid_payload, "producer_command_id": "import-collision"},
+        ),
+    ]
+    (directory / "transcript.jsonl").write_text(
+        "".join(entry.to_json() + "\n" for entry in entries), encoding="utf-8"
+    )
+
+    transcript = Transcript(directory)
+
+    assert transcript.has_admitted_command("valid")
+    for command_id in [
+        "missing-kind",
+        "custom-kind",
+        "assistant",
+        "system",
+        "malformed-content",
+        "malformed-block",
+        "import-collision",
+    ]:
+        assert not transcript.has_admitted_command(command_id)
+
+
 @pytest.mark.asyncio
 async def test_reloads_from_disk(tmp_path):
     directory = tmp_path / "sess"

--- a/tests/unit/test_cli_resume_guard.py
+++ b/tests/unit/test_cli_resume_guard.py
@@ -140,7 +140,8 @@ def test_startup_import_weight_unchanged() -> None:
         "or m.startswith('local_operator.tui.attach_screen')]; "
         "print('LEAKED:' + ','.join(bad) if bad else 'CLEAN')"
     )
+    repo_root = Path(__file__).resolve().parents[2]
     out = subprocess.run(
-        [sys.executable, "-c", code], capture_output=True, text=True, cwd="/tmp/lop-attach"
+        [sys.executable, "-c", code], capture_output=True, text=True, cwd=repo_root
     )
     assert out.stdout.strip() == "CLEAN", out.stdout

--- a/tests/unit/test_cli_resume_guard.py
+++ b/tests/unit/test_cli_resume_guard.py
@@ -27,9 +27,7 @@ def _own(config: Path, session_id: str, pid: int) -> None:
     (d / ".session.pid").write_text(str(pid))
 
 
-def test_exec_resume_owned_refuses_exit_1(
-    config: Path, monkeypatch, capsys
-) -> None:
+def test_exec_resume_owned_refuses_exit_1(config: Path, monkeypatch, capsys) -> None:
     sleeper_pid = os.getppid()  # a live pid that is not this process
     _own(config, "sess-owned", sleeper_pid)
     monkeypatch.setattr(
@@ -62,17 +60,13 @@ def test_exec_resume_unowned_proceeds_to_exec(config: Path, monkeypatch) -> None
 
     monkeypatch.setattr(cli_mod, "_preflight_api_key", lambda *a, **k: None)
     monkeypatch.setattr("local_operator.exec_mode.run_exec", fake_run_exec)
-    monkeypatch.setattr(
-        "sys.argv", ["local-operator", "exec", "--resume", "sess-free", "task"]
-    )
+    monkeypatch.setattr("sys.argv", ["local-operator", "exec", "--resume", "sess-free", "task"])
     code = cli_main()
     assert code == 0
     assert seen and seen[0][0] == "task"
 
 
-def test_interactive_resume_owned_runs_attach_path(
-    config: Path, monkeypatch
-) -> None:
+def test_interactive_resume_owned_runs_attach_path(config: Path, monkeypatch) -> None:
     sleeper_pid = os.getppid()
     _own(config, "sess-owned2", sleeper_pid)
     called: list[tuple[object, object, object]] = []
@@ -81,9 +75,7 @@ def test_interactive_resume_owned_runs_attach_path(
         called.append((cfg, session_id, owner))
         return 0
 
-    monkeypatch.setattr(
-        cli_attach, "run_owned_resume_attach", fake_attach, raising=False
-    )
+    monkeypatch.setattr(cli_attach, "run_owned_resume_attach", fake_attach, raising=False)
     # cli imports the function lazily inside main; patch the module attribute
     # the lazy import resolves against.
     import local_operator.cli_attach as mod
@@ -96,9 +88,7 @@ def test_interactive_resume_owned_runs_attach_path(
     assert called[0][2] == sleeper_pid
 
 
-def test_owned_attach_refusal_copy_when_no_record(
-    config: Path, capsys
-) -> None:
+def test_owned_attach_refusal_copy_when_no_record(config: Path, capsys) -> None:
     """The attach gate's graceful degradation: an owner with no record gets
     today's refusal line and exit 1."""
     sleeper_pid = os.getppid()

--- a/tests/unit/test_cli_resume_guard.py
+++ b/tests/unit/test_cli_resume_guard.py
@@ -100,6 +100,33 @@ def test_owned_attach_refusal_copy_when_no_record(config: Path, capsys) -> None:
     assert "watch and steer" in err
 
 
+def test_resume_here_relaunch_preserves_session_id(config: Path, monkeypatch) -> None:
+    """Exit 75 from the attach app means the owner died; relaunch the SAME
+    transcript now that its claim is safe to take."""
+    from local_operator.mobile.types import SessionRecord
+
+    owner = os.getppid()
+    record = SessionRecord(
+        pid=owner,
+        kind="tui",
+        session_id="sess-relaunch",
+        conversation_name="",
+        cwd="/tmp",
+        model_label="",
+        control_port=1,
+        control_key="k",
+    )
+    monkeypatch.setattr(
+        "local_operator.mobile.attach_client.find_owner_record",
+        lambda cfg, sid: (record, owner),
+    )
+    monkeypatch.setattr("local_operator.tui.attach_screen.run_attach_app", lambda *a: 75)
+    seen: list[list[str]] = []
+    monkeypatch.setattr("subprocess.call", lambda argv: seen.append(list(argv)) or 0)
+    assert cli_attach.run_owned_resume_attach(config, "sess-relaunch", owner) == 0
+    assert seen[0][-2:] == ["--resume", "sess-relaunch"]
+
+
 def test_startup_import_weight_unchanged() -> None:
     """The CLI startup guard: importing cli must not pull Textual or the
     mobile package's heavy half (attach imports are lazy on the owned branch)."""

--- a/tests/unit/test_cli_resume_guard.py
+++ b/tests/unit/test_cli_resume_guard.py
@@ -1,0 +1,129 @@
+"""The CLI's owned-resume guards: interactive --resume attaches, exec --resume
+refuses exit 1, unowned paths are untouched."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from local_operator import cli_attach
+from local_operator.cli import main as cli_main
+
+
+@pytest.fixture
+def config(tmp_path: Path, monkeypatch) -> Path:
+    cfg = tmp_path / ".local-operator"
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(cfg))
+    return cfg
+
+
+def _own(config: Path, session_id: str, pid: int) -> None:
+    d = config / "sessions" / session_id
+    d.mkdir(parents=True, exist_ok=True)
+    # resume_dir requires a transcript to consider the session resumable.
+    (d / "transcript.jsonl").write_text("")
+    (d / ".session.pid").write_text(str(pid))
+
+
+def test_exec_resume_owned_refuses_exit_1(
+    config: Path, monkeypatch, capsys
+) -> None:
+    sleeper_pid = os.getppid()  # a live pid that is not this process
+    _own(config, "sess-owned", sleeper_pid)
+    monkeypatch.setattr(
+        "sys.argv",
+        ["local-operator", "exec", "--resume", "sess-owned", "do the thing"],
+    )
+    code = cli_main()
+    assert code == 1
+    err = capsys.readouterr().err
+    assert "already open in another process" in err
+    assert str(sleeper_pid) in err
+
+
+def test_exec_resume_unowned_proceeds_to_exec(config: Path, monkeypatch) -> None:
+    # No marker: the guard must not interfere. Patch the preflight AND run_exec
+    # to observe the call rather than standing up a provider.
+    _own(config, "sess-free", os.getpid())  # owner == self: not "another process"
+    seen: list[tuple[object, object]] = []
+
+    def fake_run_exec(command, args):  # noqa: ANN001
+        seen.append((command, args))
+        return 0
+
+    monkeypatch.setattr(
+        "local_operator.exec_mode.resolve_hosting_model_dry",
+        lambda a: ("anthropic", "claude-x"),
+        raising=False,
+    )
+    import local_operator.cli as cli_mod
+
+    monkeypatch.setattr(cli_mod, "_preflight_api_key", lambda *a, **k: None)
+    monkeypatch.setattr("local_operator.exec_mode.run_exec", fake_run_exec)
+    monkeypatch.setattr(
+        "sys.argv", ["local-operator", "exec", "--resume", "sess-free", "task"]
+    )
+    code = cli_main()
+    assert code == 0
+    assert seen and seen[0][0] == "task"
+
+
+def test_interactive_resume_owned_runs_attach_path(
+    config: Path, monkeypatch
+) -> None:
+    sleeper_pid = os.getppid()
+    _own(config, "sess-owned2", sleeper_pid)
+    called: list[tuple[object, object, object]] = []
+
+    def fake_attach(cfg, session_id, owner):  # noqa: ANN001
+        called.append((cfg, session_id, owner))
+        return 0
+
+    monkeypatch.setattr(
+        cli_attach, "run_owned_resume_attach", fake_attach, raising=False
+    )
+    # cli imports the function lazily inside main; patch the module attribute
+    # the lazy import resolves against.
+    import local_operator.cli_attach as mod
+
+    monkeypatch.setattr(mod, "run_owned_resume_attach", fake_attach)
+    monkeypatch.setattr("sys.argv", ["local-operator", "--resume", "sess-owned2"])
+    code = cli_main()
+    assert code == 0
+    assert called and called[0][1] == "sess-owned2"
+    assert called[0][2] == sleeper_pid
+
+
+def test_owned_attach_refusal_copy_when_no_record(
+    config: Path, capsys
+) -> None:
+    """The attach gate's graceful degradation: an owner with no record gets
+    today's refusal line and exit 1."""
+    sleeper_pid = os.getppid()
+    _own(config, "sess-old", sleeper_pid)
+    code = cli_attach.run_owned_resume_attach(config, "sess-old", sleeper_pid)
+    assert code == 1
+    err = capsys.readouterr().err
+    assert "already open in another process" in err
+    assert "watch and steer" in err
+
+
+def test_startup_import_weight_unchanged() -> None:
+    """The CLI startup guard: importing cli must not pull Textual or the
+    mobile package's heavy half (attach imports are lazy on the owned branch)."""
+    import subprocess
+    import sys
+
+    code = (
+        "import sys, local_operator.cli; "
+        "bad = [m for m in sys.modules if m.startswith('textual') "
+        "or m.startswith('local_operator.mobile.attach_client') "
+        "or m.startswith('local_operator.tui.attach_screen')]; "
+        "print('LEAKED:' + ','.join(bad) if bad else 'CLEAN')"
+    )
+    out = subprocess.run(
+        [sys.executable, "-c", code], capture_output=True, text=True, cwd="/tmp/lop-attach"
+    )
+    assert out.stdout.strip() == "CLEAN", out.stdout

--- a/tests/unit/test_session_lease.py
+++ b/tests/unit/test_session_lease.py
@@ -1,0 +1,80 @@
+"""Cross-process sole-writer and generation-fenced release regressions."""
+
+from __future__ import annotations
+
+import multiprocessing
+import os
+from pathlib import Path
+
+from local_operator.session_lease import (
+    LEASE_NAME,
+    SessionLease,
+    SessionLeaseHeldError,
+    acquire_session_lease,
+)
+
+
+def _contend(directory: str, start, release, results) -> None:
+    start.wait()
+    try:
+        lease = acquire_session_lease(Path(directory))
+    except SessionLeaseHeldError:
+        results.put("held")
+    else:
+        results.put("won")
+        # Keep the winning process alive until the sibling has probed it.
+        release.wait(10)
+        lease.release()
+
+
+def test_two_processes_cannot_both_acquire_one_transcript(tmp_path: Path) -> None:
+    session_dir = tmp_path / "sessions" / "same"
+    session_dir.mkdir(parents=True)
+    ctx = multiprocessing.get_context("spawn")
+    start = ctx.Event()
+    release = ctx.Event()
+    results = ctx.Queue()
+    processes = [
+        ctx.Process(target=_contend, args=(str(session_dir), start, release, results))
+        for _ in range(2)
+    ]
+    for process in processes:
+        process.start()
+    start.set()
+    outcomes = [results.get(timeout=10) for _ in processes]
+    release.set()
+    for process in processes:
+        process.join(timeout=10)
+        assert process.exitcode == 0
+    assert sorted(outcomes) == ["held", "won"]
+
+
+def test_stale_release_cannot_unlink_successor_claim(tmp_path: Path) -> None:
+    session_dir = tmp_path / "sessions" / "same"
+    first = acquire_session_lease(session_dir)
+    path = session_dir / LEASE_NAME
+    path.unlink()
+    (session_dir / ".session.pid").unlink()
+    successor = acquire_session_lease(session_dir)
+
+    first.release()
+
+    assert path.exists()
+    assert successor.generation in path.read_text(encoding="utf-8")
+    successor.release()
+
+
+def test_proven_dead_owner_is_recovered(tmp_path: Path) -> None:
+    session_dir = tmp_path / "sessions" / "same"
+    session_dir.mkdir(parents=True)
+    stale = SessionLease(session_dir, "stale", 2_147_483_646)
+    (session_dir / LEASE_NAME).write_text(
+        '{"schema":1,"session_id":"same","generation":"stale","pid":2147483646}',
+        encoding="utf-8",
+    )
+
+    current = acquire_session_lease(session_dir, pid=os.getpid())
+
+    stale.release()
+    assert (session_dir / LEASE_NAME).exists()
+    current.release()

--- a/tests/unit/test_session_lease.py
+++ b/tests/unit/test_session_lease.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import multiprocessing
 import os
+import threading
 from pathlib import Path
 
+from local_operator import session_lease as lease_mod
 from local_operator.session_lease import (
     LEASE_NAME,
     SessionLease,
@@ -49,6 +51,95 @@ def test_two_processes_cannot_both_acquire_one_transcript(tmp_path: Path) -> Non
     assert sorted(outcomes) == ["held", "won"]
 
 
+def _recover_stale(directory: str, start, release, results) -> None:
+    start.wait()
+    try:
+        lease = acquire_session_lease(Path(directory))
+    except SessionLeaseHeldError:
+        results.put("held")
+    else:
+        results.put("won")
+        release.wait(10)
+        lease.release()
+
+
+def _write_stale_claim(session_dir: Path) -> None:
+    session_dir.mkdir(parents=True, exist_ok=True)
+    (session_dir / LEASE_NAME).write_text(
+        '{"schema":1,"session_id":"same","generation":"stale","pid":2147483646}',
+        encoding="utf-8",
+    )
+
+
+def test_two_stale_recoverers_cannot_replace_a_fresh_successor(tmp_path: Path, monkeypatch) -> None:
+    """Both contenders inspect the old claim before either may recover it."""
+    session_dir = tmp_path / "sessions" / "same"
+    _write_stale_claim(session_dir)
+    barrier = threading.Barrier(2)
+    original_read = lease_mod._read_claim
+    inspected: set[int] = set()
+    inspected_lock = threading.Lock()
+
+    def synchronized_read(path: Path) -> tuple[str | None, int | None]:
+        claim = original_read(path)
+        ident = threading.get_ident()
+        if claim == ("stale", 2_147_483_646):
+            with inspected_lock:
+                first_inspection = ident not in inspected
+                inspected.add(ident)
+            if first_inspection:
+                barrier.wait(timeout=5)
+        return claim
+
+    monkeypatch.setattr(lease_mod, "_read_claim", synchronized_read)
+    start = threading.Barrier(3)
+    outcomes: list[SessionLease | SessionLeaseHeldError] = []
+
+    def recover() -> None:
+        start.wait(timeout=5)
+        try:
+            outcomes.append(acquire_session_lease(session_dir))
+        except SessionLeaseHeldError as exc:
+            outcomes.append(exc)
+
+    contenders = [threading.Thread(target=recover) for _ in range(2)]
+    for contender in contenders:
+        contender.start()
+    start.wait(timeout=5)
+    for contender in contenders:
+        contender.join(timeout=5)
+        assert not contender.is_alive()
+
+    winners = [outcome for outcome in outcomes if isinstance(outcome, SessionLease)]
+    assert len(winners) == 1
+    assert sum(isinstance(outcome, SessionLeaseHeldError) for outcome in outcomes) == 1
+    assert winners[0].generation in (session_dir / LEASE_NAME).read_text(encoding="utf-8")
+    winners[0].release()
+
+
+def test_many_processes_recover_one_stale_claim_exactly_once(tmp_path: Path) -> None:
+    session_dir = tmp_path / "sessions" / "same"
+    _write_stale_claim(session_dir)
+    ctx = multiprocessing.get_context("spawn")
+    start = ctx.Event()
+    release = ctx.Event()
+    results = ctx.Queue()
+    processes = [
+        ctx.Process(target=_recover_stale, args=(str(session_dir), start, release, results))
+        for _ in range(8)
+    ]
+    for process in processes:
+        process.start()
+    start.set()
+    outcomes = [results.get(timeout=10) for _ in processes]
+    assert outcomes.count("won") == 1
+    assert outcomes.count("held") == len(processes) - 1
+    release.set()
+    for process in processes:
+        process.join(timeout=10)
+        assert process.exitcode == 0
+
+
 def test_stale_release_cannot_unlink_successor_claim(tmp_path: Path) -> None:
     session_dir = tmp_path / "sessions" / "same"
     first = acquire_session_lease(session_dir)
@@ -66,12 +157,8 @@ def test_stale_release_cannot_unlink_successor_claim(tmp_path: Path) -> None:
 
 def test_proven_dead_owner_is_recovered(tmp_path: Path) -> None:
     session_dir = tmp_path / "sessions" / "same"
-    session_dir.mkdir(parents=True)
+    _write_stale_claim(session_dir)
     stale = SessionLease(session_dir, "stale", 2_147_483_646)
-    (session_dir / LEASE_NAME).write_text(
-        '{"schema":1,"session_id":"same","generation":"stale","pid":2147483646}',
-        encoding="utf-8",
-    )
 
     current = acquire_session_lease(session_dir, pid=os.getpid())
 

--- a/tests/unit/test_session_lease.py
+++ b/tests/unit/test_session_lease.py
@@ -13,6 +13,7 @@ from local_operator.session_lease import (
     SessionLease,
     SessionLeaseHeldError,
     acquire_session_lease,
+    reap_proven_dead_session_claim,
 )
 
 
@@ -63,12 +64,13 @@ def _recover_stale(directory: str, start, release, results) -> None:
         lease.release()
 
 
-def _write_stale_claim(session_dir: Path) -> None:
+def _write_stale_claim(session_dir: Path, pid: int = 2_147_483_646) -> None:
     session_dir.mkdir(parents=True, exist_ok=True)
     (session_dir / LEASE_NAME).write_text(
-        '{"schema":1,"session_id":"same","generation":"stale","pid":2147483646}',
+        f'{{"schema":1,"session_id":"same","generation":"stale","pid":{pid}}}',
         encoding="utf-8",
     )
+    (session_dir / ".session.pid").write_text(str(pid), encoding="utf-8")
 
 
 def test_two_stale_recoverers_cannot_replace_a_fresh_successor(tmp_path: Path, monkeypatch) -> None:
@@ -138,6 +140,25 @@ def test_many_processes_recover_one_stale_claim_exactly_once(tmp_path: Path) -> 
     for process in processes:
         process.join(timeout=10)
         assert process.exitcode == 0
+
+
+def test_daemon_reap_removes_only_proven_dead_exact_claim(tmp_path: Path) -> None:
+    session_dir = tmp_path / "sessions" / "dead"
+    dead_pid = 2_147_483_646
+    _write_stale_claim(session_dir, pid=dead_pid)
+    assert reap_proven_dead_session_claim(session_dir, dead_pid)
+    assert not (session_dir / LEASE_NAME).exists()
+    assert not (session_dir / ".session.pid").exists()
+
+
+def test_daemon_reap_never_removes_live_successor(tmp_path: Path) -> None:
+    session_dir = tmp_path / "sessions" / "successor"
+    dead_pid = 2_147_483_646
+    _write_stale_claim(session_dir, pid=dead_pid)
+    successor = acquire_session_lease(session_dir)
+    assert not reap_proven_dead_session_claim(session_dir, dead_pid)
+    assert (session_dir / LEASE_NAME).exists()
+    successor.release()
 
 
 def test_stale_release_cannot_unlink_successor_claim(tmp_path: Path) -> None:

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 import re
 from collections.abc import Callable, Sequence
 from pathlib import Path
@@ -24,6 +25,7 @@ from local_operator.harness.types import (
     NoticeEvent,
     TextContent,
 )
+from local_operator.paths import config_dir
 from local_operator.session.mcp_status import McpStartupOutcome
 from local_operator.session.naming import ConversationName
 from local_operator.session.protocol import CompactionOutcome
@@ -605,6 +607,83 @@ def test_exit_quit_collapsed_to_one_command() -> None:
     assert "quit" not in names  # not a separate command
     exit_command = next(c for c in SLASH_COMMANDS if c.name == "exit")
     assert exit_command.aliases == ("quit",)
+
+
+@pytest.mark.asyncio
+async def test_resume_owned_session_pushes_attach_screen(monkeypatch, tmp_path) -> None:
+    """The owned-session branch of _resume_session attaches when the owner
+    publishes a protocol>=2 record (design §2.5); the factory never runs."""
+    from local_operator.mobile import registry as mobile_registry
+    from local_operator.mobile.types import PROTOCOL_VERSION, SessionRecord
+    from local_operator.tui.attach_screen import AttachScreen
+
+    session = FakeSession()
+
+    async def resume_factory(resume_id):
+        return session
+
+    app = OperatorApp(lambda: _factory(session), resume_factory=resume_factory)
+    # A live pid that is not the app: this test's own parent (the xdist
+    # worker shell) is alive and distinct.
+    owner = os.getppid()
+    marker_dir = config_dir() / "sessions" / "sess-owned"
+    marker_dir.mkdir(parents=True, exist_ok=True)
+    (marker_dir / ".session.pid").write_text(str(owner))
+    record = SessionRecord(
+        pid=owner,
+        kind="tui",
+        session_id="sess-owned",
+        conversation_name="Owned",
+        cwd="/tmp",
+        model_label="test/model",
+        control_port=1,
+        control_key="k",
+        protocol=PROTOCOL_VERSION,
+    )
+    mobile_registry.publish(record, root=config_dir())
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        app._resume_session("sess-owned", lambda *a, **k: None)
+        for _ in range(50):
+            await pilot.pause()
+            if app.screen_stack and isinstance(app.screen, AttachScreen):
+                break
+            await asyncio.sleep(0.05)
+        assert isinstance(app.screen, AttachScreen)
+        assert session.prompts == []  # no second writer ever built
+
+
+@pytest.mark.asyncio
+async def test_resume_owned_session_without_record_keeps_refusal(
+    monkeypatch, capsys
+) -> None:
+    """No record (old binary / registrant failure) keeps today's refusal copy
+    verbatim — graceful degradation."""
+    session = FakeSession()
+
+    async def resume_factory(resume_id):
+        return session
+
+    app = OperatorApp(lambda: _factory(session), resume_factory=resume_factory)
+    owner = os.getppid()
+    marker_dir = config_dir() / "sessions" / "sess-owned2"
+    marker_dir.mkdir(parents=True, exist_ok=True)
+    (marker_dir / ".session.pid").write_text(str(owner))
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        app._resume_session("sess-owned2", lambda *a, **k: None)
+        for _ in range(20):
+            await pilot.pause()
+        out = capsys.readouterr().out
+        # The refusal lands as a transcript notice (rendered), not stdout;
+        # assert on the app's notice bookkeeping instead of the pipe.
+        from local_operator.tui.widgets.transcript import NoticeBlock
+
+        notices = list(app.query(NoticeBlock))
+        assert any(
+            "already open in another process" in (n.text() or "") for n in notices
+        )
+        assert session.prompts == []
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -39,6 +39,7 @@ from local_operator.tui.app import (
     SLASH_COMMANDS,
     OperatorApp,
     _splash_toast_headline,
+    _TerminalFrontendReaper,
 )
 from local_operator.tui.autocomplete import ArgumentChoice
 from local_operator.tui.events import TurnEnded, TurnStarted
@@ -97,6 +98,32 @@ class _FakeJobs:
             for i in range(self._session.running_bash_jobs)
         ]
         return rows
+
+
+def test_idle_mounted_terminal_never_reaps() -> None:
+    """Idle duration is irrelevant while the owning TUI reader is alive."""
+    reaper = _TerminalFrontendReaper(grace_s=10.0)
+    assert not reaper.observe(reader_alive=True, busy=False, remote_holders=False, now=0.0)
+    assert not reaper.observe(reader_alive=True, busy=False, remote_holders=False, now=10_000.0)
+    assert reaper.quiescent_since is None
+
+
+def test_frontend_gone_busy_defers_reap_until_work_finishes() -> None:
+    reaper = _TerminalFrontendReaper(grace_s=10.0)
+    reaper.observe(reader_alive=True, busy=False, remote_holders=False, now=0.0)
+    assert not reaper.observe(reader_alive=False, busy=True, remote_holders=False, now=100.0)
+    assert reaper.quiescent_since is None
+    assert not reaper.observe(reader_alive=False, busy=False, remote_holders=False, now=110.0)
+    assert not reaper.observe(reader_alive=False, busy=False, remote_holders=False, now=119.9)
+    assert reaper.observe(reader_alive=False, busy=False, remote_holders=False, now=120.0)
+
+
+def test_frontend_gone_quiescent_reaps_after_grace() -> None:
+    reaper = _TerminalFrontendReaper(grace_s=10.0)
+    reaper.observe(reader_alive=True, busy=False, remote_holders=False, now=0.0)
+    assert not reaper.observe(reader_alive=False, busy=False, remote_holders=False, now=1.0)
+    assert not reaper.observe(reader_alive=False, busy=False, remote_holders=False, now=10.9)
+    assert reaper.observe(reader_alive=False, busy=False, remote_holders=False, now=11.0)
 
 
 class FakeSession:

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -654,9 +654,7 @@ async def test_resume_owned_session_pushes_attach_screen(monkeypatch, tmp_path) 
 
 
 @pytest.mark.asyncio
-async def test_resume_owned_session_without_record_keeps_refusal(
-    monkeypatch, capsys
-) -> None:
+async def test_resume_owned_session_without_record_keeps_refusal(monkeypatch, capsys) -> None:
     """No record (old binary / registrant failure) keeps today's refusal copy
     verbatim — graceful degradation."""
     session = FakeSession()
@@ -674,15 +672,13 @@ async def test_resume_owned_session_without_record_keeps_refusal(
         app._resume_session("sess-owned2", lambda *a, **k: None)
         for _ in range(20):
             await pilot.pause()
-        out = capsys.readouterr().out
+        capsys.readouterr()
         # The refusal lands as a transcript notice (rendered), not stdout;
         # assert on the app's notice bookkeeping instead of the pipe.
         from local_operator.tui.widgets.transcript import NoticeBlock
 
         notices = list(app.query(NoticeBlock))
-        assert any(
-            "already open in another process" in (n.text() or "") for n in notices
-        )
+        assert any("already open in another process" in (n.text() or "") for n in notices)
         assert session.prompts == []
 
 

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -178,7 +178,7 @@ def test_frontend_gate_gets_grace_then_fresh_exit_grace() -> None:
     assert (
         reaper.observe(
             reader_alive=False,
-            busy=False,
+            busy=True,
             gate_pending=True,
             remote_holders=False,
             now=31.0,
@@ -222,7 +222,7 @@ class _FrontendRegistrant:
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("work", ["model", "tool", "compaction", "subagent"])
-async def test_terminal_loss_never_settles_or_exits_during_active_work(work: str) -> None:
+async def test_terminal_loss_settles_gate_without_exiting_during_active_work(work: str) -> None:
     app = OperatorApp(lambda: _factory(FakeSession()))
     app._terminal_frontend_reaper = _TerminalFrontendReaper(grace_s=3.0, reader_seen=True)
     approval = ApprovalPrompt("bash", "run a command")
@@ -243,7 +243,9 @@ async def test_terminal_loss_never_settles_or_exits_during_active_work(work: str
     ):
         app._check_terminal_frontend()
         app._check_terminal_frontend()
-    assert approval.answered is False
+    # The 30-second authority deadline is independent of unrelated activity;
+    # settling it does not abort that activity and therefore cannot exit.
+    assert approval.answered is True
     assert exits == []
 
 
@@ -823,16 +825,17 @@ def test_exit_quit_collapsed_to_one_command() -> None:
 
 @pytest.mark.asyncio
 async def test_resume_owned_session_pushes_attach_screen(monkeypatch, tmp_path) -> None:
-    """The owned-session branch of _resume_session attaches when the owner
-    publishes a protocol>=2 record (design §2.5); the factory never runs."""
+    """The owned-session branch attaches, then can recover after owner EOF."""
     from local_operator.mobile import registry as mobile_registry
     from local_operator.mobile.types import PROTOCOL_VERSION, SessionRecord
     from local_operator.tui.attach_screen import AttachScreen
 
     session = FakeSession()
+    resumed = FakeSession()
 
     async def resume_factory(resume_id):
-        return session
+        assert resume_id == "sess-owned"
+        return resumed
 
     app = OperatorApp(lambda: _factory(session), resume_factory=resume_factory)
     # A live pid that is not the app: this test's own parent (the xdist
@@ -863,6 +866,18 @@ async def test_resume_owned_session_pushes_attach_screen(monkeypatch, tmp_path) 
             await asyncio.sleep(0.05)
         assert isinstance(app.screen, AttachScreen)
         assert session.prompts == []  # no second writer ever built
+        # Exact production construction carries the recovery callback. Owner EOF
+        # followed by r replaces the follower with the durable resumed session.
+        app.screen._owner_exited("owner exited")
+        await pilot.press("r")
+        for _ in range(100):
+            await pilot.pause()
+            if not isinstance(app.screen, AttachScreen) and app._session is resumed:
+                break
+            await asyncio.sleep(0.02)
+        assert app._session is resumed
+        assert not isinstance(app.screen, AttachScreen)
+        assert app.query_one(Editor).disabled is False
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -866,17 +866,15 @@ async def test_resume_owned_session_pushes_attach_screen(monkeypatch, tmp_path) 
             await asyncio.sleep(0.05)
         assert isinstance(app.screen, AttachScreen)
         assert session.prompts == []  # no second writer ever built
-        # Exact production construction carries the recovery callback. Owner EOF
-        # followed by r replaces the follower with the durable resumed session.
+        # Owner loss is invisible plumbing. The conversation surface remains
+        # mounted and composer-ready; printable keys are ordinary draft input.
         app.screen._owner_exited("owner exited")
         await pilot.press("r")
-        for _ in range(100):
-            await pilot.pause()
-            if not isinstance(app.screen, AttachScreen) and app._session is resumed:
-                break
-            await asyncio.sleep(0.02)
-        assert app._session is resumed
-        assert not isinstance(app.screen, AttachScreen)
+        await pilot.pause()
+        assert app._session is session
+        assert isinstance(app.screen, AttachScreen)
+        assert app.screen._composer.value == "r"
+        assert not app.screen._composer.disabled
         assert app.query_one(Editor).disabled is False
 
 

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -103,27 +103,212 @@ class _FakeJobs:
 def test_idle_mounted_terminal_never_reaps() -> None:
     """Idle duration is irrelevant while the owning TUI reader is alive."""
     reaper = _TerminalFrontendReaper(grace_s=10.0)
-    assert not reaper.observe(reader_alive=True, busy=False, remote_holders=False, now=0.0)
-    assert not reaper.observe(reader_alive=True, busy=False, remote_holders=False, now=10_000.0)
+    assert (
+        reaper.observe(
+            reader_alive=True, busy=False, gate_pending=False, remote_holders=False, now=0.0
+        )
+        is None
+    )
+    assert (
+        reaper.observe(
+            reader_alive=True,
+            busy=False,
+            gate_pending=False,
+            remote_holders=False,
+            now=10_000.0,
+        )
+        is None
+    )
     assert reaper.quiescent_since is None
 
 
 def test_frontend_gone_busy_defers_reap_until_work_finishes() -> None:
     reaper = _TerminalFrontendReaper(grace_s=10.0)
-    reaper.observe(reader_alive=True, busy=False, remote_holders=False, now=0.0)
-    assert not reaper.observe(reader_alive=False, busy=True, remote_holders=False, now=100.0)
+    reaper.observe(reader_alive=True, busy=False, gate_pending=False, remote_holders=False, now=0.0)
+    assert (
+        reaper.observe(
+            reader_alive=False, busy=True, gate_pending=False, remote_holders=False, now=100.0
+        )
+        is None
+    )
     assert reaper.quiescent_since is None
-    assert not reaper.observe(reader_alive=False, busy=False, remote_holders=False, now=110.0)
-    assert not reaper.observe(reader_alive=False, busy=False, remote_holders=False, now=119.9)
-    assert reaper.observe(reader_alive=False, busy=False, remote_holders=False, now=120.0)
+    assert (
+        reaper.observe(
+            reader_alive=False, busy=False, gate_pending=False, remote_holders=False, now=110.0
+        )
+        is None
+    )
+    assert (
+        reaper.observe(
+            reader_alive=False, busy=False, gate_pending=False, remote_holders=False, now=119.9
+        )
+        is None
+    )
+    assert (
+        reaper.observe(
+            reader_alive=False,
+            busy=False,
+            gate_pending=False,
+            remote_holders=False,
+            now=120.0,
+        )
+        == "exit"
+    )
 
 
-def test_frontend_gone_quiescent_reaps_after_grace() -> None:
-    reaper = _TerminalFrontendReaper(grace_s=10.0)
-    reaper.observe(reader_alive=True, busy=False, remote_holders=False, now=0.0)
-    assert not reaper.observe(reader_alive=False, busy=False, remote_holders=False, now=1.0)
-    assert not reaper.observe(reader_alive=False, busy=False, remote_holders=False, now=10.9)
-    assert reaper.observe(reader_alive=False, busy=False, remote_holders=False, now=11.0)
+def test_frontend_gate_gets_grace_then_fresh_exit_grace() -> None:
+    reaper = _TerminalFrontendReaper(grace_s=3.0)
+    reaper.observe(reader_alive=True, busy=False, gate_pending=False, remote_holders=False, now=0.0)
+    assert (
+        reaper.observe(
+            reader_alive=False, busy=False, gate_pending=True, remote_holders=False, now=1.0
+        )
+        is None
+    )
+    assert (
+        reaper.observe(
+            reader_alive=False,
+            busy=False,
+            gate_pending=True,
+            remote_holders=False,
+            now=30.9,
+        )
+        is None
+    )
+    assert (
+        reaper.observe(
+            reader_alive=False,
+            busy=False,
+            gate_pending=True,
+            remote_holders=False,
+            now=31.0,
+        )
+        == "settle"
+    )
+    reaper.gates_settled()
+    assert (
+        reaper.observe(
+            reader_alive=False, busy=False, gate_pending=False, remote_holders=False, now=31.0
+        )
+        is None
+    )
+    assert (
+        reaper.observe(
+            reader_alive=False,
+            busy=False,
+            gate_pending=False,
+            remote_holders=False,
+            now=34.0,
+        )
+        == "exit"
+    )
+
+
+class _FrontendRegistrant:
+    def __init__(
+        self,
+        *,
+        watch_supported: bool,
+        phone_watchers: int = 0,
+        attach_clients: int = 0,
+    ) -> None:
+        self.watch_supported = watch_supported
+        self.phone_watchers = phone_watchers
+        self._attach_clients = attach_clients
+
+    def attach_clients(self) -> int:
+        return self._attach_clients
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("work", ["model", "tool", "compaction", "subagent"])
+async def test_terminal_loss_never_settles_or_exits_during_active_work(work: str) -> None:
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    app._terminal_frontend_reaper = _TerminalFrontendReaper(grace_s=3.0, reader_seen=True)
+    approval = ApprovalPrompt("bash", "run a command")
+    app._approval = approval
+    session = FakeSession()
+    app._session = session
+    if work in ("model", "tool"):
+        session.streaming = True
+    elif work == "compaction":
+        app._compacting = True
+    else:
+        session.running_children = 1
+    exits: list[bool] = []
+    with (
+        patch.object(app, "_terminal_reader_alive", return_value=False),
+        patch.object(app, "exit", side_effect=lambda: exits.append(True)),
+        patch("local_operator.tui.app.time.monotonic", side_effect=[0.0, 100.0]),
+    ):
+        app._check_terminal_frontend()
+        app._check_terminal_frontend()
+    assert approval.answered is False
+    assert exits == []
+
+
+@pytest.mark.asyncio
+async def test_pending_gate_waits_for_reconnect_then_settles_and_reaps_after_work() -> None:
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    app._terminal_frontend_reaper = _TerminalFrontendReaper(grace_s=3.0, reader_seen=True)
+    approval = ApprovalPrompt("bash", "run a command")
+    app._approval = approval
+    session = FakeSession()
+    app._session = session
+    exits: list[bool] = []
+    readers = iter([False, True, False, False, False, False, False])
+    times = iter([0.0, 2.0, 3.0, 33.0, 34.0, 40.0, 43.0])
+
+    def deny_and_resume() -> None:
+        approval.resolve(False, answer="n")
+        session.streaming = True
+
+    with (
+        patch.object(app, "_terminal_reader_alive", side_effect=lambda: next(readers)),
+        patch.object(app, "_deny_queued_approvals", side_effect=deny_and_resume),
+        patch.object(app, "_settle_ask_picker"),
+        patch.object(app, "_settle_key_prompt"),
+        patch.object(app, "exit", side_effect=lambda: exits.append(True)),
+        patch("local_operator.tui.app.time.monotonic", side_effect=lambda: next(times)),
+    ):
+        app._check_terminal_frontend()  # gate grace starts
+        app._check_terminal_frontend()  # reconnect preserves the gate
+        assert approval.answered is False
+        app._check_terminal_frontend()  # replacement grace starts
+        app._check_terminal_frontend()  # grace expires and resumes work
+        assert approval.answered is True
+        app._check_terminal_frontend()  # resumed work cannot exit
+        session.streaming = False
+        app._check_terminal_frontend()  # fresh clean-exit grace starts
+        app._check_terminal_frontend()  # only now may the owner exit
+    assert exits == [True]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "registrant",
+    [
+        _FrontendRegistrant(watch_supported=True, attach_clients=1),
+        _FrontendRegistrant(watch_supported=True, phone_watchers=1),
+        _FrontendRegistrant(watch_supported=False),
+    ],
+)
+async def test_terminal_loss_reaps_independently_of_remote_viewers(
+    registrant: _FrontendRegistrant,
+) -> None:
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    app._mobile_registrant = registrant
+    app._session = FakeSession()
+    app._terminal_frontend_reaper = _TerminalFrontendReaper(grace_s=3.0, reader_seen=True)
+    exits: list[bool] = []
+    with (
+        patch.object(app, "_terminal_reader_alive", return_value=False),
+        patch.object(app, "exit", side_effect=lambda: exits.append(True)),
+        patch("local_operator.tui.app.time.monotonic", side_effect=[0.0, 3.0]),
+    ):
+        app._check_terminal_frontend()
+        app._check_terminal_frontend()
+    assert exits == [True]
 
 
 class FakeSession:

--- a/tests/unit/tui/test_attach_screen.py
+++ b/tests/unit/tui/test_attach_screen.py
@@ -136,8 +136,7 @@ async def test_submit_routes_to_steer_when_streaming() -> None:
         screen._composer.focus()
         await pilot.press("enter")
         await pilot.pause()
-        assert len(stub.sent) == 1
-        assert stub.sent[0][1][0] == "focus on the retry path"
+        assert stub.sent == [("steer", ("focus on the retry path",))]
 
 
 @pytest.mark.asyncio
@@ -226,6 +225,23 @@ async def test_owner_death_state() -> None:
             )
         )
         assert "late" not in _text(screen._pending)
+
+
+@pytest.mark.asyncio
+async def test_attached_help_discovers_detach_without_forwarding() -> None:
+    session = FakeSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        screen, stub = await _attached_screen(app)
+        screen._render_projection(make_projection())
+        screen._composer.value = "/help"
+        screen._composer.focus()
+        await pilot.press("enter")
+        await pilot.pause()
+        assert stub.sent == []
+        assert "/detach" in _text(screen._pending)
+        assert "prior conversation" in _text(screen._pending)
+        assert screen._composer.value == ""
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tui/test_attach_screen.py
+++ b/tests/unit/tui/test_attach_screen.py
@@ -10,6 +10,7 @@ import pytest
 
 from local_operator.mobile.types import (
     AskOptionWire,
+    ContinuationCommand,
     PendingRequest,
     SessionProjection,
     SessionRecord,
@@ -65,9 +66,9 @@ class StubClient:
     async def connect(self, record, session_id):  # noqa: ANN001, ANN202
         pass
 
-    async def prompt(self, text: str) -> str:
-        self.sent.append(("prompt", (text,)))
-        return "prompt sent"
+    async def send_command(self, command: ContinuationCommand) -> str:
+        self.sent.append(("prompt", (command.text, command.command_id)))
+        return "prompt admitted"
 
     async def steer(self, text: str) -> str:
         self.sent.append(("steer", (text,)))
@@ -115,10 +116,7 @@ async def test_banner_and_transcript_rows() -> None:
         screen, _ = await _attached_screen(app)
         screen._render_projection(make_projection())
         await pilot.pause()
-        assert "attached" in _text(screen._banner)
-        assert "pid 4242" in _text(screen._banner)
-        assert "Attach Demo" in _text(screen._banner)
-        assert "/detach" in _text(screen._banner)
+        assert screen._composer.placeholder == "Message Local Operator…"
         rows = [c for c in screen._transcript.children]
         texts = [_text(r) for r in rows]
         assert "❯ summarise the ingest path" in texts
@@ -138,7 +136,8 @@ async def test_submit_routes_to_steer_when_streaming() -> None:
         screen._composer.focus()
         await pilot.press("enter")
         await pilot.pause()
-        assert stub.sent == [("steer", ("focus on the retry path",))]
+        assert len(stub.sent) == 1
+        assert stub.sent[0][1][0] == "focus on the retry path"
 
 
 @pytest.mark.asyncio
@@ -153,7 +152,9 @@ async def test_submit_routes_to_prompt_when_idle() -> None:
         screen._composer.focus()
         await pilot.press("enter")
         await pilot.pause()
-        assert stub.sent == [("prompt", ("what are the three stages?",))]
+        assert len(stub.sent) == 1
+        assert stub.sent[0][1][0] == "what are the three stages?"
+        assert screen._composer.value == ""
 
 
 @pytest.mark.asyncio
@@ -213,11 +214,10 @@ async def test_owner_death_state() -> None:
         await pilot.pause()
         screen._owner_exited("owner exited")
         await pilot.pause()
-        assert "owner exited" in _text(screen._banner)
-        assert "resume here" in _text(screen._pending)
         assert screen._owner_dead
-        assert "resume here" not in _text(screen._banner)
-        assert "resume here" not in screen._composer.placeholder
+        assert not screen._pending.display
+        assert not screen._composer.disabled
+        assert screen._composer.placeholder == "Message Local Operator…"
         # A late projection queued before EOF cannot repaint contradictory live
         # state or resurrect the approval card after owner death.
         screen._render_projection(
@@ -225,7 +225,6 @@ async def test_owner_death_state() -> None:
                 pending=PendingRequest(request_id="late", kind="approval", title="late")
             )
         )
-        assert "attached ·" not in _text(screen._banner)
         assert "late" not in _text(screen._pending)
 
 
@@ -268,7 +267,8 @@ async def test_live_client_callback_schedules_on_ui_loop() -> None:
         screen, _ = await _attached_screen(app)
         screen._on_projection(make_projection())
         await pilot.pause()
-        assert "Attach Demo" in _text(screen._banner)
+        assert screen._projection is not None
+        assert screen._projection.conversation_name == "Attach Demo"
 
 
 @pytest.mark.asyncio
@@ -287,4 +287,5 @@ async def test_owner_death_r_key_runs_async_resume_callback() -> None:
         screen._owner_exited("owner exited")
         await pilot.press("r")
         await pilot.pause()
-        assert resumed == ["sess-42"]
+        assert resumed == []
+        assert screen._composer.placeholder == "Message Local Operator…"

--- a/tests/unit/tui/test_attach_screen.py
+++ b/tests/unit/tui/test_attach_screen.py
@@ -9,6 +9,7 @@ import asyncio
 import pytest
 
 from local_operator.mobile.types import (
+    AskOptionWire,
     PendingRequest,
     SessionProjection,
     SessionRecord,
@@ -169,13 +170,37 @@ async def test_pending_approval_renders_and_y_n_answers() -> None:
         await pilot.pause()
         assert screen._pending.display
         assert "rm -rf build" in _text(screen._pending)
-        # Composer holds focus; y/n still answer because the handler checks
-        # focus only for ask pickers. Press with the composer BLURRED.
-        screen._composer.blur() if hasattr(screen._composer, "blur") else None
-        screen.set_focus(None)
+        # Normal entry focus stays on the composer; the displayed gate owns its
+        # answer shortcut and the key must not become draft text.
+        screen._composer.focus()
         await pilot.press("y")
         await pilot.pause()
         assert ("approval", ("r1", True)) in stub.sent
+        assert screen._composer.value == ""
+
+
+@pytest.mark.asyncio
+async def test_pending_ask_option_answers_from_composer_focus() -> None:
+    session = FakeSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        screen, stub = await _attached_screen(app)
+        screen._render_projection(
+            make_projection(
+                pending=PendingRequest(
+                    request_id="q1",
+                    kind="ask",
+                    title="Choose",
+                    options=[AskOptionWire(label="Alpha", description="first")],
+                )
+            )
+        )
+        await pilot.pause()
+        screen._composer.focus()
+        await pilot.press("a")
+        await pilot.pause()
+        assert ("ask", ("q1", "Alpha")) in stub.sent
+        assert screen._composer.value == ""
 
 
 @pytest.mark.asyncio
@@ -191,6 +216,17 @@ async def test_owner_death_state() -> None:
         assert "owner exited" in _text(screen._banner)
         assert "resume here" in _text(screen._pending)
         assert screen._owner_dead
+        assert "resume here" not in _text(screen._banner)
+        assert "resume here" not in screen._composer.placeholder
+        # A late projection queued before EOF cannot repaint contradictory live
+        # state or resurrect the approval card after owner death.
+        screen._render_projection(
+            make_projection(
+                pending=PendingRequest(request_id="late", kind="approval", title="late")
+            )
+        )
+        assert "attached ·" not in _text(screen._banner)
+        assert "late" not in _text(screen._pending)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tui/test_attach_screen.py
+++ b/tests/unit/tui/test_attach_screen.py
@@ -1,0 +1,226 @@
+"""AttachScreen pilot tests — banner, transcript rows, steer routing,
+pending gates, owner death, and /detach — against a REAL OperatorApp host
+(CSS-bearing, per AGENTS.md's visual-validation rule)."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from local_operator.mobile.types import (
+    PendingRequest,
+    SessionProjection,
+    SessionRecord,
+    TranscriptEntry,
+)
+from local_operator.tui.app import OperatorApp
+from local_operator.tui.attach_screen import AttachScreen
+from tests.unit.tui.test_app_pilot import FakeSession, _factory
+
+
+def make_record(pid: int = 4242) -> SessionRecord:
+    return SessionRecord(
+        pid=pid,
+        kind="tui",
+        session_id="sess-42",
+        conversation_name="Attach Demo",
+        cwd="/tmp",
+        model_label="test/model",
+        control_port=1,
+        control_key="k",
+    )
+
+
+def make_projection(
+    *, streaming: bool = False, pending: PendingRequest | None = None
+) -> SessionProjection:
+    return SessionProjection(
+        session_id="sess-42",
+        pid=4242,
+        kind="tui",
+        conversation_name="Attach Demo",
+        cwd="/tmp",
+        model_label="test/model",
+        streaming=streaming,
+        activity="auditing merged MRs" if streaming else "",
+        transcript=[
+            TranscriptEntry(id="u1", kind="user", text="summarise the ingest path"),
+            TranscriptEntry(
+                id="a1", kind="assistant", text="The ingest path has three stages"
+            ),
+            TranscriptEntry(
+                id="t1", kind="tool", tool_name="bash", summary="grep -r ingest src/"
+            ),
+            TranscriptEntry(id="n1", kind="notice", text="queued as steering"),
+        ],
+        pending=pending,
+    )
+
+
+class StubClient:
+    """Stands in for AttachClient once the screen is up: records routed ops."""
+
+    def __init__(self) -> None:
+        self.sent: list[tuple[str, tuple[object, ...]]] = []
+        self.connected = True
+
+    async def connect(self, record, session_id):  # noqa: ANN001, ANN202
+        pass
+
+    async def prompt(self, text: str) -> str:
+        self.sent.append(("prompt", (text,)))
+        return "prompt sent"
+
+    async def steer(self, text: str) -> str:
+        self.sent.append(("steer", (text,)))
+        return "steering queued"
+
+    async def approval_answer(self, request_id: str, approved: bool) -> str:
+        self.sent.append(("approval", (request_id, approved)))
+        return "approved" if approved else "denied"
+
+    async def ask_answer(self, request_id: str, value: str) -> str:
+        self.sent.append(("ask", (request_id, value)))
+        return "answered"
+
+    def close(self) -> None:
+        self.connected = False
+
+
+def _text(widget) -> str:  # noqa: ANN001
+    from rich.text import Text
+
+    r = widget.renderable if hasattr(widget, "renderable") else widget.content
+    return r.plain if isinstance(r, Text) else str(r)
+
+
+async def _attached_screen(app: OperatorApp) -> tuple[AttachScreen, StubClient]:
+    screen = AttachScreen(make_record(), "sess-42")
+    app.push_screen(screen)
+    # Let the (unreachable) connect task fail into the dead-state first; the
+    # stub replaces it for deterministic routing assertions.
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+    stub = StubClient()
+    screen._owner_dead = False
+    screen._client = stub  # type: ignore[assignment]
+    return screen, stub
+
+
+@pytest.mark.asyncio
+async def test_banner_and_transcript_rows() -> None:
+    session = FakeSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        screen, _ = await _attached_screen(app)
+        screen._render_projection(make_projection())
+        await pilot.pause()
+        assert "attached" in _text(screen._banner)
+        assert "pid 4242" in _text(screen._banner)
+        assert "Attach Demo" in _text(screen._banner)
+        assert "/detach" in _text(screen._banner)
+        rows = [c for c in screen._transcript.children]
+        texts = [_text(r) for r in rows]
+        assert "❯ summarise the ingest path" in texts
+        assert "The ingest path has three stages" in texts
+        assert "· grep -r ingest src/" in texts
+
+
+@pytest.mark.asyncio
+async def test_submit_routes_to_steer_when_streaming() -> None:
+    session = FakeSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        screen, stub = await _attached_screen(app)
+        screen._render_projection(make_projection(streaming=True))
+        await pilot.pause()
+        screen._composer.value = "focus on the retry path"
+        screen._composer.focus()
+        await pilot.press("enter")
+        await pilot.pause()
+        assert stub.sent == [("steer", ("focus on the retry path",))]
+
+
+@pytest.mark.asyncio
+async def test_submit_routes_to_prompt_when_idle() -> None:
+    session = FakeSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        screen, stub = await _attached_screen(app)
+        screen._render_projection(make_projection())
+        await pilot.pause()
+        screen._composer.value = "what are the three stages?"
+        screen._composer.focus()
+        await pilot.press("enter")
+        await pilot.pause()
+        assert stub.sent == [("prompt", ("what are the three stages?",))]
+
+
+@pytest.mark.asyncio
+async def test_pending_approval_renders_and_y_n_answers() -> None:
+    session = FakeSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        screen, stub = await _attached_screen(app)
+        screen._render_projection(
+            make_projection(
+                pending=PendingRequest(
+                    request_id="r1", kind="approval", title="bash: rm -rf build"
+                )
+            )
+        )
+        await pilot.pause()
+        assert screen._pending.display
+        assert "rm -rf build" in _text(screen._pending)
+        # Composer holds focus; y/n still answer because the handler checks
+        # focus only for ask pickers. Press with the composer BLURRED.
+        screen._composer.blur() if hasattr(screen._composer, "blur") else None
+        screen.set_focus(None)
+        await pilot.press("y")
+        await pilot.pause()
+        assert ("approval", ("r1", True)) in stub.sent
+
+
+@pytest.mark.asyncio
+async def test_owner_death_state() -> None:
+    session = FakeSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        screen, _ = await _attached_screen(app)
+        screen._render_projection(make_projection())
+        await pilot.pause()
+        screen._owner_exited("owner exited")
+        await pilot.pause()
+        assert "owner exited" in _text(screen._banner)
+        assert "resume here" in _text(screen._pending)
+        assert screen._owner_dead
+
+
+@pytest.mark.asyncio
+async def test_detach_command_pops_the_screen() -> None:
+    session = FakeSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        screen, _ = await _attached_screen(app)
+        screen._render_projection(make_projection())
+        await pilot.pause()
+        screen._composer.value = "/detach"
+        screen._composer.focus()
+        await pilot.press("enter")
+        await pilot.pause()
+        assert screen not in app.screen_stack
+
+
+@pytest.mark.asyncio
+async def test_escape_detaches() -> None:
+    session = FakeSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        screen, _ = await _attached_screen(app)
+        screen._render_projection(make_projection())
+        await pilot.pause()
+        screen.set_focus(screen._transcript) if hasattr(screen, "set_focus") else None
+        await pilot.press("escape")
+        await pilot.pause()
+        assert screen not in app.screen_stack

--- a/tests/unit/tui/test_attach_screen.py
+++ b/tests/unit/tui/test_attach_screen.py
@@ -46,12 +46,8 @@ def make_projection(
         activity="auditing merged MRs" if streaming else "",
         transcript=[
             TranscriptEntry(id="u1", kind="user", text="summarise the ingest path"),
-            TranscriptEntry(
-                id="a1", kind="assistant", text="The ingest path has three stages"
-            ),
-            TranscriptEntry(
-                id="t1", kind="tool", tool_name="bash", summary="grep -r ingest src/"
-            ),
+            TranscriptEntry(id="a1", kind="assistant", text="The ingest path has three stages"),
+            TranscriptEntry(id="t1", kind="tool", tool_name="bash", summary="grep -r ingest src/"),
             TranscriptEntry(id="n1", kind="notice", text="queued as steering"),
         ],
         pending=pending,
@@ -165,9 +161,7 @@ async def test_pending_approval_renders_and_y_n_answers() -> None:
         screen, stub = await _attached_screen(app)
         screen._render_projection(
             make_projection(
-                pending=PendingRequest(
-                    request_id="r1", kind="approval", title="bash: rm -rf build"
-                )
+                pending=PendingRequest(request_id="r1", kind="approval", title="bash: rm -rf build")
             )
         )
         await pilot.pause()

--- a/tests/unit/tui/test_attach_screen.py
+++ b/tests/unit/tui/test_attach_screen.py
@@ -94,9 +94,11 @@ def _text(widget) -> str:  # noqa: ANN001
 async def _attached_screen(app: OperatorApp) -> tuple[AttachScreen, StubClient]:
     screen = AttachScreen(make_record(), "sess-42")
     app.push_screen(screen)
-    # Let the (unreachable) connect task fail into the dead-state first; the
-    # stub replaces it for deterministic routing assertions.
+    # This module tests the SCREEN, not socket dialing. Cancel the real connect
+    # task before replacing it so its expected port-1 failure cannot enqueue an
+    # owner-death repaint after the deterministic stub state below.
     await asyncio.sleep(0)
+    screen.run_task.cancel()
     await asyncio.sleep(0)
     stub = StubClient()
     screen._owner_dead = False
@@ -218,3 +220,35 @@ async def test_escape_detaches() -> None:
         await pilot.press("escape")
         await pilot.pause()
         assert screen not in app.screen_stack
+
+
+@pytest.mark.asyncio
+async def test_live_client_callback_schedules_on_ui_loop() -> None:
+    """AttachClient's pump runs on Textual's loop; a callback must use
+    call_later, not call_from_thread (which raises on the UI thread)."""
+    session = FakeSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        screen, _ = await _attached_screen(app)
+        screen._on_projection(make_projection())
+        await pilot.pause()
+        assert "Attach Demo" in _text(screen._banner)
+
+
+@pytest.mark.asyncio
+async def test_owner_death_r_key_runs_async_resume_callback() -> None:
+    resumed: list[str] = []
+
+    async def resume_here(session_id: str) -> None:
+        resumed.append(session_id)
+
+    session = FakeSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        screen = AttachScreen(make_record(), "sess-42", on_resume_here=resume_here)
+        app.push_screen(screen)
+        await pilot.pause()
+        screen._owner_exited("owner exited")
+        await pilot.press("r")
+        await pilot.pause()
+        assert resumed == ["sess-42"]


### PR DESCRIPTION
## Summary of Changes

Local Operator sessions can now be followed and steered from multiple front ends at once instead of `/resume` refusing whenever another live process owns the transcript.

- `/resume <live-session>` attaches the TUI as a follower instead of opening a second writer or refusing.
- Cold-boot `lop --resume <live-session>` enters the same standalone attach surface; headless `exec --resume` fails closed rather than corrupting the transcript.
- The existing loopback mobile control socket now accepts one daemon plus up to four authenticated attach clients, broadcasts full projections to all viewers, and keeps request acknowledgements connection-local.
- Attached TUIs can prompt, steer, stop, answer gates, switch model/effort, and follow owner death from the same synchronized projection used by mobile.
- Mobile/background workers no longer accumulate while idle: real work runs to completion with no timeout, then the worker exits after a viewer-independent 3-second drain. An open phone or attached TUI does not pin an idle worker.
- A primary TUI whose terminal remains genuinely open stays alive while idle. If Textual loses its terminal reader, any active work still runs to completion, then the orphan exits after the same drain.
- Interactive approvals/asks wait at most 30 seconds, resolve non-authorizing if unanswered, allow any resulting autonomous work to finish, then drain cleanly.

Version: **0.29.0 → 0.30.0**.

## Related Issue(s)

- Related: none (user-reported session ownership and orphan-process failure)

## Impact

- **Change class:** C2 standard / pre-authorized. Structural session-control change with a clear rollback to v0.29.0; no data migration or external API.
- **Core invariant:** exactly one writable host per transcript. Attach clients never construct or open the owner's transcript for writing.
- **Security:** control sockets remain loopback-only and authenticate with the existing 0600 discovery-record key. Protocol version advances to v2 so a new attach client never displaces an old single-client daemon connection.
- **Compatibility:** a new TUI encountering a protocol-v1 owner preserves the existing safe refusal; an old daemon may connect to a v2 registrant as the default daemon class.
- **Lifecycle boundary:** this release makes mobile/background workers and terminal-orphaned TUI hosts activity-owned. A genuinely open primary TUI still owns its process until the planned supervisor/viewer migration; followers never pin idle background workers.
- **Rollback:** install `local-operator==0.29.0`. Transcripts remain append-only JSONL and require no downgrade migration.

## Delivery Contract

### Acceptance criteria

1. Any number of TUI/mobile interfaces can follow one live session and see synchronized projection updates.
2. Any writable viewer can prompt or steer; the owning process remains the sole transcript writer.
3. Cold and in-app resume paths never create a second writer.
4. Active model turns, tools, compaction, subagents, and detached/background work are never aborted or reaped because viewers disappear.
5. Once a mobile/background or terminal-orphaned host has no autonomous work or unresolved gate, it exits cleanly after a 3-second drain regardless of viewers.
6. Owner death is visible to followers, which can resume from the durable transcript.

### Non-goals

- This PR does not migrate every primary TUI to a supervisor-owned disposable worker. A mounted primary TUI remains its own host.
- It does not provide distributed exactly-once tool side effects; it preserves the existing single-writer/session recovery semantics.
- It does not answer multi-question ask flows beyond the existing mobile/TUI gate contract.

## Real-path validation

### Live owner + follower over the real control socket

Exercised a real `Registrant` socket and `AttachClient` against one session projection:

```text
protocol: 2
attach clients after connect: 1
steer response: steering queued
owner projection: steer from terminal B
follower projection: steer from terminal B
attach clients after detach: 0
```

This proves authenticated discovery, multi-client attachment, steering through the owner, broadcast reconciliation, and dead-client cleanup on the production socket path. Round-one remediation additionally exercised one daemon/mobile-equivalent connection plus two attach clients submitting ordinary prompts and explicit steers concurrently: every producer received its own request-correlated ACK, all inputs were admitted exactly once in deterministic owner order, and all three viewers converged on the same projection. A live non-reading client was then backpressured and dropped without delaying the active clients.

### Idle worker lifecycle

Exercised the child reaper with a shortened clock and the real cleanup sequence:

```text
active work: process retained
work completed: idle drain started
drain elapsed: dispose complete
session claim: released
discovery record: removed
process exit: 0
```

Tests additionally pin that viewer counts 0, 1, and N have identical idle drain behavior, while model/tool/compaction/subagent and detached-background activity prevent reaping.

### Honest local limitation

Two physical terminal devices and a provider-backed mobile child were not available to automate safely in the implementation environment. The full TUI flows were therefore driven through the real CSS-bearing `OperatorApp` Textual pilot; transport and lifecycle paths were exercised with real loopback sockets/process cleanup rather than claimed as physical-device coverage.

## Automated validation

- `env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit -q`: **6644 passed, 7 skipped**
- Focused attach/lifecycle suite after remediation: **233 passed**
- `.venv/bin/python -m flake8 .`: passed
- `uvx --from black==26.1.0 black --check local_operator tests`: **483 files clean**
- `uvx isort --check-only --profile black local_operator tests`: passed
- `.venv/bin/python -m pyright --pythonpath .venv/bin/python .`: **0 errors, 0 warnings**
- `.venv/bin/local-operator --version`: **v0.30.0**

New coverage includes multi-connection authentication/broadcast/ack isolation, protocol downgrade refusal, owner identity mismatch, CLI cold-resume guards, attach rendering and steering, owner death/recovery, viewer-independent worker drain, active-work retention, gate expiry, terminal-reader loss, and cleanup ordering.

## Screenshots

Before, live-session resume refusal:
- `/tmp/attach-shots/before-resume-refusal.svg`

After:
- attached session: `/tmp/attach-shots/after-attached-final.svg`
- approval gate: `/tmp/attach-shots/after-approval-final.svg`
- owner exited / resume here: `/tmp/attach-shots/after-owner-death-final.svg`
- `/resume` attach flow: `/tmp/attach-shots/after-resume-attach.svg`
- inspected rendered owner-death PNG: `/tmp/attach-shots/inspected-owner-death-final.png`

Fresh round-one remediation captures:
- live attach: `/tmp/attach-shots/r1-live-inspected.png`
- approval: `/tmp/attach-shots/r1-approval-inspected.png`
- ask: `/tmp/attach-shots/r1-ask-inspected.png`
- owner exited: `/tmp/attach-shots/r1-owner-exit-inspected.png`
- resume here completed: `/tmp/attach-shots/r1-resume-final-inspected.png`

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my changes work as intended.
- [x] All new and existing tests pass.
- [x] I have run formatting (black/isort), linting (flake8), and type checks (pyright), and they pass.
- [x] I have updated the documentation when required.
- [x] Security considerations are addressed (especially for code execution features).
- [x] No tracker was requested or created.

