### PR TITLE
chore(release): bump version to 0.31.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.30.0"
+version = "0.31.0"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
## Summary of Changes

The attach/transparent-continuation feature (#289) merged with `pyproject.toml` still at `0.30.0`, but `v0.30.0` was already tagged and published to PyPI ("durable subagent history") while #289 was in review. This bump moves the version to **0.31.0** so the multi-front-end session feature can publish under its own release, mirroring the collision handling in #284.

## Related Issue(s)

- Related: version collision after #289 merged behind an already-published v0.30.0

## Impact

- Version-only change: `0.30.0 → 0.31.0` in `pyproject.toml`. No runtime behavior, API, or dependency change.
- Unblocks the PyPI publish for the #289 feature set.

## Testing Details

- No source references hardcode the version; `__version__`/`--version` resolve from installed metadata.
- Version-related unit tests pass: `pytest -k version` → 28 passed.

## Checklist

- [x] I have performed a self-review of my code.
- [x] All new and existing tests pass.
- [x] I have run formatting (black/isort), linting (flake8), and type checks (pyright), and they pass.
