### PR TITLE
perf: reduce compaction and MCP replay costs

### DIFF
--- a/local_operator/mcp/manager.py
+++ b/local_operator/mcp/manager.py
@@ -1880,6 +1880,7 @@ class McpManager:
                 tool_call_id,
                 args,
                 signal,
+                context,
                 deferred=deferred,
             )
 
@@ -1945,6 +1946,7 @@ class McpManager:
         tool_call_id: str,
         args: dict[str, Any],
         signal: AbortSignal | None,
+        context: ToolContext,
         *,
         deferred: bool,
     ) -> ToolResult:
@@ -1994,7 +1996,10 @@ class McpManager:
                     return self._error_result(tool_call_id, tool_label, exc)
             else:
                 return self._error_result(tool_call_id, tool_label, exc)
-        return format_mcp_result(result, tool_call_id, tool_label)
+        # Flattening can walk megabytes of MCP content and spilling performs
+        # filesystem I/O. Keep both off the event loop so one verbose server
+        # cannot starve streaming, cancellation, or sibling tool progress.
+        return await asyncio.to_thread(format_mcp_result, result, tool_call_id, tool_label, context)
 
     async def _race_abort(
         self, coro: Coroutine[Any, Any, _RaceT], signal: AbortSignal | None

--- a/local_operator/mcp/tool_bridge.py
+++ b/local_operator/mcp/tool_bridge.py
@@ -11,6 +11,7 @@ runs once an SDK-validated content block has actually arrived.
 
 from __future__ import annotations
 
+import copy
 import re
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any
@@ -19,6 +20,7 @@ from local_operator.harness.intent import INTENT_FIELD, apply_intent_schema
 from local_operator.harness.types import (
     AgentTool,
     TextContent,
+    ToolContext,
     ToolExecuteFn,
     ToolResult,
 )
@@ -201,10 +203,38 @@ def _model_block_text(block: ContentBlock) -> str | None:
     return None
 
 
+def _without_redundant_content_text(server_result: dict[str, Any]) -> dict[str, Any]:
+    """Retain protocol metadata while dropping text already held by the spill.
+
+    MCP content may mix text with images and embedded resources. Removing the
+    whole ``content`` field would lose media and URI metadata, while retaining
+    it unchanged would persist the oversized text a second time. Only an actual
+    spill calls this helper, so ordinary payloads remain byte-for-byte stable.
+    """
+    sanitized = copy.deepcopy(server_result)
+    raw_content = sanitized.get("content")
+    if not isinstance(raw_content, list):
+        return sanitized
+
+    content: list[Any] = []
+    for block in raw_content:
+        if not isinstance(block, dict):
+            content.append(block)
+            continue
+        if block.get("type") == "text":
+            continue
+        if block.get("type") == "resource" and isinstance(block.get("resource"), dict):
+            block["resource"].pop("text", None)
+        content.append(block)
+    sanitized["content"] = content
+    return sanitized
+
+
 def format_mcp_result(
     result: CallToolResult | dict[str, Any],
     tool_call_id: str = "",
     tool_name: str = "",
+    context: ToolContext | None = None,
 ) -> ToolResult:
     """Flatten an MCP ``tools/call`` result into a harness ``ToolResult``.
 
@@ -237,12 +267,26 @@ def format_mcp_result(
     text = "\n\n".join(parts)
     if is_error:
         text = f"Error: {text}"
+
+    details: dict[str, Any] = {"server_result": server_result}
+    if context is not None:
+        # Keep the optional SDK isolated at this module boundary: importing the
+        # established built-in spill path locally preserves config-only callers'
+        # cheap ``tool_bridge`` import when MCP support is absent.
+        from local_operator.tools.builtin import spill_truncate
+
+        text, spill = spill_truncate(text, tool_name, context)
+        if spill is not None:
+            details.update(spill)
+            if server_result is not None:
+                details["server_result"] = _without_redundant_content_text(server_result)
+
     return ToolResult(
         tool_call_id=tool_call_id,
         tool_name=tool_name,
         content=[TextContent(text=text)],
         is_error=is_error,
-        details={"server_result": server_result},
+        details=details,
     )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.31.0"
+version = "0.31.1"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/scripts/bench_compaction_replay.py
+++ b/scripts/bench_compaction_replay.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+"""Cumulative context-replay benchmark for mid-turn compaction.
+
+A model request replays the conversation accumulated so far. Measuring only the
+largest request therefore misses the bill users actually pay: a long tool run
+replays earlier tool results again at every subsequent boundary. This benchmark
+builds a deterministic synthetic run of independently paired tool calls and
+measures the cumulative estimated tokens sent to the model.
+
+The ``before`` arm preserves the pre-fix forward-only cut selection locally so
+its baseline cannot drift as production code changes. The ``after`` arm calls
+the real :func:`find_cut_point`. Both arms use the same messages, threshold,
+summary size, and token estimator, and every accepted partition is checked for
+tool call/result integrity.
+
+Run:
+    .venv/bin/python scripts/bench_compaction_replay.py
+    .venv/bin/python scripts/bench_compaction_replay.py --json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Callable, Sequence
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO))
+
+from local_operator.compaction.cutpoint import (  # noqa: E402
+    _message_tokens,
+    find_cut_point,
+)
+from local_operator.harness.types import (  # noqa: E402
+    AgentMessage,
+    CustomMessage,
+    Message,
+    ToolCall,
+)
+
+CutSelector = Callable[[Sequence[AgentMessage], int], int | None]
+
+
+@dataclass(frozen=True)
+class Result:
+    """Replay footprint and compaction outcomes for one selector."""
+
+    cumulative_replay_tokens: int
+    peak_context_tokens: int
+    final_context_tokens: int
+    compactions: int
+    starved_boundaries: int
+
+
+def _tokens(messages: Sequence[AgentMessage]) -> int:
+    """Use the production estimator for the exact history sent to a model."""
+    return sum(_message_tokens(message) for message in messages)
+
+
+def _legacy_find_cut_point(messages: Sequence[AgentMessage], keep_recent_tokens: int) -> int | None:
+    """Pre-fix selector: forward-only snap and no tool-calling boundary.
+
+    This intentionally contains only the behavior relevant to the incident.
+    Keeping it in the benchmark makes ``before`` reproducible after the Git
+    commit that originally exhibited the bug is no longer easy to check out.
+    """
+    if not messages or keep_recent_tokens <= 0:
+        return None
+
+    accumulated = 0
+    index = len(messages)
+    while index > 0 and accumulated < keep_recent_tokens:
+        index -= 1
+        accumulated += _tokens([messages[index]])
+    if index == 0 and accumulated < keep_recent_tokens:
+        return None
+
+    while index < len(messages):
+        message = messages[index]
+        valid = (
+            isinstance(message, CustomMessage) and message.custom_type == "compaction_summary"
+        ) or (
+            isinstance(message, Message)
+            and (message.role == "user" or (message.role == "assistant" and not message.tool_calls))
+        )
+        if valid:
+            break
+        index += 1
+    if index >= len(messages) or index <= 1:
+        return None
+    return index
+
+
+def _assert_pair_integrity(messages: Sequence[AgentMessage], cut: int) -> None:
+    """Reject a saving obtained by handing a provider an orphaned pair."""
+    summarized_calls = {
+        call.id
+        for message in messages[:cut]
+        if isinstance(message, Message)
+        for call in message.tool_calls
+    }
+    kept_results = {
+        message.tool_call_id
+        for message in messages[cut:]
+        if isinstance(message, Message) and message.role == "tool" and message.tool_call_id
+    }
+    kept_calls = {
+        call.id
+        for message in messages[cut:]
+        if isinstance(message, Message)
+        for call in message.tool_calls
+    }
+    kept_result_ids = {
+        message.tool_call_id
+        for message in messages[cut:]
+        if isinstance(message, Message) and message.role == "tool" and message.tool_call_id
+    }
+    assert not summarized_calls & kept_results
+    assert kept_calls <= kept_result_ids
+
+
+def _run(
+    selector: CutSelector,
+    *,
+    calls: int,
+    output_chars: int,
+    threshold_tokens: int,
+    keep_recent_tokens: int,
+    summary_repetitions: int,
+) -> Result:
+    """Replay one run, compacting at each completed tool boundary."""
+    messages: list[AgentMessage] = [
+        Message.user("Investigate the failure and keep working until it is resolved. " * 20),
+        Message.assistant("I will inspect the system and follow the evidence."),
+        Message.user("Preserve exact tool evidence while you work. " * 20),
+    ]
+    cumulative = _tokens(messages)
+    peak = cumulative
+    compactions = 0
+    starved = 0
+
+    # Repeated prose is deliberate: it approximates bounded command output and
+    # tokenizes consistently across machines without reading user transcripts.
+    payload = "worker output: operation completed with diagnostic detail\n" * 200
+    payload = (payload * ((output_chars // len(payload)) + 1))[:output_chars]
+
+    for number in range(calls):
+        call_id = f"call-{number}"
+        assistant = Message.assistant(f"Running diagnostic step {number}.")
+        assistant.tool_calls = [
+            ToolCall(id=call_id, name="bash", arguments={"command": f"step {number}"})
+        ]
+        messages.extend(
+            [
+                assistant,
+                Message(
+                    role="tool",
+                    content=Message.user(payload).content,
+                    tool_call_id=call_id,
+                    tool_name="bash",
+                ),
+            ]
+        )
+
+        context_tokens = _tokens(messages)
+        if context_tokens >= threshold_tokens:
+            cut = selector(messages, keep_recent_tokens)
+            if cut is None:
+                starved += 1
+            else:
+                _assert_pair_integrity(messages, cut)
+                messages = [
+                    CustomMessage(
+                        custom_type="compaction_summary",
+                        details={
+                            "summary": "Earlier diagnostics summarized. " * summary_repetitions
+                        },
+                    ),
+                    *messages[cut:],
+                ]
+                compactions += 1
+                context_tokens = _tokens(messages)
+
+        # The next inference replays the post-boundary history. This is the
+        # cumulative cost that one-shot context-size measurements omit.
+        cumulative += context_tokens
+        peak = max(peak, context_tokens)
+
+    return Result(
+        cumulative_replay_tokens=cumulative,
+        peak_context_tokens=peak,
+        final_context_tokens=_tokens(messages),
+        compactions=compactions,
+        starved_boundaries=starved,
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--calls", type=int, default=100)
+    parser.add_argument("--output-chars", type=int, default=8_000)
+    parser.add_argument("--threshold-tokens", type=int, default=30_000)
+    parser.add_argument("--keep-recent-tokens", type=int, default=8_000)
+    parser.add_argument("--summary-repetitions", type=int, default=12)
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+
+    common = dict(
+        calls=args.calls,
+        output_chars=args.output_chars,
+        threshold_tokens=args.threshold_tokens,
+        keep_recent_tokens=args.keep_recent_tokens,
+        summary_repetitions=args.summary_repetitions,
+    )
+    before = _run(_legacy_find_cut_point, **common)
+    after = _run(find_cut_point, **common)
+    reduction = 1 - (after.cumulative_replay_tokens / before.cumulative_replay_tokens)
+    report = {
+        "workload": common,
+        "before": asdict(before),
+        "after": asdict(after),
+        "cumulative_replay_reduction_percent": round(reduction * 100, 2),
+    }
+
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print(f"workload: {args.calls} tool calls x {args.output_chars:,} output chars")
+        print(f"before cumulative replay: {before.cumulative_replay_tokens:,} tokens")
+        print(f"after cumulative replay:  {after.cumulative_replay_tokens:,} tokens")
+        print(f"reduction:                {reduction:.1%}")
+        peaks = f"{before.peak_context_tokens:,} / {after.peak_context_tokens:,}"
+        print(f"before/after peak:        {peaks}")
+        print(f"before starved boundaries:{before.starved_boundaries:>10}")
+        print(f"after compactions:        {after.compactions:>10}")
+
+    passed = (
+        args.calls > 0
+        and args.output_chars > 0
+        and args.threshold_tokens > 0
+        and args.keep_recent_tokens > 0
+        and args.summary_repetitions > 0
+        and reduction > 0
+        and before.starved_boundaries > 0
+        and after.compactions > 0
+        and after.starved_boundaries == 0
+        and after.peak_context_tokens < before.peak_context_tokens
+    )
+    return 0 if passed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/bench_compaction_replay.py
+++ b/scripts/bench_compaction_replay.py
@@ -43,6 +43,10 @@ from local_operator.harness.types import (  # noqa: E402
 
 CutSelector = Callable[[Sequence[AgentMessage], int], int | None]
 
+# The canonical workload currently saves 73.03%. Keep enough headroom for
+# estimator tuning while refusing a regression to a merely positive result.
+MIN_CUMULATIVE_REPLAY_REDUCTION = 0.50
+
 
 @dataclass(frozen=True)
 class Result:
@@ -243,7 +247,7 @@ def main() -> int:
         and args.threshold_tokens > 0
         and args.keep_recent_tokens > 0
         and args.summary_repetitions > 0
-        and reduction > 0
+        and reduction >= MIN_CUMULATIVE_REPLAY_REDUCTION
         and before.starved_boundaries > 0
         and after.compactions > 0
         and after.starved_boundaries == 0

--- a/scripts/bench_mcp_spill.py
+++ b/scripts/bench_mcp_spill.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Deterministic footprint benchmark for oversized MCP tool results.
+
+The baseline formats the same synthetic server result without a ``ToolContext``,
+which is the pre-spill behavior. The compact arm uses the production MCP bridge,
+spill store, and production message token estimator, then reads the saved text
+back to prove the advertised expansion path is real.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import tempfile
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO))
+
+from local_operator.compaction.cutpoint import _message_tokens  # noqa: E402
+from local_operator.harness.types import Message, ToolContext  # noqa: E402
+from local_operator.mcp.tool_bridge import format_mcp_result  # noqa: E402
+from local_operator.tools.spill import get_store  # noqa: E402
+
+MIN_MODEL_TOKEN_REDUCTION = 0.50
+MIN_METADATA_BYTE_REDUCTION = 0.50
+
+
+@dataclass(frozen=True)
+class BenchmarkResult:
+    baseline_model_tokens: int
+    compact_model_tokens: int
+    model_token_reduction_percent: float
+    baseline_metadata_bytes: int
+    compact_metadata_bytes: int
+    metadata_reduction_percent: float
+    spill_bytes: int
+    spill_complete: bool
+    recovery_matches: bool
+
+
+def _tool_message(text: str) -> Message:
+    message = Message(role="tool", tool_call_id="call", tool_name="mcp__bench_rows")
+    message.content = Message.user(text).content
+    return message
+
+
+def _metadata_bytes(details: dict[str, Any] | None) -> int:
+    return len(json.dumps(details, sort_keys=True, separators=(",", ":")).encode())
+
+
+def run_benchmark(
+    config_dir: Path, *, rows: int = 1_000, value_chars: int = 256
+) -> BenchmarkResult:
+    """Measure one under-cap payload so spill recovery can be asserted exactly."""
+    os.environ["LOCAL_OPERATOR_CONFIG_DIR"] = str(config_dir)
+    lines = [f"row {index:04d}: " + (f"value-{index % 10} " * value_chars) for index in range(rows)]
+    text = "\n".join(lines)
+    server_result = {
+        "content": [{"type": "text", "text": text}],
+        "structuredContent": {"rowCount": rows, "columns": ["id", "value"]},
+        "isError": False,
+        "meta": {"cursor": "next-page", "protocolVersion": "2025-06-18"},
+    }
+
+    baseline = format_mcp_result(server_result, "call", "mcp__bench_rows")
+    compact = format_mcp_result(
+        server_result,
+        "call",
+        "mcp__bench_rows",
+        ToolContext(session_id="mcp-benchmark"),
+    )
+    assert compact.details is not None
+    spill = compact.details.get("spill")
+    assert isinstance(spill, dict)
+    handle = str(spill["handle"])
+    recovered = get_store().read_lines(handle, 1, rows)
+    recovered_text = "\n".join(recovered[0]) if recovered is not None else ""
+
+    baseline_tokens = _message_tokens(_tool_message(baseline.text))
+    compact_tokens = _message_tokens(_tool_message(compact.text))
+    baseline_bytes = _metadata_bytes(baseline.details)
+    compact_bytes = _metadata_bytes(compact.details)
+    return BenchmarkResult(
+        baseline_model_tokens=baseline_tokens,
+        compact_model_tokens=compact_tokens,
+        model_token_reduction_percent=round((1 - compact_tokens / baseline_tokens) * 100, 2),
+        baseline_metadata_bytes=baseline_bytes,
+        compact_metadata_bytes=compact_bytes,
+        metadata_reduction_percent=round((1 - compact_bytes / baseline_bytes) * 100, 2),
+        spill_bytes=int(spill["bytes"]),
+        spill_complete=bool(spill["complete"]),
+        recovery_matches=recovered_text == text,
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--rows", type=int, default=1_000)
+    parser.add_argument("--value-chars", type=int, default=256)
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+    with tempfile.TemporaryDirectory(prefix="lop-mcp-bench-") as tmp:
+        result = run_benchmark(Path(tmp), rows=args.rows, value_chars=args.value_chars)
+
+    report = asdict(result)
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print(
+            f"model-visible tokens: {result.baseline_model_tokens:,} -> {result.compact_model_tokens:,}"
+        )
+        print(f"model-token reduction: {result.model_token_reduction_percent:.2f}%")
+        print(
+            f"transcript metadata: {result.baseline_metadata_bytes:,} -> {result.compact_metadata_bytes:,} bytes"
+        )
+        print(f"metadata reduction: {result.metadata_reduction_percent:.2f}%")
+        print(f"spill: {result.spill_bytes:,} bytes, complete={result.spill_complete}")
+        print(f"recovery matches: {result.recovery_matches}")
+
+    passed = (
+        result.model_token_reduction_percent >= MIN_MODEL_TOKEN_REDUCTION * 100
+        and result.metadata_reduction_percent >= MIN_METADATA_BYTE_REDUCTION * 100
+        and result.spill_complete
+        and result.recovery_matches
+    )
+    return 0 if passed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/bench_mcp_spill.py
+++ b/scripts/bench_mcp_spill.py
@@ -111,13 +111,11 @@ def main() -> int:
     if args.json:
         print(json.dumps(report, indent=2, sort_keys=True))
     else:
-        print(
-            f"model-visible tokens: {result.baseline_model_tokens:,} -> {result.compact_model_tokens:,}"
-        )
+        tokens = f"{result.baseline_model_tokens:,} -> {result.compact_model_tokens:,}"
+        print(f"model-visible tokens: {tokens}")
         print(f"model-token reduction: {result.model_token_reduction_percent:.2f}%")
-        print(
-            f"transcript metadata: {result.baseline_metadata_bytes:,} -> {result.compact_metadata_bytes:,} bytes"
-        )
+        metadata = f"{result.baseline_metadata_bytes:,} -> {result.compact_metadata_bytes:,} bytes"
+        print(f"transcript metadata: {metadata}")
         print(f"metadata reduction: {result.metadata_reduction_percent:.2f}%")
         print(f"spill: {result.spill_bytes:,} bytes, complete={result.spill_complete}")
         print(f"recovery matches: {result.recovery_matches}")

--- a/tests/unit/mcp/test_manager.py
+++ b/tests/unit/mcp/test_manager.py
@@ -572,6 +572,33 @@ class TestToolCallHygieneAndRetry:
         await manager.disconnect_all()
 
     @pytest.mark.asyncio
+    async def test_call_finalizes_with_context_off_event_loop(
+        self, project: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        manager = McpManager(str(project))
+
+        async def fake_connect(name: str, cfg: Any) -> ServerConnection:
+            return _make_conn(name, cfg)
+
+        calls: list[tuple[Any, ...]] = []
+
+        async def capture_to_thread(function: Any, *args: Any) -> ToolResult:
+            calls.append((function, *args))
+            return function(*args)
+
+        monkeypatch.setattr(manager, "_connect_server", fake_connect)
+        monkeypatch.setattr(asyncio, "to_thread", capture_to_thread)
+        await manager.discover_and_connect()
+
+        tool = next(t for t in manager.get_tools() if t.name == "mcp__fast_search")
+        context = ToolContext(session_id="mcp-context")
+        result = await tool.execute("c1", {"q": "x"}, None, None, context)
+        assert result.text == "ok"
+        assert len(calls) == 1
+        assert calls[0][-1] is context
+        await manager.disconnect_all()
+
+    @pytest.mark.asyncio
     async def test_non_retriable_error_returns_error_result_without_reconnect(
         self, project: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/unit/mcp/test_tool_bridge.py
+++ b/tests/unit/mcp/test_tool_bridge.py
@@ -16,6 +16,7 @@ from mcp.types import (
 )
 
 from local_operator.harness.intent import INTENT_PROPERTY
+from local_operator.harness.types import ToolContext
 from local_operator.mcp.tool_bridge import (
     INTENT_FIELD,
     build_agent_tool,
@@ -25,6 +26,7 @@ from local_operator.mcp.tool_bridge import (
     normalize_input_schema,
     prepare_outbound_args,
 )
+from local_operator.tools import spill
 
 
 class TestCreateMcpToolName:
@@ -242,6 +244,63 @@ class TestFormatMcpResult:
         details = format_mcp_result(result).details
         assert details is not None
         assert details["server_result"] == result.model_dump()
+
+    def test_small_contextual_result_is_unchanged(self, tmp_path, monkeypatch) -> None:
+        """Adding spill context is a no-op below the established 8 KiB budget."""
+        monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "cfg"))
+        result = {
+            "content": [{"type": "text", "text": "ok"}],
+            "structuredContent": {"rows": [{"id": 1}]},
+            "isError": False,
+            "meta": {"cursor": "next"},
+        }
+        formatted = format_mcp_result(result, context=ToolContext(session_id="small"))
+        assert formatted.text == "ok"
+        assert formatted.details == {"server_result": result}
+
+    def test_spill_removes_only_duplicate_text_and_recovers_it(self, tmp_path, monkeypatch) -> None:
+        """Spilled text has one durable copy while structured/media metadata survives."""
+        monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "cfg"))
+        body = "MCP evidence line\n" * 1_000
+        result = {
+            "content": [
+                {"type": "text", "text": body},
+                {"type": "image", "data": "pixels", "mimeType": "image/png"},
+                {
+                    "type": "resource",
+                    "resource": {"uri": "file:///report", "text": body, "mimeType": "text/plain"},
+                },
+            ],
+            "structuredContent": {"rows": [{"id": 1, "value": "kept"}]},
+            "isError": True,
+            "meta": {"cursor": "next"},
+        }
+        formatted = format_mcp_result(
+            result, "call", "mcp__demo_large", ToolContext(session_id="mcp-spill")
+        )
+        details = formatted.details
+        assert details is not None
+        handle = details["spill"]["handle"]
+        assert formatted.is_error is True
+        assert formatted.text.startswith("Error: MCP evidence line")
+        assert handle in formatted.text
+        assert details["server_result"] == {
+            "content": [
+                {"type": "image", "data": "pixels", "mimeType": "image/png"},
+                {
+                    "type": "resource",
+                    "resource": {"uri": "file:///report", "mimeType": "text/plain"},
+                },
+            ],
+            "structuredContent": {"rows": [{"id": 1, "value": "kept"}]},
+            "isError": True,
+            "meta": {"cursor": "next"},
+        }
+        stored = spill.get_store().read_lines(handle, 1, 2)
+        assert stored is not None
+        lines, total = stored
+        assert lines == ["Error: MCP evidence line", "MCP evidence line"]
+        assert total > 1_000
 
 
 class TestIsRetriableConnectionError:

--- a/tests/unit/scripts/test_bench_compaction_replay.py
+++ b/tests/unit/scripts/test_bench_compaction_replay.py
@@ -1,7 +1,11 @@
 """The replay benchmark must measure the incident, not merely print numbers."""
 
 from local_operator.compaction.cutpoint import find_cut_point
-from scripts.bench_compaction_replay import _legacy_find_cut_point, _run
+from scripts.bench_compaction_replay import (
+    MIN_CUMULATIVE_REPLAY_REDUCTION,
+    _legacy_find_cut_point,
+    _run,
+)
 
 
 def test_mid_turn_fix_reduces_cumulative_replay_without_starving():
@@ -21,5 +25,6 @@ def test_mid_turn_fix_reduces_cumulative_replay_without_starving():
     assert before.compactions == 0
     assert after.starved_boundaries == 0
     assert after.compactions > 0
-    assert after.cumulative_replay_tokens < before.cumulative_replay_tokens
+    reduction = 1 - (after.cumulative_replay_tokens / before.cumulative_replay_tokens)
+    assert reduction >= MIN_CUMULATIVE_REPLAY_REDUCTION
     assert after.peak_context_tokens < before.peak_context_tokens

--- a/tests/unit/scripts/test_bench_compaction_replay.py
+++ b/tests/unit/scripts/test_bench_compaction_replay.py
@@ -1,0 +1,25 @@
+"""The replay benchmark must measure the incident, not merely print numbers."""
+
+from local_operator.compaction.cutpoint import find_cut_point
+from scripts.bench_compaction_replay import _legacy_find_cut_point, _run
+
+
+def test_mid_turn_fix_reduces_cumulative_replay_without_starving():
+    """Both arms share one workload; only cut selection differs."""
+    common = dict(
+        calls=30,
+        output_chars=4_000,
+        threshold_tokens=8_000,
+        keep_recent_tokens=2_000,
+        summary_repetitions=4,
+    )
+
+    before = _run(_legacy_find_cut_point, **common)
+    after = _run(find_cut_point, **common)
+
+    assert before.starved_boundaries > 0
+    assert before.compactions == 0
+    assert after.starved_boundaries == 0
+    assert after.compactions > 0
+    assert after.cumulative_replay_tokens < before.cumulative_replay_tokens
+    assert after.peak_context_tokens < before.peak_context_tokens

--- a/tests/unit/scripts/test_bench_mcp_spill.py
+++ b/tests/unit/scripts/test_bench_mcp_spill.py
@@ -1,0 +1,18 @@
+"""The MCP benchmark must prove prompt, transcript, and recovery savings."""
+
+from scripts.bench_mcp_spill import (
+    MIN_METADATA_BYTE_REDUCTION,
+    MIN_MODEL_TOKEN_REDUCTION,
+    run_benchmark,
+)
+
+
+def test_oversized_mcp_result_reduces_both_copies_and_remains_recoverable(tmp_path):
+    result = run_benchmark(tmp_path / "cfg", rows=100, value_chars=64)
+
+    assert result.model_token_reduction_percent >= MIN_MODEL_TOKEN_REDUCTION * 100
+    assert result.metadata_reduction_percent >= MIN_METADATA_BYTE_REDUCTION * 100
+    assert result.compact_model_tokens < result.baseline_model_tokens
+    assert result.compact_metadata_bytes < result.baseline_metadata_bytes
+    assert result.spill_complete is True
+    assert result.recovery_matches is True

--- a/tests/unit/session/test_transcript.py
+++ b/tests/unit/session/test_transcript.py
@@ -8,7 +8,8 @@ from pathlib import Path
 
 import pytest
 
-from local_operator.harness.types import CustomMessage, Message
+from local_operator.harness.types import CustomMessage, Message, ToolContext
+from local_operator.mcp.tool_bridge import format_mcp_result
 from local_operator.session.transcript import (
     ENTRY_MESSAGE,
     Transcript,
@@ -413,6 +414,41 @@ async def test_message_round_trip_keeps_provider_payload(transcript):
     assert isinstance(restored, Message)
     assert restored.provider_payload == {"details": {"path": "/tmp/x"}, "useless": False}
     assert restored.tool_call_id == "c1"
+
+
+@pytest.mark.asyncio
+async def test_spilled_mcp_metadata_round_trip_omits_duplicate_text(
+    transcript, tmp_path, monkeypatch
+):
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "cfg"))
+    body = "large MCP row\n" * 1_000
+    result = format_mcp_result(
+        {
+            "content": [{"type": "text", "text": body}],
+            "structuredContent": {"rowCount": 1_000},
+            "isError": False,
+        },
+        "c1",
+        "mcp__demo_rows",
+        ToolContext(session_id="transcript-spill"),
+    )
+    message = Message(
+        role="tool",
+        content=result.content,
+        tool_call_id=result.tool_call_id,
+        tool_name=result.tool_name,
+        provider_payload={"details": result.details},
+    )
+    await transcript.append_message(message)
+
+    restored = transcript.build_llm_history()[0]
+    assert isinstance(restored, Message)
+    assert restored.provider_payload is not None
+    details = restored.provider_payload["details"]
+    assert details["server_result"]["content"] == []
+    assert details["server_result"]["structuredContent"] == {"rowCount": 1_000}
+    assert details["spill"]["handle"].startswith("spill://")
+    assert body not in transcript.path.read_text()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary of Changes

Completes the `0.31.1` efficiency release with two complementary context reductions:

- A deterministic replay benchmark for the already-landed mid-turn compaction fix. The canonical 100-call workload drops cumulative estimated replay from 6,384,513 to 1,721,845 tokens, a 73.03% reduction, and now enforces a conservative 50% regression floor.
- Production MCP result compaction. Oversized flattened MCP text uses the established 8 KiB spill contract off the event loop, remains expandable through `read spill://...`, and no longer persists a duplicate textual copy inside transcript metadata.

Ordinary below-limit MCP responses are unchanged. Spilled results retain structured content, image/resource metadata, errors, top-level protocol metadata, and standard spill metadata. Embedded resource text is removed only after a successful spill because the spill already owns the recoverable textual copy. Version remains `0.31.1`.

## Related Issue(s)

- Follow-up evidence for #143

## Impact

- Long tool runs compact successfully instead of replaying an ever-growing unsummarized history.
- Verbose MCP servers can no longer place an uncapped flattened result on the event loop and duplicate the same text in `server_result` transcript metadata.
- MCP result flattening and spill filesystem work run through `asyncio.to_thread`, so large payload processing does not stall streaming, cancellation, or sibling tools.
- The existing spill store remains the single truncation and expansion mechanism. Its per-entry cap is 4 MiB; payloads beyond it correctly report `complete: false`, so exact full recovery is promised only for complete entries.

## Benchmark Evidence

### Cumulative compaction replay

```text
.venv/bin/python scripts/bench_compaction_replay.py --json
before cumulative replay: 6,384,513 tokens
after cumulative replay:  1,721,845 tokens
reduction:                73.03%
before peak context:      126,013 tokens
after peak context:       29,301 tokens
before starved boundaries:77
after compactions:        5
```

The benchmark uses production message shapes and token estimation, validates call/result pairing at every accepted cut, and enforces a documented 50% minimum reduction.

### Oversized MCP results

Canonical structurally measured synthetic result: 1,000 rows with one oversized MCP text block plus structured and protocol metadata.

```text
.venv/bin/python scripts/bench_mcp_spill.py --json
model-visible tokens:     774,000 -> 1,713       (99.78% reduction)
transcript metadata:      2,060,195 -> 279 bytes (99.99% reduction)
spill bytes:              2,058,999
spill complete:           true
recovery matches:         true
```

A real production `read` tool call against the generated handle returned the requested range:

```text
spill://974a5fe120239c40b4f29128ad9f4429 — lines 1-3 of 1000
1| MCP-ROW-0000 payload
2| MCP-ROW-0001 payload
3| MCP-ROW-0002 payload
```

## Testing Details

Focused behavior and transcript coverage:

```text
env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest \
  tests/unit/mcp/test_tool_bridge.py \
  tests/unit/mcp/test_manager.py \
  tests/unit/scripts/test_bench_mcp_spill.py \
  tests/unit/scripts/test_bench_compaction_replay.py \
  tests/unit/session/test_transcript.py -q
117 passed
```

Full static gates from `AGENTS.md`:

```text
.venv/bin/python -m flake8 .                                      clean
uvx --from black==26.1.0 black --check local_operator tests       489 files unchanged
uvx isort --check-only --profile black local_operator tests       clean
.venv/bin/python -m pyright --pythonpath .venv/bin/python .       0 errors, 0 warnings
```

Full-suite attempts exercised 6,712 tests. Two parallel runs reached 6,704 and 6,705 passes respectively but ended on unrelated existing timing-sensitive tests:

- First: `test_history_prepend_preserves_anchor_and_home_dedupes_requests` (1 failure, 6,704 passed, 7 skipped).
- Second: `test_terminal_advance_reprojects_and_stale_phone_tap_is_safe`, `test_jobs_says_wait_for_a_job_that_has_not_been_admitted`, `test_n_denies_one_tool_and_lets_the_turn_continue`, and `test_the_composing_row_sheds_its_label_before_its_facts` (4 failures, 6,701 passed, 7 skipped).
- Every failure passed immediately in isolation: 1, 1, and 2 tests respectively.
- Per the no-looping constraint, no further parallel full-suite retries were made. A final serial full-suite rerun was started to remove xdist timing; the harness detached from its output at 74% and did not retain its terminal summary, so it is not represented as a passing run.

## Checklist

- [x] Version remains `0.31.1`.
- [x] Small MCP results preserve their exact text and server payload.
- [x] Error status/prefix, structured content, media/resources, and protocol metadata are covered.
- [x] Spill recovery is exercised through the real `read` tool path.
- [x] Benchmark regression floors cover both efficiency paths.
- [x] Formatting, lint, type checks, and focused tests pass.
