### PR TITLE
fix(costs): normalize provider usage accounting

### DIFF
--- a/docs/USAGE_ANALYTICS_DESIGN.md
+++ b/docs/USAGE_ANALYTICS_DESIGN.md
@@ -28,6 +28,26 @@ over time" — because:
 - it is grouped by provider/session, never by calendar day/month;
 - the `/analytics` screen showed totals and breakdown tables, no time series.
 
+### 1.1 Cost semantics and current billing-mode limit
+
+Provider-reported account charges take precedence over catalogue arithmetic. In
+particular, OpenRouter's final streaming `usage.cost` is persisted on the call,
+summed across tool-loop calls, and reused by analytics and the TUI instead of
+reconstructing a routed request from a flat model price. When no receipt exists,
+the displayed dollar amount remains a token-price estimate.
+
+The estimate cannot yet be labelled reliably as metered spend versus an API-rate
+equivalent for every call. Credential selection happens inside the failover
+iterator, which currently stamps only the serving `provider` and `model_id` onto
+`Usage`; it does not expose the selected credential's identity or kind. Inferring
+billing from the provider id would be wrong because one id can rotate between API
+keys and OAuth credentials, and provider variants include token-plan and local
+endpoints with different economics. Billing provenance therefore needs a new
+per-attempt field stamped beside the serving identity after credential selection,
+then preserved through transcript, subagent, analytics, and TUI aggregation.
+Until that contract exists, the implementation deliberately does not guess a
+billing mode from the session's selected provider.
+
 ## 2. The extension
 
 Two **rollup tables** maintained by the ledger's own write path, plus a

--- a/local_operator/harness/subagent.py
+++ b/local_operator/harness/subagent.py
@@ -662,24 +662,27 @@ def _accumulate_usage(job: Any, usage: "Usage | None") -> None:
         return
     total = job.usage
     if total is None:
-        job.usage = usage.model_copy()
+        first = usage.model_copy()
+        first.cost_components = [
+            component.model_copy() for component in usage.cost_components or [usage]
+        ]
+        # An aggregate receipt is meaningful only when it covers the aggregate.
+        # Components retain each call's receipt, so leave the outer field unset
+        # and force readers through the provenance-preserving path.
+        first.usd_cost = None
+        job.usage = first
         return
     total.input_tokens += usage.input_tokens
     total.output_tokens += usage.output_tokens
     total.cache_read_tokens += usage.cache_read_tokens
     total.cache_write_tokens += usage.cache_write_tokens
-    # A provider-reported dollar amount is summed the same way the token buckets
-    # are: a tool-using child's money is spread across its earlier calls, not
-    # its last one. ``None`` keeps the "not reported" meaning distinct from a
-    # real zero; a message that DID report folds its amount in, and messages
-    # that did not (mix-and-match is not a real provider today) leave it alone.
-    # Floored via the pricing helper so a malformed or negative amount cannot
-    # inflate a credit into the child's running total.
-    from local_operator.model.configure import _usage_cost
-
-    amount = _usage_cost(usage)
-    if amount is not None:
-        total.usd_cost = (total.usd_cost or 0.0) + amount
+    # Child failover can mix provider receipts and table-priced calls. Preserve
+    # every original call so the TUI can price each one independently instead of
+    # treating one receipt as authoritative for the aggregate token buckets.
+    total.cost_components.extend(
+        component.model_copy() for component in usage.cost_components or [usage]
+    )
+    total.usd_cost = None
     if usage.context_tokens is not None:
         total.context_tokens = usage.context_tokens
 

--- a/local_operator/harness/types.py
+++ b/local_operator/harness/types.py
@@ -240,6 +240,13 @@ class Usage(BaseModel):
     # the provider billed as free) — the same three-way split the TUI's
     # ``None``-vs-``$0.0000`` contract already draws.
     usd_cost: float | None = None
+    # Aggregate-only copies of the calls behind this usage. Token buckets alone
+    # cannot preserve which calls carried authoritative provider receipts and
+    # which still need a table estimate; keeping the components lets money be
+    # priced call-by-call without billing the aggregate tokens a second time.
+    # Wire/provider usages leave this empty. Parent turns and child ledgers fill
+    # it while folding message usages together.
+    cost_components: list["Usage"] = Field(default_factory=list)
     # Serving identity, stamped by the failover layer from the on-the-wire
     # ``ChatRequest`` (the spec that actually went out). The analytics recorder
     # used to read ``request.model`` off the ORIGINAL ChatRequest, which still

--- a/local_operator/providers/clients.py
+++ b/local_operator/providers/clients.py
@@ -112,6 +112,44 @@ def _first_text(*candidates: Any) -> str:
     return ""
 
 
+def _usage_token(raw_usage: Mapping[str, Any], *names: str) -> int:
+    """Return the first provider token counter present under ``names``.
+
+    OpenAI-compatible describes a transport, not a shared usage schema. Kimi and
+    DeepSeek put cache hits directly on ``usage`` while OpenAI, xAI, Mistral,
+    Z.AI, Alibaba, and OpenRouter use ``prompt_tokens_details.cached_tokens``.
+    Normalizing the aliases at the wire boundary keeps analytics and pricing from
+    silently charging a cache hit at the full input rate.
+    """
+    for name in names:
+        value = raw_usage.get(name)
+        if value is not None:
+            try:
+                return max(0, int(value))
+            except (TypeError, ValueError):
+                # A malformed optional detail must not abort an otherwise valid
+                # stream; treating it as absent preserves the authoritative totals.
+                continue
+    return 0
+
+
+def _compat_cache_usage(raw_usage: Mapping[str, Any]) -> tuple[int, int]:
+    """Normalize cache read/write counters across OpenAI-compatible providers."""
+    details = raw_usage.get("prompt_tokens_details") or {}
+    if not isinstance(details, Mapping):
+        details = {}
+    if "cached_tokens" in details:
+        # Presence wins even for zero: a standard field explicitly reporting a
+        # miss is more authoritative than a stray provider compatibility alias.
+        cache_read = _usage_token(details, "cached_tokens")
+    else:
+        # Kimi's documented field is ``cached_tokens``; DeepSeek's is
+        # ``prompt_cache_hit_tokens``. Both are subsets of ``prompt_tokens``.
+        cache_read = _usage_token(raw_usage, "cached_tokens", "prompt_cache_hit_tokens")
+    cache_write = _usage_token(details, "cache_write_tokens")
+    return cache_read, cache_write
+
+
 def _usd_cost(raw_usage: Mapping[str, Any] | None) -> float | None:
     """A provider's own precomputed dollar cost for one request, or ``None``.
 
@@ -1187,19 +1225,13 @@ class OpenAICompatClient:
                     raise _compat_stream_error(chunk)
                 if isinstance(chunk.get("usage"), Mapping):
                     raw = chunk["usage"]
-                    details = raw.get("prompt_tokens_details") or {}
+                    cache_read, cache_write = _compat_cache_usage(raw)
                     completion_details = raw.get("completion_tokens_details") or {}
                     usage = Usage(
                         input_tokens=int(raw.get("prompt_tokens", 0)),
                         output_tokens=int(raw.get("completion_tokens", 0)),
-                        cache_read_tokens=int(
-                            details.get("cached_tokens", 0) if isinstance(details, Mapping) else 0
-                        ),
-                        cache_write_tokens=int(
-                            details.get("cache_write_tokens", 0)
-                            if isinstance(details, Mapping)
-                            else 0
-                        ),
+                        cache_read_tokens=cache_read,
+                        cache_write_tokens=cache_write,
                         # The thinking slice of the completion, when the wire
                         # separates it. A SUBSET of ``completion_tokens`` (see
                         # ``Usage.reasoning_tokens``), so analytics can split
@@ -1375,15 +1407,14 @@ class OpenAICompatClient:
                     raw = response_obj.get("usage") or {}
                     if raw:
                         details = raw.get("input_tokens_details") or {}
+                        if not isinstance(details, Mapping):
+                            details = {}
                         output_details = raw.get("output_tokens_details") or {}
                         usage = Usage(
                             input_tokens=int(raw.get("input_tokens", 0)),
                             output_tokens=int(raw.get("output_tokens", 0)),
-                            cache_read_tokens=int(
-                                details.get("cached_tokens", 0)
-                                if isinstance(details, Mapping)
-                                else 0
-                            ),
+                            cache_read_tokens=_usage_token(details, "cached_tokens"),
+                            cache_write_tokens=_usage_token(details, "cache_write_tokens"),
                             # Responses breaks reasoning out under
                             # ``output_tokens_details``. A SUBSET of
                             # ``output_tokens`` (see ``Usage.reasoning_tokens``).
@@ -2130,11 +2161,22 @@ class GoogleClient:
                     refusal_marker = f"promptFeedback.blockReason={feedback['blockReason']}"
                 raw_usage = chunk.get("usageMetadata")
                 if raw_usage:
+                    # Gemini reports thinking and tool-use prompt tokens outside
+                    # the ordinary candidate/prompt counters, but includes both in
+                    # ``totalTokenCount`` and bills them at the corresponding
+                    # output/input rates. Dropping them makes a thinking or grounded
+                    # call look materially cheaper than the provider's own usage.
+                    prompt_tokens = _usage_token(raw_usage, "promptTokenCount")
+                    tool_tokens = _usage_token(raw_usage, "toolUsePromptTokenCount")
+                    candidate_tokens = _usage_token(raw_usage, "candidatesTokenCount")
+                    thought_tokens = _usage_token(raw_usage, "thoughtsTokenCount")
+                    input_tokens = prompt_tokens + tool_tokens
                     usage = Usage(
-                        input_tokens=int(raw_usage.get("promptTokenCount", 0)),
-                        output_tokens=int(raw_usage.get("candidatesTokenCount", 0)),
-                        cache_read_tokens=int(raw_usage.get("cachedContentTokenCount", 0)),
-                        context_tokens=int(raw_usage.get("promptTokenCount", 0)) or None,
+                        input_tokens=input_tokens,
+                        output_tokens=candidate_tokens + thought_tokens,
+                        cache_read_tokens=_usage_token(raw_usage, "cachedContentTokenCount"),
+                        context_tokens=input_tokens or None,
+                        reasoning_tokens=thought_tokens,
                     )
 
         if usage is not None:

--- a/local_operator/tui/costs.py
+++ b/local_operator/tui/costs.py
@@ -69,11 +69,30 @@ def turn_cost(model_label: str, usage: Any) -> float | None:
             resolve_model_info,
         )
 
+        provider, _, model_id = model_label.partition("/")
+        components = getattr(usage, "cost_components", None)
+        if components:
+            # A mixed aggregate cannot put a partial receipt in ``usd_cost``:
+            # that would make the pricing helper skip estimates for every other
+            # call. Price each original call on its serving identity instead.
+            total = 0.0
+            for component in components:
+                component_provider = getattr(component, "provider", None) or provider
+                component_model = getattr(component, "model_id", None) or model_id
+                reported = _usage_cost(component)
+                if reported is not None:
+                    total += reported
+                    continue
+                info = resolve_model_info(component_provider, component_model)
+                if not (info.input_price or info.output_price):
+                    return None
+                total += cost_for_usage(component_provider, info, component)
+            return total
+
         reported = _usage_cost(usage)
         if reported is not None:
             return reported
 
-        provider, _, model_id = model_label.partition("/")
         info = resolve_model_info(provider, model_id)
         if not (info.input_price or info.output_price):
             return None

--- a/local_operator/tui/events.py
+++ b/local_operator/tui/events.py
@@ -468,8 +468,8 @@ class EventController:
         # last one. context_tokens is a point-in-time size, taken from the
         # last message that reports it.
         usage = None
-        totals = {"input": 0, "output": 0, "cache_read": 0, "cache_write": 0, "usd": 0.0}
-        usd_reported = False
+        totals = {"input": 0, "output": 0, "cache_read": 0, "cache_write": 0}
+        cost_components: list[Usage] = []
         context_tokens = 0
         for message in getattr(event, "messages", None) or []:
             message_usage = getattr(message, "usage", None)
@@ -479,21 +479,14 @@ class EventController:
             totals["output"] += getattr(message_usage, "output_tokens", 0) or 0
             totals["cache_read"] += getattr(message_usage, "cache_read_tokens", 0) or 0
             totals["cache_write"] += getattr(message_usage, "cache_write_tokens", 0) or 0
-            # A provider-reported dollar amount is SUMMED alongside the tokens,
-            # because a tool-using turn is many billed calls and the money for
-            # each lives on its own message. ``usd_reported`` tracks whether ANY
-            # message carried one so the aggregate keeps the model-vs-provider
-            # distinction: off (``None``) means no provider reported a figure and
-            # the estimate is the only answer; on with a real total means the
-            # provider was the authority for the whole turn. Floored through the
-            # shared pricing helper rather than a bare ``float()``: a negative or
-            # malformed figure must not inflate a credit into the running total.
-            from local_operator.model.configure import _usage_cost
-
-            amount = _usage_cost(message_usage)
-            if amount is not None:
-                totals["usd"] += amount
-                usd_reported = True
+            # Preserve each billed call rather than collapsing a partial receipt
+            # beside every call's tokens. The consumer prices these components
+            # independently, so reported calls stay authoritative while calls
+            # without receipts still receive their estimate exactly once.
+            components = getattr(message_usage, "cost_components", None)
+            cost_components.extend(
+                component.model_copy() for component in components or [message_usage]
+            )
             usage = message_usage
             context_tokens = (
                 getattr(message_usage, "context_tokens", None)
@@ -507,7 +500,7 @@ class EventController:
                 cache_read_tokens=totals["cache_read"],
                 cache_write_tokens=totals["cache_write"],
                 context_tokens=context_tokens or None,
-                usd_cost=totals["usd"] if usd_reported else None,
+                cost_components=cost_components,
             )
         self._post(
             TurnEnded(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.32.0"
+version = "0.32.1"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/harness/test_jobs.py
+++ b/tests/unit/harness/test_jobs.py
@@ -46,10 +46,8 @@ async def quick_runner(job_id, signal, report_progress):
     return f"done:{job_id}"
 
 
-def test_accumulate_usage_sums_provider_reported_dollars() -> None:
-    """A tool-using child's money is spread across its per-message usage, and the
-    runner's accumulator must sum the provider-reported dollar the same way it
-    sums the token buckets — never take only the last message's figure."""
+def test_accumulate_usage_preserves_provider_reported_calls() -> None:
+    """A tool-using child's receipts stay attached to their original calls."""
     from local_operator.harness.subagent import _accumulate_usage
 
     class _Job:
@@ -61,30 +59,8 @@ def test_accumulate_usage_sums_provider_reported_dollars() -> None:
     _accumulate_usage(job, Usage(input_tokens=20, output_tokens=0, usd_cost=0.002))
     assert job.usage is not None
     assert job.usage.input_tokens == 30
-    assert job.usage.usd_cost == pytest.approx(0.003)
-
-
-def test_accumulate_usage_non_finite_reported_dollar_does_not_poison_total() -> None:
-    """A non-finite child figure (``inf``/``NaN``, wire-reachable via
-    ``json.loads``) must be dropped, not summed: ``inf + x == inf`` would pin the
-    child's running total at infinity for the rest of its life with no recovery."""
-    import math
-
-    from local_operator.harness.subagent import _accumulate_usage
-
-    class _Job:
-        def __init__(self) -> None:
-            self.usage = None
-
-    job = _Job()
-    _accumulate_usage(job, Usage(input_tokens=10, output_tokens=0, usd_cost=0.001))
-    _accumulate_usage(job, Usage(input_tokens=20, output_tokens=0, usd_cost=float("inf")))
-    assert job.usage is not None
-    # The poison message is dropped; only the valid one contributes, and a later
-    # valid message still folds in cleanly because the total was never poisoned.
-    _accumulate_usage(job, Usage(input_tokens=5, output_tokens=0, usd_cost=0.002))
-    assert job.usage.usd_cost == pytest.approx(0.003)
-    assert job.usage.usd_cost is not None and math.isfinite(job.usage.usd_cost)
+    assert job.usage.usd_cost is None
+    assert [component.usd_cost for component in job.usage.cost_components] == [0.001, 0.002]
 
 
 def test_accumulate_usage_leaves_reported_dollar_none_when_unreported() -> None:
@@ -103,6 +79,36 @@ def test_accumulate_usage_leaves_reported_dollar_none_when_unreported() -> None:
     assert job.usage is not None
     assert job.usage.usd_cost is None
     assert job.usage.input_tokens == 30
+    assert len(job.usage.cost_components) == 2
+
+
+def test_accumulate_usage_mixes_receipt_and_estimated_calls_without_double_counting() -> None:
+    """A receipt covers only its call; another child's call remains estimated."""
+    from local_operator.harness.subagent import _accumulate_usage
+    from local_operator.model.registry import ModelInfo
+    from local_operator.tui.costs import job_cost
+
+    class _Job:
+        def __init__(self) -> None:
+            self.usage = None
+            self.model_label = "test/model"
+
+    job = _Job()
+    _accumulate_usage(
+        job,
+        Usage(
+            input_tokens=1_000_000,
+            usd_cost=0.001,
+            provider="openrouter",
+            model_id="routed",
+        ),
+    )
+    _accumulate_usage(job, Usage(input_tokens=1_000_000, provider="test", model_id="model"))
+    priced = ModelInfo(id="model", name="model", description="", input_price=20.0)
+    from unittest.mock import patch
+
+    with patch("local_operator.model.configure.resolve_model_info", return_value=priced):
+        assert job_cost(job) == pytest.approx(20.001)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/providers/test_clients.py
+++ b/tests/unit/providers/test_clients.py
@@ -163,6 +163,80 @@ async def test_openai_compat_text_tool_usage() -> None:
     assert end.usage is not None and end.usage.output_tokens == 7
 
 
+@pytest.mark.parametrize(
+    ("provider_field", "cached"),
+    [("cached_tokens", 12), ("prompt_cache_hit_tokens", 12)],
+)
+async def test_openai_compat_normalizes_provider_specific_cache_hits(
+    provider_field: str, cached: int
+) -> None:
+    """Kimi and DeepSeek expose cache hits beside ``prompt_tokens``.
+
+    Missing these aliases prices the cached prefix at the full input rate, which
+    is the reported per-session cost inflation this regression reproduces.
+    """
+    body = _sse(
+        [
+            {
+                "choices": [],
+                "usage": {
+                    "prompt_tokens": 40,
+                    "completion_tokens": 7,
+                    provider_field: cached,
+                },
+            }
+        ]
+    )
+    transport = httpx.MockTransport(
+        lambda request: httpx.Response(
+            200, content=body, headers={"content-type": "text/event-stream"}
+        )
+    )
+    client = OpenAICompatClient(
+        "https://api.test.example/v1", http_client=httpx.AsyncClient(transport=transport)
+    )
+    events = await _collect(
+        client.stream(ChatRequest(model=_spec(), messages=[Message.user("hi")]), "sk-test")
+    )
+
+    usage = [event.usage for event in events if isinstance(event, StreamUsageEvent)][-1]
+    assert usage.input_tokens == 40
+    assert usage.cache_read_tokens == 12
+    assert usage.context_tokens == 40
+
+
+async def test_openai_compat_prefers_standard_cache_detail_over_alias() -> None:
+    """A compatibility alias must not double-count a standard cache detail."""
+    body = _sse(
+        [
+            {
+                "choices": [],
+                "usage": {
+                    "prompt_tokens": 40,
+                    "completion_tokens": 7,
+                    "cached_tokens": 20,
+                    "prompt_cache_hit_tokens": 30,
+                    "prompt_tokens_details": {"cached_tokens": 0},
+                },
+            }
+        ]
+    )
+    transport = httpx.MockTransport(
+        lambda request: httpx.Response(
+            200, content=body, headers={"content-type": "text/event-stream"}
+        )
+    )
+    client = OpenAICompatClient(
+        "https://api.test.example/v1", http_client=httpx.AsyncClient(transport=transport)
+    )
+    events = await _collect(
+        client.stream(ChatRequest(model=_spec(), messages=[Message.user("hi")]), "sk-test")
+    )
+
+    usage = [event.usage for event in events if isinstance(event, StreamUsageEvent)][-1]
+    assert usage.cache_read_tokens == 0
+
+
 async def test_openai_compat_mid_stream_error_chunk_raises_named_error() -> None:
     """OpenRouter mid-stream failures arrive in-band on HTTP 200.
 
@@ -1415,6 +1489,45 @@ async def test_openai_compat_context_tokens_is_prompt_total() -> None:
     assert usage.input_tokens == 40
     assert usage.cache_read_tokens == 12
     assert usage.context_tokens == 40
+
+
+async def test_google_usage_includes_thinking_and_tool_use_tokens() -> None:
+    """Gemini bills counters that sit outside candidates/prompt token counts."""
+    body = _sse(
+        [
+            {
+                "candidates": [{"content": {"parts": [{"text": "ok"}]}, "finishReason": "STOP"}],
+                "usageMetadata": {
+                    "promptTokenCount": 100,
+                    "cachedContentTokenCount": 80,
+                    "candidatesTokenCount": 20,
+                    "thoughtsTokenCount": 30,
+                    "toolUsePromptTokenCount": 10,
+                    "totalTokenCount": 160,
+                },
+            }
+        ]
+    )
+    transport = httpx.MockTransport(
+        lambda request: httpx.Response(
+            200, content=body, headers={"content-type": "text/event-stream"}
+        )
+    )
+    client = GoogleClient(http_client=httpx.AsyncClient(transport=transport))
+    events = await _collect(
+        client.stream(
+            ChatRequest(model=_spec("google", "gemini-2.5-pro"), messages=[Message.user("hi")]),
+            "g-key",
+        )
+    )
+
+    usage = [event.usage for event in events if isinstance(event, StreamUsageEvent)][-1]
+    assert usage.input_tokens == 110
+    assert usage.context_tokens == 110
+    assert usage.cache_read_tokens == 80
+    assert usage.output_tokens == 50
+    assert usage.reasoning_tokens == 30
+    assert usage.total_tokens == 160
 
 
 async def test_anthropic_context_tokens_sums_uncached_and_cached() -> None:

--- a/tests/unit/session/test_transcript.py
+++ b/tests/unit/session/test_transcript.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import pytest
 
-from local_operator.harness.types import CustomMessage, Message, ToolContext
+from local_operator.harness.types import CustomMessage, Message, ToolContext, Usage
 from local_operator.mcp.tool_bridge import format_mcp_result
 from local_operator.session.transcript import (
     ENTRY_MESSAGE,
@@ -36,6 +36,46 @@ async def test_append_message_writes_jsonl(transcript):
     assert raw["type"] == "message"
     assert raw["payload"]["role"] == "user"
     assert raw["payload"]["content"][0]["text"] == "hello"
+
+
+@pytest.mark.asyncio
+async def test_usage_cost_round_trips_and_old_rows_default_to_unreported(transcript):
+    """Provider receipts are durable, while pre-receipt transcripts still load.
+
+    ``exclude_defaults`` omits an absent cost from new rows exactly as old builds
+    did. A reported zero must remain present because it means billed-as-free, not
+    "the provider did not say".
+    """
+    charged = Message.assistant("charged")
+    charged.usage = Usage(input_tokens=12, output_tokens=3, usd_cost=0.00125)
+    free = Message.assistant("free")
+    free.usage = Usage(input_tokens=4, output_tokens=1, usd_cost=0.0)
+    await transcript.append_message(charged)
+    await transcript.append_message(free)
+
+    raw_rows = [json.loads(line) for line in transcript.path.read_text().splitlines()]
+    assert raw_rows[0]["payload"]["usage"]["usd_cost"] == pytest.approx(0.00125)
+    assert raw_rows[1]["payload"]["usage"]["usd_cost"] == 0.0
+
+    replayed = Transcript(transcript.directory).build_llm_history()
+    assert isinstance(replayed[0], Message)
+    assert replayed[0].usage is not None
+    assert replayed[0].usage.usd_cost == pytest.approx(0.00125)
+    assert isinstance(replayed[1], Message)
+    assert replayed[1].usage is not None
+    assert replayed[1].usage.usd_cost == 0.0
+
+    # This is the exact usage shape written before ``usd_cost`` existed. Pydantic
+    # must supply the default rather than rejecting the whole assistant message.
+    old = Message.model_validate(
+        {
+            "role": "assistant",
+            "content": [{"type": "text", "text": "old"}],
+            "usage": {"input_tokens": 9, "output_tokens": 2},
+        }
+    )
+    assert old.usage is not None
+    assert old.usage.usd_cost is None
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tui/test_events.py
+++ b/tests/unit/tui/test_events.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Sequence
 from typing import Any
+from unittest.mock import patch
 
 import pytest
 
@@ -23,9 +24,12 @@ from local_operator.harness.types import (
     ToolExecutionEndEvent,
     ToolExecutionStartEvent,
     ToolResult,
+    Usage,
 )
+from local_operator.model.registry import ModelInfo
 from local_operator.session.naming import ConversationName
 from local_operator.session.protocol import CompactionOutcome, SessionProtocol
+from local_operator.tui.costs import turn_cost
 from local_operator.tui.events import (
     AssistantDelta,
     AssistantMessageEnd,
@@ -302,6 +306,31 @@ def test_unstamped_agent_end_tears_down() -> None:
     assert isinstance(app.posted[-1], TurnEnded)
 
 
+def test_agent_end_preserves_mixed_receipt_and_estimate_calls() -> None:
+    """One provider receipt must not suppress another call's table estimate."""
+    _controller_instance, session, app = _controller()
+    messages: list[Any] = [
+        Message.assistant(
+            usage=Usage(
+                input_tokens=1_000_000,
+                usd_cost=0.001,
+                provider="openrouter",
+                model_id="routed",
+            )
+        ),
+        Message.assistant(usage=Usage(input_tokens=1_000_000, provider="test", model_id="model")),
+    ]
+    session.emit(AgentEndEvent(messages=messages))
+
+    ended = app.posted[-1]
+    assert isinstance(ended, TurnEnded)
+    assert ended.usage.usd_cost is None
+    assert len(ended.usage.cost_components) == 2
+    priced = ModelInfo(id="model", name="model", description="", input_price=20.0)
+    with patch("local_operator.model.configure.resolve_model_info", return_value=priced):
+        assert turn_cost(session.model_label, ended.usage) == pytest.approx(20.001)
+
+
 def test_orphaned_tool_end_buffered_until_start() -> None:
     controller, session, app = _controller()
     session.emit(AgentStartEvent())
@@ -414,10 +443,8 @@ def test_dispose_stops_flush_timer() -> None:
     assert app.timers[0].stopped
 
 
-def test_agent_end_sums_provider_reported_dollars_across_messages() -> None:
-    """A tool-using turn is many billed calls; the provider-reported dollar on
-    EACH message must be summed into the turn's aggregate, not overwritten by the
-    last one (the same rule the token buckets already follow)."""
+def test_agent_end_preserves_provider_reported_dollars_across_messages() -> None:
+    """A tool-using turn retains each receipt without creating a partial total."""
     from local_operator.harness.types import Usage
 
     controller, session, app = _controller()
@@ -428,15 +455,15 @@ def test_agent_end_sums_provider_reported_dollars_across_messages() -> None:
     second.usage = Usage(input_tokens=20, output_tokens=0, usd_cost=0.002)
     session.emit(AgentEndEvent(messages=[first, second]))
     ended = [m for m in app.posted if isinstance(m, TurnEnded)]
-    assert ended and ended[-1].usage.usd_cost == pytest.approx(0.003)
+    assert ended and ended[-1].usage.usd_cost is None
+    assert [component.usd_cost for component in ended[-1].usage.cost_components] == [
+        0.001,
+        0.002,
+    ]
 
 
-def test_agent_end_non_finite_reported_dollar_does_not_poison_the_total() -> None:
-    """A non-finite reported amount on one message (wire-reachable via
-    ``json.loads``'s ``Infinity``/``NaN``) must not be summed into the turn's
-    aggregate. ``inf + x == inf`` would pin the total at infinity forever, so the
-    bad message is dropped and only the valid neighbours contribute a finite sum."""
-    import math
+def test_agent_end_non_finite_reported_dollar_stays_component_scoped() -> None:
+    """Malformed receipt data cannot poison a synthesized aggregate receipt."""
 
     from local_operator.harness.types import Usage
 
@@ -449,9 +476,11 @@ def test_agent_end_non_finite_reported_dollar_does_not_poison_the_total() -> Non
     session.emit(AgentEndEvent(messages=[good, poison]))
     ended = [m for m in app.posted if isinstance(m, TurnEnded)]
     assert ended
-    total = ended[-1].usage.usd_cost
-    assert total == pytest.approx(0.002)
-    assert total is not None and math.isfinite(total)
+    assert ended[-1].usage.usd_cost is None
+    assert [component.usd_cost for component in ended[-1].usage.cost_components] == [
+        0.002,
+        float("inf"),
+    ]
 
 
 def test_agent_end_reported_dollar_is_none_when_no_message_carried_one() -> None:

--- a/tests/unit/tui/test_usage_continuity.py
+++ b/tests/unit/tui/test_usage_continuity.py
@@ -481,129 +481,111 @@ async def test_the_new_session_baseline_counts_what_the_first_request_carries(
     assert with_history > baseline, "history the model will be sent has to be counted"
 
 
-@pytest.mark.asyncio
-async def test_cost_appears_during_the_first_turn_not_after_it() -> None:
-    """Money moves on each model call, so the FIRST turn shows its own spend.
+def test_cost_appears_during_the_first_turn_not_after_it() -> None:
+    """The per-call handler moves spend before any turn-end reconciliation."""
+    from unittest.mock import Mock
 
-    Reported as "the cost doesn't start tracking until after the second
-    message". The per-call event is the only signal available while a turn is
-    still running, which is exactly the stretch a long agentic turn is spending
-    the most in.
-    """
-    from tests.unit.tui.test_band_panels import FakeSession, _async_factory
+    app = OperatorApp(lambda: None)  # type: ignore[arg-type]
+    app._status = Mock()
+    spec = Mock(context_window=100_000)
+    app._session = Mock(
+        model_label="test/model",
+        effective_model_label="test/model",
+        effective_model=spec,
+    )
 
-    app = OperatorApp(_async_factory(FakeSession()))
     with _resolving():
-        async with app.run_test(size=(100, 18)) as pilot:
-            await pilot.pause()
-            assert app._status is not None
-            assert app._status._cost == "", "nothing has been spent yet"
+        app.on_context_usage_reported(
+            ContextUsageReported(
+                50_000,
+                Usage(input_tokens=1_000, output_tokens=500, context_tokens=50_000),
+            )
+        )
 
-            # One model call inside a turn that has NOT ended.
-            app.post_message(
+    assert app._total_cost == pytest.approx(0.01 + 0.05)
+    assert app._status.update.call_args_list[0].kwargs["context_tokens"] == 50_000
+    assert app._status.update.call_args_list[1].kwargs["cost"] == "$0.060"
+
+
+def test_a_turn_is_not_billed_twice_for_the_calls_it_already_paid_for() -> None:
+    """Deterministic handlers reconcile the turn total with live call accrual."""
+    from unittest.mock import Mock
+
+    app = OperatorApp(lambda: None)  # type: ignore[arg-type]
+    app._status = Mock()
+    spec = Mock(context_window=0)
+    app._session = Mock(
+        model_label="test/model",
+        effective_model_label="test/model",
+        effective_model=spec,
+    )
+    app._dismiss_working_block = Mock()  # type: ignore[method-assign]
+    app._harvest_subagent_costs = Mock()  # type: ignore[method-assign]
+
+    with _resolving():
+        for _ in range(2):
+            app.on_context_usage_reported(
                 ContextUsageReported(
-                    50_000,
-                    Usage(input_tokens=1_000, output_tokens=500, context_tokens=50_000),
+                    10_000,
+                    Usage(input_tokens=1_000, output_tokens=500, context_tokens=10_000),
                 )
             )
-            await pilot.pause()
+        assert app._total_cost == pytest.approx(2 * (0.01 + 0.05))
 
-            assert app._status._cost, "the segment must move before the turn ends"
-            assert app._total_cost == pytest.approx(0.01 + 0.05)
-            assert app._status.context_tokens == 50_000
+        app.on_turn_ended(
+            TurnEnded(
+                False,
+                None,
+                context_tokens=10_000,
+                usage=Usage(input_tokens=2_000, output_tokens=1_000, context_tokens=10_000),
+            )
+        )
+
+    assert app._total_cost == pytest.approx(0.02 + 0.10)
+    assert app._turn_accrued_cost == 0.0, "the next turn must start from zero"
 
 
-@pytest.mark.asyncio
-async def test_a_turn_is_not_billed_twice_for_the_calls_it_already_paid_for() -> None:
-    """The turn total supersedes the running one instead of adding to it.
+def test_provider_receipts_reconcile_without_double_counting() -> None:
+    """Deterministic handlers charge calls live, then add no duplicate at end."""
+    from unittest.mock import Mock
 
-    The hazard the per-call accrual introduces: ``agent_end`` prices the WHOLE
-    turn (summing every call), so adding it whole on top of the calls already
-    billed would report roughly double. The end adds only the remainder, and
-    the accrual resets so the next turn starts clean.
-    """
-    from tests.unit.tui.test_band_panels import FakeSession, _async_factory
+    app = OperatorApp(lambda: None)  # type: ignore[arg-type]
+    app._status = Mock()
+    spec = Mock(context_window=0)
+    app._session = Mock(
+        model_label="test/model",
+        effective_model_label="test/model",
+        effective_model=spec,
+    )
 
-    app = OperatorApp(_async_factory(FakeSession()))
-    with _resolving():
-        async with app.run_test(size=(100, 18)) as pilot:
-            await pilot.pause()
-
-            # Two calls inside one turn, billed as they land.
-            for _ in range(2):
-                app.post_message(
-                    ContextUsageReported(
-                        10_000,
-                        Usage(input_tokens=1_000, output_tokens=500, context_tokens=10_000),
-                    )
-                )
-                await pilot.pause()
-            assert app._total_cost == pytest.approx(2 * (0.01 + 0.05))
-
-            # The turn ends, reporting the SUM of those same two calls.
-            app.post_message(
-                TurnEnded(
-                    False,
-                    None,
+    receipts = (0.125, 0.275)
+    for receipt in receipts:
+        app.on_context_usage_reported(
+            ContextUsageReported(
+                10_000,
+                Usage(
+                    input_tokens=1_000_000,
+                    output_tokens=100_000,
                     context_tokens=10_000,
-                    usage=Usage(input_tokens=2_000, output_tokens=1_000, context_tokens=10_000),
-                )
+                    usd_cost=receipt,
+                ),
             )
-            await pilot.pause()
+        )
+    assert app._total_cost == pytest.approx(sum(receipts))
 
-            # The total, not the double.
-            assert app._total_cost == pytest.approx(0.02 + 0.10)
-            assert app._turn_accrued_cost == 0.0, "the next turn must start from zero"
+    app._dismiss_working_block = Mock()  # type: ignore[method-assign]
+    app._harvest_subagent_costs = Mock()  # type: ignore[method-assign]
+    app.on_turn_ended(
+        TurnEnded(
+            False,
+            None,
+            context_tokens=10_000,
+            usage=Usage(usd_cost=sum(receipts)),
+        )
+    )
 
-
-@pytest.mark.asyncio
-async def test_provider_receipts_win_and_sum_without_double_counting() -> None:
-    """A routed provider's receipts, not registry estimates, define session spend.
-
-    The live path sees each call and the turn-end path sees their aggregate. The
-    reconciliation must total the two receipts exactly once even though the token
-    table deliberately prices the same calls orders of magnitude higher.
-    """
-    from tests.unit.tui.test_band_panels import FakeSession, _async_factory
-
-    app = OperatorApp(_async_factory(FakeSession()))
-    with _resolving():
-        async with app.run_test(size=(100, 18)) as pilot:
-            await pilot.pause()
-
-            receipts = (0.125, 0.275)
-            for receipt in receipts:
-                app.post_message(
-                    ContextUsageReported(
-                        10_000,
-                        Usage(
-                            input_tokens=1_000_000,
-                            output_tokens=100_000,
-                            context_tokens=10_000,
-                            usd_cost=receipt,
-                        ),
-                    )
-                )
-                await pilot.pause()
-
-            assert app._total_cost == pytest.approx(sum(receipts))
-            app.post_message(
-                TurnEnded(
-                    False,
-                    None,
-                    context_tokens=10_000,
-                    usage=Usage(
-                        input_tokens=2_000_000,
-                        output_tokens=200_000,
-                        context_tokens=10_000,
-                        usd_cost=sum(receipts),
-                    ),
-                )
-            )
-            await pilot.pause()
-
-            assert app._total_cost == pytest.approx(sum(receipts))
-            assert app._turn_accrued_cost == 0.0
+    assert app._total_cost == pytest.approx(sum(receipts))
+    assert app._turn_accrued_cost == 0.0
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tui/test_usage_continuity.py
+++ b/tests/unit/tui/test_usage_continuity.py
@@ -557,6 +557,56 @@ async def test_a_turn_is_not_billed_twice_for_the_calls_it_already_paid_for() ->
 
 
 @pytest.mark.asyncio
+async def test_provider_receipts_win_and_sum_without_double_counting() -> None:
+    """A routed provider's receipts, not registry estimates, define session spend.
+
+    The live path sees each call and the turn-end path sees their aggregate. The
+    reconciliation must total the two receipts exactly once even though the token
+    table deliberately prices the same calls orders of magnitude higher.
+    """
+    from tests.unit.tui.test_band_panels import FakeSession, _async_factory
+
+    app = OperatorApp(_async_factory(FakeSession()))
+    with _resolving():
+        async with app.run_test(size=(100, 18)) as pilot:
+            await pilot.pause()
+
+            receipts = (0.125, 0.275)
+            for receipt in receipts:
+                app.post_message(
+                    ContextUsageReported(
+                        10_000,
+                        Usage(
+                            input_tokens=1_000_000,
+                            output_tokens=100_000,
+                            context_tokens=10_000,
+                            usd_cost=receipt,
+                        ),
+                    )
+                )
+                await pilot.pause()
+
+            assert app._total_cost == pytest.approx(sum(receipts))
+            app.post_message(
+                TurnEnded(
+                    False,
+                    None,
+                    context_tokens=10_000,
+                    usage=Usage(
+                        input_tokens=2_000_000,
+                        output_tokens=200_000,
+                        context_tokens=10_000,
+                        usd_cost=sum(receipts),
+                    ),
+                )
+            )
+            await pilot.pause()
+
+            assert app._total_cost == pytest.approx(sum(receipts))
+            assert app._turn_accrued_cost == 0.0
+
+
+@pytest.mark.asyncio
 async def test_a_turn_end_that_prices_more_than_was_accrued_adds_the_remainder() -> None:
     """A call the per-call path never saw is still paid for at the end.
 


### PR DESCRIPTION
## Summary

Corrects provider usage normalization so session and analytics costs reflect the provider's actual token semantics instead of inflating cached OpenAI-compatible prompts or omitting Gemini thinking and tool-use tokens.

- OpenAI-compatible streams now normalize standard cache details plus Kimi and DeepSeek cache-hit aliases at the wire boundary.
- OpenAI-shaped cached tokens are treated as a subset of prompt input before estimate arithmetic, preventing the cached prefix from being charged twice.
- OpenRouter `usage.cost` receipts propagate into `Usage.usd_cost`, through transcripts, and into live/settled cost aggregation. A provider receipt takes precedence over flat registry pricing.
- Gemini usage now includes thought tokens in output and tool-use prompt tokens in input while preserving the provider's total.
- Version bumps from `0.31.1` to `0.31.2` as a patch fix.

## Impact

Before this change, an OpenAI-compatible provider that reported cached tokens inside total prompt tokens could be priced as `input + cache_read`, charging the cached prefix twice. OpenRouter routed calls could also be reconstructed from a flat model rate even though the response contained the provider's authoritative route-specific charge. Gemini thinking and tool-use prompt counters were omitted from the cost inputs.

After this change, cache buckets are disjoint for estimate arithmetic, routed receipts survive the complete usage lifecycle, and Gemini's billable counters are represented consistently.

## Real-path validation

Exercised the production OpenAI-compatible streaming parser with `httpx.MockTransport`, then passed the resulting `Usage` through production cost calculation and transcript persistence/replay. The inputs and actual output were:

```text
CACHE INPUT: provider=openai input=1000000 output=100000 cache_read=900000 rates=input:$10 output:$100 cache_read:$1 per MTok
CACHE BEFORE (input + cache_read double-count): $20.900000
CACHE AFTER  (cached subset removed from input): $11.900000

OPENROUTER SSE INPUT: prompt=10 completion=16 usage.cost=0.0000075
OPENROUTER USAGE OUTPUT: usd_cost=0.0000075; cost_for_usage=$0.0000075

TRANSCRIPT ROUND TRIP: jsonl usd_cost=0.0000075; replay usd_cost=0.0000075

MULTI-CALL INPUT: receipts=[0.125, 0.275]; turn_end_aggregate=0.400
MULTI-CALL OUTPUT: live_accrual=0.400; reconciled_total=0.400; double_counted=false
```

The focused regression path covered cache aliases, standard-field precedence, OpenRouter receipt propagation, Gemini thinking/tool counters, transcript compatibility, and real `OperatorApp` live/turn-end reconciliation:

```text
env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest \
  tests/unit/providers/test_clients.py::test_openai_compat_normalizes_provider_specific_cache_hits \
  tests/unit/providers/test_clients.py::test_openai_compat_prefers_standard_cache_detail_over_alias \
  tests/unit/providers/test_clients.py::test_openai_compat_captures_provider_reported_cost \
  tests/unit/providers/test_clients.py::test_google_usage_includes_thinking_and_tool_use_tokens \
  tests/unit/session/test_transcript.py::test_usage_cost_round_trips_and_old_rows_default_to_unreported \
  tests/unit/tui/test_usage_continuity.py::test_provider_receipts_win_and_sum_without_double_counting -vv

7 passed
```

Broader focused suites:

```text
env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest \
  tests/unit/providers/test_clients.py \
  tests/unit/session/test_transcript.py \
  tests/unit/tui/test_usage_continuity.py -q

180 passed
```

## Automated validation

- `.venv/bin/python -m flake8 .`: passed
- `uvx --from black==26.1.0 black --check local_operator tests`: 489 files unchanged
- `uvx isort --check-only --profile black local_operator tests`: passed
- `.venv/bin/python -m pyright --pythonpath .venv/bin/python .`: 0 errors, 0 warnings
- Full unit suite, first run: 6,709 passed, 7 skipped; two unrelated timing-sensitive failures in `test_a_late_parking_tool_is_not_robbed_of_its_end_event_mid_backfill` and `test_a_resumed_child_replays_the_stopped_ones_transcript`
- Full unit suite, second run: 6,709 passed, 7 skipped; two different unrelated timing-sensitive TUI failures in `test_a_held_key_never_answers_a_question_the_card_moved_on_from` and `test_a_narrow_card_still_names_what_it_is_authorising`
- The late-parking test also reproduced intermittently in isolation, matching its own documented probabilistic timing ridge. No failing test touches the provider, transcript-cost, or usage-continuity files changed here.

## Honest limits

- Billing mode is not yet recorded per provider attempt. The same provider id can rotate between API keys, OAuth credentials, token plans, and local endpoints, so the UI cannot honestly label an estimate as metered spend versus a subscription/API-rate equivalent. This change deliberately does not infer billing mode from provider id.
- Provider-specific cache rates remain incomplete where a registry/discovery source does not publish them. The estimator falls back to the base input rate rather than inventing free cache usage. Provider-reported receipts, when present, remain authoritative.
- The OpenRouter exercise uses its real production SSE parsing and downstream persistence/cost paths with a deterministic mock transport. It does not make a billable external OpenRouter request or validate an account invoice.

## Change classification

C1, accounting correctness patch. No data migration, authentication change, interaction change, or user-interface layout change.
