### PR TITLE
fix(costs): persist nested subagent spend

### DIFF
--- a/local_operator/harness/jobs.py
+++ b/local_operator/harness/jobs.py
@@ -27,7 +27,7 @@ import time
 import uuid
 from typing import Any, Awaitable, Callable, Literal
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 from local_operator.harness.types import AbortSignal, Usage
 
@@ -164,6 +164,14 @@ class AsyncJob(BaseModel):
     # run. ``context_tokens`` is point-in-time (the LAST reported value) and
     # is therefore replaced rather than summed.
     usage: Usage | None = None
+    # Runtime-only link to the CHILD session's own ledger. A direct task row
+    # records only that child's model calls; delegated grandchildren belong to
+    # the child's manager instead. Keeping the ownership edge on the row lets a
+    # top-level observer walk the full tree without copying descendant usage
+    # into every ancestor (which would make nested spend count once per depth).
+    # Excluded from persistence because restored rows have no live child session;
+    # the parent's last-observed cost map preserves their already-harvested spend.
+    child_jobs: Any | None = Field(default=None, exclude=True)
     # The CHILD model's context window, so a reader can render usage as a
     # PERCENTAGE of what the child actually has. Captured at launch beside
     # ``model_label``, off the spec the child was already built with — never

--- a/local_operator/harness/jobs.py
+++ b/local_operator/harness/jobs.py
@@ -75,6 +75,46 @@ JOB_RESULT_MESSAGE_TYPE = "job_result"
 ProgressFn = Callable[[str], None]
 
 
+def _usage_components(usage: Usage | None, model_label: str | None) -> list[Usage]:
+    """Detach priceable calls from one direct usage aggregate."""
+    if usage is None:
+        return []
+    provider, _, model_id = (model_label or "").partition("/")
+    source = usage.cost_components or [usage]
+    components: list[Usage] = []
+    for item in source:
+        component = item.model_copy(deep=True)
+        component.cost_components = []
+        component.provider = component.provider or provider or None
+        component.model_id = component.model_id or model_id or None
+        components.append(component)
+    return components
+
+
+def _merge_accounting_component(
+    grouped: dict[tuple[str | None, str | None, bool], Usage], component: Usage
+) -> None:
+    """Bound a subtree summary without erasing receipt-vs-estimate provenance."""
+    has_receipt = component.usd_cost is not None
+    key = (component.provider, component.model_id, has_receipt)
+    total = grouped.get(key)
+    if total is None:
+        total = component.model_copy(deep=True)
+        total.cost_components = []
+        grouped[key] = total
+        return
+    total.input_tokens += component.input_tokens
+    total.output_tokens += component.output_tokens
+    total.cache_read_tokens += component.cache_read_tokens
+    total.cache_write_tokens += component.cache_write_tokens
+    total.reasoning_tokens += component.reasoning_tokens
+    if component.context_tokens is not None:
+        total.context_tokens = component.context_tokens
+    if has_receipt:
+        # The key prevents a receipt-backed call from absorbing estimated calls.
+        total.usd_cost = (total.usd_cost or 0.0) + (component.usd_cost or 0.0)
+
+
 class AsyncJob(BaseModel):
     """One registered background job. ``agent_id`` names the subagent the job
     RUNS (when applicable); ``owner_id`` names who registered it."""
@@ -164,13 +204,18 @@ class AsyncJob(BaseModel):
     # run. ``context_tokens`` is point-in-time (the LAST reported value) and
     # is therefore replaced rather than summed.
     usage: Usage | None = None
-    # Runtime-only link to the CHILD session's own ledger. A direct task row
-    # records only that child's model calls; delegated grandchildren belong to
-    # the child's manager instead. Keeping the ownership edge on the row lets a
-    # top-level observer walk the full tree without copying descendant usage
-    # into every ancestor (which would make nested spend count once per depth).
-    # Excluded from persistence because restored rows have no live child session;
-    # the parent's last-observed cost map preserves their already-harvested spend.
+    # Settled descendants, collapsed by serving identity and accounting mode.
+    # ``usage`` remains SELF-only so row surfaces never mistake subtree tokens
+    # for this child's context. Components are copied here at the ownership
+    # boundary because the child manager is disposable and its local job ids are
+    # not globally unique. Grouping receipt-backed calls separately from table-
+    # priced calls preserves exact provider bills without letting one receipt
+    # suppress estimates for its siblings.
+    descendant_usage: list[Usage] = Field(default_factory=list)
+    # A live edge exists only while the child can still mutate its own ledger.
+    # It is runtime-only and deliberately cleared after the final settlement
+    # snapshot, otherwise one retained observability row pins the disposed child
+    # Session through its manager's bound completion callback.
     child_jobs: Any | None = Field(default=None, exclude=True)
     # The CHILD model's context window, so a reader can render usage as a
     # PERCENTAGE of what the child actually has. Captured at launch beside
@@ -240,6 +285,10 @@ class AsyncJobManager:
         # single call site guards it.
         self._on_roster_change = on_roster_change
         self._jobs: dict[str, AsyncJob] = {}
+        # Terminal rows hand their subtree into this bounded accumulator before
+        # retention can remove them. The owning parent runner later copies this
+        # snapshot onto its AsyncJob; polling never participates in durability.
+        self._settled_accounting: dict[tuple[str | None, str | None, bool], Usage] = {}
         self._signals: dict[str, AbortSignal] = {}
         self._tasks: dict[str, asyncio.Task[None]] = {}
         self._sinks: dict[str, DeliverySink] = {}
@@ -279,6 +328,39 @@ class AsyncJobManager:
             1 for job in self._jobs.values() if job.status == "running" and not job.queued
         )
         return running >= self._max_running
+
+    def accounting_components(self) -> list[Usage]:
+        """A detached, provenance-preserving snapshot of this whole ledger.
+
+        Job ids are manager-local, so accounting never flattens rows by id.
+        Components instead collapse by the facts that control pricing: serving
+        provider/model and whether an authoritative receipt exists. This keeps
+        the summary proportional to distinct billing routes rather than child
+        fan-out or model-call count, while retaining every token and dollar.
+        """
+        return self._accounting_components(set())
+
+    def _accounting_components(self, seen: set[int]) -> list[Usage]:
+        identity = id(self)
+        if identity in seen:
+            return []
+        seen.add(identity)
+        grouped = {
+            key: component.model_copy(deep=True)
+            for key, component in self._settled_accounting.items()
+        }
+        for job in self._jobs.values():
+            # Terminal rows are already in ``_settled_accounting``. Counting
+            # retained rows again would make totals depend on retention length.
+            if job.type != "task" or job.status != "running":
+                continue
+            components = [*_usage_components(job.usage, job.model_label), *job.descendant_usage]
+            child_manager = job.child_jobs
+            if isinstance(child_manager, AsyncJobManager):
+                components.extend(child_manager._accounting_components(seen))
+            for component in components:
+                _merge_accounting_component(grouped, component)
+        return [component.model_copy(deep=True) for component in grouped.values()]
 
     def _notify_roster_change(self) -> None:
         """Signal the owner that the task roster moved (add / settle / status).
@@ -344,6 +426,8 @@ class AsyncJobManager:
                 row.status = "interrupted"
             row.restored = True
             self._jobs[row.id] = row
+            if row.status != "running":
+                self._record_settled_accounting(row)
 
     # -- registration -------------------------------------------------------
 
@@ -753,9 +837,21 @@ class AsyncJobManager:
         """
         if job.settled_at is None:
             job.settled_at = time.time()
+            # Same transition as the settle stamp: after this line retention may
+            # erase the row immediately without erasing its financial history.
+            self._record_settled_accounting(job)
         event = self._settled_events.get(job.id)
         if event is not None:
             event.set()
+
+    def _record_settled_accounting(self, job: AsyncJob) -> None:
+        """Transfer one terminal subtree exactly once into manager ownership."""
+        components = [*_usage_components(job.usage, job.model_label), *job.descendant_usage]
+        child_manager = job.child_jobs
+        if isinstance(child_manager, AsyncJobManager):
+            components.extend(child_manager.accounting_components())
+        for component in components:
+            _merge_accounting_component(self._settled_accounting, component)
 
     def _sweep_due(self) -> None:
         """Drop settled jobs older than the retention window.

--- a/local_operator/harness/subagent.py
+++ b/local_operator/harness/subagent.py
@@ -369,9 +369,10 @@ def _make_runner(
                     )
                     or child.model.context_window
                 )
-                # The direct row owns this child's calls; its manager owns any
-                # grandchildren. Retain the edge rather than flattening usage
-                # upward, so one recursive reader sees each job exactly once.
+                # Live reads may expose descendants before this child settles.
+                # The edge is only a lease: the finalizer atomically replaces it
+                # with detached components before disposal can evict rows or pin
+                # the child Session through its manager callback.
                 job.child_jobs = child.jobs
             if comms is not None:
                 # Before the prompt runs: the parent may already have a
@@ -474,6 +475,14 @@ def _make_runner(
                 # that no longer exists.
                 comms.detach(job_id)
             if child is not None:
+                if job is not None:
+                    # Settlement is the ownership handoff. Snapshot BEFORE
+                    # dispose, whose cancellation/sweep path may immediately
+                    # evict retention_ms=0 descendants; clear the edge in the
+                    # same event-loop turn so the retained parent row cannot
+                    # retain the disposed child graph.
+                    job.descendant_usage = child.jobs.accounting_components()
+                    job.child_jobs = None
                 await _dispose_child(child)
 
     return runner

--- a/local_operator/harness/subagent.py
+++ b/local_operator/harness/subagent.py
@@ -369,6 +369,10 @@ def _make_runner(
                     )
                     or child.model.context_window
                 )
+                # The direct row owns this child's calls; its manager owns any
+                # grandchildren. Retain the edge rather than flattening usage
+                # upward, so one recursive reader sees each job exactly once.
+                job.child_jobs = child.jobs
             if comms is not None:
                 # Before the prompt runs: the parent may already have a
                 # question queued for this child, and attach is what flushes

--- a/local_operator/harness/subagent.py
+++ b/local_operator/harness/subagent.py
@@ -475,15 +475,18 @@ def _make_runner(
                 # that no longer exists.
                 comms.detach(job_id)
             if child is not None:
-                if job is not None:
-                    # Settlement is the ownership handoff. Snapshot BEFORE
-                    # dispose, whose cancellation/sweep path may immediately
-                    # evict retention_ms=0 descendants; clear the edge in the
-                    # same event-loop turn so the retained parent row cannot
-                    # retain the disposed child graph.
-                    job.descendant_usage = child.jobs.accounting_components()
-                    job.child_jobs = None
-                await _dispose_child(child)
+                try:
+                    # Disposal owns cancellation settlement for every running
+                    # descendant. Await it before detaching the ledger so a
+                    # cancellation cleanup's final provider delta reaches the
+                    # manager accumulator even when retention evicts its row.
+                    await _dispose_child(child)
+                finally:
+                    if job is not None:
+                        # Clear the live edge even if teardown itself fails: a
+                        # retained parent row must never pin the child Session.
+                        job.descendant_usage = child.jobs.accounting_components()
+                        job.child_jobs = None
 
     return runner
 
@@ -581,19 +584,28 @@ def _answered_prefix(messages: list[Any]) -> list[Any]:
 
 
 async def _dispose_child(child: "Session") -> None:
-    """Dispose the child even when the runner itself is being cancelled.
+    """Finish child teardown even while the runner itself is being cancelled.
 
-    Shielded: on the cancellation path the outer await raises immediately,
-    but the dispose task shielded inside keeps running and completes on the
-    loop — the child's transcript flush and task-group close must not be
-    skipped because its parent job was cancelled.
+    Shielding alone is insufficient here: it lets teardown continue but returns
+    control before descendant cancellation has settled, which makes the caller's
+    accounting handoff stale. Keep joining the one dispose task after each outer
+    cancellation so teardown remains single-shot and the ledger is final when
+    this function returns.
     """
-    try:
-        await asyncio.shield(child.dispose())
-    except asyncio.CancelledError:
-        pass  # the shielded dispose task continues without us
-    except Exception:
-        logger.warning("subagent child session dispose failed", exc_info=True)
+    dispose_task = asyncio.create_task(child.dispose())
+    while not dispose_task.done():
+        try:
+            await asyncio.shield(dispose_task)
+        except asyncio.CancelledError:
+            continue
+        except Exception:
+            logger.warning("subagent child session dispose failed", exc_info=True)
+            return
+    if not dispose_task.cancelled():
+        try:
+            dispose_task.result()
+        except Exception:
+            logger.warning("subagent child session dispose failed", exc_info=True)
 
 
 async def _publish_terminal_outcome(

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -774,6 +774,10 @@ _ROSTER_ROW_FIELDS = frozenset(
         "model_label",
         "context_window",
         "usage",
+        # Bounded by distinct provider/model/accounting-mode tuples, not child
+        # count. This is the durable half of nested accounting after a child
+        # manager is disposed and therefore must survive process resume.
+        "descendant_usage",
         "restored",
         # Small bounded strings, stamped at registration: a restored row must
         # still say what kind of child it was ("task"/"scout") and at what
@@ -5154,9 +5158,10 @@ class Session:
         The manager fires this on the hot path of a registration or settle, so
         it must not block or await: it spawns the snapshot write on the session
         task group and returns at once. A child session (one with a ``job_id``)
-        does not persist a roster of its own — it is itself a leaf whose
-        transcript the PARENT already tracks — so the hook is a no-op there,
-        keeping a grandchild's churn off the child's transcript.
+        does not persist a roster of its own: its parent runner snapshots that
+        ledger into the owning row at settlement. Keeping intermediate churn
+        off the child transcript avoids quadratic snapshots while the final
+        subtree survives durably.
         """
         if self._disposed or self._job_id is not None:
             return

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -12836,19 +12836,14 @@ class OperatorApp(App[None]):
         return turn_cost(_effective_label(self._session), usage)
 
     def _harvest_subagent_costs(self) -> None:
-        """Record what each child has spent, keyed by job id.
+        """Record each root task's whole subtree, keyed in the root namespace.
 
-        REPLACES each entry rather than adding to a running total, because a
-        child's figure grows while it works: the same job is observed many times
-        and only its latest value is its spend.
-
-        Called from the 1 Hz poll rather than only at turn end. A delegated child
-        outlives the turn that launched it — the parent finishes, the band goes
-        idle, and the child keeps spending for minutes — so a turn-end-only
-        harvest would leave the total frozen through exactly the period when it
-        is moving. This is also why the entries are never dropped: settled jobs
-        leave the ledger after ``AsyncJobManager``'s retention window, and a
-        total that falls when a finished child is evicted is worse than none.
+        REPLACES each entry because a running subtree grows. Descendants are
+        read live only for display freshness; their owning root row receives a
+        detached summary before settlement, so polling is never the durability
+        mechanism. Keeping one accumulator entry per root also respects the
+        actual uniqueness boundary: independent child managers may reuse the
+        same local job id without overwriting one another.
         """
         session = self._session
         manager = getattr(session, "jobs", None)
@@ -12859,23 +12854,56 @@ class OperatorApp(App[None]):
         except Exception:  # noqa: BLE001 — a status number never takes the app down
             return
         label = getattr(session, "model_label", "")
-        pending = list(jobs)
-        seen: set[int] = set()
-        while pending:
-            job = pending.pop()
-            identity = id(job)
-            if identity in seen:
-                continue
-            seen.add(identity)
-            cost = job_cost(job, default_model_label=label)
-            if cost is not None:
-                self._subagent_costs[job.id] = cost
+        for job in jobs:
+            direct = job_cost(job, default_model_label=label)
+            descendant = 0.0
+            components = list(getattr(job, "descendant_usage", ()) or ())
             child_manager = getattr(job, "child_jobs", None)
             if child_manager is not None:
                 try:
-                    pending.extend(child_manager.list())
+                    # The live lease is replaced by the same bounded snapshot at
+                    # settlement, so this branch changes freshness, not totals.
+                    accounting = getattr(child_manager, "accounting_components", None)
+                    if callable(accounting):
+                        snapshot = accounting()
+                        if isinstance(snapshot, (list, tuple)):
+                            components = list(snapshot)
+                    else:
+                        # Reduced/embedder hosts expose only ``list()``. Sum
+                        # within this root instead of assigning manager-local ids
+                        # into the app-wide accumulator, preserving collision
+                        # safety even on that compatibility path.
+                        descendant += self._live_manager_cost(child_manager, label, set())
                 except Exception:  # noqa: BLE001 — one unreadable branch must not hide its siblings
-                    continue
+                    pass
+            unpriceable = False
+            for component in components:
+                provider = getattr(component, "provider", None) or ""
+                model_id = getattr(component, "model_id", None) or ""
+                cost = turn_cost(f"{provider}/{model_id}" if provider else model_id, component)
+                if cost is None:
+                    unpriceable = True
+                    break
+                descendant += cost
+            if unpriceable:
+                continue
+            if direct is not None or components or descendant:
+                self._subagent_costs[job.id] = (direct or 0.0) + descendant
+
+    def _live_manager_cost(self, manager: Any, default_label: str, seen: set[int]) -> float:
+        """Compatibility total for a live manager lacking durable snapshots."""
+        identity = id(manager)
+        if identity in seen:
+            return 0.0
+        seen.add(identity)
+        total = 0.0
+        for row in manager.list():
+            cost = job_cost(row, default_model_label=default_label)
+            total += cost or 0.0
+            nested = getattr(row, "child_jobs", None)
+            if nested is not None:
+                total += self._live_manager_cost(nested, default_label, seen)
+        return total
 
     def _spend_text(self, total: float | None = None) -> str:
         """The session's spend as the band should SPELL it, mark included.

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -12859,10 +12859,23 @@ class OperatorApp(App[None]):
         except Exception:  # noqa: BLE001 — a status number never takes the app down
             return
         label = getattr(session, "model_label", "")
-        for job in jobs:
+        pending = list(jobs)
+        seen: set[int] = set()
+        while pending:
+            job = pending.pop()
+            identity = id(job)
+            if identity in seen:
+                continue
+            seen.add(identity)
             cost = job_cost(job, default_model_label=label)
             if cost is not None:
                 self._subagent_costs[job.id] = cost
+            child_manager = getattr(job, "child_jobs", None)
+            if child_manager is not None:
+                try:
+                    pending.extend(child_manager.list())
+                except Exception:  # noqa: BLE001 — one unreadable branch must not hide its siblings
+                    continue
 
     def _spend_text(self, total: float | None = None) -> str:
         """The session's spend as the band should SPELL it, mark included.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.33.0"
+version = "0.33.1"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/harness/test_jobs.py
+++ b/tests/unit/harness/test_jobs.py
@@ -13,6 +13,7 @@ from local_operator.harness.jobs import (
     OUTPUT_TAIL_CHARS,
     AsyncJob,
     AsyncJobManager,
+    JobStatus,
 )
 from local_operator.harness.types import Usage
 
@@ -80,6 +81,99 @@ def test_accumulate_usage_leaves_reported_dollar_none_when_unreported() -> None:
     assert job.usage.usd_cost is None
     assert job.usage.input_tokens == 30
     assert len(job.usage.cost_components) == 2
+
+
+def _task_row(
+    job_id: str,
+    *,
+    usage: Usage | None = None,
+    model_label: str = "test/model",
+    descendant_usage: list[Usage] | None = None,
+    status: JobStatus = "completed",
+) -> AsyncJob:
+    return AsyncJob(
+        id=job_id,
+        type="task",
+        status=status,
+        start_time=1.0,
+        label=job_id,
+        model_label=model_label,
+        usage=usage,
+        descendant_usage=descendant_usage or [],
+    )
+
+
+def test_accounting_summary_is_bounded_for_hundred_child_fanout() -> None:
+    manager = AsyncJobManager()
+    manager.restore(
+        [
+            _task_row(
+                f"child-{index}",
+                usage=Usage(input_tokens=1, provider="test", model_id="model"),
+            )
+            for index in range(100)
+        ]
+    )
+    summary = manager.accounting_components()
+    assert len(summary) == 1
+    assert summary[0].input_tokens == 100
+
+
+def test_accounting_summary_covers_every_production_nesting_level() -> None:
+    leaf_manager = AsyncJobManager()
+    leaf_manager.restore([_task_row("grandchild", usage=Usage(input_tokens=3))])
+    child_manager = AsyncJobManager()
+    child = _task_row("child", usage=Usage(input_tokens=2), status="running")
+    child.child_jobs = leaf_manager
+    child_manager._jobs[child.id] = child
+    root = _task_row("root", usage=Usage(input_tokens=1), status="running")
+    root.child_jobs = child_manager
+    manager = AsyncJobManager()
+    manager._jobs[root.id] = root
+
+    summary = manager.accounting_components()
+    assert sum(item.input_tokens for item in summary) == 6
+
+
+def test_accounting_summary_keeps_duplicate_ids_from_independent_managers() -> None:
+    left = AsyncJobManager()
+    right = AsyncJobManager()
+    left.restore([_task_row("same-id", usage=Usage(input_tokens=2))])
+    right.restore([_task_row("same-id", usage=Usage(input_tokens=3))])
+    root = AsyncJobManager()
+    root.restore(
+        [
+            _task_row(
+                "root",
+                descendant_usage=[*left.accounting_components(), *right.accounting_components()],
+            )
+        ]
+    )
+    assert sum(item.input_tokens for item in root.accounting_components()) == 5
+
+
+def test_accounting_summary_preserves_mixed_receipts_and_estimates() -> None:
+    manager = AsyncJobManager()
+    manager.restore(
+        [
+            _task_row(
+                "mixed",
+                descendant_usage=[
+                    Usage(
+                        input_tokens=9,
+                        usd_cost=0.25,
+                        provider="openrouter",
+                        model_id="routed",
+                    ),
+                    Usage(input_tokens=2, provider="test", model_id="model"),
+                ],
+            )
+        ]
+    )
+    summary = manager.accounting_components()
+    assert len(summary) == 2
+    assert sorted(item.usd_cost for item in summary if item.usd_cost is not None) == [0.25]
+    assert sum(item.input_tokens for item in summary) == 11
 
 
 def test_accumulate_usage_mixes_receipt_and_estimated_calls_without_double_counting() -> None:
@@ -403,6 +497,63 @@ async def test_unregister_sink():
     await wait_for(lambda: require_job(manager, job_id).status == "completed")
     assert inbox == []  # dead-lettered again
     await manager.dispose()
+
+
+@pytest.mark.asyncio
+async def test_retention_zero_preserves_accounting_before_any_harvest():
+    manager = AsyncJobManager(retention_ms=0)
+
+    async def priced(job_id, signal, report_progress):
+        job = require_job(manager, job_id)
+        job.model_label = "test/model"
+        job.usage = Usage(input_tokens=7, provider="test", model_id="model")
+        return "done"
+
+    job_id = manager.register("task", "priced", priced)
+    await manager.settled_event(job_id).wait()
+    assert manager.list() == []
+    summary = manager.accounting_components()
+    assert len(summary) == 1
+    assert summary[0].input_tokens == 7
+
+
+@pytest.mark.asyncio
+async def test_resumed_run_adds_to_restored_accounting_once():
+    manager = AsyncJobManager()
+    manager.restore([_task_row("prior", usage=Usage(input_tokens=4))])
+
+    async def resumed(job_id, signal, report_progress):
+        job = require_job(manager, job_id)
+        job.model_label = "test/model"
+        job.usage = Usage(input_tokens=6, provider="test", model_id="model")
+        return "continued"
+
+    job_id = manager.register("task", "resumed", resumed)
+    await manager.settled_event(job_id).wait()
+    assert sum(item.input_tokens for item in manager.accounting_components()) == 10
+    # Retention and repeated snapshots read the manager accumulator; neither
+    # re-folds the still-retained terminal row.
+    assert sum(item.input_tokens for item in manager.accounting_components()) == 10
+
+
+@pytest.mark.asyncio
+async def test_cancel_hands_prior_usage_to_accounting_once():
+    manager = AsyncJobManager(retention_ms=0)
+    started = asyncio.Event()
+
+    async def spending(job_id, signal, report_progress):
+        job = require_job(manager, job_id)
+        job.model_label = "test/model"
+        job.usage = Usage(input_tokens=4, provider="test", model_id="model")
+        started.set()
+        await signal.wait()
+
+    job_id = manager.register("task", "spending", spending)
+    await started.wait()
+    assert await manager.cancel(job_id)
+    assert sum(item.input_tokens for item in manager.accounting_components()) == 4
+    assert not await manager.cancel(job_id)
+    assert sum(item.input_tokens for item in manager.accounting_components()) == 4
 
 
 @pytest.mark.asyncio

--- a/tests/unit/session/test_launch_subagent.py
+++ b/tests/unit/session/test_launch_subagent.py
@@ -10,7 +10,9 @@ the full lifecycle.
 from __future__ import annotations
 
 import asyncio
+import gc
 import json
+import weakref
 
 import pytest
 
@@ -106,9 +108,8 @@ async def test_launch_subagent_runs_child_and_emits_lifecycle(tmp_path, monkeypa
     assert job.type == "task"
     assert job.label == "sub"
 
-    # The parent row links to the child's separately owned ledger while the
-    # child is live, so recursive accounting can see grandchildren without
-    # flattening their usage into every ancestor.
+    # The parent row links to the child's separately owned ledger only while
+    # live; settlement replaces the edge with detached accounting.
     await wait_for(lambda: job.child_jobs is not None)
     assert job.child_jobs is not parent.jobs
 
@@ -124,6 +125,8 @@ async def test_launch_subagent_runs_child_and_emits_lifecycle(tmp_path, monkeypa
     assert ends[0].job_id == job_id
     assert ends[0].status == "completed"
     assert "child did the work" in (ends[0].result_text or "")
+    await wait_for(lambda: job.status == "completed")
+    assert job.child_jobs is None
 
     # The child actually ran its own provider turn through the shared stream.
     assert stream.requests
@@ -603,6 +606,33 @@ async def test_a_team_parent_stamps_the_member_brief_on_the_child(tmp_path, monk
     assert "Review before merge." in child_prompt
     assert "user-dashboard" in child_prompt
     assert "implement the button" in child_prompt
+    await parent.dispose()
+
+
+@pytest.mark.asyncio
+async def test_settled_row_does_not_retain_disposed_child_session(tmp_path, monkeypatch):
+    """The accounting snapshot must not keep an observability-to-owner edge."""
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    parent = make_session(tmp_path, OneShotStream())
+    captured: list[weakref.ReferenceType[Session]] = []
+
+    def remember_child(event):
+        if isinstance(event, SubagentStartEvent):
+            record = parent.subagent_comms._records[event.job_id]
+            assert record.child is not None
+            captured.append(weakref.ref(record.child))
+
+    parent.subscribe(remember_child)
+    job_id = parent._launch_subagent(label="collectible", prompt="finish")
+    await wait_for(
+        lambda: (row := parent.jobs.get(job_id)) is not None and row.status == "completed"
+    )
+    await wait_for(lambda: bool(captured))
+    for _ in range(3):
+        gc.collect()
+        await asyncio.sleep(0)
+    assert captured[0]() is None
+    assert parent.jobs.get(job_id) is not None
     await parent.dispose()
 
 

--- a/tests/unit/session/test_launch_subagent.py
+++ b/tests/unit/session/test_launch_subagent.py
@@ -106,6 +106,12 @@ async def test_launch_subagent_runs_child_and_emits_lifecycle(tmp_path, monkeypa
     assert job.type == "task"
     assert job.label == "sub"
 
+    # The parent row links to the child's separately owned ledger while the
+    # child is live, so recursive accounting can see grandchildren without
+    # flattening their usage into every ancestor.
+    await wait_for(lambda: job.child_jobs is not None)
+    assert job.child_jobs is not parent.jobs
+
     # Wait for the child run to settle and the parent stream to see the end.
     await wait_for(lambda: any(e.type == "subagent_end" for e in events))
 

--- a/tests/unit/session/test_launch_subagent.py
+++ b/tests/unit/session/test_launch_subagent.py
@@ -17,6 +17,7 @@ import weakref
 import pytest
 
 from local_operator.harness.comms import SubagentComms
+from local_operator.harness.jobs import AsyncJobManager
 from local_operator.harness.types import (
     AbortSignal,
     AgentEvent,
@@ -29,6 +30,7 @@ from local_operator.harness.types import (
     StreamToolCallDelta,
     SubagentEndEvent,
     SubagentStartEvent,
+    Usage,
 )
 from local_operator.mobile.projection import ProjectionFold, SessionProjection
 from local_operator.session.session import Session
@@ -127,6 +129,7 @@ async def test_launch_subagent_runs_child_and_emits_lifecycle(tmp_path, monkeypa
     assert "child did the work" in (ends[0].result_text or "")
     await wait_for(lambda: job.status == "completed")
     assert job.child_jobs is None
+    assert job.descendant_usage == []
 
     # The child actually ran its own provider turn through the shared stream.
     assert stream.requests
@@ -683,6 +686,80 @@ async def test_launch_subagent_cancels_on_parent_dispose(tmp_path, monkeypatch):
     await parent.dispose()
     assert (job := parent.jobs.get(job_id)) is not None
     assert job.status == "cancelled"
+
+
+@pytest.mark.asyncio
+async def test_cancel_hands_off_final_descendant_usage_after_disposal(tmp_path, monkeypatch):
+    """Cancellation joins descendant settlement before detaching its ledger.
+
+    This is the production ordering from the review probe: the running row first
+    exposes four tokens, cancellation cleanup finalizes six, and zero retention
+    removes the row immediately. The parent must keep six without retaining the
+    disposed child Session.
+    """
+    from local_operator.harness import subagent as subagent_mod
+
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    descendant_started = asyncio.Event()
+    child_refs: list[weakref.ReferenceType[Session]] = []
+    child_managers: list[AsyncJobManager] = []
+    orig_build = subagent_mod._build_child_session
+
+    async def build_with_running_descendant(**kwargs):
+        child = await orig_build(**kwargs)
+        child.jobs = AsyncJobManager(retention_ms=0)
+        child_refs.append(weakref.ref(child))
+        child_managers.append(child.jobs)
+
+        async def descendant(job_id, signal, report_progress):
+            row = child.jobs.get(job_id)
+            assert row is not None
+            row.usage = Usage(input_tokens=4)
+            descendant_started.set()
+            try:
+                await asyncio.Future()
+            except asyncio.CancelledError:
+                # Models a provider call that reports its final receipt while
+                # unwinding cancellation, after the pre-dispose live snapshot.
+                row.usage = Usage(input_tokens=6)
+                raise
+
+        child.jobs.register("task", "nested", descendant)
+        return child
+
+    class _HangStream:
+        def __call__(self, request, signal):
+            async def gen():
+                await asyncio.Future()
+                yield StreamEndEvent(stop_reason="stop")
+
+            return gen()
+
+    monkeypatch.setattr(subagent_mod, "_build_child_session", build_with_running_descendant)
+    parent = make_session(tmp_path, _HangStream())
+    job_id = parent._launch_subagent(label="slow", prompt="never finish")
+    await asyncio.wait_for(descendant_started.wait(), timeout=5.0)
+    row = parent.jobs.get(job_id)
+    assert row is not None
+    live_child_jobs = row.child_jobs
+    assert isinstance(live_child_jobs, AsyncJobManager)
+    assert sum(item.input_tokens for item in live_child_jobs.accounting_components()) == 4
+
+    assert await parent.jobs.cancel(job_id) is True
+    assert row.status == "cancelled"
+    assert row.child_jobs is None
+    assert sum(item.input_tokens for item in row.descendant_usage) == 6
+    assert child_managers[0].list() == []
+    assert sum(item.input_tokens for item in parent.jobs.accounting_components()) == 6
+
+    # The probe kept the manager only to inspect zero-retention settlement; drop
+    # that artificial reference before proving the production parent edge is gone.
+    child_managers.clear()
+    for _ in range(3):
+        gc.collect()
+        await asyncio.sleep(0)
+    assert child_refs[0]() is None
+    await parent.dispose()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/session/test_resume_subagents_todos.py
+++ b/tests/unit/session/test_resume_subagents_todos.py
@@ -150,6 +150,44 @@ async def test_a_completed_subagent_is_restored_and_resumable(tmp_path, monkeypa
 
 
 @pytest.mark.asyncio
+async def test_descendant_accounting_survives_process_resume(tmp_path, monkeypatch):
+    """Nested spend lives on the owning row, not an in-process child manager."""
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    from local_operator.harness.types import Usage
+
+    parent = _session(tmp_path, OneShotStream())
+    await parent.async_init()
+    job_id = parent._launch_subagent(label="nested", prompt="do nested work")
+    await wait_for(lambda: _status(parent, job_id) == "completed")
+    row = parent.jobs.get(job_id)
+    assert row is not None
+    row.descendant_usage = [
+        Usage(
+            input_tokens=5,
+            usd_cost=0.125,
+            provider="openrouter",
+            model_id="routed",
+        ),
+        Usage(input_tokens=7, provider="test", model_id="m"),
+    ]
+    await parent._persist_subagent_roster()
+    await parent.dispose()
+
+    resumed = _session(tmp_path, IdleStream())
+    await resumed.async_init()
+    restored = resumed.jobs.get(job_id)
+    assert restored is not None
+    assert [
+        (item.provider, item.model_id, item.usd_cost) for item in restored.descendant_usage
+    ] == [
+        ("openrouter", "routed", 0.125),
+        ("test", "m", None),
+    ]
+    assert sum(item.input_tokens for item in resumed.jobs.accounting_components()) >= 12
+    await resumed.dispose()
+
+
+@pytest.mark.asyncio
 async def test_role_and_effort_survive_a_resume(tmp_path, monkeypatch):
     """The child's agent ROLE and effort TIER are on the roster allowlist, so a
     restored row still names them.

--- a/tests/unit/tui/test_cost_aggregation.py
+++ b/tests/unit/tui/test_cost_aggregation.py
@@ -63,6 +63,7 @@ class _TaskJob:
         self.trajectory: list[dict[str, Any]] | None = None
         self.usage = usage
         self.model_label = model_label
+        self.child_jobs: Any | None = None
 
 
 class _Session(FakeSession):
@@ -85,6 +86,14 @@ def _band_cost(app: OperatorApp) -> str:
     """What the status line is currently holding in its cost segment."""
     assert app._status is not None
     return app._status._cost
+
+
+def _harvest(session: _Session) -> OperatorApp:
+    """Exercise the production tree walk without mounting an unrelated frame."""
+    app = OperatorApp(_async_factory(session))
+    app._session = session
+    app._harvest_subagent_costs()
+    return app
 
 
 @pytest.mark.asyncio
@@ -112,6 +121,96 @@ async def test_band_total_is_own_spend_plus_children() -> None:
     assert app._subagent_costs == {"kid": pytest.approx(1.0)}
     assert app._spend_total() == pytest.approx(11.0)
     assert _band_cost(app) == "$11.00"
+
+
+def test_harvest_counts_a_hundred_direct_children_once_each() -> None:
+    session = _Session("anthropic/haiku")
+    session.jobs = _fake_jobs(
+        *(
+            _TaskJob(
+                f"kid-{index}",
+                usage=Usage(input_tokens=1_000_000),
+                model_label="anthropic/haiku",
+            )
+            for index in range(100)
+        )
+    )
+    with _resolving():
+        app = _harvest(session)
+        app._harvest_subagent_costs()
+    assert len(app._subagent_costs) == 100
+    assert app._spend_total() == pytest.approx(100.0)
+
+
+def test_harvest_walks_every_nesting_depth_without_counting_ancestors_twice() -> None:
+    leaf = _TaskJob(
+        "great-grandchild",
+        usage=Usage(input_tokens=4_000_000),
+        model_label="anthropic/haiku",
+    )
+    grandchild = _TaskJob(
+        "grandchild",
+        usage=Usage(input_tokens=3_000_000),
+        model_label="anthropic/haiku",
+    )
+    child = _TaskJob("child", usage=Usage(input_tokens=2_000_000), model_label="anthropic/haiku")
+    grandchild.child_jobs = _fake_jobs(leaf)
+    child.child_jobs = _fake_jobs(grandchild)
+    session = _Session("anthropic/opus")
+    session.jobs = _fake_jobs(child)
+    with _resolving():
+        app = _harvest(session)
+        for _ in range(10):
+            app._harvest_subagent_costs()
+    assert app._subagent_costs == {
+        "child": pytest.approx(2.0),
+        "grandchild": pytest.approx(3.0),
+        "great-grandchild": pytest.approx(4.0),
+    }
+    assert app._spend_total() == pytest.approx(9.0)
+
+
+def test_nested_harvest_preserves_provider_receipts_and_table_estimates() -> None:
+    receipt = _TaskJob(
+        "receipt",
+        usage=Usage(input_tokens=9_000_000, usd_cost=0.25),
+        model_label="openrouter/routed",
+    )
+    estimate = _TaskJob(
+        "estimate",
+        usage=Usage(input_tokens=2_000_000),
+        model_label="anthropic/haiku",
+    )
+    parent = _TaskJob("parent", usage=Usage(input_tokens=1_000_000), model_label="anthropic/haiku")
+    parent.child_jobs = _fake_jobs(receipt, estimate)
+    session = _Session("anthropic/opus")
+    session.jobs = _fake_jobs(parent)
+    with _resolving():
+        app = _harvest(session)
+    assert app._subagent_costs == {
+        "parent": pytest.approx(1.0),
+        "receipt": pytest.approx(0.25),
+        "estimate": pytest.approx(2.0),
+    }
+    assert app._spend_total() == pytest.approx(3.25)
+
+
+def test_nested_cost_survives_branch_eviction_after_it_was_harvested() -> None:
+    grandchild = _TaskJob(
+        "grandchild",
+        usage=Usage(input_tokens=2_000_000),
+        model_label="anthropic/haiku",
+        status="completed",
+    )
+    child = _TaskJob("child", usage=Usage(input_tokens=1_000_000), model_label="anthropic/haiku")
+    child.child_jobs = _fake_jobs(grandchild)
+    session = _Session("anthropic/opus")
+    session.jobs = _fake_jobs(child)
+    with _resolving():
+        app = _harvest(session)
+        child.child_jobs = _fake_jobs()
+        app._harvest_subagent_costs()
+    assert app._spend_total() == pytest.approx(3.0)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tui/test_cost_aggregation.py
+++ b/tests/unit/tui/test_cost_aggregation.py
@@ -63,6 +63,7 @@ class _TaskJob:
         self.trajectory: list[dict[str, Any]] | None = None
         self.usage = usage
         self.model_label = model_label
+        self.descendant_usage: list[Usage] = []
         self.child_jobs: Any | None = None
 
 
@@ -162,11 +163,8 @@ def test_harvest_walks_every_nesting_depth_without_counting_ancestors_twice() ->
         app = _harvest(session)
         for _ in range(10):
             app._harvest_subagent_costs()
-    assert app._subagent_costs == {
-        "child": pytest.approx(2.0),
-        "grandchild": pytest.approx(3.0),
-        "great-grandchild": pytest.approx(4.0),
-    }
+    # One collision-proof accumulator key at the root; the value is its subtree.
+    assert app._subagent_costs == {"child": pytest.approx(9.0)}
     assert app._spend_total() == pytest.approx(9.0)
 
 
@@ -187,11 +185,7 @@ def test_nested_harvest_preserves_provider_receipts_and_table_estimates() -> Non
     session.jobs = _fake_jobs(parent)
     with _resolving():
         app = _harvest(session)
-    assert app._subagent_costs == {
-        "parent": pytest.approx(1.0),
-        "receipt": pytest.approx(0.25),
-        "estimate": pytest.approx(2.0),
-    }
+    assert app._subagent_costs == {"parent": pytest.approx(3.25)}
     assert app._spend_total() == pytest.approx(3.25)
 
 
@@ -208,6 +202,10 @@ def test_nested_cost_survives_branch_eviction_after_it_was_harvested() -> None:
     session.jobs = _fake_jobs(child)
     with _resolving():
         app = _harvest(session)
+        # A real settlement copies this before clearing its live edge.
+        child.descendant_usage = [
+            Usage(input_tokens=2_000_000, provider="anthropic", model_id="haiku")
+        ]
         child.child_jobs = _fake_jobs()
         app._harvest_subagent_costs()
     assert app._spend_total() == pytest.approx(3.0)


### PR DESCRIPTION
## Summary

Makes nested subagent accounting durable so the root session total remains the identity of its own provider calls plus every direct and nested subagent call, independent of polling, retention, or process resume.

- Each task row now owns a bounded, detached descendant usage summary grouped by provider, model, and receipt provenance.
- Child settlement snapshots nested accounting before disposal clears the live manager edge, so zero-retention descendants cannot disappear before the root TUI polls.
- Job managers transfer terminal task usage into a settled accumulator exactly once; repeated reads and retention sweeps do not re-fold or erase spend.
- Persisted subagent roster rows carry descendant usage through process resume.
- The root status band replaces one accumulator entry per direct child with that child's full subtree, avoiding manager-local job-id collisions and depth-based double counting.
- Version bumps from `0.32.1` to `0.32.2` as a patch fix.

## Impact

Before this change, nested subagent spend depended on the root TUI observing live child-manager edges. If a nested row was evicted before polling, a child session settled and disposed, or the parent process resumed from disk, part of the subtree could disappear from the root total. Repeated tree walks also had to reason about manager-local ids and ancestor duplication.

After this change, settlement transfers each subtree into durable accounting ownership before disposal. The root total is stable before the first poll, after retention, across resume, and across repeated polls while preserving provider receipts separately from table-priced estimates.

## Before reproduction

The pre-fix root harvester walked runtime-only `child_jobs` edges while persisted rows retained only direct `usage`. This made nested cost durability depend on observation timing:

```text
nested job settles
retention_ms=0 evicts nested row
child session disposes and clears its runtime graph
root polls or process resumes
nested usage is no longer available to the root total
```

The regression tests pin the missing cases directly: zero-retention accounting before any harvest, settlement ownership, nested subtree transfer, roster persistence, process resume, repeated polling, duplicate ids across independent managers, and mixed provider receipts plus estimates.

## Real-path validation

Exercised production `AsyncJobManager`, `AsyncJob` serialization/validation, and `OperatorApp._harvest_subagent_costs` objects with deterministic rates. The probe creates a nested call under `retention_ms=0`, waits until its row has already been evicted before any root poll, settles the direct and root rows through detached production summaries, polls five times, serializes the persisted row, restores it into a new manager, and polls five more times.

```text
root identity: parent(5) + root direct(2) + direct child(3) + nested(4) = 14
retention before poll: nested rows=0, retained tokens=4
repeated polling totals: [14.0, 14.0, 14.0, 14.0, 14.0]
resume tokens: 9
resume repeated polling totals: [14.0, 14.0, 14.0, 14.0, 14.0]
```

Command:

```text
env -u NO_COLOR TERM=xterm-256color PYTHONPATH="$PWD" \
  .venv/bin/python /tmp/lop_nested_accounting_probe.py
```

Focused regression suites:

```text
env -u NO_COLOR TERM=xterm-256color PYTHONPATH="$PWD" \
  .venv/bin/python -m pytest \
  tests/unit/harness/test_jobs.py \
  tests/unit/session/test_launch_subagent.py \
  tests/unit/session/test_resume_subagents_todos.py \
  tests/unit/tui/test_cost_aggregation.py -q

88 passed, 22 warnings in 10.50s
```

## Automated validation

All commands ran from this worktree with `PYTHONPATH="$PWD"` so subprocess tests imported the branch under test rather than the editable installation's checkout.

- `env -u NO_COLOR TERM=xterm-256color PYTHONPATH="$PWD" .venv/bin/python -m pytest tests/unit -q`: **6,724 passed, 7 skipped, 429 warnings in 109.91s**
- `PYTHONPATH="$PWD" .venv/bin/python -m flake8 .`: passed
- `PYTHONPATH="$PWD" uvx --from black==26.1.0 black --check local_operator tests`: **491 files unchanged**
- `PYTHONPATH="$PWD" uvx isort --check-only --profile black local_operator tests`: passed
- `PYTHONPATH="$PWD" .venv/bin/python -m pyright --pythonpath .venv/bin/python .`: **0 errors, 0 warnings**

## Change classification

C1, accounting durability patch. No data migration, authentication change, new interaction, or visual layout change.
