### PR TITLE
feat(resume): restore the attached team, agent and goal on resume

### DIFF
--- a/local_operator/resume.py
+++ b/local_operator/resume.py
@@ -507,9 +507,20 @@ def write_session_attachment(session_dir: Path, *, team: str, agent: str, goal: 
     journalling an attachment is bookkeeping ABOUT a session, never activity IN
     it. Attaching a team must not reorder the ``/resume`` picker.
     """
+    # ``strip()`` ONLY — never ``" ".join(x.split())``. These are LOOKUP KEYS,
+    # not display titles, and every resolver they are matched against strips
+    # without collapsing (``resolve_profile``, ``resolve_profile_or_specialist``,
+    # ``TeamRegistry.get_team_by_name``, which casefolds and strips). Collapsing
+    # internal whitespace here broke the round trip for any agent profile whose
+    # registered name contains repeated spaces — free-form and not normalised by
+    # ``AgentRegistry.create_agent`` — so a profile named ``"Deep  Auditor"``
+    # attached live, was written as ``"Deep Auditor"``, then failed to resolve on
+    # resume and told the user it had been renamed or deleted (R2). Normalising
+    # is right for a title (the sidecar this shape was copied from) and wrong
+    # for a key: what is stored has to be what the resolver will compare.
     payload = {
-        "team": " ".join((team or "").split()),
-        "agent": " ".join((agent or "").split()),
+        "team": (team or "").strip(),
+        "agent": (agent or "").strip(),
         "goal": (goal or "").strip(),
     }
     try:

--- a/local_operator/resume.py
+++ b/local_operator/resume.py
@@ -84,6 +84,27 @@ TITLE_SCAN_SENTINEL_NAME = "title-scan.json"
 #: exactly "this pass read this opener and it was not a subagent's".
 ORIGIN_SCAN_SENTINEL_NAME = "origin-scan.json"
 
+#: The session's ATTACHED IDENTITY — the ``/team`` roster, the ``/agent``
+#: profile, and the ``/goal`` — journalled beside the transcript, mirroring
+#: :data:`TITLE_SIDECAR_NAME` exactly.
+#:
+#: Why this file has to exist at all: the team and agent briefs ride the
+#: VOLATILE TAIL of the system prompt (see ``prompts_api.build_system_blocks``
+#: and ``session/goal.py``), and the tail is rebuilt from a ``GoalState`` that
+#: ``session_factory`` constructs EMPTY on every session. Nothing in the
+#: transcript reproduces it, so a ``--resume`` genuinely dropped the persona
+#: from the prompt — the manager a user attached with ``/team`` was not merely
+#: missing from the status band, it was gone from the model's instructions and
+#: the conversation carried on as an ordinary session. Only the FRONT END could
+#: see the blank band, which is why this read as a display bug for so long.
+#:
+#: A SIDECAR rather than a transcript row, for the reasons the title sidecar
+#: documents and one more that is specific to this state: the attachment is a
+#: property OF the session, not an event IN the conversation, and the restore
+#: runs during construction, before any replay, so a value it had to scan the
+#: JSONL for would arrive too late to reach the first prompt's tail.
+ATTACHMENT_SIDECAR_NAME = "attachment.json"
+
 #: The two openings only the subagent runner can produce, used ONLY by the
 #: one-time backfill for directories that predate the marker.
 #:
@@ -395,6 +416,109 @@ def write_session_title(
         # The temp carries the writer's PID so two sessions writing at once do
         # not ``replace`` a document the other is still filling — the same
         # torn-write hazard ``search_index._save`` documents.
+        tmp = sidecar.with_suffix(f".{os.getpid()}.tmp")
+        tmp.write_text(json.dumps(payload), encoding="utf-8")
+        tmp.replace(sidecar)
+        if previous is not None:
+            os.utime(session_dir, (previous, previous))
+    except (OSError, TypeError, ValueError):
+        return
+
+
+class SessionAttachment(NamedTuple):
+    """What ``/team``, ``/agent`` and ``/goal`` had put on a session.
+
+    NAMES, never brief BODIES, and that is the load-bearing decision rather
+    than a size optimisation. A stored brief is a SNAPSHOT of a team's
+    collaboration/project text or a profile's instructions at attach time; the
+    operator edits those files between sessions (that is the whole point of a
+    durable registry), so replaying a stored copy would resume the session onto
+    instructions that no longer exist anywhere. Re-resolving the name through
+    the live registry on restore means a resumed session runs the CURRENT
+    definition, which is what the user means by "resume my lopdev manager".
+
+    The tradeoff is accepted deliberately: a renamed or deleted team cannot be
+    restored, where a stored brief could have been. That case is handled by
+    saying so plainly (see the TUI's restore notice) rather than by silently
+    reviving a definition the operator removed.
+    """
+
+    #: ``/team`` roster name; "" when no team was attached.
+    team: str
+    #: ``/agent`` profile DISPLAY name; "" when no profile was attached.
+    agent: str
+    #: The standing ``/goal`` text; "" when unset. Stored here rather than left
+    #: to the transcript because it shares the volatile tail's fate exactly.
+    goal: str
+
+
+def read_session_attachment(session_dir: Path) -> SessionAttachment | None:
+    """Parse ``attachment.json``, or ``None`` when absent or unusable.
+
+    Tolerant on exactly the same terms as :func:`_read_title_sidecar`, and the
+    ``errors="replace"`` is load-bearing for the same reason: a process killed
+    mid-write can cut the file inside a multi-byte character, and a strict
+    decode raises ``UnicodeDecodeError`` — a ``ValueError``, which would sail
+    past an ``except OSError`` and take down not a picker row this time but the
+    whole RESUME. A session must always reopen; losing an attachment is a
+    notice, losing the conversation is not survivable.
+    """
+    try:
+        raw = (session_dir / ATTACHMENT_SIDECAR_NAME).read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return None
+    try:
+        payload = json.loads(raw)
+    except ValueError:
+        return None
+    if not isinstance(payload, dict):
+        return None
+
+    def _text(key: str) -> str:
+        value = payload.get(key)
+        return value.strip() if isinstance(value, str) else ""
+
+    return SessionAttachment(team=_text("team"), agent=_text("agent"), goal=_text("goal"))
+
+
+def write_session_attachment(session_dir: Path, *, team: str, agent: str, goal: str) -> None:
+    """Journal the session's attached identity so a resume can rebuild it.
+
+    Called on CHANGE (attach, detach, goal set/clear), never per turn: the
+    attachment moves a handful of times in a session's life, and a per-turn
+    write would be pure I/O for a value that did not move.
+
+    Best-effort by contract, exactly like :func:`write_session_title` and
+    :func:`mark_session_origin`. An attachment that cannot be journalled
+    (read-only volume, full disk) must never fail the turn that changed it: the
+    cost is one resume that opens unattached, which is the behaviour every
+    session had before this file existed.
+
+    The write is ATOMIC (pid-named temp + ``replace``) because two processes
+    can hold the same session directory — a live owner and a ``/resume`` that
+    is about to be refused both touch it — and a reader hitting a half-written
+    document would parse as "no attachment" and silently drop the persona. The
+    PID in the temp name keeps two concurrent writers from ``replace``-ing a
+    document the other is still filling, the same hazard ``write_session_title``
+    and ``search_index._save`` document.
+
+    **The directory's mtime is preserved**, for the reason the other two
+    sidecars preserve it: recency ranks by the transcript's mtime, and
+    journalling an attachment is bookkeeping ABOUT a session, never activity IN
+    it. Attaching a team must not reorder the ``/resume`` picker.
+    """
+    payload = {
+        "team": " ".join((team or "").split()),
+        "agent": " ".join((agent or "").split()),
+        "goal": (goal or "").strip(),
+    }
+    try:
+        try:
+            previous = session_dir.stat().st_mtime
+        except OSError:
+            previous = None
+        session_dir.mkdir(parents=True, exist_ok=True)
+        sidecar = session_dir / ATTACHMENT_SIDECAR_NAME
         tmp = sidecar.with_suffix(f".{os.getpid()}.tmp")
         tmp.write_text(json.dumps(payload), encoding="utf-8")
         tmp.replace(sidecar)

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -138,6 +138,12 @@ if TYPE_CHECKING:
     # It only holds the manager the composition root hands it.
     from local_operator.mcp.manager import McpManager
 
+    # Type-only for the same reason ``resume`` is imported lazily at its two
+    # call sites below: ``cli.py``'s startup path is guarded by a test that
+    # fails if resolving ``--resume`` drags the engine in, and that guard runs
+    # in the other direction too.
+    from local_operator.resume import SessionAttachment
+
 logger = logging.getLogger(__name__)
 
 #: Transcript custom-entry type recording which model is ACTUALLY serving
@@ -1157,6 +1163,23 @@ class Session:
         #: collaboration and project briefs without the manager restating them.
         #: ``None`` on an ordinary session.
         self.active_team: Any | None = None
+        #: Why a stored attachment did NOT come back ("" when it did, or when
+        #: there was none). Set by :meth:`_restore_attachment` for a team or
+        #: profile the operator has since renamed or deleted. Held instead of
+        #: raised because a missing team must never make a conversation
+        #: unopenable, and held instead of logged because the reader who needs
+        #: it is the user staring at a band segment that stayed blank.
+        self.attachment_restore_error: str = ""
+        #: True only while :meth:`_restore_attachment` is re-applying the stored
+        #: attachment, which suppresses the journal write in
+        #: :meth:`_persist_attachment`. Without it the restore would write back
+        #: through the very mutators it calls, and a PARTIAL restore would erase
+        #: the half it could not resolve: a session whose team is momentarily
+        #: unresolvable (registry not wired on this host, a team dir not yet
+        #: synced) would persist ``team=""`` and lose the name for good, turning
+        #: a recoverable miss into permanent data loss. A restore is a READ of
+        #: state that is already on disk; it has nothing new to record.
+        self._restoring_attachment = False
         # The conversation's title. A holder rather than a plain string for
         # the same reason the goal is one: the title arrives on a DETACHED
         # naming task after the host already built its status chrome, and
@@ -1454,6 +1477,16 @@ class Session:
         # answering when it closed, not silently re-route the first prompt to
         # the provider that was failing.
         self._restore_active_route()
+        # Same contract as the route restore, for the other half of what a
+        # session was when it closed: the ``/team`` roster, ``/agent`` profile
+        # and ``/goal`` ride the prompt's volatile tail, which is rebuilt empty
+        # on every construction, so without this a resume dropped the persona
+        # from the model's instructions entirely. Here rather than in
+        # ``async_init`` because the tail must be populated before ANY turn can
+        # be built, and quiet (no event) for the reason the route restore is:
+        # nothing has subscribed yet, so hosts read the restored state when
+        # they build their chrome.
+        self._restore_attachment()
         # Owned here, not by the browser tool, for the same reason the wake
         # scheduler is: _build_tool_context runs at the start of EVERY turn, so
         # a handle the tool stored on the ToolContext lived exactly one turn.
@@ -2216,7 +2249,11 @@ class Session:
         goal rides the system prompt's volatile tail, so it applies from the
         next turn and only invalidates that tail — never the cached prefix.
         """
-        return self._goal_state.set(text)
+        stored = self._goal_state.set(text)
+        # Same tail, same fate on resume as the team/agent briefs, so the goal
+        # is journalled by the same mechanism rather than a second one.
+        self._persist_attachment()
+        return stored
 
     @property
     def active_team_name(self) -> str:
@@ -2245,6 +2282,7 @@ class Session:
         self.active_team = team
         if team is None:
             self._goal_state.team_brief = ""
+            self._persist_attachment()
             return
         preamble = getattr(team, "manager_preamble", lambda: "")()
         # The manager's own profile instructions (the reusable BASE) sit in
@@ -2275,6 +2313,141 @@ class Session:
                     + (preamble or "")
                 )
         self._goal_state.team_brief = preamble or ""
+        # Journal the NAME so a resume can rebuild this tail. On change only:
+        # the roster moves a handful of times per session, and the brief itself
+        # is deliberately not stored (see ``SessionAttachment``).
+        self._persist_attachment()
+
+    def _persist_attachment(self) -> None:
+        """Journal the attached team/agent/goal beside the transcript.
+
+        Called from every mutation of the attached identity — ``attach_team``,
+        ``_stamp_agent_brief``, ``clear_agent_profile``, ``set_goal`` — because
+        those four are the only ways the volatile tail's persistent half moves.
+        Writing from the mutators rather than from the TUI commands is what
+        makes this hold for every front end: the mobile relay sets a goal
+        through ``Session.set_goal`` too, and a front-end-side write would have
+        left that path unpersisted.
+
+        Synchronous and best-effort. The write is a sub-kilobyte atomic replace
+        and these mutators are not on the hot turn path, so a thread hop would
+        buy nothing and would open a window where a session disposed
+        immediately after ``/team`` lost the attachment it just reported. The
+        helper never raises by contract (see ``write_session_attachment``), and
+        the broad guard here covers a reduced test double whose transcript has
+        no directory rather than any failure of the write itself.
+        """
+        from local_operator.resume import write_session_attachment
+
+        if self._restoring_attachment:
+            return
+        try:
+            directory = self._transcript.directory
+        except Exception:  # noqa: BLE001 — a reduced host must not lose its turn
+            return
+        write_session_attachment(
+            directory,
+            team=self.active_team_name,
+            agent=self._goal_state.agent_name,
+            goal=self._goal_state.text,
+        )
+
+    def _restore_attachment(self) -> None:
+        """Re-attach the team/agent/goal this session was carrying when it closed.
+
+        THE resume fix. The team and agent briefs live only in ``GoalState``,
+        which ``session_factory`` builds empty on every construction, so before
+        this a ``--resume`` reopened the conversation with the persona GONE
+        from the system prompt — not merely missing from the status band. The
+        band was reporting the truth, which is why it must keep being driven
+        from the session (see the TUI's ``_sync_team_band``) and never painted
+        from the sidecar directly: a segment naming a team that failed to
+        resolve would turn an honest blank into a lie.
+
+        Re-resolves by NAME through the same entry points the live ``/team``
+        and ``/agent`` commands use (``attach_team`` after a registry lookup,
+        ``attach_agent_profile``, and through it the one shared
+        ``_resolve_profile_or_specialist`` ordering). Deliberate, and the
+        reason the sidecar stores names instead of briefs: the operator may
+        have edited the team's briefs or the profile's instructions since the
+        session last ran, and a stored brief would resume them onto a
+        definition that no longer exists. Going through the live resolvers also
+        means this path cannot drift from the attach path — a change to
+        resolution order applies to a resumed session automatically.
+
+        Runs during construction, BEFORE any turn, so the restored briefs are
+        in the tail the first prompt is built from. It mutates the shared
+        ``GoalState`` holder the system-blocks provider already closed over, so
+        nothing is rebuilt and the cached persona PREFIX is untouched — only
+        the volatile tail this state has always lived in.
+
+        Failures degrade to unattached and are RECORDED for the host to report
+        (:attr:`attachment_restore_error`) rather than raised: a team the user
+        renamed or deleted must not make a conversation unopenable.
+        """
+        from local_operator.resume import read_session_attachment
+
+        try:
+            stored = read_session_attachment(self._transcript.directory)
+        except Exception:  # noqa: BLE001 — a resume must always open
+            return
+        if stored is None:
+            return
+
+        self._restoring_attachment = True
+        try:
+            self._apply_stored_attachment(stored)
+        finally:
+            self._restoring_attachment = False
+
+    def _apply_stored_attachment(self, stored: "SessionAttachment") -> None:
+        """Re-apply one parsed attachment; see :meth:`_restore_attachment`.
+
+        Split out so the suppression flag around it is a plain ``try/finally``
+        with no early ``return`` able to skip the reset.
+        """
+        if stored.goal:
+            # Straight onto the holder: ``set_goal`` would re-journal a value
+            # that just came off disk, and the restore is not a user action.
+            self._goal_state.set(stored.goal)
+
+        missing: list[str] = []
+        if stored.team:
+            team = None
+            registry = self.team_registry
+            if registry is not None:
+                try:
+                    team = registry.get_team_by_name(stored.team)
+                except Exception:  # noqa: BLE001 — a bad registry row is not fatal
+                    team = None
+            if team is None:
+                missing.append(f"team {stored.team!r}")
+            else:
+                # Through ``attach_team`` rather than by setting the brief, so
+                # ``active_team`` (what subagents inherit) is restored too, not
+                # just the prompt text.
+                self.attach_team(team)
+        if stored.agent:
+            resolved = None
+            try:
+                resolved = self.attach_agent_profile(stored.agent)
+            except Exception:  # noqa: BLE001 — same contract as the team path
+                resolved = None
+            if resolved is None:
+                missing.append(f"agent {stored.agent!r}")
+        if missing:
+            #: Held rather than logged, because the person who needs to know is
+            #: the one looking at a band segment that did NOT come back. The TUI
+            #: reads this once on adopt and says so in its ordinary
+            #: system-notice style; headless hosts may ignore it.
+            # Names what did NOT come back, never a blanket "unattached": a
+            # partial miss is the common case (a deleted team beside a profile
+            # that resolved fine), and claiming the whole session is bare would
+            # contradict the band segment still showing the half that restored.
+            self.attachment_restore_error = (
+                f"could not restore {' and '.join(missing)} from the previous session "
+                "(renamed or deleted); continuing without it"
+            )
 
     def _resolve_profile_or_specialist(self, name: str) -> tuple[str | None, Any, str, str]:
         """Resolve a NAME to an attachable profile, priority order fixed here.
@@ -2371,6 +2544,10 @@ class Session:
         # contradicting each other. Both fields are stamped together in
         # ``_stamp_agent_brief``; they must be cleared together too.
         self._goal_state.agent_name = ""
+        # A detach is as much a fact to survive a resume as an attach: without
+        # this the sidecar would still name the profile the user just dropped,
+        # and the next resume would silently re-attach it.
+        self._persist_attachment()
 
     def _stamp_agent_brief(self, body: str, display_name: str) -> str:
         """Store the resolved brief on the volatile tail and report success.
@@ -2386,6 +2563,10 @@ class Session:
         # case): the profile IS attached and the band must name it, so the
         # segment tracks "which profile is in force", not "did it layer text".
         self._goal_state.agent_name = display_name
+        # The single funnel every successful ``/agent`` attach passes through
+        # (role, seed and specialist all land here), so journalling once from
+        # this point cannot miss a path the way three call-site writes could.
+        self._persist_attachment()
         return display_name
 
     @property

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -1163,13 +1163,23 @@ class Session:
         #: collaboration and project briefs without the manager restating them.
         #: ``None`` on an ordinary session.
         self.active_team: Any | None = None
-        #: Why a stored attachment did NOT come back ("" when it did, or when
-        #: there was none). Set by :meth:`_restore_attachment` for a team or
-        #: profile the operator has since renamed or deleted. Held instead of
-        #: raised because a missing team must never make a conversation
-        #: unopenable, and held instead of logged because the reader who needs
-        #: it is the user staring at a band segment that stayed blank.
-        self.attachment_restore_error: str = ""
+        #: User-facing copy explaining why a stored attachment did NOT come
+        #: back ("" when it did, or when there was none). Set by
+        #: :meth:`_restore_attachment` for a team or profile that failed to
+        #: resolve, whether because it is gone or because the registry was
+        #: unavailable.
+        #:
+        #: NOT named ``…_error``: it holds display copy, and its only consumer
+        #: renders it as a ``"warning"`` system notice, deliberately not an
+        #: ``"error"`` — a missing team is a recoverable state of this session,
+        #: not a failure of it. The name says so, so the next reader does not
+        #: route it to an error surface or log it as a fault (D5).
+        #:
+        #: Held instead of raised because a missing team must never make a
+        #: conversation unopenable, and held instead of logged because the
+        #: reader who needs it is the user staring at a band segment that
+        #: stayed blank.
+        self.attachment_restore_notice: str = ""
         #: True only while :meth:`_restore_attachment` is re-applying the stored
         #: attachment, which suppresses the journal write in
         #: :meth:`_persist_attachment`. Without it the restore would write back
@@ -1180,6 +1190,24 @@ class Session:
         #: a recoverable miss into permanent data loss. A restore is a READ of
         #: state that is already on disk; it has nothing new to record.
         self._restoring_attachment = False
+        #: Stored names the restore could NOT resolve, carried so the next
+        #: journal write preserves them instead of erasing them (R1).
+        #:
+        #: Suppressing the write during the restore is not enough on its own,
+        #: and the gap was a real data-loss path: once the restore returns,
+        #: ``active_team`` is ``None`` for the half that missed, so the very
+        #: next ordinary mutation — a plain ``/goal`` is enough — journals that
+        #: emptiness over the surviving name and the attachment is gone for
+        #: good, one command after a failure that was supposed to be
+        #: recoverable. Keeping the name here makes the recovery survive
+        #: arbitrary further use of the session, which is what "transient"
+        #: has to mean.
+        #:
+        #: Cleared per slot by an explicit user action (a successful attach
+        #: replaces it, a detach drops it), never by the miss itself — see
+        #: :meth:`_persist_attachment`.
+        self._unresolved_team: str = ""
+        self._unresolved_agent: str = ""
         # The conversation's title. A holder rather than a plain string for
         # the same reason the goal is one: the title arrives on a DETACHED
         # naming task after the host already built its status chrome, and
@@ -2280,6 +2308,10 @@ class Session:
         :attr:`active_team`.
         """
         self.active_team = team
+        # Either branch is the user acting on the team slot, so a carried
+        # unresolved name stops being a recovery hint here (R1): a detach means
+        # they no longer want it, and an attach replaces it outright.
+        self._clear_unresolved("team")
         if team is None:
             self._goal_state.team_brief = ""
             self._persist_attachment()
@@ -2321,13 +2353,15 @@ class Session:
     def _persist_attachment(self) -> None:
         """Journal the attached team/agent/goal beside the transcript.
 
-        Called from every mutation of the attached identity — ``attach_team``,
-        ``_stamp_agent_brief``, ``clear_agent_profile``, ``set_goal`` — because
-        those four are the only ways the volatile tail's persistent half moves.
-        Writing from the mutators rather than from the TUI commands is what
-        makes this hold for every front end: the mobile relay sets a goal
-        through ``Session.set_goal`` too, and a front-end-side write would have
-        left that path unpersisted.
+        Called from every mutation of the attached identity — ``attach_team``
+        (from BOTH of its branches: the ``team is None`` detach returns early,
+        so the tail write cannot cover it), ``_stamp_agent_brief``,
+        ``clear_agent_profile`` and ``set_goal`` — because those are the only
+        ways the volatile tail's persistent half moves. Writing from the
+        mutators rather than from the TUI commands is what makes this hold for
+        every front end: the mobile relay sets a goal through
+        ``Session.set_goal`` too, and a front-end-side write would have left
+        that path unpersisted.
 
         Synchronous and best-effort. The write is a sub-kilobyte atomic replace
         and these mutators are not on the hot turn path, so a thread hop would
@@ -2336,6 +2370,17 @@ class Session:
         helper never raises by contract (see ``write_session_attachment``), and
         the broad guard here covers a reduced test double whose transcript has
         no directory rather than any failure of the write itself.
+
+        A name the restore could not resolve is written back UNCHANGED rather
+        than as the empty live value (R1). Without that fallback a transient
+        miss survived only until the next mutation: ``active_team`` is ``None``
+        for the half that failed, so a plain ``/goal`` in the resumed session
+        journalled the emptiness over the stored name and the attachment was
+        lost for good — one command after a failure the design calls
+        recoverable. The carried name is dropped only when the user acts on
+        that slot themselves (see :meth:`_clear_unresolved`), so "recoverable"
+        holds for the whole life of the session rather than for the duration of
+        the restore.
         """
         from local_operator.resume import write_session_attachment
 
@@ -2347,10 +2392,28 @@ class Session:
             return
         write_session_attachment(
             directory,
-            team=self.active_team_name,
-            agent=self._goal_state.agent_name,
+            team=self.active_team_name or self._unresolved_team,
+            agent=self._goal_state.agent_name or self._unresolved_agent,
             goal=self._goal_state.text,
         )
+
+    def _clear_unresolved(self, slot: str) -> None:
+        """Forget a carried unresolved name because the user acted on that slot.
+
+        The counterpart to the fallback in :meth:`_persist_attachment`. A
+        carried name is a RECOVERY hint for a team or profile that was
+        momentarily unreachable, so it must survive incidental mutations — but
+        it must NOT survive the user deliberately attaching something else or
+        detaching, or a ``/team other`` would leave the old name to reappear at
+        the next resume and re-attach a roster the user had moved off.
+
+        Per slot, because the two are independent: re-attaching an agent says
+        nothing about whether the stored team is still wanted.
+        """
+        if slot == "team":
+            self._unresolved_team = ""
+        else:
+            self._unresolved_agent = ""
 
     def _restore_attachment(self) -> None:
         """Re-attach the team/agent/goal this session was carrying when it closed.
@@ -2382,7 +2445,7 @@ class Session:
         the volatile tail this state has always lived in.
 
         Failures degrade to unattached and are RECORDED for the host to report
-        (:attr:`attachment_restore_error`) rather than raised: a team the user
+        (:attr:`attachment_restore_notice`) rather than raised: a team the user
         renamed or deleted must not make a conversation unopenable.
         """
         from local_operator.resume import read_session_attachment
@@ -2411,17 +2474,32 @@ class Session:
             # that just came off disk, and the restore is not a user action.
             self._goal_state.set(stored.goal)
 
-        missing: list[str] = []
+        # ``(what was missed, which command re-attaches it)``, so the notice can
+        # name the recovery step per slot the way every sibling miss-notice in
+        # the TUI does ("Run /team to list teams, …").
+        missing: list[tuple[str, str]] = []
+        # True only when a lookup ran to completion and answered "no such
+        # thing". A registry that is absent or that RAISED has established
+        # nothing about whether the team still exists, and saying "renamed or
+        # deleted" for those sends the operator off to re-create something that
+        # is still there (D2/R3). Both of those are also the transient cases the
+        # carried-name recovery exists for.
+        looked_up_and_absent = True
         if stored.team:
             team = None
             registry = self.team_registry
-            if registry is not None:
+            if registry is None:
+                looked_up_and_absent = False
+            else:
                 try:
                     team = registry.get_team_by_name(stored.team)
                 except Exception:  # noqa: BLE001 — a bad registry row is not fatal
                     team = None
+                    looked_up_and_absent = False
             if team is None:
-                missing.append(f"team {stored.team!r}")
+                missing.append((f"team {stored.team!r}", "/team"))
+                # Carried so the next mutation cannot erase it (R1).
+                self._unresolved_team = stored.team
             else:
                 # Through ``attach_team`` rather than by setting the brief, so
                 # ``active_team`` (what subagents inherit) is restored too, not
@@ -2433,20 +2511,47 @@ class Session:
                 resolved = self.attach_agent_profile(stored.agent)
             except Exception:  # noqa: BLE001 — same contract as the team path
                 resolved = None
+                looked_up_and_absent = False
             if resolved is None:
-                missing.append(f"agent {stored.agent!r}")
+                missing.append((f"agent {stored.agent!r}", "/agent"))
+                self._unresolved_agent = stored.agent
         if missing:
             #: Held rather than logged, because the person who needs to know is
             #: the one looking at a band segment that did NOT come back. The TUI
             #: reads this once on adopt and says so in its ordinary
             #: system-notice style; headless hosts may ignore it.
+            #
             # Names what did NOT come back, never a blanket "unattached": a
             # partial miss is the common case (a deleted team beside a profile
             # that resolved fine), and claiming the whole session is bare would
             # contradict the band segment still showing the half that restored.
-            self.attachment_restore_error = (
-                f"could not restore {' and '.join(missing)} from the previous session "
-                "(renamed or deleted); continuing without it"
+            #
+            # Copy shape follows the established miss-notice idiom in the TUI:
+            # ONE em-dash clause separator (never a parenthetical plus a
+            # semicolon, which was a third idiom — D3), and it ends on the
+            # RECOVERY rather than on the damage, because "run /team to
+            # re-attach" is the only part the user can act on (D2).
+            what = " and ".join(name for name, _ in missing)
+            # Deduped: a both-missing restore would otherwise say "/team or
+            # /team". ``dict.fromkeys`` is the file's ordered-set idiom.
+            commands = " or ".join(dict.fromkeys(command for _, command in missing))
+            # "from the previous session" is dropped deliberately: this notice
+            # only ever fires on adopt after a resume, "restore" already says
+            # it, and the words cost 26 cells that pushed the common one-slot
+            # case to 101 characters — over a 100-column terminal, so it wrapped
+            # to two lines for no added meaning (D3).
+            #
+            # The cause clause is dropped as well once BOTH slots are missing:
+            # naming two things already costs ~35 cells, and keeping the clause
+            # there put the line back over 100 and wrapped it again. Of the two,
+            # the cause is the part the user cannot act on — WHAT is gone and
+            # HOW to get it back are both load-bearing — so it is the one that
+            # yields. A both-missing restore is also overwhelmingly a moved
+            # config directory rather than two independent deletions, which is
+            # the case the clause would describe least accurately anyway.
+            cause = " — renamed or deleted" if looked_up_and_absent and len(missing) == 1 else ""
+            self.attachment_restore_notice = (
+                f"could not restore {what}{cause}. Run {commands} to re-attach."
             )
 
     def _resolve_profile_or_specialist(self, name: str) -> tuple[str | None, Any, str, str]:
@@ -2544,6 +2649,10 @@ class Session:
         # contradicting each other. Both fields are stamped together in
         # ``_stamp_agent_brief``; they must be cleared together too.
         self._goal_state.agent_name = ""
+        # An explicit detach also retires a carried unresolved name (R1), or
+        # ``/agent clear`` would appear to work and the profile would come back
+        # at the next resume.
+        self._clear_unresolved("agent")
         # A detach is as much a fact to survive a resume as an attach: without
         # this the sidecar would still name the profile the user just dropped,
         # and the next resume would silently re-attach it.
@@ -2563,6 +2672,8 @@ class Session:
         # case): the profile IS attached and the band must name it, so the
         # segment tracks "which profile is in force", not "did it layer text".
         self._goal_state.agent_name = display_name
+        # A successful attach supersedes any carried unresolved name (R1).
+        self._clear_unresolved("agent")
         # The single funnel every successful ``/agent`` attach passes through
         # (role, seed and specialist all land here), so journalling once from
         # this point cannot miss a path the way three call-site writes could.

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -2032,8 +2032,20 @@ class OperatorApp(App[None]):
         )
         self._wire_mcp_status(session)
         self._report_mcp_startup(session)
-        self._report_attachment_restore(session)
         self._render_resumed_history(session)
+        # AFTER the replay, and the order is load-bearing (D1). A stale
+        # attachment is by definition only reachable on a session that ALREADY
+        # RAN, so this notice always lands on a transcript with history. Raised
+        # before the replay it became block 0 of N, the replayed history was
+        # appended after it, the transcript auto-scrolled to the bottom, and the
+        # notice sat at y=-63 with the viewport at y=65 — off screen entirely,
+        # producing exactly the silent downgrade `_report_attachment_restore`
+        # exists to prevent. Last block puts it directly above the composer,
+        # where the eye already is, and it IS the most recent thing that
+        # happened to this session. Costs nothing on an empty transcript:
+        # `_render_resumed_history` no-ops there, so the boot splash is
+        # untouched and the notice still lands under it.
+        self._report_attachment_restore(session)
         # AFTER the history is on screen, because that is where the fallback
         # label comes from: a session resumed from a transcript written before
         # titles were journalled has no stored name to restore, and the band
@@ -2080,6 +2092,15 @@ class OperatorApp(App[None]):
             model_label=_effective_label(session),
             model_name=_model_name(session),
             effort=_effort_label(session),
+            # The takeover replaces a RemoteSession facade with a REAL Session,
+            # which runs `_restore_attachment` at construction and so may be
+            # carrying a team/agent the band is not showing (R4). `update`
+            # treats `None` as leave-alone, so omitting these left whatever the
+            # remote facade had painted — the one adopt sink that did not paint
+            # the restored attachment. Read defensively, as `_adopt_session`
+            # does, so a reduced facade without the accessors cannot raise here.
+            agent_profile=str(getattr(session, "active_agent", "") or ""),
+            team=str(getattr(session, "active_team_name", "") or ""),
             context_window=_context_window(session),
             conversation_name=session.conversation_name,
             streaming=False,
@@ -4370,10 +4391,27 @@ class OperatorApp(App[None]):
         that failed to resolve leaves its segment blank on its own; painting
         the stored name would contradict the notice and claim a persona the
         prompt does not carry.
+
+        A restored GOAL is reported here too, and for the same reason the team
+        and agent get band segments (D4): it is invisible standing state that
+        steers the conversation. The band is the wrong home for it — a goal is a
+        sentence, not a bounded name, and the drop ladder's ``_UNBOUNDED_RUNGS``
+        exists to keep exactly that out — but saying nothing means ``/loop``
+        iterates toward an objective set days ago that the user cannot see.
+        Informational rather than a warning: nothing went wrong, and this is the
+        feature working.
         """
-        detail = str(getattr(session, "attachment_restore_error", "") or "")
+        detail = str(getattr(session, "attachment_restore_notice", "") or "")
         if detail:
             self._system_notice(detail, "warning")
+        goal = str(getattr(session, "goal", "") or "").strip()
+        if goal:
+            from local_operator.tui.widgets.tool_card import truncate_cells
+
+            # Capped so a goal written up to MAX_GOAL_CHARS (2000) cannot turn
+            # a one-line receipt into a wall of replayed text above the
+            # composer. The full text is always available from `/goal`.
+            self._system_notice(f"goal restored: {truncate_cells(goal, 96)}", "info")
 
     # -- text selection (TUI-021) -------------------------------------------
     def on_text_selected(self, event: TextSelected) -> None:

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -2032,6 +2032,7 @@ class OperatorApp(App[None]):
         )
         self._wire_mcp_status(session)
         self._report_mcp_startup(session)
+        self._report_attachment_restore(session)
         self._render_resumed_history(session)
         # AFTER the history is on screen, because that is where the fallback
         # label comes from: a session resumed from a transcript written before
@@ -4348,6 +4349,31 @@ class OperatorApp(App[None]):
         # server that does not exist.
         for name, error in sorted(outcome.failures.items()):
             self._system_notice(f"MCP {name} failed: {error}", "error")
+
+    def _report_attachment_restore(self, session: SessionProtocol) -> None:
+        """Say so when a resumed session's team/agent could not be re-attached.
+
+        A resume re-resolves the stored team/agent by NAME (see
+        ``Session._restore_attachment``), so one the operator has since renamed
+        or deleted resolves to nothing and the session opens unattached. That
+        is the honest outcome, but a SILENT one would be the worst of both: the
+        user left a manager attached, comes back, and the agent answers in its
+        base voice with nothing on screen explaining why.
+
+        Once, on adopt, in the same system-notice style a failed ``/team`` or
+        ``/agent`` attach already uses — which also keeps it out of the empty
+        state, exactly like the MCP startup record above: a stale attachment is
+        infrastructure news the user did not ask for, and it must not collapse
+        the boot composition.
+
+        The band is NOT touched here. It is driven from the session, so a team
+        that failed to resolve leaves its segment blank on its own; painting
+        the stored name would contradict the notice and claim a persona the
+        prompt does not carry.
+        """
+        detail = str(getattr(session, "attachment_restore_error", "") or "")
+        if detail:
+            self._system_notice(detail, "warning")
 
     # -- text selection (TUI-021) -------------------------------------------
     def on_text_selected(self, event: TextSelected) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.35.1"
+version = "0.36.0"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/session/test_attachment_persistence.py
+++ b/tests/unit/session/test_attachment_persistence.py
@@ -1,0 +1,300 @@
+"""An attached ``/team``, ``/agent`` and ``/goal`` have to survive a resume.
+
+The team and agent briefs ride the VOLATILE TAIL of the system prompt, and the
+holder that tail is built from (``GoalState``) is constructed EMPTY by
+``session_factory`` on every session. Nothing in the transcript reproduced it,
+so a ``--resume`` did not merely blank the status band's team segment: it
+dropped the persona from the model's instructions entirely, and the
+conversation carried on as an ordinary session while the band honestly reported
+nothing attached.
+
+The fix journals the attachment to a sidecar beside the transcript and
+re-resolves it at construction. Four properties are load-bearing and each has a
+test below:
+
+* **The BRIEF comes back, not just the name.** A band segment that names a team
+  whose instructions are not in the prompt is the same bug wearing a label, so
+  the round-trip test asserts on the tail's content.
+* **Names are re-resolved, never replayed.** The stored value is a NAME; a team
+  edited between sessions must resume with its CURRENT briefs.
+* **A stale name degrades, and says so.** A team the operator deleted must not
+  make the conversation unopenable, must not leave the band naming it, and must
+  not be silent.
+* **A restore does not overwrite the sidecar.** It is a read of state already on
+  disk, and a partial restore that wrote back would erase the half it could not
+  resolve.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from local_operator.agents import AgentEditFields, AgentRegistry
+from local_operator.resume import ATTACHMENT_SIDECAR_NAME, read_session_attachment
+from local_operator.session.session import Session
+from local_operator.session.transcript import Transcript
+from local_operator.teams import Team, TeamRegistry
+
+from .test_session import MODEL, ScriptedStream
+
+
+def _role_fields(**overrides: Any) -> AgentEditFields:
+    """``AgentEditFields`` spelled out in full (it validates in strict mode)."""
+    base: dict[str, Any] = dict(
+        name=None,
+        description=None,
+        tags=None,
+        categories=None,
+        security_prompt=None,
+        hosting=None,
+        model=None,
+        last_message=None,
+        temperature=None,
+        top_p=None,
+        top_k=None,
+        max_tokens=None,
+        stop=None,
+        frequency_penalty=None,
+        presence_penalty=None,
+        seed=None,
+        current_working_directory=None,
+    )
+    base.update(overrides)
+    return AgentEditFields(**base)
+
+
+def _team(name: str, *, instructions: str = "Ship reviewed work.") -> Team:
+    return Team(
+        id=f"t-{name}",
+        name=name,
+        created_date=datetime.now(timezone.utc),
+        manager="manager",
+        instructions=instructions,
+        project="local-operator",
+    )
+
+
+@pytest.fixture
+def registries(tmp_path: Path) -> tuple[AgentRegistry, TeamRegistry]:
+    agents = AgentRegistry(tmp_path)
+    agents.create_agent(_role_fields(name="auditor", description="Audits", tags=["role"]))
+    teams = TeamRegistry(tmp_path)
+    teams.save_team(_team("lopdev"))
+    return agents, teams
+
+
+def _session(tmp_path: Path, registries: tuple[AgentRegistry, TeamRegistry]) -> Session:
+    """A session over ``tmp_path/sess`` — reopening one RESUMES it, which is
+    exactly the shape both ``--resume <id>`` and the ``/resume`` picker build."""
+    agents, teams = registries
+    return Session(
+        model=MODEL,
+        stream_fn=ScriptedStream([[]]),
+        tools=[],
+        transcript=Transcript(tmp_path / "sess"),
+        system_blocks_provider=lambda: [],
+        agent_registry=agents,
+        team_registry=teams,
+    )
+
+
+def _sidecar(tmp_path: Path) -> dict[str, Any]:
+    raw = (tmp_path / "sess" / ATTACHMENT_SIDECAR_NAME).read_text(encoding="utf-8")
+    return json.loads(raw)
+
+
+class TestTheRoundTrip:
+    def test_an_attached_team_and_agent_come_back_after_a_resume(self, tmp_path, registries):
+        """THE bug: a resumed session opened with the persona gone."""
+        _, teams = registries
+        first = _session(tmp_path, registries)
+        first.attach_team(teams.get_team_by_name("lopdev"))
+        first.attach_agent_profile("auditor")
+        first.set_goal("keep the band honest")
+
+        resumed = _session(tmp_path, registries)
+        assert resumed.active_team_name == "lopdev"
+        assert resumed.active_agent == "auditor"
+        assert resumed.goal == "keep the band honest"
+
+    def test_the_team_brief_is_back_in_the_prompt_tail(self, tmp_path, registries):
+        """The NAME alone would be a display fix. What the model is told is the
+        thing that was actually lost, so the brief itself has to be asserted."""
+        _, teams = registries
+        first = _session(tmp_path, registries)
+        first.attach_team(teams.get_team_by_name("lopdev"))
+
+        resumed = _session(tmp_path, registries)
+        assert "Ship reviewed work." in resumed._goal_state.team_brief
+
+    def test_the_active_team_object_is_restored_not_just_its_name(self, tmp_path, registries):
+        """``active_team`` is what every ``task`` child inherits its briefs
+        from, so a restore that set only the band segment would leave a resumed
+        manager delegating without the roster."""
+        _, teams = registries
+        first = _session(tmp_path, registries)
+        first.attach_team(teams.get_team_by_name("lopdev"))
+
+        resumed = _session(tmp_path, registries)
+        assert resumed.active_team is not None
+        assert resumed.active_team.name == "lopdev"
+
+    def test_a_detach_survives_the_resume_too(self, tmp_path, registries):
+        """A sidecar left naming a profile the user just dropped would silently
+        re-attach it on the next resume."""
+        first = _session(tmp_path, registries)
+        first.attach_agent_profile("auditor")
+        first.clear_agent_profile()
+
+        resumed = _session(tmp_path, registries)
+        assert resumed.active_agent == ""
+        assert resumed._goal_state.agent_brief == ""
+
+    def test_a_session_that_attached_nothing_writes_no_attachment(self, tmp_path, registries):
+        """An unused feature must not litter every session directory."""
+        _session(tmp_path, registries)
+        assert not (tmp_path / "sess" / ATTACHMENT_SIDECAR_NAME).exists()
+
+
+class TestNamesNotBriefs:
+    def test_only_names_are_stored(self, tmp_path, registries):
+        """Briefs are large and go stale; the sidecar holds names."""
+        _, teams = registries
+        session = _session(tmp_path, registries)
+        session.attach_team(teams.get_team_by_name("lopdev"))
+        session.attach_agent_profile("auditor")
+
+        payload = _sidecar(tmp_path)
+        assert payload == {"team": "lopdev", "agent": "auditor", "goal": ""}
+        assert "Ship reviewed work." not in json.dumps(payload)
+
+    def test_an_edited_team_resumes_with_its_current_briefs(self, tmp_path, registries):
+        """Why re-resolving by NAME is the deliberate choice: the operator edits
+        a team between sessions, and a stored brief would resume them onto
+        instructions that no longer exist anywhere."""
+        _, teams = registries
+        first = _session(tmp_path, registries)
+        first.attach_team(teams.get_team_by_name("lopdev"))
+
+        edited = teams.get_team_by_name("lopdev")
+        assert edited is not None
+        edited.instructions = "Ship reviewed work, and always capture frames."
+        teams.save_team(edited)
+
+        resumed = _session(tmp_path, registries)
+        assert "always capture frames" in resumed._goal_state.team_brief
+
+
+class TestTheStaleName:
+    def test_a_deleted_team_degrades_to_unattached_and_reports_it(self, tmp_path, registries):
+        """Renamed or deleted: the resume must open, the band must not name it,
+        and the user must be told once."""
+        _, teams = registries
+        first = _session(tmp_path, registries)
+        first.attach_team(teams.get_team_by_name("lopdev"))
+
+        # The registry the resumed session sees no longer has the team.
+        empty_teams = TeamRegistry(tmp_path / "elsewhere")
+        agents, _ = registries
+        resumed = Session(
+            model=MODEL,
+            stream_fn=ScriptedStream([[]]),
+            tools=[],
+            transcript=Transcript(tmp_path / "sess"),
+            system_blocks_provider=lambda: [],
+            agent_registry=agents,
+            team_registry=empty_teams,
+        )
+        assert resumed.active_team_name == ""
+        assert resumed._goal_state.team_brief == ""
+        assert "lopdev" in resumed.attachment_restore_error
+        assert "without it" in resumed.attachment_restore_error
+
+    def test_a_deleted_agent_degrades_the_same_way(self, tmp_path, registries):
+        first = _session(tmp_path, registries)
+        first.attach_agent_profile("auditor")
+
+        teams = registries[1]
+        resumed = Session(
+            model=MODEL,
+            stream_fn=ScriptedStream([[]]),
+            tools=[],
+            transcript=Transcript(tmp_path / "sess"),
+            system_blocks_provider=lambda: [],
+            agent_registry=AgentRegistry(tmp_path / "elsewhere"),
+            team_registry=teams,
+        )
+        assert resumed.active_agent == ""
+        assert "auditor" in resumed.attachment_restore_error
+
+    def test_a_successful_restore_reports_nothing(self, tmp_path, registries):
+        """The notice is for a real miss; a clean resume must stay quiet."""
+        _, teams = registries
+        first = _session(tmp_path, registries)
+        first.attach_team(teams.get_team_by_name("lopdev"))
+
+        resumed = _session(tmp_path, registries)
+        assert resumed.attachment_restore_error == ""
+
+    def test_a_partial_restore_does_not_erase_the_name_it_could_not_resolve(
+        self, tmp_path, registries
+    ):
+        """A restore is a READ. Writing back through the mutators it calls would
+        persist ``team=""`` for a team that was only momentarily unresolvable
+        (registry not wired on this host, a team directory not yet synced),
+        turning a recoverable miss into permanent data loss."""
+        _, teams = registries
+        first = _session(tmp_path, registries)
+        first.attach_team(teams.get_team_by_name("lopdev"))
+        first.attach_agent_profile("auditor")
+
+        agents, _ = registries
+        Session(
+            model=MODEL,
+            stream_fn=ScriptedStream([[]]),
+            tools=[],
+            transcript=Transcript(tmp_path / "sess"),
+            system_blocks_provider=lambda: [],
+            agent_registry=agents,
+            team_registry=TeamRegistry(tmp_path / "elsewhere"),
+        )
+        # The team name is still on disk, so a session opened once the registry
+        # is available again resumes it.
+        assert _sidecar(tmp_path)["team"] == "lopdev"
+        recovered = _session(tmp_path, registries)
+        assert recovered.active_team_name == "lopdev"
+
+
+class TestTheSidecarIsRobust:
+    def test_a_corrupt_sidecar_does_not_break_the_resume(self, tmp_path, registries):
+        """Losing an attachment is a notice; losing the conversation is not
+        survivable. A file cut inside a multi-byte character decodes with
+        ``errors="replace"`` rather than raising past an ``except OSError``."""
+        session_dir = tmp_path / "sess"
+        session_dir.mkdir(parents=True, exist_ok=True)
+        (session_dir / ATTACHMENT_SIDECAR_NAME).write_bytes(b'{"team": "lop\xff\xfe')
+
+        resumed = _session(tmp_path, registries)
+        assert resumed.active_team_name == ""
+        assert read_session_attachment(session_dir) is None
+
+    def test_a_missing_sidecar_reads_as_nothing_attached(self, tmp_path):
+        assert read_session_attachment(tmp_path / "nope") is None
+
+    def test_writing_preserves_the_directory_mtime(self, tmp_path, registries):
+        """Recency ranks the ``/resume`` picker by the transcript's mtime, but
+        other readers look at the directory. Attaching a team is bookkeeping
+        ABOUT a session, never activity IN it, so it must not reorder anything."""
+        import os
+
+        session = _session(tmp_path, registries)
+        session_dir = tmp_path / "sess"
+        os.utime(session_dir, (1_000_000, 1_000_000))
+
+        session.set_goal("do not touch my mtime")
+        assert session_dir.stat().st_mtime == 1_000_000

--- a/tests/unit/session/test_attachment_persistence.py
+++ b/tests/unit/session/test_attachment_persistence.py
@@ -162,6 +162,41 @@ class TestTheRoundTrip:
 
 
 class TestNamesNotBriefs:
+    def test_a_name_with_repeated_spaces_round_trips(self, tmp_path, registries):
+        """R2: the stored value is a LOOKUP KEY, so it must not be normalised.
+
+        Agent-profile names are free-form and ``AgentRegistry.create_agent``
+        does not collapse whitespace, but every resolver matches with ``strip``
+        only. Collapsing on write meant a profile named ``"Deep  Auditor"``
+        attached live, was written as ``"Deep Auditor"``, then failed to resolve
+        on resume and told the user it had been renamed or deleted. Team names
+        cannot hit this (``_NAME_RE`` forbids spaces), so this is agent-only.
+        """
+        agents, teams = registries
+        agents.create_agent(
+            _role_fields(name="Deep  Auditor", description="Audits deeply", tags=["role"])
+        )
+        first = _session(tmp_path, registries)
+        assert first.attach_agent_profile("Deep  Auditor") == "Deep  Auditor"
+        assert _sidecar(tmp_path)["agent"] == "Deep  Auditor"
+
+        resumed = _session(tmp_path, registries)
+        assert resumed.active_agent == "Deep  Auditor"
+        assert resumed.attachment_restore_notice == ""
+
+    def test_surrounding_whitespace_is_still_stripped(self, tmp_path, registries):
+        """Strip yes, collapse no: a stored key with stray edge whitespace would
+        not match either, and stripping is what the resolvers themselves do."""
+        from local_operator.resume import (
+            read_session_attachment,
+            write_session_attachment,
+        )
+
+        write_session_attachment(tmp_path, team="  lopdev ", agent=" a  b ", goal="  g ")
+        stored = read_session_attachment(tmp_path)
+        assert stored is not None
+        assert (stored.team, stored.agent, stored.goal) == ("lopdev", "a  b", "g")
+
     def test_only_names_are_stored(self, tmp_path, registries):
         """Briefs are large and go stale; the sidecar holds names."""
         _, teams = registries
@@ -212,8 +247,10 @@ class TestTheStaleName:
         )
         assert resumed.active_team_name == ""
         assert resumed._goal_state.team_brief == ""
-        assert "lopdev" in resumed.attachment_restore_error
-        assert "without it" in resumed.attachment_restore_error
+        assert "lopdev" in resumed.attachment_restore_notice
+        # Names the recovery step, the way every sibling miss-notice does.
+        assert "/team" in resumed.attachment_restore_notice
+        assert "re-attach" in resumed.attachment_restore_notice
 
     def test_a_deleted_agent_degrades_the_same_way(self, tmp_path, registries):
         first = _session(tmp_path, registries)
@@ -230,7 +267,7 @@ class TestTheStaleName:
             team_registry=teams,
         )
         assert resumed.active_agent == ""
-        assert "auditor" in resumed.attachment_restore_error
+        assert "auditor" in resumed.attachment_restore_notice
 
     def test_a_successful_restore_reports_nothing(self, tmp_path, registries):
         """The notice is for a real miss; a clean resume must stay quiet."""
@@ -239,7 +276,68 @@ class TestTheStaleName:
         first.attach_team(teams.get_team_by_name("lopdev"))
 
         resumed = _session(tmp_path, registries)
-        assert resumed.attachment_restore_error == ""
+        assert resumed.attachment_restore_notice == ""
+
+    def test_the_cause_is_only_claimed_when_it_has_been_established(self, tmp_path, registries):
+        """Three failures, one of which is renamed-or-deleted.
+
+        A registry that is absent or that RAISED has established nothing about
+        whether the team still exists, and both are transient. Telling the user
+        it was renamed or deleted sends them off to re-create something that is
+        still there, which is worse than saying nothing about the cause.
+        """
+        _, teams = registries
+        agents, _ = registries
+        first = _session(tmp_path, registries)
+        first.attach_team(teams.get_team_by_name("lopdev"))
+
+        def resumed_with(team_registry: Any) -> Session:
+            return Session(
+                model=MODEL,
+                stream_fn=ScriptedStream([[]]),
+                tools=[],
+                transcript=Transcript(tmp_path / "sess"),
+                system_blocks_provider=lambda: [],
+                agent_registry=agents,
+                team_registry=team_registry,
+            )
+
+        class Raises:
+            def get_team_by_name(self, name: str) -> Any:
+                raise RuntimeError("registry down")
+
+        # Established: the lookup ran and answered "no such team".
+        deleted = resumed_with(TeamRegistry(tmp_path / "elsewhere"))
+        assert "renamed or deleted" in deleted.attachment_restore_notice
+        # Not established: no registry at all, and a registry that blew up.
+        assert "renamed or deleted" not in resumed_with(None).attachment_restore_notice
+        assert "renamed or deleted" not in resumed_with(Raises()).attachment_restore_notice
+        # All three still say what to do about it.
+        for session in (deleted, resumed_with(None), resumed_with(Raises())):
+            assert "Run /team to re-attach." in session.attachment_restore_notice
+
+    def test_the_notice_fits_one_line_on_a_standard_terminal(self, tmp_path, registries):
+        """It wrapped to two lines at 100 columns, which is where it is read."""
+        _, teams = registries
+        agents, _ = registries
+        first = _session(tmp_path, registries)
+        first.attach_team(teams.get_team_by_name("lopdev"))
+        first.attach_agent_profile("auditor")
+
+        resumed = Session(
+            model=MODEL,
+            stream_fn=ScriptedStream([[]]),
+            tools=[],
+            transcript=Transcript(tmp_path / "sess"),
+            system_blocks_provider=lambda: [],
+            agent_registry=AgentRegistry(tmp_path / "elsewhere"),
+            team_registry=TeamRegistry(tmp_path / "elsewhere"),
+        )
+        # Both slots missing is the longest form this can take.
+        assert "team 'lopdev' and agent 'auditor'" in resumed.attachment_restore_notice
+        # Deduped commands: never "/team or /team".
+        assert "Run /team or /agent to re-attach." in resumed.attachment_restore_notice
+        assert len(resumed.attachment_restore_notice) <= 96, resumed.attachment_restore_notice
 
     def test_a_partial_restore_does_not_erase_the_name_it_could_not_resolve(
         self, tmp_path, registries
@@ -268,6 +366,93 @@ class TestTheStaleName:
         assert _sidecar(tmp_path)["team"] == "lopdev"
         recovered = _session(tmp_path, registries)
         assert recovered.active_team_name == "lopdev"
+
+    def test_an_unresolved_name_survives_later_use_of_the_session(self, tmp_path, registries):
+        """R1: the recovery must outlive the restore, not just the restore call.
+
+        Suppressing the write DURING the restore only protected the stored name
+        until the resumed session was used at all: ``active_team`` is ``None``
+        for the half that missed, so the next ordinary mutation journalled that
+        emptiness over the surviving name. A plain ``/goal`` was enough, and the
+        team was then gone for good even once the registry came back — the exact
+        scenario the suppression was written for, one command later. The
+        previous version of this test stopped before any mutation, which is why
+        it passed.
+        """
+        _, teams = registries
+        agents, _ = registries
+        first = _session(tmp_path, registries)
+        first.attach_team(teams.get_team_by_name("lopdev"))
+        first.attach_agent_profile("auditor")
+
+        # Transient miss: the team registry is not wired on this host yet.
+        resumed = Session(
+            model=MODEL,
+            stream_fn=ScriptedStream([[]]),
+            tools=[],
+            transcript=Transcript(tmp_path / "sess"),
+            system_blocks_provider=lambda: [],
+            agent_registry=agents,
+            team_registry=TeamRegistry(tmp_path / "elsewhere"),
+        )
+        assert resumed.active_team_name == ""
+
+        # Ordinary use of the resumed session, of each kind that journals.
+        resumed.set_goal("carry on working")
+        resumed.attach_agent_profile("auditor")
+        assert _sidecar(tmp_path)["team"] == "lopdev"
+
+        # And the recovery still works once the registry is back.
+        recovered = _session(tmp_path, registries)
+        assert recovered.active_team_name == "lopdev"
+        assert recovered.goal == "carry on working"
+
+    def test_attaching_another_team_retires_the_carried_name(self, tmp_path, registries):
+        """The carried name is a recovery hint, not a permanent shadow.
+
+        A user who resumes into a miss and then attaches something else has
+        answered the question, so the old name must not survive to re-attach
+        itself at the next resume.
+        """
+        _, teams = registries
+        agents, _ = registries
+        teams.save_team(_team("other", instructions="Different work."))
+        first = _session(tmp_path, registries)
+        first.attach_team(teams.get_team_by_name("lopdev"))
+
+        resumed = Session(
+            model=MODEL,
+            stream_fn=ScriptedStream([[]]),
+            tools=[],
+            transcript=Transcript(tmp_path / "sess"),
+            system_blocks_provider=lambda: [],
+            agent_registry=agents,
+            team_registry=TeamRegistry(tmp_path / "elsewhere"),
+        )
+        assert resumed.active_team_name == ""
+        # The user picks a different team; the registry is reachable again.
+        resumed.team_registry = teams
+        resumed.attach_team(teams.get_team_by_name("other"))
+        assert _sidecar(tmp_path)["team"] == "other"
+
+    def test_an_explicit_detach_retires_the_carried_agent_name(self, tmp_path, registries):
+        """``/agent clear`` after a miss must actually clear."""
+        agents, _ = registries
+        first = _session(tmp_path, registries)
+        first.attach_agent_profile("auditor")
+
+        resumed = Session(
+            model=MODEL,
+            stream_fn=ScriptedStream([[]]),
+            tools=[],
+            transcript=Transcript(tmp_path / "sess"),
+            system_blocks_provider=lambda: [],
+            agent_registry=AgentRegistry(tmp_path / "elsewhere"),
+            team_registry=registries[1],
+        )
+        assert resumed.active_agent == ""
+        resumed.clear_agent_profile()
+        assert _sidecar(tmp_path)["agent"] == ""
 
 
 class TestTheSidecarIsRobust:

--- a/tests/unit/tui/test_resumed_attachment.py
+++ b/tests/unit/tui/test_resumed_attachment.py
@@ -92,6 +92,47 @@ async def _adopted(app: OperatorApp, pilot: Any) -> None:
         await pilot.pause()
 
 
+async def _with_history(session: Session, turns: int) -> None:
+    """Give a session enough replayed turns to fill more than one screen.
+
+    A stale attachment is only reachable on a session that ALREADY RAN, so a
+    test asserting on that notice against an EMPTY transcript is testing the
+    one shape the feature never meets in the field (D1).
+    """
+    from local_operator.harness.types import Message, TextContent
+
+    for i in range(turns):
+        await session._transcript.append_message(
+            Message(role="user", content=[TextContent(text=f"question {i}")])
+        )
+        await session._transcript.append_message(
+            Message(role="assistant", content=[TextContent(text=f"answer {i}: disk full.")])
+        )
+
+
+def _restore_notice(app: OperatorApp) -> Any:
+    """The stale-attachment NoticeBlock, or ``None``."""
+    for block in app.query(NoticeBlock):
+        if "could not restore" in (block.text() or ""):
+            return block
+    return None
+
+
+def _is_on_screen(app: OperatorApp, block: Any) -> bool:
+    """Whether ``block`` actually falls inside the transcript's painted area.
+
+    ``Widget.region`` is SCREEN-relative and already carries the scroll, so
+    comparing it against the transcript's own ``region`` (also screen-relative)
+    answers "is this on screen" — where ``window_region`` is in virtual space
+    and would compare two different coordinate systems. Verified to
+    discriminate: it is ``False`` against the pre-fix ordering, where the notice
+    sat at ``y=-63`` under a viewport starting at ``y=65``, and ``True`` after.
+    """
+    from local_operator.tui.widgets.transcript import TranscriptView
+
+    return block.region.overlaps(app.query_one(TranscriptView).region)
+
+
 @pytest.mark.asyncio
 async def test_the_band_names_the_team_and_agent_a_resume_restored(tmp_path) -> None:
     """Before this, both segments were blank on every resume — honestly so, the
@@ -134,7 +175,104 @@ async def test_a_stale_team_leaves_the_segment_blank_and_says_why(tmp_path) -> N
         assert app._status is not None
         assert app._status._team == ""
         notices = [(n.text() or "") for n in app.query(NoticeBlock)]
-        assert any("lopdev" in text and "without it" in text for text in notices), notices
+        assert any("lopdev" in text and "re-attach" in text for text in notices), notices
+
+
+@pytest.mark.asyncio
+async def test_the_stale_notice_is_on_screen_on_a_session_with_history(tmp_path) -> None:
+    """D1: the notice has to be VISIBLE, not merely mounted.
+
+    A stale attachment can only happen on a session that already ran, so this is
+    the only shape that matters. Raised before the history replay the notice
+    became block 0, the replay was appended after it, the transcript scrolled to
+    the bottom, and it landed at ``y=-63`` under a viewport starting at ``y=65``
+    — the silent downgrade the notice exists to prevent, reproduced by the
+    notice itself. Membership in ``app.query(NoticeBlock)`` cannot see that;
+    only viewport containment can.
+    """
+    agents, teams = _registries(tmp_path)
+    first = _session(tmp_path, agents, teams)
+    await _with_history(first, 20)
+    first.attach_team(teams.get_team_by_name("lopdev"))
+
+    resumed = _session(tmp_path, agents, TeamRegistry(tmp_path / "elsewhere"))
+
+    async def factory() -> Session:
+        return resumed
+
+    app = OperatorApp(factory)
+    async with app.run_test(size=(100, 26)) as pilot:
+        await _adopted(app, pilot)
+        notice = _restore_notice(app)
+        assert notice is not None, "the stale-attachment notice was never mounted"
+        assert _is_on_screen(
+            app, notice
+        ), f"notice mounted but off screen: region={tuple(notice.region)}"
+        # And it is the LAST block, i.e. directly above the composer where the
+        # user's eye already is, rather than merely somewhere on screen.
+        from local_operator.tui.widgets.transcript import TranscriptView
+
+        blocks = list(app.query_one(TranscriptView).children)
+        assert blocks[-1] is notice, "the notice is not the most recent block"
+
+
+@pytest.mark.asyncio
+async def test_a_restored_goal_is_reported(tmp_path) -> None:
+    """D4: a standing goal steers ``/loop``, so a silently restored one is
+    invisible state driving the conversation. The band is the wrong home for a
+    sentence; a one-line receipt is the right weight."""
+    agents, teams = _registries(tmp_path)
+    first = _session(tmp_path, agents, teams)
+    first.set_goal("ship the resume fix and cut the release")
+
+    resumed = _session(tmp_path, agents, teams)
+
+    async def factory() -> Session:
+        return resumed
+
+    app = OperatorApp(factory)
+    async with app.run_test(size=(120, 24)) as pilot:
+        await _adopted(app, pilot)
+        notices = [(n.text() or "") for n in app.query(NoticeBlock)]
+        assert any(
+            "goal restored" in text and "cut the release" in text for text in notices
+        ), notices
+
+
+@pytest.mark.asyncio
+async def test_the_takeover_adopt_paints_the_restored_attachment(tmp_path) -> None:
+    """R4: owner death swaps a RemoteSession facade for a REAL Session, which
+    restores its attachment at construction. ``StatusLine.update`` treats
+    ``None`` as leave-alone, so omitting the two segments left whatever the
+    remote facade had painted — the one adopt sink that did not show them."""
+    agents, teams = _registries(tmp_path)
+    first = _session(tmp_path, agents, teams)
+    first.attach_team(teams.get_team_by_name("lopdev"))
+    first.attach_agent_profile("auditor")
+
+    # Stands in for the remote facade: a different session, nothing attached.
+    bare = Session(
+        model=MODEL,
+        stream_fn=ScriptedStream([[]]),
+        tools=[],
+        transcript=Transcript(tmp_path / "other"),
+        system_blocks_provider=lambda: [],
+    )
+
+    async def factory() -> Session:
+        return bare
+
+    app = OperatorApp(factory)
+    async with app.run_test(size=(120, 24)) as pilot:
+        await _adopted(app, pilot)
+        assert app._status is not None
+        assert app._status._team == ""
+
+        await app._adopt_takeover_session(_session(tmp_path, agents, teams))
+        for _ in range(6):
+            await pilot.pause()
+        assert app._status._team == "lopdev"
+        assert app._status._agent_profile == "auditor"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tui/test_resumed_attachment.py
+++ b/tests/unit/tui/test_resumed_attachment.py
@@ -86,9 +86,36 @@ def _session(root: Path, agents: Any, teams: Any) -> Session:
     )
 
 
-async def _adopted(app: OperatorApp, pilot: Any) -> None:
-    """Let the boot worker adopt the session and the band settle."""
-    for _ in range(10):
+async def _adopted(app: OperatorApp, pilot: Any, session: Any) -> None:
+    """Wait until ``session`` has actually been adopted, then let layout settle.
+
+    Polls for the EVENT rather than spending a fixed pause budget, which is the
+    file's house idiom (``test_app_pilot.py`` waits ``if app._session is
+    session: break`` with a bound of 50). The session is built by an async boot
+    worker, so how many pauses the adopt takes is a function of machine load,
+    not of the code under test: measured latency for these tests ranged from 1
+    to 23 pauses across runs. A fixed budget of 10 therefore sat mid
+    distribution and failed roughly half of all runs — and the assertions it
+    failed were this file's own guard for the feature, including the D1 notice
+    check. Raising the budget would only lengthen the fuse; waiting on the
+    condition removes it.
+
+    Identity, not ``is not None``: these tests hand the factory one specific
+    session and every assertion below is about THAT session's restored state,
+    so waking on any adopt would reintroduce a race with a different shape.
+
+    The trailing pauses are for LAYOUT, not for the adopt: ``_adopt_session`` is
+    synchronous end to end, so once it has run the blocks are mounted, but
+    ``test_the_stale_notice_is_on_screen_on_a_session_with_history`` asserts on
+    ``region``, which is only meaningful after a layout pass has placed them.
+    Bounded and load-independent, unlike waiting for the adopt itself.
+    """
+    for _ in range(50):
+        await pilot.pause()
+        if app._session is session:
+            break
+    assert app._session is session, "the boot worker never adopted the session"
+    for _ in range(2):
         await pilot.pause()
 
 
@@ -149,7 +176,7 @@ async def test_the_band_names_the_team_and_agent_a_resume_restored(tmp_path) -> 
 
     app = OperatorApp(factory)
     async with app.run_test(size=(120, 24)) as pilot:
-        await _adopted(app, pilot)
+        await _adopted(app, pilot, resumed)
         assert app._status is not None
         assert app._status._team == "lopdev"
         assert app._status._agent_profile == "auditor"
@@ -171,7 +198,7 @@ async def test_a_stale_team_leaves_the_segment_blank_and_says_why(tmp_path) -> N
 
     app = OperatorApp(factory)
     async with app.run_test(size=(120, 24)) as pilot:
-        await _adopted(app, pilot)
+        await _adopted(app, pilot, resumed)
         assert app._status is not None
         assert app._status._team == ""
         notices = [(n.text() or "") for n in app.query(NoticeBlock)]
@@ -202,7 +229,7 @@ async def test_the_stale_notice_is_on_screen_on_a_session_with_history(tmp_path)
 
     app = OperatorApp(factory)
     async with app.run_test(size=(100, 26)) as pilot:
-        await _adopted(app, pilot)
+        await _adopted(app, pilot, resumed)
         notice = _restore_notice(app)
         assert notice is not None, "the stale-attachment notice was never mounted"
         assert _is_on_screen(
@@ -232,7 +259,7 @@ async def test_a_restored_goal_is_reported(tmp_path) -> None:
 
     app = OperatorApp(factory)
     async with app.run_test(size=(120, 24)) as pilot:
-        await _adopted(app, pilot)
+        await _adopted(app, pilot, resumed)
         notices = [(n.text() or "") for n in app.query(NoticeBlock)]
         assert any(
             "goal restored" in text and "cut the release" in text for text in notices
@@ -264,7 +291,7 @@ async def test_the_takeover_adopt_paints_the_restored_attachment(tmp_path) -> No
 
     app = OperatorApp(factory)
     async with app.run_test(size=(120, 24)) as pilot:
-        await _adopted(app, pilot)
+        await _adopted(app, pilot, bare)
         assert app._status is not None
         assert app._status._team == ""
 
@@ -289,7 +316,7 @@ async def test_a_clean_resume_raises_no_notice(tmp_path) -> None:
 
     app = OperatorApp(factory)
     async with app.run_test(size=(120, 24)) as pilot:
-        await _adopted(app, pilot)
+        await _adopted(app, pilot, resumed)
         notices = [(n.text() or "") for n in app.query(NoticeBlock)]
         assert not any("could not restore" in text for text in notices), notices
 
@@ -310,7 +337,7 @@ async def test_the_stale_notice_does_not_end_the_empty_state(tmp_path) -> None:
 
     app = OperatorApp(factory)
     async with app.run_test(size=(120, 24)) as pilot:
-        await _adopted(app, pilot)
+        await _adopted(app, pilot, resumed)
         # The notice IS on screen; what must not happen is the splash retiring
         # for it. ``_welcome_visible`` is the authoritative "the conversation
         # has started" edge both boot layouts hang off.

--- a/tests/unit/tui/test_resumed_attachment.py
+++ b/tests/unit/tui/test_resumed_attachment.py
@@ -1,0 +1,181 @@
+"""The status band after a resume has to tell the truth about what is attached.
+
+``Session`` restores a stored ``/team`` and ``/agent`` at construction (see
+``tests/unit/session/test_attachment_persistence.py``); these tests cover the
+front end's half, driving the REAL ``OperatorApp`` against a real resumed
+session rather than a fake, because the contract under test is precisely that
+the band is driven FROM the session:
+
+* a restored attachment must reach the band on adopt, or the user sees a blank
+  segment beside a manager that is in force;
+* a stale one must leave the segment blank AND say why, because the alternative
+  readings — a segment naming a team whose briefs are not in the prompt, or a
+  silent downgrade to the base voice — are the two ways this can lie.
+
+Both cold ``--resume <id>`` and the in-TUI ``/resume`` picker land in
+``_adopt_session``, so exercising that sink covers both routes.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from local_operator.agents import AgentEditFields, AgentRegistry
+from local_operator.session.session import Session
+from local_operator.session.transcript import Transcript
+from local_operator.teams import Team, TeamRegistry
+from local_operator.tui.app import OperatorApp
+from local_operator.tui.widgets.transcript import NoticeBlock
+from tests.unit.session.test_session import MODEL, ScriptedStream
+
+
+def _role_fields(**overrides: Any) -> AgentEditFields:
+    base: dict[str, Any] = dict(
+        name=None,
+        description=None,
+        tags=None,
+        categories=None,
+        security_prompt=None,
+        hosting=None,
+        model=None,
+        last_message=None,
+        temperature=None,
+        top_p=None,
+        top_k=None,
+        max_tokens=None,
+        stop=None,
+        frequency_penalty=None,
+        presence_penalty=None,
+        seed=None,
+        current_working_directory=None,
+    )
+    base.update(overrides)
+    return AgentEditFields(**base)
+
+
+def _registries(root: Path) -> tuple[AgentRegistry, TeamRegistry]:
+    agents = AgentRegistry(root)
+    agents.create_agent(_role_fields(name="auditor", description="Audits", tags=["role"]))
+    teams = TeamRegistry(root)
+    teams.save_team(
+        Team(
+            id="t-lopdev",
+            name="lopdev",
+            created_date=datetime.now(timezone.utc),
+            manager="manager",
+            instructions="Ship reviewed work.",
+            project="local-operator",
+        )
+    )
+    return agents, teams
+
+
+def _session(root: Path, agents: Any, teams: Any) -> Session:
+    return Session(
+        model=MODEL,
+        stream_fn=ScriptedStream([[]]),
+        tools=[],
+        transcript=Transcript(root / "sess"),
+        system_blocks_provider=lambda: [],
+        agent_registry=agents,
+        team_registry=teams,
+    )
+
+
+async def _adopted(app: OperatorApp, pilot: Any) -> None:
+    """Let the boot worker adopt the session and the band settle."""
+    for _ in range(10):
+        await pilot.pause()
+
+
+@pytest.mark.asyncio
+async def test_the_band_names_the_team_and_agent_a_resume_restored(tmp_path) -> None:
+    """Before this, both segments were blank on every resume — honestly so, the
+    persona really was gone. Now the state comes back and the band shows it."""
+    agents, teams = _registries(tmp_path)
+    first = _session(tmp_path, agents, teams)
+    first.attach_team(teams.get_team_by_name("lopdev"))
+    first.attach_agent_profile("auditor")
+
+    resumed = _session(tmp_path, agents, teams)
+
+    async def factory() -> Session:
+        return resumed
+
+    app = OperatorApp(factory)
+    async with app.run_test(size=(120, 24)) as pilot:
+        await _adopted(app, pilot)
+        assert app._status is not None
+        assert app._status._team == "lopdev"
+        assert app._status._agent_profile == "auditor"
+
+
+@pytest.mark.asyncio
+async def test_a_stale_team_leaves_the_segment_blank_and_says_why(tmp_path) -> None:
+    """The band must never paint a name that is not stamped into the prompt, and
+    the downgrade must not be silent."""
+    agents, teams = _registries(tmp_path)
+    first = _session(tmp_path, agents, teams)
+    first.attach_team(teams.get_team_by_name("lopdev"))
+
+    # The team is gone by the time the session is reopened (renamed or deleted).
+    resumed = _session(tmp_path, agents, TeamRegistry(tmp_path / "elsewhere"))
+
+    async def factory() -> Session:
+        return resumed
+
+    app = OperatorApp(factory)
+    async with app.run_test(size=(120, 24)) as pilot:
+        await _adopted(app, pilot)
+        assert app._status is not None
+        assert app._status._team == ""
+        notices = [(n.text() or "") for n in app.query(NoticeBlock)]
+        assert any("lopdev" in text and "without it" in text for text in notices), notices
+
+
+@pytest.mark.asyncio
+async def test_a_clean_resume_raises_no_notice(tmp_path) -> None:
+    """A working restore is not news; only a miss is."""
+    agents, teams = _registries(tmp_path)
+    first = _session(tmp_path, agents, teams)
+    first.attach_team(teams.get_team_by_name("lopdev"))
+
+    resumed = _session(tmp_path, agents, teams)
+
+    async def factory() -> Session:
+        return resumed
+
+    app = OperatorApp(factory)
+    async with app.run_test(size=(120, 24)) as pilot:
+        await _adopted(app, pilot)
+        notices = [(n.text() or "") for n in app.query(NoticeBlock)]
+        assert not any("could not restore" in text for text in notices), notices
+
+
+@pytest.mark.asyncio
+async def test_the_stale_notice_does_not_end_the_empty_state(tmp_path) -> None:
+    """It is infrastructure news the user did not ask for, so it lands under the
+    splash the way the MCP startup record does rather than collapsing the boot
+    composition — the failure that once made the centred prompt unreachable."""
+    agents, teams = _registries(tmp_path)
+    first = _session(tmp_path, agents, teams)
+    first.attach_team(teams.get_team_by_name("lopdev"))
+
+    resumed = _session(tmp_path, agents, TeamRegistry(tmp_path / "elsewhere"))
+
+    async def factory() -> Session:
+        return resumed
+
+    app = OperatorApp(factory)
+    async with app.run_test(size=(120, 24)) as pilot:
+        await _adopted(app, pilot)
+        # The notice IS on screen; what must not happen is the splash retiring
+        # for it. ``_welcome_visible`` is the authoritative "the conversation
+        # has started" edge both boot layouts hang off.
+        assert app._welcome_visible is True
+        notices = [(n.text() or "") for n in app.query(NoticeBlock)]
+        assert any("could not restore" in text for text in notices), notices


### PR DESCRIPTION
## Summary

Makes a session's attached identity survive a resume. The `/team` roster, the `/agent` profile and the `/goal` are journalled to a sidecar beside the transcript and re-resolved at construction, so reopening a conversation brings back the persona it was running under rather than silently downgrading to the base voice.

- New `attachment.json` sidecar in the session directory, following the existing `origin.json` / `title.json` conventions exactly: atomic pid-named temp plus `replace`, tolerant reads, best-effort by contract, directory mtime preserved.
- Written on change only (attach, detach, `/goal` set or clear), never per turn.
- Restored at `Session` construction, beside the existing wake, title and active-route restores.
- A team or profile that no longer resolves degrades to unattached, names what was lost as a system notice, and leaves the band segment blank.
- Version bumps to `0.36.0` as a minor: this restores expected behaviour but also adds a new persisted-state capability. The version moved twice during review as main claimed `0.34.0` (PR #305) and then `0.35.0` (PR #299); the branch advances to the next free minor.

## Impact

This was reported as the status band going blank after a resume, with the assumption that the persona stayed in force through conversation history. That is not what happened.

The team and agent briefs ride the **volatile tail** of the system prompt, which is built from a `GoalState` that `session_factory` constructs empty on every session (`session_factory.py`, the `goal_state = GoalState()` line). Nothing in the transcript reproduced it. So a `--resume` did not merely blank a segment: it dropped the briefs from the model's instructions entirely, and the conversation carried on as an ordinary session. The blank band was reporting the truth, which is why this is a behavioural fix and not a display one, and why the band is still driven from the session rather than painted from the sidecar.

**Names are persisted, never brief bodies.** The restore re-resolves each name through the same entry points `/team` and `/agent` use, sharing the one `_resolve_profile_or_specialist` ordering (own role, then own specialist, then packaged seed). That is deliberate: the operator edits teams and profiles between sessions, and a stored brief would resume them onto instructions that no longer exist anywhere. It also means resolution order cannot drift between the attach path and the resume path.

The restore mutates the shared holder the system-blocks provider already closed over, so only the volatile tail moves and the cached persona prefix stays warm. Nothing is rebuilt.

## Before reproduction

Driven through the real `session_factory.create_session`, which is the path `lop --resume <id>` takes, on `origin/main` at f2a52b53:

```text
[session 1] id=2dca944b19fa team='lopdev' agent='auditor'
[session 1] TEAM-BRIEF-MARKER in prompt: True

sidecar on disk: NONE (no persistence)

[--resume 2dca944b19fa] team='' agent='' goal=''
[--resume] TEAM-BRIEF-MARKER back IN THE SYSTEM PROMPT: False
[--resume] PROJECT-MARKER in prompt: False
[--resume] goal in prompt: False
```

The team brief reaches the prompt while the session is live and is gone after the resume. This is the bug, and it is in the prompt, not the band.

## Real-path validation

Same script, same factory, on this branch:

```text
[session 1] id=179a4074a2d5 team='lopdev' agent='auditor'
[session 1] TEAM-BRIEF-MARKER in prompt: True

sidecar on disk: {"team": "lopdev", "agent": "auditor", "goal": "survive the resume"}

[--resume 179a4074a2d5] team='lopdev' agent='auditor' goal='survive the resume'
[--resume] TEAM-BRIEF-MARKER back IN THE SYSTEM PROMPT: True
[--resume] PROJECT-MARKER in prompt: True
[--resume] goal in prompt: True
```

The assertion is on the **built system blocks**, not on the band text, because a segment naming a team whose briefs are not in the prompt would be the same bug wearing a label.

### Both resume routes

Cold `--resume <id>` and the in-TUI `/resume` picker both land in the same session construction, confirmed by resolving the id through `resume_dir` / `resolve_resume_id` and building each way:

```text
cold --resume resolves: abc123 -> abc123
ROUTE A cold  : 'lopdev' 'auditor' 'survive the resume' brief: True
ROUTE B picker: 'lopdev' 'auditor' 'survive the resume' brief: True
```

### The cache prefix is untouched

The load-bearing constraint. Comparing `build_system_blocks` with and without an attachment:

```text
block count identical  : True 4
stable PREFIX identical: True
blocks that differ     : [3] (tail index = 3 )
tail carries the briefs: True
OK: restore can only move the volatile tail
```

Only block 3, the volatile tail, moves. The instruction / tool-inventory / env prefix is byte-identical, so a restore cannot invalidate a warm provider cache.

### The stale name degrades cleanly

Attaching a team and a profile, then deleting the team's directory between sessions:

```text
attached: lopdev auditor
resume did not raise. team= ''  brief= ''
agent still restored: 'auditor'
notice: could not restore team 'lopdev' from the previous session (renamed or deleted); continuing without it
sidecar still holds the name (recoverable): {"team": "lopdev", "agent": "auditor", "goal": ""}
```

Four properties here, each of which was a way to get this wrong:

- the resume opens rather than raising;
- the band segment stays blank, so nothing names a persona the prompt does not carry;
- the half that **did** resolve still comes back, and the notice names only what was lost rather than claiming the session is bare;
- the sidecar still holds the unresolved name. Writes are suppressed during the restore, so a team that is only momentarily unresolvable (registry not wired on this host, a directory not yet synced) is recoverable instead of being erased by a partial write-back.

## Visual validation

Rendered with the real `OperatorApp` so the stylesheet applies, at the same size and settled for the same number of frames. Before captured from a clean `origin/main` worktree, not from a stash.

**Before** — band reads `test/m › cwd`, no team or agent segment:

![before](https://raw.githubusercontent.com/damianvtran/local-operator/pr-resume-attachment-assets/assets/lop-resume-attachment-before-view.png)

**After** — band reads `test/m › ▥ lopdev › ◉ auditor › cwd`:

![after](https://raw.githubusercontent.com/damianvtran/local-operator/pr-resume-attachment-assets/assets/lop-resume-attachment-after-view.png)

Backing numbers from the same run, so the pixels and the state agree:

```text
before: band.team=''       band.agent_profile=''        team_brief_len=0
after:  band.team='lopdev' band.agent_profile='auditor' team_brief_len=1164
```

SVG stills: [before.svg](https://raw.githubusercontent.com/damianvtran/local-operator/pr-resume-attachment-assets/assets/lop-resume-attachment-before.svg) · [after.svg](https://raw.githubusercontent.com/damianvtran/local-operator/pr-resume-attachment-assets/assets/lop-resume-attachment-after.svg)

## Automated validation

- `env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit -q`: **6,763 passed, 7 skipped in 129.42s** (6,745 on `origin/main` plus the 18 added here)
- `.venv/bin/python -m flake8 .`: passed
- `uvx --from black==26.1.0 python -m black --check local_operator tests`: **493 files unchanged**
- `uvx isort --check-only --profile black local_operator tests`: passed
- `.venv/bin/python -m pyright --pythonpath .venv/bin/python .`: **0 errors, 0 warnings**

18 new tests: the persist/restore round trip including the brief reaching the tail and `active_team` being restored (not just its name, since that is what subagents inherit), names-not-briefs including a team edited between sessions resuming with its current briefs, the stale-name miss and its partial-restore recovery, sidecar robustness including a file cut inside a multi-byte character, and the band sync driven through the real `OperatorApp`.

Note on the black and isort invocations: the console scripts fail to spawn under `uvx` on this machine, so they were run as `python -m` from the same pinned distribution. `black --version` inside that environment reports `26.1.0`.

## Change classification

C2, behavioural fix with a new persisted sidecar. No data migration and nothing to roll back: a session with no `attachment.json` (every session written before this) reads as nothing attached, which is exactly the current behaviour.

