### PR TITLE
fix(session): stop a mid-batch model switch from bricking the session

### DIFF
--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -497,6 +497,95 @@ _PERSISTABLE_CUSTOM_TYPES: frozenset[str] = frozenset(
 )
 
 
+def _pair_spliced_tool_results(messages: list[Message]) -> list[Message]:
+    """``messages`` with any message spliced INTO a tool batch moved after it.
+
+    The last line of defence for the invariant Layer 1 (``_append_or_park_journal``)
+    enforces at the source: the rendered history must never carry a non-tool
+    message between an assistant's ``tool_calls`` and the ``tool_result``s
+    answering them. A session already bricked IN MEMORY predates that guard and
+    cannot be helped by it, and a future writer appending straight to
+    ``_context.messages`` would reintroduce the same 400. This runs at request
+    assembly so neither case reaches a provider.
+
+    The constraint is POSITIONAL, not set membership. Verified against the live
+    Anthropic API (claude-sonnet-4-5, 2026-08-25), because
+    ``AnthropicClient._build_body`` coalesces tool results onto a preceding user
+    message and the difference decides what a repair has to do::
+
+        [tool_result, tool_result]            -> 200
+        [tool_result, tool_result, text]      -> 200
+        [text, tool_result, tool_result]      -> 400
+        interloper as its own message between -> 400
+
+    So results must be the LEADING run of the message that follows the calls,
+    and the repair is to MOVE the interloper after them. Synthesizing
+    placeholder results instead is wrong and was tested as such: it draws a
+    different 400 (``unexpected tool_use_id found in tool_result blocks``)
+    because the genuine results still arrive behind the placeholders.
+    Synthesis is only correct for a genuinely UNANSWERED tail, which is
+    :meth:`Session._history_snapshot`'s job — an unanswered batch is left
+    untouched here.
+
+    Relative order among several interlopers is preserved, and moving them is
+    safe ONLY because everything that can land in that window is a
+    harness-authored notice (``session_model_switch``, ``session_incident``):
+    reordering advisory chrome against a tool batch changes nothing the user
+    wrote. **If a custom type is ever added that carries user-authored text,
+    this assumption needs revisiting** — moving a user's words past a tool
+    batch would silently reorder the conversation they see.
+    """
+    # Hot path: ``_render_history`` runs on every provider call, and the
+    # overwhelming majority of histories have no tool batch to violate.
+    if not any(message.role == "assistant" and message.tool_calls for message in messages):
+        return messages
+
+    out: list[Message] = []
+    index = 0
+    total = len(messages)
+    repaired = False
+    while index < total:
+        message = messages[index]
+        out.append(message)
+        index += 1
+        if message.role != "assistant" or not message.tool_calls:
+            continue
+        # Collect the batch's answers and anything spliced among them, stopping
+        # at the first message that is neither — that is the end of the batch,
+        # and a trailing non-tool message there is already legal.
+        expected = {call.id for call in message.tool_calls}
+        results: list[Message] = []
+        interlopers: list[Message] = []
+        scan = index
+        while scan < total and expected:
+            candidate = messages[scan]
+            if candidate.role == "tool":
+                results.append(candidate)
+                expected.discard(candidate.tool_call_id or "")
+            else:
+                interlopers.append(candidate)
+            scan += 1
+        if expected or not interlopers:
+            # Unanswered tail (leave it to ``_wire_legal_snapshot``) or nothing
+            # spliced. Either way this batch is not ours to touch.
+            continue
+        out.extend(results)
+        out.extend(interlopers)
+        index = scan
+        repaired = True
+
+    if repaired:
+        # After Layer 1 this is dead code. Logging at warning rather than debug
+        # is deliberate: silence here would hide a regression that reintroduces
+        # the splice, and the repair would mask it right up until some future
+        # shape it cannot fix.
+        logger.warning(
+            "repaired a message spliced into an open tool batch; a journal "
+            "append bypassed the turn-boundary guard (see _append_or_park_journal)"
+        )
+    return out
+
+
 def _paired_prefix(messages: Sequence[AgentMessage]) -> list[AgentMessage]:
     """``messages`` truncated so it never ENDS in unanswered tool calls.
 
@@ -1226,6 +1315,16 @@ class Session:
         # Error text from the run just ended, journalled as a session incident
         # once persistence finishes (see _run_turn / journal_incident).
         self._pending_incident: str | None = None
+        #: Journal notices (model switch / session incident) whose LIVE append
+        #: arrived while a turn owned the message list. They are already on
+        #: disk; only the live splice is parked, because appending one between
+        #: an assistant's ``tool_calls`` and their ``tool_result``s builds a
+        #: list no provider accepts and NOTHING repairs it afterwards, so the
+        #: session re-sends the illegal prefix on every later turn and is
+        #: bricked for good. Drained at the turn-safe boundaries (steering
+        #: drain, pipeline exit, prompt entry, dispose) in the manner of
+        #: ``_pending_shell_records``.
+        self._pending_context_journal: list[CustomMessage] = []
         # (new_label, transient) of the last model switch made model-visible, so
         # the two edges that can both fire for one change (``set_model`` and a
         # route-settled event) do not double-announce. See journal_model_switch.
@@ -1369,6 +1468,14 @@ class Session:
         that reaches a provider has to be free of them.
         """
         rendered = self._convert_to_llm(self._live_todo_reminders(messages))
+        # Immediately after the conversion and before any other pass, so EVERY
+        # caller of this method is covered by one application: the turn path,
+        # compaction, `_history_snapshot` and the token counter. Repairing at
+        # the render rather than in a client fixes both wires at once — the
+        # OpenAI Responses path emits a bare `role:user` item between
+        # `function_call` and `function_call_output` and is rejected for the
+        # same reason Anthropic rejects the coalesced form.
+        rendered = _pair_spliced_tool_results(rendered)
         if self._images_rejected:
             # Nothing to rebound once images are being dropped outright, and
             # dropping first saves decoding a block that is about to become a
@@ -2574,6 +2681,10 @@ class Session:
             # receipt may have queued while the previous owner still held the
             # lock. It must be visible before this prompt builds its request.
             await self._flush_shell_records()
+            # Same race, same window: a journal notice parked by the previous
+            # owner must reach the model before this prompt's request is built,
+            # or the switch it announces goes unmentioned for another turn.
+            self._flush_context_journal()
             # A fresh user prompt supersedes any earlier interrupt request.
             self._abort_requested = False
             if self._is_streaming:
@@ -3177,6 +3288,10 @@ class Session:
             # Same shell-receipt boundary as prompt(): a wake turn must not
             # build from context that omits a command already visible in TUI.
             await self._flush_shell_records()
+            # Same boundary, same reason: a notice parked by a turn that ended
+            # without reaching a steering drain (an abort mid-batch) rejoins
+            # here, before this turn builds its request.
+            self._flush_context_journal()
             # Same flush as prompt(): a wake-delivery turn is still a prompt
             # path, and the catch-up must not be stranded behind it.
             self._handle_missed_wakes()
@@ -3227,6 +3342,11 @@ class Session:
             # provider message list. Persist it before releasing `_turn_lock`,
             # when no next prompt can build from a half-updated conversation.
             await self._flush_shell_records()
+            # Likewise for a journal notice parked mid-turn. The tool batch is
+            # closed by now, so the append is legal, and doing it here means an
+            # aborted turn still hands the notice to the next one instead of
+            # stranding it until the session is disposed.
+            self._flush_context_journal()
 
     async def _flush_held_end(self) -> None:
         """Emit the boundary event the pipeline was holding, if any."""
@@ -3625,6 +3745,61 @@ class Session:
             )
             return None
 
+    def _append_or_park_journal(self, message: CustomMessage) -> None:
+        """Put a journal notice on the live context, or park it for a boundary.
+
+        The live context may not take a non-tool message while a turn owns it.
+        ``AgentLoop`` appends the assistant message the moment the model turn
+        ends and appends the tool results only once the WHOLE batch returns
+        (``_append_results``), so for the entire duration of a tool batch the
+        list ends in an assistant whose ``tool_calls`` have no answers.
+        Splicing a notice in there produces
+        ``assistant(tool_use) -> user -> tool_result``, which every provider
+        rejects ("`tool_use` ids were found without `tool_result` blocks
+        immediately after") — and because nothing repairs the live list, the
+        session re-sends that prefix on every later turn and is bricked until
+        it is restarted. Observed live: a ``/model`` press mid-batch killed a
+        session outright, including a bare "Continue".
+
+        BOTH conditions are tested, for the reason :meth:`prompt` spells out:
+        ``_is_streaming`` covers only ``_run_turn``, while ``_turn_lock`` spans
+        the whole pipeline including a post-compaction auto-continuation.
+        ``record_shell`` and ``adopt_aside`` guard on the same pair.
+
+        The delay is accepted, not a compromise to be "fixed" later by
+        re-splicing: the notice is advisory, the env block's ``Model:`` line
+        already carries the live identity, and the transcript write has already
+        happened, so the worst case is that a switch NOTICE lands at the end of
+        a long tool batch instead of inside it. Re-splicing to make it prompt
+        is precisely the bug above.
+        """
+        if self._is_streaming or self._turn_lock.locked():
+            self._pending_context_journal.append(message)
+            return
+        self._context.messages.append(message)
+
+    def _drain_context_journal(self) -> list[CustomMessage]:
+        """Pop every parked journal notice, oldest first.
+
+        Synchronous and total: the transcript write already happened at park
+        time, so there is nothing here that can fail and nothing to retry —
+        unlike ``_flush_shell_records``, which pops only after a successful
+        write. Callers either extend the live context with the result or hand
+        it to the loop ahead of steering messages.
+        """
+        parked = self._pending_context_journal
+        self._pending_context_journal = []
+        return parked
+
+    def _flush_context_journal(self) -> None:
+        """Fold parked journal notices into the live context at a safe
+        boundary. A parked notice must never be silently dropped: it is the
+        only thing telling the model it was switched or that the last run
+        failed."""
+        parked = self._drain_context_journal()
+        if parked:
+            self._context.messages.extend(parked)
+
     async def journal_incident(self, raw: str) -> None:
         """Persist and surface WHY the session last failed.
 
@@ -3648,7 +3823,7 @@ class Session:
         )
         try:
             await self._transcript.append_message(message)
-            self._context.messages.append(message)
+            self._append_or_park_journal(message)
         except OSError:
             logger.warning("could not journal session incident", exc_info=True)
 
@@ -3712,7 +3887,7 @@ class Session:
             # fallback is live-context-only (see _is_persistable_message).
             if _is_persistable_message(message):
                 await self._transcript.append_message(message)
-            self._context.messages.append(message)
+            self._append_or_park_journal(message)
         except OSError:
             logger.warning("could not journal model switch", exc_info=True)
 
@@ -3793,6 +3968,30 @@ class Session:
         overwhelmingly common case — this is called at EVERY tool and message
         boundary, and an event per boundary would be noise with no receiver.
         """
+        # Journal notices parked by ``_append_or_park_journal`` ride out ahead
+        # of the steering messages. This is the loop's own injection boundary —
+        # it runs only after ``_append_results`` has closed the tool batch — so
+        # it is the earliest point at which a notice can rejoin the context
+        # legally, and ordering it first keeps "you were switched" ahead of the
+        # steer the user typed after switching. Already persisted at park time,
+        # so these are NOT re-appended to the transcript here.
+        # Journal notices parked by ``_append_or_park_journal`` rejoin the live
+        # context HERE, appended directly rather than returned. This is the
+        # loop's own injection boundary — it runs only after ``_append_results``
+        # has closed the tool batch — so it is the earliest point at which a
+        # notice can rejoin legally, and it lands ahead of any steering message
+        # the caller is about to drain in (``_drain_pending`` appends those
+        # after), which keeps "you were switched" before the steer the user
+        # typed after switching.
+        #
+        # NOT returned, and that distinction is load-bearing: anything this
+        # method hands back becomes a loop INJECTION, and a non-empty injection
+        # list keeps the inner loop running (``while has_more_tool_calls or
+        # pending``). Returning an advisory notice would therefore buy an entire
+        # extra provider call to tell the model something the next turn would
+        # have carried for free. Already persisted at park time, so there is no
+        # transcript write here either.
+        self._flush_context_journal()
         messages: list[AgentMessage] = []
         while not self._steering_queue.empty():
             message = self._steering_queue.get_nowait()
@@ -5782,6 +5981,13 @@ class Session:
             # switch made moments before quitting is exactly the write that
             # must still land for the next `--resume` to honour it.
             await self._flush_selected_model()
+            # Fold any still-parked journal notice back into the live context
+            # before the durability flush reads it. The transcript write
+            # already happened at park time, so `--resume` is correct either
+            # way and `_persist_new_messages` dedups by id; this keeps the
+            # in-memory list consistent with what was persisted rather than
+            # leaving a notice stranded in the FIFO at teardown.
+            self._flush_context_journal()
             # HC-11: cancel tracked background tasks (wake deliveries, aside
             # persistence), then close the session task group.
             for task in list(self._background_tasks):

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -541,7 +541,11 @@ def _pair_spliced_tool_results(messages: list[Message]) -> list[Message]:
     is examined by more than one of them. An earlier version let an UNANSWERED
     batch rescan to the end of the list, which made a history of open batches
     quadratic (3.7s at 4000 messages against 2.3ms answered); see
-    ``test_pair_spliced_tool_results_scans_each_message_once``.
+    ``test_pair_spliced_tool_results_scans_each_message_once`` for the speed
+    property and
+    ``test_pair_spliced_tool_results_does_not_pull_the_next_batch_into_an_open_one``
+    for the correctness property, which are pinned separately because the bound
+    carries both.
     """
     # Hot path: ``_render_history`` runs on every provider call, and the
     # overwhelming majority of histories have no tool batch to violate.
@@ -576,10 +580,19 @@ def _pair_spliced_tool_results(messages: list[Message]) -> list[Message]:
                 # rescanned to the end of the list for EVERY later assistant
                 # message -- 4000 messages took 3.7s instead of 2.3ms.
                 #
-                # It is also the more correct stop. Swallowing the next batch
-                # would move ITS results onto this batch's assistant and push
-                # that assistant behind its own answers, turning one illegal
-                # shape into a different one.
+                # It is also the more correct stop, in one specific shape: a
+                # batch whose answer arrives LATE, after the next batch has
+                # already opened. Only then does ``expected`` empty at all, so
+                # only then can the repair fire on a window that spans two
+                # batches -- ``A1(x) A2(y,z) T(y) T(z) T(x)`` would come out as
+                # ``A1 T(y) T(z) T(x) A2``, with A2 emitted BEHIND its own
+                # answers: one illegal shape traded for another.
+                #
+                # A batch that is never answered at all is NOT this case, and
+                # was never at risk: ``expected`` stays non-empty, so the
+                # ``if expected: continue`` guard below suppresses the repair
+                # with or without this bound. Do not reach for an unanswered
+                # batch to justify the stop -- reach for the late answer.
                 break
             if candidate.role == "tool":
                 results.append(candidate)

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -524,7 +524,7 @@ def _pair_spliced_tool_results(messages: list[Message]) -> list[Message]:
     different 400 (``unexpected tool_use_id found in tool_result blocks``)
     because the genuine results still arrive behind the placeholders.
     Synthesis is only correct for a genuinely UNANSWERED tail, which is
-    :meth:`Session._history_snapshot`'s job — an unanswered batch is left
+    :meth:`Session._wire_legal_snapshot`'s job — an unanswered batch is left
     untouched here.
 
     Relative order among several interlopers is preserved, and moving them is
@@ -534,6 +534,14 @@ def _pair_spliced_tool_results(messages: list[Message]) -> list[Message]:
     wrote. **If a custom type is ever added that carries user-authored text,
     this assumption needs revisiting** — moving a user's words past a tool
     batch would silently reorder the conversation they see.
+
+    Linear in ``len(messages)``, and that has to stay true because this sits on
+    every provider call. Each batch's inner scan stops at the next assistant
+    carrying ``tool_calls``, so the scanned windows are disjoint and no message
+    is examined by more than one of them. An earlier version let an UNANSWERED
+    batch rescan to the end of the list, which made a history of open batches
+    quadratic (3.7s at 4000 messages against 2.3ms answered); see
+    ``test_pair_spliced_tool_results_scans_each_message_once``.
     """
     # Hot path: ``_render_history`` runs on every provider call, and the
     # overwhelming majority of histories have no tool batch to violate.
@@ -559,9 +567,28 @@ def _pair_spliced_tool_results(messages: list[Message]) -> list[Message]:
         scan = index
         while scan < total and expected:
             candidate = messages[scan]
+            if candidate.role == "assistant" and candidate.tool_calls:
+                # A new batch opens here, so this one is over whatever is still
+                # unanswered. Bounding the scan is what keeps the whole pass
+                # linear: every batch's window ends at the next batch's start,
+                # so the windows are disjoint and each message is examined by at
+                # most one of them. Without this bound an unanswered batch
+                # rescanned to the end of the list for EVERY later assistant
+                # message -- 4000 messages took 3.7s instead of 2.3ms.
+                #
+                # It is also the more correct stop. Swallowing the next batch
+                # would move ITS results onto this batch's assistant and push
+                # that assistant behind its own answers, turning one illegal
+                # shape into a different one.
+                break
             if candidate.role == "tool":
                 results.append(candidate)
-                expected.discard(candidate.tool_call_id or "")
+                # Guarded rather than ``or ""``: coercing a missing id to the
+                # empty string would let an unidentified result answer a call
+                # only if some call also had an empty id. A result with no id
+                # answers nothing, so it closes no call.
+                if candidate.tool_call_id is not None:
+                    expected.discard(candidate.tool_call_id)
             else:
                 interlopers.append(candidate)
             scan += 1
@@ -601,7 +628,7 @@ def _paired_prefix(messages: Sequence[AgentMessage]) -> list[AgentMessage]:
     tool_call_id"). Measured: a Ctrl+C mid-batch left two unpaired calls on
     disk and an unusable session.
 
-    :meth:`Session._history_snapshot` faces the same illegal tail for a
+    :meth:`Session._wire_legal_snapshot` faces the same illegal tail for a
     request it is about to send and pairs the calls with placeholders. This is
     the persistence counterpart, and it DROPS rather than pairs: a placeholder
     is the honest answer to "what are you doing right now", but on disk it
@@ -1470,7 +1497,7 @@ class Session:
         rendered = self._convert_to_llm(self._live_todo_reminders(messages))
         # Immediately after the conversion and before any other pass, so EVERY
         # caller of this method is covered by one application: the turn path,
-        # compaction, `_history_snapshot` and the token counter. Repairing at
+        # compaction, `_wire_legal_snapshot` and the token counter. Repairing at
         # the render rather than in a client fixes both wires at once — the
         # OpenAI Responses path emits a bare `role:user` item between
         # `function_call` and `function_call_output` and is rejected for the
@@ -3784,18 +3811,19 @@ class Session:
         Synchronous and total: the transcript write already happened at park
         time, so there is nothing here that can fail and nothing to retry —
         unlike ``_flush_shell_records``, which pops only after a successful
-        write. Callers either extend the live context with the result or hand
-        it to the loop ahead of steering messages.
+        write. Split out from its one caller, ``_flush_context_journal``, so
+        the drain is testable on its own.
         """
         parked = self._pending_context_journal
         self._pending_context_journal = []
         return parked
 
     def _flush_context_journal(self) -> None:
-        """Fold parked journal notices into the live context at a safe
-        boundary. A parked notice must never be silently dropped: it is the
-        only thing telling the model it was switched or that the last run
-        failed."""
+        """Fold parked journal notices into the live context at a safe boundary.
+
+        A parked notice must never be silently dropped: it is the only thing
+        telling the model it was switched or that the last run failed.
+        """
         parked = self._drain_context_journal()
         if parked:
             self._context.messages.extend(parked)
@@ -3968,13 +3996,6 @@ class Session:
         overwhelmingly common case — this is called at EVERY tool and message
         boundary, and an event per boundary would be noise with no receiver.
         """
-        # Journal notices parked by ``_append_or_park_journal`` ride out ahead
-        # of the steering messages. This is the loop's own injection boundary —
-        # it runs only after ``_append_results`` has closed the tool batch — so
-        # it is the earliest point at which a notice can rejoin the context
-        # legally, and ordering it first keeps "you were switched" ahead of the
-        # steer the user typed after switching. Already persisted at park time,
-        # so these are NOT re-appended to the transcript here.
         # Journal notices parked by ``_append_or_park_journal`` rejoin the live
         # context HERE, appended directly rather than returned. This is the
         # loop's own injection boundary — it runs only after ``_append_results``

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.33.1"
+version = "0.33.2"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/session/test_background_journal_splice.py
+++ b/tests/unit/session/test_background_journal_splice.py
@@ -628,14 +628,27 @@ def test_pair_spliced_tool_results_scans_each_message_once():
 def test_pair_spliced_tool_results_does_not_pull_the_next_batch_into_an_open_one():
     """Bounding the scan is a correctness fix, not only a speed one.
 
-    An unbounded scan looking for the first batch's missing answer would walk
-    into the SECOND batch, collect its assistant message as an interloper and
-    its results as the first batch's, then emit that assistant behind its own
-    answers — trading one illegal shape for another.
+    The shape that needs the bound is a LATE ANSWER: the first batch's result
+    arrives only after the second batch has opened. An unbounded scan hunting
+    that answer walks through the second batch, banking its assistant message
+    as an interloper and its results as the first batch's, then emits that
+    assistant behind its own answers — one illegal shape traded for another::
+
+        in         A1(x) A2(y,z) T(y) T(z) T(x)
+        unbounded  A1(x) T(y) T(z) T(x) A2(y,z)   <- A2 behind its answers
+        bounded    A1(x) A2(y,z) T(y) T(z) T(x)   <- left alone, correct
+
+    A batch that is never answered AT ALL does not exercise this and must not
+    be used here: ``expected`` never empties, so the ``if expected: continue``
+    guard suppresses the repair with or without the bound and the test passes
+    on the broken code. That is exactly what an earlier version of this test
+    did. Verified both ways against a tree with only the bound removed: this
+    fixture fails there and passes with the bound restored.
     """
-    first, first_result, _ = _batch("toolu_1A", "toolu_1B")  # 1B never answered
+    first, first_result = _batch("toolu_1A")
     second, second_a, second_b = _batch("toolu_2A", "toolu_2B")
-    history = [first, first_result, second, second_a, second_b]
+    # The first batch's answer lands LAST, behind the whole second batch.
+    history = [first, second, second_a, second_b, first_result]
 
     repaired = _pair_spliced_tool_results(history)
 

--- a/tests/unit/session/test_background_journal_splice.py
+++ b/tests/unit/session/test_background_journal_splice.py
@@ -577,6 +577,71 @@ def test_pair_spliced_tool_results_warns_when_it_fires(caplog):
     ), "the repair fired without logging"
 
 
+class _CountingHistory(list[Message]):
+    """A message list that counts INDEXED reads, so a rescan is measurable.
+
+    Only ``__getitem__`` is counted, which isolates the pairing scan: the
+    function's early exit iterates (``for message in messages``) and so does
+    not register here.
+    """
+
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.reads = 0
+
+    def __getitem__(self, index):
+        self.reads += 1
+        return super().__getitem__(index)
+
+
+def test_pair_spliced_tool_results_scans_each_message_once():
+    """The pass is linear, asserted by counting rather than by timing.
+
+    Regression test for a quadratic scan: when a batch went unanswered the
+    loop did not advance past it, so every later assistant message rescanned
+    to the end of the list. On a 4000-message history of open batches that was
+    3.7s against 2.3ms for the answered shape, on a function that runs at
+    EVERY provider call. A wall-clock assertion would be flaky on a loaded
+    machine, so this counts reads instead: with each batch's window bounded by
+    the next batch's start the windows are disjoint, so no message is read by
+    more than one of them plus once by the outer walk.
+    """
+    messages: list[Message] = []
+    for index in range(400):
+        assistant, result_a, _ = _batch(f"toolu_{index}A", f"toolu_{index}B")
+        # Only the first call is answered, so `expected` never empties and the
+        # inner scan has no early exit to save it.
+        messages.extend([assistant, result_a])
+
+    history = _CountingHistory(messages)
+    repaired = _pair_spliced_tool_results(history)
+
+    assert [message.id for message in repaired] == [
+        message.id for message in messages
+    ], "unanswered batches are _wire_legal_snapshot's job and must be left alone"
+    assert history.reads <= 2 * len(history), (
+        f"the scan read {history.reads} times for {len(history)} messages; "
+        "an unanswered batch is being rescanned instead of advanced past"
+    )
+
+
+def test_pair_spliced_tool_results_does_not_pull_the_next_batch_into_an_open_one():
+    """Bounding the scan is a correctness fix, not only a speed one.
+
+    An unbounded scan looking for the first batch's missing answer would walk
+    into the SECOND batch, collect its assistant message as an interloper and
+    its results as the first batch's, then emit that assistant behind its own
+    answers — trading one illegal shape for another.
+    """
+    first, first_result, _ = _batch("toolu_1A", "toolu_1B")  # 1B never answered
+    second, second_a, second_b = _batch("toolu_2A", "toolu_2B")
+    history = [first, first_result, second, second_a, second_b]
+
+    repaired = _pair_spliced_tool_results(history)
+
+    assert [message.id for message in repaired] == [message.id for message in history]
+
+
 # --- Layer 2: end-to-end self-heal and both wires -----------------------------
 
 

--- a/tests/unit/session/test_background_journal_splice.py
+++ b/tests/unit/session/test_background_journal_splice.py
@@ -1,0 +1,665 @@
+"""A background journal append must never land INSIDE an open tool batch.
+
+The failure these tests pin down was observed live (session ``5187e748833c``):
+a user pressed ``/model`` while the agent was running a tool batch, and every
+turn from then on — including a bare "Continue" — died on the same Anthropic
+400::
+
+    messages.2: `tool_use` ids were found without `tool_result` blocks
+    immediately after: toolu_019T5KXtGAzsqT7jbDbRyecz, toolu_01KW58PLNHHQv75fBBvqz53h
+
+The PERSISTED transcript of that session is well formed — every ``tool_use``
+is followed by its ``tool_result``, and replaying it through
+``_default_convert_to_llm`` + ``AnthropicClient._build_body`` produces a legal
+body. So this is not transcript corruption. The malformed thing was the LIVE
+``_context.messages`` list, and it was malformed because of an ordering the
+transcript cannot show:
+
+1. ``AgentLoop._run`` appends the assistant message the moment the model turn
+   ends and appends the tool results only once the WHOLE batch returns
+   (``_append_results``). For the entire duration of a tool batch the live list
+   therefore ends in an assistant message whose ``tool_calls`` have no answers.
+2. ``Session.set_model`` ends by firing ``journal_model_switch`` through
+   ``_spawn_background`` — "Background because ``set_model`` is sync and runs
+   on the UI loop".
+3. ``journal_model_switch`` (and ``journal_incident``) did a bare
+   ``self._context.messages.append(message)`` with NO turn-boundary guard, and
+   ``_default_convert_to_llm`` renders both custom types as ``role="user"``.
+
+The fix is two layers, and this file tests both:
+
+- **Layer 1** parks the LIVE append (never the transcript write) whenever a
+  turn owns the message list, and drains the FIFO at the turn-safe boundaries.
+  That closes the source.
+- **Layer 2** repairs at request assembly (``_pair_spliced_tool_results`` in
+  ``_render_history``), which is the only thing that can help a session already
+  bricked in memory or a future writer that bypasses Layer 1.
+
+The determinism here is not a sleep. The fake tool calls ``set_model`` and then
+drains the session's own background task set to completion before returning its
+result, so the interleaving under test is forced rather than raced.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from local_operator.harness.types import (
+    AgentTool,
+    ChatRequest,
+    Message,
+    ModelSpec,
+    StreamEndEvent,
+    StreamTextDelta,
+    StreamToolCallDelta,
+    TextContent,
+    ToolCall,
+    ToolResult,
+)
+from local_operator.providers.clients import (
+    AnthropicClient,
+    _messages_to_openai_responses,
+)
+from local_operator.session.session import (
+    SESSION_MODEL_SWITCH_MESSAGE_TYPE,
+    CustomMessage,
+    Session,
+    _pair_spliced_tool_results,
+)
+
+from .test_session import MODEL, ScriptedStream, make_session
+
+#: What the user switches TO mid-batch. A different provider AND model id, so
+#: ``set_model`` takes the genuine-switch path rather than the same-pair knob
+#: early return that never journals. Mirrors the live incident.
+SWITCHED = ModelSpec(provider="anthropic", model_id="claude-opus-5", context_window=200_000)
+
+#: The spec the assertions build a wire body against. Only the pair matters —
+#: ``_build_body`` reads ``model_id`` and the token ceiling, nothing routing.
+WIRE_MODEL = SWITCHED
+
+
+async def _drain_background(session: Session) -> None:
+    """Run every task ``_spawn_background`` has outstanding to completion.
+
+    This is what makes the repro deterministic: the bug needs the background
+    journal append to land while the tool batch is still open, and the honest
+    way to force that ordering is to drive the spawned task at the chosen
+    point rather than sleeping and hoping the scheduler cooperates. Looped
+    because a drained task can spawn another (the selection write and the
+    switch notice are two separate spawns), and bounded so a self-respawning
+    task fails the test instead of hanging it.
+    """
+    for _ in range(10):
+        pending = [task for task in list(session._background_tasks) if not task.done()]
+        if not pending:
+            return
+        await asyncio.gather(*pending, return_exceptions=True)
+    raise AssertionError("background tasks never settled")
+
+
+def _switching_tool(holder: dict[str, Session]) -> AgentTool:
+    """A tool that switches the model while its own batch is still open.
+
+    Stands in for the user pressing ``/model`` mid-turn: the TUI's key handler
+    calls ``set_model`` on the same loop, at a moment when the assistant
+    message is already in the live context and no tool result is.
+    """
+
+    async def execute(tool_call_id, args, signal, on_update, context):
+        session = holder["session"]
+        session.set_model(SWITCHED, explicit=True)
+        # The switch's journal is fire-and-forget; force it to land HERE,
+        # before this result is appended, which is the window under test.
+        await _drain_background(session)
+        return ToolResult(
+            tool_call_id=tool_call_id, tool_name="echo", content=[TextContent(text="ok")]
+        )
+
+    return AgentTool(name="echo", parameters={"type": "object"}, execute=execute)
+
+
+def _tool_then_text() -> ScriptedStream:
+    """Two calls: a two-call tool batch, then a closing text turn.
+
+    Two tool calls rather than one because the live 400 named two ids, and a
+    batch of two proves the splice lands ahead of the whole group rather than
+    interleaving with it.
+    """
+    return ScriptedStream(
+        [
+            [
+                StreamToolCallDelta(index=0, id="toolu_A", name="echo", argument_delta="{}"),
+                StreamToolCallDelta(index=1, id="toolu_B", name="echo", argument_delta="{}"),
+                StreamEndEvent(stop_reason="toolUse"),
+            ],
+            [StreamTextDelta(delta="done"), StreamEndEvent(stop_reason="stop")],
+            [StreamTextDelta(delta="again"), StreamEndEvent(stop_reason="stop")],
+        ]
+    )
+
+
+def _wire_messages(request: ChatRequest) -> list[dict[str, Any]]:
+    """The body Anthropic actually receives for ``request``."""
+    return AnthropicClient()._build_body(
+        ChatRequest(
+            model=WIRE_MODEL,
+            system_blocks=list(request.system_blocks),
+            messages=list(request.messages),
+            tools=[],
+        )
+    )["messages"]
+
+
+def _dangling_tool_use(messages: list[dict[str, Any]]) -> list[str]:
+    """``tool_use`` ids Anthropic will reject as unanswered.
+
+    "Immediately after" is stricter than "somewhere in the next message", and
+    the difference is the whole bug. ``AnthropicClient._build_body`` COALESCES
+    tool results onto a preceding user message, so the splice does not survive
+    as a separate user turn on the wire — it becomes a text block sitting AHEAD
+    of the tool_result blocks inside one user message. That still 400s.
+
+    Both halves were verified against the live API (claude-sonnet-4-5,
+    2026-08-25), which is why the rule is written as a leading-run check
+    rather than a set membership:
+
+        [tool_result, tool_result]           -> HTTP 200
+        [tool_result, tool_result, text]     -> HTTP 200
+        [text, tool_result, tool_result]     -> HTTP 400, names both ids
+        text as its own user message between -> HTTP 400, names both ids
+
+    So only the tool_results in the next message's LEADING run count as
+    answers; anything the splice pushes in front of them orphans the whole
+    batch.
+    """
+    dangling: list[str] = []
+    for index, message in enumerate(messages):
+        content = message.get("content")
+        if message.get("role") != "assistant" or not isinstance(content, list):
+            continue
+        ids = [block["id"] for block in content if block.get("type") == "tool_use"]
+        if not ids:
+            continue
+        following = messages[index + 1] if index + 1 < len(messages) else None
+        answered: set[str] = set()
+        if following is not None and isinstance(following.get("content"), list):
+            for block in following["content"]:
+                if block.get("type") != "tool_result":
+                    break  # the leading run ends at the first non-result block
+                answered.add(block.get("tool_use_id"))
+        dangling.extend(id_ for id_ in ids if id_ not in answered)
+    return dangling
+
+
+def _responses_dangling(items: list[dict[str, Any]]) -> list[str]:
+    """``function_call`` ids the OpenAI Responses wire leaves unanswered.
+
+    The same positional rule as :func:`_dangling_tool_use`, expressed for the
+    Responses item stream: a run of ``function_call`` items must be followed
+    immediately by their ``function_call_output`` items. A bare ``role:user``
+    item spliced between them is the shape ``clients.py`` emits for a journal
+    notice, and it is rejected for the same reason Anthropic rejects the
+    coalesced form.
+    """
+    dangling: list[str] = []
+    index = 0
+    while index < len(items):
+        if items[index].get("type") != "function_call":
+            index += 1
+            continue
+        calls: list[str] = []
+        while index < len(items) and items[index].get("type") == "function_call":
+            calls.append(items[index].get("call_id", ""))
+            index += 1
+        answered: set[str] = set()
+        while index < len(items) and items[index].get("type") == "function_call_output":
+            answered.add(items[index].get("call_id", ""))
+            index += 1
+        dangling.extend(call for call in calls if call not in answered)
+    return dangling
+
+
+def _roles(session: Session) -> list[str]:
+    """The live context's shape, customs named by their type."""
+    return [
+        getattr(message, "role", None) or f"custom:{getattr(message, 'custom_type', '?')}"
+        for message in session._context.messages
+    ]
+
+
+def _switch_notice(text: str = "switched to anthropic/claude-opus-5") -> CustomMessage:
+    return CustomMessage(
+        custom_type=SESSION_MODEL_SWITCH_MESSAGE_TYPE,
+        attribution="system",
+        details={"text": text, "new_label": "anthropic/claude-opus-5", "transient": False},
+    )
+
+
+def _batch(*call_ids: str) -> list[Message]:
+    """``assistant(tool_calls) + its answers`` — a legal, closed tool batch."""
+    assistant = Message.assistant("")
+    assistant.tool_calls = [ToolCall(id=call_id, name="echo", arguments={}) for call_id in call_ids]
+    results = [
+        Message(
+            role="tool",
+            content=[TextContent(text="ok")],
+            tool_call_id=call_id,
+            tool_name="echo",
+        )
+        for call_id in call_ids
+    ]
+    return [assistant, *results]
+
+
+# --- Layer 1: the live context never takes the splice -------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_mid_batch_model_switch_does_not_splice_into_the_tool_batch(tmp_path):
+    """The switch notice lands AFTER the batch, not between its halves.
+
+    Asserted on the request the loop ACTUALLY issued for the turn's second
+    provider call, not on a list reconstructed by the test: the corruption has
+    to be absent on the wire to explain why the 400 is gone.
+    """
+    holder: dict[str, Session] = {}
+    stream = _tool_then_text()
+    session = make_session(tmp_path, stream, tools=[_switching_tool(holder)])
+    holder["session"] = session
+    try:
+        await session.prompt("go")
+    finally:
+        await session.dispose()
+
+    # The live list: the notice waited for the batch to close instead of
+    # splicing between the assistant that asked for the tools and its results.
+    assert _roles(session) == [
+        "user",
+        "assistant",
+        "tool",
+        "tool",
+        "custom:session_model_switch",
+        "assistant",
+    ], f"unexpected live shape: {_roles(session)}"
+
+    # And through the real renderer + the real Anthropic body builder.
+    assert len(stream.requests) >= 2, "the turn never made its post-batch call"
+    wire = _wire_messages(stream.requests[1])
+    shape = [
+        (message["role"], [block.get("type") for block in message["content"]]) for message in wire
+    ]
+    assert _dangling_tool_use(wire) == [], (
+        "the switch notice orphaned the tool batch on the wire: every tool_use "
+        f"must be answered by the leading tool_result run of the next message. wire was {shape}"
+    )
+    # The notice must still REACH the model — parking is a delay, not a drop.
+    assert any(
+        "claude-opus-5" in str(block.get("text", ""))
+        for message in wire
+        if isinstance(message.get("content"), list)
+        for block in message["content"]
+        if block.get("type") == "text"
+    ), "the parked switch notice never reached the model"
+
+
+@pytest.mark.asyncio
+async def test_a_later_turn_rides_a_clean_prefix(tmp_path):
+    """The session stays usable — this is the "Continue" that used to 400."""
+    holder: dict[str, Session] = {}
+    stream = _tool_then_text()
+    session = make_session(tmp_path, stream, tools=[_switching_tool(holder)])
+    holder["session"] = session
+    try:
+        await session.prompt("go")
+        await session.prompt("Continue")
+    finally:
+        await session.dispose()
+
+    assert len(stream.requests) >= 3, "the follow-up turn never reached the provider"
+    wire = _wire_messages(stream.requests[2])
+    assert _dangling_tool_use(wire) == [], (
+        "the follow-up turn re-sent an unrepaired prefix, so the session could "
+        "never recover on its own"
+    )
+
+
+@pytest.mark.asyncio
+async def test_journal_incident_is_parked_the_same_way(tmp_path):
+    """The sibling door: ``journal_incident`` shares the guard.
+
+    ``_on_mcp_incident`` fires it from a background task and the failover path
+    calls it on every provider error, so an incident landing mid-batch would
+    corrupt the context exactly as the model switch did. Driven through
+    ``_on_mcp_incident`` so the real trigger is covered, not just the method.
+    """
+    holder: dict[str, Session] = {}
+    stream = _tool_then_text()
+
+    async def execute(tool_call_id, args, signal, on_update, context):
+        session = holder["session"]
+        # Only the FIRST call of the batch trips the breaker. Both calls
+        # journalling would prove nothing extra and would make the expected
+        # shape depend on batch size rather than on the guard.
+        if tool_call_id == "toolu_A":
+            session._on_mcp_incident("files", "circuit breaker opened")
+            await _drain_background(session)
+        return ToolResult(
+            tool_call_id=tool_call_id, tool_name="echo", content=[TextContent(text="ok")]
+        )
+
+    tool = AgentTool(name="echo", parameters={"type": "object"}, execute=execute)
+    session = make_session(tmp_path, stream, tools=[tool], model=MODEL)
+    holder["session"] = session
+    try:
+        await session.prompt("go")
+    finally:
+        await session.dispose()
+
+    assert _roles(session) == [
+        "user",
+        "assistant",
+        "tool",
+        "tool",
+        "custom:session_incident",
+        "assistant",
+    ], f"unexpected live shape: {_roles(session)}"
+    assert len(stream.requests) >= 2
+    wire = _wire_messages(stream.requests[1])
+    assert (
+        _dangling_tool_use(wire) == []
+    ), "journal_incident spliced its notice into the open batch, orphaning it"
+
+
+@pytest.mark.asyncio
+async def test_the_direct_await_failover_path_is_guarded_too(tmp_path):
+    """``_on_route_settled`` awaits ``journal_model_switch`` ON the turn loop.
+
+    It is not a ``_spawn_background`` caller, so a guard placed at the call
+    sites would have missed it entirely. The guard lives INSIDE the journal
+    methods precisely so this path is covered for free: a provider failing
+    over mid-batch is the single most likely way to hit this window in
+    production, because the failover fires exactly when a request is in flight.
+    """
+    from local_operator.providers.failover import FallbackTarget
+
+    holder: dict[str, Session] = {}
+    stream = _tool_then_text()
+
+    async def execute(tool_call_id, args, signal, on_update, context):
+        session = holder["session"]
+        # Directly awaited, mid-batch, exactly as the failover driver does it.
+        await session._on_route_settled(
+            FallbackTarget(selector="anthropic/claude-opus-5"), "provider error: HTTP 529"
+        )
+        return ToolResult(
+            tool_call_id=tool_call_id, tool_name="echo", content=[TextContent(text="ok")]
+        )
+
+    tool = AgentTool(name="echo", parameters={"type": "object"}, execute=execute)
+    session = make_session(tmp_path, stream, tools=[tool], model=MODEL)
+    holder["session"] = session
+    try:
+        await session.prompt("go")
+    finally:
+        await session.dispose()
+
+    roles = _roles(session)
+    assert "custom:session_model_switch" in roles, "the failover notice never reached the context"
+    assert roles.index("custom:session_model_switch") > roles.index("tool"), (
+        "the failover notice spliced into the open batch instead of waiting for "
+        f"it to close: {roles}"
+    )
+    wire = _wire_messages(stream.requests[1])
+    assert _dangling_tool_use(wire) == [], "the direct-await failover path orphaned the batch"
+
+
+# --- Layer 1: a parked notice is never lost -----------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_notice_parked_by_an_aborted_turn_is_delivered_at_the_next_prompt(tmp_path):
+    """Parking is a delay, never a drop.
+
+    A turn that ends without reaching a steering drain (aborted mid-batch)
+    still has to hand its parked notice to the next turn — otherwise the model
+    is never told it was switched, which is the very thing the journal exists
+    to do.
+    """
+    stream = ScriptedStream(
+        [
+            [StreamTextDelta(delta="one"), StreamEndEvent(stop_reason="stop")],
+            [StreamTextDelta(delta="two"), StreamEndEvent(stop_reason="stop")],
+        ]
+    )
+    session = make_session(tmp_path, stream)
+    try:
+        # Park by hand with the lock held: this is the state an aborted turn
+        # leaves behind, without needing to race a real abort.
+        await session._turn_lock.acquire()
+        try:
+            await session.journal_model_switch("anthropic/claude-opus-5")
+            assert len(session._pending_context_journal) == 1, "the notice was not parked"
+            assert not any(
+                isinstance(message, CustomMessage) for message in session._context.messages
+            ), "the notice reached the live context while the lock was held"
+        finally:
+            session._turn_lock.release()
+
+        await session.prompt("next")
+        assert session._pending_context_journal == [], "the parked notice was never drained"
+        assert "custom:session_model_switch" in _roles(session)
+        # It has to be in the request this prompt built, not merely in the list
+        # afterwards: a notice delivered after the turn it was meant for is the
+        # same as a lost one.
+        sent = stream.requests[0].messages
+        assert any(
+            "claude-opus-5" in message.text for message in sent
+        ), "the drained notice did not reach the request"
+    finally:
+        await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_a_notice_parked_at_dispose_still_reached_the_transcript(tmp_path):
+    """The transcript write happens at PARK time, so ``--resume`` is safe even
+    if the process dies before any drain boundary runs."""
+    stream = ScriptedStream([[StreamEndEvent(stop_reason="stop")]])
+    session = make_session(tmp_path, stream)
+    await session._turn_lock.acquire()
+    try:
+        await session.journal_model_switch("anthropic/claude-opus-5")
+        assert len(session._pending_context_journal) == 1
+    finally:
+        session._turn_lock.release()
+    await session.dispose()
+
+    # Drained into the live list at dispose...
+    assert session._pending_context_journal == []
+    assert "custom:session_model_switch" in _roles(session)
+    # ...and on disk regardless, because the write preceded the park. Asserted
+    # through the renderer: `build_llm_history` returns AgentMessage, and it is
+    # the RENDERED form that a resumed session would actually send.
+    replayed = session._render_history(list(session._transcript.build_llm_history()))
+    assert any(
+        "claude-opus-5" in message.text for message in replayed
+    ), "the parked notice never reached the transcript"
+
+
+# --- Layer 2: the pure repair -------------------------------------------------
+
+
+def test_pair_spliced_tool_results_moves_an_interloper_after_the_results():
+    assistant, result_a, result_b = _batch("toolu_A", "toolu_B")
+    notice = Message.user("switched to anthropic/claude-opus-5")
+    spliced = [Message.user("go"), assistant, notice, result_a, result_b]
+
+    repaired = _pair_spliced_tool_results(spliced)
+
+    # Identity, not equality: the repair must MOVE the caller's own objects, not
+    # rebuild them. Compaction memoizes token estimates per message object (see
+    # `Message`), so a rendered copy would silently invalidate that cache.
+    assert [message.id for message in repaired] == [
+        spliced[0].id,
+        assistant.id,
+        result_a.id,
+        result_b.id,
+        notice.id,
+    ]
+    assert repaired[-1] is notice
+
+
+def test_pair_spliced_tool_results_keeps_multiple_interlopers_in_order():
+    assistant, result_a, result_b = _batch("toolu_A", "toolu_B")
+    first = Message.user("switched to opus")
+    second = Message.user("provider error: HTTP 529")
+    spliced = [assistant, first, result_a, second, result_b]
+
+    repaired = _pair_spliced_tool_results(spliced)
+
+    assert [message.id for message in repaired] == [
+        assistant.id,
+        result_a.id,
+        result_b.id,
+        first.id,
+        second.id,
+    ], "interlopers must move after the results and keep their relative order"
+
+
+def test_pair_spliced_tool_results_returns_a_legal_list_unchanged():
+    assistant, result_a, result_b = _batch("toolu_A", "toolu_B")
+    legal = [Message.user("go"), assistant, result_a, result_b, Message.assistant("done")]
+
+    repaired = _pair_spliced_tool_results(legal)
+
+    assert repaired == legal
+    # A trailing message AFTER a closed batch is legal (verified live: the
+    # [tool_result, tool_result, text] shape returns 200), so nothing moves.
+    assert [message.id for message in repaired] == [message.id for message in legal]
+
+
+def test_pair_spliced_tool_results_leaves_an_unanswered_tail_alone():
+    """An open batch is ``_wire_legal_snapshot``'s job, not this one.
+
+    Synthesizing placeholders here would be actively wrong: the architect
+    tested it against the live API and it draws a different 400
+    (``unexpected tool_use_id found in tool_result blocks``) as soon as the
+    genuine results arrive behind the placeholders.
+    """
+    assistant, result_a, _ = _batch("toolu_A", "toolu_B")
+    # toolu_B never answered; a notice sits behind the partial batch.
+    partial = [assistant, result_a, Message.user("switched to opus")]
+
+    repaired = _pair_spliced_tool_results(partial)
+
+    assert [message.id for message in repaired] == [message.id for message in partial]
+
+
+def test_pair_spliced_tool_results_is_a_noop_without_tool_calls():
+    plain = [Message.user("go"), Message.assistant("hi")]
+    assert _pair_spliced_tool_results(plain) is plain, "the early exit should return the input"
+
+
+def test_pair_spliced_tool_results_warns_when_it_fires(caplog):
+    """Silence would hide a Layer 1 regression: after the guard this is dead
+    code, so the one time it runs it has to say so."""
+    assistant, result_a, result_b = _batch("toolu_A", "toolu_B")
+    spliced = [assistant, Message.user("switched"), result_a, result_b]
+
+    with caplog.at_level("WARNING"):
+        _pair_spliced_tool_results(spliced)
+
+    assert any(
+        "spliced into an open tool batch" in record.message for record in caplog.records
+    ), "the repair fired without logging"
+
+
+# --- Layer 2: end-to-end self-heal and both wires -----------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_session_bricked_in_memory_heals_itself_on_the_next_turn(tmp_path):
+    """Layer 1 cannot help a context that is ALREADY spliced.
+
+    This is the live incident's actual recovery story: a session corrupted
+    before the fix shipped, or by a future writer that bypasses the guard,
+    must still be able to send a legal request.
+    """
+    stream = ScriptedStream([[StreamTextDelta(delta="ok"), StreamEndEvent(stop_reason="stop")]])
+    session = make_session(tmp_path, stream)
+    assistant, result_a, result_b = _batch("toolu_A", "toolu_B")
+    # Hand it the exact bricked shape, notice included.
+    session._context.messages.extend([assistant, _switch_notice(), result_a, result_b])
+    try:
+        await session.prompt("Continue")
+    finally:
+        await session.dispose()
+
+    wire = _wire_messages(stream.requests[0])
+    shape = [
+        (message["role"], [block.get("type") for block in message["content"]]) for message in wire
+    ]
+    assert _dangling_tool_use(wire) == [], f"the bricked session did not heal: {shape}"
+
+
+@pytest.mark.asyncio
+async def test_both_wires_accept_the_repaired_history(tmp_path):
+    """Anthropic coalesces, Responses emits a bare item — same rejection.
+
+    Patching ``AnthropicClient`` alone would have left the OpenAI Responses
+    path broken in exactly the same way, which is why the repair lives at the
+    render and not in a client.
+    """
+    stream = ScriptedStream([[StreamEndEvent(stop_reason="stop")]])
+    session = make_session(tmp_path, stream)
+    assistant, result_a, result_b = _batch("toolu_A", "toolu_B")
+    session._context.messages.extend([assistant, _switch_notice(), result_a, result_b])
+    try:
+        rendered = session._render_history(list(session._context.messages))
+    finally:
+        await session.dispose()
+
+    anthropic_body = AnthropicClient()._build_body(
+        ChatRequest(model=WIRE_MODEL, system_blocks=[], messages=rendered, tools=[])
+    )["messages"]
+    assert _dangling_tool_use(anthropic_body) == [], "Anthropic wire still orphans the batch"
+
+    responses_items = _messages_to_openai_responses(rendered)
+    assert _responses_dangling(responses_items) == [], (
+        "OpenAI Responses wire still orphans the batch: a bare role:user item "
+        "sits between function_call and function_call_output"
+    )
+
+
+@pytest.mark.asyncio
+async def test_resume_replays_a_clean_history_in_write_order(tmp_path):
+    """The transcript's row order is WRITE order, not live-append order.
+
+    ``journal_model_switch`` awaits its transcript write BEFORE the live
+    append, while the assistant message is written later at the batch
+    boundary — so a clean-looking transcript proves nothing about the live
+    list, and the reverse has to be checked separately. This is that check:
+    what ``--resume`` rebuilds must be legal too.
+    """
+    holder: dict[str, Session] = {}
+    stream = _tool_then_text()
+    session = make_session(tmp_path, stream, tools=[_switching_tool(holder)])
+    holder["session"] = session
+    try:
+        await session.prompt("go")
+    finally:
+        await session.dispose()
+
+    replayed = list(session._transcript.build_llm_history())
+    body = AnthropicClient()._build_body(
+        ChatRequest(
+            model=WIRE_MODEL,
+            system_blocks=[],
+            messages=session._render_history(replayed),
+            tools=[],
+        )
+    )["messages"]
+    assert _dangling_tool_use(body) == [], "a resumed session replays an illegal body"


### PR DESCRIPTION
## Summary

Switching models mid-tool-batch permanently bricked a session. Every later turn, including a bare "Continue", died on the same Anthropic 400, and the only recovery was to abandon the session.

- `journal_model_switch` and `journal_incident` now park their **live** context append when a turn owns the message list, draining the FIFO at the turn-safe boundaries. The transcript write is unchanged.
- `_pair_spliced_tool_results` repairs an already-spliced history at request assembly, in `_render_history`, so a session bricked in memory heals itself and both provider wires are covered by one application.
- Version bumps from `0.33.1` to `0.33.2` as a patch fix.

## Impact

Before this change, pressing `/model` while the agent was running tools spliced the switch notice between the assistant's `tool_use` blocks and the `tool_result` blocks answering them. Nothing repaired the live list, so the illegal prefix was re-sent on every subsequent request and the session was unusable until restarted. Observed live in session `5187e748833c`.

After this change, the notice waits for the tool batch to close and lands immediately after it. A session that was already corrupted in memory, or corrupted by a future writer that bypasses the guard, still assembles a legal request.

## The bug

`Session.set_model` fires `_spawn_background(journal_model_switch(...))`, which appended a `CustomMessage` straight to `_context.messages` with no turn-boundary guard. `AgentLoop._run` appends the assistant message the moment the model turn ends and appends the tool results only once the whole batch returns (`_append_results`), so for the entire duration of a tool batch the live list ends in an assistant whose `tool_calls` have no answers. `_default_convert_to_llm` renders the notice as `role="user"`, splicing it into the open batch:

```text
assistant(tool_use, tool_use) -> user(notice) -> tool_result, tool_result
```

The invariant, in one sentence:

> `_context.messages` must never contain a non-tool message between an assistant message carrying `tool_calls` and the complete set of `tool_result` messages answering them, and no request may be assembled from a list that violates it.

Two things about this bug are easy to get wrong and are recorded in the code:

**The persisted transcript proves nothing.** Row order is WRITE order, not live-append order. `journal_model_switch` awaits its transcript write *before* the live append while the assistant is written later at the batch boundary, so the transcript of a bricked session looks perfectly clean. `--resume` was never broken; the live list was.

**The wire constraint is positional, not set membership.** `AnthropicClient._build_body` coalesces tool results onto a preceding user message, so the splice does not survive as its own turn: it becomes a text block sitting *ahead* of the `tool_result` blocks inside one user message. Measured against the live API:

| shape | result |
|---|---|
| `[tool_result, tool_result]` | 200 |
| `[tool_result, tool_result, text]` | 200 |
| `[text, tool_result, tool_result]` | **400** |
| interloper as its own user message between | **400** |

That is why the repair **moves** the interloper after the results rather than synthesizing placeholders. Placeholders were tested against the live API and produce a *different* 400 (`unexpected tool_use_id found in tool_result blocks`) because the genuine results still arrive behind them. Synthesis is only correct for a genuinely unanswered tail, which is `_wire_legal_snapshot`'s job and is left alone.

## Design

**Layer 1 — park until a safe boundary.** A new `_pending_context_journal` FIFO holds notices whose live append arrived mid-turn. The guard tests `_is_streaming or _turn_lock.locked()`, both conditions, for the reason `prompt` spells out: `_is_streaming` covers only `_run_turn`, while the lock spans the whole pipeline including post-compaction auto-continuation. `record_shell` and `adopt_aside` guard on the same pair.

The guard sits **inside** the journal methods, not at their call sites, so the direct-await failover path (`_on_route_settled`) is covered for free. That path runs on the loop inside a turn and splices identically, and it is the most likely way to hit this window in production because failover fires exactly when a request is in flight.

Drained at four boundaries: `_drain_steering`, `_run_turn_pipeline` exit, the top of `prompt`/`_prompt_messages`, and `dispose`. A parked notice is never silently lost, and the transcript write already happened so `--resume` is safe regardless.

**Layer 2 — repair at request assembly.** Applied in `_render_history` immediately after `_convert_to_llm`, which is the single site covering the turn path, compaction, `_history_snapshot` and the token counter. It fixes both wires at once: the OpenAI Responses path emits a bare `role:user` item between `function_call` and `function_call_output` and is rejected for the same reason, so patching `AnthropicClient` alone would have left it broken. Logs at `warning` when it fires, because after Layer 1 it should be dead code and silence would hide a regression. O(n) with an early exit when no assistant carries tool calls, since this is on the hot path.

## Real-path validation

**The verbatim production 400, reproduced and then cleared against the live Anthropic API.** A probe builds the exact bricked context (the incident's own tool-use ids), renders it through the session's own `_render_history`, hands it to the real `AnthropicClient._build_body`, and POSTs it to `api.anthropic.com/v1/messages` using the session's stored OAuth credential. BEFORE renders with Layer 2 disabled, which is what `origin/main` produces today.

```text
BEFORE (Layer 2 disabled) wire shape:
  ("user",      ["text"])
  ("assistant", ["text", "tool_use", "tool_use"])
  ("user",      ["text", "tool_result", "tool_result"])   <- notice ahead of the results
  ("user",      ["text"])

BEFORE -> HTTP 400
{"type":"error","error":{"type":"invalid_request_error","message":"messages.2: `tool_use` ids
were found without `tool_result` blocks immediately after: toolu_019T5KXtGAzsqT7jbDbRyecz,
toolu_01KW58PLNHHQv75fBBvqz53h. Each `tool_use` block must have a corresponding `tool_result`
block in the next message."},"request_id":"req_011CePxU2rGWSp23L8Dxoeik"}
```

That is the production error string, naming both of the original incident's tool ids. With the fix as shipped:

```text
AFTER (as shipped) wire shape:
  ("user",      ["text"])
  ("assistant", ["text", "tool_use", "tool_use"])
  ("user",      ["tool_result", "tool_result"])           <- results lead the message
  ("user",      ["text"])                                 <- notice moved after
  ("user",      ["text"])

AFTER -> HTTP 200
{"model":"claude-sonnet-4-5-20250929","id":"msg_011CePxU4sJtWGiBUP3MS3H7","type":"message",
"role":"assistant","content":[{"type":"text","text":"I need to read the files in the current
directory. Let me first see what files are available."}],"stop_reason":"end_turn",
"usage":{"input_tokens":168,...}}
```

**The repro failing on `origin/main` and passing after.** The regression tests were first written against the unmodified base (worktree at `f2a52b53`), where all three original cases fail:

```text
$ .venv/bin/python -m pytest tests/unit/session/test_background_journal_splice.py -q   # on origin/main
FAILED ...::test_a_mid_batch_model_switch_splices_a_user_message_into_the_tool_batch
FAILED ...::test_the_corrupt_prefix_is_re_sent_on_every_later_turn
FAILED ...::test_journal_incident_splices_the_same_way
3 failed in 2.17s
```

Each failed with `assert ['toolu_A', 'toolu_B'] == []` — both calls orphaned on the wire. On this branch, with the suite extended to 15 cases:

```text
$ env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest \
    tests/unit/session/test_background_journal_splice.py -q
15 passed in 4.74s
```

The determinism is not a sleep: the fake tool calls `set_model` and then drains the session's own `_background_tasks` to completion before returning its result, so the interleaving is forced rather than raced.

## Test coverage

The 15 cases assert precise shapes, not the absence of an exception.

- **Layer 1, the three doors.** Mid-batch `set_model`; the same through `_on_mcp_incident`; the same through the direct-await `_on_route_settled` failover path. Each asserts the live context shape *and* the absence of dangling `tool_use` on a body built by the real Anthropic client from the request the loop actually issued.
- **A later turn rides a clean prefix** — the "Continue" that used to 400.
- **A parked notice is never lost.** Parked mid-turn then aborted, asserted delivered into the *request* the next `prompt` builds, not merely present in the list afterwards. Parked then disposed, asserted to have reached the transcript.
- **`_pair_spliced_tool_results` as a pure unit.** Interloper moved after the results (asserted by object identity, since compaction memoizes token estimates per message object); multiple interlopers keep relative order; a legal list returned unchanged; an unanswered tail left alone; the no-tool-calls early exit; and the warning log fires.
- **Self-heal.** A session handed a pre-spliced `_context.messages` runs a turn and the captured body is legal.
- **Both wires.** Spliced input asserted clean on the Anthropic body *and* on `_messages_to_openai_responses` items.
- **Resume stays clean**, replayed in write order.

## Automated validation

Full suite, deterministically ordered:

```text
$ env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit -q -p no:randomly
6760 passed, 7 skipped, 431 warnings in 109.86s
```

Gates:

```text
$ .venv/bin/python -m flake8 .                                          # clean
$ .venv/bin/python -m black --check local_operator tests                # 492 files unchanged
$ .venv/bin/python -m isort --check-only --profile black local_operator tests   # clean
$ .venv/bin/python -m pyright --pythonpath .venv/bin/python .           # 0 errors, 0 warnings
```

`black` is the pinned 26.1.0 from the venv; `uvx` could not spawn in this environment, and the venv carries the identical pinned version (`python -m black, 26.1.0`).

## A note on two flaky tests

An earlier full-suite run under random ordering showed two failures that are **pre-existing flakes on unmodified `origin/main`**, not regressions from this change. Both were checked against a clean `f2a52b53` worktree:

- `tests/unit/tui/test_subagent_view.py::test_history_prepend_preserves_anchor_and_home_dedupes_requests` — fails 3 of 4 runs on clean `origin/main` in isolation.
- `tests/unit/harness/test_comms.py::test_a_resumed_child_replays_the_stopped_ones_transcript` — passes 3 of 3 in isolation on both trees; order-sensitive.

Both pass in the deterministic full run above. Left alone as out of scope for this fix, and flagged here rather than silently worked around.

## Scope

Deliberately unchanged: `_default_convert_to_llm`'s `role="user"` rendering (correct, the model must read these), `_paired_prefix`, `_wire_legal_snapshot`, `set_model`'s mid-turn switch semantics and its `_spawn_background` call, the loop's append ordering, the pending/aside/steering machinery, the transcript format, and `adopt_aside`'s refusal. `build_llm_history` needs no change: replaying the real bricked transcript already produces a legal body.

One design note worth flagging for review: `_drain_steering` appends parked notices to the context **directly** rather than returning them. Anything that method returns becomes a loop *injection*, and a non-empty injection list keeps the inner loop running, so returning an advisory notice bought an entire extra provider call. That was caught by two existing tests in `TestASwitchedModelTakesEffectAtTheNextCall` and is now recorded in a comment so it is not reintroduced.

The parked-notice delay is accepted rather than a compromise to be "fixed" later by re-splicing: the notice is advisory and the env block's `Model:` line already carries live identity, so the worst case is a switch notice landing at the end of a long tool batch instead of inside it. `_pair_spliced_tool_results`'s docstring records that it only ever moves harness-authored notices, and that the assumption needs revisiting if a custom type is ever added that carries user-authored text.
