### PR TITLE
fix(subagent): keep a resumed child's role, and name it in the dock

### DIFF
--- a/local_operator/harness/comms.py
+++ b/local_operator/harness/comms.py
@@ -1442,15 +1442,12 @@ class SubagentComms:
         # silently downgraded every resumed child to a generic no-role one.
         agent = record.agent_role or "task"
         effort = record.effort or None
-        # ``effort`` alone is display-only — ``run_subagent`` records it on the
-        # job and never re-reads it, because the LAUNCH path resolves the tier
-        # into a ``model_spec`` before calling (``Session._resolve_subagent_model``).
-        # A resume is a second launch and has to do that same resolution, or a
-        # child launched at ``hi`` would come back on the parent's model while
-        # the panel still displayed ``hi``. Resolved through the parent because
-        # the tier-to-model mapping lives in the operator's config, and the
-        # role's own default tier applies when the launch pinned none — which
-        # is exactly the precedence the first launch used.
+        # A resume is a SECOND LAUNCH, so it must re-resolve the tier into a
+        # model the way the first one did (``run_subagent`` explains why the
+        # tier does not survive that resolution and rides separately). Passing
+        # ``effort`` alone would return a child launched at ``hi`` on the
+        # parent's model while the panel still displayed ``hi``.
+        #
         # Guarded rather than called outright: ``_session`` is a full
         # ``Session`` in production, but this class is also driven by the
         # reduced hosts and test doubles that supply only the queue/steer/

--- a/local_operator/harness/comms.py
+++ b/local_operator/harness/comms.py
@@ -54,6 +54,7 @@ from local_operator.harness.types import (
     CustomMessage,
     Message,
     MessageEndEvent,
+    ModelSpec,
     StaleAside,
 )
 from local_operator.session.peer import PEER_MESSAGE_MESSAGE_TYPE
@@ -1426,12 +1427,51 @@ class SubagentComms:
         jobs = self._jobs()
         if jobs is None:
             return None, "no job manager attached to this session"
+        # The role and tier are carried FORWARD, not re-defaulted. Everything
+        # that makes a child what it is hangs off ``agent``: ``_resolve_role``
+        # picks the preamble (a role's instructions, a specialist's own
+        # ``system_prompt.md``, or ``SCOUT_PREAMBLE``), and the profile it
+        # returns decides the tool allowlist. That allowlist is a CAPABILITY
+        # BOUNDARY rather than advice (see ``_build_child_session``): resumed
+        # without it, a reviewer regains ``edit``/``write`` and can "helpfully"
+        # fix the very code it was asked to review, a scout loses its
+        # read-only promise, and the MCP tools restricted roles are denied
+        # come back wholesale. It also re-stamps ``origin.json`` with the
+        # agent, so a defaulted resume overwrites the real role on disk.
+        # ``run_subagent`` defaults ``agent`` to ``"task"``, so omitting these
+        # silently downgraded every resumed child to a generic no-role one.
+        agent = record.agent_role or "task"
+        effort = record.effort or None
+        # ``effort`` alone is display-only — ``run_subagent`` records it on the
+        # job and never re-reads it, because the LAUNCH path resolves the tier
+        # into a ``model_spec`` before calling (``Session._resolve_subagent_model``).
+        # A resume is a second launch and has to do that same resolution, or a
+        # child launched at ``hi`` would come back on the parent's model while
+        # the panel still displayed ``hi``. Resolved through the parent because
+        # the tier-to-model mapping lives in the operator's config, and the
+        # role's own default tier applies when the launch pinned none — which
+        # is exactly the precedence the first launch used.
+        # Guarded rather than called outright: ``_session`` is a full
+        # ``Session`` in production, but this class is also driven by the
+        # reduced hosts and test doubles that supply only the queue/steer/
+        # subscribe surface (see ``ChildSession``). A parent that cannot price
+        # a tier must still be able to resume its child on the parent's model,
+        # so a missing resolver degrades instead of raising.
+        model_spec: ModelSpec | None = None
+        resolve = getattr(self._session, "_resolve_subagent_model", None)
+        if callable(resolve):
+            resolved = resolve(agent, effort)
+            if isinstance(resolved, ModelSpec):
+                model_spec = resolved
         new_job_id = run_subagent(
             label=record.label,
             prompt=message,
             parent_session=self._session,
             jobs_manager=jobs,
+            model_spec=model_spec,
             resume_dir=record.session_dir,
+            agent=agent,
+            effort=effort,
         )
         # The pause is over the moment its continuation exists. Left set, the
         # old record would keep advertising ``paused`` in the roster forever

--- a/local_operator/tui/widgets/subagent_panel.py
+++ b/local_operator/tui/widgets/subagent_panel.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import time
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Any, Callable
+from typing import Any, Callable, NamedTuple
 
 from rich.cells import cell_len
 from rich.style import Style
@@ -432,8 +432,10 @@ def _read_row(job: Any, *, fallback_id: str, current: bool) -> RowFacts:
 #:    the page, where a state or a number is not. The two surfaces are read in
 #:    one glance and must not rank the same field differently. It is also the
 #:    only rung whose acceptance is CONDITIONAL: :func:`_row_rung` rejects it
-#:    whenever keeping the role would shorten the activity, so the rule below
-#:    stays true of the role too and the role costs only what is free.
+#:    whenever keeping the shared column would shorten ANY row's activity,
+#:    including a roleless row that reserves blank cells for alignment. Thus
+#:    the rule below stays true for the whole mixed roster, not only the rows
+#:    that render a role.
 #: 1. COST sheds next — it is monotonic and slow, and nothing an operator
 #:    acts on inside a second.
 #: 2. CONTEXT then SHORTENS before it drops: ``5%`` keeps the segment for two
@@ -464,14 +466,44 @@ def _read_row(job: Any, *, fallback_id: str, current: bool) -> RowFacts:
 #: it is beneath any width this dock is read at, and the alternative — freezing
 #: the budget once it stops shrinking — buys monotonicity by holding cells the
 #: narrowest rows most need.
-_RUNGS: tuple[tuple[str, bool, bool, int | None], ...] = (
-    ("full", True, True, None),
-    ("full", True, False, None),
-    ("full", False, False, None),
-    ("nodec", False, False, None),
-    ("short", False, False, None),
-    ("none", False, False, None),
-    ("none", False, False, LABEL_FLOOR),
+class _Rung(NamedTuple):
+    """One monotone reduction step, named so its policy is not positional.
+
+    This table is read in the painter, both measurement passes and the shared
+    role-column gate. Positional ``[2]`` meant ``keep_role`` only to a reader
+    who counted four unlike tuple fields correctly every time; a named row
+    makes adding or reordering a field a type-checked change instead of a
+    silent policy swap (agent review round 2, N1).
+    """
+
+    context_spelling: str
+    keep_cost: bool
+    keep_role: bool
+    label_budget: int | None
+
+
+_RUNGS: tuple[_Rung, ...] = (
+    _Rung("full", True, True, None),
+    _Rung("full", True, False, None),
+    _Rung("full", False, False, None),
+    _Rung("nodec", False, False, None),
+    _Rung("short", False, False, None),
+    _Rung("none", False, False, None),
+    _Rung("none", False, False, LABEL_FLOOR),
+)
+
+#: The first counterpart of the role-bearing rung that keeps every OTHER
+#: field unchanged. Derived from the table instead of assumed to be
+#: ``index + 1``: the D3 guard compares exactly these two candidates, and a
+#: future rung inserted between them must not silently change what "without
+#: role" means (agent review round 2, N2).
+_NO_ROLE_RUNG = next(
+    index
+    for index, rung in enumerate(_RUNGS)
+    if not rung.keep_role
+    and rung.context_spelling == _RUNGS[0].context_spelling
+    and rung.keep_cost == _RUNGS[0].keep_cost
+    and rung.label_budget == _RUNGS[0].label_budget
 )
 
 
@@ -491,17 +523,18 @@ def _row_rung(
     numbers and the label budget are non-increasing in the index, so
     acceptance is monotone and the first hit is the answer.
 
-    The ROLE rung is additionally rejected when keeping the role would cost the
-    row a shorter ACTIVITY than dropping it would (D3). The ladder's stated
-    principle is that the activity is never traded for a number — it is the
-    row's only statement of what the child is DOING, where the role is
-    identity sugar the label already half-carries and is re-derivable by
-    opening the page. Charging the role against the activity's budget inverted
-    that: between 82 and 84 cells the operator lost words of the activity to
-    keep a word they could infer, and narrowing from 82 to 81 then made the
-    activity spring back LONGER, a new non-monotonic jump in the band this
-    column created. Comparing the two candidate layouts directly is what keeps
-    the code honest to the docstring; the role now costs only where it is free.
+    The ROLE rung is additionally rejected when keeping the shared role COLUMN
+    would cost ANY row a shorter ACTIVITY than dropping it would (D3/R4). The
+    ladder's stated principle is that activity is never traded for a number —
+    it is the row's only statement of what the child is DOING, where the role
+    is identity sugar the label already half-carries and is re-derivable by
+    opening the page. The column is roster-wide, so this comparison must be
+    symmetric: a roleless row still reserves the blank column to preserve D1's
+    alignment, and checking only rows whose own ``role`` was non-empty merely
+    moved the 82/81 springback onto the plain-task row (agent review round 2,
+    R4). Comparing every row against the table-derived no-role counterpart
+    keeps alignment where the activity can afford it and sheds the whole
+    column where any row cannot.
     """
     for index in range(len(_RUNGS)):
         label, role, context, cost, activity = _lay_out(
@@ -515,11 +548,12 @@ def _row_rung(
             + _role_cells(index, role, role_column)
         )
         numbers = sum(len(STATS_SEAM) + cell_len(part) for part in (context, cost) if part)
-        if role and facts.activity:
-            # What this row's activity would be one rung down, i.e. with the
-            # role shed and nothing else changed. Only rung 0 carries a role,
-            # so index + 1 is exactly the no-role counterpart of this layout.
-            without = _lay_out(facts, stats, width, index + 1, column, clock, role_column)[4]
+        if role_column and _RUNGS[index].keep_role and facts.activity:
+            # Compare with the table-derived counterpart that changes ONLY
+            # ``keep_role``. Crucially this runs for a roleless row too: it
+            # renders whitespace rather than a role, but pays the same shared
+            # column so the measurements beneath the roster remain aligned.
+            without = _lay_out(facts, stats, width, _NO_ROLE_RUNG, column, clock, role_column)[4]
             if cell_len(activity) < cell_len(without):
                 continue
         if not facts.activity:
@@ -576,7 +610,7 @@ def _role_width(rung: int, role: str, role_column: int) -> int:
     below the role's own rung and the ladder would hand the activity fewer
     cells than it had before this field existed.
     """
-    if not _RUNGS[min(rung, len(_RUNGS) - 1)][2]:
+    if not _RUNGS[min(rung, len(_RUNGS) - 1)].keep_role:
         return 0
     return max(role_column, cell_len(role))
 
@@ -607,7 +641,11 @@ def _lay_out(
     being shoved sideways by each row's own role length. Zero means "lay this
     row out alone", which is what a caller measuring a single row wants.
     """
-    spelling, keep_cost, keep_role, budget = _RUNGS[min(rung, len(_RUNGS) - 1)]
+    policy = _RUNGS[min(rung, len(_RUNGS) - 1)]
+    spelling = policy.context_spelling
+    keep_cost = policy.keep_cost
+    keep_role = policy.keep_role
+    budget = policy.label_budget
     # The last rungs carry no reading at all; every other spelling is one the
     # band names too (`status_line.CONTEXT_FORMS`), so the same child's
     # occupancy cannot be written two ways four rows apart.
@@ -686,14 +724,14 @@ def panel_layout(
     )
     while rung < len(_RUNGS) - 1:
         column = _label_column(rows, width, rung, clock)
-        role_column = _role_column(rows) if _RUNGS[rung][2] else 0
+        role_column = _role_column(rows) if _RUNGS[rung].keep_role else 0
         if all(
             _row_rung(facts, stats, width, column, clock, role_column) <= rung
             for facts, stats in rows
         ):
             return rung, column, clock, role_column
         rung += 1
-    role_column = _role_column(rows) if _RUNGS[rung][2] else 0
+    role_column = _role_column(rows) if _RUNGS[rung].keep_role else 0
     return rung, _label_column(rows, width, rung, clock), clock, role_column
 
 

--- a/local_operator/tui/widgets/subagent_panel.py
+++ b/local_operator/tui/widgets/subagent_panel.py
@@ -284,6 +284,17 @@ class RowFacts:
     #: restating what the page's title says three rows above it — see
     #: :func:`compose_row`.
     current: bool = False
+    #: The child's ROLE (``AsyncJob.agent_role``, recorded at registration by
+    #: ``run_subagent``), or ``""`` when there is nothing worth saying.
+    #:
+    #: Empty for the ``"task"`` default, matching the full-page view's title
+    #: (``subagent_view._title_row``): every child is a task unless told
+    #: otherwise, so the word says nothing a reader did not already assume and
+    #: would cost eight cells on every ordinary row. Without this the list
+    #: names a child only by the label its parent happened to choose, so
+    #: whether ``review-301-r2`` is a reviewer or a coder that was asked to
+    #: look at a review was a guess.
+    agent_role: str = ""
 
 
 def row_facts(job: Any, *, fallback_id: str, current: bool) -> RowFacts:
@@ -366,6 +377,13 @@ def _read_row(job: Any, *, fallback_id: str, current: bool) -> RowFacts:
         # and glancing at the dock instead of scanning the page is why the
         # dock stayed visible — so that one is kept.
         activity = ""
+    # ``strip_control_sequences`` for the same reason the label gets it: a
+    # role name reaches this from an operator-authored registry entry, which
+    # is not a trusted source of terminal-safe text.
+    agent_role = strip_control_sequences(str(getattr(job, "agent_role", "") or "")).strip()
+    if agent_role == "task":
+        # The no-role default carries no information (see ``RowFacts``).
+        agent_role = ""
     return RowFacts(
         label=strip_control_sequences(str(getattr(job, "label", "") or fallback_id)),
         status=status,
@@ -374,6 +392,7 @@ def _read_row(job: Any, *, fallback_id: str, current: bool) -> RowFacts:
         elapsed=job_elapsed(job),
         activity=activity,
         current=current,
+        agent_role=agent_role,
     )
 
 
@@ -385,7 +404,18 @@ def _read_row(job: Any, *, fallback_id: str, current: bool) -> RowFacts:
 #: reduction order (``status_line._DROP_LADDER``) because the two surfaces are
 #: read in one glance:
 #:
-#: 1. COST sheds first — it is monotonic and slow, and nothing an operator
+#: 0. The ROLE sheds first, and it is the only rung above the ladder as it
+#:    stood: the widest rung is the previous widest rung PLUS the role, so a
+#:    terminal that showed a given set of fields before this column existed
+#:    still shows exactly that set at exactly that width, and only a terminal
+#:    with spare cells gains the new one. That is what makes this column
+#:    additive rather than a re-litigation of every width below it. It leads
+#:    for the same reason the full-page view's title makes it the most
+#:    disposable field (``subagent_view._title_row``): the role is identity
+#:    sugar the label already half-carries, and it is re-derivable by opening
+#:    the page, where a state or a number is not. The two surfaces are read in
+#:    one glance and must not rank the same field differently.
+#: 1. COST sheds next — it is monotonic and slow, and nothing an operator
 #:    acts on inside a second.
 #: 2. CONTEXT then SHORTENS before it drops: ``5%`` keeps the segment for two
 #:    cells instead of thirteen, and a bare percentage still answers "is this
@@ -398,8 +428,8 @@ def _read_row(job: Any, *, fallback_id: str, current: bool) -> RowFacts:
 #: of what the child is DOING — every number here is re-derivable by opening
 #: the page — so it truncates against :data:`ACTIVITY_FLOOR` and disappears
 #: only when even the floor cannot be paid.
-#: ``(context spelling, keep cost, label budget)``; ``None`` means "a third of
-#: the width", which is only known at measure time.
+#: ``(context spelling, keep cost, keep role, label budget)``; ``None`` means
+#: "a third of the width", which is only known at measure time.
 #:
 #: The context has THREE spellings, not two, because the middle one is what
 #: keeps a mixed-model fan-out comparable: ``24%`` and ``31%`` beside each
@@ -415,13 +445,14 @@ def _read_row(job: Any, *, fallback_id: str, current: bool) -> RowFacts:
 #: it is beneath any width this dock is read at, and the alternative — freezing
 #: the budget once it stops shrinking — buys monotonicity by holding cells the
 #: narrowest rows most need.
-_RUNGS: tuple[tuple[str, bool, int | None], ...] = (
-    ("full", True, None),
-    ("full", False, None),
-    ("nodec", False, None),
-    ("short", False, None),
-    ("none", False, None),
-    ("none", False, LABEL_FLOOR),
+_RUNGS: tuple[tuple[str, bool, bool, int | None], ...] = (
+    ("full", True, True, None),
+    ("full", True, False, None),
+    ("full", False, False, None),
+    ("nodec", False, False, None),
+    ("short", False, False, None),
+    ("none", False, False, None),
+    ("none", False, False, LABEL_FLOOR),
 )
 
 
@@ -435,14 +466,14 @@ def _row_rung(facts: RowFacts, stats: JobStats, width: int, column: int, clock: 
     acceptance is monotone and the first hit is the answer.
     """
     for index in range(len(_RUNGS)):
-        label, context, cost, activity = _lay_out(facts, stats, width, index, column, clock)
+        label, role, context, cost, activity = _lay_out(facts, stats, width, index, column, clock)
         head = (
             _CHROME_CELLS
             + max(cell_len(label), column)
             + max(cell_len(facts.elapsed), clock)
             + _glyph_cells(facts)
         )
-        numbers = sum(len(STATS_SEAM) + cell_len(part) for part in (context, cost) if part)
+        numbers = sum(len(STATS_SEAM) + cell_len(part) for part in (role, context, cost) if part)
         if not facts.activity:
             if head + numbers <= width:
                 return index
@@ -485,14 +516,14 @@ def _glyph_cells(facts: RowFacts) -> int:
 
 def _lay_out(
     facts: RowFacts, stats: JobStats, width: int, rung: int, column: int = 0, clock: int = 0
-) -> tuple[str, str, str, str]:
-    """``(label, context, cost, activity)`` exactly as ``rung`` will paint them.
+) -> tuple[str, str, str, str, str]:
+    """``(label, role, context, cost, activity)`` exactly as ``rung`` paints them.
 
     ``column`` is the shared label width the row will be padded to; the
     activity is measured against it, not against this row's own label, or a
     short-labelled row would be handed slack the padding is about to spend.
     """
-    spelling, keep_cost, budget = _RUNGS[min(rung, len(_RUNGS) - 1)]
+    spelling, keep_cost, keep_role, budget = _RUNGS[min(rung, len(_RUNGS) - 1)]
     # The last rungs carry no reading at all; every other spelling is one the
     # band names too (`status_line.CONTEXT_FORMS`), so the same child's
     # occupancy cannot be written two ways four rows apart.
@@ -501,6 +532,12 @@ def _lay_out(
         if spelling == "none"
         else context_spelling(stats.context_tokens, stats.context_window, form=spelling)
     )
+    # A row with no role to show pays nothing for the column at any rung: the
+    # segment is per-ROW, unlike cost, which sheds for the whole list at once
+    # so a blank cell there cannot be read as "did not fit". Here a missing
+    # role means the child is a plain task, which is the same thing the
+    # full-page title says by omitting it.
+    role = facts.agent_role if keep_role else ""
     if not keep_cost:
         cost = ""
     elif stats.cost is not None:
@@ -522,10 +559,10 @@ def _lay_out(
         + max(cell_len(facts.elapsed), clock)
         + _glyph_cells(facts)
     )
-    numbers = sum(len(STATS_SEAM) + cell_len(part) for part in (context, cost) if part)
+    numbers = sum(len(STATS_SEAM) + cell_len(part) for part in (role, context, cost) if part)
     room = width - head - numbers - ACTIVITY_GAP
     activity = truncate_cells(facts.activity, room) if facts.activity and room > 0 else ""
-    return label, context, cost, activity
+    return label, role, context, cost, activity
 
 
 def panel_layout(rows: Sequence[tuple[RowFacts, JobStats]], width: int) -> tuple[int, int, int]:
@@ -613,7 +650,7 @@ def compose_row(
     dim = Style(color=theme_mod.semantic_color("dim"))
     faint = Style(color=theme_mod.semantic_color("faint"))
 
-    label, context, cost, activity = _lay_out(facts, stats, width, rung, column, clock)
+    label, role, context, cost, activity = _lay_out(facts, stats, width, rung, column, clock)
     glyph, _word, token = status_glyph(
         facts.status, queued=facts.queued, spinner_glyph=spinner_glyph
     )
@@ -629,7 +666,7 @@ def compose_row(
         # statements inside twenty-five rows, in three vocabularies; the row's
         # job in this mode is WHICH subagent, and the numbers are the one
         # thing the title does not carry. Non-current rows are unchanged.
-        for index, value in enumerate(part for part in (context, cost) if part):
+        for index, value in enumerate(part for part in (role, context, cost) if part):
             if index:
                 row.append(STATS_SEAM, style=faint)
             row.append(value, style=muted)
@@ -651,7 +688,15 @@ def compose_row(
     # else's. Durations right-align by convention and the pad abuts the glyph,
     # so no seam moves.
     row.append(f" {facts.elapsed.rjust(max(clock, cell_len(facts.elapsed)))}", style=muted)
-    for value in (context, cost):
+    # The role leads the numbers run rather than trailing it: it qualifies WHAT
+    # the child is, the way the page title reads ``Subagent · reviewer ·
+    # <label>``, and reading it after the clock and the percentage would put
+    # the row's identity behind its measurements. It takes the same ` · ` seam
+    # and ``muted`` ink as every other segment here — a second visual idiom
+    # beside an established one is a defect — which also means it inherits the
+    # contrast decision recorded above (``dim`` is under WCAG AA on this
+    # ground; ``muted`` is 7.93:1).
+    for value in (role, context, cost):
         if value:
             row.append(STATS_SEAM, style=faint)
             row.append(value, style=muted)
@@ -1105,6 +1150,22 @@ class SubagentPanel(Container):
             ceiling = self.screen.size.width or 0
         except Exception:
             ceiling = 0  # not on a screen yet; the arrange that follows fixes it
+        if ceiling:
+            # The screen ceiling has to be charged the SAME padding the rows
+            # already pay. ``.band-body`` is ``padding: 0 1``, and Textual is
+            # border-box, so a row inside it never has more than
+            # ``screen - 2`` cells even though the screen is ``screen`` wide.
+            # Comparing an unpadded ceiling against a padded ``own`` only
+            # matters once the panel over-grows its dock (``#band`` is
+            # ``width: auto``, so a long row widens it past the screen and the
+            # surplus is clipped) — and there the ladder was handed two cells
+            # that do not exist, kept a rung the terminal could not show, and
+            # the row lost its tail to a hard cut with no ellipsis: precisely
+            # the failure the ceiling exists to prevent, two cells short of
+            # preventing it. Read off the container rather than hardcoding 2,
+            # so a stylesheet change to the rail cannot silently desync this.
+            padding = self._list.styles.padding
+            ceiling = max(0, ceiling - padding.left - padding.right)
         own = self._list.size.width or self.size.width or 0
         if own and ceiling:
             return min(own, ceiling)

--- a/local_operator/tui/widgets/subagent_panel.py
+++ b/local_operator/tui/widgets/subagent_panel.py
@@ -432,10 +432,12 @@ def _read_row(job: Any, *, fallback_id: str, current: bool) -> RowFacts:
 #:    the page, where a state or a number is not. The two surfaces are read in
 #:    one glance and must not rank the same field differently. It is also the
 #:    only rung whose acceptance is CONDITIONAL: :func:`_row_rung` rejects it
-#:    whenever keeping the shared column would shorten ANY row's activity,
-#:    including a roleless row that reserves blank cells for alignment. Thus
-#:    the rule below stays true for the whole mixed roster, not only the rows
-#:    that render a role.
+#:    whenever keeping the shared column would drive ANY row's activity below
+#:    :data:`ACTIVITY_FLOOR`, including a roleless row that reserves blank
+#:    cells for alignment. The threshold is a WIDTH CAPACITY, not the current
+#:    length of a child-authored progress sentence, so live activity changes
+#:    cannot make the whole column flicker in and out (design review round 3,
+#:    D8).
 #: 1. COST sheds next — it is monotonic and slow, and nothing an operator
 #:    acts on inside a second.
 #: 2. CONTEXT then SHORTENS before it drops: ``5%`` keeps the segment for two
@@ -492,20 +494,6 @@ _RUNGS: tuple[_Rung, ...] = (
     _Rung("none", False, False, LABEL_FLOOR),
 )
 
-#: The first counterpart of the role-bearing rung that keeps every OTHER
-#: field unchanged. Derived from the table instead of assumed to be
-#: ``index + 1``: the D3 guard compares exactly these two candidates, and a
-#: future rung inserted between them must not silently change what "without
-#: role" means (agent review round 2, N2).
-_NO_ROLE_RUNG = next(
-    index
-    for index, rung in enumerate(_RUNGS)
-    if not rung.keep_role
-    and rung.context_spelling == _RUNGS[0].context_spelling
-    and rung.keep_cost == _RUNGS[0].keep_cost
-    and rung.label_budget == _RUNGS[0].label_budget
-)
-
 
 def _row_rung(
     facts: RowFacts,
@@ -524,17 +512,19 @@ def _row_rung(
     acceptance is monotone and the first hit is the answer.
 
     The ROLE rung is additionally rejected when keeping the shared role COLUMN
-    would cost ANY row a shorter ACTIVITY than dropping it would (D3/R4). The
-    ladder's stated principle is that activity is never traded for a number —
-    it is the row's only statement of what the child is DOING, where the role
-    is identity sugar the label already half-carries and is re-derivable by
-    opening the page. The column is roster-wide, so this comparison must be
-    symmetric: a roleless row still reserves the blank column to preserve D1's
-    alignment, and checking only rows whose own ``role`` was non-empty merely
-    moved the 82/81 springback onto the plain-task row (agent review round 2,
-    R4). Comparing every row against the table-derived no-role counterpart
-    keeps alignment where the activity can afford it and sheds the whole
-    column where any row cannot.
+    would leave ANY row fewer than :data:`ACTIVITY_FLOOR` cells for activity
+    (D3/R4/D8). The column is roster-wide, so this capacity check is symmetric:
+    a roleless row still reserves the blank column to preserve D1's alignment.
+
+    Crucially the veto compares CAPACITY, not the current activity's displayed
+    length. The earlier symmetric guard compared against the full unbounded,
+    child-authored sentence; one chatty row therefore moved the role column's
+    visibility floor from width 88 to 127 and made the whole column flicker at
+    a fixed width as that live string changed (design review round 3, D8).
+    Activities already truncate everywhere else. A stable column is the more
+    valuable list-wide invariant, so the role survives while every row can pay
+    the established floor and sheds only when width, not prose, makes that
+    floor unaffordable.
     """
     for index in range(len(_RUNGS)):
         label, role, context, cost, activity = _lay_out(
@@ -548,13 +538,17 @@ def _row_rung(
             + _role_cells(index, role, role_column)
         )
         numbers = sum(len(STATS_SEAM) + cell_len(part) for part in (context, cost) if part)
-        if role_column and _RUNGS[index].keep_role and facts.activity:
-            # Compare with the table-derived counterpart that changes ONLY
-            # ``keep_role``. Crucially this runs for a roleless row too: it
-            # renders whitespace rather than a role, but pays the same shared
-            # column so the measurements beneath the roster remain aligned.
-            without = _lay_out(facts, stats, width, _NO_ROLE_RUNG, column, clock, role_column)[4]
-            if cell_len(activity) < cell_len(without):
+        if role_column and _RUNGS[index].keep_role:
+            # The progress sentence — including whether one happens to be
+            # present this tick — is deliberately NOT consulted here: it
+            # changes live and is unbounded, so it cannot be allowed to toggle
+            # a roster-wide column. Measure only the stable chrome/numeric
+            # fields and reserve the established activity floor on EVERY row.
+            # This applies to roleless rows too, which pay the shared blank
+            # column for D1 alignment (R4). The result is a function of width
+            # and roster identity/stats, never one child's current prose (D8).
+            activity_room = width - head - numbers - ACTIVITY_GAP
+            if activity_room < ACTIVITY_FLOOR:
                 continue
         if not facts.activity:
             if head + numbers <= width:

--- a/local_operator/tui/widgets/subagent_panel.py
+++ b/local_operator/tui/widgets/subagent_panel.py
@@ -115,6 +115,30 @@ LABEL_FLOOR = 12
 #: beside the label, not the label itself.
 ROLE_CEILING = 14
 
+#: Maximum cells the row gives the two live numeric readings. Both are
+#: explicitly truncated to these budgets before they paint, and the role-rung
+#: gate reserves the SAME maxima whether a reading currently exists or not.
+#: That coupling is load-bearing: usage/context/cost arrive live and their raw
+#: formatters interpolate uncapped magnitudes, so measuring the current strings
+#: made the roster-wide role column appear/disappear at a fixed width after the
+#: first usage report or as spend grew (agent review round 3, R5).
+#:
+#: Context's normal full form is ``24.1%/200k`` (11 cells); fourteen preserves
+#: even ``999.9%/1000M`` whole and visibly ellipsises pathological magnitudes.
+#: Cost's ordinary largest precision is ``$999.99`` (7); ten preserves nine
+#: digits of useful magnitude before the ellipsis. The exact values matter less
+#: than sharing them between paint and acceptance: no live string may consume
+#: cells the width-only gate did not reserve.
+CONTEXT_CEILING = 14
+COST_CEILING = 10
+
+#: :func:`format_duration` is bounded at six cells by construction (``100d+``
+#: is the terminal spelling), independently tested in ``test_status_line``.
+#: Name the contract here because the role gate reserves this maximum rather
+#: than the current elapsed spelling, so a clock transition cannot toggle the
+#: whole column (R5).
+CLOCK_CEILING = 6
+
 #: Width the ladder assumes before the first layout has measured a row. Wide
 #: rather than narrow on purpose: an over-generous guess degrades to Rich's
 #: own ellipsis at the row's real edge, while an under-generous one would shed
@@ -434,10 +458,10 @@ def _read_row(job: Any, *, fallback_id: str, current: bool) -> RowFacts:
 #:    only rung whose acceptance is CONDITIONAL: :func:`_row_rung` rejects it
 #:    whenever keeping the shared column would drive ANY row's activity below
 #:    :data:`ACTIVITY_FLOOR`, including a roleless row that reserves blank
-#:    cells for alignment. The threshold is a WIDTH CAPACITY, not the current
-#:    length of a child-authored progress sentence, so live activity changes
-#:    cannot make the whole column flicker in and out (design review round 3,
-#:    D8).
+#:    cells for alignment. The threshold is a WIDTH CAPACITY whose other inputs
+#:    are explicit maxima, not current activity/elapsed/context/cost strings,
+#:    so no live update can make the whole column flicker in and out (design
+#:    review round 3 D8, agent review round 3 R5).
 #: 1. COST sheds next — it is monotonic and slow, and nothing an operator
 #:    acts on inside a second.
 #: 2. CONTEXT then SHORTENS before it drops: ``5%`` keeps the segment for two
@@ -513,18 +537,17 @@ def _row_rung(
 
     The ROLE rung is additionally rejected when keeping the shared role COLUMN
     would leave ANY row fewer than :data:`ACTIVITY_FLOOR` cells for activity
-    (D3/R4/D8). The column is roster-wide, so this capacity check is symmetric:
-    a roleless row still reserves the blank column to preserve D1's alignment.
+    (D3/R4/D8/R5). The column is roster-wide, so this capacity check is
+    symmetric: a roleless row still reserves the blank column for D1 alignment.
 
-    Crucially the veto compares CAPACITY, not the current activity's displayed
-    length. The earlier symmetric guard compared against the full unbounded,
-    child-authored sentence; one chatty row therefore moved the role column's
-    visibility floor from width 88 to 127 and made the whole column flicker at
-    a fixed width as that live string changed (design review round 3, D8).
-    Activities already truncate everywhere else. A stable column is the more
-    valuable list-wide invariant, so the role survives while every row can pay
-    the established floor and sheds only when width, not prose, makes that
-    floor unaffordable.
+    The veto consumes only WIDTH and bounded inputs. It does not measure the
+    current activity (D8), elapsed spelling, or live context/cost strings (R5):
+    all three change without a resize, and raw numeric formatters can grow with
+    magnitude. Instead it reserves ``CLOCK_CEILING`` and the maximum cells of
+    every numeric segment this rung can paint. `_lay_out` truncates those
+    segments to the same ceilings, so acceptance and rendering cannot diverge.
+    The result may conservatively shed the role earlier than today's short
+    values require, but it cannot flicker as stats arrive or counters grow.
     """
     for index in range(len(_RUNGS)):
         label, role, context, cost, activity = _lay_out(
@@ -539,15 +562,22 @@ def _row_rung(
         )
         numbers = sum(len(STATS_SEAM) + cell_len(part) for part in (context, cost) if part)
         if role_column and _RUNGS[index].keep_role:
-            # The progress sentence — including whether one happens to be
-            # present this tick — is deliberately NOT consulted here: it
-            # changes live and is unbounded, so it cannot be allowed to toggle
-            # a roster-wide column. Measure only the stable chrome/numeric
-            # fields and reserve the established activity floor on EVERY row.
-            # This applies to roleless rows too, which pay the shared blank
-            # column for D1 alignment (R4). The result is a function of width
-            # and roster identity/stats, never one child's current prose (D8).
-            activity_room = width - head - numbers - ACTIVITY_GAP
+            # Reserve MAXIMUM rendered widths, not today's strings. Elapsed,
+            # context and cost all update live; using ``head``/``numbers`` here
+            # let the first usage report or a magnitude transition toggle the
+            # whole column without a resize (R5). The painter applies the same
+            # ceilings in `_lay_out`, making this conservative but truthful.
+            fixed_head = (
+                _CHROME_CELLS
+                + max(cell_len(label), column)
+                + CLOCK_CEILING
+                + _glyph_cells(facts)
+                + _role_cells(index, role, role_column)
+            )
+            fixed_numbers = len(STATS_SEAM) + CONTEXT_CEILING
+            if _RUNGS[index].keep_cost:
+                fixed_numbers += len(STATS_SEAM) + COST_CEILING
+            activity_room = width - fixed_head - fixed_numbers - ACTIVITY_GAP
             if activity_room < ACTIVITY_FLOOR:
                 continue
         if not facts.activity:
@@ -646,7 +676,10 @@ def _lay_out(
     context = (
         ""
         if spelling == "none"
-        else context_spelling(stats.context_tokens, stats.context_window, form=spelling)
+        else truncate_cells(
+            context_spelling(stats.context_tokens, stats.context_window, form=spelling),
+            CONTEXT_CEILING,
+        )
     )
     # Bounded before it is measured, so one verbose specialist cannot make the
     # shared column below 34 cells wide and evict its peers' roles (D2).
@@ -654,7 +687,7 @@ def _lay_out(
     if not keep_cost:
         cost = ""
     elif stats.cost is not None:
-        cost = format_cost(stats.cost)
+        cost = truncate_cells(format_cost(stats.cost), COST_CEILING)
     else:
         # The band's own vocabulary for "billed, and nobody can price it".
         # Safe on a row now that the whole column sheds at one rung: at a rung

--- a/local_operator/tui/widgets/subagent_panel.py
+++ b/local_operator/tui/widgets/subagent_panel.py
@@ -99,6 +99,22 @@ ACTIVITY_FLOOR = 16
 #: indistinguishable — which is the one thing a list of rows may not do.
 LABEL_FLOOR = 12
 
+#: The widest a ROLE segment may be before it is truncated with the usual `…`.
+#:
+#: Role names are operator-authored (`agent op=create`) and have no length cap,
+#: and the `agent`/`team` tooling actively encourages descriptive specialist
+#: names — `user-dashboard-agent` is 20 cells, and nothing stops a 60-cell one.
+#: Left unbounded the segment is a per-LIST cost paid by every row: the longest
+#: role in the roster decides whether ANYBODY gets one, so a single verbose
+#: specialist silently strips the role from its short-named peers and the
+#: feature reads as "the role column is gone again" (design review round 1, D2).
+#: Fourteen holds every packaged role whole (`ux-reviewer` is the longest at 11)
+#: and `architect`, `designer`, `reviewer` and `coder` with room to spare, while
+#: keeping the shared column below in the same order of magnitude as the label's
+#: own floor. A truncated role still identifies the child: it is a disambiguator
+#: beside the label, not the label itself.
+ROLE_CEILING = 14
+
 #: Width the ladder assumes before the first layout has measured a row. Wide
 #: rather than narrow on purpose: an over-generous guess degrades to Rich's
 #: own ellipsis at the row's real edge, while an under-generous one would shed
@@ -414,7 +430,10 @@ def _read_row(job: Any, *, fallback_id: str, current: bool) -> RowFacts:
 #:    disposable field (``subagent_view._title_row``): the role is identity
 #:    sugar the label already half-carries, and it is re-derivable by opening
 #:    the page, where a state or a number is not. The two surfaces are read in
-#:    one glance and must not rank the same field differently.
+#:    one glance and must not rank the same field differently. It is also the
+#:    only rung whose acceptance is CONDITIONAL: :func:`_row_rung` rejects it
+#:    whenever keeping the role would shorten the activity, so the rule below
+#:    stays true of the role too and the role costs only what is free.
 #: 1. COST sheds next — it is monotonic and slow, and nothing an operator
 #:    acts on inside a second.
 #: 2. CONTEXT then SHORTENS before it drops: ``5%`` keeps the segment for two
@@ -456,7 +475,14 @@ _RUNGS: tuple[tuple[str, bool, bool, int | None], ...] = (
 )
 
 
-def _row_rung(facts: RowFacts, stats: JobStats, width: int, column: int, clock: int = 0) -> int:
+def _row_rung(
+    facts: RowFacts,
+    stats: JobStats,
+    width: int,
+    column: int,
+    clock: int = 0,
+    role_column: int = 0,
+) -> int:
     """The LEAST-REDUCED rung this row still reads correctly at.
 
     Walks :data:`_RUNGS` widest-first and takes the first that fits, so a
@@ -464,16 +490,38 @@ def _row_rung(facts: RowFacts, stats: JobStats, width: int, column: int, clock: 
     the reduction every row can live with. Well-founded because both the
     numbers and the label budget are non-increasing in the index, so
     acceptance is monotone and the first hit is the answer.
+
+    The ROLE rung is additionally rejected when keeping the role would cost the
+    row a shorter ACTIVITY than dropping it would (D3). The ladder's stated
+    principle is that the activity is never traded for a number — it is the
+    row's only statement of what the child is DOING, where the role is
+    identity sugar the label already half-carries and is re-derivable by
+    opening the page. Charging the role against the activity's budget inverted
+    that: between 82 and 84 cells the operator lost words of the activity to
+    keep a word they could infer, and narrowing from 82 to 81 then made the
+    activity spring back LONGER, a new non-monotonic jump in the band this
+    column created. Comparing the two candidate layouts directly is what keeps
+    the code honest to the docstring; the role now costs only where it is free.
     """
     for index in range(len(_RUNGS)):
-        label, role, context, cost, activity = _lay_out(facts, stats, width, index, column, clock)
+        label, role, context, cost, activity = _lay_out(
+            facts, stats, width, index, column, clock, role_column
+        )
         head = (
             _CHROME_CELLS
             + max(cell_len(label), column)
             + max(cell_len(facts.elapsed), clock)
             + _glyph_cells(facts)
+            + _role_cells(index, role, role_column)
         )
-        numbers = sum(len(STATS_SEAM) + cell_len(part) for part in (role, context, cost) if part)
+        numbers = sum(len(STATS_SEAM) + cell_len(part) for part in (context, cost) if part)
+        if role and facts.activity:
+            # What this row's activity would be one rung down, i.e. with the
+            # role shed and nothing else changed. Only rung 0 carries a role,
+            # so index + 1 is exactly the no-role counterpart of this layout.
+            without = _lay_out(facts, stats, width, index + 1, column, clock, role_column)[4]
+            if cell_len(activity) < cell_len(without):
+                continue
         if not facts.activity:
             if head + numbers <= width:
                 return index
@@ -514,14 +562,50 @@ def _glyph_cells(facts: RowFacts) -> int:
     return max(_GLYPH_COL, cell_len(glyph))
 
 
+def _role_width(rung: int, role: str, role_column: int) -> int:
+    """Cells the role FIELD occupies on one row, seam EXCLUDED.
+
+    One definition shared by the two measurement sites and the painter, because
+    a budget computed one way and spent another is exactly how a row ends up
+    one cell over its width. The width is the shared ``role_column`` rather
+    than this row's own role, so a roleless row pays the same as its peers and
+    the seam run after it stays put (D1).
+
+    Zero at any rung that has already SHED the role: a rung with no role at all
+    must charge nothing, or the blank column would be paid for at every width
+    below the role's own rung and the ladder would hand the activity fewer
+    cells than it had before this field existed.
+    """
+    if not _RUNGS[min(rung, len(_RUNGS) - 1)][2]:
+        return 0
+    return max(role_column, cell_len(role))
+
+
+def _role_cells(rung: int, role: str, role_column: int) -> int:
+    """:func:`_role_width` plus the seam that precedes it, or zero for neither."""
+    width = _role_width(rung, role, role_column)
+    return len(STATS_SEAM) + width if width else 0
+
+
 def _lay_out(
-    facts: RowFacts, stats: JobStats, width: int, rung: int, column: int = 0, clock: int = 0
+    facts: RowFacts,
+    stats: JobStats,
+    width: int,
+    rung: int,
+    column: int = 0,
+    clock: int = 0,
+    role_column: int = 0,
 ) -> tuple[str, str, str, str, str]:
     """``(label, role, context, cost, activity)`` exactly as ``rung`` paints them.
 
     ``column`` is the shared label width the row will be padded to; the
     activity is measured against it, not against this row's own label, or a
     short-labelled row would be handed slack the padding is about to spend.
+
+    ``role_column`` is the same idea for the role: the width EVERY row's role
+    field occupies, so what follows it starts in one vertical line instead of
+    being shoved sideways by each row's own role length. Zero means "lay this
+    row out alone", which is what a caller measuring a single row wants.
     """
     spelling, keep_cost, keep_role, budget = _RUNGS[min(rung, len(_RUNGS) - 1)]
     # The last rungs carry no reading at all; every other spelling is one the
@@ -532,12 +616,9 @@ def _lay_out(
         if spelling == "none"
         else context_spelling(stats.context_tokens, stats.context_window, form=spelling)
     )
-    # A row with no role to show pays nothing for the column at any rung: the
-    # segment is per-ROW, unlike cost, which sheds for the whole list at once
-    # so a blank cell there cannot be read as "did not fit". Here a missing
-    # role means the child is a plain task, which is the same thing the
-    # full-page title says by omitting it.
-    role = facts.agent_role if keep_role else ""
+    # Bounded before it is measured, so one verbose specialist cannot make the
+    # shared column below 34 cells wide and evict its peers' roles (D2).
+    role = truncate_cells(facts.agent_role, ROLE_CEILING) if keep_role else ""
     if not keep_cost:
         cost = ""
     elif stats.cost is not None:
@@ -558,38 +639,75 @@ def _lay_out(
         + max(cell_len(label), column)
         + max(cell_len(facts.elapsed), clock)
         + _glyph_cells(facts)
+        # The role is charged as a COLUMN, not as a number: every row pays the
+        # shared width whether or not it has a role to put in it, which is what
+        # keeps the context, the cost and the activity on one vertical line
+        # (D1). A row that suppresses its role therefore pays for the blank and
+        # stays flush with its peers, instead of pulling its whole tail left.
+        + _role_cells(rung, role, role_column)
     )
-    numbers = sum(len(STATS_SEAM) + cell_len(part) for part in (role, context, cost) if part)
+    numbers = sum(len(STATS_SEAM) + cell_len(part) for part in (context, cost) if part)
     room = width - head - numbers - ACTIVITY_GAP
     activity = truncate_cells(facts.activity, room) if facts.activity and room > 0 else ""
     return label, role, context, cost, activity
 
 
-def panel_layout(rows: Sequence[tuple[RowFacts, JobStats]], width: int) -> tuple[int, int, int]:
-    """``(rung, label column)`` for the whole list — the panel's one layout.
+def panel_layout(
+    rows: Sequence[tuple[RowFacts, JobStats]], width: int
+) -> tuple[int, int, int, int]:
+    """``(rung, label column, clock, role column)`` — the panel's one layout.
 
-    Two decisions that cannot be made apart. The rung says which fields every
-    row carries; the column says where they sit, so that two children's spend
+    Decisions that cannot be made apart. The rung says which fields every
+    row carries; the columns say where they sit, so that two children's spend
     can be compared by looking down instead of reading across. Padding costs
     the shorter rows cells they were spending on activity slack, which can
-    push a row under its floor — so the rung is re-checked WITH the column
-    applied and reduced until the pair fits, rather than each being solved
+    push a row under its floor — so the rung is re-checked WITH the columns
+    applied and reduced until they fit, rather than each being solved
     against a layout the other has not happened yet.
 
-    Terminates: the column is non-increasing in the rung (the last rung caps
-    the label at :data:`LABEL_FLOOR`) and the final rung carries no numbers at
-    all, so the loop is bounded by ``len(_RUNGS)``.
+    The ROLE column is settled the same way and for the same reason as the
+    label's: an inline role of a different length on every row shoved that
+    row's context, cost and activity sideways by a different amount, turning a
+    column of four ``$`` signs into four x positions (design review round 1,
+    D1). Bounded by :data:`ROLE_CEILING` before it is measured, so the column
+    cannot be widened without limit by one operator-authored specialist name.
+
+    Terminates: the columns are non-increasing in the rung (the last rung caps
+    the label at :data:`LABEL_FLOOR` and no rung past the first carries a role)
+    and the final rung carries no numbers at all, so the loop is bounded by
+    ``len(_RUNGS)``.
     """
     # The clock column is width-independent — a duration is as wide as it is —
     # so it is settled once, before the rung search that consumes it.
     clock = max((cell_len(facts.elapsed) for facts, _ in rows), default=0)
-    rung = max((_row_rung(facts, stats, width, 0, clock) for facts, stats in rows), default=0)
+    rung = max(
+        (_row_rung(facts, stats, width, 0, clock, _role_column(rows)) for facts, stats in rows),
+        default=0,
+    )
     while rung < len(_RUNGS) - 1:
         column = _label_column(rows, width, rung, clock)
-        if all(_row_rung(facts, stats, width, column, clock) <= rung for facts, stats in rows):
-            return rung, column, clock
+        role_column = _role_column(rows) if _RUNGS[rung][2] else 0
+        if all(
+            _row_rung(facts, stats, width, column, clock, role_column) <= rung
+            for facts, stats in rows
+        ):
+            return rung, column, clock, role_column
         rung += 1
-    return rung, _label_column(rows, width, rung, clock), clock
+    role_column = _role_column(rows) if _RUNGS[rung][2] else 0
+    return rung, _label_column(rows, width, rung, clock), clock, role_column
+
+
+def _role_column(rows: Sequence[tuple[RowFacts, JobStats]]) -> int:
+    """Cells the role field occupies on EVERY row that shows one.
+
+    Width-independent: the roles are already bounded by :data:`ROLE_CEILING`,
+    so this is a property of the roster rather than of the terminal, and a
+    roster with no roles at all yields zero and costs nothing.
+    """
+    return max(
+        (cell_len(truncate_cells(facts.agent_role, ROLE_CEILING)) for facts, _ in rows),
+        default=0,
+    )
 
 
 def _label_column(
@@ -622,6 +740,7 @@ def compose_row(
     rung: int,
     column: int = 0,
     clock: int = 0,
+    role_column: int = 0,
 ) -> Text:
     """One row at the panel's chosen ``rung``: identity, state, numbers, activity.
 
@@ -650,7 +769,16 @@ def compose_row(
     dim = Style(color=theme_mod.semantic_color("dim"))
     faint = Style(color=theme_mod.semantic_color("faint"))
 
-    label, role, context, cost, activity = _lay_out(facts, stats, width, rung, column, clock)
+    label, role, context, cost, activity = _lay_out(
+        facts, stats, width, rung, column, clock, role_column
+    )
+    # The cells the role field occupies on THIS row, seam included. A row with
+    # no role pays the same width as its peers so the segments after it stay in
+    # column (D1), but pays it as pure whitespace: emitting the ` · ` seam with
+    # nothing after it would paint a separator separating nothing, which reads
+    # as a missing value rather than as a child with nothing to say.
+    role_width = _role_width(rung, role, role_column)
+    role_pad = " " * max(0, role_width - cell_len(role))
     glyph, _word, token = status_glyph(
         facts.status, queued=facts.queued, spinner_glyph=spinner_glyph
     )
@@ -666,8 +794,13 @@ def compose_row(
         # statements inside twenty-five rows, in three vocabularies; the row's
         # job in this mode is WHICH subagent, and the numbers are the one
         # thing the title does not carry. Non-current rows are unchanged.
-        for index, value in enumerate(part for part in (role, context, cost) if part):
-            if index:
+        if role:
+            row.append(role, style=muted)
+            row.append(role_pad, style=dim)
+        elif role_width:
+            row.append(" " * (role_width + len(STATS_SEAM)), style=dim)
+        for index, value in enumerate(part for part in (context, cost) if part):
+            if index or role:
                 row.append(STATS_SEAM, style=faint)
             row.append(value, style=muted)
         row.truncate(width, overflow="ellipsis")
@@ -696,7 +829,13 @@ def compose_row(
     # beside an established one is a defect — which also means it inherits the
     # contrast decision recorded above (``dim`` is under WCAG AA on this
     # ground; ``muted`` is 7.93:1).
-    for value in (role, context, cost):
+    if role:
+        row.append(STATS_SEAM, style=faint)
+        row.append(role, style=muted)
+        row.append(role_pad, style=dim)
+    elif role_width:
+        row.append(" " * (role_width + len(STATS_SEAM)), style=dim)
+    for value in (context, cost):
         if value:
             row.append(STATS_SEAM, style=faint)
             row.append(value, style=muted)
@@ -786,6 +925,7 @@ class SubagentRow(Static):
         rung: int,
         column: int,
         clock: int,
+        role_column: int = 0,
     ) -> bool:
         """Repaint from already-derived state; returns the row's running-ness.
 
@@ -807,6 +947,11 @@ class SubagentRow(Static):
             rung,
             column,
             clock,
+            # In the fingerprint because the role column is a property of the
+            # ROSTER: a child arriving or leaving can change it without
+            # changing anything else about this row, and a row that skipped
+            # that repaint would keep a stale pad and sit out of column.
+            role_column,
         )
         if fingerprint == self._fingerprint:
             return facts.running
@@ -827,6 +972,7 @@ class SubagentRow(Static):
                 rung=rung,
                 column=column,
                 clock=clock,
+                role_column=role_column,
             ),
             layout=False,
         )
@@ -934,6 +1080,10 @@ class SubagentPanel(Container):
         self._rung = 0
         self._column = 0
         self._clock = 0
+        #: Shared width of the role field, so the segments after it line up on
+        #: every row (:func:`panel_layout`). Zero when no child on the roster
+        #: carries a role, which is the ordinary fan-out and costs nothing.
+        self._role_column = 0
         self.display = False
 
     def compose(self):  # type: ignore[override]
@@ -1103,7 +1253,7 @@ class SubagentPanel(Container):
                 continue
             facts = row_facts(job, fallback_id=job_id, current=row.current)
             measured.append((job_id, row, facts, self._stats_for(job_id, job, reread_stats)))
-        self._rung, self._column, self._clock = panel_layout(
+        self._rung, self._column, self._clock, self._role_column = panel_layout(
             [(facts, stats) for _, _, facts, stats in measured], width
         )
         for _job_id, row, facts, stats in measured:
@@ -1115,6 +1265,7 @@ class SubagentPanel(Container):
                 rung=self._rung,
                 column=self._column,
                 clock=self._clock,
+                role_column=self._role_column,
             )
         self._paint_header()
         self._dirty = False
@@ -1303,6 +1454,7 @@ class SubagentPanel(Container):
                         rung=self._rung,
                         column=self._column,
                         clock=self._clock,
+                        role_column=self._role_column,
                     )
         # Sampled AFTER the paint, from the rows this tick has just produced.
         # Read beforehand it said False for a queued child that started in

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.39.0"
+version = "0.40.0"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/harness/test_comms.py
+++ b/tests/unit/harness/test_comms.py
@@ -981,6 +981,101 @@ def test_resume_refuses_when_the_transcript_is_gone_from_disk(tmp_path):
     assert "gone from disk" in (error or "")
 
 
+def test_a_resume_carries_the_childs_role_and_tier_forward(tmp_path, monkeypatch):
+    """A resumed child comes back as WHAT IT WAS, not as a generic task.
+
+    ``run_subagent`` defaults ``agent`` to ``"task"``, so a resume that omits
+    it silently rebuilt every reviewer, designer, scout and specialist as a
+    no-role child. That is a capability regression and not a cosmetic one: the
+    role decides the tool ALLOWLIST, so a resumed reviewer regained ``edit``
+    and could rewrite the code it was reviewing, and a resumed scout lost its
+    read-only promise. It also decides the preamble, the MCP exclusion, and
+    the ``agent`` re-stamped into ``origin.json``.
+
+    Asserted at the ``run_subagent`` seam because that is where the fact is
+    lost; the end-to-end consequences are exercised in the subagent tests.
+    """
+    from local_operator.harness import comms as comms_mod
+
+    seen: dict[str, object] = {}
+
+    def spy(**kwargs):
+        seen.update(kwargs)
+        return "job-2"
+
+    monkeypatch.setattr("local_operator.harness.subagent.run_subagent", spy)
+    jobs = FakeJobs()
+    parent = FakeParent(jobs)
+    # The parent prices the tier exactly as the LAUNCH path does; a resume is
+    # a second launch and has to perform the same resolution, or the child
+    # comes back on the parent's model while the panel still says `hi`.
+    resolved = comms_mod.ModelSpec(provider="anthropic", model_id="claude-opus-5")
+    parent._resolve_subagent_model = lambda agent, effort: resolved  # type: ignore[attr-defined]
+    comms = SubagentComms(parent)  # type: ignore[arg-type]
+    jobs.add("job-1", status="cancelled")
+    comms.record_launch("job-1", "review-301-r2", agent_role="reviewer", effort="hi")
+    comms.attach("job-1", FakeChild(), tmp_path / "child")
+    (tmp_path / "child").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "child" / TRANSCRIPT_FILENAME).write_text("{}\n", encoding="utf-8")
+    comms.detach("job-1")
+
+    new_id, error = comms.resume("job-1", "carry on")
+
+    assert error is None and new_id == "job-2"
+    assert seen["agent"] == "reviewer"
+    assert seen["effort"] == "hi"
+    assert seen["model_spec"] is resolved
+    assert seen["resume_dir"] == tmp_path / "child"
+
+
+def test_a_resume_of_a_plain_child_stays_a_plain_child(tmp_path, monkeypatch):
+    """The no-role default round-trips as the default rather than as ``""``."""
+    seen: dict[str, object] = {}
+    monkeypatch.setattr(
+        "local_operator.harness.subagent.run_subagent",
+        lambda **kwargs: (seen.update(kwargs), "job-2")[1],
+    )
+    jobs = FakeJobs()
+    comms = SubagentComms(FakeParent(jobs))  # type: ignore[arg-type]
+    jobs.add("job-1", status="cancelled")
+    comms.record_launch("job-1", "docs")
+    comms.attach("job-1", FakeChild(), tmp_path / "child")
+    (tmp_path / "child").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "child" / TRANSCRIPT_FILENAME).write_text("{}\n", encoding="utf-8")
+    comms.detach("job-1")
+
+    new_id, error = comms.resume("job-1", "carry on")
+
+    assert error is None and new_id == "job-2"
+    assert seen["agent"] == "task"
+    assert seen["effort"] is None
+    # A parent that cannot price a tier still resumes, on its own model.
+    assert seen["model_spec"] is None
+
+
+def test_a_restored_record_still_knows_what_its_child_was(tmp_path):
+    """The role has to survive the PROCESS, not just the job row.
+
+    ``_ChildRecord`` is in memory, so a parent session that is itself resumed
+    rebuilds its children from the persisted snapshot. If the role did not
+    round-trip there, resuming a child after a restart would hit exactly the
+    same defect from the other side.
+    """
+    jobs = FakeJobs()
+    first = SubagentComms(FakeParent(jobs))  # type: ignore[arg-type]
+    jobs.add("job-1", status="cancelled")
+    first.record_launch("job-1", "review-301-r2", agent_role="reviewer", effort="hi")
+    first.attach("job-1", FakeChild(), tmp_path / "child")
+    first.detach("job-1")
+
+    restored = SubagentComms(FakeParent(FakeJobs()))  # type: ignore[arg-type]
+    restored.restore(first.snapshot())
+
+    record = restored._records["job-1"]
+    assert record.agent_role == "reviewer"
+    assert record.effort == "hi"
+
+
 # --- the hub tool surface -----------------------------------------------------
 
 

--- a/tests/unit/tui/test_subagent_stats.py
+++ b/tests/unit/tui/test_subagent_stats.py
@@ -37,6 +37,7 @@ from local_operator.tui.widgets.subagent_panel import (
     SubagentPanel,
     SubagentRow,
     _glyph_cells,
+    _lay_out,
     compose_row,
     job_elapsed,
     job_stats,
@@ -587,35 +588,87 @@ def test_one_long_role_does_not_evict_its_peers_roles() -> None:
     rows = _column(jobs, 100)
     assert "reviewer" in rows[0], rows
     assert long_name not in rows[1], "the role is rendered untruncated"
-    assert cell_len(_plain(jobs[1], 200).split("·")[1].strip()) <= ROLE_CEILING
+    # Assert the renderer's role field directly. Splitting on a bare `·` can
+    # silently select the wrong segment when an operator-authored label or the
+    # model's activity contains that character (agent review round 2, M1).
+    facts = row_facts(jobs[1], fallback_id=jobs[1].id, current=False)
+    stats = job_stats(jobs[1], default_model_label=PARENT_MODEL)
+    rung, column, clock, role_column = panel_layout([(facts, stats)], 200)
+    role = _lay_out(facts, stats, 200, rung, column, clock, role_column)[1]
+    assert cell_len(role) <= ROLE_CEILING
+    assert role.endswith("…")
 
 
-def test_the_role_never_costs_the_activity_a_single_cell() -> None:
-    """The ladder's stated rule, applied to the field that was breaking it.
+def test_the_role_column_never_costs_any_rows_activity_a_single_cell() -> None:
+    """The D3 guarantee on the MIXED roster a real dock actually lays out.
 
     The role is "the most disposable field"; the activity is "never traded for
-    a number". Charging the role against the activity's budget inverted both at
-    once, and made narrowing the terminal LENGTHEN the activity. A role is now
-    offered only where it is free (design review round 1, D3).
+    a number". The shared column is paid by every row to preserve alignment,
+    including a plain task that renders no role of its own. The guard must
+    therefore compare every row — not only a row whose own role is non-empty —
+    against the identical roster with the role column removed (agent review
+    round 2, R4). A single-row `_plain` probe cannot observe this defect because
+    its role column collapses to that row's own role.
     """
-    with_role = Job(label="review-301-r2", progress="auditing merged MRs", agent_role="reviewer")
-    without = Job(label="review-301-r2", progress="auditing merged MRs")
-    for job in (with_role, without):
-        job.usage = Usage(input_tokens=48_000, output_tokens=9_000, context_tokens=48_200)
-    for width in range(200, 39, -1):
-        shown = _plain(with_role, width).split("    ")[-1]
-        bare = _plain(without, width).split("    ")[-1]
-        assert cell_len(shown) >= cell_len(bare), f"role shortened the activity at {width}"
+
+    def roster(*, with_roles: bool) -> list[Job]:
+        roles = ("", "reviewer", "ux-reviewer") if with_roles else ("", "", "")
+        jobs = [
+            Job(
+                "plain",
+                "sweep-notes",
+                progress="collecting notes from everywhere and checking every source",
+                agent_role=roles[0],
+            ),
+            Job("review", "review-303", progress="auditing merged MRs", agent_role=roles[1]),
+            Job("ux", "ux-303", progress="walking the flow", agent_role=roles[2]),
+        ]
+        for job in jobs:
+            job.usage = Usage(input_tokens=48_000, output_tokens=9_000, context_tokens=48_200)
+        return jobs
+
+    def activities(jobs: list[Job], width: int) -> list[str]:
+        measured = [
+            (
+                row_facts(job, fallback_id=job.id, current=False),
+                job_stats(job, default_model_label=PARENT_MODEL),
+            )
+            for job in jobs
+        ]
+        rung, column, clock, role_column = panel_layout(measured, width)
+        return [
+            _lay_out(facts, stats, width, rung, column, clock, role_column)[4]
+            for facts, stats in measured
+        ]
+
+    mixed = roster(with_roles=True)
+    baseline = roster(with_roles=False)
+    for width in range(200, 11, -1):
+        shown = activities(mixed, width)
+        bare = activities(baseline, width)
+        assert [cell_len(value) for value in shown] == [
+            cell_len(value) for value in bare
+        ], f"the shared role column shortened an activity at {width}: {shown!r} vs {bare!r}"
 
 
-def test_a_plain_task_row_is_unchanged_by_the_role_column() -> None:
-    """A child with no role pays nothing for the column at any width. The
-    segment is per-ROW (unlike cost, which sheds for the whole list at once),
-    so an ordinary fan-out is laid out exactly as before."""
+def test_a_plain_task_roster_is_unchanged_by_the_role_column() -> None:
+    """A roster with NO roles pays nothing for the column at any width.
+
+    This is intentionally a multi-row assertion. Comparing a lone roleless row
+    to a lone `agent_role="task"` row is vacuous because :func:`row_facts` maps
+    `"task"` to `""` before layout; it says nothing about the mixed-roster
+    column that R4 concerned.
+    """
+    plain = [
+        Job("j1", "docs", progress="auditing merged MRs"),
+        Job("j2", "tests", progress="running 3 tools"),
+    ]
+    default_task = [
+        Job("j1", "docs", progress="auditing merged MRs", agent_role="task"),
+        Job("j2", "tests", progress="running 3 tools", agent_role="task"),
+    ]
     for width in range(120, 39, -1):
-        assert _plain(Job(progress="auditing merged MRs"), width) == _plain(
-            Job(progress="auditing merged MRs", agent_role="task"), width
-        )
+        assert _column(plain, width) == _column(default_task, width)
 
 
 # -- the band under the page -------------------------------------------------

--- a/tests/unit/tui/test_subagent_stats.py
+++ b/tests/unit/tui/test_subagent_stats.py
@@ -86,9 +86,14 @@ class Job:
         usage: Usage | None = None,
         result_text: str | None = None,
         error_text: str | None = None,
+        agent_role: str = "",
     ) -> None:
         self.id = job_id
         self.type = "task"
+        # The child's ROLE, as ``run_subagent`` records it at registration.
+        # Defaults to "" rather than "task" so the existing rows in this file
+        # keep saying what they said: a plain task shows no role segment.
+        self.agent_role = agent_role
         self.status = status
         self.label = label
         self.start_time = time.time() - age
@@ -454,6 +459,91 @@ def test_the_floors_are_what_the_ladder_stops_at() -> None:
     """The two constants are load-bearing, so they are asserted, not assumed."""
     assert ACTIVITY_FLOOR >= len("running 3 tools")
     assert LABEL_FLOOR >= len("MR review a")
+
+
+# -- the role column ---------------------------------------------------------
+#
+# A row named a child only by the label its parent happened to choose, so
+# whether `review-301-r2` was a reviewer or a coder asked to look at a review
+# was a guess. The column says which, and the tests below pin the three things
+# that make it safe to add: it is the FIRST thing shed, it costs a plain task
+# nothing, and it does not disturb any width that could not afford it.
+
+
+def test_a_row_names_the_childs_role_when_there_is_room_for_it() -> None:
+    """The column's whole point, at a width that can pay for it."""
+    job = Job(
+        label="review-301-r2",
+        progress="auditing merged MRs",
+        agent_role="reviewer",
+        usage=Usage(input_tokens=48_000, output_tokens=9_000, context_tokens=48_200),
+    )
+    # Between the clock and the context, in the panel's own ` · ` seam: the
+    # role qualifies WHAT the child is, so it leads the numbers rather than
+    # trailing them (the full-page title reads `Subagent · reviewer · <label>`).
+    assert " · reviewer · " in _plain(job, 120)
+
+
+def test_the_default_task_role_is_never_printed() -> None:
+    """``task`` is the no-role default: every child is a task unless told
+    otherwise, so the word says nothing a reader did not already assume and
+    would cost eight cells on every ordinary row. Matches the full-page view's
+    title, which hides it for the same reason."""
+    assert "task" not in _plain(Job(progress="auditing merged MRs", agent_role="task"), 120)
+    assert "task" not in _plain(Job(progress="auditing merged MRs"), 120)
+
+
+def test_the_role_is_the_first_thing_the_ladder_sheds() -> None:
+    """It sheds before the cost, which is the widest rung the ladder had
+    before this column existed. That ordering is what makes the column
+    ADDITIVE: a terminal that could not afford the role is laid out exactly as
+    it was, and only spare cells buy the new field."""
+    job = Job(
+        label="review-301-r2",
+        progress="auditing merged MRs",
+        agent_role="reviewer",
+        usage=Usage(input_tokens=48_000, output_tokens=9_000, context_tokens=48_200),
+    )
+    role_widths = [w for w in range(120, 53, -1) if "reviewer" in _plain(job, w)]
+    cost_widths = [w for w in range(120, 53, -1) if "$" in _plain(job, w)]
+    assert role_widths and cost_widths
+    # The narrowest width still showing the role is wider than the narrowest
+    # still showing the cost: the role gave up first.
+    assert min(role_widths) > min(cost_widths)
+
+
+def test_the_role_column_is_monotone_in_width() -> None:
+    """A segment must never come BACK as the terminal gets narrower.
+
+    The panel's documented property, re-checked with the new field in the
+    ladder — the status band has a known non-monotonic shedding bug and this
+    surface must not grow one of its own.
+    """
+    job = Job(label="review-301-r2", progress="auditing merged MRs", agent_role="reviewer")
+    was_present = True
+    for width in range(120, 53, -1):
+        present = "reviewer" in _plain(job, width)
+        assert not (present and not was_present), f"role reappeared at {width}"
+        was_present = present
+
+
+def test_a_role_row_never_overruns_the_width_it_was_given() -> None:
+    """The new segment is measured, not merely appended: a row that overflows
+    its dock is the failure the whole ladder exists to prevent."""
+    for role in ("reviewer", "designer", "architect", ""):
+        job = Job(label="review-301-r2", progress="auditing merged MRs", agent_role=role)
+        for width in range(120, 19, -1):
+            assert cell_len(_plain(job, width)) <= width, f"{role} at {width}"
+
+
+def test_a_plain_task_row_is_unchanged_by_the_role_column() -> None:
+    """A child with no role pays nothing for the column at any width. The
+    segment is per-ROW (unlike cost, which sheds for the whole list at once),
+    so an ordinary fan-out is laid out exactly as before."""
+    for width in range(120, 39, -1):
+        assert _plain(Job(progress="auditing merged MRs"), width) == _plain(
+            Job(progress="auditing merged MRs", agent_role="task"), width
+        )
 
 
 # -- the band under the page -------------------------------------------------

--- a/tests/unit/tui/test_subagent_stats.py
+++ b/tests/unit/tui/test_subagent_stats.py
@@ -631,6 +631,89 @@ def test_the_role_column_is_stable_when_live_activity_text_changes() -> None:
         ), f"live progress toggled the role column at {width}: {short_rows!r} vs {long_rows!r}"
 
 
+def test_the_role_column_is_stable_when_all_live_stats_change() -> None:
+    """Elapsed, usage/context and cost cannot toggle a roster-wide column.
+
+    D8 removed activity prose from the width decision, but R5 found the same
+    class one level deeper: the first usage report, elapsed-width transitions,
+    and uncapped numeric magnitudes still changed ``head``/``numbers`` and
+    therefore role visibility at a fixed width. The gate now reserves bounded
+    maxima and the painter truncates to those exact caps. This pair deliberately
+    spans absent→huge values for ALL THREE live inputs and must discriminate
+    against c4c39b0d (agent review round 3, R5).
+    """
+
+    def roster(*, reported: bool) -> list[Job]:
+        usage = (
+            Usage(
+                input_tokens=10**30,
+                output_tokens=10**30,
+                context_tokens=10**30,
+                usd_cost=10**30,
+            )
+            if reported
+            else None
+        )
+        age = 86_400 * 100_000 if reported else 1
+        jobs = [
+            Job("plain", "sweep-notes", progress="collecting release notes", age=age, usage=usage),
+            Job(
+                "review",
+                "review-303",
+                progress="auditing merged MRs",
+                age=age,
+                usage=usage,
+                agent_role="reviewer",
+            ),
+            Job(
+                "ux",
+                "ux-303",
+                progress="walking the flow",
+                age=age,
+                usage=usage,
+                agent_role="ux-reviewer",
+            ),
+        ]
+        for job in jobs:
+            if reported:
+                # One token of capacity against an enormous live context makes
+                # the percentage formatter's raw output unbounded; `usd_cost`
+                # does the same through the authoritative receipt path.
+                job.context_window = 1
+        return jobs
+
+    before = roster(reported=False)
+    after = roster(reported=True)
+    for width in range(200, 11, -1):
+        before_rows = _column(before, width)
+        after_rows = _column(after, width)
+        assert ("reviewer" in before_rows[1]) == ("reviewer" in after_rows[1]), (
+            f"live elapsed/usage/cost toggled the role column at {width}: "
+            f"{before_rows!r} vs {after_rows!r}"
+        )
+
+    # The acceptance budget and painter are coupled. Import the new budgets
+    # locally so the fixed-width visibility assertion above can be applied to
+    # the previous head as a genuine behavioural discriminator rather than
+    # failing collection merely because those names did not exist there.
+    from local_operator.tui.widgets.subagent_panel import CONTEXT_CEILING, COST_CEILING
+
+    measured = [
+        (
+            row_facts(job, fallback_id=job.id, current=False),
+            job_stats(job, default_model_label=PARENT_MODEL),
+        )
+        for job in after
+    ]
+    rung, column, clock, role_column = panel_layout(measured, 200)
+    laid_out = [
+        _lay_out(facts, stats, 200, rung, column, clock, role_column) for facts, stats in measured
+    ]
+    assert any("…" in context or "…" in cost for _, _, context, cost, _ in laid_out)
+    assert all(cell_len(context) <= CONTEXT_CEILING for _, _, context, _, _ in laid_out)
+    assert all(cell_len(cost) <= COST_CEILING for _, _, _, cost, _ in laid_out)
+
+
 def test_the_shared_role_column_never_pushes_activity_below_its_floor() -> None:
     """R4 remains symmetric, but its bounded guarantee is stated truthfully.
 

--- a/tests/unit/tui/test_subagent_stats.py
+++ b/tests/unit/tui/test_subagent_stats.py
@@ -32,6 +32,7 @@ from local_operator.tui.widgets.status_line import StatusLine, SubagentBand
 from local_operator.tui.widgets.subagent_panel import (
     ACTIVITY_FLOOR,
     LABEL_FLOOR,
+    ROLE_CEILING,
     JobStats,
     SubagentPanel,
     SubagentRow,
@@ -121,7 +122,7 @@ def _plain(job: Job, width: int, *, parent: str = PARENT_MODEL, current: bool = 
     """One row as the string a reader sees, laid out alone at ``width``."""
     facts = row_facts(job, fallback_id=job.id, current=current)
     stats = job_stats(job, default_model_label=parent)
-    rung, column, clock = panel_layout([(facts, stats)], width)
+    rung, column, clock, role_column = panel_layout([(facts, stats)], width)
     return compose_row(
         facts=facts,
         stats=stats,
@@ -130,6 +131,7 @@ def _plain(job: Job, width: int, *, parent: str = PARENT_MODEL, current: bool = 
         rung=rung,
         column=column,
         clock=clock,
+        role_column=role_column,
     ).plain
 
 
@@ -142,7 +144,7 @@ def _column(jobs: list[Job], width: int) -> list[str]:
         )
         for job in jobs
     ]
-    rung, column, clock = panel_layout(measured, width)
+    rung, column, clock, role_column = panel_layout(measured, width)
     return [
         compose_row(
             facts=f,
@@ -152,6 +154,7 @@ def _column(jobs: list[Job], width: int) -> list[str]:
             rung=rung,
             column=column,
             clock=clock,
+            role_column=role_column,
         ).plain
         for f, s in measured
     ]
@@ -520,11 +523,17 @@ def test_the_role_column_is_monotone_in_width() -> None:
     surface must not grow one of its own.
     """
     job = Job(label="review-301-r2", progress="auditing merged MRs", agent_role="reviewer")
-    was_present = True
-    for width in range(120, 53, -1):
-        present = "reviewer" in _plain(job, width)
-        assert not (present and not was_present), f"role reappeared at {width}"
-        was_present = present
+    # BOTH branches: ``compose_row`` renders the current row through a separate
+    # path (the page is already showing that child, so the row drops the glyph,
+    # the clock and the activity), and the role was threaded into that path
+    # too. Sweeping only the ordinary branch would leave the one the reader
+    # sees while a page is open unasserted (agent review round 1, R3).
+    for current in (False, True):
+        was_present = True
+        for width in range(120, 53, -1):
+            present = "reviewer" in _plain(job, width, current=current)
+            assert not (present and not was_present), f"role reappeared at {width} ({current=})"
+            was_present = present
 
 
 def test_a_role_row_never_overruns_the_width_it_was_given() -> None:
@@ -534,6 +543,69 @@ def test_a_role_row_never_overruns_the_width_it_was_given() -> None:
         job = Job(label="review-301-r2", progress="auditing merged MRs", agent_role=role)
         for width in range(120, 19, -1):
             assert cell_len(_plain(job, width)) <= width, f"{role} at {width}"
+
+
+def test_the_role_is_a_shared_column_so_the_numbers_stay_aligned() -> None:
+    """What follows the role starts in the SAME cell on every row.
+
+    An inline role of a different length per row shoved that row's context,
+    cost and activity sideways by a different amount: four `$` signs that had
+    formed a vertical line sat at four x positions, and the plain-task row was
+    worst, its whole tail pulled left of its peers. Comparing two children's
+    spend is a scan down a column, so there has to be a column (design review
+    round 1, D1).
+    """
+    jobs = [
+        Job("j1", "resume-team-state", progress="wiring the resume path", agent_role="coder"),
+        Job("j2", "review-301-r2", progress="auditing merged MRs", agent_role="reviewer"),
+        Job("j3", "design-301-r2", progress="capturing frames", agent_role="designer"),
+        Job("j4", "sweep-notes", progress="collecting notes"),  # no role at all
+    ]
+    for job in jobs:
+        job.usage = Usage(input_tokens=48_000, output_tokens=9_000, context_tokens=48_200)
+    rows = _column(jobs, 110)
+    starts = [row.index("%/") for row in rows]
+    assert len(set(starts)) == 1, rows
+    # The roleless row pays the column as WHITESPACE, not as a seam separating
+    # nothing: a lone `·` reads as a missing value rather than as a child with
+    # nothing to say.
+    assert " ·  · " not in rows[3]
+
+
+def test_one_long_role_does_not_evict_its_peers_roles() -> None:
+    """Role names are operator-authored and uncapped, and the column is shared,
+    so an untruncated 34-cell specialist name would decide for the whole dock
+    whether ANYBODY gets a role. Bounding it keeps the cost per roster
+    predictable (design review round 1, D2)."""
+    long_name = "enrichment-data-quality-specialist"
+    jobs = [
+        Job("j1", "review-301-r2", progress="auditing merged MRs", agent_role="reviewer"),
+        Job("j2", "dq-child", progress="scoring records", agent_role=long_name),
+    ]
+    for job in jobs:
+        job.usage = Usage(input_tokens=48_000, output_tokens=9_000, context_tokens=48_200)
+    rows = _column(jobs, 100)
+    assert "reviewer" in rows[0], rows
+    assert long_name not in rows[1], "the role is rendered untruncated"
+    assert cell_len(_plain(jobs[1], 200).split("·")[1].strip()) <= ROLE_CEILING
+
+
+def test_the_role_never_costs_the_activity_a_single_cell() -> None:
+    """The ladder's stated rule, applied to the field that was breaking it.
+
+    The role is "the most disposable field"; the activity is "never traded for
+    a number". Charging the role against the activity's budget inverted both at
+    once, and made narrowing the terminal LENGTHEN the activity. A role is now
+    offered only where it is free (design review round 1, D3).
+    """
+    with_role = Job(label="review-301-r2", progress="auditing merged MRs", agent_role="reviewer")
+    without = Job(label="review-301-r2", progress="auditing merged MRs")
+    for job in (with_role, without):
+        job.usage = Usage(input_tokens=48_000, output_tokens=9_000, context_tokens=48_200)
+    for width in range(200, 39, -1):
+        shown = _plain(with_role, width).split("    ")[-1]
+        bare = _plain(without, width).split("    ")[-1]
+        assert cell_len(shown) >= cell_len(bare), f"role shortened the activity at {width}"
 
 
 def test_a_plain_task_row_is_unchanged_by_the_role_column() -> None:
@@ -867,6 +939,47 @@ async def test_a_mounted_panel_lays_out_against_the_screen_not_its_own_width() -
             assert "%" in row, row  # the context stayed, shortened
         # Both rows shed the same field, so a blank cost means one thing.
         assert "auditing merged" in rows[0] and "running 3 tools" in rows[1]
+
+
+@pytest.mark.asyncio
+async def test_an_overgrown_panel_charges_the_rail_padding_to_its_ceiling() -> None:
+    """The screen ceiling must be net of `.band-body`'s own `padding: 0 1`.
+
+    `#band` is `width: auto`, so a long row grows the panel PAST the screen and
+    the surplus is clipped. The ladder clamps to the screen for exactly that
+    case — but the rows sit inside `.band-body`, which is `padding: 0 1`, and
+    Textual is border-box, so a row never has more than `screen - 2` cells. An
+    unpadded ceiling therefore handed the ladder two cells that do not exist:
+    it kept a rung the terminal could not show, and the row lost its tail to a
+    hard cut with no ellipsis, which is the exact failure the ceiling exists to
+    prevent. Read off the container rather than hardcoded, so a stylesheet
+    change to the rail cannot silently desync it (agent review round 1, R1).
+    """
+    jobs = [
+        Job(
+            "j1",
+            "a-deliberately-long-child-label-that-overgrows-the-dock",
+            progress="auditing merged MRs and then some more words",
+            usage=Usage(input_tokens=48_000, output_tokens=9_000, context_tokens=48_200),
+        )
+    ]
+    session = FakeSession()
+    session.jobs = _fake_jobs(*jobs)
+    app = OperatorApp(_async_factory(session))
+    async with app.run_test(size=(60, 40)) as pilot:
+        await pilot.pause()
+        panel = app.query_one(SubagentPanel)
+        panel.sync(session)
+        await pilot.pause()
+        panel._tick()
+        await pilot.pause()
+
+        screen = app.screen.size.width
+        padding = panel._list.styles.padding
+        assert padding.left + padding.right == 2, "the rail's padding is the premise"
+        # The panel really did over-grow; otherwise this asserts nothing.
+        assert panel.size.width >= screen
+        assert panel._row_width() == screen - 2
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tui/test_subagent_stats.py
+++ b/tests/unit/tui/test_subagent_stats.py
@@ -599,56 +599,69 @@ def test_one_long_role_does_not_evict_its_peers_roles() -> None:
     assert role.endswith("…")
 
 
-def test_the_role_column_never_costs_any_rows_activity_a_single_cell() -> None:
-    """The D3 guarantee on the MIXED roster a real dock actually lays out.
+def test_the_role_column_is_stable_when_live_activity_text_changes() -> None:
+    """A child-authored sentence cannot toggle a roster-wide identity column.
 
-    The role is "the most disposable field"; the activity is "never traded for
-    a number". The shared column is paid by every row to preserve alignment,
-    including a plain task that renders no role of its own. The guard must
-    therefore compare every row — not only a row whose own role is non-empty —
-    against the identical roster with the role column removed (agent review
-    round 2, R4). A single-row `_plain` probe cannot observe this defect because
-    its role column collapses to that row's own role.
+    R4 correctly made the activity-floor check symmetric across a mixed roster,
+    but its first form compared against the FULL current sentence. Since that
+    sentence is live and unbounded, one roleless child's progress moved the
+    column's visibility floor from 88 to 127 and made every peer's role flicker
+    at a fixed width. The veto now reserves the stable ACTIVITY_FLOOR instead:
+    whether the column exists is a function of width and the roster's bounded
+    structural fields, never one child's current prose (design round 3, D8).
     """
 
-    def roster(*, with_roles: bool) -> list[Job]:
-        roles = ("", "reviewer", "ux-reviewer") if with_roles else ("", "", "")
+    def roster(progress: str) -> list[Job]:
         jobs = [
-            Job(
-                "plain",
-                "sweep-notes",
-                progress="collecting notes from everywhere and checking every source",
-                agent_role=roles[0],
-            ),
-            Job("review", "review-303", progress="auditing merged MRs", agent_role=roles[1]),
-            Job("ux", "ux-303", progress="walking the flow", agent_role=roles[2]),
+            Job("plain", "sweep-notes", progress=progress),
+            Job("review", "review-303", progress="auditing merged MRs", agent_role="reviewer"),
+            Job("ux", "ux-303", progress="walking the flow", agent_role="ux-reviewer"),
         ]
         for job in jobs:
             job.usage = Usage(input_tokens=48_000, output_tokens=9_000, context_tokens=48_200)
         return jobs
 
-    def activities(jobs: list[Job], width: int) -> list[str]:
-        measured = [
-            (
-                row_facts(job, fallback_id=job.id, current=False),
-                job_stats(job, default_model_label=PARENT_MODEL),
-            )
-            for job in jobs
-        ]
+    short = roster("collecting release notes")
+    long = roster("collecting notes from everywhere and checking every source twice")
+    for width in range(200, 11, -1):
+        short_rows = _column(short, width)
+        long_rows = _column(long, width)
+        assert ("reviewer" in short_rows[1]) == (
+            "reviewer" in long_rows[1]
+        ), f"live progress toggled the role column at {width}: {short_rows!r} vs {long_rows!r}"
+
+
+def test_the_shared_role_column_never_pushes_activity_below_its_floor() -> None:
+    """R4 remains symmetric, but its bounded guarantee is stated truthfully.
+
+    A roleless row pays the shared blank column while roles are shown because
+    D1 requires what follows to align. That bounded cost is acceptable while
+    the established activity floor fits; once WIDTH cannot pay the floor on
+    any row, the whole role rung sheds. Unlike the old guard, sentence length
+    is irrelevant, so this cannot flicker as progress changes.
+    """
+    jobs = [
+        Job("plain", "sweep-notes", progress="collecting notes from everywhere"),
+        Job("review", "review-303", progress="auditing merged MRs", agent_role="reviewer"),
+        Job("ux", "ux-303", progress="walking the flow", agent_role="ux-reviewer"),
+    ]
+    for job in jobs:
+        job.usage = Usage(input_tokens=48_000, output_tokens=9_000, context_tokens=48_200)
+    measured = [
+        (
+            row_facts(job, fallback_id=job.id, current=False),
+            job_stats(job, default_model_label=PARENT_MODEL),
+        )
+        for job in jobs
+    ]
+    for width in range(200, 11, -1):
         rung, column, clock, role_column = panel_layout(measured, width)
-        return [
+        activities = [
             _lay_out(facts, stats, width, rung, column, clock, role_column)[4]
             for facts, stats in measured
         ]
-
-    mixed = roster(with_roles=True)
-    baseline = roster(with_roles=False)
-    for width in range(200, 11, -1):
-        shown = activities(mixed, width)
-        bare = activities(baseline, width)
-        assert [cell_len(value) for value in shown] == [
-            cell_len(value) for value in bare
-        ], f"the shared role column shortened an activity at {width}: {shown!r} vs {bare!r}"
+        if role_column:
+            assert all(cell_len(activity) >= ACTIVITY_FLOOR for activity in activities)
 
 
 def test_a_plain_task_roster_is_unchanged_by_the_role_column() -> None:


### PR DESCRIPTION
## Summary

Two related changes to the subagent subsystem, shipped together because the second is what made the first invisible.

- **Fix**: `SubagentComms.resume()` relaunched a stopped child without its role or effort tier, so every resumed reviewer, designer, scout and specialist came back as a generic no-role child.
- **Feature**: the subagents panel now names each child's TYPE as a column, so a row says what a child *is* rather than only the label its parent happened to choose.
- Fixes a pre-existing width bug in the panel's drop ladder that the new column exposed.
- Version bumps `0.33.1` -> `0.35.0` (fix + feature = minor). See "Version coordination" below.

## Part 1 - a resumed subagent lost its persona

`resume()` called `run_subagent` passing neither `agent=` nor `effort=`. That parameter defaults to `agent: str = "task"`, and `_ChildRecord` had been carrying `agent_role`/`effort` all along - the information was simply not forwarded.

This is a **capability regression, not a cosmetic one**. A role's tool allowlist is a boundary, not advice (`subagent.py`, `_build_child_session`):

- a resumed `reviewer` regained `edit`/`write` and could "helpfully" fix the very code it was asked to review;
- a resumed `scout` lost its read-only promise;
- MCP tools are excluded wholesale for restricted roles, and an unrestricted resume handed them back;
- `_resolve_role()` decides the preamble (a role's instructions, a specialist's own `system_prompt.md`, or `SCOUT_PREAMBLE`), and a resumed child got none of it;
- `_build_child_session` re-stamps `origin.json` with `agent=` on resume, so the defaulted resume **overwrote the real role on disk**;
- `job.agent_role`/`job.effort` were re-registered as the default, so the panel and page title then misreported what the child was.

`effort` is documented as display-only because the caller has already resolved it into a `model_spec` (`Session._resolve_subagent_model`). A resume is a second launch and has to perform that same resolution, or a child launched at `hi` silently returns on the parent's model while the panel still displays `hi`. `resume()` now does so, degrading to the parent's model on a host that cannot price a tier.

### Neighbouring paths: audited, and sound

The brief asked whether the same class of defect exists nearby. It does not - all three are fixed by the single change or were already correct, so nothing was gold-plated:

| Path | Verdict |
|---|---|
| **Grandchild** (a child that itself delegates) | A grandchild resumes through its own parent's `SubagentComms`, i.e. the same code path one level down. Fixed by the same change. |
| **Team inheritance** (`active_team` is in-memory on the parent) | Sound. `_make_runner` re-stamps `team.member_preamble(agent)` from the LIVE parent on every launch, and a resume is a launch, so the brief is re-applied. It was being applied to the wrong `agent` before this fix, and is now correct. |
| **Cross-process restart** (`agent_role` is in memory) | Sound. `snapshot()`/`restore()` already round-trip `agent_role` and `effort`, so a resumed parent session that then resumes a child keeps the role. Pinned with a new test so it stays that way. |

## Part 2 - the agent type in the subagents list

A row was `bullet, label, glyph, elapsed, context%, cost, activity`, with nothing saying whether a child was a reviewer, designer, coder or plain task.

- Sourced from `job.agent_role`, and **`task` is never printed** - matching `subagent_view._title_row`, which hides the no-role default for the same reason: every child is a task unless told otherwise, so the word says nothing a reader did not assume and would cost cells on every ordinary row.
- Uses the panel's established idiom: the same ` · ` seam and `muted` ink as the other segments. It leads the numbers run because it qualifies *what* the child is, the way the page title reads `Subagent · reviewer · <label>`.
- Enters the **existing drop ladder as a new widest rung** rather than being bolted on. This is what makes it additive: the widest rung is the previous widest rung plus the role, so a terminal that could not already afford it is laid out **byte-identically** to before, and only spare cells buy the new field. It sheds first, before cost - the same ranking the full-page title gives it as its most disposable field.
- Ladder **monotonicity is preserved** (verified below). The known non-monotonic shedding bug in the status band is untouched and out of scope.

### A pre-existing width bug this exposed

`_row_width()` clamps the ladder to the screen so a long row cannot outgrow its dock. That ceiling did **not** charge `.band-body`'s own `padding: 0 1`, while the rows themselves do pay it (Textual is border-box). It only bites once the panel over-grows - `#band` is `width: auto`, so a long row widens it past the screen - and there the ladder was handed two cells that do not exist, kept a rung the terminal could not show, and rows lost their tails to a **hard cut with no ellipsis**: exactly the failure the ceiling exists to prevent, two cells short of preventing it. The padding is now read off the container rather than hardcoded, so a stylesheet change to the rail cannot silently desync it.

## Testing evidence

### Part 1 - real execution, before and after

A probe drove the **real launch path** (`Session._launch_subagent` -> `run_subagent` -> `_build_child_session`), cancelled a real `reviewer` child, resumed it through `comms.resume()`, and inspected the resumed child's actual tool surface, prompt and on-disk `origin.json`.

**Before** (`origin/main`):

```text
--- ORIGINAL reviewer child (job 90ebb0a6b17b) ---
  job.agent_role       = 'reviewer'
  job.effort           = 'hi'
  origin.json agent    = 'reviewer'
  launched as agent=   = 'reviewer'
  resolved profile     = 'reviewer'
  role preamble present= True
  prompt head          = '[role: reviewer]\nYou are an INDEPENDENT reviewer. You did not write this code.'
  has edit tool        = False
  has write tool       = False
  tool surface         = ['bash', 'glob', 'grep', 'hub', 'list_variables', 'read', 'read_variable', 'todo']

--- RESUMED reviewer child (job 4b7e7afe8708) ---
  job.agent_role       = 'task'          <-- role lost
  job.effort           = None            <-- tier lost
  origin.json agent    = 'task'          <-- CORRUPTED ON DISK
  launched as agent=   = 'task'
  resolved profile     = None            <-- no profile
  role preamble present= False           <-- no preamble
  prompt head          = 'You were interrupted. Wrap up.'
  has edit tool        = True            <-- SAFETY REGRESSION
  has write tool       = True            <-- SAFETY REGRESSION
  tool surface         = ['bash', 'browser', 'edit', 'eval', 'glob', 'grep', 'hub', 'jobs',
                          'list_variables', 'lsp', 'read', 'read_variable', 'task', 'todo',
                          'wait', 'web_fetch', 'web_search', 'write']
```

**After** (this branch) - the resumed child is indistinguishable from the original:

```text
--- RESUMED reviewer child (job 4a8897c6f14a) ---
  job.agent_role       = 'reviewer'
  job.effort           = 'hi'
  origin.json agent    = 'reviewer'
  launched as agent=   = 'reviewer'
  resolved profile     = 'reviewer'
  role preamble present= True
  prompt head          = '[role: reviewer]\nYou are an INDEPENDENT reviewer. You did not write this code.'
  has edit tool        = False
  has write tool       = False
  tool surface         = ['bash', 'glob', 'grep', 'hub', 'list_variables', 'read', 'read_variable', 'todo']
```

Nested and restart cases, driven the same way against real sessions:

```text
=== A. GRANDCHILD role survives its own resume ===
  grandchild original agent = 'scout'  edit=False
  grandchild resumed  agent = 'scout'  edit=False
  VERDICT: OK

=== B. RESTART: role recoverable after the parent process exits ===
  snapshot carried agent_role = 'reviewer' effort = 'hi'
  resumed after restart agent = 'reviewer'  edit=False
  VERDICT: OK

=== C. TEAM preamble on a resumed child ===
  original carries team brief = True
  resumed  carries team brief = True
  resumed prompt head = '[team: lopdev / coder]\nTEAM-BRIEF-SENTINEL\n\n[role: coder]\nYo'
  VERDICT: OK
```

The new regression tests were confirmed to actually catch the defect: reverting only the `agent=`/`effort=`/`model_spec=` arguments fails them with `KeyError: 'agent'`, and restoring the fix passes.

### Part 2 - rendered frames, captured with the real `OperatorApp`

Captured per AGENTS.md "Visual validation" using the real `OperatorApp` (which declares `CSS_PATH`; the lightweight hosts do not apply the stylesheet). The before-frames were taken from a **separate pristine worktree at `origin/main`**, never by stashing. The wall clock and spinner phase are pinned in the shot script so a frame pair differs in exactly one thing.

Reproducing the operator's screenshot (`resume-team-state`, `review-301-r2`, `design-301-r2`):

**Before** - the role is guessable only from the label:

```text
Subagents
• resume-team-state  ⣟  7m49s · 24.0%/200k · $0.240    wiring the resume path
• review-301-r2      ⣟  2m22s · 48.2%/200k · $0.482    auditing merged MRs
• design-301-r2      ⣟   1m1s · 11.4%/200k · $0.114    reading rendered frames
```

**After** - the row says what each child is:

```text
Subagents
• resume-team-state  ⣽  7m49s · coder · 24.0%/200k · $0.240    wiring the resume path
• review-301-r2      ⣽  2m22s · reviewer · 48.2%/200k · $0.482    auditing merged MRs
• design-301-r2      ⣽   1m1s · designer · 11.4%/200k · $0.114    reading rendered frames
```

Frames were rendered and **looked at**, not just diffed as markup. Both are attached below.

Drop-ladder behaviour across widths, read out of the real mounted panel (`X` = pinned spinner):

```text
panel=106  rung=0  '• review-301-r2      X  2m22s · reviewer · 48.2%/200k · $0.482    auditing merged MRs'
panel= 88  rung=0  '• review-301-r2      X  2m22s · reviewer · 48.2%/200k · $0.482    auditing merged MRs'
panel= 80  rung=1  '• review-301-r2      X  2m22s · 48.2%/200k · $0.482    auditing merged MRs'   <- role sheds first
panel= 74  rung=1  '• review-301-r2      X  2m22s · 48.2%/200k · $0.482    auditing merged…'
panel= 62  rung=2  '• review-301-r2      X  2m22s · 48.2%/200k    auditing merged…'               <- then cost
panel= 52  rung=5  '• review-301-r2      X  2m22s    auditing merged MRs'                          <- then context
```

Ladder properties verified by sweeping **every width from 200 down to 12**:

```text
transitions (width, rung, (role,ctx,cost,act)):
   (81, 1, (False, True, True, True))
   (70, 2, (False, True, False, True))
   (54, 5, (False, False, False, True))
   (28, 6, (False, False, False, False))
MONOTONICITY VIOLATIONS: none
OVERFLOW ROWS: none
```

And the additive claim, checked mechanically against the `origin/main` worktree by rendering both trees at every width from 12 to 200:

```text
A. no-role parity vs baseline:  IDENTICAL at all widths
B. role visible at widths: 82..200
C. widths WITHOUT role that differ from baseline: none
```

### Suites

Targeted to the touched files, `-n0` (this machine is under memory pressure from concurrent agents):

```text
env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest -n0 -p no:randomly \
  tests/unit/harness/test_comms.py              100 passed
  tests/unit/tui/test_subagent_stats.py          43 passed
  tests/unit/tui/test_subagent_view.py           50 passed
  tests/unit/session/test_launch_subagent.py \
  tests/unit/harness/test_comms_persistence.py   44 passed
```

Gates all clean: `flake8`, `black --check` (26.1.0), `isort --check-only --profile black`, `pyright` (`0 errors, 0 warnings`).

**On the flake baseline**: full-suite runs on this machine currently show a handful of timing failures under parallel workers (`test_a_resumed_child_replays_the_stopped_ones_transcript`, mobile discovery records, `test_loop` backfill). Every one of them reproduces on an **untouched `origin/main` worktree** and all pass serially with `-n0`; they are file-descriptor exhaustion from concurrent agents (`ulimit -n 4096` passes 6773/6773), not defects in this change.

One test artifact worth naming: `test_esc_with_no_children_says_nothing_about_subagents` asserts no visible row contains the substring `"subagent"`, which my worktree path (`/tmp/lop-subagent-persona`) trivially satisfies via the cwd shown in the status band. It passes in a worktree whose path lacks that word. Pre-existing fragility, deliberately left alone.

## Version coordination

PR #301 (`feat(resume): restore the attached team, agent and goal on resume`) is still **open** and takes `0.33.1 -> 0.34.0`. This PR takes **`0.35.0`** on the assumption #301 merges first. If #301 merges after this one, the version needs reconciling. The two changes are complementary and do not overlap: #301 persists an attached team/agent across a *user session* resume; this is the *subagent* half.

## Deliberately not done

- The **status band's** known non-monotonic shedding bug is untouched (out of scope, and named here only so it is not mistaken for something this introduced).
- The pre-existing `KeyError: 'j1'` row-mount race in `test_a_mounted_panel_lays_out_against_the_screen_not_its_own_width`, which reproduces identically on `origin/main`.
- The `"subagent"`-substring test fragility described above.
