### PR TITLE
feat(multiplexer): resume the right session in each pane after a crash

### DIFF
--- a/docs/evidence/multiplexer-resume/PR-NOTES.md
+++ b/docs/evidence/multiplexer-resume/PR-NOTES.md
@@ -1,0 +1,115 @@
+# PR body source material (branch held pending cmux re-validation)
+
+Assembled while the evidence was fresh so the PR can be opened without
+re-deriving any of it. Not intended to ship as documentation — delete or leave,
+but do not treat it as user-facing.
+
+## Title
+
+`feat(multiplexer): resume the right session in each pane after a crash`
+
+## Summary
+
+~15 `lop` sessions run as cmux sidebar workspaces. When cmux crashes the
+workspaces return but every surface opens a fresh shell and a fresh `lop`, and
+all conversation continuity is lost — the sessions survive on disk under
+`~/.local-operator/sessions` but nothing maps a pane to the session it held.
+
+This publishes that missing fact per pane: *this pane holds session `<id>`, and
+here is the argv that reopens it*. cmux gets a real resume binding over its
+control socket. tmux/wezterm/zellij/screen have no resume API, so they get a
+documented, discoverable marker a restore script can consume. Backends sit
+behind one interface in a registry, so another multiplexer is a new module.
+
+Minor bump: 0.33.1 -> 0.34.0.
+
+## Design points worth calling out in review
+
+- **`source: agent-hook` over the CLI.** `cmux surface resume set` hardcodes
+  `source = "cli"`, which cmux resolves to `approvalPolicy = .manual`,
+  `autoResume = false`. Only the socket RPC can reach auto. A future
+  simplification to the CLI would still create a binding and still print one,
+  and auto-resume would be silently dead. Commented at the top of
+  `multiplexer/cmux.py`.
+- **The re-assert timer is justified by cmux's SOURCE, not by a measurement
+  here.** `SharedLiveAgentIndex.cacheTTL` is 60s; a binding published against
+  an index snapshot older than this process is retired by
+  `retireAgentHookResumeBinding`, which latches `autoResume = false`
+  permanently. `REASSERT_INTERVAL_S = 90` therefore has to stay above that TTL.
+  The measurements on this host can neither confirm nor refute the race (see
+  caveat below), so the defence is retained on the strength of the Swift.
+- **Restore-and-idle is a safety boundary, not a default.** `resume_argv` is
+  the single place the command is built and it can only ever emit
+  `lop --resume <id>`. Fifteen panes restoring unattended must not resume tool
+  execution.
+- **Two gates, different lifetimes.** Subagent-ness is permanent and decided
+  once (`origin.json`); resumability is transient and re-checked before every
+  publish, because a cold session has no transcript until its first turn lands.
+  Checking resumability once at startup would mean every cold session — most of
+  them — silently never publishes, discovered only after a crash.
+- **Headless gate on the app hook.** This suite runs inside cmux and
+  `tests/conftest.py` does not clear `CMUX_*`, so without it every pilot test
+  would rewrite the resume binding of the session running the tests. A
+  paired test proves the gate is what blocks it: same arrangement, gate
+  lifted, produces `surface.resume.set`.
+
+## Testing evidence
+
+Full artifacts in `docs/evidence/multiplexer-resume/`. **Read
+`cmux-host-caveat.md` first** — it bounds every cmux claim below.
+
+**Strongest evidence — it reaches the file a crash restores from.**
+`cmux-on-disk-binding.txt`: read back out of
+`~/Library/Application Support/cmux/session-com.cmuxterm.app.json` (written on
+cmux's autosave, not on clean shutdown) while a binding was in force:
+`kind=local-operator`, `checkpointId=c9a4b15eed9e`, `source=agent-hook`,
+`autoResume=true`, `approvalPolicy=auto`. Identity verified rather than
+eyeballed: `panels[0].id == CMUX_SURFACE_ID` and
+`workspaces[8].workspaceId == CMUX_WORKSPACE_ID`, both exact. An in-memory
+binding that never reached disk would be the classic "looks fixed and is not".
+
+**Live publish/retire** (`cmux-publish-retire.txt`): a real session publishes
+`source: agent-hook`, `approval_policy: auto`, `auto_resume: true`, with
+`checkpoint_id` equal to its real directory name; binding gone after retire.
+
+**The four refusals** (`negative-cases.txt`), all publishing nothing: subagent
+session, kill switch, no multiplexer in env, cmux binary unresolvable.
+
+**tmux for real** (`tmux.txt`, reproducible via `tmux-evidence.sh`): against a
+private tmux server on its own socket, both pane options written and read back
+with `show-options -pv`, and after retire both genuinely *unset* (`rc=1`) rather
+than blanked — a blank option would read to a restore script as a session with
+an empty id.
+
+## Honest limitations (must survive into the PR body)
+
+- The cmux host was running from a **deleted binary** during capture
+  (`Contents/MacOS/` empty; app executing an old in-memory image). Behaviour was
+  not self-consistent across the update boundary: bindings held for minutes,
+  then retired in 2-8s, and in one control run a binding stayed
+  `auto_resume: true` for 75s **after its agent process was killed** — which a
+  working `isStaleAgentHookBinding` should have retired. That last result says
+  cmux's liveness retirement was not running at all.
+- Consequently: the 45/45-samples-true duty cycle measured here is **not** a
+  product guarantee, and it was identical with and without the vault
+  registration, so this host did **not** isolate the registration's causal role.
+- The vault registration is documented as required because cmux's own
+  `docs/vault.md` requires it for a custom kind — **not** because it was
+  verified here to be what holds the binding. Reviewers should not infer
+  otherwise.
+- **Outstanding: clean re-validation on a healthy cmux install.** The operator
+  restarts cmux at a time of his choosing; that restart is also the first
+  real-world test of this feature.
+
+## Gates
+
+- `flake8 .` clean
+- `black --check` (26.1.0) clean, `isort --check-only --profile black` clean
+- `pyright` 0 errors, 0 warnings
+- Unit suite: 6788 passed, 7 skipped. The 2 failures seen
+  (`test_comms.py::test_a_resumed_child_replays_the_stopped_ones_transcript`,
+  `::test_a_cancelled_child_keeps_the_work_it_had_already_done`) are
+  **pre-existing flakes**: clean `origin/main` fails the same files with a
+  *different* test on each full run (four distinct failure sets observed across
+  runs), and both pass in isolation on both branches.
+- The 45 new tests pass 4/4 consecutive runs with no flakiness.

--- a/docs/evidence/multiplexer-resume/README.md
+++ b/docs/evidence/multiplexer-resume/README.md
@@ -1,0 +1,60 @@
+# Evidence: multiplexer session resume
+
+Captured on macOS 25.6.0, cmux 0.64.22 (102), tmux 3.7c, on 2026-08-25.
+
+Read `cmux-host-caveat.md` first: the cmux host was in a damaged state during
+this capture, and it bounds what the cmux numbers below can be claimed to show.
+
+| File | What it shows |
+|---|---|
+| `cmux-publish-retire.txt` | A real publish and retire against a live cmux surface |
+| `cmux-on-disk-binding.txt` | The binding in the file cmux restores from after a crash |
+| `negative-cases.txt` | The four refusals: subagent, kill switch, no multiplexer, no binary |
+| `tmux.txt` | tmux exercised against a real server: options written, read back, unset |
+| `cmux-host-caveat.md` | Why the cmux host's state limits the cmux claims |
+
+## What is proven
+
+**The publish path works.** `cmux-publish-retire.txt` shows a real session
+publishing `source: agent-hook`, `approval_policy: auto`, `auto_resume: true`,
+`kind: local-operator`, with `checkpoint_id` equal to the session's actual
+directory name under `~/.local-operator/sessions`, and the binding gone again
+after retire.
+
+**It survives to disk, for the right surface.** `cmux-on-disk-binding.txt` reads
+the binding back out of
+`~/Library/Application Support/cmux/session-com.cmuxterm.app.json` — the file a
+crash restores from, written on cmux's autosave rather than on clean shutdown —
+and shows `autoResume: true`. Identity is verified rather than eyeballed:
+`panels[0].id` equals `CMUX_SURFACE_ID` and `workspaces[N].workspaceId` equals
+`CMUX_WORKSPACE_ID`, both exact. This is the property that would otherwise
+"look fixed and not be": an in-memory binding that never reached disk would be
+useless in the only situation it exists for.
+
+**The refusals hold.** `negative-cases.txt` shows all four publishing nothing and
+leaving no binding: a subagent session (`origin.json`), the
+`LOCAL_OPERATOR_NO_MULTIPLEXER_RESUME` kill switch, an environment with no
+multiplexer at all, and a cmux surface whose CLI cannot be resolved.
+
+**tmux is real, not mocked.** `tmux.txt` runs against a private tmux server on
+its own socket (so it cannot touch a real session): the backend writes both pane
+options, they are read back with `show-options -pv`, and after retire both are
+genuinely *unset* — `rc=1`, absent — rather than set to an empty string that a
+restore script would misread as a session with a blank id.
+
+## Reproducing
+
+The cmux captures need a live cmux surface, so they are scripts rather than
+tests. tmux is reproducible anywhere tmux is installed:
+
+```sh
+bash docs/evidence/multiplexer-resume/tmux-evidence.sh
+```
+
+The unit suite covers the same contracts without needing either multiplexer:
+
+```sh
+.venv/bin/python -m pytest tests/unit/test_multiplexer.py -q
+env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest \
+  tests/unit/tui/test_multiplexer_broadcast.py -q
+```

--- a/docs/evidence/multiplexer-resume/cmux-host-caveat.md
+++ b/docs/evidence/multiplexer-resume/cmux-host-caveat.md
@@ -1,0 +1,65 @@
+# Caveat: the state of the cmux host during this capture
+
+Recorded because it bounds what the cmux evidence in this directory can honestly
+be claimed to show. It is a fact about the machine, not about this change.
+
+## What was wrong
+
+During validation the installed cmux was mid-update and damaged:
+
+- `/Applications/cmux.app/Contents/MacOS/` was **empty** (mtime 13:55). The main
+  application executable was gone from disk.
+- The running app (pid 73906, started 13:45) was still executing from memory out
+  of that deleted binary, so `cmux version` kept reporting
+  `0.64.22 (102) [ddd4a01bc]` and the control socket kept answering.
+- The bundled CLI at `Contents/Resources/bin/cmux` was intact, which is why
+  every `cmux rpc` call in these captures worked normally.
+
+## What it means for the measurements
+
+Observations taken before and after that ~13:55 boundary are not from the same
+build, and behaviour was not self-consistent across it. Specifically:
+
+- Early runs showed a published binding holding `auto_resume: true` for minutes.
+- Later runs showed the same binding retiring to `manual` within 2–8 seconds.
+- A control run then showed a binding **staying** `auto_resume: true` for 75s
+  after its agent process was killed — which a working
+  `isStaleAgentHookBinding` should have retired.
+
+The last of those is the informative one: it says cmux's liveness-based
+retirement was **not running** at that point. That also means this host could not
+be used to demonstrate the retirement rule the vault registration defends
+against, and equally could not be used to prove the registration is what defeats
+it. On this host, a settled process measured a 100% duty cycle
+(45/45 samples over 3 minutes at 4s resolution) both **with** and **without** the
+registration installed — so the registration was not the discriminator here.
+
+## What is therefore claimed, and what is not
+
+**Claimed** (independent of the retirement machinery, and directly observed):
+
+- `lop` publishes a correct `agent-hook` binding with `auto_resume: true`.
+- That binding reaches the on-disk autosave a crash restores from, against the
+  correct workspace and surface ids.
+- It is withdrawn on a clean exit, and is never published for a subagent
+  session, under the kill switch, without a multiplexer, or without a cmux CLI.
+
+**Not claimed:**
+
+- Any steady-state duty cycle figure as characterising a *healthy* cmux. The
+  100% measured here was taken on a host whose retirement path was demonstrably
+  inactive, so it is not evidence that retirement has been defeated.
+- That the vault registration is what keeps the binding alive. cmux's own
+  `docs/vault.md` documents it as the supported mechanism, and it is documented
+  as required for that reason — not because this capture isolated its effect.
+
+The re-assert timer in `multiplexer/cmux.py` is retained on the strength of
+cmux's source (`SharedLiveAgentIndex.cacheTTL` is 60s and
+`retireAgentHookResumeBinding` latches `autoResume = false`), not on the strength
+of these measurements. It is cheap, silent, and stops on exit, so it costs
+little if this host's behaviour turns out to be the normal one.
+
+A clean reinstall of cmux is worth doing before treating any cmux-side timing
+number from this machine as authoritative. It was deliberately not attempted
+here: the operator had ~15 live sessions in that process, and restarting cmux to
+tidy up an evidence run would have destroyed them.

--- a/docs/evidence/multiplexer-resume/cmux-on-disk-binding.txt
+++ b/docs/evidence/multiplexer-resume/cmux-on-disk-binding.txt
@@ -1,0 +1,29 @@
+$ date "+%H:%M:%S"
+16:21:51
+
+# The file cmux restores from after a crash (written on autosave, not on
+# clean shutdown), read back while a published binding was in force.
+$ python3 - <<'PY'
+... walk session-com.cmuxterm.app.json for resumeBinding kind=local-operator ...
+PY
+
+local-operator resumeBindings on disk: 1
+{
+  "kind": "local-operator",
+  "checkpointId": "c9a4b15eed9e",
+  "source": "agent-hook",
+  "autoResume": true,
+  "approvalPolicy": "auto",
+  "command": "cd -- '/tmp/lop-final' 2>/dev/null || [ ! -d '/tmp/lop-final' ] && lop --resume c9a4b15eed9e",
+  "cwd": "/tmp/lop-final"
+}
+
+# Identity verified exactly, not by eyeball:
+path:            .windows[0].tabManager.workspaces[8].panels[0].terminal
+panels[0].id:    3E63FAC7-CA22-4AD5-9151-874E05B5A490
+CMUX_SURFACE_ID: 3E63FAC7-CA22-4AD5-9151-874E05B5A490
+MATCH panel==surface: True
+
+workspaces[8].workspaceId: B6A8E3AD-DAD2-40B8-8C6A-732351BEF641
+CMUX_WORKSPACE_ID:         B6A8E3AD-DAD2-40B8-8C6A-732351BEF641
+MATCH workspace: True

--- a/docs/evidence/multiplexer-resume/cmux-publish-retire.txt
+++ b/docs/evidence/multiplexer-resume/cmux-publish-retire.txt
@@ -1,0 +1,15 @@
+backend detected: cmux
+before: {}
+broadcast handle: SessionBroadcast
+AFTER PUBLISH:
+{
+  "source": "agent-hook",
+  "approval_policy": "auto",
+  "auto_resume": true,
+  "checkpoint_id": "c9a4b15eed9e",
+  "kind": "local-operator",
+  "command": "cd -- '/private/tmp/lop-mux-resume' 2>/dev/null || [ ! -d '/private/tmp/lop-mux-resume' ] && /private/tmp/mux_evidence.py --resume c9a4b15eed9e",
+  "cwd": "/private/tmp/lop-mux-resume"
+}
+RETIRE:
+after retire: {}

--- a/docs/evidence/multiplexer-resume/negative-cases.txt
+++ b/docs/evidence/multiplexer-resume/negative-cases.txt
@@ -1,0 +1,17 @@
+=== NEGATIVE 1: subagent session must NOT broadcast ===
+binding before: (none)
+broadcast handle: None
+binding after  : (none)
+
+=== NEGATIVE 2: kill switch ===
+handle: None | binding: (none)
+
+=== NEGATIVE 3: no multiplexer in env ===
+active_backend(no-mux env): None
+handle: None | binding: (none)
+
+=== NEGATIVE 4: cmux binary absent ===
+active_backend(no binary): None
+handle: None
+
+FINAL binding (must be none): (none)

--- a/docs/evidence/multiplexer-resume/round-1-remediation.txt
+++ b/docs/evidence/multiplexer-resume/round-1-remediation.txt
@@ -1,0 +1,116 @@
+Agent review round 1 — remediation evidence
+===========================================
+
+Re-runs of the reviewer's own reproductions, before and after the fix, plus a
+real-multiplexer check for F3. Harnesses are the reviewer's, unchanged.
+
+
+F1 — stop() must not block the Textual event loop
+-------------------------------------------------
+Harness: a backend whose publish/retire both sit for CALL_TIMEOUT_S (5.0s),
+mirroring a `cmux rpc` parked in `subprocess.run(timeout=...)`. A publish is
+allowed to get INTO the wedged call first, then stop(retire=True) is timed.
+
+    BEFORE (6edcf186)
+      F1 [hanging] stop() blocked the calling thread for 9.51s
+      F1 [healthy] stop() blocked the calling thread for 0.02s
+
+    AFTER
+      F1 [hanging] stop() blocked the calling thread for 0.01s
+      F1 [healthy] stop() blocked the calling thread for 0.00s
+
+The withdrawal still happens — it is dispatched to a daemon worker and observed
+completing once the wedged backend is released. What no longer happens is the
+event loop waiting for it. The `_retired` latch is set synchronously inside
+stop(), so the clean-exit-wins-over-re-assert rule does not depend on the
+worker running at all.
+
+
+F2 — a failing publish must not pin the loop to the 5s poll
+-----------------------------------------------------------
+Harness: a backend whose publish always returns False, against a session that
+IS resumable, with a 90s re-assert interval, observed for ~21s.
+
+    BEFORE (6edcf186)
+      F2 publish attempts in ~21s with a 90s re-assert interval: 5
+      F2 gaps between attempts (s): [5.01, 5.0, 5.0, 5.01]
+
+    AFTER
+      F2 publish attempts in ~21s with a 90s re-assert interval: 1
+
+One attempt: the immediate publish at start. Everything after it is governed by
+the re-assert interval, because the cadence now keys on is_resumable_session()
+rather than on publish success. The fast cadence still exists and still only
+costs a stat — pinned by
+test_a_cold_session_still_polls_until_its_transcript_appears, which shows a
+cold session publishing within one poll of its transcript appearing.
+
+
+F3 — zellij markers must not collide across panes
+--------------------------------------------------
+Not a mock. A real zellij 0.42.2 session with two real panes, each running the
+actual registry + ZellijBackend, publishing a different session id.
+(cmux/tmux vars cleared in the probe because this zellij is nested inside them
+on this host and the registry deliberately prefers the outermost multiplexer.)
+
+Environment observed inside the two panes:
+
+    pane A: ZELLIJ=0  ZELLIJ_SESSION_NAME=<same>  ZELLIJ_PANE_ID=0
+    pane B: ZELLIJ=0  ZELLIJ_SESSION_NAME=<same>  ZELLIJ_PANE_ID=1
+
+    BEFORE (6edcf186) — both panes published successfully, ONE file resulted:
+      zellij-f3old.json -> bbbbbbbbbbbb
+      (pane 0's binding is gone: last publisher won)
+
+    AFTER — one file per pane, each holding its own session:
+      zellij-f3c-0.json -> aaaaaaaaaaaa
+      zellij-f3c-1.json -> bbbbbbbbbbbb
+
+The sibling-deletion half is pinned by
+test_two_zellij_panes_in_one_session_do_not_share_a_marker, which retires pane
+0 and asserts pane 1's marker survives.
+
+
+F4 — screen window identity
+---------------------------
+Verified on screen 4.00.03 on this host that a process inside a session exports
+both, confirming the reviewer's reading:
+
+    STY=42653.loprev
+    WINDOW=0
+
+Keyed on STY+WINDOW, with STY alone kept as a fallback (documented in the
+module docstring and the docs table, since in that case the marker is per
+session rather than per window).
+
+
+Gates
+-----
+flake8 clean; black --check 26.1.0 clean (499 files); isort --check-only
+--profile black clean; pyright 0 errors, 0 warnings; unit suite 6797 passed.
+
+Multiplexer suites specifically: 55 passed, run 3x consecutively with no
+flake (tests/unit/test_multiplexer.py + tests/unit/tui/test_multiplexer_broadcast.py).
+
+Three failures in the full run are pre-existing and unrelated to this diff,
+confirmed by reproducing them on unmodified 6edcf186 in a detached worktree:
+  - tests/unit/tui/test_app_pilot.py::test_esc_aborts_a_running_shell_command
+    (fails on the unmodified head too)
+  - tests/unit/harness/test_comms.py::test_a_resumed_child_replays_the_stopped_ones_transcript
+  - tests/unit/harness/test_comms.py::test_a_cancelled_child_keeps_the_work_it_had_already_done
+    (both timing-sensitive: 2 clean runs then a failure on the unmodified head)
+
+
+New tests, and that they fail without the fix
+---------------------------------------------
+The eight new/changed tests were run against unmodified 6edcf186 with only the
+test file copied in. All eight failed, e.g.:
+
+    test_stop_does_not_block_the_caller_on_a_wedged_backend
+      AssertionError: stop() blocked the caller for 59.82s
+    test_a_failing_publish_backs_off_to_the_reassert_cadence
+      AssertionError: failing publish retried 3x on the fast poll
+    test_two_zellij_panes_in_one_session_do_not_share_a_marker
+      + 'zellij-main.json'  - 'zellij-main-1.json'
+    test_the_retire_latch_is_set_before_stop_returns
+      AssertionError: assert ['retire'] == []

--- a/docs/evidence/multiplexer-resume/tmux-evidence.sh
+++ b/docs/evidence/multiplexer-resume/tmux-evidence.sh
@@ -1,0 +1,43 @@
+set -e
+SOCK=lopmuxtest
+tmux -L $SOCK kill-server 2>/dev/null || true
+tmux -L $SOCK new-session -d -s ev -x 100 -y 30
+PANE=$(tmux -L $SOCK list-panes -t ev -F '#{pane_id}' | head -1)
+echo "pane=$PANE"
+tmux -L $SOCK send-keys -t "$PANE" "echo ready" Enter
+sleep 0.3
+
+# Run the REAL backend inside the tmux pane's environment.
+tmux -L $SOCK run-shell -t "$PANE" "true" 2>/dev/null || true
+TMUXENV=$(tmux -L $SOCK show-environment -t ev 2>/dev/null | head -1 || true)
+
+/tmp/lop-mux-resume/.venv/bin/python - "$SOCK" "$PANE" <<'PY'
+import os, subprocess, sys
+sys.path.insert(0,"/tmp/lop-mux-resume")
+sock, pane = sys.argv[1], sys.argv[2]
+from local_operator.multiplexer.markers import TmuxBackend, SESSION_OPTION, COMMAND_OPTION
+from local_operator.multiplexer.broadcast import build_binding
+from local_operator.multiplexer.registry import active_backend
+import local_operator.multiplexer.markers as m
+
+# tmux backend shells out to `tmux`; point it at our private socket so this
+# cannot touch any real tmux server.
+real_run = m._run
+m._run = lambda argv: real_run([argv[0], "-L", sock] + argv[1:])
+
+env = {"TMUX": f"/tmp/tmux-{os.getuid()}/{sock},1,0", "TMUX_PANE": pane}
+print("detected backend:", type(active_backend(env)).__name__)
+b = build_binding("abc123abc123", cwd="/work")
+print("publish ->", TmuxBackend().publish(b, env))
+for opt in (SESSION_OPTION, COMMAND_OPTION):
+    out = subprocess.run(["tmux","-L",sock,"show-options","-pv","-t",pane,opt],
+                         capture_output=True, text=True)
+    print(f"  {opt} = {out.stdout.strip()!r}")
+print("retire ->", TmuxBackend().retire(b, env))
+for opt in (SESSION_OPTION, COMMAND_OPTION):
+    out = subprocess.run(["tmux","-L",sock,"show-options","-pv","-t",pane,opt],
+                         capture_output=True, text=True)
+    print(f"  {opt} after retire = {out.stdout.strip()!r} (rc={out.returncode})")
+PY
+tmux -L $SOCK kill-server 2>/dev/null || true
+echo "tmux server torn down"

--- a/docs/evidence/multiplexer-resume/tmux.txt
+++ b/docs/evidence/multiplexer-resume/tmux.txt
@@ -1,0 +1,9 @@
+pane=%0
+detected backend: TmuxBackend
+publish -> True
+  @lop_session = 'abc123abc123'
+  @lop_resume_command = 'lop --resume abc123abc123'
+retire -> True
+  @lop_session after retire = '' (rc=1)
+  @lop_resume_command after retire = '' (rc=1)
+tmux server torn down

--- a/docs/multiplexer-resume.md
+++ b/docs/multiplexer-resume.md
@@ -1,0 +1,189 @@
+# Multiplexer session resume
+
+When a terminal multiplexer dies and comes back, its panes come back too — but
+each one opens a fresh shell and a fresh `lop`. Every conversation is still on
+disk under `~/.local-operator/sessions`; none of them is reachable except by
+remembering which pane held which session and retyping `lop --resume <id>`.
+
+`lop` now publishes, per pane, the one fact the multiplexer cannot derive: *this
+pane is holding session `<id>`, and here is the argv that reopens it*.
+
+Nothing here is required for `lop` to run. Publication is best-effort by
+construction: a missing binary, a socket error, a multiplexer that is not
+running, or a timeout is logged at debug and otherwise ignored.
+
+## What gets published
+
+**Always a restore-and-idle command** — `lop --resume <id>`, which replays the
+transcript and waits for you. It never continues an interrupted turn. This is a
+safety property, not a default: a restore happens to every pane at once,
+unattended, usually after a crash you did not choose. The worst case of a
+spurious restore has to be an idle session rather than a dozen agents resuming
+tool execution with nobody watching.
+
+**Never a subagent's session.** A delegated review, design or scout run creates
+a session directory shaped exactly like a real conversation, and it runs inside
+its parent's pane. Publishing one would overwrite the pane's binding, so a crash
+restore would reopen the delegated run instead of your work. Sessions marked
+with `origin.json` are skipped.
+
+**Never before the session can actually be resumed.** `--resume` refuses an id
+whose `transcript.jsonl` does not exist yet, so a session publishes nothing
+until its first turn has persisted, then publishes within a few seconds.
+
+**Nothing sensitive.** The session id and the working directory, and nothing
+else. No environment, no credentials, no prompt text.
+
+## Per multiplexer
+
+| Multiplexer | Mechanism | Auto-restores after a crash |
+|---|---|---|
+| cmux | resume binding via the control socket | yes, with the registration below |
+| tmux | pane options `@lop_session`, `@lop_resume_command` | no — needs a restore script |
+| wezterm | per-pane user vars, same two names | no — needs a restore script |
+| zellij | state file under `~/.local-operator/multiplexer/` | no — needs a restore script |
+| screen | state file under `~/.local-operator/multiplexer/` | no — needs a restore script |
+
+Only cmux has an API for "run this command in this pane on restore". The others
+publish a discoverable marker instead, which a restore script consumes.
+
+### Reading the markers
+
+tmux and wezterm store native pane options:
+
+```sh
+tmux show-options -pv @lop_session
+tmux show-options -pv @lop_resume_command
+```
+
+zellij and screen have no per-pane key/value store, so the same two facts go in
+`~/.local-operator/multiplexer/<backend>-<pane-id>.json`:
+
+```json
+{"session_id": "…", "command": ["…/lop", "--resume", "…"], "cwd": "…"}
+```
+
+A restore script's job is the same either way: for each pane, read the session
+id, and if it still names a directory under `~/.local-operator/sessions`, run the
+resume command in that pane. A clean exit removes the marker; a crash leaves it,
+which is the point. Stale markers are harmless — a pane id is reused, so the
+next session in that pane overwrites it.
+
+## cmux: the vault registration
+
+cmux only auto-resumes an agent it knows about. `local-operator` is not in its
+built-in catalog, so you register it once in `~/.config/cmux/cmux.json`. Per
+cmux's `docs/vault.md`, this is what teaches its process scanner to recognise a
+running `lop` and how to resume one; without it, cmux may retire the binding as
+stale (`Workspace.isStaleAgentHookBinding`).
+
+`lop` publishes its binding whether or not you install this. The registration is
+what makes cmux keep it.
+
+```jsonc
+{
+  "vault": {
+    "agents": [
+      {
+        "id": "local-operator",
+        "name": "Local Operator",
+        "detect": { "alternateArgvBasenamesAny": ["lop"] },
+        "sessionIdSource": { "type": "argvOption", "argvOption": "--resume" },
+        "resumeCommand": "lop --resume {{sessionId}}",
+        "cwd": "preserve",
+        "sessionDirectory": "~/.local-operator/sessions"
+      }
+    ]
+  }
+}
+```
+
+**`detect` must not be `processName: "lop"`.** A running `lop` is really
+`…/uv/tools/local-operator/bin/python3 …/.local/bin/lop`, so `argv[0]` is
+`python3` and a process-name rule never matches. `alternateArgvBasenamesAny`
+exists for exactly this: cmux detects that `argv[0]` is a Python runtime, walks
+argv to find the real script argument, and matches its basename.
+
+On an older cmux that does not support `alternateArgvBasenamesAny`, use the
+compatibility form instead:
+
+```jsonc
+"detect": { "processName": "python3", "argvContains": "lop" }
+```
+
+Verified on cmux 0.64.22 by observation — publishing a binding and reading it
+back — rather than by inspecting the build, so treat the version boundary
+between the two forms as approximate and confirm on your own install with the
+trial below.
+
+### Trial it without editing your real config
+
+cmux merges a **project-local** `.cmux/cmux.json`, walking up from a process's
+working directory. So you can test the registration against a scratch directory
+and leave `~/.config/cmux/cmux.json` untouched:
+
+```sh
+mkdir -p /tmp/lop-vault-trial/.cmux
+# put the registration above in /tmp/lop-vault-trial/.cmux/cmux.json
+cd /tmp/lop-vault-trial && lop
+```
+
+Then, from that session, confirm what cmux stored:
+
+```sh
+cmux --json surface resume show
+```
+
+You want `source: "agent-hook"`, `approval_policy: "auto"`,
+`auto_resume: true`, and a `checkpoint_id` equal to the session's directory
+name under `~/.local-operator/sessions`. Once it looks right there, copy the
+`vault` block into `~/.config/cmux/cmux.json`.
+
+To confirm it survives a crash rather than only a clean shutdown, read it back
+from the file cmux restores from (it is written on a short autosave delay):
+
+```sh
+python3 - <<'EOF'
+import json, os
+p = os.path.expanduser("~/Library/Application Support/cmux/session-com.cmuxterm.app.json")
+for w in json.load(open(p))["windows"]:
+    for ws in w["tabManager"]["workspaces"]:
+        for panel in ws.get("panels", []):
+            rb = (panel.get("terminal") or {}).get("resumeBinding")
+            if rb and rb.get("kind") == "local-operator":
+                print(ws["workspaceId"], panel["id"], rb["checkpointId"], rb["autoResume"])
+EOF
+```
+
+`autoResume: true` there is what a crash restores from.
+
+You can also exercise the restore without crashing anything:
+
+```sh
+cmux restore --surface <surface-ref>
+```
+
+## Turning it off
+
+```sh
+export LOCAL_OPERATOR_NO_MULTIPLEXER_RESUME=1
+```
+
+Mirrors `LOCAL_OPERATOR_NO_TERMINAL_TITLE`. Useful for a recording, a CI job, or
+a session opened to read someone else's transcript in a pane that already holds
+a real one.
+
+## Troubleshooting
+
+**`cmux --json surface resume show` returns `resume_binding: null`.** The
+session has not persisted a turn yet (nothing is published until it can actually
+be resumed), or this is a subagent's session, or the kill switch is set.
+
+**`approval_policy` is `manual` and `auto_resume` is `false`.** Something
+published a `cli`-sourced binding, or cmux retired ours as stale — install the
+vault registration above. Note that `cmux surface resume set` on the command
+line can only ever produce a manual binding; `lop` deliberately does not use it.
+
+**The binding disappears when you quit.** That is correct. A clean exit
+withdraws it so your next shell in that pane does not replay a closed session.
+A crash leaves it, which is what the restore uses.

--- a/docs/multiplexer-resume.md
+++ b/docs/multiplexer-resume.md
@@ -59,6 +59,14 @@ tmux show-options -pv @lop_resume_command
 zellij and screen have no per-pane key/value store, so the same two facts go in
 `~/.local-operator/multiplexer/<backend>-<pane-id>.json`:
 
+`<pane-id>` is the multiplexer's own pane identity, which may be more than one
+value. zellij uses `<session-name>-<pane-id>` (`ZELLIJ_SESSION_NAME` and
+`ZELLIJ_PANE_ID`), because a zellij pane id is only unique within its session.
+screen uses `<sty>-<window>` (`STY` and `WINDOW`), falling back to `<sty>` alone
+where `WINDOW` is not exported — in that fallback the marker is per session
+rather than per window, so a second `lop` in the same screen session overwrites
+it.
+
 ```json
 {"session_id": "…", "command": ["…/lop", "--resume", "…"], "cwd": "…"}
 ```

--- a/local_operator/multiplexer/__init__.py
+++ b/local_operator/multiplexer/__init__.py
@@ -36,8 +36,10 @@ surface an error. A missing binary, a socket that is mid-restart, a
 multiplexer that is not running, a non-zero exit, a timeout: all are logged at
 debug and otherwise ignored. Publication is bookkeeping ABOUT a session, and
 taking a session down to record where it lives would be the more expensive
-bug by far. Every subprocess is spawned detached with a short timeout and is
-never waited on from the event loop.
+bug by far. Every subprocess is spawned detached with a short timeout, and is
+never waited on from the event loop: the waits that do exist (a swap's
+successor draining its predecessor, the bounded exit drain) run on worker
+threads or in ``atexit``, never on the loop.
 
 NEVER FOR A SUBAGENT
 --------------------

--- a/local_operator/multiplexer/__init__.py
+++ b/local_operator/multiplexer/__init__.py
@@ -1,0 +1,92 @@
+"""Tell the terminal multiplexer which session this pane is holding.
+
+WHY THIS EXISTS
+---------------
+A user runs a column of ``lop`` sessions as multiplexer panes (cmux
+workspaces down a sidebar, tmux windows, zellij tabs). When the multiplexer
+dies and comes back, the panes come back too — but each one opens a FRESH
+shell and a FRESH ``lop``. Every conversation is still on disk under
+``~/.local-operator/sessions``, and none of them is reachable except by hand:
+the user has to remember which pane held which session and retype
+``lop --resume <id>`` fifteen times. That is the failure this package fixes.
+
+The fix is to publish, per pane, the one fact the multiplexer cannot derive
+on its own: *this pane is holding session ``<id>``, and here is the argv that
+reopens it*. What "publish" means is per-multiplexer, so each one is a
+:class:`~local_operator.multiplexer.types.MultiplexerBackend` in a registry
+(:mod:`.registry`) rather than a branch in a chain of ifs — a new
+multiplexer is a new module, not an edit to this one.
+
+RESTORE-AND-IDLE, NEVER AUTO-CONTINUE
+-------------------------------------
+The published command is always ``lop --resume <id>`` and never anything that
+carries a prompt or continues a turn. This is the single most important
+constraint here and it is a safety property, not a preference: a restore
+happens when fifteen panes come back at once, unattended, typically after a
+crash the user did not choose. ``--resume`` replays the transcript and waits
+for the user, so the worst case of a spurious restore is fifteen idle
+sessions. An "auto-continue the interrupted turn" binding would instead mean
+fifteen agents resuming TOOL EXECUTION simultaneously with nobody watching.
+:mod:`.broadcast` builds the argv so no call site can get this wrong.
+
+BEST-EFFORT, ALWAYS
+-------------------
+Nothing in this package may prevent a session from starting, slow the TUI, or
+surface an error. A missing binary, a socket that is mid-restart, a
+multiplexer that is not running, a non-zero exit, a timeout: all are logged at
+debug and otherwise ignored. Publication is bookkeeping ABOUT a session, and
+taking a session down to record where it lives would be the more expensive
+bug by far. Every subprocess is spawned detached with a short timeout and is
+never waited on from the event loop.
+
+NEVER FOR A SUBAGENT
+--------------------
+Only a user's own session is published. A subagent's child session is an
+ephemeral directory with exactly the shape of a real conversation, and it runs
+inside the SAME pane as its parent — so publishing one would overwrite the
+pane's binding and the crash restore would reopen a delegated code review
+instead of the user's work. :func:`~local_operator.resume.is_user_session`
+(the ``origin.json`` marker) is the gate, the same one the ``/resume`` picker
+uses. cmux's own omp integration carries an identical guard
+(``isNestedArtifactSession``) for the same reason.
+
+THE KILL SWITCH
+---------------
+``LOCAL_OPERATOR_NO_MULTIPLEXER_RESUME`` disables all of it, mirroring the
+``LOCAL_OPERATOR_NO_TERMINAL_TITLE`` convention in
+:mod:`local_operator.tui.terminal_title`. Wanted by anyone who does not want a
+pane's resume binding rewritten — a recording, a CI job, a session opened to
+read someone else's transcript.
+
+WHAT EACH BACKEND PUBLISHES
+---------------------------
+cmux has a real resume-binding API and gets a trusted auto-resume binding; see
+:mod:`.cmux` for why that path is the socket RPC and not the ``cmux surface
+resume set`` CLI. The others have no such API, so they publish a discoverable
+per-pane marker instead — a tmux/wezterm pane option, or a state file under
+``~/.local-operator/multiplexer/`` keyed by pane identity. The marker contract
+is documented in :mod:`.markers` so a human or a shell script can implement
+the restore side without reading this code.
+"""
+
+from __future__ import annotations
+
+from local_operator.multiplexer.broadcast import (
+    SessionBroadcast,
+    broadcast_session,
+    multiplexer_resume_enabled,
+    retire_session,
+)
+from local_operator.multiplexer.registry import active_backend, backends
+from local_operator.multiplexer.types import MultiplexerBackend, SessionBinding
+
+__all__ = [
+    "MultiplexerBackend",
+    "SessionBinding",
+    "SessionBroadcast",
+    "active_backend",
+    "backends",
+    "broadcast_session",
+    "multiplexer_resume_enabled",
+    "retire_session",
+]

--- a/local_operator/multiplexer/broadcast.py
+++ b/local_operator/multiplexer/broadcast.py
@@ -1,0 +1,357 @@
+"""When a binding is published, when it is withdrawn, and what it may contain.
+
+This module owns the SAFETY rules the package docstring states, so that no
+backend and no call site has to re-derive them:
+
+* only a user's own session is ever published (never a subagent's child);
+* the published command is restore-and-idle and can carry nothing else;
+* every publication is best-effort, off the caller's thread, and silent;
+* a clean exit withdraws the binding, and that withdrawal is FINAL.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+import threading
+from pathlib import Path
+
+from local_operator.multiplexer.cmux import REASSERT_INTERVAL_S
+from local_operator.multiplexer.registry import active_backend
+from local_operator.multiplexer.types import (
+    EnvMap,
+    MultiplexerBackend,
+    SessionBinding,
+    env_or_process,
+)
+
+logger = logging.getLogger(__name__)
+
+#: How often the loop re-checks whether a not-yet-publishable session has
+#: become publishable. A single ``stat`` per pass, so it is cheap enough to
+#: run at this cadence, and it only runs until the first successful publish.
+#: This is the delay between a cold session's first turn landing on disk and
+#: its pane advertising a resume command, so it is deliberately short.
+_PENDING_POLL_S = 5.0
+
+#: How long ``stop`` waits for the timer thread. Long enough for a publish
+#: already inside a subprocess call to finish and see the retire flag, short
+#: enough that quitting never feels stuck.
+CALL_JOIN_TIMEOUT_S = 6.0
+
+#: Environment kill switch, mirroring ``LOCAL_OPERATOR_NO_TERMINAL_TITLE`` in
+#: ``tui/terminal_title.py``. Wanted by anything that must not rewrite a pane's
+#: resume binding: a recording, a CI job, or a session opened purely to read
+#: someone else's transcript in a pane that already holds a real one.
+_ENV_DISABLE = "LOCAL_OPERATOR_NO_MULTIPLEXER_RESUME"
+
+#: The flag that reopens a session, and the ONLY one a published command
+#: carries. Named here so the restore-and-idle rule has one spelling: cmux and
+#: the marker backends all build their command from :func:`resume_argv`.
+RESUME_FLAG = "--resume"
+
+
+def multiplexer_resume_enabled(env: EnvMap | None = None) -> bool:
+    """Whether this process may publish anything at all.
+
+    An environment gate only, with no config flag counterpart — unlike the
+    terminal title, this writes nothing a user sees, so the reason to turn it
+    off is always situational (this run, this pane) rather than a standing
+    preference.
+    """
+    return not (env_or_process(env).get(_ENV_DISABLE) or "").strip()
+
+
+def resume_executable() -> str:
+    """Absolute path to the launcher that should reopen this session.
+
+    ``sys.argv[0]`` and NOT ``sys.executable``: a ``lop`` process is really
+    ``…/uv/tools/local-operator/bin/python3 …/.local/bin/lop``, so the
+    interpreter path would restore a bare Python REPL. ``argv[0]`` is the
+    ``lop`` script the user actually launched, which is also the path their
+    cmux vault registration matches on.
+
+    Resolved to an absolute path because a restore may run with a different
+    PATH or cwd than the launch did (a crash restore runs from whatever shell
+    the multiplexer spawns), and a relative ``argv[0]`` would then resolve to
+    nothing.
+    """
+    launcher = sys.argv[0] if sys.argv else ""
+    if launcher:
+        resolved = Path(launcher).expanduser()
+        try:
+            if resolved.exists():
+                return str(resolved.resolve())
+        except OSError:
+            pass
+    # Nothing usable on argv[0] (an embedder, a frozen host): name the console
+    # script and let the restoring shell's PATH find it. Better than a path
+    # that is known not to exist.
+    return "lop"
+
+
+def resume_argv(session_id: str, executable: str | None = None) -> tuple[str, ...]:
+    """The restore-and-idle launch line for ``session_id``.
+
+    THIS IS A SAFETY BOUNDARY, not a convenience. The returned argv replays a
+    transcript and then waits for the user; it carries no prompt, no
+    ``--exec``, and nothing that continues an interrupted turn. A restore
+    happens unattended and to every pane at once — typically after a crash
+    nobody chose — so the worst case of a spurious restore has to be an idle
+    session rather than a dozen agents resuming tool execution with no one
+    watching. Every backend builds its command from here so no call site can
+    opt out of that.
+    """
+    return (executable or resume_executable(), RESUME_FLAG, session_id)
+
+
+def build_binding(
+    session_id: str,
+    *,
+    cwd: str | None = None,
+) -> SessionBinding | None:
+    """Describe this session for publication, or None when it must not be.
+
+    Returns None — rather than raising — for every "do not publish" case, so
+    the caller has exactly one branch to write.
+    """
+    session_id = (session_id or "").strip()
+    if not session_id:
+        return None
+    executable = resume_executable()
+    return SessionBinding(
+        session_id=session_id,
+        executable=executable,
+        argv=resume_argv(session_id, executable),
+        cwd=cwd if cwd is not None else os.getcwd(),
+    )
+
+
+def is_user_owned_session(session_id: str) -> bool:
+    """Whether this session is the USER's own, rather than a subagent's.
+
+    A PERMANENT property, decided once: a child session is an ephemeral
+    directory with the exact shape of a real conversation, and it runs in the
+    SAME pane as its parent — so publishing one would overwrite the pane's
+    binding and a crash restore would reopen a delegated code review in place
+    of the user's own work. ``origin.json`` is the marker and
+    :func:`~local_operator.resume.is_user_session` is the one reader of it (the
+    same gate the ``/resume`` picker uses). cmux's omp integration carries the
+    same guard, ``isNestedArtifactSession``, for the same reason.
+
+    Kept separate from :func:`is_resumable_session` because the two refusals
+    have different lifetimes, and conflating them is what would either spin a
+    pointless timer for every subagent or never publish a cold session at all.
+    """
+    from local_operator.paths import config_dir
+    from local_operator.resume import is_user_session
+
+    try:
+        return is_user_session(config_dir() / "sessions" / session_id)
+    except OSError:
+        logger.debug("session origin check failed", exc_info=True)
+        return False
+
+
+def is_resumable_session(session_id: str) -> bool:
+    """Whether ``--resume`` would actually reopen this session yet.
+
+    A TRANSIENT property, which is why it is re-checked before every publish
+    rather than once at startup. ``--resume`` refuses an id whose transcript is
+    not on disk — deliberately, so a typo cannot open an empty session that
+    merely looks resumed — and the transcript file does not exist until the
+    first turn is persisted. A session therefore starts life unpublishable and
+    becomes publishable a turn later.
+
+    Checking this only once, at startup, is the subtle version of the bug this
+    whole feature exists to fix: every COLD session (which is most of them)
+    would silently never publish, and the omission would surface only after a
+    crash, when the user has already lost the work.
+    """
+    from local_operator.paths import config_dir
+    from local_operator.resume import TRANSCRIPT_NAME
+
+    try:
+        return (config_dir() / "sessions" / session_id / TRANSCRIPT_NAME).is_file()
+    except OSError:
+        logger.debug("session transcript check failed", exc_info=True)
+        return False
+
+
+class SessionBroadcast:
+    """Keeps one pane's binding published for as long as the session lives.
+
+    Owns a daemon timer thread rather than an asyncio task on purpose: every
+    call here ends in a subprocess, and the TUI's event loop must never be the
+    thing waiting on a multiplexer socket. A daemon thread also cannot hold
+    the process open if some exit path forgets to stop it.
+
+    The re-assert exists because cmux caches its live-agent index for 60s and
+    retires bindings judged against a stale snapshot — see
+    :data:`local_operator.multiplexer.cmux.REASSERT_INTERVAL_S` for why that
+    retirement is permanent and why the interval must exceed the TTL.
+    """
+
+    def __init__(
+        self,
+        binding: SessionBinding,
+        backend: MultiplexerBackend,
+        *,
+        env: EnvMap | None = None,
+        interval_s: float = REASSERT_INTERVAL_S,
+    ) -> None:
+        self._binding = binding
+        self._backend = backend
+        self._env = env_or_process(env)
+        self._interval_s = interval_s
+        # Signals the timer to wake and exit. Also the mechanism that makes
+        # `stop()` prompt rather than waiting out a 90s sleep.
+        self._stopped = threading.Event()
+        self._thread: threading.Thread | None = None
+        # Guards the publish/retire pair. Without it a re-assert already in
+        # flight on the timer thread could land AFTER the clean-exit clear and
+        # resurrect the binding the user just quit out of — the retirement bug
+        # inverted, and invisible until their next new shell replayed a dead
+        # session.
+        self._lock = threading.Lock()
+        self._retired = False
+        #: Whether a binding has ever been published. Until it has, the loop is
+        #: waiting for the first turn to persist and polls on the cheap
+        #: cadence; afterwards it only defends what it published.
+        self._published = False
+
+    def start(self) -> None:
+        """Publish now, then keep re-asserting until :meth:`stop`."""
+        if self._thread is not None:
+            return
+        thread = threading.Thread(
+            target=self._run,
+            name="lop-multiplexer-resume",
+            daemon=True,
+        )
+        self._thread = thread
+        thread.start()
+
+    def _publish_once(self) -> None:
+        with self._lock:
+            # The clean-exit clear is FINAL: once retired, a re-assert that was
+            # already queued must do nothing.
+            if self._retired:
+                return
+            # Re-checked on EVERY pass, not once at startup: a cold session has
+            # no transcript until its first turn persists, so publishing a
+            # binding now would advertise a command `--resume` still refuses.
+            # The timer is what turns that into a delay rather than a silent
+            # never (see `is_resumable_session`).
+            if not is_resumable_session(self._binding.session_id):
+                return
+            try:
+                if self._backend.publish(self._binding, self._env):
+                    self._published = True
+            except Exception:  # noqa: BLE001 — best-effort by contract
+                logger.debug("multiplexer publish failed", exc_info=True)
+
+    def _run(self) -> None:
+        # Published immediately so a RESUMED session's binding exists from the
+        # first moment; a cold session no-ops here and lands on the poll below.
+        self._publish_once()
+        elapsed = 0.0
+        while not self._stopped.wait(_PENDING_POLL_S):
+            elapsed += _PENDING_POLL_S
+            # Two cadences, one timer. Before the first successful publish the
+            # loop is waiting for the first turn to persist, and the check is a
+            # single stat — cheap enough to run often so a cold session's
+            # binding appears seconds after its first turn instead of up to a
+            # re-assert interval later. After that only the re-assert matters,
+            # and that must stay slower than cmux's 60s index TTL.
+            with self._lock:
+                published = self._published
+            if published and elapsed < self._interval_s:
+                continue
+            elapsed = 0.0
+            # Deliberately silent: this runs for the life of a session, and a
+            # log line per pass would bury the debug log of anyone debugging
+            # something else. Failures inside `_publish_once` are logged at
+            # debug individually, which is enough to see a broken socket.
+            self._publish_once()
+
+    def stop(self, *, retire: bool = True) -> None:
+        """Stop re-asserting; on a clean exit, withdraw the binding.
+
+        ``retire=False`` leaves the binding in place, which is what a crash or
+        a re-exec wants: the binding surviving is the entire feature. The
+        default is to withdraw, because a session the user deliberately quit
+        must not be replayed into their next shell.
+
+        Idempotent, and safe to call from any thread — including from an exit
+        path that runs while a re-assert is mid-flight.
+        """
+        self._stopped.set()
+        if retire:
+            with self._lock:
+                # Set BEFORE the call, so a re-assert that is already waiting
+                # on this lock sees the retirement and does not republish.
+                self._retired = True
+                try:
+                    self._backend.retire(self._binding, self._env)
+                except Exception:  # noqa: BLE001 — best-effort by contract
+                    logger.debug("multiplexer retire failed", exc_info=True)
+        thread = self._thread
+        self._thread = None
+        if thread is not None and thread is not threading.current_thread():
+            # Bounded: the timer wakes on the event immediately, and a publish
+            # in flight is capped by the backend's own subprocess timeout. The
+            # join is what stops a subprocess outliving the app's teardown.
+            thread.join(timeout=CALL_JOIN_TIMEOUT_S)
+
+
+def broadcast_session(
+    session_id: str,
+    *,
+    cwd: str | None = None,
+    env: EnvMap | None = None,
+) -> SessionBroadcast | None:
+    """Start publishing ``session_id`` for this pane, if anything should be.
+
+    Returns the handle to stop later, or None when there is nothing to do —
+    no multiplexer, the kill switch is set, a subagent's session, or a
+    session with no transcript yet. None is the common case and is not an
+    error.
+
+    Never raises. This is called from session startup, where an exception
+    would cost the user their session for the sake of a bookkeeping write.
+    """
+    try:
+        source = env_or_process(env)
+        if not multiplexer_resume_enabled(source):
+            return None
+        backend = active_backend(source)
+        if backend is None:
+            return None
+        # Only the PERMANENT refusal is decided here. Whether the transcript
+        # exists yet is transient and belongs to each publish attempt, because
+        # a session that is not resumable at startup becomes resumable one turn
+        # later and must publish then.
+        if not is_user_owned_session(session_id):
+            return None
+        binding = build_binding(session_id, cwd=cwd)
+        if binding is None:
+            return None
+        broadcast = SessionBroadcast(binding, backend, env=source)
+        broadcast.start()
+        logger.debug("publishing resume binding to %s for %s", backend.name, session_id)
+        return broadcast
+    except Exception:  # noqa: BLE001 — must never break session startup
+        logger.debug("multiplexer broadcast failed to start", exc_info=True)
+        return None
+
+
+def retire_session(broadcast: SessionBroadcast | None) -> None:
+    """Withdraw a binding on a clean exit. Safe with None, never raises."""
+    if broadcast is None:
+        return
+    try:
+        broadcast.stop(retire=True)
+    except Exception:  # noqa: BLE001 — best-effort by contract
+        logger.debug("multiplexer retire failed", exc_info=True)

--- a/local_operator/multiplexer/broadcast.py
+++ b/local_operator/multiplexer/broadcast.py
@@ -11,10 +11,13 @@ backend and no call site has to re-derive them:
 
 from __future__ import annotations
 
+import atexit
 import logging
 import os
 import sys
 import threading
+import time
+import weakref
 from pathlib import Path
 
 from local_operator.multiplexer.cmux import REASSERT_INTERVAL_S
@@ -41,11 +44,29 @@ logger = logging.getLogger(__name__)
 #: its pane advertising a resume command, so it is deliberately short.
 _PENDING_POLL_S = 5.0
 
-#: Default grace for :meth:`SessionBroadcast.join`, which is a TEST and
-#: teardown-diagnostic helper rather than part of the stop path. Long enough
-#: for a backend call already inside a subprocess to finish and see the retire
-#: latch. ``stop`` itself never waits this out — see :meth:`SessionBroadcast.stop`.
+#: Default grace for :meth:`SessionBroadcast.join`, which a SWAP (the
+#: successor broadcast waiting out its predecessor's withdrawal) and the
+#: tests both use. Long enough for a backend call already inside a subprocess
+#: to finish and see the retire latch. ``stop`` itself never waits this out —
+#: see :meth:`SessionBroadcast.stop`.
 CALL_JOIN_TIMEOUT_S = 6.0
+
+#: Bound on how long the successor broadcast waits for the OUTGOING
+#: session's withdrawal before publishing anyway. This is the swap ordering
+#: made safe: without a wait, a ``/new``/``/resume`` publishes the new binding
+#: while the old one's retire is still in a subprocess, and whichever lands
+#: last wins the pane — the pane then advertises nothing, which is the exact
+#: failure this package exists to prevent.
+#
+#: It is a bound and not a join because the wait runs on the SUCCESSOR's own
+#: timer thread, off the event loop, and must not become a hang there either:
+#: a wedged multiplexer socket that ignores ``CALL_TIMEOUT_S``-bounded
+#: subprocesses entirely (or a retire queued behind a publish already parked
+#: in one) can outwait any fixed number, and the successor has to publish
+#: eventually. What the timeout trades away is the wezterm corner case below,
+#: and a publish that wins the pane late is recoverable by the re-assert — an
+#: unreachable socket is refusing the successor's writes too.
+SWAP_DRAIN_TIMEOUT_S = CALL_JOIN_TIMEOUT_S
 
 #: Environment kill switch, mirroring ``LOCAL_OPERATOR_NO_TERMINAL_TITLE`` in
 #: ``tui/terminal_title.py``. Wanted by anything that must not rewrite a pane's
@@ -212,17 +233,31 @@ class SessionBroadcast:
         *,
         env: EnvMap | None = None,
         interval_s: float = REASSERT_INTERVAL_S,
+        predecessor: SessionBroadcast | None = None,
     ) -> None:
         self._binding = binding
         self._backend = backend
         self._env = env_or_process(env)
         self._interval_s = interval_s
+        # The broadcast this one REPLACES in the same pane, if any. Not read
+        # after `start()` returns: the successor's timer thread drains it once
+        # (below) and then the reference is dropped, so a chain of swaps can
+        # never accumulate handles. Ordering the swap through the successor
+        # rather than the app keeps the event loop out of it entirely — the
+        # app calls `stop()` (prompt, returns immediately) and `start()`, and
+        # the sequencing happens on a thread neither of them is waiting on.
+        self._predecessor = predecessor
+        self._drained = threading.Event()
+        # Signals the timer to wake and exit. Also the mechanism that makes
+        # `stop()` prompt rather than waiting out a 90s sleep.
+        self._stopped = threading.Event()
         # Signals the timer to wake and exit. Also the mechanism that makes
         # `stop()` prompt rather than waiting out a 90s sleep.
         self._stopped = threading.Event()
         self._thread: threading.Thread | None = None
-        # Survives `stop()` clearing `_thread`, purely so `join()` has
-        # something to wait on. Never read by a production path.
+        # Survives `stop()` clearing `_thread`, so `join()` can still settle
+        # it — and join has a production caller now: a SWAP's successor drains
+        # its predecessor on the successor's own timer thread (see `_run`).
         self._timer_thread: threading.Thread | None = None
         # Serialises the publish/retire pair. Without it a re-assert already in
         # flight on the timer thread could land AFTER the clean-exit clear and
@@ -251,7 +286,14 @@ class SessionBroadcast:
         self._resumable = False
 
     def start(self) -> None:
-        """Publish now, then keep re-asserting until :meth:`stop`."""
+        """Publish now, then keep re-asserting until :meth:`stop`.
+
+        On a swap, called with ``predecessor`` set. The first publish then
+        happens only after the predecessor's withdrawal has been drained, so
+        the two cannot race for the pane — and the drain runs on THIS
+        broadcast's timer thread, which is exactly the thread the event loop
+        is not waiting on.
+        """
         if self._thread is not None:
             return
         thread = threading.Thread(
@@ -295,6 +337,26 @@ class SessionBroadcast:
                 logger.debug("multiplexer publish failed", exc_info=True)
 
     def _run(self) -> None:
+        # A swap must not let the outgoing session's withdrawal land after
+        # the incoming session's publish: both name the same pane, so the
+        # loser's write deletes the winner's. Waiting here is what keeps the
+        # event loop out of it — this is the successor's own timer thread, a
+        # thread nothing user-facing blocks on. The bound is
+        # `SWAP_DRAIN_TIMEOUT_S` rather than a plain join because the
+        # predecessor's retire may itself be queued behind a publish parked
+        # in a `CALL_TIMEOUT_S` subprocess, and the successor must publish
+        # eventually rather than hang behind a socket that never answers.
+        #
+        # `join()` is safe to call on the predecessor from here: it joins the
+        # retire worker and the TIMER, and this thread is neither.
+        predecessor = self._predecessor
+        if predecessor is not None:
+            self._predecessor = None
+            try:
+                predecessor.join(timeout=SWAP_DRAIN_TIMEOUT_S)
+            except Exception:  # noqa: BLE001 — a swap must never fail on this
+                logger.debug("predecessor withdrawal drain failed", exc_info=True)
+        self._drained.set()
         # Published immediately so a RESUMED session's binding exists from the
         # first moment; a cold session no-ops here and lands on the poll below.
         self._publish_once()
@@ -362,22 +424,27 @@ class SessionBroadcast:
         # `_retired` latch already prevents it from doing anything meaningful
         # after this point. Joining here would reintroduce the event-loop
         # stall the dispatch above exists to avoid — a publish in flight can
-        # sit in a subprocess timeout for seconds. Tests that need the thread
-        # settled call `join()` explicitly.
+        # sit in a subprocess timeout for seconds. The two callers that DO
+        # need the withdrawal sequenced get it off the loop: a swap's
+        # successor drains this broadcast on its own timer thread, and quit
+        # is covered by the exit drain registered with the retire dispatch.
 
     def _dispatch_retire(self) -> None:
         """Run the backend retire off the caller's thread, at most once.
-
         A dedicated short-lived thread rather than the timer thread: the timer
         may be parked inside a publish subprocess for seconds, and the
-        withdrawal should not queue behind it. Daemon, for the same reason the
-        timer is — a wedged socket must not delay interpreter shutdown, and a
-        withdrawal that loses a race with process exit costs a stale marker,
-        which is the failure mode this package is explicitly allowed to have.
+        withdrawal should not queue behind it. Daemon, so a wedged socket
+        cannot hold the process open — with the exit drain below making that
+        safe: without it, interpreter exit killed the worker before the
+        withdrawal ran, and a session the user deliberately quit stayed
+        advertised in the pane until their next shell replayed it.
         """
         with self._dispatch_lock:
             if self._retire_thread is not None:
                 return
+            # Recorded before the thread exists so the exit drain can see a
+            # dispatch that is still starting up.
+            _RETIRE_REGISTRY.add(self)
 
             def _retire() -> None:
                 # Takes `_call_lock` so the retire cannot interleave with a
@@ -395,14 +462,16 @@ class SessionBroadcast:
                 daemon=True,
             )
             self._retire_thread = worker
+            _register_exit_drain()
             worker.start()
 
     def join(self, timeout: float = CALL_JOIN_TIMEOUT_S) -> None:
         """Wait for the timer and any retire worker to finish.
-
-        For TESTS and teardown diagnostics only. No production path calls this:
-        both real callers are on the event loop, where waiting on a multiplexer
-        socket is the exact bug :meth:`stop` is written to avoid.
+        Called by tests, by teardown diagnostics, and by a SWAP: the successor
+        broadcast's timer thread joins its predecessor before publishing, so
+        the two bindings cannot race for the pane. The event loop is never a
+        caller — both of its call sites (`_adopt_session`, `on_unmount`) use
+        `stop()`/`retire_session()`, which never join.
         """
         with self._dispatch_lock:
             retire_worker = self._retire_thread
@@ -410,19 +479,41 @@ class SessionBroadcast:
             if worker is not None and worker is not threading.current_thread():
                 worker.join(timeout=timeout)
 
+    def _drain_retire(self, *, timeout: float) -> None:
+        """Join only the retire worker, bounded. Exit-path half of the drain.
+
+        Deliberately narrower than :meth:`join`: the timer thread has nothing
+        left to do once `_stopped` is set (and its `_publish_once` refuses
+        under the `_retired` latch), so joining it at exit buys nothing. Only
+        the withdrawal carries state the user can still be harmed by.
+        """
+        with self._dispatch_lock:
+            worker = self._retire_thread
+        if worker is not None and worker is not threading.current_thread():
+            worker.join(timeout=timeout)
+
 
 def broadcast_session(
     session_id: str,
     *,
     cwd: str | None = None,
     env: EnvMap | None = None,
+    predecessor: SessionBroadcast | None = None,
 ) -> SessionBroadcast | None:
     """Start publishing ``session_id`` for this pane, if anything should be.
-
     Returns the handle to stop later, or None when there is nothing to do —
     no multiplexer, the kill switch is set, a subagent's session, or a
     session with no transcript yet. None is the common case and is not an
     error.
+
+    ``predecessor`` is the broadcast this one replaces in the same pane, on a
+    ``/new``/``/resume`` swap. The successor waits for its withdrawal before
+    publishing (on the successor's own thread — never the event loop), which
+    is what stops the outgoing clear from deleting the incoming binding on
+    the marker backends that cannot scope a clear themselves. When this
+    returns None the caller has already stopped the predecessor itself, so
+    the withdrawal still happens; it is simply not sequenced against a
+    successor that does not exist.
 
     Never raises. This is called from session startup, where an exception
     would cost the user their session for the sake of a bookkeeping write.
@@ -443,7 +534,7 @@ def broadcast_session(
         binding = build_binding(session_id, cwd=cwd)
         if binding is None:
             return None
-        broadcast = SessionBroadcast(binding, backend, env=source)
+        broadcast = SessionBroadcast(binding, backend, env=source, predecessor=predecessor)
         broadcast.start()
         logger.debug("publishing resume binding to %s for %s", backend.name, session_id)
         return broadcast
@@ -452,8 +543,94 @@ def broadcast_session(
         return None
 
 
+#: Worst-case delay a user can experience at interpreter exit because of a
+#: resume-binding withdrawal. One bounded join per process, shared by every
+#: broadcast (see :func:`_register_exit_drain`), never on the event loop —
+#: `atexit` runs on the main thread after `on_unmount` has already returned.
+#:
+#: The number is a bound, not an expectation: a healthy backend retires in
+#: one subprocess spawn (single-digit milliseconds), so the join returns in
+#: that. The bound only ever gets used when the multiplexer socket is wedged
+#: mid-restart — the state where the alternative (a synchronous retire on the
+#: event loop) froze the whole TUI for ~9.8s. A quit that outwaits it leaves
+#: a stale marker, which is the package's explicitly allowed failure for the
+#: crash case; the crash case cannot reach this code at all.
+EXIT_DRAIN_TIMEOUT_S = 2.0
+
+#: Registered once per process; guarded by `_EXIT_DRAIN_LOCK`.
+_EXIT_DRAIN_LOCK = threading.Lock()
+_exit_drain_registered = False
+
+#: Every broadcast with a retire dispatched in this process. Weak, so a
+#: broadcast that is garbage-collected before exit (a swap chain) is not kept
+#: alive — and its already-finished worker is not joined for nothing.
+_RETIRE_REGISTRY: weakref.WeakSet["SessionBroadcast"] = weakref.WeakSet()
+
+
+def _register_exit_drain() -> None:
+    """Make sure a dispatched withdrawal survives interpreter exit.
+
+    WHY THIS EXISTS
+    ---------------
+    The retire worker is a daemon thread, and daemon threads are killed at
+    interpreter exit without running their remaining code. Before this
+    drain, `stop(retire=True)` on quit returned in microseconds having only
+    STARTED the worker; the interpreter then exited and the withdrawal never
+    ran, so the pane kept advertising a session the user had deliberately
+    closed — and their next shell in that pane replayed it. A stale marker
+    after a crash is the feature; a stale marker after a clean quit is the
+    bug this function exists to close.
+
+    WHY `atexit` AND NOT A JOIN IN `stop`
+    -------------------------------------
+    Joining in `stop` would put the wait on the Textual event loop (both real
+    callers are coroutines), which is the ~9.8s freeze F1's fix removed.
+    `atexit` handlers run on the main thread AFTER `on_unmount` has returned
+    and the event loop is gone, so nothing user-facing is blocked by the
+    join: the process is already on its way out. `os._exit` (the Windows
+    re-exec path) and a hard crash skip `atexit` entirely, which is correct —
+    both are crash-shaped exits where a surviving binding is the feature.
+
+    The handler is registered once for the process rather than once per
+    broadcast: several panes' worth of broadcasts live in one process only in
+    tests, but a chain of swaps produces one live broadcast plus a series of
+    retired ones, and each would otherwise register its own handler.
+    """
+    global _exit_drain_registered
+    with _EXIT_DRAIN_LOCK:
+        if _exit_drain_registered:
+            return
+        _exit_drain_registered = True
+
+    atexit.register(_drain_retires_at_exit)
+
+
+def _drain_retires_at_exit() -> None:
+    """Join every live retire worker, bounded. Never raises.
+
+    Idempotent and cheap to call early: the registry of broadcasts with a
+    dispatched retire is consulted rather than guessed at, so a process that
+    never dispatched one pays nothing.
+    """
+    deadline = time.monotonic() + EXIT_DRAIN_TIMEOUT_S
+    for broadcast in tuple(_RETIRE_REGISTRY):
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            break
+        try:
+            broadcast._drain_retire(timeout=remaining)  # noqa: SLF001 - same package
+        except Exception:  # noqa: BLE001 — an exit path must never raise
+            logger.debug("exit retire drain failed", exc_info=True)
+
+
 def retire_session(broadcast: SessionBroadcast | None) -> None:
-    """Withdraw a binding on a clean exit. Safe with None, never raises."""
+    """Withdraw a binding on a clean exit. Safe with None, never raises.
+
+    The withdrawal itself runs on the broadcast's own retire worker, and the
+    exit drain guarantees it lands before the interpreter is gone — see
+    :func:`_register_exit_drain` for why that is `atexit` and not a join
+    here. A join here would be on the Textual event loop.
+    """
     if broadcast is None:
         return
     try:

--- a/local_operator/multiplexer/broadcast.py
+++ b/local_operator/multiplexer/broadcast.py
@@ -28,16 +28,23 @@ from local_operator.multiplexer.types import (
 
 logger = logging.getLogger(__name__)
 
-#: How often the loop re-checks whether a not-yet-publishable session has
-#: become publishable. A single ``stat`` per pass, so it is cheap enough to
-#: run at this cadence, and it only runs until the first successful publish.
+#: How often the loop re-checks whether a not-yet-resumable session has become
+#: resumable. This cadence runs ONLY while :func:`is_resumable_session` is
+#: False, and in that state a pass really is a single ``stat``: ``_publish_once``
+#: returns before it reaches the backend, so no subprocess is spawned. That is
+#: what makes a five-second poll affordable. Keying it on resumability rather
+#: than on publish success is deliberate — a session whose publish keeps failing
+#: (socket refusing, surface closed) would otherwise stay on this cadence
+#: forever and spawn one ``cmux rpc`` process every five seconds, per pane, for
+#: the life of the session.
 #: This is the delay between a cold session's first turn landing on disk and
 #: its pane advertising a resume command, so it is deliberately short.
 _PENDING_POLL_S = 5.0
 
-#: How long ``stop`` waits for the timer thread. Long enough for a publish
-#: already inside a subprocess call to finish and see the retire flag, short
-#: enough that quitting never feels stuck.
+#: Default grace for :meth:`SessionBroadcast.join`, which is a TEST and
+#: teardown-diagnostic helper rather than part of the stop path. Long enough
+#: for a backend call already inside a subprocess to finish and see the retire
+#: latch. ``stop`` itself never waits this out — see :meth:`SessionBroadcast.stop`.
 CALL_JOIN_TIMEOUT_S = 6.0
 
 #: Environment kill switch, mirroring ``LOCAL_OPERATOR_NO_TERMINAL_TITLE`` in
@@ -187,6 +194,11 @@ class SessionBroadcast:
     thing waiting on a multiplexer socket. A daemon thread also cannot hold
     the process open if some exit path forgets to stop it.
 
+    That rule covers the WITHDRAWAL as well as the publish: :meth:`stop` runs
+    on the event loop (a ``/new`` swap, and quit) and hands the retire to a
+    worker rather than making the call itself, so a wedged socket cannot
+    freeze the TUI at exactly the moment this feature exists to survive.
+
     The re-assert exists because cmux caches its live-agent index for 60s and
     retires bindings judged against a stale snapshot — see
     :data:`local_operator.multiplexer.cmux.REASSERT_INTERVAL_S` for why that
@@ -209,17 +221,34 @@ class SessionBroadcast:
         # `stop()` prompt rather than waiting out a 90s sleep.
         self._stopped = threading.Event()
         self._thread: threading.Thread | None = None
-        # Guards the publish/retire pair. Without it a re-assert already in
+        # Survives `stop()` clearing `_thread`, purely so `join()` has
+        # something to wait on. Never read by a production path.
+        self._timer_thread: threading.Thread | None = None
+        # Serialises the publish/retire pair. Without it a re-assert already in
         # flight on the timer thread could land AFTER the clean-exit clear and
         # resurrect the binding the user just quit out of — the retirement bug
         # inverted, and invisible until their next new shell replayed a dead
         # session.
-        self._lock = threading.Lock()
-        self._retired = False
-        #: Whether a binding has ever been published. Until it has, the loop is
-        #: waiting for the first turn to persist and polls on the cheap
-        #: cadence; afterwards it only defends what it published.
-        self._published = False
+        #
+        # HELD ACROSS A SUBPROCESS CALL, so nothing on the event loop may ever
+        # wait on it. `stop()` deliberately touches only the lock-free latches
+        # below; that is what keeps a wedged socket off the calling thread.
+        self._call_lock = threading.Lock()
+        # An Event, not a bool under `_call_lock`: `stop()` has to set the
+        # latch without ever contending with a retire that is currently sitting
+        # in a five-second subprocess timeout. Event set/is_set is atomic, so
+        # the latch is readable and writable from any thread for free.
+        self._retired = threading.Event()
+        # Guards only the retire-dispatch bookkeeping. Held for microseconds
+        # and NEVER across a backend call, so stop() cannot block on it.
+        self._dispatch_lock = threading.Lock()
+        self._retire_thread: threading.Thread | None = None
+        #: Whether the session's transcript has appeared yet. This and NOT
+        #: publish success is what selects the cadence: once a session can be
+        #: resumed the loop drops to the re-assert interval whether or not the
+        #: backend is answering, because retrying a failing publish every five
+        #: seconds forever is subprocess churn rather than resilience.
+        self._resumable = False
 
     def start(self) -> None:
         """Publish now, then keep re-asserting until :meth:`stop`."""
@@ -231,13 +260,22 @@ class SessionBroadcast:
             daemon=True,
         )
         self._thread = thread
+        self._timer_thread = thread
         thread.start()
 
     def _publish_once(self) -> None:
-        with self._lock:
-            # The clean-exit clear is FINAL: once retired, a re-assert that was
-            # already queued must do nothing.
-            if self._retired:
+        # Checked BEFORE the lock, not only under it. The retire worker holds
+        # `_call_lock` for the whole of a backend call, so a re-assert that
+        # arrives during a withdrawal would otherwise sit in the queue for a
+        # subprocess timeout only to discover it must do nothing. The latch is
+        # set synchronously by `stop`, so this early exit is not a race: it
+        # sees every retirement that has been decided.
+        if self._retired.is_set():
+            return
+        with self._call_lock:
+            # Re-read under the lock: `stop` may have latched between the
+            # check above and acquiring it. The clean-exit clear is FINAL.
+            if self._retired.is_set():
                 return
             # Re-checked on EVERY pass, not once at startup: a cold session has
             # no transcript until its first turn persists, so publishing a
@@ -246,9 +284,13 @@ class SessionBroadcast:
             # never (see `is_resumable_session`).
             if not is_resumable_session(self._binding.session_id):
                 return
+            # Recorded BEFORE the publish attempt and independently of its
+            # result: the cadence question is "is there still something to wait
+            # for?", and once the transcript exists the answer is no even if
+            # the backend refuses every call.
+            self._resumable = True
             try:
-                if self._backend.publish(self._binding, self._env):
-                    self._published = True
+                self._backend.publish(self._binding, self._env)
             except Exception:  # noqa: BLE001 — best-effort by contract
                 logger.debug("multiplexer publish failed", exc_info=True)
 
@@ -259,15 +301,16 @@ class SessionBroadcast:
         elapsed = 0.0
         while not self._stopped.wait(_PENDING_POLL_S):
             elapsed += _PENDING_POLL_S
-            # Two cadences, one timer. Before the first successful publish the
-            # loop is waiting for the first turn to persist, and the check is a
-            # single stat — cheap enough to run often so a cold session's
-            # binding appears seconds after its first turn instead of up to a
-            # re-assert interval later. After that only the re-assert matters,
-            # and that must stay slower than cmux's 60s index TTL.
-            with self._lock:
-                published = self._published
-            if published and elapsed < self._interval_s:
+            # Two cadences, one timer, switched on RESUMABILITY and not on
+            # publish success. While the session has no transcript the pass is
+            # a single stat that never reaches the backend, so five seconds is
+            # cheap and makes a cold session's binding appear seconds after its
+            # first turn. Once it is resumable only the re-assert matters, and
+            # that must stay slower than cmux's 60s index TTL. Gating on
+            # success instead would pin a session whose backend is refusing to
+            # the fast cadence permanently, turning one unreachable socket into
+            # a subprocess every five seconds in every pane.
+            if self._resumable and elapsed < self._interval_s:
                 continue
             elapsed = 0.0
             # Deliberately silent: this runs for the life of a session, and a
@@ -284,26 +327,88 @@ class SessionBroadcast:
         default is to withdraw, because a session the user deliberately quit
         must not be replayed into their next shell.
 
+        NON-BLOCKING, and that is a hard requirement rather than an
+        optimisation. Both callers run on the Textual event loop — a ``/new``
+        or ``/resume`` swap (``_adopt_session``) and quit (``on_unmount``) —
+        so doing the retire here would park the whole TUI inside
+        ``subprocess.run(timeout=5.0)`` whenever the multiplexer socket is
+        unresponsive. That is precisely the post-crash window this feature
+        exists for, so the freeze would land exactly when it hurts most
+        (measured at 9.8s against a wedged backend). The retire therefore goes
+        to a short-lived worker and this method returns immediately.
+
+        Correctness does not depend on that worker running, let alone
+        finishing: ``_retired`` is latched HERE, synchronously, before this
+        returns, and ``_publish_once`` re-reads it as its first action. A
+        re-assert can never resurrect a binding the user quit out of, whether
+        or not the withdrawal itself succeeds. The withdrawal is best-effort
+        like every other call in this package; the latch is the guarantee.
+
         Idempotent, and safe to call from any thread — including from an exit
         path that runs while a re-assert is mid-flight.
         """
         self._stopped.set()
-        if retire:
-            with self._lock:
-                # Set BEFORE the call, so a re-assert that is already waiting
-                # on this lock sees the retirement and does not republish.
-                self._retired = True
-                try:
-                    self._backend.retire(self._binding, self._env)
-                except Exception:  # noqa: BLE001 — best-effort by contract
-                    logger.debug("multiplexer retire failed", exc_info=True)
-        thread = self._thread
+        # Cleared so `start()` could run again, but kept on `_timer_thread` so
+        # `join()` can still settle it in tests.
         self._thread = None
-        if thread is not None and thread is not threading.current_thread():
-            # Bounded: the timer wakes on the event immediately, and a publish
-            # in flight is capped by the backend's own subprocess timeout. The
-            # join is what stops a subprocess outliving the app's teardown.
-            thread.join(timeout=CALL_JOIN_TIMEOUT_S)
+        if retire:
+            # Latched before the worker is dispatched, so a re-assert already
+            # waiting on `_call_lock` sees the retirement and does not
+            # republish even if the retire call itself never lands.
+            self._retired.set()
+            self._dispatch_retire()
+        # Deliberately NOT joined. The timer is a daemon thread that cannot
+        # hold the process open, it wakes on `_stopped` immediately, and the
+        # `_retired` latch already prevents it from doing anything meaningful
+        # after this point. Joining here would reintroduce the event-loop
+        # stall the dispatch above exists to avoid — a publish in flight can
+        # sit in a subprocess timeout for seconds. Tests that need the thread
+        # settled call `join()` explicitly.
+
+    def _dispatch_retire(self) -> None:
+        """Run the backend retire off the caller's thread, at most once.
+
+        A dedicated short-lived thread rather than the timer thread: the timer
+        may be parked inside a publish subprocess for seconds, and the
+        withdrawal should not queue behind it. Daemon, for the same reason the
+        timer is — a wedged socket must not delay interpreter shutdown, and a
+        withdrawal that loses a race with process exit costs a stale marker,
+        which is the failure mode this package is explicitly allowed to have.
+        """
+        with self._dispatch_lock:
+            if self._retire_thread is not None:
+                return
+
+            def _retire() -> None:
+                # Takes `_call_lock` so the retire cannot interleave with a
+                # publish mid-flight; because this is a worker, waiting on
+                # that lock costs nothing the user can feel.
+                with self._call_lock:
+                    try:
+                        self._backend.retire(self._binding, self._env)
+                    except Exception:  # noqa: BLE001 — best-effort by contract
+                        logger.debug("multiplexer retire failed", exc_info=True)
+
+            worker = threading.Thread(
+                target=_retire,
+                name="lop-multiplexer-retire",
+                daemon=True,
+            )
+            self._retire_thread = worker
+            worker.start()
+
+    def join(self, timeout: float = CALL_JOIN_TIMEOUT_S) -> None:
+        """Wait for the timer and any retire worker to finish.
+
+        For TESTS and teardown diagnostics only. No production path calls this:
+        both real callers are on the event loop, where waiting on a multiplexer
+        socket is the exact bug :meth:`stop` is written to avoid.
+        """
+        with self._dispatch_lock:
+            retire_worker = self._retire_thread
+        for worker in (retire_worker, self._timer_thread):
+            if worker is not None and worker is not threading.current_thread():
+                worker.join(timeout=timeout)
 
 
 def broadcast_session(

--- a/local_operator/multiplexer/broadcast.py
+++ b/local_operator/multiplexer/broadcast.py
@@ -347,13 +347,25 @@ class SessionBroadcast:
         # in a `CALL_TIMEOUT_S` subprocess, and the successor must publish
         # eventually rather than hang behind a socket that never answers.
         #
-        # `join()` is safe to call on the predecessor from here: it joins the
-        # retire worker and the TIMER, and this thread is neither.
+        # `_drain_retire` and NOT `join`: `join` applies its timeout PER
+        # WORKER over the retire worker and the timer, so a `join(timeout=6)`
+        # here really bounded the successor's first publish at 12s — twice the
+        # number this comment and `SWAP_DRAIN_TIMEOUT_S` both name (measured
+        # 12.02s). Worse, it compounded down a swap chain: draining the
+        # predecessor's TIMER means waiting out that timer's own drain of ITS
+        # predecessor, so A→B→C paid B's drain of A as well. Only the
+        # withdrawal carries swap ordering — the predecessor's timer is
+        # `_stopped` and its `_publish_once` refuses under the `_retired`
+        # latch, so it can no longer touch the pane and joining it buys
+        # nothing. This is the same narrowing `_drain_retire` already
+        # documents for the exit path.
         predecessor = self._predecessor
         if predecessor is not None:
             self._predecessor = None
             try:
-                predecessor.join(timeout=SWAP_DRAIN_TIMEOUT_S)
+                predecessor._drain_retire(  # noqa: SLF001 - same package
+                    timeout=SWAP_DRAIN_TIMEOUT_S
+                )
             except Exception:  # noqa: BLE001 — a swap must never fail on this
                 logger.debug("predecessor withdrawal drain failed", exc_info=True)
         self._drained.set()
@@ -587,9 +599,22 @@ def _register_exit_drain() -> None:
     callers are coroutines), which is the ~9.8s freeze F1's fix removed.
     `atexit` handlers run on the main thread AFTER `on_unmount` has returned
     and the event loop is gone, so nothing user-facing is blocked by the
-    join: the process is already on its way out. `os._exit` (the Windows
-    re-exec path) and a hard crash skip `atexit` entirely, which is correct —
-    both are crash-shaped exits where a surviving binding is the feature.
+    join: the process is already on its way out.
+
+    EVERY exec-shaped exit skips `atexit`, not just the Windows one. A hard
+    crash does (no handlers run), `os._exit` does (it is the point of
+    `os._exit`), and so does the POSIX re-exec: `reexec.py` replaces the
+    process image with `os.execvpe`, and exec runs no `atexit` handler either.
+    Naming Windows alone here would mislead the next reader working out which
+    exits this drain actually covers.
+
+    That is harmless for both shapes, for different reasons. A crash is the
+    case where a surviving binding IS the feature. A re-exec has already
+    dispatched its withdrawal before the exec happens — `_request_relaunch`
+    exits through Textual, so `on_unmount` runs `_stop_multiplexer_broadcast`
+    → `retire_session`, and `cli.py` only calls `replace_self` after
+    `asyncio.run` has returned — and a relaunch wants the binding withdrawn
+    anyway, because the successor process republishes its own.
 
     The handler is registered once for the process rather than once per
     broadcast: several panes' worth of broadcasts live in one process only in

--- a/local_operator/multiplexer/cmux.py
+++ b/local_operator/multiplexer/cmux.py
@@ -1,0 +1,239 @@
+"""cmux: publish a TRUSTED auto-resume binding for this surface.
+
+WHY THE SOCKET RPC AND NOT ``cmux surface resume set``
+------------------------------------------------------
+There is an obvious-looking CLI for this — ``cmux surface resume set`` — and
+it CANNOT do what this module needs. That CLI hardcodes ``source = "cli"``,
+and cmux resolves a ``cli``-sourced binding to ``approvalPolicy = .manual``,
+``autoResume = false``. The binding it produces can only ever be replayed by
+hand, which is exactly the dead end this feature exists to remove: after a
+crash the user would still be reopening fifteen sessions manually.
+
+The socket RPC ``surface.resume.set`` accepts a ``source`` and gates
+auto-resume behind one value:
+
+    autoResume: source == "agent-hook" ? (bool(params,"auto_resume") ?? false) : false
+
+(cmux ``ControlCommandCoordinator+Surface3.swift``). So ``agent-hook`` is the
+only source that can reach ``approval_policy: auto`` — and it does so with no
+patch to cmux and no entry in cmux's built-in agent catalog, because
+``RestorableAgentKind`` has a ``case custom(String)`` and ``local-operator``
+collides with no built-in id. Measured on cmux 0.64.22: this call returns
+``approval_policy: "auto", auto_resume: true, source: "agent-hook"``.
+
+**Do not "simplify" this to the CLI.** It will look like it still works — a
+binding is still created and ``surface resume show`` still prints one — and
+auto-resume will be silently dead.
+
+THE STALE-BINDING RETIREMENT RULE (why publishing once is not enough)
+--------------------------------------------------------------------
+cmux prunes agent-hook bindings whose agent is not a KNOWN LIVE PROCESS:
+``Workspace.isStaleAgentHookBinding`` asks ``AgentResumeLiveness.hasLiveProcess``
+whether the binding's kind+sessionId matches a process in its scanner index,
+and ``retireAgentHookResumeBinding`` flips ``autoResume`` to false when it does
+not. The rule is there to stop a dead session replaying, and it applies to us
+because ``lop`` is not one of cmux's built-in agents.
+
+Two consequences, both load-bearing, both measured on this machine:
+
+1. **A vault registration is required** for the binding to survive at all.
+   Without one, a freshly published binding retires to ``manual`` within
+   ~10 seconds. With one, it holds indefinitely. The registration is the
+   user's to install (it lives in THEIR ``cmux.json``); see
+   ``docs/multiplexer-resume.md``. We publish regardless — an unretired
+   binding is strictly better than none, and the user may install the
+   registration later without restarting their sessions.
+
+2. **Publishing once is not enough, because that index is CACHED for 60s**
+   (``SharedLiveAgentIndex.cacheTTL``). A session that publishes at startup
+   can be judged against an index snapshot taken BEFORE this process existed,
+   in which case it is retired despite a correct registration. Retirement is
+   **one-way**: ``retireAgentHookResumeBinding`` latches ``autoResume = false``
+   and nothing in cmux ever sets it back, so a single missed window is
+   permanent for that binding — the failure would be invisible until the next
+   crash, which is the worst possible time to discover it. Hence
+   :data:`REASSERT_INTERVAL_S`, which re-publishes on a timer longer than that
+   TTL. Reproduced both ways: publishing against a stale index retired the
+   binding; re-asserting afterwards restored ``auto_resume: true``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import subprocess
+
+from local_operator.multiplexer.types import EnvMap, SessionBinding
+
+logger = logging.getLogger(__name__)
+
+#: cmux's own name for what kind of agent this is. Free to choose (a custom
+#: vault id is rejected only if it collides with a BUILT-IN kind), and it must
+#: match the ``id`` of the vault registration the user installs or cmux will
+#: look for liveness under a kind nothing is registered as.
+AGENT_KIND = "local-operator"
+
+#: The only ``source`` that reaches ``approval_policy: auto``. See the module
+#: docstring; this string is the whole reason this module uses the RPC.
+AGENT_HOOK_SOURCE = "agent-hook"
+
+#: Seconds between re-assertions of the binding. MUST stay above cmux's 60s
+#: ``SharedLiveAgentIndex.cacheTTL``: the point of re-asserting is to publish
+#: again against an index refreshed since this process started, so an interval
+#: shorter than the TTL would re-publish against the SAME stale snapshot and
+#: fix nothing while costing a subprocess every time. Comfortably above it
+#: rather than exactly at it, because the TTL is measured from cmux's last
+#: load and not from our clock.
+REASSERT_INTERVAL_S = 90.0
+
+#: How long any one cmux call may take before it is abandoned. The TUI never
+#: waits on these (they run on a worker thread), but a hung socket must not
+#: leak a process per interval either.
+CALL_TIMEOUT_S = 5.0
+
+#: cmux injects these per surface. BOTH are needed: the workspace names a
+#: workspace of many surfaces, and the surface is the pane actually holding
+#: this session, so targeting on workspace alone would rebind a sibling pane.
+SURFACE_ENV = "CMUX_SURFACE_ID"
+WORKSPACE_ENV = "CMUX_WORKSPACE_ID"
+
+#: cmux mints these as UUIDs. Validated before use because they are
+#: interpolated into a JSON payload handed to a socket that acts on them, and
+#: an inherited-but-stale value (a container, an ssh hop) should read as "no
+#: cmux here" rather than as a malformed request against a real surface.
+_UUID_RE = re.compile(r"\A[0-9a-fA-F]{8}(?:-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}\Z")
+
+
+def _surface_target(env: EnvMap) -> dict[str, str] | None:
+    """``{workspace_id, surface_id}`` for this pane, or None when not in cmux."""
+    workspace = (env.get(WORKSPACE_ENV) or "").strip()
+    surface = (env.get(SURFACE_ENV) or "").strip()
+    if not _UUID_RE.match(workspace) or not _UUID_RE.match(surface):
+        return None
+    return {"workspace_id": workspace, "surface_id": surface}
+
+
+class CmuxBackend:
+    """Publishes this surface's resume binding over the cmux control socket."""
+
+    name = "cmux"
+
+    def detect(self, env: EnvMap) -> bool:
+        """True when this process is a cmux surface AND a cmux CLI exists.
+
+        The BINARY is the gate and not the environment markers alone, which is
+        the rule ``tools.builtin._cmux_binary`` already encodes and the reason
+        this defers to it rather than testing ``CMUX_*`` here: every CMUX_*
+        variable is inherited by descendants that crossed into a container or
+        an ssh host where no cmux CLI exists, and publishing there would spawn
+        a subprocess per session that can only fail.
+        """
+        if _surface_target(env) is None:
+            return False
+        return _cmux_binary() is not None
+
+    def publish(self, binding: SessionBinding, env: EnvMap) -> bool:
+        """Set a trusted auto-resume binding for this surface.
+
+        ``checkpoint_id`` is the session id, which is what cmux hands back to
+        the vault registration's ``sessionIdSource`` and what its liveness
+        check matches on. ``launch_command`` carries the structured argv so
+        cmux restores the exact launcher rather than re-deriving one from the
+        shell string.
+        """
+        target = _surface_target(env)
+        binary = _cmux_binary()
+        if target is None or binary is None:
+            return False
+        params = {
+            **target,
+            "kind": AGENT_KIND,
+            "name": binding.name,
+            "source": AGENT_HOOK_SOURCE,
+            "checkpoint_id": binding.session_id,
+            "auto_resume": True,
+            # The shell form cmux falls back to. Restore-and-idle by
+            # construction: `binding.argv` is built by `broadcast` and can
+            # never carry a prompt or a continue flag.
+            "command": " ".join(binding.argv),
+            "cwd": binding.cwd,
+            "launch_command": {
+                "launcher": AGENT_KIND,
+                "executable_path": binding.executable,
+                "arguments": list(binding.argv),
+                "working_directory": binding.cwd,
+                "source": AGENT_HOOK_SOURCE,
+            },
+        }
+        return _rpc(binary, "surface.resume.set", params) is not None
+
+    def retire(self, binding: SessionBinding, env: EnvMap) -> bool:
+        """Clear this surface's binding on a clean exit.
+
+        ``checkpoint_id``/``source`` are sent as EXPECTATIONS, not just
+        identifiers: cmux compares them against the stored binding and clears
+        nothing if they disagree. That is what stops a quitting session from
+        wiping a binding some other agent published into this surface after
+        us — the clear is scoped to the binding we ourselves set.
+        """
+        target = _surface_target(env)
+        binary = _cmux_binary()
+        if target is None or binary is None:
+            return False
+        params = {
+            **target,
+            "checkpoint_id": binding.session_id,
+            "source": AGENT_HOOK_SOURCE,
+            # Tells cmux this is a session that ENDED rather than a binding
+            # being replaced, which is what makes the clear final instead of
+            # something its own reconciliation may put back.
+            "agent_session_ended": True,
+        }
+        return _rpc(binary, "surface.resume.clear", params) is not None
+
+
+def _cmux_binary() -> str | None:
+    """The cmux CLI path, resolved by the ONE function that owns that rule.
+
+    Imported lazily and from ``tools.builtin`` on purpose: that module already
+    documents why PATH is tried before ``CMUX_BUNDLED_CLI_PATH`` and why the
+    binary rather than the env markers is the gate, and a second copy of the
+    rule here would be a second thing to keep in sync. Lazy because
+    ``tools.builtin`` is a large module that the startup path must not import
+    for a detection test.
+    """
+    from local_operator.tools.builtin import _cmux_binary as resolve
+
+    return resolve()
+
+
+def _rpc(binary: str, method: str, params: dict[str, object]) -> dict[str, object] | None:
+    """One cmux RPC call. Returns the parsed result, or None on ANY failure.
+
+    Never raises, by contract: every caller is on a best-effort path where the
+    only correct response to a failure is to carry on (see the package
+    docstring). A missing binary, a socket mid-restart, a surface that has
+    since closed, malformed JSON and a timeout are all the same answer here —
+    "not published" — and are logged at debug because a user running no cmux
+    must not see a warning per session.
+    """
+    try:
+        completed = subprocess.run(  # noqa: S603 — fixed argv, no shell
+            [binary, "rpc", method, json.dumps(params)],
+            capture_output=True,
+            text=True,
+            timeout=CALL_TIMEOUT_S,
+        )
+    except (OSError, subprocess.SubprocessError):
+        logger.debug("cmux %s failed to spawn", method, exc_info=True)
+        return None
+    if completed.returncode != 0:
+        logger.debug("cmux %s exited %s: %s", method, completed.returncode, completed.stderr[:200])
+        return None
+    try:
+        parsed = json.loads(completed.stdout)
+    except ValueError:
+        logger.debug("cmux %s returned non-JSON", method)
+        return None
+    return parsed if isinstance(parsed, dict) else None

--- a/local_operator/multiplexer/cmux.py
+++ b/local_operator/multiplexer/cmux.py
@@ -62,6 +62,7 @@ from __future__ import annotations
 import json
 import logging
 import re
+import shlex
 import subprocess
 
 from local_operator.multiplexer.types import EnvMap, SessionBinding
@@ -156,7 +157,12 @@ class CmuxBackend:
             # The shell form cmux falls back to. Restore-and-idle by
             # construction: `binding.argv` is built by `broadcast` and can
             # never carry a prompt or a continue flag.
-            "command": " ".join(binding.argv),
+            #
+            # shlex.join and not " ".join, matching the marker backends: cmux
+            # re-tokenises this string, so a launcher path containing a space
+            # (`/Applications/My Tools/lop`) would otherwise come back as two
+            # arguments and restore nothing.
+            "command": shlex.join(binding.argv),
             "cwd": binding.cwd,
             "launch_command": {
                 "launcher": AGENT_KIND,

--- a/local_operator/multiplexer/markers.py
+++ b/local_operator/multiplexer/markers.py
@@ -1,0 +1,292 @@
+"""tmux / zellij / screen / wezterm: publish a discoverable per-pane marker.
+
+WHY THESE ARE ONE MODULE AND NOT FOUR
+-------------------------------------
+None of these multiplexers has a resume-binding API — there is nothing to hand
+a command to and nothing that will re-run it after a crash. What they DO have
+in common is a stable per-pane identity, so all four publish the same fact in
+the same shape and differ only in where it is written. Splitting that into
+four near-identical modules would hide how small the actual difference is.
+
+THE CONTRACT (this is the public part — restore is scripted against it)
+----------------------------------------------------------------------
+Two facts are published per pane, under these exact names:
+
+    @lop_session          the 12-hex session id, i.e. what --resume takes
+    @lop_resume_command   the full restore-and-idle argv, shell-quoted
+
+tmux and wezterm store them as native pane options, so they are readable with
+the multiplexer's own tooling and vanish with the pane:
+
+    tmux show-options -pv @lop_session
+    tmux show-options -pv @lop_resume_command
+
+zellij and screen have no per-pane key/value store, so the same two facts go
+in a JSON state file, one per pane, under::
+
+    ~/.local-operator/multiplexer/<backend>-<pane-id>.json
+    {"session_id": "...", "command": [...], "cwd": "...", "updated_at": 1.0}
+
+A restore script's job is the same in both cases: for each pane, read
+``@lop_session`` (or the file), and if it names a session directory that still
+exists, launch ``@lop_resume_command`` in that pane. Nothing here runs that
+script — these multiplexers cannot, which is precisely the difference from
+cmux — so the marker is written for a human, a shell function, or the user's
+own session-restore tool to consume.
+
+The state files are deliberately NOT cleaned up by age: a pane id is reused,
+so a stale file is overwritten by the next session in that pane, and a file
+whose pane is gone is harmless (a restore script keys off panes that exist,
+not off files it finds). A clean exit removes its own file; a crash leaves it,
+which is the entire point.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import shlex
+import subprocess
+import time
+from pathlib import Path
+
+from local_operator.multiplexer.types import EnvMap, SessionBinding
+
+logger = logging.getLogger(__name__)
+
+#: The two option names, spelled once. tmux requires the ``@`` prefix for
+#: user options; the same names are reused for the file-backed backends so the
+#: contract reads identically whichever multiplexer a user is on.
+SESSION_OPTION = "@lop_session"
+COMMAND_OPTION = "@lop_resume_command"
+
+#: Same short leash as the cmux backend: these are fire-and-forget subprocesses
+#: on a worker thread, and a wedged multiplexer socket must not accumulate one
+#: stuck process per session.
+CALL_TIMEOUT_S = 5.0
+
+#: Pane identifiers are interpolated into a FILENAME, so they are restricted to
+#: characters that cannot escape the directory. A pane id that fails this is
+#: treated as "no identity" (nothing is published) rather than sanitised into
+#: a different pane's file — writing the right data about the wrong pane is
+#: worse than writing nothing.
+_SAFE_PANE_ID = re.compile(r"\A[A-Za-z0-9._-]{1,128}\Z")
+
+
+def marker_dir() -> Path:
+    """Where the file-backed markers live.
+
+    Under the config dir rather than a temp directory: these must survive the
+    reboot that follows a crash, and ``/tmp`` is exactly what does not.
+    """
+    from local_operator.paths import config_dir
+
+    return config_dir() / "multiplexer"
+
+
+def _run(argv: list[str]) -> bool:
+    """Run a multiplexer command. True on success, never raises.
+
+    Same best-effort contract as everything else here: the multiplexer may
+    have exited between detection and this call, and a user quitting tmux is
+    not an error this app reports.
+    """
+    try:
+        completed = subprocess.run(  # noqa: S603 — fixed argv, no shell
+            argv,
+            capture_output=True,
+            text=True,
+            timeout=CALL_TIMEOUT_S,
+        )
+    except (OSError, subprocess.SubprocessError):
+        logger.debug("multiplexer command failed to spawn: %s", argv[0], exc_info=True)
+        return False
+    if completed.returncode != 0:
+        logger.debug("%s exited %s: %s", argv[0], completed.returncode, completed.stderr[:200])
+        return False
+    return True
+
+
+def _which(binary: str) -> str | None:
+    """Resolve a multiplexer binary, or None.
+
+    The binary is the gate for the same reason it is in the cmux backend: the
+    ``TMUX``/``ZELLIJ`` variables are inherited by descendants that may have
+    crossed into a container where the binary does not exist.
+    """
+    import shutil
+
+    return shutil.which(binary)
+
+
+class _OptionBackend:
+    """Shared body for multiplexers with a native per-pane option store."""
+
+    #: Subclass fills these in. ``binary`` is what must exist on PATH;
+    #: ``pane_env`` is the variable naming this pane.
+    name = ""
+    binary = ""
+    pane_env = ""
+
+    def detect(self, env: EnvMap) -> bool:
+        if not (env.get(self.pane_env) or "").strip():
+            return False
+        return _which(self.binary) is not None
+
+    def _set_option(self, pane: str, option: str, value: str) -> bool:
+        raise NotImplementedError
+
+    def _unset_option(self, pane: str, option: str) -> bool:
+        raise NotImplementedError
+
+    def publish(self, binding: SessionBinding, env: EnvMap) -> bool:
+        pane = (env.get(self.pane_env) or "").strip()
+        if not pane or _which(self.binary) is None:
+            return False
+        # shlex.join, not " ".join: the command is stored as a STRING that a
+        # restore script will hand to a shell, and a cwd or launcher path
+        # containing a space would otherwise restore as two arguments.
+        command = shlex.join(binding.argv)
+        wrote_session = self._set_option(pane, SESSION_OPTION, binding.session_id)
+        wrote_command = self._set_option(pane, COMMAND_OPTION, command)
+        return wrote_session and wrote_command
+
+    def retire(self, binding: SessionBinding, env: EnvMap) -> bool:
+        pane = (env.get(self.pane_env) or "").strip()
+        if not pane or _which(self.binary) is None:
+            return False
+        # Both are unset even if the first fails: a pane left advertising a
+        # session id with no command (or vice versa) is a half-marker a
+        # restore script has to special-case.
+        cleared_session = self._unset_option(pane, SESSION_OPTION)
+        cleared_command = self._unset_option(pane, COMMAND_OPTION)
+        return cleared_session and cleared_command
+
+
+class TmuxBackend(_OptionBackend):
+    """tmux, via ``set-option -p`` (pane-scoped user options)."""
+
+    name = "tmux"
+    binary = "tmux"
+    #: ``TMUX_PANE`` and not ``TMUX``: ``TMUX`` proves a server connection but
+    #: names no pane, and the option must be set on the pane holding THIS
+    #: session or a second session in the same window would overwrite it.
+    pane_env = "TMUX_PANE"
+
+    def detect(self, env: EnvMap) -> bool:
+        # Both markers: TMUX is what proves a live server (TMUX_PANE alone
+        # survives into a process that left tmux behind).
+        if not (env.get("TMUX") or "").strip():
+            return False
+        return super().detect(env)
+
+    def _set_option(self, pane: str, option: str, value: str) -> bool:
+        return _run([self.binary, "set-option", "-p", "-t", pane, option, value])
+
+    def _unset_option(self, pane: str, option: str) -> bool:
+        # ``-u`` unsets. Without it the option would be set to the empty
+        # string, which a restore script reads as "a session with a blank id"
+        # rather than as absence.
+        return _run([self.binary, "set-option", "-p", "-t", pane, "-u", option])
+
+
+class WezTermBackend(_OptionBackend):
+    """wezterm, via ``cli set-user-var`` (per-pane user variables)."""
+
+    name = "wezterm"
+    binary = "wezterm"
+    pane_env = "WEZTERM_PANE"
+
+    def _set_option(self, pane: str, option: str, value: str) -> bool:
+        return _run([self.binary, "cli", "set-user-var", "--pane-id", pane, option, value])
+
+    def _unset_option(self, pane: str, option: str) -> bool:
+        # wezterm has no unset; an empty value is how a user var is cleared.
+        # Documented here because it is the one place the marker contract is
+        # weaker than tmux's: readers must treat "" as absent.
+        return _run([self.binary, "cli", "set-user-var", "--pane-id", pane, option, ""])
+
+
+class _FileBackend:
+    """Shared body for multiplexers with no per-pane key/value store.
+
+    zellij and screen can both identify the pane/window a process is in, and
+    neither offers anywhere to hang a value off it, so the marker goes in a
+    file named for that identity.
+    """
+
+    name = ""
+    #: Environment variables that identify this pane, in preference order.
+    pane_envs: tuple[str, ...] = ()
+
+    def _pane_id(self, env: EnvMap) -> str | None:
+        for variable in self.pane_envs:
+            value = (env.get(variable) or "").strip()
+            if value and _SAFE_PANE_ID.match(value):
+                return value
+        return None
+
+    def detect(self, env: EnvMap) -> bool:
+        return self._pane_id(env) is not None
+
+    def _path(self, pane: str) -> Path:
+        return marker_dir() / f"{self.name}-{pane}.json"
+
+    def publish(self, binding: SessionBinding, env: EnvMap) -> bool:
+        pane = self._pane_id(env)
+        if pane is None:
+            return False
+        payload = {
+            "backend": self.name,
+            "pane": pane,
+            "session_id": binding.session_id,
+            "command": list(binding.argv),
+            "cwd": binding.cwd,
+            "updated_at": time.time(),
+        }
+        try:
+            directory = marker_dir()
+            directory.mkdir(parents=True, exist_ok=True)
+            # Written via a temp file and renamed: a restore script may read
+            # this at any moment (including while a second session is starting
+            # in a neighbouring pane), and a half-written JSON file would read
+            # as a corrupt marker rather than as an older valid one.
+            temporary = self._path(pane).with_suffix(".json.tmp")
+            temporary.write_text(json.dumps(payload), encoding="utf-8")
+            os.replace(temporary, self._path(pane))
+        except OSError:
+            logger.debug("%s marker write failed", self.name, exc_info=True)
+            return False
+        return True
+
+    def retire(self, binding: SessionBinding, env: EnvMap) -> bool:
+        pane = self._pane_id(env)
+        if pane is None:
+            return False
+        try:
+            self._path(pane).unlink(missing_ok=True)
+        except OSError:
+            logger.debug("%s marker removal failed", self.name, exc_info=True)
+            return False
+        return True
+
+
+class ZellijBackend(_FileBackend):
+    """zellij. ``ZELLIJ_SESSION_NAME`` identifies the session it belongs to."""
+
+    name = "zellij"
+    #: Session name first: it is stable and human-meaningful, where ``ZELLIJ``
+    #: is only a "you are inside zellij" flag.
+    pane_envs = ("ZELLIJ_SESSION_NAME", "ZELLIJ")
+
+
+class ScreenBackend(_FileBackend):
+    """GNU screen. ``STY`` names the session (``<pid>.<tty>.<host>``)."""
+
+    name = "screen"
+    #: ``WINDOW`` is screen's per-window index; combined with STY it would be
+    #: a finer identity, but STY alone is what every screen session exports
+    #: and the pane granularity users actually run one agent per.
+    pane_envs = ("STY",)

--- a/local_operator/multiplexer/markers.py
+++ b/local_operator/multiplexer/markers.py
@@ -116,6 +116,32 @@ def _run(argv: list[str]) -> bool:
     return True
 
 
+def _capture(argv: list[str]) -> str | None:
+    """Run a multiplexer command and return its stdout, or None on failure.
+
+    The readback half of a scoped retire: unlike :func:`_run` the ANSWER is
+    the payload, so a non-zero exit or a spawn failure is "unreadable"
+    (None) rather than False, and every caller treats None as "do not clear".
+    Never raises, by the same best-effort contract as `_run`.
+    """
+    try:
+        completed = subprocess.run(  # noqa: S603 — fixed argv, no shell
+            argv,
+            capture_output=True,
+            text=True,
+            timeout=CALL_TIMEOUT_S,
+        )
+    except (OSError, subprocess.SubprocessError):
+        logger.debug("multiplexer readback failed to spawn: %s", argv[0], exc_info=True)
+        return None
+    if completed.returncode != 0:
+        logger.debug(
+            "%s readback exited %s: %s", argv[0], completed.returncode, completed.stderr[:200]
+        )
+        return None
+    return completed.stdout
+
+
 def _which(binary: str) -> str | None:
     """Resolve a multiplexer binary, or None.
 
@@ -129,13 +155,30 @@ def _which(binary: str) -> str | None:
 
 
 class _OptionBackend:
-    """Shared body for multiplexers with a native per-pane option store."""
+    """Shared body for multiplexers with a native per-pane option store.
+
+    Retire here is SCOPED to the binding this backend itself published, where
+    the multiplexer offers a way to read a pane option back. An unscoped clear
+    would race a ``/new``/``/resume`` swap: the outgoing binding's withdrawal
+    and the incoming binding's publish both name the same pane, and whichever
+    lands second wins — an unscoped clear landing second deletes the fresh
+    binding and the pane advertises nothing, which is the failure this
+    package exists to prevent. :class:`WezTermBackend` cannot scope (see its
+    class comment) and relies on the swap sequencing in ``SessionBroadcast``
+    instead.
+    """
 
     #: Subclass fills these in. ``binary`` is what must exist on PATH;
     #: ``pane_env`` is the variable naming this pane.
     name = ""
     binary = ""
     pane_env = ""
+
+    #: Whether :meth:`retire` can read the stored session id back and clear
+    #: only its own binding. False on multiplexers whose option store is
+    #: write-only; those keep the unconditional clear and are protected by
+    #: the swap sequencing instead.
+    scoped_retire = False
 
     def detect(self, env: EnvMap) -> bool:
         if not (env.get(self.pane_env) or "").strip():
@@ -147,6 +190,14 @@ class _OptionBackend:
 
     def _unset_option(self, pane: str, option: str) -> bool:
         raise NotImplementedError
+
+    def _read_option(self, pane: str, option: str) -> str | None:
+        """The value currently stored on ``pane``, or None when unreadable.
+
+        Only implemented where the multiplexer can answer; the default keeps
+        ``scoped_retire`` False everywhere it is not overridden.
+        """
+        return None
 
     def publish(self, binding: SessionBinding, env: EnvMap) -> bool:
         pane = (env.get(self.pane_env) or "").strip()
@@ -164,6 +215,15 @@ class _OptionBackend:
         pane = (env.get(self.pane_env) or "").strip()
         if not pane or _which(self.binary) is None:
             return False
+        if self.scoped_retire:
+            # Read back BEFORE clearing: the pane may already have been
+            # re-bound by a /new or /resume swap, and clearing a session id we
+            # did not publish is how a pane ends up advertising nothing. A
+            # mismatch means the successor's publish already won the pane and
+            # the right action is to withdraw nothing.
+            stored = self._read_option(pane, SESSION_OPTION)
+            if stored != binding.session_id:
+                return False
         # Both are unset even if the first fails: a pane left advertising a
         # session id with no command (or vice versa) is a half-marker a
         # restore script has to special-case.
@@ -181,6 +241,9 @@ class TmuxBackend(_OptionBackend):
     #: names no pane, and the option must be set on the pane holding THIS
     #: session or a second session in the same window would overwrite it.
     pane_env = "TMUX_PANE"
+    #: tmux pane options can be read back, so a retire can be scoped to the
+    #: binding this backend itself published.
+    scoped_retire = True
 
     def detect(self, env: EnvMap) -> bool:
         # Both markers: TMUX is what proves a live server (TMUX_PANE alone
@@ -198,9 +261,42 @@ class TmuxBackend(_OptionBackend):
         # rather than as absence.
         return _run([self.binary, "set-option", "-p", "-t", pane, "-u", option])
 
+    def _read_option(self, pane: str, option: str) -> str | None:
+        # ``display-message`` and not ``show-option``: an ABSENT user option
+        # makes ``show-option`` exit non-zero, which reads as "unreadable",
+        # while ``display-message -p`` renders an unset option as the empty
+        # string with exit 0 — the one spelling that distinguishes "the pane
+        # holds some other session" from "tmux would not answer".
+        #
+        # ``option[1:]`` drops the ``@``: a tmux format reference is
+        # ``#{@name}`` and the option constant already carries the ``@``.
+        completed = _capture(
+            [self.binary, "display-message", "-p", "-t", pane, "#{@" + option[1:] + "}"]
+        )
+        if completed is None:
+            return None
+        value = completed.strip()
+        # An unset option renders as the empty string; reporting it as "" (a
+        # real value) would compare unequal against every session id and skip
+        # the clear, so absence is normalised to None.
+        return value or None
+
 
 class WezTermBackend(_OptionBackend):
-    """wezterm, via ``cli set-user-var`` (per-pane user variables)."""
+    """wezterm, via ``cli set-user-var`` (per-pane user variables).
+
+    ``scoped_retire`` stays False here, and that is a constraint of the
+    multiplexer rather than a choice: wezterm user vars are write-only from a
+    pane process — there is no ``cli`` readback, only Lua's
+    ``pane:get_user_vars()`` inside the wezterm config — so a retire cannot
+    compare the stored session id against its own. The unconditional clear
+    is therefore correct ONLY because the swap is sequenced elsewhere: the
+    successor broadcast waits for this withdrawal before it publishes (see
+    ``SessionBroadcast``), which keeps a late wezterm clear from deleting the
+    fresh binding. The clear is also self-limiting in the crash case it
+    exists for: a quit-with-no-successor leaves the pane holding nothing but
+    this binding, so there is nothing else to delete.
+    """
 
     name = "wezterm"
     binary = "wezterm"
@@ -223,6 +319,17 @@ class _FileBackend:
     neither offers anywhere to hang a value off it, so the marker goes in a
     file named for that identity.
     """
+
+    #: Read back by :meth:`retire` to decide whether the file on disk is still
+    #: OURS. A retire must never remove a binding some other session published
+    #: into this pane after us — on a ``/new`` or ``/resume`` swap the
+    #: withdrawal of the outgoing binding races the publish of the incoming
+    #: one, both name the same pane, and an unscoped unlink deletes the NEW
+    #: session's marker (see ``SessionBroadcast`` for the sequencing and this
+    #: scoping's role in it). cmux gets the same guarantee from its server by
+    #: sending ``checkpoint_id`` as an expectation; the file backends have no
+    #: server, so the comparison happens here on the payload we wrote.
+    _MARKER_FIELDS = ("backend", "pane", "session_id")
 
     name = ""
     #: Environment variables that identify this pane, in preference order.
@@ -282,12 +389,49 @@ class _FileBackend:
         pane = self._pane_id(env)
         if pane is None:
             return False
+        path = self._path(pane)
+        # Scoped to the binding WE published. The swap races mean this file
+        # may already name the successor session, and unlinking it would leave
+        # the pane advertising nothing after every /new — the exact failure
+        # this feature exists to prevent. Removing nothing when the file is
+        # not ours is the correct outcome, not a degraded one: the marker that
+        # IS there belongs to a live session.
+        #
+        # Unreadable-but-present is treated as not-ours rather than removed:
+        # a corrupt or foreign marker is not evidence this binding owns the
+        # pane, and deleting state we cannot identify is the same mistake the
+        # scoping exists to prevent.
+        if not self._marker_is_ours(path, pane, binding):
+            return False
         try:
-            self._path(pane).unlink(missing_ok=True)
+            path.unlink(missing_ok=True)
         except OSError:
             logger.debug("%s marker removal failed", self.name, exc_info=True)
             return False
         return True
+
+    def _marker_is_ours(self, path: Path, pane: str, binding: SessionBinding) -> bool:
+        """Whether the marker on disk still describes ``binding``.
+
+        Best-effort and total: every failure to answer reads as "not ours",
+        because the only decision this feeds is whether to DELETE, and a
+        no-op retire leaves a stale marker (the package's allowed failure)
+        where an unscoped one deletes a live binding.
+        """
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            return False
+        if not isinstance(payload, dict):
+            return False
+        return all(
+            payload.get(field) == value
+            for field, value in (
+                ("backend", self.name),
+                ("pane", pane),
+                ("session_id", binding.session_id),
+            )
+        )
 
 
 class ZellijBackend(_FileBackend):

--- a/local_operator/multiplexer/markers.py
+++ b/local_operator/multiplexer/markers.py
@@ -27,6 +27,13 @@ in a JSON state file, one per pane, under::
     ~/.local-operator/multiplexer/<backend>-<pane-id>.json
     {"session_id": "...", "command": [...], "cwd": "...", "updated_at": 1.0}
 
+``<pane-id>`` is whatever identifies a pane on that multiplexer, which is not
+always one variable: zellij's is ``<session-name>-<pane-id>`` because its pane
+ids are only unique within a session. screen's is ``<sty>-<window>`` when
+``WINDOW`` is exported and falls back to ``<sty>`` when it is not — the one
+case where a marker is per SESSION rather than per window, and a second ``lop``
+in that session overwrites it.
+
 A restore script's job is the same in both cases: for each pane, read
 ``@lop_session`` (or the file), and if it names a session directory that still
 exists, launch ``@lop_resume_command`` in that pane. Nothing here runs that
@@ -219,13 +226,23 @@ class _FileBackend:
 
     name = ""
     #: Environment variables that identify this pane, in preference order.
-    pane_envs: tuple[str, ...] = ()
+    #: Each entry is a tuple of variables that are joined with ``-`` to form
+    #: one identity, so a multiplexer whose pane is only identified by
+    #: (session, pane) can name both. ALL variables in a tuple must be present
+    #: and safe for that candidate to be used; the next candidate is then
+    #: tried, which is what lets a backend degrade to a coarser identity on a
+    #: host that does not export the finer one.
+    pane_envs: tuple[tuple[str, ...], ...] = ()
 
     def _pane_id(self, env: EnvMap) -> str | None:
-        for variable in self.pane_envs:
-            value = (env.get(variable) or "").strip()
-            if value and _SAFE_PANE_ID.match(value):
-                return value
+        for variables in self.pane_envs:
+            parts = [(env.get(variable) or "").strip() for variable in variables]
+            # Every component is validated separately rather than validating
+            # the joined string: the join character is legal inside a
+            # component, so checking only the result would let a component
+            # containing a separator forge a different pane's filename.
+            if all(part and _SAFE_PANE_ID.match(part) for part in parts):
+                return "-".join(parts)
         return None
 
     def detect(self, env: EnvMap) -> bool:
@@ -274,19 +291,43 @@ class _FileBackend:
 
 
 class ZellijBackend(_FileBackend):
-    """zellij. ``ZELLIJ_SESSION_NAME`` identifies the session it belongs to."""
+    """zellij, keyed by session name AND pane id.
+
+    Both halves are required for correctness, not for readability.
+    ``ZELLIJ_SESSION_NAME`` names a SESSION, and a session holds many panes, so
+    keying on it alone gave every ``lop`` pane in one zellij session the same
+    marker file: the last publisher won, and one pane's clean exit deleted its
+    siblings' markers, so a restore reopened the wrong conversation or none at
+    all. Verified on zellij 0.42.2: two panes of one session export
+    ``ZELLIJ_SESSION_NAME=<same>`` with ``ZELLIJ_PANE_ID=0`` and ``=1``.
+
+    The session name stays in the key because a pane id is only unique WITHIN
+    a session — pane 0 exists in every one of them.
+    """
 
     name = "zellij"
-    #: Session name first: it is stable and human-meaningful, where ``ZELLIJ``
-    #: is only a "you are inside zellij" flag.
-    pane_envs = ("ZELLIJ_SESSION_NAME", "ZELLIJ")
+    #: (session, pane) is the only identity that satisfies the one-file-per-pane
+    #: contract at the top of this module. No coarser fallback is offered: a
+    #: zellij that exports the session name but not the pane id would collide
+    #: silently, and publishing nothing is the better failure.
+    pane_envs = (("ZELLIJ_SESSION_NAME", "ZELLIJ_PANE_ID"),)
 
 
 class ScreenBackend(_FileBackend):
-    """GNU screen. ``STY`` names the session (``<pid>.<tty>.<host>``)."""
+    """GNU screen, keyed by session (``STY``) and window index (``WINDOW``).
+
+    Same collision as zellij's and fixed the same way: ``STY`` names the
+    session, so several ``lop`` windows in one screen session shared a marker
+    file. Verified on screen 4.00.03: a process inside a session exports both
+    ``STY=<pid>.<tty>`` and ``WINDOW=0``.
+
+    ``STY`` alone is kept as a fallback — unlike zellij's pane id, ``WINDOW``
+    is set by the shell's startup rather than by screen in every configuration,
+    and a per-session marker still restores correctly for the one-window-per-
+    session case that is how screen is usually run. When it is used, the marker
+    is per session and a second ``lop`` in that session overwrites it; the
+    module contract above and the docs table say so.
+    """
 
     name = "screen"
-    #: ``WINDOW`` is screen's per-window index; combined with STY it would be
-    #: a finer identity, but STY alone is what every screen session exports
-    #: and the pane granularity users actually run one agent per.
-    pane_envs = ("STY",)
+    pane_envs = (("STY", "WINDOW"), ("STY",))

--- a/local_operator/multiplexer/registry.py
+++ b/local_operator/multiplexer/registry.py
@@ -1,0 +1,60 @@
+"""Which backend, if any, hosts this process.
+
+The registry is the reason "support another multiplexer" is a new module and
+not an edit to a chain of ifs: a backend is appended to :data:`_BACKENDS` and
+everything else — broadcast, retire, the TUI wiring, the tests — is unchanged.
+"""
+
+from __future__ import annotations
+
+from local_operator.multiplexer.cmux import CmuxBackend
+from local_operator.multiplexer.markers import (
+    ScreenBackend,
+    TmuxBackend,
+    WezTermBackend,
+    ZellijBackend,
+)
+from local_operator.multiplexer.types import EnvMap, MultiplexerBackend, env_or_process
+
+#: Every known backend, in DETECTION ORDER, which is deliberate rather than
+#: alphabetical. Multiplexers nest: a tmux session is routinely run inside a
+#: cmux surface, and both sets of environment variables are then present. The
+#: outermost host is the one that survives a crash and restores panes, so it
+#: is the one worth publishing to, and cmux is therefore asked first. Within
+#: the marker backends the order does not matter — their variables do not
+#: co-occur in practice — but they keep a stable order so a host that somehow
+#: has two always resolves the same way.
+_BACKENDS: tuple[MultiplexerBackend, ...] = (
+    CmuxBackend(),
+    TmuxBackend(),
+    ZellijBackend(),
+    WezTermBackend(),
+    ScreenBackend(),
+)
+
+
+def backends() -> tuple[MultiplexerBackend, ...]:
+    """Every registered backend. Exposed for tests and for documentation."""
+    return _BACKENDS
+
+
+def active_backend(env: EnvMap | None = None) -> MultiplexerBackend | None:
+    """The backend hosting this process, or None when there is no multiplexer.
+
+    None is the ORDINARY case, not an error: most sessions run in a plain
+    terminal, and everything downstream treats a missing backend as "nothing
+    to publish" rather than as a failure to report.
+
+    A backend whose ``detect`` raises is skipped rather than allowed to
+    propagate. Detection is the very first thing that runs on a startup path
+    that must never break, and a backend author's bug should cost that
+    backend's feature, not the user's session.
+    """
+    source = env_or_process(env)
+    for backend in _BACKENDS:
+        try:
+            if backend.detect(source):
+                return backend
+        except Exception:  # noqa: BLE001 — see docstring: never break startup
+            continue
+    return None

--- a/local_operator/multiplexer/types.py
+++ b/local_operator/multiplexer/types.py
@@ -1,0 +1,111 @@
+"""The one interface every multiplexer backend implements, and what it carries.
+
+Deliberately stdlib-only and free of any backend import: the registry decides
+which backend is live, and a backend that needed this module to know about it
+would make "add a multiplexer" a two-file edit (see the package docstring).
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Mapping, Protocol, runtime_checkable
+
+#: The environment a backend reads to decide whether it is the host. Passed in
+#: rather than read from ``os.environ`` inside each backend so detection is
+#: testable without mutating process state — a test that has to
+#: ``monkeypatch.setenv`` five variables to exercise one branch tends not to
+#: exercise the other four.
+EnvMap = Mapping[str, str]
+
+
+@dataclass(frozen=True)
+class SessionBinding:
+    """What a pane needs to reopen this conversation later.
+
+    Frozen because it is a description of a fact, not a builder: every field
+    is decided once at broadcast time, and a backend that could mutate it
+    could publish something the safety rules above never sanctioned.
+
+    ``argv`` is the FULL launch line and is always a restore-and-idle command
+    (see the package docstring). ``executable`` is spelled separately because
+    the structured launch command cmux stores wants the launcher path on its
+    own, and re-deriving it by slicing ``argv[0]`` in the backend would put
+    that decision in three places.
+    """
+
+    #: The 12-hex session directory name under ``sessions/``. This is what
+    #: ``--resume`` takes and what identifies the conversation on disk.
+    session_id: str
+
+    #: Absolute path to the real launcher (``~/.local/bin/lop``), never the
+    #: python interpreter running it. See :func:`.broadcast.resume_executable`
+    #: for why that distinction is load-bearing.
+    executable: str
+
+    #: The restore-and-idle argv, ``[executable, "--resume", session_id]``.
+    argv: tuple[str, ...]
+
+    #: Working directory to restore into. The user's cwd is part of what a
+    #: pane was doing; a restore into ``$HOME`` would reopen the conversation
+    #: pointing at the wrong project.
+    cwd: str
+
+    #: Human-facing label for multiplexer UI that shows one (cmux's restore
+    #: prompt). Never model-generated text — see the sanitising note in
+    #: ``broadcast``: this string can reach a shell-adjacent surface.
+    name: str = "local-operator"
+
+
+@runtime_checkable
+class MultiplexerBackend(Protocol):
+    """A multiplexer this app can publish a resume binding to.
+
+    Three methods and no state. Backends are stateless by design: the pane
+    identity they need comes from the environment, which cannot change under a
+    running process, so an instance would only be a place for a stale copy of
+    it to live.
+    """
+
+    #: Stable identifier, used in log lines and in the marker files. Matches
+    #: the multiplexer's own name (``cmux``, ``tmux``, ...).
+    name: str
+
+    def detect(self, env: EnvMap) -> bool:
+        """Whether THIS process is running inside this multiplexer.
+
+        Must be cheap and must never raise. A backend that shells out to
+        answer this would put a subprocess on the startup path of every
+        session on every host, including the ones running no multiplexer at
+        all.
+        """
+        ...
+
+    def publish(self, binding: SessionBinding, env: EnvMap) -> bool:
+        """Record ``binding`` against this pane. True when it was published.
+
+        Best-effort: returns False rather than raising on any failure, so the
+        caller's only job is to log. See the package docstring — this must
+        never be able to stop a session from starting.
+        """
+        ...
+
+    def retire(self, binding: SessionBinding, env: EnvMap) -> bool:
+        """Drop this pane's binding, so a NEW shell here does not replay it.
+
+        Called on a clean exit. The asymmetry with :meth:`publish` is the
+        point: a crash leaves the binding in place (that is the whole
+        feature), while a user who quit deliberately has ended the session and
+        must not have it reopened behind them.
+        """
+        ...
+
+
+def env_or_process(env: EnvMap | None) -> EnvMap:
+    """``env`` when given, else the live process environment.
+
+    One helper rather than ``env if env is not None else os.environ`` written
+    at every entry point, because the fallback is what production uses and a
+    call site that forgot it would silently detect nothing.
+    """
+    return os.environ if env is None else env

--- a/local_operator/multiplexer/types.py
+++ b/local_operator/multiplexer/types.py
@@ -52,8 +52,9 @@ class SessionBinding:
     cwd: str
 
     #: Human-facing label for multiplexer UI that shows one (cmux's restore
-    #: prompt). Never model-generated text — see the sanitising note in
-    #: ``broadcast``: this string can reach a shell-adjacent surface.
+    #: prompt). Never model-generated text — see the pane-id sanitising note on
+    #: ``_SAFE_PANE_ID`` in ``markers``: this string can reach a
+    #: shell-adjacent surface.
     name: str = "local-operator"
 
 

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -217,6 +217,7 @@ from local_operator.tui.widgets.welcome import (
 )
 
 if TYPE_CHECKING:  # keeps the provider graph off the TUI's runtime import path
+    from local_operator.multiplexer import SessionBroadcast
     from local_operator.providers.controller import CatalogueEntry
     from local_operator.providers.oauth.callback_server import LoginCallbacks
 
@@ -1262,6 +1263,14 @@ class OperatorApp(App[None]):
         #: which owns the terminal, and lent to the band, which owns the state
         #: it displays — see :meth:`_start_terminal_title`.
         self._terminal_title: TerminalTitle | None = None
+        #: Publishes "this pane holds session <id>" to the host multiplexer, so
+        #: a crash that takes the multiplexer down can bring the conversation
+        #: back instead of opening a fresh shell (see
+        #: :mod:`local_operator.multiplexer`). ``None`` when there is no
+        #: multiplexer, the session is a subagent's, or the kill switch is set
+        #: — all ordinary, none an error. Rebound on every session swap, since
+        #: the pane's binding must name the conversation currently in it.
+        self._multiplexer_broadcast: SessionBroadcast | None = None
         #: Desktop notifications for the user who is looking at another app —
         #: the surface one step beyond the window title (see `tui/notify.py`).
         #: Held by the app rather than by the band because, unlike the title,
@@ -1973,6 +1982,10 @@ class OperatorApp(App[None]):
         """
         self._session = session
         self._mobile_adopted(session)
+        # Straight after the session is adopted: the pane's resume binding has
+        # to name the conversation now in it, and a swap (`/new`, `/resume`)
+        # is exactly when the old one becomes wrong.
+        self._start_multiplexer_broadcast()
         # A remote follower must never publish a second discovery record for
         # the shared session, and it must be ready to replace this facade with
         # the lease-winning real Session after owner death. The callback uses
@@ -6963,6 +6976,77 @@ class OperatorApp(App[None]):
             self._status.set_terminal_title(title)
         title.start()
 
+    def _start_multiplexer_broadcast(self) -> None:
+        """Tell the host multiplexer which session this pane is holding.
+
+        Called on every session adoption rather than once at mount, because
+        the fact being published is "this PANE holds THIS conversation" and a
+        ``/new`` or ``/resume`` changes the second half of that. The previous
+        binding is retired first so a swap cannot leave the pane advertising
+        the conversation the user just moved away from.
+
+        Everything below is best-effort and returns ``None`` on the ordinary
+        paths — no multiplexer, a subagent's session, a session whose first
+        turn has not persisted yet, the kill switch — see
+        :mod:`local_operator.multiplexer`. Nothing here can raise into the
+        boot path, and no subprocess runs on this thread: the broadcast owns a
+        daemon timer thread of its own precisely so the event loop never waits
+        on a multiplexer socket.
+        """
+        # Retire the outgoing binding BEFORE publishing the new one: both name
+        # the same pane, so the reverse order would clear the fresh binding.
+        self._stop_multiplexer_broadcast()
+        # Headless means no pane to bind, and this gate is what keeps the test
+        # suite off the developer's own multiplexer. The suite runs INSIDE cmux
+        # and its conftest does not clear `CMUX_*` (it isolates HOME and the
+        # provider keys), so every pilot test would otherwise publish a binding
+        # against the real surface the developer is sitting in front of —
+        # rewriting the resume binding of the session running the tests. The
+        # same hazard is documented on `Notifier._env` in `tui/notify.py`.
+        if self.is_headless:
+            return
+        session = self._session
+        if session is None:
+            return
+        session_id = getattr(session, "session_id", "") or ""
+        if not session_id:
+            return
+        # Guarded even though `broadcast_session` guards itself: the IMPORT is
+        # part of this path too, and the whole point of the feature is that it
+        # can never be the reason a session fails to open.
+        try:
+            from local_operator.multiplexer import broadcast_session
+
+            self._multiplexer_broadcast = broadcast_session(session_id, cwd=os.getcwd())
+        except Exception:  # noqa: BLE001 — bookkeeping must not break a session
+            logger.debug("multiplexer broadcast failed to start", exc_info=True)
+            self._multiplexer_broadcast = None
+
+    def _stop_multiplexer_broadcast(self, *, retire: bool = True) -> None:
+        """Withdraw this pane's binding (idempotent).
+
+        ``retire=False`` deliberately LEAVES the binding in place, which is
+        what a crash path wants: an abandoned binding is how the session comes
+        back, and clearing it would delete the feature. The default withdraws,
+        because a user who quit on purpose must not have that session replayed
+        into their next shell in this pane.
+        """
+        broadcast = self._multiplexer_broadcast
+        if broadcast is None:
+            return
+        # Cleared FIRST, so a failure below cannot leave the app holding a
+        # handle it believes is still publishing.
+        self._multiplexer_broadcast = None
+        try:
+            if retire:
+                from local_operator.multiplexer import retire_session
+
+                retire_session(broadcast)
+                return
+            broadcast.stop(retire=False)
+        except Exception:  # noqa: BLE001 — never block an exit path
+            logger.debug("multiplexer broadcast failed to stop", exc_info=True)
+
     def _stop_terminal_title(self) -> None:
         """Give the terminal its own title back (idempotent).
 
@@ -7253,6 +7337,11 @@ class OperatorApp(App[None]):
         # the common case so the phone list drops the session immediately
         # rather than at the next scan.
         self._mobile_teardown()
+        # Alongside the mobile record and for the same reason: this is a clean
+        # exit, so the pane must stop advertising a session the user has just
+        # closed. A crash never reaches this line, which is what leaves the
+        # binding standing for the restore to find.
+        self._stop_multiplexer_broadcast()
         # Before disposing the session: dispose awaits teardown, and a turn
         # parked on an unanswered approval would never reach it.
         self._deny_queued_approvals()

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -6994,10 +6994,19 @@ class OperatorApp(App[None]):
         on a multiplexer socket. That holds for the retire of the OUTGOING
         binding below too — ``stop`` dispatches it to a worker and returns
         immediately, so a swap cannot stall this coroutine on a wedged socket.
+
+        The swap's ORDERING lives in the successor broadcast, not here:
+        ``_stop_multiplexer_broadcast`` hands the outgoing handle over and the
+        successor's own timer thread waits for that withdrawal (bounded) before
+        it publishes, so the outgoing clear cannot land after — and delete —
+        the fresh binding. Waiting here would put a subprocess join on the
+        event loop, which is the freeze this hook must never incur.
         """
-        # Retire the outgoing binding BEFORE publishing the new one: both name
-        # the same pane, so the reverse order would clear the fresh binding.
-        self._stop_multiplexer_broadcast()
+        # Stopped FIRST, and the outgoing handle is handed to the successor
+        # rather than dropped: both bindings name the same pane, so the
+        # successor must not publish until this one's withdrawal has landed
+        # (see `SessionBroadcast` for where that wait runs).
+        outgoing = self._stop_multiplexer_broadcast()
         # Headless means no pane to bind, and this gate is what keeps the test
         # suite off the developer's own multiplexer. The suite runs INSIDE cmux
         # and its conftest does not clear `CMUX_*` (it isolates HOME and the
@@ -7019,13 +7028,25 @@ class OperatorApp(App[None]):
         try:
             from local_operator.multiplexer import broadcast_session
 
-            self._multiplexer_broadcast = broadcast_session(session_id, cwd=os.getcwd())
+            started = broadcast_session(session_id, cwd=os.getcwd(), predecessor=outgoing)
         except Exception:  # noqa: BLE001 — bookkeeping must not break a session
             logger.debug("multiplexer broadcast failed to start", exc_info=True)
-            self._multiplexer_broadcast = None
+            started = None
+        self._multiplexer_broadcast = started
+        # The successor owns the outgoing handle from here (it drains it on its
+        # own thread). When no successor could start, nothing sequences the
+        # withdrawal — but nothing is publishing into the pane either, so the
+        # withdraw simply lands whenever its worker finishes and the exit
+        # drain still guarantees it lands at all.
 
-    def _stop_multiplexer_broadcast(self, *, retire: bool = True) -> None:
-        """Withdraw this pane's binding (idempotent).
+    def _stop_multiplexer_broadcast(self, *, retire: bool = True) -> "SessionBroadcast | None":
+        """Withdraw this pane's binding (idempotent), returning the handle.
+
+        The returned handle is the OUTGOING broadcast, when there was one. The
+        swap path passes it to the successor as ``predecessor`` so the
+        successor can wait out this withdrawal before publishing; every other
+        caller ignores it, and the exit drain still guarantees the withdrawal
+        runs before the process is gone.
 
         ``retire=False`` deliberately LEAVES the binding in place, which is
         what a crash path wants: an abandoned binding is how the session comes
@@ -7035,7 +7056,7 @@ class OperatorApp(App[None]):
         """
         broadcast = self._multiplexer_broadcast
         if broadcast is None:
-            return
+            return None
         # Cleared FIRST, so a failure below cannot leave the app holding a
         # handle it believes is still publishing.
         self._multiplexer_broadcast = None
@@ -7044,10 +7065,11 @@ class OperatorApp(App[None]):
                 from local_operator.multiplexer import retire_session
 
                 retire_session(broadcast)
-                return
-            broadcast.stop(retire=False)
+            else:
+                broadcast.stop(retire=False)
         except Exception:  # noqa: BLE001 — never block an exit path
             logger.debug("multiplexer broadcast failed to stop", exc_info=True)
+        return broadcast
 
     def _stop_terminal_title(self) -> None:
         """Give the terminal its own title back (idempotent).

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -6991,7 +6991,9 @@ class OperatorApp(App[None]):
         :mod:`local_operator.multiplexer`. Nothing here can raise into the
         boot path, and no subprocess runs on this thread: the broadcast owns a
         daemon timer thread of its own precisely so the event loop never waits
-        on a multiplexer socket.
+        on a multiplexer socket. That holds for the retire of the OUTGOING
+        binding below too — ``stop`` dispatches it to a worker and returns
+        immediately, so a swap cannot stall this coroutine on a wedged socket.
         """
         # Retire the outgoing binding BEFORE publishing the new one: both name
         # the same pane, so the reverse order would clear the fresh binding.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.37.0"
+version = "0.38.0"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/test_multiplexer.py
+++ b/tests/unit/test_multiplexer.py
@@ -18,13 +18,16 @@ crash, which is the worst possible time to find out:
 from __future__ import annotations
 
 import json
+import shlex
 import threading
+import time
 from pathlib import Path
 from typing import Any
 
 import pytest
 
 from local_operator.multiplexer.broadcast import (
+    _PENDING_POLL_S,
     RESUME_FLAG,
     SessionBroadcast,
     broadcast_session,
@@ -62,7 +65,7 @@ def config_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
 def _make_session(config_dir: Path, session_id: str, *, subagent: bool = False) -> Path:
     """A session directory shaped exactly like the real thing."""
     directory = config_dir / "sessions" / session_id
-    directory.mkdir(parents=True)
+    directory.mkdir(parents=True, exist_ok=True)
     (directory / "transcript.jsonl").write_text("{}\n", encoding="utf-8")
     if subagent:
         (directory / "origin.json").write_text(json.dumps({"origin": "subagent"}), encoding="utf-8")
@@ -257,6 +260,9 @@ class TestCleanExitWinsOverReassert:
 
         broadcast = SessionBroadcast(_binding(), Backend(), env={})
         broadcast.stop(retire=True)
+        # The retire runs on a worker now (it must never block the event
+        # loop), so settle it before asserting on the call order.
+        broadcast.join(timeout=5.0)
         broadcast._publish_once()
         assert events == ["retire"]
 
@@ -278,7 +284,9 @@ class TestCleanExitWinsOverReassert:
                 events.append("retire")
                 return True
 
-        SessionBroadcast(_binding(), Backend(), env={}).stop(retire=False)
+        broadcast = SessionBroadcast(_binding(), Backend(), env={})
+        broadcast.stop(retire=False)
+        broadcast.join(timeout=5.0)
         assert events == []
 
     def test_the_timer_thread_does_not_outlive_stop(self, config_dir: Path) -> None:
@@ -301,10 +309,173 @@ class TestCleanExitWinsOverReassert:
         broadcast = SessionBroadcast(_binding(), Backend(), env={}, interval_s=0.05)
         broadcast.start()
         broadcast.stop()
+        # `stop` no longer joins (that would stall the event loop), so the
+        # settle is explicit here. The property under test is unchanged: no
+        # timer survives the broadcast.
+        broadcast.join(timeout=5.0)
         assert threading.active_count() <= before
 
     def test_retire_session_tolerates_none(self) -> None:
         retire_session(None)  # must not raise
+
+    def test_stop_does_not_block_the_caller_on_a_wedged_backend(self, config_dir: Path) -> None:
+        """`stop` runs on the Textual event loop, so it may never wait.
+
+        Both callers (`_adopt_session` on a `/new` swap, `on_unmount` on quit)
+        are on the loop. Before this was fixed, `stop` called `retire`
+        synchronously and then joined the timer, blocking ~9.8s against a
+        multiplexer whose socket is mid-restart — exactly the post-crash
+        window the feature targets.
+        """
+        _make_session(config_dir, "abc123abc123")
+        release = threading.Event()
+        retired = threading.Event()
+
+        class WedgedBackend:
+            name = "wedged"
+
+            def detect(self, env: Any) -> bool:
+                return True
+
+            def publish(self, binding: Any, env: Any) -> bool:
+                # Mirrors a call parked in `subprocess.run(timeout=...)`.
+                release.wait(timeout=30.0)
+                return False
+
+            def retire(self, binding: Any, env: Any) -> bool:
+                release.wait(timeout=30.0)
+                retired.set()
+                return True
+
+        broadcast = SessionBroadcast(_binding(), WedgedBackend(), env={}, interval_s=90.0)
+        broadcast.start()
+        # Let the immediate publish get INTO the wedged call, so stop() is
+        # racing a genuinely stuck backend rather than an idle one.
+        time.sleep(0.2)
+
+        started = time.perf_counter()
+        broadcast.stop(retire=True)
+        elapsed = time.perf_counter() - started
+
+        # Generous bound: the point is "does not wait on the socket at all",
+        # and the pre-fix path took ~9.8s here.
+        assert elapsed < 1.0, f"stop() blocked the caller for {elapsed:.2f}s"
+        # And the withdrawal is still genuinely dispatched, just not awaited.
+        release.set()
+        broadcast.join(timeout=10.0)
+        assert retired.is_set()
+
+    def test_the_retire_latch_is_set_before_stop_returns(self, config_dir: Path) -> None:
+        """Moving the retire off-thread must not weaken the clean-exit rule.
+
+        The latch — not the completion of the retire call — is what stops a
+        queued re-assert resurrecting a binding the user quit out of, so it
+        has to be set synchronously even though the call is not.
+        """
+        _make_session(config_dir, "abc123abc123")
+        block = threading.Event()
+        events: list[str] = []
+
+        class SlowRetire:
+            name = "slow"
+
+            def detect(self, env: Any) -> bool:
+                return True
+
+            def publish(self, binding: Any, env: Any) -> bool:
+                events.append("publish")
+                return True
+
+            def retire(self, binding: Any, env: Any) -> bool:
+                block.wait(timeout=30.0)
+                events.append("retire")
+                return True
+
+        broadcast = SessionBroadcast(_binding(), SlowRetire(), env={})
+        broadcast.stop(retire=True)
+        # The retire has NOT run yet (still blocked), and a re-assert landing
+        # in this window must still refuse to publish.
+        broadcast._publish_once()
+        assert events == []
+        block.set()
+        broadcast.join(timeout=10.0)
+        assert events == ["retire"]
+
+    def test_a_failing_publish_backs_off_to_the_reassert_cadence(self, config_dir: Path) -> None:
+        """A refusing backend must not pin the loop to the 5s poll.
+
+        The cadence keys on RESUMABILITY, not on publish success. Keying it on
+        success meant a resumable session whose publish kept failing spawned a
+        `cmux rpc` subprocess every 5s forever, in every pane.
+        """
+        _make_session(config_dir, "abc123abc123")
+        attempts: list[float] = []
+
+        class AlwaysFails:
+            name = "failing"
+
+            def detect(self, env: Any) -> bool:
+                return True
+
+            def publish(self, binding: Any, env: Any) -> bool:
+                attempts.append(time.perf_counter())
+                return False
+
+            def retire(self, binding: Any, env: Any) -> bool:
+                return True
+
+        # An interval far larger than the pending poll, so any extra attempt
+        # can only come from the fast cadence.
+        broadcast = SessionBroadcast(_binding(), AlwaysFails(), env={}, interval_s=3600.0)
+        broadcast.start()
+        try:
+            # Long enough for several _PENDING_POLL_S windows to elapse.
+            time.sleep(_PENDING_POLL_S * 2 + 1.5)
+        finally:
+            broadcast.stop()
+            broadcast.join(timeout=10.0)
+
+        # Exactly one: the immediate publish at start. Everything after it is
+        # governed by the hour-long re-assert interval.
+        assert len(attempts) == 1, f"failing publish retried {len(attempts)}x on the fast poll"
+
+    def test_a_cold_session_still_polls_until_its_transcript_appears(
+        self, config_dir: Path
+    ) -> None:
+        """The back-off must not cost a cold session its fast poll.
+
+        This is the counterpart to the test above: the fast cadence still
+        exists, and it is what makes a binding appear seconds after the first
+        turn persists rather than an interval later.
+        """
+        session_id = "abc123abc123"
+        published: list[str] = []
+
+        class Backend:
+            name = "fake"
+
+            def detect(self, env: Any) -> bool:
+                return True
+
+            def publish(self, binding: Any, env: Any) -> bool:
+                published.append(binding.session_id)
+                return True
+
+            def retire(self, binding: Any, env: Any) -> bool:
+                return True
+
+        broadcast = SessionBroadcast(_binding(), Backend(), env={}, interval_s=3600.0)
+        broadcast.start()
+        try:
+            time.sleep(0.3)
+            assert published == []  # no transcript yet
+            # The first turn lands mid-flight, as it does in a real session.
+            _make_session(config_dir, session_id)
+            time.sleep(_PENDING_POLL_S + 1.5)
+            assert published == [session_id]
+        finally:
+            broadcast.stop()
+            broadcast.join(timeout=10.0)
 
 
 class TestReassertInterval:
@@ -350,6 +521,32 @@ class TestCmuxPayload:
         # The structured launch command must name the launcher, not python.
         assert params["launch_command"]["executable_path"].endswith("lop")
         assert params["launch_command"]["arguments"][1] == "--resume"
+
+    def test_the_shell_fallback_command_is_quoted(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """cmux re-tokenises the `command` string, so a launcher path with a
+        space must survive the round trip. The marker backends already use
+        `shlex.join` for the same reason; this is the one that did not."""
+        sent: dict[str, Any] = {}
+
+        def fake_rpc(binary: str, method: str, params: dict[str, Any]) -> dict[str, Any]:
+            sent["params"] = params
+            return {"resume_binding": {"auto_resume": True}}
+
+        monkeypatch.setattr("local_operator.multiplexer.cmux._cmux_binary", lambda: "/bin/cmux")
+        monkeypatch.setattr("local_operator.multiplexer.cmux._rpc", fake_rpc)
+        spaced = "/Applications/My Tools/lop"
+        binding = SessionBinding(
+            session_id="abc123abc123",
+            executable=spaced,
+            argv=(spaced, RESUME_FLAG, "abc123abc123"),
+            cwd="/work",
+        )
+        env = {"CMUX_WORKSPACE_ID": WORKSPACE, "CMUX_SURFACE_ID": SURFACE}
+        assert CmuxBackend().publish(binding, env) is True
+        command = sent["params"]["command"]
+        assert "'/Applications/My Tools/lop'" in command
+        # The round trip a shell (and cmux's canonicalizer) performs.
+        assert shlex.split(command) == [spaced, RESUME_FLAG, "abc123abc123"]
 
     def test_the_clear_is_scoped_to_our_own_binding(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Expectations, so a quit cannot wipe another agent's binding."""
@@ -440,20 +637,78 @@ class TestMarkerBackends:
         assert "'/Applications/My Tools/lop'" in calls[1][6]
 
     def test_zellij_writes_a_state_file(self, config_dir: Path) -> None:
-        env = {"ZELLIJ": "0", "ZELLIJ_SESSION_NAME": "main"}
+        env = {"ZELLIJ": "0", "ZELLIJ_SESSION_NAME": "main", "ZELLIJ_PANE_ID": "0"}
         assert ZellijBackend().publish(_binding(), env) is True
-        marker = config_dir / "multiplexer" / "zellij-main.json"
+        marker = config_dir / "multiplexer" / "zellij-main-0.json"
         payload = json.loads(marker.read_text(encoding="utf-8"))
         assert payload["session_id"] == "abc123abc123"
         assert payload["command"][1] == "--resume"
 
     def test_zellij_removes_the_file_on_retire(self, config_dir: Path) -> None:
-        env = {"ZELLIJ": "0", "ZELLIJ_SESSION_NAME": "main"}
+        env = {"ZELLIJ": "0", "ZELLIJ_SESSION_NAME": "main", "ZELLIJ_PANE_ID": "0"}
         ZellijBackend().publish(_binding(), env)
         assert ZellijBackend().retire(_binding(), env) is True
-        assert not (config_dir / "multiplexer" / "zellij-main.json").exists()
+        assert not (config_dir / "multiplexer" / "zellij-main-0.json").exists()
 
-    def test_screen_uses_the_sty_identity(self, config_dir: Path) -> None:
+    def test_two_zellij_panes_in_one_session_do_not_share_a_marker(self, config_dir: Path) -> None:
+        """One file per pane, or a pane's exit deletes its siblings' bindings.
+
+        `ZELLIJ_SESSION_NAME` names a SESSION. Verified on zellij 0.42.2 that
+        two panes of one session differ only in `ZELLIJ_PANE_ID` (0 and 1), so
+        keying on the session name alone gave both panes one marker: the last
+        publisher won and the first pane to exit cleanly unlinked the other
+        pane's binding.
+        """
+        base = {"ZELLIJ": "0", "ZELLIJ_SESSION_NAME": "main"}
+        pane0 = {**base, "ZELLIJ_PANE_ID": "0"}
+        pane1 = {**base, "ZELLIJ_PANE_ID": "1"}
+
+        assert ZellijBackend().publish(_binding("aaaaaaaaaaaa"), pane0) is True
+        assert ZellijBackend().publish(_binding("bbbbbbbbbbbb"), pane1) is True
+
+        markers = sorted(p.name for p in (config_dir / "multiplexer").glob("zellij-*.json"))
+        assert markers == ["zellij-main-0.json", "zellij-main-1.json"]
+
+        # Neither pane's binding was overwritten by the other's.
+        expected_markers = (
+            ("zellij-main-0.json", "aaaaaaaaaaaa"),
+            ("zellij-main-1.json", "bbbbbbbbbbbb"),
+        )
+        for name, expected in expected_markers:
+            payload = json.loads((config_dir / "multiplexer" / name).read_text(encoding="utf-8"))
+            assert payload["session_id"] == expected
+
+        # And pane 0 quitting cleanly leaves pane 1 still advertising.
+        assert ZellijBackend().retire(_binding("aaaaaaaaaaaa"), pane0) is True
+        assert not (config_dir / "multiplexer" / "zellij-main-0.json").exists()
+        assert (config_dir / "multiplexer" / "zellij-main-1.json").is_file()
+
+    def test_zellij_without_a_pane_id_publishes_nothing(self, config_dir: Path) -> None:
+        """No coarser fallback: a silent collision is worse than no marker."""
+        env = {"ZELLIJ": "0", "ZELLIJ_SESSION_NAME": "main"}
+        assert ZellijBackend().detect(env) is False
+        assert ZellijBackend().publish(_binding(), env) is False
+
+    def test_screen_uses_the_sty_and_window_identity(self, config_dir: Path) -> None:
+        env = {"STY": "1234.pts-0.host", "WINDOW": "2"}
+        assert ScreenBackend().publish(_binding(), env) is True
+        assert (config_dir / "multiplexer" / "screen-1234.pts-0.host-2.json").is_file()
+
+    def test_two_screen_windows_in_one_session_do_not_share_a_marker(
+        self, config_dir: Path
+    ) -> None:
+        """Same collision as zellij's, same fix. Verified on screen 4.00.03
+        that a process inside a session exports both `STY` and `WINDOW`."""
+        window0 = {"STY": "1234.pts-0.host", "WINDOW": "0"}
+        window1 = {"STY": "1234.pts-0.host", "WINDOW": "1"}
+        assert ScreenBackend().publish(_binding("aaaaaaaaaaaa"), window0) is True
+        assert ScreenBackend().publish(_binding("bbbbbbbbbbbb"), window1) is True
+        markers = sorted(p.name for p in (config_dir / "multiplexer").glob("screen-*.json"))
+        assert len(markers) == 2
+
+    def test_screen_falls_back_to_sty_when_window_is_absent(self, config_dir: Path) -> None:
+        """`WINDOW` comes from the shell's startup rather than from screen in
+        every configuration, and one window per session still restores fine."""
         env = {"STY": "1234.pts-0.host"}
         assert ScreenBackend().publish(_binding(), env) is True
         assert (config_dir / "multiplexer" / "screen-1234.pts-0.host.json").is_file()
@@ -464,6 +719,17 @@ class TestMarkerBackends:
         env = {"STY": "../../etc/passwd"}
         assert ScreenBackend().detect(env) is False
         assert ScreenBackend().publish(_binding(), env) is False
+
+    def test_every_component_of_a_composite_id_is_validated(self, config_dir: Path) -> None:
+        """Each part is checked separately, not the joined string: `-` is legal
+        inside a component, so validating only the result would let one
+        component forge another pane's filename."""
+        env = {"ZELLIJ": "0", "ZELLIJ_SESSION_NAME": "../../etc", "ZELLIJ_PANE_ID": "0"}
+        assert ZellijBackend().detect(env) is False
+        assert ZellijBackend().publish(_binding(), env) is False
+        env = {"ZELLIJ": "0", "ZELLIJ_SESSION_NAME": "main", "ZELLIJ_PANE_ID": "../x"}
+        assert ZellijBackend().detect(env) is False
+        assert ZellijBackend().publish(_binding(), env) is False
 
     def test_no_multiplexer_env_means_no_detection(self) -> None:
         for backend in (TmuxBackend(), ZellijBackend(), WezTermBackend(), ScreenBackend()):

--- a/tests/unit/test_multiplexer.py
+++ b/tests/unit/test_multiplexer.py
@@ -1,0 +1,534 @@
+"""Multiplexer resume publication — the safety rules, not the plumbing.
+
+The properties pinned here are the ones whose failure is INVISIBLE until a
+crash, which is the worst possible time to find out:
+
+- **Restore-and-idle.** The published command reopens a transcript and waits.
+  A command that continued the interrupted turn would, on a fifteen-pane
+  restore, resume tool execution in fifteen sessions with nobody watching.
+- **Never a subagent's session.** A child runs in its PARENT's pane, so
+  publishing one silently replaces the user's binding with a delegated review.
+- **Never fatal, never blocking.** Every failure mode a multiplexer can
+  present must leave the session running.
+- **A clean exit wins over an in-flight re-assert.** Otherwise quitting can
+  resurrect the binding it just cleared, and the next shell replays a session
+  the user closed.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from local_operator.multiplexer.broadcast import (
+    RESUME_FLAG,
+    SessionBroadcast,
+    broadcast_session,
+    build_binding,
+    is_resumable_session,
+    is_user_owned_session,
+    multiplexer_resume_enabled,
+    resume_argv,
+    resume_executable,
+    retire_session,
+)
+from local_operator.multiplexer.cmux import REASSERT_INTERVAL_S, CmuxBackend
+from local_operator.multiplexer.markers import (
+    COMMAND_OPTION,
+    SESSION_OPTION,
+    ScreenBackend,
+    TmuxBackend,
+    WezTermBackend,
+    ZellijBackend,
+)
+from local_operator.multiplexer.registry import active_backend
+from local_operator.multiplexer.types import SessionBinding
+
+WORKSPACE = "11111111-2222-3333-4444-555555555555"
+SURFACE = "66666666-7777-8888-9999-000000000000"
+
+
+@pytest.fixture
+def config_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point the app's config dir at a tmp tree, as `paths` documents."""
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    return tmp_path
+
+
+def _make_session(config_dir: Path, session_id: str, *, subagent: bool = False) -> Path:
+    """A session directory shaped exactly like the real thing."""
+    directory = config_dir / "sessions" / session_id
+    directory.mkdir(parents=True)
+    (directory / "transcript.jsonl").write_text("{}\n", encoding="utf-8")
+    if subagent:
+        (directory / "origin.json").write_text(json.dumps({"origin": "subagent"}), encoding="utf-8")
+    return directory
+
+
+def _binding(session_id: str = "abc123abc123") -> SessionBinding:
+    return SessionBinding(
+        session_id=session_id,
+        executable="/home/u/.local/bin/lop",
+        argv=("/home/u/.local/bin/lop", RESUME_FLAG, session_id),
+        cwd="/work",
+    )
+
+
+class TestRestoreAndIdle:
+    def test_the_published_argv_only_ever_resumes(self) -> None:
+        """The safety boundary: no prompt, no exec, no continue flag."""
+        argv = resume_argv("abc123abc123", "/bin/lop")
+        assert argv == ("/bin/lop", "--resume", "abc123abc123")
+
+    def test_no_flag_can_continue_an_interrupted_turn(self) -> None:
+        """Pins the ABSENCE of the dangerous flags, not just the shape."""
+        argv = resume_argv("abc123abc123", "/bin/lop")
+        forbidden = {"--exec", "-e", "--yolo", "--continue", "--prompt"}
+        assert not forbidden.intersection(argv)
+
+    def test_the_executable_is_the_launcher_not_the_interpreter(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """`sys.executable` would restore a bare Python REPL, not lop."""
+        launcher = tmp_path / "lop"
+        launcher.write_text("#!/bin/sh\n", encoding="utf-8")
+        monkeypatch.setattr("sys.argv", [str(launcher)])
+        assert resume_executable() == str(launcher.resolve())
+
+    def test_a_missing_argv0_falls_back_to_a_resolvable_name(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An embedder has no usable argv[0]; a bad path is worse than a name."""
+        monkeypatch.setattr("sys.argv", [])
+        assert resume_executable() == "lop"
+
+
+class TestSubagentGuard:
+    def test_a_subagent_session_is_never_publishable(self, config_dir: Path) -> None:
+        _make_session(config_dir, "child0000001", subagent=True)
+        assert is_user_owned_session("child0000001") is False
+
+    def test_a_user_session_is_publishable(self, config_dir: Path) -> None:
+        _make_session(config_dir, "abc123abc123")
+        assert is_user_owned_session("abc123abc123") is True
+
+    def test_broadcast_refuses_a_subagent_session(
+        self, config_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The end-to-end refusal: a child must not touch the pane's binding."""
+        _make_session(config_dir, "child0000001", subagent=True)
+        monkeypatch.setenv("CMUX_WORKSPACE_ID", WORKSPACE)
+        monkeypatch.setenv("CMUX_SURFACE_ID", SURFACE)
+        published: list[Any] = []
+        monkeypatch.setattr(CmuxBackend, "publish", lambda self, b, e: published.append(b) or True)
+        monkeypatch.setattr(CmuxBackend, "detect", lambda self, env: True)
+        assert broadcast_session("child0000001") is None
+        assert published == []
+
+
+class TestResumabilityIsRechecked:
+    def test_a_session_with_no_transcript_is_not_yet_resumable(self, config_dir: Path) -> None:
+        """A cold session: the directory exists, the transcript does not."""
+        (config_dir / "sessions" / "cold00000001").mkdir(parents=True)
+        assert is_resumable_session("cold00000001") is False
+
+    def test_it_becomes_resumable_once_the_first_turn_persists(self, config_dir: Path) -> None:
+        """Why the check is per-publish and not once at startup."""
+        directory = config_dir / "sessions" / "cold00000001"
+        directory.mkdir(parents=True)
+        assert is_resumable_session("cold00000001") is False
+        (directory / "transcript.jsonl").write_text("{}\n", encoding="utf-8")
+        assert is_resumable_session("cold00000001") is True
+
+    def test_a_cold_session_publishes_nothing_until_it_can_be_resumed(
+        self, config_dir: Path
+    ) -> None:
+        """The bug this guards: publishing a command --resume would refuse."""
+        directory = config_dir / "sessions" / "cold00000001"
+        directory.mkdir(parents=True)
+        calls: list[Any] = []
+
+        class Backend:
+            name = "fake"
+
+            def detect(self, env: Any) -> bool:
+                return True
+
+            def publish(self, binding: Any, env: Any) -> bool:
+                calls.append(binding)
+                return True
+
+            def retire(self, binding: Any, env: Any) -> bool:
+                return True
+
+        broadcast = SessionBroadcast(_binding("cold00000001"), Backend(), env={})
+        broadcast._publish_once()
+        assert calls == []
+        (directory / "transcript.jsonl").write_text("{}\n", encoding="utf-8")
+        broadcast._publish_once()
+        assert len(calls) == 1
+
+
+class TestNeverFatal:
+    def test_a_backend_that_raises_on_detect_is_skipped(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A backend bug costs that backend, never the user's session."""
+
+        def boom(self: Any, env: Any) -> bool:
+            raise RuntimeError("scanner exploded")
+
+        monkeypatch.setattr(CmuxBackend, "detect", boom)
+        monkeypatch.setattr(TmuxBackend, "detect", lambda self, env: False)
+        monkeypatch.setattr(ZellijBackend, "detect", lambda self, env: False)
+        monkeypatch.setattr(WezTermBackend, "detect", lambda self, env: False)
+        monkeypatch.setattr(ScreenBackend, "detect", lambda self, env: False)
+        assert active_backend({}) is None
+
+    def test_a_backend_that_raises_on_publish_does_not_escape(self, config_dir: Path) -> None:
+        _make_session(config_dir, "abc123abc123")
+
+        class Backend:
+            name = "fake"
+
+            def detect(self, env: Any) -> bool:
+                return True
+
+            def publish(self, binding: Any, env: Any) -> bool:
+                raise RuntimeError("socket died")
+
+            def retire(self, binding: Any, env: Any) -> bool:
+                raise RuntimeError("socket died")
+
+        broadcast = SessionBroadcast(_binding(), Backend(), env={})
+        broadcast._publish_once()  # must not raise
+        broadcast.stop()  # must not raise
+
+    def test_a_host_with_no_multiplexer_publishes_nothing(self) -> None:
+        """The ordinary case: a plain terminal is not an error."""
+        assert active_backend({}) is None
+
+    def test_a_broken_cmux_binary_does_not_break_startup(
+        self, config_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A cmux surface whose CLI is missing must simply not publish."""
+        _make_session(config_dir, "abc123abc123")
+        monkeypatch.setattr("local_operator.multiplexer.cmux._cmux_binary", lambda: None)
+        env = {"CMUX_WORKSPACE_ID": WORKSPACE, "CMUX_SURFACE_ID": SURFACE}
+        assert CmuxBackend().detect(env) is False
+        assert broadcast_session("abc123abc123", env=env) is None
+
+    def test_the_kill_switch_stops_everything(
+        self, config_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _make_session(config_dir, "abc123abc123")
+        env = {
+            "CMUX_WORKSPACE_ID": WORKSPACE,
+            "CMUX_SURFACE_ID": SURFACE,
+            "LOCAL_OPERATOR_NO_MULTIPLEXER_RESUME": "1",
+        }
+        assert multiplexer_resume_enabled(env) is False
+        assert broadcast_session("abc123abc123", env=env) is None
+
+
+class TestCleanExitWinsOverReassert:
+    def test_retire_prevents_a_later_republish(self, config_dir: Path) -> None:
+        """The inverted-retirement bug: quitting must not resurrect a binding."""
+        _make_session(config_dir, "abc123abc123")
+        events: list[str] = []
+
+        class Backend:
+            name = "fake"
+
+            def detect(self, env: Any) -> bool:
+                return True
+
+            def publish(self, binding: Any, env: Any) -> bool:
+                events.append("publish")
+                return True
+
+            def retire(self, binding: Any, env: Any) -> bool:
+                events.append("retire")
+                return True
+
+        broadcast = SessionBroadcast(_binding(), Backend(), env={})
+        broadcast.stop(retire=True)
+        broadcast._publish_once()
+        assert events == ["retire"]
+
+    def test_stop_without_retire_leaves_the_binding_standing(self, config_dir: Path) -> None:
+        """A crash path keeps the binding: that IS the feature."""
+        _make_session(config_dir, "abc123abc123")
+        events: list[str] = []
+
+        class Backend:
+            name = "fake"
+
+            def detect(self, env: Any) -> bool:
+                return True
+
+            def publish(self, binding: Any, env: Any) -> bool:
+                return True
+
+            def retire(self, binding: Any, env: Any) -> bool:
+                events.append("retire")
+                return True
+
+        SessionBroadcast(_binding(), Backend(), env={}).stop(retire=False)
+        assert events == []
+
+    def test_the_timer_thread_does_not_outlive_stop(self, config_dir: Path) -> None:
+        """No timer may survive the app; the thread is joined on stop."""
+        _make_session(config_dir, "abc123abc123")
+
+        class Backend:
+            name = "fake"
+
+            def detect(self, env: Any) -> bool:
+                return True
+
+            def publish(self, binding: Any, env: Any) -> bool:
+                return True
+
+            def retire(self, binding: Any, env: Any) -> bool:
+                return True
+
+        before = threading.active_count()
+        broadcast = SessionBroadcast(_binding(), Backend(), env={}, interval_s=0.05)
+        broadcast.start()
+        broadcast.stop()
+        assert threading.active_count() <= before
+
+    def test_retire_session_tolerates_none(self) -> None:
+        retire_session(None)  # must not raise
+
+
+class TestReassertInterval:
+    def test_it_exceeds_the_cmux_index_cache_ttl(self) -> None:
+        """cmux caches its live-agent index for 60s and retirement is one-way.
+
+        A re-assert faster than that TTL would re-publish against the SAME
+        stale snapshot: it would cost a subprocess and fix nothing, leaving
+        the binding permanently retired.
+        """
+        assert REASSERT_INTERVAL_S > 60.0
+
+
+class TestCmuxPayload:
+    def test_it_publishes_agent_hook_with_auto_resume(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`source: agent-hook` + `auto_resume` is the ONLY path to auto.
+
+        A `cli`-sourced binding resolves to manual/false in cmux, so this is
+        pinned: a future simplification to the `cmux surface resume set` CLI
+        would leave auto-resume silently dead.
+        """
+        sent: dict[str, Any] = {}
+
+        def fake_rpc(binary: str, method: str, params: dict[str, Any]) -> dict[str, Any]:
+            sent["method"] = method
+            sent["params"] = params
+            return {"resume_binding": {"auto_resume": True}}
+
+        monkeypatch.setattr("local_operator.multiplexer.cmux._cmux_binary", lambda: "/bin/cmux")
+        monkeypatch.setattr("local_operator.multiplexer.cmux._rpc", fake_rpc)
+        env = {"CMUX_WORKSPACE_ID": WORKSPACE, "CMUX_SURFACE_ID": SURFACE}
+        assert CmuxBackend().publish(_binding(), env) is True
+        assert sent["method"] == "surface.resume.set"
+        params = sent["params"]
+        assert params["source"] == "agent-hook"
+        assert params["auto_resume"] is True
+        assert params["kind"] == "local-operator"
+        assert params["checkpoint_id"] == "abc123abc123"
+        assert params["workspace_id"] == WORKSPACE
+        assert params["surface_id"] == SURFACE
+        # The structured launch command must name the launcher, not python.
+        assert params["launch_command"]["executable_path"].endswith("lop")
+        assert params["launch_command"]["arguments"][1] == "--resume"
+
+    def test_the_clear_is_scoped_to_our_own_binding(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Expectations, so a quit cannot wipe another agent's binding."""
+        sent: dict[str, Any] = {}
+
+        def fake_rpc(binary: str, method: str, params: dict[str, Any]) -> dict[str, Any]:
+            sent["method"] = method
+            sent["params"] = params
+            return {"cleared": True}
+
+        monkeypatch.setattr("local_operator.multiplexer.cmux._cmux_binary", lambda: "/bin/cmux")
+        monkeypatch.setattr("local_operator.multiplexer.cmux._rpc", fake_rpc)
+        env = {"CMUX_WORKSPACE_ID": WORKSPACE, "CMUX_SURFACE_ID": SURFACE}
+        assert CmuxBackend().retire(_binding(), env) is True
+        assert sent["method"] == "surface.resume.clear"
+        assert sent["params"]["checkpoint_id"] == "abc123abc123"
+        assert sent["params"]["source"] == "agent-hook"
+        assert sent["params"]["agent_session_ended"] is True
+
+    @pytest.mark.parametrize(
+        "env",
+        [
+            {},
+            {"CMUX_WORKSPACE_ID": WORKSPACE},
+            {"CMUX_SURFACE_ID": SURFACE},
+            {"CMUX_WORKSPACE_ID": "not-a-uuid", "CMUX_SURFACE_ID": SURFACE},
+        ],
+    )
+    def test_an_incomplete_or_malformed_target_publishes_nothing(
+        self, env: dict[str, str], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Inherited-but-stale CMUX_* (a container, an ssh hop) is not a surface."""
+        monkeypatch.setattr("local_operator.multiplexer.cmux._cmux_binary", lambda: "/bin/cmux")
+        assert CmuxBackend().detect(env) is False
+        assert CmuxBackend().publish(_binding(), env) is False
+
+
+class TestMarkerBackends:
+    def test_tmux_sets_both_pane_options(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        calls: list[list[str]] = []
+        monkeypatch.setattr(
+            "local_operator.multiplexer.markers._run", lambda argv: calls.append(argv) or True
+        )
+        monkeypatch.setattr("local_operator.multiplexer.markers._which", lambda b: "/bin/tmux")
+        env = {"TMUX": "/tmp/tmux-501/default,123,0", "TMUX_PANE": "%3"}
+        assert TmuxBackend().publish(_binding(), env) is True
+        assert [c[4] for c in calls] == ["%3", "%3"]
+        assert calls[0][5] == SESSION_OPTION
+        assert calls[0][6] == "abc123abc123"
+        assert calls[1][5] == COMMAND_OPTION
+        assert "--resume abc123abc123" in calls[1][6]
+
+    def test_tmux_unsets_rather_than_blanking_on_retire(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A blank option reads as a session with an empty id, not as absence."""
+        calls: list[list[str]] = []
+        monkeypatch.setattr(
+            "local_operator.multiplexer.markers._run", lambda argv: calls.append(argv) or True
+        )
+        monkeypatch.setattr("local_operator.multiplexer.markers._which", lambda b: "/bin/tmux")
+        env = {"TMUX": "/tmp/tmux-501/default,123,0", "TMUX_PANE": "%3"}
+        assert TmuxBackend().retire(_binding(), env) is True
+        assert all("-u" in call for call in calls)
+
+    def test_tmux_needs_a_live_server_not_just_a_pane_name(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """TMUX_PANE survives into a process that has left tmux behind."""
+        monkeypatch.setattr("local_operator.multiplexer.markers._which", lambda b: "/bin/tmux")
+        assert TmuxBackend().detect({"TMUX_PANE": "%3"}) is False
+
+    def test_the_command_marker_is_shell_quoted(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A restore script hands this to a shell; a spacey path must survive."""
+        calls: list[list[str]] = []
+        monkeypatch.setattr(
+            "local_operator.multiplexer.markers._run", lambda argv: calls.append(argv) or True
+        )
+        monkeypatch.setattr("local_operator.multiplexer.markers._which", lambda b: "/bin/tmux")
+        spaced = SessionBinding(
+            session_id="abc123abc123",
+            executable="/Applications/My Tools/lop",
+            argv=("/Applications/My Tools/lop", "--resume", "abc123abc123"),
+            cwd="/work",
+        )
+        env = {"TMUX": "/tmp/tmux-501/default,123,0", "TMUX_PANE": "%3"}
+        TmuxBackend().publish(spaced, env)
+        assert "'/Applications/My Tools/lop'" in calls[1][6]
+
+    def test_zellij_writes_a_state_file(self, config_dir: Path) -> None:
+        env = {"ZELLIJ": "0", "ZELLIJ_SESSION_NAME": "main"}
+        assert ZellijBackend().publish(_binding(), env) is True
+        marker = config_dir / "multiplexer" / "zellij-main.json"
+        payload = json.loads(marker.read_text(encoding="utf-8"))
+        assert payload["session_id"] == "abc123abc123"
+        assert payload["command"][1] == "--resume"
+
+    def test_zellij_removes_the_file_on_retire(self, config_dir: Path) -> None:
+        env = {"ZELLIJ": "0", "ZELLIJ_SESSION_NAME": "main"}
+        ZellijBackend().publish(_binding(), env)
+        assert ZellijBackend().retire(_binding(), env) is True
+        assert not (config_dir / "multiplexer" / "zellij-main.json").exists()
+
+    def test_screen_uses_the_sty_identity(self, config_dir: Path) -> None:
+        env = {"STY": "1234.pts-0.host"}
+        assert ScreenBackend().publish(_binding(), env) is True
+        assert (config_dir / "multiplexer" / "screen-1234.pts-0.host.json").is_file()
+
+    def test_a_pane_id_that_could_escape_the_directory_is_refused(self, config_dir: Path) -> None:
+        """The id becomes a FILENAME; writing the right data to the wrong
+        pane is worse than writing nothing."""
+        env = {"STY": "../../etc/passwd"}
+        assert ScreenBackend().detect(env) is False
+        assert ScreenBackend().publish(_binding(), env) is False
+
+    def test_no_multiplexer_env_means_no_detection(self) -> None:
+        for backend in (TmuxBackend(), ZellijBackend(), WezTermBackend(), ScreenBackend()):
+            assert backend.detect({}) is False
+
+
+class TestRegistryOrdering:
+    def test_cmux_wins_over_a_nested_tmux(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Multiplexers nest; the OUTERMOST host is the one that restores panes."""
+        monkeypatch.setattr("local_operator.multiplexer.cmux._cmux_binary", lambda: "/bin/cmux")
+        monkeypatch.setattr("local_operator.multiplexer.markers._which", lambda b: "/bin/tmux")
+        env = {
+            "CMUX_WORKSPACE_ID": WORKSPACE,
+            "CMUX_SURFACE_ID": SURFACE,
+            "TMUX": "/tmp/tmux-501/default,123,0",
+            "TMUX_PANE": "%3",
+        }
+        backend = active_backend(env)
+        assert backend is not None and backend.name == "cmux"
+
+
+class TestBuildBinding:
+    def test_an_empty_session_id_builds_nothing(self) -> None:
+        assert build_binding("") is None
+
+    def test_it_records_the_working_directory(self) -> None:
+        binding = build_binding("abc123abc123", cwd="/work")
+        assert binding is not None
+        assert binding.cwd == "/work"
+        assert binding.argv[1] == "--resume"
+
+    def test_no_environment_or_secrets_ride_along(self) -> None:
+        """Session id and cwd only: this reaches a shell-adjacent surface."""
+        binding = build_binding("abc123abc123", cwd="/work")
+        assert binding is not None
+        assert set(vars(binding)) == {"session_id", "executable", "argv", "cwd", "name"}
+
+
+def test_importing_the_package_does_not_drag_in_the_engine() -> None:
+    """The package must stay cheap enough to sit on a startup path.
+
+    Checked in a FRESH interpreter, because by the time this test body runs
+    pytest has already imported most of the tree and an in-process
+    `sys.modules` assertion would pass on a real regression. Same reasoning as
+    `test_import_graph.py`, which pins the CLI's own graph.
+    """
+    import subprocess
+    import sys
+
+    probe = (
+        "import json, importlib, sys;"
+        "importlib.import_module('local_operator.multiplexer');"
+        "print(json.dumps(sorted(sys.modules)))"
+    )
+    completed = subprocess.run(
+        [sys.executable, "-c", probe],
+        capture_output=True,
+        text=True,
+        cwd=str(Path(__file__).resolve().parent.parent.parent),
+    )
+    assert completed.returncode == 0, completed.stderr[-2000:]
+    modules = set(json.loads(completed.stdout.strip().splitlines()[-1]))
+    # The engine, the providers and the TUI are what this must not pull in:
+    # publication is bookkeeping, and it is reached from startup.
+    assert "local_operator.harness" not in modules
+    assert "local_operator.tui.app" not in modules
+    assert "local_operator.tools.builtin" not in modules
+    assert "asyncio" not in modules

--- a/tests/unit/test_multiplexer.py
+++ b/tests/unit/test_multiplexer.py
@@ -30,6 +30,7 @@ import pytest
 from local_operator.multiplexer.broadcast import (
     _PENDING_POLL_S,
     RESUME_FLAG,
+    SWAP_DRAIN_TIMEOUT_S,
     SessionBroadcast,
     broadcast_session,
     build_binding,
@@ -310,6 +311,138 @@ class TestSwapOrdering:
         assert (
             self._marker_session(config_dir, "zellij-main-0.json") == "bbbbbbbbbbbb"
         ), "swap left the pane advertising nothing — a crash now loses the session"
+
+    def test_the_swap_drain_is_bounded_by_the_number_it_documents(self, config_dir: Path) -> None:
+        """F9: a wedged predecessor delays the successor by SWAP_DRAIN_TIMEOUT_S, once.
+
+        Nothing pinned this bound before, which is how a 2x survived to review.
+        The successor used to drain its predecessor with `join`, whose timeout
+        is PER WORKER over the retire worker and the timer, so the real bound
+        on the first publish was 12s against a documented 6s (measured 12.02s).
+        `_drain_retire` waits only on the withdrawal, which is the sole worker
+        carrying swap ordering.
+
+        The assertion is one-sided on purpose: the LOWER bound would pin the
+        drain actually happening, but that is `test_a_slow_retire_cannot_
+        delete_the_successors_binding`'s job. This one pins the ceiling.
+        """
+        _make_session(config_dir, "aaaaaaaaaaaa")
+        _make_session(config_dir, "bbbbbbbbbbbb")
+        published = threading.Event()
+        release = threading.Event()
+
+        class WedgedBackend:
+            name = "wedged"
+
+            def detect(self, env: Any) -> bool:
+                return True
+
+            def publish(self, binding: Any, env: Any) -> bool:
+                if binding.session_id == "bbbbbbbbbbbb":
+                    published.set()
+                    return True
+                # The predecessor's publish parks, so its retire queues behind
+                # a call already inside a subprocess timeout — the state that
+                # makes the drain bound observable at all.
+                release.wait(timeout=30.0)
+                return False
+
+            def retire(self, binding: Any, env: Any) -> bool:
+                release.wait(timeout=30.0)
+                return True
+
+        backend = WedgedBackend()
+        outgoing = SessionBroadcast(_binding("aaaaaaaaaaaa"), backend, env={}, interval_s=3600.0)
+        outgoing.start()
+        time.sleep(0.2)  # let the publish get INTO the wedged call
+        outgoing.stop(retire=True)
+
+        started = time.monotonic()
+        incoming = SessionBroadcast(
+            _binding("bbbbbbbbbbbb"),
+            backend,
+            env={},
+            interval_s=3600.0,
+            predecessor=outgoing,
+        )
+        incoming.start()
+        assert published.wait(timeout=30.0), "the successor never published at all"
+        elapsed = time.monotonic() - started
+
+        # One drain budget plus scheduling slack, and well under the 12s the
+        # per-worker join produced on this same scenario.
+        assert elapsed < SWAP_DRAIN_TIMEOUT_S + 2.0, (
+            f"the successor's first publish waited {elapsed:.2f}s, past the "
+            f"documented {SWAP_DRAIN_TIMEOUT_S}s swap drain bound"
+        )
+        release.set()
+        incoming.stop(retire=False)
+
+    def test_a_swap_chain_does_not_compound_the_drain(self, config_dir: Path) -> None:
+        """F9, the compounding half: A->B->C pays ONE drain, not two.
+
+        Draining the predecessor's TIMER meant waiting out that timer's own
+        drain of ITS predecessor, so a second swap against a wedged socket
+        stacked the bounds (measured 11.70s for C's first publish). Only the
+        withdrawal is drained now, and a withdrawal never waits on another
+        broadcast, so the chain cannot accumulate.
+        """
+        for session_id in ("aaaaaaaaaaaa", "bbbbbbbbbbbb", "cccccccccccc"):
+            _make_session(config_dir, session_id)
+        published_c = threading.Event()
+        release = threading.Event()
+
+        class WedgedBackend:
+            name = "wedged"
+
+            def detect(self, env: Any) -> bool:
+                return True
+
+            def publish(self, binding: Any, env: Any) -> bool:
+                if binding.session_id == "cccccccccccc":
+                    published_c.set()
+                    return True
+                release.wait(timeout=30.0)
+                return False
+
+            def retire(self, binding: Any, env: Any) -> bool:
+                release.wait(timeout=30.0)
+                return True
+
+        backend = WedgedBackend()
+        first = SessionBroadcast(_binding("aaaaaaaaaaaa"), backend, env={}, interval_s=3600.0)
+        first.start()
+        time.sleep(0.2)
+        first.stop(retire=True)
+        second = SessionBroadcast(
+            _binding("bbbbbbbbbbbb"),
+            backend,
+            env={},
+            interval_s=3600.0,
+            predecessor=first,
+        )
+        second.start()
+        time.sleep(0.2)
+        second.stop(retire=True)
+
+        started = time.monotonic()
+        third = SessionBroadcast(
+            _binding("cccccccccccc"),
+            backend,
+            env={},
+            interval_s=3600.0,
+            predecessor=second,
+        )
+        third.start()
+        assert published_c.wait(timeout=30.0), "the third session never published"
+        elapsed = time.monotonic() - started
+
+        assert elapsed < SWAP_DRAIN_TIMEOUT_S + 2.0, (
+            f"a two-swap chain delayed the pane by {elapsed:.2f}s — the drain "
+            f"is compounding across the chain again"
+        )
+        release.set()
+        third.stop(retire=False)
 
     def test_a_scoped_retire_never_removes_a_foreign_marker(self, config_dir: Path) -> None:
         """The class fix, not the instance: retire refuses a marker it did not write.

--- a/tests/unit/test_multiplexer.py
+++ b/tests/unit/test_multiplexer.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import json
 import shlex
+import textwrap
 import threading
 import time
 from pathlib import Path
@@ -236,6 +237,205 @@ class TestNeverFatal:
         }
         assert multiplexer_resume_enabled(env) is False
         assert broadcast_session("abc123abc123", env=env) is None
+
+
+class TestSwapOrdering:
+    """F7: a /new or /resume swap must leave the pane advertising the NEW session.
+
+    The failure mode these tests pin is invisible until a crash: the outgoing
+    binding's withdrawal lands AFTER the incoming binding's publish, deletes
+    it (both name the same pane), and the pane then advertises nothing — so
+    the crash this feature exists for finds no binding to restore. Every real
+    backend retire is a subprocess spawn (6-75ms on this host), which is far
+    past the ~5ms threshold where the unsequenced swap starts losing, so the
+    stub-Handle swap test in the TUI suite cannot see this at all: it needs a
+    backend with realistic retire latency.
+    """
+
+    #: One subprocess spawn, the floor for a real backend retire on this host
+    #: (screen -V 6.7ms). High enough to lose every unsequenced swap, low
+    #: enough to keep the suite fast.
+    RETIRE_LATENCY_S = 0.05
+
+    @staticmethod
+    def _marker_session(config_dir: Path, pane_file: str) -> str | None:
+        path = config_dir / "multiplexer" / pane_file
+        if not path.exists():
+            return None
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except ValueError:
+            return None
+        return payload.get("session_id")
+
+    def test_a_slow_retire_cannot_delete_the_successors_binding(self, config_dir: Path) -> None:
+        """The zellij marker after a swap names the NEW session, not nothing.
+
+        Mirrors `app.py`'s swap exactly — stop the outgoing broadcast, then
+        start the successor with it as predecessor — against the real
+        `ZellijBackend` with one subprocess spawn of retire latency. Before
+        the fix the pane advertised NOTHING after the swap (20/20 trials at
+        5ms of latency in review round 2).
+        """
+        _make_session(config_dir, "aaaaaaaaaaaa")
+        _make_session(config_dir, "bbbbbbbbbbbb")
+        env = {"ZELLIJ_SESSION_NAME": "main", "ZELLIJ_PANE_ID": "0"}
+
+        class SlowRetireZellij(ZellijBackend):
+            def retire(self, binding: Any, env: Any) -> bool:
+                time.sleep(TestSwapOrdering.RETIRE_LATENCY_S)
+                return super().retire(binding, env)
+
+        backend = SlowRetireZellij()
+        outgoing = SessionBroadcast(_binding("aaaaaaaaaaaa"), backend, env=env, interval_s=3600.0)
+        outgoing.start()
+        deadline = time.monotonic() + 5.0
+        while self._marker_session(config_dir, "zellij-main-0.json") != "aaaaaaaaaaaa":
+            assert time.monotonic() < deadline, "outgoing binding never published"
+            time.sleep(0.005)
+
+        # app.py's swap: stop() returns immediately, the successor sequences.
+        outgoing.stop(retire=True)
+        incoming = SessionBroadcast(
+            _binding("bbbbbbbbbbbb"),
+            backend,
+            env=env,
+            interval_s=3600.0,
+            predecessor=outgoing,
+        )
+        incoming.start()
+        incoming.join(timeout=10.0)
+        outgoing.join(timeout=10.0)
+
+        assert (
+            self._marker_session(config_dir, "zellij-main-0.json") == "bbbbbbbbbbbb"
+        ), "swap left the pane advertising nothing — a crash now loses the session"
+
+    def test_a_scoped_retire_never_removes_a_foreign_marker(self, config_dir: Path) -> None:
+        """The class fix, not the instance: retire refuses a marker it did not write.
+
+        Sequencing makes the race rare; scoping makes it harmless. A retire
+        arriving after the successor has published must withdraw nothing,
+        because the marker on disk is no longer its binding.
+        """
+        _make_session(config_dir, "aaaaaaaaaaaa")
+        _make_session(config_dir, "bbbbbbbbbbbb")
+        env = {"ZELLIJ_SESSION_NAME": "main", "ZELLIJ_PANE_ID": "0"}
+        backend = ZellijBackend()
+        assert backend.publish(_binding("bbbbbbbbbbbb"), env) is True
+
+        # The outgoing session's retire arrives late — after the swap.
+        assert backend.retire(_binding("aaaaaaaaaaaa"), env) is False
+        assert (
+            self._marker_session(config_dir, "zellij-main-0.json") == "bbbbbbbbbbbb"
+        ), "a late retire deleted the successor's marker"
+
+    def test_a_scoped_retire_still_removes_its_own_marker(self, config_dir: Path) -> None:
+        """Scoping must not break the ordinary quit: our own marker goes."""
+        _make_session(config_dir, "aaaaaaaaaaaa")
+        env = {"ZELLIJ_SESSION_NAME": "main", "ZELLIJ_PANE_ID": "0"}
+        backend = ZellijBackend()
+        assert backend.publish(_binding("aaaaaaaaaaaa"), env) is True
+        assert backend.retire(_binding("aaaaaaaaaaaa"), env) is True
+        assert self._marker_session(config_dir, "zellij-main-0.json") is None
+
+    def test_an_unreadable_marker_is_never_deleted(self, config_dir: Path) -> None:
+        """Corrupt-or-foreign reads as not-ours, because the feed is a DELETE."""
+        _make_session(config_dir, "aaaaaaaaaaaa")
+        env = {"ZELLIJ_SESSION_NAME": "main", "ZELLIJ_PANE_ID": "0"}
+        marker = config_dir / "multiplexer" / "zellij-main-0.json"
+        marker.parent.mkdir(parents=True, exist_ok=True)
+        marker.write_text("{not json", encoding="utf-8")
+        assert ZellijBackend().retire(_binding("aaaaaaaaaaaa"), env) is False
+        assert marker.exists(), "an unidentifiable marker must not be removed"
+
+    def test_tmux_retire_reads_back_and_scopes_to_its_own_session(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The option backend scopes the same way, via `display-message` readback."""
+        options: dict[str, str] = {}
+
+        def fake_run(argv: list[str]) -> bool:
+            # ``-u`` puts the option name at a different index than a set does,
+            # so the fake mirrors the real argv shapes: set is ``... <option>
+            # <value>`` and unset is ``... -u <option>``.
+            if "-u" in argv:
+                options.pop(argv[-1], None)
+            else:
+                options[argv[-2]] = argv[-1]
+            return True
+
+        monkeypatch.setattr("local_operator.multiplexer.markers._run", fake_run)
+        monkeypatch.setattr(
+            "local_operator.multiplexer.markers._capture",
+            lambda argv: options.get("@lop_session"),
+        )
+        monkeypatch.setattr("local_operator.multiplexer.markers._which", lambda b: "/bin/tmux")
+        env = {"TMUX": "/tmp/tmux-501/default,123,0", "TMUX_PANE": "%3"}
+        backend = TmuxBackend()
+
+        # Successor published first: the pane holds another session's binding.
+        options["@lop_session"] = "bbbbbbbbbbbb"
+        assert backend.retire(_binding("aaaaaaaaaaaa"), env) is False
+        assert "@lop_session" in options, "a foreign clear deleted the fresh binding"
+
+        # Our own binding: cleared, both halves.
+        options["@lop_session"] = "aaaaaaaaaaaa"
+        assert backend.retire(_binding("aaaaaaaaaaaa"), env) is True
+        assert "@lop_session" not in options
+
+    def test_a_wezterm_clear_cannot_scope_and_relies_on_sequencing(
+        self, config_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """wezterm's write-only user vars make scoping impossible there.
+
+        This pins WHY the swap is sequenced rather than only scoped: without
+        the predecessor wait, this backend's unconditional clear deletes the
+        successor's binding every time. The sequencing is exercised end to
+        end in the TUI swap test; this asserts the property it protects.
+        """
+        _make_session(config_dir, "aaaaaaaaaaaa")
+        _make_session(config_dir, "bbbbbbbbbbbb")
+        options: dict[str, str] = {}
+
+        def fake_run(argv: list[str]) -> bool:
+            # wezterm has no unset: a clear is a set with an empty value, so
+            # the fake mirrors that shape (empty value = absent).
+            if len(argv) > 6 and argv[6] == "":
+                options.pop(argv[5], None)
+            else:
+                options[argv[5]] = argv[6]
+            return True
+
+        monkeypatch.setattr("local_operator.multiplexer.markers._run", fake_run)
+        monkeypatch.setattr("local_operator.multiplexer.markers._which", lambda b: "/bin/wezterm")
+        env = {"WEZTERM_PANE": "7"}
+
+        class SlowRetireWezTerm(WezTermBackend):
+            def retire(self, binding: Any, env: Any) -> bool:
+                time.sleep(TestSwapOrdering.RETIRE_LATENCY_S)
+                return super().retire(binding, env)
+
+        backend = SlowRetireWezTerm()
+        outgoing = SessionBroadcast(_binding("aaaaaaaaaaaa"), backend, env=env, interval_s=3600.0)
+        outgoing.start()
+        deadline = time.monotonic() + 5.0
+        while options.get("@lop_session") != "aaaaaaaaaaaa":
+            assert time.monotonic() < deadline, "outgoing binding never published"
+            time.sleep(0.005)
+
+        outgoing.stop(retire=True)
+        incoming = SessionBroadcast(
+            _binding("bbbbbbbbbbbb"),
+            backend,
+            env=env,
+            interval_s=3600.0,
+            predecessor=outgoing,
+        )
+        incoming.start()
+        incoming.join(timeout=10.0)
+        outgoing.join(timeout=10.0)
+        assert options.get("@lop_session") == "bbbbbbbbbbbb"
 
 
 class TestCleanExitWinsOverReassert:
@@ -477,6 +677,128 @@ class TestCleanExitWinsOverReassert:
             broadcast.stop()
             broadcast.join(timeout=10.0)
 
+    def test_the_withdrawal_lands_before_interpreter_exit(self, tmp_path: Path) -> None:
+        """F8: a deliberate quit must actually withdraw, not just decide to.
+
+        The retire worker is a daemon thread, and daemon threads are killed at
+        interpreter exit without running what is left of their target. Before
+        the exit drain, `stop(retire=True)` on quit returned in microseconds
+        having only STARTED the worker — the process then exited, the
+        withdrawal never ran, and the pane kept advertising a session the user
+        had deliberately closed until their next shell replayed it.
+
+        Run in a SUBPROCESS because the property IS process death: an
+        in-process test would have to exit to observe it.
+        """
+        import subprocess
+        import sys
+
+        child = textwrap.dedent(
+            """
+            import os, sys, time
+            from pathlib import Path
+            sys.path.insert(0, {repo!r})
+            os.environ["LOCAL_OPERATOR_CONFIG_DIR"] = {config!r}
+            from local_operator.multiplexer.broadcast import (
+                SessionBroadcast, build_binding,
+            )
+            from local_operator.multiplexer.markers import ZellijBackend
+
+            class SlowRetireZellij(ZellijBackend):
+                # One subprocess spawn's worth of latency, as every real
+                # backend retire pays; before the drain this was all it took
+                # for interpreter exit to eat the withdrawal.
+                def retire(self, binding, env):
+                    time.sleep(0.05)
+                    return super().retire(binding, env)
+
+            env = {{"ZELLIJ_SESSION_NAME": "main", "ZELLIJ_PANE_ID": "0"}}
+            # The session must be resumable or nothing publishes; the child
+            # has to create it itself because the fixture's monkeypatching
+            # does not cross the process boundary.
+            session = Path(os.environ["LOCAL_OPERATOR_CONFIG_DIR"]) / "sessions" / "cccccccccccc"
+            session.mkdir(parents=True, exist_ok=True)
+            # The trailing newline is spelled \\n in the source: a real one
+            # inside this literal would break dedent's common-prefix
+            # computation and the child would arrive still-indented.
+            (session / "transcript.jsonl").write_text("{{}}\\n")
+            broadcast = SessionBroadcast(
+                build_binding("cccccccccccc"), SlowRetireZellij(),
+                env=env, interval_s=3600.0,
+            )
+            broadcast.start()
+            path = None
+            from local_operator.multiplexer.markers import marker_dir
+            deadline = time.monotonic() + 5.0
+            while not (marker_dir() / "zellij-main-0.json").exists():
+                assert time.monotonic() < deadline
+                time.sleep(0.005)
+            # The clean quit, exactly as on_unmount performs it: stop and
+            # return, letting the process end. Nothing else may run.
+            broadcast.stop(retire=True)
+            """.format(
+                repo=str(Path(__file__).resolve().parent.parent.parent),
+                config=str(tmp_path),
+            )
+        )
+        completed = subprocess.run(
+            [sys.executable, "-c", child], capture_output=True, text=True, timeout=60
+        )
+        assert completed.returncode == 0, completed.stderr[-2000:]
+
+        marker = tmp_path / "multiplexer" / "zellij-main-0.json"
+        assert not marker.exists(), (
+            "the withdrawal never ran: a cleanly-quit session is still " "advertised in its pane"
+        )
+
+    def test_a_wedged_retire_bounds_the_quit_delay(self, tmp_path: Path) -> None:
+        """The exit drain is bounded: a wedged socket delays quit, it cannot hang it.
+
+        The drain exists to land the F8 withdrawal; this pins its other half —
+        the worst case it may add to a deliberate quit. The bound is generous
+        against the 2s budget (interpreter startup is inside the measurement)
+        and far under the 30s a wedged backend would otherwise add.
+        """
+        import subprocess
+        import sys
+
+        child = textwrap.dedent(
+            """
+            import os, sys, time
+            sys.path.insert(0, {repo!r})
+            os.environ["LOCAL_OPERATOR_CONFIG_DIR"] = {config!r}
+            from local_operator.multiplexer.broadcast import (
+                SessionBroadcast, build_binding,
+            )
+
+            class Wedged:
+                name = "wedged"
+                def detect(self, env): return True
+                def publish(self, binding, env): return True
+                def retire(self, binding, env):
+                    time.sleep(30.0)   # a socket that never answers
+                    return True
+
+            broadcast = SessionBroadcast(
+                build_binding("abc123abc123"), Wedged(), env={{}}, interval_s=3600.0
+            )
+            broadcast.start()
+            time.sleep(0.2)
+            broadcast.stop(retire=True)
+            """.format(
+                repo=str(Path(__file__).resolve().parent.parent.parent),
+                config=str(tmp_path),
+            )
+        )
+        started = time.monotonic()
+        completed = subprocess.run(
+            [sys.executable, "-c", child], capture_output=True, text=True, timeout=60
+        )
+        elapsed = time.monotonic() - started
+        assert completed.returncode == 0, completed.stderr[-2000:]
+        # 2s drain budget + interpreter startup + scheduling slack.
+        assert elapsed < 10.0, f"a wedged socket delayed quit by {elapsed:.1f}s"
+
 
 class TestReassertInterval:
     def test_it_exceeds_the_cmux_index_cache_ttl(self) -> None:
@@ -606,6 +928,12 @@ class TestMarkerBackends:
         calls: list[list[str]] = []
         monkeypatch.setattr(
             "local_operator.multiplexer.markers._run", lambda argv: calls.append(argv) or True
+        )
+        # The readback our own scoping performs: the pane is assumed to hold
+        # THIS binding, so the retire proceeds to the unset under test.
+        monkeypatch.setattr(
+            "local_operator.multiplexer.markers._capture",
+            lambda argv: _binding().session_id,
         )
         monkeypatch.setattr("local_operator.multiplexer.markers._which", lambda b: "/bin/tmux")
         env = {"TMUX": "/tmp/tmux-501/default,123,0", "TMUX_PANE": "%3"}

--- a/tests/unit/tui/test_multiplexer_broadcast.py
+++ b/tests/unit/tui/test_multiplexer_broadcast.py
@@ -1,0 +1,185 @@
+"""The app's half of multiplexer resume publication.
+
+The single most important property here is that the SUITE ITSELF must not
+publish. This repository's tests are routinely run inside a cmux surface, and
+``tests/conftest.py`` isolates HOME and the provider keys but deliberately not
+``CMUX_*`` — so without the headless gate every pilot test in this directory
+would rewrite the resume binding of the very session the developer is running
+the tests from. That failure is silent, and it damages state outside the
+suite, which is the kind of bug a test has to prevent rather than report.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+import local_operator.multiplexer.cmux as cmux_mod
+from local_operator.session.protocol import SessionProtocol
+from local_operator.tui.app import OperatorApp
+from tests.unit.tui.test_app_pilot import FakeSession, _factory
+
+
+@pytest.fixture
+def resumable_session(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Back the id ``FakeSession`` reports with a real resumable directory.
+
+    Without this, `is_resumable_session` refuses and nothing publishes for
+    reasons that have nothing to do with the property under test.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    directory = tmp_path / "sessions" / FakeSession().session_id
+    directory.mkdir(parents=True)
+    (directory / "transcript.jsonl").write_text("{}\n", encoding="utf-8")
+
+
+@pytest.fixture
+def spy_rpc(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """Record every cmux RPC that would have been sent, and send none."""
+    seen: list[str] = []
+    monkeypatch.setattr(
+        cmux_mod, "_rpc", lambda binary, method, params: seen.append(method) or None
+    )
+    monkeypatch.setattr(cmux_mod, "_cmux_binary", lambda: "/bin/cmux")
+    return seen
+
+
+@pytest.mark.asyncio
+async def test_a_headless_app_publishes_nothing(
+    spy_rpc: list[str], resumable_session: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The guard that keeps this suite off the developer's own cmux surface.
+
+    Deliberately arranged so the headless gate is the ONLY thing left stopping
+    a publish: the session id `FakeSession` reports is backed by a real
+    resumable directory, and the cmux target/binary are both satisfied. Without
+    that setup this test would pass for the wrong reason — an unresumable
+    session publishes nothing regardless of the gate, so the assertion would
+    hold even if the gate were deleted.
+
+    Proven by construction: flipping `is_headless` to False in the same
+    arrangement produces `surface.resume.set`, which is the next test.
+    """
+    monkeypatch.setenv("CMUX_WORKSPACE_ID", "11111111-2222-3333-4444-555555555555")
+    monkeypatch.setenv("CMUX_SURFACE_ID", "66666666-7777-8888-9999-000000000000")
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        assert app.is_headless is True
+        app._session = cast(SessionProtocol, FakeSession())
+        app._start_multiplexer_broadcast()
+        await asyncio.sleep(0.5)
+    assert spy_rpc == []
+
+
+@pytest.mark.asyncio
+async def test_the_same_arrangement_publishes_once_the_gate_is_lifted(
+    spy_rpc: list[str], resumable_session: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The control for the test above: proves the gate is what blocks it."""
+    monkeypatch.setenv("CMUX_WORKSPACE_ID", "11111111-2222-3333-4444-555555555555")
+    monkeypatch.setenv("CMUX_SURFACE_ID", "66666666-7777-8888-9999-000000000000")
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        monkeypatch.setattr(OperatorApp, "is_headless", property(lambda self: False))
+        app._session = cast(SessionProtocol, FakeSession())
+        app._start_multiplexer_broadcast()
+        await asyncio.sleep(0.5)
+        assert "surface.resume.set" in spy_rpc
+
+
+@pytest.mark.asyncio
+async def test_the_pane_binding_is_not_left_behind_on_exit(spy_rpc: list[str]) -> None:
+    """A clean exit leaves no broadcast handle for a later turn to re-assert."""
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+    assert getattr(app, "_multiplexer_broadcast", None) is None
+
+
+@pytest.mark.asyncio
+async def test_a_session_swap_rebinds_the_pane(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The pane must advertise the conversation currently in it.
+
+    What is pinned is the ORDER: retire the outgoing binding, THEN publish the
+    new one. Both name the same pane, so the reverse order would clear the
+    binding it had just published and leave the pane advertising nothing.
+
+    Three things have to be arranged for this path to run at all, and each one
+    is a real precondition rather than test scaffolding:
+
+    * ``is_headless`` must be False. It is Textual's property, not this app's,
+      so it is patched on ``OperatorApp`` itself — patching ``type(app)``
+      reaches into the framework and changes every app in the process.
+    * the session must report a ``session_id``; the pilot's ``FakeSession``
+      has none, which is exactly why the hook is a no-op under the other
+      tests in this file.
+    * the publish/retire pair are imported inside the hook, so they are
+      patched on the package they are imported FROM.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    events: list[str] = []
+
+    class Handle:
+        def stop(self, *, retire: bool = True) -> None:
+            events.append(f"stop(retire={retire})")
+
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+
+        # `events.append(...) or Handle()` would work, but spelled explicitly:
+        # a lambda whose first expression returns None is exactly the kind of
+        # thing that silently yields the wrong object when edited later.
+        def fake_broadcast(session_id: str, **kwargs: Any) -> Handle:
+            events.append("publish")
+            return Handle()
+
+        monkeypatch.setattr(
+            "local_operator.multiplexer.broadcast_session", fake_broadcast, raising=True
+        )
+        monkeypatch.setattr(
+            "local_operator.multiplexer.retire_session",
+            lambda handle: handle.stop(retire=True) if handle is not None else None,
+            raising=True,
+        )
+        monkeypatch.setattr(OperatorApp, "is_headless", property(lambda self: False))
+        # `FakeSession` already reports a `session_id` ("sess"), which is all
+        # the hook reads; the other tests in this file no-op only because they
+        # never reach this point with a session adopted.
+        app._session = cast(SessionProtocol, FakeSession())
+        app._start_multiplexer_broadcast()
+        app._start_multiplexer_broadcast()
+        # Asserted INSIDE the context: leaving it unmounts the app, which
+        # correctly retires the live binding and would append a fourth event.
+        assert events == ["publish", "stop(retire=True)", "publish"]
+
+    # And that unmount retire is itself part of the contract: a clean exit
+    # never leaves the pane advertising a closed session.
+    assert events[-1] == "stop(retire=True)"
+
+
+@pytest.mark.asyncio
+async def test_a_broadcast_failure_never_reaches_the_user(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Publication is bookkeeping; it must not be able to break a session."""
+    app = OperatorApp(lambda: _factory(FakeSession()))
+
+    def boom(*args: Any, **kwargs: Any) -> Any:
+        raise RuntimeError("cmux socket died")
+
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        monkeypatch.setattr("local_operator.multiplexer.broadcast_session", boom)
+        monkeypatch.setattr(type(app), "is_headless", property(lambda self: False))
+        # The app's hook swallows it; the session carries on.
+        with pytest.raises(RuntimeError):
+            boom()
+        try:
+            app._start_multiplexer_broadcast()
+        except RuntimeError:  # pragma: no cover - the failure this test forbids
+            pytest.fail("a broadcast failure escaped into the app")


### PR DESCRIPTION
## Summary

~15 `lop` sessions run as cmux sidebar workspaces. When cmux crashes the workspaces return, but every surface opens a fresh shell and a fresh `lop`, and all conversation continuity is lost. The sessions survive on disk under `~/.local-operator/sessions`; nothing maps a pane back to the session it held.

This publishes that missing fact per pane: *this pane holds session `<id>`, and here is the argv that reopens it*.

- cmux gets a real resume binding over its control socket.
- tmux, WezTerm, Zellij and screen have no resume API, so they get a documented, discoverable pane marker a restore script can consume.
- Backends sit behind one interface in a registry, so another multiplexer is a new module rather than an edit to a chain of conditionals.
- Version bumps from `0.33.1` to `0.34.0` as a minor feature.

Change class: **C2, standard / pre-authorized.** No RFC or tracker record is attached; this MR is the system of record.

## Impact

Before: a cmux crash cost every running conversation. Recovery meant remembering which pane held which session and retyping `lop --resume <id>` for each one.

After: each pane advertises its session, so a restore reopens the conversation that pane was holding.

Publication is best-effort by construction. A missing binary, a socket error, a multiplexer that is not running, or a timeout is logged at debug and otherwise ignored. It can never be the reason a session fails to start.

## Design points worth review attention

**`source: agent-hook` over the CLI.** `cmux surface resume set` hardcodes `source = "cli"`, which cmux resolves to `approvalPolicy = .manual`, `autoResume = false`. Only the socket RPC reaches auto. A future simplification to the CLI would still create a binding and still print one, and auto-resume would be silently dead. Commented at the top of `multiplexer/cmux.py`.

**The re-assert timer is justified by cmux's source, not by a measurement here.** `SharedLiveAgentIndex.cacheTTL` is 60s; a binding published against an index snapshot older than this process is retired by `retireAgentHookResumeBinding`, which latches `autoResume = false`. `REASSERT_INTERVAL_S = 90` therefore has to stay above that TTL. The measurements on this host can neither confirm nor refute the race (see limitations), so the defence is retained on the strength of the Swift.

**Restore-and-idle is a safety boundary, not a default.** `resume_argv` is the single place the command is built, and it can only ever emit `lop --resume <id>`. Fifteen panes restoring unattended must not resume tool execution.

**Two gates, different lifetimes.** Subagent-ness is permanent and decided once (`origin.json`); resumability is transient and re-checked before every publish, because a cold session has no transcript until its first turn lands. Checking resumability once at startup would mean most sessions silently never publish, discovered only after a crash.

**Headless gate on the app hook.** This suite runs inside cmux and `tests/conftest.py` does not clear `CMUX_*`, so without the gate every pilot test would rewrite the resume binding of the session running the tests. A paired test proves the gate is load-bearing: same arrangement, gate lifted, produces `surface.resume.set`.

## Testing evidence

Full artifacts in `docs/evidence/multiplexer-resume/`. **Read `cmux-host-caveat.md` first** — it bounds every cmux claim below.

**Strongest evidence: the binding reaches the file a crash restores from.** `cmux-on-disk-binding.txt` reads it back out of `~/Library/Application Support/cmux/session-com.cmuxterm.app.json`, which is written on cmux's autosave rather than on clean shutdown:

```text
kind            local-operator
checkpointId    c9a4b15eed9e
source          agent-hook
autoResume      true
approvalPolicy  auto
```

Identity was verified rather than eyeballed: `panels[0].id == CMUX_SURFACE_ID` and `workspaces[8].workspaceId == CMUX_WORKSPACE_ID`, both exact. An in-memory binding that never reached disk would be the classic "looks fixed and is not".

**Live publish and retire** (`cmux-publish-retire.txt`): a real session publishes `source: agent-hook`, `approval_policy: auto`, `auto_resume: true`, with `checkpoint_id` equal to its real session directory name. The binding is gone after retire.

**The four refusals** (`negative-cases.txt`), all publishing nothing: subagent session, kill switch set, no multiplexer in the environment, cmux binary unresolvable.

**tmux exercised for real** (`tmux.txt`, reproducible via `tmux-evidence.sh`): against a private tmux server on its own socket, both pane options are written and read back with `show-options -pv`, and after retire both are genuinely *unset* (`rc=1`) rather than blanked. A blank option would read to a restore script as a session with an empty id.

## Honest limitations

These are stated because the evidence does not support the stronger claim, and a reviewer should not infer coverage that does not exist.

- The cmux host was running from a **deleted binary** during capture (`Contents/MacOS/` empty; the app executing an old in-memory image). Behaviour was not self-consistent across the update boundary: bindings held for minutes, then retired in 2-8s, and in one control run a binding stayed `auto_resume: true` for 75s *after its agent process was killed*, which a working `isStaleAgentHookBinding` should have retired. That last result indicates cmux's liveness retirement was not running at all.
- Consequently the 45/45-samples-true duty cycle measured here is **not** a product guarantee. It was identical with and without the vault registration, so this host did **not** isolate the registration's causal role.
- The vault registration is documented as required because cmux's own `docs/vault.md` requires it for a custom kind, **not** because it was verified here to be what holds the binding.
- **Outstanding: clean re-validation on a healthy cmux install.** The host binary has since been restored, but the running process is still the old in-memory image, so a restart is required before the end-to-end path can be confirmed. That restart is itself the first real-world test of this feature. Worst case the sessions come back cold, which is exactly today's behaviour and no worse.

## Gates

```text
flake8 .                             clean
black --check (26.1.0)               clean
isort --check-only --profile black   clean
pyright                              0 errors, 0 warnings
unit suite                           6788 passed, 7 skipped
```

The 2 failures observed (`test_comms.py::test_a_resumed_child_replays_the_stopped_ones_transcript`, `::test_a_cancelled_child_keeps_the_work_it_had_already_done`) are **pre-existing flakes**, verified rather than assumed: clean `origin/main` fails the same files with a *different* test on each full run (four distinct failure sets observed), and both pass in isolation on both branches. The 45 new tests pass 4/4 consecutive runs.

## Rollback

Revert the merge commit. The feature adds no migration and no persisted state of its own; the only external side effect is a cmux resume binding, which cmux clears on its own once the publishing process exits.
