### PR TITLE
feat(providers): patient backoff for connectivity-loss errors

### DIFF
--- a/local_operator/providers/failover.py
+++ b/local_operator/providers/failover.py
@@ -127,13 +127,16 @@ _TIMEOUT_MARKERS = ("timeout", "timed out", "deadline exceeded", "stream stalled
 #:   - "no route to host" / "errno 65": ``EHOSTUNREACH`` (macOS 65, Linux 113).
 #:   - "network is down" / "errno 50": ``ENETDOWN`` — the interface is still
 #:     coming up.
-#:   - "connection refused" / "errno 61": ``ECONNREFUSED`` (macOS 61, Linux
-#:     111). Included because during a reconnect a captive portal or the local
-#:     stack refuses at the socket layer before any HTTP response exists. This
-#:     one CAN also mean a genuinely-down endpoint rather than an offline
-#:     machine, but the patient path is safe either way: the backoff is
-#:     abortable, and once the (minutes-long) budget is spent the diagnostic
-#:     error still surfaces, so a real outage is not hidden, only waited out.
+#:
+#: DELIBERATELY EXCLUDED — do not re-add: ``ECONNREFUSED`` ("connection refused"
+#: / errno 61 on macOS, 111 on Linux). A refused connection is a TCP RST from the
+#: destination, which PROVES the host was reachable — the exact opposite of the
+#: offline machine this path exists for. An offline machine cannot even resolve
+#: or route to a host, so it yields the DNS/route/net-unreachable failures above,
+#: never a refusal. Treating a refusal as connectivity loss would give a
+#: genuinely-down LOCAL provider (ollama, LM Studio, a localhost proxy) the
+#: 8-minute patient wait AND suppress the fallback-chain walk that otherwise
+#: routes around it — a regression. A refusal stays an ordinary transient error.
 _CONNECTIVITY_LOSS_MARKERS = (
     "nodename nor servname",
     "errno 8",
@@ -146,8 +149,6 @@ _CONNECTIVITY_LOSS_MARKERS = (
     "errno 65",
     "network is down",
     "errno 50",
-    "connection refused",
-    "errno 61",
 )
 
 
@@ -1196,6 +1197,22 @@ def _normalize_chains(chains: Mapping[str, Any]) -> dict[str, list[Any]]:
     return normalized
 
 
+def _coerce_int(value: Any, default: int) -> int:
+    """A config integer that degrades to ``default`` on junk input.
+
+    ``from_settings`` re-parses on every model call and must never raise, so a
+    non-numeric or missing value (``None`` when the key is absent) falls back to
+    the shipped default rather than killing the turn. Mirrors the ``float()``
+    guard the ``usageReservePercent`` path already uses at this same boundary.
+    """
+    if value is None:
+        return default
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
 @dataclasses.dataclass(frozen=True)
 class RetrySettings:
     """The ``values.retry.*`` config surface."""
@@ -1229,22 +1246,24 @@ class RetrySettings:
             reserve_percent = min(100.0, max(0.0, float(reserve)))
         except (TypeError, ValueError):
             reserve_percent = 10.0
+        # A malformed connectivity budget must degrade to the shipped default,
+        # not crash from_settings on EVERY turn (it re-parses per model call).
+        # Same contract as usageReservePercent above: a bad value in the retry
+        # block is a preference the harness can safely ignore, never a fatal.
+        connectivity_max_retries = _coerce_int(
+            retry.get("connectivityMaxRetries", retry.get("connectivity_max_retries")),
+            CONNECTIVITY_MAX_RETRIES,
+        )
+        connectivity_backoff_cap_ms = _coerce_int(
+            retry.get("connectivityBackoffCapMs", retry.get("connectivity_backoff_cap_ms")),
+            CONNECTIVITY_BACKOFF_CAP_MS,
+        )
         return RetrySettings(
             enabled=bool(retry.get("enabled", True)),
             max_retries=int(retry.get("maxRetries", retry.get("max_retries", 10))),
             base_delay_ms=int(retry.get("baseDelayMs", retry.get("base_delay_ms", 500))),
-            connectivity_max_retries=int(
-                retry.get(
-                    "connectivityMaxRetries",
-                    retry.get("connectivity_max_retries", CONNECTIVITY_MAX_RETRIES),
-                )
-            ),
-            connectivity_backoff_cap_ms=int(
-                retry.get(
-                    "connectivityBackoffCapMs",
-                    retry.get("connectivity_backoff_cap_ms", CONNECTIVITY_BACKOFF_CAP_MS),
-                )
-            ),
+            connectivity_max_retries=connectivity_max_retries,
+            connectivity_backoff_cap_ms=connectivity_backoff_cap_ms,
             model_fallback=bool(retry.get("modelFallback", retry.get("model_fallback", True))),
             usage_aware_fallback=bool(
                 retry.get("usageAwareFallback", retry.get("usage_aware_fallback", False))
@@ -2052,7 +2071,7 @@ async def stream_with_failover(
                     # Patient budget spent while still offline: surface the most
                     # diagnostic failure of the walk, same as any other
                     # exhaustion, so the reported-error semantics stay intact.
-                    raise reported if reported is not None else exc
+                    raise (reported if reported is not None else exc) from exc
                 if is_server_side_failure(exc):
                     server_fault_requests += 1
                     server_faults_by_target[route_key] = server_fault_requests

--- a/local_operator/providers/failover.py
+++ b/local_operator/providers/failover.py
@@ -97,6 +97,59 @@ _WEAK_USAGE_LIMIT_MARKERS = ("usage", "insufficient")
 
 _TIMEOUT_MARKERS = ("timeout", "timed out", "deadline exceeded", "stream stalled")
 
+#: Substrings that mean "this MACHINE cannot reach ANY network right now" — a
+#: DNS lookup, route, or socket connect that failed before a single HTTP byte
+#: was exchanged, so no provider was actually reached. Matched against the same
+#: lowercased ``class name + detail`` haystack :func:`wrap_transport_error`
+#: builds, because the exception class and its errno text are the whole of the
+#: evidence: a connectivity loss carries no HTTP status and no provider words.
+#:
+#: This is a DIFFERENT condition from an ordinary transient 5xx even though both
+#: classify ``kind="transient"``. A 5xx means a reachable provider is unwell, so
+#: the fix is to retry FAST (8s cap) and rotate to another credential/provider.
+#: A connectivity loss means the laptop was closed, carried between office and
+#: home, and is mid-reconnect to wifi — every provider is equally unreachable,
+#: so rotating credentials and walking the fallback chain are pure waste. What
+#: that scenario needs instead is PATIENCE: a minutes-long backoff (see
+#: :func:`connectivity_backoff_delay_ms`) that keeps the interactive session
+#: alive across a normal reconnect rather than dying inside ~80s.
+#:
+#: Each marker cites the errno/wording it catches. macOS and Linux word the same
+#: failure differently, so both spellings are listed:
+#:   - "nodename nor servname" / "errno 8": macOS ``getaddrinfo`` DNS failure —
+#:     the exact string the reported ``ConnectError`` carried on reconnect.
+#:   - "temporary failure in name resolution" / "name or service not known" /
+#:     "getaddrinfo failed": Linux/glibc ``EAI_AGAIN`` / ``EAI_NONAME`` and the
+#:     generic resolver-failure wording.
+#:   - "network is unreachable" / "errno 51": no route to the network at all
+#:     (macOS ``ENETUNREACH`` 51, Linux 101) — the interface has no default
+#:     route yet after waking.
+#:   - "no route to host" / "errno 65": ``EHOSTUNREACH`` (macOS 65, Linux 113).
+#:   - "network is down" / "errno 50": ``ENETDOWN`` — the interface is still
+#:     coming up.
+#:   - "connection refused" / "errno 61": ``ECONNREFUSED`` (macOS 61, Linux
+#:     111). Included because during a reconnect a captive portal or the local
+#:     stack refuses at the socket layer before any HTTP response exists. This
+#:     one CAN also mean a genuinely-down endpoint rather than an offline
+#:     machine, but the patient path is safe either way: the backoff is
+#:     abortable, and once the (minutes-long) budget is spent the diagnostic
+#:     error still surfaces, so a real outage is not hidden, only waited out.
+_CONNECTIVITY_LOSS_MARKERS = (
+    "nodename nor servname",
+    "errno 8",
+    "temporary failure in name resolution",
+    "name or service not known",
+    "getaddrinfo failed",
+    "network is unreachable",
+    "errno 51",
+    "no route to host",
+    "errno 65",
+    "network is down",
+    "errno 50",
+    "connection refused",
+    "errno 61",
+)
+
 
 def _is_usage_limit(status: int | None, message: str) -> bool:
     """429, or a body that SAYS it ran out.
@@ -464,6 +517,40 @@ def is_transient_error(error: BaseException) -> bool:
     return classify_provider_error(error) in ("transient", "timeout")
 
 
+def is_connectivity_loss(error: BaseException) -> bool:
+    """The MACHINE is offline — DNS/route/socket-connect failed before any HTTP.
+
+    A narrow refinement of :func:`is_transient_error`, not a replacement: a
+    connectivity loss IS transient (it heals on its own), but it is the specific
+    transient that means *no provider was reached at all*, so unlike a 5xx the
+    right response is a patient minutes-long wait rather than a fast retry-then-
+    rotate. It exists for the close-laptop / change-location / reconnect-wifi
+    cycle, which takes several minutes — longer than the ordinary ~80s transport
+    budget — during which every provider and every credential is equally
+    unreachable and rotation buys nothing.
+
+    Read from the same lowercased ``class name + detail`` haystack
+    :func:`wrap_transport_error` builds, so it works both on the wrapped
+    :class:`ProviderError` (whose ``message`` is ``"<ClassName>: <detail>"``)
+    and on a raw exception a caller has in hand. Deliberately NOT gated on
+    ``kind``: :func:`wrap_transport_error` keeps these ``kind="transient"``
+    because "transient provider error" is the right frame for the user, so the
+    class/errno text is the only signal that separates them from a 5xx.
+    """
+    if isinstance(error, ProviderError):
+        # `message` already carries the wrapped "<ClassName>: <detail>" text
+        # (see wrap_transport_error), and the class name is the load-bearing
+        # half — httpx.ConnectError is routinely raised with an errno-only
+        # detail. status must be absent: a real HTTP response means a provider
+        # WAS reached, so it is a 5xx/timeout, never a connectivity loss.
+        if error.status is not None:
+            return False
+        haystack = error.message.lower()
+    else:
+        haystack = f"{type(error).__name__}: {error}".lower()
+    return any(marker in haystack for marker in _CONNECTIVITY_LOSS_MARKERS)
+
+
 def is_invalidated_credential_error(error: BaseException) -> bool:
     """The credential was EXPLICITLY revoked by the IdP — soft-delete worthy.
 
@@ -820,6 +907,29 @@ def expand_fallback_candidates(selector: str, chain: Sequence[Any]) -> list[str]
 
 BACKOFF_CAP_MS = 8000
 BACKOFF_JITTER_FRACTION = 0.25
+
+#: The per-sleep ceiling for a CONNECTIVITY-LOSS backoff, far larger than
+#: :data:`BACKOFF_CAP_MS`. An ordinary transient 5xx retries against a REACHABLE
+#: provider, so its 8s cap keeps an interactive turn snappy. A connectivity loss
+#: means the machine itself is offline (laptop closed, carried between office and
+#: home, mid-reconnect to wifi), which resolves on the order of minutes, not
+#: seconds — so hammering every 8s just burns the retry budget while still
+#: offline. Letting the individual sleeps grow to a minute matches the real
+#: recovery timescale: one wake-up probe per ~minute is enough to catch the
+#: reconnect, and there is nothing to be snappy for while there is no network.
+CONNECTIVITY_BACKOFF_CAP_MS = 60_000
+
+#: How many patient connectivity-loss retries one target may make before the
+#: diagnostic error is surfaced. With the default 500ms base and the 60s cap the
+#: delays grow 0.5,1,2,4,8,16,32s then sit at 60s, so 15 retries is a worst-case
+#: total wait of ~9 minutes (0.5+1+2+4+8+16+32 + 60*8 = 543.5s) before a still-
+#: offline machine gives up — comfortably past a normal close/move/reconnect
+#: cycle, while still bounded so a genuinely dead network eventually surfaces
+#: rather than hanging the session forever. Separate from ``max_retries``, which
+#: sizes the FAST transport budget against a reachable provider and must stay
+#: small; conflating them would either make 5xx retries crawl or make an offline
+#: machine give up in ~80s (the reported disruption).
+CONNECTIVITY_MAX_RETRIES = 15
 # Interactive sessions must never disappear into a provider's quota-reset
 # window. A 429 can carry Retry-After values of many minutes or hours; sleeping
 # that duration before credential rotation makes the TUI look hung and prevents
@@ -896,6 +1006,31 @@ MAX_FIRST_CREDENTIAL_SERVER_RETRIES = 3
 def backoff_delay_ms(base_delay_ms: int, attempt: int, *, rng: random.Random | None = None) -> int:
     """``min(base * 2^(attempt-1), 8000)`` with 25% downward jitter."""
     raw = min(base_delay_ms * (2 ** max(0, attempt - 1)), BACKOFF_CAP_MS)
+    jitter_source = rng or random
+    return max(0, int(raw - raw * BACKOFF_JITTER_FRACTION * jitter_source.random()))
+
+
+def connectivity_backoff_delay_ms(
+    base_delay_ms: int,
+    attempt: int,
+    *,
+    cap_ms: int = CONNECTIVITY_BACKOFF_CAP_MS,
+    rng: random.Random | None = None,
+) -> int:
+    """The patient variant of :func:`backoff_delay_ms` for a machine that is
+    OFFLINE — same exponential growth and 25% downward jitter, but capped at
+    ``cap_ms`` (defaults to :data:`CONNECTIVITY_BACKOFF_CAP_MS`, ~60s) instead of
+    the fast 8s ceiling.
+
+    A separate function rather than a parameter on ``backoff_delay_ms`` so the
+    call sites read as two distinct policies — fast for a reachable provider,
+    patient for no network — and so the fast cap can never be widened by
+    accident. With the default base and cap the delays climb 0.5,1,2,4,8,16,32s
+    and then sit at 60s, which is the cadence a reconnect actually happens on.
+    The cap is a parameter, not the constant, so ``retry.connectivityBackoffCapMs``
+    is honoured without a second code path.
+    """
+    raw = min(base_delay_ms * (2 ** max(0, attempt - 1)), cap_ms)
     jitter_source = rng or random
     return max(0, int(raw - raw * BACKOFF_JITTER_FRACTION * jitter_source.random()))
 
@@ -1068,6 +1203,14 @@ class RetrySettings:
     enabled: bool = True
     max_retries: int = 10
     base_delay_ms: int = 500
+    #: The PATIENT budget for a connectivity loss (machine offline). Distinct
+    #: from ``max_retries`` because the two size different things: ``max_retries``
+    #: is the FAST budget against a reachable provider (5xx/timeout), which must
+    #: stay small, while these keep an interactive session alive across a
+    #: minutes-long close/move/reconnect cycle. Defaults deliver that
+    #: out-of-the-box — no config required — see the two constants they mirror.
+    connectivity_max_retries: int = CONNECTIVITY_MAX_RETRIES
+    connectivity_backoff_cap_ms: int = CONNECTIVITY_BACKOFF_CAP_MS
     model_fallback: bool = True
     usage_aware_fallback: bool = False
     usage_reserve_percent: float = 10.0
@@ -1090,6 +1233,18 @@ class RetrySettings:
             enabled=bool(retry.get("enabled", True)),
             max_retries=int(retry.get("maxRetries", retry.get("max_retries", 10))),
             base_delay_ms=int(retry.get("baseDelayMs", retry.get("base_delay_ms", 500))),
+            connectivity_max_retries=int(
+                retry.get(
+                    "connectivityMaxRetries",
+                    retry.get("connectivity_max_retries", CONNECTIVITY_MAX_RETRIES),
+                )
+            ),
+            connectivity_backoff_cap_ms=int(
+                retry.get(
+                    "connectivityBackoffCapMs",
+                    retry.get("connectivity_backoff_cap_ms", CONNECTIVITY_BACKOFF_CAP_MS),
+                )
+            ),
             model_fallback=bool(retry.get("modelFallback", retry.get("model_fallback", True))),
             usage_aware_fallback=bool(
                 retry.get("usageAwareFallback", retry.get("usage_aware_fallback", False))
@@ -1643,6 +1798,16 @@ async def stream_with_failover(
         access: "OAuthAccess | None" = None  # credential record for this attempt
         current_token: str | None = None
         transport_retries = 0
+        # Patient retries spent waiting out a CONNECTIVITY LOSS (machine offline).
+        # Kept SEPARATE from `transport_retries` because the two size opposite
+        # things: the fast transport budget must stay small so a 5xx does not
+        # crawl, while this rides out a minutes-long reconnect. It also does not
+        # feed the server-fault counters or rotation — when there is no network,
+        # every credential and every fallback provider is equally unreachable,
+        # so this path retries the SAME target in place until the network comes
+        # back (or the patient budget is spent), never rotating on the strength
+        # of a failure the credential did not cause.
+        connectivity_retries = 0
         retry_same_key = False
         # Requests aimed at THIS target's provider that came back a server-side
         # fault, counted across every credential it rotates through.
@@ -1859,6 +2024,35 @@ async def stream_with_failover(
                     raise  # partial output already reached the caller
                 record(exc, primary=is_primary)
                 target_retry_after_ms = max(target_retry_after_ms, exc.retry_after_ms or 0)
+                # A pre-wrapped connectivity loss (a client that turns httpx into
+                # a ProviderError itself) takes the PATIENT path, ahead of the
+                # server-fault ledger below. An offline machine's failure is not
+                # the credential's or the provider's fault and every target is
+                # equally unreachable, so it must neither charge the per-provider
+                # fault ceiling nor rotate — it waits, in place, on a minutes-
+                # long backoff, until the network returns or the patient budget
+                # is spent. The sleep stays abortable, so Ctrl-C still wins.
+                # Gated on retry.enabled so an isolated/decorative call still
+                # makes exactly one attempt (the `not retry.enabled` raise below
+                # would otherwise be pre-empted by this patient loop).
+                if retry.enabled and is_connectivity_loss(exc):
+                    if connectivity_retries < retry.connectivity_max_retries:
+                        connectivity_retries += 1
+                        await _abortable_sleep(
+                            connectivity_backoff_delay_ms(
+                                retry.base_delay_ms,
+                                connectivity_retries,
+                                cap_ms=retry.connectivity_backoff_cap_ms,
+                                rng=rng,
+                            ),
+                            signal,
+                        )
+                        retry_same_key = True
+                        continue
+                    # Patient budget spent while still offline: surface the most
+                    # diagnostic failure of the walk, same as any other
+                    # exhaustion, so the reported-error semantics stay intact.
+                    raise reported if reported is not None else exc
                 if is_server_side_failure(exc):
                     server_fault_requests += 1
                     server_faults_by_target[route_key] = server_fault_requests
@@ -1952,6 +2146,36 @@ async def stream_with_failover(
                     # into the log.
                     raise wrapped from exc
                 record(wrapped, primary=is_primary)
+                # This is the arm a CONNECTIVITY LOSS actually arrives on: no
+                # client in clients.py catches httpx, so a DNS/route/connect
+                # failure on a closed-then-reconnecting laptop reaches here raw
+                # and `wrap_transport_error` stamps it kind="transient". Give it
+                # the PATIENT budget BEFORE the server-fault ledger and the
+                # rotation logic below: an offline machine's failure is nobody's
+                # fault and every provider/credential is equally unreachable, so
+                # charging the fault ceiling or rotating buys nothing — the only
+                # thing that helps is waiting, in place, for the network to come
+                # back. The backoff is abortable, so Ctrl-C still breaks out.
+                # Gated on retry.enabled so an isolated/decorative call still
+                # makes exactly one attempt rather than entering the patient loop
+                # ahead of the `not retry.enabled` raise below.
+                if retry.enabled and is_connectivity_loss(wrapped):
+                    if connectivity_retries < retry.connectivity_max_retries:
+                        connectivity_retries += 1
+                        await _abortable_sleep(
+                            connectivity_backoff_delay_ms(
+                                retry.base_delay_ms,
+                                connectivity_retries,
+                                cap_ms=retry.connectivity_backoff_cap_ms,
+                                rng=rng,
+                            ),
+                            signal,
+                        )
+                        retry_same_key = True
+                        continue
+                    # Patient budget spent while still offline: surface the most
+                    # diagnostic failure, preserving the reported-error contract.
+                    raise (reported if reported is not None else wrapped) from exc
                 if is_server_side_failure(wrapped):
                     server_fault_requests += 1
                     server_faults_by_target[route_key] = server_fault_requests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.33.2"
+version = "0.34.0"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/providers/test_failover.py
+++ b/tests/unit/providers/test_failover.py
@@ -29,7 +29,10 @@ from local_operator.providers.auth_store import AuthStore
 from local_operator.providers.clients import OpenAICompatClient
 from local_operator.providers.failover import (
     AUTH_RETRY_MAX_ATTEMPTS,
+    BACKOFF_CAP_MS,
     CHAIN_EFFORT_LADDER,
+    CONNECTIVITY_BACKOFF_CAP_MS,
+    CONNECTIVITY_MAX_RETRIES,
     SUPPORTED_EFFORTS,
     AuthRetryKeyState,
     FailoverRouteState,
@@ -39,9 +42,11 @@ from local_operator.providers.failover import (
     _request_has_rotated,
     backoff_delay_ms,
     classify_provider_error,
+    connectivity_backoff_delay_ms,
     expand_fallback_candidates,
     expand_fallback_targets,
     is_auth_error,
+    is_connectivity_loss,
     is_direct_credential_rotation_error,
     is_image_rejection,
     is_transient_error,
@@ -3632,3 +3637,191 @@ def test_append_auth_recovery_generic_without_provider() -> None:
     rendered = "authentication failed (HTTP 401): bad key"
     out = append_auth_recovery(rendered, None)
     assert "/login <provider>" in out
+
+
+# ---------------------------------------------------------------------------
+# Connectivity loss — patient backoff for an OFFLINE machine
+# ---------------------------------------------------------------------------
+#
+# These cover the close-laptop / change-location / reconnect-wifi cycle: the
+# machine is briefly fully offline (DNS/route/socket-connect fails before any
+# HTTP), which takes minutes, so the ordinary ~80s transport budget gave up
+# while the network was still down. The patient path must ride that out WITHOUT
+# slowing an ordinary reachable-provider 5xx, and must stay abortable.
+
+
+@pytest.mark.parametrize(
+    "detail",
+    [
+        # The exact string the reported ConnectError carried on reconnect.
+        "[Errno 8] nodename nor servname provided, or not known",
+        "[Errno 51] Network is unreachable",
+        "[Errno 65] No route to host",
+        "[Errno 61] Connection refused",
+        "Temporary failure in name resolution",
+        "Name or service not known",
+        "getaddrinfo failed",
+    ],
+)
+def test_connectivity_markers_classify_as_connectivity_loss(detail: str) -> None:
+    """Every offline-reconnect wording classifies, wrapped and raw, and keeps
+    the user-facing "transient" frame rather than inventing a new kind."""
+    raw = httpx.ConnectError(detail)
+    wrapped = wrap_transport_error(raw)
+    assert is_connectivity_loss(raw)
+    assert is_connectivity_loss(wrapped)
+    # Frame label is unchanged: connectivity loss stays a transient error.
+    assert wrapped.kind == "transient"
+
+
+def test_ordinary_transient_5xx_is_not_connectivity_loss() -> None:
+    """A reachable provider returning 5xx must NOT take the patient path — it
+    carries an HTTP status, which proves a provider was reached."""
+    assert not is_connectivity_loss(ProviderError(503, "service unavailable", retryable=True))
+    assert not is_connectivity_loss(ProviderError(500, "boom", retryable=True))
+    # A bare timeout is transient/timeout but not a connectivity loss either.
+    assert not is_connectivity_loss(wrap_transport_error(httpx.ReadTimeout("timed out")))
+
+
+def test_connectivity_backoff_is_patient_not_the_8s_cap() -> None:
+    """The patient delays grow past the 8s fast cap toward the ~60s ceiling,
+    which is what lets the total budget span minutes."""
+    delays = [
+        connectivity_backoff_delay_ms(500, attempt, rng=random.Random(0))
+        for attempt in range(1, 12)
+    ]
+    # Early attempts match the fast schedule; later ones blow past 8s (the fast
+    # cap) up to the connectivity ceiling — the whole point of the patient path.
+    assert delays[0] <= 500
+    assert max(delays) > BACKOFF_CAP_MS
+    assert max(delays) <= CONNECTIVITY_BACKOFF_CAP_MS
+
+
+async def test_connectivity_loss_recovers_within_patient_budget(monkeypatch) -> None:
+    """Fail offline K times, then the network returns and the stream completes —
+    where the old ~80s (8s-cap x maxRetries) budget would have given up.
+
+    The sleeps are captured, not slept, so the "minutes" pass instantly. The
+    delay SEQUENCE is asserted to prove the patient cap (not the 8s one) is in
+    force, and the attempt count proves it retried far past `maxRetries`.
+    """
+    sleeps: list[int] = []
+    attempts = {"n": 0}
+    # More offline failures than an ordinary maxRetries=10 budget would tolerate,
+    # to prove the patient budget is the one in force.
+    offline_failures = 12
+
+    async def capture_sleep(delay_ms: int, signal: Any) -> None:
+        sleeps.append(delay_ms)
+
+    monkeypatch.setattr("local_operator.providers.failover._abortable_sleep", capture_sleep)
+
+    def flaky(
+        request: ChatRequest, api_key: str | None, oauth_access: Any = None
+    ) -> AsyncIterator[Any]:
+        attempts["n"] += 1
+        if attempts["n"] <= offline_failures:
+            raise httpx.ConnectError("[Errno 8] nodename nor servname provided, or not known")
+
+        async def ok() -> AsyncIterator[Any]:
+            yield StreamEndEvent(stop_reason="stop")
+
+        return ok()
+
+    async def client_for(spec: ModelSpec) -> Any:
+        return _FnClient(flaky)
+
+    auth = FakeAuth({"openai": ["k1"]})
+    settings = {"retry": {"maxRetries": 10, "baseDelayMs": 500, "fallbackChains": {}}}
+    events = [event async for event in stream_with_failover(_request(), auth, settings, client_for)]
+
+    # The stream completed rather than dying: the reconnect was ridden out.
+    assert any(isinstance(e, StreamEndEvent) for e in events)
+    # It retried MORE than maxRetries in place — the patient budget, not the fast
+    # one — and never rotated the credential (offline is nobody's fault).
+    assert attempts["n"] == offline_failures + 1
+    assert len(sleeps) == offline_failures
+    assert auth.rotations == []
+    # The delays climbed past the 8s fast cap toward the patient 60s ceiling.
+    assert max(sleeps) > BACKOFF_CAP_MS
+    assert max(sleeps) <= CONNECTIVITY_BACKOFF_CAP_MS
+
+
+async def test_ordinary_transient_5xx_still_uses_fast_budget(monkeypatch) -> None:
+    """Regression guard: a reachable provider's 5xx must stay on the 8s cap and
+    the small server-fault budget, NOT the patient path."""
+    sleeps: list[int] = []
+
+    async def capture_sleep(delay_ms: int, signal: Any) -> None:
+        sleeps.append(delay_ms)
+
+    monkeypatch.setattr("local_operator.providers.failover._abortable_sleep", capture_sleep)
+
+    def always_500(
+        request: ChatRequest, api_key: str | None, oauth_access: Any = None
+    ) -> AsyncIterator[Any]:
+        raise ProviderError(503, "service unavailable", retryable=True)
+
+    async def client_for(spec: ModelSpec) -> Any:
+        return _FnClient(always_500)
+
+    auth = FakeAuth({"openai": ["k1"]})
+    settings = {"retry": {"maxRetries": 10, "baseDelayMs": 500, "fallbackChains": {}}}
+    with pytest.raises(ProviderError) as excinfo:
+        async for _ in stream_with_failover(_request(), auth, settings, client_for):
+            pass
+
+    assert excinfo.value.status == 503
+    # Every sleep respected the FAST 8s cap; none reached the patient ceiling.
+    assert sleeps  # it did retry
+    assert max(sleeps) <= BACKOFF_CAP_MS
+
+
+async def test_connectivity_loss_backoff_is_abortable() -> None:
+    """Ctrl-C during a patient connectivity-loss wait breaks out immediately —
+    the abort must not be swallowed by the minutes-long sleep."""
+    from local_operator.harness.types import AbortSignal
+
+    def offline(
+        request: ChatRequest, api_key: str | None, oauth_access: Any = None
+    ) -> AsyncIterator[Any]:
+        raise httpx.ConnectError("[Errno 8] nodename nor servname provided, or not known")
+
+    async def client_for(spec: ModelSpec) -> Any:
+        return _FnClient(offline)
+
+    signal = AbortSignal()
+    # A very long base so the FIRST patient sleep would hang the test if the
+    # abort did not win the race.
+    settings = {"retry": {"baseDelayMs": 60_000, "fallbackChains": {}}}
+
+    async def abort_soon() -> None:
+        await asyncio.sleep(0.05)
+        signal.abort("user cancelled")
+
+    task = asyncio.create_task(abort_soon())
+    with pytest.raises(ProviderError) as excinfo:
+        async for _ in stream_with_failover(
+            _request(), FakeAuth({"openai": ["k"]}), settings, client_for, signal=signal
+        ):
+            pass
+    assert excinfo.value.kind == "aborted"
+    await task
+
+
+def test_connectivity_config_keys_parse_camel_and_snake() -> None:
+    """Both key spellings parse; defaults survive a reconnect out of the box."""
+    camel = RetrySettings.from_settings(
+        {"retry": {"connectivityMaxRetries": 7, "connectivityBackoffCapMs": 30_000}}
+    )
+    assert camel.connectivity_max_retries == 7
+    assert camel.connectivity_backoff_cap_ms == 30_000
+    snake = RetrySettings.from_settings(
+        {"retry": {"connectivity_max_retries": 9, "connectivity_backoff_cap_ms": 45_000}}
+    )
+    assert snake.connectivity_max_retries == 9
+    assert snake.connectivity_backoff_cap_ms == 45_000
+    # No config → the shipped defaults, which give a ~9-minute offline window.
+    default = RetrySettings.from_settings(None)
+    assert default.connectivity_max_retries == CONNECTIVITY_MAX_RETRIES
+    assert default.connectivity_backoff_cap_ms == CONNECTIVITY_BACKOFF_CAP_MS

--- a/tests/unit/providers/test_failover.py
+++ b/tests/unit/providers/test_failover.py
@@ -3657,7 +3657,6 @@ def test_append_auth_recovery_generic_without_provider() -> None:
         "[Errno 8] nodename nor servname provided, or not known",
         "[Errno 51] Network is unreachable",
         "[Errno 65] No route to host",
-        "[Errno 61] Connection refused",
         "Temporary failure in name resolution",
         "Name or service not known",
         "getaddrinfo failed",
@@ -3681,6 +3680,14 @@ def test_ordinary_transient_5xx_is_not_connectivity_loss() -> None:
     assert not is_connectivity_loss(ProviderError(500, "boom", retryable=True))
     # A bare timeout is transient/timeout but not a connectivity loss either.
     assert not is_connectivity_loss(wrap_transport_error(httpx.ReadTimeout("timed out")))
+    # ECONNREFUSED is a TCP RST from the destination, so the host WAS reachable
+    # — the opposite of an offline machine. It must classify as an ordinary
+    # transient (fast retry + fallback walk), never connectivity loss, so a
+    # down local provider (ollama/LM Studio) is routed around rather than given
+    # the 8-minute patient wait. See the exclusion note on the marker tuple.
+    refused = wrap_transport_error(httpx.ConnectError("[Errno 61] Connection refused"))
+    assert not is_connectivity_loss(refused)
+    assert refused.kind == "transient"
 
 
 def test_connectivity_backoff_is_patient_not_the_8s_cap() -> None:
@@ -3745,6 +3752,63 @@ async def test_connectivity_loss_recovers_within_patient_budget(monkeypatch) -> 
     # The delays climbed past the 8s fast cap toward the patient 60s ceiling.
     assert max(sleeps) > BACKOFF_CAP_MS
     assert max(sleeps) <= CONNECTIVITY_BACKOFF_CAP_MS
+
+
+async def test_connectivity_loss_does_not_walk_fallback_chain(monkeypatch) -> None:
+    """The patient path retries the PRIMARY in place and never walks the chain.
+
+    When the machine is offline every fallback provider is equally unreachable,
+    so walking the chain just multiplies the same failure across providers. This
+    asserts the invariant directly: with a configured second target, an Errno 8
+    connectivity error on the primary must never cause the fallback's client to
+    be constructed. (The recovery test above uses a single-provider store, which
+    proves no credential rotation but not this cross-provider invariant.)
+    """
+    sleeps: list[int] = []
+    specs_seen: list[str] = []
+    attempts = {"n": 0}
+    offline_failures = 4
+
+    async def capture_sleep(delay_ms: int, signal: Any) -> None:
+        sleeps.append(delay_ms)
+
+    monkeypatch.setattr("local_operator.providers.failover._abortable_sleep", capture_sleep)
+
+    def offline_then_ok(
+        request: ChatRequest, api_key: str | None, oauth_access: Any = None
+    ) -> AsyncIterator[Any]:
+        attempts["n"] += 1
+        if attempts["n"] <= offline_failures:
+            raise httpx.ConnectError("[Errno 8] nodename nor servname provided, or not known")
+
+        async def ok() -> AsyncIterator[Any]:
+            yield StreamEndEvent(stop_reason="stop")
+
+        return ok()
+
+    async def client_for(spec: ModelSpec) -> Any:
+        specs_seen.append(f"{spec.provider}/{spec.model_id}")
+        return _FnClient(offline_then_ok)
+
+    auth = FakeAuth({"openai": ["k1"], "anthropic": ["k2"]})
+    settings = {
+        "retry": {
+            "maxRetries": 10,
+            "baseDelayMs": 500,
+            "fallbackChains": {
+                "default": [{"provider": "anthropic", "model": "claude-opus-5", "effort": "high"}]
+            },
+        }
+    }
+    events = [event async for event in stream_with_failover(_request(), auth, settings, client_for)]
+
+    assert any(isinstance(e, StreamEndEvent) for e in events)
+    # The ONLY client ever built is the primary's: the fallback target's client
+    # was never constructed, so the chain was not walked.
+    assert set(specs_seen) == {"openai/gpt-4o"}
+    # It rode out the offline window in place — no rotation to the sibling either.
+    assert attempts["n"] == offline_failures + 1
+    assert auth.rotations == []
 
 
 async def test_ordinary_transient_5xx_still_uses_fast_budget(monkeypatch) -> None:
@@ -3825,3 +3889,13 @@ def test_connectivity_config_keys_parse_camel_and_snake() -> None:
     default = RetrySettings.from_settings(None)
     assert default.connectivity_max_retries == CONNECTIVITY_MAX_RETRIES
     assert default.connectivity_backoff_cap_ms == CONNECTIVITY_BACKOFF_CAP_MS
+
+
+def test_connectivity_config_bad_value_falls_back_to_default() -> None:
+    """A non-numeric budget must degrade to the default, not crash from_settings
+    (which re-parses on every model call). Mirrors usageReservePercent."""
+    bad = RetrySettings.from_settings(
+        {"retry": {"connectivityMaxRetries": "lots", "connectivityBackoffCapMs": None}}
+    )
+    assert bad.connectivity_max_retries == CONNECTIVITY_MAX_RETRIES
+    assert bad.connectivity_backoff_cap_ms == CONNECTIVITY_BACKOFF_CAP_MS


### PR DESCRIPTION
## Summary

Moving between networks (close laptop → walk to the car → reconnect to home wifi) killed in-flight sessions with:

```
✕ transient provider error: ConnectError: [Errno 8] nodename nor servname provided, or not known
```

That error is a DNS-resolution failure: the machine is briefly, fully offline. The harness already *retried* it (it wraps to `kind="transient"`, `retryable=True`), but the retry budget was tiny — the transient backoff caps each sleep at `BACKOFF_CAP_MS` (8s) over `maxRetries` (10), a total window of only ~80s. A normal close/move/reconnect cycle takes several minutes, so the budget ran out while the machine was still offline and the turn died.

This adds a dedicated **patient backoff** for connectivity-loss errors: the harness now rides out a reconnect for ~8 minutes on the shipped defaults, so a session survives the laptop coming back onto wifi. Ordinary provider 5xx/timeout retries are unchanged and stay fast.

- New `is_connectivity_loss()` predicate classifies the machine-is-offline family (DNS failure, network unreachable, no route to host, socket-level connection refused) distinctly from a reachable-but-5xx provider. The user-facing frame label is unchanged (`transient provider error`) — no new `ProviderErrorKind`.
- New `connectivity_backoff_delay_ms()` + `CONNECTIVITY_BACKOFF_CAP_MS` (60s) / `CONNECTIVITY_MAX_RETRIES` (15) give connectivity loss its own larger cap and longer budget, wired into **both** retry arms of `stream_with_failover` (the raw-exception arm these errors actually take, and the pre-wrapped `ProviderError` arm for completeness). Connectivity loss retries the **same** target in place and never rotates credentials or walks the fallback chain — being offline is nobody's fault and no other provider is reachable either.
- Configurable via `retry.connectivityMaxRetries` / `retry.connectivityBackoffCapMs` (snake_case accepted), defaulting to the ~8-minute window with zero config.
- The patient sleep remains abortable: Ctrl-C / abort breaks out immediately.
- Version bumps `0.33.2` → `0.34.0` (minor — new capability).

## Impact

**Before:** brief loss of network during an active turn surfaced `transient provider error: ConnectError: [Errno 8] …` within ~80s and ended the turn. Reopening the laptop after a commute meant a dead session.

**After:** connectivity loss is ridden out with exponential backoff climbing to a 60s ceiling for ~8 minutes (default). When wifi returns, the in-flight request resumes on the same credential and the turn completes as if nothing happened. A provider that is *reachable* but returning 5xx still fails fast on the unchanged 8s cap, so a genuinely broken upstream is not papered over.

## Design

Connectivity loss is a *narrower* transient than a 5xx: the whole machine is offline, so credential rotation and fallback-chain walking are futile (no provider is reachable). The predicate is therefore checked **ahead of** the server-fault retry logic in both `except` arms, retrying the same target in place on a separate `connectivity_retries` counter that does not charge the server-fault ceiling. Markers are matched against the same lowercased `class-name + detail` haystack `wrap_transport_error` already builds, each with an errno/scenario citation in `_CONNECTIVITY_LOSS_MARKERS`.

## Real-path validation

All evidence below is produced against the real `local_operator.providers.failover` module (not mocks of it), run from the worktree venv.

### 1. The exact error from the report classifies correctly, frame label unchanged

```
=== 1. The exact error from the screenshot classifies as connectivity loss ===
  raw str:      'transient provider error: ConnectError: [Errno 8] nodename nor servname provided, or not known'
  frame kind:   transient   (user still sees 'transient provider error')
  connectivity: True
  is_transient: True

=== 2. Other real offline signals also classify ===
  True   ConnectError: [Errno 51] Network is unreachable
  True   ConnectError: [Errno 65] No route to host
  True   ConnectError: [Errno 61] Connection refused
  True   gaierror: [Errno 8] nodename nor servname provided, or not known
  True   Temporary failure in name resolution
  True   getaddrinfo failed

=== 3. An ordinary reachable-but-5xx failure is NOT connectivity loss (stays fast) ===
  503 kind=transient  connectivity=False  transient=True
```

### 2. Shipped defaults give a ~8-minute offline tolerance; 5xx stays on the fast cap

```
=== 4. Delay sequence + total offline tolerance with SHIPPED DEFAULTS (no config) ===
  defaults: connectivity_max_retries=15, cap_ms=60000, base_delay_ms=500
  per-attempt sleeps (ms, with jitter): 394, 810, 1789, 3741, 6977, 14380, 25729, 55450, 52851, 51249, 46378, 52429, 55772, 48662, 50724
  TOTAL offline tolerance: 467.3s (~7.8 min) across 15 retries

=== 5. Contrast: an ordinary 5xx transient stays on the fast 8s cap ===
  5xx sleeps (ms): 394, 810, 1789, 3741, 6977, 7190, 6432, 7393, 7046, 6833
  max single 5xx sleep: 7393ms (<= 8000 cap) — unchanged, not slowed
```

### 3. End-to-end: a stream that goes offline mid-turn and recovers completes

`test_connectivity_loss_recovers_within_patient_budget` drives the real `stream_with_failover`: the client raises the verbatim `ConnectError: [Errno 8] …` **12 times** (more than `maxRetries=10` would tolerate), then the network returns and it streams a normal completion. The stream completes, it retried in place 13 times, the credential was **never rotated**, and the delays climbed past the 8s cap toward the 60s ceiling — the old budget would have surfaced the error and killed the turn before attempt 10.

## Tests

7 new tests in `tests/unit/providers/test_failover.py`, all green (`13 passed` for the connectivity/regression subset; `176 passed` full failover suite; `642 passed` full providers suite):

- `test_connectivity_markers_classify_as_connectivity_loss` — parametrized over the real Errno 8 string + Errno 51/65/61, name-resolution, getaddrinfo.
- `test_ordinary_transient_5xx_is_not_connectivity_loss` — a status-bearing 5xx is excluded.
- `test_connectivity_backoff_is_patient_not_the_8s_cap` — delays exceed 8s up to the 60s ceiling.
- `test_connectivity_loss_recovers_within_patient_budget` — the end-to-end recovery above.
- `test_ordinary_transient_5xx_still_uses_fast_budget` — regression guard: 5xx stays on 8s cap and the small server-fault budget.
- `test_connectivity_loss_backoff_is_abortable` — abort during a 60s patient sleep raises `kind="aborted"` immediately.
- `test_connectivity_config_keys_parse_camel_and_snake` — both spellings + shipped defaults.

## Gates

```
flake8 .                                   PASS
black --check (26.1.0)                      492 files unchanged
isort --check-only --profile black          PASS
pyright                                      0 errors, 0 warnings, 0 informations
pytest tests/unit/providers                  642 passed
```
