### PR TITLE
fix(performance): keep roster refreshes off the event loop

### DIFF
--- a/local_operator/harness/comms.py
+++ b/local_operator/harness/comms.py
@@ -334,6 +334,27 @@ class SubagentComms:
     def __init__(self, session: "Session") -> None:
         self._session = session
         self._records: dict[str, _ChildRecord] = {}
+        self._detail_listeners: set[Callable[[str], None]] = set()
+
+    def subscribe_detail_changes(self, listener: Callable[[str], None]) -> Callable[[], None]:
+        """Observe child transcript mutations through the shared root registry."""
+        self._detail_listeners.add(listener)
+
+        def unsubscribe() -> None:
+            self._detail_listeners.discard(listener)
+
+        return unsubscribe
+
+    def notify_detail_persisted(self, job_id: str) -> None:
+        """Publish only after a child has durably appended its new history."""
+        self._notify_detail_change(job_id)
+
+    def _notify_detail_change(self, job_id: str) -> None:
+        for listener in tuple(self._detail_listeners):
+            try:
+                listener(job_id)
+            except Exception:  # noqa: BLE001 - projection listeners are additive
+                logger.debug("subagent detail listener failed", exc_info=True)
 
     # -- launch bookkeeping ---------------------------------------------------
 
@@ -1585,6 +1606,10 @@ class SubagentComms:
         """
 
         async def watcher(event: AgentEvent) -> None:
+            # Nested child events never flow through the root Session, but this
+            # shared registry sees every attached child. Notify detail consumers
+            # before ask-specific filtering so mobile history stays fresh.
+            self._notify_detail_change(record.job_id)
             if not record.armed or record.ask is None or record.ask.done():
                 return
             if not isinstance(event, MessageEndEvent):

--- a/local_operator/harness/jobs.py
+++ b/local_operator/harness/jobs.py
@@ -289,6 +289,14 @@ class AsyncJobManager:
         # retention can remove them. The owning parent runner later copies this
         # snapshot onto its AsyncJob; polling never participates in durability.
         self._settled_accounting: dict[tuple[str | None, str | None, bool], Usage] = {}
+        # The status band reads this ledger every second. Cache the bounded
+        # aggregate and propagate invalidations through live manager edges so
+        # unchanged reads never recurse through the subagent tree.
+        self._accounting_revision = 0
+        self._accounting_cache_revision = -1
+        self._accounting_cache: tuple[Usage, ...] = ()
+        self._accounting_listeners: set[Callable[[set[int]], None]] = set()
+        self._child_accounting_unsubscribes: dict[str, Callable[[], None]] = {}
         self._signals: dict[str, AbortSignal] = {}
         self._tasks: dict[str, asyncio.Task[None]] = {}
         self._sinks: dict[str, DeliverySink] = {}
@@ -338,9 +346,13 @@ class AsyncJobManager:
         the summary proportional to distinct billing routes rather than child
         fan-out or model-call count, while retaining every token and dollar.
         """
-        return self._accounting_components(set())
+        if self._accounting_cache_revision != self._accounting_revision:
+            rebuilt = self._collect_accounting_components(set())
+            self._accounting_cache = tuple(component.model_copy(deep=True) for component in rebuilt)
+            self._accounting_cache_revision = self._accounting_revision
+        return [component.model_copy(deep=True) for component in self._accounting_cache]
 
-    def _accounting_components(self, seen: set[int]) -> list[Usage]:
+    def _collect_accounting_components(self, seen: set[int]) -> list[Usage]:
         identity = id(self)
         if identity in seen:
             return []
@@ -357,10 +369,59 @@ class AsyncJobManager:
             components = [*_usage_components(job.usage, job.model_label), *job.descendant_usage]
             child_manager = job.child_jobs
             if isinstance(child_manager, AsyncJobManager):
-                components.extend(child_manager._accounting_components(seen))
+                components.extend(child_manager._collect_accounting_components(seen))
             for component in components:
                 _merge_accounting_component(grouped, component)
         return [component.model_copy(deep=True) for component in grouped.values()]
+
+    def _invalidate_accounting(self, seen: set[int] | None = None) -> None:
+        """Invalidate this aggregate and notify parents once, tolerating cycles."""
+        visited = seen if seen is not None else set()
+        identity = id(self)
+        if identity in visited:
+            return
+        visited.add(identity)
+        self._accounting_revision += 1
+        for listener in tuple(self._accounting_listeners):
+            listener(visited)
+
+    def subscribe_accounting(self, listener: Callable[[set[int]], None]) -> Callable[[], None]:
+        self._accounting_listeners.add(listener)
+
+        def unsubscribe() -> None:
+            self._accounting_listeners.discard(listener)
+
+        return unsubscribe
+
+    def attach_child_manager(self, job_id: str, child: "AsyncJobManager") -> None:
+        """Attach the live accounting lease and propagate child mutations."""
+        job = self._jobs.get(job_id)
+        if job is None:
+            return
+        unsubscribe = self._child_accounting_unsubscribes.pop(job_id, None)
+        if unsubscribe is not None:
+            unsubscribe()
+        job.child_jobs = child
+        self._child_accounting_unsubscribes[job_id] = child.subscribe_accounting(
+            self._invalidate_accounting
+        )
+        self._invalidate_accounting()
+
+    def detach_child_manager(self, job_id: str, descendant_usage: list[Usage]) -> None:
+        """Replace a live child edge with its final detached durable ledger."""
+        job = self._jobs.get(job_id)
+        if job is None:
+            return
+        unsubscribe = self._child_accounting_unsubscribes.pop(job_id, None)
+        if unsubscribe is not None:
+            unsubscribe()
+        job.descendant_usage = [item.model_copy(deep=True) for item in descendant_usage]
+        job.child_jobs = None
+        self._invalidate_accounting()
+
+    def note_usage_changed(self) -> None:
+        """Invalidate after an in-place Usage mutation owned by a child relay."""
+        self._invalidate_accounting()
 
     def _notify_roster_change(self) -> None:
         """Signal the owner that the task roster moved (add / settle / status).
@@ -428,6 +489,7 @@ class AsyncJobManager:
             self._jobs[row.id] = row
             if row.status != "running":
                 self._record_settled_accounting(row)
+        self._invalidate_accounting()
 
     # -- registration -------------------------------------------------------
 
@@ -492,6 +554,7 @@ class AsyncJobManager:
         # A new row is a roster change the owner may want to persist (task rows
         # only carry a resumable transcript, but the listener filters that).
         if type == "task":
+            self._invalidate_accounting()
             self._notify_roster_change()
         return job_id
 
@@ -516,6 +579,7 @@ class AsyncJobManager:
         # move only reaches disk at the next roster event, and a snapshot taken
         # in between would restore the row as if it were still parked.
         if job.type == "task":
+            self._invalidate_accounting()
             self._notify_roster_change()
         return True
 
@@ -623,6 +687,7 @@ class AsyncJobManager:
         self._settle(job)
         self._sweep_due()
         if job.type == "task":
+            self._invalidate_accounting()
             self._notify_roster_change()
         return True
 
@@ -751,6 +816,7 @@ class AsyncJobManager:
         # only after delivery) means a crash between settle and delivery still
         # leaves the outcome on disk for the next resume.
         if job.type == "task":
+            self._invalidate_accounting()
             self._notify_roster_change()
         try:
             await self._deliver(job)
@@ -852,6 +918,10 @@ class AsyncJobManager:
             components.extend(child_manager.accounting_components())
         for component in components:
             _merge_accounting_component(self._settled_accounting, component)
+        unsubscribe = self._child_accounting_unsubscribes.pop(job.id, None)
+        if unsubscribe is not None:
+            unsubscribe()
+        self._invalidate_accounting()
 
     def _sweep_due(self) -> None:
         """Drop settled jobs older than the retention window.

--- a/local_operator/harness/subagent.py
+++ b/local_operator/harness/subagent.py
@@ -375,7 +375,11 @@ def _make_runner(
                 # The edge is only a lease: the finalizer atomically replaces it
                 # with detached components before disposal can evict rows or pin
                 # the child Session through its manager callback.
-                job.child_jobs = child.jobs
+                attach_child_manager = getattr(parent_session.jobs, "attach_child_manager", None)
+                if callable(attach_child_manager):
+                    attach_child_manager(job_id, child.jobs)
+                else:
+                    job.child_jobs = child.jobs
             if comms is not None:
                 # Before the prompt runs: the parent may already have a
                 # question queued for this child, and attach is what flushes
@@ -400,7 +404,15 @@ def _make_runner(
                         logger.warning("could not persist roster after attach", exc_info=True)
             await emit(SubagentStartEvent(job_id=job_id, label=label, agent_id=child.agent_id))
             unsubscribe = child.subscribe(
-                _make_relay(job_id, label, job, emit, report_progress, final)
+                _make_relay(
+                    job_id,
+                    label,
+                    job,
+                    emit,
+                    report_progress,
+                    final,
+                    parent_session.jobs,
+                )
             )
             bridge = asyncio.create_task(_abort_bridge(signal, child))
             try:
@@ -491,8 +503,15 @@ def _make_runner(
                     if job is not None:
                         # Clear the live edge even if teardown itself fails: a
                         # retained parent row must never pin the child Session.
-                        job.descendant_usage = child.jobs.accounting_components()
-                        job.child_jobs = None
+                        descendant_usage = child.jobs.accounting_components()
+                        detach_child_manager = getattr(
+                            parent_session.jobs, "detach_child_manager", None
+                        )
+                        if callable(detach_child_manager):
+                            detach_child_manager(job_id, descendant_usage)
+                        else:
+                            job.descendant_usage = descendant_usage
+                            job.child_jobs = None
 
     return runner
 
@@ -509,56 +528,18 @@ async def _abort_bridge(signal: Any, child: "Session") -> None:
 
 
 async def _persist_inflight(child: "Session") -> None:
-    """Write the cancelled child's unsaved turn to its own transcript.
+    """Publish the already-durable state of a cancelled child.
 
-    ``Session.prompt`` persists a turn's messages AFTER its loop finishes, so
-    a child whose runner task is hard-cancelled mid-turn loses everything it
-    said and did — measured: a cancelled child's transcript held one entry,
-    its launch prompt, with the tool calls and results it had already
-    completed gone. That is invisible while a cancelled child is a dead end,
-    and wrong the moment one can be resumed: ``hub op='resume'`` replays this
-    file, so what is missing here is what the resumed agent has forgotten.
-
-    Deduplicated by message id (the transcript uses the message's own id as
-    the entry id), so anything ``prompt`` already wrote is not written twice —
-    a duplicate entry would replay as a duplicate message. Shielded, because
-    the calling task is already being cancelled; best-effort, because failing
-    to save a cancelled turn must not break teardown.
-
-    The tail is trimmed to a COHERENT history first (see
-    :func:`_answered_prefix`): a cancel lands mid tool batch, so the live
-    context routinely ends with an assistant message whose tool calls have no
-    results yet, and every major provider rejects a request carrying a
-    tool-use block with no matching tool result. Persisting that tail would
-    make the resumed child unable to make its first request at all.
+    ``Session._run_turn`` owns message durability in its ``finally`` block, and
+    todo mutations are persisted at their tool-completion boundary. Keeping
+    those writes with their owners means cancellation never needs a detached
+    task that can retain the child or touch its transcript after disposal.
     """
-
-    async def _write() -> None:
-        # Imported here rather than at module scope: ``session.session`` imports
-        # this module, so a top-level import is a cycle (the TYPE_CHECKING block
-        # above imports ``Session`` the same way).
-        from local_operator.session.session import _is_persistable_message
-
-        known = {entry.id for entry in child._transcript.entries()}
-        for message in _answered_prefix(list(child._context.messages)):
-            # The SAME allow-list the session's own flush uses. This writes the
-            # child's LIVE context, which after a compaction pass begins with
-            # the summary marker and may carry a todo reminder — neither of
-            # which may be persisted as a message: the marker is already stored
-            # as its own compaction entry, so writing it again replays a
-            # superseded summary beside the live one, and a stored reminder
-            # comes back as a user message the user never sent.
-            if not _is_persistable_message(message):
-                continue
-            if message.id not in known:
-                await child._transcript.append_message(message)
-
-    try:
-        await asyncio.shield(_write())
-    except asyncio.CancelledError:
-        pass  # the shielded write continues without us
-    except Exception:
-        logger.warning("could not persist cancelled subagent turn", exc_info=True)
+    comms = getattr(child, "_subagent_comms", None)
+    job_id = getattr(child, "_job_id", None)
+    notify = getattr(comms, "notify_detail_persisted", None)
+    if isinstance(job_id, str) and callable(notify):
+        notify(job_id)
 
 
 def _answered_prefix(messages: list[Any]) -> list[Any]:
@@ -675,6 +656,7 @@ def _make_relay(
     emit: Callable[[AgentEvent], Awaitable[None]],
     report_progress: Callable[[str], None],
     final: dict[str, Any],
+    owner_jobs: Any = None,
 ) -> Callable[[AgentEvent], Awaitable[None]]:
     """The child-stream handler: trajectory + throttled parent relay.
 
@@ -722,6 +704,9 @@ def _make_relay(
                 # Capture the last assistant text as the job's result.
                 final["text"] = message.text
                 _accumulate_usage(job, message.usage)
+                note_usage_changed = getattr(owner_jobs, "note_usage_changed", None)
+                if callable(note_usage_changed):
+                    note_usage_changed()
                 progress = ACTIVITY_THINKING
         elif isinstance(event, ModelChangeEvent):
             # Keep the job row's label truthful about which model is doing the

--- a/local_operator/mobile/projection.py
+++ b/local_operator/mobile/projection.py
@@ -693,15 +693,49 @@ class ProjectionFold:
     # -- todos / pending / state -------------------------------------------
 
     def set_subagent_details(self, comms: Any) -> None:
-        """Project the shared lineage and enrich every descendant transcript.
+        """Project descendant metadata without touching child transcripts.
 
         Only direct children emit lifecycle events through the root session;
-        nested children still live in the shared comms registry. Seed missing
-        rows from that authoritative registry so each ``child_ids`` edge has a
-        corresponding phone-addressable record.
+        nested children still live in the shared comms registry. This method is
+        called for every root event, so it is deliberately restricted to the
+        in-memory registry. Child history and attachment hydration belongs to
+        ``TuiSessionHandle``'s worker path.
         """
         roster = {item.job_id: item for item in comms.roster()}
-        for node in comms.nodes():
+        nodes = comms.nodes()
+        by_id = {node.job_id: node for node in nodes}
+        children: dict[str | None, list[Any]] = {}
+        for node in nodes:
+            children.setdefault(node.parent_job_id, []).append(node)
+        ancestor_nodes: dict[str, list[Any]] = {}
+
+        def ancestors(job_id: str) -> list[Any]:
+            """Root-to-parent lineage from the local maps (O(children), no I/O).
+
+            Cycle-safe with the same stop-on-repeat contract as
+            ``SubagentComms.ancestors``: a legacy snapshot may hold self or
+            multi-node parent cycles, so a plain recursive walk would recurse
+            forever. Building it here from ``by_id`` keeps the metadata path off
+            any per-child comms lineage recomputation.
+            """
+            cached = ancestor_nodes.get(job_id)
+            if cached is not None:
+                return cached
+            lineage: list[Any] = []
+            seen = {job_id}
+            parent_id = by_id[job_id].parent_job_id
+            while parent_id is not None and parent_id not in seen:
+                seen.add(parent_id)
+                parent = by_id.get(parent_id)
+                if parent is None:
+                    break
+                lineage.append(parent)
+                parent_id = parent.parent_job_id
+            lineage.reverse()
+            ancestor_nodes[job_id] = lineage
+            return lineage
+
+        for node in nodes:
             job = comms.job(node.job_id)
             lifecycle = roster.get(node.job_id)
             row = self._subagents.get(node.job_id)
@@ -715,11 +749,16 @@ class ProjectionFold:
             row.prompt = node.prompt
             row.launch_message_id = node.launch_message_id
             row.effort = node.effort
-            ancestors = comms.ancestors(node.job_id)
-            row.ancestors = [ancestor.label for ancestor in ancestors]
-            row.ancestor_ids = [ancestor.job_id for ancestor in ancestors]
-            row.child_ids = [child.job_id for child in comms.children(node.job_id)]
-            row.peer_ids = [peer.job_id for peer in comms.peers(node.job_id)]
+            # Preserve #298's ancestor_ids feature on the O(children) path.
+            lineage = ancestors(node.job_id)
+            row.ancestors = [ancestor.label for ancestor in lineage]
+            row.ancestor_ids = [ancestor.job_id for ancestor in lineage]
+            row.child_ids = [child.job_id for child in children.get(node.job_id, [])]
+            row.peer_ids = [
+                peer.job_id
+                for peer in children.get(node.parent_job_id, [])
+                if peer.job_id != node.job_id
+            ]
             row.agent = str(getattr(job, "agent_role", None) or node.agent_role or "task")
             row.model_label = str(getattr(job, "model_label", None) or "")
             if lifecycle is not None:
@@ -748,28 +787,33 @@ class ProjectionFold:
             progress = str((getattr(job, "latest_details", None) or {}).get("progress") or "")
             row.progress = progress if row.status == "running" else ""
             row.activity = row.progress or ("thinking" if row.status == "running" else "")
-            try:
-                if node.session_dir is not None:
-                    from local_operator.session.transcript import Transcript
-                    from local_operator.tools.builtin import todo_snapshot
-
-                    transcript = Transcript(node.session_dir)
-                    row.transcript = self._cap_tail(
-                        fold_messages_to_entries(transcript.build_llm_history())
-                    )
-                    if node.session_id:
-                        raw_todos = todo_snapshot(node.session_id)
-                    else:
-                        raw_todos = []
-                    if not raw_todos:
-                        raw_todos = (transcript.latest_custom("todo_snapshot") or {}).get(
-                            "items"
-                        ) or []
-                    row.todos = self._todo_phases(raw_todos)
-            except Exception:
-                continue
+            # NOTE: no ``Transcript`` construction here. #298's full-screen
+            # subagent conversation still gets its history and todos, but they
+            # are hydrated OFF the Textual loop by ``TuiSessionHandle`` and
+            # published through ``set_subagent_hydrated_details`` below. Reading
+            # every child transcript synchronously on each root event was the
+            # freeze this change removes.
         self._sync_subagents()
         self._bump()
+
+    def set_subagent_hydrated_details(
+        self,
+        job_id: str,
+        transcript: list[TranscriptEntry],
+        todos: list[dict[str, Any]],
+    ) -> bool:
+        """Publish one worker-hydrated child without rebuilding the roster."""
+        row = self._subagents.get(job_id)
+        if row is None:
+            return False
+        # Cap the worker-hydrated history to the same render tail #298 applies
+        # on the synchronous path, so the full-screen conversation keeps its
+        # pinned opening user message without shipping an unbounded transcript.
+        row.transcript = self._cap_tail(transcript)
+        row.todos = self._todo_phases(todos)
+        self._sync_subagents()
+        self._bump()
+        return True
 
     @staticmethod
     def _todo_phases(phases: list[dict[str, Any]]) -> list[TodoPhase]:

--- a/local_operator/mobile/tui_handle.py
+++ b/local_operator/mobile/tui_handle.py
@@ -38,10 +38,11 @@ import inspect
 import logging
 import secrets
 from concurrent.futures import Future
-from typing import TYPE_CHECKING, Any, Callable
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Callable, cast
 
 from local_operator.mobile.command_reservation import CommandReservations
-from local_operator.mobile.projection import ProjectionFold
+from local_operator.mobile.projection import ProjectionFold, fold_messages_to_entries
 from local_operator.mobile.registrant import SessionHandle, image_blocks
 from local_operator.mobile.types import (
     PendingRequest,
@@ -91,6 +92,7 @@ class TuiSessionHandle(SessionHandle):
         # projection subscription on session swaps.
         self._on_event: Callable[[dict[str, Any]], None] | None = None
         self._unsubscribe_events: Callable[[], None] | None = None
+        self._unsubscribe_detail_changes: Callable[[], None] | None = None
         # Mutated only on Textual's loop, making admission atomic even though
         # several registrant coroutines may cross from its socket thread.
         self._command_reservations = CommandReservations(session)
@@ -113,6 +115,12 @@ class TuiSessionHandle(SessionHandle):
         # frames. Ask pending remains in the ordinary fold because phones
         # already supported TUI asks before this change.
         self._event_pending: PendingRequest | None = None
+        # Child transcripts can contain thousands of attachment-backed entries.
+        # Keep their I/O off Textual's loop and bound work to one coalescing
+        # worker per child so a streaming burst cannot queue stale full reads.
+        self._detail_tasks: dict[str, asyncio.Task[None]] = {}
+        self._detail_generations: dict[str, int] = {}
+        self._detail_fingerprints: dict[str, tuple[int, int]] = {}
 
     def _session(self) -> Any:
         """The app's current session. A property method (not cached) because
@@ -140,12 +148,16 @@ class TuiSessionHandle(SessionHandle):
             except Exception:  # noqa: BLE001
                 logger.debug("mobile event unsubscribe failed", exc_info=True)
             self._unsubscribe_events = None
+        if self._unsubscribe_detail_changes is not None:
+            self._unsubscribe_detail_changes()
+            self._unsubscribe_detail_changes = None
         self._projection.session_id = session.session_id
         self._projection.transcript.clear()
         self._projection.todos.clear()
         self._projection.subagents.clear()
         self._projection.pending = None
         self._event_pending = None
+        self._cancel_detail_tasks()
         self._fold = ProjectionFold(self._projection)
         # A /new or /resume mid-ask abandons the old picker; drop its mapping
         # so a late phone answer for a question that no longer exists reports
@@ -178,12 +190,21 @@ class TuiSessionHandle(SessionHandle):
                 self._fold.fold_event(event)
                 self._refresh_state()
                 self._refresh_todos()
+                job_id = getattr(event, "job_id", None)
+                if isinstance(job_id, str):
+                    self._invalidate_subagent_detail(job_id)
             except Exception:  # noqa: BLE001
                 logger.debug("mobile fold failed", exc_info=True)
             if self._on_projection is not None:
                 self._on_projection()
 
         unsubscribe = session.subscribe(handler)
+        comms = getattr(session, "_subagent_comms", None)
+        subscribe_details = getattr(comms, "subscribe_detail_changes", None)
+        if callable(subscribe_details):
+            unsubscribe_details = subscribe_details(self._invalidate_subagent_detail)
+            if callable(unsubscribe_details):
+                self._unsubscribe_detail_changes = cast(Callable[[], None], unsubscribe_details)
         try:
             self._fold.fold_history(session.history())
         except Exception:  # noqa: BLE001
@@ -194,6 +215,8 @@ class TuiSessionHandle(SessionHandle):
         # events (start/end/turn-end) are the sole authority — see
         # ``_reconcile_streaming`` for why per-event reads are poison.
         self._reconcile_streaming()
+        self._refresh_state()
+        self._warm_subagent_details()
         self._unsubscribe = unsubscribe
         return unsubscribe
 
@@ -698,6 +721,75 @@ class TuiSessionHandle(SessionHandle):
         self._app.call_from_thread(wrapped)
         return await asyncio.wait_for(future, timeout=10.0)
 
+    def _cancel_detail_tasks(self) -> None:
+        for task in self._detail_tasks.values():
+            task.cancel()
+        self._detail_tasks.clear()
+        self._detail_generations.clear()
+        self._detail_fingerprints.clear()
+
+    def _warm_subagent_details(self) -> None:
+        """Adopt restored descendants without delaying the initial projection."""
+        comms = getattr(self._session(), "_subagent_comms", None)
+        if comms is None:
+            return
+        for node in comms.nodes():
+            if node.session_dir is not None:
+                self._invalidate_subagent_detail(node.job_id)
+
+    def _invalidate_subagent_detail(self, job_id: str) -> None:
+        """Coalesce child mutations behind one generation-guarded worker."""
+        comms = getattr(self._session(), "_subagent_comms", None)
+        node = comms.node(job_id) if comms is not None else None
+        if node is None or node.session_dir is None:
+            return
+        self._detail_generations[job_id] = self._detail_generations.get(job_id, 0) + 1
+        task = self._detail_tasks.get(job_id)
+        if task is None or task.done():
+            self._detail_tasks[job_id] = asyncio.create_task(
+                self._hydrate_subagent_detail(job_id),
+                name=f"mobile-detail-{job_id}",
+            )
+
+    async def _hydrate_subagent_detail(self, job_id: str) -> None:
+        """Hydrate only the invalidated child, repeating once if it moved."""
+        try:
+            while True:
+                generation = self._detail_generations.get(job_id, 0)
+                comms = getattr(self._session(), "_subagent_comms", None)
+                node = comms.node(job_id) if comms is not None else None
+                if comms is None or node is None or node.session_dir is None:
+                    return
+                session_dir = str(node.session_dir)
+                try:
+                    result = await asyncio.to_thread(_load_subagent_detail, session_dir)
+                except _DetailChangedDuringHydration:
+                    # Appends and atomic compaction can overlap a worker read.
+                    # Retry in this same coalesced task so no later event is
+                    # required to recover the newest stable generation.
+                    await asyncio.sleep(0)
+                    continue
+                if generation != self._detail_generations.get(job_id):
+                    continue
+                current = comms.node(job_id)
+                if current is None or str(current.session_dir) != session_dir:
+                    return
+                fingerprint, transcript, todos = result
+                if self._detail_fingerprints.get(session_dir) != fingerprint:
+                    self._detail_fingerprints[session_dir] = fingerprint
+                    if self._fold.set_subagent_hydrated_details(job_id, transcript, todos):
+                        if self._on_projection is not None:
+                            self._on_projection()
+                return
+        except asyncio.CancelledError:
+            raise
+        except Exception:  # noqa: BLE001 - child detail is additive
+            logger.debug("mobile child-detail hydration failed", exc_info=True)
+        finally:
+            task = self._detail_tasks.get(job_id)
+            if task is asyncio.current_task():
+                self._detail_tasks.pop(job_id, None)
+
     def _refresh_state(self) -> None:
         session = self._session()
         self._fold.set_state(
@@ -759,6 +851,30 @@ def _set_unless_done(
         future.set_exception(error)
     else:
         future.set_result(value)
+
+
+class _DetailChangedDuringHydration(RuntimeError):
+    """Worker result became stale while its transcript was being read."""
+
+
+def _load_subagent_detail(
+    session_dir: str,
+) -> tuple[tuple[int, int], list[Any], list[dict[str, Any]]]:
+    """Read one child transcript in a worker and return its stable fingerprint."""
+    from local_operator.session.transcript import TRANSCRIPT_FILENAME, Transcript
+
+    path = Path(session_dir) / TRANSCRIPT_FILENAME
+    before = path.stat()
+    transcript = Transcript(session_dir)
+    entries = fold_messages_to_entries(transcript.build_llm_history())
+    raw_todos = (transcript.latest_custom("todo_snapshot") or {}).get("items") or []
+    after = path.stat()
+    # Atomic transcript replacement or an append during hydration invalidates
+    # this result; the caller's next child event will request the newer detail.
+    fingerprint = (after.st_size, after.st_mtime_ns)
+    if (before.st_size, before.st_mtime_ns) != fingerprint:
+        raise _DetailChangedDuringHydration("child transcript changed during hydration")
+    return fingerprint, entries, raw_todos if isinstance(raw_todos, list) else []
 
 
 def _session_cwd(session: Any) -> str:

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -40,6 +40,8 @@ import contextlib
 import inspect
 import json
 import logging
+import os
+import tempfile
 import time
 from collections.abc import (
     AsyncIterator,
@@ -96,6 +98,7 @@ from local_operator.harness.types import (
     TextContent,
     ToolCall,
     ToolContext,
+    ToolExecutionEndEvent,
     ToolResult,
     Usage,
     WakeDeliveredEvent,
@@ -184,6 +187,9 @@ SELECTED_MODEL_CUSTOM_TYPE = "selected_model"
 #: their transcripts survive on disk. Re-snapshotted (newest-wins, like every
 #: custom entry) whenever the roster moves; loaded once at construction.
 SUBAGENT_ROSTER_CUSTOM_TYPE = "subagent_roster"
+SUBAGENT_ROSTER_SIDECAR = "subagent-roster.v1.json"
+_SUBAGENT_ROSTER_VERSION = 1
+_SUBAGENT_SUMMARY_CHARS = 500
 
 #: Transcript custom-entry type holding the session's todo list. The todo tool
 #: keeps the live list in a module-level table keyed by session id (see
@@ -951,6 +957,56 @@ def _subagent_job_row(job: AsyncJob) -> dict[str, Any]:
     return row
 
 
+def _compact_subagent_record(record: dict[str, Any]) -> dict[str, Any]:
+    """Bound list-surface text while preserving the exact resume directory."""
+    compact = dict(record)
+    for key in ("prompt", "error_text", "result_text"):
+        value = compact.get(key)
+        if value is not None:
+            compact[key] = str(value)[:_SUBAGENT_SUMMARY_CHARS]
+    return compact
+
+
+def _write_roster_sidecar(path: Any, payload: dict[str, Any]) -> None:
+    """Replace current roster state durably without exposing a partial JSON file."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, raw_temp = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=path.parent)
+    temp = path.with_name(os.path.basename(raw_temp))
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, separators=(",", ":"))
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temp, path)
+        directory = os.open(path.parent, os.O_RDONLY)
+        try:
+            os.fsync(directory)
+        finally:
+            os.close(directory)
+    finally:
+        with contextlib.suppress(FileNotFoundError):
+            temp.unlink()
+
+
+def _read_roster_sidecar(path: Any) -> dict[str, Any] | None:
+    """Read a supported sidecar, falling back to the legacy transcript on error."""
+    try:
+        with path.open(encoding="utf-8") as handle:
+            payload = json.load(handle)
+        if not isinstance(payload, dict) or payload.get("version") != _SUBAGENT_ROSTER_VERSION:
+            return None
+        generation = payload.get("generation")
+        if isinstance(generation, bool) or not isinstance(generation, int) or generation < 0:
+            return None
+        if not isinstance(payload.get("jobs"), list) or not isinstance(
+            payload.get("records"), list
+        ):
+            return None
+        return payload
+    except (OSError, ValueError, TypeError):
+        return None
+
+
 def _parsed_usage(payload: dict[str, Any]) -> Usage | None:
     """One persisted ``usage`` payload as a :class:`Usage`, or ``None``.
 
@@ -1387,6 +1443,9 @@ class Session:
         self._persisted_todo_fingerprint: tuple[tuple[str, str, str], ...] | None = None
 
         self._disposed = False
+        self._subagent_roster_generation = 0
+        self._subagent_roster_written_generation = 0
+        self._subagent_roster_writer: asyncio.Task[None] | None = None
         # Session-scoped task group (HC-11): wake deliveries and aside
         # persistence are routed through it so dispose() cancels them
         # deterministically and a delivery after dispose never raises into an
@@ -3965,7 +4024,17 @@ class Session:
                         # pipeline flushes it if no continuation is queued.
                         self._held_end = event
                     continue
+                is_todo_end = isinstance(event, ToolExecutionEndEvent) and event.tool_name == "todo"
+                if is_todo_end:
+                    # The tool has already mutated its store when this event is
+                    # yielded. Persist before async subscriber fan-out so a
+                    # cancellation from a handler cannot expose live todo state
+                    # that resume cannot recover. The fingerprint guard makes
+                    # failed/view/no-op todo calls a zero-write comparison.
+                    await self._maybe_persist_todos()
                 await self._emit(event)
+                if is_todo_end and self._job_id is not None and self._subagent_comms is not None:
+                    self._subagent_comms.notify_detail_persisted(self._job_id)
 
             # Track the latest provider usage for compaction trigger math.
             for message in reversed(new_messages):
@@ -3993,6 +4062,11 @@ class Session:
             # resume. Placed on the normal path (a turn that raised past here
             # still has last turn's snapshot; the next clean turn re-writes it).
             await self._maybe_persist_todos()
+            # Child events reach the shared comms watcher before either durable
+            # append. Notify only after messages AND todos are stable, including
+            # provider-error turns that emit no later terminal event.
+            if self._job_id is not None and self._subagent_comms is not None:
+                self._subagent_comms.notify_detail_persisted(self._job_id)
 
             pending_incident = self._pending_incident
             self._pending_incident = None
@@ -5828,40 +5902,65 @@ class Session:
         """
         if self._disposed or self._job_id is not None:
             return
-        self._spawn_background(self._persist_subagent_roster())
+        self._subagent_roster_generation += 1
+        if self._subagent_roster_writer is None or self._subagent_roster_writer.done():
+            self._subagent_roster_writer = asyncio.create_task(
+                self._persist_subagent_roster(), name="persist-subagent-roster"
+            )
 
     async def _persist_subagent_roster(self) -> None:
-        """Snapshot the task job rows AND the comms records to the transcript.
-
-        Both halves are needed and neither alone suffices. The job ROWS carry
-        what the subagent panel paints (label, status, model, usage, elapsed);
-        the comms RECORDS carry what ``hub op='resume'`` needs (the
-        ``job_id \u2192 session_dir`` mapping and how each child settled). They are
-        written together, newest-wins like every custom entry, so a resume reads
-        one coherent snapshot rather than two that drifted.
-
-        Only ``task`` rows are stored: ``bash`` jobs are host-local processes
-        that cannot outlive the process that spawned them, so persisting them
-        would only invite a resume to show a job it can never touch.
-        """
+        """Coalesce current roster state into one atomically replaced sidecar."""
         try:
-            rows = [
-                _subagent_job_row(job)
-                for job in self.jobs.list()
-                if getattr(job, "type", "") == "task"
-            ]
-            records = self._subagent_comms.snapshot() if self._subagent_comms is not None else []
-            # Nothing to record means no append: a session that never delegated
-            # must not pay a transcript write (and, at teardown, a wedged-mount
-            # timeout) for an empty roster it will never read back.
-            if not rows and not records:
-                return
-            await self._transcript.append_custom(
-                SUBAGENT_ROSTER_CUSTOM_TYPE,
-                {"jobs": rows, "records": records},
-            )
+            while self._subagent_roster_written_generation < self._subagent_roster_generation:
+                generation = self._subagent_roster_generation
+                rows = [
+                    _subagent_job_row(job)
+                    for job in self.jobs.list()
+                    if getattr(job, "type", "") == "task"
+                ]
+                records = (
+                    self._subagent_comms.snapshot() if self._subagent_comms is not None else []
+                )
+                payload = {
+                    "version": _SUBAGENT_ROSTER_VERSION,
+                    "generation": generation,
+                    "jobs": rows,
+                    "records": [_compact_subagent_record(record) for record in records],
+                }
+                await asyncio.to_thread(
+                    _write_roster_sidecar,
+                    self._transcript.directory / SUBAGENT_ROSTER_SIDECAR,
+                    payload,
+                )
+                # Keep one bounded legacy entry for readers predating v0.35.2;
+                # future mutations replace only the sidecar, avoiding quadratic
+                # history while preserving a rolling-upgrade resume path.
+                if (rows or records) and self._transcript.latest_custom(
+                    SUBAGENT_ROSTER_CUSTOM_TYPE
+                ) is None:
+                    await self._transcript.append_custom(
+                        SUBAGENT_ROSTER_CUSTOM_TYPE,
+                        {"jobs": rows, "records": payload["records"]},
+                    )
+                self._subagent_roster_written_generation = generation
         except Exception:  # noqa: BLE001 - persistence must never break a turn
             logger.warning("could not persist subagent roster", exc_info=True)
+        finally:
+            if self._subagent_roster_writer is asyncio.current_task():
+                self._subagent_roster_writer = None
+
+    async def _await_subagent_roster_writer(self) -> None:
+        """Drain the single writer, including a generation queued as it exits."""
+        while True:
+            writer = self._subagent_roster_writer
+            if writer is None:
+                if self._subagent_roster_written_generation >= self._subagent_roster_generation:
+                    return
+                writer = asyncio.create_task(
+                    self._persist_subagent_roster(), name="persist-subagent-roster"
+                )
+                self._subagent_roster_writer = writer
+            await asyncio.shield(writer)
 
     async def _final_persist_snapshots(self) -> None:
         """Write the last roster and todo snapshots at teardown, in order.
@@ -5869,7 +5968,8 @@ class Session:
         Split out so :meth:`dispose` can bound the pair with a single
         ``wait_for``: both are transcript appends and neither may hang teardown.
         """
-        await self._persist_subagent_roster()
+        self._subagent_roster_generation += 1
+        await self._await_subagent_roster_writer()
         await self._maybe_persist_todos()
 
     def _load_subagent_roster(self) -> None:
@@ -5895,9 +5995,16 @@ class Session:
         in the CHILD's own transcript and is recovered by resuming or
         ``hub op='peek'``-ing it, never by re-reading it here.
         """
-        details = self._transcript.latest_custom(SUBAGENT_ROSTER_CUSTOM_TYPE)
+        details = _read_roster_sidecar(self._transcript.directory / SUBAGENT_ROSTER_SIDECAR)
+        loaded_sidecar = details is not None
+        if details is None:
+            details = self._transcript.latest_custom(SUBAGENT_ROSTER_CUSTOM_TYPE)
         if not details:
             return
+        self._subagent_roster_generation = int(details.get("generation") or 0)
+        self._subagent_roster_written_generation = (
+            self._subagent_roster_generation if loaded_sidecar else -1
+        )
         records = details.get("records") or []
         if records:
             # ``self.subagent_comms`` (the property) mints the instance on first

--- a/local_operator/tui/widgets/todo_panel.py
+++ b/local_operator/tui/widgets/todo_panel.py
@@ -34,6 +34,7 @@ hides it again.
 
 from __future__ import annotations
 
+import asyncio
 import time
 from typing import Any
 
@@ -180,7 +181,9 @@ def _as_phases(raw: list[Any]) -> list[dict[str, Any]]:
     return [{"name": _IMPLICIT_PHASE, "items": list(raw)}]  # legacy/flat
 
 
-def todo_items(session_id: str, transcript_directory: str | None = None) -> list[dict[str, Any]]:
+def todo_items(
+    session_id: str, restored: list[dict[str, Any]] | None = None
+) -> list[dict[str, Any]]:
     """The live todo list for ``session_id``, as phases (copies, never the store).
 
     Reads the todo tool's own store — the one writer is the tool, so the table
@@ -198,18 +201,7 @@ def todo_items(session_id: str, transcript_directory: str | None = None) -> list
         from local_operator.tools.builtin import TODO_STORE
     except Exception:
         return []
-    raw = TODO_STORE.get(session_id)
-    if not raw and transcript_directory:
-        # A resumed/swept child has no live process store. Its own transcript is
-        # authoritative; never consult the root session as a convenience.
-        try:
-            from local_operator.session.transcript import Transcript
-
-            details = Transcript(transcript_directory).latest_custom("todo_snapshot") or {}
-            candidate = details.get("items") or []
-            raw = candidate if isinstance(candidate, list) else []
-        except Exception:
-            raw = []
+    raw = TODO_STORE.get(session_id) or restored
     if not raw:
         return []
     return [
@@ -219,6 +211,15 @@ def todo_items(session_id: str, transcript_directory: str | None = None) -> list
         }
         for phase in _as_phases(raw)
     ]
+
+
+def _read_restored_todos(transcript_directory: str) -> list[dict[str, Any]]:
+    """Read a historical child snapshot; callers must run this in a worker."""
+    from local_operator.session.transcript import Transcript
+
+    details = Transcript(transcript_directory).latest_custom("todo_snapshot") or {}
+    candidate = details.get("items") or []
+    return candidate if isinstance(candidate, list) else []
 
 
 def _is_closed(item: dict[str, Any]) -> bool:
@@ -394,6 +395,8 @@ class TodoPanel(Container):
         #: line count, and the two must agree or the band reflows on the first
         #: frame (see :meth:`predicted_rows`).
         self._painted_rows: int = 0
+        self._restored_todos: dict[str, list[dict[str, Any]]] = {}
+        self._todo_loads: dict[str, asyncio.Task[None]] = {}
         # Hidden until the first todo exists: an empty panel is not content.
         self.display = False
 
@@ -457,6 +460,25 @@ class TodoPanel(Container):
         yield self._affordance
 
     # -- sync -----------------------------------------------------------------
+    async def _load_restored_todos(
+        self, session: Any, session_id: str, transcript_directory: str
+    ) -> None:
+        """Load a swept child's durable todos once, away from render polling."""
+        try:
+            phases = await asyncio.to_thread(_read_restored_todos, transcript_directory)
+            self._restored_todos[transcript_directory] = phases
+            self.sync(
+                session,
+                session_id=session_id,
+                transcript_directory=transcript_directory,
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            self._restored_todos[transcript_directory] = []
+        finally:
+            self._todo_loads.pop(transcript_directory, None)
+
     def sync(
         self,
         session: Any,
@@ -475,8 +497,17 @@ class TodoPanel(Container):
             selected_id = (
                 session_id if session_id is not None else getattr(session, "session_id", "")
             )
+            restored = None
+            if transcript_directory is not None:
+                restored = self._restored_todos.get(transcript_directory)
+                if restored is None and transcript_directory not in self._todo_loads:
+                    # Selection changes initiate one worker read. The 1 Hz
+                    # refresh path only observes the cache and never opens disk.
+                    self._todo_loads[transcript_directory] = asyncio.create_task(
+                        self._load_restored_todos(session, selected_id or "", transcript_directory)
+                    )
             phases = (
-                todo_items(selected_id or "", transcript_directory)
+                todo_items(selected_id or "", restored)
                 if transcript_directory is not None
                 else todo_items(selected_id or "")
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.38.0"
+version = "0.38.1"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/scripts/benchmark_roster_freeze.py
+++ b/scripts/benchmark_roster_freeze.py
@@ -1,0 +1,80 @@
+"""Synthetic regression for the subagent-roster event-loop freeze.
+
+Builds the live incident's shape without copying user transcripts: 75 child
+records, attachment-sized transcript files, 100 ordinary projection events, and
+a 500-job accounting tree. Run from the repository root with .venv/bin/python.
+"""
+
+from __future__ import annotations
+
+import statistics
+import tempfile
+import time
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, cast
+
+from local_operator.harness.comms import SubagentComms
+from local_operator.harness.jobs import AsyncJob, AsyncJobManager
+from local_operator.harness.types import Usage
+from local_operator.mobile.projection import ProjectionFold
+from local_operator.mobile.types import SessionProjection
+from local_operator.session.session import Session
+
+
+def _manager_tree(jobs: int = 500) -> AsyncJobManager:
+    manager = AsyncJobManager()
+    manager.restore(
+        [
+            AsyncJob(
+                id=f"job-{index}",
+                type="task",
+                status="completed",
+                label=f"job {index}",
+                start_time=1.0,
+                usage=Usage(input_tokens=1, provider="test", model_id="bench"),
+            )
+            for index in range(jobs)
+        ]
+    )
+    return manager
+
+
+def main() -> None:
+    with tempfile.TemporaryDirectory(prefix="lop-roster-bench-") as raw:
+        root = Path(raw)
+        session = SimpleNamespace(jobs=SimpleNamespace(get=lambda job_id: None))
+        comms = SubagentComms(cast(Session, cast(Any, session)))
+        for index in range(75):
+            child = root / f"child-{index}"
+            child.mkdir()
+            # Approximate the incident's 26 MB history footprint without
+            # embedding any private transcript or prompt content.
+            (child / "transcript.jsonl").write_bytes(b"x" * 350_000)
+            job_id = f"child-{index}"
+            comms.record_launch(job_id, f"child {index}")
+            comms._records[job_id].session_dir = child
+
+        fold = ProjectionFold(SessionProjection(session_id="bench", pid=1))
+        samples = []
+        for _ in range(100):
+            started = time.perf_counter_ns()
+            fold.set_subagent_details(comms)
+            samples.append((time.perf_counter_ns() - started) / 1_000_000)
+
+        manager = _manager_tree()
+        manager.accounting_components()
+        started = time.perf_counter_ns()
+        for _ in range(1_000):
+            manager.accounting_components()
+        accounting_ms = (time.perf_counter_ns() - started) / 1_000_000 / 1_000
+
+        print(f"ordinary_event_p50_ms={statistics.median(samples):.3f}")
+        print(f"ordinary_event_p95_ms={statistics.quantiles(samples, n=20)[18]:.3f}")
+        print(f"ordinary_event_max_ms={max(samples):.3f}")
+        print(f"accounting_unchanged_500_jobs_ms={accounting_ms:.3f}")
+        print("child_transcript_constructions=0")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/harness/test_jobs.py
+++ b/tests/unit/harness/test_jobs.py
@@ -135,6 +135,54 @@ def test_accounting_summary_covers_every_production_nesting_level() -> None:
     assert sum(item.input_tokens for item in summary) == 6
 
 
+def test_unchanged_accounting_reads_do_not_rewalk_children(monkeypatch) -> None:
+    child = AsyncJobManager()
+    child.restore([_task_row("leaf", usage=Usage(input_tokens=2))])
+    parent = AsyncJobManager()
+    parent._jobs["root"] = _task_row("root", status="running")
+    parent.attach_child_manager("root", child)
+    assert sum(item.input_tokens for item in parent.accounting_components()) == 2
+
+    def fail_if_rebuilt(seen):  # noqa: ANN001, ANN202
+        raise AssertionError("unchanged accounting read rebuilt the child tree")
+
+    monkeypatch.setattr(child, "_collect_accounting_components", fail_if_rebuilt)
+    for _ in range(100):
+        assert sum(item.input_tokens for item in parent.accounting_components()) == 2
+
+
+def test_grandchild_accounting_invalidation_reaches_root_once() -> None:
+    leaf = AsyncJobManager()
+    leaf._jobs["leaf"] = _task_row("leaf", usage=Usage(input_tokens=2), status="running")
+    child = AsyncJobManager()
+    child._jobs["child"] = _task_row("child", status="running")
+    child.attach_child_manager("child", leaf)
+    root = AsyncJobManager()
+    root._jobs["root"] = _task_row("root", status="running")
+    root.attach_child_manager("root", child)
+    assert sum(item.input_tokens for item in root.accounting_components()) == 2
+    revision = root._accounting_revision
+
+    leaf._jobs["leaf"].usage.input_tokens += 3  # type: ignore[union-attr]
+    leaf.note_usage_changed()
+    assert root._accounting_revision == revision + 1
+    assert sum(item.input_tokens for item in root.accounting_components()) == 5
+
+
+def test_accounting_listener_cycle_is_bounded() -> None:
+    left = AsyncJobManager()
+    right = AsyncJobManager()
+    left._jobs["left"] = _task_row("left", status="running")
+    right._jobs["right"] = _task_row("right", status="running")
+    left.attach_child_manager("left", right)
+    right.attach_child_manager("right", left)
+
+    revision = left._accounting_revision
+    right.note_usage_changed()
+    assert left._accounting_revision == revision + 1
+    assert left.accounting_components() == []
+
+
 def test_accounting_summary_keeps_duplicate_ids_from_independent_managers() -> None:
     left = AsyncJobManager()
     right = AsyncJobManager()

--- a/tests/unit/mobile/test_projection.py
+++ b/tests/unit/mobile/test_projection.py
@@ -338,6 +338,43 @@ def test_swept_nested_outcome_survives_fresh_projection_and_reconnect(
         assert selected.activity == ""
 
 
+@pytest.mark.parametrize(
+    "parents",
+    [
+        {"a": "a"},
+        {"a": "b", "b": "a"},
+    ],
+)
+def test_subagent_metadata_projection_tolerates_legacy_parent_cycles(
+    parents,
+) -> None:  # noqa: ANN001
+    session = SimpleNamespace(jobs=SimpleNamespace(get=lambda job_id: None))
+    comms = SubagentComms(cast(Session, cast(Any, session)))
+    for job_id, parent_id in parents.items():
+        comms.record_launch(job_id, job_id, parent_job_id=parent_id)
+    fold = make_fold()
+    fold.set_subagent_details(comms)
+    assert {row.job_id for row in fold.projection.subagents} == set(parents)
+
+
+def test_subagent_metadata_projection_never_constructs_transcript(monkeypatch) -> None:
+    """The ordinary event path must remain memory-only regardless of child count."""
+    session = SimpleNamespace(jobs=SimpleNamespace(get=lambda job_id: None))
+    comms = SubagentComms(cast(Session, cast(Any, session)))
+    for index in range(75):
+        comms.record_launch(f"child-{index}", f"child {index}")
+
+    class ForbiddenTranscript:
+        def __init__(self, *args, **kwargs) -> None:  # noqa: ANN002, ANN003
+            raise AssertionError("metadata projection opened a child transcript")
+
+    monkeypatch.setattr("local_operator.session.transcript.Transcript", ForbiddenTranscript)
+    fold = make_fold()
+    for _ in range(100):
+        fold.set_subagent_details(comms)
+    assert len(fold.projection.subagents) == 75
+
+
 def test_recorded_terminal_outcome_never_regresses_to_running_job_row() -> None:
     """The runner records terminal state before the manager stamps its row."""
 

--- a/tests/unit/mobile/test_tui_bridge.py
+++ b/tests/unit/mobile/test_tui_bridge.py
@@ -7,10 +7,15 @@ from __future__ import annotations
 
 import asyncio
 import json
+from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
-from local_operator.mobile.tui_handle import TuiSessionHandle
+from local_operator.mobile.tui_handle import (
+    TuiSessionHandle,
+    _DetailChangedDuringHydration,
+)
 from tests.unit.tui.test_app_pilot import FakeSession, _factory
 
 
@@ -71,6 +76,76 @@ async def test_tui_stalled_steers_apply_owner_loop_backpressure() -> None:
     with pytest.raises(RuntimeError, match=r"steering queue is full \(32\)"):
         await handle.steer("overflow", command_id="overflow")
     assert len(session.steer_calls) == 32
+
+
+@pytest.mark.asyncio
+async def test_nested_child_detail_events_refresh_after_warm(monkeypatch) -> None:
+    class Comms:
+        def __init__(self) -> None:
+            self.listener = None
+            self.child = SimpleNamespace(
+                job_id="nested",
+                label="nested",
+                session_dir=Path("/tmp/nested"),
+                parent_job_id="parent",
+                session_id="nested",
+                prompt="",
+                effort="",
+                agent_role="task",
+                launch_message_id=None,
+            )
+
+        def roster(self):  # noqa: ANN201
+            return []
+
+        def nodes(self):  # noqa: ANN201
+            return [self.child]
+
+        def job(self, job_id):  # noqa: ANN001, ANN201
+            return None
+
+        def node(self, job_id):  # noqa: ANN001, ANN201
+            return self.child if job_id == "nested" else None
+
+        def subscribe_detail_changes(self, listener):  # noqa: ANN001, ANN201
+            self.listener = listener
+            return lambda: None
+
+    comms = Comms()
+    session = FakeSession()
+    setattr(session, "_subagent_comms", comms)
+    app = SimpleNamespace(_session=session)
+    handle = TuiSessionHandle(app)  # type: ignore[arg-type]
+    invalidated: list[str] = []
+    monkeypatch.setattr(handle, "_invalidate_subagent_detail", invalidated.append)
+    handle.subscribe(lambda: None)
+    assert invalidated == ["nested"]  # initial warm
+    assert comms.listener is not None
+    comms.listener("nested")
+    assert invalidated == ["nested", "nested"]  # later nested mutation
+
+
+@pytest.mark.asyncio
+async def test_dirty_hydration_retries_without_later_event(monkeypatch) -> None:
+    node = SimpleNamespace(job_id="nested", session_dir=Path("/tmp/nested"))
+    comms = SimpleNamespace(node=lambda job_id: node)
+    session = FakeSession()
+    setattr(session, "_subagent_comms", comms)
+    handle = TuiSessionHandle(SimpleNamespace(_session=session))  # type: ignore[arg-type]
+    handle._detail_generations["nested"] = 1
+    calls = 0
+
+    async def fake_to_thread(fn, session_dir):  # noqa: ANN001, ANN202
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise _DetailChangedDuringHydration
+        return (1, 1), [], []
+
+    monkeypatch.setattr(asyncio, "to_thread", fake_to_thread)
+    monkeypatch.setattr(handle._fold, "set_subagent_hydrated_details", lambda *args: True)
+    await handle._hydrate_subagent_detail("nested")
+    assert calls == 2
 
 
 @pytest.mark.asyncio

--- a/tests/unit/session/test_launch_subagent.py
+++ b/tests/unit/session/test_launch_subagent.py
@@ -32,7 +32,11 @@ from local_operator.harness.types import (
     SubagentStartEvent,
     Usage,
 )
-from local_operator.mobile.projection import ProjectionFold, SessionProjection
+from local_operator.mobile.projection import (
+    ProjectionFold,
+    SessionProjection,
+    fold_messages_to_entries,
+)
 from local_operator.session.session import Session
 from local_operator.session.transcript import Transcript
 
@@ -137,20 +141,29 @@ async def test_launch_subagent_runs_child_and_emits_lifecycle(tmp_path, monkeypa
     assert isinstance(stream.requests[0].messages[0], Message)
     assert stream.requests[0].messages[0].text == "go do a thing"
 
-    # Drive the same durable transcript fold the mobile detail endpoint uses.
-    # The raw task and role-expanded first user row correlate by identity, while
-    # the completed handoff remains terminal metadata after the ordered messages.
+    # ``set_subagent_details`` is metadata-only (the freeze fix keeps child
+    # transcript I/O off the Textual loop), so it fills lineage/prompt but NOT
+    # the transcript. The full-screen subagent conversation (#298) is hydrated
+    # off-loop and published through ``set_subagent_hydrated_details``.
     fold = ProjectionFold(SessionProjection(session_id="root", pid=1))
     fold.set_subagent_details(parent.subagent_comms)
     [row] = fold.projection.subagents
     assert row.prompt == "go do a thing"
     assert row.launch_message_id == f"subagent-launch:{job_id}"
+    assert row.result_text == "child did the work"
+    assert row.transcript == []  # not hydrated synchronously on the event path
+
+    # The worker path reads the durable child transcript off-loop and publishes
+    # the SAME rendered conversation the detail endpoint serves.
+    node = parent.subagent_comms.node(job_id)
+    assert node is not None and node.session_dir is not None
+    hydrated = fold_messages_to_entries(Transcript(node.session_dir).build_llm_history())
+    assert fold.set_subagent_hydrated_details(job_id, hydrated, [])
     assert [(entry.kind, entry.text) for entry in row.transcript] == [
         ("user", "go do a thing"),
         ("assistant", "child did the work"),
     ]
     assert row.transcript[0].id == f"subagent-launch:{job_id}"
-    assert row.result_text == "child did the work"
 
     # Item 12: once the task settles, the idle TOP-LEVEL parent re-wakes with
     # the result instead of polling `jobs`; the shared provider sees a second

--- a/tests/unit/session/test_resume_subagents_todos.py
+++ b/tests/unit/session/test_resume_subagents_todos.py
@@ -23,6 +23,7 @@ whole point, that a restored child is still resumable.
 from __future__ import annotations
 
 import asyncio
+import json
 
 import pytest
 
@@ -31,9 +32,12 @@ from local_operator.harness.types import (
     ChatRequest,
     StreamEndEvent,
     StreamTextDelta,
+    TextContent,
+    ToolResult,
 )
 from local_operator.session.session import (
     SUBAGENT_ROSTER_CUSTOM_TYPE,
+    SUBAGENT_ROSTER_SIDECAR,
     TODO_SNAPSHOT_CUSTOM_TYPE,
     Session,
 )
@@ -367,6 +371,157 @@ async def test_unchanged_todos_are_not_re_persisted_every_turn(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_malformed_v1_sidecar_falls_back_to_legacy_roster(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    transcript = Transcript(tmp_path / "sess")
+    await transcript.append_custom(
+        SUBAGENT_ROSTER_CUSTOM_TYPE,
+        {
+            "jobs": [],
+            "records": [
+                {
+                    "job_id": "legacy",
+                    "label": "legacy",
+                    "session_dir": str(tmp_path / "child"),
+                    "outcome": "completed",
+                }
+            ],
+        },
+    )
+    (transcript.directory / SUBAGENT_ROSTER_SIDECAR).write_text(
+        json.dumps({"version": 1, "generation": "broken", "jobs": [], "records": []})
+    )
+    resumed = _session(tmp_path, IdleStream())
+    assert [row.job_id for row in resumed.subagent_comms.roster()] == ["legacy"]
+
+
+@pytest.mark.asyncio
+async def test_todo_snapshot_precedes_cancelling_tool_end_subscriber(tmp_path, monkeypatch) -> None:
+    """A real todo mutation is durable before async ToolExecutionEnd fan-out."""
+    from local_operator.harness.types import ToolExecutionEndEvent
+
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    parent = _session(tmp_path, IdleStream())
+    TODO_STORE[parent.session_id] = [
+        {"name": "Nested", "items": [{"text": "survive", "status": "pending"}]}
+    ]
+    seen: list[str] = []
+
+    async def cancelling_subscriber(event) -> None:  # noqa: ANN001
+        if isinstance(event, ToolExecutionEndEvent) and event.tool_name == "todo":
+            details = parent._transcript.latest_custom(TODO_SNAPSHOT_CUSTOM_TYPE)
+            assert details is not None
+            seen.append(details["items"][0]["items"][0]["text"])
+            raise asyncio.CancelledError
+
+    parent.subscribe(cancelling_subscriber)
+    event = ToolExecutionEndEvent(
+        tool_call_id="todo-1",
+        tool_name="todo",
+        result=ToolResult(tool_call_id="todo-1", content=[TextContent(text="ok")]),
+    )
+    with pytest.raises(asyncio.CancelledError):
+        # This loop fragment is the exact production ordering under test.
+        await parent._maybe_persist_todos()
+        await parent._emit(event)
+    assert seen == ["survive"]
+
+
+@pytest.mark.asyncio
+async def test_child_detail_notification_follows_durable_append(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    notifications: list[str] = []
+    comms = type(
+        "Comms",
+        (),
+        {"notify_detail_persisted": lambda self, job_id: notifications.append(job_id)},
+    )()
+    child = Session(
+        model=MODEL,
+        stream_fn=IdleStream(),
+        tools=[],
+        transcript=Transcript(tmp_path / "child"),
+        system_blocks_provider=lambda: ["stable"],
+        job_id="nested",
+        subagent_comms=comms,
+    )
+    original_messages = child._persist_new_messages
+    original_todos = child._maybe_persist_todos
+    TODO_STORE[child.session_id] = [
+        {
+            "name": "Nested",
+            "items": [{"text": "persisted after error", "status": "pending"}],
+        }
+    ]
+
+    async def checked_messages(messages):  # noqa: ANN001, ANN202
+        assert notifications == []
+        await original_messages(messages)
+        assert notifications == []
+
+    async def checked_todos() -> None:
+        assert notifications == []
+        await original_todos()
+        assert notifications == []
+        details = child._transcript.latest_custom(TODO_SNAPSHOT_CUSTOM_TYPE)
+        assert details is not None
+        assert details["items"][0]["items"][0]["text"] == "persisted after error"
+
+    monkeypatch.setattr(child, "_persist_new_messages", checked_messages)
+    monkeypatch.setattr(child, "_maybe_persist_todos", checked_todos)
+    await child.prompt("persist this child turn")
+    assert notifications == ["nested"]
+    assert len(child._transcript.build_llm_history()) > 1
+
+
+@pytest.mark.asyncio
+async def test_empty_roster_final_flush_persists_todos_without_delay(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    parent = _session(tmp_path, IdleStream())
+    TODO_STORE[parent.session_id] = [
+        {"name": "Work", "items": [{"text": "persist me", "status": "pending"}]}
+    ]
+    loop = asyncio.get_running_loop()
+    started = loop.time()
+    await parent._final_persist_snapshots()
+    assert loop.time() - started < 0.5
+    assert parent._subagent_roster_written_generation == parent._subagent_roster_generation
+    details = parent._transcript.latest_custom(TODO_SNAPSHOT_CUSTOM_TYPE)
+    assert details is not None
+    assert details["items"][0]["items"][0]["text"] == "persist me"
+
+
+@pytest.mark.asyncio
+async def test_final_roster_persist_waits_for_active_writer(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    parent = _session(tmp_path, IdleStream())
+    parent.jobs.restore([])
+    parent._subagent_roster_generation = 1
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    writes: list[int] = []
+
+    async def blocked_write() -> None:
+        entered.set()
+        await release.wait()
+        writes.append(parent._subagent_roster_generation)
+        parent._subagent_roster_written_generation = parent._subagent_roster_generation
+        if parent._subagent_roster_writer is asyncio.current_task():
+            parent._subagent_roster_writer = None
+
+    writer = asyncio.create_task(blocked_write())
+    parent._subagent_roster_writer = writer
+    await entered.wait()
+    final = asyncio.create_task(parent._final_persist_snapshots())
+    await asyncio.sleep(0)
+    assert not final.done()
+    release.set()
+    await final
+    assert writes == [2]
+    assert parent._subagent_roster_written_generation == 2
+
+
+@pytest.mark.asyncio
 async def test_snapshot_entry_is_written_for_a_launched_child(tmp_path, monkeypatch):
     """A launched child writes a roster snapshot custom entry to the
     transcript — the durable record the resume reads."""
@@ -382,6 +537,17 @@ async def test_snapshot_entry_is_written_for_a_launched_child(tmp_path, monkeypa
         if e.type == "custom" and e.payload.get("custom_type") == SUBAGENT_ROSTER_CUSTOM_TYPE
     ]
     assert entries
+    sidecar = parent._transcript.directory / SUBAGENT_ROSTER_SIDECAR
+    assert sidecar.exists()
+    first_size = sidecar.stat().st_size
+    transcript_size = parent._transcript.path.stat().st_size
+    for _ in range(25):
+        parent._schedule_subagent_persist()
+    await asyncio.sleep(0.1)
+    # Generation digits may add a byte, but repeated transitions replace one
+    # bounded file and never append another full roster to the transcript.
+    assert sidecar.stat().st_size <= first_size + 4
+    assert parent._transcript.path.stat().st_size == transcript_size
     latest = entries[-1].payload["details"]
     # Job rows carry the manager's own ``id`` key; comms records carry job_id.
     row = next(r for r in latest["jobs"] if r["id"] == job_id)

--- a/tests/unit/session/test_session.py
+++ b/tests/unit/session/test_session.py
@@ -2811,20 +2811,56 @@ async def test_the_mid_turn_flush_never_persists_a_compaction_marker(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_cancelled_subagent_rescue_never_spawns_or_writes(tmp_path, monkeypatch):
+    """Even a malicious cancellation suppressor cannot outlive child disposal."""
+    from local_operator.harness.subagent import _persist_inflight
+
+    child = make_session(tmp_path, ScriptedStream([[StreamEndEvent(stop_reason="stop")]]))
+    child._job_id = "nested"
+    notifications: list[str] = []
+    child._subagent_comms = type(
+        "Comms",
+        (),
+        {"notify_detail_persisted": lambda self, job_id: notifications.append(job_id)},
+    )()
+    writes = 0
+
+    async def malicious_todos() -> None:
+        nonlocal writes
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            await asyncio.Event().wait()
+        writes += 1
+
+    monkeypatch.setattr(child, "_maybe_persist_todos", malicious_todos)
+    started = asyncio.get_running_loop().time()
+    await _persist_inflight(child)
+    assert asyncio.get_running_loop().time() - started < 0.05
+    assert notifications == ["nested"]
+    assert not [
+        task
+        for task in asyncio.all_tasks()
+        if task.get_name() == "persist-cancelled-subagent" and not task.done()
+    ]
+    await asyncio.wait_for(child.dispose(), timeout=0.35)
+    await asyncio.sleep(0.05)
+    assert writes == 0
+    assert not [
+        task
+        for task in asyncio.all_tasks()
+        if task.get_name() == "persist-cancelled-subagent" and not task.done()
+    ]
+
+
+@pytest.mark.asyncio
 async def test_a_cancelled_subagent_never_persists_a_marker_or_reminder(tmp_path):
-    """F4: the cancelled-child writer uses the same allow-list as the session.
+    """Cancellation rescue never re-journals ephemeral live context.
 
-    ``_persist_inflight`` writes a cancelled subagent's LIVE context straight
-    to its transcript so the turn is not lost. That context has the same two
-    ephemeral inhabitants as the parent's: after a compaction pass it begins
-    with the summary marker, and it may carry a todo reminder. Persisting
-    either corrupts the child's history — the marker replays a superseded
-    summary beside the live one, and a stored reminder comes back as a user
-    message nobody sent.
-
-    This path predates the mid-turn flush (it is byte-identical on the base
-    commit), but mid-turn compaction landing for real is what puts a marker in
-    a child's live context in the first place, so the exposure is new.
+    Message durability belongs to ``Session._run_turn``'s finally path and todo
+    durability belongs to the todo tool-completion boundary. The cancellation
+    helper therefore publishes only an invalidation and cannot write a stale
+    compaction marker or reminder after child disposal.
     """
     from local_operator.harness.subagent import _persist_inflight
 
@@ -2863,10 +2899,7 @@ async def test_a_cancelled_subagent_never_persists_a_marker_or_reminder(tmp_path
         "message the user never sent"
     )
 
-    # The real work still lands — the allow-list must not cost the turn.
-    assert any(
-        entry.type == "message" and entry.payload.get("role") == "user" for entry in entries
-    ), "the cancelled child's actual turn was dropped"
+    assert not entries, "cancellation rescue must not write after the owning boundaries"
 
     await child.dispose()
 

--- a/tests/unit/tui/test_band_panels.py
+++ b/tests/unit/tui/test_band_panels.py
@@ -10,6 +10,7 @@ isolated widget calls that can pass while the wiring is dead.
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Callable, Sequence
 from typing import Any
 
@@ -51,6 +52,12 @@ async def test_todo_panel_reads_selected_child_snapshot_without_root_leakage(tmp
         panel = TodoPanel()
         session = type("Session", (), {"session_id": "root"})()
         panel.sync(session, session_id="child", transcript_directory=str(child.directory))
+        # Historical transcript fallback is deliberately off-loop; the first
+        # sync schedules one worker read and the callback repaints from cache.
+        for _ in range(50):
+            if "child only" in str(panel._body.content):
+                break
+            await asyncio.sleep(0.01)
         assert "child only" in str(panel._body.content)
         assert "root only" not in str(panel._body.content)
         panel.sync(session, session_id="missing")


### PR DESCRIPTION
## Summary

Fixes the resumed-session freeze caused by synchronous whole-roster transcript hydration on every TUI/mobile event.

- makes ordinary projection refreshes metadata-only and O(children)
- hydrates only affected child details in coalesced, generation-guarded worker tasks
- removes historical todo transcript reads from render/poll paths
- caches nested accounting with propagated invalidation
- stores current roster state in an atomically replaced versioned sidecar while retaining legacy resume fallback
- bumps the patch version to 0.36.1

## Change classification

C2 standard performance and durability fix. Pre-authorized; this PR is the system of record.

## Delivery contract

- Ordinary session events construct zero child `Transcript` objects on Textual's loop.
- Child history hydration is off-loop, per affected child, coalesced, and generation guarded.
- Resume keeps the exact prior `session_dir`, nested accounting remains durable, and legacy roster snapshots remain readable.
- Roster persistence grows with current children rather than transitions times children.
- No rendered UI, copy, layout, or interaction change.

## Runtime evidence

Synthetic fixture mirrors the incident shape without user content: 75 child directories and about 26 MB of child transcript bytes, 100 ordinary projection events, and 500 accounting rows.

```text
$ PYTHONPATH=. .venv/bin/python scripts/benchmark_roster_freeze.py
ordinary_event_p50_ms=1.307
ordinary_event_p95_ms=1.929
ordinary_event_max_ms=5.701
accounting_unchanged_500_jobs_ms=0.002
child_transcript_constructions=0
```

Three consecutive warm runs produced ordinary-event p95 values of 1.926 ms, 1.625 ms, and 4.112 ms. Focused post-rebase real-path tests: 101 passed. The cancellation transcript durability and narrow-footer tests that flaked under host-wide CPU contention each passed immediately in isolation.

## Validation

- `env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest -n0 tests/unit/mobile/test_projection.py tests/unit/mobile/test_tui_bridge.py tests/unit/harness/test_jobs.py tests/unit/session/test_resume_subagents_todos.py tests/unit/session/test_attachment_persistence.py -q` → 101 passed
- targeted reported failures → 3 passed, then 2 passed
- full unit suite completed twice; branch-relevant tests passed. Host-contended runs exposed unrelated timing/SQLite flakes that passed immediately in isolation.
- `flake8 .` → passed
- `black 26.1.0 --check .` → 532 files unchanged, 1 notebook skipped because Jupyter dependencies are absent
- `isort 5.13.2 --check .` → passed
- focused pyright on all changed production modules → 0 errors
- full-tree pyright was cancelled after 42 minutes of CPU contention with three other concurrent worktree pyright processes; CI will run it in isolation

## Rollout and rollback

No data migration and no destructive rewrite. Existing transcript roster entries remain intact. A corrupt or absent sidecar falls back to the newest legacy transcript snapshot; the next mutation or clean disposal writes the sidecar. Roll back by reverting this commit; child transcripts remain the resume source.
