### PR TITLE
chore(release): bump version to 0.37.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.36.0"
+version = "0.37.0"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
## Summary

Version-only bump `0.36.0` → `0.37.0` to unblock the release train.

## Why

`v0.36.0` was published from PR #301 ("Durable resume context") and is live on PyPI. Two features then merged onto `main` **without bumping the version**:
- #307 — Chrome Web Store staged publishing automation
- #306 — peer-to-peer session messaging (`lop send` / `lop sessions`)

So `origin/main` carried `version = 0.36.0`, colliding with a released version. This bumps to `0.37.0` so the two post-0.36.0 features ship under a fresh, publishable version. No code change; pyproject only.

## Testing evidence

Version-only change. The peer-messaging feature (#306) landed with full agent review (4 rounds), design + UX rounds, live end-to-end evidence, and green CI on Python 3.12/3.13 before merge; the local full Python 3.12 suite passed (6882 passed, 7 skipped) at its head. This PR touches only `pyproject.toml`.
