### PR TITLE
fix(extension): give the popup explicit feedback for pairing and origin decisions

### DIFF
--- a/docs/design/branding-bridge.md
+++ b/docs/design/branding-bridge.md
@@ -118,7 +118,7 @@ Pairing prompt:
 - Heading: **"Pair with Local Operator"**
 - Body: "Type the 6-digit code from the Local Operator app. Pairing links this
   browser to your app and nothing else."
-- Field label: "Pairing code" · Button: "Pair" · Error: "That code didn't match. Codes expire after a minute — check the app for a fresh one."
+- Field label: "Pairing code" · Button: "Pair" · Error: "That code didn't match. Codes expire after two minutes — check the app for a fresh one."
 
 Per-site allow prompt:
 - Heading: **"Let the agent use github.com?"**

--- a/extension/src/popup/origin-flow.ts
+++ b/extension/src/popup/origin-flow.ts
@@ -1,0 +1,66 @@
+/* Pure decisions for the popup's origin-consent flow, DOM-free for the
+ * pure-node test suite — the same pattern as pair-flow.ts, for the same class
+ * of bug.
+ *
+ * The race: clicking Allow/Deny sends `origin_decision` to the worker, but
+ * session storage's `pendingOrigin` and /health's `pending_origin` keep
+ * reporting the prompt until that round-trip lands. A render() driven by
+ * either source would leave the prompt on screen with three live buttons and
+ * no sign the click took effect. The acknowledgement must therefore render
+ * from the CLICK alone, and a stale prompt echo must hold the ack rather than
+ * resurrect the buttons. */
+
+export type OriginDecision = "once" | "always" | "deny";
+
+/** The decision this popup already made, keyed by ORIGIN — finding A6's rule:
+ * a redirect chain resolves each hop independently, so a DIFFERENT pending
+ * origin is a new prompt even while this one's ack is still settling. */
+export interface DecidedOrigin {
+  origin: string;
+  decision: OriginDecision;
+}
+
+export interface DecisionAck {
+  title: string;
+  sub: string;
+  tone: "success" | "neutral";
+  check: boolean;
+}
+
+/** The acknowledgement each decision renders. Deny is a COMPLETED choice, not
+ * a failure, so it takes the neutral register and no check — danger is
+ * reserved for states the user must recover from (error/incompatible), and a
+ * check over "denied" would read as the wrong verdict. */
+export function ackForDecision(decision: OriginDecision): DecisionAck {
+  if (decision === "deny") {
+    return {
+      title: "Site denied.",
+      sub: "The agent won't use this site.",
+      tone: "neutral",
+      check: false,
+    };
+  }
+  // "always" is a standing grant, so its ack must say it outlives this moment
+  // and where to take it back — the consent prompt's own revocability promise.
+  const standing =
+    decision === "always" ? " Always-allowed sites can be taken back any time in Settings." : "";
+  return {
+    title: "Site allowed.",
+    sub: `The agent is continuing.${standing}`,
+    tone: "success",
+    check: true,
+  };
+}
+
+/** Which origin view a render shows. A pending origin equal to the one just
+ * decided is the stale echo of the race above — hold the ack. A different
+ * pending origin is a genuinely new prompt (A6). No pending origin means the
+ * round-trip landed and the caller should clear its latch so a future prompt
+ * for the SAME origin (e.g. a retry after deny) is not swallowed. */
+export function originPromptView(
+  pendingOrigin: string | undefined,
+  decided: DecidedOrigin | null,
+): "prompt" | "ack" | "none" {
+  if (!pendingOrigin) return "none";
+  return decided && decided.origin === pendingOrigin ? "ack" : "prompt";
+}

--- a/extension/src/popup/pair-flow.ts
+++ b/extension/src/popup/pair-flow.ts
@@ -26,7 +26,7 @@ export type PairVerdict = { ok: true; token: string } | { ok: false; message: st
 
 /** Fold a pair_result frame into exactly one of two outcomes. `ok` without a
  * token is treated as a failure: a success we cannot store a credential for
- * would render "Patched in." over a connection that can never authenticate. */
+ * would render "Paired." over a connection that can never authenticate. */
 export function pairVerdict(frame: PairResultFrame): PairVerdict {
   if (frame.ok && frame.token) return { ok: true, token: frame.token };
   return { ok: false, message: frame.message ?? PAIR_MISMATCH_MESSAGE };

--- a/extension/src/popup/pair-flow.ts
+++ b/extension/src/popup/pair-flow.ts
@@ -1,0 +1,45 @@
+/* Pure decisions for the popup's pairing flow, kept DOM-free so the pure-node
+ * test suite can exercise them (popup.ts touches `document` at module scope and
+ * cannot be imported under node).
+ *
+ * The race these functions exist for: the daemon answers `pair_result.ok` on
+ * the popup's own WebSocket the moment the code is accepted, but /health only
+ * reports `paired: true` after the background worker reconnects with the new
+ * token. In that window a render() driven by /health would put the pairing form
+ * back on screen; the user, seeing no feedback, re-submits the consumed
+ * one-time code and gets a misleading "No live pairing code" error. Success
+ * must therefore render from the pair_result frame ALONE and never be
+ * downgraded by a stale health probe. */
+
+/** The default mismatch copy (branding doc's pairing-error microcopy). */
+export const PAIR_MISMATCH_MESSAGE =
+  "That code didn't match. Codes expire after two minutes — check the app for a fresh one.";
+
+export interface PairResultFrame {
+  event?: string;
+  ok?: boolean;
+  token?: string;
+  message?: string;
+}
+
+export type PairVerdict = { ok: true; token: string } | { ok: false; message: string };
+
+/** Fold a pair_result frame into exactly one of two outcomes. `ok` without a
+ * token is treated as a failure: a success we cannot store a credential for
+ * would render "Patched in." over a connection that can never authenticate. */
+export function pairVerdict(frame: PairResultFrame): PairVerdict {
+  if (frame.ok && frame.token) return { ok: true, token: frame.token };
+  return { ok: false, message: frame.message ?? PAIR_MISMATCH_MESSAGE };
+}
+
+/** Which view a reachable-daemon render shows. `locallyPaired` records that
+ * THIS popup already saw pair_result.ok, so a health probe that has not caught
+ * up yet ("the race") holds the explicit success state instead of falling back
+ * to the form. */
+export function viewForHealth(
+  healthPaired: boolean,
+  locallyPaired: boolean,
+): "connected" | "paired" | "pairing" {
+  if (healthPaired) return "connected";
+  return locallyPaired ? "paired" : "pairing";
+}

--- a/extension/src/popup/popup.css
+++ b/extension/src/popup/popup.css
@@ -263,9 +263,15 @@ input:disabled {
 .btn:disabled:hover {
   background: var(--surface);
 }
+/* Filled and outlined variants keep their identity while disabled: hover must
+ * not repaint a locked button, whatever its tone. */
 .btn.primary:disabled:hover {
   background: var(--ink);
   border-color: var(--ink);
+}
+.btn.danger:disabled:hover {
+  background: var(--surface);
+  border-color: var(--danger);
 }
 
 .actions {

--- a/extension/src/popup/popup.css
+++ b/extension/src/popup/popup.css
@@ -204,6 +204,13 @@ input:focus-visible {
   outline: 2px solid var(--ink);
   outline-offset: 1px;
 }
+/* In-flight pairing: the locked field drops to the sunken well so the form
+ * visibly stops accepting input without adding a spinner — hairlines and tone
+ * shifts are this system's whole motion vocabulary. */
+input:disabled {
+  background: var(--sunken);
+  color: var(--ink-dim);
+}
 
 /* Buttons follow the token ramp, not a flat black. Primary = ink fill, the
  * system's strongest affordance; secondary = surface with a hairline; danger =
@@ -246,6 +253,20 @@ input:focus-visible {
 .btn.danger:hover {
   background: color-mix(in srgb, var(--danger) 10%, var(--surface));
 }
+/* A disabled button steps down the ink ramp instead of greying out: the same
+ * subtle register as ink-muted text, and the primary keeps its fill so the
+ * "Pairing…" label reads as the button working, not the button broken. */
+.btn:disabled {
+  cursor: default;
+  opacity: 0.6;
+}
+.btn:disabled:hover {
+  background: var(--surface);
+}
+.btn.primary:disabled:hover {
+  background: var(--ink);
+  border-color: var(--ink);
+}
 
 .actions {
   margin-top: 16px;
@@ -264,6 +285,16 @@ input:focus-visible {
   display: flex;
   width: 100%;
   margin-top: 8px;
+}
+
+/* The pairing-success check: the one glyph allowed the semantic success tone
+ * (state, not identity — the header mark stays --ink). Sized to the title's
+ * optical weight; the card's top rule goes --success in the same beat. */
+.check {
+  width: 28px;
+  height: 28px;
+  color: var(--success);
+  margin-bottom: 10px;
 }
 
 .error {

--- a/extension/src/popup/popup.html
+++ b/extension/src/popup/popup.html
@@ -56,8 +56,11 @@
           >
             <path d="M4 12.5 L9.5 18 L20 6.5" stroke-width="2.5" />
           </svg>
-          <h1 class="title">Patched in.</h1>
-          <p class="sub">Pairing confirmed. Connecting this browser to Local Operator…</p>
+          <!-- "Paired.", not the branding doc's "Patched in." — the "Patch"
+               naming is retired (docs/store/assets.md: do not reuse it); the
+               doc supplies the microcopy PATTERN, not the name. -->
+          <h1 class="title">Paired.</h1>
+          <p class="sub">Code accepted. Connecting this browser to Local Operator…</p>
         </section>
 
         <section id="pairing" class="state hidden">

--- a/extension/src/popup/popup.html
+++ b/extension/src/popup/popup.html
@@ -38,6 +38,28 @@
           <p class="trough" id="connected-detail"></p>
         </section>
 
+        <!-- Explicit pairing-success state, shown from the pair_result frame
+             alone (popup.ts): /health lags the pair by a worker reconnect, and
+             a form left on screen invites re-submitting the consumed code. The
+             check is stroked in the semantic success token — status, not
+             identity, so tinting is allowed (unlike the mark above). -->
+        <section id="paired" class="state hidden" role="status">
+          <svg
+            class="check"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+            focusable="false"
+          >
+            <path d="M4 12.5 L9.5 18 L20 6.5" stroke-width="2.5" />
+          </svg>
+          <h1 class="title">Patched in.</h1>
+          <p class="sub">Pairing confirmed. Connecting this browser to Local Operator…</p>
+        </section>
+
         <section id="pairing" class="state hidden">
           <h1 class="title">Pair with Local Operator</h1>
           <p class="sub">Enter the code shown in Local Operator.</p>

--- a/extension/src/popup/popup.html
+++ b/extension/src/popup/popup.html
@@ -101,6 +101,30 @@
           </div>
         </section>
 
+        <!-- Origin-decision acknowledgement, shown from the click alone
+             (popup.ts): session storage and /health echo the prompt until the
+             worker round-trip lands, and a prompt left up with live buttons
+             reads as the click not working. Title/sub/tone/check are set per
+             decision by showOriginAck — allow is a success (check + success
+             tone), deny a completed neutral choice (no check, never danger). -->
+        <section id="origin-ack" class="state hidden" role="status">
+          <svg
+            id="origin-ack-check"
+            class="check"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+            focusable="false"
+          >
+            <path d="M4 12.5 L9.5 18 L20 6.5" stroke-width="2.5" />
+          </svg>
+          <h1 class="title" id="origin-ack-title"></h1>
+          <p class="sub" id="origin-ack-sub"></p>
+        </section>
+
         <section
           id="origin"
           class="state hidden"

--- a/extension/src/popup/popup.ts
+++ b/extension/src/popup/popup.ts
@@ -1,9 +1,18 @@
 import { DEFAULT_PORT, getLocal, getSession } from "../state";
+import { pairVerdict, viewForHealth } from "./pair-flow";
 
-type State = "connected" | "pairing" | "disconnected" | "incompatible" | "origin";
-const sections = ["connected", "pairing", "disconnected", "incompatible", "origin"].map((id) =>
-  document.getElementById(id),
+type State = "connected" | "paired" | "pairing" | "disconnected" | "incompatible" | "origin";
+const sections = ["connected", "paired", "pairing", "disconnected", "incompatible", "origin"].map(
+  (id) => document.getElementById(id),
 );
+
+// True once THIS popup saw pair_result.ok. The daemon confirms pairing on the
+// popup's own socket before /health reports paired (the worker still has to
+// reconnect with the new token), so a health-driven render in that window must
+// hold the explicit success view instead of putting the form back — a re-shown
+// form invites re-submitting the consumed one-time code, which then fails with
+// a misleading "No live pairing code". See pair-flow.ts.
+let locallyPaired = false;
 
 interface Health {
   extension_connected: boolean;
@@ -21,6 +30,7 @@ interface Health {
 // mark is never tinted — see popup.css. Mirrors callback_page.py's _TONE_VARS.
 const TONE: Record<State, string> = {
   connected: "var(--success)",
+  paired: "var(--success)",
   pairing: "var(--hairline-strong)",
   disconnected: "var(--hairline-strong)",
   incompatible: "var(--danger)",
@@ -99,7 +109,9 @@ async function render(): Promise<void> {
     show("connected");
     return;
   }
-  show("pairing");
+  // Health has not confirmed the new token yet: keep the success view if this
+  // popup already paired (the race above), otherwise offer the form.
+  show(viewForHealth(false, locallyPaired));
 }
 
 function hostnameOf(origin: string | undefined): string {
@@ -118,12 +130,27 @@ codeInput?.addEventListener("input", () => {
   codeInput.value = codeInput.value.replace(/\D/g, "").slice(0, 6);
 });
 
+// Lock the form for the duration of one submission: a second click while the
+// first is in flight would spend the same one-time code twice, and the second
+// attempt always fails confusingly. The disabled ramp in popup.css plus the
+// relabelled button are the in-progress affordance.
+function setPairBusy(busy: boolean): void {
+  const input = document.getElementById("pair-code") as HTMLInputElement | null;
+  const button = document.querySelector<HTMLButtonElement>("#pair-form button[type='submit']");
+  if (input) input.disabled = busy;
+  if (button) {
+    button.disabled = busy;
+    button.textContent = busy ? "Pairing…" : "Pair";
+  }
+}
+
 document.getElementById("pair-form")?.addEventListener("submit", async (event) => {
   event.preventDefault();
   const input = document.getElementById("pair-code") as HTMLInputElement | null;
   const error = document.getElementById("pair-error");
   if (!input || !error) return;
   error.classList.add("hidden");
+  setPairBusy(true);
   const { token, port = DEFAULT_PORT } = await getLocal();
   try {
     const wire = new WebSocket(`ws://127.0.0.1:${port}/extension`);
@@ -147,31 +174,40 @@ document.getElementById("pair-form")?.addEventListener("submit", async (event) =
     const verdict = await new Promise<MessageEvent>((resolve) => {
       wire.onmessage = resolve;
     });
-    const frame = JSON.parse(String(verdict.data)) as {
-      event: string;
-      ok: boolean;
-      token?: string;
-      message?: string;
-    };
-    if (frame.ok && frame.token) {
-      await chrome.storage.local.set({ token: frame.token });
+    const outcome = pairVerdict(JSON.parse(String(verdict.data)));
+    if (outcome.ok) {
+      await chrome.storage.local.set({ token: outcome.token });
       wire.close();
+      // Confirm SUCCESS from the pair_result frame alone, before any health
+      // round-trip: the worker has not reconnected with the new token yet, so
+      // /health still says unpaired and a render() here would re-show the form
+      // (the race documented at `locallyPaired`). The explicit success state is
+      // the user's feedback; render() below only upgrades it to the connected
+      // view once health confirms.
+      locallyPaired = true;
+      show("paired");
       await new Promise((resolve) => setTimeout(resolve, 250));
       await render();
     } else {
-      error.textContent =
-        frame.message ??
-        "That code didn't match. Codes expire after two minutes — check the app for a fresh one.";
+      error.textContent = outcome.message;
       error.classList.remove("hidden");
       // A live pairing error turns the status rule danger — the one place the
       // pairing state spends colour, and only on a real failure.
       document.getElementById("card")?.style.setProperty("--tone", "var(--danger)");
+      // Unlock BEFORE focusing: a disabled input refuses focus, and the
+      // `finally` unlock runs only after this handler returns. (The finally
+      // re-call is idempotent.)
+      setPairBusy(false);
       input.focus();
     }
   } catch {
     error.textContent = "Could not reach Local Operator on this machine.";
     error.classList.remove("hidden");
     document.getElementById("card")?.style.setProperty("--tone", "var(--danger)");
+  } finally {
+    // Always unlock, success included: if health later drops (daemon restart)
+    // the user lands back on this form, and it must not arrive pre-disabled.
+    setPairBusy(false);
   }
 });
 

--- a/extension/src/popup/popup.ts
+++ b/extension/src/popup/popup.ts
@@ -1,10 +1,29 @@
 import { DEFAULT_PORT, getLocal, getSession } from "../state";
 import { pairVerdict, viewForHealth } from "./pair-flow";
+import {
+  ackForDecision,
+  originPromptView,
+  type DecidedOrigin,
+  type OriginDecision,
+} from "./origin-flow";
 
-type State = "connected" | "paired" | "pairing" | "disconnected" | "incompatible" | "origin";
-const sections = ["connected", "paired", "pairing", "disconnected", "incompatible", "origin"].map(
-  (id) => document.getElementById(id),
-);
+type State =
+  | "connected"
+  | "paired"
+  | "pairing"
+  | "disconnected"
+  | "incompatible"
+  | "origin"
+  | "origin-ack";
+const sections = [
+  "connected",
+  "paired",
+  "pairing",
+  "disconnected",
+  "incompatible",
+  "origin",
+  "origin-ack",
+].map((id) => document.getElementById(id));
 
 // True once THIS popup saw pair_result.ok. The daemon confirms pairing on the
 // popup's own socket before /health reports paired (the worker still has to
@@ -13,6 +32,14 @@ const sections = ["connected", "paired", "pairing", "disconnected", "incompatibl
 // form invites re-submitting the consumed one-time code, which then fails with
 // a misleading "No live pairing code". See pair-flow.ts.
 let locallyPaired = false;
+
+// The origin decision THIS popup already made — the consent flow's copy of the
+// same race: `origin_decision` goes to the worker, but session storage and
+// /health keep echoing the prompt until that round-trip lands, so a render in
+// the window would resurrect the three buttons over a click that already took
+// effect. Keyed by origin so a different pending origin still prompts (A6).
+// See origin-flow.ts.
+let decidedOrigin: DecidedOrigin | null = null;
 
 interface Health {
   extension_connected: boolean;
@@ -35,6 +62,9 @@ const TONE: Record<State, string> = {
   disconnected: "var(--hairline-strong)",
   incompatible: "var(--danger)",
   origin: "var(--hairline-strong)",
+  // Placeholder only: the ack's real tone is per-decision (success for allow,
+  // neutral for deny) and showOriginAck overrides it right after show().
+  "origin-ack": "var(--hairline-strong)",
 };
 
 function show(state: State): void {
@@ -63,6 +93,19 @@ async function render(): Promise<void> {
   // shows it even after a worker restart.
   const { pendingOrigin } = await getSession();
   const health = await daemonHealth();
+  // Compare by ORIGIN (not display hostname): the latch must match exactly the
+  // key the decision was sent under (A6).
+  const pendingOriginValue = pendingOrigin?.origin || health?.pending_origin;
+  const originView = originPromptView(pendingOriginValue, decidedOrigin);
+  if (originView === "none") {
+    // Round-trip landed and the prompt is gone: clear the latch so a future
+    // prompt for the SAME origin (a retry after deny) is not swallowed.
+    decidedOrigin = null;
+  } else if (originView === "ack") {
+    // Stale echo of the decided prompt — hold the acknowledgement.
+    showOriginAck(decidedOrigin!.decision);
+    return;
+  }
   const pendingHost = pendingOrigin?.hostname || hostnameOf(health?.pending_origin);
   if (pendingHost) {
     // The heading is fixed prose; the host — the string the user must verify
@@ -71,6 +114,9 @@ async function render(): Promise<void> {
     // heading id stays constant, so no per-host text in the serif face.
     const host = document.getElementById("origin-host");
     if (host) host.textContent = pendingHost;
+    // A fresh prompt must arrive with live buttons even if a previous
+    // decision's lock is still set.
+    setOriginBusy(false);
     show("origin");
     return;
   }
@@ -217,9 +263,47 @@ document.getElementById("origin-allow")?.addEventListener("click", () => void de
 document.getElementById("origin-always")?.addEventListener("click", () => void decide("always"));
 document.getElementById("origin-deny")?.addEventListener("click", () => void decide("deny"));
 
-async function decide(decision: "once" | "always" | "deny"): Promise<void> {
+// Lock the three consent buttons the moment one is clicked: the session-storage
+// read below is async, and a second click in that window would double-send the
+// decision. render()'s prompt path unlocks for the next genuine prompt.
+function setOriginBusy(busy: boolean): void {
+  for (const id of ["origin-allow", "origin-always", "origin-deny"]) {
+    const button = document.getElementById(id) as HTMLButtonElement | null;
+    if (button) button.disabled = busy;
+  }
+}
+
+function showOriginAck(decision: OriginDecision): void {
+  const ack = ackForDecision(decision);
+  const title = document.getElementById("origin-ack-title");
+  const sub = document.getElementById("origin-ack-sub");
+  if (title) title.textContent = ack.title;
+  if (sub) sub.textContent = ack.sub;
+  document.getElementById("origin-ack-check")?.classList.toggle("hidden", !ack.check);
+  show("origin-ack");
+  // Per-decision tone override: allow is a real success (the agent proceeds),
+  // deny is a completed choice — neutral, never danger, which is reserved for
+  // states the user must recover from.
+  document
+    .getElementById("card")
+    ?.style.setProperty(
+      "--tone",
+      ack.tone === "success" ? "var(--success)" : "var(--hairline-strong)",
+    );
+}
+
+async function decide(decision: OriginDecision): Promise<void> {
+  setOriginBusy(true);
   const { pendingOrigin } = await getSession();
   if (pendingOrigin) {
+    // Acknowledge from the CLICK alone, before the worker round-trip: session
+    // storage and /health keep echoing this prompt until `origin_decision`
+    // lands, and a render in that window would put the three buttons back with
+    // no sign the click worked — the same race as pairing success. The latch
+    // holds the ack through stale echoes; render() takes over to Connected
+    // once the echo clears.
+    decidedOrigin = { origin: pendingOrigin.origin, decision };
+    showOriginAck(decision);
     // Decisions are keyed by ORIGIN so a redirect chain resolves each hop
     // independently (finding A6).
     await chrome.runtime.sendMessage({

--- a/extension/src/popup/popup.ts
+++ b/extension/src/popup/popup.ts
@@ -41,6 +41,13 @@ let locallyPaired = false;
 // See origin-flow.ts.
 let decidedOrigin: DecidedOrigin | null = null;
 
+// The origin the prompt is currently showing, whichever source supplied it.
+// After a worker restart session storage is empty and the prompt renders from
+// /health's pending_origin alone; a decision click must still acknowledge (and
+// key its latch) against THAT origin, or the click lands on the one branch
+// where the missing-feedback bug survives (review finding m1).
+let shownPromptOrigin: string | undefined;
+
 interface Health {
   extension_connected: boolean;
   paired: boolean;
@@ -98,6 +105,7 @@ async function render(): Promise<void> {
   const pendingOriginValue = pendingOrigin?.origin || health?.pending_origin;
   const originView = originPromptView(pendingOriginValue, decidedOrigin);
   if (originView === "none") {
+    shownPromptOrigin = undefined;
     // Round-trip landed and the prompt is gone: clear the latch so a future
     // prompt for the SAME origin (a retry after deny) is not swallowed.
     decidedOrigin = null;
@@ -114,6 +122,7 @@ async function render(): Promise<void> {
     // heading id stays constant, so no per-host text in the serif face.
     const host = document.getElementById("origin-host");
     if (host) host.textContent = pendingHost;
+    shownPromptOrigin = pendingOriginValue;
     // A fresh prompt must arrive with live buttons even if a previous
     // decision's lock is still set.
     setOriginBusy(false);
@@ -135,6 +144,13 @@ async function render(): Promise<void> {
     return;
   }
   if (health.paired) {
+    // Handoff complete: the worker holds the new token and health confirms it,
+    // so the pairing latch has done its job. Clearing it here means a LATER
+    // unpair (daemon revoke → close 4003) renders the form again instead of a
+    // stale success view (review finding m2). A revoke landing inside the
+    // pre-confirmation window is not distinguishable from the race itself and
+    // stays covered by the latch until the popup reopens.
+    locallyPaired = false;
     // Name the site the agent is driving so the user can see it without
     // hunting for a background tab (finding U3). The URL rides in a labelled
     // trough (the callback page's treatment); when nothing is open the label
@@ -200,10 +216,33 @@ document.getElementById("pair-form")?.addEventListener("submit", async (event) =
   const { token, port = DEFAULT_PORT } = await getLocal();
   try {
     const wire = new WebSocket(`ws://127.0.0.1:${port}/extension`);
-    await new Promise((resolve, reject) => {
-      wire.onopen = resolve;
-      wire.onerror = reject;
+    // ONE shared rejection wired to error AND close for every await below: a
+    // socket that drops after open but before pair_result must land in
+    // `catch` — a bare onmessage promise would suspend forever, and with the
+    // busy lock held that means a form disabled until the popup is reopened
+    // (review finding M1). The no-op catch keeps a post-handshake close (our
+    // own close() included, if handlers weren't detached) from surfacing as an
+    // unhandled rejection.
+    let failed: (reason: Error) => void = () => {};
+    const failure = new Promise<never>((_, reject) => {
+      failed = reject;
     });
+    void failure.catch(() => {});
+    wire.onerror = () => failed(new Error("socket error"));
+    wire.onclose = () => failed(new Error("socket closed"));
+    await Promise.race([
+      new Promise((resolve) => {
+        wire.onopen = resolve;
+      }),
+      failure,
+    ]);
+    const nextMessage = (): Promise<MessageEvent> =>
+      Promise.race([
+        new Promise<MessageEvent>((resolve) => {
+          wire.onmessage = resolve;
+        }),
+        failure,
+      ]);
     wire.send(
       JSON.stringify({
         event: "hello",
@@ -213,16 +252,15 @@ document.getElementById("pair-form")?.addEventListener("submit", async (event) =
         browser: navigator.userAgent,
       }),
     );
-    await new Promise((resolve) => {
-      wire.onmessage = resolve;
-    });
+    await nextMessage();
     wire.send(JSON.stringify({ event: "pair", code: input.value.trim() }));
-    const verdict = await new Promise<MessageEvent>((resolve) => {
-      wire.onmessage = resolve;
-    });
+    const verdict = await nextMessage();
     const outcome = pairVerdict(JSON.parse(String(verdict.data)));
     if (outcome.ok) {
       await chrome.storage.local.set({ token: outcome.token });
+      // Detach before closing: this close is deliberate, not a failure.
+      wire.onerror = null;
+      wire.onclose = null;
       wire.close();
       // Confirm SUCCESS from the pair_result frame alone, before any health
       // round-trip: the worker has not reconnected with the new token yet, so
@@ -295,24 +333,37 @@ function showOriginAck(decision: OriginDecision): void {
 async function decide(decision: OriginDecision): Promise<void> {
   setOriginBusy(true);
   const { pendingOrigin } = await getSession();
-  if (pendingOrigin) {
+  // Fall back to the origin the prompt actually rendered from: after a worker
+  // restart the session record is gone and only /health carried the origin
+  // (finding m1) — the click must acknowledge either way.
+  const origin = pendingOrigin?.origin ?? shownPromptOrigin;
+  if (origin) {
     // Acknowledge from the CLICK alone, before the worker round-trip: session
     // storage and /health keep echoing this prompt until `origin_decision`
     // lands, and a render in that window would put the three buttons back with
     // no sign the click worked — the same race as pairing success. The latch
     // holds the ack through stale echoes; render() takes over to Connected
     // once the echo clears.
-    decidedOrigin = { origin: pendingOrigin.origin, decision };
+    decidedOrigin = { origin, decision };
     showOriginAck(decision);
     // Decisions are keyed by ORIGIN so a redirect chain resolves each hop
     // independently (finding A6).
     await chrome.runtime.sendMessage({
       event: "origin_decision",
-      origin: pendingOrigin.origin,
+      origin,
       decision,
     });
   }
   await render();
 }
+
+// Re-render whenever the worker changes connection state: the worker learns a
+// new token only on its own reconnect (its retry alarm can be ~30s out), and
+// without this the "Connecting…" success view sits until the user pokes the
+// popup (review finding m3). connState flips exactly when something the popup
+// shows has changed, so this is cheaper and quieter than polling /health.
+chrome.storage.onChanged.addListener((changes, area) => {
+  if (area === "session" && changes.connState) void render();
+});
 
 void render();

--- a/extension/tests/pure.test.mjs
+++ b/extension/tests/pure.test.mjs
@@ -54,3 +54,38 @@ test("log filter keeps level matches and limits to the most recent", async () =>
     assert.deepEqual(filterEntries(entries, "all", 2).map((e) => e.text), ["c", "d"]);
   } finally { await module.close(); }
 });
+
+test("pair verdict renders success only with a storable token", async () => {
+  const module = await load("src/popup/pair-flow.ts");
+  try {
+    const { pairVerdict, PAIR_MISMATCH_MESSAGE } = module.loaded;
+    assert.deepEqual(pairVerdict({ event: "pair_result", ok: true, token: "t1" }), {
+      ok: true,
+      token: "t1",
+    });
+    // ok without a token is a failure: nothing to authenticate future
+    // connections with, so "Patched in." would be a lie.
+    assert.deepEqual(pairVerdict({ ok: true }), { ok: false, message: PAIR_MISMATCH_MESSAGE });
+    // daemon-provided message wins over the default mismatch copy.
+    assert.deepEqual(pairVerdict({ ok: false, message: "No live pairing code" }), {
+      ok: false,
+      message: "No live pairing code",
+    });
+    assert.deepEqual(pairVerdict({}), { ok: false, message: PAIR_MISMATCH_MESSAGE });
+  } finally { await module.close(); }
+});
+
+test("health render holds the success view during the pair/health race", async () => {
+  const module = await load("src/popup/pair-flow.ts");
+  try {
+    const { viewForHealth } = module.loaded;
+    // The race: pair_result.ok arrived but the worker has not reconnected, so
+    // health still says unpaired — the form must NOT come back.
+    assert.equal(viewForHealth(false, true), "paired");
+    // Health caught up: the connected view (with URL details) takes over.
+    assert.equal(viewForHealth(true, true), "connected");
+    assert.equal(viewForHealth(true, false), "connected");
+    // Never paired in this popup: the form is the right offer.
+    assert.equal(viewForHealth(false, false), "pairing");
+  } finally { await module.close(); }
+});

--- a/extension/tests/pure.test.mjs
+++ b/extension/tests/pure.test.mjs
@@ -89,3 +89,39 @@ test("health render holds the success view during the pair/health race", async (
     assert.equal(viewForHealth(false, false), "pairing");
   } finally { await module.close(); }
 });
+
+test("origin decision acks render per decision, deny staying neutral", async () => {
+  const module = await load("src/popup/origin-flow.ts");
+  try {
+    const { ackForDecision } = module.loaded;
+    const once = ackForDecision("once");
+    assert.equal(once.title, "Site allowed.");
+    assert.equal(once.sub, "The agent is continuing.");
+    assert.deepEqual([once.tone, once.check], ["success", true]);
+    // "always" is a standing grant: the ack must say it persists and where to
+    // revoke it.
+    const always = ackForDecision("always");
+    assert.equal(always.tone, "success");
+    assert.match(always.sub, /Always-allowed sites can be taken back any time in Settings\./);
+    // Deny is a completed choice, not a failure: neutral, no check.
+    const deny = ackForDecision("deny");
+    assert.deepEqual([deny.title, deny.tone, deny.check], ["Site denied.", "neutral", false]);
+  } finally { await module.close(); }
+});
+
+test("origin render holds the ack through the decision round-trip race", async () => {
+  const module = await load("src/popup/origin-flow.ts");
+  try {
+    const { originPromptView } = module.loaded;
+    const decided = { origin: "https://example.com", decision: "always" };
+    // The race: the prompt is still echoed after the click — hold the ack, do
+    // not resurrect the buttons.
+    assert.equal(originPromptView("https://example.com", decided), "ack");
+    // A DIFFERENT pending origin is a new prompt even mid-settle (A6).
+    assert.equal(originPromptView("https://other.example", decided), "prompt");
+    // Round-trip landed: nothing pending, caller clears its latch.
+    assert.equal(originPromptView(undefined, decided), "none");
+    // Never decided in this popup: the prompt is correct.
+    assert.equal(originPromptView("https://example.com", null), "prompt");
+  } finally { await module.close(); }
+});


### PR DESCRIPTION
## Summary

Fixes two instances of the same popup defect class, both reproduced live: an async round-trip between a user action and the view it should change leaves the OLD view on screen with live controls, so the user cannot tell the action worked.

1. **Pairing**: on a successful pair the popup gave no feedback — the success path re-rendered from `/health`, which reports `paired` only after the background worker reconnects with the new token. Losing that race re-showed the form; the user re-submitted the consumed one-time code and got a misleading "No live pairing code" error.
2. **Origin consent**: clicking **Allow once / Always allow / Deny** on "Let the agent use this site?" changed nothing — session storage and `/health` echo the prompt until `origin_decision` lands in the worker, so the prompt stayed up with all three buttons active while the agent-side open had already succeeded.

## What changed

Both fixes follow one pattern: render the acknowledgement **from the user's action alone**, latch it so a stale echo cannot downgrade it, disable the controls for the flight, and let the normal `render()` flow take over once the daemon confirms.

- **`extension/src/popup/pair-flow.ts`** (new) — pure `pairVerdict` / `viewForHealth`; DOM-free so the pure-node suite can cover the race (`popup.ts` touches `document` at module scope).
- **`extension/src/popup/origin-flow.ts`** (new) — pure `ackForDecision` / `originPromptView`, same pattern. The latch is keyed by ORIGIN so a *different* pending origin still prompts mid-settle (finding A6 keying untouched), and it clears when the echo lands so a same-origin retry re-prompts. Deny renders neutral, not danger — a completed choice, not a failure.
- **`popup.ts`** — `show("paired")` immediately on `pair_result.ok`; `showOriginAck(decision)` immediately on any consent click; `locallyPaired` / `decidedOrigin` latches consulted by `render()`; `setPairBusy` / `setOriginBusy` disable controls in flight ("Pairing…" relabel; consent buttons unlock when a fresh prompt renders). Error path unchanged.
- **`popup.html`** — `#paired` and `#origin-ack` sections (`role="status"`): success-tone rule + `--success` check for successes; "Paired." / "Site allowed. The agent is continuing." (+ standing-grant/Settings note for Always allow) / "Site denied." microcopy. Header mark stays untinted.
- **`popup.css`** — `:disabled` ramps (input drops to the sunken well; buttons at 0.6 opacity, primary keeps its fill), `.check` sizing/tone.
- **`tests/pure.test.mjs`** — 4 new tests: pair verdict folding, pair/health race hold, per-decision acks (deny neutral, always-allow revocability copy), origin race hold + A6 cross-origin + latch-clear cases.

## Testing evidence

- `pnpm typecheck` clean; `pnpm test` 14/14 (4 new); `pnpm build` clean, dist carries both states.
- **Render verification** of the built dist in a real browser (script stripped, target state unhidden — `chrome.*` doesn't exist outside an extension), five states screenshotted and reviewed by eye:
  - *Paired.* — success rule, green check, serif title, untinted mark ("Code accepted. Connecting this browser to Local Operator…").
  - *Pairing in flight* — input locked to the sunken well retaining the code, primary button dimmed and relabelled "Pairing…".
  - *Site allowed (Always allow)* — success rule, check, "The agent is continuing. Always-allowed sites can be taken back any time in Settings."
  - *Site denied* — neutral rule, no check, "The agent won't use this site."
  - *Consent prompt locked* — all three buttons dimmed, Deny keeping its danger outline.

  Screenshots at `/tmp/popup-verify/*.png` on the dev machine (gh CLI cannot attach images — drag them onto the PR if a visual record is wanted). Reproduce any state: `pnpm build`, open `dist/popup/popup.html` with the `<script>` tag removed and the target section's `hidden` class dropped.
- Not exercised live end-to-end: a fresh pair (this machine's extension is already paired) and a live consent click (needs an unpaired-origin agent open). The race decisions themselves are pinned by the pure tests.


## Review

Round 1 (scope 04702e6e..005cdf46): 2 major, 3 minor, 2 nits — all remediated in 480256d8 (see remediation comment). Round 2 pending on the current head.
