### PR TITLE
fix(extension): instant scroll in hidden tabs and populated AX snapshots

### DIFF
--- a/extension/src/commands/scroll.ts
+++ b/extension/src/commands/scroll.ts
@@ -1,4 +1,10 @@
 import { BridgeCommandError, cdp, requireSurface } from "../cdp";
+import {
+  defaultScrollExpression,
+  deltaScrollExpression,
+  SCROLL_INTO_VIEW_FN,
+  scrollExpressionFor,
+} from "../scroll-expressions";
 import { getSession } from "../state";
 
 interface CallResult { result: { value?: unknown } }
@@ -18,10 +24,6 @@ interface Metrics {
 // the rest move one page-sized step in that direction. Kept here (not the page)
 // so the set is fixed and no page-provided string is ever executed.
 const DIRECTIONS = new Set(["top", "bottom", "up", "down", "left", "right"]);
-
-// A "page" step leaves this much overlap so the agent does not skip a band of
-// content between reads — the same courtesy a PageDown key gives.
-const PAGE_OVERLAP_PX = 80;
 
 /**
  * Read the scroll position and whether more content remains past the viewport.
@@ -100,6 +102,12 @@ async function nodeObjectId(tabId: number, selector: string, epoch: number): Pro
  * calling the FIXED `window.scrollBy`/`scrollTo` / `Element.scrollIntoView`
  * DOM methods via Runtime, which run regardless of tab visibility and never
  * activate the tab — preserving the no-focus-steal guarantee.
+ *
+ * CONSTRAINT — behavior:'instant' everywhere: those DOM methods honour the
+ * page's CSS `scroll-behavior: smooth`, which never progresses in a hidden tab
+ * because Chrome throttles requestAnimationFrame to zero there. All scroll
+ * expressions live in scroll-expressions.ts, which documents and enforces the
+ * instant override (and keeps them loadable by the pure tests).
  */
 export async function scroll(params: Record<string, unknown>): Promise<Record<string, unknown>> {
   const surface = await requireSurface(params.tab);
@@ -116,14 +124,14 @@ export async function scroll(params: Record<string, unknown>): Promise<Record<st
     const objectId = await nodeObjectId(tabId, selector, surface.epoch);
     await cdp(tabId, "Runtime.callFunctionOn", {
       objectId,
-      functionDeclaration: `function(){ this.scrollIntoView({block:'center', inline:'center'}); }`,
+      functionDeclaration: SCROLL_INTO_VIEW_FN,
       returnByValue: true,
     });
   } else if (hasX || hasY) {
     const dx = hasX ? Number(params.x) : 0;
     const dy = hasY ? Number(params.y) : 0;
     await cdp(tabId, "Runtime.evaluate", {
-      expression: `window.scrollBy(${dx}, ${dy})`,
+      expression: deltaScrollExpression(dx, dy),
       returnByValue: true,
     });
   } else if (direction) {
@@ -142,40 +150,16 @@ export async function scroll(params: Record<string, unknown>): Promise<Record<st
     // Default: one viewport down (minus overlap), the "read more of this page"
     // gesture the agent reaches for most.
     await cdp(tabId, "Runtime.evaluate", {
-      expression: `window.scrollBy(0, window.innerHeight - ${PAGE_OVERLAP_PX})`,
+      expression: defaultScrollExpression(),
       returnByValue: true,
     });
   }
 
-  // Let a smooth/asynchronous scroll settle before reading position, so the
-  // reported scrollY is where the viewport actually landed.
+  // Scrolls are instant now, but scroll-linked effects (lazy loading, sticky
+  // headers, IntersectionObserver reveals) may still reflow the page right
+  // after; a short settle keeps the reported position and moreBelow honest.
   await new Promise((resolve) => setTimeout(resolve, 150));
   const metrics = await readMetrics(tabId);
   const tab = await chrome.tabs.get(tabId);
   return { ...metrics, url: tab.url ?? "", title: tab.title ?? "" };
-}
-
-// Fixed expression per direction. Separated so the branch selection stays in TS
-// and the page only ever receives constant code.
-function scrollExpressionFor(direction: string): string {
-  const page = `(window.innerHeight - ${PAGE_OVERLAP_PX})`;
-  const across = `(window.innerWidth - ${PAGE_OVERLAP_PX})`;
-  switch (direction) {
-    case "top":
-      return `window.scrollTo(window.scrollX, 0)`;
-    case "bottom": {
-      const de = `(document.scrollingElement||document.documentElement)`;
-      return `window.scrollTo(window.scrollX, ${de}.scrollHeight)`;
-    }
-    case "up":
-      return `window.scrollBy(0, -${page})`;
-    case "down":
-      return `window.scrollBy(0, ${page})`;
-    case "left":
-      return `window.scrollBy(-${across}, 0)`;
-    case "right":
-      return `window.scrollBy(${across}, 0)`;
-    default:
-      return `void 0`;
-  }
 }

--- a/extension/src/commands/snapshot.ts
+++ b/extension/src/commands/snapshot.ts
@@ -4,7 +4,21 @@ import { setRefs } from "../state";
 
 export async function snapshot(params: Record<string, unknown>): Promise<Record<string, unknown>> {
   const surface = await requireSurface(params.tab);
-  const result = await cdp<{ nodes: AXNode[] }>(surface.tabId, "Accessibility.getFullAXTree");
+  // Accessibility.getFullAXTree only returns a populated tree once
+  // Accessibility.enable has run on THIS debugger session; without it Chrome
+  // answers with just the root node (observed live: one-line snapshots). We
+  // disable again after the read so the a11y engine is not kept hot on the tab
+  // between snapshots — the stored refs are backendDOMNodeIds, which belong to
+  // the DOM (not the AX tree) and remain resolvable after disable.
+  await cdp(surface.tabId, "Accessibility.enable");
+  let result: { nodes: AXNode[] };
+  try {
+    result = await cdp<{ nodes: AXNode[] }>(surface.tabId, "Accessibility.getFullAXTree");
+  } finally {
+    // Best-effort: a failed disable (tab closing mid-command) must not mask
+    // the snapshot result or the original error.
+    await cdp(surface.tabId, "Accessibility.disable").catch(() => {});
+  }
   const rendered = compactAX(result.nodes, surface.epoch);
   await setRefs(rendered.refs);
   const tab = await chrome.tabs.get(surface.tabId);

--- a/extension/src/commands/snapshot.ts
+++ b/extension/src/commands/snapshot.ts
@@ -2,6 +2,17 @@ import { compactAX, type AXNode } from "../ax-compact";
 import { cdp, requireSurface } from "../cdp";
 import { setRefs } from "../state";
 
+// Serializes the enable→read→disable window below. The worker dispatches
+// daemon frames fire-and-forget (worker.ts onmessage), so two concurrent
+// snapshots could otherwise interleave as enable/enable/read/DISABLE/read —
+// the second read then hits a disabled a11y engine, the exact one-node bug
+// this file fixes. The daemon pipelines commands per tab today, so this is
+// latent, but the extension should not depend on that scheduling promise.
+// A promise chain (not a refcount) keeps it simple: snapshots are rare and
+// heavy, so serializing them costs nothing observable. Failures are swallowed
+// by each link's own try/finally, so the chain can never poison later calls.
+let axQueue: Promise<unknown> = Promise.resolve();
+
 export async function snapshot(params: Record<string, unknown>): Promise<Record<string, unknown>> {
   const surface = await requireSurface(params.tab);
   // Accessibility.getFullAXTree only returns a populated tree once
@@ -10,15 +21,17 @@ export async function snapshot(params: Record<string, unknown>): Promise<Record<
   // disable again after the read so the a11y engine is not kept hot on the tab
   // between snapshots — the stored refs are backendDOMNodeIds, which belong to
   // the DOM (not the AX tree) and remain resolvable after disable.
-  await cdp(surface.tabId, "Accessibility.enable");
-  let result: { nodes: AXNode[] };
-  try {
-    result = await cdp<{ nodes: AXNode[] }>(surface.tabId, "Accessibility.getFullAXTree");
-  } finally {
-    // Best-effort: a failed disable (tab closing mid-command) must not mask
-    // the snapshot result or the original error.
-    await cdp(surface.tabId, "Accessibility.disable").catch(() => {});
-  }
+  const run = async (): Promise<{ nodes: AXNode[] }> => {
+    await cdp(surface.tabId, "Accessibility.enable");
+    try {
+      return await cdp<{ nodes: AXNode[] }>(surface.tabId, "Accessibility.getFullAXTree");
+    } finally {
+      // Best-effort: a failed disable (tab closing mid-command) must not mask
+      // the snapshot result or the original error.
+      await cdp(surface.tabId, "Accessibility.disable").catch(() => {});
+    }
+  };
+  const result = await (axQueue = axQueue.catch(() => {}).then(run)) as { nodes: AXNode[] };
   const rendered = compactAX(result.nodes, surface.epoch);
   await setRefs(rendered.refs);
   const tab = await chrome.tabs.get(surface.tabId);

--- a/extension/src/scroll-expressions.ts
+++ b/extension/src/scroll-expressions.ts
@@ -15,9 +15,10 @@
 // content between reads — the same courtesy a PageDown key gives.
 export const PAGE_OVERLAP_PX = 80;
 
-/** One viewport down (minus overlap): the default "read more" gesture. */
+/** One viewport down (minus overlap): the default "read more" gesture. It is
+ * exactly the "down" direction, delegated so the two stay one expression. */
 export function defaultScrollExpression(): string {
-  return `window.scrollBy({left: 0, top: window.innerHeight - ${PAGE_OVERLAP_PX}, behavior: 'instant'})`;
+  return scrollExpressionFor("down");
 }
 
 /** Explicit pixel deltas; callers must pass finite numbers, never page input. */
@@ -28,7 +29,7 @@ export function deltaScrollExpression(dx: number, dy: number): string {
 /** Body for Runtime.callFunctionOn against a resolved node: center the element
  * so it is usable after the scroll rather than jammed against a viewport edge. */
 export const SCROLL_INTO_VIEW_FN =
-  `function(){ this.scrollIntoView({block:'center', inline:'center', behavior:'instant'}); }`;
+  `function(){ this.scrollIntoView({block: 'center', inline: 'center', behavior: 'instant'}); }`;
 
 /** Fixed expression per direction keyword; unknown directions are a no-op. */
 export function scrollExpressionFor(direction: string): string {

--- a/extension/src/scroll-expressions.ts
+++ b/extension/src/scroll-expressions.ts
@@ -1,0 +1,55 @@
+// Fixed scroll expressions, kept in a chrome-free module so the pure tests can
+// load them (cdp.ts registers chrome listeners at module scope and cannot be
+// bundled into a Node test). Only constant code ever reaches the page: the
+// caller selects a branch or supplies validated numbers, never strings.
+//
+// CONSTRAINT — behavior:'instant' everywhere: window.scrollBy/scrollTo and
+// Element.scrollIntoView honour the page's CSS `scroll-behavior: smooth`, and a
+// smooth scroll is a requestAnimationFrame-driven animation. Chrome throttles
+// rAF to ZERO in hidden tabs, so in our intentionally-background surface a
+// smooth scroll starts an animation that never advances — observed live as
+// scrollY stuck at 0 after repeated scrolls. 'instant' overrides the page CSS
+// and does not depend on the animation-frame clock.
+
+// A "page" step leaves this much overlap so the agent does not skip a band of
+// content between reads — the same courtesy a PageDown key gives.
+export const PAGE_OVERLAP_PX = 80;
+
+/** One viewport down (minus overlap): the default "read more" gesture. */
+export function defaultScrollExpression(): string {
+  return `window.scrollBy({left: 0, top: window.innerHeight - ${PAGE_OVERLAP_PX}, behavior: 'instant'})`;
+}
+
+/** Explicit pixel deltas; callers must pass finite numbers, never page input. */
+export function deltaScrollExpression(dx: number, dy: number): string {
+  return `window.scrollBy({left: ${dx}, top: ${dy}, behavior: 'instant'})`;
+}
+
+/** Body for Runtime.callFunctionOn against a resolved node: center the element
+ * so it is usable after the scroll rather than jammed against a viewport edge. */
+export const SCROLL_INTO_VIEW_FN =
+  `function(){ this.scrollIntoView({block:'center', inline:'center', behavior:'instant'}); }`;
+
+/** Fixed expression per direction keyword; unknown directions are a no-op. */
+export function scrollExpressionFor(direction: string): string {
+  const page = `(window.innerHeight - ${PAGE_OVERLAP_PX})`;
+  const across = `(window.innerWidth - ${PAGE_OVERLAP_PX})`;
+  switch (direction) {
+    case "top":
+      return `window.scrollTo({left: window.scrollX, top: 0, behavior: 'instant'})`;
+    case "bottom": {
+      const de = `(document.scrollingElement||document.documentElement)`;
+      return `window.scrollTo({left: window.scrollX, top: ${de}.scrollHeight, behavior: 'instant'})`;
+    }
+    case "up":
+      return `window.scrollBy({left: 0, top: -${page}, behavior: 'instant'})`;
+    case "down":
+      return `window.scrollBy({left: 0, top: ${page}, behavior: 'instant'})`;
+    case "left":
+      return `window.scrollBy({left: -${across}, top: 0, behavior: 'instant'})`;
+    case "right":
+      return `window.scrollBy({left: ${across}, top: 0, behavior: 'instant'})`;
+    default:
+      return `void 0`;
+  }
+}

--- a/extension/tests/pure.test.mjs
+++ b/extension/tests/pure.test.mjs
@@ -36,6 +36,26 @@ test("AX compaction assigns epoch-scoped click refs", async () => {
   } finally { await module.close(); }
 });
 
+test("scroll expressions force instant behavior in every mode", async () => {
+  const module = await load("src/scroll-expressions.ts");
+  try {
+    const { scrollExpressionFor, defaultScrollExpression, deltaScrollExpression, SCROLL_INTO_VIEW_FN } = module.loaded;
+    // Pages can opt into CSS scroll-behavior:smooth, and Chrome throttles rAF
+    // to zero in hidden tabs, so a smooth scroll never progresses in our
+    // background surface. Every fixed expression must override with 'instant'.
+    for (const direction of ["top", "bottom", "up", "down", "left", "right"]) {
+      const expr = scrollExpressionFor(direction);
+      assert.match(expr, /behavior: 'instant'/, `${direction} must scroll instantly`);
+      assert.match(expr, /window\.scroll(By|To)\(\{/, `${direction} must use the options form`);
+    }
+    assert.match(defaultScrollExpression(), /behavior: 'instant'/);
+    assert.match(deltaScrollExpression(10, -20), /left: 10, top: -20, behavior: 'instant'/);
+    assert.match(SCROLL_INTO_VIEW_FN, /behavior:'instant'/);
+    // Unknown direction stays a no-op, never interpolated page-bound code.
+    assert.equal(scrollExpressionFor("sideways"), "void 0");
+  } finally { await module.close(); }
+});
+
 test("log filter keeps level matches and limits to the most recent", async () => {
   const module = await load("src/log-capture.ts");
   try {

--- a/extension/tests/pure.test.mjs
+++ b/extension/tests/pure.test.mjs
@@ -50,7 +50,7 @@ test("scroll expressions force instant behavior in every mode", async () => {
     }
     assert.match(defaultScrollExpression(), /behavior: 'instant'/);
     assert.match(deltaScrollExpression(10, -20), /left: 10, top: -20, behavior: 'instant'/);
-    assert.match(SCROLL_INTO_VIEW_FN, /behavior:'instant'/);
+    assert.match(SCROLL_INTO_VIEW_FN, /behavior: 'instant'/);
     // Unknown direction stays a no-op, never interpolated page-bound code.
     assert.equal(scrollExpressionFor("sideways"), "void 0");
   } finally { await module.close(); }


### PR DESCRIPTION
## What

Two extension bridge bugs found in live beta against the real paired Chrome, both in `extension/src`:

- **Scroll no-op on pages with CSS `scroll-behavior: smooth`** (`commands/scroll.ts`). Reproduced live on https://local-operator.com/browser-extension/privacy: two `direction:"down"` calls left scrollY at 0 (screenshot-verified), a selector scrollIntoView moved only 42px. The extension's tab is intentionally inactive and Chrome throttles requestAnimationFrame to zero in hidden tabs, so the smooth-scroll animation the page's CSS opts into never progresses. Every fixed scroll expression now forces `behavior:'instant'`. The expressions move to a new chrome-free `scroll-expressions.ts` so the pure tests can load them (cdp.ts touches `chrome` at module scope); the fixed-expression security constraint is preserved — no page-supplied string is ever executed. The 150ms settle sleep stays: scrolls are instant but scroll-linked effects (lazy loads, IntersectionObserver reveals) can still reflow right after.

- **Snapshot returns only the root node** (`commands/snapshot.ts`). Reproduced live twice: exactly one line, `- RootWebArea "…" [e1]`. `Accessibility.getFullAXTree` was called without `Accessibility.enable` on the debugger session. Now: enable → getFullAXTree → disable (best-effort, in `finally`) so the a11y engine is not kept hot on the tab between snapshots. Refs are safe across disable: they store `backendDOMNodeId`s, which belong to the DOM, and were verified resolvable via `DOM.pushNodesByBackendIdsToFrontend` after disable.

## Testing evidence

`pnpm typecheck` clean, `pnpm test` 11/11 (new pure test asserts every scroll mode — six directions, default, delta, scrollIntoView — forces `behavior:'instant'`, and unknown directions stay `void 0`), `pnpm build` clean.

Protocol validation over **raw CDP websocket against a throwaway headless Chrome 151.0.7922.174** (/tmp profile, `--remote-debugging-port`; the live paired Chrome was deliberately not touched). Test page: `html{scroll-behavior:smooth}`, 20000px body, tab backgrounded by activating a second tab — `document.visibilityState` confirmed `"hidden"`:

```
scrollY start: 0
plain scrollBy(0,600) after 1s:            scrollY=0      <- bug reproduced under rAF throttling
instant scrollBy after 0.2s:               scrollY=600    <- fix proven
plain scrollIntoView(deep) after 1s:       scrollY=0      <- bug reproduced
instant scrollIntoView(deep) after 0.2s:   scrollY=14776  <- fix proven
enable-first getFullAXTree: 19 nodes, 13 named (RootWebArea, heading, button, link, textbox, …)
backendDOMNodeId 5 resolvable after Accessibility.disable: nodeId=8
```

Honest caveat: the one-node bare `getFullAXTree` failure did **not** reproduce in headless Chrome (bare call also returned 19 nodes on a pristine tab — headless keeps the a11y engine active). The one-node tree was observed twice live on the real paired Chrome; enable-first is the documented protocol contract, and the evidence above proves it does not regress the working case (identical tree with and without prior enable).

## Not in this PR

- Live re-verification against the paired Chrome (requires the user's bridge; the daemon and pairing were deliberately left untouched).
- click/type paths untouched — they already resolve nodes without scroll behavior involvement.
