### PR TITLE
fix: keep one subagent row across resumes

### DIFF
--- a/local_operator/harness/comms.py
+++ b/local_operator/harness/comms.py
@@ -426,14 +426,18 @@ class SubagentComms:
         if record is None:
             record = _ChildRecord(job_id=job_id, label=job_id)
             self._records[job_id] = record
-        # The directory, not the human label, identifies a resumed child. Fold
-        # the predecessor before exposing the live record so every roster read
-        # observes either the old attempt or the new one, never both.
+        # The directory, not the human label, identifies a resumed child. Only
+        # a terminal predecessor can be replaced: two live children may share a
+        # fixture directory, and collapsing those would hide autonomous work.
+        # Fold before exposing the continuation so every roster read observes
+        # either the old attempt or the new one, never both.
         prior = next(
             (
                 item
                 for item in self._records.values()
-                if item.job_id != job_id and item.session_dir == session_dir
+                if item.job_id != job_id
+                and item.session_dir == session_dir
+                and (item.child is None or item.settled)
             ),
             None,
         )

--- a/local_operator/harness/comms.py
+++ b/local_operator/harness/comms.py
@@ -321,6 +321,9 @@ class _ChildRecord:
     #: content are one durable fact after the ephemeral job row is swept.
     result_text: str | None = None
     error_text: str | None = None
+    #: Attempt handles superseded by this record. Persisted so a parent can
+    #: keep using an id it mentioned before either process or child resumed.
+    attempt_aliases: list[str] = field(default_factory=list)
 
 
 class SubagentComms:
@@ -335,6 +338,7 @@ class SubagentComms:
         self._session = session
         self._records: dict[str, _ChildRecord] = {}
         self._detail_listeners: set[Callable[[str], None]] = set()
+        self._aliases: dict[str, str] = {}
 
     def subscribe_detail_changes(self, listener: Callable[[str], None]) -> Callable[[], None]:
         """Observe child transcript mutations through the shared root registry."""
@@ -422,8 +426,34 @@ class SubagentComms:
         if record is None:
             record = _ChildRecord(job_id=job_id, label=job_id)
             self._records[job_id] = record
+        # The directory, not the human label, identifies a resumed child. Fold
+        # the predecessor before exposing the live record so every roster read
+        # observes either the old attempt or the new one, never both.
+        prior = next(
+            (
+                item
+                for item in self._records.values()
+                if item.job_id != job_id and item.session_dir == session_dir
+            ),
+            None,
+        )
+        if prior is not None:
+            record.label = prior.label
+            record.parent_job_id = prior.parent_job_id
+            record.agent_role = prior.agent_role
+            record.effort = prior.effort
+            record.attempt_aliases = list(
+                dict.fromkeys([*prior.attempt_aliases, prior.job_id, *record.attempt_aliases])
+            )
+            self._records.pop(prior.job_id, None)
+        for alias in record.attempt_aliases:
+            self._aliases[alias] = job_id
         record.child = child
         record.session_dir = session_dir
+        jobs = self._jobs()
+        bind = getattr(jobs, "bind_logical_identity", None) if jobs is not None else None
+        if callable(bind):
+            bind(job_id, str(session_dir))
         record.settled = False
         record.unsubscribe = child.subscribe(self._make_reply_watcher(record))
         for message in record.pending:
@@ -452,7 +482,7 @@ class SubagentComms:
         """Release the live child. An unanswered question fails here rather
         than burning its caller's full timeout: the child is gone, no answer
         is coming."""
-        record = self._records.get(job_id)
+        record = self._record(job_id)
         if record is None:
             return
         record.settled = True
@@ -480,7 +510,7 @@ class SubagentComms:
         context carries a job id this instance knows is a CHILD, and gets the
         child-shaped tool.
         """
-        return job_id is not None and job_id in self._records
+        return job_id is not None and self._record(job_id) is not None
 
     # -- lineage --------------------------------------------------------------
 
@@ -495,7 +525,7 @@ class SubagentComms:
         return [node for job_id in self._records if (node := self.node(job_id)) is not None]
 
     def node(self, job_id: str) -> SubagentNode | None:
-        record = self._records.get(job_id)
+        record = self._record(job_id)
         if record is None:
             return None
         session_id = record.session_dir.name if record.session_dir is not None else None
@@ -626,7 +656,7 @@ class SubagentComms:
         roster would show a deliberately parked child as an ordinary
         cancellation. Only :meth:`resume` ends a pause.
         """
-        record = self._records.get(job_id)
+        record = self._record(job_id)
         if record is None:
             return None
 
@@ -703,6 +733,7 @@ class SubagentComms:
                     "error_text": record.error_text,
                     "paused": record.paused,
                     "settled_at": record.settled_at,
+                    "attempt_aliases": list(record.attempt_aliases),
                 }
             )
         return rows
@@ -724,7 +755,29 @@ class SubagentComms:
         live child of this session must never be clobbered by a stale snapshot
         of its predecessor.
         """
-        for row in rows:
+        # Newest wins for legacy snapshots that retained one record per resume
+        # attempt. Older ids become aliases of that winner rather than vanished
+        # handles, which preserves parent messages and old transcript references.
+        winners: list[dict[str, Any]] = []
+        by_dir: dict[str, dict[str, Any]] = {}
+        for row in reversed(rows):
+            raw_dir = row.get("session_dir")
+            logical_id = str(raw_dir) if raw_dir else ""
+            winner = by_dir.get(logical_id) if logical_id else None
+            if winner is not None:
+                old_id = str(row.get("job_id") or "")
+                aliases = [
+                    *row.get("attempt_aliases", []),
+                    old_id,
+                    *winner.get("attempt_aliases", []),
+                ]
+                winner["attempt_aliases"] = list(dict.fromkeys(alias for alias in aliases if alias))
+                continue
+            copied = dict(row)
+            winners.append(copied)
+            if logical_id:
+                by_dir[logical_id] = copied
+        for row in reversed(winners):
             job_id = str(row.get("job_id") or "")
             if not job_id or job_id in self._records:
                 continue
@@ -747,9 +800,17 @@ class SubagentComms:
                     str(row["result_text"]) if row.get("result_text") is not None else None
                 ),
                 error_text=(str(row["error_text"]) if row.get("error_text") is not None else None),
+                attempt_aliases=[str(alias) for alias in row.get("attempt_aliases", []) if alias],
             )
             self._records[job_id] = record
+            for alias in record.attempt_aliases:
+                if alias != job_id:
+                    self._aliases[alias] = job_id
         self._evict_overflow()
+
+    def _record(self, job_id: str) -> _ChildRecord | None:
+        """Resolve either a current attempt id or any durable predecessor."""
+        return self._records.get(self._aliases.get(job_id, job_id))
 
     async def peek(
         self,
@@ -777,7 +838,7 @@ class SubagentComms:
         exists, so an out-of-range request is an error about the range, not a
         transcript dump.
         """
-        record = self._records.get(job_id)
+        record = self._record(job_id)
         if record is None:
             return PeekWindow(job_id, job_id, "gone", 0, error=f"unknown subagent {job_id!r}")
         info = self._describe(record, time.time())
@@ -1012,11 +1073,11 @@ class SubagentComms:
         )
 
     def label_of(self, job_id: str) -> str:
-        record = self._records.get(job_id)
+        record = self._record(job_id)
         return record.label if record is not None else job_id
 
     def session_dir_of(self, job_id: str) -> Path | None:
-        record = self._records.get(job_id)
+        record = self._record(job_id)
         return record.session_dir if record is not None else None
 
     # -- parent -> child ------------------------------------------------------
@@ -1033,7 +1094,7 @@ class SubagentComms:
         that way — including on resume, where a note framed as an aside and a
         redirection framed as an order are very different things to replay.
         """
-        record = self._records.get(job_id)
+        record = self._record(job_id)
         if record is None:
             return Delivery(job_id, job_id, "failed", f"unknown subagent {job_id!r}")
         if record.child is None:
@@ -1107,7 +1168,7 @@ class SubagentComms:
         this session next yields" is not an actionable answer for the one
         caller who cannot yield without making another call.
         """
-        record = self._records.get(job_id)
+        record = self._record(job_id)
         if record is None:
             return Reply(job_id, job_id, error=f"unknown subagent {job_id!r}")
         # ONE guard for BOTH paths, and it has to be here rather than beside
@@ -1239,7 +1300,7 @@ class SubagentComms:
     async def cancel(self, job_id: str) -> Delivery:
         """Stop a child. Idempotent from the caller's point of view: a second
         cancel reports the state rather than pretending to act."""
-        record = self._records.get(job_id)
+        record = self._record(job_id)
         label = record.label if record is not None else job_id
         jobs = self._jobs()
         if jobs is None:
@@ -1286,7 +1347,7 @@ class SubagentComms:
         and replay costs a transcript rehydration on resume and frees
         everything meanwhile.
         """
-        record = self._records.get(job_id)
+        record = self._record(job_id)
         if record is None:
             return Delivery(job_id, job_id, "failed", f"unknown subagent {job_id!r}")
         if record.session_dir is None:
@@ -1335,7 +1396,7 @@ class SubagentComms:
         """
         from local_operator.harness.subagent import run_subagent
 
-        record = self._records.get(job_id)
+        record = self._record(job_id)
         if record is None:
             return None, f"unknown subagent {job_id!r}"
         if record.session_dir is None:
@@ -1396,7 +1457,7 @@ class SubagentComms:
         rather than delivered. Unarmed messages therefore fall through to the
         note path below; nothing is lost either way.
         """
-        record = self._records.get(job_id)
+        record = self._record(job_id)
         label = record.label if record is not None else job_id
         if record is not None and record.armed and record.ask is not None and not record.ask.done():
             self._journal_communication(
@@ -1537,7 +1598,7 @@ class SubagentComms:
         )
 
     def _deliver(self, job_id: str, message: CustomMessage) -> Delivery:
-        record = self._records.get(job_id)
+        record = self._record(job_id)
         if record is None:
             return Delivery(job_id, job_id, "failed", f"unknown subagent {job_id!r}")
         if record.child is None:

--- a/local_operator/harness/jobs.py
+++ b/local_operator/harness/jobs.py
@@ -252,6 +252,12 @@ class AsyncJob(BaseModel):
     # ladder it cannot see.
     agent_role: str | None = None
     effort: str | None = None
+    # A task's transcript directory is the durable identity of the work across
+    # resume attempts. ``id`` remains the attempt handle returned by tools;
+    # these fields let the ledger replace an older attempt in place while old
+    # handles continue resolving to the newest attempt.
+    logical_id: str | None = None
+    attempt_aliases: list[str] = Field(default_factory=list)
 
 
 class AsyncJobManager:
@@ -285,6 +291,10 @@ class AsyncJobManager:
         # single call site guards it.
         self._on_roster_change = on_roster_change
         self._jobs: dict[str, AsyncJob] = {}
+        # Historical attempt ids remain valid after a resume replaces the
+        # visible row. Values point directly at the current attempt; flattening
+        # on every bind avoids alias chains whose meaning depends on order.
+        self._aliases: dict[str, str] = {}
         # Terminal rows hand their subtree into this bounded accumulator before
         # retention can remove them. The owning parent runner later copies this
         # snapshot onto its AsyncJob; polling never participates in durability.
@@ -318,7 +328,7 @@ class AsyncJobManager:
     # -- queries ------------------------------------------------------------
 
     def get(self, job_id: str, *, owner_id: str | None = None) -> AsyncJob | None:
-        job = self._jobs.get(job_id)
+        job = self._jobs.get(self._aliases.get(job_id, job_id))
         if job is None:
             return None
         if owner_id is not None and job.owner_id != owner_id:
@@ -438,6 +448,41 @@ class AsyncJobManager:
         except Exception:  # noqa: BLE001 - a bad listener must not break jobs
             logger.warning("roster-change listener raised", exc_info=True)
 
+    def bind_logical_identity(self, job_id: str, logical_id: str) -> None:
+        """Make ``job_id`` the current attempt for one durable task run.
+
+        Called when the child transcript directory becomes known. The method is
+        synchronous because attach and resume run on one event loop: no caller
+        can observe a half-moved row or race two attempts into the visible list.
+        """
+        current = self._jobs.get(job_id)
+        if current is None or current.type != "task":
+            return
+        current.logical_id = logical_id
+        prior = next(
+            (
+                row
+                for row in self._jobs.values()
+                if row.id != job_id and row.type == "task" and row.logical_id == logical_id
+            ),
+            None,
+        )
+        inherited = list(current.attempt_aliases)
+        if prior is not None:
+            if prior.status == "running" and not prior.restored:
+                raise RuntimeError(
+                    f"logical task {logical_id!r} is already running as job {prior.id}"
+                )
+            inherited = [*prior.attempt_aliases, prior.id, *inherited]
+            self._jobs.pop(prior.id, None)
+        aliases = list(dict.fromkeys(alias for alias in inherited if alias != job_id))
+        current.attempt_aliases = aliases
+        for alias in aliases:
+            self._aliases[alias] = job_id
+        for alias, target in list(self._aliases.items()):
+            if target in aliases:
+                self._aliases[alias] = job_id
+
     def restore(self, rows: list["AsyncJob"]) -> None:
         """Rehydrate task rows from a persisted roster at resume.
 
@@ -473,7 +518,24 @@ class AsyncJobManager:
         byte-identical snapshot on every resume (and, if a host ever constructs
         a Session off-loop, raise a spurious warning from the persist spawn).
         """
-        for row in rows:
+        # Snapshots are launch-ordered, so newest-first makes the current
+        # attempt win when migrating legacy snapshots that persisted every
+        # resume as another row. Reversing before insertion preserves ordinary
+        # row order after the winning set has been selected.
+        restored: list[AsyncJob] = []
+        seen_logical: set[str] = set()
+        for row in reversed(rows):
+            logical_id = row.logical_id
+            if logical_id and logical_id in seen_logical:
+                current = next(item for item in restored if item.logical_id == logical_id)
+                current.attempt_aliases = list(
+                    dict.fromkeys([*row.attempt_aliases, row.id, *current.attempt_aliases])
+                )
+                continue
+            if logical_id:
+                seen_logical.add(logical_id)
+            restored.append(row)
+        for row in reversed(restored):
             if row.id in self._jobs:
                 continue
             if row.status == "running":
@@ -487,6 +549,9 @@ class AsyncJobManager:
                 row.status = "interrupted"
             row.restored = True
             self._jobs[row.id] = row
+            for alias in row.attempt_aliases:
+                if alias != row.id:
+                    self._aliases[alias] = row.id
             if row.status != "running":
                 self._record_settled_accounting(row)
         self._invalidate_accounting()
@@ -588,7 +653,7 @@ class AsyncJobManager:
     def mark_consumed(self, job_id: str) -> None:
         """Flag a job's result as already handed to the model (see the
         ``consumed`` field): auto-delivery checks it and stays quiet."""
-        job = self._jobs.get(job_id)
+        job = self.get(job_id)
         if job is not None:
             job.consumed = True
 
@@ -608,9 +673,10 @@ class AsyncJobManager:
     async def cancel(self, job_id: str, *, owner_id: str | None = None) -> bool:
         """Cancel a job. An owner mismatch is treated as not-found so a
         subagent teardown cannot cancel its parent's jobs."""
-        job = self._jobs.get(job_id)
+        job = self.get(job_id)
         if job is None:
             return False
+        job_id = job.id
         if owner_id is not None and job.owner_id != owner_id:
             return False
         if job.status != "running":
@@ -734,7 +800,7 @@ class AsyncJobManager:
         to kill the job it is reporting for because the row was already swept
         by retention.
         """
-        job = self._jobs.get(job_id)
+        job = self.get(job_id)
         if job is None or not text:
             return
         job.output_seq += len(text)
@@ -757,7 +823,7 @@ class AsyncJobManager:
         caller has an incomplete record and is told so rather than being
         handed a contiguous-looking excerpt that silently skips a step.
         """
-        job = self._jobs.get(job_id)
+        job = self.get(job_id)
         if job is None:
             return None
         seq = job.output_seq
@@ -876,7 +942,7 @@ class AsyncJobManager:
         happened. This is the race the poll loop hid by re-reading status.
         """
 
-        job = self._jobs.get(job_id)
+        job = self.get(job_id)
         if job is None:
             # No row: nothing will ever settle this id, so hand back a pre-set
             # event WITHOUT storing it. Storing one would strand an entry that
@@ -885,6 +951,7 @@ class AsyncJobManager:
             settled = asyncio.Event()
             settled.set()
             return settled
+        job_id = job.id
         event = self._settled_events.get(job_id)
         if event is None:
             event = asyncio.Event()

--- a/local_operator/harness/jobs.py
+++ b/local_operator/harness/jobs.py
@@ -212,6 +212,19 @@ class AsyncJob(BaseModel):
     # priced calls preserves exact provider bills without letting one receipt
     # suppress estimates for its siblings.
     descendant_usage: list[Usage] = Field(default_factory=list)
+    # Settled predecessor attempts folded out of the visible roster. This is
+    # separate from descendant_usage because the current process's manager
+    # already owns these components in its settled accumulator; treating them as
+    # current live subtree spend would count them twice. The persisted copy is
+    # what lets a replacement process rebuild the accumulator from the sole
+    # surviving row.
+    prior_attempt_usage: list[Usage] = Field(default_factory=list)
+    # Runtime ownership marker for prior_attempt_usage. bind_logical_identity()
+    # folds a predecessor whose accounting is already in this manager, whereas
+    # restore() starts with an empty accumulator and must ingest the durable
+    # components. Excluding the marker keeps that process-local distinction out
+    # of the authoritative sidecar.
+    prior_attempt_usage_owned: bool = Field(default=False, exclude=True)
     # A live edge exists only while the child can still mutate its own ledger.
     # It is runtime-only and deliberately cleared after the final settlement
     # snapshot, otherwise one retained observability row pins the disposed child
@@ -474,6 +487,21 @@ class AsyncJobManager:
                     f"logical task {logical_id!r} is already running as job {prior.id}"
                 )
             inherited = [*prior.attempt_aliases, prior.id, *inherited]
+            grouped: dict[tuple[str | None, str | None, bool], Usage] = {}
+            for component in [
+                *current.prior_attempt_usage,
+                *prior.prior_attempt_usage,
+                *_usage_components(prior.usage, prior.model_label),
+                *prior.descendant_usage,
+            ]:
+                _merge_accounting_component(grouped, component)
+            current.prior_attempt_usage = [
+                component.model_copy(deep=True) for component in grouped.values()
+            ]
+            # Every foldable predecessor is terminal and was therefore already
+            # transferred to this manager, either by settle() or restore(). Keep
+            # the durable copy off this process's live and settlement totals.
+            current.prior_attempt_usage_owned = True
             self._jobs.pop(prior.id, None)
         aliases = list(dict.fromkeys(alias for alias in inherited if alias != job_id))
         current.attempt_aliases = aliases
@@ -997,6 +1025,8 @@ class AsyncJobManager:
     def _record_settled_accounting(self, job: AsyncJob) -> None:
         """Transfer one terminal subtree exactly once into manager ownership."""
         components = [*_usage_components(job.usage, job.model_label), *job.descendant_usage]
+        if not job.prior_attempt_usage_owned:
+            components.extend(job.prior_attempt_usage)
         child_manager = job.child_jobs
         if isinstance(child_manager, AsyncJobManager):
             components.extend(child_manager.accounting_components())

--- a/local_operator/harness/jobs.py
+++ b/local_operator/harness/jobs.py
@@ -482,6 +482,12 @@ class AsyncJobManager:
         for alias, target in list(self._aliases.items()):
             if target in aliases:
                 self._aliases[alias] = job_id
+        # Registration persists before the runner can attach under the default
+        # task factory. The identity fold is therefore a second durability
+        # boundary: without this notification, that provisional two-row roster
+        # remains the newest snapshot if the parent exits while the continuation
+        # is still running.
+        self._notify_roster_change()
 
     def restore(self, rows: list["AsyncJob"]) -> None:
         """Rehydrate task rows from a persisted roster at resume.
@@ -530,6 +536,17 @@ class AsyncJobManager:
                 current = next(item for item in restored if item.logical_id == logical_id)
                 current.attempt_aliases = list(
                     dict.fromkeys([*row.attempt_aliases, row.id, *current.attempt_aliases])
+                )
+                # Legacy snapshots represented each continuation as a separate
+                # row. The visible roster now keeps only the newest attempt, but
+                # every discarded attempt remains billable. Carry its direct
+                # and descendant components onto the winner exactly once so a
+                # later restore cannot make accounting depend on which row won.
+                current.descendant_usage.extend(
+                    [
+                        *_usage_components(row.usage, row.model_label),
+                        *(item.model_copy(deep=True) for item in row.descendant_usage),
+                    ]
                 )
                 continue
             if logical_id:

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -925,6 +925,10 @@ _ROSTER_ROW_FIELDS = frozenset(
         # count. This is the durable half of nested accounting after a child
         # manager is disposed and therefore must survive process resume.
         "descendant_usage",
+        # Folded attempts no longer have visible rows. Their bounded accounting
+        # components must travel with the winner so the sidecar can reconstruct
+        # the full logical child after a process restart.
+        "prior_attempt_usage",
         "restored",
         # Small bounded strings, stamped at registration: a restored row must
         # still say what kind of child it was ("task"/"scout") and at what

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -933,6 +933,10 @@ _ROSTER_ROW_FIELDS = frozenset(
         # rest of this allowlist exists to prevent for the model/usage fields.
         "agent_role",
         "effort",
+        # Resume reconciliation metadata is bounded by attempts of this one
+        # logical child and keeps legacy handles valid after process restore.
+        "logical_id",
+        "attempt_aliases",
     }
 )
 
@@ -6006,17 +6010,36 @@ class Session:
             self._subagent_roster_generation if loaded_sidecar else -1
         )
         records = details.get("records") or []
+        logical_by_job: dict[str, str] = {}
+        aliases_by_job: dict[str, list[str]] = {}
         if records:
             # ``self.subagent_comms`` (the property) mints the instance on first
             # use; restoring into it is what makes the children addressable.
             try:
                 self.subagent_comms.restore(list(records))
+                for record in self.subagent_comms.snapshot():
+                    job_id = str(record.get("job_id") or "")
+                    session_dir = str(record.get("session_dir") or "")
+                    if job_id and session_dir:
+                        aliases = [
+                            str(alias) for alias in record.get("attempt_aliases", []) if alias
+                        ]
+                        aliases_by_job[job_id] = aliases
+                        for attempt_id in [*aliases, job_id]:
+                            logical_by_job[attempt_id] = session_dir
             except Exception:  # noqa: BLE001 - a bad snapshot must not stop boot
                 logger.warning("could not restore subagent records", exc_info=True)
         rows: list[AsyncJob] = []
         for raw in details.get("jobs") or []:
             try:
-                rows.append(AsyncJob.model_validate(raw))
+                payload = dict(raw)
+                job_id = str(payload.get("id") or "")
+                # Legacy job snapshots predate ``logical_id``; the comms half
+                # already carried the transcript directory, so join the two by
+                # attempt id before asking the manager to collapse duplicates.
+                payload.setdefault("logical_id", logical_by_job.get(job_id))
+                payload.setdefault("attempt_aliases", aliases_by_job.get(job_id, []))
+                rows.append(AsyncJob.model_validate(payload))
             except Exception:
                 logger.warning("dropping malformed persisted subagent row: %r", raw)
         if rows:

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -8714,6 +8714,13 @@ class OperatorApp(App[None]):
             job = lookup(job_id) if callable(lookup) else manager.get(job_id) if manager else None
         except Exception:
             job = manager.get(job_id) if manager is not None else None
+        # Comms accepts durable predecessor IDs, but the panel contains only the
+        # current attempt. Canonicalize as soon as resolution succeeds so the
+        # page state, selected row, ancestry, and later refreshes all speak one
+        # identity instead of leaving an invisible historical row selected.
+        resolved_job_id = str(getattr(job, "id", "") or "")
+        if resolved_job_id:
+            job_id = resolved_job_id
         try:
             transcript_directory = comms.session_dir_of(job_id) if comms is not None else None
         except Exception:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.38.1"
+version = "0.39.0"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/harness/test_comms.py
+++ b/tests/unit/harness/test_comms.py
@@ -1456,9 +1456,8 @@ def test_the_roster_marks_a_child_whose_transcript_is_gone(tmp_path):
     assert comms.resume("job-1", "carry on")[0] is None
 
 
-def test_the_roster_refuses_to_offer_a_second_resume_of_one_transcript(tmp_path):
-    """Two children on one transcript directory destroy each other's history,
-    so the roster must not advertise a resume that ``resume`` would refuse."""
+def test_the_roster_replaces_a_terminal_attempt_with_its_continuation(tmp_path):
+    """A resumed transcript is one logical child, not one row per attempt."""
     comms, jobs, _child, _parent = wire()
     (tmp_path / TRANSCRIPT_FILENAME).write_text("{}\n")
     comms.attach("job-1", FakeChild(), tmp_path)
@@ -1470,10 +1469,10 @@ def test_the_roster_refuses_to_offer_a_second_resume_of_one_transcript(tmp_path)
     comms.record_launch("job-2", "parser")
     comms.attach("job-2", FakeChild(), tmp_path)
 
-    rows = {row.job_id: row for row in comms.roster()}
+    rows = comms.roster()
 
-    assert rows["job-1"].resumable is False
-    assert "already resumed as job job-2" in (rows["job-1"].detail or "")
+    assert [row.job_id for row in rows] == ["job-2"]
+    assert comms.session_dir_of("job-1") == tmp_path
 
 
 @pytest.mark.asyncio

--- a/tests/unit/harness/test_comms_persistence.py
+++ b/tests/unit/harness/test_comms_persistence.py
@@ -97,6 +97,32 @@ def test_restore_preserves_a_failure_outcome(tmp_path) -> None:
     assert info.detail is not None and "boom" in info.detail
 
 
+def test_restore_collapses_legacy_resume_records_and_preserves_aliases(tmp_path) -> None:
+    session_dir = tmp_path / "child"
+    rows = [
+        {"job_id": "old", "label": "same", "session_dir": str(session_dir)},
+        {"job_id": "new", "label": "same", "session_dir": str(session_dir)},
+    ]
+    comms = SubagentComms(FakeParent(FakeJobs()))  # type: ignore[arg-type]
+    comms.restore(rows)
+
+    assert [item.job_id for item in comms.roster()] == ["new"]
+    assert comms.session_dir_of("old") == session_dir
+    assert comms.label_of("old") == "same"
+    assert comms.snapshot()[0]["attempt_aliases"] == ["old"]
+
+
+def test_identical_labels_with_distinct_transcripts_remain_distinct(tmp_path) -> None:
+    comms = SubagentComms(FakeParent(FakeJobs()))  # type: ignore[arg-type]
+    comms.restore(
+        [
+            {"job_id": "one", "label": "same", "session_dir": str(tmp_path / "one")},
+            {"job_id": "two", "label": "same", "session_dir": str(tmp_path / "two")},
+        ]
+    )
+    assert [item.job_id for item in comms.roster()] == ["one", "two"]
+
+
 def test_restore_skips_an_id_that_is_already_live(tmp_path) -> None:
     """A stale snapshot must not overwrite a running child of this session."""
     jobs = FakeJobs()

--- a/tests/unit/harness/test_jobs_restore.py
+++ b/tests/unit/harness/test_jobs_restore.py
@@ -35,7 +35,8 @@ async def wait_for(predicate, timeout: float = 2.0) -> None:
 
 
 def _row(job_id: str, status: JobStatus = "completed", **kw) -> AsyncJob:
-    return AsyncJob(id=job_id, type="task", status=status, start_time=1.0, label=job_id, **kw)
+    values = {"start_time": 1.0, "label": job_id, **kw}
+    return AsyncJob(id=job_id, type="task", status=status, **values)
 
 
 @pytest.mark.asyncio
@@ -120,6 +121,62 @@ async def test_roster_change_hook_fires_on_register_and_settle() -> None:
     before_settle = len(calls)
     await wait_for(lambda: manager.get(job_id).status == "completed")  # type: ignore[union-attr]
     assert len(calls) > before_settle  # settle fired it again
+    await manager.dispose()
+
+
+@pytest.mark.asyncio
+async def test_fresh_identical_launches_remain_distinct() -> None:
+    manager = AsyncJobManager()
+    manager.restore([_row("one", label="same"), _row("two", label="same")])
+    assert [job.id for job in manager.list()] == ["one", "two"]
+
+
+@pytest.mark.asyncio
+async def test_repeated_resume_attempts_replace_one_logical_row_and_alias_ids() -> None:
+    manager = AsyncJobManager()
+    manager.restore([_row("old", logical_id="/tmp/child")])
+
+    async def runner(job_id, signal, report_progress):
+        await asyncio.sleep(5)
+
+    current = manager.register("task", "same", runner)
+    await asyncio.sleep(0)
+    manager.bind_logical_identity(current, "/tmp/child")
+    assert [job.id for job in manager.list()] == [current]
+    assert manager.get("old") is manager.get(current)
+    assert manager.get(current).attempt_aliases == ["old"]  # type: ignore[union-attr]
+    await manager.dispose()
+
+
+@pytest.mark.asyncio
+async def test_legacy_duplicate_snapshot_keeps_newest_and_all_aliases() -> None:
+    manager = AsyncJobManager()
+    manager.restore(
+        [
+            _row("oldest", start_time=1.0, logical_id="/tmp/child"),
+            _row("middle", start_time=2.0, logical_id="/tmp/child"),
+            _row("newest", start_time=3.0, logical_id="/tmp/child"),
+        ]
+    )
+    assert [job.id for job in manager.list()] == ["newest"]
+    assert manager.get("oldest") is manager.get("newest")
+    assert manager.get("middle") is manager.get("newest")
+
+
+@pytest.mark.asyncio
+async def test_bind_rejects_two_live_attempts_for_one_transcript() -> None:
+    manager = AsyncJobManager(max_running=3)
+
+    async def runner(job_id, signal, report_progress):
+        await asyncio.sleep(5)
+
+    first = manager.register("task", "same", runner)
+    manager.bind_logical_identity(first, "/tmp/child")
+    second = manager.register("task", "same", runner)
+    await asyncio.sleep(0)
+    with pytest.raises(RuntimeError, match="already running"):
+        manager.bind_logical_identity(second, "/tmp/child")
+    assert [job.id for job in manager.list()] == [first, second]
     await manager.dispose()
 
 

--- a/tests/unit/harness/test_jobs_restore.py
+++ b/tests/unit/harness/test_jobs_restore.py
@@ -23,6 +23,7 @@ import asyncio
 import pytest
 
 from local_operator.harness.jobs import AsyncJob, AsyncJobManager, JobStatus
+from local_operator.harness.types import Usage
 
 
 async def wait_for(predicate, timeout: float = 2.0) -> None:
@@ -133,7 +134,8 @@ async def test_fresh_identical_launches_remain_distinct() -> None:
 
 @pytest.mark.asyncio
 async def test_repeated_resume_attempts_replace_one_logical_row_and_alias_ids() -> None:
-    manager = AsyncJobManager()
+    calls: list[str] = []
+    manager = AsyncJobManager(on_roster_change=lambda: calls.append("persist"))
     manager.restore([_row("old", logical_id="/tmp/child")])
 
     async def runner(job_id, signal, report_progress):
@@ -141,7 +143,9 @@ async def test_repeated_resume_attempts_replace_one_logical_row_and_alias_ids() 
 
     current = manager.register("task", "same", runner)
     await asyncio.sleep(0)
+    before_bind = len(calls)
     manager.bind_logical_identity(current, "/tmp/child")
+    assert len(calls) == before_bind + 1
     assert [job.id for job in manager.list()] == [current]
     assert manager.get("old") is manager.get(current)
     assert manager.get(current).attempt_aliases == ["old"]  # type: ignore[union-attr]
@@ -153,14 +157,39 @@ async def test_legacy_duplicate_snapshot_keeps_newest_and_all_aliases() -> None:
     manager = AsyncJobManager()
     manager.restore(
         [
-            _row("oldest", start_time=1.0, logical_id="/tmp/child"),
-            _row("middle", start_time=2.0, logical_id="/tmp/child"),
-            _row("newest", start_time=3.0, logical_id="/tmp/child"),
+            _row(
+                "oldest",
+                start_time=1.0,
+                logical_id="/tmp/child",
+                usage=Usage(input_tokens=4, provider="test", model_id="model"),
+                descendant_usage=[Usage(input_tokens=2, provider="test", model_id="descendant")],
+            ),
+            _row(
+                "middle",
+                start_time=2.0,
+                logical_id="/tmp/child",
+                usage=Usage(input_tokens=6, provider="test", model_id="model"),
+                descendant_usage=[Usage(input_tokens=3, provider="test", model_id="descendant")],
+            ),
+            _row(
+                "newest",
+                start_time=3.0,
+                logical_id="/tmp/child",
+                usage=Usage(input_tokens=8, provider="test", model_id="model"),
+                descendant_usage=[Usage(input_tokens=5, provider="test", model_id="descendant")],
+            ),
         ]
     )
     assert [job.id for job in manager.list()] == ["newest"]
     assert manager.get("oldest") is manager.get("newest")
     assert manager.get("middle") is manager.get("newest")
+    assert {item.model_id: item.input_tokens for item in manager.accounting_components()} == {
+        "model": 18,
+        "descendant": 10,
+    }
+    # Accounting is transferred to the settled accumulator once; repeated reads
+    # must not re-fold the retained winner and double legacy attempts.
+    assert sum(item.input_tokens for item in manager.accounting_components()) == 28
 
 
 @pytest.mark.asyncio

--- a/tests/unit/harness/test_jobs_restore.py
+++ b/tests/unit/harness/test_jobs_restore.py
@@ -153,6 +153,47 @@ async def test_repeated_resume_attempts_replace_one_logical_row_and_alias_ids() 
 
 
 @pytest.mark.asyncio
+async def test_repeated_live_folds_carry_prior_usage_without_double_counting() -> None:
+    manager = AsyncJobManager(max_running=3)
+    manager.restore(
+        [
+            _row(
+                "old",
+                logical_id="/tmp/child",
+                usage=Usage(input_tokens=4, provider="test", model_id="m"),
+            )
+        ]
+    )
+
+    async def runner(job_id, signal, report_progress):
+        await asyncio.sleep(5)
+
+    middle = manager.register("task", "same", runner)
+    await asyncio.sleep(0)
+    manager.bind_logical_identity(middle, "/tmp/child")
+    assert sum(item.input_tokens for item in manager.accounting_components()) == 4
+    middle_row = manager.get(middle)
+    assert middle_row is not None
+    middle_row.usage = Usage(input_tokens=3, provider="test", model_id="m")
+    middle_row.status = "completed"
+    manager._settle(middle_row)
+
+    newest = manager.register("task", "same", runner)
+    await asyncio.sleep(0)
+    manager.bind_logical_identity(newest, "/tmp/child")
+    current = manager.get(newest)
+    assert current is not None
+    assert current.attempt_aliases == ["old", middle]
+    assert sum(item.input_tokens for item in current.prior_attempt_usage) == 7
+    assert sum(item.input_tokens for item in manager.accounting_components()) == 7
+    assert sum(item.input_tokens for item in manager.accounting_components()) == 7
+    await manager.dispose()
+    # Cancelling the newest attempt settles it. Its durable predecessor ledger
+    # remains metadata in this process rather than entering the accumulator again.
+    assert sum(item.input_tokens for item in manager.accounting_components()) == 7
+
+
+@pytest.mark.asyncio
 async def test_legacy_duplicate_snapshot_keeps_newest_and_all_aliases() -> None:
     manager = AsyncJobManager()
     manager.restore(

--- a/tests/unit/session/test_resume_subagents_todos.py
+++ b/tests/unit/session/test_resume_subagents_todos.py
@@ -204,7 +204,11 @@ async def test_live_continuation_persists_one_logical_row_before_restart(tmp_pat
     )
 
     def _binding_is_durable() -> bool:
-        details = resumed._transcript.latest_custom(SUBAGENT_ROSTER_CUSTOM_TYPE) or {}
+        sidecar = resumed._transcript.directory / SUBAGENT_ROSTER_SIDECAR
+        try:
+            details = json.loads(sidecar.read_text())
+        except (OSError, ValueError):
+            return False
         return [row.get("id") for row in details.get("jobs", [])] == [new_id] and [
             row.get("job_id") for row in details.get("records", [])
         ] == [new_id]

--- a/tests/unit/session/test_resume_subagents_todos.py
+++ b/tests/unit/session/test_resume_subagents_todos.py
@@ -34,6 +34,7 @@ from local_operator.harness.types import (
     StreamTextDelta,
     TextContent,
     ToolResult,
+    Usage,
 )
 from local_operator.session.session import (
     SUBAGENT_ROSTER_CUSTOM_TYPE,
@@ -225,10 +226,51 @@ async def test_live_continuation_persists_one_logical_row_before_restart(tmp_pat
 
 
 @pytest.mark.asyncio
+async def test_live_continuation_preserves_prior_accounting_across_restart(tmp_path, monkeypatch):
+    """A folded predecessor's settled usage must live in the authoritative row."""
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+
+    parent = _session(tmp_path, OneShotStream())
+    await parent.async_init()
+    old_id = parent._launch_subagent(label="accounted", prompt="first attempt")
+    await wait_for(lambda: _status(parent, old_id) == "completed")
+    old_row = parent.jobs.get(old_id)
+    assert old_row is not None
+    old_row.usage = Usage(input_tokens=4, provider="test", model_id="m")
+    parent.jobs.note_usage_changed()
+    await parent._persist_subagent_roster()
+    await parent.dispose()
+
+    hanging = HangingStream()
+    resumed = _session(tmp_path, hanging)
+    await resumed.async_init()
+    new_id, error = resumed.subagent_comms.resume(old_id, "continue")
+    assert error is None and new_id is not None
+    await hanging.started.wait()
+    await wait_for(
+        lambda: resumed.jobs.get(new_id) is not None
+        and resumed.jobs.get(new_id).logical_id is not None  # type: ignore[union-attr]
+    )
+    assert sum(item.input_tokens for item in resumed.jobs.accounting_components()) == 4
+    await resumed._persist_subagent_roster()
+
+    restarted = _session(tmp_path, IdleStream())
+    await restarted.async_init()
+    current = restarted.jobs.get(new_id)
+    assert current is not None
+    assert [row.id for row in restarted.jobs.list() if row.type == "task"] == [new_id]
+    assert restarted.jobs.get(old_id) is current
+    assert sum(item.input_tokens for item in restarted.jobs.accounting_components()) == 4
+    assert sum(item.input_tokens for item in restarted.jobs.accounting_components()) == 4
+
+    await restarted.dispose()
+    await resumed.dispose()
+
+
+@pytest.mark.asyncio
 async def test_descendant_accounting_survives_process_resume(tmp_path, monkeypatch):
     """Nested spend lives on the owning row, not an in-process child manager."""
     monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
-    from local_operator.harness.types import Usage
 
     parent = _session(tmp_path, OneShotStream())
     await parent.async_init()

--- a/tests/unit/session/test_resume_subagents_todos.py
+++ b/tests/unit/session/test_resume_subagents_todos.py
@@ -82,6 +82,22 @@ async def _todo(ctx, call_id: str, args: dict[str, object]) -> None:
     await execute_todo(call_id, args, None, None, ctx)
 
 
+class HangingStream:
+    """A provider turn that stays live until the owning job is cancelled."""
+
+    def __init__(self) -> None:
+        self.started = asyncio.Event()
+
+    def __call__(self, request: ChatRequest, signal: AbortSignal | None):
+        async def gen():
+            self.started.set()
+            assert signal is not None
+            await signal.wait()
+            yield StreamEndEvent(stop_reason="aborted")
+
+        return gen()
+
+
 class IdleStream:
     """A parent stream that answers every turn with a single text delta.
 
@@ -161,6 +177,46 @@ async def test_a_completed_subagent_is_restored_and_resumable(tmp_path, monkeypa
     assert resumed.jobs.get(job_id) is resumed.jobs.get(new_job_id)
     assert [item.job_id for item in resumed.subagent_comms.roster()] == [new_job_id]
     assert resumed.subagent_comms.session_dir_of(job_id) == session_dir
+    await resumed.dispose()
+
+
+@pytest.mark.asyncio
+async def test_live_continuation_persists_one_logical_row_before_restart(tmp_path, monkeypatch):
+    """Binding is the durability boundary, not eventual child settlement."""
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+
+    parent = _session(tmp_path, OneShotStream())
+    await parent.async_init()
+    old_id = parent._launch_subagent(label="explore", prompt="do a thing")
+    await wait_for(lambda: _status(parent, old_id) == "completed")
+    await parent._persist_subagent_roster()
+    await parent.dispose()
+
+    hanging = HangingStream()
+    resumed = _session(tmp_path, hanging)
+    await resumed.async_init()
+    new_id, error = resumed.subagent_comms.resume(old_id, "keep going")
+    assert error is None and new_id is not None
+    await hanging.started.wait()
+    await wait_for(
+        lambda: resumed.jobs.get(new_id) is not None
+        and resumed.jobs.get(new_id).logical_id is not None  # type: ignore[union-attr]
+    )
+
+    def _binding_is_durable() -> bool:
+        details = resumed._transcript.latest_custom(SUBAGENT_ROSTER_CUSTOM_TYPE) or {}
+        return [row.get("id") for row in details.get("jobs", [])] == [new_id] and [
+            row.get("job_id") for row in details.get("records", [])
+        ] == [new_id]
+
+    await wait_for(_binding_is_durable)
+    restarted = _session(tmp_path, IdleStream())
+    await restarted.async_init()
+    assert [row.id for row in restarted.jobs.list() if row.type == "task"] == [new_id]
+    assert restarted.jobs.get(old_id) is restarted.jobs.get(new_id)
+    assert [item.job_id for item in restarted.subagent_comms.roster()] == [new_id]
+
+    await restarted.dispose()
     await resumed.dispose()
 
 

--- a/tests/unit/session/test_resume_subagents_todos.py
+++ b/tests/unit/session/test_resume_subagents_todos.py
@@ -150,6 +150,17 @@ async def test_a_completed_subagent_is_restored_and_resumable(tmp_path, monkeypa
     new_job_id, error = resumed.subagent_comms.resume(job_id, "keep going")
     assert error is None
     assert new_job_id and new_job_id != job_id
+
+    def _is_reconciled() -> bool:
+        row = resumed.jobs.get(new_job_id)
+        return row is not None and row.logical_id == str(session_dir)
+
+    await wait_for(_is_reconciled)
+    rows = [j for j in resumed.jobs.list() if j.type == "task"]
+    assert [row.id for row in rows] == [new_job_id]
+    assert resumed.jobs.get(job_id) is resumed.jobs.get(new_job_id)
+    assert [item.job_id for item in resumed.subagent_comms.roster()] == [new_job_id]
+    assert resumed.subagent_comms.session_dir_of(job_id) == session_dir
     await resumed.dispose()
 
 

--- a/tests/unit/tui/test_subagent_view.py
+++ b/tests/unit/tui/test_subagent_view.py
@@ -27,7 +27,11 @@ from local_operator.harness.comms import (
     HUB_MESSAGE_TYPE,
     SubagentComms,
 )
-from local_operator.harness.jobs import CANCELLED_BEFORE_START
+from local_operator.harness.jobs import (
+    CANCELLED_BEFORE_START,
+    AsyncJob,
+    AsyncJobManager,
+)
 from local_operator.harness.types import CustomMessage, Message, TextContent, ToolCall
 from local_operator.session.session import Session
 from local_operator.session.transcript import (
@@ -728,6 +732,54 @@ async def test_the_page_renders_the_childs_messages_and_tool_calls() -> None:
         page = " ".join(view.rendered_rows())
         assert "audit the ingest path" in page  # the title names the subagent
         assert "Two tests fail on the retry budget." in page
+
+
+@pytest.mark.asyncio
+async def test_historical_attempt_opens_and_selects_the_current_visible_row() -> None:
+    session = FakeSession()
+    manager = AsyncJobManager()
+    current = AsyncJob(
+        id="current",
+        type="task",
+        status="completed",
+        start_time=1.0,
+        settled_at=2.0,
+        label="continued child",
+        logical_id="/tmp/child",
+        attempt_aliases=["historical"],
+    )
+    manager.restore([current])
+    session.jobs = manager
+    comms = SubagentComms(session)  # type: ignore[arg-type]
+    comms.restore(
+        [
+            {
+                "job_id": "current",
+                "label": "continued child",
+                "session_dir": "/tmp/child",
+                "attempt_aliases": ["historical"],
+            }
+        ]
+    )
+    session._subagent_comms = comms
+
+    app = OperatorApp(_async_factory(session))
+    async with app.run_test(size=(120, 40)) as pilot:
+        for _ in range(80):
+            await pilot.pause()
+            if app._session is not None:
+                break
+        app._refresh_band()
+        await pilot.pause()
+        app._open_subagent_view("historical")
+        await pilot.pause()
+
+        view = app.query_one(SubagentView)
+        panel = app._subagent_panel
+        assert view.job_id == "current"
+        assert panel is not None
+        assert list(panel._rows) == ["current"]
+        assert panel._rows["current"].current is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- keep one logical Subagents row when a stopped child is resumed, while preserving per-attempt job IDs and usage history
- derive continuation identity from the durable child session directory instead of labels or prompts
- reconcile legacy restart snapshots and route historical job IDs to the current attempt without collapsing genuinely separate launches

## Testing
- `env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit -q` -> `6996 passed, 7 skipped`
- `.venv/bin/python -m flake8 .` -> passed
- `.venv/bin/python -m black --check .` -> 550 files unchanged
- `.venv/bin/python -m isort --check .` -> passed
- changed-file pyright over all modified Python files -> `0 errors, 0 warnings, 0 informations`
- focused comms and resume coverage -> `125 passed`

## Real-path evidence
The tests exercise the actual job/comms/session snapshot path used by task resume: a terminal attempt is restored, resumed with the same child session directory, and reconciled to one current logical row. They also verify historical job IDs alias to the current attempt, repeated resumes stay collapsed, live jobs that happen to share a fake session path remain distinct, and separate launches with identical labels are not merged.

## Visual impact
The visible result is deliberately subtractive: the stale pre-resume row is removed and the current attempt occupies the one logical slot, keeping row count and panel height stable. No colors, spacing, or row content styling changed. Design and UX review will use rendered real-`OperatorApp` evidence before merge.
